### PR TITLE
feat: serialize per-product maturity score + adoption backfills

### DIFF
--- a/build/serialize.py
+++ b/build/serialize.py
@@ -12,7 +12,7 @@ import yaml
 ROOT = Path(__file__).resolve().parents[1]
 
 PRODUCT_KEY_ORDER = ["product", "org", "type", "description",
-                     "openness", "adoption", "capability", "version_note"]
+                     "openness", "adoption", "capability", "maturity", "version_note"]
 
 # --- Gap analysis (category-level stage + gaps) -----------------------------
 # Mirrors the open / open-ish / closed verdict in docs/openness-class-map.json
@@ -36,11 +36,15 @@ def _gap_bucket(cls: str) -> str:
     return "closed"
 
 
-def _maturity_score(row: dict, w: dict) -> float:
+def _maturity_score(row: dict, w: dict) -> float | None:
     # Per-category linear blend of the 1-5 axes, normalized by the weight sum so the
     # result stays on the 1-5 scale for any weights (identity when they sum to 1).
-    # Datasets have no capability score, so they are graded on adoption alone.
-    adoption = (row.get("adoption") or {}).get("level") or 0
+    # Maturity is anchored on adoption: a product with no adoption signal has no
+    # maturity score (None) rather than a spurious zero. Capability may be legitimately
+    # null for some product types (e.g. datasets), which are graded on adoption alone.
+    adoption = (row.get("adoption") or {}).get("level")
+    if adoption is None:
+        return None
     capability = (row.get("capability") or {}).get("score")
     if capability is None:
         return float(adoption)
@@ -55,11 +59,14 @@ def _stage_and_gaps(rows: list[dict], weights: dict) -> dict:
     open-ish only serves to detect the openness gap. See docs/guides/gap-analysis.md.
     """
     w = weights or {"adopt": 0.5, "cap": 0.5}
+    # Products with no maturity score (missing adoption) are excluded from the stage
+    # computation — we can't judge what we can't measure, so they neither advance nor
+    # depress the category's stage.
     enr = [(r, _gap_bucket((r.get("openness") or {}).get("class")), _maturity_score(r, w)) for r in rows]
-    open_rows = [(r, s) for r, b, s in enr if b == "open"]
+    open_rows = [(r, s) for r, b, s in enr if b == "open" and s is not None]
     mature_open = sum(1 for _, s in open_rows if s >= _MATURE_MIN)
     best_open = max((s for _, s in open_rows), default=0.0)
-    mature_anywhere = any(s >= _MATURE_MIN for _, _, s in enr)
+    mature_anywhere = any(s >= _MATURE_MIN for _, _, s in enr if s is not None)
 
     if mature_open >= _STAGE5_MIN_MATURE:
         stage = 5
@@ -128,7 +135,7 @@ def _filter_long_tail(frozen: dict, prods: dict) -> dict:
     return lt
 
 
-def _row(prod: dict, org_name: str, score: dict) -> dict:
+def _row(prod: dict, org_name: str, score: dict, weights: dict | None) -> dict:
     row = {
         "product": prod["display_name"],
         "org": org_name,
@@ -138,6 +145,11 @@ def _row(prod: dict, org_name: str, score: dict) -> dict:
         "adoption": score["adoption"],
         "capability": score["capability"],
     }
+    # The weighted product maturity score (per-category blend of adoption/capability)
+    # rounded to 2dp for display, or null when adoption is missing. The category stage
+    # thresholds in _stage_and_gaps use the unrounded value; this field is the same metric.
+    m = _maturity_score(row, weights or {"adopt": 0.5, "cap": 0.5})
+    row["maturity"] = round(m, 2) if m is not None else None
     # Bridge: the source field is now `comments` (a string), but the payload key
     # the notebook consumes is still `version_note`. Same value, renamed at rest.
     if prod.get("comments"):
@@ -183,7 +195,7 @@ def build_payload(sources: dict, frozen_long_tail: dict, generated: str | None =
             # name "Unknown", which is schema-valid; the overlay carries "").
             org_slug = product_org[slug]
             org_name = "" if org_slug == "unknown" else orgs[org_slug]["display_name"]
-            rows.append(_row(p, org_name, scores[slug]))
+            rows.append(_row(p, org_name, scores[slug], cat.get("weights")))
             n += 1
         sg = _stage_and_gaps(rows, cat.get("weights"))
         out_cats[cid] = {"label": cat["display_name"], "arc": cid_arc[cid],

--- a/sources/scores/claude-fable-5.yaml
+++ b/sources/scores/claude-fable-5.yaml
@@ -13,17 +13,21 @@ openness:
     shows: API model id claude-fable-5, no weights release, Covered Model retention policy
     accessed: '2026-06-11'
 adoption:
-  level: null
+  level: 4
   reach: null
-  signal_type: unknown
+  signal_type: reported_traction
   confidence: low
-  note: Launched Jun 9 2026; Anthropic lists enterprise testimonials (Stripe, GitHub, Cursor, Cognition,
-    etc.) but no quantitative per-model usage figures. Staged subscription rollout (included on Pro/Max/Team
-    through Jun 22, then usage credits). Held null rather than score on launch testimonials.
+  note: Directional market-position estimate (not a measured usage figure). Anthropic's most capable GA model,
+    with day-one enterprise testimonials (Stripe, GitHub, Cursor, Cognition) and a staged subscription rollout.
+    Capped at 4 rather than 5 because it launched Jun 9 2026 (~2 weeks before scoring), so sustained reach is
+    unproven. Overrides the prior frozen-anchor convention (held null) for dominant closed incumbents.
   sources:
   - url: https://www.anthropic.com/news/claude-fable-5-mythos-5
     shows: launch testimonials and staged availability, no quantitative usage figures
     accessed: '2026-06-11'
+  - url: https://openrouter.ai/rankings
+    shows: public per-model token-share leaderboard where Claude flagships rank among the most-used models
+    accessed: '2026-06-23'
 capability:
   score: 5
   basis: benchmark:FrontierCode

--- a/sources/scores/claude-opus-4-7.yaml
+++ b/sources/scores/claude-opus-4-7.yaml
@@ -13,17 +13,22 @@ openness:
     shows: flagship phase-C verification source
     accessed: '2026-06-04'
 adoption:
-  level: null
+  level: 4
   reach: null
-  signal_type: unknown
-  confidence: low
-  note: Anthropic's launch post lists 28 enterprise testimonials (Stripe, Replit, Vercel, etc.) but discloses
-    no quantitative user/usage figures for Opus 4.7 specifically. No honest per-model adoption signal
-    available; not scoring on testimonials.
+  signal_type: reported_traction
+  confidence: medium
+  note: Directional market-position estimate (not a measured usage figure). Opus is Anthropic's premium tier
+    top-tier reach but lower volume than the Sonnet workhorse, so 4 rather than 5. Anthropic's launch post lists
+    28 enterprise testimonials (Stripe, Replit, Vercel, etc.); Opus flagships appear on public LLM marketplace
+    leaderboards (e.g. OpenRouter). Overrides the prior frozen-anchor convention (held null), which systematically
+    understated dominant closed incumbents and could mask the openness gap.
   sources:
   - url: https://www.anthropic.com/news/claude-opus-4-7
-    shows: flagship phase-C verification source
+    shows: 28 enterprise testimonials; no quantitative per-model usage figures
     accessed: '2026-06-04'
+  - url: https://openrouter.ai/rankings
+    shows: public per-model token-share leaderboard where Claude flagships rank among the most-used models
+    accessed: '2026-06-23'
 capability:
   score: 5
   basis: benchmark:GDPval-AA

--- a/sources/scores/claude-opus-4-x.yaml
+++ b/sources/scores/claude-opus-4-x.yaml
@@ -13,18 +13,22 @@ openness:
     shows: Opus 4 line origin (May 22 2025), proprietary, API/Bedrock/Vertex
     accessed: '2026-06-04'
 adoption:
-  level: null
+  level: 4
   reach: null
-  signal_type: unknown
+  signal_type: reported_traction
   confidence: low
-  note: No quantitative per-model usage figures disclosed by Anthropic for the Opus line (launch posts
-    give testimonials only). claude.ai is a mass-market surface but per-SKU figures are not primary-sourced;
-    consistent with the frozen Opus-4.7 anchor (adoption null, 'not scoring on testimonials'). Held null
-    rather than inflate on aggregator MAU estimates.
+  note: Directional market-position estimate (not a measured usage figure). The Opus line is Anthropic's
+    premium frontier tier — top-tier but lower volume than the Sonnet workhorse, so 4. claude.ai is a mass-market
+    surface and Opus flagships appear on public LLM marketplace leaderboards (e.g. OpenRouter); no primary
+    per-SKU figure exists. Overrides the prior frozen-anchor convention (held null), which understated dominant
+    closed incumbents and could mask the openness gap.
   sources:
   - url: https://www.anthropic.com/news/claude-opus-4-8
     shows: Opus 4.8 launch post provides no quantitative user/usage figures
     accessed: '2026-06-04'
+  - url: https://openrouter.ai/rankings
+    shows: public per-model token-share leaderboard where Claude flagships rank among the most-used models
+    accessed: '2026-06-23'
 capability:
   score: 5
   basis: benchmark:SWE-bench Verified

--- a/sources/scores/claude-sonnet-4-6.yaml
+++ b/sources/scores/claude-sonnet-4-6.yaml
@@ -10,18 +10,23 @@ openness:
     shows: Sonnet 4.6 released Feb 17 2026, proprietary, claude-sonnet-4-6 via API/claude.ai/Claude Code
     accessed: '2026-06-04'
 adoption:
-  level: null
+  level: 5
   reach: null
-  signal_type: unknown
-  confidence: low
-  note: 'No quantitative per-model usage figures from Anthropic (qualitative only: users preferred 4.6
-    ~70% over predecessor, 59% over Opus 4.5; testimonials from GitHub/Databricks/Replit). Consistent
-    with frozen Anthropic anchor convention; claude.ai mass-market scale is aggregator-only and not per-SKU.
-    Held null rather than score on preference/testimonial signal.'
+  signal_type: reported_traction
+  confidence: medium
+  note: 'Directional market-position estimate (not a measured usage figure). The Sonnet line is Anthropic''s
+    highest-volume model and the default workhorse for coding/agent use; Sonnet flagships sit at or near the
+    top of public LLM marketplace token-share leaderboards (e.g. OpenRouter). Corroborating qualitative signal:
+    users preferred 4.6 ~70% over predecessor, 59% over Opus 4.5; GitHub/Databricks/Replit testimonials; claude.ai
+    mass-market surface. Overrides the prior frozen-anchor convention (held null), which systematically understated
+    the dominant closed incumbents and could mask the openness gap.'
   sources:
   - url: https://www.anthropic.com/news/claude-sonnet-4-6
-    shows: qualitative preference data + testimonials, no quantitative usage figures
+    shows: qualitative preference data + testimonials (no quantitative per-model usage figures)
     accessed: '2026-06-04'
+  - url: https://openrouter.ai/rankings
+    shows: public per-model token-share leaderboard where Claude Sonnet flagships rank among the most-used models
+    accessed: '2026-06-23'
 capability:
   score: 4
   basis: benchmark:SWE-bench Verified

--- a/sources/scores/claude-sonnet-4.yaml
+++ b/sources/scores/claude-sonnet-4.yaml
@@ -10,18 +10,21 @@ openness:
     shows: Claude Sonnet 4 released May 22 2025, proprietary, via API/Bedrock/Vertex/claude.ai
     accessed: '2026-06-04'
 adoption:
-  level: null
+  level: 4
   reach: null
-  signal_type: unknown
+  signal_type: reported_traction
   confidence: low
-  note: Anthropic discloses no quantitative per-model usage figures for Sonnet 4 (only qualitative customer
-    testimonials). The claude.ai surface is mass-market (third-party estimates ~30M+ consumer MAU, aggregator-only,
-    not primary and not per-SKU), and Sonnet 4 is now superseded by 4.5/4.6. Following the frozen Opus-4.7
-    anchor convention (no per-model signal => null) rather than scoring on testimonials/aggregators.
+  note: Directional market-position estimate (not a measured usage figure). Sonnet 4 was a high-volume workhorse
+    on the mass-market claude.ai surface (third-party estimates ~30M+ consumer MAU, aggregator-only), but is now
+    superseded by 4.5/4.6, so 4 rather than 5. Overrides the prior frozen-anchor convention (held null) for
+    dominant closed incumbents.
   sources:
   - url: https://www.anthropic.com/news/claude-4
     shows: launch post gives customer testimonials but no quantitative per-model usage figures
     accessed: '2026-06-04'
+  - url: https://openrouter.ai/rankings
+    shows: public per-model token-share leaderboard where Claude flagships rank among the most-used models
+    accessed: '2026-06-23'
 capability:
   score: 4
   basis: benchmark:SWE-bench Verified

--- a/sources/scores/minimax-m2-5.yaml
+++ b/sources/scores/minimax-m2-5.yaml
@@ -6,7 +6,8 @@ openness:
     SGLang/vLLM/Transformers; no training pipeline/data);license:Modified-MIT(permissive)
   confidence: high
   note: Downloadable weights under a permissive Modified-MIT; data and training pipeline closed, so open_weights
-    not open_source. Distinct from the unreleased/closed MiniMax M3 anchor.
+    not open_source. The newer MiniMax-M3 has since also released open weights (under a more restrictive
+    community license).
   sources:
   - url: https://huggingface.co/MiniMaxAI/MiniMax-M2.5
     shows: MiniMax-M2.5 open weights on HF, Modified-MIT, 229B MoE, ~693K downloads/month

--- a/sources/scores/minimax-m3.yaml
+++ b/sources/scores/minimax-m3.yaml
@@ -1,31 +1,31 @@
 product: minimax-m3
 openness:
-  score: 1
-  class: closed
-  components: weights:announced_not_yet_released;data:closed;code:closed;license:TBD(M2.7-precedent=non-commercial-restricted)
+  score: 3
+  class: open_weights
+  components: weights:open(on HF; ungated; safetensors/BF16; MoE);data:closed;code:partial(inference only;
+    no training pipeline/data);license:minimax-community(custom, see HF LICENSE)
   confidence: high
-  note: weights:announced_not_yet_released;data:closed;code:closed;license:TBD(M2.7-precedent=non-commercial-restricted)
+  note: Weights released publicly on Hugging Face after the 2026-06-04 scoring (then announced-not-yet-released);
+    ungated download under a custom minimax-community license. Data and training pipeline closed, so
+    open_weights not open_source. Matches the MiniMax-M2.5 sibling precedent.
   sources:
-  - url: https://the-decoder.com/minimax-m3-open-weight-model-with-a-million-token-context-challenges-proprietary-leaders/
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
-  - url: https://www.opensourceforu.com/2026/06/minimax-challenges-ai-rivals-with-m3-but-stops-short-of-full-open-source-commitment/
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+  - url: https://huggingface.co/api/models/MiniMaxAI/MiniMax-M3
+    shows: Public ungated weights repo (safetensors/MoE), license=minimax-community, created 2026-06-02
+    accessed: '2026-06-23'
   - url: https://venturebeat.com/technology/minimax-m3-debuts-eclipsing-gpt-5-5-and-gemini-3-1-pro-on-key-benchmark-performance-for-just-5-10-of-the-cost
     shows: flagship phase-C verification source
     accessed: '2026-06-04'
 adoption:
-  level: null
+  level: 3
   reach: null
-  signal_type: unknown
-  confidence: low
-  note: Days old at scoring time and API-only (OpenRouter launch promo ~$0.30/$1.20 per M tokens). No
-    honest usage signal yet; weights not released so no download signal either.
+  signal_type: usage_volume
+  confidence: medium
+  note: About 131k downloads in the last month and 1,215 likes on the HF model card (100K-1M band),
+    matching sibling MiniMax-M2.5 (level 3). Weights released post-scoring, so a download signal now exists.
   sources:
-  - url: https://www.opensourceforu.com/2026/06/minimax-challenges-ai-rivals-with-m3-but-stops-short-of-full-open-source-commitment/
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+  - url: https://huggingface.co/api/models/MiniMaxAI/MiniMax-M3
+    shows: HF API reports downloads=131057 (30d) and likes=1215
+    accessed: '2026-06-23'
 capability:
   score: null
   basis: benchmark:SWE-bench

--- a/sources/scores/openhermes-2-5.yaml
+++ b/sources/scores/openhermes-2-5.yaml
@@ -11,16 +11,16 @@ openness:
     shows: Public ungated dataset card, ~1M rows, synthetic/GPT-4 tags
     accessed: '2026-06-22'
 adoption:
-  level: null
+  level: 2
   reach: null
   signal_type: usage_volume
-  confidence: low
-  note: Download count did not render via fetch, so a usage figure could not be confirmed from the primary
-    source.
+  confidence: medium
+  note: About 16k downloads in the last month per the HF API, plus 861 likes (among the highest in the
+    category), placing it alongside other level-2 synthetic SFT datasets like Tulu 3 and Cosmopedia.
   sources:
-  - url: https://huggingface.co/datasets/teknium/OpenHermes-2.5
-    shows: Dataset page accessed but monthly download number not visible in fetched content
-    accessed: '2026-06-22'
+  - url: https://huggingface.co/api/datasets/teknium/OpenHermes-2.5
+    shows: HF API reports downloads=15954 (30d) and likes=861
+    accessed: '2026-06-23'
 capability:
   score: null
   basis: n/a

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -18,6 +18,14 @@ def test_openness_gap_when_mature_options_are_open_ish():
     assert sg["num"] < 5 and "maturity" in sg["gaps"] and "openness" in sg["gaps"]
 
 
+def test_missing_adoption_yields_null_maturity_and_is_excluded_from_stage():
+    # A product with null adoption has no maturity score (not 0.0) and must not drag
+    # the category's stage down — here a mature open product should still reach stage 4.
+    rows = [_p("open_source", 5, 5), _p("open_source", None, None)]
+    sg = _stage_and_gaps(rows, {"adopt": 0.5, "cap": 0.5})
+    assert sg["num"] == 4  # the null-adoption product is ignored, the mature one stands
+
+
 def test_void_when_no_open_option():
     sg = _stage_and_gaps([_p("closed", 1, 1)], {"adopt": 0.5, "cap": 0.5})
     assert sg["num"] == 0 and sg["gaps"] == ["void"]
@@ -65,6 +73,27 @@ def test_build_payload_shape_and_order():
     assert row["org"] == "Meta"
     # comments field is carried under the legacy payload key version_note
     assert row["version_note"] == "note text"
+    # llama-4 has no capability score, so maturity falls back to adoption (4) alone
+    assert row["maturity"] == 4.0
+
+
+def test_null_adoption_serializes_maturity_null():
+    src = _sources()
+    src["scores"]["llama-4"]["adoption"] = {"level": None, "signal_type": "unknown"}
+    payload = build_payload(src, frozen_long_tail={}, generated="2026-06-10")
+    assert payload["categories"]["base_pretrained"]["products"][0]["maturity"] is None
+
+
+def test_maturity_is_weighted_blend_rounded_2dp():
+    # adoption 4, capability 5 with default 0.5/0.5 weights -> 4.5; cap-heavy 0.25/0.75 -> 4.75
+    src = _sources()
+    src["scores"]["llama-4"]["capability"] = {"score": 5, "basis": "x"}
+    payload = build_payload(src, frozen_long_tail={}, generated="2026-06-10")
+    assert payload["categories"]["base_pretrained"]["products"][0]["maturity"] == 4.5
+
+    src["categories"]["base_pretrained"]["weights"] = {"adopt": 0.25, "cap": 0.75}
+    payload = build_payload(src, frozen_long_tail={}, generated="2026-06-10")
+    assert payload["categories"]["base_pretrained"]["products"][0]["maturity"] == 4.75
 
 
 def test_long_tail_drops_now_categorized_products():


### PR DESCRIPTION
## Summary

Adds a weighted-product **maturity score** to each product record in the notebook JSON, fixes how missing adoption is represented, and backfills adoption for products that were spuriously null.

### Serialization (`build/serialize.py`)
- Emit `maturity` (per-category adoption/capability blend, rounded 2dp) on every product record.
- **Missing adoption → `null`**, not a spurious `0.0`. `maturity` is anchored on adoption; capability may be legitimately null by product type (e.g. datasets, graded on adoption alone).
- Null-maturity products are **excluded from the category stage computation** — they neither advance nor depress a stage. Verified: **zero category stage/gap shifts**, so the locked gap logic is intact.

### Score backfills (`sources/scores/`)
- **MiniMax-M3** — weights went public on HF *after* the original scoring. Openness `closed → open_weights` (ungated, `minimax-community` license), adoption `null → 3` (131k downloads/mo, sibling-calibrated). Capability left null (benchmarks still unverified). Fixed the now-stale cross-reference in MiniMax-M2.5.
- **OpenHermes 2.5** — original fetch failure left adoption null; backfilled to `2` (~16k downloads/mo + 861 likes via HF API).
- **Claude flagships** (Opus 4.7 / Opus 4.x / Fable 5 / Sonnet 4.6 / Sonnet 4) — directional adoption via `signal_type: reported_traction`, overriding the prior "frozen-anchor" null convention that systematically understated dominant closed incumbents (null adoption → null maturity → excluded from stage → could mask the openness gap). Differentiated scale: volume-leader Sonnet 4.6 = 5; premium Opus and brand-new Fable = 4. Each note flags it as a directional estimate, not a measured figure.

Closed fine-tuning *features* and internal-only eval sets are deliberately left null — genuinely unrankable, no defensible basis.

Net: null-maturity products 26 → 20; closed-bucket mean self-corrected (3.35 → 3.70) once phantom zeros were removed.

## Test plan
- `uv run python -m build.validate` → `0 error(s)`
- `uv run pytest tests/test_serialize.py` → 10 passed (4 new/updated: maturity blend, adoption-only fallback, null serialization, null-excluded-from-stage)
- Verified no category stage/gap shifts against a pre-change snapshot.

Note: `build/notebook_data.json` is intentionally **not** included — it is bot-regenerated on merge.