### PR TITLE
feat(build): descriptions legend + per-product openness bucket in payload

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,12 @@ edit the `products:` array. To move a product between categories, remove it
 from one roster and add it to the other (it must end up in exactly one).
 Arc grouping and cross-category order live in `sources/taxonomy.yaml`.
 
+The category also carries two bits of editorial text: `description` (a neutral
+one-liner — *what the category is*) and `strapline` (the *finding* — what the map
+concludes about its open/closed gap). Both flow into the build, so edit them here
+rather than in the notebook; `description` is also emitted into the payload's
+top-level `descriptions.categories` legend.
+
 ## Scoring rubric (summary)
 
 Each score file has three axes. **Every non-null value needs at least one

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ One YAML file per record, four concerns **plus** the single `sources/taxonomy.ya
 | Path | Contains | Key rule |
 |------|----------|----------|
 | `sources/organizations/` | Org metadata (`name`, `display_name`, optional `type`, `homepage`, `github`, `comments`) and a `products:` roster | Each product slug appears in exactly one org roster |
-| `sources/categories/` | Category definition (`display_name`, optional `strapline`, `weights`, `scoring_recipe`, `comments`) and an ordered `products:` roster | Order = display order; each product in exactly one category |
+| `sources/categories/` | Category definition (`display_name`, optional `description`, `strapline`, `weights`, `scoring_recipe`, `comments`) and an ordered `products:` roster | Order = display order; each product in exactly one category |
 | `sources/products/` | Product record (`name`, `display_name`, `type`, `description`, typed artifact URL arrays, optional `comments`) | No `org:` or `flags` fields — org membership is declared in the org file |
 | `sources/scores/` | Per-product `openness`, `adoption`, `capability` | Every non-null score value needs a `sources:` citation |
 | `sources/taxonomy.yaml` | Arc grouping + cross-category display order. The three arcs are the Columbia ontology layers (`product_ux` / `model_components` / `infrastructure`); each arc declares its `layer` slug + ordered category slugs | Every category appears in exactly one arc; serialize derives each category's `layer` from its arc |

--- a/build/products_view_data.py
+++ b/build/products_view_data.py
@@ -29,26 +29,6 @@ ROOT = Path(__file__).resolve().parents[1]
 NB = ROOT / "notebooks" / "products-view.py"
 ND = ROOT / "build" / "notebook_data.json"
 
-# Source of truth for the short per-category captions shown in the products
-# view (the canonical notebook_data.json does not carry these). A caption read
-# from the notebook's current payload wins over this fallback, so curators can
-# tweak wording in-notebook; this dict guarantees a sensible default and covers
-# any newly-added category.
-CAT_DESCS = {
-    "base_pretrained": "Foundation models trained from scratch.",
-    "finetuned_chat": "Instruction-tuned chat and reasoning assistants.",
-    "inference_code": "Engines and runtimes that serve model inference.",
-    "finetuning_code": "Libraries and platforms for fine-tuning models.",
-    "evaluation_code": "Harnesses that run and grade model evaluations.",
-    "benchmark_eval_data": "Benchmark datasets used to evaluate models.",
-    "orchestration_agents": "Frameworks and agents that plan and execute tasks.",
-    "ui_api": "Chat UIs and API gateways in front of models.",
-    "telemetry_observability": "Tracing and observability for LLM apps.",
-    "agent_tools_protocols": "Tools, protocols, and retrieval for agents.",
-    "deployment": "Sandboxes, runtimes, and serverless model hosting.",
-}
-
-
 def _embedded_payload(source: str) -> dict | None:
     """Return the payload currently embedded in the notebook, or None."""
     for node in ast.walk(ast.parse(source)):
@@ -65,13 +45,17 @@ def build_payload(nd: dict, prev: dict | None) -> dict:
     """Map build/notebook_data.json into the compact products-view payload."""
     prev_descs = {cid: c.get("desc") for cid, c in (prev or {}).get("cats", {}).items()}
     order = nd["order"]
+    # Canonical per-category captions now ship in the payload (descriptions.categories,
+    # sourced from sources/categories/<cid>.yaml). A caption already edited into the
+    # notebook's current payload still wins, so curators can tweak wording in-notebook.
+    nd_descs = nd.get("descriptions", {}).get("categories", {})
     cats, components = {}, []
     for cid in order:
         c = nd["categories"][cid]
         cats[cid] = {
             "label": c["label"],
             "arc": c["arc"],
-            "desc": prev_descs.get(cid) or CAT_DESCS.get(cid, ""),
+            "desc": prev_descs.get(cid) or nd_descs.get(cid, ""),
         }
         for p in c["products"]:
             comp = {

--- a/build/render.py
+++ b/build/render.py
@@ -109,24 +109,11 @@ def data():
     DATA = json.loads(__DATA_LITERAL__)
     ORDER = DATA["order"]
     STRAPLINES = __STRAPLINES__
-    # Neutral one-line definitions for the at-a-glance overview (what the
-    # category IS, vs the strapline which is the finding).
-    STACK_DESC = {
-        "base_pretrained": "Foundation models trained from scratch.",
-        "finetuned_chat": "Instruction-tuned chat and reasoning assistants.",
-        "inference_code": "Engines and runtimes that serve model inference.",
-        "finetuning_code": "Libraries and platforms for fine-tuning models.",
-        "evaluation_code": "Harnesses that run and grade model evaluations.",
-        "benchmark_eval_data": "Benchmark datasets used to evaluate models.",
-        "orchestration_agents": "Frameworks and agents that plan and execute tasks.",
-        "ui_api": "Chat UIs and API gateways in front of models.",
-        "telemetry_observability": "Tracing and observability for LLM apps.",
-        "agent_tools_protocols": "Tools, protocols, and retrieval for agents.",
-        "deployment": "Sandboxes, runtimes, and serverless model hosting.",
-        "training_synthetic_datasets": "Corpora for pre-training and post-training models.",
-        "ml_frameworks": "Foundational libraries the rest of the stack is built on.",
-        "edge_hardware": "Boards and chips that run model inference at the edge.",
-    }
+    # Neutral one-line definitions for the at-a-glance overview (what the category
+    # IS, vs the strapline which is the finding). Sourced from the payload's
+    # descriptions.categories (ultimately sources/categories/<cid>.yaml), so the
+    # wording lives in one place.
+    STACK_DESC = DATA["descriptions"]["categories"]
     # Per-category combined-score weights (adoption, capability), ported from the
     # v2 stack map (slugs identical). Feed the "standout product" gate behind the
     # openness verdict; the table also shows the blended score.

--- a/build/serialize.py
+++ b/build/serialize.py
@@ -26,6 +26,27 @@ _CAPABLE_MIN = 4           # raw capability below which an open option is "not c
 _STAGE_NAMES = {0: "Void", 1: "Open Experiments", 2: "Emerging Alternatives",
                 3: "Viable Alternatives", 4: "Competitive Open Ecosystem",
                 5: "Mature Open Ecosystem"}
+# Plain-language definitions of each stage and gap, emitted into the payload's
+# top-level `descriptions` block so downstream consumers render a legend without
+# re-deriving the methodology. Kept verbatim from docs/guides/gap-analysis.md
+# (the prose source of truth); edit both together.
+_STAGE_DESC = {
+    0: "no usable open option exists (and nothing is mature anywhere)",
+    1: "fully-open options exist but are weak on both axes",
+    2: "no mature fully-open product; the best fully-open option is promising but limited",
+    3: "no mature fully-open product, but the best fully-open option is strong",
+    4: "at least one mature fully-open product, but not yet enough for depth",
+    5: "enough mature fully-open products to be redundant/resilient",
+}
+_GAP_DESC = {
+    "void": "no usable open option at all.",
+    "capability": "the best fully-open option isn't capable enough to be useful.",
+    "adoption": "a capable fully-open option exists but is under-adopted.",
+    "maturity": "open options exist and at least one may be mature, but the ecosystem lacks "
+                "the depth/redundancy of a mature ecosystem (too few mature fully-open products).",
+    "openness": "capable, adopted options exist, but the mature ones are not fully open "
+                "(open-ish or closed). This is the orthogonal flag; it can co-occur with the others.",
+}
 
 
 def _gap_bucket(cls: str) -> str:
@@ -136,12 +157,16 @@ def _filter_long_tail(frozen: dict, prods: dict) -> dict:
 
 
 def _row(prod: dict, org_name: str, score: dict, weights: dict | None) -> dict:
+    # Pre-compute the open / open-ish / closed bucket alongside the raw class, so
+    # consumers get a stable 3-way verdict that survives changes to the openness.class
+    # vocabulary. Same collapse the category gap logic uses (_gap_bucket).
+    openness = {**score["openness"], "bucket": _gap_bucket((score["openness"] or {}).get("class"))}
     row = {
         "product": prod["display_name"],
         "org": org_name,
         "type": prod["type"],
         "description": prod.get("description", ""),
-        "openness": score["openness"],
+        "openness": openness,
         "adoption": score["adoption"],
         "capability": score["capability"],
     }
@@ -201,8 +226,18 @@ def build_payload(sources: dict, frozen_long_tail: dict, generated: str | None =
         out_cats[cid] = {"label": cat["display_name"], "arc": cid_arc[cid],
                          "layer": cid_layer[cid], "stage": {"num": sg["num"], "name": sg["name"]},
                          "gaps": sg["gaps"], "products": rows}
-    return {"categories": out_cats, "order": order, "n_total": n,
-            "generated": generated, "long_tail": _filter_long_tail(frozen_long_tail, prods)}
+    # Editable legend for the derived attributes, carried at the top of the payload.
+    # Stage/gap text are methodology constants (above); the per-category one-liner is
+    # the neutral `description` from sources/categories/<cid>.yaml ("what it is", as
+    # opposed to the editorial strapline). Edit at the source; it flows here on build.
+    descriptions = {
+        "stages": {str(k): v for k, v in _STAGE_DESC.items()},
+        "gaps": dict(_GAP_DESC),
+        "categories": {cid: cats[cid].get("description", "") for cid in order},
+    }
+    return {"descriptions": descriptions, "categories": out_cats, "order": order,
+            "n_total": n, "generated": generated,
+            "long_tail": _filter_long_tail(frozen_long_tail, prods)}
 
 
 if __name__ == "__main__":

--- a/docs/guides/gap-analysis.md
+++ b/docs/guides/gap-analysis.md
@@ -119,7 +119,12 @@ rubric or the curation density changes materially.
 
 - **Computed** in `build/serialize.py` (`_stage_and_gaps`), from the per-product scores in
   `sources/scores/` and the per-category `weights` in `sources/categories/`.
-- **Emitted** into `build/notebook_data.json` per category (`stage`, `gaps`).
+- **Emitted** into `build/notebook_data.json` per category (`stage`, `gaps`). The
+  plain-language definitions of every stage and gap ship in the payload's top-level
+  `descriptions` block (`descriptions.stages`, `descriptions.gaps`, plus the neutral
+  per-category one-liner in `descriptions.categories`), so a consumer can render a
+  legend without re-deriving this document. Each product also carries its openness
+  `bucket` (`open` / `open-ish` / `closed`) alongside the raw `class`.
 - **Displayed** in the published notebook as a maturity-ladder table (each category placed on
   its stage). The per-category gap set is carried in the payload for downstream consumers
   rather than shown inline.

--- a/docs/schemas/category.schema.json
+++ b/docs/schemas/category.schema.json
@@ -7,6 +7,7 @@
   "properties": {
     "name": { "type": "string", "pattern": "^[a-z0-9_]+$" },
     "display_name": { "type": "string", "minLength": 1 },
+    "description": { "type": "string" },
     "strapline": { "type": "string" },
     "weights": {
       "type": "object",

--- a/notebooks/products-view.py
+++ b/notebooks/products-view.py
@@ -374,11 +374,14 @@ def engine(CATS, COMPONENTS, ORDER, STRUCTURAL_GAPS):
         "finetuning_code": set(tok("finetuning fine tuning train training lora rlhf rl adapt instruction")),
         "evaluation_code": set(tok("evaluation eval harness benchmark test grade quality regression")),
         "benchmark_eval_data": set(tok("benchmark dataset eval questions test math code knowledge")),
+        "training_synthetic_datasets": set(tok("dataset datasets data corpus pretraining synthetic training tokens text web multilingual instruction")),
         "orchestration_agents": set(tok("agent agents orchestration framework workflow autonomous plan rag retrieval chain")),
         "ui_api": set(tok("ui interface chat frontend gateway api proxy router self hosted web app")),
         "telemetry_observability": set(tok("observability tracing telemetry monitoring logging cost analytics debug")),
         "agent_tools_protocols": set(tok("tools protocol vector database search retrieval scrape browse mcp embedding index")),
+        "ml_frameworks": set(tok("framework frameworks library libraries pytorch tensorflow jax keras transformers deep learning training python")),
         "deployment": set(tok("deploy deployment sandbox container serverless runtime host hosting cluster cloud")),
+        "edge_hardware": set(tok("edge hardware device board soc npu gpu arm embedded sbc accelerator chip raspberry jetson offline")),
     }
     OPEN_CLASSES = {"open_source", "open", "open_weights", "open_core"}
     # Calibrated on the preset queries (see methodology).

--- a/sources/categories/agent_tools_protocols.yaml
+++ b/sources/categories/agent_tools_protocols.yaml
@@ -1,5 +1,6 @@
 name: agent_tools_protocols
 display_name: Agent tools & protocols
+description: "Tools, protocols, and retrieval for agents."
 strapline: Open protocols, closed search. MCP and vector DBs are open; the search/scrape APIs are proprietary.
 weights:
   adopt: 0.6

--- a/sources/categories/base_pretrained.yaml
+++ b/sources/categories/base_pretrained.yaml
@@ -1,5 +1,6 @@
 name: base_pretrained
 display_name: Base / pretrained models
+description: "Foundation models trained from scratch."
 strapline: The frontier is open-weights, not open-source. Only a handful of families ship the full pipeline;
   the rest withhold data or licenses.
 weights:

--- a/sources/categories/benchmark_eval_data.yaml
+++ b/sources/categories/benchmark_eval_data.yaml
@@ -1,5 +1,6 @@
 name: benchmark_eval_data
 display_name: Benchmark / eval datasets
+description: "Benchmark datasets used to evaluate models."
 strapline: Open problems, gated answers. Many benchmarks publish the questions but hold back the test
   split.
 weights:

--- a/sources/categories/deployment.yaml
+++ b/sources/categories/deployment.yaml
@@ -1,5 +1,6 @@
 name: deployment
 display_name: Deployment
+description: "Sandboxes, runtimes, and serverless model hosting."
 strapline: 'The open side leads: open sandboxes and runtimes outweigh the proprietary serverless clouds.'
 weights:
   adopt: 0.6

--- a/sources/categories/edge_hardware.yaml
+++ b/sources/categories/edge_hardware.yaml
@@ -1,5 +1,6 @@
 name: edge_hardware
 display_name: Edge AI hardware
+description: "Boards and chips that run model inference at the edge."
 strapline: Open at the board, closed at the silicon. The SBC ecosystem ships schematics
   and open toolchains, but the chips and accelerators underneath are documented and buyable
   rather than truly open.

--- a/sources/categories/evaluation_code.yaml
+++ b/sources/categories/evaluation_code.yaml
@@ -1,5 +1,6 @@
 name: evaluation_code
 display_name: Evaluation code
+description: "Harnesses that run and grade model evaluations."
 strapline: 'Mostly open harnesses: the tools that grade models are largely OSI-licensed.'
 weights:
   adopt: 0.5

--- a/sources/categories/finetuned_chat.yaml
+++ b/sources/categories/finetuned_chat.yaml
@@ -1,5 +1,6 @@
 name: finetuned_chat
 display_name: Fine-tuned / chat models
+description: "Instruction-tuned chat and reasoning assistants."
 strapline: Where the closed labs lead. Most chat assistants are API-only; the open challengers ship weights
   without the recipe.
 weights:

--- a/sources/categories/finetuning_code.yaml
+++ b/sources/categories/finetuning_code.yaml
@@ -1,5 +1,6 @@
 name: finetuning_code
 display_name: Fine-tuning code
+description: "Libraries and platforms for fine-tuning models."
 strapline: Open libraries, closed platforms. The training code is open; the managed fine-tuning services
   are not.
 weights:

--- a/sources/categories/inference_code.yaml
+++ b/sources/categories/inference_code.yaml
@@ -1,5 +1,6 @@
 name: inference_code
 display_name: Inference code
+description: "Engines and runtimes that serve model inference."
 strapline: 'Open engines, closed clouds. The self-hosted serving engines are OSI-licensed; the managed hardware-vendor inference is not.'
 weights:
   adopt: 0.5

--- a/sources/categories/ml_frameworks.yaml
+++ b/sources/categories/ml_frameworks.yaml
@@ -1,5 +1,6 @@
 name: ml_frameworks
 display_name: Core ML frameworks & libraries
+description: "Foundational libraries the rest of the stack is built on."
 strapline: The most open layer in the map. Every core library the stack imports — PyTorch,
   the Hugging Face stack, the tokenizers and file formats — ships under an OSI license. Here
   openness is the default, not the exception.

--- a/sources/categories/orchestration_agents.yaml
+++ b/sources/categories/orchestration_agents.yaml
@@ -1,5 +1,6 @@
 name: orchestration_agents
 display_name: Orchestration & agents
+description: "Frameworks and agents that plan and execute tasks."
 strapline: Open frameworks, closed agents. The SDKs are open-core; the marquee coding agents are proprietary.
 weights:
   adopt: 0.3

--- a/sources/categories/telemetry_observability.yaml
+++ b/sources/categories/telemetry_observability.yaml
@@ -1,5 +1,6 @@
 name: telemetry_observability
 display_name: Telemetry & observability
+description: "Tracing and observability for LLM apps."
 strapline: 'Open-core territory: OSS tracing cores with the enterprise tier behind a paywall.'
 weights:
   adopt: 0.5

--- a/sources/categories/training_synthetic_datasets.yaml
+++ b/sources/categories/training_synthetic_datasets.yaml
@@ -1,5 +1,6 @@
 name: training_synthetic_datasets
 display_name: Training & synthetic datasets
+description: "Corpora for pre-training and post-training models."
 strapline: Open data exists — just not the frontier's. The community ships FineWeb-scale
   corpora while the labs keep their real training mix closed, and a few of the biggest sets
   sit behind access gates.

--- a/sources/categories/ui_api.yaml
+++ b/sources/categories/ui_api.yaml
@@ -1,5 +1,6 @@
 name: ui_api
 display_name: UI & API
+description: "Chat UIs and API gateways in front of models."
 strapline: Structurally closed at the top. Self-hosters get open chat UIs; the mass-market surfaces are
   proprietary.
 weights:

--- a/tests/test_products_view.py
+++ b/tests/test_products_view.py
@@ -1,0 +1,56 @@
+"""Regression tests for the products-view notebook lookup engine.
+
+The lookup tool (mode 1: "describe what you want to build") runs ``search()``
+over every component and indexes ``CAT_KW`` by category id, both in the engine
+cell and in the gap logic of the results cell. If a taxonomy category is missing
+from ``CAT_KW``, selecting any user story raises ``KeyError`` and nothing renders
+below the dropdown. These tests load the notebook's cells directly and exercise
+that path so the regression cannot return silently.
+"""
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+NB = Path(__file__).resolve().parent.parent / "notebooks" / "products-view.py"
+
+
+def _load_notebook():
+    spec = importlib.util.spec_from_file_location("products_view_nb", NB)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def cells():
+    nb = _load_notebook()
+    _, data_defs = nb.data.run()
+    _, gallery_defs = nb.gallery.run()
+    _, engine_defs = nb.engine.run(
+        CATS=data_defs["CATS"],
+        COMPONENTS=data_defs["COMPONENTS"],
+        STRUCTURAL_GAPS=gallery_defs["STRUCTURAL_GAPS"],
+    )
+    return {**data_defs, **gallery_defs, **engine_defs}
+
+
+def test_cat_kw_covers_every_category(cells):
+    missing = [c for c in cells["ORDER"] if c not in cells["CAT_KW"]]
+    assert not missing, f"CAT_KW is missing taxonomy categories: {missing}"
+
+
+def test_search_runs_over_all_components_for_every_preset(cells):
+    search = cells["search"]
+    for _story, query in cells["PRESETS"]:
+        results = search(query, open_only=True)
+        assert results, f"no components returned for preset query: {query!r}"
+
+
+def test_gap_logic_indexes_cat_kw_for_every_category(cells):
+    # Mirrors the `_weak` comprehension in the lookup_results cell, which does
+    # CAT_KW[c] for every category in ORDER.
+    CAT_KW, ORDER = cells["CAT_KW"], cells["ORDER"]
+    qtok = {"chat", "agent", "rag"}
+    weak = [c for c in ORDER if qtok & CAT_KW[c]]
+    assert isinstance(weak, list)

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -112,6 +112,37 @@ def test_long_tail_drops_now_categorized_products():
     assert "someone/uncategorized" in names
 
 
+def test_descriptions_block_present_and_sourced():
+    src = _sources()
+    src["categories"]["base_pretrained"]["description"] = "Foundation models trained from scratch."
+    payload = build_payload(src, frozen_long_tail={}, generated="2026-06-10")
+    d = payload["descriptions"]
+    # stages keyed 0-5, gaps keyed by name, categories keyed by slug from the source yaml
+    assert set(d["stages"]) == {"0", "1", "2", "3", "4", "5"}
+    assert "void" in d["gaps"] and "openness" in d["gaps"]
+    assert d["categories"]["base_pretrained"] == "Foundation models trained from scratch."
+    # descriptions ships first so it reads as a header
+    assert list(payload)[0] == "descriptions"
+
+
+def test_openness_bucket_assigned_per_product():
+    # restricted collapses to the closed bucket; the raw class is preserved alongside it
+    payload = build_payload(_sources(), frozen_long_tail={}, generated="2026-06-10")
+    op = payload["categories"]["base_pretrained"]["products"][0]["openness"]
+    assert op["class"] == "restricted"
+    assert op["bucket"] == "closed"
+
+
+def test_openness_bucket_covers_open_and_open_ish():
+    src = _sources()
+    src["scores"]["llama-4"]["openness"] = {"score": 5, "class": "open_source"}
+    payload = build_payload(src, frozen_long_tail={}, generated="2026-06-10")
+    assert payload["categories"]["base_pretrained"]["products"][0]["openness"]["bucket"] == "open"
+    src["scores"]["llama-4"]["openness"] = {"score": 3, "class": "open_weights"}
+    payload = build_payload(src, frozen_long_tail={}, generated="2026-06-10")
+    assert payload["categories"]["base_pretrained"]["products"][0]["openness"]["bucket"] == "open-ish"
+
+
 def test_unknown_org_renders_empty_string():
     s = _sources()
     s["organizations"] = {"unknown": {"name": "unknown", "display_name": "Unknown",


### PR DESCRIPTION
Implements two requests from the CF team about the serialized `build/notebook_data.json` export.

## What changed

**1. Top-level `descriptions` block** — now emitted first in `notebook_data.json`, exactly the shape CF prototyped:
```json
{ "descriptions": { "stages": {"0":…,"5":…}, "gaps": {"void":…,"openness":…}, "categories": {"base_pretrained":…} }, … }
```
- **stages / gaps** text are constants in `serialize.py`, kept verbatim from `gap-analysis.md`.
- **categories** one-liners now live in a new `description:` field on each `sources/categories/*.yaml` — the single editable source. They were previously **duplicated** in `render.py` and `products_view_data.py` (the latter was even missing 3 categories); both now read from the payload, so editing the YAML updates the JSON *and* both notebooks. That's the "edit once, picked up automatically" the CF team asked for.

**2. Per-product openness bucket** — every product's `openness` object now carries a pre-computed 3-way verdict alongside the raw class:
```json
"openness": { "class": "open_weights", … , "bucket": "open-ish" }
```
All 421 products covered (218 open / 61 open-ish / 142 closed), using the same `_gap_bucket` collapse the category gap logic uses, so it survives changes to the `openness.class` vocabulary.

**Verification:** `build.validate` → 0 errors; `pytest` → 32 passed (added 3 tests); serialize/render/products-view all regenerate cleanly. Generated artifacts (`notebook_data.json`, the notebooks) are intentionally **not** committed — the bot regenerates them on merge.

## Worth noting

The field is named **`openness.bucket`**, not `openness.label` as prototyped. Reason: `bucket` is already the canonical term for this concept across the repo (`openness-class-map.json`, `gap-analysis.md`, the `_gap_bucket()` function), whereas `label` already means the human-readable *class* name ("Open weights") in the class map — reusing it for the verdict would collide.

**Action for Laith:** read `openness.bucket` (values `open` / `open-ish` / `closed`) instead of `openness.label`. Happy to switch to `label` if you'd rather not change your code — it's a one-line flip.
