### PR TITLE
Add Claude Fable 5 to the product registry

### DIFF
--- a/sources/categories/base_pretrained.yaml
+++ b/sources/categories/base_pretrained.yaml
@@ -37,6 +37,7 @@ products:
 - nemotron-3
 - gpt-5
 - claude-opus-4-7
+- claude-fable-5
 - gemini-3-5-flash
 - grok-4-20
 - apertus

--- a/sources/organizations/anthropic.yaml
+++ b/sources/organizations/anthropic.yaml
@@ -5,6 +5,7 @@ homepage: https://www.anthropic.com
 github:
 - url: https://github.com/anthropics
 products:
+- claude-fable-5
 - claude-opus-4-7
 - claude-sonnet-4
 - claude-opus-4-x

--- a/sources/products/claude-fable-5.yaml
+++ b/sources/products/claude-fable-5.yaml
@@ -1,0 +1,13 @@
+name: claude-fable-5
+display_name: Claude Fable 5
+type: model
+description: Anthropic's first Mythos-class model for general availability (June 2026), sitting above Opus
+  in capability. Same underlying weights as Claude Mythos 5 but wrapped with safety classifiers that route
+  sensitive cybersecurity, biology/chemistry, and distillation queries to Claude Opus 4.8 (~5% of sessions).
+  Built for long-horizon agentic coding, knowledge work, vision, and scientific research with a 1M-token
+  context window and up to 128K output. Tops Cognition FrontierCode and Hebbia Finance among frontier models;
+  state-of-the-art on CursorBench and FrontierBench per early partner testing. $10/$50 per Mtok via API,
+  Bedrock, Vertex, and Foundry.
+comments: Anthropic Claude Fable 5 (model id claude-fable-5), released Jun 9 2026. Mythos-class tier above
+  Opus; generally available counterpart to restricted Claude Mythos 5 (Project Glasswing). 30-day mandatory
+  data retention (Covered Model). Verified via Anthropic Fable 5 launch post and API docs June 2026.

--- a/sources/scores/claude-fable-5.yaml
+++ b/sources/scores/claude-fable-5.yaml
@@ -1,0 +1,42 @@
+product: claude-fable-5
+openness:
+  score: 1
+  class: closed
+  components: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
+  confidence: high
+  note: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
+  sources:
+  - url: https://www.anthropic.com/news/claude-fable-5-mythos-5
+    shows: Mythos-class flagship, proprietary, claude-fable-5 via API and cloud marketplaces only
+    accessed: '2026-06-11'
+  - url: https://platform.claude.com/docs/en/about-claude/models/introducing-claude-fable-5-and-claude-mythos-5
+    shows: API model id claude-fable-5, no weights release, Covered Model retention policy
+    accessed: '2026-06-11'
+adoption:
+  level: null
+  reach: null
+  signal_type: unknown
+  confidence: low
+  note: Launched Jun 9 2026; Anthropic lists enterprise testimonials (Stripe, GitHub, Cursor, Cognition,
+    etc.) but no quantitative per-model usage figures. Staged subscription rollout (included on Pro/Max/Team
+    through Jun 22, then usage credits). Held null rather than score on launch testimonials.
+  sources:
+  - url: https://www.anthropic.com/news/claude-fable-5-mythos-5
+    shows: launch testimonials and staged availability, no quantitative usage figures
+    accessed: '2026-06-11'
+capability:
+  score: 5
+  basis: benchmark:FrontierCode
+  value: null
+  confidence: high
+  note: 'Anthropic-reported: highest among frontier models on Cognition FrontierCode (even at medium effort);
+    top on Hebbia Finance Benchmark; SOTA on CursorBench and FrontierBench per partner testing; leads Opus
+    4.8 on long-horizon coding, knowledge work, vision, and memory tasks. Vendor-reported; underlying Mythos
+    weights with classifier fallback on ~5% of sessions.'
+  sources:
+  - url: https://www.anthropic.com/news/claude-fable-5-mythos-5
+    shows: FrontierCode highest among frontier models; SOTA across software engineering, knowledge work, vision
+    accessed: '2026-06-11'
+  - url: https://www.anthropic.com/claude/fable
+    shows: most capable generally available Claude model; long-horizon agentic flagship positioning
+    accessed: '2026-06-11'


### PR DESCRIPTION
## Summary

- Adds `claude-fable-5` as Anthropic's Mythos-class frontier model (released Jun 9, 2026; API id `claude-fable-5`).
- Scores it closed/API-only (openness 1) with capability 5 based on Anthropic's FrontierCode and partner benchmark claims; adoption held null pending quantitative signals.
- Links the product to the `anthropic` org and the `base_pretrained` category roster.

## Test plan

- [x] `uv run python -m build.validate` prints `0 error(s)`


Made with [Cursor](https://cursor.com)