### PR TITLE
feat: recalibrate maturity for flagship open tools

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,37 @@ Each score file has three axes. **Every non-null value needs at least one
 - **capability** (`score:` 1-5, `basis:` e.g. `benchmark:MLPerf`): benchmark or
   comparative evidence; `null` with a reason if no defensible basis exists.
 
+### Adoption level bands
+
+The `adoption.level` is graded against monthly usage volume — package-registry
+downloads (PyPI, npm), Hugging Face downloads, or equivalent active-user / request
+counts. Use the band the product's verified monthly volume falls into:
+
+| Level | Monthly usage volume | Reading |
+|------:|----------------------|---------|
+| **5** | **> 10M / mo** | Ecosystem standard — the default choice for its job (e.g. PyTorch, LangChain, MLflow, Ray). |
+| **4** | 1M – 10M / mo | Widely adopted; a leading option in its category (e.g. vLLM, TRL, Diffusers). |
+| **3** | 100k – 1M / mo | Real, non-trivial usage; established but not dominant. |
+| **2** | 10k – 100k / mo | Emerging; a meaningful user base but still niche. |
+| **1** | < 10k / mo | Early / experimental; little verified usage. |
+
+Notes on applying the bands:
+
+- **Use real usage, not popularity.** Downloads, active users, deployments, and
+  request volume are the basis. **GitHub stars are a weak last-resort signal and
+  never raise adoption above level 3** (`signal_type: stars_fallback`, enforced by
+  validation).
+- **Ecosystem-standard status can stand in for a clean count.** A few infrastructure
+  tools have no single download figure but are unambiguously the default in their
+  category (e.g. a C/C++ engine, a managed platform). These may sit at level 4–5 on
+  documented ecosystem-standard status with `signal_type: reported_traction`; say so
+  in the `note`.
+- **Borderline cases.** When volume sits right at a band edge (e.g. ~10–13M/mo at the
+  level-5 floor), lean on whether the product is genuinely the ecosystem default before
+  promoting, and record the reasoning in the `note`.
+- The `reach` field is a free-text label for the same figure (e.g. `'>10M'`,
+  `1M-10M`); keep it consistent with the chosen level.
+
 Look at `sources/scores/vllm.yaml` for a complete worked example.
 
 ## Suggesting without writing YAML

--- a/sources/scores/accelerate.yaml
+++ b/sources/scores/accelerate.yaml
@@ -10,15 +10,20 @@ openness:
     shows: Standard Apache License 2.0 full text
     accessed: '2026-06-22'
 adoption:
-  level: 4
-  reach: 23M+/month
+  level: 5
+  reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: PyPI last_month downloads of 23,028,484 fall in the 5M-50M Level 4 band.
+  note: 'Re-scored 4->5. 25.01M PyPI downloads in the last 30 days. The map''s
+    prevailing usage_volume level-5 floor is >10M/mo (cf. pydantic-ai ~31M,
+    llama-index ~10.18M at level 5); the prior note bucketed it into a 5M-50M=L4
+    band used only in one ml_frameworks batch, below map peers of equal volume.
+    Accelerate is the standard distributed-training launcher under the HF stack
+    (TRL/PEFT depend on it) and clears the prevailing floor.'
   sources:
-  - url: https://pypistats.org/api/packages/accelerate/recent
-    shows: last_month downloads = 23,028,484
-    accessed: '2026-06-22'
+  - url: https://pepy.tech/projects/accelerate
+    shows: 25,013,751 downloads in last 30 days
+    accessed: '2026-06-25'
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/gradio.yaml
+++ b/sources/scores/gradio.yaml
@@ -10,15 +10,21 @@ openness:
     shows: Standard Apache License 2.0 full text
     accessed: '2026-06-22'
 adoption:
-  level: 4
-  reach: 12M+/month
+  level: 5
+  reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: PyPI last_month downloads of 12,691,392 fall in the 5M-50M Level 4 band.
+  note: 'Re-scored 4->5. 12.69M PyPI downloads in the last 30 days. The map''s
+    prevailing usage_volume level-5 floor is >10M/mo (cf. pydantic-ai ~31M,
+    llama-index ~10.18M at level 5); the prior note explicitly bucketed it into a
+    5M-50M=L4 band that only this ml_frameworks batch used, below map peers of equal
+    volume. Gradio is the default ML demo/UI framework (the standard backend for HF
+    Spaces) and clears the prevailing floor. Conservative: it sits just above 10M,
+    so the bump rests on volume plus ecosystem-standard status, not volume alone.'
   sources:
-  - url: https://pypistats.org/api/packages/gradio/recent
-    shows: last_month downloads = 12,691,392
-    accessed: '2026-06-22'
+  - url: https://pepy.tech/projects/gradio
+    shows: 12,685,121 downloads in last 30 days
+    accessed: '2026-06-25'
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/jax.yaml
+++ b/sources/scores/jax.yaml
@@ -10,15 +10,20 @@ openness:
     shows: Repo shows Apache-2.0 license and full source
     accessed: '2026-06-22'
 adoption:
-  level: 4
-  reach: 19M+/mo
+  level: 5
+  reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: 19.3M PyPI downloads in the last 30 days.
+  note: 'Re-scored 4->5. 18.92M PyPI downloads in the last 30 days. The map''s
+    prevailing usage_volume level-5 floor is >10M/mo (cf. pydantic-ai ~31M,
+    llama-index ~10.18M, langgraph ~58M, all level 5); the prior level 4 applied a
+    stricter 5M-50M band used only in one ml_frameworks batch, which sat below map
+    peers of equal volume. JAX at ~19M/mo is the foundation of a major ML ecosystem
+    (Flax, the Google research stack) and clears the prevailing floor.'
   sources:
-  - url: https://pepy.tech/projects/jax
-    shows: 19,260,713 downloads in last 30 days
-    accessed: '2026-06-22'
+  - url: https://pypistats.org/api/packages/jax/recent
+    shows: last_month downloads = 18,921,715
+    accessed: '2026-06-25'
 capability:
   score: 5
   basis: feature_matrix

--- a/sources/scores/keras.yaml
+++ b/sources/scores/keras.yaml
@@ -10,15 +10,20 @@ openness:
     shows: Repo shows Apache-2.0 license and full source
     accessed: '2026-06-22'
 adoption:
-  level: 4
-  reach: 21M+/mo
+  level: 5
+  reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: 21.7M PyPI downloads in the last 30 days.
+  note: 'Re-scored 4->5. 21.53M PyPI downloads in the last 30 days. The map''s
+    prevailing usage_volume level-5 floor is >10M/mo (cf. pydantic-ai ~31M,
+    llama-index ~10.18M at level 5); the prior level 4 applied a stricter 5M-50M
+    band used only in one ml_frameworks batch, below map peers of equal volume.
+    Keras is the standard high-level training API across TF/JAX/PyTorch and clears
+    the prevailing floor.'
   sources:
   - url: https://pepy.tech/projects/keras
-    shows: 21.7M downloads in last 30 days
-    accessed: '2026-06-22'
+    shows: 21,532,407 downloads in last 30 days
+    accessed: '2026-06-25'
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/mlflow.yaml
+++ b/sources/scores/mlflow.yaml
@@ -18,19 +18,22 @@ openness:
     shows: flagship phase-C verification source
     accessed: '2026-06-04'
 adoption:
-  level: 4
-  reach: 1M-10M
+  level: 5
+  reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: Reported 25-30M+ monthly package downloads, trusted by 5,000+ organizations, 800+ contributors.
-    Monthly download volume places it in the 1-10M+ range.
+  note: 'Re-scored 4->5. 37.10M PyPI downloads in the last 30 days (verified on
+    pypistats; the prior note already reported 25-30M+ but mislabeled the reach as
+    1M-10M). The map''s prevailing usage_volume level-5 floor is >10M/mo (cf.
+    pydantic-ai ~31M, langgraph ~58M at level 5). MLflow is the de facto open
+    experiment-tracking / ML-lifecycle platform and clears the floor comfortably.'
   sources:
-  - url: https://mlflow.org/
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+  - url: https://pypistats.org/api/packages/mlflow/recent
+    shows: last_month downloads = 37,102,636
+    accessed: '2026-06-25'
   - url: https://github.com/mlflow/mlflow
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+    shows: mlflow/mlflow repo (experiment-tracking platform) confirmed live
+    accessed: '2026-06-25'
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/onnx.yaml
+++ b/sources/scores/onnx.yaml
@@ -10,15 +10,19 @@ openness:
     shows: Apache License Version 2.0 full text
     accessed: '2026-06-22'
 adoption:
-  level: 4
-  reach: ~19.8M/mo
+  level: 5
+  reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: PyPI last_month downloads ~19.76M.
+  note: 'Re-scored 4->5. 20.65M PyPI downloads in the last 30 days. The map''s
+    prevailing usage_volume level-5 floor is >10M/mo (cf. pydantic-ai ~31M,
+    llama-index ~10.18M at level 5; the companion onnxruntime is already level 5 at
+    ~74.7M); the prior level 4 applied the stricter ml_frameworks-batch band. ONNX
+    is the de facto cross-framework model-exchange standard and clears the floor.'
   sources:
-  - url: https://pypistats.org/api/packages/onnx/recent
-    shows: last_month=19,763,965 downloads
-    accessed: '2026-06-22'
+  - url: https://pepy.tech/projects/onnx
+    shows: 20,653,241 downloads in last 30 days
+    accessed: '2026-06-25'
 capability:
   score: 5
   basis: feature_matrix

--- a/sources/scores/peft.yaml
+++ b/sources/scores/peft.yaml
@@ -11,16 +11,20 @@ openness:
     shows: Apache License Version 2.0 text
     accessed: '2026-06-04'
 adoption:
-  level: 4
-  reach: 1M-10M
+  level: 5
+  reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: ~10.78M PyPI downloads last month; the canonical adapter/LoRA library, dependency of TRL and most
-    LoRA-based fine-tuning stacks; highest download volume in this category batch.
+  note: 'Re-scored 4->5. 10.28M PyPI downloads in the last 30 days; the canonical
+    adapter/LoRA library and a dependency of TRL and most LoRA fine-tuning stacks.
+    The map''s prevailing usage_volume level-5 floor is >10M/mo (cf. llama-index
+    ~10.18M, pydantic-ai ~31M at level 5); PEFT clears it. Conservative note: at
+    ~10.3M it sits just above the floor, so the bump is borderline and rests on
+    volume plus its dependency-graph centrality in the HF fine-tuning stack.'
   sources:
-  - url: https://pypistats.org/packages/peft
-    shows: 'Downloads last month: 10,778,709'
-    accessed: '2026-06-04'
+  - url: https://pypistats.org/api/packages/peft/recent
+    shows: last_month downloads = 10,281,112
+    accessed: '2026-06-25'
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/qdrant.yaml
+++ b/sources/scores/qdrant.yaml
@@ -15,18 +15,20 @@ openness:
     shows: v1.18.2 (4 Jun 2026); Qdrant Cloud managed tier with free option
     accessed: '2026-06-04'
 adoption:
-  level: 4
-  reach: 1M-10M
+  level: 5
+  reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: qdrant-client ~26.1M PyPI downloads in the last month, a strong, primary usage_volume signal
-    placing it in the 1-10M+ monthly band; a leading open vector DB for RAG/agent retrieval. Sits one
-    above the Milvus anchor's A3 on download volume (Milvus anchored at A3); reasonable given Qdrant's
-    very high client-download count.
+  note: 'Re-scored 4->5. qdrant-client 23.06M PyPI downloads in the last 30 days
+    (verified on pypistats; the prior note already reported ~26.1M but mislabeled
+    the reach as 1M-10M). The map''s prevailing usage_volume level-5 floor is
+    >10M/mo (cf. pydantic-ai ~31M, langgraph ~58M at level 5); Qdrant''s client
+    volume clears it. It remains one above the Milvus anchor (A3) on download
+    volume, a leading open vector DB for RAG/agent retrieval.'
   sources:
-  - url: https://pypistats.org/packages/qdrant-client
-    shows: ~26.1M monthly PyPI downloads
-    accessed: '2026-06-04'
+  - url: https://pypistats.org/api/packages/qdrant-client/recent
+    shows: last_month downloads = 23,061,488
+    accessed: '2026-06-25'
 capability:
   score: 4
   basis: benchmark:ANN-Benchmarks

--- a/sources/scores/ray.yaml
+++ b/sources/scores/ray.yaml
@@ -18,23 +18,23 @@ openness:
     shows: flagship phase-C verification source
     accessed: '2026-06-04'
 adoption:
-  level: 4
-  reach: 1M-10M
-  signal_type: reported_traction
+  level: 5
+  reach: '>10M'
+  signal_type: usage_volume
   confidence: high
-  note: Widely used distributed-compute / serving substrate (Ray Serve, Ray Tune) across ML industry;
-    under PyTorch Foundation with large contributor community. 42.8k stars. No single clean download/user
-    count verified, so reported_traction; level 4 reflects broad industry-scale deployment claims rather
-    than a precise count.
+  note: 'Re-scored 4->5. The prior record had no verified download count
+    (reported_traction). Direct registry data now shows ray at 61.31M PyPI
+    downloads in the last 30 days, comfortably above the map''s prevailing
+    usage_volume level-5 floor of >10M/mo (and above even the stricter 50M floor the
+    HF-stack files use, cf. pytorch ~88.6M, triton ~64.7M at level 5). Ray is the
+    standard open distributed-compute / model-serving substrate (Ray Serve, Tune,
+    Train, Data) under the PyTorch Foundation.'
   sources:
-  - url: https://github.com/ray-project/ray
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
-  - url: https://www.ray.io/
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+  - url: https://pepy.tech/projects/ray
+    shows: 61,306,813 downloads in last 30 days
+    accessed: '2026-06-25'
   - url: https://www.anyscale.com/blog/ray-by-anyscale-joins-pytorch-foundation
-    shows: flagship phase-C verification source
+    shows: Ray under the PyTorch Foundation (governance / ecosystem standing)
     accessed: '2026-06-04'
 capability:
   score: 4

--- a/sources/scores/sentencepiece.yaml
+++ b/sources/scores/sentencepiece.yaml
@@ -10,15 +10,20 @@ openness:
     shows: LICENSE file is the verbatim Apache License Version 2.0
     accessed: '2026-06-22'
 adoption:
-  level: 4
-  reach: 35M+/month
+  level: 5
+  reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: PyPI last-month downloads of 35,443,864 fall in the 5M-50M range.
+  note: 'Re-scored 4->5. 37.65M PyPI downloads in the last 30 days. The map''s
+    prevailing usage_volume level-5 floor is >10M/mo (cf. pydantic-ai ~31M,
+    langgraph ~58M at level 5); the prior note bucketed it into a 5M-50M=L4 band
+    used only in one ml_frameworks batch, leaving a 37M/mo tokenizer below map peers
+    of equal or lower volume. SentencePiece is the de facto subword tokenizer
+    underpinning most LLM/NMT pipelines and clears the prevailing floor.'
   sources:
-  - url: https://pypistats.org/api/packages/sentencepiece/recent
-    shows: last_month = 35,443,864 PyPI downloads
-    accessed: '2026-06-22'
+  - url: https://pepy.tech/projects/sentencepiece
+    shows: 37,654,106 downloads in last 30 days
+    accessed: '2026-06-25'
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/tensorflow.yaml
+++ b/sources/scores/tensorflow.yaml
@@ -10,15 +10,21 @@ openness:
     shows: Repo shows Apache License 2.0 and full source
     accessed: '2026-06-22'
 adoption:
-  level: 4
-  reach: 21M+/mo
+  level: 5
+  reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: 21.9M PyPI downloads in the last 30 days.
+  note: 'Re-scored 4->5. 21.06M PyPI downloads in the last 30 days. The map''s prevailing
+    usage_volume level-5 floor is >10M/mo (cf. pydantic-ai ~31M, llama-index ~10.18M,
+    langgraph ~58M, fastmcp ~72.7M, all level 5); the prior level 4 here applied a
+    stricter 5M-50M band used only in one ml_frameworks scoring batch, which placed
+    these frameworks inconsistently below map peers of equal or lower volume.
+    TensorFlow at 21M/mo is one of the two foundational training frameworks and
+    clears the prevailing floor.'
   sources:
   - url: https://pepy.tech/projects/tensorflow
-    shows: 21,890,544 downloads in last 30 days
-    accessed: '2026-06-22'
+    shows: 21,057,167 downloads in last 30 days
+    accessed: '2026-06-25'
 capability:
   score: 5
   basis: feature_matrix


### PR DESCRIPTION
## What this fixes

A measured scoring artifact, not a policy change. Among fully-open products (`openness.class` in open_source / open / open_core / open_hardware), the per-product `maturity` score had a pile-up of **59 products at exactly 4.0** — one notch below the `_MATURE_MIN = 4.5` "mature" bar. Because the stage engine counts only fully-open products at >=4.5, that 4.0 cliff manufactured a `maturity` gap on most categories, even where the open ecosystem is plainly mature.

### Root cause: an inconsistent adoption band

The cliff is not random. It traces to two competing `usage_volume` adoption conventions in `sources/scores/`:

- **Prevailing map convention:** level-5 floor at **>10M monthly downloads** — e.g. `pydantic-ai` (~31M), `llama-index` (~10.18M), `langgraph` (~58M), `fastmcp` (~72.7M) are all level 5.
- **A minority band** used in one `ml_frameworks` scoring batch (all dated 2026-06-22): "5M-50M = level 4". This left 20-40M/mo foundational frameworks (TensorFlow, JAX, Accelerate, SentencePiece...) at level 4 — *below* map peers of equal or lower volume. A few non-batch files (PEFT, MLflow, Qdrant) had the same mislabel: their notes already cited 10-37M downloads but carried `reach: 1M-10M` and level 4.

This PR reconciles the inconsistency on the **inputs** side only. It does **not** touch `_MATURE_MIN`, the Stage-5 count, the stage bands, or any other constant in `serialize.py`.

The chosen convention is now codified as a canonical adoption band table in the scoring rubric ([`CONTRIBUTING.md` → Scoring rubric → Adoption level bands](CONTRIBUTING.md#adoption-level-bands)): level-5 floor at **>10M/mo**, then 1M-10M (L4), 100k-1M (L3), 10k-100k (L2), <10k (L1), with the stars-never-above-3 caveat. Each of the 11 bumps below is the >10M floor applied — they are self-justifying against that table.

## What changed

Adoption re-scored **4 -> 5** for 11 fully-open flagships, each with direct primary-registry evidence clearing the prevailing >10M/mo floor. Capability scores were left untouched everywhere. Every changed value carries a refreshed `sources:` citation (accessed 2026-06-25) and a re-score rationale note.

| Product | Category | weights (a/c) | adoption | capability | maturity | source (downloads / 30d) |
|---|---|---|---|---|---|---|
| TensorFlow | ml_frameworks | .6/.4 | 4 -> **5** | 5 | 4.4 -> **5.0** | pepy 21,057,167 |
| JAX | ml_frameworks | .6/.4 | 4 -> **5** | 5 | 4.4 -> **5.0** | pypistats 18,921,715 |
| ONNX | ml_frameworks | .6/.4 | 4 -> **5** | 5 | 4.4 -> **5.0** | pepy 20,653,241 |
| Keras | ml_frameworks | .6/.4 | 4 -> **5** | 4 | 4.0 -> **4.6** | pepy 21,532,407 |
| Gradio | ml_frameworks | .6/.4 | 4 -> **5** | 4 | 4.0 -> **4.6** | pepy 12,685,121 |
| SentencePiece | ml_frameworks | .6/.4 | 4 -> **5** | 4 | 4.0 -> **4.6** | pepy 37,654,106 |
| Accelerate | ml_frameworks | .6/.4 | 4 -> **5** | 4 | 4.0 -> **4.6** | pepy 25,013,751 |
| PEFT | finetuning_code | .5/.5 | 4 -> **5** | 4 | 4.0 -> **4.5** | pypistats 10,281,112 |
| MLflow | telemetry_observability | .5/.5 | 4 -> **5** | 4 | 4.0 -> **4.5** | pypistats 37,102,636 |
| Qdrant | agent_tools_protocols | .6/.4 | 4 -> **5** | 4 | 4.0 -> **4.6** | pypistats 23,061,488 (qdrant-client) |
| Ray | deployment | .6/.4 | 4 -> **5** | 4 | 4.0 -> **4.6** | pepy 61,306,813 |

The pile-up at exactly 4.0 drops from **59 to 51** fully-open products.

### Resulting category stage shifts

| Category | Stage | Gaps | Why |
|---|---|---|---|
| `telemetry_observability` | 3 -> **4** (Competitive Open Ecosystem) | `[maturity, openness]` -> `[maturity]` | MLflow becomes the first mature *fully-open* option, removing the openness gap |
| `agent_tools_protocols` | 4 -> **5** (Mature Open Ecosystem) | `[maturity]` -> `[]` | Qdrant becomes the 4th mature fully-open product, clearing the Stage-5 depth bar |

`ml_frameworks` (already Stage 5), `finetuning_code`, and `deployment` keep their stage but gain depth/redundancy — the expected behavior of an input fix that doesn't move policy.

## What was deliberately left as-is (conservative bar)

The map's credibility rests on the demanding 4.5 bar, so anything ambiguous stays put:

- **5-10M/mo (below the floor):** Diffusers (~7.4M), Flax (~5.3M) — correctly level 4.
- **1-4M/mo:** vLLM (~3M), TRL (~3.8M), Unsloth (~2.4M), Opik, Weave, TruLens — level 4 is right.
- **Inferred / non-registry signals:** Ollama (52M *pulls*, third-party blog), llama.cpp (C++, no clean registry count) — the existing curator already held these at 4 on explicit reasoning; not bumped.
- **Anomalous figure:** Browser Use shows ~164M/mo on pepy, which looks CI/mirror-inflated and could not be cross-checked against mirror-excluded stats this session — left at 4.
- **Capability** untouched everywhere (e.g. LangChain stays 4.3, OpenHands 4.4): within-category capability anchors are a separate judgment and inflating them would juice the bar.

## Calls for Carl to double-check

1. **The convention question — resolved.** This PR commits to the >10M/mo = level-5 floor (the map's majority precedent) and now documents it as a canonical band table in `CONTRIBUTING.md` so it stops drifting. A few core-infra files (transformers, pytorch, triton) phrased their level-5 as a stricter "50M+ threshold"; under a 50M floor only Ray (61M) would qualify among these 11. If you'd rather make the stricter 50M floor canonical, the table is the one place to change it and most of these bumps would revert.
2. **Borderline cases:** PEFT (~10.3M) and Gradio (~12.7M) sit just above 10M; their bumps lean partly on ecosystem-standard status. Comfortable, or hold at 4?
3. The two stage shifts (telemetry 3->4, agent_tools 4->5) are the visible consequences — sanity-check they read as true.

**These are draft proposals for review, not a merge.**

## Verification

```
$ uv run python -m build.validate
0 error(s)

$ uv run pytest -q
35 passed in 2.19s
```

`build/notebook_data.json` and `notebooks/ai-stack-map.py` were regenerated locally for the before/after analysis but are **not** committed (the bot regenerates them on merge).
