### PR TITLE
Refresh long-tail dedup counts against current scored set

### DIFF
--- a/build/_frozen_long_tail.json
+++ b/build/_frozen_long_tail.json
@@ -4,18 +4,18 @@
     "models": 6428,
     "packages": 2823,
     "total": 24626,
-    "scored": 285,
-    "overlap": 102,
-    "scored_outside": 182,
-    "uncategorized": 24524,
-    "universe": 24808
+    "scored": 335,
+    "overlap": 144,
+    "scored_outside": 191,
+    "uncategorized": 24482,
+    "universe": 24817
   },
   "top": [
     {
       "name": "openclaw/openclaw",
       "type": "repo",
       "usage_label": "365,635 stars",
-      "description": "Your own personal AI assistant. Any OS. Any Platform. The lobster way. \ud83e\udd9e "
+      "description": "Your own personal AI assistant. Any OS. Any Platform. The lobster way. 🦞 "
     },
     {
       "name": "tensorflow/tensorflow",
@@ -27,7 +27,7 @@
       "name": "ultraworkers/claw-code",
       "type": "repo",
       "usage_label": "188,924 stars",
-      "description": "The repo is finally unlocked. enjoy the party! The fastest repo in history to surpass 100K stars \u2b50. Join Discord: https:"
+      "description": "The repo is finally unlocked. enjoy the party! The fastest repo in history to surpass 100K stars ⭐. Join Discord: https:"
     },
     {
       "name": "n8n-io/n8n",
@@ -57,25 +57,19 @@
       "name": "f/prompts.chat",
       "type": "repo",
       "usage_label": "160,986 stars",
-      "description": "f.k.a. Awesome ChatGPT Prompts. Share, discover, and collect prompts from the community. Free and open source \u2014 self-hos"
+      "description": "f.k.a. Awesome ChatGPT Prompts. Share, discover, and collect prompts from the community. Free and open source — self-hos"
     },
     {
       "name": "huggingface/transformers",
       "type": "repo",
       "usage_label": "160,031 stars",
-      "description": "\ud83e\udd17 Transformers: the model-definition framework for state-of-the-art machine learning models in text, vision, audio, and "
+      "description": "🤗 Transformers: the model-definition framework for state-of-the-art machine learning models in text, vision, audio, and "
     },
     {
       "name": "Snailclimb/JavaGuide",
       "type": "repo",
       "usage_label": "155,279 stars",
-      "description": "Java \u9762\u8bd5 & \u540e\u7aef\u901a\u7528\u9762\u8bd5\u6307\u5357\uff0c\u8986\u76d6\u8ba1\u7b97\u673a\u57fa\u7840\u3001\u6570\u636e\u5e93\u3001\u5206\u5e03\u5f0f\u3001\u9ad8\u5e76\u53d1\u3001\u7cfb\u7edf\u8bbe\u8ba1\u4e0e AI \u5e94\u7528\u5f00\u53d1"
-    },
-    {
-      "name": "anomalyco/opencode",
-      "type": "repo",
-      "usage_label": "151,003 stars",
-      "description": "The open source coding agent."
+      "description": "Java 面试 & 后端通用面试指南，覆盖计算机基础、数据库、分布式、高并发、系统设计与 AI 应用开发"
     },
     {
       "name": "langflow-ai/langflow",
@@ -87,73 +81,73 @@
       "name": "cross-encoder/ms-marco-MiniLM-L6-v2",
       "type": "model",
       "usage_label": "31.2M downloads",
-      "description": "cross-encoder \u00b7 text-ranking"
+      "description": "cross-encoder · text-ranking"
     },
     {
       "name": "BAAI/bge-small-en-v1.5",
       "type": "model",
       "usage_label": "27.9M downloads",
-      "description": "BAAI \u00b7 feature-extraction"
+      "description": "BAAI · feature-extraction"
     },
     {
       "name": "Falconsai/nsfw_image_detection",
       "type": "model",
       "usage_label": "27.1M downloads",
-      "description": "Falconsai \u00b7 image-classification"
+      "description": "Falconsai · image-classification"
     },
     {
       "name": "amazon/chronos-2",
       "type": "model",
       "usage_label": "20.9M downloads",
-      "description": "amazon \u00b7 time-series-forecasting"
+      "description": "amazon · time-series-forecasting"
     },
     {
       "name": "BAAI/bge-m3",
       "type": "model",
       "usage_label": "18.7M downloads",
-      "description": "BAAI \u00b7 sentence-similarity"
+      "description": "BAAI · sentence-similarity"
     },
     {
       "name": "FacebookAI/roberta-base",
       "type": "model",
       "usage_label": "17.9M downloads",
-      "description": "FacebookAI \u00b7 fill-mask"
+      "description": "FacebookAI · fill-mask"
     },
     {
       "name": "FacebookAI/xlm-roberta-base",
       "type": "model",
       "usage_label": "17.3M downloads",
-      "description": "FacebookAI \u00b7 fill-mask"
+      "description": "FacebookAI · fill-mask"
     },
     {
       "name": "FacebookAI/roberta-large",
       "type": "model",
       "usage_label": "16.3M downloads",
-      "description": "FacebookAI \u00b7 fill-mask"
+      "description": "FacebookAI · fill-mask"
     },
     {
       "name": "Bingsu/adetailer",
       "type": "model",
       "usage_label": "14.8M downloads",
-      "description": "Bingsu \u00b7 model"
+      "description": "Bingsu · model"
     },
     {
       "name": "colbert-ir/colbertv2.0",
       "type": "model",
       "usage_label": "14.1M downloads",
-      "description": "colbert-ir \u00b7 model"
+      "description": "colbert-ir · model"
     },
     {
       "name": "BAAI/bge-large-en-v1.5",
       "type": "model",
       "usage_label": "12.9M downloads",
-      "description": "BAAI \u00b7 feature-extraction"
+      "description": "BAAI · feature-extraction"
     },
     {
       "name": "apple/DFN5B-CLIP-ViT-H-14-378",
       "type": "model",
       "usage_label": "12.0M downloads",
-      "description": "apple \u00b7 model"
+      "description": "apple · model"
     },
     {
       "name": "huggingface/documentation-images",


### PR DESCRIPTION
## Summary

Audited the uncategorized **long tail** (the ~24.6k warehouse universe: `goodailist` repos + HF models/datasets + packages) to find items already covered by our scored set, as requested. The frozen snapshot's dedup was **stale** — its `overlap`/`scored` counts were computed when we had 285 scored products; we now have 335.

A full artifact-level cross-reference (all 335 scored products vs the universe, matched by GitHub repo / HF model / HF dataset) found **144** scored products sitting in the universe — not the recorded **102**. So ~40 scored products were being double-counted in the `uncategorized` figure.

### Counts refreshed (universe composition + `total` unchanged)
| field | before | after |
|---|---|---|
| `scored` | 285 | **335** |
| `overlap` | 102 | **144** |
| `scored_outside` | 182 | **191** |
| `uncategorized` | 24,524 | **24,482** (`= total − overlap`) |
| `universe` | 24,808 | **24,817** (`= total + scored_outside`) |

`overlap = 144` = 143 exact artifact matches + **OpenCode** via the `sst → anomalyco/opencode` rename; treat it as a floor (a few other renames may exist). The header's "scores N of them in depth" now reads **335**, matching the actual product count.

### Top display
Dropped the **one** covered item shown in the `top` list: `anomalyco/opencode` (= our scored **OpenCode**), so it's no longer double-counted in the showcase (48 → 47). The other 47 are genuinely uncovered — out of scope (encoders, classical-ML packages) or routes to the open category proposals (#10 datasets, #11 frameworks).

### On openclaw
`openclaw/openclaw` is the **#1 universe repo** (377k stars, "personal AI assistant 🦞", real metadata — created 2025-11-24, dev `steipete`, 100 contributors). It is **NOT** covered by our scored set — so it's correctly uncategorized, **not** a duplicate to remove. It's the strongest candidate if we later expand coverage; adding it needs full verification/scoring, so it's out of scope for this dedup PR.

### Scope note
`build/_frozen_long_tail.json` is a hand-frozen fixture (README: "not derived from live warehouse data yet"). This PR only un-stales the scoring-dependent counts + removes the covered display item; it does not change `total` or the universe composition (the package source isn't in the catalog, so `total` can't be recomputed reliably here). A reproducible warehouse-derived generator remains the durable follow-up option.

## Test plan
- [x] `uv run python -m build.validate` → `0 error(s)`
- [x] `uv run pytest` → 20 passed
- [x] Frozen JSON valid; `top` 48 → 47 (opencode removed)
- [x] CI generated-files-guard does not block this fixture; `notebook_data.json` / notebook untouched (bot regenerates on merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)