### PR TITLE
fix: refresh MiniMax-M3 blurb to match released-weights openness

### DIFF
--- a/sources/products/minimax-m3.yaml
+++ b/sources/products/minimax-m3.yaml
@@ -1,11 +1,9 @@
 name: minimax-m3
 display_name: MiniMax M3
 type: model
-description: 'MiniMax M3 launched 1 Jun 2026: API-only at launch with MiniMax Sparse Attention, 1M-token
-  context, native multimodal. Company committed to releasing technical report + open weights within ~10
-  days, but as of scoring the weights are NOT on Hugging Face and the license is unconfirmed (predecessor
-  M2.7 used a non-commercial-restricted license).'
-comments: 'MiniMax M3 launched 1 Jun 2026: API-only at launch with MiniMax Sparse Attention, 1M-token
-  context, native multimodal. Company committed to releasing technical report + open weights within ~10
-  days, but as of scoring the weights are NOT on Hugging Face and the license is unconfirmed (predecessor
-  M2.7 used a non-commercial-restricted license).'
+description: 'MiniMax M3 launched 1 Jun 2026: API-first at launch with MiniMax Sparse Attention, 1M-token
+  context, native multimodal. Open weights have since been released on Hugging Face (ungated, ~131k downloads/month)
+  under a custom minimax-community license; training data and pipeline remain closed.'
+comments: 'MiniMax M3 launched 1 Jun 2026: API-first at launch with MiniMax Sparse Attention, 1M-token
+  context, native multimodal. Open weights have since been released on Hugging Face (ungated, ~131k downloads/month)
+  under a custom minimax-community license; training data and pipeline remain closed.'


### PR DESCRIPTION
## Summary

Follow-up to #35. The MiniMax-M3 `description`/`comments` still read *"weights are NOT on Hugging Face and the license is unconfirmed,"* which contradicts the openness field updated in #35 (`open_weights`, released on HF under the minimax-community license). This aligns the product blurb with the score so the published notebooks aren't self-contradictory.

## Test plan
- `uv run python -m build.validate` → `0 error(s)`
- No remaining "NOT on Hugging Face" text in the source.

Bot regenerates `notebook_data.json` + notebooks on merge.