### PR TITLE
Capture session learnings in skills + publish runbook

### DIFF
--- a/docs/runbooks/publish-notebook.md
+++ b/docs/runbooks/publish-notebook.md
@@ -6,8 +6,20 @@
    && uv run python build/render.py` must produce no diff).
 2. Validate: `uv run python -m build.validate` (must be clean) and
    `uv run marimo check notebooks/ai-stack-map.py`.
-3. Upload + publish to the OSO platform (MCP): `createNotebookUploadUrl`,
-   upload `notebooks/ai-stack-map.py`, then `publishNotebook`. The live slug is
-   `/currentai/ai-stack-map` (notebook id `7b29bf47`).
-4. Visual sign-off on the exported HTML before publish (no browser in-container. Export
-   and review locally).
+3. Visual sign-off on the exported HTML before publishing (no browser in-container —
+   `uv run marimo export html notebooks/ai-stack-map.py -o /tmp/preview.html` and review
+   locally; at minimum confirm it renders and shows the expected product count).
+4. Upload + publish to the OSO platform (oso-prod MCP). Live slug `/currentai/ai-stack-map`,
+   notebook id `7b29bf47-26d7-4aa2-9d5e-43bdfa33c2e4`, org `currentai`
+   (`ad7f4c1c-dd2f-430e-a831-e7f1f16e6d9e`):
+   1. `createNotebookUploadUrl({orgId})` → `{uploadUrl, uploadId}`.
+   2. `curl -X PUT -H "Content-Type: text/plain" --data-binary @notebooks/ai-stack-map.py "<uploadUrl>"` (expect HTTP 200).
+   3. `updateNotebook` with the `uploadId` — **required** (publish renders from the saved
+      source). Note: input is double-nested `{"input":{"input":{id, uploadId, description}}}`
+      and the response echoes the full ~1MB notebook, so read `success` via `jq` on the
+      saved tool-result file rather than inlining it. Good moment to refresh the stale
+      product count in the `description`.
+   4. `publishNotebook({notebookId, force:true})` — async; returns `status: PUBLISHING`.
+      Re-call **without** `force` to poll until `status: READY` (returns a `contentUrl`).
+5. Verify live: `curl` the `contentUrl` (gzipped HTML) → `gunzip` → grep for the product
+   count and a few newly-added product names.

--- a/skills/add-product/SKILL.md
+++ b/skills/add-product/SKILL.md
@@ -63,10 +63,42 @@ Creates four coordinated edits: a product file, a score file, a category roster 
 6. **Validate**: `uv run python -m build.validate` must print `0 error(s)`.
 7. **Verify the source**: never assert a product/version from memory. Confirm any 2025+
    release against a PRIMARY source (vendor HF org / blog / registry). A plausible press
-   claim that does not survive a check is rejected.
+   claim that does not survive a check is rejected. The map is a forward-dated universe
+   that can include speculative entries — if a release cannot be confirmed against any
+   primary source, mark it SKIP rather than guess.
 8. Rebuild + preview, then open a PR. Preview only: do not commit the regenerated
    `build/notebook_data.json` or `notebooks/ai-stack-map.py` (bot-owned; CI blocks
    hand-edits).
+
+## Openness class & score quick-reference
+
+Assign `class` first, then the 0–5 `score` (full rationale in
+`docs/guides/openness-spectrum.md`). Calls that are easy to get wrong:
+
+- **Models:** `closed` (proprietary/API-only, no weights) = 1; `open_weights` (weights
+  public but restrictive license and/or no open data) = 3; `open_source` (open weights +
+  data + code under an OSI license) = 5. Google's **Gemma license is NOT OSI** →
+  Gemma/CodeGemma are `open_weights`, not open_source.
+- **Software:** `open_source` (OSI license, full source, no feature-gated core) = 5;
+  `open_core` (OSS core + a commercial cloud/feature tier, e.g. LangGraph, LlamaIndex) = 4;
+  `source_available` = 2; `closed` = 0–1. **Fair-code** (e.g. n8n's Sustainable Use
+  License) and **BSL 1.1** (e.g. Pathway) are NOT OSI → `source_available`, even when
+  marketed as "open source".
+- A custom copyright line can make GitHub report `NOASSERTION` for a genuine MIT/Apache
+  license — check the LICENSE body, don't trust the GitHub classifier.
+- Keep generic version buckets (e.g. "GPT-5 line", "Claude Opus 4.x") rather than
+  splitting frontier models into every point release.
+
+## Adding in batches
+
+For more than a few products, generate the files with a small Python script
+(`yaml.safe_dump(..., sort_keys=False, allow_unicode=True)` for the product/score/org
+files, plus a helper that inserts `- <slug>` lines under the `products:` block of existing
+category/org YAMLs so their formatting is preserved) — far less error-prone than
+hand-writing each file. Verify every product against PRIMARY sources first (parallel
+research agents work well). **After a batch, two hand-authored things drift and must be
+re-checked:** category **straplines** (see the `curate-category` skill) and the
+`build/_frozen_long_tail.json` dedup counts (`scored` / `overlap` / `uncategorized`).
 
 ## Boundaries
 - Read-only on the warehouse. No MCP, no uploads.

--- a/skills/curate-category/SKILL.md
+++ b/skills/curate-category/SKILL.md
@@ -31,6 +31,12 @@ product roster** (the array order is the display order).
 
 ## Boundaries
 - Read-only on the warehouse. No MCP, no uploads.
+- **The `strapline` is the only hand-authored caption in the notebook** — every number
+  (header counts, verdict badges, openness-mix chips) is computed at render time and
+  auto-syncs. After adding/removing products, re-check that the strapline's claim still
+  matches the category's current openness mix and standout verdict; it does not update
+  itself and silently goes stale (e.g. "split down the middle" once the mix shifts to
+  mostly-open).
 - One product, one category: validation enforces it. If you want a product moved,
   remove its slug from the old roster and add it to yours in the same PR.
 - Adding a brand-new category also requires adding its slug to an arc in


### PR DESCRIPTION
## Summary

Folds the non-obvious learnings from this session's curation work into the repo's agent skills and the publish runbook, so the whole team (and future agents) benefit — not just private memory.

### `skills/add-product/SKILL.md`
- **Openness class & score quick-reference** — the calls that are easy to get wrong: Gemma license → `open_weights` (not open_source); fair-code (n8n) and BSL 1.1 (Pathway) → `source_available` (not open, despite marketing); a custom copyright line can make GitHub show `NOASSERTION` for genuine MIT; keep generic version buckets ("GPT-5 line", "Claude Opus 4.x").
- **"Adding in batches"** section — generate files with a Python script (`yaml.safe_dump` + a roster-append helper) instead of hand-writing dozens; verify against primary sources first; and **re-check straplines + `_frozen_long_tail.json` counts after a batch** (they drift).
- Strengthened the verify step: the map is a forward-dated universe with speculative entries → mark unverifiable releases SKIP rather than guess.

### `skills/curate-category/SKILL.md`
- Flags that the **`strapline` is the only hand-authored caption** — every number auto-computes, but the strapline silently goes stale after roster changes (e.g. "split down the middle" once the mix shifts to mostly-open).

### `docs/runbooks/publish-notebook.md`
- **Fixes a real bug**: the MCP flow was missing the required `updateNotebook(uploadId)` step between upload and publish. Now documents the full sequence with the double-nested input + ~1MB-echo gotcha, async publish polling (`READY`), live-verify, and the real notebook/org ids.

## Test plan
- [x] `uv run python -m build.validate` → `0 error(s)`
- [x] `uv run pytest` → 20 passed
- [x] Docs/skills only — no data or generated files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)