### PR TITLE
feat: add Thunderbolt, Lumo, Morphic, and Duck.ai to UI & API

### DIFF
--- a/sources/categories/ui_api.yaml
+++ b/sources/categories/ui_api.yaml
@@ -17,12 +17,16 @@ products:
 - jan
 - continue
 - sillytavern
+- thunderbolt
+- morphic
 - chatgpt
 - github-copilot-github-microsoft
 - claude-ai
 - gemini
 - microsoft-copilot
 - perplexity
+- lumo
+- duck-ai
 - poe
 - openrouter
 - character-ai

--- a/sources/organizations/duckduckgo.yaml
+++ b/sources/organizations/duckduckgo.yaml
@@ -1,0 +1,8 @@
+name: duckduckgo
+display_name: DuckDuckGo
+type: company
+homepage: https://duckduckgo.com
+github:
+- url: https://github.com/duckduckgo
+products:
+- duck-ai

--- a/sources/organizations/morphic.yaml
+++ b/sources/organizations/morphic.yaml
@@ -1,0 +1,8 @@
+name: morphic
+display_name: Morphic
+type: individual
+homepage: https://www.morphic.sh
+github:
+- url: https://github.com/miurla
+products:
+- morphic

--- a/sources/organizations/mzla-technologies.yaml
+++ b/sources/organizations/mzla-technologies.yaml
@@ -1,0 +1,8 @@
+name: mzla-technologies
+display_name: MZLA Technologies
+type: company
+homepage: https://www.thunderbolt.io
+github:
+- url: https://github.com/thunderbird
+products:
+- thunderbolt

--- a/sources/organizations/proton.yaml
+++ b/sources/organizations/proton.yaml
@@ -1,0 +1,8 @@
+name: proton
+display_name: Proton
+type: company
+homepage: https://proton.me
+github:
+- url: https://github.com/ProtonMail
+products:
+- lumo

--- a/sources/products/duck-ai.yaml
+++ b/sources/products/duck-ai.yaml
@@ -1,0 +1,11 @@
+name: duck-ai
+display_name: Duck.ai
+type: software
+description: DuckDuckGo's free, anonymous AI chat surface. Lets users chat with multiple third-party models
+  without an account - Anthropic's Claude 4.5 Haiku, Meta's Llama 3.3 70B, Mistral Small 3, and OpenAI's
+  GPT-4o mini on the free tier, with frontier models (GPT-5.4, Claude Sonnet 4.6, Llama 4 Maverick) for
+  subscribers. Strips personal metadata (including IP) before prompting providers, and conversations are
+  not used to train models. The differentiator is privacy - a proprietary anonymizing proxy in front of
+  otherwise-closed model APIs.
+comments: Proprietary; web-based and integrated into the DuckDuckGo browser. No source, no self-host -
+  the closed counterpart to the privacy-chat surfaces in this shelf.

--- a/sources/products/lumo.yaml
+++ b/sources/products/lumo.yaml
@@ -1,0 +1,14 @@
+name: lumo
+display_name: Proton Lumo
+type: software
+description: Privacy-first AI assistant from Proton with zero-access encryption, a no-logs policy, and
+  a "ghost mode" that discards chats on close. Runs on open-weight models from Proton's European data
+  centers, excluding third-party providers like OpenAI from inference. Web and mobile clients are open
+  source (GPLv3), though the backend service, routing layer, and model serving are not public. The differentiator
+  is confidentiality - no account is required and conversations are never used for training.
+github:
+- url: https://github.com/ProtonLumo/ios-lumo
+- url: https://github.com/ProtonLumo/android-lumo
+comments: Launched July 2025; Lumo 1.1 added advanced reasoning. Clients are GPLv3 (web client lives in
+  ProtonMail/WebClients; iOS/Android in ProtonLumo), but the service, models, and routing are not open-sourced,
+  so the "fully open source" marketing claim is contested.

--- a/sources/products/morphic.yaml
+++ b/sources/products/morphic.yaml
@@ -1,0 +1,12 @@
+name: morphic
+display_name: Morphic
+type: software
+description: Open-source AI-powered answer engine with a generative UI - answers render rich, source-credited
+  inline components (images, grids, headings) live from a streamed JSON spec rather than plain markdown.
+  Supports multiple model providers (OpenAI, Anthropic, Google, Ollama) and search backends (Tavily, SearXNG,
+  Brave, Exa), with chat history, shareable result URLs, file upload, and guest mode. The differentiator
+  is the generative-UI answer surface; it is Docker-deployable for self-hosting.
+github:
+- url: https://github.com/miurla/morphic
+comments: Apache-2.0; ~8.9k GitHub stars by mid-2026. Built on Next.js + the Vercel AI SDK. Self-hostable
+  open generative-search UI.

--- a/sources/products/thunderbolt.yaml
+++ b/sources/products/thunderbolt.yaml
@@ -1,0 +1,13 @@
+name: thunderbolt
+display_name: Thunderbolt
+type: software
+description: Open-source, self-hosted AI client from MZLA Technologies (the Mozilla Foundation subsidiary
+  behind Thunderbird), positioned as a sovereign alternative to Microsoft Copilot, ChatGPT Enterprise,
+  and Claude Enterprise. Provides chat, search, research, and task automation across web and native apps
+  (Linux, Windows, macOS, iOS, Android), integrating Anthropic, OpenAI, Mistral, OpenRouter, and local
+  Ollama models with no vendor lock-in. The differentiator is data control - organizations run their own
+  infrastructure rather than renting access.
+github:
+- url: https://github.com/thunderbird/thunderbolt
+comments: Launched April 2026 under MPL-2.0; in active development and mid-security-audit as of mid-2026.
+  Self-hosted multi-provider enterprise AI client.

--- a/sources/scores/duck-ai.yaml
+++ b/sources/scores/duck-ai.yaml
@@ -1,0 +1,35 @@
+product: duck-ai
+openness:
+  score: 1
+  class: closed
+  confidence: high
+  components: source:closed;self-host:none;license:proprietary(SaaS app + browser integration)
+  note: Proprietary anonymizing proxy in front of closed model APIs; no source, no self-host. Closed privacy-chat
+    surface in the ui_api shelf.
+  sources:
+  - url: https://duckduckgo.com/duckduckgo-help-pages/duckai/ai-chat-privacy
+    shows: DuckDuckGo's proprietary Duck.ai privacy/help documentation
+    accessed: '2026-06-17'
+adoption:
+  level: 3
+  signal_type: reported_traction
+  confidence: low
+  note: Backed by DuckDuckGo's large user base and integrated into its browser, but no Duck.ai-specific
+    usage figures are published. Conservative reported_traction pending a disclosed active-user signal.
+  sources:
+  - url: https://spreadprivacy.com/ai-chat/
+    shows: DuckDuckGo's launch of free, anonymous AI Chat across web + browser
+    accessed: '2026-06-17'
+capability:
+  score: 2
+  basis: feature_matrix
+  value: 'model breadth: Claude 4.5 Haiku, Llama 3.3 70B, Mistral Small 3, GPT-4o mini (free); frontier
+    models for subscribers; RAG: no; plugins/tools: no; multimodal: limited; multi-user: n/a (anonymous,
+    no accounts); privacy: metadata stripped, no training'
+  confidence: high
+  note: Anonymizing multi-model chat proxy - strong on privacy and model choice, but a deliberately minimal
+    surface (no RAG, plugins, agents, or multimodal generation). Lower-tier on the chat-UI feature matrix.
+  sources:
+  - url: https://duckduckgo.com/duckduckgo-help-pages/duckai/chat-models
+    shows: available models (Claude 4.5 Haiku, Llama 3.3 70B, Mistral Small 3, GPT-4o mini; subscriber models)
+    accessed: '2026-06-17'

--- a/sources/scores/lumo.yaml
+++ b/sources/scores/lumo.yaml
@@ -1,0 +1,42 @@
+product: lumo
+openness:
+  score: 3
+  class: open_core
+  components: clients:open(GPLv3 - web in ProtonMail/WebClients, iOS/Android in ProtonLumo);service:closed(backend,
+    routing, model-serving not public);license:GPLv3(clients)
+  confidence: high
+  note: Open clients (GPLv3) over a proprietary hosted service - the backend, routing, and model-serving
+    layer are not published. Marketed as "fully open source," but support and third-party reviews note
+    that only the clients are open, so open_core is the honest class.
+  sources:
+  - url: https://github.com/ProtonLumo/ios-lumo
+    shows: iOS client source under GPLv3
+    accessed: '2026-06-17'
+  - url: https://isitreallyfoss.com/projects/lumo/
+    shows: only the Lumo mobile/web apps are open; service + model interaction code not public
+    accessed: '2026-06-17'
+adoption:
+  level: 3
+  signal_type: reported_traction
+  confidence: medium
+  note: Launched July 2025 with Lumo 1.1 following; distributed across Proton's large account base (100M+
+    Proton accounts) and available on web + iOS + Android with no account required. No Lumo-specific usage
+    numbers disclosed, so reported_traction at a mid level.
+  sources:
+  - url: https://proton.me/blog/lumo-ai
+    shows: Proton's launch announcement for Lumo
+    accessed: '2026-06-17'
+capability:
+  score: 3
+  basis: feature_matrix
+  value: 'model breadth: open-weight models (no third-party providers); RAG/file upload: yes (incl. Proton
+    Drive); web search: yes; reasoning: yes (Lumo 1.1); multimodal: limited; multi-user: single-user; privacy:
+    zero-access encryption + ghost mode'
+  confidence: medium
+  note: Capable privacy assistant with file upload, web search, and a reasoning mode, but confined to
+    open-weight models and the Proton ecosystem; lighter on multimodal/plugins than frontier consumer
+    apps. Mid-tier on the chat-UI feature matrix.
+  sources:
+  - url: https://proton.me/blog/lumo-1-1
+    shows: Lumo 1.1 adds faster, advanced reasoning
+    accessed: '2026-06-17'

--- a/sources/scores/morphic.yaml
+++ b/sources/scores/morphic.yaml
@@ -1,0 +1,37 @@
+product: morphic
+openness:
+  score: 5
+  class: open_source
+  components: license:Apache-2.0(OSI);source:public(github.com/miurla/morphic);self-host:primary(Docker);no-feature-gated-core
+  confidence: high
+  note: Fully OSI-licensed (Apache-2.0), full source public, Docker-deployable for self-hosting - a true
+    open generative-search UI.
+  sources:
+  - url: https://github.com/miurla/morphic
+    shows: Apache-2.0 license; ~8.9k stars; open generative-UI answer engine
+    accessed: '2026-06-17'
+adoption:
+  level: 3
+  signal_type: stars_fallback
+  confidence: medium
+  note: ~8.9k GitHub stars by mid-2026; no download/usage telemetry available for a self-hosted web app,
+    so stars_fallback (capped at level 3). Popular as a reference open answer-engine template (also a
+    Vercel template).
+  sources:
+  - url: https://github.com/miurla/morphic
+    shows: 8.9k stars
+    accessed: '2026-06-17'
+capability:
+  score: 3
+  basis: feature_matrix
+  value: 'model breadth: OpenAI/Anthropic/Google/Ollama; search backends: Tavily/SearXNG/Brave/Exa; generative
+    UI: rich inline components from streamed JSON; chat history + shareable URLs; file upload; guest mode;
+    multi-user: limited'
+  confidence: medium
+  note: Distinctive generative-UI answer surface with multi-provider/multi-search support, but scoped
+    to search-and-answer rather than the full chat-UI feature set (lighter on multimodal, plugins, enterprise
+    auth). Mid-tier for the category.
+  sources:
+  - url: https://github.com/miurla/morphic
+    shows: 'feature set: generative UI, multi-provider, multi-search, history, sharing, file upload, guest mode'
+    accessed: '2026-06-17'

--- a/sources/scores/thunderbolt.yaml
+++ b/sources/scores/thunderbolt.yaml
@@ -1,0 +1,40 @@
+product: thunderbolt
+openness:
+  score: 5
+  class: open_source
+  components: license:MPL-2.0(OSI);source:public(github.com/thunderbird/thunderbolt);self-host:primary(enterprise
+    self-hosting);governance:MZLA-Technologies(Mozilla-Foundation-subsidiary)
+  confidence: high
+  note: OSI-licensed (MPL-2.0), full source public from launch, designed primarily for self-hosting - a
+    true open AI client.
+  sources:
+  - url: https://github.com/thunderbird/thunderbolt
+    shows: public source repo under MPL-2.0; "AI You Control" self-hosted client
+    accessed: '2026-06-17'
+  - url: https://www.phoronix.com/news/Mozilla-Thunderbolt
+    shows: MZLA launches Thunderbolt as an open-source enterprise AI client (Apr 2026)
+    accessed: '2026-06-17'
+adoption:
+  level: 2
+  signal_type: reported_traction
+  confidence: low
+  note: Launched April 2026 and still in active development / mid-security-audit; no usage figures disclosed
+    yet. Early-stage but backed by the Mozilla/Thunderbird brand. Conservative reported_traction pending
+    real adoption signal.
+  sources:
+  - url: https://www.theregister.com/2026/04/16/mozilla_thunderbolt_enterprise_ai_client/
+    shows: launch coverage; positioned vs Copilot/ChatGPT Enterprise/Claude Enterprise
+    accessed: '2026-06-17'
+capability:
+  score: 4
+  basis: feature_matrix
+  value: 'model breadth: Anthropic/OpenAI/Mistral/OpenRouter + local Ollama; surfaces: chat, search, research,
+    task automation; platforms: web + native Linux/Windows/macOS/iOS/Android; self-host: primary; multi-user:
+    enterprise-oriented'
+  confidence: medium
+  note: Broad feature surface (multi-provider, multi-platform, agentic task automation, self-host) comparable
+    to the leading open chat UIs, but newly launched and unproven; medium confidence pending maturity.
+  sources:
+  - url: https://www.ghacks.net/2026/04/20/mozillas-mzla-technologies-launches-thunderbolt-an-open-source-self-hosted-enterprise-ai-client/
+    shows: 'feature set: chat/search/research/task automation across web + native apps, multi-provider + Ollama'
+    accessed: '2026-06-17'


### PR DESCRIPTION
## Summary

Adds four chat / answer-engine products that were missing from the **UI & API** (`ui_api`) shelf. Two related products (Open WebUI, LibreChat) were already mapped; these four fill the remaining gaps surfaced in review.

| Product | Org | Openness | Notes |
|---|---|---|---|
| **Thunderbolt** | MZLA Technologies (new) | `open_source` (MPL-2.0) | Self-hosted enterprise AI client; launched Apr 2026, positioned vs Copilot/ChatGPT Enterprise. Placed in the open cluster. |
| **Proton Lumo** | Proton (new) | `open_core` | Clients GPLv3; backend/routing/models **not** public — so `open_core`, not the "fully open source" marketing claim. |
| **Morphic** | Morphic (new) | `open_source` (Apache-2.0) | Open generative-UI answer engine (~8.9k stars). Placed in the open cluster. |
| **Duck.ai** | DuckDuckGo (new) | `closed` | Proprietary anonymizing proxy to multiple closed model APIs. Placed near the mass-market privacy surfaces. |

Each product ships a `products/`, `scores/`, and org roster entry, and one line in `categories/ui_api.yaml`. No `build/` or `notebooks/` files were touched (bot-owned).

## Scoring notes
- Every non-null openness/capability value carries a **primary-source citation** (vendor docs, GitHub, license file).
- Adoption: Morphic uses `stars_fallback` (capped at 3); Thunderbolt/Lumo/Duck.ai use `reported_traction` since no per-product active-user figures are disclosed.
- The Lumo openness nuance (open clients, closed service) is documented in both the score `note` and product `comments`.