### PR TITLE
feat(gap-analysis): category stage + gaps from product scores

### DIFF
--- a/build/render.py
+++ b/build/render.py
@@ -303,16 +303,13 @@ def stack_overview(C, DATA, F, ORDER, STACK_DESC, VERDICT, mix_counts, mo,
         _m = mix_counts(_cid)
         _code, _basis = verdict_for(_cid)
         _vlabel, _vckey = VERDICT[_code]
-        _st = _cat.get("stage") or {}
-        _sn = _st.get("num", 0)
-        _scol = C["healthy"] if _sn >= 5 else C["accent"] if _sn == 4 else C["warm"] if _sn >= 2 else C["signal"]
         _chips = (
             f'<span style="color:{C["healthy"]};">\\u25cf</span> {_m["open"]} open'
             f'&nbsp;&nbsp;<span style="color:{C["warm"]};">\\u25cf</span> {_m["openish"]} open-ish'
             f'&nbsp;&nbsp;<span style="color:{C["ink_3"]};">\\u25cf</span> {_m["closed"]} closed'
         )
         _rows.append(
-            f'<div style="display:grid; grid-template-columns:32px 1fr 200px 200px; gap:18px; '
+            f'<div style="display:grid; grid-template-columns:32px 1fr 232px 150px; gap:18px; '
             f'align-items:center; padding:14px 0; border-bottom:1px solid {C["rule"]};">'
             f'<div style="font-family:{F["mono"]}; font-size:12px; color:{C["ink_3"]};">{_i:02d}</div>'
             f'<div><div style="font-family:{F["headline"]}; font-size:1.05rem; font-weight:500; '
@@ -320,13 +317,9 @@ def stack_overview(C, DATA, F, ORDER, STACK_DESC, VERDICT, mix_counts, mo,
             f'<div style="font-family:{F["body"]}; font-size:0.85rem; color:{C["ink_3"]}; '
             f'margin-top:3px; line-height:1.4;">{STACK_DESC.get(_cid, "")}</div></div>'
             f'<div style="font-family:{F["mono"]}; font-size:0.74rem; color:{C["ink_2"]};">{_chips}</div>'
-            f'<div>'
-            f'<span style="display:inline-block; font-family:{F["mono"]}; font-size:0.68rem; letter-spacing:0.05em; '
-            f'text-transform:uppercase; color:#fff; background:{C[_vckey]}; padding:4px 9px; border-radius:2px;">{_vlabel}</span>'
-            f'<div style="margin-top:6px;"><span style="display:inline-block; font-family:{F["mono"]}; '
-            f'font-size:0.66rem; font-weight:500; color:#fff; background:{_scol}; padding:3px 9px; '
-            f'border-radius:11px;">Stage {_sn} \\u00b7 {_st.get("name","")}</span></div>'
-            f'</div>'
+            f'<div style="font-family:{F["mono"]}; font-size:0.72rem; letter-spacing:0.05em; '
+            f'text-transform:uppercase; color:white; background:{C[_vckey]}; padding:7px 10px; '
+            f'text-align:center; border-radius:2px;">{_vlabel}</div>'
             f'</div>'
         )
     _total = DATA.get("n_total") or sum(len(DATA["categories"][c]["products"]) for c in ORDER)
@@ -340,8 +333,9 @@ def stack_overview(C, DATA, F, ORDER, STACK_DESC, VERDICT, mix_counts, mo,
         f'{_n_arcs} layers \\u00b7 {len(ORDER)} categories \\u00b7 {_total} scored products</h2>'
         f'<p style="font-family:{F["body"]}; font-size:0.95rem; color:{C["ink_2"]}; margin:0 0 20px; line-height:1.6;">'
         f'Each row is one category, grouped into three layers. The dots show the openness mix of all its '
-        f'products; the verdict pill names which tier leads among its standout products, and the stage chip '
-        f'places its open ecosystem on the Void \\u2192 Mature ladder. The same pills appear on each category below.</p>'
+        f'products; the badge names which tier leads among the category\\u2019s standout products: '
+        f'those that clear the combined adoption\\u00d7capability bar. Open in the long tail and closed at the '
+        f'top can coexist \\u2014 that gap is the point.</p>'
         f'{"".join(_rows)}</div>'
     )
     return
@@ -651,22 +645,13 @@ def helpers(C, DATA, F, OPEN, STRAPLINES, VERDICT, mix_counts, mo, vbucket,
         )
 
     def _verdict_spine(cid):
-        # Openness verdict pill + a plain Stage chip (gaps omitted for now), then the
-        # open / open-ish / closed dot tally.
+        # Openness verdict pill, then the open / open-ish / closed dot tally.
         _code, _basis = verdict_for(cid)
         _vlabel, _vckey = VERDICT[_code]
         _verdict = (
             f'<span style="display:inline-block; font-family:{F["mono"]}; font-size:0.72rem; '
             f'letter-spacing:0.05em; text-transform:uppercase; color:white; background:{C[_vckey]}; '
             f'padding:4px 10px; border-radius:2px;">{_vlabel}</span>'
-        )
-        _st = DATA["categories"][cid].get("stage") or {}
-        _sn = _st.get("num", 0)
-        _scol = C["healthy"] if _sn >= 5 else C["accent"] if _sn == 4 else C["warm"] if _sn >= 2 else C["signal"]
-        _stage = (
-            f'<span style="display:inline-block; font-family:{F["mono"]}; font-size:0.72rem; font-weight:500; '
-            f'color:#fff; background:{_scol}; padding:4px 10px; border-radius:11px; margin-left:8px;">'
-            f'Stage {_sn} \\u00b7 {_st.get("name","")}</span>'
         )
         _m = mix_counts(cid)
         _tally = (
@@ -675,7 +660,7 @@ def helpers(C, DATA, F, OPEN, STRAPLINES, VERDICT, mix_counts, mo, vbucket,
             f'&nbsp;&nbsp;<span style="color:{C["ink_3"]};">\\u25cf</span> {_m["closed"]} closed'
         )
         return (
-            f'<div style="margin:4px 0 12px;">{_verdict}{_stage}'
+            f'<div style="margin:4px 0 12px;">{_verdict}'
             f'<span style="font-family:{F["mono"]}; font-size:0.78rem; color:{C["ink_2"]}; '
             f'margin-left:14px;">{_tally}</span></div>'
         )
@@ -808,6 +793,76 @@ def details_payload(DATA, ORDER, mo):
     mo.Html(
         f'<iframe srcdoc="&lt;!doctype html&gt;&lt;html&gt;&lt;/html&gt;" '
         f'style="display:none;width:0;height:0;border:0;position:absolute" onload="{_boot}"></iframe>'
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def stages_table(C, DATA, F, ORDER, mo):
+    # The maturity ladder: each category's open ecosystem placed on a 0-5 stage.
+    # Only fully-open products count toward a stage (open-ish/closed do not); see
+    # docs/guides/gap-analysis.md. Stages + assignments come straight from the payload.
+    _DEFS = [
+        (0, "Void", "No meaningful open products exist."),
+        (1, "Open Experiments", "Open experiments exist, but capability and adoption are both limited."),
+        (2, "Emerging Alternatives", "Promising open products exist, but important functionality is missing and adoption is limited."),
+        (3, "Viable Alternatives", "Viable open alternatives exist for many use cases."),
+        (4, "Competitive Open Ecosystem", "Open solutions are competitive across a broad range of use cases."),
+        (5, "Mature Open Ecosystem", "Multiple open solutions are mature, widely adopted, and resilient."),
+    ]
+    _by_stage = {}
+    for _cid in ORDER:
+        _sn = (DATA["categories"][_cid].get("stage") or {}).get("num", 0)
+        _by_stage.setdefault(_sn, []).append(DATA["categories"][_cid]["label"])
+
+    def _scol(_n):
+        return C["healthy"] if _n >= 5 else C["accent"] if _n == 4 else C["warm"] if _n >= 2 else C["signal"]
+
+    _rows = []
+    for _n, _name, _desc in _DEFS:
+        _cats = _by_stage.get(_n, [])
+        _cat_html = (
+            "".join(
+                f'<span style="display:inline-block; font-family:{F["body"]}; font-size:0.82rem; '
+                f'color:{C["ink_2"]}; background:{C["paper_2"]}; padding:2px 9px; border-radius:11px; '
+                f'margin:0 5px 5px 0;">{_l}</span>'
+                for _l in _cats
+            )
+            if _cats
+            else f'<span style="font-family:{F["body"]}; font-size:0.82rem; color:{C["ink_3"]}; font-style:italic;">\\u2014</span>'
+        )
+        _rows.append(
+            f'<tr style="border-bottom:1px solid {C["rule"]}; vertical-align:top;">'
+            f'<td style="padding:14px 14px 14px 0; white-space:nowrap;">'
+            f'<span style="display:inline-flex; align-items:center; justify-content:center; width:24px; height:24px; '
+            f'font-family:{F["mono"]}; font-size:0.8rem; font-weight:600; color:#fff; background:{_scol(_n)}; '
+            f'border-radius:50%;">{_n}</span></td>'
+            f'<td style="padding:14px 16px 14px 0; font-family:{F["headline"]}; font-size:0.98rem; '
+            f'font-weight:500; color:{C["ink"]}; white-space:nowrap;">{_name}</td>'
+            f'<td style="padding:14px 16px 14px 0; font-family:{F["body"]}; font-size:0.86rem; '
+            f'color:{C["ink_2"]}; line-height:1.45; max-width:300px;">{_desc}</td>'
+            f'<td style="padding:14px 0;">{_cat_html}</td>'
+            f'</tr>'
+        )
+    _head = "".join(
+        f'<th style="padding:0 16px 8px 0; font-family:{F["mono"]}; font-size:9px; color:{C["ink_3"]}; '
+        f'text-transform:uppercase; letter-spacing:0.05em; text-align:left;">{_h}</th>'
+        for _h in ["Stage", "", "What it means", "Categories here"]
+    )
+    mo.Html(
+        f'<div style="margin:52px 0 44px;">'
+        f'<div style="font-family:{F["mono"]}; font-size:10px; color:{C["accent"]}; '
+        f'letter-spacing:0.1em; text-transform:uppercase; margin-bottom:8px;">The maturity ladder</div>'
+        f'<h2 style="font-family:{F["headline"]}; font-size:1.6rem; font-weight:500; color:{C["ink"]}; '
+        f'margin:0 0 14px; letter-spacing:-0.015em;">How mature is the open ecosystem in each category?</h2>'
+        f'<p style="font-family:{F["body"]}; font-size:0.95rem; color:{C["ink_2"]}; margin:0 0 20px; line-height:1.6;">'
+        f'Each category sits on a Void \\u2192 Mature ladder, scored on the depth of its <em>fully-open</em> '
+        f'options \\u2014 open-weights or source-available products do not count toward a stage, only toward '
+        f'flagging an openness gap. A category climbs the ladder as more of its open products clear the combined '
+        f'adoption\\u00d7capability bar.</p>'
+        f'<table style="border-collapse:collapse; width:100%;">'
+        f'<thead><tr style="border-bottom:2px solid {C["rule"]};">{_head}</tr></thead>'
+        f'<tbody>{"".join(_rows)}</tbody></table></div>'
     )
     return
 

--- a/build/render.py
+++ b/build/render.py
@@ -301,11 +301,11 @@ def stack_overview(C, DATA, F, ORDER, STACK_DESC, VERDICT, mix_counts, mo,
             )
             _last_arc = _arc
         _m = mix_counts(_cid)
+        _code, _basis = verdict_for(_cid)
+        _vlabel, _vckey = VERDICT[_code]
         _st = _cat.get("stage") or {}
         _sn = _st.get("num", 0)
         _scol = C["healthy"] if _sn >= 5 else C["accent"] if _sn == 4 else C["warm"] if _sn >= 2 else C["signal"]
-        _gaps = _cat.get("gaps") or []
-        _gaptext = " \\u00b7 ".join(_gaps) if _gaps else "no gaps"
         _chips = (
             f'<span style="color:{C["healthy"]};">\\u25cf</span> {_m["open"]} open'
             f'&nbsp;&nbsp;<span style="color:{C["warm"]};">\\u25cf</span> {_m["openish"]} open-ish'
@@ -321,10 +321,11 @@ def stack_overview(C, DATA, F, ORDER, STACK_DESC, VERDICT, mix_counts, mo,
             f'margin-top:3px; line-height:1.4;">{STACK_DESC.get(_cid, "")}</div></div>'
             f'<div style="font-family:{F["mono"]}; font-size:0.74rem; color:{C["ink_2"]};">{_chips}</div>'
             f'<div>'
-            f'<span style="display:inline-block; font-family:{F["mono"]}; font-size:0.68rem; font-weight:500; '
-            f'color:#fff; background:{_scol}; padding:3px 9px; border-radius:11px;">Stage {_sn} \\u00b7 {_st.get("name","")}</span>'
-            f'<div style="font-family:{F["mono"]}; font-size:0.64rem; color:{C["ink_3"] if _gaps else C["healthy"]}; '
-            f'margin-top:5px;">{_gaptext}</div>'
+            f'<span style="display:inline-block; font-family:{F["mono"]}; font-size:0.68rem; letter-spacing:0.05em; '
+            f'text-transform:uppercase; color:#fff; background:{C[_vckey]}; padding:4px 9px; border-radius:2px;">{_vlabel}</span>'
+            f'<div style="margin-top:6px;"><span style="display:inline-block; font-family:{F["mono"]}; '
+            f'font-size:0.66rem; font-weight:500; color:#fff; background:{_scol}; padding:3px 9px; '
+            f'border-radius:11px;">Stage {_sn} \\u00b7 {_st.get("name","")}</span></div>'
             f'</div>'
             f'</div>'
         )
@@ -339,8 +340,8 @@ def stack_overview(C, DATA, F, ORDER, STACK_DESC, VERDICT, mix_counts, mo,
         f'{_n_arcs} layers \\u00b7 {len(ORDER)} categories \\u00b7 {_total} scored products</h2>'
         f'<p style="font-family:{F["body"]}; font-size:0.95rem; color:{C["ink_2"]}; margin:0 0 20px; line-height:1.6;">'
         f'Each row is one category, grouped into three layers. The dots show the openness mix of all its '
-        f'products; the badge gives the category\\u2019s open-ecosystem maturity stage (Void \\u2192 Mature) and '
-        f'the gaps keeping it from the next rung. The same stage and gaps appear on each category below.</p>'
+        f'products; the verdict pill names which tier leads among its standout products, and the stage chip '
+        f'places its open ecosystem on the Void \\u2192 Mature ladder. The same pills appear on each category below.</p>'
         f'{"".join(_rows)}</div>'
     )
     return
@@ -650,8 +651,23 @@ def helpers(C, DATA, F, OPEN, STRAPLINES, VERDICT, mix_counts, mo, vbucket,
         )
 
     def _verdict_spine(cid):
-        # Dot tally only; the stage badge above now carries the openness verdict, so
-        # the standalone verdict pill was dropped to de-clutter the section header.
+        # Openness verdict pill + a plain Stage chip (gaps omitted for now), then the
+        # open / open-ish / closed dot tally.
+        _code, _basis = verdict_for(cid)
+        _vlabel, _vckey = VERDICT[_code]
+        _verdict = (
+            f'<span style="display:inline-block; font-family:{F["mono"]}; font-size:0.72rem; '
+            f'letter-spacing:0.05em; text-transform:uppercase; color:white; background:{C[_vckey]}; '
+            f'padding:4px 10px; border-radius:2px;">{_vlabel}</span>'
+        )
+        _st = DATA["categories"][cid].get("stage") or {}
+        _sn = _st.get("num", 0)
+        _scol = C["healthy"] if _sn >= 5 else C["accent"] if _sn == 4 else C["warm"] if _sn >= 2 else C["signal"]
+        _stage = (
+            f'<span style="display:inline-block; font-family:{F["mono"]}; font-size:0.72rem; font-weight:500; '
+            f'color:#fff; background:{_scol}; padding:4px 10px; border-radius:11px; margin-left:8px;">'
+            f'Stage {_sn} \\u00b7 {_st.get("name","")}</span>'
+        )
         _m = mix_counts(cid)
         _tally = (
             f'<span style="color:{C["healthy"]};">\\u25cf</span> {_m["open"]} open'
@@ -659,29 +675,10 @@ def helpers(C, DATA, F, OPEN, STRAPLINES, VERDICT, mix_counts, mo, vbucket,
             f'&nbsp;&nbsp;<span style="color:{C["ink_3"]};">\\u25cf</span> {_m["closed"]} closed'
         )
         return (
-            f'<div style="margin:0 0 14px; font-family:{F["mono"]}; font-size:0.78rem; '
-            f'color:{C["ink_2"]};">{_tally}</div>'
+            f'<div style="margin:4px 0 12px;">{_verdict}{_stage}'
+            f'<span style="font-family:{F["mono"]}; font-size:0.78rem; color:{C["ink_2"]}; '
+            f'margin-left:14px;">{_tally}</span></div>'
         )
-
-    def _stage_gaps_badge(cid):
-        cat = DATA["categories"][cid]
-        st = cat.get("stage") or {}
-        if not st:
-            return ""
-        _n = st.get("num", 0)
-        _sc = C["healthy"] if _n >= 5 else C["accent"] if _n == 4 else C["warm"] if _n >= 2 else C["signal"]
-        _badge = (f'<span style="font-family:{F["mono"]}; font-size:0.72rem; font-weight:500; color:#fff; '
-                  f'background:{_sc}; padding:3px 9px; border-radius:11px;">Stage {_n} \\u00b7 {st.get("name","")}</span>')
-        _chips = "".join(
-            f'<span style="font-family:{F["mono"]}; font-size:0.64rem; text-transform:uppercase; '
-            f'letter-spacing:0.04em; color:{C["ink_2"]}; background:{C["paper_2"]}; border:1px solid {C["rule"]}; '
-            f'padding:2px 8px; border-radius:11px;">{_g}</span>'
-            for _g in (cat.get("gaps") or [])
-        )
-        _none = "" if cat.get("gaps") else (f'<span style="font-family:{F["mono"]}; font-size:0.64rem; '
-                f'color:{C["healthy"]};">no gaps</span>')
-        return (f'<div style="display:flex; flex-wrap:wrap; gap:8px; align-items:center; margin:0 0 6px;">'
-                f'{_badge}{_chips}{_none}</div>')
 
     def render_section(cid, num):
         cat = DATA["categories"][cid]
@@ -719,7 +716,6 @@ def helpers(C, DATA, F, OPEN, STRAPLINES, VERDICT, mix_counts, mo, vbucket,
             f'<span style="font-family:{F["mono"]}; font-size:0.8rem; color:{C["ink_3"]};">({len(prods)})</span></h2>'
             f'<p style="font-family:{F["body"]}; font-size:0.98rem; font-weight:600; color:{C["ink_2"]}; '
             f'margin:0 0 10px; line-height:1.45;">{_strap}</p>'
-            + _stage_gaps_badge(cid)
             + _verdict_spine(cid)
             + _scoring_callout(cid)
             + f'<table style="border-collapse:collapse; width:100%;">'

--- a/build/render.py
+++ b/build/render.py
@@ -123,6 +123,9 @@ def data():
         "telemetry_observability": "Tracing and observability for LLM apps.",
         "agent_tools_protocols": "Tools, protocols, and retrieval for agents.",
         "deployment": "Sandboxes, runtimes, and serverless model hosting.",
+        "training_synthetic_datasets": "Corpora for pre-training and post-training models.",
+        "ml_frameworks": "Foundational libraries the rest of the stack is built on.",
+        "edge_hardware": "Boards and chips that run model inference at the edge.",
     }
     # Per-category combined-score weights (adoption, capability), ported from the
     # v2 stack map (slugs identical). Feed the "standout product" gate behind the
@@ -298,15 +301,18 @@ def stack_overview(C, DATA, F, ORDER, STACK_DESC, VERDICT, mix_counts, mo,
             )
             _last_arc = _arc
         _m = mix_counts(_cid)
-        _code, _basis = verdict_for(_cid)
-        _vlabel, _vckey = VERDICT[_code]
+        _st = _cat.get("stage") or {}
+        _sn = _st.get("num", 0)
+        _scol = C["healthy"] if _sn >= 5 else C["accent"] if _sn == 4 else C["warm"] if _sn >= 2 else C["signal"]
+        _gaps = _cat.get("gaps") or []
+        _gaptext = " \\u00b7 ".join(_gaps) if _gaps else "no gaps"
         _chips = (
             f'<span style="color:{C["healthy"]};">\\u25cf</span> {_m["open"]} open'
             f'&nbsp;&nbsp;<span style="color:{C["warm"]};">\\u25cf</span> {_m["openish"]} open-ish'
             f'&nbsp;&nbsp;<span style="color:{C["ink_3"]};">\\u25cf</span> {_m["closed"]} closed'
         )
         _rows.append(
-            f'<div style="display:grid; grid-template-columns:32px 1fr 232px 150px; gap:18px; '
+            f'<div style="display:grid; grid-template-columns:32px 1fr 200px 200px; gap:18px; '
             f'align-items:center; padding:14px 0; border-bottom:1px solid {C["rule"]};">'
             f'<div style="font-family:{F["mono"]}; font-size:12px; color:{C["ink_3"]};">{_i:02d}</div>'
             f'<div><div style="font-family:{F["headline"]}; font-size:1.05rem; font-weight:500; '
@@ -314,9 +320,12 @@ def stack_overview(C, DATA, F, ORDER, STACK_DESC, VERDICT, mix_counts, mo,
             f'<div style="font-family:{F["body"]}; font-size:0.85rem; color:{C["ink_3"]}; '
             f'margin-top:3px; line-height:1.4;">{STACK_DESC.get(_cid, "")}</div></div>'
             f'<div style="font-family:{F["mono"]}; font-size:0.74rem; color:{C["ink_2"]};">{_chips}</div>'
-            f'<div style="font-family:{F["mono"]}; font-size:0.72rem; letter-spacing:0.05em; '
-            f'text-transform:uppercase; color:white; background:{C[_vckey]}; padding:7px 10px; '
-            f'text-align:center; border-radius:2px;">{_vlabel}</div>'
+            f'<div>'
+            f'<span style="display:inline-block; font-family:{F["mono"]}; font-size:0.68rem; font-weight:500; '
+            f'color:#fff; background:{_scol}; padding:3px 9px; border-radius:11px;">Stage {_sn} \\u00b7 {_st.get("name","")}</span>'
+            f'<div style="font-family:{F["mono"]}; font-size:0.64rem; color:{C["ink_3"] if _gaps else C["healthy"]}; '
+            f'margin-top:5px;">{_gaptext}</div>'
+            f'</div>'
             f'</div>'
         )
     _total = DATA.get("n_total") or sum(len(DATA["categories"][c]["products"]) for c in ORDER)
@@ -330,9 +339,8 @@ def stack_overview(C, DATA, F, ORDER, STACK_DESC, VERDICT, mix_counts, mo,
         f'{_n_arcs} layers \\u00b7 {len(ORDER)} categories \\u00b7 {_total} scored products</h2>'
         f'<p style="font-family:{F["body"]}; font-size:0.95rem; color:{C["ink_2"]}; margin:0 0 20px; line-height:1.6;">'
         f'Each row is one category, grouped into three layers. The dots show the openness mix of all its '
-        f'products; the badge names which tier leads among the category\\u2019s standout products: '
-        f'those that clear the combined adoption\\u00d7capability bar. Open in the long tail and closed at the '
-        f'top can coexist \\u2014 that gap is the point.</p>'
+        f'products; the badge gives the category\\u2019s open-ecosystem maturity stage (Void \\u2192 Mature) and '
+        f'the gaps keeping it from the next rung. The same stage and gaps appear on each category below.</p>'
         f'{"".join(_rows)}</div>'
     )
     return

--- a/build/render.py
+++ b/build/render.py
@@ -642,23 +642,17 @@ def helpers(C, DATA, F, OPEN, STRAPLINES, VERDICT, mix_counts, mo, vbucket,
         )
 
     def _verdict_spine(cid):
-        _code, _basis = verdict_for(cid)
-        _vlabel, _vckey = VERDICT[_code]
+        # Dot tally only; the stage badge above now carries the openness verdict, so
+        # the standalone verdict pill was dropped to de-clutter the section header.
         _m = mix_counts(cid)
-        _badge = (
-            f'<span style="display:inline-block; font-family:{F["mono"]}; font-size:0.72rem; '
-            f'letter-spacing:0.05em; text-transform:uppercase; color:white; background:{C[_vckey]}; '
-            f'padding:4px 10px; border-radius:2px; vertical-align:middle;">{_vlabel}</span>'
-        )
         _tally = (
             f'<span style="color:{C["healthy"]};">\\u25cf</span> {_m["open"]} open'
             f'&nbsp;&nbsp;<span style="color:{C["warm"]};">\\u25cf</span> {_m["openish"]} open-ish'
             f'&nbsp;&nbsp;<span style="color:{C["ink_3"]};">\\u25cf</span> {_m["closed"]} closed'
         )
         return (
-            f'<div style="margin:4px 0 10px;">{_badge}'
-            f'<span style="font-family:{F["mono"]}; font-size:0.78rem; color:{C["ink_2"]}; '
-            f'margin-left:14px;">{_tally}</span></div>'
+            f'<div style="margin:0 0 14px; font-family:{F["mono"]}; font-size:0.78rem; '
+            f'color:{C["ink_2"]};">{_tally}</div>'
         )
 
     def _stage_gaps_badge(cid):
@@ -673,12 +667,12 @@ def helpers(C, DATA, F, OPEN, STRAPLINES, VERDICT, mix_counts, mo, vbucket,
         _chips = "".join(
             f'<span style="font-family:{F["mono"]}; font-size:0.64rem; text-transform:uppercase; '
             f'letter-spacing:0.04em; color:{C["ink_2"]}; background:{C["paper_2"]}; border:1px solid {C["rule"]}; '
-            f'padding:2px 8px; border-radius:11px;">{_g} gap</span>'
+            f'padding:2px 8px; border-radius:11px;">{_g}</span>'
             for _g in (cat.get("gaps") or [])
         )
         _none = "" if cat.get("gaps") else (f'<span style="font-family:{F["mono"]}; font-size:0.64rem; '
                 f'color:{C["healthy"]};">no gaps</span>')
-        return (f'<div style="display:flex; flex-wrap:wrap; gap:8px; align-items:center; margin:0 0 12px;">'
+        return (f'<div style="display:flex; flex-wrap:wrap; gap:8px; align-items:center; margin:0 0 6px;">'
                 f'{_badge}{_chips}{_none}</div>')
 
     def render_section(cid, num):

--- a/build/render.py
+++ b/build/render.py
@@ -658,6 +658,26 @@ def helpers(C, DATA, F, OPEN, STRAPLINES, VERDICT, mix_counts, mo, vbucket,
             f'margin-left:14px;">{_tally}</span></div>'
         )
 
+    def _stage_gaps_badge(cid):
+        cat = DATA["categories"][cid]
+        st = cat.get("stage") or {}
+        if not st:
+            return ""
+        _n = st.get("num", 0)
+        _sc = C["healthy"] if _n >= 5 else C["accent"] if _n == 4 else C["warm"] if _n >= 2 else C["signal"]
+        _badge = (f'<span style="font-family:{F["mono"]}; font-size:0.72rem; font-weight:500; color:#fff; '
+                  f'background:{_sc}; padding:3px 9px; border-radius:11px;">Stage {_n} \\u00b7 {st.get("name","")}</span>')
+        _chips = "".join(
+            f'<span style="font-family:{F["mono"]}; font-size:0.64rem; text-transform:uppercase; '
+            f'letter-spacing:0.04em; color:{C["ink_2"]}; background:{C["paper_2"]}; border:1px solid {C["rule"]}; '
+            f'padding:2px 8px; border-radius:11px;">{_g} gap</span>'
+            for _g in (cat.get("gaps") or [])
+        )
+        _none = "" if cat.get("gaps") else (f'<span style="font-family:{F["mono"]}; font-size:0.64rem; '
+                f'color:{C["healthy"]};">no gaps</span>')
+        return (f'<div style="display:flex; flex-wrap:wrap; gap:8px; align-items:center; margin:0 0 12px;">'
+                f'{_badge}{_chips}{_none}</div>')
+
     def render_section(cid, num):
         cat = DATA["categories"][cid]
         _order = DATA["order"]
@@ -694,6 +714,7 @@ def helpers(C, DATA, F, OPEN, STRAPLINES, VERDICT, mix_counts, mo, vbucket,
             f'<span style="font-family:{F["mono"]}; font-size:0.8rem; color:{C["ink_3"]};">({len(prods)})</span></h2>'
             f'<p style="font-family:{F["body"]}; font-size:0.98rem; font-weight:600; color:{C["ink_2"]}; '
             f'margin:0 0 10px; line-height:1.45;">{_strap}</p>'
+            + _stage_gaps_badge(cid)
             + _verdict_spine(cid)
             + _scoring_callout(cid)
             + f'<table style="border-collapse:collapse; width:100%;">'

--- a/build/serialize.py
+++ b/build/serialize.py
@@ -14,6 +14,83 @@ ROOT = Path(__file__).resolve().parents[1]
 PRODUCT_KEY_ORDER = ["product", "org", "type", "description",
                      "openness", "adoption", "capability", "version_note"]
 
+# --- Gap analysis (category-level stage + gaps) -----------------------------
+# Mirrors the open / open-ish / closed verdict in docs/openness-class-map.json
+# (the canonical map). Kept inline here so serialize is self-contained; if these
+# diverge from the JSON, the JSON is source of truth.
+_GAP_OPEN = {"open_source", "open", "open_core", "open_hardware"}
+_GAP_OPENISH = {"open_weights", "source_available", "gated", "open_toolchain"}
+_MATURE_MIN = 4.5          # blended adoption/capability score to count as "mature"
+_STAGE5_MIN_MATURE = 4     # mature fully-open products needed for Stage 5
+_STAGE5_MIN_TOTAL = 3      # total fully-open products needed for Stage 5
+_STAGE_NAMES = {0: "Void", 1: "Open Experiments", 2: "Emerging Alternatives",
+                3: "Viable Alternatives", 4: "Competitive Open Ecosystem",
+                5: "Mature Open Ecosystem"}
+
+
+def _gap_bucket(cls: str) -> str:
+    if cls in _GAP_OPEN:
+        return "open"
+    if cls in _GAP_OPENISH:
+        return "open-ish"
+    return "closed"
+
+
+def _maturity_score(row: dict, w: dict) -> float:
+    # Per-category linear formula over the 1-5 axes; datasets have no capability
+    # score, so they are graded on adoption alone.
+    adoption = (row.get("adoption") or {}).get("level") or 0
+    capability = (row.get("capability") or {}).get("score")
+    if capability is None:
+        return float(adoption)
+    return w["adopt"] * adoption + w["cap"] * capability
+
+
+def _stage_and_gaps(rows: list[dict], weights: dict) -> dict:
+    """Assign a maturity stage (0-5) and the set of gaps for one category.
+
+    Strict open-only: only fully-open products count toward maturity/stage;
+    open-ish only serves to detect the openness gap. See docs/guides/gap-analysis.md.
+    """
+    w = weights or {"adopt": 0.5, "cap": 0.5}
+    enr = [(_gap_bucket((r.get("openness") or {}).get("class")), _maturity_score(r, w)) for r in rows]
+    open_scores = [s for b, s in enr if b == "open"]
+    total_open = len(open_scores)
+    mature_open = sum(1 for s in open_scores if s >= _MATURE_MIN)
+    best_open = max(open_scores, default=0.0)
+    mature_any = any(s >= _MATURE_MIN for _, s in enr)
+
+    if mature_open >= _STAGE5_MIN_MATURE and total_open >= _STAGE5_MIN_TOTAL:
+        stage = 5
+    elif mature_open >= 1:
+        stage = 4
+    elif best_open < 2 and not mature_any:
+        stage = 0
+    elif best_open < 3:
+        stage = 1
+    elif best_open < 3.5:
+        stage = 2
+    else:
+        stage = 3
+
+    if stage == 5:
+        gaps: list[str] = []
+    elif stage == 0:
+        gaps = ["void"]
+    elif stage == 4:
+        gaps = ["maturity"]
+    else:
+        gaps = ["maturity"]
+        if mature_any:                       # capable mature options exist, but none fully open
+            gaps.append("openness")
+        else:                                # nothing mature anywhere -> diagnose the limiting axis
+            best = max(rows, key=lambda r: _maturity_score(r, w), default=None)
+            bcap = (best or {}).get("capability", {}) or {}
+            cap = bcap.get("score")
+            gaps.append("capability" if (cap is not None and cap < 4) else "adoption")
+
+    return {"num": stage, "name": _STAGE_NAMES[stage], "gaps": gaps}
+
 
 def _catalog_ids(prods: dict) -> dict:
     """Artifact ids now claimed by a categorized product, keyed by long-tail entry
@@ -108,8 +185,10 @@ def build_payload(sources: dict, frozen_long_tail: dict, generated: str | None =
             org_name = "" if org_slug == "unknown" else orgs[org_slug]["display_name"]
             rows.append(_row(p, org_name, scores[slug]))
             n += 1
+        sg = _stage_and_gaps(rows, cat.get("weights"))
         out_cats[cid] = {"label": cat["display_name"], "arc": cid_arc[cid],
-                         "layer": cid_layer[cid], "products": rows}
+                         "layer": cid_layer[cid], "stage": {"num": sg["num"], "name": sg["name"]},
+                         "gaps": sg["gaps"], "products": rows}
     return {"categories": out_cats, "order": order, "n_total": n,
             "generated": generated, "long_tail": _filter_long_tail(frozen_long_tail, prods)}
 

--- a/build/serialize.py
+++ b/build/serialize.py
@@ -20,9 +20,9 @@ PRODUCT_KEY_ORDER = ["product", "org", "type", "description",
 # diverge from the JSON, the JSON is source of truth.
 _GAP_OPEN = {"open_source", "open", "open_core", "open_hardware"}
 _GAP_OPENISH = {"open_weights", "source_available", "gated", "open_toolchain"}
-_MATURE_MIN = 4.5          # blended adoption/capability score to count as "mature"
-_STAGE5_MIN_MATURE = 4     # mature fully-open products needed for Stage 5
-_STAGE5_MIN_TOTAL = 3      # total fully-open products needed for Stage 5
+_MATURE_MIN = 4.5          # blended adoption/capability score for a product to be "mature"
+_STAGE5_MIN_MATURE = 4     # mature fully-open products needed for Stage 5 (Mature Open Ecosystem)
+_CAPABLE_MIN = 4           # raw capability below which an open option is "not capable yet"
 _STAGE_NAMES = {0: "Void", 1: "Open Experiments", 2: "Emerging Alternatives",
                 3: "Viable Alternatives", 4: "Competitive Open Ecosystem",
                 5: "Mature Open Ecosystem"}
@@ -37,13 +37,15 @@ def _gap_bucket(cls: str) -> str:
 
 
 def _maturity_score(row: dict, w: dict) -> float:
-    # Per-category linear formula over the 1-5 axes; datasets have no capability
-    # score, so they are graded on adoption alone.
+    # Per-category linear blend of the 1-5 axes, normalized by the weight sum so the
+    # result stays on the 1-5 scale for any weights (identity when they sum to 1).
+    # Datasets have no capability score, so they are graded on adoption alone.
     adoption = (row.get("adoption") or {}).get("level") or 0
     capability = (row.get("capability") or {}).get("score")
     if capability is None:
         return float(adoption)
-    return w["adopt"] * adoption + w["cap"] * capability
+    wa, wc = w.get("adopt", 0.5), w.get("cap", 0.5)
+    return (wa * adoption + wc * capability) / ((wa + wc) or 1.0)
 
 
 def _stage_and_gaps(rows: list[dict], weights: dict) -> dict:
@@ -53,18 +55,17 @@ def _stage_and_gaps(rows: list[dict], weights: dict) -> dict:
     open-ish only serves to detect the openness gap. See docs/guides/gap-analysis.md.
     """
     w = weights or {"adopt": 0.5, "cap": 0.5}
-    enr = [(_gap_bucket((r.get("openness") or {}).get("class")), _maturity_score(r, w)) for r in rows]
-    open_scores = [s for b, s in enr if b == "open"]
-    total_open = len(open_scores)
-    mature_open = sum(1 for s in open_scores if s >= _MATURE_MIN)
-    best_open = max(open_scores, default=0.0)
-    mature_any = any(s >= _MATURE_MIN for _, s in enr)
+    enr = [(r, _gap_bucket((r.get("openness") or {}).get("class")), _maturity_score(r, w)) for r in rows]
+    open_rows = [(r, s) for r, b, s in enr if b == "open"]
+    mature_open = sum(1 for _, s in open_rows if s >= _MATURE_MIN)
+    best_open = max((s for _, s in open_rows), default=0.0)
+    mature_anywhere = any(s >= _MATURE_MIN for _, _, s in enr)
 
-    if mature_open >= _STAGE5_MIN_MATURE and total_open >= _STAGE5_MIN_TOTAL:
+    if mature_open >= _STAGE5_MIN_MATURE:
         stage = 5
     elif mature_open >= 1:
         stage = 4
-    elif best_open < 2 and not mature_any:
+    elif best_open < 2 and not mature_anywhere:
         stage = 0
     elif best_open < 3:
         stage = 1
@@ -81,13 +82,12 @@ def _stage_and_gaps(rows: list[dict], weights: dict) -> dict:
         gaps = ["maturity"]
     else:
         gaps = ["maturity"]
-        if mature_any:                       # capable mature options exist, but none fully open
+        if mature_anywhere:                  # capable mature options exist, but none fully open
             gaps.append("openness")
-        else:                                # nothing mature anywhere -> diagnose the limiting axis
-            best = max(rows, key=lambda r: _maturity_score(r, w), default=None)
-            bcap = (best or {}).get("capability", {}) or {}
-            cap = bcap.get("score")
-            gaps.append("capability" if (cap is not None and cap < 4) else "adoption")
+        else:                                # the open ecosystem itself is immature -> which axis?
+            best = max(open_rows, key=lambda rs: rs[1])[0] if open_rows else None
+            cap = ((best or {}).get("capability") or {}).get("score")
+            gaps.append("capability" if (cap is not None and cap < _CAPABLE_MIN) else "adoption")
 
     return {"num": stage, "name": _STAGE_NAMES[stage], "gaps": gaps}
 

--- a/docs/guides/gap-analysis.md
+++ b/docs/guides/gap-analysis.md
@@ -1,0 +1,69 @@
+# Gap Analysis Guide
+
+How each category is assigned a **maturity stage (0–5)** and a set of **gaps**, from
+product scores. Computed in `build/serialize.py` (`_stage_and_gaps`) and emitted per
+category into `build/notebook_data.json` as `stage` (`{num, name}`) and `gaps` (a list),
+alongside `layer`. The published notebook renders both as a badge + chips per category.
+
+This is the MVP, **category-level** collapse of CF's 6-stage maturity ladder (Void →
+Stage 5 / competitive). Per-stage product placement is deliberately out of scope for now.
+
+## Inputs (per product)
+
+- **openness bucket** from `openness.class` → `open` / `open-ish` / `closed`
+  (the canonical map in `docs/openness-class-map.json`).
+- **adoption** `adoption.level` (1–5), **capability** `capability.score` (1–5, null for datasets).
+- **per-category weights** `weights.adopt` / `weights.cap` (sum to 1).
+
+## Maturity score & "mature"
+
+Per-category linear formula: `score = w_adopt·adoption + w_cap·capability` (1–5).
+Datasets (no capability) are graded on adoption alone. A product is **mature** when its
+score **≥ 4.5** — a deliberately high bar (near-best on both axes).
+
+**Only fully-open products count toward maturity/stage** (strict open-only). Open-ish
+products (open-weights / source-available / open-toolchain) do *not* count toward the
+ecosystem's maturity; they only surface the openness gap.
+
+## Stage
+
+| | condition |
+|---|---|
+| **5 Mature Open Ecosystem** | ≥ 4 mature fully-open products **and** ≥ 3 total fully-open |
+| **4 Competitive Open Ecosystem** | 1–3 mature fully-open products |
+| **3 Viable Alternatives** | 0 mature; best fully-open score ≥ 3.5 |
+| **2 Emerging Alternatives** | 0 mature; best fully-open score 3–3.5 |
+| **1 Open Experiments** | 0 mature; best fully-open score 2–3 |
+| **0 Void** | no viable open option (best fully-open < 2 and nothing mature anywhere) |
+
+## Gaps (a set per category — extensible)
+
+- **Stage 5** → none.
+- **Stage 0** → `void`.
+- **Stage 4** → `maturity` (competitive, but needs more mature open products for depth/resilience).
+- **Stages 1–3** → `maturity` **plus** one diagnostic:
+  - `openness` — a *mature* product exists somewhere (open-ish or closed), but none is fully open
+    (the map's core finding: open-weights ≠ open-source);
+  - else `capability` — the best option's capability < 4 (nothing capable yet);
+  - else `adoption` — capable but under-adopted.
+
+The set is designed to grow: future flags (e.g. *maintenance* / *bus-factor*) slot in once
+those signals are available, without changing the stage logic.
+
+## Current result (421 products)
+
+| Stage | Categories | Gaps |
+|---|---|---|
+| 5 Mature | ml_frameworks, orchestration_agents | — |
+| 4 Competitive | inference_code, finetuning_code, evaluation_code, benchmark_eval_data, ui_api, agent_tools_protocols, deployment | maturity |
+| 3 Viable | base_pretrained, telemetry_observability, edge_hardware | maturity, openness |
+| 2 Emerging | training_synthetic_datasets | maturity, adoption |
+| 1 Open Experiments | finetuned_chat | maturity, openness |
+
+The story: open developer **tooling** is mature; the open frontier struggles are in
+**models, data, and hardware**, which carry openness/adoption gaps.
+
+## Tunable parameters
+
+`_MATURE_MIN` (4.5), `_STAGE5_MIN_MATURE` (4), `_STAGE5_MIN_TOTAL` (3), and the stage-1–3
+score bands live at the top of the gap-analysis block in `build/serialize.py`.

--- a/docs/guides/gap-analysis.md
+++ b/docs/guides/gap-analysis.md
@@ -35,15 +35,16 @@ surface — and it is reported independently of how mature the ecosystem is othe
 - **Adoption** — `adoption.level` (1–5).
 - **Capability** — `capability.score` (1–5; may be null for product types where capability is
   not meaningful, e.g. datasets).
-- **Per-category weights** — `weights.adopt` and `weights.cap` (sum to 1), so each category
-  blends the two axes according to what matters most for that part of the stack.
+- **Per-category weights** — `weights.adopt` and `weights.cap`, so each category blends the two
+  axes according to what matters most for that part of the stack.
 
 ## Maturity score and the "mature" bar
 
-Each product gets a single **maturity score** on a 1–5 scale from a per-category linear blend:
+Each product gets a single **maturity score** on a 1–5 scale from a per-category linear blend,
+normalized by the weight sum so it stays on the 1–5 scale for any weights:
 
 ```
-score = weights.adopt · adoption + weights.cap · capability
+score = (weights.adopt · adoption + weights.cap · capability) / (weights.adopt + weights.cap)
 ```
 
 Where capability is not meaningful (null), the product is graded on adoption alone. A product
@@ -63,7 +64,7 @@ expose. Counting also distinguishes depth from a single standout (see Stage 5).
 
 | Stage | Name | Condition |
 |------:|------|-----------|
-| **5** | Mature Open Ecosystem | enough mature fully-open products **and** enough total fully-open products to be redundant/resilient |
+| **5** | Mature Open Ecosystem | enough mature fully-open products to be redundant/resilient |
 | **4** | Competitive Open Ecosystem | at least one mature fully-open product, but not yet enough for depth |
 | **3** | Viable Alternatives | no mature fully-open product, but the best fully-open option is strong |
 | **2** | Emerging Alternatives | no mature fully-open product; the best fully-open option is promising but limited |
@@ -79,8 +80,8 @@ Gaps are a **set** (zero or more) per category, so a category can carry more tha
 derived from the same metrics as the stage:
 
 - **`void`** — no usable open option at all.
-- **`capability`** — the best open option isn't capable enough to be useful.
-- **`adoption`** — a capable open option exists but is under-adopted.
+- **`capability`** — the best fully-open option isn't capable enough to be useful.
+- **`adoption`** — a capable fully-open option exists but is under-adopted.
 - **`maturity`** — open options exist and at least one may be mature, but the ecosystem lacks
   the depth/redundancy of a mature ecosystem (too few mature fully-open products).
 - **`openness`** — capable, adopted options exist, but the mature ones are not fully open
@@ -107,8 +108,9 @@ The thresholds are deliberate, tunable choices rather than fixed law. They live 
 constants at the top of the gap-analysis block in `build/serialize.py`:
 
 - the **mature** score threshold,
-- the counts of mature and total fully-open products required for **Stage 5**,
-- the best-fully-open score bands that separate **Stages 1–3**.
+- the count of mature fully-open products required for **Stage 5**,
+- the best-fully-open score bands that separate **Stages 1–3**,
+- the raw capability cutoff that splits a `capability` gap from an `adoption` gap.
 
 Adjusting them shifts how demanding each rung is; they should be reviewed when the scoring
 rubric or the curation density changes materially.

--- a/docs/guides/gap-analysis.md
+++ b/docs/guides/gap-analysis.md
@@ -1,69 +1,125 @@
-# Gap Analysis Guide
+# Gap Analysis
 
-How each category is assigned a **maturity stage (0–5)** and a set of **gaps**, from
-product scores. Computed in `build/serialize.py` (`_stage_and_gaps`) and emitted per
-category into `build/notebook_data.json` as `stage` (`{num, name}`) and `gaps` (a list),
-alongside `layer`. The published notebook renders both as a badge + chips per category.
+Gap analysis assigns every stack-map category two derived attributes, computed
+deterministically from the scores of the products in that category:
 
-This is the MVP, **category-level** collapse of CF's 6-stage maturity ladder (Void →
-Stage 5 / competitive). Per-stage product placement is deliberately out of scope for now.
+- a **maturity stage** (`0`–`5`) — how far the category's *open* ecosystem has progressed
+  toward parity with the best available option, and
+- a **set of gaps** — what is missing for it to advance.
+
+Both are recomputed from source on every build, so they never drift from the underlying
+product scores. They are emitted per category into `build/notebook_data.json` as
+`stage` (`{num, name}`) and `gaps` (a list, possibly empty), alongside `layer`, and the
+published notebook renders them as a stage badge with gap chips.
+
+Stages and gaps are assigned at the **category** level. Placing individual products on the
+ladder, or splitting a category into sub-bands, is a possible later refinement; it does not
+change the model below.
+
+## The model
+
+A category's open ecosystem climbs a ladder from **Void** (no usable open option) to a
+**Mature Open Ecosystem** (several open options are strong, widely used, and redundant). The
+stage is the rung it currently occupies. The gaps name what is keeping it off the next rung.
+
+Openness is treated as an axis **orthogonal** to maturity: a category can have strong,
+widely-adopted options that simply aren't *fully* open (e.g. open-weights rather than
+open-source). That situation is the **openness gap** — the distinction the map exists to
+surface — and it is reported independently of how mature the ecosystem is otherwise.
 
 ## Inputs (per product)
 
-- **openness bucket** from `openness.class` → `open` / `open-ish` / `closed`
-  (the canonical map in `docs/openness-class-map.json`).
-- **adoption** `adoption.level` (1–5), **capability** `capability.score` (1–5, null for datasets).
-- **per-category weights** `weights.adopt` / `weights.cap` (sum to 1).
+- **Openness bucket** — `openness.class` collapsed to `open` / `open-ish` / `closed` via the
+  canonical map in [`openness-class-map.json`](../openness-class-map.json). "Fully open" means
+  the `open` bucket; "open-ish" is partial openness (e.g. open-weights, source-available).
+- **Adoption** — `adoption.level` (1–5).
+- **Capability** — `capability.score` (1–5; may be null for product types where capability is
+  not meaningful, e.g. datasets).
+- **Per-category weights** — `weights.adopt` and `weights.cap` (sum to 1), so each category
+  blends the two axes according to what matters most for that part of the stack.
 
-## Maturity score & "mature"
+## Maturity score and the "mature" bar
 
-Per-category linear formula: `score = w_adopt·adoption + w_cap·capability` (1–5).
-Datasets (no capability) are graded on adoption alone. A product is **mature** when its
-score **≥ 4.5** — a deliberately high bar (near-best on both axes).
+Each product gets a single **maturity score** on a 1–5 scale from a per-category linear blend:
 
-**Only fully-open products count toward maturity/stage** (strict open-only). Open-ish
-products (open-weights / source-available / open-toolchain) do *not* count toward the
-ecosystem's maturity; they only surface the openness gap.
+```
+score = weights.adopt · adoption + weights.cap · capability
+```
 
-## Stage
+Where capability is not meaningful (null), the product is graded on adoption alone. A product
+is **mature** when its score clears a high threshold (a near-best-on-both-axes bar). The bar is
+intentionally demanding: because the map curates the most prominent products in each category,
+a low bar would call almost everything mature.
 
-| | condition |
-|---|---|
-| **5 Mature Open Ecosystem** | ≥ 4 mature fully-open products **and** ≥ 3 total fully-open |
-| **4 Competitive Open Ecosystem** | 1–3 mature fully-open products |
-| **3 Viable Alternatives** | 0 mature; best fully-open score ≥ 3.5 |
-| **2 Emerging Alternatives** | 0 mature; best fully-open score 3–3.5 |
-| **1 Open Experiments** | 0 mature; best fully-open score 2–3 |
-| **0 Void** | no viable open option (best fully-open < 2 and nothing mature anywhere) |
+## Counting rule: open-only
 
-## Gaps (a set per category — extensible)
+Only **fully-open** products count toward a category's maturity and stage. Open-ish products do
+not advance the stage — they are used solely to detect the openness gap. The rationale: the
+ladder measures the health of the genuinely-open ecosystem, and crediting partially-open
+products to it would blur exactly the open-source-vs-open-weights line the map is built to
+expose. Counting also distinguishes depth from a single standout (see Stage 5).
 
-- **Stage 5** → none.
-- **Stage 0** → `void`.
-- **Stage 4** → `maturity` (competitive, but needs more mature open products for depth/resilience).
-- **Stages 1–3** → `maturity` **plus** one diagnostic:
-  - `openness` — a *mature* product exists somewhere (open-ish or closed), but none is fully open
-    (the map's core finding: open-weights ≠ open-source);
-  - else `capability` — the best option's capability < 4 (nothing capable yet);
-  - else `adoption` — capable but under-adopted.
+## Stages
 
-The set is designed to grow: future flags (e.g. *maintenance* / *bus-factor*) slot in once
-those signals are available, without changing the stage logic.
+| Stage | Name | Condition |
+|------:|------|-----------|
+| **5** | Mature Open Ecosystem | enough mature fully-open products **and** enough total fully-open products to be redundant/resilient |
+| **4** | Competitive Open Ecosystem | at least one mature fully-open product, but not yet enough for depth |
+| **3** | Viable Alternatives | no mature fully-open product, but the best fully-open option is strong |
+| **2** | Emerging Alternatives | no mature fully-open product; the best fully-open option is promising but limited |
+| **1** | Open Experiments | fully-open options exist but are weak on both axes |
+| **0** | Void | no usable open option exists (and nothing is mature anywhere) |
 
-## Current result (421 products)
+The exact count and score cutoffs that separate the stages are policy parameters (below),
+chosen so the ladder discriminates rather than bunching categories at one rung.
 
-| Stage | Categories | Gaps |
-|---|---|---|
-| 5 Mature | ml_frameworks, orchestration_agents | — |
-| 4 Competitive | inference_code, finetuning_code, evaluation_code, benchmark_eval_data, ui_api, agent_tools_protocols, deployment | maturity |
-| 3 Viable | base_pretrained, telemetry_observability, edge_hardware | maturity, openness |
-| 2 Emerging | training_synthetic_datasets | maturity, adoption |
-| 1 Open Experiments | finetuned_chat | maturity, openness |
+## Gaps
 
-The story: open developer **tooling** is mature; the open frontier struggles are in
-**models, data, and hardware**, which carry openness/adoption gaps.
+Gaps are a **set** (zero or more) per category, so a category can carry more than one. They are
+derived from the same metrics as the stage:
 
-## Tunable parameters
+- **`void`** — no usable open option at all.
+- **`capability`** — the best open option isn't capable enough to be useful.
+- **`adoption`** — a capable open option exists but is under-adopted.
+- **`maturity`** — open options exist and at least one may be mature, but the ecosystem lacks
+  the depth/redundancy of a mature ecosystem (too few mature fully-open products).
+- **`openness`** — capable, adopted options exist, but the mature ones are not fully open
+  (open-ish or closed). This is the orthogonal flag; it can co-occur with the others.
 
-`_MATURE_MIN` (4.5), `_STAGE5_MIN_MATURE` (4), `_STAGE5_MIN_TOTAL` (3), and the stage-1–3
-score bands live at the top of the gap-analysis block in `build/serialize.py`.
+A fully mature ecosystem carries no gaps.
+
+The set is **extensible**: new gap types (for example *maintenance* or *bus-factor* risk, once
+those signals are tracked) can be added without changing the staging logic — they are simply
+additional flags computed per category.
+
+## Worked example (illustrative)
+
+A hypothetical category whose strongest, most-adopted products are all open-*weights* (not
+open-source), with only weak fully-open options behind them: it has no mature *fully-open*
+product, so it sits low on the ladder (Viable / Emerging) and carries a **maturity** gap; and
+because capable, adopted options do exist but aren't fully open, it also carries an
+**openness** gap. Contrast a category with several strong, widely-used open-source libraries:
+multiple mature fully-open products → Stage 5, no gaps.
+
+## Policy parameters
+
+The thresholds are deliberate, tunable choices rather than fixed law. They live as named
+constants at the top of the gap-analysis block in `build/serialize.py`:
+
+- the **mature** score threshold,
+- the counts of mature and total fully-open products required for **Stage 5**,
+- the best-fully-open score bands that separate **Stages 1–3**.
+
+Adjusting them shifts how demanding each rung is; they should be reviewed when the scoring
+rubric or the curation density changes materially.
+
+## Where it lives
+
+- **Computed** in `build/serialize.py` (`_stage_and_gaps`), from the per-product scores in
+  `sources/scores/` and the per-category `weights` in `sources/categories/`.
+- **Emitted** into `build/notebook_data.json` per category (`stage`, `gaps`).
+- **Displayed** in the published notebook (stage badge + gap chips) and available to any
+  downstream consumer reading the notebook payload.
+
+For the current assignments, read the live notebook payload — they are regenerated on every
+build and are intentionally not duplicated here.

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1,4 +1,32 @@
-from build.serialize import build_payload
+from build.serialize import build_payload, _stage_and_gaps
+
+
+def _p(cls, adoption, capability):
+    return {"openness": {"class": cls}, "adoption": {"level": adoption},
+            "capability": {"score": capability}}
+
+
+def test_stage5_mature_open_ecosystem():
+    rows = [_p("open_source", 5, 5) for _ in range(4)]  # 4 mature fully-open
+    sg = _stage_and_gaps(rows, {"adopt": 0.5, "cap": 0.5})
+    assert sg["num"] == 5 and sg["gaps"] == []
+
+
+def test_openness_gap_when_mature_options_are_open_ish():
+    rows = [_p("open_weights", 5, 5) for _ in range(3)]  # mature but open-ish, none fully open
+    sg = _stage_and_gaps(rows, {"adopt": 0.5, "cap": 0.5})
+    assert sg["num"] < 5 and "maturity" in sg["gaps"] and "openness" in sg["gaps"]
+
+
+def test_void_when_no_open_option():
+    sg = _stage_and_gaps([_p("closed", 1, 1)], {"adopt": 0.5, "cap": 0.5})
+    assert sg["num"] == 0 and sg["gaps"] == ["void"]
+
+
+def test_capability_gap_when_nothing_mature_and_weak():
+    rows = [_p("open_source", 2, 2)]  # fully open but weak on both axes
+    sg = _stage_and_gaps(rows, {"adopt": 0.5, "cap": 0.5})
+    assert "maturity" in sg["gaps"] and "capability" in sg["gaps"]
 
 
 def _sources():


### PR DESCRIPTION
## Summary

Implements the MVP **gap analysis** (category-level): each category gets a maturity **stage (0–5)** and a set of **gaps**, computed from product openness/adoption/capability + the per-category weights.

- **Data:** `serialize.py` computes it (`_stage_and_gaps`) and emits `stage` (`{num,name}`) + `gaps` (list) per category into `notebook_data.json`, next to `layer` — so CF reads `categories[<id>].stage` / `.gaps` straight from the notebook.
- **Notebook:** `render.py` shows a stage badge + gap chips on each category section (verified in the HTML export).
- **Doc:** `docs/guides/gap-analysis.md` (also serves as the spec).

## Logic (locked with Carl)

- Maturity = `w_adopt·adoption + w_cap·capability` (datasets: adoption only); **mature ≥ 4.5**.
- **Strict open-only**: only fully-open products count toward maturity/stage; open-ish only surfaces the openness gap.
- **Stage 5** = ≥4 mature fully-open **and** ≥3 total fully-open; **Stage 4** = 1–3 mature; **0–3** banded by best fully-open score.
- **Gaps** (a set, extensible): `void` / `capability` / `adoption` / `maturity` + orthogonal `openness` flag (capable mature options exist but none fully open).

## Result (421 products)

| Stage | Categories | Gaps |
|---|---|---|
| 5 Mature | ml_frameworks, orchestration_agents | — |
| 4 Competitive | inference, finetuning, evaluation, benchmark, ui_api, agent_tools, deployment | maturity |
| 3 Viable | base_pretrained, telemetry_observability, edge_hardware | maturity, openness |
| 2 Emerging | training_synthetic_datasets | maturity, adoption |
| 1 Open Experiments | finetuned_chat | maturity, openness |

## Test plan
- [x] `build.validate` → 0 errors
- [x] `pytest -q` → 26 passed (4 new gap-logic tests)
- [x] `render.py` + `marimo check` OK; HTML export shows the badges/chips
- [ ] CI · **republish** after merge

Independent of PR #32 (gaps are computed in serialize and only *displayed* by the notebook; the inline bucket map mirrors `openness-class-map.json`). Generated `ai-stack-map.py` / `notebook_data.json` not committed (bot regenerates).