### PR TITLE
Strip AI-generated visual artifacts from the notebooks

### DIFF
--- a/build/render.py
+++ b/build/render.py
@@ -301,9 +301,6 @@ def header(C, F, mo):
     # here as HTML with the live counts already substituted; see build/render.py.
     mo.Html(
         f'<div style="padding:40px 0 28px; border-bottom:2px solid {C["accent"]}; margin-bottom:36px;">'
-        f'<div style="font-family:{F["mono"]}; font-size:11px; color:{C["ink_3"]}; '
-        f'letter-spacing:0.1em; text-transform:uppercase; margin-bottom:10px;">'
-        f'Current AI</div>'
         f'<h1 style="font-family:{F["headline"]}; font-size:2.2rem; font-weight:600; '
         f'color:{C["ink"]}; margin:0 0 14px; line-height:1.05; letter-spacing:-0.025em;">'
         f'Open Source AI Map</h1>'
@@ -321,11 +318,11 @@ def stack_overview(C, DATA, F, ORDER, STACK_DESC, mix_counts, mo):
     # full openness-mix count chips.
     _rows = []
     _last_arc = None
-    for _i, _cid in enumerate(ORDER, start=1):
+    for _cid in ORDER:
         _cat = DATA["categories"][_cid]
         _arc = _cat["arc"]
         if _arc != _last_arc:
-            _bt = "none" if _last_arc is None else f"1px dashed {C['rule']}"
+            _bt = "none" if _last_arc is None else f"1px solid {C['rule']}"
             _mt = "8px" if _last_arc is None else "22px"
             _rows.append(
                 f'<div style="font-family:{F["mono"]}; font-size:10px; color:{C["accent"]}; '
@@ -340,9 +337,8 @@ def stack_overview(C, DATA, F, ORDER, STACK_DESC, mix_counts, mo):
             f'&nbsp;&nbsp;<span style="color:{C["closed"]};">\\u25cf</span> {_m["closed"]} closed'
         )
         _rows.append(
-            f'<div style="display:grid; grid-template-columns:32px 1fr 232px; gap:18px; '
+            f'<div style="display:grid; grid-template-columns:1fr 232px; gap:18px; '
             f'align-items:center; padding:14px 0; border-bottom:1px solid {C["rule"]};">'
-            f'<div style="font-family:{F["mono"]}; font-size:12px; color:{C["ink_3"]};">{_i:02d}</div>'
             f'<div><div style="font-family:{F["headline"]}; font-size:1.05rem; font-weight:600; '
             f'color:{C["ink"]}; line-height:1.2;">{_cat["label"]}</div>'
             f'<div style="font-family:{F["body"]}; font-size:0.85rem; color:{C["ink_3"]}; '
@@ -358,7 +354,7 @@ def stack_overview(C, DATA, F, ORDER, STACK_DESC, mix_counts, mo):
         f'letter-spacing:0.1em; text-transform:uppercase; margin-bottom:8px;">The stack at a glance</div>'
         f'<h2 style="font-family:{F["headline"]}; font-size:1.6rem; font-weight:600; color:{C["ink"]}; '
         f'margin:0 0 14px; letter-spacing:-0.015em;">'
-        f'{_n_arcs} layers \\u00b7 {len(ORDER)} categories \\u00b7 {_total} scored products</h2>'
+        f'{_n_arcs} layers, {len(ORDER)} categories, {_total} scored products</h2>'
         f'<p style="font-family:{F["body"]}; font-size:0.95rem; color:{C["ink_2"]}; margin:0 0 20px; line-height:1.6;">'
         f'Each row is one category, grouped into three layers. The dots show the openness mix of all its '
         f'products. Open in the long tail and closed at the '
@@ -647,7 +643,7 @@ def helpers(C, DATA, F, OPEN, STRAPLINES, VERDICT, mix_counts, mo, vbucket,
         _srcs = _category_sources(cid)
         _src_html = ""
         if _srcs:
-            _links = " &middot; ".join(
+            _links = ", ".join(
                 f'<a href="{_u.replace("&", "&amp;")}" target="_blank" rel="noopener" '
                 f'style="color:{C["accent"]}; text-decoration:none;">{_dom}</a>'
                 for _dom, _u in _srcs
@@ -658,8 +654,7 @@ def helpers(C, DATA, F, OPEN, STRAPLINES, VERDICT, mix_counts, mo, vbucket,
                 f'<div style="font-family:{F["body"]}; font-size:0.82rem; line-height:1.7;">{_links}</div>'
             )
         return (
-            f'<div style="margin:4px 0 16px; padding:14px 18px; background:{C["paper_2"]}; '
-            f'border-left:2px solid {C["ink_3"]};">'
+            f'<div style="margin:4px 0 16px; padding:14px 18px; background:{C["paper_2"]};">'
             f'<div style="font-family:{F["mono"]}; font-size:10px; color:{C["ink_3"]}; '
             f'letter-spacing:0.12em; text-transform:uppercase; margin-bottom:8px;">How this was scored</div>'
             f'<ul style="font-family:{F["body"]}; font-size:0.88rem; color:{C["ink_2"]}; '
@@ -705,7 +700,7 @@ def helpers(C, DATA, F, OPEN, STRAPLINES, VERDICT, mix_counts, mo, vbucket,
         _archead = ""
         if _first_in_arc:
             _archead = (
-                f'<div style="margin:44px 0 0; padding:14px 0 8px; border-top:1px dashed {C["rule"]};">'
+                f'<div style="margin:44px 0 0; padding:14px 0 8px; border-top:1px solid {C["rule"]};">'
                 f'<div style="font-family:{F["mono"]}; font-size:11px; color:{C["accent"]}; '
                 f'letter-spacing:0.14em; text-transform:uppercase;">{_arc}</div></div>'
             )
@@ -726,7 +721,7 @@ def helpers(C, DATA, F, OPEN, STRAPLINES, VERDICT, mix_counts, mo, vbucket,
             _archead
             + f'<div style="margin:28px 0 18px;">'
             f'<div style="font-family:{F["mono"]}; font-size:10px; color:{C["accent"]}; '
-            f'letter-spacing:0.1em; text-transform:uppercase; margin-bottom:6px;">{cat["arc"]} \\u00b7 {num:02d}</div>'
+            f'letter-spacing:0.1em; text-transform:uppercase; margin-bottom:6px;">{cat["arc"]}</div>'
             f'<h2 style="font-family:{F["headline"]}; font-size:1.4rem; font-weight:600; '
             f'color:{C["ink"]}; margin:0 0 8px;">{cat["label"]} '
             f'<span style="font-family:{F["mono"]}; font-size:0.8rem; color:{C["ink_3"]};">({len(prods)})</span></h2>'
@@ -792,17 +787,17 @@ def details_payload(DATA, ORDER, mo):
         var h='<div class="v3-bd"><div class="v3-modal"><button class="v3-x">Close \\u2715</button>'+
           '<h2>'+esc(p.product||'')+'</h2>'+
           '<div style="font-family:\\'DM Mono\\',monospace;font-size:11px;color:#a5bbbe;margin-bottom:6px;">'+
-            esc(p.org||'')+' \\u00b7 '+esc(p.type||'')+' \\u00b7 '+esc(p.category_label||'')+
-            (o.class?' \\u00b7 <span class="v3-pill" style="background:'+ocol(o.score)+';color:'+otext(o.score)+'">'+esc(o.class)+'</span>':'')+'</div>'+
+            esc(p.org||'')+', '+esc(p.type||'')+', '+esc(p.category_label||'')+
+            (o.class?' <span class="v3-pill" style="background:'+ocol(o.score)+';color:'+otext(o.score)+'">'+esc(o.class)+'</span>':'')+'</div>'+
           (p.description?'<div style="font-size:13px;color:#272726;line-height:1.5;margin:8px 0;">'+esc(p.description)+'</div>':'')+
           (p.version_note?'<div style="font-size:11.5px;color:#a5bbbe;line-height:1.45;margin:6px 0;">'+esc(p.version_note)+'</div>':'')+
-          '<div class="v3-sect">Openness \\u00b7 '+(o.score==null?'n/a':o.score+'/5')+' ('+esc(o.class||'')+')</div>'+
+          '<div class="v3-sect">Openness '+(o.score==null?'n/a':o.score+'/5')+' ('+esc(o.class||'')+')</div>'+
           row('Components',o.components)+row('Why',o.note)+row('Confidence',o.confidence)+
           '<div class="v3-row"><span class="v3-lbl">Sources</span><span class="v3-val">'+srcs(o.sources)+'</span></div>'+
-          '<div class="v3-sect">Adoption \\u00b7 '+(ad.level==null?'n/a':ad.level+'/5')+'</div>'+
+          '<div class="v3-sect">Adoption '+(ad.level==null?'n/a':ad.level+'/5')+'</div>'+
           row('Reach',ad.reach)+row('Signal',ad.signal_type)+row('Detail',ad.note)+row('Confidence',ad.confidence)+
           '<div class="v3-row"><span class="v3-lbl">Sources</span><span class="v3-val">'+srcs(ad.sources)+'</span></div>'+
-          '<div class="v3-sect">Capability \\u00b7 '+(cap.score==null?'n/a':cap.score+'/5')+'</div>'+
+          '<div class="v3-sect">Capability '+(cap.score==null?'n/a':cap.score+'/5')+'</div>'+
           row('Basis',cap.basis)+row('Value',cap.value)+row('Detail',cap.note)+row('Confidence',cap.confidence)+
           '<div class="v3-row"><span class="v3-lbl">Sources</span><span class="v3-val">'+srcs(cap.sources)+'</span></div>'+
           '</div></div>';
@@ -944,7 +939,7 @@ def uncategorized_long_tail(C, DATA, F, mo):
         _css
         + f'<div style="margin:48px 0 20px; padding:24px 0 0; border-top:2px solid {C["accent"]};">'
         f'<div style="font-family:{F["mono"]}; font-size:10px; color:{C["accent"]}; '
-        f'letter-spacing:0.1em; text-transform:uppercase; margin-bottom:8px;">The long tail \\u00b7 uncategorized</div>'
+        f'letter-spacing:0.1em; text-transform:uppercase; margin-bottom:8px;">The long tail</div>'
         f'<h2 style="font-family:{F["headline"]}; font-size:1.6rem; font-weight:600; color:{C["ink"]}; '
         f'margin:0 0 12px; letter-spacing:-0.015em;">{_c["uncategorized"]:,} more products, tracked but not yet scored</h2>'
         f'<p style="font-family:{F["body"]}; font-size:0.95rem; color:{C["ink_2"]}; margin:0 0 16px; line-height:1.6;">'
@@ -989,7 +984,7 @@ def framework_edges(C, FRAMEWORK_EDGES, F, mo):
     mo.Html(
         f'<div style="margin:48px 0 20px; padding:24px 0 0; border-top:2px solid {C["accent"]};">'
         f'<div style="font-family:{F["mono"]}; font-size:10px; color:{C["accent"]}; '
-        f'letter-spacing:0.1em; text-transform:uppercase; margin-bottom:8px;">The map\\u2019s edges \\u00b7 framework white-space</div>'
+        f'letter-spacing:0.1em; text-transform:uppercase; margin-bottom:8px;">The map\\u2019s edges</div>'
         f'<h2 style="font-family:{F["headline"]}; font-size:1.6rem; font-weight:600; color:{C["ink"]}; '
         f'margin:0 0 12px; letter-spacing:-0.015em;">What\\u2019s not on the map yet</h2>'
         f'<p style="font-family:{F["body"]}; font-size:0.95rem; color:{C["ink_2"]}; margin:0 0 18px; line-height:1.6;">'

--- a/notebooks/products-view.py
+++ b/notebooks/products-view.py
@@ -448,9 +448,6 @@ def engine(CATS, COMPONENTS, ORDER, STRUCTURAL_GAPS):
 def header(C, F, GENERATED, N_TOTAL, mo):
     mo.Html(
         f'<div style="padding:40px 0 28px; border-bottom:2px solid {C["accent"]}; margin-bottom:36px;">'
-        f'<div style="font-family:{F["mono"]}; font-size:11px; color:{C["ink_3"]}; '
-        f'letter-spacing:0.1em; text-transform:uppercase; margin-bottom:10px;">'
-        f'Current AI</div>'
         f'<h1 style="font-family:{F["headline"]}; font-size:2.2rem; font-weight:600; '
         f'color:{C["ink"]}; margin:0 0 14px; line-height:1.05; letter-spacing:-0.025em;">'
         f'You have an idea. Here’s the open stack to build it on.</h1>'
@@ -543,7 +540,7 @@ def coverage_matrix(C, CATS, F, GALLERY, HEALTH, ORDER, mo):
         f'<div style="margin:36px 0 8px;">'
         f'<div style="font-family:{F["mono"]}; font-size:10px; color:{C["accent"]}; '
         f'letter-spacing:0.1em; text-transform:uppercase; margin-bottom:8px;">'
-        f'Products × layers · the edges back to the map</div>'
+        f'Products × layers</div>'
         f'<p style="font-family:{F["body"]}; font-size:0.95rem; color:{C["ink_2"]}; margin:0 0 14px; line-height:1.6;">'
         f'Each row is a reference product; each column is one of the map’s categories, in stack order. '
         f'A filled cell means the product draws on that layer, colored by the strongest composition basis. '
@@ -563,7 +560,7 @@ def lookup_header(C, F, mo):
     mo.Html(
         f'<div style="margin:44px 0 14px; padding:24px 0 0; border-top:2px solid {C["accent"]};">'
         f'<div style="font-family:{F["mono"]}; font-size:10px; color:{C["accent"]}; '
-        f'letter-spacing:0.1em; text-transform:uppercase; margin-bottom:8px;">Lookup · mode 1</div>'
+        f'letter-spacing:0.1em; text-transform:uppercase; margin-bottom:8px;">Lookup</div>'
         f'<h2 style="font-family:{F["headline"]}; font-size:1.6rem; font-weight:600; color:{C["ink"]}; '
         f'margin:0 0 12px; letter-spacing:-0.015em;">Describe what you want to build</h2>'
         f'<p style="font-family:{F["body"]}; font-size:0.95rem; color:{C["ink_2"]}; margin:0; line-height:1.6;">'
@@ -637,7 +634,7 @@ def lookup_results(C, CATS, CAT_KW, F, OPEN_LABEL, ORDER, TH, gap_triggers,
                 f'<div style="margin:10px 0 14px;">'
                 f'<div style="font-family:{F["mono"]}; font-size:0.7rem; color:{C["ink_3"]}; '
                 f'text-transform:uppercase; letter-spacing:0.04em; margin-bottom:4px;">{CATS[_cid]["label"]}'
-                f' · <span style="color:{C["ink_2"]};">{CATS[_cid]["desc"]}</span></div>{_rows}</div>'
+                f': <span style="color:{C["ink_2"]};">{CATS[_cid]["desc"]}</span></div>{_rows}</div>'
             )
         _groups += (
             f'<div style="margin:14px 0;">'
@@ -700,8 +697,8 @@ def lookup_results(C, CATS, CAT_KW, F, OPEN_LABEL, ORDER, TH, gap_triggers,
         f'<div style="margin:8px 0 10px; padding:16px 20px; background:white; '
         f'border:1px solid {C["rule"]}; border-radius:0;">'
         f'<div style="font-family:{F["mono"]}; font-size:0.66rem; color:{C["ink_3"]}; margin-bottom:8px;">'
-        f'Query · “{_q}” · {"open components only" if _open_only else "all components"} '
-        f'· top 3 per layer, layers shown when best score ≥ {TH["show"]}</div>'
+        f'Query “{_q}”, {"open components only" if _open_only else "all components"}, '
+        f'top 3 per layer, shown when best score ≥ {TH["show"]}</div>'
         f'{_groups}{_gap_panel}</div>'
     )
     return
@@ -730,7 +727,7 @@ def gallery_cards(BASIS, BY_NAME, C, CATS, F, GALLERY, HEALTH, OPEN_LABEL, mo):
         )
 
     _cards = ""
-    for _i, _g in enumerate(GALLERY, 1):
+    for _g in GALLERY:
         _hl, _hck = HEALTH[_g["health"]]
         _arcs_html = ""
         for _arc in _ARCS:
@@ -773,7 +770,7 @@ def gallery_cards(BASIS, BY_NAME, C, CATS, F, GALLERY, HEALTH, OPEN_LABEL, mo):
             f'border:1px solid {C["rule"]}; border-radius:0;">'
             f'<div style="display:flex; justify-content:space-between; align-items:baseline; gap:12px;">'
             f'<h3 style="font-family:{F["headline"]}; font-size:1.25rem; font-weight:600; '
-            f'color:{C["ink"]}; margin:0;">{_i:02d} · {_g["title"]}</h3>'
+            f'color:{C["ink"]}; margin:0;">{_g["title"]}</h3>'
             f'<span style="font-family:{F["mono"]}; font-size:0.64rem; color:white; background:{C[_hck]}; '
             f'padding:3px 10px; border-radius:0; text-transform:uppercase; letter-spacing:0.05em; '
             f'white-space:nowrap;">{_hl}</span></div>'
@@ -784,7 +781,7 @@ def gallery_cards(BASIS, BY_NAME, C, CATS, F, GALLERY, HEALTH, OPEN_LABEL, mo):
     mo.Html(
         f'<div style="margin:44px 0 20px; padding:24px 0 0; border-top:2px solid {C["accent"]};">'
         f'<div style="font-family:{F["mono"]}; font-size:10px; color:{C["accent"]}; '
-        f'letter-spacing:0.1em; text-transform:uppercase; margin-bottom:8px;">Gallery · mode 2</div>'
+        f'letter-spacing:0.1em; text-transform:uppercase; margin-bottom:8px;">Gallery</div>'
         f'<h2 style="font-family:{F["headline"]}; font-size:1.6rem; font-weight:600; color:{C["ink"]}; '
         f'margin:0 0 12px; letter-spacing:-0.015em;">Ten things you can build (and what they’re made of)</h2>'
         f'<p style="font-family:{F["body"]}; font-size:0.95rem; color:{C["ink_2"]}; margin:0 0 22px; line-height:1.6;">'
@@ -1040,7 +1037,7 @@ def builder_demand_table(BATCH, C, CATS, COMPONENTS, F, OPEN_CLASSES, OPEN_LABEL
 @app.cell(hide_code=True)
 def methodology(C, F, TH, mo):
     _ps = [
-        f"""<strong>What counts as part of a product (the composition rules).</strong> A component is included in a reference product iff at least one rule fires: <strong>R1 · known build</strong>: it appears in a documented real-world build of this product pattern (eg, Open WebUI’s quickstart pairs it with Ollama; verl documents vLLM as its rollout engine; the Open LLM Leaderboard runs lm-evaluation-harness on Spaces). Curator-asserted from the component’s own documentation. <strong>R2 · documented component</strong>: the component’s documentation, as reflected in its map description, names the product pattern or role as a primary use case. <strong>R3 · similarity</strong>: TF-IDF cosine similarity between the product description and the component’s map description clears {TH["strong"]}. Gallery exemplars are selected by R1/R2 and capped at four per layer; R3 alone never makes an exemplar, only a lookup suggestion.""",
+        f"""<strong>What counts as part of a product (the composition rules).</strong> A component is included in a reference product iff at least one rule fires: <strong>R1, known build</strong>: it appears in a documented real-world build of this product pattern (eg, Open WebUI’s quickstart pairs it with Ollama; verl documents vLLM as its rollout engine; the Open LLM Leaderboard runs lm-evaluation-harness on Spaces). Curator-asserted from the component’s own documentation. <strong>R2, documented component</strong>: the component’s documentation, as reflected in its map description, names the product pattern or role as a primary use case. <strong>R3, similarity</strong>: TF-IDF cosine similarity between the product description and the component’s map description clears {TH["strong"]}. Gallery exemplars are selected by R1/R2 and capped at four per layer; R3 alone never makes an exemplar, only a lookup suggestion.""",
         f"""<strong>Exemplars are open-leaning by design.</strong> The map exists to chart the open stack, so gallery exemplars are drawn from open / open-core / open-weights components; closed incumbents stay visible in the parent stack map and in lookup mode with the “open components only” switch off. Where only closed components can fill a layer, that is reported as a gap, not papered over.""",
         f"""<strong>Lookup scoring.</strong> score = cosine_tfidf × (1 + 0.25·taxonomy_keyword_hit) × (1 + 0.05·(adoption−3)/2). Pure-Python TF-IDF (log-tf, smoothed idf, L2-normalized) over each component’s name, org, type, category label, and description; a small documented synonym list expands query vocabulary (“privacy” → “self-hosted, local”) at half weight. Thresholds, calibrated on the preset queries: strong match ≥ {TH["strong"]}, layer displayed ≥ {TH["show"]}, gap flagged when an implied layer’s best open match < {TH["gap"]}. Embeddings would rank better; TF-IDF ranks <em>reproducibly</em>, with no model dependency, and that trade is right for v1.""",
         f"""<strong>Gap signals are the point, not the failure mode.</strong> Three kinds: <em>weak layer</em> (your description implies a layer, the best open match stays under threshold), <em>closed only</em> (the layer answers, but only with closed components), and <em>structural</em> (no category covers the capability at all: speech, embeddings, guardrails, document parsing, generative media). Structural absences are keyword-triggered and cross-checked against the parent map’s framework white-space. All three feed Gap Analysis and Scoring as candidate categories and scoring targets.""",
@@ -1053,7 +1050,7 @@ def methodology(C, F, TH, mo):
     mo.Html(
         f'<div style="margin:48px 0 24px; padding:24px 0 0; border-top:2px solid {C["accent"]};">'
         f'<div style="font-family:{F["mono"]}; font-size:10px; color:{C["accent"]}; letter-spacing:0.1em; '
-        f'text-transform:uppercase; margin-bottom:10px;">Methodology · composition logic</div>'
+        f'text-transform:uppercase; margin-bottom:10px;">Methodology</div>'
         f'{_body}</div>'
     )
     return
@@ -1114,17 +1111,17 @@ def details_modal(CATS, COMPONENTS, mo):
         var h='<div class="v3-bd"><div class="v3-modal"><button class="v3-x">Close ✕</button>'+
           '<h2>'+esc(p.product||'')+'</h2>'+
           '<div style="font-family:\'DM Mono\',monospace;font-size:11px;color:#a5bbbe;margin-bottom:6px;">'+
-            esc(p.org||'')+' · '+esc(p.type||'')+' · '+esc(p.category_label||'')+
-            (o.class?' · <span class="v3-pill" style="background:'+ocol(o.score)+';color:'+otext(o.score)+'">'+esc(o.class)+'</span>':'')+'</div>'+
+            esc(p.org||'')+', '+esc(p.type||'')+', '+esc(p.category_label||'')+
+            (o.class?' <span class="v3-pill" style="background:'+ocol(o.score)+';color:'+otext(o.score)+'">'+esc(o.class)+'</span>':'')+'</div>'+
           (p.description?'<div style="font-size:13px;color:#272726;line-height:1.5;margin:8px 0;">'+esc(p.description)+'</div>':'')+
           (p.version_note?'<div style="font-size:11.5px;color:#a5bbbe;line-height:1.45;margin:6px 0;">'+esc(p.version_note)+'</div>':'')+
-          '<div class="v3-sect">Openness · '+(o.score==null?'n/a':o.score+'/5')+' ('+esc(o.class||'')+')</div>'+
+          '<div class="v3-sect">Openness '+(o.score==null?'n/a':o.score+'/5')+' ('+esc(o.class||'')+')</div>'+
           row('Components',o.components)+row('Why',o.note)+row('Confidence',o.confidence)+
           '<div class="v3-row"><span class="v3-lbl">Sources</span><span class="v3-val">'+srcs(o.sources)+'</span></div>'+
-          '<div class="v3-sect">Adoption · '+(ad.level==null?'n/a':ad.level+'/5')+'</div>'+
+          '<div class="v3-sect">Adoption '+(ad.level==null?'n/a':ad.level+'/5')+'</div>'+
           row('Reach',ad.reach)+row('Signal',ad.signal_type)+row('Detail',ad.note)+row('Confidence',ad.confidence)+
           '<div class="v3-row"><span class="v3-lbl">Sources</span><span class="v3-val">'+srcs(ad.sources)+'</span></div>'+
-          '<div class="v3-sect">Capability · '+(cap.score==null?'n/a':cap.score+'/5')+'</div>'+
+          '<div class="v3-sect">Capability '+(cap.score==null?'n/a':cap.score+'/5')+'</div>'+
           row('Basis',cap.basis)+row('Value',cap.value)+row('Detail',cap.note)+row('Confidence',cap.confidence)+
           '<div class="v3-row"><span class="v3-lbl">Sources</span><span class="v3-val">'+srcs(cap.sources)+'</span></div>'+
           '</div></div>';


### PR DESCRIPTION
Editorial polish (feedback via Ayah) so the notebooks read as intentionally designed rather than machine-generated. Touches `build/render.py` (ai-stack-map) and `notebooks/products-view.py`.

## Removed
- The **"Current AI" header kicker** (both notebooks).
- **All decorative numbering**: the 01–14 roster numbers, the `· 01` section-header numbers, the `NN ·` gallery-card numbers.
- **Decorative kicker suffixes**: `· uncategorized`, `· framework white-space`, `· mode 1/2`, `· composition logic`, `· the edges back to the map`.
- **Every middot word-separator** → commas/colons (the stat line, both modals' metadata + axis labels, the sources-used list, lookup label, query line, R1/R2/R3 rule labels) — **keeping** the `·` math operators in the scoring formulas.
- **Dashed arc dividers** → solid hairlines.
- The **"How this was scored" callout** left border.

## Kept (carry meaning)
- The kicker labels themselves ("keep, strip decoration").
- The data dots — the open / open-ish / closed chips and bars.

## Test plan
- `build.validate` → 0 errors; `build/products_view_data.py --check` → 0 unresolved exemplars.
- `marimo check` clean on both notebooks.
- Rendered + screenshotted both: header, roster, section, callout, sources list, and gallery all render correctly; 0 console errors.

No generated artifacts committed; the bot regenerates on merge.