### PR TITLE
Add 8 long-tail products (OpenClaw, Gemini CLI, Zed, Langflow, RAGFlow, n8n, MarkItDown, spec-kit)

### DIFF
--- a/build/_frozen_long_tail.json
+++ b/build/_frozen_long_tail.json
@@ -4,19 +4,13 @@
     "models": 6428,
     "packages": 2823,
     "total": 24626,
-    "scored": 335,
-    "overlap": 144,
+    "scored": 343,
+    "overlap": 152,
     "scored_outside": 191,
-    "uncategorized": 24482,
+    "uncategorized": 24474,
     "universe": 24817
   },
   "top": [
-    {
-      "name": "openclaw/openclaw",
-      "type": "repo",
-      "usage_label": "365,635 stars",
-      "description": "Your own personal AI assistant. Any OS. Any Platform. The lobster way. 🦞 "
-    },
     {
       "name": "tensorflow/tensorflow",
       "type": "repo",
@@ -28,12 +22,6 @@
       "type": "repo",
       "usage_label": "188,924 stars",
       "description": "The repo is finally unlocked. enjoy the party! The fastest repo in history to surpass 100K stars ⭐. Join Discord: https:"
-    },
-    {
-      "name": "n8n-io/n8n",
-      "type": "repo",
-      "usage_label": "185,927 stars",
-      "description": "Fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host "
     },
     {
       "name": "obra/superpowers",
@@ -70,12 +58,6 @@
       "type": "repo",
       "usage_label": "155,279 stars",
       "description": "Java 面试 & 后端通用面试指南，覆盖计算机基础、数据库、分布式、高并发、系统设计与 AI 应用开发"
-    },
-    {
-      "name": "langflow-ai/langflow",
-      "type": "repo",
-      "usage_label": "147,454 stars",
-      "description": "Langflow is a powerful tool for building and deploying AI-powered agents and workflows."
     },
     {
       "name": "cross-encoder/ms-marco-MiniLM-L6-v2",

--- a/sources/categories/agent_tools_protocols.yaml
+++ b/sources/categories/agent_tools_protocols.yaml
@@ -35,4 +35,5 @@ products:
 - filesystem-mcp
 - postgres-mcp
 - docling
+- markitdown
 comments: ''

--- a/sources/categories/orchestration_agents.yaml
+++ b/sources/categories/orchestration_agents.yaml
@@ -44,4 +44,10 @@ products:
 - opencode
 - semantic-kernel
 - beeai
+- gemini-cli
+- zed
+- spec-kit
+- langflow
+- ragflow
+- n8n
 comments: ''

--- a/sources/categories/ui_api.yaml
+++ b/sources/categories/ui_api.yaml
@@ -46,4 +46,5 @@ products:
 - litellm
 - lm-studio
 - gpt4all
+- openclaw
 comments: ''

--- a/sources/organizations/github-microsoft.yaml
+++ b/sources/organizations/github-microsoft.yaml
@@ -5,3 +5,4 @@ homepage: https://github.com
 products:
 - github-copilot-github-microsoft
 - github-mcp
+- spec-kit

--- a/sources/organizations/google.yaml
+++ b/sources/organizations/google.yaml
@@ -15,3 +15,4 @@ products:
 - google-cloud-run
 - codegemma
 - gemma-4
+- gemini-cli

--- a/sources/organizations/infiniflow.yaml
+++ b/sources/organizations/infiniflow.yaml
@@ -1,0 +1,8 @@
+name: infiniflow
+display_name: InfiniFlow
+type: company
+homepage: https://ragflow.io
+github:
+- url: https://github.com/infiniflow
+products:
+- ragflow

--- a/sources/organizations/langflow.yaml
+++ b/sources/organizations/langflow.yaml
@@ -1,0 +1,8 @@
+name: langflow
+display_name: Langflow (DataStax)
+type: company
+homepage: https://www.langflow.org
+github:
+- url: https://github.com/langflow-ai
+products:
+- langflow

--- a/sources/organizations/microsoft.yaml
+++ b/sources/organizations/microsoft.yaml
@@ -13,3 +13,4 @@ products:
 - autogen
 - graphrag
 - semantic-kernel
+- markitdown

--- a/sources/organizations/n8n.yaml
+++ b/sources/organizations/n8n.yaml
@@ -1,0 +1,8 @@
+name: n8n
+display_name: n8n
+type: company
+homepage: https://n8n.io
+github:
+- url: https://github.com/n8n-io
+products:
+- n8n

--- a/sources/organizations/openclaw.yaml
+++ b/sources/organizations/openclaw.yaml
@@ -1,0 +1,8 @@
+name: openclaw
+display_name: OpenClaw Foundation
+type: foundation
+homepage: https://openclaw.ai
+github:
+- url: https://github.com/openclaw
+products:
+- openclaw

--- a/sources/organizations/zed-industries.yaml
+++ b/sources/organizations/zed-industries.yaml
@@ -1,0 +1,8 @@
+name: zed-industries
+display_name: Zed Industries
+type: company
+homepage: https://zed.dev
+github:
+- url: https://github.com/zed-industries
+products:
+- zed

--- a/sources/products/gemini-cli.yaml
+++ b/sources/products/gemini-cli.yaml
@@ -1,0 +1,13 @@
+name: gemini-cli
+display_name: Gemini CLI
+type: software
+description: Google's open-source terminal AI coding agent, bringing Gemini models into the shell for coding, debugging,
+  and task automation. Ships built-in tools (Google Search grounding, file ops, shell, web fetch), is extensible
+  via MCP and GEMINI.md system-prompt files, and offers a generous free tier on a personal Google account. Unlike
+  the closed peers (Cursor, Claude Code), it is fully Apache-2.0.
+github:
+- url: https://github.com/google-gemini/gemini-cli
+npm:
+- url: https://www.npmjs.com/package/@google/gemini-cli
+comments: Apache-2.0. ~105k stars, ~2.86M npm downloads/month. Free tier via personal Google account; paid via AI
+  Studio/Vertex.

--- a/sources/products/langflow.yaml
+++ b/sources/products/langflow.yaml
@@ -1,0 +1,14 @@
+name: langflow
+display_name: Langflow
+type: software
+description: Open-source, low-code visual builder for AI agents and RAG/workflow applications. You wire components
+  on a drag-and-drop canvas, then expose flows as APIs or run them as agents. Its differentiator vs code-first peers
+  (LangChain, LlamaIndex) is the visual editor with hundreds of pre-built components, while staying model-agnostic
+  and Python-extensible.
+github:
+- url: https://github.com/langflow-ai/langflow
+pypi:
+- url: https://pypi.org/project/langflow
+comments: MIT. ~150k stars, ~71k PyPI downloads/month. Began as Logspace; acquired by DataStax (2024), now an IBM
+  company (IBM->DataStax announced Feb 2025); IBM committed to the OSS community. Commercial managed cloud exists
+  but does not gate the core.

--- a/sources/products/markitdown.yaml
+++ b/sources/products/markitdown.yaml
@@ -1,0 +1,13 @@
+name: markitdown
+display_name: MarkItDown
+type: software
+description: Lightweight Python utility from Microsoft for converting files and office documents - PDF, DOCX, PPTX,
+  XLSX, images (OCR), audio (transcription), HTML, CSV/JSON/XML, ZIP, EPub, even YouTube URLs - into Markdown optimized
+  for LLMs and agents. Offers CLI, Python API, Docker, and a plugin system, with optional Azure Document Intelligence
+  and LLM-vision for image descriptions.
+github:
+- url: https://github.com/microsoft/markitdown
+pypi:
+- url: https://pypi.org/project/markitdown
+comments: MIT (PyPI license field is null but the repo LICENSE and pyproject declare MIT). ~155k stars. Lighter
+  than Docling on layout/table depth but broader format coverage.

--- a/sources/products/n8n.yaml
+++ b/sources/products/n8n.yaml
@@ -1,0 +1,13 @@
+name: n8n
+display_name: n8n
+type: software
+description: Fair-code workflow automation platform with native AI/agent capabilities. It pairs a visual node-based
+  canvas with drop-in JavaScript/Python code, 400+ integrations, and LangChain-based nodes for building LLM agents
+  and AI workflows. It is a general automation/iPaaS platform first, with AI as a native layer, and is self-hostable.
+github:
+- url: https://github.com/n8n-io/n8n
+npm:
+- url: https://www.npmjs.com/package/n8n
+comments: 'Sustainable Use License (fair-code, NOT OSI: internal-business-use only, no resale/hosting-as-a-service)
+  + n8n Enterprise License; GitHub reports NOASSERTION. ~193k stars, ~316k npm downloads/month. n8n Cloud + Enterprise
+  are the commercial tiers.'

--- a/sources/products/openclaw.yaml
+++ b/sources/products/openclaw.yaml
@@ -1,0 +1,14 @@
+name: openclaw
+display_name: OpenClaw
+type: software
+description: 'Local-first, self-hosted personal AI assistant (''any OS, any platform''). It runs an agent gateway
+  that answers on the messaging channels you already use - WhatsApp, Telegram, Slack, Discord, Signal, iMessage,
+  Teams, Matrix and ~20 more - with companion apps for macOS/iOS/Android, voice (speak/listen), a live Canvas UI,
+  and a skills/extensions SDK. Model-agnostic: the gateway routes to your chosen LLM backend.'
+github:
+- url: https://github.com/openclaw/openclaw
+npm:
+- url: https://www.npmjs.com/package/openclaw
+comments: MIT (repo LICENSE body is MIT; GitHub shows NOASSERTION due to a custom 'OpenClaw Foundation' copyright
+  line; npm declares MIT). Community project led by Peter Steinberger (steipete). Created Nov 2025; ~379k stars,
+  ~10.3M npm downloads/month.

--- a/sources/products/ragflow.yaml
+++ b/sources/products/ragflow.yaml
@@ -1,0 +1,11 @@
+name: ragflow
+display_name: RAGFlow
+type: software
+description: Open-source RAG engine built around deep document understanding - template-based chunking and layout-aware
+  parsing of complex documents (PDFs, tables, figures, scans) to produce grounded, citation-backed answers. Unlike
+  general orchestration frameworks, it is a batteries-included RAG application/server with strong document parsing
+  and visible source citations, recently extended with agent capabilities.
+github:
+- url: https://github.com/infiniflow/ragflow
+comments: Apache-2.0. ~83k stars. Deployed via Docker Compose (no first-party PyPI/npm). Commercial managed cloud
+  / enterprise edition exists; the self-hosted engine is fully open.

--- a/sources/products/spec-kit.yaml
+++ b/sources/products/spec-kit.yaml
@@ -1,0 +1,11 @@
+name: spec-kit
+display_name: Spec Kit
+type: software
+description: GitHub's open-source toolkit for Spec-Driven Development that works with coding agents rather than
+  being one. A structured Specify -> Plan -> Tasks -> Implement workflow produces Markdown artifacts that feed each
+  phase, giving agents rich structured context instead of ad-hoc prompts. The specify CLI scaffolds these files
+  and orchestrates 30+ agents (Copilot, Claude Code, Cursor, Gemini CLI, Codex CLI, Windsurf, Zed, OpenCode).
+github:
+- url: https://github.com/github/spec-kit
+comments: MIT (c) GitHub. ~113k stars. Git-based distribution (uv tool install from the repo); no PyPI telemetry.
+  No paid tier.

--- a/sources/products/zed.yaml
+++ b/sources/products/zed.yaml
@@ -1,0 +1,11 @@
+name: zed
+display_name: Zed
+type: software
+description: High-performance, multiplayer code editor written in Rust from the creators of Atom and Tree-sitter,
+  built for human-AI collaboration. A GUI editor (peer to Cursor/Windsurf) with agentic editing, parallel agents
+  across projects, an open-source edit-prediction model (Zeta2), inline assistant, MCP servers, and pluggable external
+  agents (Claude, Codex, OpenCode) via the Agent Communication Protocol - BYO-key or Zed-hosted models.
+github:
+- url: https://github.com/zed-industries/zed
+comments: Editor is GPL-3.0-or-later; collab server AGPL-3.0; GPUI framework Apache-2.0. Paid Pro ($10/mo, hosted
+  AI) and Business ($30/seat/mo, governance) tiers layer on the OSS editor -> open-core. ~85k stars.

--- a/sources/scores/gemini-cli.yaml
+++ b/sources/scores/gemini-cli.yaml
@@ -1,0 +1,31 @@
+product: gemini-cli
+openness:
+  score: 5
+  class: open_source
+  components: license:Apache-2.0(OSI);source:public;no-feature-gated-core
+  confidence: high
+  note: Fully Apache-2.0; commercial relationship is on model quotas, not the tool.
+  sources:
+  - url: https://github.com/google-gemini/gemini-cli
+    shows: Apache-2.0, ~105k stars, open AI agent CLI
+    accessed: '2026-06-18'
+adoption:
+  level: 5
+  signal_type: usage_volume
+  confidence: high
+  note: ~2.86M npm downloads/month for @google/gemini-cli, plus ~105k stars.
+  sources:
+  - url: https://api.npmjs.org/downloads/point/last-month/@google/gemini-cli
+    shows: ~2.86M downloads/month
+    accessed: '2026-06-18'
+capability:
+  score: 5
+  basis: feature_matrix
+  value: agentic terminal loop (read/write, shell, planning); MCP extensibility; built-in Google Search grounding;
+    large context; OAuth/API-key/Vertex auth; VS Code + Actions integration
+  confidence: high
+  note: Top-tier coding agent; Search grounding is a standout vs peers.
+  sources:
+  - url: https://blog.google/innovation-and-ai/technology/developers-tools/introducing-gemini-cli-open-source-ai-agent/
+    shows: official launch; free tier, MCP, GEMINI.md
+    accessed: '2026-06-18'

--- a/sources/scores/langflow.yaml
+++ b/sources/scores/langflow.yaml
@@ -1,0 +1,31 @@
+product: langflow
+openness:
+  score: 5
+  class: open_source
+  components: license:MIT(OSI);source:public;no-feature-gated-core;commercial:DataStax-hosted(separate)
+  confidence: high
+  note: MIT core, fully open; managed cloud does not gate the OSS core.
+  sources:
+  - url: https://github.com/langflow-ai/langflow
+    shows: MIT, ~149.8k stars, visual agent builder
+    accessed: '2026-06-18'
+adoption:
+  level: 4
+  signal_type: usage_volume
+  confidence: medium
+  note: ~150k stars and ~71k PyPI downloads/month (modest pip volume; mostly Docker/desktop).
+  sources:
+  - url: https://pypi.org/project/langflow/
+    shows: package langflow, MIT
+    accessed: '2026-06-18'
+capability:
+  score: 4
+  basis: feature_matrix
+  value: visual drag-and-drop flow builder; 100s of pre-built components; agent + multi-agent; RAG pipelines; MCP;
+    API/playground deployment; Python-extensible custom components
+  confidence: medium
+  note: Mature low-code visual builder (peer to Dify); model/vendor-agnostic.
+  sources:
+  - url: https://www.langflow.org/
+    shows: visual low-code agent/RAG builder
+    accessed: '2026-06-18'

--- a/sources/scores/markitdown.yaml
+++ b/sources/scores/markitdown.yaml
@@ -1,0 +1,32 @@
+product: markitdown
+openness:
+  score: 5
+  class: open_source
+  components: license:MIT(OSI; repo LICENSE + pyproject, PyPI field null);source:public;no-feature-gated-core
+  confidence: high
+  note: Fully MIT; optional Azure/LLM features are pluggable, not gating.
+  sources:
+  - url: https://raw.githubusercontent.com/microsoft/markitdown/main/LICENSE
+    shows: MIT, Copyright Microsoft Corporation
+    accessed: '2026-06-18'
+adoption:
+  level: 3
+  signal_type: stars_fallback
+  confidence: medium
+  note: ~155k stars; PyPI monthly volume not retrievable - stars_fallback (capped at 3; true usage higher given
+    the Microsoft-backed package).
+  sources:
+  - url: https://github.com/microsoft/markitdown
+    shows: ~155k stars, MIT, file->Markdown converter
+    accessed: '2026-06-18'
+capability:
+  score: 4
+  basis: feature_matrix
+  value: converts PDF/DOCX/PPTX/XLSX/images(OCR)/audio/HTML/CSV/JSON/XML/ZIP/EPub/YouTube -> Markdown; CLI + Python
+    API + Docker; plugins; optional Azure Doc Intelligence + LLM vision
+  confidence: medium
+  note: Broadest format coverage among RAG ingestion tools; lighter on deep layout parsing than Docling.
+  sources:
+  - url: https://github.com/microsoft/markitdown
+    shows: format coverage + interfaces
+    accessed: '2026-06-18'

--- a/sources/scores/n8n.yaml
+++ b/sources/scores/n8n.yaml
@@ -1,0 +1,32 @@
+product: n8n
+openness:
+  score: 2
+  class: source_available
+  components: 'license:Sustainable-Use-License(fair-code,non-OSI: internal-use-only,no-resale/SaaS)+n8n-Enterprise-License;source:public;commercial:n8n-Cloud/Enterprise'
+  confidence: high
+  note: 'Source-available fair-code, not OSI open source: the license restricts commercial/hosted use.'
+  sources:
+  - url: https://docs.n8n.io/sustainable-use-license/
+    shows: 'Sustainable Use License: fair-code, non-OSI, use restrictions'
+    accessed: '2026-06-18'
+adoption:
+  level: 5
+  signal_type: usage_volume
+  confidence: high
+  note: ~193k stars (one of the most-starred repos) and ~316k npm downloads/month.
+  sources:
+  - url: https://www.npmjs.com/package/n8n
+    shows: npm n8n, ~316k downloads/month
+    accessed: '2026-06-18'
+capability:
+  score: 4
+  basis: feature_matrix
+  value: visual node-based workflow builder; 400+ integrations; native AI/LLM + agent nodes (LangChain); custom
+    JS/Python code; webhooks/triggers/scheduling; self-host or cloud; RBAC (gated)
+  confidence: medium
+  note: Broad automation/iPaaS scope with AI as one native layer; wider but shallower on pure agent depth than the
+    dedicated frameworks.
+  sources:
+  - url: https://github.com/n8n-io/n8n
+    shows: 'feature set: 400+ integrations, AI/agent nodes, code nodes'
+    accessed: '2026-06-18'

--- a/sources/scores/openclaw.yaml
+++ b/sources/scores/openclaw.yaml
@@ -1,0 +1,33 @@
+product: openclaw
+openness:
+  score: 5
+  class: open_source
+  components: license:MIT(OSI; body is MIT, GitHub NOASSERTION from custom copyright line);source:public;self-host:primary(local-first);no-feature-gated-core
+  confidence: high
+  note: Genuinely MIT open source; the NOASSERTION flag is a classifier artifact, not a restriction.
+  sources:
+  - url: https://github.com/openclaw/openclaw/blob/main/LICENSE
+    shows: MIT text, Copyright OpenClaw Foundation
+    accessed: '2026-06-18'
+adoption:
+  level: 5
+  signal_type: usage_volume
+  confidence: high
+  note: ~379k stars and ~10.26M npm downloads/month - exceptional for a project under a year old.
+  sources:
+  - url: https://www.npmjs.com/package/openclaw
+    shows: npm openclaw, ~10.26M downloads/month
+    accessed: '2026-06-18'
+capability:
+  score: 5
+  basis: feature_matrix
+  value: self-hosted agent gateway; 20+ messaging channels (WhatsApp/Telegram/Slack/Discord/Signal/iMessage/Teams/Matrix...);
+    voice (speak/listen); WebChat + live Canvas UI; companion apps (macOS/iOS/Android); skills/extensions SDK; model-agnostic
+    routing
+  confidence: high
+  note: Among the most ambitious open personal-assistant projects - unifies chat, voice, and many messaging surfaces;
+    broader channel reach than Open WebUI/Jan/Khoj.
+  sources:
+  - url: https://api.github.com/repos/openclaw/openclaw
+    shows: real repo, 379k stars, TS, created 2025-11-24, active
+    accessed: '2026-06-18'

--- a/sources/scores/ragflow.yaml
+++ b/sources/scores/ragflow.yaml
@@ -1,0 +1,31 @@
+product: ragflow
+openness:
+  score: 5
+  class: open_source
+  components: license:Apache-2.0(OSI);source:public;self-host:primary(Docker);commercial:cloud/enterprise(separate)
+  confidence: high
+  note: Apache-2.0 self-hostable engine; cloud is the commercial tier.
+  sources:
+  - url: https://github.com/infiniflow/ragflow
+    shows: Apache-2.0, ~83k stars, RAG engine
+    accessed: '2026-06-18'
+adoption:
+  level: 3
+  signal_type: stars_fallback
+  confidence: medium
+  note: ~83k stars; Docker-distributed with no download metric retrieved - stars_fallback (capped at 3).
+  sources:
+  - url: https://ragflow.io
+    shows: official site, InfiniFlow, self-host + cloud
+    accessed: '2026-06-18'
+capability:
+  score: 4
+  basis: feature_matrix
+  value: deep document understanding / layout-aware parsing; template-based chunking; grounded citations with source
+    traceback; hybrid (vector + full-text) retrieval; knowledge-base UI; LLM-agnostic; agent workflows
+  confidence: medium
+  note: Opinionated, document-centric RAG application; deeper parsing than general frameworks, narrower scope.
+  sources:
+  - url: https://github.com/infiniflow/ragflow
+    shows: 'feature set: deep doc understanding, citations, hybrid retrieval'
+    accessed: '2026-06-18'

--- a/sources/scores/spec-kit.yaml
+++ b/sources/scores/spec-kit.yaml
@@ -1,0 +1,31 @@
+product: spec-kit
+openness:
+  score: 5
+  class: open_source
+  components: license:MIT(OSI);source:public;no-feature-gated-core;no-commercial-tier
+  confidence: high
+  note: Fully MIT, free.
+  sources:
+  - url: https://github.com/github/spec-kit
+    shows: MIT, ~113k stars, Spec-Driven Development toolkit
+    accessed: '2026-06-18'
+adoption:
+  level: 3
+  signal_type: stars_fallback
+  confidence: medium
+  note: ~113k stars but git-distributed with no download telemetry - stars_fallback (capped at 3; true usage higher).
+  sources:
+  - url: https://api.github.com/repos/github/spec-kit
+    shows: ~113k stars, SPDX MIT
+    accessed: '2026-06-18'
+capability:
+  score: 4
+  basis: feature_matrix
+  value: four-phase Spec-Driven workflow producing chained Markdown artifacts; specify CLI scaffolding; agent-agnostic
+    (30+ agents); constitution/principles guardrail
+  confidence: medium
+  note: Methodology/orchestration layer over coding agents rather than a code-writing engine itself.
+  sources:
+  - url: https://github.blog/ai-and-ml/generative-ai/spec-driven-development-with-ai-get-started-with-a-new-open-source-toolkit/
+    shows: SDD definition, four-phase process
+    accessed: '2026-06-18'

--- a/sources/scores/zed.yaml
+++ b/sources/scores/zed.yaml
@@ -1,0 +1,32 @@
+product: zed
+openness:
+  score: 4
+  class: open_core
+  components: license:GPL-3.0-or-later(editor)+AGPL-3.0(collab-server)+Apache-2.0(GPUI);source:public;commercial:Zed-Pro/Business(hosted
+    AI)
+  confidence: high
+  note: Fully open editor core under GPL/AGPL; paid hosted-AI and governance tiers make the overall offering open-core.
+  sources:
+  - url: https://github.com/zed-industries/zed
+    shows: Rust, ~85k stars, GPL/AGPL/Apache licensing
+    accessed: '2026-06-18'
+adoption:
+  level: 4
+  signal_type: reported_traction
+  confidence: medium
+  note: ~85k stars; a widely-used released editor with paid Pro/Business tiers, but no public install count.
+  sources:
+  - url: https://zed.dev/pricing
+    shows: Personal $0 / Pro $10 / Business $30 tiers; released product
+    accessed: '2026-06-18'
+capability:
+  score: 5
+  basis: feature_matrix
+  value: GUI editor; agentic editing with task delegation + review; parallel multi-agent; OSS edit prediction (Zeta2);
+    inline assistant; multi-model BYO-key + hosted; MCP; external agents via ACP; multiplayer; native Rust perf
+  confidence: high
+  note: Full AI-editor feature set on par with Cursor/Windsurf, model-agnostic.
+  sources:
+  - url: https://zed.dev
+    shows: agentic editing, Zeta2, ACP/MCP, multi-model
+    accessed: '2026-06-18'


### PR DESCRIPTION
## Summary

First pass at promoting the highest-signal **uncovered long-tail** items into the scored map (per the dedup audit). Pulled the top uncovered, in-scope repos from the warehouse universe, verified each against primary sources, and scored them. **343 products total** (335 → 343).

| Product | Category | Openness | Adoption | Note |
|---|---|---|---|---|
| **OpenClaw** | ui_api | open_source (MIT) | usage 5 | the #1 universe repo (~379k stars, ~10.3M npm/mo), led by steipete |
| **Gemini CLI** | orchestration_agents | open_source (Apache-2.0) | usage 5 | Google terminal coding agent |
| **Zed** | orchestration_agents | **open_core** (GPL/AGPL + paid hosted AI) | reported 4 | AI code editor |
| **Langflow** | orchestration_agents | open_source (MIT) | usage 4 | visual agent builder (DataStax/IBM) |
| **RAGFlow** | orchestration_agents | open_source (Apache-2.0) | stars 3 | deep-doc-understanding RAG engine |
| **n8n** | orchestration_agents | **source_available** (fair-code) | usage 5 | AI workflow automation |
| **MarkItDown** | agent_tools_protocols | open_source (MIT) | stars 3 | file→Markdown for agents (peer to Docling) |
| **spec-kit** | orchestration_agents | open_source (MIT) | stars 3 | Spec-Driven Development toolkit (GitHub) |

Each gets `products/` + `scores/` + an org entry (5 new orgs; Gemini CLI/spec-kit/MarkItDown under existing Google/GitHub/Microsoft).

## Verification findings

- **OpenClaw is real, not synthetic** — verified repo (379k stars, created 2025-11-24, pushed today), MIT license (GitHub shows NOASSERTION only due to a custom copyright line), npm `openclaw` ~10.3M downloads/mo, top contributor Peter Steinberger (steipete). The "🦞 lobster" branding is the project's actual identity.
- **n8n → `source_available`** — it's fair-code (Sustainable Use License, non-OSI: internal-use only, no resale/hosting). GitHub reports NOASSERTION. Not open source.
- **Zed → `open_core`** — GPL-3.0 editor + AGPL collab server + paid Pro/Business hosted-AI tiers.
- **Langflow → MIT**, owned by DataStax (an IBM company).

## Long-tail dedup kept in sync

Since these 8 are now scored, the frozen long-tail snapshot is updated in the same PR:
- `overlap` 144 → **152**, `scored` 335 → **343**, `uncategorized` → **24,474**
- Dropped the now-covered entries from the top display: `openclaw`, `n8n`, `langflow` (47 → 44)

## Deferred (borderline / niche)
claude-mem, PaddleOCR, obra/superpowers, TradingAgents — left in the long tail for now. The rest of the top uncovered items are out of scope (tutorials, awesome-lists, image/video-gen) or route to the open category proposals (#9 multimodal: Whisper; #11 frameworks: Transformers/PyTorch/TensorFlow).

## Test plan
- [x] `uv run python -m build.validate` → `0 error(s)`
- [x] `uv run pytest` → 20 passed
- [x] No generated files touched (notebook_data.json / notebook regenerate on merge; `_frozen_long_tail.json` is an editable fixture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)