### PR TITLE
Add private/self-hosted AI chat, search & inference products

### DIFF
--- a/sources/categories/agent_tools_protocols.yaml
+++ b/sources/categories/agent_tools_protocols.yaml
@@ -19,6 +19,7 @@ products:
 - perplexity-sonar-api
 - pinecone
 - serper
+- searxng
 - google-grounding-api
 - apify
 - cohere-rerank-api

--- a/sources/categories/deployment.yaml
+++ b/sources/categories/deployment.yaml
@@ -28,4 +28,5 @@ products:
 - spaces
 - ollama
 - ray
+- openpcc
 comments: ''

--- a/sources/categories/ui_api.yaml
+++ b/sources/categories/ui_api.yaml
@@ -19,6 +19,9 @@ products:
 - sillytavern
 - thunderbolt
 - morphic
+- perplexica
+- khoj
+- surfsense
 - chatgpt
 - github-copilot-github-microsoft
 - claude-ai
@@ -27,6 +30,9 @@ products:
 - perplexity
 - lumo
 - duck-ai
+- maple-ai
+- privatemode
+- confer
 - poe
 - openrouter
 - character-ai

--- a/sources/organizations/confer-labs.yaml
+++ b/sources/organizations/confer-labs.yaml
@@ -1,0 +1,8 @@
+name: confer-labs
+display_name: Confer Labs
+type: company
+homepage: https://confer.to
+github:
+- url: https://github.com/ConferLabs
+products:
+- confer

--- a/sources/organizations/confident-security.yaml
+++ b/sources/organizations/confident-security.yaml
@@ -1,0 +1,8 @@
+name: confident-security
+display_name: Confident Security
+type: company
+homepage: https://confident.security
+github:
+- url: https://github.com/openpcc
+products:
+- openpcc

--- a/sources/organizations/edgeless-systems.yaml
+++ b/sources/organizations/edgeless-systems.yaml
@@ -1,0 +1,8 @@
+name: edgeless-systems
+display_name: Edgeless Systems
+type: company
+homepage: https://www.edgeless.systems
+github:
+- url: https://github.com/edgelesssys
+products:
+- privatemode

--- a/sources/organizations/itzcrazykns.yaml
+++ b/sources/organizations/itzcrazykns.yaml
@@ -1,0 +1,8 @@
+name: itzcrazykns
+display_name: ItzCrazyKns
+type: individual
+homepage: https://github.com/ItzCrazyKns
+github:
+- url: https://github.com/ItzCrazyKns
+products:
+- perplexica

--- a/sources/organizations/khoj-ai.yaml
+++ b/sources/organizations/khoj-ai.yaml
@@ -1,0 +1,8 @@
+name: khoj-ai
+display_name: Khoj AI
+type: company
+homepage: https://khoj.dev
+github:
+- url: https://github.com/khoj-ai
+products:
+- khoj

--- a/sources/organizations/opensecret.yaml
+++ b/sources/organizations/opensecret.yaml
@@ -1,0 +1,8 @@
+name: opensecret
+display_name: OpenSecret
+type: company
+homepage: https://opensecret.cloud
+github:
+- url: https://github.com/OpenSecretCloud
+products:
+- maple-ai

--- a/sources/organizations/searxng.yaml
+++ b/sources/organizations/searxng.yaml
@@ -1,0 +1,8 @@
+name: searxng
+display_name: SearXNG
+type: unknown
+homepage: https://docs.searxng.org
+github:
+- url: https://github.com/searxng
+products:
+- searxng

--- a/sources/organizations/surfsense.yaml
+++ b/sources/organizations/surfsense.yaml
@@ -1,0 +1,8 @@
+name: surfsense
+display_name: SurfSense
+type: individual
+homepage: https://www.surfsense.com
+github:
+- url: https://github.com/MODSetter
+products:
+- surfsense

--- a/sources/products/confer.yaml
+++ b/sources/products/confer.yaml
@@ -1,0 +1,17 @@
+name: confer
+display_name: Confer
+type: software
+description: End-to-end encrypted AI chat assistant from Confer Labs (founded by Moxie Marlinspike, creator
+  of Signal) whose core claim is that the operator cannot read, train on, or hand over your conversations.
+  Prompts are encrypted on-device and sent via Noise-protocol pipes into a Trusted Execution Environment on
+  a confidential VM, processed by open-source LLMs, then re-encrypted before leaving; chat history is encrypted
+  with passkey-derived keys. The differentiator is cryptographically enforced, verifiable privacy backed by
+  remote attestation, reproducible builds, and an append-only transparency log.
+github:
+- url: https://github.com/ConferLabs/confer-proxy
+- url: https://github.com/ConferLabs/confer-image
+comments: Confer publishes its inference/proxy stack and reproducible confidential-VM image (vLLM-based)
+  openly for verifiability, but NEITHER repo carries a LICENSE file (GitHub reports no declared license),
+  and the end-user client app is not public - so despite "open-source" marketing the accurate classification
+  is source-available. The service is not self-hostable; its security model depends on Confer's attestation
+  infrastructure. Repos created Dec 2025.

--- a/sources/products/khoj.yaml
+++ b/sources/products/khoj.yaml
@@ -1,0 +1,15 @@
+name: khoj
+display_name: Khoj
+type: software
+description: Open-source, self-hostable "AI second brain" / personal assistant. Chat with any cloud or local
+  LLM, get answers grounded in your own documents (PDF, Markdown, org-mode, Word, Notion) and the web, run
+  semantic search, build custom agents with their own knowledge bases, schedule automations, and do deep
+  research. The differentiator is privacy-first personal RAG surfaced across many clients - browser, Obsidian,
+  Emacs, desktop, mobile, and WhatsApp - with everything runnable on your own infrastructure.
+github:
+- url: https://github.com/khoj-ai/khoj
+pypi:
+- url: https://pypi.org/project/khoj
+comments: AGPL-3.0; ~35k GitHub stars and ~26k PyPI downloads/month by mid-2026. Khoj Cloud (the former
+  paid hosted tier) was sunset 2026-04-15; the team directs all users to self-host and states Khoj "remains
+  fully open-source", so no feature-gating remains in the shipping product. Self-host via Docker or pip.

--- a/sources/products/maple-ai.yaml
+++ b/sources/products/maple-ai.yaml
@@ -1,0 +1,15 @@
+name: maple-ai
+display_name: Maple AI
+type: software
+description: End-to-end encrypted, private AI chat assistant. Conversations are encrypted on the user's device
+  and processed inside hardware-isolated Trusted Execution Environments (AWS Nitro Enclaves + Nvidia GPU TEEs)
+  so that even the operator cannot read user data, with remote attestation that users can verify against
+  open-source builds. Maple is the flagship app built on the open OpenSecret confidential-computing platform
+  (same team), serves a menu of open-weight models, and ships as web, iOS, Android, and desktop apps. The
+  differentiator is cryptographically verifiable privacy rather than a policy promise.
+github:
+- url: https://github.com/OpenSecretCloud/Maple
+comments: Maple client is MIT-licensed; the underlying OpenSecret platform is AGPL-3.0 - both fully open
+  so anyone can rebuild and compare hashes against the live attestation. Launched Jan 2025. Serves open-weight
+  models (gpt-oss-120b, kimi-k2.5, deepseek-r1, llama-3.3-70b, qwen3-vl, gemma-3). The consumer offering at
+  trymaple.ai is a paid hosted service - openness applies to the code/architecture, not free unlimited usage.

--- a/sources/products/openpcc.yaml
+++ b/sources/products/openpcc.yaml
@@ -1,0 +1,15 @@
+name: openpcc
+display_name: OpenPCC
+type: software
+description: Open-source framework and standard for verifiably-private AI inference, explicitly modeled on
+  Apple's Private Cloud Compute but fully open, vendor-neutral, auditable, and self-deployable. It wraps every
+  inference interaction (prompt, tokens, logs, telemetry) in encryption and policy so no vendor, operator,
+  or insider can read it, combining confidential compute on commodity CPU/GPU TEEs, integrated remote attestation,
+  tamper-proof transparency logs, an HPKE-based encrypted client-server stream, and an Oblivious-HTTP anonymization
+  layer to defeat metadata/timing side-channels. Model- and provider-agnostic; ships Go and C client SDKs.
+github:
+- url: https://github.com/openpcc/openpcc
+comments: Apache-2.0; maintained by Confident Security (San Francisco; $5M seed). Launched Nov 5 2025; ~940
+  stars by mid-2026. Reference implementation in Go plus a written spec/whitepaper; related repos (twoway,
+  ohttp, bhttp) are also Apache-2.0. Confident Security operates a commercial managed service (CONFSEC) on
+  top of the open standard, but the standard and implementation themselves are fully open.

--- a/sources/products/perplexica.yaml
+++ b/sources/products/perplexica.yaml
@@ -1,0 +1,15 @@
+name: perplexica
+display_name: Perplexica
+type: software
+description: Open-source, privacy-focused AI answer engine - a self-hostable alternative to Perplexity.
+  It pairs a bundled SearXNG metasearch layer with local or cloud LLMs to return AI-generated answers with
+  cited sources, all runnable on your own machine so searches stay local. Supports multiple model providers
+  (Ollama, OpenAI, Anthropic, Gemini, Groq, any OpenAI-compatible endpoint), web/academic/discussion/image/video
+  search modes, speed/balanced/quality tiers, and file-upload RAG. The differentiator is full self-hosting
+  and privacy for the Perplexity-style answer-with-sources experience.
+github:
+- url: https://github.com/ItzCrazyKns/Vane
+comments: MIT-licensed; ~35k GitHub stars and 100k+ Docker pulls by mid-2026. NOTE the project was renamed
+  Perplexica -> Vane (~Mar 2026) to avoid name proximity to Perplexity AI; the github.com/ItzCrazyKns/Perplexica
+  URL now redirects to .../Vane. Still widely known and listed as "Perplexica". Self-host via a single
+  bundled Docker image (Next.js frontend + API + private SearXNG).

--- a/sources/products/privatemode.yaml
+++ b/sources/products/privatemode.yaml
@@ -1,0 +1,16 @@
+name: privatemode
+display_name: Privatemode
+type: software
+description: Confidential-computing AI inference service from Edgeless Systems. Prompts are encrypted on the
+  user's device and processed inside hardware-based Trusted Execution Environments (confidential VMs + Nvidia
+  H100 GPUs) so data stays encrypted even during inference and the provider cannot see it, with end-to-end
+  remote attestation making the privacy guarantee verifiable in hardware. It serves a rotating menu of open-weight
+  models behind a chat UI and an OpenAI/Anthropic-compatible API, and is positioned for regulated industries
+  (finance, law, healthcare).
+github:
+- url: https://github.com/edgelesssys/privatemode-public
+comments: Launched Feb 2025. The privatemode-public repo holds the auditable Trusted Computing Base under
+  a custom source-available license (view/compile for audit only); the privatemode-proxy, web app, and internal/oss
+  subdirectories are dual-licensed MIT. The operational service itself is proprietary/hosted. Serves third-party
+  open-weight models (e.g. gpt-oss-120b, Gemma, Kimi K2, Qwen embeddings, Whisper/Voxtral) - trains none of
+  its own.

--- a/sources/products/searxng.yaml
+++ b/sources/products/searxng.yaml
@@ -1,0 +1,15 @@
+name: searxng
+display_name: SearXNG
+type: software
+description: Free, privacy-respecting open-source metasearch engine that aggregates results from up to 269
+  search services without tracking or profiling users. Though it predates the LLM era and does no inference
+  itself, it has become the de facto self-hosted web-search backend for open AI answer engines and RAG - it
+  exposes a JSON API and runs entirely on your own infrastructure (no commercial search keys, no tracking),
+  and is integrated as a web-search provider by Open WebUI, Perplexica, Morphic, and LibreChat. It is the
+  open peer to proprietary AI search APIs like Tavily, Serper, and Exa.
+github:
+- url: https://github.com/searxng/searxng
+comments: AGPL-3.0; ~32k GitHub stars and 50M+ total Docker pulls (~1.5M/week) by mid-2026. Community-run
+  fork-successor of the older searx project. No official hosted SaaS - distributed as source/Docker for
+  self-hosting, with a network of ~70 community public instances (searx.space). Not itself an AI product;
+  it is the search/data backend AI tools call.

--- a/sources/products/surfsense.yaml
+++ b/sources/products/surfsense.yaml
@@ -1,0 +1,14 @@
+name: surfsense
+display_name: SurfSense
+type: software
+description: Open-source, privacy-focused AI research assistant positioned as a self-hostable alternative
+  to NotebookLM, Perplexity, and Glean. It connects an LLM to your personal or team knowledge base plus a
+  wide range of external sources and lets you chat over them with hybrid RAG retrieval. The differentiator
+  is unlimited sources and notebooks with no data caps, full freedom to bring your own LLM/embedding/reranker
+  models (including local ones), and a deep connector catalog - all self-hostable so data never leaves your
+  infrastructure.
+github:
+- url: https://github.com/MODSetter/SurfSense
+comments: Apache-2.0; ~15k GitHub stars by mid-2026. Self-host via Docker/Compose (PostgreSQL + pgvector).
+  Connector count and per-feature depth are taken from the maintainer-authored README and not independently
+  verified. Newer/smaller project than the leading open chat UIs.

--- a/sources/scores/confer.yaml
+++ b/sources/scores/confer.yaml
@@ -1,0 +1,42 @@
+product: confer
+openness:
+  score: 2
+  class: source_available
+  components: license:none-declared(no LICENSE file in either public repo);source:partial(confer-proxy +
+    confer-image public,client-app private);self-host:no(depends on vendor attestation infra);models:open-source(undisclosed)
+  confidence: high
+  note: 'Marketed as open-source, but neither public repo declares any license (GitHub reports license:null),
+    so re-use rights are undefined, and the end-user client is not public. Source is published for verifiability/reproducible
+    builds, not for self-deployment. Accurate classification is source-available, not open_source.'
+  sources:
+  - url: https://confer.to/blog/2026/01/private-inference/
+    shows: architecture (TEE, Noise pipes, dm-verity, reproducible nix/mkosi builds, transparency log); names
+      the confer-proxy and confer-image repos
+    accessed: '2026-06-17'
+  - url: https://github.com/ConferLabs/confer-proxy
+    shows: public proxy repo with no LICENSE file (no declared license)
+    accessed: '2026-06-17'
+adoption:
+  level: 2
+  signal_type: reported_traction
+  confidence: low
+  note: Young product (repos created Dec 2025, launched late 2025/early 2026); ~70-75 stars per repo and a
+    reported partnership "bringing foundational AI privacy to Meta", but no user/usage numbers. Notability
+    is driven mainly by the founder's reputation.
+  sources:
+  - url: https://confer.to/blog/
+    shows: product positioning and feature timeline (memory, encrypted folders, connectors, Meta partnership)
+    accessed: '2026-06-17'
+capability:
+  score: 3
+  basis: feature_matrix
+  value: 'E2EE chat with TEE inference; remote attestation + reproducible builds + transparency log; encrypted
+    chat history (passkey-derived keys); encrypted folders; cross-conversation memory; emerging connectors;
+    models: multiple open-source (task-routed via vLLM, names undisclosed); self-host: no; web client'
+  confidence: medium
+  note: Strong, genuinely novel on the privacy/crypto dimension, but a relatively standard chat feature set,
+    no self-hosting, and undisclosed models cap it at mid-tier.
+  sources:
+  - url: https://confer.to/blog/2026/01/private-inference/
+    shows: 'feature set: E2EE chat, TEE inference, attestation, transparency log, encrypted history'
+    accessed: '2026-06-17'

--- a/sources/scores/khoj.yaml
+++ b/sources/scores/khoj.yaml
@@ -1,0 +1,41 @@
+product: khoj
+openness:
+  score: 5
+  class: open_source
+  components: license:AGPL-3.0(OSI);source:public(github.com/khoj-ai/khoj);self-host:primary(Docker+pip);cloud-tier-sunset-2026-04(no
+    remaining feature-gating)
+  confidence: high
+  note: OSI-licensed (AGPL-3.0), full source public, self-hostable via Docker or pip. The paid Khoj Cloud
+    tier was discontinued 2026-04-15 and the team frames self-hosting as the complete replacement, so the
+    earlier open-core characteristics no longer apply to the shipping product.
+  sources:
+  - url: https://github.com/khoj-ai/khoj
+    shows: AGPL-3.0 license; ~35k stars; self-hostable AI personal assistant
+    accessed: '2026-06-17'
+  - url: https://app.khoj.dev/
+    shows: official notice that Khoj Cloud was sunset 2026-04-15 and Khoj "remains fully open-source"
+    accessed: '2026-06-17'
+adoption:
+  level: 3
+  reach: ~26k PyPI downloads/month
+  signal_type: usage_volume
+  confidence: medium
+  note: ~35k GitHub stars plus ~26k PyPI downloads/month (pypistats) - real install volume (usage_volume,
+    not stars-only), but modest in absolute terms, so mid-tier. Hosted cloud is now discontinued.
+  sources:
+  - url: https://pypistats.org/packages/khoj
+    shows: ~26,054 downloads last month
+    accessed: '2026-06-17'
+capability:
+  score: 4
+  basis: feature_matrix
+  value: 'model breadth: OpenAI/Anthropic/Gemini/Llama/Qwen/Mistral/DeepSeek + local Ollama; RAG over personal
+    docs (PDF/Markdown/org-mode/Word/Notion/images); multimodal: image gen + voice/TTS; agents with custom
+    knowledge bases; scheduled automations + deep research; multi-user server; clients: browser/Obsidian/Emacs/desktop/mobile/WhatsApp'
+  confidence: medium
+  note: Broad feature surface across providers, personal RAG, agents, automations, multimodality and many
+    client integrations - on par with the leading open self-hosted assistants. Top-tier for the category.
+  sources:
+  - url: https://github.com/khoj-ai/khoj
+    shows: 'feature set: multi-provider, personal-doc RAG, agents, automations, multimodal, multi-client'
+    accessed: '2026-06-17'

--- a/sources/scores/maple-ai.yaml
+++ b/sources/scores/maple-ai.yaml
@@ -1,0 +1,42 @@
+product: maple-ai
+openness:
+  score: 5
+  class: open_source
+  components: license:MIT(Maple-client)+AGPL-3.0(OpenSecret-platform),both-OSI;source:public(github.com/OpenSecretCloud);models:open-weight;hosted-tier:paid(managed-enclaves)
+  confidence: medium
+  note: Both halves of the stack are open under standard OSI licenses (Maple client MIT, OpenSecret platform
+    AGPL-3.0) and the served models are open-weight - unusually clean for a "private AI" product. Scored
+    open_source because the privacy guarantee is only credible because the code is open and attestable. A
+    defensible alternative is open_core, since the delivered offering is a paid hosted service over managed
+    enclaves.
+  sources:
+  - url: https://github.com/OpenSecretCloud/Maple
+    shows: MIT-licensed Maple client (Tauri/Rust/TS), active; multi-platform
+    accessed: '2026-06-17'
+  - url: https://github.com/OpenSecretCloud/opensecret
+    shows: AGPL-3.0 OpenSecret platform; AWS Nitro enclave / TEE confidential-computing architecture
+    accessed: '2026-06-17'
+adoption:
+  level: 3
+  signal_type: reported_traction
+  confidence: low
+  note: Launched Jan 2025; vendor reports "5x user growth in the last six months", >90% month-over-month
+    paid retention, and "billions of tokens" in year one, but no absolute user count is published. Self-reported
+    figures only, hence low confidence.
+  sources:
+  - url: https://blog.trymaple.ai/one-year-of-private-ai-how-maple-ai-made-encryption-easy/
+    shows: launch date (Jan 2025); 5x growth, >90% retention, billions of tokens processed
+    accessed: '2026-06-17'
+capability:
+  score: 4
+  basis: feature_matrix
+  value: 'models: 6+ open-weight (gpt-oss-120b, kimi-k2.5, deepseek-r1, llama-3.3-70b, qwen3-vl, gemma-3);
+    E2EE chat in TEEs with remote attestation; image/vision (gated to paid tiers); voice/transcription; OpenAI-compatible
+    API (Maple Proxy); platforms: web/iOS/Android/macOS/desktop; teams/multi-seat'
+  confidence: medium
+  note: Broad multi-model, multi-platform private chat with vision, API, and teams. Short of top because it
+    is a focused private-chat product without a confirmed agentic tool-use/web-browsing ecosystem.
+  sources:
+  - url: https://blog.trymaple.ai/maple-ai-model-guide-with-example-prompts/
+    shows: 'model lineup (open-weight) and tier/feature structure'
+    accessed: '2026-06-17'

--- a/sources/scores/openpcc.yaml
+++ b/sources/scores/openpcc.yaml
@@ -1,0 +1,45 @@
+product: openpcc
+openness:
+  score: 5
+  class: open_source
+  components: license:Apache-2.0(OSI);source:public(github.com/openpcc/openpcc + spec/whitepaper);reference-impl(Go)+client-SDKs;commercial-managed-service(CONFSEC)separate
+  confidence: high
+  note: Fully OSI-licensed (Apache-2.0) across the reference implementation and related repos, with the spec
+    and whitepaper public. Confident Security runs a commercial managed service (CONFSEC) on top, but that
+    is an open-core *business* around a fully open standard, not open-core licensing.
+  sources:
+  - url: https://github.com/openpcc/openpcc
+    shows: Apache-2.0; "open-source framework for verifiably private AI inference"; OHTTP gateway, attestation,
+      transparency log, client SDKs
+    accessed: '2026-06-17'
+  - url: https://cloudsecurityalliance.org/blog/2025/11/13/introducing-openpcc
+    shows: defines OpenPCC as an Apache-2.0 standard for provably-confidential cloud compute; launch Nov 2025;
+      Confident Security
+    accessed: '2026-06-17'
+adoption:
+  level: 2
+  signal_type: reported_traction
+  confidence: low
+  note: Launched Nov 5 2025 with a $5M seed (Decibel, Ex/Ante, South Park Commons, Halcyon, SAIF); ~940 GitHub
+    stars by mid-2026 (notable for a young infra project) but no production adopters documented in primary
+    sources. Early-stage.
+  sources:
+  - url: https://github.com/openpcc/openpcc
+    shows: ~940 stars; reference implementation
+    accessed: '2026-06-17'
+capability:
+  score: 4
+  basis: feature_matrix
+  value: 'confidential inference on commodity CPU + GPU (NVIDIA) TEEs; integrated CPU/GPU remote attestation;
+    HPKE-based encrypted client-server streaming (Two-Way); tamper-proof verifiable transparency logs; unlinkable/anonymized
+    requests via Oblivious HTTP; client SDKs (Go native + C lib for Python/JS); model/provider-agnostic (prototyped
+    on Intel TDX + H100 serving Llama-3 8B on vLLM)'
+  confidence: medium
+  note: Broad, well-architected confidential-serving stack with attestation plus anonymization that goes beyond
+    plain confidential compute. Not top because it is young with limited proven scale and no documented production
+    adopters.
+  sources:
+  - url: https://cloudsecurityalliance.org/blog/2025/11/13/introducing-openpcc
+    shows: 'technical scope: TEE inference, attestation, transparency logs, Oblivious-HTTP anonymization,
+      client SDKs'
+    accessed: '2026-06-17'

--- a/sources/scores/perplexica.yaml
+++ b/sources/scores/perplexica.yaml
@@ -1,0 +1,37 @@
+product: perplexica
+openness:
+  score: 5
+  class: open_source
+  components: license:MIT(OSI);source:public(github.com/ItzCrazyKns/Vane);self-host:primary(single
+    bundled Docker image);no-feature-gated-core
+  confidence: high
+  note: Fully OSI-licensed (MIT), complete source public, self-hosting is the primary distribution via a
+    bundled Docker image - a true open answer engine. No premium tier or gated functionality identified.
+  sources:
+  - url: https://github.com/ItzCrazyKns/Vane
+    shows: MIT license; ~35k stars; open Perplexity-alternative answer engine (formerly Perplexica)
+    accessed: '2026-06-17'
+adoption:
+  level: 3
+  reach: 100K+ Docker pulls
+  signal_type: usage_volume
+  confidence: medium
+  note: ~35k GitHub stars plus 100k+ Docker pulls on the current itzcrazykns1337/vane image by mid-2026 -
+    genuine install volume (usage_volume, not stars-only), but well below the 1M+ band, so mid-tier.
+  sources:
+  - url: https://hub.docker.com/r/itzcrazykns1337/vane
+    shows: 100K+ Docker pulls for the self-host image
+    accessed: '2026-06-17'
+capability:
+  score: 4
+  basis: feature_matrix
+  value: 'model breadth: Ollama/OpenAI/Anthropic/Gemini/Groq + any OpenAI-compatible API; search: bundled
+    SearXNG metasearch with web/academic/discussion/image/video modes + speed/balanced/quality tiers; RAG:
+    file upload (PDF/text/image); multimodal: image inputs; multi-user: none (single-user personal app)'
+  confidence: medium
+  note: Strong provider breadth, bundled metasearch, search modes, and file-upload RAG; loses a point for
+    no built-in multi-user/auth and limited multimodal generation. Scoped to search-and-answer.
+  sources:
+  - url: https://github.com/ItzCrazyKns/Vane
+    shows: 'feature set: multi-provider, bundled SearXNG, search modes, file-upload RAG'
+    accessed: '2026-06-17'

--- a/sources/scores/privatemode.yaml
+++ b/sources/scores/privatemode.yaml
@@ -1,0 +1,39 @@
+product: privatemode
+openness:
+  score: 2
+  class: source_available
+  components: license:custom-source-available(audit-only)+MIT-subdirs(proxy/web/internal-oss);source:TCB-public(github.com/edgelesssys/privatemode-public);service:proprietary-hosted;models:third-party-open-weight
+  confidence: high
+  note: 'Not open source: the security-critical Trusted Computing Base is publicly readable (and the client
+    proxy + web app are MIT), but the main license permits only viewing/compiling for audit, and the operational
+    service is a proprietary hosted offering. More open than a black-box API, less than open-core.'
+  sources:
+  - url: https://github.com/edgelesssys/privatemode-public
+    shows: TCB source (attestation agent, proxy, web app, SDK) under a custom audit-only license with MIT-licensed
+      subdirectories
+    accessed: '2026-06-17'
+adoption:
+  level: 2
+  signal_type: reported_traction
+  confidence: low
+  note: Announced Feb 18 2025; offers a free tier, pay-as-you-go, and enterprise plans, and is co-marketed
+    with Capgemini for regulated industries, but no customer or usage numbers are published. New and unquantified.
+  sources:
+  - url: https://www.edgeless.systems/blog/what-is-privatemode
+    shows: launch date (Feb 18 2025); Edgeless Systems as maker; confidential-inference positioning
+    accessed: '2026-06-17'
+capability:
+  score: 4
+  basis: feature_matrix
+  value: 'models: rotating menu of open-weight third-party models (chat/coding/embedding/speech); interfaces:
+    chat UI (no sign-up) + OpenAI/Anthropic-compatible API (streaming, tool calling, structured outputs,
+    prompt caching); confidential compute: confidential VMs + H100, end-to-end remote attestation, reproducible
+    TCB; integrations: Claude Code/OpenCode/VS Code/JetBrains/n8n/AnythingLLM'
+  confidence: medium
+  note: Broad model menu plus a drop-in OpenAI-compatible API, chat UI, and strong integration story. Not
+    top-tier because it is a confidential inference relay for others' models rather than a frontier model
+    or full platform.
+  sources:
+  - url: https://www.privatemode.ai
+    shows: 'model list, chat UI + API, integrations, confidential-compute guarantees'
+    accessed: '2026-06-17'

--- a/sources/scores/searxng.yaml
+++ b/sources/scores/searxng.yaml
@@ -1,0 +1,40 @@
+product: searxng
+openness:
+  score: 5
+  class: open_source
+  components: license:AGPL-3.0(OSI);source:public(github.com/searxng/searxng);self-host:only(no official
+    SaaS);reproducible-Docker-build;no-proprietary-backend
+  confidence: high
+  note: Fully open source under copyleft AGPL-3.0, complete source public, reproducible official Docker image,
+    no proprietary backend or gated hosted tier - self-hosting (or community public instances) is the only
+    distribution.
+  sources:
+  - url: https://github.com/searxng/searxng
+    shows: AGPL-3.0 license; ~32k stars; privacy metasearch engine, no tracking
+    accessed: '2026-06-17'
+adoption:
+  level: 4
+  reach: 50M+ total Docker pulls
+  signal_type: usage_volume
+  confidence: high
+  note: ~32k GitHub stars plus 50M+ total Docker pulls (~1.5M in a single recent week) and ~70 maintained
+    public instances - concrete deployment volume well into the high band, not stars-only. The de facto open
+    web-search backend for self-hosted AI.
+  sources:
+  - url: https://hub.docker.com/r/searxng/searxng
+    shows: official image, 50M+ total pulls, ~1.5M weekly
+    accessed: '2026-06-17'
+capability:
+  score: 4
+  basis: feature_matrix
+  value: 'engines aggregated: up to 269 search services; API: JSON (also CSV/RSS) via ?format=json, no auth
+    required by default; programmatic access: simple HTTP GET; consumed as a web-search/RAG backend by Open
+    WebUI, Perplexica, Morphic, LibreChat; self-hostable official Docker image'
+  confidence: medium
+  note: The reference open implementation of the search-backend slot - broad source aggregation, clean structured
+    JSON, fully self-hosted. Below top among AI search APIs because it is raw metasearch without the AI-native
+    extraction/reranking that proprietary peers (Tavily/Exa) layer on.
+  sources:
+  - url: https://docs.searxng.org/dev/search_api.html
+    shows: '?format=json search API; up to 269 search services aggregated'
+    accessed: '2026-06-17'

--- a/sources/scores/surfsense.yaml
+++ b/sources/scores/surfsense.yaml
@@ -1,0 +1,41 @@
+product: surfsense
+openness:
+  score: 5
+  class: open_source
+  components: license:Apache-2.0(OSI);source:public(github.com/MODSetter/SurfSense);self-host:primary(Docker/Compose);no-feature-gated-core-found
+  confidence: high
+  note: Permissive OSI license (Apache-2.0), complete source public, self-host-first via Docker/Compose.
+    No paid tier or gated features found on the repo or site (mild uncertainty - treated as fully open until
+    a commercial tier appears).
+  sources:
+  - url: https://github.com/MODSetter/SurfSense/blob/main/LICENSE
+    shows: Apache License 2.0
+    accessed: '2026-06-17'
+  - url: https://github.com/MODSetter/SurfSense
+    shows: ~15k stars; open privacy-focused NotebookLM/Perplexity alternative; Docker self-host
+    accessed: '2026-06-17'
+adoption:
+  level: 3
+  signal_type: stars_fallback
+  confidence: medium
+  note: ~15k GitHub stars by mid-2026; no download/usage telemetry available for a self-hosted web app, so
+    stars_fallback (capped at level 3). Rapid star growth but unproven real-world deployment.
+  sources:
+  - url: https://github.com/MODSetter/SurfSense
+    shows: ~14.9k stars, ~1.4k forks
+    accessed: '2026-06-17'
+capability:
+  score: 4
+  basis: feature_matrix
+  value: 'model breadth: 100+ LLMs via LiteLLM/OpenAI spec + local (Ollama/vLLM), 6000+ embedding models,
+    rerankers; connectors: 27+ (SearXNG/Tavily search, Drive/OneDrive/Dropbox, Slack/Teams/Discord, Notion/Confluence/Obsidian,
+    Linear/Jira, Gmail, YouTube, GitHub); RAG: hybrid semantic + full-text with rank fusion; multimodal:
+    podcast/video/image generation; multi-user: real-time collab + RBAC'
+  confidence: low
+  note: Unusually broad connector, model, and collaboration surface on paper, but per-feature depth and quality
+    are unverified (README-sourced) and the project is far less proven than open-webui-class tools - so 4,
+    not top, with low confidence.
+  sources:
+  - url: https://github.com/MODSetter/SurfSense
+    shows: 'feature/connector matrix: 100+ LLMs, 27+ connectors, hybrid RAG, multimodal gen, RBAC collab'
+    accessed: '2026-06-17'


### PR DESCRIPTION
## Summary

Adds **8 products** to the AI Stack Map, focused on the private / self-hosted / confidential-AI corner of the stack. Each product ships a `products/`, `scores/`, and `organizations/` file plus a category roster entry. Every non-null score carries a primary-source citation (accessed 2026-06-17).

| Product | Category | Openness | Adoption | Capability |
|---|---|---|---|---|
| **Perplexica** | ui_api | open_source 5 (MIT) | usage 3 | 4 |
| **Khoj** | ui_api | open_source 5 (AGPL-3.0) | usage 3 | 4 |
| **SurfSense** | ui_api | open_source 5 (Apache-2.0) | stars 3 | 4 |
| **Maple AI** | ui_api | open_source 5 (MIT + AGPL platform) | reported 3 | 4 |
| **Privatemode** | ui_api | source_available 2 | reported 2 | 4 |
| **Confer** | ui_api | source_available 2 | reported 2 | 3 |
| **SearXNG** | agent_tools_protocols | open_source 5 (AGPL-3.0) | usage 4 | 4 |
| **OpenPCC** | deployment | open_source 5 (Apache-2.0) | reported 2 | 4 |

## Placement calls

- **SearXNG → `agent_tools_protocols`** (not ui_api): it's the open peer to Tavily/Serper/Exa — a web-search backend AI apps call, not a human-facing chat surface.
- **OpenPCC → `deployment`** (not ui_api): confidential-inference serving infrastructure with client SDKs only, no end-user chat product.
- The remaining six are chat/answer surfaces, so they sit in `ui_api` (open self-host UIs grouped after Morphic; confidential hosted chat grouped after the lumo/duck-ai privacy cluster).

## Notable findings (documented in each file's notes/comments)

- **Perplexica was renamed → "Vane"** (~Mar 2026, to avoid clashing with Perplexity AI). Kept the recognizable `perplexica` slug/display; repo URL points at the canonical `…/Vane` redirect target.
- **Khoj Cloud was sunset 2026-04-15** — its former open-core feature-gating is gone, so it's now scored `open_source`.
- **Confer and Privatemode are *not* open source** despite "open-source" marketing. Confer's public repos carry **no LICENSE file** and its client is private; Privatemode's primary license is audit-only (with MIT-licensed client subdirs). Both scored `source_available`.

## Test plan

- [x] `uv run python -m build.validate` → `0 error(s)`
- [x] `uv run pytest` → 20 passed
- [x] No edits to `build/notebook_data.json` or `notebooks/ai-stack-map.py` (bot-regenerated on merge)