### PR TITLE
fix(ci): raise refresh job timeout to 330m for paced HF fetcher

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -15,7 +15,11 @@ concurrency:
 jobs:
   refresh:
     runs-on: ubuntu-latest
-    timeout-minutes: 180
+    # The HF link scan spends ~2h of wall time in 60s sleeps on 429s (the
+    # pacing that keeps it alive); a full paced run takes ~3.5h. 180m killed
+    # run 27345470020 at 79% of the link scan. Trim pacing or split fetchers
+    # into parallel jobs before tightening this again.
+    timeout-minutes: 330
     env:
       OSO_API_KEY: ${{ secrets.OSO_API_KEY }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}


### PR DESCRIPTION
## Summary
- Run [27345470020](https://github.com/currentai-org/os-ai-map/actions/runs/27345470020) hit the 180-minute job timeout at 79% of the HF link scan (15,600/19,757).
- The 429 pacing from 99d0033 works as intended — the fetcher survives rate limiting instead of dying — but it spent **133 × 60s ≈ 2h13m of wall time sleeping**, so a full paced run needs ~3.5h.
- Raises `timeout-minutes` 180 → 330 with a comment explaining why.

## Test plan
- Re-dispatched `refresh-data` from this branch; verifying it completes end-to-end and opens the data-refresh PR.

## Follow-up (tracked in OSO-2895)
- Trim the pacing (60s flat sleep is conservative) or split fetchers into parallel jobs, then tighten the timeout again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)