### PR TITLE
feat(sources): add ds4, llm, and datasette-agent products

### DIFF
--- a/build/_frozen_long_tail.json
+++ b/build/_frozen_long_tail.json
@@ -4,11 +4,11 @@
     "models": 6428,
     "packages": 2823,
     "total": 24626,
-    "scored": 348,
-    "overlap": 154,
-    "scored_outside": 194,
-    "uncategorized": 24472,
-    "universe": 24820
+    "scored": 351,
+    "overlap": 156,
+    "scored_outside": 195,
+    "uncategorized": 24470,
+    "universe": 24821
   },
   "top": [
     {
@@ -21,7 +21,7 @@
       "name": "ultraworkers/claw-code",
       "type": "repo",
       "usage_label": "188,924 stars",
-      "description": "The repo is finally unlocked. enjoy the party! The fastest repo in history to surpass 100K stars ⭐. Join Discord: https:"
+      "description": "The repo is finally unlocked. enjoy the party! The fastest repo in history to surpass 100K stars \u2b50. Join Discord: https:"
     },
     {
       "name": "obra/superpowers",
@@ -45,91 +45,91 @@
       "name": "f/prompts.chat",
       "type": "repo",
       "usage_label": "160,986 stars",
-      "description": "f.k.a. Awesome ChatGPT Prompts. Share, discover, and collect prompts from the community. Free and open source — self-hos"
+      "description": "f.k.a. Awesome ChatGPT Prompts. Share, discover, and collect prompts from the community. Free and open source \u2014 self-hos"
     },
     {
       "name": "huggingface/transformers",
       "type": "repo",
       "usage_label": "160,031 stars",
-      "description": "🤗 Transformers: the model-definition framework for state-of-the-art machine learning models in text, vision, audio, and "
+      "description": "\ud83e\udd17 Transformers: the model-definition framework for state-of-the-art machine learning models in text, vision, audio, and "
     },
     {
       "name": "Snailclimb/JavaGuide",
       "type": "repo",
       "usage_label": "155,279 stars",
-      "description": "Java 面试 & 后端通用面试指南，覆盖计算机基础、数据库、分布式、高并发、系统设计与 AI 应用开发"
+      "description": "Java \u9762\u8bd5 & \u540e\u7aef\u901a\u7528\u9762\u8bd5\u6307\u5357\uff0c\u8986\u76d6\u8ba1\u7b97\u673a\u57fa\u7840\u3001\u6570\u636e\u5e93\u3001\u5206\u5e03\u5f0f\u3001\u9ad8\u5e76\u53d1\u3001\u7cfb\u7edf\u8bbe\u8ba1\u4e0e AI \u5e94\u7528\u5f00\u53d1"
     },
     {
       "name": "cross-encoder/ms-marco-MiniLM-L6-v2",
       "type": "model",
       "usage_label": "31.2M downloads",
-      "description": "cross-encoder · text-ranking"
+      "description": "cross-encoder \u00b7 text-ranking"
     },
     {
       "name": "BAAI/bge-small-en-v1.5",
       "type": "model",
       "usage_label": "27.9M downloads",
-      "description": "BAAI · feature-extraction"
+      "description": "BAAI \u00b7 feature-extraction"
     },
     {
       "name": "Falconsai/nsfw_image_detection",
       "type": "model",
       "usage_label": "27.1M downloads",
-      "description": "Falconsai · image-classification"
+      "description": "Falconsai \u00b7 image-classification"
     },
     {
       "name": "amazon/chronos-2",
       "type": "model",
       "usage_label": "20.9M downloads",
-      "description": "amazon · time-series-forecasting"
+      "description": "amazon \u00b7 time-series-forecasting"
     },
     {
       "name": "BAAI/bge-m3",
       "type": "model",
       "usage_label": "18.7M downloads",
-      "description": "BAAI · sentence-similarity"
+      "description": "BAAI \u00b7 sentence-similarity"
     },
     {
       "name": "FacebookAI/roberta-base",
       "type": "model",
       "usage_label": "17.9M downloads",
-      "description": "FacebookAI · fill-mask"
+      "description": "FacebookAI \u00b7 fill-mask"
     },
     {
       "name": "FacebookAI/xlm-roberta-base",
       "type": "model",
       "usage_label": "17.3M downloads",
-      "description": "FacebookAI · fill-mask"
+      "description": "FacebookAI \u00b7 fill-mask"
     },
     {
       "name": "FacebookAI/roberta-large",
       "type": "model",
       "usage_label": "16.3M downloads",
-      "description": "FacebookAI · fill-mask"
+      "description": "FacebookAI \u00b7 fill-mask"
     },
     {
       "name": "Bingsu/adetailer",
       "type": "model",
       "usage_label": "14.8M downloads",
-      "description": "Bingsu · model"
+      "description": "Bingsu \u00b7 model"
     },
     {
       "name": "colbert-ir/colbertv2.0",
       "type": "model",
       "usage_label": "14.1M downloads",
-      "description": "colbert-ir · model"
+      "description": "colbert-ir \u00b7 model"
     },
     {
       "name": "BAAI/bge-large-en-v1.5",
       "type": "model",
       "usage_label": "12.9M downloads",
-      "description": "BAAI · feature-extraction"
+      "description": "BAAI \u00b7 feature-extraction"
     },
     {
       "name": "apple/DFN5B-CLIP-ViT-H-14-378",
       "type": "model",
       "usage_label": "12.0M downloads",
-      "description": "apple · model"
+      "description": "apple \u00b7 model"
     },
     {
       "name": "huggingface/documentation-images",

--- a/sources/categories/inference_code.yaml
+++ b/sources/categories/inference_code.yaml
@@ -24,4 +24,5 @@ products:
 - sglang
 - tensorrt-llm
 - localai
+- ds4
 comments: ''

--- a/sources/categories/orchestration_agents.yaml
+++ b/sources/categories/orchestration_agents.yaml
@@ -50,4 +50,5 @@ products:
 - langflow
 - ragflow
 - n8n
+- datasette-agent
 comments: ''

--- a/sources/categories/ui_api.yaml
+++ b/sources/categories/ui_api.yaml
@@ -47,4 +47,5 @@ products:
 - lm-studio
 - gpt4all
 - openclaw
+- llm
 comments: ''

--- a/sources/organizations/antirez.yaml
+++ b/sources/organizations/antirez.yaml
@@ -1,0 +1,8 @@
+name: antirez
+display_name: antirez (Salvatore Sanfilippo)
+type: individual
+homepage: http://antirez.com
+github:
+- url: https://github.com/antirez
+products:
+- ds4

--- a/sources/organizations/datasette.yaml
+++ b/sources/organizations/datasette.yaml
@@ -1,0 +1,12 @@
+name: datasette
+display_name: Datasette
+type: individual
+homepage: https://datasette.io
+github:
+- url: https://github.com/datasette
+- url: https://github.com/simonw
+products:
+- llm
+- datasette-agent
+comments: Simon Willison's open-source data ecosystem. The 'llm' CLI repo lives under the personal simonw account;
+  datasette-agent under the datasette org.

--- a/sources/products/datasette-agent.yaml
+++ b/sources/products/datasette-agent.yaml
@@ -1,0 +1,14 @@
+name: datasette-agent
+display_name: Datasette Agent
+type: software
+description: 'LLM-powered agent assistant for Datasette, Simon Willison''s tool for exploring and publishing structured
+  data in SQLite. A chat interface at /-/agent answers natural-language questions against databases: the agent writes
+  and runs SQL (save_query, execute_write_sql tools), explores data in the background, and renders results. Uses
+  the datasette-llm plugin to call models and exposes an extensible tool surface (charts, image generation) for
+  third-party tools.'
+github:
+- url: https://github.com/datasette/datasette-agent
+pypi:
+- url: https://pypi.org/project/datasette-agent
+comments: 'Apache-2.0 (verified LICENSE body). EARLY/ALPHA: latest PyPI 0.3a0 (15 Jun 2026), announced ~21 May 2026,
+  runs on Datasette 1.0a33. ~96 stars, 7 tags. Verified 2026-06-19.'

--- a/sources/products/ds4.yaml
+++ b/sources/products/ds4.yaml
@@ -1,0 +1,13 @@
+name: ds4
+display_name: ds4
+type: software
+description: Native local LLM inference engine by antirez (Salvatore Sanfilippo), optimized first for DeepSeek V4
+  Flash (with DeepSeek V4 PRO support on very-high-memory machines). Self-contained C/CUDA/Objective-C engine built
+  on llama.cpp/GGML with DeepSeek-specific loading, prompt rendering, tool calling, and KV state streaming (RAM
+  and on-disk SSD). Ships an HTTP server with OpenAI-compatible endpoints and an integrated coding agent, across
+  Metal (Apple Silicon), NVIDIA CUDA/DGX Spark, and AMD Strix Halo (ROCm) backends.
+github:
+- url: https://github.com/antirez/ds4
+comments: MIT-licensed (LICENSE body, (c) 2026 The ds4.c authors + ggml authors). Created 6 May 2026, ~332 commits,
+  last push 17 Jun 2026; ~14.6k stars, no tagged releases (built from source). Deliberately narrow 'one model at
+  a time' design. Verified 2026-06-19.

--- a/sources/products/llm.yaml
+++ b/sources/products/llm.yaml
@@ -1,0 +1,13 @@
+name: llm
+display_name: LLM (Datasette)
+type: software
+description: Command-line tool and Python library for interacting with large language models. Provides a unified
+  CLI and API to send prompts to remote models (OpenAI, Anthropic, Gemini, Llama, etc.) and to local models, with
+  a plugin architecture for adding new backends. Logs prompts and responses to a local SQLite database and supports
+  embeddings and templated prompts. Part of Simon Willison's Datasette ecosystem (docs at llm.datasette.io).
+github:
+- url: https://github.com/simonw/llm
+pypi:
+- url: https://pypi.org/project/llm
+comments: Apache-2.0 (verified LICENSE body). Latest release v0.31 (~24 Apr 2026, PyPI/GitHub). ~12.1k stars. Canonical
+  repo under the personal simonw account; branded under the Datasette ecosystem. Verified 2026-06-19.

--- a/sources/scores/datasette-agent.yaml
+++ b/sources/scores/datasette-agent.yaml
@@ -1,0 +1,35 @@
+product: datasette-agent
+openness:
+  score: 5
+  class: open_source
+  components: license:Apache-2.0(OSI);source:public(GitHub);PyPI;no feature-gated core
+  confidence: high
+  note: Apache-2.0 verified against LICENSE body; full source public on the datasette org; no gated tier.
+  sources:
+  - url: https://github.com/datasette/datasette-agent/blob/main/LICENSE
+    shows: Apache License 2.0 full text
+    accessed: '2026-06-19'
+adoption:
+  level: 1
+  reach: <10K
+  signal_type: stars_fallback
+  confidence: high
+  note: Pre-release alpha (PyPI 0.3a0, Jun 2026) roughly one month old; ~96 GitHub stars. Minimal adoption to date
+    — included as an emerging on-thesis structured-data agent.
+  sources:
+  - url: https://github.com/datasette/datasette-agent
+    shows: ~96 stars, 7 tags; PyPI 0.3a0 (15 Jun 2026)
+    accessed: '2026-06-19'
+capability:
+  score: 2
+  basis: feature_matrix
+  value: Natural-language-to-SQL agent over SQLite via Datasette; tools for save_query / execute_write_sql, background
+    exploration, and pluggable tools (charts, image gen). Domain-specific; not a general coding agent; no standardized
+    benchmark.
+  confidence: medium
+  note: Narrow, early structured-data agent on an alpha release; capable within its domain but limited in scope
+    and maturity, so scored 2.
+  sources:
+  - url: https://agent.datasette.io/
+    shows: 'docs: /-/agent NL-to-SQL chat, save_query/execute_write_sql tools, pluggable tool surface'
+    accessed: '2026-06-19'

--- a/sources/scores/ds4.yaml
+++ b/sources/scores/ds4.yaml
@@ -1,0 +1,34 @@
+product: ds4
+openness:
+  score: 5
+  class: open_source
+  components: license:MIT(OSI);source:public;no feature-gated core;built on ggml/llama.cpp
+  confidence: high
+  note: MIT-licensed native inference engine; full C/CUDA/Obj-C source public, no proprietary tier.
+  sources:
+  - url: https://github.com/antirez/ds4/blob/main/LICENSE
+    shows: MIT License text, (c) 2026 The ds4.c authors; (c) 2023-2026 The ggml authors
+    accessed: '2026-06-19'
+adoption:
+  level: 2
+  reach: 10K-100K
+  signal_type: stars_fallback
+  confidence: low
+  note: ~14.6k GitHub stars six weeks after launch, but driven heavily by antirez's profile; no package distribution
+    and no install/usage count, so treated as a low-confidence star-proxy pending warehouse signal.
+  sources:
+  - url: https://github.com/antirez/ds4
+    shows: ~14.6k stars, 332 commits, 0 releases, created May 2026
+    accessed: '2026-06-19'
+capability:
+  score: 3
+  basis: feature_matrix
+  value: 'Backends: Metal/CUDA/ROCm; DeepSeek V4 Flash/PRO specialization; OpenAI-compatible HTTP server; RAM +
+    SSD KV streaming; integrated coding agent. No MLPerf submission.'
+  confidence: medium
+  note: Specialized single-model-family engine rather than the breadth of llama.cpp (C4) or the datacenter-throughput
+    frontier (C5); scored 3 for a focused, capable local runtime.
+  sources:
+  - url: https://github.com/antirez/ds4
+    shows: README documents Metal/CUDA/ROCm backends, OpenAI-compatible server, SSD KV streaming, integrated agent
+    accessed: '2026-06-19'

--- a/sources/scores/llm.yaml
+++ b/sources/scores/llm.yaml
@@ -1,0 +1,39 @@
+product: llm
+openness:
+  score: 5
+  class: open_source
+  components: license:Apache-2.0(OSI);source:public(GitHub);PyPI;plugin-extensible;no feature-gated core
+  confidence: high
+  note: Apache-2.0 verified against LICENSE body; full source public; CLI/library with no gated tier (model providers
+    need their own API keys, external to the tool).
+  sources:
+  - url: https://github.com/simonw/llm/blob/main/LICENSE
+    shows: Apache License 2.0 full text
+    accessed: '2026-06-19'
+adoption:
+  level: 3
+  reach: 100K-1M
+  signal_type: usage_volume
+  confidence: medium
+  note: Established CLI/library distributed on PyPI (package 'llm', v0.31) with ~12.1k GitHub stars and a broad
+    plugin ecosystem; widely used across Simon Willison's tooling. No exact monthly download figure captured, so
+    placed at 3 on PyPI-presence + ecosystem signal.
+  sources:
+  - url: https://pypi.org/project/llm
+    shows: llm v0.31 published ~Apr 2026
+    accessed: '2026-06-19'
+  - url: https://github.com/simonw/llm
+    shows: ~12.1k stars, plugin ecosystem
+    accessed: '2026-06-19'
+capability:
+  score: 3
+  basis: feature_matrix
+  value: 'Model breadth: 100+ remote and local models via plugins; embeddings; prompt templates; SQLite logging
+    of prompts/responses; Python API. CLI/library surface, not a full chat UI.'
+  confidence: high
+  note: Strong on model breadth and extensibility, but a developer CLI/library rather than a multi-user surface;
+    lacks the built-in RAG/multimodal/auth feature stack of top ui_api entries, so scored 3.
+  sources:
+  - url: https://llm.datasette.io/
+    shows: 'docs: unified CLI/Python API for remote+local models, plugins, embeddings, templates, SQLite logging'
+    accessed: '2026-06-19'


### PR DESCRIPTION
## Summary

Curation batch sourced from the Simon Willison / antirez thread Ayah posted in **#ecosystem-engineering** (2026-06-19). All three products verified against primary sources (repo, LICENSE body, PyPI) before authoring.

| Product | Category | Org | Openness | Notes |
|---|---|---|---|---|
| `ds4` | inference_code | `antirez` *(new)* | 5 · open_source (MIT) | Native local LLM inference engine, DeepSeek-optimized, builds on llama.cpp/GGML. Sits next to `llama-cpp`. |
| `llm` | ui_api | `datasette` *(new)* | 5 · open_source (Apache-2.0) | Simon Willison's CLI + Python library for 100+ models via plugins. |
| `datasette-agent` | orchestration_agents | `datasette` *(new)* | 5 · open_source (Apache-2.0) | NL-to-SQL agent over structured data. **Alpha** (`0.3a0`) — included as an emerging on-thesis entry. |

### Skipped (already covered)
- **GLM 5.2** → existing `glm-5-2`
- **Gemma 3 4B** → existing `gemma-3` (card covers the 4B variant)

### Housekeeping
- `_frozen_long_tail.json` counts re-synced: scored 348→351, overlap 154→156 (`antirez/ds4` and `simonw/llm` are already in the goodailist universe; `datasette-agent` is not → scored_outside 194→195), uncategorized→24470, universe→24821.
- Straplines reviewed — all additions are open_source and reinforce their category's existing thesis; no edits.
- Bot-owned `notebook_data.json` / `ai-stack-map.py` intentionally not committed (regenerated on merge).

## Test plan
- `uv run python -m build.validate` → **0 error(s)**
- `uv run python -m build.serialize` + `build/render.py` → renders cleanly (351 products)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSJoir2ZDtqWE2BgxUC3jV