### PR TITLE
Re-skin notebooks to the Current AI design system

### DIFF
--- a/build/render.py
+++ b/build/render.py
@@ -56,7 +56,7 @@ app = marimo.App(width="full")
 def load_fonts(mo):
     mo.Html(
         '<style>'
-        '@import url("https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,300;9..144,400;9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap");'
+        '@import url("https://fonts.googleapis.com/css2?family=DM+Mono:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&family=Noto+Serif:ital,wght@0,400;0,600;1,400&family=Plus+Jakarta+Sans:ital,wght@0,200..800;1,200..800&display=swap");'
         '</style>'
     )
     return
@@ -65,14 +65,28 @@ def load_fonts(mo):
 @app.cell(hide_code=True)
 def style():
     F = {
-        "headline": "Fraunces, Georgia, serif",
-        "body": "Inter, -apple-system, system-ui, sans-serif",
-        "mono": "'JetBrains Mono', ui-monospace, SFMono-Regular, monospace",
+        "headline": "'Noto Serif', Georgia, serif",
+        "body": "'Plus Jakarta Sans', -apple-system, system-ui, sans-serif",
+        "mono": "'DM Mono', ui-monospace, SFMono-Regular, monospace",
     }
     C = {
-        "ink": "#1a1814", "ink_2": "#3a342b", "ink_3": "#6b6253",
-        "paper": "#f5f1ea", "paper_2": "#ede7dc", "rule": "#c9bfac",
-        "signal": "#c8341d", "healthy": "#1b6b5e", "warm": "#d97c2a", "accent": "#2a3d8f",
+        "ink": "#0b252f", "ink_2": "#272726", "ink_3": "#8fa1a4",
+        "paper": "#f7f6f6", "paper_2": "#f2f1f1", "rule": "#edecec",
+        # Openness: a single-hue salmon ramp, deepest = most open, fading to a
+        # pale (but still legible) tint for closed. Monotonic lightness, so it
+        # reads as one ordered scale; brand salmon sits mid-ramp and open
+        # products carry the most colour.
+        "healthy": "#e86f57",   # open        — deep salmon
+        "warm": "#f4886f",      # open-ish    — salmon (brand-adjacent)
+        "signal": "#f8ad99",    # restricted  — light coral
+        "closed": "#f6cabd",    # closed      — pale coral
+        "null": "#dcdcda",      # no score    — neutral grey (off the ramp)
+        # Structure + the two magnitude axes — a quiet cool pair so the openness
+        # column is where colour lives.
+        "accent": "#0b252f",    # navy — eyebrows, rules, active controls
+        "adopt": "#8aa6ac",     # adoption bar   — light slate
+        "capab": "#3f5d68",     # capability bar — dark slate
+        "white": "#ffffff", "border": "#a5bbbe", "gap_red": "#ff0d0d",
     }
     # Openness class -> (label, 0-5 score for bar fill, color key). Unifies the
     # model / software / dataset class vocabularies onto one openness gradient.
@@ -96,9 +110,9 @@ def style():
     VERDICT = {
         "open_leads": ("Open leads", "healthy"),
         "openish_leads": ("Open-ish leads", "warm"),
-        "closed_leads": ("Closed leads", "signal"),
-        "competitive": ("Competitive", "accent"),
-        "none": ("No standout", "ink_3"),
+        "closed_leads": ("Closed leads", "closed"),
+        "competitive": ("Competitive", "capab"),
+        "none": ("No standout", "null"),
     }
     return C, F, OPEN, VERDICT
 
@@ -213,8 +227,8 @@ def header(C, DATA, F, mo):
         f'<div style="padding:40px 0 28px; border-bottom:2px solid {C["accent"]}; margin-bottom:36px;">'
         f'<div style="font-family:{F["mono"]}; font-size:11px; color:{C["ink_3"]}; '
         f'letter-spacing:0.1em; text-transform:uppercase; margin-bottom:10px;">'
-        f'Current AI \\u00b7 Open Source AI Map \\u00b7 v3</div>'
-        f'<h1 style="font-family:{F["headline"]}; font-size:2.2rem; font-weight:400; '
+        f'Current AI</div>'
+        f'<h1 style="font-family:{F["headline"]}; font-size:2.2rem; font-weight:600; '
         f'color:{C["ink"]}; margin:0 0 14px; line-height:1.05; letter-spacing:-0.025em;">'
         f'Open Source AI Map</h1>'
         f'<p style="font-family:{F["body"]}; font-size:1rem; color:{C["ink_2"]}; '
@@ -257,13 +271,13 @@ def stack_overview(C, DATA, F, ORDER, STACK_DESC, mix_counts, mo):
         _chips = (
             f'<span style="color:{C["healthy"]};">\\u25cf</span> {_m["open"]} open'
             f'&nbsp;&nbsp;<span style="color:{C["warm"]};">\\u25cf</span> {_m["openish"]} open-ish'
-            f'&nbsp;&nbsp;<span style="color:{C["ink_3"]};">\\u25cf</span> {_m["closed"]} closed'
+            f'&nbsp;&nbsp;<span style="color:{C["closed"]};">\\u25cf</span> {_m["closed"]} closed'
         )
         _rows.append(
             f'<div style="display:grid; grid-template-columns:32px 1fr 232px; gap:18px; '
             f'align-items:center; padding:14px 0; border-bottom:1px solid {C["rule"]};">'
             f'<div style="font-family:{F["mono"]}; font-size:12px; color:{C["ink_3"]};">{_i:02d}</div>'
-            f'<div><div style="font-family:{F["headline"]}; font-size:1.05rem; font-weight:500; '
+            f'<div><div style="font-family:{F["headline"]}; font-size:1.05rem; font-weight:600; '
             f'color:{C["ink"]}; line-height:1.2;">{_cat["label"]}</div>'
             f'<div style="font-family:{F["body"]}; font-size:0.85rem; color:{C["ink_3"]}; '
             f'margin-top:3px; line-height:1.4;">{STACK_DESC.get(_cid, "")}</div></div>'
@@ -276,7 +290,7 @@ def stack_overview(C, DATA, F, ORDER, STACK_DESC, mix_counts, mo):
         f'<div style="margin:0 0 52px;">'
         f'<div style="font-family:{F["mono"]}; font-size:10px; color:{C["accent"]}; '
         f'letter-spacing:0.1em; text-transform:uppercase; margin-bottom:8px;">The stack at a glance</div>'
-        f'<h2 style="font-family:{F["headline"]}; font-size:1.6rem; font-weight:500; color:{C["ink"]}; '
+        f'<h2 style="font-family:{F["headline"]}; font-size:1.6rem; font-weight:600; color:{C["ink"]}; '
         f'margin:0 0 14px; letter-spacing:-0.015em;">'
         f'{_n_arcs} layers \\u00b7 {len(ORDER)} categories \\u00b7 {_total} scored products</h2>'
         f'<p style="font-family:{F["body"]}; font-size:0.95rem; color:{C["ink_2"]}; margin:0 0 20px; line-height:1.6;">'
@@ -298,7 +312,7 @@ def openness_distribution(C, DATA, F, mo):
             return C["warm"]
         if _cls in ("restricted", "source_available", "gated", "documented"):
             return C["signal"]
-        return C["ink_3"]
+        return C["closed"]
     _CLS_ORDER = ["open_source", "open", "open_hardware", "open_core", "open_weights", "open_toolchain", "source_available", "gated", "documented", "restricted", "documented_only", "closed"]
     _bars = []
     for _tk, _tl in [("model", "Models"), ("dataset", "Datasets"), ("software", "Software"), ("hardware", "Hardware")]:
@@ -316,14 +330,14 @@ def openness_distribution(C, DATA, F, mo):
         _bars.append(
             f'<div style="display:grid; grid-template-columns:84px 1fr 44px; gap:12px; align-items:center; margin:8px 0;">'
             f'<div style="font-family:{F["body"]}; font-size:0.9rem; color:{C["ink"]}; font-weight:600;">{_tl}</div>'
-            f'<div style="display:flex; border-radius:3px; overflow:hidden;">{_segs}</div>'
+            f'<div style="display:flex; border-radius:0; overflow:hidden;">{_segs}</div>'
             f'<div style="font-family:{F["mono"]}; font-size:0.78rem; color:{C["ink_3"]}; text-align:right;">{_tot}</div>'
             f'</div>'
         )
     _legend = "".join(
         f'<span style="display:inline-flex; align-items:center; margin-right:16px; font-family:{F["body"]}; font-size:0.78rem; color:{C["ink_3"]};">'
-        f'<span style="width:11px; height:11px; background:{_col}; border-radius:2px; display:inline-block; margin-right:5px;"></span>{_lab}</span>'
-        for _lab, _col in [("Open source / data", C["healthy"]), ("Open weights / core", C["warm"]), ("Restricted / gated", C["signal"]), ("Closed", C["ink_3"])]
+        f'<span style="width:11px; height:11px; background:{_col}; border-radius:0; display:inline-block; margin-right:5px;"></span>{_lab}</span>'
+        for _lab, _col in [("Open source / data", C["healthy"]), ("Open weights / core", C["warm"]), ("Restricted / gated", C["signal"]), ("Closed", C["closed"])]
     )
     mo.Html(
         f'<div style="margin:0 0 44px;">'
@@ -349,12 +363,12 @@ def filter_sort_controls(mo):
     # its whole cell so no orphaned header/callout is left over an empty table.
     _css = (
         "<style>"
-        ".v3ctrl-bar .v3ctrl-lbl{font-family:'JetBrains Mono',monospace;font-size:10px;"
-        "color:#6b6253;letter-spacing:0.08em;text-transform:uppercase;margin-right:10px;}"
-        ".v3ctrl-bar button{font-family:Inter,system-ui,sans-serif;font-size:12px;"
-        "border:1px solid #c9bfac;background:#fff;color:#3a342b;border-radius:5px;"
-        "padding:5px 12px;cursor:pointer;margin-right:6px;}"
-        ".v3ctrl-bar button.active{background:#2a3d8f;color:#fff;border-color:#2a3d8f;}"
+        ".v3ctrl-bar .v3ctrl-lbl{font-family:'DM Mono',ui-monospace,monospace;font-size:10px;"
+        "color:#a5bbbe;letter-spacing:0.08em;text-transform:uppercase;margin-right:10px;}"
+        ".v3ctrl-bar button{font-family:'DM Mono',ui-monospace,monospace;font-size:11px;"
+        "border:1px solid #a5bbbe;background:#fff;color:#0b252f;border-radius:0;"
+        "padding:5px 12px;cursor:pointer;margin-right:6px;letter-spacing:0.04em;text-transform:uppercase;}"
+        ".v3ctrl-bar button.active{background:#0b252f;color:#f2f1f1;border-color:#0b252f;}"
         "</style>"
     )
 
@@ -440,20 +454,20 @@ def helpers(C, DATA, F, OPEN, STRAPLINES, VERDICT, mix_counts, mo, vbucket,
 
     def _ocolor(score):
         if score is None:
-            return C["rule"]
+            return C["null"]
         if score >= 4:
-            return C["healthy"]
+            return C["healthy"]   # salmon — open
         if score == 3:
-            return C["warm"]
+            return C["warm"]      # light coral — open-ish
         if score == 2:
-            return C["signal"]
-        return C["ink_3"]
+            return C["signal"]    # mid slate — restricted
+        return C["closed"]        # dark slate — closed
 
     def _bars(value, on_color):
         v = int(value) if isinstance(value, (int, float)) else 0
         return "".join(
             f'<span style="display:inline-block; width:6px; height:14px; margin-right:2px; '
-            f'vertical-align:middle; background:{on_color if j < v else C["paper_2"]};"></span>'
+            f'vertical-align:middle; background:{on_color if j < v else C["rule"]};"></span>'
             for j in range(5)
         )
 
@@ -498,8 +512,8 @@ def helpers(C, DATA, F, OPEN, STRAPLINES, VERDICT, mix_counts, mo, vbucket,
             f'<td style="padding:8px 10px; font-family:{F["body"]}; font-size:0.86rem; color:{C["ink"]};">{_name}</td>'
             f'<td style="padding:8px 10px; font-family:{F["body"]}; font-size:0.78rem; color:{C["ink_3"]};">{p.get("org","") or ""}</td>'
             f'<td style="padding:8px 10px;">{openness_cell(op)}</td>'
-            f'<td style="padding:8px 10px;">{axis_bars(ad, "level", C["accent"])}</td>'
-            f'<td style="padding:8px 10px;">{axis_bars(cap, "score", C["ink_2"])}</td>'
+            f'<td style="padding:8px 10px;">{axis_bars(ad, "level", C["adopt"])}</td>'
+            f'<td style="padding:8px 10px;">{axis_bars(cap, "score", C["capab"])}</td>'
             f'<td style="padding:8px 10px;"><button class="v3-details" data-pid="{pid}">Details</button></td>'
             f'</tr>'
         )
@@ -594,17 +608,21 @@ def helpers(C, DATA, F, OPEN, STRAPLINES, VERDICT, mix_counts, mo, vbucket,
     def _verdict_spine(cid):
         # Openness verdict pill, then the open / open-ish / closed dot tally.
         _code, _basis = verdict_for(cid)
-        _vlabel, _vckey = VERDICT[_code]
+        _vlabel, _ = VERDICT[_code]
+        # The verdict is a categorical call, not an ordinal one, so colour-coding it
+        # fought the openness ramp (open-ish vs closed read alike, and competitive /
+        # no-standout fall off the ramp). Keep it a neutral tag; the colour story
+        # lives in the open / open-ish / closed chips beside it.
         _verdict = (
             f'<span style="display:inline-block; font-family:{F["mono"]}; font-size:0.72rem; '
-            f'letter-spacing:0.05em; text-transform:uppercase; color:white; background:{C[_vckey]}; '
-            f'padding:4px 10px; border-radius:2px;">{_vlabel}</span>'
+            f'letter-spacing:0.05em; text-transform:uppercase; color:{C["ink"]}; '
+            f'background:{C["paper_2"]}; padding:4px 10px; border-radius:0;">{_vlabel}</span>'
         )
         _m = mix_counts(cid)
         _tally = (
             f'<span style="color:{C["healthy"]};">\\u25cf</span> {_m["open"]} open'
             f'&nbsp;&nbsp;<span style="color:{C["warm"]};">\\u25cf</span> {_m["openish"]} open-ish'
-            f'&nbsp;&nbsp;<span style="color:{C["ink_3"]};">\\u25cf</span> {_m["closed"]} closed'
+            f'&nbsp;&nbsp;<span style="color:{C["closed"]};">\\u25cf</span> {_m["closed"]} closed'
         )
         return (
             f'<div style="margin:4px 0 12px;">{_verdict}'
@@ -643,7 +661,7 @@ def helpers(C, DATA, F, OPEN, STRAPLINES, VERDICT, mix_counts, mo, vbucket,
             + f'<div style="margin:28px 0 18px;">'
             f'<div style="font-family:{F["mono"]}; font-size:10px; color:{C["accent"]}; '
             f'letter-spacing:0.1em; text-transform:uppercase; margin-bottom:6px;">{cat["arc"]} \\u00b7 {num:02d}</div>'
-            f'<h2 style="font-family:{F["headline"]}; font-size:1.4rem; font-weight:500; '
+            f'<h2 style="font-family:{F["headline"]}; font-size:1.4rem; font-weight:600; '
             f'color:{C["ink"]}; margin:0 0 8px;">{cat["label"]} '
             f'<span style="font-family:{F["mono"]}; font-size:0.8rem; color:{C["ink_3"]};">({len(prods)})</span></h2>'
             f'<p style="font-family:{F["body"]}; font-size:0.98rem; font-weight:600; color:{C["ink_2"]}; '
@@ -673,43 +691,45 @@ def details_payload(DATA, ORDER, mo):
             _payload[_p["product"]] = {**_p, "category_label": DATA["categories"][_cid]["label"]}
     _pj = _json.dumps(_payload, ensure_ascii=False)
     _css = (
-        ".v3-details{padding:3px 9px;font-size:11px;font-family:Inter,system-ui,sans-serif;"
-        "border:1px solid #2a3d8f;background:#fff;color:#2a3d8f;border-radius:4px;cursor:pointer;font-weight:600;}"
-        ".v3-details:hover{background:#2a3d8f;color:#fff;}"
-        ".v3-bd{position:fixed;inset:0;background:rgba(26,24,20,0.55);z-index:99999;display:flex;"
-        "align-items:flex-start;justify-content:center;padding:40px 20px;overflow-y:auto;font-family:Inter,system-ui,sans-serif;}"
-        ".v3-modal{background:#fff;border-radius:10px;max-width:780px;width:100%;padding:24px 28px;box-shadow:0 20px 60px rgba(0,0,0,0.25);}"
-        ".v3-modal h2{font-family:Fraunces,Georgia,serif;font-weight:500;font-size:1.4rem;margin:0 0 4px;color:#1a1814;}"
-        ".v3-x{float:right;cursor:pointer;background:none;border:1px solid #c9bfac;border-radius:5px;padding:4px 10px;font-size:12px;color:#6b6253;}"
-        ".v3-sect{margin:16px 0 6px;font-family:'JetBrains Mono',ui-monospace,monospace;font-size:10.5px;text-transform:uppercase;"
-        "letter-spacing:0.08em;color:#2a3d8f;font-weight:600;border-bottom:1px solid #c9bfac;padding-bottom:4px;}"
-        ".v3-row{display:flex;gap:14px;margin:5px 0;font-size:13px;color:#3a342b;}"
-        ".v3-lbl{min-width:96px;color:#6b6253;font-family:'JetBrains Mono',ui-monospace,monospace;font-size:11.5px;}"
+        ".v3-details{padding:3px 9px;font-size:11px;font-family:'DM Mono',ui-monospace,monospace;"
+        "border:1px solid #a5bbbe;background:#fff;color:#0b252f;border-radius:0;cursor:pointer;font-weight:500;"
+        "letter-spacing:0.04em;text-transform:uppercase;}"
+        ".v3-details:hover{background:#0b252f;color:#f2f1f1;}"
+        ".v3-bd{position:fixed;inset:0;background:rgba(11,37,47,0.55);z-index:99999;display:flex;"
+        "align-items:flex-start;justify-content:center;padding:40px 20px;overflow-y:auto;font-family:'Plus Jakarta Sans',system-ui,sans-serif;}"
+        ".v3-modal{background:#fff;border-radius:0;max-width:780px;width:100%;padding:24px 28px;box-shadow:0px 4px 4px 0px rgba(0,0,0,0.05);}"
+        ".v3-modal h2{font-family:'Noto Serif',Georgia,serif;font-weight:600;font-size:1.4rem;letter-spacing:-0.015em;margin:0 0 4px;color:#0b252f;}"
+        ".v3-x{float:right;cursor:pointer;background:none;border:1px solid #a5bbbe;border-radius:0;padding:4px 10px;font-size:11px;color:#a5bbbe;}"
+        ".v3-sect{margin:16px 0 6px;font-family:'DM Mono',ui-monospace,monospace;font-size:10px;text-transform:uppercase;"
+        "letter-spacing:0.08em;color:#0b252f;opacity:0.5;font-weight:600;border-bottom:1px solid #edecec;padding-bottom:4px;}"
+        ".v3-row{display:flex;gap:14px;margin:5px 0;font-size:13px;color:#272726;}"
+        ".v3-lbl{min-width:96px;color:#a5bbbe;font-family:'DM Mono',ui-monospace,monospace;font-size:11px;}"
         ".v3-val{flex:1;line-height:1.45;}"
-        ".v3-pill{display:inline-block;padding:2px 8px;border-radius:10px;color:#fff;font-size:11px;font-weight:600;}"
-        ".v3-modal ul{margin:4px 0;padding-left:20px;font-size:12.5px;color:#3a342b;line-height:1.5;}"
-        ".v3-modal a{color:#2a3d8f;text-decoration:none;}.v3-modal a:hover{text-decoration:underline;}"
+        ".v3-pill{display:inline-block;padding:2px 8px;border-radius:0;color:#fff;font-size:11px;font-weight:600;}"
+        ".v3-modal ul{margin:4px 0;padding-left:20px;font-size:12.5px;color:#272726;line-height:1.5;}"
+        ".v3-modal a{color:#0b252f;text-decoration:none;}.v3-modal a:hover{text-decoration:underline;}"
     )
     _js = r\'\'\'
     (function(){
       if (window.__V3_INSTALLED__) { window.__V3_PAYLOAD__ = __PAYLOAD__; return; }
       window.__V3_INSTALLED__ = true; window.__V3_PAYLOAD__ = __PAYLOAD__;
       var esc=function(s){return String(s==null?'':s).replace(/[&<>"']/g,function(c){return ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'})[c];});};
-      function ocol(sc){return sc==null?'#6b6253':(sc>=4?'#1b6b5e':(sc==3?'#d97c2a':(sc==2?'#c8341d':'#6b6253')));}
-      function srcs(a){if(!a||!a.length)return '<span style="color:#aaa">no sources</span>';
+      function ocol(sc){return sc==null?'#dcdcda':(sc>=4?'#e86f57':(sc==3?'#f4886f':(sc==2?'#f8ad99':'#f6cabd')));}
+      function otext(sc){return '#0b252f';}
+      function srcs(a){if(!a||!a.length)return '<span style="color:#a5bbbe">no sources</span>';
         return '<ul>'+a.map(function(s){var u=s&&s.url?s.url:'';var sh=s&&s.shows?s.shows:u;
         return u?'<li><a href="'+esc(u)+'" target="_blank" rel="noopener">'+esc(sh||u)+'</a></li>':'<li>'+esc(sh)+'</li>';}).join('')+'</ul>';}
-      function row(l,v){if(v==null||v==='')v='<em style="color:#aaa">n/a</em>';
+      function row(l,v){if(v==null||v==='')v='<em style="color:#a5bbbe">n/a</em>';
         return '<div class="v3-row"><span class="v3-lbl">'+esc(l)+'</span><span class="v3-val">'+(typeof v==='string'&&v.indexOf('<')===0?v:esc(v))+'</span></div>';}
       function build(p){
         var o=p.openness||{},ad=p.adoption||{},cap=p.capability||{};
         var h='<div class="v3-bd"><div class="v3-modal"><button class="v3-x">Close \\u2715</button>'+
           '<h2>'+esc(p.product||'')+'</h2>'+
-          '<div style="font-family:\\'JetBrains Mono\\',monospace;font-size:11px;color:#6b6253;margin-bottom:6px;">'+
+          '<div style="font-family:\\'DM Mono\\',monospace;font-size:11px;color:#a5bbbe;margin-bottom:6px;">'+
             esc(p.org||'')+' \\u00b7 '+esc(p.type||'')+' \\u00b7 '+esc(p.category_label||'')+
-            (o.class?' \\u00b7 <span class="v3-pill" style="background:'+ocol(o.score)+'">'+esc(o.class)+'</span>':'')+'</div>'+
-          (p.description?'<div style="font-size:13px;color:#3a342b;line-height:1.5;margin:8px 0;">'+esc(p.description)+'</div>':'')+
-          (p.version_note?'<div style="font-size:11.5px;color:#6b6253;line-height:1.45;margin:6px 0;">'+esc(p.version_note)+'</div>':'')+
+            (o.class?' \\u00b7 <span class="v3-pill" style="background:'+ocol(o.score)+';color:'+otext(o.score)+'">'+esc(o.class)+'</span>':'')+'</div>'+
+          (p.description?'<div style="font-size:13px;color:#272726;line-height:1.5;margin:8px 0;">'+esc(p.description)+'</div>':'')+
+          (p.version_note?'<div style="font-size:11.5px;color:#a5bbbe;line-height:1.45;margin:6px 0;">'+esc(p.version_note)+'</div>':'')+
           '<div class="v3-sect">Openness \\u00b7 '+(o.score==null?'n/a':o.score+'/5')+' ('+esc(o.class||'')+')</div>'+
           row('Components',o.components)+row('Why',o.note)+row('Confidence',o.confidence)+
           '<div class="v3-row"><span class="v3-lbl">Sources</span><span class="v3-val">'+srcs(o.sources)+'</span></div>'+
@@ -768,7 +788,7 @@ def stages_table(C, DATA, F, ORDER, mo):
         _cat_html = (
             "".join(
                 f'<span style="display:inline-block; font-family:{F["body"]}; font-size:0.82rem; '
-                f'color:{C["ink_2"]}; background:{C["paper_2"]}; padding:2px 9px; border-radius:11px; '
+                f'color:{C["ink_2"]}; background:{C["paper_2"]}; padding:2px 9px; border-radius:0; '
                 f'margin:0 5px 5px 0;">{_l}</span>'
                 for _l in _cats
             )
@@ -782,7 +802,7 @@ def stages_table(C, DATA, F, ORDER, mo):
             f'box-sizing:border-box; font-family:{F["mono"]}; font-size:0.8rem; font-weight:600; color:{C["ink"]}; '
             f'background:#fff; border:1.5px solid {C["ink"]}; border-radius:50%;">{_n}</span></td>'
             f'<td style="padding:14px 16px 14px 0; font-family:{F["headline"]}; font-size:0.98rem; '
-            f'font-weight:500; color:{C["ink"]}; white-space:nowrap;">{_name}</td>'
+            f'font-weight:600; color:{C["ink"]}; white-space:nowrap;">{_name}</td>'
             f'<td style="padding:14px 16px 14px 0; font-family:{F["body"]}; font-size:0.86rem; '
             f'color:{C["ink_2"]}; line-height:1.45; max-width:300px;">{_desc}</td>'
             f'<td style="padding:14px 0;">{_cat_html}</td>'
@@ -797,7 +817,7 @@ def stages_table(C, DATA, F, ORDER, mo):
         f'<div style="margin:52px 0 44px;">'
         f'<div style="font-family:{F["mono"]}; font-size:10px; color:{C["accent"]}; '
         f'letter-spacing:0.1em; text-transform:uppercase; margin-bottom:8px;">The maturity ladder</div>'
-        f'<h2 style="font-family:{F["headline"]}; font-size:1.6rem; font-weight:500; color:{C["ink"]}; '
+        f'<h2 style="font-family:{F["headline"]}; font-size:1.6rem; font-weight:600; color:{C["ink"]}; '
         f'margin:0 0 14px; letter-spacing:-0.015em;">How mature is the open ecosystem in each category?</h2>'
         f'<p style="font-family:{F["body"]}; font-size:0.95rem; color:{C["ink_2"]}; margin:0 0 20px; line-height:1.6;">'
         f'Each category sits on a Void \\u2192 Mature ladder, scored on the depth of its <em>fully-open</em> '
@@ -815,7 +835,7 @@ def stages_table(C, DATA, F, ORDER, mo):
 def uncategorized_long_tail(C, DATA, F, mo):
     _lt = DATA["long_tail"]
     _c = _lt["counts"]
-    _TC = {"repo": C["accent"], "model": C["healthy"], "package": C["warm"], "dataset": C["signal"]}
+    _TC = {"repo": C["border"], "model": C["healthy"], "package": C["warm"], "dataset": C["signal"]}
     _btns = "".join(
         '<button data-ltf="' + _k + '" class="lt-btn' + (' active' if _k == 'all' else '') + '">' + _lab + '</button>'
         for _k, _lab in [("all", "All"), ("repo", "Repos"), ("model", "Models"), ("package", "Packages"), ("dataset", "Datasets")]
@@ -824,7 +844,7 @@ def uncategorized_long_tail(C, DATA, F, mo):
         f'<tr data-lttype="{_t["type"]}" style="border-bottom:1px solid {C["paper_2"]};">'
         f'<td style="padding:7px 10px; font-family:{F["mono"]}; font-size:0.8rem; color:{C["ink"]};">{_t["name"]}</td>'
         f'<td style="padding:7px 10px;"><span style="font-family:{F["mono"]}; font-size:0.64rem; text-transform:uppercase; '
-        f'letter-spacing:0.04em; color:#fff; background:{_TC.get(_t["type"], C["ink_3"])}; padding:2px 7px; border-radius:10px;">{_t["type"]}</span></td>'
+        f'letter-spacing:0.04em; color:{C["ink"]}; background:{_TC.get(_t["type"], C["ink_3"])}; padding:2px 7px; border-radius:0;">{_t["type"]}</span></td>'
         f'<td style="padding:7px 10px; font-family:{F["mono"]}; font-size:0.76rem; color:{C["ink_3"]}; text-align:right; white-space:nowrap;">{_t["usage_label"]}</td>'
         f'<td style="padding:7px 10px; font-family:{F["body"]}; font-size:0.8rem; color:{C["ink_3"]};">{_t["description"]}</td>'
         f'<td style="padding:7px 10px; font-family:{F["mono"]}; font-size:0.66rem; color:{C["rule"]}; text-transform:uppercase; letter-spacing:0.04em;">uncategorized</td>'
@@ -838,9 +858,9 @@ def uncategorized_long_tail(C, DATA, F, mo):
     )
     _css = (
         "<style>"
-        ".lt-bar .lt-btn{font-family:Inter,system-ui,sans-serif;font-size:11px;border:1px solid #c9bfac;"
-        "background:#fff;color:#3a342b;border-radius:5px;padding:4px 11px;cursor:pointer;margin-right:6px;}"
-        ".lt-bar .lt-btn.active{background:#2a3d8f;color:#fff;border-color:#2a3d8f;}"
+        ".lt-bar .lt-btn{font-family:'DM Mono',ui-monospace,monospace;font-size:11px;border:1px solid #a5bbbe;"
+        "background:#fff;color:#0b252f;border-radius:0;padding:4px 11px;cursor:pointer;margin-right:6px;letter-spacing:0.04em;text-transform:uppercase;}"
+        ".lt-bar .lt-btn.active{background:#0b252f;color:#f2f1f1;border-color:#0b252f;}"
         ".lt-wrap[data-lttype=repo] tr[data-lttype]:not([data-lttype=repo]){display:none;}"
         ".lt-wrap[data-lttype=model] tr[data-lttype]:not([data-lttype=model]){display:none;}"
         ".lt-wrap[data-lttype=package] tr[data-lttype]:not([data-lttype=package]){display:none;}"
@@ -859,7 +879,7 @@ def uncategorized_long_tail(C, DATA, F, mo):
         + f'<div style="margin:48px 0 20px; padding:24px 0 0; border-top:2px solid {C["accent"]};">'
         f'<div style="font-family:{F["mono"]}; font-size:10px; color:{C["accent"]}; '
         f'letter-spacing:0.1em; text-transform:uppercase; margin-bottom:8px;">The long tail \\u00b7 uncategorized</div>'
-        f'<h2 style="font-family:{F["headline"]}; font-size:1.6rem; font-weight:500; color:{C["ink"]}; '
+        f'<h2 style="font-family:{F["headline"]}; font-size:1.6rem; font-weight:600; color:{C["ink"]}; '
         f'margin:0 0 12px; letter-spacing:-0.015em;">{_c["uncategorized"]:,} more products, tracked but not yet scored</h2>'
         f'<p style="font-family:{F["body"]}; font-size:0.95rem; color:{C["ink_2"]}; margin:0 0 16px; line-height:1.6;">'
         f'We track <strong>{_c["total"]:,}</strong> open-source AI artifacts in total: '
@@ -904,7 +924,7 @@ def framework_edges(C, FRAMEWORK_EDGES, F, mo):
         f'<div style="margin:48px 0 20px; padding:24px 0 0; border-top:2px solid {C["accent"]};">'
         f'<div style="font-family:{F["mono"]}; font-size:10px; color:{C["accent"]}; '
         f'letter-spacing:0.1em; text-transform:uppercase; margin-bottom:8px;">The map\\u2019s edges \\u00b7 framework white-space</div>'
-        f'<h2 style="font-family:{F["headline"]}; font-size:1.6rem; font-weight:500; color:{C["ink"]}; '
+        f'<h2 style="font-family:{F["headline"]}; font-size:1.6rem; font-weight:600; color:{C["ink"]}; '
         f'margin:0 0 12px; letter-spacing:-0.015em;">What\\u2019s not on the map yet</h2>'
         f'<p style="font-family:{F["body"]}; font-size:0.95rem; color:{C["ink_2"]}; margin:0 0 18px; line-height:1.6;">'
         f'The Columbia framework treats openness as varying across the whole stack: at the '
@@ -976,7 +996,7 @@ def next_steps(C, F, mo):
         f'<div style="padding-top:24px; border-top:1px solid {C["rule"]}; margin:8px 0 16px;">'
         f'<div style="font-family:{F["mono"]}; font-size:10px; color:{C["accent"]}; '
         f'letter-spacing:0.1em; text-transform:uppercase; margin-bottom:8px;">Roadmap</div>'
-        f'<h2 style="font-family:{F["headline"]}; font-size:1.5rem; font-weight:500; '
+        f'<h2 style="font-family:{F["headline"]}; font-size:1.5rem; font-weight:600; '
         f'color:{C["ink"]}; margin:0 0 14px;">Next steps</h2>'
         f'<p style="font-family:{F["body"]}; font-size:0.9rem; color:{C["ink_2"]}; '
         f'line-height:1.6; margin:0 0 12px;">This map is a first pass, not a finished '

--- a/docs/guides/notebook-design.md
+++ b/docs/guides/notebook-design.md
@@ -1,0 +1,336 @@
+# Marimo Notebook Design Guide
+
+This document translates the Current AI website design system into concrete values for the Marimo notebook (`ai-stack-map.py`). The goal is visual alignment without a pixel-perfect match — the notebook is a data environment, the site is a marketing/editorial one, so some adaptation is expected.
+
+---
+
+## Fonts
+
+The site uses three typefaces. Replace the notebook's current fonts with these:
+
+| Role | Notebook (current) | Site equivalent | Google Fonts import |
+|------|--------------------|-----------------|---------------------|
+| Headlines / category names | Fraunces | **Noto Serif** | `family=Noto+Serif:ital,wght@0,400;0,600;1,400` |
+| Body / UI text | Inter | **Plus Jakarta Sans** | `family=Plus+Jakarta+Sans:ital,wght@0,300..800;1,300..800` |
+| Monospace / labels / metadata | JetBrains Mono | **DM Mono** | `family=DM+Mono:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500` |
+
+Update the `F` dict and the `load_fonts` cell:
+
+```python
+# load_fonts cell
+mo.Html(
+    '<style>'
+    '@import url("https://fonts.googleapis.com/css2?'
+    'family=DM+Mono:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500'
+    '&family=Noto+Serif:ital,wght@0,400;0,600;1,400'
+    '&family=Plus+Jakarta+Sans:ital,wght@0,200..800;1,200..800'
+    '&display=swap");'
+    '</style>'
+)
+
+# style cell F dict
+F = {
+    "headline": "'Noto Serif', Georgia, serif",
+    "body": "'Plus Jakarta Sans', -apple-system, system-ui, sans-serif",
+    "mono": "'DM Mono', ui-monospace, SFMono-Regular, monospace",
+}
+```
+
+---
+
+## Color Palette
+
+Replace the warm sepia palette in the `C` dict with the site's palette:
+
+```python
+C = {
+    # Backgrounds
+    "paper":    "#f7f6f6",   # site --paper  (was #f5f1ea)
+    "paper_2":  "#f2f1f1",   # site --light-grey (was #ede7dc)
+    "white":    "#ffffff",   # pure white for cards / modal backgrounds
+
+    # Text
+    "ink":      "#0b252f",   # site --dark-blue — primary text (was #1a1814)
+    "ink_2":    "#272726",   # site --dark-grey — secondary text (was #3a342b)
+    "ink_3":    "#a5bbbe",   # site --light-blue — muted/disabled (was #6b6253)
+
+    # Borders / rules
+    "rule":     "#edecec",   # site --grid-line (was #c9bfac)
+    "border":   "#a5bbbe",   # site --light-blue for heavier borders (was #c9bfac)
+
+    # Semantic / data colors
+    "signal":   "#f88376",   # site --salmon — open / highlight (was #c8341d red)
+    "healthy":  "#f88376",   # same salmon — site doesn't use a separate green
+    "warm":     "#fbc7bf",   # site --pink — open-ish / secondary (was #d97c2a)
+    "accent":   "#0b252f",   # site --dark-blue — active states (was #2a3d8f)
+
+    # Gaps
+    "gap_red":  "#ff0d0d",   # site --bright-red — gap diamond icons
+}
+```
+
+### Openness color mapping
+
+The site encodes openness through **shape** (full square vs. triangle) rather than color. For the notebook's color-coded approach, align the three buckets to the site palette:
+
+| Bucket | Notebook (current) | Updated value | Hex |
+|--------|-------------------|---------------|-----|
+| Open | `healthy` #1b6b5e (green) | `signal` | `#f88376` (salmon) |
+| Open-ish | `warm` #d97c2a (orange) | `warm` | `#fbc7bf` (pink) |
+| Closed | `ink_3` #6b6253 (brown) | `ink_2` | `#272726` (dark grey) |
+
+Update `_ocolor()` to match:
+
+```python
+def _ocolor(score):
+    if score is None:
+        return C["rule"]       # #edecec
+    if score >= 4:
+        return C["signal"]     # #f88376 salmon — open
+    if score == 3:
+        return C["warm"]       # #fbc7bf pink — open-ish
+    if score == 2:
+        return C["ink_2"]      # #272726 — borderline
+    return C["ink_3"]          # #a5bbbe — closed / muted
+```
+
+Bullet chips (● open / open-ish / closed) should use the same three colors.
+
+---
+
+## Typography Scale
+
+The site's type is slightly larger and more spaced than the notebook's current settings. Recommended adjustments:
+
+| Context | Current | Updated |
+|---------|---------|---------|
+| Page / notebook title (h1) | 2.2rem, Fraunces 400 | 2.2rem, Noto Serif **600**, tracking `-0.025em` |
+| Section headings (h2) | 1.6rem, Fraunces 500 | 1.6rem, Noto Serif **600**, tracking `-0.015em` |
+| Category label | 1.05rem, Fraunces 500 | 1.05rem, Noto Serif 600 |
+| Modal title | 1.4rem, Fraunces 500 | 1.4rem, Noto Serif 600 |
+| Body / descriptions | 0.95rem, Inter | 0.95rem, Plus Jakarta Sans |
+| Control labels | 10px, JetBrains Mono, `uppercase`, `0.08em` tracking | same size, **DM Mono**, keep uppercase + tracking |
+| Table column headers | 9px, mono, `uppercase` | same, DM Mono |
+| Monospace metadata (arc labels, scores) | 10–11px, JetBrains Mono | same size, DM Mono |
+| Verdict pills | 0.72rem, mono | 0.72rem, DM Mono |
+
+The site uses `font-weight: 600` on headings (Noto Serif), **not** 500. Update headline weights accordingly.
+
+---
+
+## Backgrounds & Surfaces
+
+| Surface | Current | Updated |
+|---------|---------|---------|
+| Page / notebook background | `#f5f1ea` | `#f7f6f6` (--paper) |
+| Row / card background | `#ede7dc` | `#f2f1f1` (--light-grey) |
+| Modal / detail panels | `#ffffff` | `#ffffff` (unchanged) |
+| Active nav / selected button | `#2a3d8f` | `#0b252f` (--dark-blue) |
+| Modal backdrop | `rgba(26,24,20,0.55)` | `rgba(11,37,47,0.55)` (dark-blue tint) |
+
+---
+
+## Interactive Controls (buttons, filter bar)
+
+The site's button style is minimal with `--light-blue` borders and `--dark-blue` text. Update button CSS:
+
+```css
+/* Resting state */
+.v3ctrl-bar button, .lt-bar .lt-btn {
+    font-family: 'DM Mono', ui-monospace, monospace;
+    font-size: 11px;
+    border: 1px solid #a5bbbe;    /* --light-blue */
+    background: #ffffff;
+    color: #0b252f;               /* --dark-blue */
+    border-radius: 0;             /* site uses square corners, not rounded */
+    padding: 5px 12px;
+    cursor: pointer;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+/* Active state */
+.v3ctrl-bar button.active, .lt-bar .lt-btn.active {
+    background: #0b252f;          /* --dark-blue */
+    color: #f2f1f1;               /* --light-grey */
+    border-color: #0b252f;
+}
+```
+
+Note the **`border-radius: 0`** — the site uses sharp corners throughout, not rounded.
+
+---
+
+## Details Modal
+
+```css
+.v3-modal {
+    background: #ffffff;
+    border-radius: 0;             /* sharp corners — site uses no rounding on panels */
+    max-width: 780px;
+    width: 100%;
+    padding: 24px 28px;
+    box-shadow: 0px 4px 4px 0px rgba(0,0,0,0.05);  /* site --shadow-xs */
+}
+
+.v3-modal h2 {
+    font-family: 'Noto Serif', Georgia, serif;
+    font-weight: 600;
+    font-size: 1.4rem;
+    letter-spacing: -0.015em;
+    color: #0b252f;
+}
+
+.v3-sect {
+    font-family: 'DM Mono', ui-monospace, monospace;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #0b252f;
+    opacity: 0.5;
+    font-weight: 600;
+    border-bottom: 1px solid #edecec;   /* --grid-line */
+    padding-bottom: 4px;
+}
+
+.v3-lbl {
+    color: #a5bbbe;                     /* --light-blue (muted) */
+    font-family: 'DM Mono', ui-monospace, monospace;
+    font-size: 11px;
+}
+
+/* Close button */
+.v3-x {
+    border: 1px solid #a5bbbe;
+    border-radius: 0;
+    color: #a5bbbe;
+    font-size: 11px;
+    padding: 4px 10px;
+}
+```
+
+---
+
+## Score Bars
+
+Keep the 5-segment bar structure. Update colors:
+
+```python
+def _bars(value, on_color):
+    v = int(value) if isinstance(value, (int, float)) else 0
+    empty = "#edecec"   # --grid-line (was paper_2 #ede7dc)
+    return "".join(
+        f'<span style="display:inline-block; width:6px; height:14px; margin-right:2px; '
+        f'vertical-align:middle; background:{on_color if j < v else empty};"></span>'
+        for j in range(5)
+    )
+```
+
+---
+
+## Gap Icons
+
+The site renders gap indicators as **rotated squares** (diamonds) in `--bright-red` with a white letter. Match this in the notebook:
+
+```python
+def _gap_icon(letter):
+    return (
+        f'<span style="'
+        f'display:inline-flex; align-items:center; justify-content:center; '
+        f'width:14px; height:14px; position:relative; flex-shrink:0;">'
+        f'<span style="'
+        f'position:absolute; inset:0; transform:rotate(45deg); '
+        f'background:#ff0d0d;"></span>'   # --bright-red
+        f'<span style="'
+        f'position:relative; font-family:\'Plus Jakarta Sans\',sans-serif; '
+        f'font-size:8px; font-weight:800; text-transform:uppercase; '
+        f'color:#ffffff; line-height:1;">{letter}</span>'
+        f'</span>'
+    )
+```
+
+---
+
+## Borders & Dividers
+
+The site uses a very light `--grid-line` (`#edecec`) for all internal dividers and a slightly heavier `--light-blue` (`#a5bbbe`) for component borders. Replace all uses of the notebook's `C["rule"]` (`#c9bfac`) accordingly:
+
+- Row dividers, table borders → `#edecec`
+- Component / card borders → `#a5bbbe`
+
+---
+
+## Summary of key value swaps
+
+| What | Old | New |
+|------|-----|-----|
+| Page background | `#f5f1ea` | `#f7f6f6` |
+| Card/row bg | `#ede7dc` | `#f2f1f1` |
+| Primary text | `#1a1814` | `#0b252f` |
+| Secondary text | `#3a342b` | `#272726` |
+| Muted text | `#6b6253` | `#a5bbbe` |
+| Dividers | `#c9bfac` | `#edecec` |
+| Component borders | `#c9bfac` | `#a5bbbe` |
+| Active / accent | `#2a3d8f` | `#0b252f` |
+| Open (data) | `#1b6b5e` | `#f88376` |
+| Open-ish | `#d97c2a` | `#fbc7bf` |
+| Gap icons | `#c8341d` | `#ff0d0d` |
+| Headline font | Fraunces | Noto Serif |
+| Body font | Inter | Plus Jakarta Sans |
+| Mono font | JetBrains Mono | DM Mono |
+| Border radius | 4–10px | 0 (sharp corners) |
+
+---
+
+## Implementation notes — where the notebooks diverge from this guide
+
+Everything above (typography, neutrals, surfaces, sharp corners, the navy
+structural accent, the single-salmon brand highlight) is applied as written —
+that is what carries the "looks like the site" resemblance.
+
+The one place we adapted is **data colour**. The site encodes openness through
+*shape* (square vs triangle) and uses salmon as a sparing editorial accent. The
+notebooks are dense data instruments: they colour-encode an ordinal 0–5 openness
+scale, three independent axes, a 4-way distribution, and verdict states. Mapping
+those onto the site's two data hues 1:1 collapsed distinct values (open read the
+same as restricted) and produced low-contrast / heavy-black bars. Per this
+guide's own note that "some adaptation is expected," we made these deliberate,
+reviewed changes (signed off by Carl; worth confirming with the CF design team):
+
+**Openness → a single-hue salmon *sequential* ramp** (deepest = most open,
+fading to a pale-but-legible coral for closed). One ordered intensity scale, so
+open vs restricted are unambiguous and "warmth = openness" — open products carry
+the most colour, matching how the site uses salmon as the highlight.
+
+| Openness | Hex |
+|----------|-----|
+| Open (≥4) | `#e86f57` |
+| Open-ish (3) | `#f4886f` |
+| Restricted (2) | `#f8ad99` |
+| Closed (≤1) | `#f6cabd` |
+| No score | `#dcdcda` |
+
+**Adoption & capability → a quiet cool slate pair**, so the openness column is
+the only place colour lives: adoption `#8aa6ac` (light slate), capability
+`#3f5d68` (dark slate).
+
+**Verdict pills → one neutral tag** (`#f2f1f1` fill, navy text) for all five
+states. The verdict is categorical, not ordinal, so colour-coding it on the
+salmon ramp made "open-ish leads" and "closed leads" look alike; the colour
+story already lives in the open / open-ish / closed chips beside it.
+
+**products-view only** — it reuses these slots for different concepts, so it gets
+two more harmonised families, each distinct from the salmon openness ramp:
+
+- **Composition basis** (a confidence axis) → a cool slate ramp: known build
+  `#0b252f` (navy) → documented `#5f7e88` (mid slate) → similarity `#a5bbbe`
+  (light slate).
+- **Gaps / missing layers** → a muted brand red `#cf4436` (the site marks gaps
+  in red; `#ff0d0d` reserved for actual gap icons).
+
+**Header eyebrow** trimmed from `Current AI · Open Source AI Map · v3` to just
+`Current AI`.
+
+These values live in the `C` dict of `build/render.py` (ai-stack-map, generated)
+and `notebooks/products-view.py` (hand-authored). The openness ramp is shared
+verbatim between both so the openness encoding reads identically across views.

--- a/notebooks/products-view.py
+++ b/notebooks/products-view.py
@@ -8,7 +8,7 @@ app = marimo.App(width="full")
 def load_fonts(mo):
     mo.Html(
         '<style>'
-        '@import url("https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,300;9..144,400;9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap");'
+        '@import url("https://fonts.googleapis.com/css2?family=DM+Mono:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&family=Noto+Serif:ital,wght@0,400;0,600;1,400&family=Plus+Jakarta+Sans:ital,wght@0,200..800;1,200..800&display=swap");'
         '</style>'
     )
     return
@@ -17,14 +17,25 @@ def load_fonts(mo):
 @app.cell(hide_code=True)
 def style():
     F = {
-        "headline": "Fraunces, Georgia, serif",
-        "body": "Inter, -apple-system, system-ui, sans-serif",
-        "mono": "'JetBrains Mono', ui-monospace, SFMono-Regular, monospace",
+        "headline": "'Noto Serif', Georgia, serif",
+        "body": "'Plus Jakarta Sans', -apple-system, system-ui, sans-serif",
+        "mono": "'DM Mono', ui-monospace, SFMono-Regular, monospace",
     }
     C = {
-        "ink": "#1a1814", "ink_2": "#3a342b", "ink_3": "#6b6253",
-        "paper": "#f5f1ea", "paper_2": "#ede7dc", "rule": "#c9bfac",
-        "signal": "#c8341d", "healthy": "#1b6b5e", "warm": "#d97c2a", "accent": "#2a3d8f",
+        # Shared neutrals + structure (match ai-stack-map).
+        "ink": "#0b252f", "ink_2": "#272726", "ink_3": "#8fa1a4",
+        "paper": "#f7f6f6", "paper_2": "#f2f1f1", "rule": "#edecec",
+        "accent": "#0b252f", "white": "#ffffff", "border": "#a5bbbe",
+        # Openness ramp (match ai-stack-map): deep salmon = open, fading to pale.
+        # Used only for OPEN_LABEL dots and the modal openness pill.
+        "healthy": "#e86f57", "warm": "#f4886f", "signal": "#f8ad99",
+        "closed": "#f6cabd", "null": "#dcdcda",
+        # Composition-basis confidence ramp — cool, so it never reads as openness.
+        "basis_known": "#0b252f",   # known build — navy (most confident)
+        "basis_doc": "#5f7e88",     # documented  — mid slate
+        "basis_sim": "#a5bbbe",     # similarity  — light slate
+        # Gaps / missing layers — a muted brand red (the site marks gaps in red).
+        "gap": "#cf4436", "gap_red": "#ff0d0d",
     }
     # Openness class -> (label, color key). Same vocabulary as the parent stack map.
     OPEN_LABEL = {
@@ -35,24 +46,24 @@ def style():
         "source_available": ("Source available", "signal"),
         "restricted": ("Restricted", "signal"),
         "gated": ("Gated", "warm"),
-        "documented_only": ("Documented only", "ink_3"),
-        "closed": ("Closed", "ink_3"),
+        "documented_only": ("Documented only", "closed"),
+        "closed": ("Closed", "closed"),
     }
     # Composition-rule basis tag -> (short label, color key, definition). These are
     # THE rules for when a component counts as part of a product; see methodology.
     BASIS = {
-        "known_build": ("known build", "healthy",
+        "known_build": ("known build", "basis_known",
                         "Appears in a documented real-world build of this product pattern"),
-        "documented_component": ("documented", "accent",
+        "documented_component": ("documented", "basis_doc",
                                  "Its own documentation names this product pattern as a primary use case"),
-        "similarity": ("similarity", "warm",
+        "similarity": ("similarity", "basis_sim",
                        "Description similarity clears the lookup threshold; no documented pairing"),
     }
     # Gallery health -> (label, color key).
     HEALTH = {
-        "healthy": ("All layers covered", "healthy"),
-        "partial": ("Buildable, with gaps", "warm"),
-        "gap": ("Gap probe", "signal"),
+        "healthy": ("All layers covered", "accent"),
+        "partial": ("Buildable, with gaps", "basis_doc"),
+        "gap": ("Gap probe", "gap"),
     }
     return BASIS, C, F, HEALTH, OPEN_LABEL
 
@@ -439,8 +450,8 @@ def header(C, F, GENERATED, N_TOTAL, mo):
         f'<div style="padding:40px 0 28px; border-bottom:2px solid {C["accent"]}; margin-bottom:36px;">'
         f'<div style="font-family:{F["mono"]}; font-size:11px; color:{C["ink_3"]}; '
         f'letter-spacing:0.1em; text-transform:uppercase; margin-bottom:10px;">'
-        f'Current AI · Open Source AI Map · Products view</div>'
-        f'<h1 style="font-family:{F["headline"]}; font-size:2.2rem; font-weight:400; '
+        f'Current AI</div>'
+        f'<h1 style="font-family:{F["headline"]}; font-size:2.2rem; font-weight:600; '
         f'color:{C["ink"]}; margin:0 0 14px; line-height:1.05; letter-spacing:-0.025em;">'
         f'You have an idea. Here’s the open stack to build it on.</h1>'
         f'<p style="font-family:{F["body"]}; font-size:1rem; color:{C["ink_2"]}; '
@@ -489,7 +500,7 @@ def coverage_matrix(C, CATS, F, GALLERY, HEALTH, ORDER, mo):
     # Products x layers: which layers each reference product draws on, colored
     # by the strongest composition basis in that layer. The edges back to the
     # stack map, at a glance.
-    _BC = {"known_build": C["healthy"], "documented_component": C["accent"], "similarity": C["warm"]}
+    _BC = {"known_build": C["basis_known"], "documented_component": C["basis_doc"], "similarity": C["basis_sim"]}
     _PRIO = {"known_build": 0, "documented_component": 1, "similarity": 2}
     _head = '<th style="text-align:left; padding:6px 8px;"></th>' + "".join(
         f'<th title="{CATS[_cid]["label"]}" style="padding:6px 3px; font-family:{F["mono"]}; '
@@ -506,15 +517,15 @@ def coverage_matrix(C, CATS, F, GALLERY, HEALTH, ORDER, mo):
         _hl, _hc = HEALTH[_g["health"]]
         _cells = "".join(
             (f'<td style="padding:4px 3px; text-align:center;">'
-             f'<div title="{CATS[_cid]["label"]}" style="width:16px; height:16px; border-radius:3px; '
+             f'<div title="{CATS[_cid]["label"]}" style="width:16px; height:16px; border-radius:0; '
              f'background:{_BC[_bymap[_cid]]}; margin:0 auto;"></div></td>')
             if _cid in _bymap else
             f'<td style="padding:4px 3px; text-align:center;"><div style="width:16px; height:16px; '
-            f'border-radius:3px; background:{C["paper_2"]}; margin:0 auto;"></div></td>'
+            f'border-radius:0; background:{C["paper_2"]}; margin:0 auto;"></div></td>'
             for _cid in ORDER
         )
         _gapcell = (f'<td style="padding:4px 8px; text-align:center; font-family:{F["mono"]}; '
-                    f'font-size:0.78rem; color:{C["signal"] if _g["gaps"] else C["rule"]};">'
+                    f'font-size:0.78rem; color:{C["gap"] if _g["gaps"] else C["rule"]};">'
                     f'{len(_g["gaps"]) or "—"}</td>')
         _rows += (
             f'<tr style="border-bottom:1px solid {C["paper_2"]};">'
@@ -524,9 +535,9 @@ def coverage_matrix(C, CATS, F, GALLERY, HEALTH, ORDER, mo):
         )
     _legend = "".join(
         f'<span style="margin-right:16px;"><span style="display:inline-block; width:11px; height:11px; '
-        f'border-radius:2px; background:{_c}; vertical-align:-1px; margin-right:5px;"></span>{_l}</span>'
-        for _l, _c in [("known build", C["healthy"]), ("documented component", C["accent"]),
-                       ("similarity only", C["warm"]), ("layer not needed", C["paper_2"])]
+        f'border-radius:0; background:{_c}; vertical-align:-1px; margin-right:5px;"></span>{_l}</span>'
+        for _l, _c in [("known build", C["basis_known"]), ("documented component", C["basis_doc"]),
+                       ("similarity only", C["basis_sim"]), ("layer not needed", C["paper_2"])]
     )
     mo.Html(
         f'<div style="margin:36px 0 8px;">'
@@ -553,7 +564,7 @@ def lookup_header(C, F, mo):
         f'<div style="margin:44px 0 14px; padding:24px 0 0; border-top:2px solid {C["accent"]};">'
         f'<div style="font-family:{F["mono"]}; font-size:10px; color:{C["accent"]}; '
         f'letter-spacing:0.1em; text-transform:uppercase; margin-bottom:8px;">Lookup · mode 1</div>'
-        f'<h2 style="font-family:{F["headline"]}; font-size:1.6rem; font-weight:500; color:{C["ink"]}; '
+        f'<h2 style="font-family:{F["headline"]}; font-size:1.6rem; font-weight:600; color:{C["ink"]}; '
         f'margin:0 0 12px; letter-spacing:-0.015em;">Describe what you want to build</h2>'
         f'<p style="font-family:{F["body"]}; font-size:0.95rem; color:{C["ink_2"]}; margin:0; line-height:1.6;">'
         f'Type a product description (or pick a user story) and get suggested components ranked by relevance, '
@@ -616,8 +627,8 @@ def lookup_results(C, CATS, CAT_KW, F, OPEN_LABEL, ORDER, TH, gap_triggers,
                     f'color:{C["ink"]}; font-weight:{600 if _strong else 400};">{_p["n"]}'
                     f'<span style="font-family:{F["mono"]}; font-size:0.6rem; color:{C[_ock]}; '
                     f'margin-left:7px; text-transform:uppercase;">{_ol}</span></div>'
-                    f'<div style="flex:1; background:{C["paper_2"]}; border-radius:2px; height:8px;">'
-                    f'<div style="width:{_w}%; height:8px; border-radius:2px; '
+                    f'<div style="flex:1; background:{C["paper_2"]}; border-radius:0; height:8px;">'
+                    f'<div style="width:{_w}%; height:8px; border-radius:0; '
                     f'background:{C["accent"] if _strong else C["rule"]};"></div></div>'
                     f'<div style="font-family:{F["mono"]}; font-size:0.7rem; color:{C["ink_3"]}; '
                     f'min-width:42px; text-align:right;">{_s:.3f}</div></div>'
@@ -636,7 +647,7 @@ def lookup_results(C, CATS, CAT_KW, F, OPEN_LABEL, ORDER, TH, gap_triggers,
         )
     if not _groups:
         _groups = (
-            f'<p style="font-family:{F["body"]}; font-size:0.9rem; color:{C["signal"]}; line-height:1.5;">'
+            f'<p style="font-family:{F["body"]}; font-size:0.9rem; color:{C["gap"]}; line-height:1.5;">'
             f'No layer clears the display threshold for this description. That itself is a strong gap signal: '
             f'the open stack has little to offer this product today.</p>'
         )
@@ -653,32 +664,32 @@ def lookup_results(C, CATS, CAT_KW, F, OPEN_LABEL, ORDER, TH, gap_triggers,
     for _c in _weak:
         _gap_items += (
             f'<div style="margin:5px 0; font-size:0.84rem; color:{C["ink_2"]}; line-height:1.5;">'
-            f'<span style="font-family:{F["mono"]}; font-size:0.6rem; color:white; background:{C["warm"]}; '
-            f'padding:2px 7px; border-radius:9px; text-transform:uppercase; margin-right:8px;">weak layer</span>'
+            f'<span style="font-family:{F["mono"]}; font-size:0.6rem; color:white; background:{C["gap"]}; '
+            f'padding:2px 7px; border-radius:0; text-transform:uppercase; margin-right:8px;">weak layer</span>'
             f'<strong>{CATS[_c]["label"]}</strong>: your description implies this layer, but the best '
             f'open match scores {_best_open.get(_c, 0.0):.3f} (threshold {TH["gap"]}).</div>'
         )
     for _c in _closed_only:
         _gap_items += (
             f'<div style="margin:5px 0; font-size:0.84rem; color:{C["ink_2"]}; line-height:1.5;">'
-            f'<span style="font-family:{F["mono"]}; font-size:0.6rem; color:white; background:{C["warm"]}; '
-            f'padding:2px 7px; border-radius:9px; text-transform:uppercase; margin-right:8px;">closed only</span>'
+            f'<span style="font-family:{F["mono"]}; font-size:0.6rem; color:white; background:{C["gap"]}; '
+            f'padding:2px 7px; border-radius:0; text-transform:uppercase; margin-right:8px;">closed only</span>'
             f'<strong>{CATS[_c]["label"]}</strong>: this layer answers your description, but only with '
             f'closed components.</div>'
         )
     for _t, _w in _structural:
         _gap_items += (
             f'<div style="margin:5px 0; font-size:0.84rem; color:{C["ink_2"]}; line-height:1.5;">'
-            f'<span style="font-family:{F["mono"]}; font-size:0.6rem; color:white; background:{C["signal"]}; '
-            f'padding:2px 7px; border-radius:9px; text-transform:uppercase; margin-right:8px;">structural</span>'
+            f'<span style="font-family:{F["mono"]}; font-size:0.6rem; color:white; background:{C["gap"]}; '
+            f'padding:2px 7px; border-radius:0; text-transform:uppercase; margin-right:8px;">structural</span>'
             f'<strong>{_t}</strong>: {_w}</div>'
         )
     _gap_panel = ""
     if _gap_items:
         _gap_panel = (
             f'<div style="margin:18px 0 0; padding:12px 16px; background:{C["paper"]}; '
-            f'border-left:3px solid {C["signal"]}; border-radius:0 4px 4px 0;">'
-            f'<div style="font-family:{F["mono"]}; font-size:0.62rem; color:{C["signal"]}; '
+            f'border-left:3px solid {C["gap"]}; border-radius:0;">'
+            f'<div style="font-family:{F["mono"]}; font-size:0.62rem; color:{C["gap"]}; '
             f'letter-spacing:0.08em; text-transform:uppercase; margin-bottom:4px;">'
             f'Gap signals for this description</div>{_gap_items}'
             f'<div style="font-family:{F["body"]}; font-size:0.76rem; color:{C["ink_3"]}; margin-top:8px;">'
@@ -687,7 +698,7 @@ def lookup_results(C, CATS, CAT_KW, F, OPEN_LABEL, ORDER, TH, gap_triggers,
         )
     mo.Html(
         f'<div style="margin:8px 0 10px; padding:16px 20px; background:white; '
-        f'border:1px solid {C["rule"]}; border-radius:6px;">'
+        f'border:1px solid {C["rule"]}; border-radius:0;">'
         f'<div style="font-family:{F["mono"]}; font-size:0.66rem; color:{C["ink_3"]}; margin-bottom:8px;">'
         f'Query · “{_q}” · {"open components only" if _open_only else "all components"} '
         f'· top 3 per layer, layers shown when best score ≥ {TH["show"]}</div>'
@@ -709,7 +720,7 @@ def gallery_cards(BASIS, BY_NAME, C, CATS, F, GALLERY, HEALTH, OPEN_LABEL, mo):
         return (
             f'<span class="pv-details" data-pid="{name}" title="Click for the full scorecard" '
             f'style="display:inline-block; margin:0 6px 6px 0; padding:4px 9px; '
-            f'background:white; border:1px solid {C["rule"]}; border-radius:4px; cursor:pointer;">'
+            f'background:white; border:1px solid {C["rule"]}; border-radius:0; cursor:pointer;">'
             f'<span title="{_ol}" style="display:inline-block; width:8px; height:8px; '
             f'border-radius:50%; background:{C[_ock]}; margin-right:6px;"></span>'
             f'<span style="font-family:{F["body"]}; font-size:0.82rem; color:{C["ink"]}; font-weight:600;">{name}</span>'
@@ -745,26 +756,26 @@ def gallery_cards(BASIS, BY_NAME, C, CATS, F, GALLERY, HEALTH, OPEN_LABEL, mo):
             _gitems = "".join(
                 f'<div style="margin:6px 0; font-size:0.84rem; line-height:1.5; color:{C["ink_2"]};">'
                 f'<span style="font-family:{F["mono"]}; font-size:0.62rem; color:white; '
-                f'background:{C["signal"] if _k == "structural" else C["warm"]}; padding:2px 7px; '
-                f'border-radius:9px; text-transform:uppercase; letter-spacing:0.04em; margin-right:8px;">{_k.replace("_", " ")}</span>'
+                f'background:{C["gap"]}; padding:2px 7px; '
+                f'border-radius:0; text-transform:uppercase; letter-spacing:0.04em; margin-right:8px;">{_k.replace("_", " ")}</span>'
                 f'<strong>{_t}.</strong> {_w}</div>'
                 for _k, _t, _w in _g["gaps"]
             )
             _gaps_html = (
                 f'<div style="margin:14px 0 0; padding:10px 14px; background:{C["paper"]}; '
-                f'border-left:3px solid {C["signal"]}; border-radius:0 4px 4px 0;">'
-                f'<div style="font-family:{F["mono"]}; font-size:0.62rem; color:{C["signal"]}; '
+                f'border-left:3px solid {C["gap"]}; border-radius:0;">'
+                f'<div style="font-family:{F["mono"]}; font-size:0.62rem; color:{C["gap"]}; '
                 f'letter-spacing:0.08em; text-transform:uppercase; margin-bottom:4px;">Gap signals</div>'
                 f'{_gitems}</div>'
             )
         _cards += (
             f'<div style="margin:0 0 26px; padding:20px 22px; background:white; '
-            f'border:1px solid {C["rule"]}; border-radius:6px;">'
+            f'border:1px solid {C["rule"]}; border-radius:0;">'
             f'<div style="display:flex; justify-content:space-between; align-items:baseline; gap:12px;">'
-            f'<h3 style="font-family:{F["headline"]}; font-size:1.25rem; font-weight:500; '
+            f'<h3 style="font-family:{F["headline"]}; font-size:1.25rem; font-weight:600; '
             f'color:{C["ink"]}; margin:0;">{_i:02d} · {_g["title"]}</h3>'
             f'<span style="font-family:{F["mono"]}; font-size:0.64rem; color:white; background:{C[_hck]}; '
-            f'padding:3px 10px; border-radius:10px; text-transform:uppercase; letter-spacing:0.05em; '
+            f'padding:3px 10px; border-radius:0; text-transform:uppercase; letter-spacing:0.05em; '
             f'white-space:nowrap;">{_hl}</span></div>'
             f'<p style="font-family:{F["body"]}; font-size:0.9rem; color:{C["ink_2"]}; '
             f'line-height:1.55; margin:8px 0 4px;">{_g["desc"]}</p>'
@@ -774,7 +785,7 @@ def gallery_cards(BASIS, BY_NAME, C, CATS, F, GALLERY, HEALTH, OPEN_LABEL, mo):
         f'<div style="margin:44px 0 20px; padding:24px 0 0; border-top:2px solid {C["accent"]};">'
         f'<div style="font-family:{F["mono"]}; font-size:10px; color:{C["accent"]}; '
         f'letter-spacing:0.1em; text-transform:uppercase; margin-bottom:8px;">Gallery · mode 2</div>'
-        f'<h2 style="font-family:{F["headline"]}; font-size:1.6rem; font-weight:500; color:{C["ink"]}; '
+        f'<h2 style="font-family:{F["headline"]}; font-size:1.6rem; font-weight:600; color:{C["ink"]}; '
         f'margin:0 0 12px; letter-spacing:-0.015em;">Ten things you can build (and what they’re made of)</h2>'
         f'<p style="font-family:{F["body"]}; font-size:0.95rem; color:{C["ink_2"]}; margin:0 0 22px; line-height:1.6;">'
         f'Each card is a reference product: a realistic build, its component stack drawn from the map’s '
@@ -805,8 +816,8 @@ def gaps_aggregate(C, CATS, F, GALLERY, ORDER, mo):
             f'<div style="display:flex; align-items:center; gap:10px; margin:5px 0;">'
             f'<div style="min-width:210px; font-family:{F["mono"]}; font-size:0.72rem; '
             f'color:{C["ink_2"]};">{CATS[_cid]["label"]}</div>'
-            f'<div style="flex:1; background:{C["paper_2"]}; border-radius:2px; height:12px;">'
-            f'<div style="width:{_w}%; height:12px; border-radius:2px; background:{C["accent"]};"></div></div>'
+            f'<div style="flex:1; background:{C["paper_2"]}; border-radius:0; height:12px;">'
+            f'<div style="width:{_w}%; height:12px; border-radius:0; background:{C["accent"]};"></div></div>'
             f'<div style="font-family:{F["mono"]}; font-size:0.74rem; color:{C["ink_3"]}; '
             f'min-width:80px; text-align:right;">{_demand[_cid]} of {len(GALLERY)}</div></div>'
         )
@@ -818,8 +829,8 @@ def gaps_aggregate(C, CATS, F, GALLERY, ORDER, mo):
     _gap_rows = "".join(
         f'<tr style="border-bottom:1px solid {C["paper_2"]};">'
         f'<td style="padding:8px 10px;"><span style="font-family:{F["mono"]}; font-size:0.62rem; color:white; '
-        f'background:{C["signal"] if _v["kind"] == "structural" else C["warm"]}; padding:2px 8px; '
-        f'border-radius:9px; text-transform:uppercase;">{_v["kind"].replace("_", " ")}</span></td>'
+        f'background:{C["gap"]}; padding:2px 8px; '
+        f'border-radius:0; text-transform:uppercase;">{_v["kind"].replace("_", " ")}</span></td>'
         f'<td style="padding:8px 10px; font-family:{F["body"]}; font-size:0.86rem; color:{C["ink"]}; '
         f'font-weight:600; white-space:nowrap;">{_t}</td>'
         f'<td style="padding:8px 10px; font-family:{F["body"]}; font-size:0.82rem; color:{C["ink_2"]}; '
@@ -837,7 +848,7 @@ def gaps_aggregate(C, CATS, F, GALLERY, ORDER, mo):
         f'<div style="margin:44px 0 20px; padding:24px 0 0; border-top:2px solid {C["accent"]};">'
         f'<div style="font-family:{F["mono"]}; font-size:10px; color:{C["accent"]}; '
         f'letter-spacing:0.1em; text-transform:uppercase; margin-bottom:8px;">Gaps the products reveal</div>'
-        f'<h2 style="font-family:{F["headline"]}; font-size:1.6rem; font-weight:500; color:{C["ink"]}; '
+        f'<h2 style="font-family:{F["headline"]}; font-size:1.6rem; font-weight:600; color:{C["ink"]}; '
         f'margin:0 0 12px; letter-spacing:-0.015em;">Where composition breaks down</h2>'
         f'<p style="font-family:{F["body"]}; font-size:0.95rem; color:{C["ink_2"]}; margin:0 0 16px; line-height:1.6;">'
         f'The bars below count how many of the {len(GALLERY)} reference products draw on each layer. '
@@ -925,7 +936,7 @@ def builder_demand_ui(BATCH, C, F, mo):
         f'<div style="margin:44px 0 14px; padding:24px 0 0; border-top:2px solid {C["accent"]};">'
         f'<div style="font-family:{F["mono"]}; font-size:10px; color:{C["accent"]}; '
         f'letter-spacing:0.1em; text-transform:uppercase; margin-bottom:8px;">Common combinations</div>'
-        f'<h2 style="font-family:{F["headline"]}; font-size:1.6rem; font-weight:500; color:{C["ink"]}; '
+        f'<h2 style="font-family:{F["headline"]}; font-size:1.6rem; font-weight:600; color:{C["ink"]}; '
         f'margin:0 0 12px; letter-spacing:-0.015em;">How often each open project comes up</h2>'
         f'<p style="font-family:{F["body"]}; font-size:0.95rem; color:{C["ink_2"]}; margin:0; line-height:1.6;">'
         f'We ran <strong>{BATCH["n_prompts"]}</strong> synthetic builder requests (combinations of '
@@ -991,18 +1002,18 @@ def builder_demand_table(BATCH, C, CATS, COMPONENTS, F, OPEN_CLASSES, OPEN_LABEL
     _body = ""
     for _r in _slice:
         _w = round(_r["count"] / _maxc * 100)
-        _barcol = C["healthy"] if _r["count"] else C["paper_2"]
+        _barcol = C["accent"] if _r["count"] else C["paper_2"]
         _body += (
             f'<tr style="border-bottom:1px solid {C["paper_2"]};">'
             f'<td style="padding:8px 10px; font-family:{F["body"]}; font-size:0.86rem; color:{C["ink"]}; '
             f'font-weight:600; white-space:nowrap;">{_r["name"]}</td>'
             f'<td style="padding:8px 10px; font-family:{F["body"]}; font-size:0.82rem; color:{C["ink_2"]};">{_r["cat"]}</td>'
             f'<td style="padding:8px 10px;"><span style="font-family:{F["mono"]}; font-size:0.6rem; color:white; '
-            f'background:{_r["open_color"]}; padding:2px 8px; border-radius:9px; text-transform:uppercase; '
+            f'background:{_r["open_color"]}; padding:2px 8px; border-radius:0; text-transform:uppercase; '
             f'letter-spacing:0.04em; white-space:nowrap;">{_r["open_label"]}</span></td>'
             f'<td style="padding:8px 10px; width:42%;"><div style="display:flex; align-items:center; gap:8px;">'
-            f'<div style="flex:1; background:{C["paper_2"]}; border-radius:2px; height:10px; min-width:60px;">'
-            f'<div style="width:{_w}%; height:10px; border-radius:2px; background:{_barcol};"></div></div>'
+            f'<div style="flex:1; background:{C["paper_2"]}; border-radius:0; height:10px; min-width:60px;">'
+            f'<div style="width:{_w}%; height:10px; border-radius:0; background:{_barcol};"></div></div>'
             f'<div style="font-family:{F["mono"]}; font-size:0.74rem; color:{C["ink_3"]}; min-width:28px; '
             f'text-align:right;">{_r["count"]}</div></div></td></tr>'
         )
@@ -1071,41 +1082,42 @@ def details_modal(CATS, COMPONENTS, mo):
         }
     _pj = _json.dumps(_payload, ensure_ascii=False)
     _css = (
-        ".pv-details:hover{border-color:#2a3d8f !important;box-shadow:0 1px 4px rgba(42,61,143,0.22);}"
-        ".v3-bd{position:fixed;inset:0;background:rgba(26,24,20,0.55);z-index:99999;display:flex;"
-        "align-items:flex-start;justify-content:center;padding:40px 20px;overflow-y:auto;font-family:Inter,system-ui,sans-serif;}"
-        ".v3-modal{background:#fff;border-radius:10px;max-width:780px;width:100%;padding:24px 28px;box-shadow:0 20px 60px rgba(0,0,0,0.25);}"
-        ".v3-modal h2{font-family:Fraunces,Georgia,serif;font-weight:500;font-size:1.4rem;margin:0 0 4px;color:#1a1814;}"
-        ".v3-x{float:right;cursor:pointer;background:none;border:1px solid #c9bfac;border-radius:5px;padding:4px 10px;font-size:12px;color:#6b6253;}"
-        ".v3-sect{margin:16px 0 6px;font-family:'JetBrains Mono',ui-monospace,monospace;font-size:10.5px;text-transform:uppercase;"
-        "letter-spacing:0.08em;color:#2a3d8f;font-weight:600;border-bottom:1px solid #c9bfac;padding-bottom:4px;}"
-        ".v3-row{display:flex;gap:14px;margin:5px 0;font-size:13px;color:#3a342b;}"
-        ".v3-lbl{min-width:96px;color:#6b6253;font-family:'JetBrains Mono',ui-monospace,monospace;font-size:11.5px;}"
+        ".pv-details:hover{border-color:#0b252f !important;box-shadow:0 1px 4px rgba(11,37,47,0.22);}"
+        ".v3-bd{position:fixed;inset:0;background:rgba(11,37,47,0.55);z-index:99999;display:flex;"
+        "align-items:flex-start;justify-content:center;padding:40px 20px;overflow-y:auto;font-family:'Plus Jakarta Sans',system-ui,sans-serif;}"
+        ".v3-modal{background:#fff;border-radius:0;max-width:780px;width:100%;padding:24px 28px;box-shadow:0px 4px 4px 0px rgba(0,0,0,0.05);}"
+        ".v3-modal h2{font-family:'Noto Serif',Georgia,serif;font-weight:600;font-size:1.4rem;letter-spacing:-0.015em;margin:0 0 4px;color:#0b252f;}"
+        ".v3-x{float:right;cursor:pointer;background:none;border:1px solid #a5bbbe;border-radius:0;padding:4px 10px;font-size:11px;color:#a5bbbe;}"
+        ".v3-sect{margin:16px 0 6px;font-family:'DM Mono',ui-monospace,monospace;font-size:10px;text-transform:uppercase;"
+        "letter-spacing:0.08em;color:#0b252f;opacity:0.5;font-weight:600;border-bottom:1px solid #edecec;padding-bottom:4px;}"
+        ".v3-row{display:flex;gap:14px;margin:5px 0;font-size:13px;color:#272726;}"
+        ".v3-lbl{min-width:96px;color:#a5bbbe;font-family:'DM Mono',ui-monospace,monospace;font-size:11px;}"
         ".v3-val{flex:1;line-height:1.45;}"
-        ".v3-pill{display:inline-block;padding:2px 8px;border-radius:10px;color:#fff;font-size:11px;font-weight:600;}"
-        ".v3-modal ul{margin:4px 0;padding-left:20px;font-size:12.5px;color:#3a342b;line-height:1.5;}"
-        ".v3-modal a{color:#2a3d8f;text-decoration:none;}.v3-modal a:hover{text-decoration:underline;}"
+        ".v3-pill{display:inline-block;padding:2px 8px;border-radius:0;color:#fff;font-size:11px;font-weight:600;}"
+        ".v3-modal ul{margin:4px 0;padding-left:20px;font-size:12.5px;color:#272726;line-height:1.5;}"
+        ".v3-modal a{color:#0b252f;text-decoration:none;}.v3-modal a:hover{text-decoration:underline;}"
     )
     _js = r'''
     (function(){
       if (window.__PV_INSTALLED__) { window.__PV_PAYLOAD__ = __PAYLOAD__; return; }
       window.__PV_INSTALLED__ = true; window.__PV_PAYLOAD__ = __PAYLOAD__;
       var esc=function(s){return String(s==null?'':s).replace(/[&<>"']/g,function(c){return ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'})[c];});};
-      function ocol(sc){return sc==null?'#6b6253':(sc>=4?'#1b6b5e':(sc==3?'#d97c2a':(sc==2?'#c8341d':'#6b6253')));}
-      function srcs(a){if(!a||!a.length)return '<span style="color:#aaa">no sources</span>';
+      function ocol(sc){return sc==null?'#dcdcda':(sc>=4?'#e86f57':(sc==3?'#f4886f':(sc==2?'#f8ad99':'#f6cabd')));}
+      function otext(sc){return '#0b252f';}
+      function srcs(a){if(!a||!a.length)return '<span style="color:#a5bbbe">no sources</span>';
         return '<ul>'+a.map(function(s){var u=s&&s.url?s.url:'';var sh=s&&s.shows?s.shows:u;
         return u?'<li><a href="'+esc(u)+'" target="_blank" rel="noopener">'+esc(sh||u)+'</a></li>':'<li>'+esc(sh)+'</li>';}).join('')+'</ul>';}
-      function row(l,v){if(v==null||v==='')v='<em style="color:#aaa">n/a</em>';
+      function row(l,v){if(v==null||v==='')v='<em style="color:#a5bbbe">n/a</em>';
         return '<div class="v3-row"><span class="v3-lbl">'+esc(l)+'</span><span class="v3-val">'+(typeof v==='string'&&v.indexOf('<')===0?v:esc(v))+'</span></div>';}
       function build(p){
         var o=p.openness||{},ad=p.adoption||{},cap=p.capability||{};
         var h='<div class="v3-bd"><div class="v3-modal"><button class="v3-x">Close ✕</button>'+
           '<h2>'+esc(p.product||'')+'</h2>'+
-          '<div style="font-family:\'JetBrains Mono\',monospace;font-size:11px;color:#6b6253;margin-bottom:6px;">'+
+          '<div style="font-family:\'DM Mono\',monospace;font-size:11px;color:#a5bbbe;margin-bottom:6px;">'+
             esc(p.org||'')+' · '+esc(p.type||'')+' · '+esc(p.category_label||'')+
-            (o.class?' · <span class="v3-pill" style="background:'+ocol(o.score)+'">'+esc(o.class)+'</span>':'')+'</div>'+
-          (p.description?'<div style="font-size:13px;color:#3a342b;line-height:1.5;margin:8px 0;">'+esc(p.description)+'</div>':'')+
-          (p.version_note?'<div style="font-size:11.5px;color:#6b6253;line-height:1.45;margin:6px 0;">'+esc(p.version_note)+'</div>':'')+
+            (o.class?' · <span class="v3-pill" style="background:'+ocol(o.score)+';color:'+otext(o.score)+'">'+esc(o.class)+'</span>':'')+'</div>'+
+          (p.description?'<div style="font-size:13px;color:#272726;line-height:1.5;margin:8px 0;">'+esc(p.description)+'</div>':'')+
+          (p.version_note?'<div style="font-size:11.5px;color:#a5bbbe;line-height:1.45;margin:6px 0;">'+esc(p.version_note)+'</div>':'')+
           '<div class="v3-sect">Openness · '+(o.score==null?'n/a':o.score+'/5')+' ('+esc(o.class||'')+')</div>'+
           row('Components',o.components)+row('Why',o.note)+row('Confidence',o.confidence)+
           '<div class="v3-row"><span class="v3-lbl">Sources</span><span class="v3-val">'+srcs(o.sources)+'</span></div>'+


### PR DESCRIPTION
Applies Joost's `design.md` to both published notebooks so they visually align with the Current AI site, with deliberate data-colour adaptations where the editorial palette was too thin for a data instrument.

## Summary
- **System-level alignment** (carries the "looks like the site" resemblance): Noto Serif / Plus Jakarta Sans / DM Mono, the site neutrals, sharp corners, navy structural accent, and a single salmon brand highlight.
- **Openness** → a single-hue salmon **sequential** ramp (deep = open → pale coral = closed). Shared verbatim by both notebooks so the openness encoding reads identically.
- **Adoption / capability** → a quiet cool slate pair (adoption light, capability dark).
- **Verdict pills** → one neutral tag for all five states. The verdict is categorical, not ordinal, so colour-coding it on the openness ramp made "open-ish leads" and "closed leads" look alike; colour now lives only in the open / open-ish / closed chips.
- **products-view** also gets two harmonised families distinct from openness: composition **basis** as a cool slate confidence ramp, and **gaps** as a muted brand red.
- Header eyebrow trimmed to "Current AI".

## Why we diverged from design.md
The site encodes openness by *shape* and uses salmon as a sparing accent. The notebooks colour-encode an ordinal 0–5 scale, three axes, a 4-way distribution, and verdict states; a literal 1:1 swap collapsed distinct values (open == restricted) and produced heavy near-black bars. `design.md` anticipates "some adaptation is expected." The adaptations are documented in `docs/guides/notebook-design.md` — **worth confirming with the CF design team (Joost/Pien) since they own the design translation.**

## Files
- `build/render.py` — ai-stack-map styling (the notebook is regenerated by the bot on merge; not hand-edited here).
- `notebooks/products-view.py` — hand-authored cells only; the regenerated `PAYLOAD` line is untouched.
- `docs/guides/notebook-design.md` — Joost's spec plus an "Implementation notes — where the notebooks diverge" section.

## Test plan
- `uv run python -m build.validate` → 0 errors.
- `uv run python build/products_view_data.py --check` → 421 components, 0 unresolved gallery exemplars.
- Level-1 notebook checks pass on both notebooks.
- Both notebooks rendered locally (marimo + HTML export) with 0 console errors; interactive filters and the Details modal verified.