### PR TITLE
Sync 3 category straplines with current openness numbers

### DIFF
--- a/sources/categories/base_pretrained.yaml
+++ b/sources/categories/base_pretrained.yaml
@@ -1,6 +1,6 @@
 name: base_pretrained
 display_name: Base / pretrained models
-strapline: The frontier is open-weights, not open-source. Only a couple of families ship the full pipeline;
+strapline: The frontier is open-weights, not open-source. Only a handful of families ship the full pipeline;
   the rest withhold data or licenses.
 weights:
   adopt: 0.3

--- a/sources/categories/deployment.yaml
+++ b/sources/categories/deployment.yaml
@@ -1,6 +1,6 @@
 name: deployment
 display_name: Deployment
-strapline: 'Split down the middle: open sandboxes and runtimes vs proprietary serverless clouds.'
+strapline: 'The open side leads: open sandboxes and runtimes outweigh the proprietary serverless clouds.'
 weights:
   adopt: 0.6
   cap: 0.4

--- a/sources/categories/inference_code.yaml
+++ b/sources/categories/inference_code.yaml
@@ -1,6 +1,6 @@
 name: inference_code
 display_name: Inference code
-strapline: 'The most open layer in the stack: the engines that serve models are overwhelmingly OSI-licensed.'
+strapline: 'Open engines, closed clouds. The self-hosted serving engines are OSI-licensed; the managed hardware-vendor inference is not.'
 weights:
   adopt: 0.5
   cap: 0.5


### PR DESCRIPTION
## Summary

Did a full pass over the notebook's hand-authored captions to make sure they still match the data after the recent ~75 product additions.

**Finding:** the notebook is mostly self-syncing. Every number in `render.py` — the header (`scores N of M`), the verdict tiles, per-category counts, and the openness-mix chips — is **computed at render time**, so it auto-updates when the bot regenerates. The only captions that *don't* auto-update are the **category straplines** (authored in `sources/categories/*.yaml`, baked into the notebook via `__STRAPLINES__`).

Auditing all 11 straplines against the live full mix **and** the standout verdict, **3 had drifted**:

| Category | Before | After | Why |
|---|---|---|---|
| `base_pretrained` | "only a **couple** of families ship the full pipeline" | "only a **handful**…" | now **5** fully-open families (OLMo 2, Pythia, SmolLM2, RWKV, Apertus) |
| `inference_code` | "**the most open layer**… overwhelmingly OSI-licensed" | "**Open engines, closed clouds.** The self-hosted serving engines are OSI-licensed; the managed hardware-vendor inference is not." | now 9 open / 9 closed → verdict **competitive**, no longer the most open layer |
| `deployment` | "**Split down the middle**…" | "**The open side leads:** open sandboxes and runtimes outweigh the proprietary serverless clouds." | now 18 open / 5 closed → verdict **open_leads** |

The other 8 straplines (finetuned_chat, finetuning_code, evaluation_code, benchmark_eval_data, orchestration_agents, ui_api, telemetry_observability, agent_tools_protocols) still match their data and are unchanged. Edits preserve the existing punchy "claim. detail; detail." voice.

## Test plan
- [x] `uv run python -m build.validate` → `0 error(s)`
- [x] `uv run pytest` → 20 passed
- [x] Straplines confirmed to parse and flow through the render path (`_build_straplines_literal`)
- [x] No generated files touched (bot regenerates the notebook on merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)