### PR TITLE
fix(openness): bucket hardware openness classes in the verdict logic

### DIFF
--- a/build/render.py
+++ b/build/render.py
@@ -86,6 +86,9 @@ def style():
         "gated": ("Gated", 2, "warm"),
         "documented_only": ("Documented only", 1, "ink_3"),
         "closed": ("Closed", 1, "ink_3"),
+        "open_hardware": ("Open hardware", 5, "healthy"),
+        "open_toolchain": ("Open toolchain", 3, "warm"),
+        "documented": ("Documented", 2, "signal"),
     }
     # Openness verdict code -> (label, color key into C). Colors match the
     # count chips (open=green, open-ish=orange, closed=red) so the badge
@@ -164,8 +167,8 @@ def verdict_logic(DATA, LAYER_WEIGHTS):
     #   open    = open_source / open / open_core
     #   openish = open_weights / source_available / gated
     #   closed  = restricted / documented_only / closed
-    _OPEN = {"open_source", "open", "open_core"}
-    _OPENISH = {"open_weights", "source_available", "gated"}
+    _OPEN = {"open_source", "open", "open_core", "open_hardware"}
+    _OPENISH = {"open_weights", "source_available", "gated", "open_toolchain"}
 
     def vbucket(cls):
         if cls in _OPEN:

--- a/docs/guides/openness-spectrum.md
+++ b/docs/guides/openness-spectrum.md
@@ -68,12 +68,20 @@ spectrum coordinate:
 | `gated` | Gated | 2 |
 | `documented_only` | Documented only | 1 |
 | `closed` | Closed | 1 |
+| `open_hardware` | Open hardware | 5 |
+| `open_toolchain` | Open toolchain | 3 |
+| `documented` | Documented | 2 |
+
+The last three are the **hardware** openness vocabulary (product `type: hardware`):
+open schematics + toolchain = `open_hardware`; proprietary silicon but open SDK/datasheets +
+retail-available = `open_toolchain`; datasheets public but proprietary design / firmware blobs =
+`documented`; NDA/private-sale = `restricted` (shared with the model vocabulary).
 
 **Class → three-bucket verdict** (`vbucket()` in `render.py`) — the coarse spectrum:
 
-- **open** = `open_source` / `open` / `open_core`
-- **open-ish** = `open_weights` / `source_available` / `gated`
-- **closed** = `restricted` / `documented_only` / `closed`
+- **open** = `open_source` / `open` / `open_core` / `open_hardware`
+- **open-ish** = `open_weights` / `source_available` / `gated` / `open_toolchain`
+- **closed** = `restricted` / `documented_only` / `closed` / `documented`
 
 ## Caveats — these are editorial choices
 

--- a/docs/openness-class-map.json
+++ b/docs/openness-class-map.json
@@ -10,11 +10,14 @@
     "source_available": { "label": "Source available", "gradient": 2, "bucket": "openish", "color": "#c8341d" },
     "restricted":  { "label": "Restricted",        "gradient": 2, "bucket": "closed",  "color": "#c8341d" },
     "documented_only": { "label": "Documented only", "gradient": 1, "bucket": "closed", "color": "#6b6253" },
-    "closed":      { "label": "Closed",            "gradient": 1, "bucket": "closed",  "color": "#6b6253" }
+    "closed":      { "label": "Closed",            "gradient": 1, "bucket": "closed",  "color": "#6b6253" },
+    "open_hardware":  { "label": "Open hardware",  "gradient": 5, "bucket": "open",    "color": "#1b6b5e" },
+    "open_toolchain": { "label": "Open toolchain", "gradient": 3, "bucket": "openish", "color": "#d97c2a" },
+    "documented":     { "label": "Documented",     "gradient": 2, "bucket": "closed",  "color": "#c8341d" }
   },
   "buckets": {
-    "open":    { "label": "Open",     "color": "#1b6b5e", "classes": ["open_source", "open", "open_core"] },
-    "openish": { "label": "Open-ish", "color": "#d97c2a", "classes": ["open_weights", "source_available", "gated"] },
-    "closed":  { "label": "Closed",   "color": "#c8341d", "classes": ["restricted", "documented_only", "closed"] }
+    "open":    { "label": "Open",     "color": "#1b6b5e", "classes": ["open_source", "open", "open_core", "open_hardware"] },
+    "openish": { "label": "Open-ish", "color": "#d97c2a", "classes": ["open_weights", "source_available", "gated", "open_toolchain"] },
+    "closed":  { "label": "Closed",   "color": "#c8341d", "classes": ["restricted", "documented_only", "closed", "documented"] }
   }
 }


### PR DESCRIPTION
## Summary

`vbucket()` and the `OPEN` gradient dict in `render.py` predated the hardware openness vocabulary added in the edge-hardware batch, so **all 20 edge-hardware products bucketed as `closed`** in the live notebook's open / open-ish / closed verdict (and rendered grey at gradient 1). The distribution-bar colors were updated then, but these two functions were missed.

Maps the hardware classes onto the existing 3-bucket / 0–5 gradient, consistently across all four places the mapping lives:
- `open_hardware` → **open** (gradient 5)
- `open_toolchain` → **open-ish** (gradient 3)
- `documented` → **closed** (gradient 2) — proprietary silicon you can buy/read but not rebuild
- `restricted` → closed (already, shared with the model vocab)

Touched: `render.py` (`vbucket` `_OPEN`/`_OPENISH` + the `OPEN` gradient dict), `docs/openness-class-map.json`, `docs/guides/openness-spectrum.md`.

**Result:** `edge_hardware` now reads **1 open / 6 open-ish / 13 closed** (was all 20 → closed).

## Test plan
- [x] `build.validate` → 0 errors
- [x] `pytest -q` → 22 passed
- [x] `render.py` + `marimo check notebooks/ai-stack-map.py` → OK
- [ ] CI
- [ ] **Republish** ai-stack-map after merge (the live verdict counts for edge_hardware are currently wrong)

Generated `ai-stack-map.py` not committed (bot regenerates on merge).