### PR TITLE
ci(regenerate): watch docs/methodology.md

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "sources/**"
+      - "docs/methodology.md"
       - "build/serialize.py"
       - "build/render.py"
       - "build/products_view_data.py"


### PR DESCRIPTION
`build/render.py` reads `docs/methodology.md` at build time, so methodology edits change the generated notebook. But the regenerate workflow only watched `sources/**` and `build/*.py`, so a methodology-only change (e.g. #45) didn't trigger a rebuild on merge and required a manual render + publish.

This adds `docs/methodology.md` to the workflow's trigger `paths` so methodology edits regenerate the notebook on merge, like every other build input.