### PR TITLE
Copy pass: "open source" (not "open-source") and no em dashes

### DIFF
--- a/notebooks/products-view.py
+++ b/notebooks/products-view.py
@@ -459,7 +459,7 @@ def header(C, F, GENERATED, N_TOTAL, mo):
         f'Maybe it’s a chat assistant that keeps patient records in the building. A coding agent '
         f'for your team. A question-answering service over your country’s public records. '
         f'Whatever you’re building, the hard part is rarely the idea. It’s knowing which of the '
-        f'<strong>{N_TOTAL} scored open-source AI components</strong> on this map to trust at each '
+        f'<strong>{N_TOTAL} scored open source AI components</strong> on this map to trust at each '
         f'layer of the stack. Start with the <strong>lookup tool</strong>: describe your product '
         f'in your own words and get suggested components for every layer, ranked. Or browse the '
         f'<strong>gallery</strong>: 10 reference builds, each broken down into the components '
@@ -694,7 +694,7 @@ def lookup_results(C, CATS, CAT_KW, F, OPEN_LABEL, ORDER, TH, gap_triggers,
             f'Gap signals for this description</div>{_gap_items}'
             f'<div style="font-family:{F["body"]}; font-size:0.76rem; color:{C["ink_3"]}; margin-top:8px;">'
             f'These signals feed the map’s gap analysis: a sensible product description that the stack '
-            f'answers weakly marks a place where open-source AI needs investment.</div></div>'
+            f'answers weakly marks a place where open source AI needs investment.</div></div>'
         )
     mo.Html(
         f'<div style="margin:8px 0 10px; padding:16px 20px; background:white; '

--- a/sources/categories/base_pretrained.yaml
+++ b/sources/categories/base_pretrained.yaml
@@ -1,7 +1,7 @@
 name: base_pretrained
 display_name: Base / pretrained models
 description: "Foundation models trained from scratch."
-strapline: The frontier is open-weights, not open-source. Only a handful of families ship the full pipeline;
+strapline: The frontier is open-weights, not open source. Only a handful of families ship the full pipeline;
   the rest withhold data or licenses.
 weights:
   adopt: 0.3

--- a/sources/categories/ml_frameworks.yaml
+++ b/sources/categories/ml_frameworks.yaml
@@ -1,8 +1,8 @@
 name: ml_frameworks
 display_name: Core ML frameworks & libraries
 description: "Foundational libraries the rest of the stack is built on."
-strapline: The most open layer in the map. Every core library the stack imports — PyTorch,
-  the Hugging Face stack, the tokenizers and file formats — ships under an OSI license. Here
+strapline: The most open layer in the map. Every core library the stack imports (PyTorch,
+  the Hugging Face stack, the tokenizers and file formats) ships under an OSI license. Here
   openness is the default, not the exception.
 weights:
   adopt: 0.6
@@ -31,7 +31,7 @@ products:
 - pysyft
 - feluda
 comments: 'Horizontal dependencies the model/inference/fine-tuning/UI rows are built on
-  top of — DL frameworks, the HF library stack, file formats, and optimization/runtime
+  top of: DL frameworks, the HF library stack, file formats, and optimization/runtime
   libraries. Software openness vocabulary. Dedup note: peft/trl/torchtune/axolotl/
   llama-factory/unsloth/megatron-lm stay in finetuning_code; vllm/sglang/tensorrt-llm/
   onnx-runtime/text-generation-inference stay in inference_code. Proposed in issue #11.'

--- a/sources/categories/training_synthetic_datasets.yaml
+++ b/sources/categories/training_synthetic_datasets.yaml
@@ -1,7 +1,7 @@
 name: training_synthetic_datasets
 display_name: Training & synthetic datasets
 description: "Corpora for pre-training and post-training models."
-strapline: Open data exists — just not the frontier's. The community ships FineWeb-scale
+strapline: Open data exists, just not the frontier's. The community ships FineWeb-scale
   corpora while the labs keep their real training mix closed, and a few of the biggest sets
   sit behind access gates.
 weights:
@@ -31,6 +31,6 @@ products:
 - ultrafeedback
 - hh-rlhf
 - synth
-comments: 'Pre-training corpora + post-training/synthetic/preference data — everything
+comments: 'Pre-training corpora + post-training/synthetic/preference data: everything
   consumed to BUILD a model, as opposed to benchmark_eval_data which scores one. Dataset
   openness vocabulary (open / gated / documented_only / closed). Proposed in issue #10.'

--- a/sources/products/agent2agent-protocol.yaml
+++ b/sources/products/agent2agent-protocol.yaml
@@ -2,7 +2,7 @@ name: agent2agent-protocol
 display_name: Agent2Agent Protocol
 type: software
 description: Open protocol enabling communication and interoperability between opaque agentic applications.
-  Where MCP connects agents to tools, A2A connects agents to other agents — defining task delegation,
+  Where MCP connects agents to tools, A2A connects agents to other agents, defining task delegation,
   status updates, and result passing between autonomous systems. Initiated by Google with 24K GitHub stars.
   Still early-stage but positioned as the complementary standard to MCP for multi-agent workflows.
 comments: A2A open protocol for inter-agent interoperability; contributed by Google, hosted by the Linux

--- a/sources/products/agentops.yaml
+++ b/sources/products/agentops.yaml
@@ -2,12 +2,12 @@ name: agentops
 display_name: AgentOps
 type: software
 description: Python SDK for AI agent monitoring, LLM cost tracking, and benchmarking. Purpose-built for
-  the agent era — tracks multi-step agent sessions, tool calls, and costs across frameworks (CrewAI, Agno,
+  the agent era, tracks multi-step agent sessions, tool calls, and costs across frameworks (CrewAI, Agno,
   OpenAI Agents SDK, LangChain, Autogen). Lightweight instrumentation with two-line setup. 5.6K GitHub
   stars.
 github:
 - url: https://github.com/AgentOps-AI/agentops
 pypi:
 - url: https://pypi.org/project/agentops
-comments: agentops v0.4.21 (last release 29 Aug 2025, PyPI) — no 2026 release at scoring time (>9 months
+comments: agentops v0.4.21 (last release 29 Aug 2025, PyPI), no 2026 release at scoring time (>9 months
   stale). SDK MIT-licensed; primary product is the app.agentops.ai SaaS dashboard.

--- a/sources/products/amazon-bedrock-custom-models-fine-tuning.yaml
+++ b/sources/products/amazon-bedrock-custom-models-fine-tuning.yaml
@@ -2,7 +2,7 @@ name: amazon-bedrock-custom-models-fine-tuning
 display_name: Amazon Bedrock Custom Models / Fine-Tuning
 type: software
 description: Managed fine-tuning for Anthropic Claude 3 Haiku, Meta Llama, Cohere Command, Amazon Titan,
-  and Amazon Nova models inside Bedrock — the only fully managed service offering fine-tuning of Claude
+  and Amazon Nova models inside Bedrock, the only fully managed service offering fine-tuning of Claude
   weights. Picked when teams are already on AWS and need governance, VPC isolation, and Provisioned Throughput
   serving for the resulting custom model. GA since mid-2024; usage requires Provisioned Throughput commitment
   for inference.

--- a/sources/products/amazon-bedrock-evaluations.yaml
+++ b/sources/products/amazon-bedrock-evaluations.yaml
@@ -4,7 +4,7 @@ type: software
 description: 'Managed evaluation service inside Amazon Bedrock for scoring foundation models and RAG systems
   with three modes: automatic (BERTScore, F1, accuracy, robustness, toxicity), LLM-as-a-Judge (correctness,
   completeness, harmfulness, custom prompts), and human evaluation (internal workforce or AWS-managed
-  reviewer team). Differentiates by being native to the Bedrock model catalog and Knowledge Bases — eval
+  reviewer team). Differentiates by being native to the Bedrock model catalog and Knowledge Bases; eval
   jobs run against any Bedrock-supported model, results tie directly into the model deployment pipeline,
   and comparative analysis across runs is built in. Bedrock model evaluation went GA April 2024; the LLM-as-a-Judge
   variant went GA March 2025. Bedrock as a platform serves tens of thousands of customers (per AWS, Dec

--- a/sources/products/amazon-nova-pro.yaml
+++ b/sources/products/amazon-nova-pro.yaml
@@ -5,7 +5,7 @@ description: Amazon's proprietary multimodal model line in AWS Bedrock. Current 
   2 Pro (preview), launched at re:Invent 2025 (December 2, 2025) alongside Nova 2 Lite (speed/cost tier),
   Nova 2 Omni (unified text/image/video/audio in + text/image out), and Nova 2 Sonic (speech-to-speech).
   Nova 2 Pro emphasizes agentic capability gains over the original Nova line. No 'Nova 2 Premier' exists
-  as of May 2026 — Nova 2 Pro is the top-tier model. Competitive pricing for high-volume AWS-native enterprise
+  as of May 2026; Nova 2 Pro is the top-tier model. Competitive pricing for high-volume AWS-native enterprise
   deployments with SLA guarantees.
 comments: Amazon Nova Pro (amazon.nova-pro-v1:0), released 3 Dec 2024; multimodal understanding/instruct
   model (text+image+video in, text out), 300K context. Proprietary, API-only via Amazon Bedrock. Succeeded

--- a/sources/products/amazon-nova.yaml
+++ b/sources/products/amazon-nova.yaml
@@ -3,7 +3,7 @@ display_name: Amazon Nova
 type: model
 description: Amazon's in-house foundation model family on AWS Bedrock. Originally launched December 2024
   (Nova Micro/Lite/Pro), then extended in April 2025 with Amazon Nova Premier (1M context, designed as
-  a 'teacher' for model distillation). The Nova 2 family was announced at AWS re:Invent 2025 — Nova 2
+  a 'teacher' for model distillation). The Nova 2 family was announced at AWS re:Invent 2025, Nova 2
   Lite (cost-effective reasoning), Nova 2 Pro (most intelligent tier, in preview for Nova Forge customers),
   and Nova 2 Sonic (speech-to-speech). All Nova 2 models support up to 1M tokens of context with 65K-token
   responses. Amazon's play to reduce dependence on Anthropic and Meta within its own cloud stack; closed-source,

--- a/sources/products/antigravity.yaml
+++ b/sources/products/antigravity.yaml
@@ -1,7 +1,7 @@
 name: antigravity
 display_name: Antigravity
 type: software
-description: Google's agent-first developer platform — launched as a standalone IDE in November 2025 (public
+description: Google's agent-first developer platform, launched as a standalone IDE in November 2025 (public
   preview competing with Cursor), then expanded at Google I/O in May 2026 into Antigravity 2.0 with a
   Go-based CLI, SDK, and multi-agent orchestration. The CLI replaces Gemini CLI (which sunsets for free
   tiers in June 2026). Powered by Gemini 3.5 Flash with deep Google Cloud / Firebase / Android integration.

--- a/sources/products/anyscale-fine-tuning.yaml
+++ b/sources/products/anyscale-fine-tuning.yaml
@@ -3,12 +3,12 @@ display_name: Anyscale Fine-Tuning
 type: software
 description: Ray-based managed fine-tuning platform that wraps LLMForge and ray-llm to run SFT, continued
   pretraining, LoRA, and preference optimization (DPO, KTO, ORPO, PPO) across Llama-3, Mistral, Mixtral,
-  and other open-weight families — then deploys the resulting checkpoints with LoRA multiplexing on the
+  and other open-weight families, then deploys the resulting checkpoints with LoRA multiplexing on the
   same cluster. Picked when teams want the gravity of the Ray ecosystem (Anyscale's founders created Ray
   at UC Berkeley's RISELab in 2019) but as a managed offering rather than self-hosted infra. Anyscale
   raised a $100M Series C at a $1B valuation in 2021 and has reached ~$281M total raised; Ray itself powers
   training and serving workloads at Uber, Pinterest, Spotify, OpenAI, Cohere, and Instacart, with Anyscale
   capturing the managed-platform tier above it.
 comments: LLMForge = Ray library for LLM fine-tuning, available only on the Anyscale managed platform
-  (not a public OSS project). As of 2026 Anyscale has DEPRECATED LLMForge and consolidated around open-source
+  (not a public OSS project). As of 2026 Anyscale has DEPRECATED LLMForge and consolidated around open source
   Axolotl / LLaMA-Factory with native Ray support. Confirmed via Anyscale docs June 2026.

--- a/sources/products/apertus.yaml
+++ b/sources/products/apertus.yaml
@@ -2,13 +2,13 @@ name: apertus
 display_name: Apertus
 type: model
 description: 'Switzerland''s national open LLM and one of the most transparent large models released to
-  date — built by the Swiss AI Initiative (EPFL, ETH Zurich, and the CSCS supercomputing centre) and shipped
+  date, built by the Swiss AI Initiative (EPFL, ETH Zurich, and the CSCS supercomputing centre) and shipped
   2 Sep 2025 in 8B and 70B variants under Apache 2.0. ''Apertus'' is Latin for ''open'': the release covers
   not just weights but the full training data (via reconstruction scripts), the Megatron-LM training recipe,
   intermediate checkpoints, a technical report, and EU AI Act / Swiss data-protection compliance documentation.
   Trained on 15T tokens spanning 1,811 languages (~40% non-English, including Swiss German and Romansh)
-  on 4,096 GH200 GPUs. Capability is mid-tier — roughly Llama 3.1-70B class on pretraining benchmarks
-  and exceptionally strong multilingually, though below the 2026 frontier on MMLU-style reasoning — but
+  on 4,096 GH200 GPUs. Capability is mid-tier, roughly Llama 3.1-70B class on pretraining benchmarks
+  and exceptionally strong multilingually, though below the 2026 frontier on MMLU-style reasoning, but
   it sets the bar for fully reproducible, legally compliant open models.'
 comments: Apertus family (8B + 70B, base + Instruct), released 2 Sep 2025 by the Swiss AI Initiative (EPFL,
   ETH Zurich, CSCS). 15T training tokens across 1,811 natively supported languages (~40% non-English,

--- a/sources/products/apify.yaml
+++ b/sources/products/apify.yaml
@@ -4,7 +4,7 @@ type: software
 description: Full-stack web scraping and automation platform with a marketplace of 2000+ pre-built scrapers
   (Actors) for specific websites. Provides cloud infrastructure for running scrapers at scale, proxy management,
   and anti-bot handling. The most mature commercial web scraping platform now repositioned for AI agent
-  workflows. Offers both a managed platform and Crawlee, their open-source crawling framework (23K stars).
+  workflows. Offers both a managed platform and Crawlee, their open source crawling framework (23K stars).
 comments: 'Apify full-stack web scraping/extraction platform, verified live June 2026. Proprietary SaaS
-  (35,000+ Actors store) with open-source Crawlee library (Apache-2.0) as its scraping SDK. Sub-segment:
+  (35,000+ Actors store) with open source Crawlee library (Apache-2.0) as its scraping SDK. Sub-segment:
   browser/scrape infra for agents.'

--- a/sources/products/apple-core-ml-runtime.yaml
+++ b/sources/products/apple-core-ml-runtime.yaml
@@ -1,8 +1,8 @@
 name: apple-core-ml-runtime
 display_name: Apple Core ML Runtime
 type: software
-description: On-device inference runtime that executes models across Apple's heterogeneous compute — CPU,
-  GPU, and Neural Engine — on iPhone, iPad, Mac, and Vision Pro. The compiler automatically partitions
+description: On-device inference runtime that executes models across Apple's heterogeneous compute (CPU,
+  GPU, and Neural Engine) on iPhone, iPad, Mac, and Vision Pro. The compiler automatically partitions
   model graphs across available hardware for optimal latency and power efficiency. Powers Siri, on-device
   autocorrect, image recognition, and Apple Intelligence features. The most widely deployed on-device
   inference runtime by install base (2B+ active Apple devices).

--- a/sources/products/apps.yaml
+++ b/sources/products/apps.yaml
@@ -1,7 +1,7 @@
 name: apps
 display_name: APPS
 type: dataset
-description: Automated Programming Progress Standard — 10,000 coding problems at three difficulty levels
+description: Automated Programming Progress Standard, 10,000 coding problems at three difficulty levels
   (introductory, interview, competition) drawn from open-access coding challenge sites. Published at NeurIPS
   2021. One of the first large-scale code benchmarks to test models across a realistic difficulty spectrum,
   bridging the gap between simple function-completion tasks and full competitive programming. Still used

--- a/sources/products/arduino-uno-q.yaml
+++ b/sources/products/arduino-uno-q.yaml
@@ -3,7 +3,7 @@ display_name: Arduino UNO Q
 type: hardware
 description: A hybrid single-board computer in the UNO form factor that pairs a Qualcomm Dragonwing QRB2210
   quad-core applications processor (Adreno GPU, dual ISP, running Debian Linux) with an STM32U585 microcontroller
-  for real-time control. It targets AI-accelerated vision and sound applications, programmed via the open-source
+  for real-time control. It targets AI-accelerated vision and sound applications, programmed via the open source
   Arduino App Lab. Made by Arduino (now a Qualcomm company), it ships in 2GB/16GB and 4GB/32GB variants
   around EUR 47-65, a low-cost on-ramp to Qualcomm edge-AI silicon for the maker community.
 github:

--- a/sources/products/arize.yaml
+++ b/sources/products/arize.yaml
@@ -2,8 +2,8 @@ name: arize
 display_name: Arize
 type: software
 description: Cloud-native ML and LLM observability platform (the commercial offering complementing the
-  open-source Phoenix). Production monitoring for model performance, data drift, embedding drift, and
+  open source Phoenix). Production monitoring for model performance, data drift, embedding drift, and
   LLM traces at enterprise scale. Supports real-time alerting and root cause analysis. Raised $62M+ in
-  funding. The closed counterpart to Phoenix — same team, enterprise-grade features.
-comments: Arize AX — the enterprise AI engineering / LLM observability SaaS platform (distinct from open-source
+  funding. The closed counterpart to Phoenix, same team, enterprise-grade features.
+comments: Arize AX, the enterprise AI engineering / LLM observability SaaS platform (distinct from open source
   Phoenix). Confirmed live via arize.com June 2026.

--- a/sources/products/artificial-analysis-intelligence-index.yaml
+++ b/sources/products/artificial-analysis-intelligence-index.yaml
@@ -2,7 +2,7 @@ name: artificial-analysis-intelligence-index
 display_name: Artificial Analysis Intelligence Index
 type: software
 description: 'Independent benchmarking service that runs 10+ academic and agentic evals (MMLU, GPQA, long-context,
-  etc.) against every major model and publishes the Intelligence Index — a composite score with 95% CIs.
+  etc.) against every major model and publishes the Intelligence Index, a composite score with 95% CIs.
   Picked as the go-to neutral leaderboard for model selection: their Index v3 score is widely cited and
   covers 300+ models across 100+ providers. Raised a seed round via the Nat Friedman / Daniel Gross AIGrant
   program.'

--- a/sources/products/atropos.yaml
+++ b/sources/products/atropos.yaml
@@ -4,10 +4,10 @@ type: software
 description: Language-model reinforcement-learning environments framework for collecting and evaluating
   LLM trajectories across diverse environments. Nous positions it as part of the post-training stack,
   and the GitHub repo has 1.2K stars, 362 forks, and active 2026 development, which makes it a meaningful
-  open-source training primitive.
+  open source training primitive.
 github:
 - url: https://github.com/NousResearch/atropos
-comments: 'Atropos — Nous Research LLM RL-environments framework for collecting/evaluating trajectories
+comments: 'Atropos, Nous Research LLM RL-environments framework for collecting/evaluating trajectories
   and driving RL training (RLHF/RLAIF, GRPO-style). v0.4.0 (Mar 10, 2026), confirmed live on GitHub June
   2026. Integrates with trainers Axolotl and Tinker. Borderline: it is the RL-environment/orchestration
   layer that feeds a fine-tuning trainer.'

--- a/sources/products/aws-lambda.yaml
+++ b/sources/products/aws-lambda.yaml
@@ -1,10 +1,10 @@
 name: aws-lambda
 display_name: AWS Lambda
 type: software
-description: AWS Lambda, GA serverless function service; runs on AWS Firecracker microVMs (open-sourced
+description: AWS Lambda, GA serverless function service; runs on AWS Firecracker microVMs (open sourced
   2018, powers Lambda + Fargate). The Lambda service itself is proprietary/SaaS - scored as the closed
   counterpart per the deployment recipe (Lambda/Cloud Run = closed). Verified live (AWS docs/blog) June
   2026.
-comments: AWS Lambda, GA serverless function service; runs on AWS Firecracker microVMs (open-sourced 2018,
+comments: AWS Lambda, GA serverless function service; runs on AWS Firecracker microVMs (open sourced 2018,
   powers Lambda + Fargate). The Lambda service itself is proprietary/SaaS - scored as the closed counterpart
   per the deployment recipe (Lambda/Cloud Run = closed). Verified live (AWS docs/blog) June 2026.

--- a/sources/products/aws-neuron.yaml
+++ b/sources/products/aws-neuron.yaml
@@ -4,7 +4,7 @@ type: software
 description: Proprietary SDK and runtime for running inference on AWS's custom Inferentia2 and Trainium
   chips. The Neuron Compiler converts models from PyTorch/JAX into optimized executables for AWS custom
   silicon. Offers significant cost savings vs GPU instances for supported model architectures. Integrated
-  with SageMaker and EC2. AWS's play to break NVIDIA GPU dependency for inference workloads — custom silicon
+  with SageMaker and EC2. AWS's play to break NVIDIA GPU dependency for inference workloads, custom silicon
   with a proprietary software stack.
 comments: Neuron SDK 2.30.0 (released ~May 22, 2026; 86 releases on GitHub). Serves LLM/DL inference on
   AWS Inferentia/Trainium accelerators (Inf2/Trn instances). Confirmed live June 2026.

--- a/sources/products/axolotl.yaml
+++ b/sources/products/axolotl.yaml
@@ -1,7 +1,7 @@
 name: axolotl
 display_name: Axolotl
 type: software
-description: YAML-config-driven fine-tuning framework — wraps TRL, PEFT, DeepSpeed, FSDP, and bitsandbytes
+description: YAML-config-driven fine-tuning framework, wraps TRL, PEFT, DeepSpeed, FSDP, and bitsandbytes
   behind a single config file so users can run SFT, LoRA, QLoRA, full fine-tunes, and DPO across 100+
   model families without writing training loops. Picked for serious multi-GPU production fine-tuning where
   reproducibility via config matters and where Unsloth's single-GPU optimizations don't apply. 12K GitHub

--- a/sources/products/azure-ai-foundry-observability.yaml
+++ b/sources/products/azure-ai-foundry-observability.yaml
@@ -8,7 +8,7 @@ description: Microsoft's GenAI observability product inside Azure AI Foundry (re
   (hate/unfairness, violence, protected materials), and agent-specific metrics (tool-call accuracy, task
   completion). Supports tracing for LangChain, LangGraph, OpenAI Agents SDK, and the Microsoft Agent Framework.
   Evaluations, Monitoring, and Tracing went GA via Foundry Control Plane in 2026, with continuous evaluation
-  and the Agent Monitoring Dashboard in preview — leverages Azure's enterprise footprint as the default
+  and the Agent Monitoring Dashboard in preview; leverages Azure's enterprise footprint as the default
   observability layer for Azure-hosted GenAI workloads.
 comments: 'Microsoft Foundry (formerly Azure AI Foundry) Observability: evaluations + monitoring + tracing
   reached general availability March 2026. OpenTelemetry-based tracing via Azure Monitor / Application

--- a/sources/products/azure-ai-model-inference.yaml
+++ b/sources/products/azure-ai-model-inference.yaml
@@ -1,10 +1,10 @@
 name: azure-ai-model-inference
 display_name: Azure AI Model Inference
 type: software
-description: Managed inference service providing a unified API across OpenAI models, open-source models
+description: Managed inference service providing a unified API across OpenAI models, open source models
   (Llama, Mistral, Phi), and Microsoft's own models. Handles model loading, scaling, and hardware allocation
   behind a single REST API. Supports serverless (pay-per-token) and provisioned (dedicated capacity) deployments.
-  The enterprise default for organizations on Azure — integrated with Azure AD, networking, and compliance
+  The enterprise default for organizations on Azure, integrated with Azure AD, networking, and compliance
   controls.
 comments: Microsoft Foundry Models unified inference endpoint (Azure AI Model Inference). Proprietary
   managed cloud service exposing many model deployments through one OpenAI-compatible endpoint; beta Azure

--- a/sources/products/beagley-ai.yaml
+++ b/sources/products/beagley-ai.yaml
@@ -1,7 +1,7 @@
 name: beagley-ai
 display_name: BeagleY-AI
 type: hardware
-description: An open-source single-board computer (SBC) from the BeagleBoard.org Foundation, built around
+description: An open source single-board computer (SBC) from the BeagleBoard.org Foundation, built around
   the Texas Instruments AM67A vision processor. It pairs a quad-core Cortex-A53 CPU at 1.4 GHz with a
   TI C7x deep-learning accelerator subsystem (dual C7x DSP + MMA) rated at up to 4 TOPS, an IMG BXS GPU,
   and Cortex-R5 real-time cores, with 4GB LPDDR4 and a 40-pin Raspberry Pi-compatible header (~$72). It

--- a/sources/products/beta9.yaml
+++ b/sources/products/beta9.yaml
@@ -7,5 +7,5 @@ description: Open-source Docker-based sandbox runtime positioned as a self-hosta
   sandboxes. ~1.6k stars, AGPL-3.0 licensed with a managed cloud offering.
 github:
 - url: https://github.com/beam-cloud/beta9
-comments: Beta9 — open-source serverless AI runtime (sandboxes, serverless inference endpoints, task queues);
+comments: Beta9, open source serverless AI runtime (sandboxes, serverless inference endpoints, task queues);
   worker v0.1.597 (Jun 4 2026) confirmed live on GitHub. OSS engine powering managed Beam cloud (beam.cloud).

--- a/sources/products/braintrust.yaml
+++ b/sources/products/braintrust.yaml
@@ -2,7 +2,7 @@ name: braintrust
 display_name: Braintrust
 type: software
 description: Enterprise AI product development platform with logging, tracing, evaluation, and prompt
-  playground. Focuses on the eval-to-production workflow — iterate on prompts, evaluate with custom scorers,
+  playground. Focuses on the eval-to-production workflow, iterate on prompts, evaluate with custom scorers,
   deploy with confidence, monitor in production. Strong enterprise positioning with SOC 2 compliance.
   Funded by a16z.
 comments: Braintrust AI eval/observability platform (braintrust.dev); SDK v3.16.0 (Jun 3, 2026, Apache-2.0)

--- a/sources/products/browser-use.yaml
+++ b/sources/products/browser-use.yaml
@@ -4,7 +4,7 @@ type: software
 description: Open-source agent framework that makes websites accessible to AI agents, enabling autonomous
   web browsing, form filling, data extraction, and multi-step online task completion. Built on Playwright,
   it provides a structured way for LLMs to observe page state, plan actions, and execute browser interactions.
-  95K GitHub stars with 315 contributors — one of the fastest-growing projects in the agent space, filling
+  95K GitHub stars with 315 contributors, one of the fastest-growing projects in the agent space, filling
   the crucial gap of web-native agent capabilities.
 github:
 - url: https://github.com/browser-use/browser-use

--- a/sources/products/browserbase.yaml
+++ b/sources/products/browserbase.yaml
@@ -3,9 +3,9 @@ display_name: Browserbase
 type: software
 description: Cloud-hosted headless browsers designed specifically for AI agents. Handles authentication
   persistence, CAPTCHA solving, and anti-bot detection that self-hosted Playwright cannot easily manage.
-  The managed alternative to running your own browser infrastructure — agents get a reliable, scalable
-  browser as a service. YC-backed, also maintains Stagehand (22K stars), an open-source browser agent
+  The managed alternative to running your own browser infrastructure; agents get a reliable, scalable
+  browser as a service. YC-backed, also maintains Stagehand (22K stars), an open source browser agent
   SDK.
 comments: 'Proprietary cloud headless-browser platform for agents: Browser API, Search API, Fetch API,
-  Functions, Model Gateway. Ships the open-source Stagehand SDK (browser-agent framework) on top. Verified
+  Functions, Model Gateway. Ships the open source Stagehand SDK (browser-agent framework) on top. Verified
   live via docs.browserbase.com June 2026.'

--- a/sources/products/cerebras-inference.yaml
+++ b/sources/products/cerebras-inference.yaml
@@ -2,7 +2,7 @@ name: cerebras-inference
 display_name: Cerebras Inference
 type: software
 description: Inference service running on the Cerebras Wafer-Scale Engine (WSE-3), a single chip containing
-  4 trillion transistors with 44GB of on-chip SRAM — eliminating off-chip memory bottlenecks entirely.
+  4 trillion transistors with 44GB of on-chip SRAM, eliminating off-chip memory bottlenecks entirely.
   Achieves extremely high throughput on large models by keeping the entire model on a single wafer. Available
   via API. Positioned as the fastest inference for large models where the entire model fits on one wafer.
   Raised $4.3B+, filed for IPO.

--- a/sources/products/character-ai.yaml
+++ b/sources/products/character-ai.yaml
@@ -2,8 +2,8 @@ name: character-ai
 display_name: Character.AI
 type: software
 description: Consumer chat product centered on user-created character personas, dialogue roleplay, and
-  conversational entertainment. ~20M MAU and ~6M daily visitors with two hours/day average engagement
-  — one of the stickiest consumer AI surfaces; founders' team was acqui-hired by Google in 2024 but the
+  conversational entertainment. ~20M MAU and ~6M daily visitors with two hours/day average engagement,
+  one of the stickiest consumer AI surfaces; founders' team was acqui-hired by Google in 2024 but the
   product continues to operate.
 comments: Character.AI consumer companion/roleplay chat app (web + mobile), live June 2026. Proprietary
   chat UI over its own models + (post-Google-deal) licensed models; human-in-the-loop character chat.

--- a/sources/products/chatgpt.yaml
+++ b/sources/products/chatgpt.yaml
@@ -1,10 +1,10 @@
 name: chatgpt
 display_name: ChatGPT
 type: software
-description: 'OpenAI''s flagship consumer chat product — web, desktop, and mobile apps for conversing
+description: 'OpenAI''s flagship consumer chat product, web, desktop, and mobile apps for conversing
   with GPT-5/o-series models, with built-in tools (search, code interpreter, image gen, voice, memory).
   The category-defining UI by a wide margin: 900M weekly active users and 50M paying subscribers as of
   Feb 2026, on a $25B annualized run rate.'
-comments: ChatGPT (OpenAI) consumer chat app — web + iOS/Android + desktop. Proprietary/closed UI scored
+comments: ChatGPT (OpenAI) consumer chat app, web + iOS/Android + desktop. Proprietary/closed UI scored
   as the closed counterpart in this category. Live and verified June 2026; default model GPT-5 family.
   (The model SKU is scored separately under base/finetuned categories; this record scores the chat surface.)

--- a/sources/products/claude-ai.yaml
+++ b/sources/products/claude-ai.yaml
@@ -4,6 +4,6 @@ type: software
 description: Anthropic's consumer chat product (web, desktop, mobile) for interacting with Claude Sonnet/Opus
   models, with Projects, Artifacts (live-rendered code/docs), and Computer Use. ~30M monthly active users
   and adding 1M+ daily signups as of March 2026, third-largest US mobile chatbot.
-comments: Claude.ai (Anthropic) consumer chat app — web + macOS/Windows + iOS/Android. Proprietary/closed
+comments: Claude.ai (Anthropic) consumer chat app, web + macOS/Windows + iOS/Android. Proprietary/closed
   UI scored as the closed counterpart. Verified live June 2026 (product page now at claude.com/product/overview,
   redirected from anthropic.com/claude). Uses Claude Opus/Sonnet/Haiku.

--- a/sources/products/claude-code.yaml
+++ b/sources/products/claude-code.yaml
@@ -4,10 +4,10 @@ type: software
 description: Agentic coding tool from Anthropic that lives in the terminal, understands your entire codebase,
   and autonomously executes multi-step development tasks including code generation, refactoring, git workflows,
   and testing. Differentiates through deep integration with Claude models, a rich skill/hook system for
-  customization, and native MCP tool support. 125.7K GitHub stars; source-available but not open-source
+  customization, and native MCP tool support. 125.7K GitHub stars; source-available but not open source
   (no license). Reportedly the fastest-growing developer tool in Anthropic's portfolio.
 github:
 - url: https://github.com/anthropics/claude-code
 comments: Claude Code (Anthropic), agentic coding tool across terminal/IDE/desktop/web; GA May 2025, actively
-  shipping June 2026. Proprietary/SaaS — requires a Claude subscription or Anthropic Console account.
+  shipping June 2026. Proprietary/SaaS. Requires a Claude subscription or Anthropic Console account.
   Confirmed live June 2026.

--- a/sources/products/claude-haiku-4-5.yaml
+++ b/sources/products/claude-haiku-4-5.yaml
@@ -3,7 +3,7 @@ display_name: Claude Haiku 4.5
 type: model
 description: Anthropic's small/fast tier in the Claude 4 generation, designed for high-volume low-latency
   coding and chat workloads. Sits beneath Sonnet 4.6 and Opus 4.7 in capability but at substantially lower
-  cost — the default Anthropic option for embedded agents, autocompletion, and high-QPS production routes.
+  cost, the default Anthropic option for embedded agents, autocompletion, and high-QPS production routes.
   Released alongside the Sonnet 4.5/4.6 cadence as Anthropic's three-tier lineup (Haiku/Sonnet/Opus) stabilized
   at the 4.x generation.
 comments: Anthropic Claude Haiku 4.5 (claude-haiku-4-5), released Oct 15, 2025. Post-trained instruct/agentic

--- a/sources/products/claude-opus-4-7.yaml
+++ b/sources/products/claude-opus-4-7.yaml
@@ -2,7 +2,7 @@ name: claude-opus-4-7
 display_name: Claude Opus 4.7
 type: model
 description: Anthropic's frontier closed-weights base model (April 2026), the largest tier in the Claude
-  4.x line. The base is never exposed directly — all access is to the Constitutional-AI + RLHF post-trained
+  4.x line. The base is never exposed directly. All access is to the Constitutional-AI + RLHF post-trained
   variant (Claude Opus 4.7), which tops SWE-bench Verified at 87.6% and holds two of the top four LMArena
   Elo slots (1492-1502). A leaked 'Claude Mythos Preview' trained on the same family reportedly hits 93.9%
   SWE-bench Verified. Direct competitor to GPT-5 and Gemini 3.1 Pro on the agentic-coding frontier.

--- a/sources/products/cline.yaml
+++ b/sources/products/cline.yaml
@@ -9,5 +9,5 @@ description: Autonomous coding agent available as a VS Code extension, CLI tool,
 github:
 - url: https://github.com/cline/cline
 comments: Cline (Cline Bot Inc.), CLI v3.0.17 (Jun 4 2026); GitHub cline/cline 62.7k stars. Autonomous
-  coding agent in IDE/terminal — plans tasks, edits files, runs commands with human approval. Confirmed
+  coding agent in IDE/terminal, plans tasks, edits files, runs commands with human approval. Confirmed
   live June 2026.

--- a/sources/products/cloudflare-sandboxes.yaml
+++ b/sources/products/cloudflare-sandboxes.yaml
@@ -5,7 +5,7 @@ description: 'Cloudflare''s two-tier sandboxing for AI agents, shipped during Ag
   Workers (V8 isolates, ms-scale cold start, ~100x faster and more memory-efficient than containers, open
   beta April 2026) and Sandboxes (persistent Linux environments, GA April 2026 for full-OS workloads).
   Picked when latency, edge distribution, and isolation density matter; distributed across Cloudflare''s
-  global edge network and available to all paid Workers users — the company''s headline agent infrastructure
+  global edge network and available to all paid Workers users, the company''s headline agent infrastructure
   release of 2026.'
 comments: 'Two related 2026 offerings: (a) Cloudflare Sandbox SDK (cloudflare/sandbox-sdk, @cloudflare/sandbox
   v0.11.0, 1 Jun 2026) - container-backed sandboxes on Workers/Durable Objects; (b) Dynamic Workers /

--- a/sources/products/codecontests.yaml
+++ b/sources/products/codecontests.yaml
@@ -4,7 +4,7 @@ type: dataset
 description: A competitive programming dataset containing ~13,000 problems collected from Codeforces,
   CodeChef, and other contest platforms, each with problem descriptions, solutions in multiple languages,
   and test cases. Introduced in the AlphaCode paper (2022). Designed to test models on problems requiring
-  algorithmic reasoning far beyond typical function-completion benchmarks — the hard end of code generation
+  algorithmic reasoning far beyond typical function-completion benchmarks, the hard end of code generation
   evaluation.
 github:
 - url: https://github.com/google-deepmind/code_contests
@@ -14,4 +14,4 @@ comments: 'CodeContests (deepmind/code_contests), competitive-programming datase
   (arXiv:2203.07814). 3,760 train / 117 valid / 165 test problems (4,044 total per HF viewer), ~7.6 GB,
   with public/private/generated test cases and correct+incorrect human solutions in multiple languages.
   Verified live on HF June 2026 (~56k downloads last month). [Verifier note: original record stated 13,328
-  train; HF dataset viewer shows 3,760 train / 4,044 total — corrected.]'
+  train; HF dataset viewer shows 3,760 train / 4,044 total; corrected.]'

--- a/sources/products/codellama-instruct.yaml
+++ b/sources/products/codellama-instruct.yaml
@@ -2,7 +2,7 @@ name: codellama-instruct
 display_name: CodeLlama Instruct
 type: model
 description: Code-specialized instruction-tuned Llama 2 family (7B to 70B, seed product) trained on 500B+
-  tokens of code and fine-tuned for coding chat. Pioneered the open-source coding LLM wave in 2023 and
+  tokens of code and fine-tuned for coding chat. Pioneered the open source coding LLM wave in 2023 and
   catalyzed the entire open code model ecosystem. Still used as a baseline with ~104K combined monthly
   downloads across sizes.
 huggingface_model:

--- a/sources/products/coder-oss.yaml
+++ b/sources/products/coder-oss.yaml
@@ -2,7 +2,7 @@ name: coder-oss
 display_name: Coder OSS
 type: software
 description: Open-source platform for provisioning remote dev environments (Terraform-defined workspaces
-  on K8s, VMs, or bare metal) — increasingly used as the substrate for self-hosted agent execution environments.
+  on K8s, VMs, or bare metal), increasingly used as the substrate for self-hosted agent execution environments.
   Picked over GitHub Codespaces when teams want full BYOC control and have aggressively repositioned in
   2026 toward AI-agent workspaces. ~13.3k stars, very active (2,055 commits in 90d).
 github:

--- a/sources/products/codestral.yaml
+++ b/sources/products/codestral.yaml
@@ -2,7 +2,7 @@ name: codestral
 display_name: Codestral
 type: model
 description: Mistral's proprietary code model, API-only via la Plateforme, Vertex AI, Azure AI Foundry,
-  and Bedrock. Current SKU is Codestral 25.08 (August 2025) — 30% more accepted completions and 50% fewer
+  and Bedrock. Current SKU is Codestral 25.08 (August 2025), 30% more accepted completions and 50% fewer
   runaway generations versus 25.01. Part of Mistral's broader 2026 coding stack alongside Codestral Embed
   (retrieval-tuned embeddings), Devstral 2 (open-weight agentic coding counterpart), and Mistral Vibe
   CLI (Mistral's answer to Claude Code / Gemini CLI). Distributed to thousands of developers through Continue.dev,
@@ -11,5 +11,5 @@ comments: 'Codestral 25.08 (released 30 Jul 2025), Mistral''s code-completion/FI
   with a chat mode (+5% instruction following per launch). Distributed via API (console.mistral.ai), VPC,
   and on-prem; open weights on HF under the Mistral AI Non-Production License (MNPL). NOTE: arguably a
   coding-specialist model rather than a general chat model; scored best-effort in finetuned_chat per assignment
-  with a category caveat. (Separate ''Codestral 2'', Apr 2026, was relicensed Apache-2.0 — not the SKU
+  with a category caveat. (Separate ''Codestral 2'', Apr 2026, was relicensed Apache-2.0, not the SKU
   scored here.) Verified live June 2026.'

--- a/sources/products/codex-cli.yaml
+++ b/sources/products/codex-cli.yaml
@@ -1,11 +1,11 @@
 name: codex-cli
 display_name: Codex CLI
 type: software
-description: Lightweight open-source coding agent from OpenAI that runs in your terminal. Built in Rust
+description: Lightweight open source coding agent from OpenAI that runs in your terminal. Built in Rust
   for speed, it reads your codebase, proposes a plan, and executes multi-file changes with sandboxed command
-  execution. Differentiates as OpenAI's official open-source agent offering (Apache-2.0) with tight integration
-  to OpenAI models. 84.6K GitHub stars with an extraordinary 2,893 commits in 90 days and 454 contributors
-  — the most rapidly developed OSS agent as of May 2026.
+  execution. Differentiates as OpenAI's official open source agent offering (Apache-2.0) with tight integration
+  to OpenAI models. 84.6K GitHub stars with an extraordinary 2,893 commits in 90 days and 454 contributors,
+  the most rapidly developed OSS agent as of May 2026.
 github:
 - url: https://github.com/openai/codex
 comments: OpenAI Codex CLI v0.137.0 (Jun 4 2026); GitHub openai/codex 88.6k stars, built in Rust. Open-source

--- a/sources/products/cohere-rerank-api.yaml
+++ b/sources/products/cohere-rerank-api.yaml
@@ -2,7 +2,7 @@ name: cohere-rerank-api
 display_name: Cohere Rerank API
 type: software
 description: Reranking API that takes a query and a list of documents and returns them reordered by relevance.
-  Purpose-built for RAG pipelines — agents retrieve candidate documents from a vector DB, then call Rerank
+  Purpose-built for RAG pipelines; agents retrieve candidate documents from a vector DB, then call Rerank
   to get the most relevant ones before feeding them to the LLM. The leading standalone reranking service,
   used across thousands of production RAG systems. Significantly improves retrieval quality with a single
   API call.

--- a/sources/products/command-r.yaml
+++ b/sources/products/command-r.yaml
@@ -2,12 +2,12 @@ name: command-r
 display_name: Command R+
 type: model
 description: Cohere's enterprise foundation model line, currently anchored by Command A+ (released May
-  20, 2026) — a 218B-parameter sparse MoE (25B active) with native citation generation, W4A4 lossless
+  20, 2026), a 218B-parameter sparse MoE (25B active) with native citation generation, W4A4 lossless
   quantization, and the company's first fully Apache 2.0 licensed frontier model. Runs on a single B200
   or two H100s. Positioned for sovereign AI and enterprise RAG with native support for 48 languages and
   explicit grounding spans linking every factual claim to source documents. Earlier Command R+ (104B,
   2024) is the predecessor; with Command A+ the line has flipped from API-only to open-weights.
 comments: 'Cohere c4ai-command-r-plus: 104B instruct/chat model, 128K context, RAG + multi-step tool use,
   10 languages. Original release Apr 2024 (newer 08-2024 revision exists). Verified live on HF June 2026
-  (gated, contact-info required). License CC-BY-NC (non-commercial, non-OSI). Correctly an instruct model
-  — belongs in finetuned_chat (was miscategorized as base elsewhere).'
+  (gated, contact-info required). License CC-BY-NC (non-commercial, non-OSI). Correctly an instruct model,
+  belongs in finetuned_chat (was miscategorized as base elsewhere).'

--- a/sources/products/compar-ia.yaml
+++ b/sources/products/compar-ia.yaml
@@ -1,7 +1,7 @@
 name: compar-ia
 display_name: Compar:IA
 type: software
-description: Compar:IA is an open-source LLM comparison 'arena' created by the French Government (betagouv
+description: Compar:IA is an open source LLM comparison 'arena' created by the French Government (betagouv
   / DINUM with the Ministry of Culture). Users blind-compare responses from two anonymous models, vote
   on the better answer, then see the models' identities and environmental impact, raising awareness of
   model pluralism, bias, and carbon cost. Its core mission is to build large non-English (predominantly

--- a/sources/products/composio.yaml
+++ b/sources/products/composio.yaml
@@ -3,7 +3,7 @@ display_name: Composio
 type: software
 description: Agent tooling platform that provides 1000+ pre-built tool integrations with managed authentication,
   context management, and a sandboxed execution environment. Handles the hard parts of connecting agents
-  to external services — OAuth flows, API pagination, rate limiting — so agent builders can focus on logic.
+  to external services (OAuth flows, API pagination, rate limiting) so agent builders can focus on logic.
   28K GitHub stars, YC-backed. The largest catalog of ready-to-use agent tools with built-in auth.
 github:
 - url: https://github.com/ComposioHQ/composio

--- a/sources/products/confer.yaml
+++ b/sources/products/confer.yaml
@@ -4,7 +4,7 @@ type: software
 description: End-to-end encrypted AI chat assistant from Confer Labs (founded by Moxie Marlinspike, creator
   of Signal) whose core claim is that the operator cannot read, train on, or hand over your conversations.
   Prompts are encrypted on-device and sent via Noise-protocol pipes into a Trusted Execution Environment on
-  a confidential VM, processed by open-source LLMs, then re-encrypted before leaving; chat history is encrypted
+  a confidential VM, processed by open source LLMs, then re-encrypted before leaving; chat history is encrypted
   with passkey-derived keys. The differentiator is cryptographically enforced, verifiable privacy backed by
   remote attestation, reproducible builds, and an append-only transparency log.
 github:
@@ -12,6 +12,6 @@ github:
 - url: https://github.com/ConferLabs/confer-image
 comments: Confer publishes its inference/proxy stack and reproducible confidential-VM image (vLLM-based)
   openly for verifiability, but NEITHER repo carries a LICENSE file (GitHub reports no declared license),
-  and the end-user client app is not public - so despite "open-source" marketing the accurate classification
+  and the end-user client app is not public - so despite "open source" marketing the accurate classification
   is source-available. The service is not self-hostable; its security model depends on Confer's attestation
   infrastructure. Repos created Dec 2025.

--- a/sources/products/confident-ai.yaml
+++ b/sources/products/confident-ai.yaml
@@ -1,7 +1,7 @@
 name: confident-ai
 display_name: Confident AI
 type: software
-description: Hosted SaaS layered on the open-source DeepEval library — adds dataset management, regression
+description: Hosted SaaS layered on the open source DeepEval library, adds dataset management, regression
   tracking, human annotation, custom dashboards, online evals against live traffic, alerting, and incident
   response. DeepEval itself runs 2M evals/day with 3M monthly downloads and 12.6K GitHub stars; enterprise
   customers on the cloud product include Microsoft, AstraZeneca, AXA, and BCG. YC W25, $2.2M seed.

--- a/sources/products/continue.yaml
+++ b/sources/products/continue.yaml
@@ -8,6 +8,6 @@ description: Open-source AI code assistant for VS Code and JetBrains IDEs offeri
 github:
 - url: https://github.com/continuedev/continue
 comments: Continue (continuedev/continue); VS Code extension v1.2.22 (Mar 2026), JetBrains plugin, and
-  open-source `cn` CLI. Open-source AI code assistant — chat + inline edit + autocomplete in the IDE,
+  open source `cn` CLI. Open-source AI code assistant, chat + inline edit + autocomplete in the IDE,
   now also marketing 'AI code agent' (agent mode) and CI checks. Verified live on GitHub + VS Marketplace
   June 2026.

--- a/sources/products/deepeval.yaml
+++ b/sources/products/deepeval.yaml
@@ -2,9 +2,9 @@ name: deepeval
 display_name: DeepEval
 type: software
 description: Pytest-style evaluation framework for LLM apps with 40+ built-in metrics including G-Eval,
-  hallucination, faithfulness and RAG-specific scores. Picked for CI/CD integration — drops into existing
+  hallucination, faithfulness and RAG-specific scores. Picked for CI/CD integration; drops into existing
   test suites and gates merges on metric thresholds. 15.6k stars, 263 contributors, 561 commits in last
-  90 days — the most active open-source eval framework on GitHub.
+  90 days, the most active open source eval framework on GitHub.
 github:
 - url: https://github.com/confident-ai/deepeval
 comments: DeepEval v4.0.5 ('Opus 4.8 Day-0 Support', May 28 2026). OSS eval framework (Apache-2.0) with

--- a/sources/products/deepseek-chat.yaml
+++ b/sources/products/deepseek-chat.yaml
@@ -3,9 +3,9 @@ display_name: DeepSeek Chat
 type: software
 description: Chinese consumer chat app from DeepSeek (Hangzhou) on chat.deepseek.com plus iOS/Android
   apps, exposing DeepSeek V3/R1 models with thinking mode and web search. ~131.5M MAU in January 2026
-  (90% MoM surge), second only to ChatGPT in global AI DAU rankings — driven by free access to frontier-tier
+  (90% MoM surge), second only to ChatGPT in global AI DAU rankings, driven by free access to frontier-tier
   models.
 comments: 'Hosted consumer chat UI at chat.deepseek.com (web + iOS/Android apps), currently fronting DeepSeek-V4
   Preview (stronger agent + reasoning). Verified live June 2026. Note: the underlying DeepSeek-V3/V4 model
   weights are open (MIT) and scored separately in base_pretrained; this record scores the CHAT PRODUCT/UI
-  itself, which is a proprietary free hosted service, not open-source software.'
+  itself, which is a proprietary free hosted service, not open source software.'

--- a/sources/products/deepseek-coder-v2-instruct.yaml
+++ b/sources/products/deepseek-coder-v2-instruct.yaml
@@ -3,7 +3,7 @@ display_name: DeepSeek-Coder-V2-Instruct
 type: model
 description: Dedicated coding MoE model (seed product) instruction-tuned for code generation, completion,
   and chat. Available in full (236B) and Lite (16B) variants. The Lite variant remains popular for local
-  deployment with 1.1M+ downloads. Predecessor to the V3/R1 generation that proved open-source could compete
+  deployment with 1.1M+ downloads. Predecessor to the V3/R1 generation that proved open source could compete
   on coding benchmarks.
 huggingface_model:
 - url: https://huggingface.co/deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct

--- a/sources/products/deepseek-r1.yaml
+++ b/sources/products/deepseek-r1.yaml
@@ -3,7 +3,7 @@ display_name: DeepSeek-R1
 type: model
 description: Previous-generation reasoning-first model (January 2025) using large-scale GRPO RL to develop
   chain-of-thought before answering. 671B MoE plus 1.5B–70B distilled variants. Superseded by DeepSeek-R2
-  (April 2026), which inverts the architecture thesis — R2 is a 32B dense MIT model that runs on a single
+  (April 2026), which inverts the architecture thesis; R2 is a 32B dense MIT model that runs on a single
   24GB consumer GPU and reaches 92.7% AIME 2025. R1 retains 4.3M+ monthly downloads and remains the most-used
   open reasoning model.
 huggingface_model:

--- a/sources/products/diffusers.yaml
+++ b/sources/products/diffusers.yaml
@@ -4,7 +4,7 @@ type: software
 description: Diffusers is a PyTorch library from Hugging Face providing state-of-the-art pretrained diffusion
   models for generating images, audio, and 3D molecular structures. It offers ready-to-use inference pipelines,
   interchangeable noise schedulers, and pretrained models that serve as building blocks for custom diffusion
-  systems. It is the de facto open-source library for working with diffusion-based generative models.
+  systems. It is the de facto open source library for working with diffusion-based generative models.
 github:
 - url: https://github.com/huggingface/diffusers
 pypi:

--- a/sources/products/dolma.yaml
+++ b/sources/products/dolma.yaml
@@ -4,7 +4,7 @@ type: dataset
 description: Dolma is an open pretraining corpus of roughly 3 trillion tokens drawn from Common Crawl
   web text, academic publications, code, books, and encyclopedic material. It was created by the Allen
   Institute for AI (AI2) and used to train the OLMo family of models. The release includes the corpus
-  plus an open-source toolkit for replicating and curating the data.
+  plus an open source toolkit for replicating and curating the data.
 github:
 - url: https://github.com/allenai/dolma
 huggingface_dataset:

--- a/sources/products/doubao-seed-2-0.yaml
+++ b/sources/products/doubao-seed-2-0.yaml
@@ -3,11 +3,11 @@ display_name: Doubao Seed 2.0
 type: model
 description: ByteDance's flagship closed-weight instruction-tuned model line, released February 14, 2026
   in four variants (Pro, Lite, Mini, Code) via the Volcano Engine API. The Pro tier ($0.47 input / $2.37
-  output per million tokens) posts frontier-tier benchmarks — 98.3 AIME 2025, 88.9 GPQA Diamond, 76.5
-  SWE-Bench Verified, 3020 Codeforces — at 3.7×–10× lower cost than GPT-5.2 / Claude Opus 4.5. Differentiates
+  output per million tokens) posts frontier-tier benchmarks (98.3 AIME 2025, 88.9 GPQA Diamond, 76.5
+  SWE-Bench Verified, 3020 Codeforces) at 3.7×–10× lower cost than GPT-5.2 / Claude Opus 4.5. Differentiates
   on (a) Chinese-language strength and Volcano Engine's mainland-China-native infrastructure, (b) aggressive
   price-to-performance positioning, and (c) deep distribution via the Doubao consumer chat app, which
-  crossed 100M DAU in early 2026 and reached ~345M MAU by March 2026 — the largest consumer AI chat product
+  crossed 100M DAU in early 2026 and reached ~345M MAU by March 2026, the largest consumer AI chat product
   in China. Doubao Seed 1.6 (October 2025, 256K context) remains in the lineup as the budget tier; ByteDance
   ships 19 active Doubao API SKUs in 2026.
 comments: Doubao Seed 2.0 (ByteDance), foundation model family released 14 Feb 2026; variants Pro / Lite

--- a/sources/products/e2b-sandbox.yaml
+++ b/sources/products/e2b-sandbox.yaml
@@ -9,5 +9,5 @@ description: Open-source secure cloud runtime that gives AI agents an ephemeral 
 github:
 - url: https://github.com/e2b-dev/E2B
 - url: https://github.com/e2b-dev/infra
-comments: E2B open-source sandbox infra for running AI-generated code; CLI @e2b/cli@2.10.3 (Jun 3 2026)
+comments: E2B open source sandbox infra for running AI-generated code; CLI @e2b/cli@2.10.3 (Jun 3 2026)
   confirmed live on GitHub June 2026. Isolation via Firecracker microVMs. OSS core + managed cloud (e2b.dev).

--- a/sources/products/epoch-ai-benchmarks.yaml
+++ b/sources/products/epoch-ai-benchmarks.yaml
@@ -3,7 +3,7 @@ display_name: Epoch AI Benchmarks
 type: software
 description: Independent benchmarking lab that runs and maintains canonical leaderboards for high-stakes
   evals (SWE-bench Verified, FrontierMath, GPQA Diamond) and operates the FrontierMath private math benchmark.
-  Picked when researchers want the authoritative scoreboard for a specific benchmark — Epoch's SWE-bench
+  Picked when researchers want the authoritative scoreboard for a specific benchmark; Epoch's SWE-bench
   Verified leaderboard is the one frontier labs reference in announcements. Funded by Open Philanthropy
   and lab partners.
 comments: Epoch AI benchmark database + public dashboard scoring frontier models on hard tasks (FrontierMath,

--- a/sources/products/ernie-5-1.yaml
+++ b/sources/products/ernie-5-1.yaml
@@ -5,6 +5,6 @@ description: 'Baidu''s flagship fifth-generation LLM (released May 2026): a Mixt
   depth/width/sparsity, focused on text generation, reasoning, agentic tool-use, and creative writing. Baidu emphasizes
   cost efficiency - total params ~1/3 and active params ~1/2 of ERNIE 5.0, trained at ~6% of comparable models''
   pre-training cost. 128K context.'
-comments: 'Proprietary/API-only (Baidu Qianfan API, ernie.baidu.com, AI Studio). Note ERNIE 4.5 was open-sourced
+comments: 'Proprietary/API-only (Baidu Qianfan API, ernie.baidu.com, AI Studio). Note ERNIE 4.5 was open sourced
   (Apache-2.0, June 2025) but the 5.x flagship line is closed. LMArena frontier (~#28 per mirrors; Baidu claims
   5.1-Preview #13 Text / #1 Chinese).'

--- a/sources/products/exa-search-api.yaml
+++ b/sources/products/exa-search-api.yaml
@@ -2,7 +2,7 @@ name: exa-search-api
 display_name: Exa Search API
 type: software
 description: Neural search API that understands meaning, not just keywords. Returns links and full content
-  based on semantic similarity — 'search the way an AI would.' Particularly strong for finding similar
+  based on semantic similarity, 'search the way an AI would.' Particularly strong for finding similar
   content, research papers, and niche topics where traditional keyword search fails. Well-funded (YC-backed,
   $22M+ raised), positioned as the semantic alternative to Tavily's more traditional search approach.
 pypi:

--- a/sources/products/falcon-3.yaml
+++ b/sources/products/falcon-3.yaml
@@ -2,8 +2,8 @@ name: falcon-3
 display_name: Falcon 3
 type: model
 description: TII's open-weights model line from Abu Dhabi. The original Falcon 3 family (1B/3B/7B/10B
-  Apache-2.0, December 2024) has been extended in 2025-2026 by Falcon-H1 — a hybrid Mamba-Transformer
-  architecture spanning 0.5B-34B with native 18-language support — and Falcon-H1 Arabic (3B/7B/34B, January
+  Apache-2.0, December 2024) has been extended in 2025-2026 by Falcon-H1 (a hybrid Mamba-Transformer
+  architecture spanning 0.5B-34B with native 18-language support) and Falcon-H1 Arabic (3B/7B/34B, January
   2026), positioned as the world's leading Arabic open model. Falcon H1R 7B (January 2026) outperforms
   Qwen and Nemotron variants up to 7x its size on reasoning. Adoption remains modest vs Llama/Qwen at
   equivalent size (Falcon3-7B-Instruct ~23K monthly HF downloads).

--- a/sources/products/fastmcp.yaml
+++ b/sources/products/fastmcp.yaml
@@ -3,7 +3,7 @@ display_name: FastMCP
 type: software
 description: High-level Python framework for building MCP servers and clients with minimal boilerplate.
   Provides decorator-based tool definitions, automatic schema generation, and built-in testing utilities.
-  The fastest way to create a production MCP server — 25K GitHub stars and growing rapidly. Becoming the
+  The fastest way to create a production MCP server. 25K GitHub stars and growing rapidly. Becoming the
   de facto framework for MCP server development in Python.
 github:
 - url: https://github.com/PrefectHQ/fastmcp

--- a/sources/products/feluda.yaml
+++ b/sources/products/feluda.yaml
@@ -7,5 +7,5 @@ description: Feluda is a configurable engine by Tattle for analysing multilingua
   analysing misinformation and social-media content, particularly in Indian-language contexts.
 github:
 - url: https://github.com/tattle-made/feluda
-comments: Verified live 2026-06-22 via primary sources. GPL-3.0 licensed open-source project with public
+comments: Verified live 2026-06-22 via primary sources. GPL-3.0 licensed open source project with public
   source.

--- a/sources/products/firecrawl.yaml
+++ b/sources/products/firecrawl.yaml
@@ -3,7 +3,7 @@ display_name: Firecrawl
 type: software
 description: Web scraping and crawling API built specifically for LLM consumption. Turns any URL into
   clean markdown or structured data, handling JavaScript rendering, pagination, and anti-bot measures
-  automatically. The most popular open-source web-to-LLM pipeline with 123K GitHub stars, used by agent
+  automatically. The most popular open source web-to-LLM pipeline with 123K GitHub stars, used by agent
   frameworks as the default scraping tool. Open-source with a hosted SaaS option.
 github:
 - url: https://github.com/mendableai/firecrawl

--- a/sources/products/fireworks-fine-tuning.yaml
+++ b/sources/products/fireworks-fine-tuning.yaml
@@ -4,7 +4,7 @@ type: software
 description: Managed LoRA fine-tuning for popular open-weight models (Llama, Mistral, Qwen, DeepSeek)
   with served checkpoints at base-model inference rates and tight integration to Fireworks' high-throughput
   inference engine. Picked when latency-sensitive production serving matters as much as the fine-tune
-  itself — Fireworks consistently benchmarks at the low end of TTFT for hosted open-weight models. Pricing
+  itself; Fireworks consistently benchmarks at the low end of TTFT for hosted open-weight models. Pricing
   from $0.50/M training tokens for models up to 16B.
 comments: 'Fireworks AI managed fine-tuning (docs live June 2026). Methods: SFT, DPO, RFT (reinforcement
   fine-tuning). Output produces LoRA models; warm-start continued training supported; fine-tuned models

--- a/sources/products/flax.yaml
+++ b/sources/products/flax.yaml
@@ -3,7 +3,7 @@ display_name: Flax
 type: software
 description: Flax is a neural network library and ecosystem for JAX designed for flexibility, providing
   network components (Linear, Conv, BatchNorm, attention) plus training utilities like checkpointing and
-  serialization. It is developed and maintained by Google DeepMind as an open-source project. Its newer
+  serialization. It is developed and maintained by Google DeepMind as an open source project. Its newer
   Flax NNX API emphasizes Python reference semantics for building networks with standard Python objects.
 github:
 - url: https://github.com/google/flax

--- a/sources/products/fly-sprites.yaml
+++ b/sources/products/fly-sprites.yaml
@@ -1,7 +1,7 @@
 name: fly-sprites
 display_name: Fly Sprites
 type: software
-description: Closed-source stateful sandbox product (launched Jan 2026) — Firecracker microVMs with 100GB
+description: Closed-source stateful sandbox product (launched Jan 2026), Firecracker microVMs with 100GB
   persistent NVMe storage that boot in 1–12s cold, ~300ms warm checkpoint/restore, and auto-idle when
   inactive. Picked by teams who reject ephemeral sandboxes for coding agents and want a persistent computer
   the agent can return to. Pitched explicitly against E2B/Modal/Daytona for long-running Claude Code-style

--- a/sources/products/galileo.yaml
+++ b/sources/products/galileo.yaml
@@ -2,7 +2,7 @@ name: galileo
 display_name: Galileo
 type: software
 description: AI observability and reliability platform that combines offline evals, online production
-  guardrails, and tracing — powered by their proprietary Luna-2 small judge models that detect hallucinations,
+  guardrails, and tracing, powered by their proprietary Luna-2 small judge models that detect hallucinations,
   tool errors, and policy violations at claimed 97% lower cost than LLM-as-judge. Positions as 'don't
   just monitor AI failures, stop them' and is consistently ranked in top-5 LLM observability platforms
   (Maxim, Firecrawl roundups). Series B-funded, with enterprise customers across financial services and

--- a/sources/products/gemini-2-5-flash.yaml
+++ b/sources/products/gemini-2-5-flash.yaml
@@ -2,7 +2,7 @@ name: gemini-2-5-flash
 display_name: Gemini 2.5 Flash
 type: model
 description: 'Previous-generation speed-optimized model (2025) with configurable thinking budgets. Superseded
-  by Gemini 3 Flash and Gemini 3.5 Flash (May 19, 2026), the new default in the Gemini app — ''Pro-grade
+  by Gemini 3 Flash and Gemini 3.5 Flash (May 19, 2026), the new default in the Gemini app: ''Pro-grade
   reasoning at Flash-level speed,'' #9 on the May 2026 LMArena text leaderboard (Elo 1480) and #2 on LiveCodeBench
   at 90.8%. 2.5 Flash remains a popular cost-tier for high-volume deployments.'
 comments: Google Gemini 2.5 Flash, released June 17, 2025; price-performance thinking instruct model.

--- a/sources/products/gemini-3-1-pro-preview.yaml
+++ b/sources/products/gemini-3-1-pro-preview.yaml
@@ -4,7 +4,7 @@ type: model
 description: 'Google''s current top-coding-tier closed model. Leads LiveCodeBench Pro at 2887 Elo, posts
   80.6% on SWE-bench Verified (#5 on the May 2026 leaderboard) and 88.5% on LiveCodeBench, with native
   multimodal understanding and a 1M+ token context window. Sits at #6 on the May 2026 LMArena text leaderboard
-  (Elo 1488) — effectively tied with Claude Opus 4.6/4.7 within the 95% CI. Gemini 3.5 Pro is expected
+  (Elo 1488), effectively tied with Claude Opus 4.6/4.7 within the 95% CI. Gemini 3.5 Pro is expected
   June 2026.'
 comments: Google Gemini 3.1 Pro, released in preview Feb 19, 2026; Google's most advanced reasoning instruct
   model, 1M-token context. Available via Gemini app/NotebookLM (Pro/Ultra), Gemini API (AI Studio, Antigravity,

--- a/sources/products/gemini-3-5-flash-google.yaml
+++ b/sources/products/gemini-3-5-flash-google.yaml
@@ -2,7 +2,7 @@ name: gemini-3-5-flash-google
 display_name: Gemini 3.5 Flash
 type: model
 description: 'Released at Google I/O 2026 (May 19, 2026) as the new default in the Gemini app. Marketed
-  as ''Pro-grade reasoning at Flash-level speed'' — #9 on the May 2026 LMArena text leaderboard (Elo 1480)
+  as ''Pro-grade reasoning at Flash-level speed''; #9 on the May 2026 LMArena text leaderboard (Elo 1480)
   and #2 on LiveCodeBench at 90.8%. Configurable thinking budgets let users trade reasoning depth for
   latency. Powers Antigravity / Gemini CLI and most Google-side coding-assistant deployments where cost
   matters.'

--- a/sources/products/gemini-3-5-flash.yaml
+++ b/sources/products/gemini-3-5-flash.yaml
@@ -2,7 +2,7 @@ name: gemini-3-5-flash
 display_name: Gemini 3.5 Flash
 type: model
 description: 'Released at Google I/O 2026 (May 19, 2026) as the new default in the Gemini app. Marketed
-  as ''Pro-grade reasoning at Flash-level speed'' — #9 on the May 2026 LMArena text leaderboard (Elo 1480)
+  as ''Pro-grade reasoning at Flash-level speed'': #9 on the May 2026 LMArena text leaderboard (Elo 1480)
   and #2 on LiveCodeBench at 90.8%. Configurable thinking budgets let users trade reasoning depth for
   latency. Powers Antigravity / Gemini CLI and most Google-side coding-assistant deployments where cost
   matters.'

--- a/sources/products/gemini-cli.yaml
+++ b/sources/products/gemini-cli.yaml
@@ -1,7 +1,7 @@
 name: gemini-cli
 display_name: Gemini CLI
 type: software
-description: Google's open-source terminal AI coding agent, bringing Gemini models into the shell for coding, debugging,
+description: Google's open source terminal AI coding agent, bringing Gemini models into the shell for coding, debugging,
   and task automation. Ships built-in tools (Google Search grounding, file ops, shell, web fetch), is extensible
   via MCP and GEMINI.md system-prompt files, and offers a generous free tier on a personal Google account. Unlike
   the closed peers (Cursor, Claude Code), it is fully Apache-2.0.

--- a/sources/products/gemini.yaml
+++ b/sources/products/gemini.yaml
@@ -4,6 +4,6 @@ type: software
 description: Google's consumer Gemini chat app on web, Android, iOS, and integrated across Google Workspace,
   with Live (voice), Deep Research, and image/video generation. 900M+ monthly active users by Q1 2026
   (up from 750M at end of 2025), fastest-growing standalone LLM in absolute terms.
-comments: Gemini app (Google) — consumer chat app (web + Android/iOS), proprietary/closed UI scored as
+comments: Gemini app (Google), consumer chat app (web + Android/iOS), proprietary/closed UI scored as
   the closed counterpart. Verified live June 2026; powered by Gemini 3.x model family. (Model SKUs scored
   separately; this record scores the app surface.)

--- a/sources/products/gemma-3.yaml
+++ b/sources/products/gemma-3.yaml
@@ -1,7 +1,7 @@
 name: gemma-3
 display_name: Gemma 3
 type: model
-description: Google's current open-weights model family, released March 12, 2025 — and the first open-weights
+description: Google's current open-weights model family, released March 12, 2025, and the first open-weights
   Gemma generation with native vision-language capability. Available in 1B/4B/12B/27B variants (the 1B
   is text-only; the 4B/12B/27B are vision-language models), with a 128K context window on the larger variants
   and native multilingual support for 140+ languages. The Gemma 3 27B fits at Q4 on a single 3090 yet

--- a/sources/products/github-copilot-github-microsoft.yaml
+++ b/sources/products/github-copilot-github-microsoft.yaml
@@ -5,6 +5,6 @@ description: AI pair-programmer integrated into VS Code, JetBrains, Neovim, and 
   inline code completion, chat, and code review against multiple model backends (OpenAI, Anthropic, Google).
   Differentiator is enterprise distribution via GitHub and tight IDE integration; ~4.7M paid subscribers
   and ~$1B ARR as of early 2026.
-comments: GitHub Copilot (GitHub / Microsoft) — proprietary in-IDE AI coding assistant (inline suggestions,
+comments: GitHub Copilot (GitHub / Microsoft), proprietary in-IDE AI coding assistant (inline suggestions,
   chat, agent mode) across VS Code/JetBrains/etc. Closed counterpart in ui_api. Verified live on github.com/features/copilot
   June 2026.

--- a/sources/products/github-copilot.yaml
+++ b/sources/products/github-copilot.yaml
@@ -1,9 +1,9 @@
 name: github-copilot
 display_name: GitHub Copilot
 type: software
-description: GitHub Copilot Agent Mode — assigns autonomous background coding tasks (plan/explore/execute),
+description: GitHub Copilot Agent Mode, assigns autonomous background coding tasks (plan/explore/execute),
   supports first-party Copilot agent plus Claude (Anthropic) and Codex (OpenAI). Verified live June 2026
   at github.com/features/copilot.
-comments: GitHub Copilot Agent Mode — assigns autonomous background coding tasks (plan/explore/execute),
+comments: GitHub Copilot Agent Mode, assigns autonomous background coding tasks (plan/explore/execute),
   supports first-party Copilot agent plus Claude (Anthropic) and Codex (OpenAI). Verified live June 2026
   at github.com/features/copilot.

--- a/sources/products/glean-workplace-search-ai.yaml
+++ b/sources/products/glean-workplace-search-ai.yaml
@@ -5,7 +5,7 @@ description: AI-powered workplace search across 100+ enterprise tools with permi
   knowledge-graph personalization, and generative answers. Glean’s own product pages and homepage emphasize
   that it searches everywhere employees work, then turns that context into concise answers and next steps;
   the company highlights a 141% ROI claim in its Forrester materials as an adoption signal.
-comments: Glean Search ('the foundation of enterprise AI') — AI-powered enterprise/workplace search UI
+comments: Glean Search ('the foundation of enterprise AI'), AI-powered enterprise/workplace search UI
   built on the Enterprise Graph + Personal Graph, hybrid search across 100+ connectors (Slack, Teams,
   Zoom, ServiceNow, Zendesk, GitHub, etc.), permissions-aware. Proprietary single-tenant SaaS. Verified
   live June 2026. The search layer underpins Glean Assistant; scored here as the human-facing search UI/API

--- a/sources/products/glm-4-6.yaml
+++ b/sources/products/glm-4-6.yaml
@@ -1,7 +1,7 @@
 name: glm-4-6
 display_name: GLM-4.6
 type: model
-description: Zhipu AI's current frontier model, released September 30, 2025 — a 355B-parameter MoE with
+description: Zhipu AI's current frontier model, released September 30, 2025, a 355B-parameter MoE with
   MIT-licensed open weights, a 200K context window, and published CC-Bench evaluation trajectories on
   Hugging Face for independent verification. Builds on GLM-4.5 (July 2025) and represents Zhipu's pivot
   to a fully open-weights frontier strategy. Z.ai (Zhipu's international brand) has also debuted GLM-4.6V,

--- a/sources/products/glm-4.yaml
+++ b/sources/products/glm-4.yaml
@@ -4,7 +4,7 @@ type: model
 description: 'Zhipu AI''s flagship instruction-tuned model line, now at GLM-4.6 (late 2025) following
   GLM-4.5 (July 2025). Strong multilingual coding (especially Chinese-English) with 128K+ context and
   native tool use. Notable structural shift: GLM-4.5 and 4.6 ship open-weights variants (a reversal of
-  the GLM-4 API-only stance) — Zhipu now competes directly in the open-weight frontier alongside DeepSeek,
+  the GLM-4 API-only stance); Zhipu now competes directly in the open-weight frontier alongside DeepSeek,
   Qwen, and Kimi. Widely deployed in Chinese enterprise environments via API and self-hosted weights.'
 comments: GLM-4-9B-Chat (Zhipu AI / Z.ai, org zai-org), instruction-tuned chat model; 9B params, 128K
   context (1M variant available), released ~June 2024 (arXiv 2406.12793). Open weights under the custom

--- a/sources/products/goose.yaml
+++ b/sources/products/goose.yaml
@@ -4,7 +4,7 @@ type: software
 description: Open-source extensible AI agent from Block (fka Square) that goes beyond code suggestions
   to install packages, execute commands, edit files, and run tests with any LLM. Differentiates through
   first-class MCP (Model Context Protocol) support and a Rust-based core for performance. 45.7K GitHub
-  stars with 452 contributors and 918 commits in 90 days — one of the most actively developed open-source
+  stars with 452 contributors and 918 commits in 90 days, one of the most actively developed open source
   agents, backed by a major tech company.
 github:
 - url: https://github.com/block/goose

--- a/sources/products/gpt-4-1-openai.yaml
+++ b/sources/products/gpt-4-1-openai.yaml
@@ -2,7 +2,7 @@ name: gpt-4-1-openai
 display_name: GPT-4.1
 type: model
 description: Previous-generation general-purpose instruction-tuned model (April 2025). Strong on HumanEval
-  and real-world coding with 1M token context, but two numerical generations behind by mid-2026 — OpenAI's
+  and real-world coding with 1M token context, but two numerical generations behind by mid-2026; OpenAI's
   current production line is GPT-5 → 5.2 → 5.4 → 5.5 (April 23, 2026), with GPT-5.5 Pro and 5.5 Instant
   variants. GPT-4.1 remains available via API and is still used in legacy integrations.
 comments: OpenAI GPT-4.1 (+ mini, nano), released Apr 14 2025 as API-first coding/instruct models with

--- a/sources/products/gpt-4-1.yaml
+++ b/sources/products/gpt-4-1.yaml
@@ -2,7 +2,7 @@ name: gpt-4-1
 display_name: GPT-4.1
 type: model
 description: Previous-generation general-purpose instruction-tuned model (April 2025). Strong on HumanEval
-  and real-world coding with 1M token context, but two numerical generations behind by mid-2026 — OpenAI's
+  and real-world coding with 1M token context, but two numerical generations behind by mid-2026; OpenAI's
   current production line is GPT-5 → 5.2 → 5.4 → 5.5 (April 23, 2026), with GPT-5.5 Pro and 5.5 Instant
   variants. GPT-4.1 remains available via API and is still used in legacy integrations.
 comments: OpenAI GPT-4.1, snapshot gpt-4.1-2025-04-14, ~1M-token context (1,047,576), knowledge cutoff

--- a/sources/products/gpt-4o.yaml
+++ b/sources/products/gpt-4o.yaml
@@ -3,7 +3,7 @@ display_name: GPT-4o
 type: model
 description: 'OpenAI''s legacy multimodal foundation model (May 2024) that natively handled text, image,
   and audio. Now two numerical generations behind: superseded by the GPT-5 line (GPT-5 in August 2025,
-  then 5.2, 5.3, 5.4, and GPT-5.5 on April 23, 2026 — the first fully retrained base since GPT-4.5). All
+  then 5.2, 5.3, 5.4, and GPT-5.5 on April 23, 2026, the first fully retrained base since GPT-4.5). All
   access remains API-only via post-trained variants; GPT-4o is being sunset as the ChatGPT default in
   favor of GPT-5.5 Instant (May 5, 2026). Listed as the historical closed-source baseline that open-weights
   models were measured against through 2024-2025.'

--- a/sources/products/gpt-5.yaml
+++ b/sources/products/gpt-5.yaml
@@ -2,11 +2,11 @@ name: gpt-5
 display_name: GPT-5
 type: model
 description: 'OpenAI''s current closed foundation model line: GPT-5 (August 2025), then post-training
-  iterations GPT-5.2, 5.3, 5.4, and finally GPT-5.5 (April 23, 2026) — the first fully retrained base
+  iterations GPT-5.2, 5.3, 5.4, and finally GPT-5.5 (April 23, 2026), the first fully retrained base
   since GPT-4.5. GPT-5.5 and GPT-5.5 Pro shipped via API on April 24, 2026; GPT-5.5 Instant became the
   default ChatGPT model on May 5, 2026, replacing GPT-5.3 Instant. The o-series reasoning brand has been
   folded into the GPT-5 line. GPT-5.5 is positioned as ''smartest and most agentic'' with major gains
-  in agentic coding, computer use, and knowledge work. API-only — no weights distributed; the base pretrained
+  in agentic coding, computer use, and knowledge work. API-only, no weights distributed; the base pretrained
   model is never exposed directly. The benchmark closed-source frontier that open-weights models are measured
   against in 2026.'
 comments: OpenAI GPT-5, released Aug 7, 2025; default ChatGPT model. Successor versions (5.2/5.4/5.5)

--- a/sources/products/gradio.yaml
+++ b/sources/products/gradio.yaml
@@ -1,7 +1,7 @@
 name: gradio
 display_name: Gradio
 type: software
-description: Gradio is an open-source Python package for quickly building web demos and applications for
+description: Gradio is an open source Python package for quickly building web demos and applications for
   machine learning models, APIs, or arbitrary Python functions without JavaScript, CSS, or web-hosting
   knowledge. It provides the Interface, Blocks, and ChatInterface classes plus built-in public sharing
   of demos. Originally an independent project, it is now maintained under Hugging Face after the company

--- a/sources/products/granite-code-instruct.yaml
+++ b/sources/products/granite-code-instruct.yaml
@@ -1,10 +1,10 @@
 name: granite-code-instruct
 display_name: Granite Code Instruct
 type: model
-description: IBM's enterprise-focused open-source code model line, now folded into the unified Granite
+description: IBM's enterprise-focused open source code model line, now folded into the unified Granite
   4.1 family (3B, 8B, 30B dense, base + instruct, Apache-2.0) released April 29, 2026. Granite 4.1 delivers
   significant improvements over Granite 4.0 in tool calling, instruction following, coding, and math,
-  while preserving IBM's IP-clean training-data provenance — still the go-to choice for enterprises needing
+  while preserving IBM's IP-clean training-data provenance, still the go-to choice for enterprises needing
   legal clarity on training data. Available on watsonx and Hugging Face.
 huggingface_model:
 - url: https://huggingface.co/ibm-granite/granite-34b-code-instruct-8k

--- a/sources/products/grok-3.yaml
+++ b/sources/products/grok-3.yaml
@@ -2,7 +2,7 @@ name: grok-3
 display_name: Grok 3
 type: model
 description: Previous-generation xAI flagship (February 2025), trained on the 100K-H100 Colossus cluster.
-  Superseded by Grok 4, Grok 4.1, and Grok 4.20 Heavy (Feb 2026) — the latter uses a 16-agent specialized
+  Superseded by Grok 4, Grok 4.1, and Grok 4.20 Heavy (Feb 2026); the latter uses a 16-agent specialized
   system. Grok 5 is still in training (claimed 10T params; ~33% chance of release by 2026-06-30 per prediction
   markets). Grok 3 remains available via X platform integration.
 comments: xAI Grok 3, released Feb 17, 2025; trained on the Colossus supercluster. Post-trained chat/assistant

--- a/sources/products/grok-4-20-heavy.yaml
+++ b/sources/products/grok-4-20-heavy.yaml
@@ -2,11 +2,11 @@ name: grok-4-20-heavy
 display_name: Grok 4.20 Heavy
 type: model
 description: xAI's current flagship instruction-tuned product (Feb 2026), built as a 16-agent specialized
-  system — multiple Grok-4 instances coordinated around specialized roles rather than a single monolithic
+  system, multiple Grok-4 instances coordinated around specialized roles rather than a single monolithic
   call. Marketed as xAI's top reasoning + agentic tier; ships alongside Grok 4 and Grok 4.1 as the standard
   API tiers. Grok 5 is still in training (claimed 10T params; ~33% chance of release by 2026-06-30 per
   prediction markets).
-comments: xAI Grok 4.20 Heavy — the high-effort multi-agent tier of Grok 4.20 (beta Feb 17, 2026; multi-agent
+comments: xAI Grok 4.20 Heavy, the high-effort multi-agent tier of Grok 4.20 (beta Feb 17, 2026; multi-agent
   API GA Mar 9, 2026). 'Heavy' scales the default 4-agent debate (Grok/Harper/Benjamin/Lucas) to 16 specialized
   agents; 2M-token context. Accessed via SuperGrok Heavy ($300/mo). Distinct SKU from the 'Grok 4.20'
   flagship anchor (default-effort). Superseded by Grok 4.3 but still offered. Verified live June 2026.

--- a/sources/products/grok.yaml
+++ b/sources/products/grok.yaml
@@ -3,9 +3,9 @@ display_name: Grok
 type: software
 description: xAI's consumer chat product with a standalone app (grok.com) plus deep integration into X
   (Twitter), competing on real-time data access and a less-filtered tone. ~64M MAU by early 2026 and ~17.8%
-  US chatbot share — third behind ChatGPT and Gemini, with the fastest single-year share gain of any consumer
+  US chatbot share, third behind ChatGPT and Gemini, with the fastest single-year share gain of any consumer
   chatbot.
-comments: Grok consumer AI chat assistant by xAI — the app/UI surface (grok.com + X integration + mobile),
+comments: Grok consumer AI chat assistant by xAI, the app/UI surface (grok.com + X integration + mobile),
   live June 2026 (x.ai). Scored here as the chat-UI product, NOT the Grok 4.x model SKU (the model is
   scored in base_pretrained as Grok 4.20). Proprietary; human-in-the-loop assistant with image gen + X-grounded
   search.

--- a/sources/products/groq-inference.yaml
+++ b/sources/products/groq-inference.yaml
@@ -2,7 +2,7 @@ name: groq-inference
 display_name: Groq Inference
 type: software
 description: Inference service running on custom Language Processing Unit (LPU) hardware designed from
-  the ground up for sequential token generation. Achieves industry-leading token throughput — widely benchmarked
+  the ground up for sequential token generation. Achieves industry-leading token throughput, widely benchmarked
   at 500-800 tokens/sec for Llama-class models, far exceeding GPU-based alternatives. Deterministic, SRAM-based
   architecture eliminates memory bottlenecks. Available via API with OpenAI-compatible endpoints. The
   company that put 'inference speed' in the mainstream conversation in early 2024.

--- a/sources/products/hailo-8.yaml
+++ b/sources/products/hailo-8.yaml
@@ -8,5 +8,5 @@ description: An edge AI inference accelerator delivering up to 26 TOPS at roughl
   vision.
 github:
 - url: https://github.com/hailo-ai/hailort
-comments: Verified live 2026-06-22 via primary sources. Proprietary silicon with an open-source runtime
+comments: Verified live 2026-06-22 via primary sources. Proprietary silicon with an open source runtime
   and public product briefs, but the model-compiler toolchain requires registration and silicon is closed.

--- a/sources/products/haystack.yaml
+++ b/sources/products/haystack.yaml
@@ -1,7 +1,7 @@
 name: haystack
 display_name: Haystack
 type: software
-description: deepset's open-source orchestration framework for production LLM apps in Python, built around composable
+description: deepset's open source orchestration framework for production LLM apps in Python, built around composable
   modular pipelines and agent workflows with explicit control over retrieval, routing, memory, and generation. Originally
   RAG/search-focused; Haystack 2.x is a general orchestrator.
 github:

--- a/sources/products/helicone.yaml
+++ b/sources/products/helicone.yaml
@@ -3,8 +3,8 @@ display_name: Helicone
 type: software
 description: LLM proxy that captures logs, costs, and latency with a one-line integration (swap your API
   base URL). Clean dashboard for monitoring request volumes, token usage, costs, and error rates. Positioned
-  as the lowest-friction entry point for LLM monitoring — no SDK needed, just a proxy URL change. YC W23.
-  Code is open-source (Apache-2.0) but primarily used as a cloud service.
+  as the lowest-friction entry point for LLM monitoring, no SDK needed, just a proxy URL change. YC W23.
+  Code is open source (Apache-2.0) but primarily used as a cloud service.
 github:
 - url: https://github.com/Helicone/helicone
 comments: Helicone/helicone monorepo active June 2026 (5,477 commits on main). Confirmed live on GitHub;

--- a/sources/products/hellaswag.yaml
+++ b/sources/products/hellaswag.yaml
@@ -6,7 +6,7 @@ description: A commonsense NLI and sentence-completion benchmark introduced in 2
   of a sentence in everyday contexts.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/Rowan/hellaswag
-comments: HellaSwag (Zellers et al., ACL 2019) — commonsense NLI sentence-completion benchmark. 59,950
+comments: HellaSwag (Zellers et al., ACL 2019), commonsense NLI sentence-completion benchmark. 59,950
   examples (39,905 train / 10,042 val / 10,003 test); 4-way multiple-choice over ActivityNet-derived contexts.
   Canonical commonsense benchmark reported in nearly every LLM release. Verified live June 2026 on huggingface.co/datasets/Rowan/hellaswag.
   Registry attributes to AI2/Allen Institute; primary authors are UW/AI2 (Rowan Zellers).

--- a/sources/products/helm.yaml
+++ b/sources/products/helm.yaml
@@ -1,7 +1,7 @@
 name: helm
 display_name: HELM
 type: software
-description: Holistic Evaluation of Language Models — Python framework for reproducible, transparent evaluation
+description: Holistic Evaluation of Language Models, Python framework for reproducible, transparent evaluation
   of foundation models including LLMs and multimodal models, organized around scenarios, adapters, and
   metrics. Picked for academic-grade reproducibility and breadth (accuracy, robustness, fairness, bias,
   toxicity). 2.8k stars, 128 contributors, 151 commits in last 90 days; Stanford has announced HELM will

--- a/sources/products/hermes-agent.yaml
+++ b/sources/products/hermes-agent.yaml
@@ -8,6 +8,6 @@ description: 'Open-source autonomous agent that grows with the user through pers
   GitHub stars, and shows very heavy recent development activity.'
 github:
 - url: https://github.com/NousResearch/hermes-agent
-comments: Hermes Agent by Nous Research — open-source self-improving autonomous agent (auto-generates
+comments: Hermes Agent by Nous Research, open source self-improving autonomous agent (auto-generates
   skills, persistent memory, 40+ tools, subagent delegation, NL cron, multi-channel). MIT. Released ~Feb
   2026; verified live June 2026 (latest release v0.15.2, 29 May 2026; ~181K stars).

--- a/sources/products/humaneval.yaml
+++ b/sources/products/humaneval.yaml
@@ -3,7 +3,7 @@ display_name: HumanEval
 type: dataset
 description: 164 hand-written Python programming problems with function signatures, docstrings, and unit
   tests. The original code generation benchmark, introduced in the Codex paper (2021). Still the most
-  widely cited code eval dataset — virtually every code model paper reports pass@k on HumanEval, making
+  widely cited code eval dataset; virtually every code model paper reports pass@k on HumanEval, making
   it the de facto baseline despite its small size and Python-only scope.
 github:
 - url: https://github.com/openai/human-eval

--- a/sources/products/inflection-3-0.yaml
+++ b/sources/products/inflection-3-0.yaml
@@ -3,7 +3,7 @@ display_name: Inflection 3.0
 type: model
 description: 'Inflection AI''s foundation model powering the Pi assistant and the company''s enterprise
   ''Inflection for Enterprise'' tier. After key staff (Mustafa Suleyman et al.) departed to Microsoft
-  AI in March 2024, Inflection pivoted to enterprise. Inflection 3.0 is the current flagship — powered
+  AI in March 2024, Inflection pivoted to enterprise. Inflection 3.0 is the current flagship, powered
   by Intel Gaudi 3 with on-prem or AI Cloud deployment options; no new generation publicly confirmed by
   May 2026. Notable as a case study in foundation-model market concentration dynamics: pace has slowed
   dramatically post-pivot.'

--- a/sources/products/inspect-ai.yaml
+++ b/sources/products/inspect-ai.yaml
@@ -4,11 +4,11 @@ type: software
 description: Frontier-AI evaluation framework with one interface over OpenAI, Anthropic, Google, xAI,
   Bedrock and local vLLM/Ollama backends, plus a collection of 200+ pre-built evals (Inspect Evals) co-maintained
   with Arcadia Impact and the Vector Institute. Picked by AISI, EU AI Office, and many frontier labs as
-  the standard for safety/dangerous-capability evaluations. 2.1k stars but extremely active — 1,333 commits
+  the standard for safety/dangerous-capability evaluations. 2.1k stars but extremely active, 1,333 commits
   in last 90 days, 227 contributors.
 github:
 - url: https://github.com/UKGovernmentBEIS/inspect_ai
 comments: 'UKGovernmentBEIS/inspect_ai (UK AI Security Institute + Meridian Labs), MIT, ~2.2k stars, ~5,886
-  commits — very actively developed. Framework for frontier LLM/agent evaluations: 200+ pre-built evals,
+  commits, very actively developed. Framework for frontier LLM/agent evaluations: 200+ pre-built evals,
   tool use, multi-turn, model-graded scoring, one interface over OpenAI/Anthropic/Google/xAI/Bedrock/Azure/local
   vLLM/Ollama. Confirmed live June 2026.'

--- a/sources/products/internlm-2-5.yaml
+++ b/sources/products/internlm-2-5.yaml
@@ -2,7 +2,7 @@ name: internlm-2-5
 display_name: InternLM 2.5
 type: model
 description: Shanghai AI Lab's open-weights model family. The InternLM 2.5 generation (7B/20B, July 2024,
-  1M context via dynamic NTK interpolation) was superseded by InternLM3 in January 2025 — an 8B model
+  1M context via dynamic NTK interpolation) was superseded by InternLM3 in January 2025, an 8B model
   trained on only 4T tokens that reportedly matches GPT-4o-mini, with integrated 'deep thinking' chain-of-thought
   mode and ~4x the data efficiency (IQPT) of Llama 3.1. A leading Chinese academic-origin foundation model,
   heavily used in the Chinese research community.

--- a/sources/products/jan.yaml
+++ b/sources/products/jan.yaml
@@ -1,7 +1,7 @@
 name: jan
 display_name: Jan
 type: software
-description: Cross-platform desktop app (Windows/macOS/Linux) for running open-source models 100% offline,
+description: Cross-platform desktop app (Windows/macOS/Linux) for running open source models 100% offline,
   with a clean ChatGPT-style UI, optional cloud provider integrations, and a local OpenAI-compatible API
   server on localhost:1337. Picked over alternatives for its polished native desktop experience and offline-first
   stance; 5.3M+ downloads and ~43k GitHub stars by May 2026.

--- a/sources/products/kata-containers.yaml
+++ b/sources/products/kata-containers.yaml
@@ -1,11 +1,11 @@
 name: kata-containers
 display_name: Kata Containers
 type: software
-description: Kata Containers — lightweight VMs that feel like containers; v3.31.0 (May 19 2026) confirmed
+description: Kata Containers, lightweight VMs that feel like containers; v3.31.0 (May 19 2026) confirmed
   live on GitHub. OpenInfra Foundation governed (governance not explicit on repo landing page but established
   as an OpenInfra project). Can use Firecracker/QEMU as the VMM.
 github:
 - url: https://github.com/kata-containers/kata-containers
-comments: Kata Containers — lightweight VMs that feel like containers; v3.31.0 (May 19 2026) confirmed
+comments: Kata Containers, lightweight VMs that feel like containers; v3.31.0 (May 19 2026) confirmed
   live on GitHub. OpenInfra Foundation governed (governance not explicit on repo landing page but established
   as an OpenInfra project). Can use Firecracker/QEMU as the VMM.

--- a/sources/products/khoj.yaml
+++ b/sources/products/khoj.yaml
@@ -12,4 +12,4 @@ pypi:
 - url: https://pypi.org/project/khoj
 comments: AGPL-3.0; ~35k GitHub stars and ~26k PyPI downloads/month by mid-2026. Khoj Cloud (the former
   paid hosted tier) was sunset 2026-04-15; the team directs all users to self-host and states Khoj "remains
-  fully open-source", so no feature-gating remains in the shipping product. Self-host via Docker or pip.
+  fully open source", so no feature-gating remains in the shipping product. Self-host via Docker or pip.

--- a/sources/products/kimi-k2-6.yaml
+++ b/sources/products/kimi-k2-6.yaml
@@ -3,7 +3,7 @@ display_name: Kimi K2.6
 type: model
 description: Moonshot AI's open-weight 1T-parameter MoE released 2026-04-20 under a Modified MIT license,
   with 256K context. Top-10 on SWE-bench Verified at 80.2% and ties GPT-5.4 on agentic/coding benchmarks.
-  Notable for a 300-sub-agent / 4000-step swarm capability — Moonshot ships native multi-agent scaffolding
+  Notable for a 300-sub-agent / 4000-step swarm capability. Moonshot ships native multi-agent scaffolding
   with the weights. One of the four credible open-weight frontier contenders (alongside DeepSeek V4, Qwen3-Coder-Next,
   and GLM-4.6) for chat/coding workloads in 2026.
 huggingface_model:

--- a/sources/products/lamini.yaml
+++ b/sources/products/lamini.yaml
@@ -4,7 +4,7 @@ type: software
 description: Enterprise fine-tuning stack acquired by AMD at Advancing AI 2025 (June 2025) and rolled
   into AMD's ROCm/AI software organization; the former CEO Sharon Zhou is now VP of AI at AMD. Picked
   when teams running on AMD Instinct MI300/MI325 accelerators want a first-party fine-tuning path optimized
-  for ROCm — Lamini's Mixture of Memory Experts (MoME) technique trains thousands of LoRA-style memory
+  for ROCm; Lamini's Mixture of Memory Experts (MoME) technique trains thousands of LoRA-style memory
   experts per model to drive ~95% factual recall with ~10x fewer hallucinations than vanilla SFT. The
   discrete lamini.ai SaaS has been wound down; the technology now anchors AMD's enterprise fine-tuning
   story alongside ROCm 6.x and AMD's growing data-center AI revenue ramp.

--- a/sources/products/langfuse.yaml
+++ b/sources/products/langfuse.yaml
@@ -2,7 +2,7 @@ name: langfuse
 display_name: Langfuse
 type: software
 description: Open-source LLM engineering platform providing tracing, prompt management, evaluations, cost
-  tracking, and datasets. Self-hostable or cloud-hosted. The leading open-source LLM observability platform
+  tracking, and datasets. Self-hostable or cloud-hosted. The leading open source LLM observability platform
   with broad integrations (OpenTelemetry, LangChain, OpenAI SDK, LiteLLM). YC W23, 27.7K GitHub stars.
 github:
 - url: https://github.com/langfuse/langfuse

--- a/sources/products/le-chat.yaml
+++ b/sources/products/le-chat.yaml
@@ -3,8 +3,8 @@ display_name: Le Chat
 type: software
 description: Mistral's consumer/enterprise chat product (chat.mistral.ai) running on Mistral Medium/Large
   with Flash Answers, web search, image gen, and an enterprise on-prem deployment option. 1M downloads
-  in 14 days at app launch; ~10.8M monthly desktop visits in March 2026 with 21% MoM growth — Europe's
+  in 14 days at app launch; ~10.8M monthly desktop visits in March 2026 with 21% MoM growth, Europe's
   flagship sovereign-AI chat surface.
-comments: Le Chat by Mistral AI — consumer AI chat assistant (web + mobile; app rebranded toward 'Mistral
+comments: Le Chat by Mistral AI, consumer AI chat assistant (web + mobile; app rebranded toward 'Mistral
   Vibe' by 2026), live June 2026 (mistral.ai). Proprietary chat UI primarily over Mistral's own models;
   human-in-the-loop assistant. ~1.7M app downloads by May 2026; EU MAU stated below 45M.

--- a/sources/products/lighteval.yaml
+++ b/sources/products/lighteval.yaml
@@ -1,7 +1,7 @@
 name: lighteval
 display_name: lighteval
 type: software
-description: Lightweight successor to the eval harness HF used internally — supports vLLM, transformers,
+description: Lightweight successor to the eval harness HF used internally; supports vLLM, transformers,
   TGI and OpenAI-compatible backends with a focus on speed and easy custom metric authoring. Picked when
   teams want a fast, hackable runner that integrates cleanly with the HF ecosystem (datasets, accelerate).
   2.4k stars, 120 contributors, 17 commits in last 90 days; powers parts of the Open LLM Leaderboard v2.

--- a/sources/products/livecodebench.yaml
+++ b/sources/products/livecodebench.yaml
@@ -5,7 +5,7 @@ description: Continuously updated benchmark that scrapes fresh LeetCode/Codeforc
   a model's training cutoff, ensuring contamination-free evaluation across code generation, self-repair,
   execution, and test-output prediction. v6 includes 1,000+ problems collected May 2023–2025. Per Artificial
   Analysis (May 2026), Gemini 3 Pro Preview leads at 91.7%, followed by Gemini 3 Flash Reasoning at 90.8%
-  and DeepSeek V3.2 Speciale at 89.6% — DeepSeek V4-Pro-Max reached 93.5% on a later snapshot. ~870 GitHub
+  and DeepSeek V3.2 Speciale at 89.6%; DeepSeek V4-Pro-Max reached 93.5% on a later snapshot. ~870 GitHub
   stars but disproportionate influence as the trusted dynamic complement to HumanEval/MBPP.
 github:
 - url: https://github.com/LiveCodeBench/LiveCodeBench

--- a/sources/products/llama-3-1.yaml
+++ b/sources/products/llama-3-1.yaml
@@ -2,9 +2,9 @@ name: llama-3-1
 display_name: Llama 3.1
 type: model
 description: Meta's open-weights foundation model family in 8B, 70B, and 405B parameter variants that
-  established the open-source ecosystem baseline. Trained on 15T+ tokens with grouped query attention
+  established the open source ecosystem baseline. Trained on 15T+ tokens with grouped query attention
   and a 128K context window under the Llama Community License. Superseded by Llama 4 (April 2025) and
-  Llama 5 (April 2026), but still the most widely adopted historical baseline — the 8B variant alone retains
+  Llama 5 (April 2026), but still the most widely adopted historical baseline; the 8B variant alone retains
   roughly 5M monthly Hugging Face downloads and remains the default seed for community fine-tunes.
 huggingface_model:
 - url: https://huggingface.co/meta-llama/Llama-3.1-405B

--- a/sources/products/llama-cpp.yaml
+++ b/sources/products/llama-cpp.yaml
@@ -3,7 +3,7 @@ display_name: llama.cpp
 type: software
 description: CPU and GPU inference engine for LLMs written in portable C/C++. Pioneered the GGUF quantization
   format (2-8 bit) that became the ecosystem standard for local model distribution. Runs on consumer hardware
-  — laptops, phones, Raspberry Pi — without requiring CUDA or Python. 112K+ GitHub stars make it the most-starred
+  (laptops, phones, Raspberry Pi) without requiring CUDA or Python. 112K+ GitHub stars make it the most-starred
   inference project; foundational infrastructure that powers Ollama, LM Studio, GPT4All, and dozens of
   other tools.
 github:

--- a/sources/products/lm-evaluation-harness.yaml
+++ b/sources/products/lm-evaluation-harness.yaml
@@ -2,7 +2,7 @@ name: lm-evaluation-harness
 display_name: lm-evaluation-harness
 type: software
 description: Unified framework for evaluating language models on 200+ academic NLP benchmarks (MMLU, ARC,
-  GSM8K, HellaSwag, etc.) with a single config-driven CLI. Picked as the canonical reference harness —
+  GSM8K, HellaSwag, etc.) with a single config-driven CLI. Picked as the canonical reference harness;
   it powers the Hugging Face Open LLM Leaderboard and is the standard tool for reporting reproducible
   benchmark numbers in papers. 12.6k GitHub stars, 392 contributors, 58 commits in last 90 days.
 github:

--- a/sources/products/lobe-chat.yaml
+++ b/sources/products/lobe-chat.yaml
@@ -1,7 +1,7 @@
 name: lobe-chat
 display_name: Lobe Chat
 type: software
-description: Modern-design open-source chat framework supporting OpenAI, Claude, Gemini, Ollama, Azure,
+description: Modern-design open source chat framework supporting OpenAI, Claude, Gemini, Ollama, Azure,
   DeepSeek and others, with knowledge bases, vision/TTS, plugin marketplace, and one-click deployment.
   Chosen for its polished UI and breadth of multi-modal/plugin support compared to barebones alternatives;
   ~77k GitHub stars makes it the second-most-starred OSS chat UI.

--- a/sources/products/lumo.yaml
+++ b/sources/products/lumo.yaml
@@ -10,5 +10,5 @@ github:
 - url: https://github.com/ProtonLumo/ios-lumo
 - url: https://github.com/ProtonLumo/android-lumo
 comments: Launched July 2025; Lumo 1.1 added advanced reasoning. Clients are GPLv3 (web client lives in
-  ProtonMail/WebClients; iOS/Android in ProtonLumo), but the service, models, and routing are not open-sourced,
+  ProtonMail/WebClients; iOS/Android in ProtonLumo), but the service, models, and routing are not open sourced,
   so the "fully open source" marketing claim is contested.

--- a/sources/products/maple-ai.yaml
+++ b/sources/products/maple-ai.yaml
@@ -4,7 +4,7 @@ type: software
 description: End-to-end encrypted, private AI chat assistant. Conversations are encrypted on the user's device
   and processed inside hardware-isolated Trusted Execution Environments (AWS Nitro Enclaves + Nvidia GPU TEEs)
   so that even the operator cannot read user data, with remote attestation that users can verify against
-  open-source builds. Maple is the flagship app built on the open OpenSecret confidential-computing platform
+  open source builds. Maple is the flagship app built on the open OpenSecret confidential-computing platform
   (same team), serves a menu of open-weight models, and ships as web, iOS, Android, and desktop apps. The
   differentiator is cryptographically verifiable privacy rather than a policy promise.
 github:

--- a/sources/products/math.yaml
+++ b/sources/products/math.yaml
@@ -8,5 +8,5 @@ huggingface_dataset:
 - url: https://huggingface.co/datasets/EleutherAI/hendrycks_math
 comments: 'MATH (Hendrycks et al., NeurIPS 2021, arXiv 2103.03874): 12,500 competition math problems (7,500
   train / 5,000 test) with step-by-step LaTeX solutions, Level 1-5, 7 subjects. Original HF dataset (hendrycks/competition_math)
-  verified June 2026 but ACCESS DISABLED via DMCA takedown — no longer redistributable from the canonical
+  verified June 2026 but ACCESS DISABLED via DMCA takedown; no longer redistributable from the canonical
   registry; license tag is MIT.'

--- a/sources/products/mbpp.yaml
+++ b/sources/products/mbpp.yaml
@@ -1,7 +1,7 @@
 name: mbpp
 display_name: MBPP
 type: dataset
-description: 'Mostly Basic Python Problems — 974 crowd-sourced Python programming tasks designed to be
+description: 'Mostly Basic Python Problems, 974 crowd-sourced Python programming tasks designed to be
   solvable by entry-level programmers, each with a task description, solution, and three automated test
   cases. Introduced alongside Google''s program synthesis work (2021). The complement to HumanEval: where
   HumanEval tests function-level generation with detailed docstrings, MBPP tests natural-language-to-code

--- a/sources/products/memryx-mx3.yaml
+++ b/sources/products/memryx-mx3.yaml
@@ -5,9 +5,9 @@ description: An edge AI accelerator from MemryX (USA) built on a dataflow archit
   chip provides ~6 TOPS and an M.2 module packs four chips for up to 24 TOPS at roughly 6-8W with passive
   cooling. The M.2 (2280, M-Key) module uses PCIe Gen3 and supports 4/8/16-bit weights plus BFloat16,
   with no model-zoo lock-in. Sold at retail (~$149) via Amazon, Mouser, and distributors, it won a 2025
-  Edge AI & Vision Alliance Product of the Year award and is supported by the MemryX SDK and open-source
+  Edge AI & Vision Alliance Product of the Year award and is supported by the MemryX SDK and open source
   tooling.
 github:
 - url: https://github.com/memryx/MxAccl
 comments: Verified live 2026-06-22 via primary sources. Proprietary dataflow silicon with public datasheets,
-  retail availability, and several open-source runtime/driver repos, though the compiler core is closed.
+  retail availability, and several open source runtime/driver repos, though the compiler core is closed.

--- a/sources/products/meta-ai.yaml
+++ b/sources/products/meta-ai.yaml
@@ -1,11 +1,11 @@
 name: meta-ai
 display_name: Meta AI
 type: software
-description: Meta's consumer AI assistant — a chat surface embedded directly into WhatsApp, Instagram,
+description: Meta's consumer AI assistant, a chat surface embedded directly into WhatsApp, Instagram,
   Facebook, and Messenger, plus a standalone web app at meta.ai and native iOS/Android apps. Powered by
   Llama 4/5 across most surfaces with Muse Spark (Meta Superintelligence Labs' new closed-weight model,
   launched April 8, 2026) backing the standalone app and rolling out to Family-of-Apps in mid-2026. 1B+
-  monthly active users across Meta's apps — the only consumer AI assistant with native distribution into
+  monthly active users across Meta's apps, the only consumer AI assistant with native distribution into
   ~4B existing users; the standalone Meta AI iPhone app has held a top-of-chart App Store position alongside
   ChatGPT, Claude, and Gemini since the Muse Spark launch.
 comments: Meta's consumer AI assistant embedded across WhatsApp, Instagram, Messenger, Facebook + standalone

--- a/sources/products/mistral-fine-tuning-api.yaml
+++ b/sources/products/mistral-fine-tuning-api.yaml
@@ -1,8 +1,8 @@
 name: mistral-fine-tuning-api
 display_name: Mistral Fine-Tuning API
 type: software
-description: Managed LoRA fine-tuning of Mistral 7B, Mistral Small, and other Mistral models via La Plateforme
-  — plus an open-source companion (mistral-finetune) for self-hosted training. Picked when teams want
+description: Managed LoRA fine-tuning of Mistral 7B, Mistral Small, and other Mistral models via La Plateforme,
+  plus an open source companion (mistral-finetune) for self-hosted training. Picked when teams want
   Mistral's European data residency story or open-weight portability between managed and self-hosted training.
   API priced at ~$2/M training tokens; the only managed offering for Mistral's commercial weights.
 comments: 'Mistral serverless fine-tuning on La Plateforme - confirmed live/available in 2026 (not deprecated;

--- a/sources/products/mistral-large-2.yaml
+++ b/sources/products/mistral-large-2.yaml
@@ -2,12 +2,12 @@ name: mistral-large-2
 display_name: Mistral Large 2
 type: model
 description: Mistral AI's 123B-parameter dense model (July 2024, 128K context) under the Mistral Research
-  License — Europe's flagship open-weights frontier model at release, fluent across nine languages and
+  License, Europe's flagship open-weights frontier model at release, fluent across nine languages and
   strong on code/math. Retired and replaced by Mistral Large 3 on 30 March 2025; relevant historically
   but no longer the active SKU. Mistral overall reported ~450K customers and $400M+ ARR by mid-2025.
 huggingface_model:
 - url: https://huggingface.co/mistralai/Mistral-Large-Instruct-2407
 comments: 'Mistral Large 2 (Large-Instruct-2407, July 2024; revised 2411), 123B dense, 128K context, 80+
-  languages. Mistral ships only the instruct SKU publicly — no separately released base/pretrained weights
+  languages. Mistral ships only the instruct SKU publicly; no separately released base/pretrained weights
   (CONFIRMED: HF page lists only the instruct variant). Verified live on HF June 2026; superseded by Mistral
   Large 3.'

--- a/sources/products/mistral-large-3.yaml
+++ b/sources/products/mistral-large-3.yaml
@@ -6,7 +6,7 @@ description: 'Mistral AI''s first mixture-of-experts model since Mixtral and the
   native multimodal support (text + images). Trained from scratch on 3000 H200 GPUs. Debuted at #2 on
   the LMArena OSS non-reasoning leaderboard. Combined with Ministral 3 (smaller dense variants) and Mistral
   Vibe CLI in the broader Mistral 3 stack. Runs at the compute cost of a ~41B dense model while accessing
-  the capacity of a 675B one — Europe''s flagship open-weights frontier model and the direct successor
+  the capacity of a 675B one, Europe''s flagship open-weights frontier model and the direct successor
   to the retired Mistral Large 2 (March 2025).'
 huggingface_model:
 - url: https://huggingface.co/mistralai/Mistral-Large-3-Instruct-2512

--- a/sources/products/model-context-protocol.yaml
+++ b/sources/products/model-context-protocol.yaml
@@ -3,7 +3,7 @@ display_name: Model Context Protocol
 type: software
 description: Open standard for connecting AI agents to external tools and data sources. Defines how agents
   discover, authenticate with, and invoke tools via a JSON-RPC protocol. Rapidly adopted across the agent
-  ecosystem — supported by Claude Code, Cursor, VS Code Copilot, Windsurf, and dozens of IDE and agent
+  ecosystem; supported by Claude Code, Cursor, VS Code Copilot, Windsurf, and dozens of IDE and agent
   frameworks. The emerging universal standard for agent-tool communication, with 86K+ stars on the reference
   server repo.
 comments: Open wire protocol for connecting LLMs/agents to tools and data; created by Anthropic (David

--- a/sources/products/mosaic-ai-model-training.yaml
+++ b/sources/products/mosaic-ai-model-training.yaml
@@ -2,7 +2,7 @@ name: mosaic-ai-model-training
 display_name: Mosaic AI Model Training
 type: software
 description: Databricks' managed full-fine-tune and continued-pretraining service for open-weight models
-  (Llama 3, Mistral, DBRX) built on the proprietary MosaicML training stack — claimed up to 2x faster
+  (Llama 3, Mistral, DBRX) built on the proprietary MosaicML training stack, claimed up to 2x faster
   than naive open source. Picked when training data lives in Unity Catalog and teams want Lakehouse-native
   fine-tuning with full weight ownership (resulting model registers to UC). Distinct from competitors
   in that customers get the actual weight checkpoint, not just a hosted endpoint.

--- a/sources/products/multipl-e.yaml
+++ b/sources/products/multipl-e.yaml
@@ -4,7 +4,7 @@ type: dataset
 description: Multi-programming language translation of HumanEval and MBPP into 18+ languages (JavaScript,
   TypeScript, C++, Java, Rust, Go, etc.). Enables comparing code generation performance across languages
   rather than just Python. Published at TOCS 2023. The standard benchmark for evaluating multilingual
-  code models — used in the BigCode and Open LLM Leaderboard evaluations.
+  code models, used in the BigCode and Open LLM Leaderboard evaluations.
 github:
 - url: https://github.com/nuprl/MultiPL-E
 huggingface_dataset:

--- a/sources/products/muse-spark.yaml
+++ b/sources/products/muse-spark.yaml
@@ -2,7 +2,7 @@ name: muse-spark
 display_name: Muse Spark
 type: model
 description: Meta Superintelligence Labs' flagship closed-weight API model, launched April 2026. Closed
-  top-5 on the May 2026 LMArena text leaderboard (Elo 1489) — the first non-Anthropic/Google/OpenAI model
+  top-5 on the May 2026 LMArena text leaderboard (Elo 1489), the first non-Anthropic/Google/OpenAI model
   to break the top 5 in 2026. Represents Meta's parallel closed-weights track alongside the open-weights
   Llama line (Llama 5, April 2026), effectively splitting Meta into two flagship brands. Chat/instruction-tuned
   tier sits in Cat 3 alongside other API-only frontier models.

--- a/sources/products/nemo-rl.yaml
+++ b/sources/products/nemo-rl.yaml
@@ -1,10 +1,10 @@
 name: nemo-rl
 display_name: NeMo-RL
 type: software
-description: NVIDIA's scalable open-source toolkit for RL post-training, successor to NeMo-Aligner — supports
+description: NVIDIA's scalable open source toolkit for RL post-training, successor to NeMo-Aligner. Supports
   DPO, PPO, GRPO, and reward modeling on Megatron-LM and FSDP backends with first-class multi-node H100/B200
   scaling. Picked when teams are already on the NVIDIA NeMo stack and need RL post-training that scales
-  to thousands of GPUs. 1.6K GitHub stars but 181 commits in 90 days and a growing contributor base —
+  to thousands of GPUs. 1.6K GitHub stars but 181 commits in 90 days and a growing contributor base,
   well-resourced; pairs with NeMo Customizer (managed) for enterprise users.
 github:
 - url: https://github.com/NVIDIA-NeMo/RL

--- a/sources/products/nemotron-3-nvidia.yaml
+++ b/sources/products/nemotron-3-nvidia.yaml
@@ -6,7 +6,7 @@ description: 'NVIDIA''s first-party open-weight instruction-tuned model family f
   active hybrid MoE, March–April 2026) and Nemotron 3 Super (120B / 12B active Mamba-Transformer MoE,
   March 11, 2026); Nemotron 3 Ultra (~500B / 50B active) is announced for H1 2026. Differentiates on (a)
   open training data and recipes published alongside the weights, (b) 1M-token context with strong RULER
-  scores (Super 91.8 @ 1M), and (c) being NVIDIA''s reference post-trained line for NeMo and NIM — optimized
+  scores (Super 91.8 @ 1M), and (c) being NVIDIA''s reference post-trained line for NeMo and NIM, optimized
   end-to-end against NVIDIA hardware. Adoption signal: 1.38M monthly Hugging Face downloads on Nano BF16
   plus 758K on Super BF16, and free hosting on OpenRouter and build.nvidia.com.'
 comments: 'Post-trained/instruct (SFT+RL) variants of the Nemotron 3 family: Nano (~3.2B active hybrid

--- a/sources/products/nemotron-3.yaml
+++ b/sources/products/nemotron-3.yaml
@@ -6,7 +6,7 @@ description: 'NVIDIA''s first-party open-weight instruction-tuned model family f
   active hybrid MoE, March–April 2026) and Nemotron 3 Super (120B / 12B active Mamba-Transformer MoE,
   March 11, 2026); Nemotron 3 Ultra (~500B / 50B active) is announced for H1 2026. Differentiates on (a)
   open training data and recipes published alongside the weights, (b) 1M-token context with strong RULER
-  scores (Super 91.8 @ 1M), and (c) being NVIDIA''s reference post-trained line for NeMo and NIM — optimized
+  scores (Super 91.8 @ 1M), and (c) being NVIDIA''s reference post-trained line for NeMo and NIM, optimized
   end-to-end against NVIDIA hardware. Adoption signal: 1.38M monthly Hugging Face downloads on Nano BF16
   plus 758K on Super BF16, and free hosting on OpenRouter and build.nvidia.com.'
 comments: Scored on Nemotron 3 Super (120B hybrid MoE, 12B active, 1M context), released 11 Mar 2026 at

--- a/sources/products/northflank-sandboxes.yaml
+++ b/sources/products/northflank-sandboxes.yaml
@@ -5,6 +5,6 @@ description: Closed-source managed sandbox platform offering microVM isolation v
   gVisor, any OCI image, unlimited session duration, and BYOC deployment. Picked when teams need production-grade
   isolation plus a complete platform (services, jobs, databases) beyond ephemeral sandboxes; processes
   2M+ isolated workloads/month and is SOC 2 Type 2 compliant.
-comments: Northflank Sandboxes — secure microVM/sandbox product for running untrusted / AI-generated code
+comments: Northflank Sandboxes, secure microVM/sandbox product for running untrusted / AI-generated code
   at scale (~200ms microVM spin-up), positioned for code-gen agents. Confirmed live June 2026 via northflank.com.
   Proprietary SaaS (Northflank Ltd).

--- a/sources/products/o3-o4-mini.yaml
+++ b/sources/products/o3-o4-mini.yaml
@@ -3,7 +3,7 @@ display_name: o3 / o4-mini
 type: model
 description: 'Previous reasoning tier (2025): full-scale o3 plus cost-efficient o4-mini, both using extended
   chain-of-thought. Powered Codex agent and ChatGPT''s coding mode through 2025. Folded into the GPT-5
-  line in late 2025 — OpenAI consolidated the o-series and GPT branches and is no longer maintaining o-series
+  line in late 2025; OpenAI consolidated the o-series and GPT branches and is no longer maintaining o-series
   as a separately branded reasoning family. Current reasoning capability lives in GPT-5.x with thinking
   enabled and in GPT-5.3-Codex.'
 comments: OpenAI o3 and o4-mini reasoning models, both released Apr 16 2025 (o3-mini preceded Jan 31 2025).

--- a/sources/products/ogx.yaml
+++ b/sources/products/ogx.yaml
@@ -1,7 +1,7 @@
 name: ogx
 display_name: OGX
 type: software
-description: Meta's open inference + deployment runtime for LLMs — originally launched as Llama Stack
+description: Meta's open inference + deployment runtime for LLMs; originally launched as Llama Stack
   (`meta-llama/llama-stack`) in 2024 and rebranded in 2026 as OGX / Open GenAI Stack (`ogx-ai/ogx`) with
   model-agnostic positioning. Unified APIs for inference, agents, fine-tuning, and eval; 25+ ecosystem
   partners including AWS, NVIDIA, Databricks, Groq, and Azure. MIT licensed, 8.4K+ stars with continuous

--- a/sources/products/ollama.yaml
+++ b/sources/products/ollama.yaml
@@ -3,7 +3,7 @@ display_name: Ollama
 type: software
 description: Local LLM runtime that wraps llama.cpp in a user-friendly CLI and REST API with a Docker-like
   model management experience (ollama pull, ollama run). Handles model downloading, quantization selection,
-  and GPU/CPU routing automatically. 172K GitHub stars — the most popular way for developers to run models
+  and GPU/CPU routing automatically. 172K GitHub stars, the most popular way for developers to run models
   locally. Became the default local inference backend for dozens of AI applications and MCP integrations.
 github:
 - url: https://github.com/ollama/ollama

--- a/sources/products/onnx-runtime.yaml
+++ b/sources/products/onnx-runtime.yaml
@@ -4,7 +4,7 @@ type: software
 description: 'Cross-platform inference accelerator supporting models from PyTorch, TensorFlow, and other
   frameworks via the ONNX interchange format. Runs on CPUs, GPUs, NPUs, and custom accelerators with hardware-specific
   execution providers. Used in production across Microsoft products (Windows, Office, Azure). Unique differentiator:
-  hardware-agnostic — one runtime targets NVIDIA, AMD, Intel, Qualcomm, and Apple silicon. 20K+ stars,
+  hardware-agnostic: one runtime targets NVIDIA, AMD, Intel, Qualcomm, and Apple silicon. 20K+ stars,
   steady development over 7+ years.'
 github:
 - url: https://github.com/microsoft/onnxruntime

--- a/sources/products/openai-code-interpreter.yaml
+++ b/sources/products/openai-code-interpreter.yaml
@@ -1,11 +1,11 @@
 name: openai-code-interpreter
 display_name: OpenAI Code Interpreter
 type: software
-description: Closed-source code-execution tool exposed via the Responses API and Assistants API — runs
+description: Closed-source code-execution tool exposed via the Responses API and Assistants API, runs
   Python (and bash in newer versions) in a fully sandboxed VM with attached files, so the model can compute,
   analyze data, and iterate on solutions. Picked when teams want a turnkey 'agent can run code' primitive
   bundled directly with the OpenAI model API rather than wiring up E2B/Modal themselves.
-comments: OpenAI Code Interpreter — a tool (Assistants API, migrating to Responses API) that writes and
+comments: OpenAI Code Interpreter, a tool (Assistants API, migrating to Responses API) that writes and
   runs Python in a proprietary OpenAI-managed sandbox; processes files up to 512MB, sessions billed at
   $0.03/session (1-hour default). Confirmed live June 2026 via OpenAI developer docs. Proprietary; isolation
   mechanism undisclosed.

--- a/sources/products/openai-evals-api-dashboard.yaml
+++ b/sources/products/openai-evals-api-dashboard.yaml
@@ -1,12 +1,12 @@
 name: openai-evals-api-dashboard
 display_name: OpenAI Evals API & Dashboard
 type: software
-description: Managed evaluation product inside the OpenAI Platform — Evals API plus a Dashboard UI that
+description: Managed evaluation product inside the OpenAI Platform, Evals API plus a Dashboard UI that
   lets developers define eval datasets, run them against any OpenAI model, grade with custom or built-in
   graders, and track regressions across versions. Picked by teams already on OpenAI who want the 'measure
   → improve → ship' loop without standing up infra. Pricing rolls into standard OpenAI API token usage.
-comments: 'Hosted, proprietary evaluation product on the OpenAI platform (API + web dashboard) — distinct
-  from the open-source openai/evals repo. Lets developers define grading criteria, upload JSONL test sets,
+comments: 'Hosted, proprietary evaluation product on the OpenAI platform (API + web dashboard), distinct
+  from the open source openai/evals repo. Lets developers define grading criteria, upload JSONL test sets,
   run against Chat Completions/Responses APIs, and inspect pass/fail + cost metrics. BEING SUNSET: dashboard
   read-only 31 Oct 2026, full shutdown 30 Nov 2026 (OpenAI recommends Datasets as replacement). Confirmed
   live June 2026 via OpenAI developer docs.'

--- a/sources/products/openai-fine-tuning-api.yaml
+++ b/sources/products/openai-fine-tuning-api.yaml
@@ -1,7 +1,7 @@
 name: openai-fine-tuning-api
 display_name: OpenAI Fine-Tuning API
 type: software
-description: Managed fine-tuning for GPT-4o, GPT-4o-mini, GPT-4.1, and o-series via the OpenAI API — supports
+description: Managed fine-tuning for GPT-4o, GPT-4o-mini, GPT-4.1, and o-series via the OpenAI API; supports
   supervised fine-tuning, DPO (added late 2024), and vision fine-tuning. Picked when the use case demands
   GPT-4-tier quality at lower latency/cost on a narrow task; the only way to fine-tune OpenAI's frontier
   weights. Training priced at ~$3/M tokens for GPT-4o-mini and GPT-4o (GPT-4.1 family ~$0.80-3/M); models

--- a/sources/products/openai-internal-evals.yaml
+++ b/sources/products/openai-internal-evals.yaml
@@ -9,4 +9,4 @@ description: OpenAI maintains proprietary internal evaluation suites for coding 
 comments: OpenAI internal dangerous-capability evaluations referenced in the Preparedness Framework (v2,
   updated 15 Apr 2025). The scored artifact is the internal eval sets used for Tracked Categories. Verified
   via the OpenAI Preparedness Framework v2 PDF (cdn.openai.com) and openai.com/index/updating-our-preparedness-framework.
-  NOT the separate open-source openai/evals harness (that is evaluation_code, not a dataset).
+  NOT the separate open source openai/evals harness (that is evaluation_code, not a dataset).

--- a/sources/products/openfn.yaml
+++ b/sources/products/openfn.yaml
@@ -1,12 +1,12 @@
 name: openfn
 display_name: OpenFn
 type: software
-description: OpenFn (Open Function Group) is an open-source workflow automation and data-integration platform
+description: OpenFn (Open Function Group) is an open source workflow automation and data-integration platform
   used by governments and NGOs to orchestrate service workflows across legacy systems, web APIs, databases,
   and increasingly LLMs/AI tools. Its flagship product, Lightning, is built in Elixir/Phoenix and ships
   with 70+ adaptors. It is a verified Digital Public Good and Digital Square Global Good, maintained by
   a public benefit corporation since 2014.
 github:
 - url: https://github.com/OpenFn/lightning
-comments: Verified live 2026-06-22 via primary sources. Fully open-source DPG with copyleft licensing
+comments: Verified live 2026-06-22 via primary sources. Fully open source DPG with copyleft licensing
   and no feature-gated core.

--- a/sources/products/openhands.yaml
+++ b/sources/products/openhands.yaml
@@ -4,7 +4,7 @@ type: software
 description: Open-source autonomous coding agent (formerly OpenDevin) that can write code, run commands,
   browse the web, and interact with APIs to complete software engineering tasks end-to-end. Differentiates
   through a sandboxed execution environment and strong SWE-bench performance, consistently ranking among
-  the top open-source agents. 74.5K GitHub stars with 460+ contributors and extremely active development
+  the top open source agents. 74.5K GitHub stars with 460+ contributors and extremely active development
   (710+ commits in 90 days).
 github:
 - url: https://github.com/All-Hands-AI/OpenHands

--- a/sources/products/openllmetry.yaml
+++ b/sources/products/openllmetry.yaml
@@ -3,7 +3,7 @@ display_name: OpenLLMetry
 type: software
 description: OpenTelemetry-based instrumentation library for LLM applications. Auto-instruments LangChain,
   LlamaIndex, OpenAI SDK, and other popular frameworks. Exports telemetry data to any OTel-compatible
-  backend (Jaeger, Grafana, Datadog, etc). The 'OpenTelemetry for LLMs' approach — standards-based, vendor-neutral.
+  backend (Jaeger, Grafana, Datadog, etc). The 'OpenTelemetry for LLMs' approach, standards-based, vendor-neutral.
   7.1K GitHub stars.
 github:
 - url: https://github.com/traceloop/openllmetry

--- a/sources/products/openpipe.yaml
+++ b/sources/products/openpipe.yaml
@@ -1,11 +1,11 @@
 name: openpipe
 display_name: OpenPipe
 type: software
-description: OpenPipe ships the open-source Agent Reinforcement Trainer (ART, Apache-2.0, ~9.7K stars)
-  alongside a closed managed prompt-logging and fine-tuning platform — an open-core stack for SFT and
+description: OpenPipe ships the open source Agent Reinforcement Trainer (ART, Apache-2.0, ~9.7K stars)
+  alongside a closed managed prompt-logging and fine-tuning platform, an open-core stack for SFT and
   RL post-training of agents. Acquired by CoreWeave in September 2025 to anchor their RL-for-agents capability
   alongside Weights & Biases; ART continues active development as the open library, with the platform
   serving as the commercial wrapper.
-comments: Scored on ART (Agent Reinforcement Trainer), OpenPipe's open-source fine-tuning/RL library (GRPO).
+comments: Scored on ART (Agent Reinforcement Trainer), OpenPipe's open source fine-tuning/RL library (GRPO).
   v0.5.17 (Mar 13, 2026), confirmed live on GitHub June 2026. OpenPipe also runs a managed training/hosting
   platform on top of the OSS library.

--- a/sources/products/openrlhf.yaml
+++ b/sources/products/openrlhf.yaml
@@ -3,12 +3,12 @@ display_name: OpenRLHF
 type: software
 description: Ray-based distributed RLHF/agentic-RL framework that distributes Actor, Reward, Reference,
   and Critic models across GPUs for full-scale 70B+ training. Picked over TRL when training scale exceeds
-  a single node and the workload is RL-heavy (PPO, DAPO, REINFORCE++, GRPO, KTO) — combines Ray + vLLM
+  a single node and the workload is RL-heavy (PPO, DAPO, REINFORCE++, GRPO, KTO), combines Ray + vLLM
   for high-throughput rollouts with DeepSpeed ZeRO-3 for memory-efficient training. 9.5K GitHub stars,
   87 contributors, published research backing (arxiv 2405.11143); used by labs scaling preference optimization.
 github:
 - url: https://github.com/OpenRLHF/OpenRLHF
 comments: OpenRLHF (OpenRLHF/OpenRLHF), Apache-2.0, confirmed live June 2026 (~9.6K stars). Self-described
-  'first high-performance production-ready open-source RLHF framework'; PPO, REINFORCE++, GRPO, RLOO;
+  'first high-performance production-ready open source RLHF framework'; PPO, REINFORCE++, GRPO, RLOO;
   Ray scheduling + vLLM rollout + DeepSpeed; scales to 70B+ models; named users incl. Google, ByteDance,
   Tencent, Alibaba, Baidu, Allen AI.

--- a/sources/products/openrouter.yaml
+++ b/sources/products/openrouter.yaml
@@ -7,5 +7,5 @@ description: 'Commercial API gateway that exposes 400+ models from 60+ providers
   raising $120M at a $1.3B valuation (CapitalG-led) in early 2026.'
 comments: OpenRouter unified LLM API gateway/router, live June 2026 (openrouter.ai homepage). Routes/aggregates
   API calls across 400+ models and 60+ providers behind one OpenAI-compatible API; not a chat UI but a
-  routing gateway — squarely the ui_api gateway slot alongside the LiteLLM anchor. Proprietary hosted
+  routing gateway, squarely the ui_api gateway slot alongside the LiteLLM anchor. Proprietary hosted
   service.

--- a/sources/products/opensandbox.yaml
+++ b/sources/products/opensandbox.yaml
@@ -1,13 +1,13 @@
 name: opensandbox
 display_name: OpenSandbox
 type: software
-description: Apache-2.0 sandbox runtime from Alibaba aimed squarely at AI agents — defines a 'Sandbox
+description: Apache-2.0 sandbox runtime from Alibaba aimed squarely at AI agents, defines a 'Sandbox
   Protocol' with standard lifecycle/execution APIs and ships multi-language SDKs (Python, Java, JS, .NET)
   plus Docker and Kubernetes runtimes. Picked by teams wanting an open protocol-driven alternative to
   E2B at K8s scale; ~10.8k stars and 910 commits in the last 90d signal serious investment.
 github:
 - url: https://github.com/alibaba/OpenSandbox
-comments: Alibaba OpenSandbox — general-purpose sandbox platform for AI agents (coding agents, GUI agents,
-  agent eval, RL training); open-sourced Mar 2026; components/execd 1.0.18 (May 25 2026) confirmed live
+comments: Alibaba OpenSandbox, general-purpose sandbox platform for AI agents (coding agents, GUI agents,
+  agent eval, RL training); open sourced Mar 2026; components/execd 1.0.18 (May 25 2026) confirmed live
   on GitHub. Go execd daemon; Docker/Kubernetes runtimes; multi-language SDKs (Python/TS/Go/Java); MCP
   server. Self-host only (no managed tier observed).

--- a/sources/products/openvino.yaml
+++ b/sources/products/openvino.yaml
@@ -1,7 +1,7 @@
 name: openvino
 display_name: OpenVINO
 type: software
-description: OpenVINO is an open-source toolkit for optimizing and deploying AI inference across computer
+description: OpenVINO is an open source toolkit for optimizing and deploying AI inference across computer
   vision, speech, NLP, and generative AI. It converts models from PyTorch, TensorFlow, and ONNX and deploys
   across CPUs (x86, ARM), Intel integrated/discrete GPUs, and Intel NPUs, with a GenAI API for LLM pipelines.
   It is developed by Intel and integrates with Hugging Face Optimum Intel and vLLM.

--- a/sources/products/opik.yaml
+++ b/sources/products/opik.yaml
@@ -3,8 +3,8 @@ display_name: Opik
 type: software
 description: Open-source platform for debugging, evaluating, and monitoring LLM applications, RAG systems,
   and agentic workflows. Provides comprehensive tracing, automated evaluations, and production-ready dashboards.
-  Built by Comet ML (established ML experiment tracking company). Fast-growing at 19.4K GitHub stars —
-  the second most-starred open-source LLM observability tool after Langfuse.
+  Built by Comet ML (established ML experiment tracking company). Fast-growing at 19.4K GitHub stars,
+  the second most-starred open source LLM observability tool after Langfuse.
 github:
 - url: https://github.com/comet-ml/opik
 comments: opik v2.0.57 (released 4 Jun 2026, PyPI/GitHub); confirmed live June 2026. Self-hostable OSS

--- a/sources/products/osworld.yaml
+++ b/sources/products/osworld.yaml
@@ -2,13 +2,13 @@ name: osworld
 display_name: OSWorld
 type: software
 description: Scalable, real-computer environment for benchmarking multimodal agents on 369 open-ended
-  tasks across Ubuntu, Windows and macOS — agents drive a virtual desktop and are scored by execution-based
+  tasks across Ubuntu, Windows and macOS; agents drive a virtual desktop and are scored by execution-based
   test scripts. Picked because it is the leading harness for computer-use agents (Claude Computer Use,
   OpenAI Operator both publish OSWorld scores). 2.9k stars, 86 contributors, 55 commits in last 90 days.
 github:
 - url: https://github.com/xlang-ai/OSWorld
-comments: 'OSWorld — scalable real-computer environment + execution-based evaluation harness for multimodal/computer-use
+comments: 'OSWorld: scalable real-computer environment + execution-based evaluation harness for multimodal/computer-use
   agents (NeurIPS 2024). Apache-2.0. 369 tasks (361 excl. 8 problematic Google Drive tasks). De-facto
   standard for computer-use agents (GPT-5.4 75.0%, Claude Opus 4.6 72.7%, Claude Sonnet 4.6 72.5% on OSWorld-Verified
   cited in 2026 releases). Confirmed live June 2026. Dual artifact: ships both the task set and the runner;
-  registry placed it in evaluation_code (the harness) — note the dataset overlaps benchmark_eval_data.'
+  registry placed it in evaluation_code (the harness); note the dataset overlaps benchmark_eval_data.'

--- a/sources/products/patronus-evaluation-platform.yaml
+++ b/sources/products/patronus-evaluation-platform.yaml
@@ -1,11 +1,11 @@
 name: patronus-evaluation-platform
 display_name: Patronus Evaluation Platform
 type: software
-description: Managed evaluation platform built around proprietary judge models — Lynx (8B hallucination
+description: Managed evaluation platform built around proprietary judge models, Lynx (8B hallucination
   detector), GLIDER (3.8B explainable rubric judge) and Percival (agent execution-trace analyzer). Picked
   by enterprises needing managed eval models rather than spinning up their own LLM-as-judge. Raised $20M;
   usage-based pricing $10-$20 per 1,000 evaluator API calls.
-comments: Patronus AI hosted GenAI evaluation/optimization platform ('Core Platform'); open-source client
+comments: Patronus AI hosted GenAI evaluation/optimization platform ('Core Platform'); open source client
   SDKs (patronus-py, latest v0.1.25 Jan 2026; patronus-api-node) that connect to proprietary hosted infra.
   Built-in evaluators Lynx (hallucination), Glider; experiments, production monitoring/tracing, Percival,
   RL Envs. Confirmed live June 2026.

--- a/sources/products/peft.yaml
+++ b/sources/products/peft.yaml
@@ -4,7 +4,7 @@ type: software
 description: State-of-the-art Parameter-Efficient Fine-Tuning library implementing LoRA, QLoRA, DoRA,
   adapters, prompt tuning, prefix tuning, and IA3 as a drop-in wrapper around transformers models. Picked
   because it's the underlying adapter engine that TRL, Axolotl, Unsloth, and most other frameworks compose
-  on top of — touching PEFT is unavoidable in the modern fine-tuning stack. 21.2K GitHub stars, 300 contributors,
+  on top of; touching PEFT is unavoidable in the modern fine-tuning stack. 21.2K GitHub stars, 300 contributors,
   116 commits in 90 days.
 github:
 - url: https://github.com/huggingface/peft

--- a/sources/products/perplexity-sonar-api.yaml
+++ b/sources/products/perplexity-sonar-api.yaml
@@ -3,7 +3,7 @@ display_name: Perplexity Sonar API
 type: software
 description: Search-augmented LLM API that combines real-time web search with language model reasoning
   to produce sourced, grounded answers. Unlike Tavily (which returns raw search results), Perplexity returns
-  synthesized answers with citations — agents get a research assistant, not just a search engine. Both
+  synthesized answers with citations; agents get a research assistant, not just a search engine. Both
   a consumer product and a developer API. Raised $500M+, valued at $9B+, the most well-funded company
   in the AI search space.
 comments: 'Proprietary search-grounded API: Sonar / Sonar Pro models, plus Search API (ranked web results)

--- a/sources/products/phi-4.yaml
+++ b/sources/products/phi-4.yaml
@@ -2,7 +2,7 @@ name: phi-4
 display_name: Phi-4
 type: model
 description: 'Microsoft''s 14B-parameter small language model that punches well above its weight class
-  on reasoning, math, and code — released December 2024 under MIT license. Trained on heavily curated
+  on reasoning, math, and code, released December 2024 under MIT license. Trained on heavily curated
   and synthetic data, demonstrating the ''small models with high-quality data'' thesis. As of May 2026
   the Phi-4 line is still current: Microsoft has extended it with Phi-4-mini, Phi-4-multimodal, and Phi-4-reasoning
   / Phi-4-reasoning-plus (May 2025), plus Phi-4-reasoning-vision-15B (March 2026). No Phi-5 has been announced.'

--- a/sources/products/playwright-mcp.yaml
+++ b/sources/products/playwright-mcp.yaml
@@ -3,7 +3,7 @@ display_name: Playwright MCP
 type: software
 description: MCP server that gives AI agents full browser automation capabilities via Playwright. Agents
   can navigate pages, click elements, fill forms, take screenshots, and extract structured data from web
-  pages — all through the MCP protocol. The standard open-source approach for giving agents a browser,
+  pages, all through the MCP protocol. The standard open source approach for giving agents a browser,
   with 33K GitHub stars. Backed by Microsoft and tightly integrated with VS Code and Copilot.
 github:
 - url: https://github.com/microsoft/playwright-mcp

--- a/sources/products/poe.yaml
+++ b/sources/products/poe.yaml
@@ -5,6 +5,6 @@ description: Multi-model chat aggregator letting users talk to GPT-5.2, Claude O
   image/video generators, and 1M+ user-created bots from one interface, with a points-based unified pricing
   model. Differentiator is breadth (200+ models in one app) plus a creator economy of custom bots; recently
   added 200-person group chats. Run by Quora.
-comments: Poe by Quora — multi-model chat aggregator app (web + mobile/desktop), live June 2026 (poe.com
+comments: Poe by Quora, multi-model chat aggregator app (web + mobile/desktop), live June 2026 (poe.com
   confirms). Single UI fronting many providers' bots (ChatGPT, Claude, Gemini, DeepSeek) + image/video/audio
   models + millions of user-created bots. Human-in-the-loop chat aggregator; proprietary.

--- a/sources/products/predibase.yaml
+++ b/sources/products/predibase.yaml
@@ -3,11 +3,11 @@ display_name: Predibase
 type: software
 description: 'Predibase managed fine-tuning/serving platform, acquired by Rubrik June 25 2025 (now an
   AI Agent Operations platform under Rubrik). Pioneered the first end-to-end Reinforcement Fine-Tuning
-  (RFT) platform for LLMs. Methods: SFT, RFT (GRPO-style), continued pretraining; fine-tunes open-source
+  (RFT) platform for LLMs. Methods: SFT, RFT (GRPO-style), continued pretraining; fine-tunes open source
   models; LoRA eXchange (LoRAX) OSS serving + turbo serving engine. Proprietary managed SaaS/VPC platform
   (OSS LoRAX + Ludwig are separate components). Confirmed live June 2026.'
 comments: 'Predibase managed fine-tuning/serving platform, acquired by Rubrik June 25 2025 (now an AI
   Agent Operations platform under Rubrik). Pioneered the first end-to-end Reinforcement Fine-Tuning (RFT)
-  platform for LLMs. Methods: SFT, RFT (GRPO-style), continued pretraining; fine-tunes open-source models;
+  platform for LLMs. Methods: SFT, RFT (GRPO-style), continued pretraining; fine-tunes open source models;
   LoRA eXchange (LoRAX) OSS serving + turbo serving engine. Proprietary managed SaaS/VPC platform (OSS
   LoRAX + Ludwig are separate components). Confirmed live June 2026.'

--- a/sources/products/pysyft.yaml
+++ b/sources/products/pysyft.yaml
@@ -1,7 +1,7 @@
 name: pysyft
 display_name: Syft / PySyft
 type: software
-description: PySyft is OpenMined's open-source library for privacy-preserving and remote data science,
+description: PySyft is OpenMined's open source library for privacy-preserving and remote data science,
   letting data scientists run computations on private data they cannot see or copy via secure 'Datasite'
   servers. It supports techniques associated with federated learning and differential privacy and offers
   a NumPy-like remote analysis interface. It is one of the most established open frameworks for collaborative

--- a/sources/products/qdrant.yaml
+++ b/sources/products/qdrant.yaml
@@ -4,7 +4,7 @@ type: software
 description: High-performance vector database and search engine built in Rust, designed for the next generation
   of AI applications. Stores vectors with rich payloads and supports advanced filtering, making it ideal
   for RAG retrieval pipelines that agents call to access knowledge bases. 31K+ GitHub stars, available
-  as open-source self-hosted or managed cloud. The leading Rust-native vector DB, competing with Milvus
+  as open source self-hosted or managed cloud. The leading Rust-native vector DB, competing with Milvus
   and Pinecone.
 github:
 - url: https://github.com/qdrant/qdrant

--- a/sources/products/qualcomm-ai-engine-direct.yaml
+++ b/sources/products/qualcomm-ai-engine-direct.yaml
@@ -8,5 +8,5 @@ description: On-device inference runtime for Qualcomm's Snapdragon processors ta
   runtime for Android on-device AI workloads.
 comments: Qualcomm AI Engine Direct SDK (aka Qualcomm AI Runtime / QNN) for on-device inference on Snapdragon
   NPU/HTP (Hexagon), GPU (Adreno), CPU (Kryo). Distributed as a proprietary SDK (separate Qualcomm download);
-  open-source helper wrapper (quic/ai-engine-direct-helper, BSD-3) exists. Integrated as backend for LiteRT
+  open source helper wrapper (quic/ai-engine-direct-helper, BSD-3) exists. Integrated as backend for LiteRT
   and ExecuTorch. Confirmed live June 2026.

--- a/sources/products/qwen-2-5.yaml
+++ b/sources/products/qwen-2-5.yaml
@@ -2,8 +2,8 @@ name: qwen-2-5
 display_name: Qwen 2.5
 type: model
 description: 'Alibaba''s Apache-2.0 open-weights family (0.5B-72B dense plus a 57B-A14B MoE) trained on
-  18T+ tokens, with specialist code and math variants. Now the previous-generation Qwen line — superseded
-  by Qwen3 (April 2025) and Qwen3.5 / Qwen3.7-Max (2026) — but still the most-downloaded non-Western open
+  18T+ tokens, with specialist code and math variants. Now the previous-generation Qwen line, superseded
+  by Qwen3 (April 2025) and Qwen3.5 / Qwen3.7-Max (2026), but still the most-downloaded non-Western open
   model: the 2.5 lineup recorded 750M+ Hugging Face downloads in 2025 and over 113K Qwen-derivative models
   now exist on the Hub, anchored largely by 2.5''s 7B variant.'
 huggingface_model:

--- a/sources/products/qwen3.yaml
+++ b/sources/products/qwen3.yaml
@@ -3,10 +3,10 @@ display_name: Qwen3
 type: model
 description: 'Alibaba''s current open-weights flagship line, launched April 28, 2025 under Apache 2.0.
   Includes six dense models (0.6B / 1.7B / 4B / 8B / 14B / 32B) and two MoE variants (30B-A3B and 235B-A22B),
-  trained on 36T tokens. Introduced hybrid reasoning — a single model that exposes both ''Thinking'' (chain-of-thought)
+  trained on 36T tokens. Introduced hybrid reasoning, a single model that exposes both ''Thinking'' (chain-of-thought)
   and ''Non-Thinking'' (fast-response) modes via a runtime switch. Extended in 2025-2026 with Qwen3-Next-80B-A3B
-  (ultra-sparse MoE with hybrid attention, September 2025), Qwen3.5 / Qwen3.5-Plus (February 16, 2026
-  — 397B-A17B Apache 2.0), and Qwen3.7-Max (May 20-21, 2026 — Alibaba''s proprietary ''agent-era'' flagship,
+  (ultra-sparse MoE with hybrid attention, September 2025), Qwen3.5 / Qwen3.5-Plus (February 16, 2026,
+  397B-A17B Apache 2.0), and Qwen3.7-Max (May 20-21, 2026, Alibaba''s proprietary ''agent-era'' flagship,
   #1 on Artificial Analysis Intelligence Index at 57, capable of 35-hour autonomous runs and 1000+ tool
   calls). Qwen3.7-Max is closed-weights, signalling a hybrid open/closed strategy.'
 huggingface_model:

--- a/sources/products/ragas.yaml
+++ b/sources/products/ragas.yaml
@@ -3,7 +3,7 @@ display_name: Ragas
 type: software
 description: Evaluation framework purpose-built for Retrieval-Augmented Generation pipelines with 30+
   metrics covering retrieval quality (context precision/recall), generation faithfulness, and answer relevance.
-  Picked when the system under test is RAG — Ragas decomposes pipeline failure into retrieval vs. generation
+  Picked when the system under test is RAG; Ragas decomposes pipeline failure into retrieval vs. generation
   buckets in a way general harnesses do not. 14k stars, 240 contributors.
 github:
 - url: https://github.com/explodinggradients/ragas

--- a/sources/products/reka-core.yaml
+++ b/sources/products/reka-core.yaml
@@ -7,9 +7,9 @@ description: Reka AI's multimodal foundation model that natively processes text,
   Flash 3 (open-weights, 2025) and Reka Nexus (a multi-agent 'AI workforce' product). Reka Core remains
   API-only as the closed flagship; no verified 2026 successor to Core itself was found in this audit,
   though the surrounding product line has evolved.
-comments: 'Reka Core, frontier-class multimodal LLM announced 15 Apr 2024; 128K context. Proprietary —
+comments: 'Reka Core, frontier-class multimodal LLM announced 15 Apr 2024; 128K context. Proprietary:
   API/on-prem/on-device; no open weights. Instruction/multimodal-chat model. Verified live: launch page
   confirms API/on-prem/on-device availability and the MMMU/Claude-3-Opus claims. NOTE: ''~5T tokens /
   32 languages / from scratch'' details are NOT on the cited launch page (they originate in Reka''s separate
-  technical report) — verify against that source if retained. >12mo old; scored best-effort and flagged
+  technical report); verify against that source if retained. >12mo old; scored best-effort and flagged
   stale.'

--- a/sources/products/replit-agent-code-execution-api.yaml
+++ b/sources/products/replit-agent-code-execution-api.yaml
@@ -5,9 +5,9 @@ description: Closed-source cloud dev platform with Nix-based environments suppor
   exposing a Code Execution API that runs untrusted/AI-generated code in sandboxed VMs. Picked when teams
   want a tightly integrated build+run+deploy story (Replit Agent 4 leans heavily on this) rather than
   an unbundled SDK. Raised $400M Series D in March 2026 at a $9B valuation; 50M+ users.
-comments: 'Replit Code Execution API for AI agents (replit.com/blog/ai-agents-code-execution) — a stateless
+comments: 'Replit Code Execution API for AI agents (replit.com/blog/ai-agents-code-execution), a stateless
   sandboxed API for running untrusted (primarily Python) code, isolated via omegajail (Replit''s unprivileged
   container sandbox) on Autoscale Deployments, ~100ms start. Confirmed live June 2026; `replit-code-exec`
   PyPI client exists. Proprietary service. NOTE: ''Replit Agent'' is an autonomous coding agent (orchestration),
-  but the deployment-relevant artifact here is the code-execution sandbox — scored as deployment per the
+  but the deployment-relevant artifact here is the code-execution sandbox, scored as deployment per the
   recipe litmus.'

--- a/sources/products/replit-agent.yaml
+++ b/sources/products/replit-agent.yaml
@@ -2,10 +2,10 @@ name: replit-agent
 display_name: Replit Agent
 type: software
 description: Cloud-based autonomous development agent embedded in Replit's online IDE that can build entire
-  applications from natural language descriptions — scaffolding projects, installing packages, writing
+  applications from natural language descriptions, scaffolding projects, installing packages, writing
   code, configuring databases, and deploying to production. Differentiates through zero-setup cloud execution
   (no local environment needed) and end-to-end deployment capability, making it the most accessible agent
   for non-developers. Replit has 30M+ registered users; raised $200M+ total funding.
-comments: Replit Agent (Agent 4 generation), autonomous AI app-building agent in the Replit cloud IDE
-  — parallel multi-task build, design + functionality in parallel. Verified live June 2026 at replit.com/agent;
+comments: Replit Agent (Agent 4 generation), autonomous AI app-building agent in the Replit cloud IDE,
+  parallel multi-task build, design + functionality in parallel. Verified live June 2026 at replit.com/agent;
   proprietary, consumption-priced on top of Replit subscriptions.

--- a/sources/products/sambanova-cloud.yaml
+++ b/sources/products/sambanova-cloud.yaml
@@ -1,7 +1,7 @@
 name: sambanova-cloud
 display_name: SambaNova Cloud
 type: software
-description: Inference service running on custom Reconfigurable Dataflow Architecture (RDA) chips — the
+description: Inference service running on custom Reconfigurable Dataflow Architecture (RDA) chips, the
   SN40L processor with 1TB+ on-chip memory. Designed for large models that don't fit in GPU memory without
   tensor parallelism. Offers both cloud API and on-premise appliance (DataScale) for enterprise deployments.
   Competitive with Groq and Cerebras on throughput for large models. Raised $1.5B+, primarily targeting

--- a/sources/products/searxng.yaml
+++ b/sources/products/searxng.yaml
@@ -1,7 +1,7 @@
 name: searxng
 display_name: SearXNG
 type: software
-description: Free, privacy-respecting open-source metasearch engine that aggregates results from up to 269
+description: Free, privacy-respecting open source metasearch engine that aggregates results from up to 269
   search services without tracking or profiling users. Though it predates the LLM era and does no inference
   itself, it has become the de facto self-hosted web-search backend for open AI answer engines and RAG - it
   exposes a JSON API and runs entirely on your own infrastructure (no commercial search keys, no tracking),

--- a/sources/products/semantic-kernel.yaml
+++ b/sources/products/semantic-kernel.yaml
@@ -1,7 +1,7 @@
 name: semantic-kernel
 display_name: Semantic Kernel
 type: software
-description: Microsoft's lightweight open-source SDK for building AI agents and integrating LLMs into C#, Python,
+description: Microsoft's lightweight open source SDK for building AI agents and integrating LLMs into C#, Python,
   or Java code. It exposes your code as model-callable 'plugins' (often via OpenAPI), with connectors to AI services
   and vector stores, telemetry, and responsible-AI hooks. Its differentiator vs the Python-first frameworks is genuine,
   first-class multi-language support (.NET and Java, not Python-only).

--- a/sources/products/serper.yaml
+++ b/sources/products/serper.yaml
@@ -3,7 +3,7 @@ display_name: Serper
 type: software
 description: Fast, low-cost Google Search API designed for developers and AI agents. Returns structured
   Google SERP data (organic results, knowledge graph, related searches) via a simple REST API. Positioned
-  as the cheapest way to give agents Google-quality search results — $0.001/query at scale. Widely used
+  as the cheapest way to give agents Google-quality search results, $0.001/query at scale. Widely used
   in LangChain and agent frameworks as a cost-effective alternative to Tavily for high-volume use cases.
 comments: 'Serper.dev Google Search API, verified live June 2026. Proprietary closed search API (web/images/news/maps/shopping/video/scholar).
   Sub-segment: search APIs (Tavily/Exa peer, closed counterpart).'

--- a/sources/products/simple-evals.yaml
+++ b/sources/products/simple-evals.yaml
@@ -2,12 +2,12 @@ name: simple-evals
 display_name: simple-evals
 type: software
 description: OpenAI's lightweight reference harness used to produce the model cards for GPT-4o, o1, and
-  successors — includes MMLU, MATH, GPQA, MGSM, DROP, HumanEval and SimpleQA. Picked when researchers
+  successors. Includes MMLU, MATH, GPQA, MGSM, DROP, HumanEval and SimpleQA. Picked when researchers
   want the exact numbers OpenAI reports rather than community variants. 4.5k stars, used as the authoritative
   reproduction script for GPT scorecards.
 github:
 - url: https://github.com/openai/simple-evals
 comments: openai/simple-evals GitHub repo (MIT, ~4.5k stars). Lightweight zero-shot/CoT eval library bundling
-  MMLU, MATH, GPQA, DROP, MGSM, HumanEval, SimpleQA, BrowseComp, HealthBench. DEPRECATED July 2025 — no
+  MMLU, MATH, GPQA, DROP, MGSM, HumanEval, SimpleQA, BrowseComp, HealthBench. DEPRECATED July 2025; no
   longer updated for new models/benchmarks; only HealthBench/BrowseComp/SimpleQA reference impls maintained.
   Confirmed live (deprecated) June 2026.

--- a/sources/products/sipeed-maixcam.yaml
+++ b/sources/products/sipeed-maixcam.yaml
@@ -3,7 +3,7 @@ display_name: Sipeed MaixCAM
 type: hardware
 description: A compact AI vision and audio dev board built around the SOPHGO SG2002 SoC (a 1 GHz RISC-V
   C906 big core plus a 700 MHz small core) with a 1 TOPS INT8 NPU that also supports BF16 models, 256MB
-  DDR3, a 2.3-inch IPS touchscreen, and dual MIPI-CSI camera input. It is programmed via the open-source
+  DDR3, a 2.3-inch IPS touchscreen, and dual MIPI-CSI camera input. It is programmed via the open source
   MaixPy (Python) and MaixCDK (C/C++) SDKs and sold through Taobao/AliExpress. It matters as an ultra-low-cost
   RISC-V edge-AI vision module with strong open tooling.
 github:

--- a/sources/products/smolagents.yaml
+++ b/sources/products/smolagents.yaml
@@ -10,5 +10,5 @@ description: Minimal code-first agent framework from Hugging Face (~1,000 lines 
   and Cohere agent-building guides.
 github:
 - url: https://github.com/huggingface/smolagents
-comments: smolagents by Hugging Face — minimal (~1k-LOC core) code-writing agent framework ('agents that
+comments: smolagents by Hugging Face, minimal (~1k-LOC core) code-writing agent framework ('agents that
   think in code'). Apache-2.0. Verified live June 2026 on GitHub.

--- a/sources/products/snowflake-cortex-fine-tuning.yaml
+++ b/sources/products/snowflake-cortex-fine-tuning.yaml
@@ -2,12 +2,12 @@ name: snowflake-cortex-fine-tuning
 display_name: Snowflake Cortex Fine-Tuning
 type: software
 description: Serverless fine-tuning function inside Snowflake Cortex AI for Llama 3 (8B/70B), Llama 3.1
-  (8B/70B), Mistral 7B, and Mixtral 8x7B — training and inference both run on Snowflake compute without
+  (8B/70B), Mistral 7B, and Mixtral 8x7B. Training and inference both run on Snowflake compute without
   exporting data to a third-party platform. Picked when training data already lives in Snowflake tables
   and the value of in-perimeter governance (Unity-style RBAC, audit trails, region pinning across AWS
   US-West-2/US-East-1/EU-Central-1 and Azure East US 2) outweighs catalog breadth. GA on 2025-02-07; billed
-  per-token in Snowflake credits with no Provisioned Throughput required to serve the tuned model — a
+  per-token in Snowflake credits with no Provisioned Throughput required to serve the tuned model, a
   differentiator versus Bedrock.
-comments: Snowflake Cortex Fine-tuning — fully managed, generally-available PEFT service inside Snowflake.
+comments: Snowflake Cortex Fine-tuning, fully managed, generally-available PEFT service inside Snowflake.
   Fine-tunes a fixed set of base models (llama3-8b/70b, llama3.1-8b/70b, mistral-7b, mixtral-8x7b). Token-priced.
   Confirmed live via Snowflake docs June 2026.

--- a/sources/products/spaces.yaml
+++ b/sources/products/spaces.yaml
@@ -1,7 +1,7 @@
 name: spaces
 display_name: Spaces
 type: software
-description: Managed sandbox platform for hosting interactive ML apps — supports Gradio, Streamlit, Docker,
+description: Managed sandbox platform for hosting interactive ML apps, supports Gradio, Streamlit, Docker,
   and static SDKs with a free CPU tier, paid CPU/GPU upgrades, and a ZeroGPU shared-pool tier. Differentiates
   through tight integration with the Hugging Face Hub (one-click deploy from any model card) and community
   discoverability, making it the default demo surface for nearly every open-weight model release. ~400K+
@@ -9,7 +9,7 @@ description: Managed sandbox platform for hosting interactive ML apps — suppor
   canonical 'where you go to try an open model in your browser'.
 github:
 - url: https://github.com/gradio-app/gradio
-comments: Hugging Face Spaces — managed hosting/runtime for ML demo apps via Gradio, Streamlit, Docker
+comments: Hugging Face Spaces, managed hosting/runtime for ML demo apps via Gradio, Streamlit, Docker
   (arbitrary Dockerfile), or static HTML, with CPU/GPU hardware tiers. Confirmed live June 2026 via huggingface.co
   and HF Hub docs. Proprietary managed platform built on OSS SDKs (Gradio is OSS); the Spaces hosting
   platform itself is closed.

--- a/sources/products/spec-kit.yaml
+++ b/sources/products/spec-kit.yaml
@@ -1,7 +1,7 @@
 name: spec-kit
 display_name: Spec Kit
 type: software
-description: GitHub's open-source toolkit for Spec-Driven Development that works with coding agents rather than
+description: GitHub's open source toolkit for Spec-Driven Development that works with coding agents rather than
   being one. A structured Specify -> Plan -> Tasks -> Implement workflow produces Markdown artifacts that feed each
   phase, giving agents rich structured context instead of ad-hoc prompts. The specify CLI scaffolds these files
   and orchestrates 30+ agents (Copilot, Claude Code, Cursor, Gemini CLI, Codex CLI, Windsurf, Zed, OpenCode).

--- a/sources/products/suna.yaml
+++ b/sources/products/suna.yaml
@@ -1,7 +1,7 @@
 name: suna
 display_name: Suna
 type: software
-description: Open-source generalist AI agent positioned as an 'autonomous company operating system' —
+description: Open-source generalist AI agent positioned as an 'autonomous company operating system';
   can browse the web, write and execute code, manage files, interact with APIs, and complete complex multi-step
   business tasks. Differentiates through an ambitious scope beyond coding (document creation, data analysis,
   web research) with a polished web UI. 19.8K GitHub stars with explosive development velocity (2,522

--- a/sources/products/swe-bench-verified.yaml
+++ b/sources/products/swe-bench-verified.yaml
@@ -4,9 +4,9 @@ type: dataset
 description: 500 human-verified instances drawn from the broader SWE-bench dataset, each a real GitHub
   issue paired with a test-verified solution patch. Created through collaboration between Princeton NLP
   and OpenAI to reduce noise in the original 2,294-instance set. The gold-standard benchmark for evaluating
-  coding agents on realistic software engineering tasks — leaderboard results drive agent development
+  coding agents on realistic software engineering tasks. Leaderboard results drive agent development
   across the industry. As of April 2026, OpenAI's internal audit found 59.4% of the hardest unsolved problems
-  had flawed test cases and that frontier models can reproduce gold patches verbatim — OpenAI now prefers
+  had flawed test cases and that frontier models can reproduce gold patches verbatim. OpenAI now prefers
   SWE-bench Pro for headline coding evaluations.
 github:
 - url: https://github.com/princeton-nlp/SWE-bench

--- a/sources/products/swe-bench.yaml
+++ b/sources/products/swe-bench.yaml
@@ -3,10 +3,10 @@ display_name: SWE-bench
 type: software
 description: 'Docker-based evaluation harness that benchmarks coding agents on 2,294 real GitHub issues
   from 12 popular Python repositories, producing pass-rate scores against held-out tests. Picked because
-  it is the de-facto industry standard for measuring software-engineering agent capability — every frontier
+  it is the de-facto industry standard for measuring software-engineering agent capability. Every frontier
   lab (Anthropic, OpenAI, Google) reports SWE-bench Verified scores. ~5k stars on GitHub and Epoch AI
   maintains an authoritative leaderboard. Note: OpenAI''s April 2026 audit flagged that 59.4% of the hardest
-  unsolved problems in SWE-bench Verified had flawed test cases — they now prefer the harder SWE-bench
+  unsolved problems in SWE-bench Verified had flawed test cases; they now prefer the harder SWE-bench
   Pro and SWE-bench Bash variants for frontier evaluation.'
 github:
 - url: https://github.com/princeton-nlp/SWE-bench

--- a/sources/products/swift.yaml
+++ b/sources/products/swift.yaml
@@ -3,7 +3,7 @@ display_name: SWIFT
 type: software
 description: Alibaba ModelScope's unified PEFT/full-parameter CPT/SFT/DPO/GRPO toolkit covering 600+ LLMs
   and 300+ MLLMs (Qwen3, DeepSeek-R1, GLM, Llama4, InternVL, etc.). Picked over LLaMA-Factory when working
-  in the ModelScope ecosystem or when broad multimodal model coverage matters — SWIFT often ships day-zero
+  in the ModelScope ecosystem or when broad multimodal model coverage matters. SWIFT often ships day-zero
   recipes for Chinese-origin models. 14.2K GitHub stars, 147 contributors, 335 commits in 90 days; published
   as AAAI 2025.
 comments: ms-swift (SWIFT) by ModelScope/Alibaba, v4.2.3 (patch) released May 31 2026. Fine-tuning + deployment

--- a/sources/products/tavily-search-api.yaml
+++ b/sources/products/tavily-search-api.yaml
@@ -3,13 +3,13 @@ display_name: Tavily Search API
 type: software
 description: Search API purpose-built for AI agents, returning clean, structured results optimized for
   LLM consumption rather than human browsing. Includes search, extract, crawl, and map endpoints. The
-  default search provider in most agent tutorials and frameworks — integrated into LangChain, CrewAI,
+  default search provider in most agent tutorials and frameworks; integrated into LangChain, CrewAI,
   and AutoGen out of the box. YC-backed, rapidly growing as the canonical 'give your agent web search'
   solution.
 pypi:
 - url: https://pypi.org/project/tavily-python
 comments: 'Proprietary web-access API for agents: search, extract, crawl, map, research endpoints; Python/JS
   SDKs. PRECISION (verify 2026-06-04): Nebius announced an agreement to acquire Tavily on 10 Feb 2026
-  for $275M (up to $400M on milestones), expected to close within weeks — an acquisition agreement, not
+  for $275M (up to $400M on milestones), expected to close within weeks, an acquisition agreement, not
   necessarily a fully-closed deal at announcement. Verified live via docs.tavily.com + tavily.com June
   2026.'

--- a/sources/products/tensorflow.yaml
+++ b/sources/products/tensorflow.yaml
@@ -1,7 +1,7 @@
 name: tensorflow
 display_name: TensorFlow
 type: software
-description: TensorFlow is an end-to-end open-source platform for machine learning, offering stable Python
+description: TensorFlow is an end-to-end open source platform for machine learning, offering stable Python
   and C++ APIs for building and deploying ML models across CPUs, GPUs, and TPUs. It was developed by Google
   Brain and remains maintained by Google with broad community involvement. It is one of the two dominant
   deep learning frameworks and powers large-scale research and production deployments.

--- a/sources/products/tinker.yaml
+++ b/sources/products/tinker.yaml
@@ -2,11 +2,11 @@ name: tinker
 display_name: Tinker
 type: software
 description: 'Managed training API for researchers that lets teams control the training loop while Thinking
-  Machines handles the infrastructure. It exposes four core primitives — forward_backward, optim_step,
-  sample, and save_state — and supports frontier open-weight models including Qwen, GPT-OSS, Llama, DeepSeek,
+  Machines handles the infrastructure. It exposes four core primitives (forward_backward, optim_step,
+  sample, and save_state) and supports frontier open-weight models including Qwen, GPT-OSS, Llama, DeepSeek,
   and Nemotron. Scale signal: Thinking Machines announced a multi-year, gigawatt-scale strategic partnership
   with NVIDIA and said NVIDIA made a significant investment to support the company’s long-term growth.'
-comments: Tinker — Thinking Machines Lab's managed LoRA fine-tuning/training API (announced Oct 1 2025;
+comments: Tinker, Thinking Machines Lab's managed LoRA fine-tuning/training API (announced Oct 1 2025;
   now paid, usage-priced per-million-tokens + $0.10/GB-mo storage). Fine-tunes open-weight models 1B-550B
   (Qwen, Llama, DeepSeek, GPT-OSS, Moonshot, Nemotron incl. Qwen3-235B-A22B). Only the tinker-cookbook
   (Apache-2.0) is open; the training engine is a hosted proprietary service. Confirmed live June 2026.

--- a/sources/products/tinyllama-1-1b-chat-v1-0.yaml
+++ b/sources/products/tinyllama-1-1b-chat-v1-0.yaml
@@ -8,5 +8,5 @@ description: A 1.1B instruction-tuned chat model from the TinyLlama project, bui
 huggingface_model:
 - url: https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0
 comments: 1.1B chat model (Llama 2 architecture), DPO-aligned finetune of TinyLlama-1.1B (pretrained on
-  3T tokens). Released 2023/early-2024; v1.0. License Apache-2.0. Verified live on HF June 2026 — foundational
+  3T tokens). Released 2023/early-2024; v1.0. License Apache-2.0. Verified live on HF June 2026; foundational
   small-chat model still heavily pulled.

--- a/sources/products/together-inference-engine.yaml
+++ b/sources/products/together-inference-engine.yaml
@@ -1,7 +1,7 @@
 name: together-inference-engine
 display_name: Together Inference Engine
 type: software
-description: Proprietary inference engine optimized for serving open-source models at scale with Flash
+description: Proprietary inference engine optimized for serving open source models at scale with Flash
   Attention, speculative decoding, and custom CUDA kernels. Supports a wide catalog of open models with
   fast switching. Also offers a dedicated endpoints product for reserved GPU capacity. Founded by researchers
   from Stanford, Berkeley, and CMU. Differentiated by combining inference speed with strong research output

--- a/sources/products/torchtune.yaml
+++ b/sources/products/torchtune.yaml
@@ -1,11 +1,11 @@
 name: torchtune
 display_name: torchtune
 type: software
-description: torchtune (pytorch/torchtune), BSD-3-Clause, confirmed live June 2026 but DEPRECATED — repo
+description: torchtune (pytorch/torchtune), BSD-3-Clause, confirmed live June 2026 but DEPRECATED; repo
   states 'torchtune is no longer actively maintained; development wound down in 2025.' Provided SFT, knowledge
   distillation, DPO/PPO/GRPO, QAT; single/multi-device/multi-node; FSDP2; HF Hub + W&B integration.
 github:
 - url: https://github.com/pytorch/torchtune
-comments: torchtune (pytorch/torchtune), BSD-3-Clause, confirmed live June 2026 but DEPRECATED — repo
+comments: torchtune (pytorch/torchtune), BSD-3-Clause, confirmed live June 2026 but DEPRECATED; repo
   states 'torchtune is no longer actively maintained; development wound down in 2025.' Provided SFT, knowledge
   distillation, DPO/PPO/GRPO, QAT; single/multi-device/multi-node; FSDP2; HF Hub + W&B integration.

--- a/sources/products/transformers.yaml
+++ b/sources/products/transformers.yaml
@@ -4,7 +4,7 @@ type: software
 description: Transformers is a model-definition framework for state-of-the-art machine learning across
   text, vision, audio, and multimodal models, supporting both inference and training. It is maintained
   by Hugging Face and provides a unified API to load and run over a million pretrained model checkpoints
-  from the Hugging Face Hub. It is a foundational library underpinning much of the modern open-source
+  from the Hugging Face Hub. It is a foundational library underpinning much of the modern open source
   ML and LLM ecosystem.
 github:
 - url: https://github.com/huggingface/transformers

--- a/sources/products/trl.yaml
+++ b/sources/products/trl.yaml
@@ -1,11 +1,11 @@
 name: trl
 display_name: TRL
 type: software
-description: The de facto reference library for post-training transformers — supports SFT, DPO, GRPO,
+description: The de facto reference library for post-training transformers, supports SFT, DPO, GRPO,
   PPO, KTO, reward modeling, and other preference-optimization methods through unified Trainer APIs. Picked
   over alternatives because it sits at the center of the HF ecosystem (transformers, datasets, accelerate,
   PEFT) and ships canonical reference implementations that papers and other frameworks build on. 18.4K
-  GitHub stars, 482 contributors, ~400 commits in 90 days — extremely active.
+  GitHub stars, 482 contributors, ~400 commits in 90 days; extremely active.
 github:
 - url: https://github.com/huggingface/trl
 pypi:

--- a/sources/products/unsloth.yaml
+++ b/sources/products/unsloth.yaml
@@ -2,7 +2,7 @@ name: unsloth
 display_name: Unsloth
 type: software
 description: Performance-optimized fine-tuning library that rewrites kernels in Triton/CUDA to deliver
-  2-5x faster training with 60-80% less memory on a single GPU — makes 7B/13B LoRA fine-tuning feasible
+  2-5x faster training with 60-80% less memory on a single GPU, makes 7B/13B LoRA fine-tuning feasible
   on a consumer RTX 4090. Picked when hardware is constrained and the workload fits one GPU; Unsloth's
   kernels also slot under TRL trainers so it complements rather than replaces the broader ecosystem. 65K
   GitHub stars and ~1500 commits in 90 days makes it the fastest-moving repo in the category; widely promoted

--- a/sources/products/v0.yaml
+++ b/sources/products/v0.yaml
@@ -6,7 +6,7 @@ description: AI-powered generative UI and full-stack development agent from Verc
   manage state, connect to APIs, and iterate based on visual feedback. Differentiates through frontend-first
   design quality and tight Next.js/Vercel deployment integration. Evolved from a UI generation tool into
   a full autonomous development agent in 2025.
-comments: 'v0 by Vercel (v0.app), agentic full-stack web app builder (''agentic by default'' — autonomous
+comments: 'v0 by Vercel (v0.app), agentic full-stack web app builder (''agentic by default'', autonomous
   plan/create-tasks/connect-DB as it builds); web + iOS, subscription (v0 Pro). Verified live June 2026
   at v0.app. (Note: prior record''s ''powered by Claude Opus 4.8'' could NOT be confirmed on the product
-  page — no model named publicly; claim softened.)'
+  page. No model named publicly; claim softened.)'

--- a/sources/products/vals-ai.yaml
+++ b/sources/products/vals-ai.yaml
@@ -2,7 +2,7 @@ name: vals-ai
 display_name: Vals AI
 type: software
 description: Domain-specialist benchmarking service that runs proprietary, held-out evals over finance,
-  law, software, and healthcare tasks — including a private Canadian-court-case QA benchmark and the Vals
+  law, software, and healthcare tasks, including a private Canadian-court-case QA benchmark and the Vals
   Index. Picked by enterprises that need closed/private benchmarks because public benchmarks suffer from
   contamination. Publishes a leaderboard of all major frontier models scored on these private sets.
 comments: Vals AI independent LLM evaluation platform; Vals Index + Vals Multimodal Index + domain benchmarks

--- a/sources/products/vellum.yaml
+++ b/sources/products/vellum.yaml
@@ -1,11 +1,11 @@
 name: vellum
 display_name: Vellum
 type: software
-description: Consumer-facing 'Personal Intelligence' agent — a multi-platform (web, macOS, iOS, CLI) assistant
+description: Consumer-facing 'Personal Intelligence' agent, a multi-platform (web, macOS, iOS, CLI) assistant
   with episodic, semantic, and procedural memory that takes actions on the user's behalf. Pivoted in 2026
   from an LLMops/prompt-engineering platform (prompts, workflows, evals) to a consumer agent product after
   a $20M Series A in July 2025; legacy LLMops surface still available but no longer the headline.
-comments: Vellum (vellum.ai) — a PERSONAL AI ASSISTANT/agent ('the AI layer for your life', 8-type structured
+comments: Vellum (vellum.ai), a PERSONAL AI ASSISTANT/agent ('the AI layer for your life', 8-type structured
   memory, multi-channel autonomous action across Mac/Web/iOS/Slack/Telegram, proactive hourly check-ins,
   out-of-process credential isolation). The agent's full source ships MIT-licensed at github.com/vellum-ai/vellum-assistant
   (backend gateway, multi-platform clients, skill framework); a managed cloud (memory/security) is offered

--- a/sources/products/verl.yaml
+++ b/sources/products/verl.yaml
@@ -2,10 +2,10 @@ name: verl
 display_name: verl
 type: software
 description: HybridFlow flexible and efficient RL post-training framework developed by ByteDance Seed
-  MLSys and HKU — purpose-built for RLHF and reasoning RL on math and code tasks. Picked when teams need
+  MLSys and HKU, purpose-built for RLHF and reasoning RL on math and code tasks. Picked when teams need
   state-of-the-art GRPO/PPO at frontier scale; verl shipped early support for DeepSeek-R1-style reasoning
   RL recipes and has become a reference implementation in the post-DeepSeek wave. 21.5K GitHub stars,
-  618 contributors, ~420 commits in 90 days — one of the fastest-growing repos in the category.
+  618 contributors, ~420 commits in 90 days, one of the fastest-growing repos in the category.
 github:
 - url: https://github.com/volcengine/verl
 comments: verl (Volcano Engine RL / HybridFlow), v0.8.0 released June 1 2026. Initiated by ByteDance Seed,

--- a/sources/products/vertex-ai-gen-ai-evaluation-service.yaml
+++ b/sources/products/vertex-ai-gen-ai-evaluation-service.yaml
@@ -6,7 +6,7 @@ description: 'Managed evaluation service on Vertex AI (now part of Gemini Enterp
   LLM-as-judge with Gemini as the judge model (including adaptive rubrics that auto-generate per-prompt
   pass/fail tests), and AutoSxS pairwise pipelines that A/B test two models with a judge declaring a winner.
   Differentiates on tight integration with Vertex AI pipelines, Model Garden, Gemini tuning workflows,
-  and LiteLLM for third-party models — eval datasets can be built from production logs or synthetic data
+  and LiteLLM for third-party models; eval datasets can be built from production logs or synthetic data
   and run across seven global regions. Used by Vertex AI customers including Wendy''s, Wayfair, Verizon,
   Mercedes-Benz, and Etsy (per Google Cloud case studies) as the canonical eval surface for Gemini-based
   applications.'

--- a/sources/products/vertex-ai-model-observability.yaml
+++ b/sources/products/vertex-ai-model-observability.yaml
@@ -1,7 +1,7 @@
 name: vertex-ai-model-observability
 display_name: Vertex AI Model Observability
 type: software
-description: Google Cloud's built-in production monitoring surface for Gen AI on Vertex AI — a predefined
+description: Google Cloud's built-in production monitoring surface for Gen AI on Vertex AI, a predefined
   Cloud Monitoring dashboard tracking usage, throughput, token consumption, latency, and error rates (including
   429 capacity errors) for Gemini and other Vertex AI Model Garden foundation models. Extended in 2026
   by Vertex AI Agent Builder with sessions, traces, logs, agent performance dashboards, multi-turn auto-raters,

--- a/sources/products/vertex-ai-tuning.yaml
+++ b/sources/products/vertex-ai-tuning.yaml
@@ -2,7 +2,7 @@ name: vertex-ai-tuning
 display_name: Vertex AI Tuning
 type: software
 description: Managed supervised fine-tuning and preference tuning for Gemini 2.0/2.5 Flash and Pro inside
-  Google Cloud Vertex AI — covers text, image, audio, and document tuning with as few as 100 labeled examples.
+  Google Cloud Vertex AI, covers text, image, audio, and document tuning with as few as 100 labeled examples.
   Picked when teams need Gemini-tier quality customized to a domain and want GCP-native data residency,
   IAM, and Vertex pipeline integration. The only path to fine-tune Gemini weights.
 comments: 'Google Cloud Vertex AI tuning for Gemini (docs live June 2026). Methods: supervised fine-tuning

--- a/sources/products/vllm.yaml
+++ b/sources/products/vllm.yaml
@@ -4,7 +4,7 @@ type: software
 description: High-throughput LLM serving engine built on PagedAttention, which treats KV cache as virtual
   memory pages to near-eliminate memory waste during batched inference. Supports continuous batching,
   tensor parallelism, speculative decoding, and 40+ model architectures. The de facto standard for self-hosted
-  production model serving — used by Anyscale, Databricks, and most open-source inference deployments.
+  production model serving, used by Anyscale, Databricks, and most open source inference deployments.
 github:
 - url: https://github.com/vllm-project/vllm
 comments: v0.22.0, released May 29, 2026 (GitHub releases). Confirmed to exist as of June 2026.

--- a/sources/products/weave.yaml
+++ b/sources/products/weave.yaml
@@ -3,7 +3,7 @@ display_name: Weave
 type: software
 description: Toolkit for developing and monitoring AI-powered applications, built by Weights & Biases.
   Provides tracing, evaluation, and dataset management for LLM applications. Leverages W&B's established
-  ML experiment tracking platform and enterprise customer base. Code is open-source (Apache-2.0) but primarily
+  ML experiment tracking platform and enterprise customer base. Code is open source (Apache-2.0) but primarily
   consumed via the W&B cloud platform. 1.1K GitHub stars.
 github:
 - url: https://github.com/wandb/weave

--- a/sources/products/webcontainers.yaml
+++ b/sources/products/webcontainers.yaml
@@ -1,15 +1,15 @@
 name: webcontainers
 display_name: WebContainers
 type: software
-description: WebAssembly Node.js runtime that boots a full dev environment — filesystem, package manager,
-  terminal, dev server — inside the browser with no remote VM. Picked when an agent and user need to share
+description: WebAssembly Node.js runtime that boots a full dev environment (filesystem, package manager,
+  terminal, dev server) inside the browser with no remote VM. Picked when an agent and user need to share
   an in-browser sandbox with millisecond startup and near-zero server cost. `webcontainer-core` is MIT
   (~4.6K stars) but stale (last push April 2025); the production WebContainer API and StackBlitz/Bolt.new
   platform are proprietary. Powers Bolt.new, which hit 7M+ users and $40M ARR by Dec 2025; StackBlitz
   raised Series B in Jan 2025 at $700M valuation.
 github:
 - url: https://github.com/stackblitz/webcontainer-core
-comments: WebContainers by StackBlitz — a browser-based (WASM) runtime that executes Node.js / npm projects
+comments: WebContainers by StackBlitz, a browser-based (WASM) runtime that executes Node.js / npm projects
   fully client-side in the browser tab. Distributed as @webcontainer/api on npm. Confirmed live June 2026
   via webcontainers.io. The public github.com/stackblitz/webcontainer-core repo is MIT but is only an
   issue tracker / docs hub; the actual runtime is a proprietary StackBlitz service requiring a commercial

--- a/sources/products/whylabs.yaml
+++ b/sources/products/whylabs.yaml
@@ -2,11 +2,11 @@ name: whylabs
 display_name: WhyLabs
 type: software
 description: AI observability platform for monitoring ML models and LLM applications in production. Provides
-  data drift detection, performance monitoring, and LLM security guardrails. Built on the open-source
+  data drift detection, performance monitoring, and LLM security guardrails. Built on the open source
   whylogs profiling library and LangKit LLM monitoring toolkit. Differentiated by statistical profiling
-  approach — monitors distributions rather than individual requests, enabling cost-effective monitoring
+  approach, monitors distributions rather than individual requests, enabling cost-effective monitoring
   at scale.
 comments: 'WhyLabs ML/LLM observability. COMPANY DISCONTINUED: whylabs.ai states ''WhyLabs, Inc. is discontinuing
-  operations'' and open-sourced the full platform plus whylogs and LangKit. The hosted SaaS observability
+  operations'' and open sourced the full platform plus whylogs and LangKit. The hosted SaaS observability
   platform is no longer operating; the OSS libraries remain on GitHub (whylogs Apache-2.0, 2.8k stars,
   latest release v1.6.4 Dec 2024).'

--- a/sources/products/windsurf.yaml
+++ b/sources/products/windsurf.yaml
@@ -1,12 +1,12 @@
 name: windsurf
 display_name: Windsurf
 type: software
-description: AI-native IDE (VS Code fork) with 'Cascade' — an agentic flow engine that maintains context
+description: AI-native IDE (VS Code fork) with 'Cascade', an agentic flow engine that maintains context
   across multi-step coding tasks, automatically suggests and executes terminal commands, file edits, and
   debugging steps. Differentiates through 'Flows' that blend co-pilot suggestions with autonomous agent
   actions, plus strong context awareness across large codebases. Reportedly millions of users across free
   and paid tiers; Codeium raised $150M at a $1.25B valuation before being acquired by Windsurf (the brand
   name superseded Codeium).
 comments: Windsurf (formerly Codeium) acquired by Cognition (def. agreement July 2025) and rebranded 'Devin
-  Desktop' on June 2 2026 — windsurf.com redirects to devin.ai/desktop. Agent manager wrapped in a full
+  Desktop' on June 2 2026; windsurf.com redirects to devin.ai/desktop. Agent manager wrapped in a full
   IDE; Cascade legacy, successor Devin Local (Rust). Verified June 2026.

--- a/sources/products/yi-1-5.yaml
+++ b/sources/products/yi-1-5.yaml
@@ -4,10 +4,10 @@ type: model
 description: Kai-Fu Lee's 01.AI foundation model family in 6B, 9B, and 34B variants, with continued pretraining
   on 500B tokens over Yi-1.0. Strong performance on Chinese and English benchmarks. Apache 2.0 licensed.
   One of the top Chinese-origin open-weights models, though increasingly competing with Qwen for mindshare
-  in the Chinese open-source community.
+  in the Chinese open source community.
 huggingface_model:
 - url: https://huggingface.co/01-ai/Yi-1.5-34B
-comments: Yi-1.5 base family (6B/9B/34B + 32K context variants), open-sourced 2024-05-13 by 01.AI. Continuously
+comments: Yi-1.5 base family (6B/9B/34B + 32K context variants), open sourced 2024-05-13 by 01.AI. Continuously
   pre-trained on Yi with +500B tokens (3.6T total). Base SKUs (Yi-1.5-9B, Yi-1.5-34B) scored here; Yi-1.5-*-Chat
   are the instruct SKUs (finetuned_chat). Verified live on HF June 2026; a dated 2024-era generation vs
   2026 frontier.

--- a/sources/products/zed.yaml
+++ b/sources/products/zed.yaml
@@ -3,7 +3,7 @@ display_name: Zed
 type: software
 description: High-performance, multiplayer code editor written in Rust from the creators of Atom and Tree-sitter,
   built for human-AI collaboration. A GUI editor (peer to Cursor/Windsurf) with agentic editing, parallel agents
-  across projects, an open-source edit-prediction model (Zeta2), inline assistant, MCP servers, and pluggable external
+  across projects, an open source edit-prediction model (Zeta2), inline assistant, MCP servers, and pluggable external
   agents (Claude, Codex, OpenCode) via the Agent Communication Protocol - BYO-key or Zed-hosted models.
 github:
 - url: https://github.com/zed-industries/zed

--- a/sources/scores/agenta.yaml
+++ b/sources/scores/agenta.yaml
@@ -5,7 +5,7 @@ openness:
   components: license:MIT(OSI, core);source:public;self-hostable;commercial:Agenta-Cloud-managed-tier(free
     tier available)
   confidence: high
-  note: MIT/OSI core, self-hostable via GitHub, with a managed cloud tier — open_core. (Borderline open_source;
+  note: MIT/OSI core, self-hostable via GitHub, with a managed cloud tier, open_core. (Borderline open_source;
     scored open_core for the hosted commercial tier.)
   sources:
   - url: https://github.com/Agenta-AI/agenta
@@ -32,7 +32,7 @@ capability:
     test cases from prod/CSV), observability/tracing(OTel-native, OpenLLMetry/OpenInference compatible,
     cost/latency), multi-model playground
   confidence: high
-  note: Broad feature matrix across prompt mgmt, evals, and OTel observability — comparable to Langfuse
+  note: Broad feature matrix across prompt mgmt, evals, and OTel observability, comparable to Langfuse
     anchor (C4). Capability is decoupled from its lower adoption.
   sources:
   - url: https://github.com/Agenta-AI/agenta

--- a/sources/scores/agentops.yaml
+++ b/sources/scores/agentops.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_core
   components: license:MIT(OSI, SDK);source:public(SDK + self-hostable app dir);commercial:app.agentops.ai-SaaS-dashboard-is-the-primary-product
   confidence: medium
-  note: SDK is MIT/OSI and self-host is possible, but the hosted dashboard is the product surface — closer
+  note: SDK is MIT/OSI and self-host is possible, but the hosted dashboard is the product surface, closer
     to open_core than pure open_source. Scored 4.
   sources:
   - url: https://github.com/AgentOps-AI/agentops

--- a/sources/scores/algolia-ai-search.yaml
+++ b/sources/scores/algolia-ai-search.yaml
@@ -18,7 +18,7 @@ adoption:
   note: 18,000+ customers across 150+ countries; processes over 1 billion queries every 5 seconds at sub-20ms
     average latency. Named users incl. Stripe, Decathlon, Ubisoft. Query volume is enormous; end-user
     reach (consumers hitting Algolia-powered search) is effectively mass-scale, but as a B2B tool the
-    direct customer base sits in the heavy-trending band — placed at 4 on verified query-volume.
+    direct customer base sits in the heavy-trending band; placed at 4 on verified query-volume.
   sources:
   - url: https://www.algolia.com/products/ai-search/
     shows: 18,000+ customers, 1B+ queries/5s, sub-20ms latency, named enterprise users
@@ -30,7 +30,7 @@ capability:
     sub-20ms latency at 1B+ queries/5s, multi-content-type
   confidence: high
   note: Mature hybrid search feature matrix (semantic + keyword, personalization, AI ranking) at very
-    low latency and massive scale — frontier-adjacent for managed site/retrieval search. Rated 4; closed
+    low latency and massive scale, frontier-adjacent for managed site/retrieval search. Rated 4; closed
     system so no independent ANN-Benchmarks number, basis is feature_matrix.
   sources:
   - url: https://www.algolia.com/products/ai-search/

--- a/sources/scores/amazon-bedrock-custom-models-fine-tuning.yaml
+++ b/sources/scores/amazon-bedrock-custom-models-fine-tuning.yaml
@@ -5,7 +5,7 @@ openness:
   components: source:closed;training-code:closed;runs-on:AWS-Bedrock-only;license:Proprietary(managed
     AWS service, token+storage billed)
   confidence: high
-  note: Proprietary managed customization service inside AWS Bedrock — no source, runs only on AWS against
+  note: Proprietary managed customization service inside AWS Bedrock, no source, runs only on AWS against
     Bedrock-hosted foundation models.
   sources:
   - url: https://docs.aws.amazon.com/bedrock/latest/userguide/custom-models.html

--- a/sources/scores/amazon-q-developer.yaml
+++ b/sources/scores/amazon-q-developer.yaml
@@ -28,7 +28,7 @@ capability:
   confidence: medium
   note: AWS claims top SWE-Bench Leaderboard placement but no clean current SWE-bench Verified figure
     is independently verifiable, so the benchmark claim is downgraded to vendor-stated and capability
-    scored on feature matrix at 4 — strong agentic breadth, below a verified-benchmark ceiling.
+    scored on feature matrix at 4, strong agentic breadth, below a verified-benchmark ceiling.
   sources:
   - url: https://aws.amazon.com/q/developer/
     shows: agentic task autonomy + AWS-stated SWE-Bench leaderboard claim (vendor-stated, not independently

--- a/sources/scores/anyscale-fine-tuning.yaml
+++ b/sources/scores/anyscale-fine-tuning.yaml
@@ -29,7 +29,7 @@ capability:
   score: 2
   basis: feature_matrix
   value: 'Methods: LoRA + full-parameter FT; YAML config; scaling via Ray Train/Ray Data + DeepSpeed/Accelerate.
-    No advanced quantization/algorithm coverage — Anyscale itself cites Axolotl/LLaMA-Factory as providing
+    No advanced quantization/algorithm coverage; Anyscale itself cites Axolotl/LLaMA-Factory as providing
     enhanced functionality, the reason for deprecation.'
   confidence: medium
   note: Modest method/feature coverage relative to live OSS peers; Anyscale's own deprecation rationale

--- a/sources/scores/apertus.yaml
+++ b/sources/scores/apertus.yaml
@@ -9,7 +9,7 @@ openness:
   note: 'Among the most transparent large-model releases to date: open weights, open data (reconstruction
     scripts rather than a raw dump, to respect opt-out/robots.txt and strip personal data), open training
     code/recipe, intermediate checkpoints, a technical report (arXiv 2509.14233), and EU AI Act + Swiss
-    data-protection/copyright compliance docs — all Apache-2.0. Sits in the OLMo/Pythia full-openness
+    data-protection/copyright compliance docs. All Apache-2.0. Sits in the OLMo/Pythia full-openness
     tier.'
   sources:
   - url: https://huggingface.co/swiss-ai/Apertus-70B-2509
@@ -29,7 +29,7 @@ adoption:
   signal_type: usage_volume
   confidence: medium
   note: Newer release (Sep 2025) with strong institutional/sovereign-AI interest but modest raw download
-    volume — swiss-ai/Apertus-70B-2509 shows ~1.5K downloads/month and 149 likes on HF (June 2026); cumulative
+    volume; swiss-ai/Apertus-70B-2509 shows ~1.5K downloads/month and 149 likes on HF (June 2026); cumulative
     across the 8B/70B base+Instruct SKUs lands in the 10K-100K band. Distributed via Swisscom, Hugging
     Face, and the Public AI network. Comparable adoption tier to Falcon 3 / Yi-1.5.
   sources:
@@ -45,12 +45,12 @@ capability:
   confidence: medium
   note: 'Mid-tier capability: competitive with the prior open generation (Llama 3.1-70B class) on pretraining
     benchmarks and unusually strong multilingually, but below the 2026 frontier on MMLU-style reasoning/knowledge.
-    The value proposition is full openness + multilingual breadth + legal compliance, not raw SOTA — same
+    The value proposition is full openness + multilingual breadth + legal compliance, not raw SOTA, same
     profile as OLMo 2.'
   sources:
   - url: https://huggingface.co/swiss-ai/Apertus-70B-2509
     shows: 'pretraining benchmark table: Apertus-70B avg 67.5% vs Llama 3.1-70B 67.3%'
     accessed: '2026-06-08'
   - url: https://arxiv.org/pdf/2509.14233
-    shows: Apertus technical report — benchmark results and methodology
+    shows: Apertus technical report, benchmark results and methodology
     accessed: '2026-06-08'

--- a/sources/scores/apify.yaml
+++ b/sources/scores/apify.yaml
@@ -14,7 +14,7 @@ openness:
       contribution
     accessed: '2026-06-04'
   - url: https://github.com/apify/crawlee
-    shows: Crawlee Apache-2.0 license (OSI), Apify's open-source scraping library
+    shows: Crawlee Apache-2.0 license (OSI), Apify's open source scraping library
     accessed: '2026-06-04'
 adoption:
   level: 3
@@ -38,7 +38,7 @@ capability:
   value: 'coverage: 35,000+ prebuilt Actors; HTTP + headless (Playwright/Puppeteer/Selenium); proxy rotation/session
     mgmt; structured output; serverless custom Actors; MCP-client integration'
   confidence: high
-  note: Broad scrape/browse feature matrix — multi-engine crawling, proxy/anti-block, structured extraction,
+  note: Broad scrape/browse feature matrix, multi-engine crawling, proxy/anti-block, structured extraction,
     serverless deploy, and MCP integration for agents. Among the most complete scrape platforms; rated
     4 (frontier-adjacent for the browser/scrape sub-segment).
   sources:

--- a/sources/scores/apps.yaml
+++ b/sources/scores/apps.yaml
@@ -6,7 +6,7 @@ openness:
     documents 10k problems, 131,777 tests, difficulty levels, schema);redistributable:yes;paper:public(NeurIPS
     2021)
   confidence: high
-  note: 'Clean open data: MIT, downloadable, documented datasheet, public paper — full open class.'
+  note: 'Clean open data: MIT, downloadable, documented datasheet, public paper: full open class.'
   sources:
   - url: https://huggingface.co/datasets/codeparrot/apps
     shows: MIT license, 10,000 problems, 131,777 test cases, 13,834 monthly downloads
@@ -29,5 +29,5 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: Dataset — not capability-scored.
+  note: Dataset, not capability-scored.
   sources: []

--- a/sources/scores/arize.yaml
+++ b/sources/scores/arize.yaml
@@ -2,7 +2,7 @@ product: arize
 openness:
   score: 1
   class: closed
-  components: weights:n/a;source:closed(proprietary SaaS);self-host:none for core AX features;note:open-source
+  components: weights:n/a;source:closed(proprietary SaaS);self-host:none for core AX features;note:open source
     Phoenix is a separate companion product, not the AX platform
   confidence: high
   note: Arize AX is closed/proprietary SaaS with no self-hostable core; only the separate Phoenix project

--- a/sources/scores/artificial-analysis-intelligence-index.yaml
+++ b/sources/scores/artificial-analysis-intelligence-index.yaml
@@ -5,10 +5,10 @@ openness:
   components: platform:closed(proprietary benchmarking site + methodology); methodology:documented(public
     methodology page, per-eval breakdown, temp/token params); datasets:closed(maintains internal copies
     of all eval datasets); harness:partial-open(Stirrup MIT, used for the agentic GDPval-AA eval only,
-    413 stars) — the full Intelligence Index harness is not open
+    413 stars); the full Intelligence Index harness is not open
   confidence: high
   note: Methodology is well-documented and one component harness (Stirrup) is MIT-OSS, but the Index itself
-    — pipeline, internal dataset copies, grader config — is proprietary => open_core (closed-leaning with
+    (pipeline, internal dataset copies, grader config) is proprietary => open_core (closed-leaning with
     a documented methodology + one OSS sub-tool). Not pure closed given Stirrup + transparent methodology;
     not source_available since the core isn't published.
   sources:
@@ -46,7 +46,7 @@ capability:
     (contamination-resistant) but not externally reproducible'
   confidence: high
   note: 'Frontier-grade composite coverage spanning agentic/coding/general/scientific with contamination-resistant
-    internal datasets and standardized running — strong capability. Not a 5: it is a curated index/methodology
+    internal datasets and standardized running. Strong capability. Not a 5: it is a curated index/methodology
     rather than an open community harness, and held-out/proprietary running limits external reproducibility.'
   sources:
   - url: https://artificialanalysis.ai/methodology/intelligence-benchmarking

--- a/sources/scores/autogpt.yaml
+++ b/sources/scores/autogpt.yaml
@@ -3,9 +3,9 @@ openness:
   score: 3
   class: source_available
   confidence: high
-  components: license:DUAL — autogpt_platform/ under PolyForm Shield (non-OSI, source-available, anti-compete);
+  components: license:DUAL, autogpt_platform/ under PolyForm Shield (non-OSI, source-available, anti-compete);
     everything else (Classic, Forge, agbenchmark) MIT(OSI);source:public
-  note: 'Verified dual license: the current flagship — the AutoGPT Platform — is PolyForm Shield (source-available,
+  note: 'Verified dual license: the current flagship, the AutoGPT Platform, is PolyForm Shield (source-available,
     non-OSI), while legacy components stay MIT. Mixed-tier: scored source_available because the active
     product is non-OSI. Confirmed via primary GitHub source.'
   sources:

--- a/sources/scores/aws-neuron.yaml
+++ b/sources/scores/aws-neuron.yaml
@@ -2,7 +2,7 @@ product: aws-neuron
 openness:
   score: 1
   class: closed
-  components: license:mixed/proprietary-core;runtime:proprietary(Neuron Runtime+Compiler not open-sourced);open-glue:Linux
+  components: license:mixed/proprietary-core;runtime:proprietary(Neuron Runtime+Compiler not open sourced);open-glue:Linux
     kernel driver(Apache-2.0),vLLM-Neuron integration(open, in vLLM org),NKI library, samples(MIT-0);hardware-lock:AWS-Inferentia/Trainium-only
   confidence: high
   note: Headline inference path (Neuron Compiler + Neuron Runtime) is proprietary AWS, only runnable on

--- a/sources/scores/axolotl.yaml
+++ b/sources/scores/axolotl.yaml
@@ -33,7 +33,7 @@ capability:
     FSDP1/FSDP2, DeepSpeed, multi-node Torchrun/Ray, Sequence Parallelism + ND Parallelism (CP+TP+FSDP);
     precision: BF16/4-8bit. Broadest single-tool method+parallelism matrix in this batch.'
   confidence: high
-  note: Very wide method and parallelism coverage (ND parallelism, multi-node) — strong C4; below Megatron-LM
+  note: Very wide method and parallelism coverage (ND parallelism, multi-node), strong C4; below Megatron-LM
     frontier-scale-training anchor on demonstrated extreme scale.
   sources:
   - url: https://github.com/axolotl-ai-cloud/axolotl

--- a/sources/scores/beta9.yaml
+++ b/sources/scores/beta9.yaml
@@ -9,7 +9,7 @@ openness:
     3 (vs 4) for AGPL copyleft tempering commercial reuse, consistent with Daytona's treatment.
   sources:
   - url: https://github.com/beam-cloud/beta9
-    shows: AGPL-3.0 license; open-source serverless AI runtime; engine powering managed Beam cloud (beam.cloud)
+    shows: AGPL-3.0 license; open source serverless AI runtime; engine powering managed Beam cloud (beam.cloud)
     accessed: '2026-06-04'
 adoption:
   level: 2

--- a/sources/scores/braintrust.yaml
+++ b/sources/scores/braintrust.yaml
@@ -2,11 +2,11 @@ product: braintrust
 openness:
   score: 1
   class: closed
-  components: license:Apache-2.0(OSI, client SDKs only — Python/TS/Go/Ruby/C#);platform:proprietary(Brainstore
+  components: license:Apache-2.0(OSI, client SDKs only, Python/TS/Go/Ruby/C#);platform:proprietary(Brainstore
     custom DB, evals/tracing/automation all SaaS);self-host:enterprise-only(hybrid)
   confidence: high
-  note: Open SDKs but a closed SaaS core (Brainstore backend, dashboards, automation are proprietary)
-    — no OSS core, so 'closed' (not open_core) like LangSmith/Galileo per recipe's closed examples. The
+  note: Open SDKs but a closed SaaS core (Brainstore backend, dashboards, automation are proprietary);
+    no OSS core, so 'closed' (not open_core) like LangSmith/Galileo per recipe's closed examples. The
     Apache-2.0 client SDK is instrumentation only and does not open the product.
   sources:
   - url: https://github.com/braintrustdata/braintrust-sdk
@@ -39,7 +39,7 @@ capability:
     langs). Quality-gate/automation depth exceeds the anchor tier.
   confidence: high
   note: Deepest eval+automation feature surface in this batch (CI-style quality gates, Topics auto-clustering,
-    continuous scoring) — a frontier-definer for eval-first LLM observability; rated 5 above the MLflow/Langfuse
+    continuous scoring), a frontier-definer for eval-first LLM observability; rated 5 above the MLflow/Langfuse
     C4 anchors on feature breadth.
   sources:
   - url: https://www.braintrust.dev/

--- a/sources/scores/browser-use.yaml
+++ b/sources/scores/browser-use.yaml
@@ -17,7 +17,7 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: ~27M PyPI downloads in the last month (browser-use) — strong real install/usage volume, not stars.
+  note: ~27M PyPI downloads in the last month (browser-use), strong real install/usage volume, not stars.
     97.2k GitHub stars corroborate but are not the basis. Solidly in the 1-10M+ monthly-download band;
     one of the most-used agent browser-automation libraries.
   sources:

--- a/sources/scores/browserbase.yaml
+++ b/sources/scores/browserbase.yaml
@@ -7,11 +7,11 @@ openness:
     scored is the closed managed platform
   confidence: high
   note: The scored product is the managed browser-infrastructure service, which is closed/proprietary;
-    only the separate Stagehand client SDK is open — do not let the open SDK reclassify the closed service.
+    only the separate Stagehand client SDK is open; do not let the open SDK reclassify the closed service.
   sources:
   - url: https://docs.browserbase.com/
-    shows: one API key for cloud browsers/search/fetch/runtime — managed proprietary platform; Stagehand
-      SDK noted as the open-source client
+    shows: one API key for cloud browsers/search/fetch/runtime, managed proprietary platform; Stagehand
+      SDK noted as the open source client
     accessed: '2026-06-04'
 adoption:
   level: 3
@@ -20,7 +20,7 @@ adoption:
   confidence: medium
   note: No primary usage figure for the Browserbase managed service itself was published. Best primary
     proxy is its own SDK, Stagehand, which Browserbase docs cite at 22k GitHub stars and 700k+ weekly
-    downloads — a strong open-SDK adoption signal that approximates the platform's developer reach (100K-1M
+    downloads, a strong open-SDK adoption signal that approximates the platform's developer reach (100K-1M
     band). The closed service's own user/session count is undisclosed.
   sources:
   - url: https://docs.browserbase.com/

--- a/sources/scores/character-ai.yaml
+++ b/sources/scores/character-ai.yaml
@@ -25,13 +25,13 @@ adoption:
 capability:
   score: 2
   basis: feature_matrix
-  value: 'chat-UI matrix: narrow/specialized — strong character-creation + persona/roleplay + voice +
+  value: 'chat-UI matrix: narrow/specialized: strong character-creation + persona/roleplay + voice +
     multi-user community, but no model selection (single-provider, own models), limited RAG/grounding,
     limited multimodal/document tooling vs general assistants. Deep in its niche, narrow on the general
     chat-UI feature set.'
   confidence: medium
   note: Specialized companion-chat UI; rich in persona/voice features but narrow on the general feature
-    matrix (no model breadth, weak grounding) — low capability relative to the general-assistant frontier
+    matrix (no model breadth, weak grounding); low capability relative to the general-assistant frontier
     in this category.
   sources:
   - url: https://www.businessofapps.com/data/character-ai-statistics/

--- a/sources/scores/claude-ai.yaml
+++ b/sources/scores/claude-ai.yaml
@@ -17,7 +17,7 @@ adoption:
   signal_type: active_users
   confidence: low
   note: Anthropic does NOT disclose official Claude.ai MAU. Third-party estimates (no primary vendor figure
-    available) put consumer MAU ~18.9M web at start of 2026 rising toward ~30M by mid-2026 — i.e. comfortably
+    available) put consumer MAU ~18.9M web at start of 2026 rising toward ~30M by mid-2026, i.e. comfortably
     above 1M but well below the >10M-billion scale of ChatGPT/Gemini app. Placed at level 4 on best-available
     estimate; confidence low because the headline number is an estimate, not a vendor primary disclosure
     (flagged).

--- a/sources/scores/claude-code.yaml
+++ b/sources/scores/claude-code.yaml
@@ -32,7 +32,7 @@ capability:
   value: Backed by frontier Claude Opus models leading SWE-bench Verified (Claude Opus 4.8 ~88.6%, 4.7
     ~87.6%); Claude Code is the reference agent harness for these scores.
   confidence: high
-  note: Frontier-defining coding agent — pairs the leading SWE-bench Verified models with a mature multi-surface
+  note: Frontier-defining coding agent, pairs the leading SWE-bench Verified models with a mature multi-surface
     agent harness (sub-agents, hooks, MCP, scheduling). One of the 1-2 capability frontier-definers in
     this category. Headline SWE-bench Verified 88.6% triangulated to Anthropic primary source.
   sources:

--- a/sources/scores/claude-opus-4-x.yaml
+++ b/sources/scores/claude-opus-4-x.yaml
@@ -18,7 +18,7 @@ adoption:
   signal_type: reported_traction
   confidence: low
   note: Directional market-position estimate (not a measured usage figure). The Opus line is Anthropic's
-    premium frontier tier — top-tier but lower volume than the Sonnet workhorse, so 4. claude.ai is a mass-market
+    premium frontier tier, top-tier but lower volume than the Sonnet workhorse, so 4. claude.ai is a mass-market
     surface and Opus flagships appear on public LLM marketplace leaderboards (e.g. OpenRouter); no primary
     per-SKU figure exists. Overrides the prior frozen-anchor convention (held null), which understated dominant
     closed incumbents and could mask the openness gap.

--- a/sources/scores/codecontests.yaml
+++ b/sources/scores/codecontests.yaml
@@ -20,7 +20,7 @@ adoption:
   confidence: medium
   note: 'Well-known competitive-programming benchmark (the AlphaCode dataset) and a recurring reference
     for code-reasoning evals, but materially less ubiquitous than HumanEval/GSM8K/SWE-bench in current
-    release reports. ~56k HF downloads/month — lowest in the batch — places it in the 100K-1M annualized
+    release reports. ~56k HF downloads/month (lowest in the batch) places it in the 100K-1M annualized
     band. Honest signal: solid research adoption, not headline-eval scale.'
   sources:
   - url: https://huggingface.co/datasets/deepmind/code_contests

--- a/sources/scores/codestral.yaml
+++ b/sources/scores/codestral.yaml
@@ -5,7 +5,7 @@ openness:
   components: weights:open(downloadable on HF);data:closed;code:closed(no training pipeline);license:Mistral-AI-Non-Production-License(MNPL,
     non-OSI, research/testing only; commercial license on demand)
   confidence: high
-  note: Weights downloadable but under MNPL (non-OSI, non-production) — open-weights gated by a use-restricted
+  note: Weights downloadable but under MNPL (non-OSI, non-production); open-weights gated by a use-restricted
     license, so restricted not open_weights.
   sources:
   - url: https://mistral.ai/news/codestral/
@@ -33,9 +33,9 @@ capability:
   score: 3
   basis: benchmark:HumanEval/MBPP
   value: HumanEval pass@1 ~86.6%, MBPP ~91.2%; strong on completion/FIM and RepoBench long-context, but
-    ~22B specialist — weak on agentic SWE-bench (single-run resolves only a small fraction)
+    ~22B specialist, weak on agentic SWE-bench (single-run resolves only a small fraction)
   confidence: medium
-  note: Strong code-completion specialist for its size, but a narrow FIM model — mid-tier on a chat/agentic
+  note: Strong code-completion specialist for its size, but a narrow FIM model, mid-tier on a chat/agentic
     capability axis where the comparison set is 2026 frontier agentic coders.
   sources:
   - url: https://mistral.ai/news/codestral/

--- a/sources/scores/command-r.yaml
+++ b/sources/scores/command-r.yaml
@@ -5,7 +5,7 @@ openness:
   confidence: high
   components: weights:open(gated, contact-info required);data:closed;code:closed;license:CC-BY-NC(non-commercial,
     non-OSI)+Cohere-Acceptable-Use-Policy
-  note: Weights downloadable but under CC-BY-NC — a non-commercial, non-OSI license with field-of-use
+  note: Weights downloadable but under CC-BY-NC, a non-commercial, non-OSI license with field-of-use
     restrictions => restricted. Marketed as 'open weights' despite the non-commercial cap.
   sources:
   - url: https://huggingface.co/CohereLabs/c4ai-command-r-plus
@@ -27,7 +27,7 @@ capability:
   score: 2
   basis: benchmark:MMLU
   value: Open LLM Leaderboard avg 74.6 (MMLU 75.7, ARC-C 70.99, HellaSwag 88.6, GSM8K 70.7, TruthfulQA
-    56.3) — strong vs 2024 peers (DBRX, Mixtral 8x7B)
+    56.3), strong vs 2024 peers (DBRX, Mixtral 8x7B)
   confidence: medium
   note: A 2024-era frontier-ish chat/RAG model, now well below the 2026 open instruct frontier (no modern
     reasoning/agentic coding scores; legacy MMLU-class benchmarks only). Scored 2 against a 2026 comparison

--- a/sources/scores/composio.yaml
+++ b/sources/scores/composio.yaml
@@ -6,7 +6,7 @@ openness:
     hosted platform + Rube MCP server (auth, hosted tool execution) is the commercial layer
   confidence: high
   note: SDK/core is MIT and public; the hosted multi-app integration/auth platform is the proprietary
-    tier — classic open-core.
+    tier, classic open-core.
   sources:
   - url: https://github.com/ComposioHQ/composio
     shows: MIT LICENSE, public SDK source, 1000+ toolkits, ~28.6k stars
@@ -18,7 +18,7 @@ adoption:
   confidence: medium
   note: 'CORRECTION (adversarial verify 2026-06-04): prior record claimed no primary download figure and
     capped at stars_fallback level 3. pypistats now shows the composio PyPI package at ~3.17M downloads
-    in the last month — a measured usage_volume signal in the 1M-10M band — so upgraded to level 4 / usage_volume
+    in the last month (a measured usage_volume signal in the 1M-10M band), so upgraded to level 4 / usage_volume
     and the stars_fallback cap is removed. Corroborated by ~28.6k GitHub stars and framework integrations
     (OpenAI, Anthropic, LangChain, LlamaIndex) plus the hosted platform.'
   sources:
@@ -29,7 +29,7 @@ adoption:
     shows: ~28.6k stars, integrations across major agent frameworks
     accessed: '2026-06-04'
   - url: https://pypi.org/project/composio/
-    shows: active package, latest v0.13.1 (May 2026) — confirms maintenance
+    shows: active package, latest v0.13.1 (May 2026); confirms maintenance
     accessed: '2026-06-04'
 capability:
   score: 4

--- a/sources/scores/confer.yaml
+++ b/sources/scores/confer.yaml
@@ -3,9 +3,9 @@ openness:
   score: 2
   class: source_available
   components: license:none-declared(no LICENSE file in either public repo);source:partial(confer-proxy +
-    confer-image public,client-app private);self-host:no(depends on vendor attestation infra);models:open-source(undisclosed)
+    confer-image public,client-app private);self-host:no(depends on vendor attestation infra);models:open source(undisclosed)
   confidence: high
-  note: 'Marketed as open-source, but neither public repo declares any license (GitHub reports license:null),
+  note: 'Marketed as open source, but neither public repo declares any license (GitHub reports license:null),
     so re-use rights are undefined, and the end-user client is not public. Source is published for verifiability/reproducible
     builds, not for self-deployment. Accurate classification is source-available, not open_source.'
   sources:
@@ -32,7 +32,7 @@ capability:
   basis: feature_matrix
   value: 'E2EE chat with TEE inference; remote attestation + reproducible builds + transparency log; encrypted
     chat history (passkey-derived keys); encrypted folders; cross-conversation memory; emerging connectors;
-    models: multiple open-source (task-routed via vLLM, names undisclosed); self-host: no; web client'
+    models: multiple open source (task-routed via vLLM, names undisclosed); self-host: no; web client'
   confidence: medium
   note: Strong, genuinely novel on the privacy/crypto dimension, but a relatively standard chat feature set,
     no self-hosting, and undisclosed models cap it at mid-tier.

--- a/sources/scores/confident-ai.yaml
+++ b/sources/scores/confident-ai.yaml
@@ -10,7 +10,7 @@ openness:
     framework's openness.
   sources:
   - url: https://www.confident-ai.com/
-    shows: proprietary cloud platform distinct from open-source DeepEval; self-hosted enterprise option
+    shows: proprietary cloud platform distinct from open source DeepEval; self-hosted enterprise option
     accessed: '2026-06-04'
   - url: https://github.com/confident-ai/deepeval
     shows: DeepEval (the separate framework) is Apache-2.0; platform is the integrated paid companion
@@ -21,7 +21,7 @@ adoption:
   signal_type: reported_traction
   confidence: medium
   note: Vendor discloses '500+ leading AI companies' incl. Panasonic, Samsung, Epic Games, Humach. Corroborated
-    by the strong pull of its open-source funnel DeepEval (~15.9k GitHub stars, used-by 1.3k repos), which
+    by the strong pull of its open source funnel DeepEval (~15.9k GitHub stars, used-by 1.3k repos), which
     drives platform signups. Level 3 on disclosed named-customer traction; no precise active-user/usage-volume
     number for the platform itself.
   sources:

--- a/sources/scores/continue.yaml
+++ b/sources/scores/continue.yaml
@@ -12,7 +12,7 @@ openness:
     shows: Apache-2.0; public source; AI code assistant (chat/edit/autocomplete + agent)
     accessed: '2026-06-04'
   - url: https://marketplace.visualstudio.com/items?itemName=Continue.continue
-    shows: open-source AI code agent extension listing
+    shows: open source AI code agent extension listing
     accessed: '2026-06-04'
 adoption:
   level: 4
@@ -35,7 +35,7 @@ capability:
   value: 'model breadth: yes (model-agnostic, any provider/local); chat: yes; inline edit: yes; autocomplete/tab:
     yes; agent mode: yes; RAG over codebase: yes; multimodal: partial; multi-IDE: VSCode+JetBrains+CLI'
   confidence: medium
-  note: Leading open-source in-IDE AI assistant; broad model-agnostic coverage with chat/edit/autocomplete/agent
+  note: Leading open source in-IDE AI assistant; broad model-agnostic coverage with chat/edit/autocomplete/agent
     and codebase RAG. Strong feature breadth for an open editor assistant, just below the polished closed
     frontier (Copilot/Cursor).
   sources:

--- a/sources/scores/cursor.yaml
+++ b/sources/scores/cursor.yaml
@@ -5,7 +5,7 @@ openness:
   confidence: high
   components: license:Proprietary(closed SaaS IDE, no public source);model:multi-provider (OpenAI/Anthropic/Gemini/xAI)
     but the product is proprietary
-  note: Fully proprietary commercial product; no open-source license or public source.
+  note: Fully proprietary commercial product; no open source license or public source.
   sources:
   - url: https://www.cursor.com/
     shows: proprietary commercial IDE, no OSS licensing, enterprise/Fortune-500 positioning

--- a/sources/scores/datasette-agent.yaml
+++ b/sources/scores/datasette-agent.yaml
@@ -14,8 +14,8 @@ adoption:
   reach: <10K
   signal_type: stars_fallback
   confidence: high
-  note: Pre-release alpha (PyPI 0.3a0, Jun 2026) roughly one month old; ~96 GitHub stars. Minimal adoption to date
-    — included as an emerging on-thesis structured-data agent.
+  note: Pre-release alpha (PyPI 0.3a0, Jun 2026) roughly one month old; ~96 GitHub stars. Minimal adoption to date,
+    included as an emerging on-thesis structured-data agent.
   sources:
   - url: https://github.com/datasette/datasette-agent
     shows: ~96 stars, 7 tags; PyPI 0.3a0 (15 Jun 2026)

--- a/sources/scores/deepseek-v3-base.yaml
+++ b/sources/scores/deepseek-v3-base.yaml
@@ -14,7 +14,7 @@ openness:
       supported, 6,510 downloads/mo
     accessed: '2026-06-04'
   - url: https://huggingface.co/deepseek-ai/DeepSeek-V3-Base/blob/main/LICENSE-MODEL
-    shows: DeepSeek Model License — commercial use permitted with use-based restrictions
+    shows: DeepSeek Model License, commercial use permitted with use-based restrictions
     accessed: '2026-06-04'
 adoption:
   level: 4

--- a/sources/scores/deepseek-v4-pro-base.yaml
+++ b/sources/scores/deepseek-v4-pro-base.yaml
@@ -5,7 +5,7 @@ openness:
   components: weights:open(downloadable on HF, both Pro-Base and Flash-Base);data:closed;code:partial(inference/serving;
     no training pipeline);license:MIT(permissive, no use restrictions)
   confidence: high
-  note: 'MIT-licensed open weights (confirmed via the repo''s LICENSE blob — note the HF page itself shows
+  note: 'MIT-licensed open weights (confirmed via the repo''s LICENSE blob, note the HF page itself shows
     ''No model card'', so license relied on the LICENSE file directly), data/training pipeline closed.
     Matches the DeepSeek-V4-Pro anchor (O3 open_weights). Confidence raised to high: independently re-verified
     the live repo (1.6T, 24,567 dl/mo) AND the MIT LICENSE blob (first line "MIT License", DeepSeek 2023)
@@ -23,7 +23,7 @@ adoption:
   signal_type: usage_volume
   confidence: medium
   note: Base released ~6 weeks before scoring; ~24.5k base-checkpoint downloads/mo (confirmed) and broad
-    serving of the V4-Pro chat line across providers. Calibrated to the DeepSeek-V4-Pro anchor (A4) —
+    serving of the V4-Pro chat line across providers. Calibrated to the DeepSeek-V4-Pro anchor (A4),
     strong early traction, too recent to confirm >10M independently.
   sources:
   - url: https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro-Base
@@ -37,7 +37,7 @@ capability:
   score: 5
   basis: benchmark:SWE-bench/MMLU-Pro/GPQA
   value: 'DeepSeek-V4-Pro (chat sibling of this base): SWE-bench Verified 80.6%, MMLU-Pro 87.5, GPQA Diamond
-    90.1, LiveCodeBench 93.5 — strongest open-source model at release (per frozen anchor).'
+    90.1, LiveCodeBench 93.5, strongest open source model at release (per frozen anchor).'
   confidence: medium
   note: 'Frontier-tier for the category; benchmarks reflect the post-trained V4-Pro built on this base.
     Matches the DeepSeek-V4-Pro anchor (C5). Note: these figures are from the frozen anchor, not re-verified

--- a/sources/scores/deepseek-v4-pro.yaml
+++ b/sources/scores/deepseek-v4-pro.yaml
@@ -22,7 +22,7 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: Released Apr 24 2026 — ~6 weeks of production at scoring time. Available open-weights + API (permanent
+  note: Released Apr 24 2026; ~6 weeks of production at scoring time. Available open-weights + API (permanent
     pricing set May 22 2026) and served across providers (OpenRouter, DeepInfra). Strong early traction
     consistent with DeepSeek family scale, but too recent to confirm >10M-equivalent reach independently;
     placed at 4 pending sustained data.
@@ -42,8 +42,8 @@ capability:
   value: null
   confidence: high
   note: SWE-bench Verified 80.6% (trails Claude Opus 4.6 by ~0.2), MMLU-Pro 87.5, GPQA Diamond 90.1, LiveCodeBench
-    Pass@1 93.5 (reported best of any model). V4-Pro-Max described as the strongest open-source model
-    available — at/near closed frontier on coding and reasoning.
+    Pass@1 93.5 (reported best of any model). V4-Pro-Max described as the strongest open source model
+    available, at/near closed frontier on coding and reasoning.
   sources:
   - url: https://codersera.com/blog/deepseek-v4-pro-review-benchmarks-pricing-2026/
     shows: flagship phase-C verification source

--- a/sources/scores/devin.yaml
+++ b/sources/scores/devin.yaml
@@ -11,7 +11,7 @@ openness:
     shows: proprietary SaaS coding agent, app.devin.ai signup, Individual/Teams plans
     accessed: '2026-06-04'
   - url: https://devin.ai/pricing
-    shows: paid tiers Free/$20 Pro/$200 Max/Teams/Enterprise — proprietary SaaS
+    shows: paid tiers Free/$20 Pro/$200 Max/Teams/Enterprise, proprietary SaaS
     accessed: '2026-06-04'
 adoption:
   level: 3
@@ -31,8 +31,8 @@ capability:
   value: 'Cognition''s own technical report: 13.86% (2024, 570-problem subset); Devin 2.0 ~45.8% SWE-bench
     Verified (unassisted single-agent, vendor-reported and corroborated)'
   confidence: medium
-  note: Devin 2.0 at 45.8% SWE-bench Verified is independently corroborated (single-agent, no human-in-loop)
-    — mid-tier, well below the OpenHands SWE-bench-Verified SOTA anchor. Scored 3.
+  note: Devin 2.0 at 45.8% SWE-bench Verified is independently corroborated (single-agent, no human-in-loop),
+    mid-tier, well below the OpenHands SWE-bench-Verified SOTA anchor. Scored 3.
   sources:
   - url: https://cognition.ai/blog/swe-bench-technical-report
     shows: Cognition-reported 13.86% SWE-bench, unassisted end-to-end methodology

--- a/sources/scores/devstral.yaml
+++ b/sources/scores/devstral.yaml
@@ -25,11 +25,11 @@ adoption:
 capability:
   score: 3
   basis: benchmark:SWE-bench Verified
-  value: 'Devstral Small 1.1 SWE-bench Verified 53.6% (OpenHands scaffold); #1 open-source at its release'
+  value: 'Devstral Small 1.1 SWE-bench Verified 53.6% (OpenHands scaffold); #1 open source at its release'
   confidence: high
   note: Best open coding model in its release window at a small 24B size, but below 2026 frontier coders
     (Qwen3.6 27B 77.2, GLM-5.1, Kimi K2.6 80%+). Strong-for-size, mid-tier overall.
   sources:
   - url: https://huggingface.co/mistralai/Devstral-Small-2507
-    shows: 'SWE-bench Verified table: Devstral Small 1.1 = 53.6%, top open-source'
+    shows: 'SWE-bench Verified table: Devstral Small 1.1 = 53.6%, top open source'
     accessed: '2026-06-04'

--- a/sources/scores/doubao-seed-2-0.yaml
+++ b/sources/scores/doubao-seed-2-0.yaml
@@ -5,7 +5,7 @@ openness:
   components: weights:closed;data:closed;code:closed;license:Proprietary(Doubao app + Volcano Engine API
     only; no downloadable weights)
   confidence: high
-  note: No weights released — served only through the Doubao app and Volcano Engine API. Fully closed.
+  note: No weights released, served only through the Doubao app and Volcano Engine API. Fully closed.
   sources:
   - url: https://technode.com/2026/02/14/bytedance-releases-doubao-seed-2-0-positions-pro-model-against-gpt-5-2-and-gemini-3-pro/
     shows: Doubao Seed 2.0 available on Doubao app and Volcano Engine API (no open weights)

--- a/sources/scores/e2b-sandbox.yaml
+++ b/sources/scores/e2b-sandbox.yaml
@@ -9,7 +9,7 @@ openness:
     per recipe (E2B named as open-core example).
   sources:
   - url: https://github.com/e2b-dev/E2B
-    shows: Apache-2.0 license; open-source sandbox infra + Terraform self-host; managed cloud at e2b.dev
+    shows: Apache-2.0 license; open source sandbox infra + Terraform self-host; managed cloud at e2b.dev
     accessed: '2026-06-04'
 adoption:
   level: 4

--- a/sources/scores/epoch-ai-benchmarks.yaml
+++ b/sources/scores/epoch-ai-benchmarks.yaml
@@ -7,8 +7,8 @@ openness:
     contamination; some public);no-unified-OSI-harness-product
   confidence: medium
   note: 'Mixed-tier: public results dashboard plus some MIT/Apache-licensed eval components, but the headline
-    benchmark (FrontierMath) is deliberately private and there is no single OSI-licensed end-to-end harness
-    — closer to source_available than fully open_source.'
+    benchmark (FrontierMath) is deliberately private and there is no single OSI-licensed end-to-end harness,
+    closer to source_available than fully open_source.'
   sources:
   - url: https://github.com/epoch-research
     shows: public org repos incl SWE-bench docker registry, eci-public (MIT), MirrorCode-data; mostly
@@ -42,7 +42,7 @@ capability:
   confidence: medium
   note: Strong feature_matrix on hard/frontier benchmark coverage and trusted standardized results, especially
     math. Not a general agentic-eval harness; held-out design limits self-serve reproducibility. Placed
-    at 4 — authoritative but not a frontier-defining general harness like lm-eval-harness.
+    at 4, authoritative but not a frontier-defining general harness like lm-eval-harness.
   sources:
   - url: https://epoch.ai/benchmarks
     shows: 'operated benchmarks list: FrontierMath, GPQA Diamond, SWE-bench Verified, SimpleQA Verified,

--- a/sources/scores/evalplus.yaml
+++ b/sources/scores/evalplus.yaml
@@ -6,7 +6,7 @@ openness:
     on both framework and datasets);datasheet:present(card documents structure: task_id/prompt/canonical_solution/test);redistributable:yes;framework-code:open(Apache-2.0)'
   confidence: high
   note: 'Clean open data: Apache-2.0 on both datasets and the evaluation framework, downloadable with
-    a documented schema — full open class.'
+    a documented schema, full open class.'
   sources:
   - url: https://huggingface.co/datasets/evalplus/humanevalplus
     shows: Apache-2.0 license, 164 problems, 25,817 monthly downloads, documented schema
@@ -36,6 +36,6 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: Dataset — not capability-scored. Its distinguishing quality (far denser test suites that catch
+  note: Dataset, not capability-scored. Its distinguishing quality (far denser test suites that catch
     overfitting vs base HumanEval/MBPP) is a quality strength, noted but not on the 1-5 axis.
   sources: []

--- a/sources/scores/exa-search-api.yaml
+++ b/sources/scores/exa-search-api.yaml
@@ -8,7 +8,7 @@ openness:
   note: Closed neural-search API; no self-hostable core, the index and ranking models are proprietary.
   sources:
   - url: https://exa.ai/about
-    shows: search-as-a-service, API dashboard, no self-host/open-source option
+    shows: search-as-a-service, API dashboard, no self-host/open source option
     accessed: '2026-06-04'
 adoption:
   level: 3
@@ -30,7 +30,7 @@ capability:
     entity lists); positioned for high-compute complex queries; scaling to hundreds of thousands of searches/sec
     (vendor)
   confidence: medium
-  note: Strong on {coverage, structured output} — Websets' verify-and-enrich pipeline is a differentiated
+  note: Strong on {coverage, structured output}; Websets' verify-and-enrich pipeline is a differentiated
     capability beyond plain search; near-frontier among agent search APIs.
   sources:
   - url: https://exa.ai/about

--- a/sources/scores/fastmcp.yaml
+++ b/sources/scores/fastmcp.yaml
@@ -31,7 +31,7 @@ capability:
     protocol lifecycle management; the standard high-level MCP server framework
   confidence: medium
   note: Most feature-complete framework for authoring the tool-protocol layer (MCP); scored 4 on protocol-tooling
-    feature breadth — a 5 is reserved for the protocol/category-definer (MCP itself).
+    feature breadth; a 5 is reserved for the protocol/category-definer (MCP itself).
   sources:
   - url: https://github.com/jlowin/fastmcp
     shows: 'framework feature set: schema gen/validation, server+client, auth, deployment'

--- a/sources/scores/feluda.yaml
+++ b/sources/scores/feluda.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components: license:GPL-3.0(OSI copyleft);source:public
   confidence: high
-  note: GPL-3.0 licensed open-source project with public source.
+  note: GPL-3.0 licensed open source project with public source.
   sources:
   - url: https://github.com/tattle-made/feluda
     shows: GPL-3.0 license, public source under tattle-made org

--- a/sources/scores/firecracker.yaml
+++ b/sources/scores/firecracker.yaml
@@ -15,8 +15,8 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: Underpins AWS Lambda and AWS Fargate — among the highest-volume serverless platforms in the world
-    (trillions of invocations) — plus downstream use in Kata Containers, Flintlock, and E2B. Production
+  note: Underpins AWS Lambda and AWS Fargate, among the highest-volume serverless platforms in the world
+    (trillions of invocations), plus downstream use in Kata Containers, Flintlock, and E2B. Production
     reach far exceeds >10M end-equivalent. (34.8k stars corroborate only.)
   sources:
   - url: https://github.com/firecracker-microvm/firecracker
@@ -25,7 +25,7 @@ adoption:
 capability:
   score: 5
   basis: feature_matrix
-  value: isolation:hardware-virtualized microVM (KVM) — strongest isolation tier; cold-start:~125ms boot,
+  value: isolation:hardware-virtualized microVM (KVM), strongest isolation tier; cold-start:~125ms boot,
     <5MiB memory overhead per microVM; language/runtime breadth:runs any OCI/container or function workload
     (kernel-level, language-agnostic); scale:powers Lambda/Fargate fleets
   confidence: high

--- a/sources/scores/firecrawl.yaml
+++ b/sources/scores/firecrawl.yaml
@@ -33,7 +33,7 @@ capability:
     handling; markdown/JSON/screenshot/structured output; P95 latency 3.4s, claims 96% web coverage
   confidence: medium
   note: 'Broad scrape/browse feature coverage (the recipe''s search/scrape dimensions: coverage, freshness,
-    structured output, rate limits) — among the most capable open scrape tools; not a 5 (no benchmark,
+    structured output, rate limits), among the most capable open scrape tools; not a 5 (no benchmark,
     and frontier reserved for category-definers).'
   sources:
   - url: https://github.com/mendableai/firecrawl

--- a/sources/scores/fly-sprites.yaml
+++ b/sources/scores/fly-sprites.yaml
@@ -6,7 +6,7 @@ openness:
     only, no open runtime);isolation:Firecracker(Firecracker itself is OSS/AWS, but the Sprites product/orchestration
     is proprietary)
   confidence: high
-  note: Proprietary managed sandbox SaaS; no open-source runtime published (only client SDKs). Underlying
+  note: Proprietary managed sandbox SaaS; no open source runtime published (only client SDKs). Underlying
     Firecracker is OSS but the product is not.
   sources:
   - url: https://sprites.dev/

--- a/sources/scores/galileo.yaml
+++ b/sources/scores/galileo.yaml
@@ -2,14 +2,14 @@ product: galileo
 openness:
   score: 1
   class: closed
-  components: license:proprietary;source:closed;deploy:SaaS/VPC/on-prem(managed);no-OSS-core(open-source
+  components: license:proprietary;source:closed;deploy:SaaS/VPC/on-prem(managed);no-OSS-core(open source
     contributions exist as separate tools/benchmarks, not the product)
   confidence: high
   note: Proprietary platform; recipe lists Galileo explicitly as a closed example. No OSI-licensed core
     product.
   sources:
   - url: https://galileo.ai/
-    shows: proprietary platform; SaaS/VPC/on-prem deploy, no open-source core product
+    shows: proprietary platform; SaaS/VPC/on-prem deploy, no open source core product
     accessed: '2026-06-04'
 adoption:
   level: 3

--- a/sources/scores/gemini-3-1-pro-preview.yaml
+++ b/sources/scores/gemini-3-1-pro-preview.yaml
@@ -34,7 +34,7 @@ capability:
   value: GPQA Diamond 94.3% (Thinking High), ARC-AGI-2 77.1%, SWE-bench Verified 80.6%, Humanity's Last
     Exam 44.4% (no tools)/51.4% (with tools), MMMU-Pro 80.5%
   confidence: high
-  note: Frontier-definer for chat/reasoning at scoring time — leads or near-leads GPQA, ARC-AGI-2 and
+  note: Frontier-definer for chat/reasoning at scoring time, leads or near-leads GPQA, ARC-AGI-2 and
     SWE-bench. Scored 5; calibrates with the Gemini 3.5 Flash anchor (cap 5). Google-reported figures
     from the model card.
   sources:

--- a/sources/scores/github-copilot.yaml
+++ b/sources/scores/github-copilot.yaml
@@ -16,7 +16,7 @@ adoption:
   reach: '>10M'
   signal_type: active_users
   confidence: high
-  note: 'GitHub Copilot surpassed 20M+ all-time users (Microsoft July 2025 earnings) — ''world''s most
+  note: 'GitHub Copilot surpassed 20M+ all-time users (Microsoft July 2025 earnings): ''world''s most
     widely adopted AI developer tool.'' Agent mode is the autonomous surface of that base. >10M band.
     Note: 20M is all-time, not active; agent-mode-specific count not disclosed, but base scale firmly
     supports level 5.'
@@ -35,7 +35,7 @@ capability:
     + Codex), deep GitHub/PR/CI integration; no first-party SWE-bench number on the agent-mode page
   confidence: medium
   note: Broad agentic feature set with frontier-model backends and best-in-class repo integration; no
-    published SWE-bench for Copilot agent mode itself, so feature_matrix at 4 — strong but below a verified-benchmark
+    published SWE-bench for Copilot agent mode itself, so feature_matrix at 4, strong but below a verified-benchmark
     ceiling.
   sources:
   - url: https://github.com/features/copilot

--- a/sources/scores/glean-assistant.yaml
+++ b/sources/scores/glean-assistant.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   confidence: high
   components: client:proprietary;deployment:single-tenant SaaS;source:closed;license:Proprietary
-  note: Glean Assistant is a proprietary enterprise SaaS — no public source, no open-core/self-host OSS
+  note: Glean Assistant is a proprietary enterprise SaaS, no public source, no open-core/self-host OSS
     tier. Closed.
   sources:
   - url: https://www.glean.com/product/assistant
@@ -17,7 +17,7 @@ adoption:
   confidence: medium
   note: Glean surpassed $300M ARR (28 May 2026, vendor press), 15 months after $100M; nearly doubled Fortune
     500 customer count YoY; 85%+ of customers use it across 5+ departments; 45% wDAU/wMAU engagement ratio;
-    operating in 28 countries. ARR/enterprise-seat scale implies low-millions of enterprise seats — placed
+    operating in 28 countries. ARR/enterprise-seat scale implies low-millions of enterprise seats; placed
     at 4 on reported enterprise traction. No raw seat/user count disclosed, so confidence medium and signal_type
     reported_traction (revenue + deployment breadth, not a measured user count).
   sources:
@@ -31,9 +31,9 @@ capability:
   value: 'enterprise chat-UI feature set: model breadth (Model Hub, multiple frontier LLMs + adaptive
     model selection); RAG (Enterprise Graph over 100+ connectors); multimodal output (images/slides/interactive
     pages); plugins/actions (workflow triggers, record updates, Skills); multi-user/enterprise (single-tenant,
-    permissions-aware) — strong across all five ui_api chat-UI axes; plus agentic sub-agent orchestration'
+    permissions-aware); strong across all five ui_api chat-UI axes; plus agentic sub-agent orchestration'
   confidence: high
-  note: Among the most feature-complete enterprise assistant UIs — multi-model hub, deep enterprise RAG,
+  note: Among the most feature-complete enterprise assistant UIs, multi-model hub, deep enterprise RAG,
     multimodal, actions, permissions-aware multi-user. Top-tier within ui_api for enterprise context;
     scored 4 (reserving 5 for an unambiguous category frontier-definer).
   sources:

--- a/sources/scores/glean-workplace-search-ai.yaml
+++ b/sources/scores/glean-workplace-search-ai.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   confidence: high
   components: client:proprietary;deployment:single-tenant SaaS;source:closed;license:Proprietary
-  note: Glean Search is proprietary enterprise SaaS — no public source, no OSS/self-host tier. Closed.
+  note: Glean Search is proprietary enterprise SaaS; no public source, no OSS/self-host tier. Closed.
   sources:
   - url: https://www.glean.com/product/overview
     shows: Glean Search as proprietary single-tenant SaaS enterprise search on Enterprise Graph
@@ -17,7 +17,7 @@ adoption:
   note: 'Search is the foundational layer of the same Glean platform that crossed $300M ARR (May 2026)
     with near-doubled Fortune 500 count and 85%+ multi-department usage; effectively co-extensive with
     Glean''s deployed seat base. Same caveat as Glean Assistant: no raw user count disclosed, so reported_traction
-    at confidence medium. Adoption shared with the Assistant record (same platform) — not an independent
+    at confidence medium. Adoption shared with the Assistant record (same platform), not an independent
     measurement.'
   sources:
   - url: https://www.glean.com/press/glean-surpasses-300m-arr-unrivaled-enterprise-context-fuels-ai-adoption
@@ -31,7 +31,7 @@ capability:
     results; single-tenant security; AI-assistant-grounding output'
   confidence: high
   note: Best-in-class enterprise search on connector breadth, knowledge-graph relevance, and permissions-aware
-    retrieval — a recognized leader in the enterprise-search-for-AI space. Scored 4 (top-tier; 5 reserved
+    retrieval, a recognized leader in the enterprise-search-for-AI space. Scored 4 (top-tier; 5 reserved
     for an unambiguous frontier-definer).
   sources:
   - url: https://www.glean.com/product/overview

--- a/sources/scores/glm-4-9b.yaml
+++ b/sources/scores/glm-4-9b.yaml
@@ -7,7 +7,7 @@ openness:
     restrictions, Chinese jurisdiction)'
   confidence: high
   note: Weights downloadable but glm-4 license is non-OSI with registration-gated commercial use + use
-    restrictions — restricted, not open_weights. HF card confirms a custom glm-4 LICENSE file (full restriction
+    restrictions, restricted, not open_weights. HF card confirms a custom glm-4 LICENSE file (full restriction
     text in the linked LICENSE).
   sources:
   - url: https://huggingface.co/THUDM/glm-4-9b-hf

--- a/sources/scores/glm-4.yaml
+++ b/sources/scores/glm-4.yaml
@@ -7,7 +7,7 @@ openness:
     derivatives; field-of-use prohibitions)'
   confidence: high
   note: Downloadable weights but governed by a non-OSI custom license with registration and attribution
-    obligations — restricted, not open_weights. No MAU cap.
+    obligations, restricted, not open_weights. No MAU cap.
   sources:
   - url: https://huggingface.co/zai-org/GLM-4-9B-Chat/blob/main/LICENSE
     shows: 'GLM-4 custom non-OSI license: commercial use needs registration, ''Built with glm-4'' attribution,

--- a/sources/scores/google-cloud-run.yaml
+++ b/sources/scores/google-cloud-run.yaml
@@ -2,7 +2,7 @@ product: google-cloud-run
 openness:
   score: 1
   class: closed
-  components: service:proprietary(Google SaaS);source:closed;isolation-runtime:gVisor(open-source, github.com/google/gvisor)
+  components: service:proprietary(Google SaaS);source:closed;isolation-runtime:gVisor(open source, github.com/google/gvisor)
     but the Cloud Run product/control-plane is proprietary;managed-only(no self-host)
   confidence: high
   note: Proprietary managed serverless platform; only the underlying gVisor sandbox runtime is OSS, not
@@ -12,7 +12,7 @@ openness:
     shows: Cloud Run described as fully-managed Google serverless container product (proprietary SaaS)
     accessed: '2026-06-04'
   - url: https://github.com/google/gvisor
-    shows: gVisor (Cloud Run's isolation runtime) is the open-source component, distinct from the closed
+    shows: gVisor (Cloud Run's isolation runtime) is the open source component, distinct from the closed
       product
     accessed: '2026-06-04'
 adoption:

--- a/sources/scores/google-cloud-tpu-inference.yaml
+++ b/sources/scores/google-cloud-tpu-inference.yaml
@@ -2,7 +2,7 @@ product: google-cloud-tpu-inference
 openness:
   score: 1
   class: closed
-  components: license:proprietary;runtime:Pathways(Google-internal distributed runtime, not open-sourced);hardware-lock:Google
+  components: license:proprietary;runtime:Pathways(Google-internal distributed runtime, not open sourced);hardware-lock:Google
     TPU-only;managed:Google Cloud/GKE;note:JetStream(separate, Apache-2.0 OSS) is the open serving frontend
     but the scored product is the proprietary Pathways/TPU runtime
   confidence: high
@@ -11,7 +11,7 @@ openness:
   sources:
   - url: https://cloud.google.com/blog/products/compute/ai-hypercomputer-inference-updates-for-google-cloud-tpu-and-gpu
     shows: Pathways runtime offered as managed Google Cloud component (not labeled open source); JetStream
-      described as the open-source engine separately
+      described as the open source engine separately
     accessed: '2026-06-04'
 adoption:
   level: 3

--- a/sources/scores/google-coral-dev-board.yaml
+++ b/sources/scores/google-coral-dev-board.yaml
@@ -12,7 +12,7 @@ openness:
     shows: 'datasheet: 4 TOPS, 2 TOPS/W, SoM form factor, TFLite, Google-designed Edge TPU'
     accessed: '2026-06-22'
   - url: https://github.com/google-coral/libedgetpu
-    shows: open-source Edge TPU userspace runtime driver
+    shows: open source Edge TPU userspace runtime driver
     accessed: '2026-06-22'
 adoption:
   level: 4

--- a/sources/scores/google-grounding-api.yaml
+++ b/sources/scores/google-grounding-api.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components: license:proprietary(GCP-managed API);source:closed;managed:Vertex-AI/Gemini-Agent-Platform
   confidence: high
-  note: Fully proprietary Google Cloud managed grounding service; no open-source component or self-host.
+  note: Fully proprietary Google Cloud managed grounding service; no open source component or self-host.
     Tied to Gemini + Google Search index.
   sources:
   - url: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/grounding/overview
@@ -29,7 +29,7 @@ capability:
   value: 'coverage: full Google Search index grounding; freshness=live web; structured grounding metadata
     + citations/grounding-support attribution returned to the model'
   confidence: medium
-  note: Grounds LLM output in the full Google Search index with citation/grounding-support metadata —
+  note: Grounds LLM output in the full Google Search index with citation/grounding-support metadata,
     best-in-class web freshness/coverage for agent grounding. Rated 4 on the coverage/freshness/structured-output
     matrix; capped below 5 as detailed per-feature confirmation came from the overview page only (deeper
     feature docs not fetched this run).

--- a/sources/scores/gpt-4o.yaml
+++ b/sources/scores/gpt-4o.yaml
@@ -34,7 +34,7 @@ capability:
   confidence: medium
   note: 'Frontier in 2024 but surpassed by 2026 reasoning frontier (GPT-5 C5, Gemini 3.5 C5); per the
     recipe, a mid-2025-and-earlier model that has been surpassed scores 3, not 5. Caveat: the cited OpenAI
-    docs page (verified 2026-06-04) shows NO benchmark figures — it only calls GPT-4o ''our most capable
+    docs page (verified 2026-06-04) shows NO benchmark figures; it only calls GPT-4o ''our most capable
     model outside our o-series''; the MMLU/MMMU values are launch-era external numbers and need a primary
     benchmark source to back the headline.'
   sources:

--- a/sources/scores/granite-code-instruct.yaml
+++ b/sources/scores/granite-code-instruct.yaml
@@ -49,5 +49,5 @@ capability:
     shows: HumanEvalSynthesis pass@1 per-language scores
     accessed: '2026-06-04'
   - url: https://research.ibm.com/blog/granite-code-models-open-source
-    shows: Granite-8B-Code matches SOTA among open-source code LLMs on HumanEvalPack at 2024 release
+    shows: Granite-8B-Code matches SOTA among open source code LLMs on HumanEvalPack at 2024 release
     accessed: '2026-06-04'

--- a/sources/scores/grok-3.yaml
+++ b/sources/scores/grok-3.yaml
@@ -9,7 +9,7 @@ openness:
     Grok 3 weights are not released.)
   sources:
   - url: https://x.ai/news/grok-3
-    shows: Grok 3 Beta launch (proprietary), 'Age of Reasoning Agents' — confirmed via search; no open
+    shows: Grok 3 Beta launch (proprietary), 'Age of Reasoning Agents'; confirmed via search; no open
       weights
     accessed: '2026-06-04'
 adoption:

--- a/sources/scores/grok-4-20-heavy.yaml
+++ b/sources/scores/grok-4-20-heavy.yaml
@@ -3,16 +3,16 @@ openness:
   score: 1
   class: closed
   components: weights:closed;data:closed;code:closed;license:Proprietary(SuperGrok Heavy / xAI API, no
-    downloadable weights; xAI open-sources only its system prompts)
+    downloadable weights; xAI open sources only its system prompts)
   confidence: high
-  note: Closed proprietary model; only the Grok system prompts are open-sourced, not weights/data/training
+  note: Closed proprietary model; only the Grok system prompts are open sourced, not weights/data/training
     code. Consistent with the Grok 4.20 anchor (closed).
   sources:
   - url: https://artificialanalysis.ai/models/grok-4-20
     shows: Grok 4.20 proprietary API model, no open weights
     accessed: '2026-06-04'
   - url: https://natural20.com/coverage/grok-420-xai-four-agents-system-benchmarks-jailbreak
-    shows: Heavy = 16-agent high-effort tier; xAI open-sources prompts only
+    shows: Heavy = 16-agent high-effort tier; xAI open sources prompts only
     accessed: '2026-06-04'
 adoption:
   level: 2
@@ -35,7 +35,7 @@ capability:
   confidence: medium
   note: Strong but a notch below the GPT-5/Gemini 3.5/Opus 4.7 frontier leaders on the AA Intelligence
     Index. Heavy is the max-effort mode of the same model; scored 4 to match the Grok 4.20 anchor (capability
-    4) — high-effort agent scaling does not move it into the 5 frontier-definer band. AA Index/AIME are
+    4); high-effort agent scaling does not move it into the 5 frontier-definer band. AA Index/AIME are
     independent; LMArena Elo provisional.
   sources:
   - url: https://artificialanalysis.ai/models/grok-4-20

--- a/sources/scores/gsm8k.yaml
+++ b/sources/scores/gsm8k.yaml
@@ -17,7 +17,7 @@ adoption:
   signal_type: usage_volume
   confidence: high
   note: The standard grade-school math-reasoning benchmark, cited near-universally in LLM release reports
-    for years. ~948k HF downloads/month on the canonical config — the highest in this batch — puts annualized
+    for years. ~948k HF downloads/month on the canonical config (the highest in this batch) puts annualized
     usage comfortably into the 1-10M band.
   sources:
   - url: https://huggingface.co/datasets/openai/gsm8k

--- a/sources/scores/gvisor.yaml
+++ b/sources/scores/gvisor.yaml
@@ -16,7 +16,7 @@ adoption:
   signal_type: usage_volume
   confidence: high
   note: Underpins Google Cloud Run ('Powered by gVisor' on gvisor.dev) and is the sandbox layer for GKE
-    Sandbox / App Engine / Cloud Functions — billions of container executions across Google Cloud. Reach
+    Sandbox / App Engine / Cloud Functions, billions of container executions across Google Cloud. Reach
     far exceeds >10M end-equivalent. (18.5k stars corroborate only.)
   sources:
   - url: https://gvisor.dev/docs/
@@ -28,7 +28,7 @@ adoption:
 capability:
   score: 5
   basis: feature_matrix
-  value: isolation:application-kernel (userspace syscall interception, defense-in-depth) — distinct strong-isolation
+  value: isolation:application-kernel (userspace syscall interception, defense-in-depth), distinct strong-isolation
     third approach between seccomp and full VM; cold-start:fast userspace startup; language/runtime breadth:any
     Linux container workload (kernel-level); scale:powers Cloud Run/GKE Sandbox
   confidence: high

--- a/sources/scores/hailo-8.yaml
+++ b/sources/scores/hailo-8.yaml
@@ -5,14 +5,14 @@ openness:
   components: schematics:no;toolchain:open runtime (HailoRT) + closed/registration Dataflow Compiler;datasheets:public
     briefs;blobs:proprietary silicon + firmware;retail:global modules
   confidence: high
-  note: Proprietary silicon with an open-source runtime and public product briefs, but the model-compiler
+  note: Proprietary silicon with an open source runtime and public product briefs, but the model-compiler
     toolchain requires registration and silicon is closed.
   sources:
   - url: https://hailo.ai/products/ai-accelerators/hailo-8-ai-accelerator/
     shows: 'official product page: form factors, frameworks, software suite'
     accessed: '2026-06-22'
   - url: https://github.com/hailo-ai/hailort
-    shows: open-source HailoRT inference runtime
+    shows: open source HailoRT inference runtime
     accessed: '2026-06-22'
 adoption:
   level: 4

--- a/sources/scores/helicone.yaml
+++ b/sources/scores/helicone.yaml
@@ -5,7 +5,7 @@ openness:
   components: license:Apache-2.0(OSI);source:public;self-host supported;hosted Helicone Cloud with paid
     tiers(free=10k req/mo) = commercial SaaS layer atop OSS core
   confidence: high
-  note: Apache-2.0 OSS core with a hosted commercial cloud (tiered pricing) — classic open-core, same
+  note: Apache-2.0 OSS core with a hosted commercial cloud (tiered pricing), classic open-core, same
     shelf as Langfuse/LangWatch (O4).
   sources:
   - url: https://github.com/Helicone/helicone

--- a/sources/scores/helm.yaml
+++ b/sources/scores/helm.yaml
@@ -18,8 +18,8 @@ adoption:
   confidence: medium
   note: 'Headline signal is influence/standard-setting, not install volume: HELM is a widely-cited standardized
     public leaderboard from Stanford CRFM spanning multiple modalities (capabilities/safety/vision/medical),
-    referenced across the research community. PyPI distribution (crfm-helm) is only ~3,142 downloads/month
-    — most usage is via the hosted leaderboard and academic citation rather than pip, so download volume
+    referenced across the research community. PyPI distribution (crfm-helm) is only ~3,142 downloads/month;
+    most usage is via the hosted leaderboard and academic citation rather than pip, so download volume
     understates reach. Level 3 reflects meaningful research/standard adoption short of mass production
     deployment.'
   sources:
@@ -38,7 +38,7 @@ capability:
     medical (MedHELM), audio, and enterprise; unified model access across OpenAI/Anthropic/Google/etc.;
     metrics beyond accuracy; standardized reproducible format + web UI.'
   confidence: high
-  note: Frontier-defining on coverage and standardization — the holistic multi-modality leaderboard standard.
+  note: Frontier-defining on coverage and standardization, the holistic multi-modality leaderboard standard.
     One of the 1-2 category leaders, scored 5. (Weaker than Inspect AI on agentic-eval support, but broader
     on benchmark/modality coverage.)
   sources:

--- a/sources/scores/hermes-4-14b.yaml
+++ b/sources/scores/hermes-4-14b.yaml
@@ -16,7 +16,7 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: ~35,066 HF downloads/mo — the most-downloaded Hermes 4 SKU (small size + permissive license drive
+  note: ~35,066 HF downloads/mo, the most-downloaded Hermes 4 SKU (small size + permissive license drive
     uptake). Early-adopter scale.
   sources:
   - url: https://huggingface.co/NousResearch/Hermes-4-14B

--- a/sources/scores/hermes-agent.yaml
+++ b/sources/scores/hermes-agent.yaml
@@ -4,14 +4,14 @@ openness:
   class: open_source
   components: license:MIT(OSI);source:public(github.com/NousResearch/hermes-agent);no-feature-gated-core;model-agnostic(multi-provider);self-host-by-design
   confidence: high
-  note: Fully MIT-licensed, complete public source, self-hosted by design, no proprietary core — top openness,
+  note: Fully MIT-licensed, complete public source, self-hosted by design, no proprietary core; top openness,
     above open-core framework anchors.
   sources:
   - url: https://github.com/NousResearch/hermes-agent
     shows: MIT LICENSE, full public source, self-improving multi-channel agent (Python)
     accessed: '2026-06-04'
   - url: https://hermes-agent.nousresearch.com
-    shows: open-source MIT autonomous agent product page
+    shows: open source MIT autonomous agent product page
     accessed: '2026-06-04'
 adoption:
   level: 4
@@ -19,7 +19,7 @@ adoption:
   signal_type: usage_volume
   confidence: medium
   note: 'Real usage signal beyond stars (adoption!=stars rule): Hermes Agent reported #1 on OpenRouter''s
-    GLOBAL token rankings — confirmed by Nous Research''s own announcement (~271B tokens, May 6 2026)
+    GLOBAL token rankings, confirmed by Nous Research''s own announcement (~271B tokens, May 6 2026)
     and an OpenRouter app page; secondary reports give ~224B daily tokens by May 10 (surpassing OpenClaw''s
     ~186B). Both figures are reported; token-volume mapped to 1-10M-equivalent reach (inference, not a
     disclosed installed-user count). GitHub stars (~181K, <4 months) corroborate but are not the basis.

--- a/sources/scores/huggingchat-chat-ui.yaml
+++ b/sources/scores/huggingchat-chat-ui.yaml
@@ -22,7 +22,7 @@ adoption:
     of the hosted product; the discontinuity + relaunch lowers confidence.
   sources:
   - url: https://huggingface.co/chat
-    shows: live HuggingChat Omni interface, Omni router, 123+ open-source models, MCP
+    shows: live HuggingChat Omni interface, Omni router, 123+ open source models, MCP
     accessed: '2026-06-04'
   - url: https://www.startuphub.ai/ai-news/startup-news/2025/hugging-face-closes-huggingchat-to-make-way-for-next-generation-ai-tools
     shows: HuggingChat served 1M+ users / 100k+ assistants before July 2025 sunset

--- a/sources/scores/inspect-ai.yaml
+++ b/sources/scores/inspect-ai.yaml
@@ -5,7 +5,7 @@ openness:
   components: license:MIT(OSI);source:public(full framework, 200+ evals);governance:public-sector(UK AISI)+Meridian
     Labs; no managed/gated tier
   confidence: high
-  note: Fully OSI (MIT), government-backed, no proprietary core — full pipeline open.
+  note: Fully OSI (MIT), government-backed, no proprietary core, full pipeline open.
   sources:
   - url: https://github.com/UKGovernmentBEIS/inspect_ai
     shows: MIT license; framework for LLM evals with 200+ pre-built evals; UK AISI maintainer; 2.2k stars,
@@ -19,7 +19,7 @@ adoption:
   note: 'Headline signal (per recipe: adoption by frontier labs / cited in release-grade safety work):
     adopted as the evaluation framework of choice by major labs incl. Anthropic, Google DeepMind, and
     xAI/Grok, and powers nearly all of UK AISI''s automated frontier-model evaluations. Corroborated by
-    ~9.9M PyPI downloads in the last 30 days (pepy.tech) / 10.5M (pypistats) — though that figure is inflated
+    ~9.9M PyPI downloads in the last 30 days (pepy.tech) / 10.5M (pypistats), though that figure is inflated
     by CI/dependency traffic, so lab adoption is treated as the primary basis. Placed at level 4, not
     5, because the human-operator base (eval engineers at labs/AISI) is far smaller than mass-market scale.'
   sources:

--- a/sources/scores/internlm-2-5.yaml
+++ b/sources/scores/internlm-2-5.yaml
@@ -2,7 +2,7 @@ product: internlm-2-5
 openness:
   score: 3
   class: open_weights
-  components: weights:open(custom 'Free Commercial License' — academic free, commercial use free but requires
+  components: weights:open(custom 'Free Commercial License', academic free, commercial use free but requires
     an application form);data:closed(pretraining corpus not released);code:open(Apache-2.0 training/inference
     code on GitHub);license:Apache-2.0(code, OSI) + custom weights license(non-OSI, application step)
   confidence: medium

--- a/sources/scores/jan.yaml
+++ b/sources/scores/jan.yaml
@@ -5,7 +5,7 @@ openness:
   confidence: high
   components: license:Apache-2.0(OSI);source:public(github.com/janhq/jan);no-feature-gated-core;self-host:primary(desktop
     app, 100% offline-capable)
-  note: Fully OSI-licensed (Apache-2.0), full source public, no proprietary feature-gated core — a true
+  note: Fully OSI-licensed (Apache-2.0), full source public, no proprietary feature-gated core, a true
     open chat UI.
   sources:
   - url: https://github.com/janhq/jan/blob/dev/LICENSE

--- a/sources/scores/kata-containers.yaml
+++ b/sources/scores/kata-containers.yaml
@@ -26,7 +26,7 @@ adoption:
 capability:
   score: 4
   basis: feature_matrix
-  value: isolation:hardware VM (pluggable VMM — QEMU/Firecracker/Cloud Hypervisor) — strong VM-class isolation;
+  value: isolation:hardware VM (pluggable VMM, QEMU/Firecracker/Cloud Hypervisor), strong VM-class isolation;
     cold-start:VM boot (slower than pure userspace); language/runtime breadth:any OCI container (language-agnostic,
     K8s-native); persistence:container lifecycle; scale:K8s clusters
   confidence: high

--- a/sources/scores/khoj.yaml
+++ b/sources/scores/khoj.yaml
@@ -13,7 +13,7 @@ openness:
     shows: AGPL-3.0 license; ~35k stars; self-hostable AI personal assistant
     accessed: '2026-06-17'
   - url: https://app.khoj.dev/
-    shows: official notice that Khoj Cloud was sunset 2026-04-15 and Khoj "remains fully open-source"
+    shows: official notice that Khoj Cloud was sunset 2026-04-15 and Khoj "remains fully open source"
     accessed: '2026-06-17'
 adoption:
   level: 3

--- a/sources/scores/kimi-k2-6.yaml
+++ b/sources/scores/kimi-k2-6.yaml
@@ -4,11 +4,11 @@ openness:
   class: open_weights
   components: weights:open(downloadable on HF);data:closed;code:partial(inference/deploy; no training
     data or full pipeline);license:Modified-MIT(standard MIT below 100M MAU / $20M monthly rev; above
-    thresholds requires 'Kimi K2' UI attribution — attribution-only, not a use cap)
+    thresholds requires 'Kimi K2' UI attribution, attribution-only, not a use cap)
   confidence: high
   note: weights:open(downloadable on HF);data:closed;code:partial(inference/deploy; no training data or
     full pipeline);license:Modified-MIT(standard MIT below 100M MAU / $20M monthly rev; above thresholds
-    requires 'Kimi K2' UI attribution — attribution-only, not a use cap)
+    requires 'Kimi K2' UI attribution, attribution-only, not a use cap)
   sources:
   - url: https://huggingface.co/moonshotai/Kimi-K2.6
     shows: flagship phase-C verification source

--- a/sources/scores/laminar.yaml
+++ b/sources/scores/laminar.yaml
@@ -12,7 +12,7 @@ openness:
     shows: Apache-2.0 license; Rust+TS source public; OTel-native tracing/evals/datasets features
     accessed: '2026-06-04'
   - url: https://pypi.org/project/lmnr/
-    shows: lmnr v0.7.52 (27 May 2026), open-source LLM engineering platform SDK
+    shows: lmnr v0.7.52 (27 May 2026), open source LLM engineering platform SDK
     accessed: '2026-06-04'
 adoption:
   level: 3

--- a/sources/scores/langchain.yaml
+++ b/sources/scores/langchain.yaml
@@ -20,7 +20,7 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: LangChain + LangGraph open-source frameworks surpassed 1B cumulative downloads with 90M+ combined
+  note: LangChain + LangGraph open source frameworks surpassed 1B cumulative downloads with 90M+ combined
     monthly downloads. Monthly volume exceeds 10M, placing it at the top band.
   sources:
   - url: https://www.langchain.com/langchain

--- a/sources/scores/langfuse.yaml
+++ b/sources/scores/langfuse.yaml
@@ -20,7 +20,7 @@ adoption:
   reach: 100K-1M
   signal_type: reported_traction
   confidence: high
-  note: Described as the most widely adopted open-source LLM engineering platform; acquired by ClickHouse
+  note: Described as the most widely adopted open source LLM engineering platform; acquired by ClickHouse
     Mar 2026. No precise verified download/active-user count, rated 3 on reported traction.
   sources:
   - url: https://github.com/langfuse/langfuse

--- a/sources/scores/langsmith.yaml
+++ b/sources/scores/langsmith.yaml
@@ -11,7 +11,7 @@ openness:
     software, not source-available.
   sources:
   - url: https://www.langchain.com/langsmith
-    shows: LangSmith described as managed SaaS with BYOC/self-host enterprise options; open-source items
+    shows: LangSmith described as managed SaaS with BYOC/self-host enterprise options; open source items
       are LangChain/LangGraph frameworks, not LangSmith
     accessed: '2026-06-04'
 adoption:

--- a/sources/scores/langwatch.yaml
+++ b/sources/scores/langwatch.yaml
@@ -6,7 +6,7 @@ openness:
     langwatch/ee/ require commercial license for production;source:public
   confidence: high
   note: 'Explicit open-core: Apache-2.0 core + MIT SDKs, with an /ee enterprise directory (SCIM, audit
-    logs, billing) commercially licensed — same pattern as the Langfuse O4 anchor.'
+    logs, billing) commercially licensed, same pattern as the Langfuse O4 anchor.'
   sources:
   - url: https://github.com/langwatch/langwatch
     shows: Apache-2.0 core, MIT SDKs, langwatch/ee/ enterprise modules requiring commercial license

--- a/sources/scores/le-chat.yaml
+++ b/sources/scores/le-chat.yaml
@@ -5,7 +5,7 @@ openness:
   components: license:proprietary(SaaS app);source:closed(the Le Chat product; underlying Mistral models
     are open-weights but the chat UI/service is not);self-host:none
   confidence: high
-  note: The Le Chat product/service is proprietary SaaS (closed) — distinct from Mistral's open-weight
+  note: The Le Chat product/service is proprietary SaaS (closed), distinct from Mistral's open-weight
     models scored elsewhere; closed counterpart on the shelf.
   sources:
   - url: https://techcrunch.com/2025/02/19/mistrals-le-chat-tops-1m-downloads-in-just-14-days/
@@ -18,7 +18,7 @@ adoption:
   confidence: medium
   note: ~1.7M app downloads by May 2026 (TechCrunch reported 1M in 14 days at Feb 2025 launch); Mistral
     states EU monthly active recipients below 45M (a DSA ceiling, not a measured MAU); ~10.8M desktop
-    visits to mistral.ai Mar 2026. Honest read places real active users in the 1-10M band — level 4. The
+    visits to mistral.ai Mar 2026. Honest read places real active users in the 1-10M band, level 4. The
     <45M is a regulatory cap not an actual count, so not used as the headline.
   sources:
   - url: https://techcrunch.com/2025/02/19/mistrals-le-chat-tops-1m-downloads-in-just-14-days/

--- a/sources/scores/lighteval.yaml
+++ b/sources/scores/lighteval.yaml
@@ -16,7 +16,7 @@ adoption:
   signal_type: usage_volume
   confidence: medium
   note: ~37,239 PyPI downloads in the last month (pypistats). Powers the HF Open LLM Leaderboard and is
-    the reproducible eval suite behind it — meaningful in the eval/research community but a smaller install
+    the reproducible eval suite behind it; meaningful in the eval/research community but a smaller install
     base than general-purpose harnesses. 2.4k GitHub stars corroborate only. Headline = PyPI volume (primary).
   sources:
   - url: https://pypistats.org/packages/lighteval
@@ -34,7 +34,7 @@ capability:
     via inspect-ai backend'
   confidence: high
   note: Strong across the recipe's feature-matrix dimensions (coverage, backend breadth, reproducibility,
-    some agentic support). Not a 5 — lm-evaluation-harness remains the broader de-facto standard cited
+    some agentic support). Not a 5; lm-evaluation-harness remains the broader de-facto standard cited
     in more frontier release reports; lighteval is the HF-leaderboard-tied counterpart.
   sources:
   - url: https://github.com/huggingface/lighteval

--- a/sources/scores/livecodebench.yaml
+++ b/sources/scores/livecodebench.yaml
@@ -7,7 +7,7 @@ openness:
     problems with hidden test cases bundled
   confidence: medium
   note: Open and downloadable with a datasheet, but the HF card declares only a generic 'cc' license (no
-    specific CC variant), so the exact reuse terms are ambiguous — scored open but not a clean CC-BY;
+    specific CC variant), so the exact reuse terms are ambiguous. Scored open but not a clean CC-BY;
     capped at 4.
   sources:
   - url: https://huggingface.co/datasets/livecodebench/code_generation_lite
@@ -21,7 +21,7 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: medium
-  note: 71,393 monthly HF downloads (primary). De facto standard contamination-free coding benchmark —
+  note: 71,393 monthly HF downloads (primary). De facto standard contamination-free coding benchmark;
     LiveCodeBench appears as a headline coding metric in frontier model release reports (e.g. DeepSeek-V4-Pro
     reports LiveCodeBench Pass@1 93.5 in the frozen flagship set). 'Usage' here is downloads + benchmark
     citation, not end-users; placed at 4 on download volume plus release-report standard status, which

--- a/sources/scores/llama-3-1.yaml
+++ b/sources/scores/llama-3-1.yaml
@@ -16,7 +16,7 @@ openness:
       weights behind terms acceptance
     accessed: '2026-06-04'
   - url: https://github.com/meta-llama/llama-models/blob/main/models/llama3_1/LICENSE
-    shows: Llama 3.1 Community License Section 2 — 700M MAU commercial threshold requiring a separate
+    shows: Llama 3.1 Community License Section 2, 700M MAU commercial threshold requiring a separate
       Meta license (verified, replaces the prior Llama 2 proxy)
     accessed: '2026-06-04'
 adoption:
@@ -25,7 +25,7 @@ adoption:
   signal_type: usage_volume
   confidence: medium
   note: 'Foundational base family. CORRECTED: HF page for the 3.1 8B base shows ~1.29M downloads/month
-    (not the ''tens of thousands'' the record claimed) — the single base SKU alone is in the millions/mo.
+    (not the ''tens of thousands'' the record claimed); the single base SKU alone is in the millions/mo.
     Family-level reach (Llama ~476M cumulative HF downloads per ATOM, second only to Qwen) well into 1-10M+
     band. Calibrated to Llama 4 anchor (A4).'
   sources:

--- a/sources/scores/lovable.yaml
+++ b/sources/scores/lovable.yaml
@@ -4,8 +4,8 @@ openness:
   class: closed
   components: source:closed;license:proprietary(SaaS);self-host:no
   confidence: high
-  note: Proprietary SaaS app builder; closed source. (GPT Engineer, its open-source predecessor, is a
-    separate legacy repo — the scored product is the proprietary Lovable platform.)
+  note: Proprietary SaaS app builder; closed source. (GPT Engineer, its open source predecessor, is a
+    separate legacy repo; the scored product is the proprietary Lovable platform.)
   sources:
   - url: https://lovable.dev
     shows: proprietary SaaS AI app builder, chat-to-build, one-click deploy
@@ -31,7 +31,7 @@ capability:
     deploy, MCP server, integrations; no published SWE-bench/GAIA
   confidence: low
   note: Capable autonomous app builder targeted at non-developers; full-app generation rather than benchmark
-    SWE work, no first-party benchmark — scored 3 on feature matrix.
+    SWE work, no first-party benchmark; scored 3 on feature matrix.
   sources:
   - url: https://lovable.dev
     shows: autonomous build-from-prompt, MCP server, integrations features

--- a/sources/scores/math.yaml
+++ b/sources/scores/math.yaml
@@ -3,11 +3,11 @@ openness:
   score: 2
   class: gated
   components: data:NOT downloadable from canonical HF repo (access disabled, DMCA takedown);license:MIT(declared);datasheet:present(card
-    still documents schema);redistributability:BLOCKED on the primary registry — problems sourced from
+    still documents schema);redistributability:BLOCKED on the primary registry; problems sourced from
     AMC/AIME competitions, takedown reflects unresolved rights
   confidence: medium
   note: Declared MIT, but the canonical HF dataset is access-disabled under a DMCA takedown, so it is
-    not currently redistributable from the primary registry — scored gated/blocked rather than open. Mirrors
+    not currently redistributable from the primary registry; scored gated/blocked rather than open. Mirrors
     and eval harnesses still embed it, but the primary source is walled; revisit if the takedown is resolved.
   sources:
   - url: https://huggingface.co/datasets/hendrycks/competition_math
@@ -18,7 +18,7 @@ adoption:
   reach: 1M-10M
   signal_type: reported_traction
   confidence: medium
-  note: MATH is one of the most-cited math-reasoning standards — MATH / MATH-500 appears as a headline
+  note: MATH is one of the most-cited math-reasoning standards; MATH / MATH-500 appears as a headline
     metric across frontier model release reports (the top adoption signal for a benchmark). Despite the
     canonical HF repo being takedown-walled, the benchmark itself remains pervasively used via mirrors
     and eval harnesses. Level 4 on release-report standard status; no clean current download count obtainable
@@ -32,5 +32,5 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: Dataset — not capability-scored.
+  note: Dataset, not capability-scored.
   sources: []

--- a/sources/scores/memryx-mx3.yaml
+++ b/sources/scores/memryx-mx3.yaml
@@ -5,14 +5,14 @@ openness:
   components: schematics:no;toolchain:open runtime (MxAccl) + utils + driver mirror, closed NeuralCompiler;datasheets:public;blobs:proprietary
     silicon;retail:Amazon/Mouser ~$149
   confidence: high
-  note: Proprietary dataflow silicon with public datasheets, retail availability, and several open-source
+  note: Proprietary dataflow silicon with public datasheets, retail availability, and several open source
     runtime/driver repos, though the compiler core is closed.
   sources:
   - url: https://developer.memryx.com/specs/M.2_datasheet.html
     shows: 'MX3 M.2 datasheet: chip count, TOPS, data formats, power'
     accessed: '2026-06-22'
   - url: https://github.com/memryx/MxAccl
-    shows: open-source MemryX C++ runtime library
+    shows: open source MemryX C++ runtime library
     accessed: '2026-06-22'
 adoption:
   level: 3

--- a/sources/scores/meta-ai.yaml
+++ b/sources/scores/meta-ai.yaml
@@ -40,7 +40,7 @@ capability:
     + image gen); embedded across messaging surfaces; consumer single-user (no enterprise RAG / multi-provider
     model hub / org-data grounding); limited plugin/tool breadth vs frontier chat UIs'
   confidence: medium
-  note: Broad-reach consumer assistant but narrow on the ui_api feature axes — one provider, consumer-only,
+  note: Broad-reach consumer assistant but narrow on the ui_api feature axes, one provider, consumer-only,
     limited enterprise/RAG/plugin depth. Not a category frontier-definer on capability.
   sources:
   - url: https://www.demandsage.com/meta-ai-users/

--- a/sources/scores/microsoft-copilot.yaml
+++ b/sources/scores/microsoft-copilot.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components: license:proprietary(SaaS/embedded);source:closed;self-host:none;model:OpenAI+Microsoft(closed)
   confidence: high
-  note: Fully proprietary, SaaS/embedded — the closed counterpart on the UI/API shelf.
+  note: Fully proprietary, SaaS/embedded, the closed counterpart on the UI/API shelf.
   sources:
   - url: https://learn.microsoft.com/en-us/microsoft-365/admin/activity-reports/microsoft-copilot-usage?view=o365-worldwide
     shows: Microsoft 365 Copilot Chat is a Microsoft-operated proprietary product (admin usage reporting
@@ -18,7 +18,7 @@ adoption:
   note: ~420M monthly active users across all Copilot surfaces (Windows/Edge/M365/Bing/mobile) reported
     Q1 2026, with ~160M enterprise-licensed; far above the >10M threshold. Actively-engaged M365 seats
     are much lower (~33M), but the consumer + embedded surface reach is mass-market. Headline aggregated
-    figure traces to Microsoft disclosures via aggregators — primary per-surface breakdown not directly
+    figure traces to Microsoft disclosures via aggregators; primary per-surface breakdown not directly
     fetched, so medium confidence.
   sources:
   - url: https://www.businessofapps.com/data/microsoft-copilot-statistics/

--- a/sources/scores/milvus.yaml
+++ b/sources/scores/milvus.yaml
@@ -22,7 +22,7 @@ adoption:
   reach: 100K-1M
   signal_type: reported_traction
   confidence: high
-  note: Described as the default open-source engine for billion-scale semantic search; LF AI & Data graduate.
+  note: Described as the default open source engine for billion-scale semantic search; LF AI & Data graduate.
     No precise verified deployment/download count, rated 3 on reported traction.
   sources:
   - url: https://github.com/milvus-io/milvus

--- a/sources/scores/mistral-large-2.yaml
+++ b/sources/scores/mistral-large-2.yaml
@@ -3,9 +3,9 @@ openness:
   score: 2
   class: restricted
   components: 'weights:open(downloadable on HF);data:closed;code:closed;license:Mistral-Research-License(MRL,
-    non-OSI: research/non-commercial only — commercial use requires a paid Mistral agreement)'
+    non-OSI: research/non-commercial only; commercial use requires a paid Mistral agreement)'
   confidence: high
-  note: 'Weights downloadable but under the Mistral Research License — non-commercial/research-only (CONFIRMED:
+  note: 'Weights downloadable but under the Mistral Research License, non-commercial/research-only (CONFIRMED:
     card explicitly restricts to personal/scientific/academic non-profit use; commercial requires contacting
     Mistral). Notable contrast with Mistral Large 3''s Apache-2.0. No base-only weights published; public
     SKU is instruct.'

--- a/sources/scores/mmlu.yaml
+++ b/sources/scores/mmlu.yaml
@@ -5,7 +5,7 @@ openness:
   components: data:downloadable(HF parquet, cais/mmlu);license:MIT(OSI/open);datasheet:present(card documents
     57 subjects, splits dev/val/test, schema);redistributable:yes;paper:public(ICLR 2021)
   confidence: high
-  note: 'Clean open data: MIT, downloadable, documented datasheet, public paper — full open class.'
+  note: 'Clean open data: MIT, downloadable, documented datasheet, public paper: full open class.'
   sources:
   - url: https://huggingface.co/datasets/cais/mmlu
     shows: MIT license, 57 subjects, 231,400 rows / 14,042 test, 541,723 monthly downloads, documented
@@ -16,9 +16,9 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: 541,723 monthly HF downloads (primary) — highest in this batch. MMLU is the canonical general-knowledge
+  note: 541,723 monthly HF downloads (primary), highest in this batch. MMLU is the canonical general-knowledge
     LLM benchmark, reported in essentially every frontier model release (OpenAI, Anthropic, Google, Meta,
-    DeepSeek, Qwen) since 2021 — the strongest possible release-report standard signal. Even post-saturation
+    DeepSeek, Qwen) since 2021, the strongest possible release-report standard signal. Even post-saturation
     it remains a universal reference. Level 5 on download volume + ubiquitous release-report citation.
   sources:
   - url: https://huggingface.co/datasets/cais/mmlu
@@ -32,6 +32,6 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: Dataset — not capability-scored. Saturation/contamination (top models 88-94%, superseded by MMLU-Pro
+  note: Dataset, not capability-scored. Saturation/contamination (top models 88-94%, superseded by MMLU-Pro
     for differentiation) is a quality caveat noted in version_note, not an openness or capability deduction.
   sources: []

--- a/sources/scores/multipl-e.yaml
+++ b/sources/scores/multipl-e.yaml
@@ -7,7 +7,7 @@ openness:
     a non-OSI 'BSD-3-Clause + no-ML-training' modified license, conflicting with the MIT on the HF data
     artifact
   confidence: medium
-  note: The scored artifact (HF dataset) is MIT and openly downloadable with a datasheet — open class.
+  note: The scored artifact (HF dataset) is MIT and openly downloadable with a datasheet, open class.
     But the source repo carries a modified BSD-3 with an explicit 'may not be used as training data for
     ML' clause (non-OSI), a conflict worth flagging; scored on the data artifact's MIT terms, capped at
     4 for the licensing inconsistency.
@@ -40,5 +40,5 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: Dataset/translation framework — not capability-scored.
+  note: Dataset/translation framework, not capability-scored.
   sources: []

--- a/sources/scores/muse-spark.yaml
+++ b/sources/scores/muse-spark.yaml
@@ -5,13 +5,13 @@ openness:
   components: weights:closed;data:closed;code:closed;license:Proprietary(meta.ai/Meta AI app + private
     API preview; no downloadable weights)
   confidence: high
-  note: No weights released — a closed assistant-surface model; only a private API preview. Fully closed.
+  note: No weights released, a closed assistant-surface model; only a private API preview. Fully closed.
   sources:
   - url: https://ai.meta.com/blog/introducing-muse-spark-msl/
     shows: Muse Spark available at meta.ai and Meta AI app + private API preview; no open weights
     accessed: '2026-06-04'
   - url: https://about.fb.com/news/2026/04/introducing-muse-spark-meta-superintelligence-labs/
-    shows: 'Meta primary newsroom post: Muse Spark proprietary (hope to open-source future versions);
+    shows: 'Meta primary newsroom post: Muse Spark proprietary (hope to open source future versions);
       powers Meta AI app/meta.ai + private API preview to select partners'
     accessed: '2026-06-04'
 adoption:
@@ -20,7 +20,7 @@ adoption:
   signal_type: active_users
   confidence: low
   note: Powers the Meta AI assistant on meta.ai and the Meta AI app (rolling out to WhatsApp/Instagram/Facebook/Messenger/AI
-    glasses), an enormous consumer surface — but Meta discloses no Muse Spark-specific user count, and
+    glasses), an enormous consumer surface, but Meta discloses no Muse Spark-specific user count, and
     at scoring time it is not yet the model behind the full family of surfaces. Placed at 4 on the consumer-app
     surface it powers; not 5 because no standalone figure and rollout incomplete. Attributed honestly
     to the surface, not the model.

--- a/sources/scores/new-relic-ai-monitoring.yaml
+++ b/sources/scores/new-relic-ai-monitoring.yaml
@@ -17,8 +17,8 @@ adoption:
   signal_type: usage_volume
   confidence: medium
   note: New Relic platform reported at ~6.6M platform users / 75,000+ businesses in 2026 (1-10M band).
-    Figure is platform-wide, not AIM-specific, and the hard numbers came from aggregators (landbase/zoominfo)
-    — vendor product page confirms the AIM module and broad enterprise tiers but I did not fetch a primary
+    Figure is platform-wide, not AIM-specific, and the hard numbers came from aggregators (landbase/zoominfo);
+    vendor product page confirms the AIM module and broad enterprise tiers but I did not fetch a primary
     user count; treat level as platform-attributed and directional.
   sources:
   - url: https://newrelic.com/platform/ai-monitoring

--- a/sources/scores/northflank-sandboxes.yaml
+++ b/sources/scores/northflank-sandboxes.yaml
@@ -5,7 +5,7 @@ openness:
   components: service:proprietary(Northflank managed SaaS);source:closed;isolation:microVM;no self-hostable
     open runtime
   confidence: high
-  note: Proprietary managed deployment/sandbox platform; no open-source runtime published.
+  note: Proprietary managed deployment/sandbox platform; no open source runtime published.
   sources:
   - url: https://northflank.com/
     shows: Northflank Sandboxes = secure microVM sandbox for untrusted/code-gen execution; proprietary

--- a/sources/scores/olmo-2.yaml
+++ b/sources/scores/olmo-2.yaml
@@ -42,7 +42,7 @@ capability:
   confidence: high
   note: OLMo 2 32B is the most capable; reported competitive with GPT-3.5-Turbo / GPT-4o-mini class and
     Qwen 2.5 on academic benchmarks but below current frontier open models (DeepSeek-V4, Qwen 3.6). Mid-tier
-    capability — the value proposition is full openness, not raw SOTA.
+    capability; the value proposition is full openness, not raw SOTA.
   sources:
   - url: https://allenai.org/blog/olmo2
     shows: flagship phase-C verification source

--- a/sources/scores/onnx-runtime.yaml
+++ b/sources/scores/onnx-runtime.yaml
@@ -18,7 +18,7 @@ adoption:
   note: '~74.7M PyPI downloads in the last month for the onnxruntime package; GitHub reports ''used by''
     ~89.9k repositories. Embedded across Microsoft products and the broader ML deployment stack. Well
     into the >10M band on download volume. (Note: onnxruntime spans general ML inference, not only LLM
-    serving — see capability/recategorize note.)'
+    serving; see capability/recategorize note.)'
   sources:
   - url: https://pypistats.org/packages/onnxruntime
     shows: ~74.7M downloads last month

--- a/sources/scores/openai-code-interpreter.yaml
+++ b/sources/scores/openai-code-interpreter.yaml
@@ -19,7 +19,7 @@ adoption:
   confidence: low
   note: Code Interpreter ships inside ChatGPT (advanced data analysis) and the Assistants/Responses API;
     the ChatGPT surface it rides has ~1B weekly users (flagship anchor record, GPT-5). No standalone Code-Interpreter
-    usage figure is disclosed, so adoption is attributed to the surface — placed conservatively at 4 (a
+    usage figure is disclosed, so adoption is attributed to the surface, placed conservatively at 4 (a
     fraction of ChatGPT users invoke code execution) with low confidence given no primary per-tool number.
   sources:
   - url: https://developers.openai.com/api/docs/assistants/tools/code-interpreter
@@ -34,7 +34,7 @@ capability:
     scale: OpenAI infra'
   confidence: low
   note: Reliable Python-only data-analysis sandbox with iterative retry, but single-language, undisclosed
-    isolation, and session-scoped — narrower than general-purpose deployment sandboxes. Mid-tier; capability
+    isolation, and session-scoped, narrower than general-purpose deployment sandboxes. Mid-tier; capability
     detail limited because OpenAI does not document the isolation/scale internals.
   sources:
   - url: https://developers.openai.com/api/docs/assistants/tools/code-interpreter

--- a/sources/scores/openai-evals-api-dashboard.yaml
+++ b/sources/scores/openai-evals-api-dashboard.yaml
@@ -32,7 +32,7 @@ capability:
     deprecated.
   confidence: medium
   note: Convenient managed eval surface for OpenAI-model users, but narrow (single-provider, no benchmark
-    library) and on a deprecation path — not a frontier harness.
+    library) and on a deprecation path, not a frontier harness.
   sources:
   - url: https://developers.openai.com/api/docs/guides/evals
     shows: grading methods, dataset upload, run execution vs OpenAI APIs, dashboard + cost analysis

--- a/sources/scores/openai-fine-tuning-api.yaml
+++ b/sources/scores/openai-fine-tuning-api.yaml
@@ -5,7 +5,7 @@ openness:
   components: source:closed;training-code:closed;runs-on:OpenAI-platform-only;license:Proprietary(paid
     API service)
   confidence: high
-  note: Proprietary managed fine-tuning service — no source, runs only on OpenAI's platform against OpenAI's
+  note: Proprietary managed fine-tuning service, no source, runs only on OpenAI's platform against OpenAI's
     closed models.
   sources:
   - url: https://developers.openai.com/api/docs/guides/model-optimization

--- a/sources/scores/openfn.yaml
+++ b/sources/scores/openfn.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components: license:LGPL-3.0/GPL-3.0(OSI copyleft);source:public;no feature-gated core per maintainers
   confidence: high
-  note: Fully open-source DPG with copyleft licensing and no feature-gated core.
+  note: Fully open source DPG with copyleft licensing and no feature-gated core.
   sources:
   - url: https://github.com/OpenFn/lightning
     shows: OpenFn/lightning, dual-licensed LGPL-3.0/GPL-3.0, fully open source, verified DPG

--- a/sources/scores/openllmetry.yaml
+++ b/sources/scores/openllmetry.yaml
@@ -35,7 +35,7 @@ capability:
     export(25+ platforms); NO native prompt management, evals/LLM-as-judge, or datasets/annotation in
     the OSS layer
   confidence: high
-  note: Strong on tracing + integrations but narrow vs full platforms — it is an instrumentation layer,
+  note: Strong on tracing + integrations but narrow vs full platforms; it is an instrumentation layer,
     not an eval/prompt/dataset suite. Below the MLflow/Langfuse/Phoenix/Opik feature breadth (C4).
   sources:
   - url: https://github.com/traceloop/openllmetry

--- a/sources/scores/openpcc.yaml
+++ b/sources/scores/openpcc.yaml
@@ -9,7 +9,7 @@ openness:
     is an open-core *business* around a fully open standard, not open-core licensing.
   sources:
   - url: https://github.com/openpcc/openpcc
-    shows: Apache-2.0; "open-source framework for verifiably private AI inference"; OHTTP gateway, attestation,
+    shows: Apache-2.0; "open source framework for verifiably private AI inference"; OHTTP gateway, attestation,
       transparency log, client SDKs
     accessed: '2026-06-17'
   - url: https://cloudsecurityalliance.org/blog/2025/11/13/introducing-openpcc

--- a/sources/scores/openpipe.yaml
+++ b/sources/scores/openpipe.yaml
@@ -12,7 +12,7 @@ openness:
     shows: Apache-2.0 license text (OpenPipe, Inc. 2025; LGPL-3.0 notice for vendored portions)
     accessed: '2026-06-04'
   - url: https://github.com/OpenPipe/ART
-    shows: ART = open-source GRPO RL trainer; v0.5.17 release; active dev
+    shows: ART = open source GRPO RL trainer; v0.5.17 release; active dev
     accessed: '2026-06-04'
 adoption:
   level: 2

--- a/sources/scores/openrlhf.yaml
+++ b/sources/scores/openrlhf.yaml
@@ -29,7 +29,7 @@ capability:
     rollout + DeepSpeed; multi-turn agent RL; scales to 70B+ across multiple GPUs. Deep, production-grade
     distributed RLHF specialization; narrower than general FT tools but strong on large-scale RL.'
   confidence: medium
-  note: Strong distributed-RLHF capability (Ray+vLLM+DeepSpeed, 70B+) — C4; below the Megatron-LM frontier-scale
+  note: Strong distributed-RLHF capability (Ray+vLLM+DeepSpeed, 70B+), C4; below the Megatron-LM frontier-scale
     anchor and method scope is RL-centric rather than full-spectrum.
   sources:
   - url: https://github.com/OpenRLHF/OpenRLHF

--- a/sources/scores/openrouter.yaml
+++ b/sources/scores/openrouter.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components: license:proprietary(hosted gateway);source:closed(SDK present, core service closed);self-host:none
   confidence: high
-  note: Proprietary hosted routing gateway — the closed counterpart to open gateways (LiteLLM); listed
+  note: Proprietary hosted routing gateway, the closed counterpart to open gateways (LiteLLM); listed
     as closed in the recipe.
   sources:
   - url: https://openrouter.ai/
@@ -34,7 +34,7 @@ capability:
     + data policies; OpenAI-compatible drop-in API; provider/model ranking analytics. Hits every gateway
     feature-matrix dimension at the top of the category.'
   confidence: high
-  note: Frontier-defining for the gateway slot — broadest provider coverage + routing/fallback at the
+  note: Frontier-defining for the gateway slot, broadest provider coverage + routing/fallback at the
     largest measured token scale; the closed counterpart that sets the bar LiteLLM (C4) approaches on
     the open side.
   sources:

--- a/sources/scores/opensandbox.yaml
+++ b/sources/scores/opensandbox.yaml
@@ -5,7 +5,7 @@ openness:
   components: license:Apache-2.0(OSI);source:public(Go execd + multi-language SDKs);runtimes:Docker/Kubernetes;no-managed-tier-observed;no-feature-gated-core
   confidence: high
   note: Apache-2.0, fully self-hostable, no managed/enterprise gating observed => open_source (not open_core).
-    Alibaba says it open-sourced the sandbox infra used internally.
+    Alibaba says it open sourced the sandbox infra used internally.
   sources:
   - url: https://github.com/alibaba/OpenSandbox
     shows: Apache-2.0 license; general-purpose AI-agent sandbox; Docker/K8s runtimes; multi-language SDKs;
@@ -17,7 +17,7 @@ adoption:
   signal_type: stars_fallback
   confidence: low
   note: 'Only ~2-3 months old; no PyPI/download or named-deployment figures surfaced. ~11.3k GitHub stars
-    (3,845 within 72h of launch) is the only signal — stars_fallback, which caps level at 3. Placed at
+    (3,845 within 72h of launch) is the only signal, stars_fallback, which caps level at 3. Placed at
     2: rapid early stars but no usage volume yet. Revisit as usage data emerges.'
   sources:
   - url: https://github.com/alibaba/OpenSandbox

--- a/sources/scores/opik.yaml
+++ b/sources/scores/opik.yaml
@@ -35,7 +35,7 @@ capability:
     metrics(hallucination/moderation/relevance/context-precision), prompt playground, datasets, cost tracking
   confidence: high
   note: Covers all six feature-matrix dimensions; on par with MLflow/Langfuse anchors (C4). Not scored
-    5 — closed Arize AX leads category capability.
+    5; closed Arize AX leads category capability.
   sources:
   - url: https://github.com/comet-ml/opik
     shows: tracing, evals, LLM-as-judge, prompt management, datasets, OTel

--- a/sources/scores/osworld.yaml
+++ b/sources/scores/osworld.yaml
@@ -21,7 +21,7 @@ adoption:
   confidence: medium
   note: 'Top adoption signal for a harness = cited as the standard in frontier release reports: OSWorld
     scores reported in OpenAI (CUA 38.1%, GPT-5.4 75.0%), Anthropic (Claude Sonnet 4.5 61.4%, Sonnet 4.6
-    72.5%, Opus 4.6 72.7%) computer-use launches through 2026. Reach band is directional — the harness
+    72.5%, Opus 4.6 72.7%) computer-use launches through 2026. Reach band is directional. The harness
     is run by a concentrated set of frontier labs/agent teams rather than a mass install base. 2.9k stars
     corroborate only.'
   sources:
@@ -39,7 +39,7 @@ capability:
     trajectories; model-backend breadth: any VLM/LLM agent (Operator, GPT, Gemini, Claude, UI-TARS, Agent-S,
     Qwen, CogAgent baselines); reproducibility: multi-platform virtualization (VMware/VirtualBox/Docker/AWS)'
   confidence: high
-  note: Frontier-defining within evaluation_code for the computer-use/agentic axis — execution-based,
+  note: Frontier-defining within evaluation_code for the computer-use/agentic axis. Execution-based,
     real-environment agent evaluation is the hardest eval modality and OSWorld is its reference harness.
     A 5 here is for the category's frontier-definers; OSWorld qualifies for agentic eval.
   sources:

--- a/sources/scores/patronus-evaluation-platform.yaml
+++ b/sources/scores/patronus-evaluation-platform.yaml
@@ -6,7 +6,7 @@ openness:
     client-SDKs:open(patronus-py public on GitHub, v0.1.25, but only 7 stars and wires to the hosted API);
     eval engine + proprietary evaluators not self-hostable
   confidence: medium
-  note: Open-source SDK is a thin client to a closed hosted evaluation backend — the core scoring engine
+  note: Open-source SDK is a thin client to a closed hosted evaluation backend; the core scoring engine
     and managed evaluators are proprietary => open_core, low end (the OSS surface is a connector, not
     the product). License text not displayed on the SDK repo page (note).
   sources:
@@ -23,7 +23,7 @@ adoption:
   reach: null
   signal_type: unknown
   confidence: low
-  note: No disclosed user/customer counts or usage volume found on the docs/homepage this run; open-source
+  note: No disclosed user/customer counts or usage volume found on the docs/homepage this run; open source
     SDK has only 7 GitHub stars (stars_fallback would cap at hobbyist and is not an honest signal for
     a hosted platform). Declining to assign a level rather than infer from marketing.
   sources:

--- a/sources/scores/perplexity-sonar-api.yaml
+++ b/sources/scores/perplexity-sonar-api.yaml
@@ -8,7 +8,7 @@ openness:
   note: Fully closed search-grounded API; no weights, source, or self-host path.
   sources:
   - url: https://docs.perplexity.ai/
-    shows: Sonar/Search/Embeddings APIs, token + per-request pricing — proprietary hosted service
+    shows: Sonar/Search/Embeddings APIs, token + per-request pricing, proprietary hosted service
     accessed: '2026-06-04'
 adoption:
   level: 4
@@ -34,7 +34,7 @@ capability:
     ranked Search API with filtering; Embeddings API for RAG; Agent API routes to external models (e.g.
     GPT-5.x)
   confidence: medium
-  note: Strong {coverage, freshness, structured output} — grounded answers + raw search + embeddings in
+  note: Strong {coverage, freshness, structured output}, grounded answers + raw search + embeddings in
     one API; near-frontier among agent search/retrieval APIs but a wrapper-plus-search rather than a category-defining
     5.
   sources:

--- a/sources/scores/perplexity.yaml
+++ b/sources/scores/perplexity.yaml
@@ -17,7 +17,7 @@ adoption:
   note: CEO Aravind Srinivas (cited Apr 2026) reports 100M+ MAU across all products; standalone chatbot
     ~33M MAU; ~780M queries/mo (May 2025) growing >20% MoM to an estimated 1.2-1.5B/mo by mid-2026. Even
     the standalone-chat figure (33M) clears >10M. Headline user count is CEO-attributed via aggregators
-    (Sacra), not a directly-fetched primary disclosure — medium confidence.
+    (Sacra), not a directly-fetched primary disclosure, medium confidence.
   sources:
   - url: https://www.businessofapps.com/data/perplexity-ai-statistics/
     shows: 100M+ MAU all products / ~33M standalone chatbot (CEO-attributed, compiled)

--- a/sources/scores/phoenix.yaml
+++ b/sources/scores/phoenix.yaml
@@ -5,14 +5,14 @@ openness:
   components: 'license:Elastic-License-2.0(ELv2, non-OSI: prohibits offering as a managed/hosted service
     to third parties);source:public;self-hostable;commercial:Arize-AX-SaaS-is-separate-closed-product'
   confidence: high
-  note: LICENSE file is ELv2 verbatim, not an OSI license; Arize markets Phoenix as 'the open-source platform'
+  note: LICENSE file is ELv2 verbatim, not an OSI license; Arize markets Phoenix as 'the open source platform'
     (open_washed). Source-available + self-hostable, but not OSI open_source.
   sources:
   - url: https://github.com/Arize-ai/phoenix/blob/main/LICENSE
     shows: Elastic License 2.0 (ELv2) full text
     accessed: '2026-06-04'
   - url: https://arize.com/phoenix/
-    shows: marketed as 'the open-source platform'; 'ELv2 licensed. 9k+ GitHub stars'
+    shows: marketed as 'the open source platform'; 'ELv2 licensed. 9k+ GitHub stars'
     accessed: '2026-06-04'
 adoption:
   level: 4

--- a/sources/scores/pinecone.yaml
+++ b/sources/scores/pinecone.yaml
@@ -5,7 +5,7 @@ openness:
   components: license:proprietary(SaaS);source:closed;self-host:none(BYOC runs Pinecone-managed in customer
     VPC, not OSS);managed:Pinecone-Cloud
   confidence: high
-  note: Fully proprietary managed vector DB; no open-source core (contrast Milvus/Qdrant which are OSI-licensed).
+  note: Fully proprietary managed vector DB; no open source core (contrast Milvus/Qdrant which are OSI-licensed).
     BYOC is still closed-source software run in customer cloud.
   sources:
   - url: https://www.pinecone.io/pricing/

--- a/sources/scores/playwright-mcp.yaml
+++ b/sources/scores/playwright-mcp.yaml
@@ -30,7 +30,7 @@ capability:
     console, tabs, file upload, code-eval; cross-browser via Playwright
   confidence: medium
   note: Deep, broad browser-control surface (the leading agentic browser tool); scored 4 on the scrape/browse
-    feature matrix — strong coverage but no standardized benchmark and not the single category-definer.
+    feature matrix, strong coverage but no standardized benchmark and not the single category-definer.
   sources:
   - url: https://github.com/microsoft/playwright-mcp
     shows: browser automation feature set via structured snapshots

--- a/sources/scores/predibase.yaml
+++ b/sources/scores/predibase.yaml
@@ -2,8 +2,8 @@ product: predibase
 openness:
   score: 2
   class: open_core
-  components: core-platform:closed(proprietary post-training stack + turbo serving);OSS-components:LoRAX(open-source
-    multi-LoRA serving)+Ludwig(open-source);runs-on:Predibase-SaaS-or-customer-VPC;license:Proprietary(managed)
+  components: core-platform:closed(proprietary post-training stack + turbo serving);OSS-components:LoRAX(open source
+    multi-LoRA serving)+Ludwig(open source);runs-on:Predibase-SaaS-or-customer-VPC;license:Proprietary(managed)
     with Apache-licensed LoRAX/Ludwig adjuncts
   confidence: high
   note: 'Open-core: the founders created and maintain OSS LoRAX (multi-LoRA serving) and Ludwig, but the
@@ -12,7 +12,7 @@ openness:
     at the serving/declarative-ML edges.'
   sources:
   - url: https://docs.predibase.com/
-    shows: managed platform to fine-tune & serve open-source LLMs; SFT/RFT/continued-pretraining; built
+    shows: managed platform to fine-tune & serve open source LLMs; SFT/RFT/continued-pretraining; built
       by LoRAX creators; SaaS/VPC
     accessed: '2026-06-04'
   - url: https://www.rubrik.com/company/newsroom/press-releases/25/rubrik-to-acquire-predibase-to-accelerate-agentic-ai-adoption
@@ -41,7 +41,7 @@ capability:
   value: 'Methods: supervised fine-tuning, reinforcement fine-tuning (first end-to-end RFT platform for
     LLMs, GRPO-style; learns from outcomes/feedback without heavy data prep), continued pretraining; LoRA
     + LoRAX multi-adapter serving (hundreds of fine-tuned models per GPU); turbo serving (~2x). Tunes
-    open-source base models.'
+    open source base models.'
   confidence: medium
   note: 'Strong managed method depth - notably the pioneer of end-to-end RFT for LLMs - plus efficient
     multi-LoRA serving over open models. Scored 4: matches the RFT-capable managed services (OpenAI/Azure/Fireworks

--- a/sources/scores/promptlayer.yaml
+++ b/sources/scores/promptlayer.yaml
@@ -5,7 +5,7 @@ openness:
   components: license:Apache-2.0(OSI, client library MagnivOrg/prompt-layer-library only);platform:proprietary-SaaS(API-key
     gated, hosted prompt registry/logging/evals);self-host:no(managed only)
   confidence: high
-  note: Open client SDK over a closed hosted backend (prompt CMS, logging, evals are SaaS) — no OSS core,
+  note: Open client SDK over a closed hosted backend (prompt CMS, logging, evals are SaaS), no OSS core,
     so 'closed' alongside the Braintrust/LangSmith pattern; the open library is instrumentation only.
   sources:
   - url: https://github.com/MagnivOrg/prompt-layer-library
@@ -31,7 +31,7 @@ capability:
     Missing: deep LLM-as-judge eval + broad OTel/framework observability vs anchors.'
   confidence: medium
   note: Strong prompt-lifecycle/versioning focus but shallower eval + production observability than MLflow/Langfuse
-    (C4) per 2026 comparisons — rated 3, mid-tier.
+    (C4) per 2026 comparisons, rated 3, mid-tier.
   sources:
   - url: https://github.com/MagnivOrg/prompt-layer-library
     shows: version/test/monitor prompts and agents with evals, tracing, regression sets

--- a/sources/scores/pythia.yaml
+++ b/sources/scores/pythia.yaml
@@ -24,7 +24,7 @@ adoption:
   confidence: high
   note: 'Heavily used as a research/interpretability benchmark suite (de facto standard for training-dynamics
     studies); cited extensively. Hugging Face download volume across the 16 models is in the 100k-1M aggregate
-    range — meaningful for research but not production deployment. Honest signal: research adoption, not
+    range, meaningful for research but not production deployment. Honest signal: research adoption, not
     end-user scale.'
   sources:
   - url: https://huggingface.co/EleutherAI/pythia-6.9b

--- a/sources/scores/qdrant.yaml
+++ b/sources/scores/qdrant.yaml
@@ -5,7 +5,7 @@ openness:
   components: license:Apache-2.0(OSI, engine core);source:public(Rust);managed-tier:Qdrant Cloud (hosted,
     paid + free tier)
   confidence: high
-  note: Engine core is Apache-2.0 OSI, but a managed Qdrant Cloud tier sits on top — recipe explicitly
+  note: Engine core is Apache-2.0 OSI, but a managed Qdrant Cloud tier sits on top; recipe explicitly
     classes Qdrant Cloud as open_core, so scored 4 rather than the pure-OSS 5 the Milvus anchor carries.
   sources:
   - url: https://github.com/qdrant/qdrant/blob/master/LICENSE
@@ -19,7 +19,7 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: qdrant-client ~26.1M PyPI downloads in the last month — a strong, primary usage_volume signal
+  note: qdrant-client ~26.1M PyPI downloads in the last month, a strong, primary usage_volume signal
     placing it in the 1-10M+ monthly band; a leading open vector DB for RAG/agent retrieval. Sits one
     above the Milvus anchor's A3 on download volume (Milvus anchored at A3); reasonable given Qdrant's
     very high client-download count.

--- a/sources/scores/qwen-2-5.yaml
+++ b/sources/scores/qwen-2-5.yaml
@@ -2,8 +2,8 @@ product: qwen-2-5
 openness:
   score: 2
   class: restricted
-  components: weights:open(downloadable on HF);data:closed;code:partial(inference; no training pipeline);license:mixed
-    — 0.5B-14B Apache-2.0, but flagship 72B & 3B under Qwen-License-Agreement(non-OSI, 100M MAU commercial
+  components: weights:open(downloadable on HF);data:closed;code:partial(inference; no training pipeline);license:mixed,
+    0.5B-14B Apache-2.0, but flagship 72B & 3B under Qwen-License-Agreement(non-OSI, 100M MAU commercial
     cap)
   confidence: high
   note: 'Flagship 72B base carries the Qwen License with a 100M MAU cap (CONFIRMED in license Section
@@ -11,7 +11,7 @@ openness:
     smaller sizes are Apache. Mixed-tier across the family.'
   sources:
   - url: https://huggingface.co/Qwen/Qwen2.5-72B/blob/main/LICENSE
-    shows: Qwen License Agreement Section 4 — 100M MAU commercial cap requiring separate authorization
+    shows: Qwen License Agreement Section 4, 100M MAU commercial cap requiring separate authorization
     accessed: '2026-06-04'
   - url: https://huggingface.co/Qwen/Qwen2.5-72B
     shows: base 72B model (not instruct), qwen license tag, 68,655 downloads/mo
@@ -21,7 +21,7 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: medium
-  note: Qwen family ~942M cumulative HF downloads (>50% of all global open-source downloads per ATOM);
+  note: Qwen family ~942M cumulative HF downloads (>50% of all global open source downloads per ATOM);
     Qwen2.5 was the dominant fine-tune base through 2025. The 72B base alone shows 68,655 downloads/mo
     (confirmed). Family reach unambiguously >10M; calibrated to Qwen 3.6 anchor (A5).
   sources:
@@ -32,7 +32,7 @@ capability:
   score: 3
   basis: benchmark:Artificial Analysis Intelligence Index
   value: 'Qwen2.5 72B: AA Intelligence Index 16, ranked #10/39, ''well above average'' among similar-size
-    open non-reasoning models — but a 2024 generation surpassed by Qwen3/Qwen 3.6.'
+    open non-reasoning models, but a 2024 generation surpassed by Qwen3/Qwen 3.6.'
   confidence: medium
   note: Strong for its generation, mid-tier in 2026; below the Qwen 3.6 anchor (C5).
   sources:

--- a/sources/scores/qwen-3-6.yaml
+++ b/sources/scores/qwen-3-6.yaml
@@ -27,10 +27,10 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: 'ATOM Report (Apr 2026): Qwen family ~942.1M cumulative HF downloads (>50% of all global open-source
+  note: 'ATOM Report (Apr 2026): Qwen family ~942.1M cumulative HF downloads (>50% of all global open source
     downloads), overtook Llama in Sept 2025; >113,000 derivative models (>200,000 incl tagged); 69% of
     new fine-tunes by Feb 2026 build on Qwen. Qwen 3.6 is the current flagship generation of that dominant
-    family — unambiguously >10M reach.'
+    family, unambiguously >10M reach.'
   sources:
   - url: https://arxiv.org/html/2604.07190v1
     shows: flagship phase-C verification source

--- a/sources/scores/qwen2-5-coder-instruct.yaml
+++ b/sources/scores/qwen2-5-coder-instruct.yaml
@@ -28,7 +28,7 @@ capability:
   value: Aider code-repair 73.7 (comparable to GPT-4o); McEval 65.9, MdEval 75.2 (1st among open at 2024
     release); SOTA open coder at launch
   confidence: high
-  note: Best open-source code LLM at its Sep 2024 release (GPT-4o-class on Aider), but a 2024 dense model
+  note: Best open source code LLM at its Sep 2024 release (GPT-4o-class on Aider), but a 2024 dense model
     now mid-tier vs 2026 frontier coders. Aider 73.7 from the primary Qwen blog.
   sources:
   - url: https://qwenlm.github.io/blog/qwen2.5-coder-family/

--- a/sources/scores/ragas.yaml
+++ b/sources/scores/ragas.yaml
@@ -16,7 +16,7 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: ~1.51M PyPI downloads in the last 30 days (pypistats) — de facto standard for RAG/LLM-app evaluation,
+  note: ~1.51M PyPI downloads in the last 30 days (pypistats), de facto standard for RAG/LLM-app evaluation,
     widely integrated (LangChain, LlamaIndex, observability platforms). Stars (14.2k) corroborate. Solidly
     in the 1M-10M monthly band.
   sources:

--- a/sources/scores/replit-agent-code-execution-api.yaml
+++ b/sources/scores/replit-agent-code-execution-api.yaml
@@ -2,7 +2,7 @@ product: replit-agent-code-execution-api
 openness:
   score: 2
   class: open_core
-  components: service:proprietary(Replit managed Autoscale Deployments);sandbox-runtime:omegajail(open-source,
+  components: service:proprietary(Replit managed Autoscale Deployments);sandbox-runtime:omegajail(open source,
     github.com/omegaup/omegajail unprivileged container);client:replit-code-exec(PyPI / github.com/replit/replit-code-exec,
     ISC, ARCHIVED 2025-02-11);no self-hostable execution service
   confidence: medium
@@ -12,7 +12,7 @@ openness:
     OSS core product to self-host.
   sources:
   - url: https://replit.com/blog/ai-agents-code-execution
-    shows: Code Execution API uses omegajail (open-source unprivileged container sandbox) on Replit's
+    shows: Code Execution API uses omegajail (open source unprivileged container sandbox) on Replit's
       proprietary Autoscale Deployments; replit-code-exec PyPI client; Python-focused
     accessed: '2026-06-04'
   - url: https://github.com/replit/replit-code-exec
@@ -35,7 +35,7 @@ adoption:
     at 4 (platform-surface reach); the API alone would be lower.
   sources:
   - url: https://cloud.google.com/blog/products/serverless/whats-new-for-cloud-run-at-next26
-    shows: Replit runs >1M live projects (on Cloud Run) — primary-source scale signal for the Replit surface
+    shows: Replit runs >1M live projects (on Cloud Run), primary-source scale signal for the Replit surface
     accessed: '2026-06-04'
   - url: https://replit.com/products/agent
     shows: Replit Agent product page (the agent surface the code-exec API backs)

--- a/sources/scores/sambanova-cloud.yaml
+++ b/sources/scores/sambanova-cloud.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components: license:proprietary;software-stack:closed(SambaFlow compiler/runtime not open);hardware:SN40L-RDU-only;delivery:managed-cloud-API
   confidence: high
-  note: Proprietary managed cloud inference on SambaNova's own RDU silicon; no open-source software disclosed.
+  note: Proprietary managed cloud inference on SambaNova's own RDU silicon; no open source software disclosed.
     Scored closed.
   sources:
   - url: https://sambanova.ai/blog/sn40l-chip-best-inference-solution

--- a/sources/scores/scale-evaluation.yaml
+++ b/sources/scores/scale-evaluation.yaml
@@ -7,8 +7,8 @@ openness:
     transparency) but no open eval code or self-hostable engine; human-eval workforce is a proprietary
     service
   confidence: high
-  note: Proprietary by design — the deliberately-private benchmark datasets and hosted expert-eval workforce
-    are the moat; no open-source eval code. Closed.
+  note: Proprietary by design; the deliberately-private benchmark datasets and hosted expert-eval workforce
+    are the moat; no open source eval code. Closed.
   sources:
   - url: https://scale.com/genai-platform
     shows: 'Scale GenAI Platform: automated + expert-human evaluation ''Trust Feedback Loop''; test against
@@ -43,7 +43,7 @@ capability:
     by design (private datasets); standardization: high (neutral third-party)'
   confidence: medium
   note: 'Very broad professional eval coverage (multi-domain private benchmarks + expert workforce + adversarial
-    red-teaming + real-preference) — strong commercial capability. Not a 5: closed/non-reproducible and
+    red-teaming + real-preference), strong commercial capability. Not a 5: closed/non-reproducible and
     not a community-standard harness in the open-eval-code sense.'
   sources:
   - url: https://scale.com/blog/leaderboard

--- a/sources/scores/scale-seal-leaderboard.yaml
+++ b/sources/scores/scale-seal-leaderboard.yaml
@@ -12,7 +12,7 @@ openness:
   sources:
   - url: https://scale.com/blog/leaderboard
     shows: Scale states SEAL datasets remain private/unpublished, combining proprietary held-out sets
-      (~1,000 examples) with some open-source sets
+      (~1,000 examples) with some open source sets
     accessed: '2026-06-04'
 adoption:
   level: 3

--- a/sources/scores/serper.yaml
+++ b/sources/scores/serper.yaml
@@ -28,7 +28,7 @@ capability:
   value: 'coverage: web/images/news/maps/shopping/video/scholar/patents/autocomplete; structured JSON
     output; ~1-2s latency; freshness=live Google index'
   confidence: medium
-  note: Broad search-type coverage with structured output and live freshness — solid feature matrix for
+  note: Broad search-type coverage with structured output and live freshness; solid feature matrix for
     a search API, but thinner than full agent-search tools (no built-in extraction/answer synthesis like
     Tavily/Exa). Rated 3 on coverage/freshness/structured-output dimensions.
   sources:

--- a/sources/scores/sillytavern.yaml
+++ b/sources/scores/sillytavern.yaml
@@ -5,7 +5,7 @@ openness:
   confidence: high
   components: license:AGPL-3.0(OSI, copyleft);source:public(github.com/SillyTavern/SillyTavern);self-host:only(local
     install);no-managed-tier;extensions:third-party
-  note: AGPL-3.0 (OSI-approved copyleft), full source public, self-host only — fully open. No proprietary/SaaS
+  note: AGPL-3.0 (OSI-approved copyleft), full source public, self-host only, fully open. No proprietary/SaaS
     tier.
   sources:
   - url: https://github.com/SillyTavern/SillyTavern
@@ -17,7 +17,7 @@ adoption:
   signal_type: stars_fallback
   confidence: low
   note: No published download/install or active-user counts found (self-hosted desktop app, no telemetry).
-    Falling back to 28.9k GitHub stars + 300+ contributors as the only honest signal — capped at level
+    Falling back to 28.9k GitHub stars + 300+ contributors as the only honest signal, capped at level
     3 per the stars-fallback rule. Likely a large enthusiast/roleplay community but unverified.
   sources:
   - url: https://github.com/SillyTavern/SillyTavern
@@ -30,7 +30,7 @@ capability:
     + TTS integration); RAG/lorebooks: yes; plugins/extensions: yes (third-party); multi-user: no (single-user
     local)'
   confidence: medium
-  note: Feature-rich for its niche — broad backend coverage, image-gen/TTS, extensions, character/roleplay
+  note: Feature-rich for its niche, broad backend coverage, image-gen/TTS, extensions, character/roleplay
     tooling (Visual Novel mode). Specialized toward roleplay rather than general-purpose assistant work;
     mid-tier on the general chat-UI matrix.
   sources:

--- a/sources/scores/sipeed-maixcam.yaml
+++ b/sources/scores/sipeed-maixcam.yaml
@@ -12,7 +12,7 @@ openness:
     shows: 'spec page: SG2002 RISC-V, 1 TOPS NPU, 256MB DDR3, open schematics/datasheets, MaixPy/MaixCDK'
     accessed: '2026-06-22'
   - url: https://github.com/sipeed/MaixPy
-    shows: open-source (Apache-2.0) Python SDK for MaixCAM
+    shows: open source (Apache-2.0) Python SDK for MaixCAM
     accessed: '2026-06-22'
 adoption:
   level: 3
@@ -23,7 +23,7 @@ adoption:
     among hobbyist and RISC-V edge-AI developers.
   sources:
   - url: https://github.com/sipeed/MaixPy
-    shows: active open-source repo and release cadence
+    shows: active open source repo and release cadence
     accessed: '2026-06-22'
 capability:
   score: 2

--- a/sources/scores/smolagents.yaml
+++ b/sources/scores/smolagents.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components: license:Apache-2.0(OSI);source:public(github.com/huggingface/smolagents);no-feature-gated-core;model-agnostic
   confidence: high
-  note: Fully OSI-licensed (Apache-2.0), entire library public, no proprietary/managed core — top openness,
+  note: Fully OSI-licensed (Apache-2.0), entire library public, no proprietary/managed core, top openness,
     above open-core framework anchors (CrewAI/LangChain).
   sources:
   - url: https://github.com/huggingface/smolagents
@@ -16,7 +16,7 @@ adoption:
   signal_type: usage_volume
   confidence: high
   note: 694,642 PyPI downloads in the last month (pypistats, confirmed). Monthly download volume in the
-    100K-1M band — meaningful but below heavyweight framework anchors (LangChain, CrewAI).
+    100K-1M band, meaningful but below heavyweight framework anchors (LangChain, CrewAI).
   sources:
   - url: https://pypistats.org/packages/smolagents
     shows: 694,642 downloads in the last month (verified)

--- a/sources/scores/spaces.yaml
+++ b/sources/scores/spaces.yaml
@@ -6,7 +6,7 @@ openness:
     self-hostable Spaces);hardware-tiers:CPU free + paid GPU upgrades
   confidence: medium
   note: The app SDKs (Gradio etc.) are OSS and apps run as arbitrary Docker, but the Spaces hosting/orchestration
-    platform is a closed managed service — open SDKs over a proprietary host = open_core-ish. Not self-hostable
+    platform is a closed managed service; open SDKs over a proprietary host = open_core-ish. Not self-hostable
     as Spaces.
   sources:
   - url: https://huggingface.co/docs/hub/spaces

--- a/sources/scores/suna.yaml
+++ b/sources/scores/suna.yaml
@@ -5,7 +5,7 @@ openness:
   confidence: high
   components: license:Elastic License 2.0(non-OSI, source-available, restricts hosting as a managed service);source:public;managed
     cloud + self-host tiers
-  note: Verified Elastic License 2.0 in the LICENSE file — source-available, NOT OSI; restricts providing
+  note: Verified Elastic License 2.0 in the LICENSE file, source-available, NOT OSI; restricts providing
     the software as a hosted/managed service. Marketed as 'open source' but carries managed-service restrictions;
     flagged open_washed.
   sources:

--- a/sources/scores/swe-bench-verified.yaml
+++ b/sources/scores/swe-bench-verified.yaml
@@ -7,7 +7,7 @@ openness:
     itself (the public 500-instance set is fully released; gold patches + tests included);data-source:real
     GitHub PR/issue pairs
   confidence: medium
-  note: Effectively open — ungated, downloadable, full gold patches and tests, datasheet present — but
+  note: Effectively open (ungated, downloadable, full gold patches and tests, datasheet present) but
     the HF dataset card declares NO explicit license field, so the data-license class is inferred from
     the MIT harness repo and public redistribution rather than a stated data license. Scored 4 not 5 on
     that ambiguity. (Distinct from SWE-bench's broader/hidden variants which can carry held-out splits.)

--- a/sources/scores/swift.yaml
+++ b/sources/scores/swift.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components: license:Apache-2.0(OSI);source:public;maintainer:ModelScope(Alibaba);no feature-gated core
   confidence: high
-  note: Fully OSI-licensed open-source training/deploy framework; source public.
+  note: Fully OSI-licensed open source training/deploy framework; source public.
   sources:
   - url: https://github.com/modelscope/ms-swift
     shows: Apache-2.0 license; v4.2.3 (May 31 2026); ModelScope/Alibaba maintainer

--- a/sources/scores/tavily-search-api.yaml
+++ b/sources/scores/tavily-search-api.yaml
@@ -9,7 +9,7 @@ openness:
     are open, the search service itself is proprietary.
   sources:
   - url: https://docs.tavily.com/
-    shows: API keys, credits, rate limits, hosted endpoints — no self-hostable open core
+    shows: API keys, credits, rate limits, hosted endpoints, no self-hostable open core
     accessed: '2026-06-04'
 adoption:
   level: 4

--- a/sources/scores/tensorrt-llm.yaml
+++ b/sources/scores/tensorrt-llm.yaml
@@ -20,7 +20,7 @@ adoption:
   signal_type: reported_traction
   confidence: high
   note: Production inference optimizer/runtime for NVIDIA GPUs; used in MLPerf submissions (HGX H100 GPT-J
-    ~3x gains). Described in 2026 as the 'specialist's tool' — narrower adoption than vLLM/SGLang due
+    ~3x gains). Described in 2026 as the 'specialist's tool', narrower adoption than vLLM/SGLang due
     to compilation overhead and NVIDIA-only scope. ~13.8k stars. Level 3 reflects significant but more
     specialized usage; no clean user/download count verified.
   sources:

--- a/sources/scores/thunderbolt.yaml
+++ b/sources/scores/thunderbolt.yaml
@@ -12,7 +12,7 @@ openness:
     shows: public source repo under MPL-2.0; "AI You Control" self-hosted client
     accessed: '2026-06-17'
   - url: https://www.phoronix.com/news/Mozilla-Thunderbolt
-    shows: MZLA launches Thunderbolt as an open-source enterprise AI client (Apr 2026)
+    shows: MZLA launches Thunderbolt as an open source enterprise AI client (Apr 2026)
     accessed: '2026-06-17'
 adoption:
   level: 2

--- a/sources/scores/ti-am67a.yaml
+++ b/sources/scores/ti-am67a.yaml
@@ -13,7 +13,7 @@ openness:
     shows: 'official page: 4 TOPS C7x+MMA, quad A53, public datasheet, ACTIVE status, SDKs'
     accessed: '2026-06-22'
   - url: https://github.com/TexasInstruments/edgeai-tidl-tools
-    shows: open-source TIDL deep-learning toolchain for AM67A-class processors
+    shows: open source TIDL deep-learning toolchain for AM67A-class processors
     accessed: '2026-06-22'
 adoption:
   level: 3

--- a/sources/scores/tinker.yaml
+++ b/sources/scores/tinker.yaml
@@ -34,8 +34,8 @@ capability:
     like Qwen3-235B-A22B, DeepSeek, Nemotron); abstracts distributed multi-GPU training behind 4-function
     API. Largest demonstrated: 550B-class MoE fine-tuning.'
   confidence: medium
-  note: Strong fine-tuning capability — frontier-scale model breadth and managed distributed training
-    — but LoRA-centric (not full FT / full RL stack), so 4 not 5. Feature-matrix basis; no MLPerf-Training
+  note: Strong fine-tuning capability (frontier-scale model breadth and managed distributed training)
+    but LoRA-centric (not full FT / full RL stack), so 4 not 5. Feature-matrix basis; no MLPerf-Training
     submission.
   sources:
   - url: https://thinkingmachines.ai/tinker/

--- a/sources/scores/tinyllama-1-1b-chat-v1-0.yaml
+++ b/sources/scores/tinyllama-1-1b-chat-v1-0.yaml
@@ -6,7 +6,7 @@ openness:
   components: weights:open(Apache-2.0);base:TinyLlama-1.1B(open, 3T-token pretrain documented);post-training:SFT
     on UltraChat + DPO on UltraFeedback(both public datasets);code:open(pretraining project public);license:Apache-2.0(OSI)
   note: 'Unusually transparent for a chat model: open base, and named public alignment datasets (UltraChat
-    SFT + UltraFeedback DPO). Scored 4 open_weights — just short of full open_source since the base pretraining
+    SFT + UltraFeedback DPO). Scored 4 open_weights, just short of full open_source since the base pretraining
     data is documented but the end-to-end reproducible pipeline is not packaged as one release. Strongest
     openness in this batch alongside Nemotron.'
   sources:
@@ -18,7 +18,7 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: ~2.31M HF downloads last month — a workhorse tiny-chat model for edge/testing/CI and educational
+  note: ~2.31M HF downloads last month, a workhorse tiny-chat model for edge/testing/CI and educational
     use. Solidly in the 1-10M monthly-download band.
   sources:
   - url: https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0
@@ -31,7 +31,7 @@ capability:
     benchmarks
   confidence: high
   note: Intentionally tiny (1.1B, 2023 Llama-2 architecture). Its value is footprint and openness, not
-    capability — scored 1 against a 2026 frontier comparison set. Not built to compete on reasoning/coding
+    capability; scored 1 against a 2026 frontier comparison set. Not built to compete on reasoning/coding
     suites.
   sources:
   - url: https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0

--- a/sources/scores/together-inference-engine.yaml
+++ b/sources/scores/together-inference-engine.yaml
@@ -5,7 +5,7 @@ openness:
   components: engine:proprietary(Together Inference Engine);source:closed(though Together publishes OSS
     research e.g. FlashAttention/ThunderKittens separately);access:managed-cloud-API-only;license:Proprietary
   confidence: high
-  note: The inference engine/service itself is proprietary, API-only; closed per recipe. (Together open-sources
+  note: The inference engine/service itself is proprietary, API-only; closed per recipe. (Together open sources
     research components like FlashAttention separately, but those are not the serving engine.)
   sources:
   - url: https://www.together.ai/

--- a/sources/scores/torchtune.yaml
+++ b/sources/scores/torchtune.yaml
@@ -31,11 +31,11 @@ capability:
   basis: feature_matrix
   value: 'Methods: SFT, knowledge distillation, DPO/PPO/GRPO, QAT; parallelism: single-device, multi-device,
     multi-node, FSDP2; memory-efficiency focus; integrations (HF Hub, W&B). Capability frozen at 2025
-    wind-down — no FP8/FP4 or newer-method additions; behind actively-developed peers and the Megatron-LM
+    wind-down; no FP8/FP4 or newer-method additions; behind actively-developed peers and the Megatron-LM
     anchor.'
   confidence: medium
   note: Competent native-PyTorch method/parallelism coverage but development halted in 2025, so it no
-    longer tracks the moving frontier — C3.
+    longer tracks the moving frontier, C3.
   sources:
   - url: https://github.com/pytorch/torchtune
     shows: SFT/distillation/DPO/PPO/GRPO/QAT, FSDP2, single/multi-device/multi-node

--- a/sources/scores/unsloth.yaml
+++ b/sources/scores/unsloth.yaml
@@ -33,7 +33,7 @@ capability:
     models; multiple quant formats. Single-node memory/speed optimization is its frontier edge; less focused
     on multi-node frontier-scale parallelism than Megatron-LM.'
   confidence: high
-  note: Best-in-class single-/consumer-GPU efficiency (kernel-level), broad method coverage; C4 — not
+  note: Best-in-class single-/consumer-GPU efficiency (kernel-level), broad method coverage; C4, not
     the frontier multi-node-scale anchor.
   sources:
   - url: https://github.com/unslothai/unsloth

--- a/sources/scores/vals-ai.yaml
+++ b/sources/scores/vals-ai.yaml
@@ -6,7 +6,7 @@ openness:
     Index on non-public datasets);eval-harness:closed
   confidence: high
   note: Closed third-party eval platform; benchmarks deliberately held private to prevent dataset leakage,
-    eval infra not open-sourced.
+    eval infra not open sourced.
   sources:
   - url: https://www.vals.ai
     shows: proprietary SaaS eval platform, 'proprietary benchmarks' require contact, no GitHub/self-host

--- a/sources/scores/vellum.yaml
+++ b/sources/scores/vellum.yaml
@@ -8,7 +8,7 @@ openness:
   note: 'CORRECTED from record''s ''closed/score 1''. Primary check disproves it: the agent''s complete
     source is public and MIT-licensed (LICENSE file: ''Copyright (c) 2025 Vellum AI'', full app incl.
     backend gateway, Mac/Slack/Telegram clients, sandboxed skill framework, memory system), self-hostable
-    by design — not a client/SDK stub. Vendor''s own marketing comparison table paradoxically labels Vellum
+    by design, not a client/SDK stub. Vendor''s own marketing comparison table paradoxically labels Vellum
     ''Proprietary'' (vs MIT for Hermes/OpenClaw) because it sells a managed cloud tier; but the core agent
     is genuinely open source. Class=open_source; score 4 rather than 5 because the differentiated managed
     memory/security layer is a hosted add-on and the vendor markets the primary offering as proprietary
@@ -22,7 +22,7 @@ openness:
     shows: Vellum positioning as a personal assistant vs Hermes/OpenClaw (confirms entity)
     accessed: '2026-06-04'
   - url: https://github.com/vellum-ai/vellum-assistant
-    shows: 'PRIMARY: full open-source agent source (gateway+clients+skill framework+memory), MIT, ~577
+    shows: 'PRIMARY: full open source agent source (gateway+clients+skill framework+memory), MIT, ~577
       stars, 120+ releases (latest v0.8.7 Jun 2026)'
     accessed: '2026-06-04'
   - url: https://github.com/vellum-ai/vellum-assistant/blob/main/LICENSE
@@ -35,7 +35,7 @@ adoption:
   confidence: low
   note: No download/user/usage metrics disclosed (it's a self-hosted app, not a registry package). Only
     signal available is GitHub stars (~577 on vellum-ai/vellum-assistant), used here strictly as a last-resort
-    proxy per the adoption!=stars rule — small/new entrant. Previously null; set to a conservative level
+    proxy per the adoption!=stars rule; small/new entrant. Previously null; set to a conservative level
     1 now that a real (if weak) signal exists.
   sources:
   - url: https://github.com/vellum-ai/vellum-assistant

--- a/sources/scores/vertex-ai-tuning.yaml
+++ b/sources/scores/vertex-ai-tuning.yaml
@@ -5,7 +5,7 @@ openness:
   components: source:closed;training-code:closed;runs-on:Google-Cloud-Vertex-AI-only;license:Proprietary(managed
     GCP service)
   confidence: high
-  note: Proprietary managed tuning service inside Vertex AI — no source, runs only on Google Cloud against
+  note: Proprietary managed tuning service inside Vertex AI; no source, runs only on Google Cloud against
     closed Gemini models.
   sources:
   - url: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/tune-models

--- a/sources/scores/weave.yaml
+++ b/sources/scores/weave.yaml
@@ -6,7 +6,7 @@ openness:
     SaaS platform hosts traces/evals; full platform is proprietary, self-host is enterprise);eval+tracing-client:OSS
   confidence: high
   note: Apache-2.0 OSS instrumentation SDK (@weave.op tracing + eval scoring) but the trace store / dashboards
-    / monitoring backend is the proprietary W&B SaaS platform — open-core, calibrated below MLflow O5
+    / monitoring backend is the proprietary W&B SaaS platform, open-core, calibrated below MLflow O5
     (fully-OSS core) and at/with Langfuse O4 (OSS core + commercial backend).
   sources:
   - url: https://github.com/wandb/weave

--- a/sources/scores/webcontainers.yaml
+++ b/sources/scores/webcontainers.yaml
@@ -6,9 +6,9 @@ openness:
     for OSS/prototypes, commercial license required for for-profit production (charge beyond 10k API req/mo);distribution:@webcontainer/api
     npm (proprietary binary)
   confidence: high
-  note: The MIT 'open' repo holds no implementation — the runtime is closed and gated by a commercial
+  note: The MIT 'open' repo holds no implementation; the runtime is closed and gated by a commercial
     license for production use. Best classed source_available leaning closed; flag open_washed for the
-    MIT-issue-tracker-as-open-source framing.
+    MIT-issue-tracker-as-open source framing.
   sources:
   - url: https://github.com/stackblitz/webcontainer-core
     shows: MIT repo is a central hub for issues/bug reports, not the runtime implementation
@@ -39,7 +39,7 @@ capability:
     per-session in-browser; scale: runs on the end-user''s device (no server cost, no server scale)'
   confidence: medium
   note: Unique in-browser execution with instant start and zero server cost, but Node/JS-only and not
-    a general-purpose server-side code sandbox for arbitrary languages — a different (narrower) capability
+    a general-purpose server-side code sandbox for arbitrary languages, a different (narrower) capability
     profile than microVM/container peers. Mid-tier within deployment.
   sources:
   - url: https://webcontainers.io/

--- a/sources/scores/whylabs.yaml
+++ b/sources/scores/whylabs.yaml
@@ -2,16 +2,16 @@ product: whylabs
 openness:
   score: 4
   class: open_source
-  components: license:Apache-2.0(OSI, whylogs + LangKit + open-sourced platform);source:public(github.com/whylabs);hosted-SaaS:discontinued;status:company-ceased-ops,
-    platform open-sourced on closure
+  components: license:Apache-2.0(OSI, whylogs + LangKit + open sourced platform);source:public(github.com/whylabs);hosted-SaaS:discontinued;status:company-ceased-ops,
+    platform open sourced on closure
   confidence: high
   note: 'Scored on what remains accessible: the OSS stack. whylogs (data logging) + LangKit (LLM monitoring)
-    are Apache-2.0 OSI, and WhyLabs open-sourced its platform on shutdown. Not 5 because the hosted monitoring
+    are Apache-2.0 OSI, and WhyLabs open sourced its platform on shutdown. Not 5 because the hosted monitoring
     backend is no longer maintained/operating and the OSS pieces are libraries rather than a turnkey live
     observability product.'
   sources:
   - url: https://whylabs.ai/langkit
-    shows: '''WhyLabs, Inc. is discontinuing operations''; platform/whylogs/LangKit open-sourced'
+    shows: '''WhyLabs, Inc. is discontinuing operations''; platform/whylogs/LangKit open sourced'
     accessed: '2026-06-04'
   - url: https://github.com/whylabs/whylogs
     shows: whylogs Apache-2.0, 2.8k stars, public source
@@ -22,7 +22,7 @@ adoption:
   signal_type: stars_fallback
   confidence: low
   note: 'Hosted SaaS shut down (no active platform users). Remaining signal is the OSS libraries: whylogs
-    ~2.8k GitHub stars, last release Dec 2024 — stars_fallback caps at 3; placed at 2 given the dead commercial
+    ~2.8k GitHub stars, last release Dec 2024; stars_fallback caps at 3; placed at 2 given the dead commercial
     product and stalled release cadence. Honest signal is modest residual OSS usage, not a live platform.'
   sources:
   - url: https://github.com/whylabs/whylogs
@@ -33,11 +33,11 @@ capability:
   basis: feature_matrix
   value: 'whylogs(data logging/profiling, drift + data-quality monitoring, privacy-preserving) + LangKit(LLM
     text-quality/safety metrics: sentiment, toxicity, prompt-injection signals). No live tracing backend,
-    no eval-experiment/prompt-mgmt platform (open-sourced but unmaintained). Narrow vs anchor C4 tools.'
+    no eval-experiment/prompt-mgmt platform (open sourced but unmaintained). Narrow vs anchor C4 tools.'
   confidence: medium
   note: As living, usable capability it is a pair of monitoring libraries (drift + LLM safety metrics),
     not a full tracing/eval/prompt platform; with the hosted backend gone and releases stalled since Dec
-    2024, rated 2 — well below the MLflow/Langfuse C4 anchors.
+    2024, rated 2, well below the MLflow/Langfuse C4 anchors.
   sources:
   - url: https://github.com/whylabs/whylogs
     shows: whylogs data-logging/drift/data-quality monitoring library feature set; release cadence stalled


### PR DESCRIPTION
A brand/style consistency pass across the curated copy that appears in the published notebooks: standardise on **"open source"** (not "open-source") and remove **em dashes** from human-readable text.

## Scope
- **`notebooks/products-view.py`** — the 2 rendered "open-source" strings (its other em dashes are code comments and the `—` empty-cell/fallback glyphs, intentionally kept).
- **`sources/categories`** — straplines/comments (3 files).
- **`sources/products` + `sources/scores`** (351 files) — product descriptions and source notes, i.e. the data the regenerate bot folds into both notebooks (modal descriptions, the source list, the products-view gallery).

The ai-stack-map authored prose (`docs/methodology.md` + `render.py`) was handled in the methodology PR (#41).

## How
- **"open source"**: applied URL-safe — replacements skip `http(s)://` tokens, so links and repo paths (e.g. `crewai.com/open-source`, `github.com/google/gvisor`) are untouched, and the `open_source` class token (underscore) is unaffected. 166 prose replacements.
- **Em dashes**: there's no mechanical replacement that avoids comma splices, so this was a per-context pass (8 parallel agents over disjoint file batches, plus 2 hand-fixed stragglers). Each `—` became a comma, semicolon, period, parentheses, or colon based on the sentence. En dashes in numeric ranges and the table/empty-cell `—` glyphs were preserved.

## Verification
- `uv run python -m build.validate` → 0 errors (YAML intact across all 351 files).
- `uv run python -m build.serialize` + `build/products_view_data.py --check` → 421 products, 0 unresolved gallery exemplars.
- **Content-integrity audit**: a line-level diff check confirmed every changed line differs *only* in punctuation, casing, or "open source" — no wording, numbers, or URLs were altered, and no line counts changed.

No generated artifacts committed; the bot regenerates `notebook_data.json` and both notebook payloads on merge.