### PR TITLE
docs refresh + monochrome stage ladder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,5 +126,7 @@ After a PR merges, a maintainer (OSO MCP write access) may need to:
 
 - Query conventions: `docs/guides/queries.md`
 - Notebook style: `docs/guides/notebooks.md`
-- Coverage backlog: `docs/catalog-gaps.md`
+- Openness scoring: `docs/guides/openness-spectrum.md`
+- Gap analysis (stages + gaps): `docs/guides/gap-analysis.md`
+- Coverage backlog: tracked in GitHub issues
 - Warehouse inventory: `warehouse/models/README.md`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Invariants (validated in CI):
    ```yaml
    name: <slug>
    display_name: <Display Name>
-   type: model | software | dataset
+   type: model | software | dataset | hardware
    description: <one paragraph: what it is, why it matters>
    github:
    - url: https://github.com/org/repo
@@ -95,6 +95,7 @@ Each score file has three axes. **Every non-null value needs at least one
   - models: `open_source`, `open_weights`, `restricted`, `closed`
   - software: `open_source`, `source_available`, `open_core`, `closed`
   - datasets: `open`, `gated`, `documented_only`, `closed`
+  - hardware: `open_hardware`, `open_toolchain`, `documented`, `restricted`, `closed`
 - **adoption** (`level:` 1-5, `signal_type:` one of `active_users`,
   `usage_volume`, `reported_traction`, `stars_fallback`, `unknown`): real usage
   (downloads, active users, deployments) beats stars. `stars_fallback` can

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ The public data + modeling home behind the [AI Stack Map](https://oso.xyz/curren
 
 Curated YAML in `sources/` feeds a deterministic build pipeline that serializes to
 `build/notebook_data.json`, renders to `notebooks/ai-stack-map.py`, and publishes to
-the OSO platform. There is no front-end in this repo; the website lives in
-`ecosystem-mapping/app/`.
+the OSO platform. There is no front-end in this repo.
 
 ---
 
@@ -28,10 +27,10 @@ those on merge to `main`. Code and data are [MIT licensed](LICENSE).
 |------|------|
 | `sources/` | Curated YAML: organizations, categories, products, scores + `taxonomy.yaml` |
 | `build/` | Validate, serialize, render pipeline |
-| `notebooks/` | Generated marimo notebook (`ai-stack-map.py`) |
+| `notebooks/` | Marimo notebooks: generated `ai-stack-map.py` + hand-authored `products-view.py` (payload generated) |
 | `warehouse/` | UDM SQL, ingest fetchers, and external CSV catalog |
 | `docs/schemas/` | JSON Schemas for all source file types |
-| `docs/guides/` | Query and notebook conventions |
+| `docs/guides/` | Query, notebook, openness, and gap-analysis conventions |
 | `docs/runbooks/` | Maintainer deploy steps (MCP write access) |
 | `skills/` | Agent skills for common editor workflows |
 | `tests/` | pytest suite for build helpers |
@@ -73,6 +72,9 @@ uv run marimo export html notebooks/ai-stack-map.py -o /tmp/preview.html
 
 Serialize and render locally for preview only. Do not commit `build/notebook_data.json` or
 `notebooks/ai-stack-map.py`.
+
+The companion `notebooks/products-view.py` is hand-authored; only its embedded data payload
+is regenerated, by `uv run python build/products_view_data.py` (the bot refreshes it on merge).
 
 Note: `build/_frozen_long_tail.json` is a hand-frozen long-tail snapshot (fixture, not derived from
 live warehouse data yet).
@@ -140,4 +142,6 @@ See `docs/runbooks/`:
 
 - Query conventions: `docs/guides/queries.md`
 - Notebook style: `docs/guides/notebooks.md`
+- Openness scoring: `docs/guides/openness-spectrum.md`
+- Gap analysis (stages + gaps): `docs/guides/gap-analysis.md`
 - Warehouse inventory: `warehouse/models/README.md`

--- a/build/render.py
+++ b/build/render.py
@@ -815,9 +815,6 @@ def stages_table(C, DATA, F, ORDER, mo):
         _sn = (DATA["categories"][_cid].get("stage") or {}).get("num", 0)
         _by_stage.setdefault(_sn, []).append(DATA["categories"][_cid]["label"])
 
-    def _scol(_n):
-        return C["healthy"] if _n >= 5 else C["accent"] if _n == 4 else C["warm"] if _n >= 2 else C["signal"]
-
     _rows = []
     for _n, _name, _desc in _DEFS:
         _cats = _by_stage.get(_n, [])
@@ -835,8 +832,8 @@ def stages_table(C, DATA, F, ORDER, mo):
             f'<tr style="border-bottom:1px solid {C["rule"]}; vertical-align:top;">'
             f'<td style="padding:14px 14px 14px 0; white-space:nowrap;">'
             f'<span style="display:inline-flex; align-items:center; justify-content:center; width:24px; height:24px; '
-            f'font-family:{F["mono"]}; font-size:0.8rem; font-weight:600; color:#fff; background:{_scol(_n)}; '
-            f'border-radius:50%;">{_n}</span></td>'
+            f'box-sizing:border-box; font-family:{F["mono"]}; font-size:0.8rem; font-weight:600; color:{C["ink"]}; '
+            f'background:#fff; border:1.5px solid {C["ink"]}; border-radius:50%;">{_n}</span></td>'
             f'<td style="padding:14px 16px 14px 0; font-family:{F["headline"]}; font-size:0.98rem; '
             f'font-weight:500; color:{C["ink"]}; white-space:nowrap;">{_name}</td>'
             f'<td style="padding:14px 16px 14px 0; font-family:{F["body"]}; font-size:0.86rem; '

--- a/docs/guides/gap-analysis.md
+++ b/docs/guides/gap-analysis.md
@@ -120,8 +120,9 @@ rubric or the curation density changes materially.
 - **Computed** in `build/serialize.py` (`_stage_and_gaps`), from the per-product scores in
   `sources/scores/` and the per-category `weights` in `sources/categories/`.
 - **Emitted** into `build/notebook_data.json` per category (`stage`, `gaps`).
-- **Displayed** in the published notebook (stage badge + gap chips) and available to any
-  downstream consumer reading the notebook payload.
+- **Displayed** in the published notebook as a maturity-ladder table (each category placed on
+  its stage). The per-category gap set is carried in the payload for downstream consumers
+  rather than shown inline.
 
 For the current assignments, read the live notebook payload — they are regenerated on every
 build and are intentionally not duplicated here.

--- a/docs/guides/queries.md
+++ b/docs/guides/queries.md
@@ -91,10 +91,10 @@ GROUP BY pc.collection_name, c.display_name
 
 ## Gap semantics
 
-- [`docs/catalog-gaps.md`](../catalog-gaps.md) = coverage/ingestion backlog (missing orgs/repos).
+- Coverage/ingestion gaps (missing orgs/repos) are tracked in GitHub issues.
 - `scores.ossd_coverage` = per-org oss-directory match rates.
 
 ## Pointers
 
 - Inventory + schedules: [`warehouse/models/README.md`](../../warehouse/models/README.md)
-- Coverage backlog: [`docs/catalog-gaps.md`](../catalog-gaps.md)
+- Coverage backlog: tracked in GitHub issues

--- a/skills/add-product/SKILL.md
+++ b/skills/add-product/SKILL.md
@@ -21,7 +21,7 @@ Creates four coordinated edits: a product file, a score file, a category roster 
    ```yaml
    name: <slug>
    display_name: <Display Name>
-   type: model | software | dataset
+   type: model | software | dataset | hardware
    description: <one paragraph>
    github:
      - url: https://github.com/<owner>/<repo>
@@ -84,6 +84,13 @@ Assign `class` first, then the 0–5 `score` (full rationale in
   `source_available` = 2; `closed` = 0–1. **Fair-code** (e.g. n8n's Sustainable Use
   License) and **BSL 1.1** (e.g. Pathway) are NOT OSI → `source_available`, even when
   marketed as "open source".
+- **Datasets:** `open` (public download + OSI-compatible/open-data license) = 5;
+  `gated` (free but access-gated, e.g. click-through or HF gating) = 2; `documented_only`
+  (composition documented but data not redistributable) = 1; `closed` = 0–1.
+- **Hardware:** `open_hardware` (open schematics/RTL + open toolchain) = 5; `open_toolchain`
+  (proprietary silicon but open SDK/datasheets, e.g. a board with a published BSP) = 3;
+  `documented` (datasheets public, design and firmware proprietary) = 2; `restricted` /
+  `closed` (NDA-gated or fully proprietary) = 0–1.
 - A custom copyright line can make GitHub report `NOASSERTION` for a genuine MIT/Apache
   license — check the LICENSE body, don't trust the GitHub classifier.
 - Keep generic version buckets (e.g. "GPT-5 line", "Claude Opus 4.x") rather than

--- a/skills/pyoso-analyst/SKILL.md
+++ b/skills/pyoso-analyst/SKILL.md
@@ -55,7 +55,7 @@ If you detect a request that requires write access, you must:
    - Keep heavy queries in memoized/parameterized cells when possible.
 
 5. **Report results with limitations**
-   - If a requested dataset is missing, point to `docs/catalog-gaps.md`.
+   - If a requested dataset is missing, flag it as a coverage gap (tracked in GitHub issues).
    - Summarize what you can validate vs what needs OSO-side remediation.
 
 ## Quick Reference


### PR DESCRIPTION
## Summary
- **Docs review**: add the `hardware` product type and hardware/dataset openness classes (CONTRIBUTING + add-product skill); remove dangling `docs/catalog-gaps.md` links (file was deleted) and point the coverage backlog at GitHub issues; README drops a stale website path, mentions `products-view.py`, and lists the openness-spectrum + gap-analysis guides; gap-analysis guide now describes the maturity-ladder table display.
- **Notebook**: stage numbers in the maturity-ladder table render as black-outlined circles (ink on white) instead of the traffic-light fill.

## Test plan
- `build.validate` clean, `marimo check` clean, HTML export renders.
- Generated artifacts left to the regenerate bot.