### PR TITLE
Mine LF AI landscape / Octoverse / HF reports — add 5 products

### DIFF
--- a/sources/categories/agent_tools_protocols.yaml
+++ b/sources/categories/agent_tools_protocols.yaml
@@ -34,4 +34,5 @@ products:
 - notion-mcp
 - filesystem-mcp
 - postgres-mcp
+- docling
 comments: ''

--- a/sources/categories/base_pretrained.yaml
+++ b/sources/categories/base_pretrained.yaml
@@ -43,4 +43,5 @@ products:
 - apertus
 - smollm2
 - gemma-4
+- rwkv
 comments: ''

--- a/sources/categories/orchestration_agents.yaml
+++ b/sources/categories/orchestration_agents.yaml
@@ -42,4 +42,6 @@ products:
 - nano-graphrag
 - pathway
 - opencode
+- semantic-kernel
+- beeai
 comments: ''

--- a/sources/categories/telemetry_observability.yaml
+++ b/sources/categories/telemetry_observability.yaml
@@ -30,4 +30,5 @@ products:
 - azure-ai-foundry-observability
 - mlflow
 - langfuse
+- trulens
 comments: ''

--- a/sources/organizations/ibm.yaml
+++ b/sources/organizations/ibm.yaml
@@ -4,3 +4,5 @@ type: company
 homepage: https://www.ibm.com
 products:
 - granite-code-instruct
+- docling
+- beeai

--- a/sources/organizations/microsoft.yaml
+++ b/sources/organizations/microsoft.yaml
@@ -12,3 +12,4 @@ products:
 - playwright-mcp
 - autogen
 - graphrag
+- semantic-kernel

--- a/sources/organizations/rwkv.yaml
+++ b/sources/organizations/rwkv.yaml
@@ -1,0 +1,8 @@
+name: rwkv
+display_name: RWKV Project
+type: foundation
+homepage: https://rwkv.com
+github:
+- url: https://github.com/RWKV
+products:
+- rwkv

--- a/sources/organizations/snowflake.yaml
+++ b/sources/organizations/snowflake.yaml
@@ -4,3 +4,4 @@ type: company
 homepage: https://www.snowflake.com
 products:
 - snowflake-cortex-fine-tuning
+- trulens

--- a/sources/products/beeai.yaml
+++ b/sources/products/beeai.yaml
@@ -1,0 +1,15 @@
+name: beeai
+display_name: BeeAI Framework
+type: software
+description: Open-source toolkit for production-ready multi-agent systems with full feature parity across Python
+  and TypeScript - its signature differentiator vs the Python-first peers. Emphasizes production concerns (caching,
+  memory, OpenTelemetry observability), constraint-based agent governance, native MCP + A2A interop, and 10+ LLM
+  backends.
+github:
+- url: https://github.com/i-am-bee/beeai-framework
+npm:
+- url: https://www.npmjs.com/package/beeai-framework
+pypi:
+- url: https://pypi.org/project/beeai-framework
+comments: Apache-2.0. IBM-originated, now under the Linux Foundation (LF AI & Data), alongside Docling and Data
+  Prep Kit. ~3.3k stars.

--- a/sources/products/docling.yaml
+++ b/sources/products/docling.yaml
@@ -1,0 +1,14 @@
+name: docling
+display_name: Docling
+type: software
+description: Open-source SDK and CLI that parses PDF, DOCX, PPTX, XLSX, HTML, EPUB, images, and audio into unified
+  structured output (Markdown, lossless JSON, HTML, DocTags) for gen-AI and RAG pipelines. Unlike web-URL-to-Markdown
+  services (Firecrawl, Jina Reader), it does deep local document understanding of rich binary docs - layout/reading-order
+  analysis, table-structure recognition, formula/code extraction, OCR, and VLM integration - running locally as
+  a library.
+github:
+- url: https://github.com/docling-project/docling
+pypi:
+- url: https://pypi.org/project/docling
+comments: MIT; originated at IBM Research, inducted into the Linux Foundation AI & Data Foundation (Docling Project)
+  on 2025-04-29 under community governance. ~62k stars (exceptionally high).

--- a/sources/products/rwkv.yaml
+++ b/sources/products/rwkv.yaml
@@ -1,0 +1,14 @@
+name: rwkv
+display_name: RWKV
+type: model
+description: Open-weights LLM family with a novel architecture that is 100% RNN yet trains in parallel like a GPT
+  transformer - combining linear-time inference, constant memory (no KV-cache), and effectively unbounded context.
+  The current generation, RWKV-7 'Goose', introduces 'Dynamic State Evolution' for expressivity beyond the limits
+  of attention.
+github:
+- url: https://github.com/BlinkDL/RWKV-LM
+huggingface_model:
+- url: https://huggingface.co/RWKV
+comments: Apache-2.0 with open weights, an open 3.1T-token multilingual corpus, and open training code - a fully-open
+  pipeline (rare for a model). The RWKV Project is an LF AI & Data (Generative AI Commons) non-profit led by Bo
+  Peng (BlinkDL). ~14.6k stars on RWKV-LM.

--- a/sources/products/semantic-kernel.yaml
+++ b/sources/products/semantic-kernel.yaml
@@ -1,0 +1,13 @@
+name: semantic-kernel
+display_name: Semantic Kernel
+type: software
+description: Microsoft's lightweight open-source SDK for building AI agents and integrating LLMs into C#, Python,
+  or Java code. It exposes your code as model-callable 'plugins' (often via OpenAPI), with connectors to AI services
+  and vector stores, telemetry, and responsible-AI hooks. Its differentiator vs the Python-first frameworks is genuine,
+  first-class multi-language support (.NET and Java, not Python-only).
+github:
+- url: https://github.com/microsoft/semantic-kernel
+pypi:
+- url: https://pypi.org/project/semantic-kernel
+comments: MIT. ~28k stars. Microsoft has converged Semantic Kernel + AutoGen into the Microsoft Agent Framework
+  (the successor); SK is now in maintenance mode (bug/security fixes only), supported ~1 year past MAF GA.

--- a/sources/products/trulens.yaml
+++ b/sources/products/trulens.yaml
@@ -1,0 +1,14 @@
+name: trulens
+display_name: TruLens
+type: software
+description: Open-source library for evaluation and tracing of LLM apps and AI agents. Its differentiator is 'feedback
+  functions' - programmatic evaluators including the RAG triad (groundedness, context relevance, answer relevance)
+  plus toxicity and others - combined with app instrumentation and tracing, making it more eval-first than gateway/observability-first
+  peers.
+github:
+- url: https://github.com/truera/trulens
+pypi:
+- url: https://pypi.org/project/trulens
+comments: MIT. Created by TruEra, which Snowflake acquired in 2024; now maintained by Snowflake (the GitHub org
+  remains 'truera'). A separate hosted Snowflake Cortex AI Observability product exists; the library stays fully
+  open. ~3.4k stars, ~39k PyPI downloads/month.

--- a/sources/scores/beeai.yaml
+++ b/sources/scores/beeai.yaml
@@ -1,0 +1,31 @@
+product: beeai
+openness:
+  score: 5
+  class: open_source
+  components: license:Apache-2.0(OSI);source:public(Python+TS);no-feature-gated-core
+  confidence: high
+  note: Apache-2.0 across Python + TypeScript with no commercial gating.
+  sources:
+  - url: https://github.com/i-am-bee/beeai-framework
+    shows: Apache-2.0, ~3.3k stars, dual-language agent framework
+    accessed: '2026-06-18'
+adoption:
+  level: 3
+  signal_type: stars_fallback
+  confidence: medium
+  note: ~3.3k stars; package download volume not retrievable - stars_fallback (capped at 3).
+  sources:
+  - url: https://github.com/i-am-bee/beeai-framework
+    shows: ~3.3k stars
+    accessed: '2026-06-18'
+capability:
+  score: 4
+  basis: feature_matrix
+  value: Python+TS parity; agents/multi-agent workflows; RAG; tools; memory; YAML + decorator orchestration (parallelism/retries/replanning);
+    constraint governance; MCP + A2A; OpenTelemetry; 10+ LLM backends
+  confidence: medium
+  note: Distinctive dual-language parity and production focus; smaller adoption than the leading frameworks.
+  sources:
+  - url: https://lfaidata.foundation/projects/beeai/
+    shows: LF-hosted; dual-language production agent framework
+    accessed: '2026-06-18'

--- a/sources/scores/docling.yaml
+++ b/sources/scores/docling.yaml
@@ -1,0 +1,32 @@
+product: docling
+openness:
+  score: 5
+  class: open_source
+  components: license:MIT(OSI);source:public(github.com/docling-project/docling);self-host:primary;no-feature-gated-core
+  confidence: high
+  note: MIT, local-first document parsing, fully self-hostable with integrated open-weight models.
+  sources:
+  - url: https://github.com/docling-project/docling
+    shows: MIT, ~61.8k stars, multi-format document parser
+    accessed: '2026-06-18'
+adoption:
+  level: 3
+  signal_type: stars_fallback
+  confidence: medium
+  note: ~62k stars (exceptionally high) but PyPI download volume not surfaced - stars_fallback (capped at 3; true
+    usage almost certainly higher).
+  sources:
+  - url: https://github.com/docling-project/docling
+    shows: ~61.8k stars
+    accessed: '2026-06-18'
+capability:
+  score: 5
+  basis: feature_matrix
+  value: parses PDF/DOCX/PPTX/XLSX/HTML/EPUB/images/audio -> Markdown/JSON/HTML/DocTags; layout + reading-order;
+    table-structure recognition; formula/code extraction; OCR; VLM integration
+  confidence: high
+  note: Deepest local document understanding among RAG ingestion tools; web-URL parsers lack rich binary-doc depth.
+  sources:
+  - url: https://github.com/docling-project/docling
+    shows: 'feature set: multi-format, layout, tables, OCR, VLM'
+    accessed: '2026-06-18'

--- a/sources/scores/rwkv.yaml
+++ b/sources/scores/rwkv.yaml
@@ -1,0 +1,32 @@
+product: rwkv
+openness:
+  score: 5
+  class: open_source
+  components: weights:open(Apache-2.0);data:open(3.1T-token multilingual corpus);code:open(github.com/BlinkDL/RWKV-LM);license:Apache-2.0(OSI)
+  confidence: high
+  note: 'Fully-open pipeline: open weights, open training data, and open training code under Apache-2.0.'
+  sources:
+  - url: https://arxiv.org/abs/2503.14456
+    shows: 'RWKV-7 Goose: Apache-2.0 weights + data + code, 3.1T open corpus'
+    accessed: '2026-06-18'
+adoption:
+  level: 3
+  signal_type: stars_fallback
+  confidence: medium
+  note: ~14.6k stars on RWKV-LM; HF download volume low/noisy - stars_fallback (capped at 3).
+  sources:
+  - url: https://github.com/BlinkDL/RWKV-LM
+    shows: ~14.6k stars, RWKV-7 Goose
+    accessed: '2026-06-18'
+capability:
+  score: 4
+  basis: benchmark:RWKV-7 Goose (arXiv:2503.14456)
+  value: 'RWKV-7 ''Goose'' 2.9B: claimed 3B SoTA multilingual and matching 3B SoTA English on far fewer training
+    tokens; MMLU rose to ~43% across generations'
+  confidence: medium
+  note: Strong intelligence-per-token for its size via a linear-time RNN architecture; not at frontier absolute
+    capability.
+  sources:
+  - url: https://arxiv.org/abs/2503.14456
+    shows: RWKV-7 3B SoTA-multilingual claims, Pareto vs transformers
+    accessed: '2026-06-18'

--- a/sources/scores/semantic-kernel.yaml
+++ b/sources/scores/semantic-kernel.yaml
@@ -1,0 +1,33 @@
+product: semantic-kernel
+openness:
+  score: 5
+  class: open_source
+  components: license:MIT(OSI);source:public(C#/Python/Java);model-agnostic;no-feature-gated-core
+  confidence: high
+  note: MIT multi-language SDK; first-class Azure connectors but model-agnostic and self-hostable.
+  sources:
+  - url: https://github.com/microsoft/semantic-kernel
+    shows: MIT, ~28.2k stars, multi-language agent SDK
+    accessed: '2026-06-18'
+adoption:
+  level: 3
+  signal_type: stars_fallback
+  confidence: medium
+  note: ~28k stars; PyPI volume not surfaced. Entering maintenance as Microsoft Agent Framework becomes the successor
+    - stars_fallback (capped at 3).
+  sources:
+  - url: https://github.com/microsoft/semantic-kernel
+    shows: ~28.2k stars; MAF-successor banner
+    accessed: '2026-06-18'
+capability:
+  score: 4
+  basis: feature_matrix
+  value: multi-LLM connectors; plugin/OpenAPI system; auto function-calling orchestration; agent abstractions; memory/vector
+    connectors; telemetry; RAI filters; first-class .NET + Java
+  confidence: medium
+  note: Enterprise multi-language orchestration with uniquely strong .NET/Java coverage; now superseded by Microsoft
+    Agent Framework.
+  sources:
+  - url: https://learn.microsoft.com/en-us/agent-framework/overview/
+    shows: MAF is the successor to SK + AutoGen
+    accessed: '2026-06-18'

--- a/sources/scores/trulens.yaml
+++ b/sources/scores/trulens.yaml
@@ -1,0 +1,33 @@
+product: trulens
+openness:
+  score: 5
+  class: open_source
+  components: license:MIT(OSI);source:public(github.com/truera/trulens);commercial:Snowflake-Cortex-AI-Observability(separate
+    hosted product);library:not-feature-gated
+  confidence: high
+  note: MIT library that is fully functional standalone; the Snowflake Cortex hosted product is separate, not a
+    gate on the library.
+  sources:
+  - url: https://github.com/truera/trulens
+    shows: MIT, ~3.4k stars, LLM eval + tracing
+    accessed: '2026-06-18'
+adoption:
+  level: 4
+  signal_type: usage_volume
+  confidence: medium
+  note: ~38.7k PyPI downloads/month (pypistats) alongside ~3.4k stars.
+  sources:
+  - url: https://pypistats.org/packages/trulens
+    shows: 38,729 downloads last month
+    accessed: '2026-06-18'
+capability:
+  score: 4
+  basis: feature_matrix
+  value: feedback functions / LLM-as-judge (RAG triad, toxicity); instrumentation + tracing; experiment comparison
+    across versions; Streamlit dashboard; OpenAI/HF/LiteLLM/Cortex providers
+  confidence: medium
+  note: Eval-first observability; lighter than Langfuse/Helicone on production gateway and prompt management.
+  sources:
+  - url: https://www.snowflake.com/en/blog/trulens-open-source-ai/
+    shows: Snowflake acquired TruEra; TruLens stays open source
+    accessed: '2026-06-18'


### PR DESCRIPTION
## Summary

Mined the resource batch Ayah sent (LF AI & Data landscape, HF State of Open-Source AI Spring 2026, Octoverse, GitHub most-influential, plus several broad OSS catalogs). Adds the **5 clearly-in-scope, primary-source-verified clean-fit products**:

| Category | Added | Notes |
|---|---|---|
| `orchestration_agents` | **Semantic Kernel** (MIT, Microsoft) | ⚠️ in maintenance — superseded by Microsoft Agent Framework |
| `orchestration_agents` | **BeeAI** (Apache-2.0, IBM/LF) | dual-language Python+TS agent framework |
| `agent_tools_protocols` | **Docling** (MIT, IBM/LF) | RAG document parser; ~62k stars |
| `telemetry_observability` | **TruLens** (MIT, Snowflake/TruEra) | eval + tracing via feedback functions |
| `base_pretrained` | **RWKV** (Apache-2.0) | fully-open RNN-architecture LLM family (RWKV-7 "Goose") |

Products 330 → 335. Each gets `products/` + `scores/` + an org entry (1 new org: RWKV Project; Docling/BeeAI credited to IBM with LF-hosting noted; TruLens → Snowflake).

## Mining outcome (the honest headline: small net-new yield)

The map is already comprehensive, so most candidates were dups or out of scope:

- **3 sources yielded nothing**: `opensourceindex.io` is OSCI (ranks *companies* by contributions), `awesome-oss-research-data` is meta-datasets *about* OSS (relevant to OSO's own analytics, not map products), `cornelius/awesome-open-source` is OSS-governance content.
- **Octoverse / HF State / most-influential** are trend pieces — nearly everything named is already mapped. Strongest signal is trends, not products (AI repos doubled to 4.3M; LLM-SDK imports +178% YoY; MCP momentum).
- **LF AI & Data landscape** is the most productive source but ~90% classical-ML / data-infra (out of scope for an LLM-application map).
- Excluded as classical-ML/edge/responsible-ML (not the LLM stack): IREE, Ludwig, FlagAI, Adlik, Kompute, AIF360/ART/AIX360, FATE/OpenFL. OPEA and Monocle were borderline LF genAI projects left out to keep quality high — easy to add if wanted.

## Reinforces the open category proposals

Almost every other net-new find routes to an already-open proposal — independent evidence they're worth creating:
- **#9 Multimodal models**: Moondream (tiny VLM)
- **#12 Robotics**: LeRobot, Pollen Robotics, RoboMIND, Learning-to-Drive (L2D)
- **#11 Core ML frameworks**: Transformers, Kernel Hub

I'll add these as comments on the respective issues.

## Test plan
- [x] `uv run python -m build.validate` → `0 error(s)`
- [x] `uv run pytest` → 20 passed
- [x] No generated files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)