### PR TITLE
feat: add fully-open instruct models to finetuned_chat

### DIFF
--- a/build/_frozen_long_tail.json
+++ b/build/_frozen_long_tail.json
@@ -4,11 +4,11 @@
     "models": 6428,
     "packages": 2823,
     "total": 24626,
-    "scored": 421,
+    "scored": 426,
     "overlap": 226,
-    "scored_outside": 195,
+    "scored_outside": 200,
     "uncategorized": 24400,
-    "universe": 24821
+    "universe": 24826
   },
   "top": [
     {

--- a/sources/categories/finetuned_chat.yaml
+++ b/sources/categories/finetuned_chat.yaml
@@ -18,6 +18,11 @@ products:
 - devstral
 - mistral-7b-instruct-v0-2
 - starcoder2
+- olmo-2-instruct
+- olmoe-instruct
+- tulu-3
+- zephyr
+- k2-chat
 - phi-4-mini-instruct
 - granite-code-instruct
 - o3-o4-mini

--- a/sources/organizations/ai2.yaml
+++ b/sources/organizations/ai2.yaml
@@ -4,4 +4,7 @@ type: lab
 homepage: https://allenai.org
 products:
 - olmo-2
+- olmo-2-instruct
+- olmoe-instruct
+- tulu-3
 comments: Same entity as allen-institute-for-ai; merge candidate.

--- a/sources/organizations/hugging-face.yaml
+++ b/sources/organizations/hugging-face.yaml
@@ -27,3 +27,4 @@ products:
 - tokenizers
 - huggingface-hub
 - optimum
+- zephyr

--- a/sources/organizations/llm360.yaml
+++ b/sources/organizations/llm360.yaml
@@ -1,0 +1,8 @@
+name: llm360
+display_name: LLM360
+type: lab
+homepage: https://www.llm360.ai
+github:
+- url: https://github.com/LLM360
+products:
+- k2-chat

--- a/sources/products/k2-chat.yaml
+++ b/sources/products/k2-chat.yaml
@@ -1,0 +1,16 @@
+name: k2-chat
+display_name: K2 Chat
+type: model
+description: 'LLM360''s fully-open 65B instruction-tuned chat model (K2-Chat). LLM360
+  is the reference "fully reproducible" LLM project: it releases data-prep code, training
+  code, intermediate checkpoints, and named instruction-tuning data, all Apache-2.0.
+  A clean fully-open exemplar; modest adoption and last updated Jan 2025. Verified live
+  on HF June 2026.'
+github:
+- url: https://github.com/LLM360/k2-train
+- url: https://github.com/LLM360/k2-data-prep
+huggingface_model:
+- url: https://huggingface.co/LLM360/K2-Chat
+comments: Apache-2.0; open weights + open data-prep + open training code + open checkpoints.
+  65B. Reported to outperform Llama 2 70B Chat using ~35% less compute. Niche adoption
+  (~651 HF downloads/month).

--- a/sources/products/olmo-2-instruct.yaml
+++ b/sources/products/olmo-2-instruct.yaml
@@ -1,0 +1,18 @@
+name: olmo-2-instruct
+display_name: OLMo 2 Instruct
+type: model
+description: 'Instruction-tuned chat SKUs of Ai2''s OLMo 2 family (7B/13B/32B-Instruct),
+  post-trained with the fully-open Tulu 3 pipeline (SFT -> DPO -> RLVR) on top of the
+  open OLMo 2 base. Distinct from the base OLMo 2 family entry (base_pretrained): separate
+  HF repos, separate post-training, and the chat-relevant capability axis (IFEval, AlpacaEval).
+  Verified live on HF June 2026.'
+github:
+- url: https://github.com/allenai/OLMo
+- url: https://github.com/allenai/open-instruct
+huggingface_model:
+- url: https://huggingface.co/allenai/OLMo-2-1124-7B-Instruct
+- url: https://huggingface.co/allenai/OLMo-2-1124-13B-Instruct
+- url: https://huggingface.co/allenai/OLMo-2-0325-32B-Instruct
+comments: 'Scored on the OLMo 2 Instruct SKUs (0325 32B-Instruct is the most capable).
+  Apache-2.0; fully-open weights + data + recipe + intermediate checkpoints. Post-training
+  via the Tulu 3 recipe.'

--- a/sources/products/olmoe-instruct.yaml
+++ b/sources/products/olmoe-instruct.yaml
@@ -1,0 +1,15 @@
+name: olmoe-instruct
+display_name: OLMoE Instruct
+type: model
+description: 'Ai2''s fully-open Mixture-of-Experts instruct model (OLMoE-1B-7B-0924-Instruct:
+  1.3B active / 6.9B total, SFT + DPO). Released with open pretraining data (OLMoE-mix-0924,
+  built on Dolma + DataComp), open post-training data, open training code, and 244
+  intermediate checkpoints. Verified live on HF June 2026.'
+github:
+- url: https://github.com/allenai/OLMoE
+huggingface_model:
+- url: https://huggingface.co/allenai/OLMoE-1B-7B-0924-Instruct
+huggingface_dataset:
+- url: https://huggingface.co/datasets/allenai/OLMoE-mix-0924
+comments: Apache-2.0; fully-open MoE (weights + data + code + intermediate checkpoints).
+  State-of-the-art among ~1B-active-parameter models at release.

--- a/sources/products/tulu-3.yaml
+++ b/sources/products/tulu-3.yaml
@@ -1,0 +1,22 @@
+name: tulu-3
+display_name: Tulu 3
+type: model
+description: 'Ai2''s open post-training model family (Llama-3.1-Tulu-3 8B / 70B / 405B),
+  the reference fully-open post-training recipe: open SFT + preference data, open training
+  code (open-instruct), and the RLVR (Reinforcement Learning with Verifiable Rewards)
+  method, applied on top of Meta''s Llama 3.1 base. Note: the recipe/data/code are
+  Apache-2.0 and fully reproducible, but the released weights inherit Meta''s Llama 3.1
+  Community License (non-OSI), so the artifact is open-recipe over restricted weights.
+  Verified live on HF June 2026.'
+github:
+- url: https://github.com/allenai/open-instruct
+huggingface_model:
+- url: https://huggingface.co/allenai/Llama-3.1-Tulu-3-8B
+- url: https://huggingface.co/allenai/Llama-3.1-Tulu-3-70B
+- url: https://huggingface.co/allenai/Llama-3.1-Tulu-3-405B
+huggingface_dataset:
+- url: https://huggingface.co/datasets/allenai/tulu-3-sft-mixture
+comments: 'Weights under Llama 3.1 Community License (non-OSI); Ai2''s post-training data,
+  code, recipe, and eval framework (open-instruct, OLMES) are Apache-2.0. Classed as
+  restricted on the weights license, consistent with how other Llama-Community models
+  are scored.'

--- a/sources/products/zephyr.yaml
+++ b/sources/products/zephyr.yaml
@@ -1,0 +1,19 @@
+name: zephyr
+display_name: Zephyr
+type: model
+description: 'Hugging Face H4''s fully-open chat model line. The flagship zephyr-7b-beta
+  is a DPO fine-tune of Mistral-7B, trained with the open alignment-handbook recipe on
+  the public UltraChat and UltraFeedback datasets and relicensed MIT. A late-2023 model
+  that remains a widely-downloaded, fully-reproducible 7B open baseline. Also includes
+  the zephyr-orpo-141b MoE variant (Apache-2.0). Verified live on HF June 2026.'
+github:
+- url: https://github.com/huggingface/alignment-handbook
+huggingface_model:
+- url: https://huggingface.co/HuggingFaceH4/zephyr-7b-beta
+- url: https://huggingface.co/HuggingFaceH4/zephyr-orpo-141b-A35b-v0.1
+huggingface_dataset:
+- url: https://huggingface.co/datasets/HuggingFaceH4/ultrachat_200k
+- url: https://huggingface.co/datasets/HuggingFaceH4/ultrafeedback_binarized
+comments: 'Scored on zephyr-7b-beta (MIT; base Mistral-7B Apache-2.0). Fully-open: weights
+  + open DPO datasets (UltraChat/UltraFeedback, MIT) + open training code (alignment-handbook,
+  Apache-2.0). Late-2023 capability, still ~165k HF downloads/month.'

--- a/sources/scores/k2-chat.yaml
+++ b/sources/scores/k2-chat.yaml
@@ -1,0 +1,44 @@
+product: k2-chat
+openness:
+  score: 5
+  class: open_source
+  components: weights:open(Apache-2.0);data:open(named instruction sets + open data-prep
+    code);code:open(k2-train training code);checkpoints:open;license:Apache-2.0(OSI)
+  confidence: high
+  note: 'LLM360 is the reference fully-reproducible LLM project: open weights + open
+    data-prep code + open training code + open checkpoints, all Apache-2.0. A clean
+    open_source exemplar (tier 5) for the instruct category.'
+  sources:
+  - url: https://huggingface.co/LLM360/K2-Chat
+    shows: License Apache-2.0; 65B instruct; open data/code/checkpoints
+    accessed: '2026-06-25'
+  - url: https://github.com/LLM360
+    shows: k2-train (training code) and k2-data-prep (data preparation code), Apache-2.0
+    accessed: '2026-06-25'
+adoption:
+  level: 2
+  reach: 10K-100K
+  signal_type: usage_volume
+  confidence: medium
+  note: 'LOW-CONFIDENCE PROMINENCE CALL (flagged for review): ~651 HF downloads/month,
+    21,298 all-time, 37 likes; last modified Jan 2025. Niche, not a mass-adoption model.
+    Included as a clean fully-open exemplar rather than on popularity. Aggregate all-time
+    volume puts it just into the 10K-100K band -> level 2; monthly volume alone would
+    argue level 1.'
+  sources:
+  - url: https://huggingface.co/LLM360/K2-Chat
+    shows: ~651 downloads last month; 21,298 all-time; 37 likes; last modified 2025-01-12
+    accessed: '2026-06-25'
+capability:
+  score: 3
+  basis: benchmark:MMLU/GSM8K
+  value: K2-Chat MMLU 69.14, GSM8K 77.10, BBH 70.37, HumanEval 60.82, TruthfulQA 57.32
+  confidence: medium
+  note: Reported to outperform Llama 2 70B Chat using ~35% less compute. Solid mid-tier
+    for a 2024 fully-open 65B; below 2026 frontier chat models. Numbers are card-reported
+    (not independently re-run) -> medium confidence.
+  sources:
+  - url: https://huggingface.co/LLM360/K2-Chat
+    shows: MMLU 69.14, GSM8K 77.10, BBH 70.37, HumanEval 60.82; outperforms Llama 2 70B
+      Chat with ~35% less compute
+    accessed: '2026-06-25'

--- a/sources/scores/olmo-2-instruct.yaml
+++ b/sources/scores/olmo-2-instruct.yaml
@@ -1,0 +1,46 @@
+product: olmo-2-instruct
+openness:
+  score: 5
+  class: open_source
+  components: weights:open(Apache-2.0);data:open(Dolma/OLMo-Mix pretraining + Tulu 3
+    post-training mixtures);code:open(OLMo + open-instruct training code, recipes);checkpoints:open(intermediate);license:Apache-2.0(OSI)
+  confidence: high
+  note: 'Genuinely fully-open instruct line: Apache-2.0 weights + open pretraining and
+    post-training data + open training code/recipe + intermediate checkpoints. Open_source
+    tier 5. Post-trained with the open Tulu 3 SFT->DPO->RLVR pipeline. Cards note limited
+    safety training.'
+  sources:
+  - url: https://huggingface.co/allenai/OLMo-2-0325-32B-Instruct
+    shows: License Apache-2.0; Tulu 3 SFT+DPO+RLVR post-training; fully-open data/code/checkpoints
+    accessed: '2026-06-25'
+  - url: https://allenai.org/blog/olmo2
+    shows: '"best fully open language model to date"; releases weights, data, code, recipes,
+      intermediate checkpoints, and instruction-tuned models'
+    accessed: '2026-06-25'
+adoption:
+  level: 3
+  reach: 10K-100K
+  signal_type: usage_volume
+  confidence: high
+  note: Combined ~58k HF downloads/month across the three named instruct SKUs (7B-Instruct
+    ~45.2k, 13B-Instruct ~6.9k, 32B-Instruct ~5.9k). 32B-Instruct carries the highest
+    likes (147). Solid research/practitioner reach; below the Qwen/Llama instruct workhorses.
+  sources:
+  - url: https://huggingface.co/allenai/OLMo-2-1124-7B-Instruct
+    shows: ~45,191 downloads last month
+    accessed: '2026-06-25'
+  - url: https://huggingface.co/allenai/OLMo-2-0325-32B-Instruct
+    shows: ~5,918 downloads last month; 147 likes
+    accessed: '2026-06-25'
+capability:
+  score: 3
+  basis: benchmark:MMLU/IFEval/AlpacaEval
+  value: OLMo-2-32B-Instruct MMLU 77.3, GSM8K 87.6, IFEval 85.6, AlpacaEval2 LC 42.8
+  confidence: high
+  note: 32B-Instruct competitive with GPT-4o-mini / Qwen2.5-32B class and outperforms
+    GPT-3.5 Turbo on most benchmarks; mid-tier on a scale where 5 = 2026 frontier chat.
+    The value proposition is full openness, not raw SOTA.
+  sources:
+  - url: https://huggingface.co/allenai/OLMo-2-0325-32B-Instruct
+    shows: MMLU 77.3, GSM8K 87.6, IFEval 85.6; comparison vs GPT-4o-mini and Qwen2.5-32B
+    accessed: '2026-06-25'

--- a/sources/scores/olmoe-instruct.yaml
+++ b/sources/scores/olmoe-instruct.yaml
@@ -1,0 +1,48 @@
+product: olmoe-instruct
+openness:
+  score: 5
+  class: open_source
+  components: weights:open(Apache-2.0);data:open(OLMoE-mix-0924 pretraining + Tulu/UltraFeedback
+    post-training);code:open(OLMoE training code, SFT/DPO/KTO recipes);checkpoints:open(244
+    intermediate);license:Apache-2.0(OSI)
+  confidence: high
+  note: 'Fully-open MoE: Apache-2.0 weights + open pretraining data (OLMoE-mix-0924, on
+    Dolma/DataComp) + open post-training data + open code + 244 intermediate checkpoints.
+    Open_source tier 5.'
+  sources:
+  - url: https://huggingface.co/allenai/OLMoE-1B-7B-0924-Instruct
+    shows: License Apache-2.0; SFT+DPO instruct; open data and code
+    accessed: '2026-06-25'
+  - url: https://allenai.org/blog/olmoe-an-open-small-and-state-of-the-art-mixture-of-experts-model-c258432d0514
+    shows: released with open data, code, evaluations, logs, and intermediate training
+      checkpoints
+    accessed: '2026-06-25'
+adoption:
+  level: 3
+  reach: 10K-100K
+  signal_type: usage_volume
+  confidence: high
+  note: ~37.9k HF downloads/month on the instruct SKU; 96 likes. Solid reach for a fully-open
+    research MoE.
+  sources:
+  - url: https://huggingface.co/allenai/OLMoE-1B-7B-0924-Instruct
+    shows: ~37,880 downloads last month; 96 likes
+    accessed: '2026-06-25'
+capability:
+  score: 2
+  basis: benchmark:MMLU/AlpacaEval
+  value: OLMoE-1B-7B-Instruct MMLU 51.9, GSM8k 45.5, HumanEval 54.8, AlpacaEval1 84.0,
+    IFEval 48.1
+  confidence: medium
+  note: State-of-the-art among ~1B-active-parameter models at release (beats Gemma2,
+    Llama2-13B-Chat, OLMo-7B, DeepSeekMoE-16B per the blog), but absolute capability is
+    low-tier vs full-size 2026 chat models given the 1.3B active budget. Scored 2 on
+    absolute capability. Exact per-competitor numbers live in arXiv 2409.02060 (blog
+    charts are images), so the comparative claims are directional -- hence medium confidence.
+  sources:
+  - url: https://huggingface.co/allenai/OLMoE-1B-7B-0924-Instruct
+    shows: MMLU 51.9, GSM8k 45.5, HumanEval 54.8, AlpacaEval 84.0, IFEval 48.1
+    accessed: '2026-06-25'
+  - url: https://allenai.org/blog/olmoe-an-open-small-and-state-of-the-art-mixture-of-experts-model-c258432d0514
+    shows: positioned state-of-the-art at the ~1B-active cost class
+    accessed: '2026-06-25'

--- a/sources/scores/tulu-3.yaml
+++ b/sources/scores/tulu-3.yaml
@@ -1,0 +1,57 @@
+product: tulu-3
+openness:
+  score: 3
+  class: restricted
+  components: weights:open(downloadable);license:Llama-3.1-Community(non-OSI;700M-MAU
+    cap + use policy);post-training-data:open(Apache-2.0/ODC-BY);code:open(open-instruct
+    Apache-2.0);recipe:open(SFT->DPO->RLVR);evals:open(OLMES)
+  confidence: high
+  note: 'NOT fully-open: the released weights inherit Meta''s Llama 3.1 Community License
+    (non-OSI, 700M-MAU cap), so the class is restricted -- same calibration as other
+    Llama-Community models in the map. Scored 3 rather than the bare-Llama-Instruct 2
+    because the entire post-training layer (data, code, RLVR recipe, eval framework) is
+    genuinely open and reproducible (Apache-2.0). Data license is ODC-BY/Apache per Ai2
+    practice; the exact dataset-card license string is medium confidence, but the headline
+    open-recipe-over-restricted-weights call is high confidence.'
+  sources:
+  - url: https://huggingface.co/allenai/Llama-3.1-Tulu-3-8B
+    shows: 'License: Llama 3.1 Community License Agreement (non-OSI); base meta-llama/Llama-3.1-8B'
+    accessed: '2026-06-25'
+  - url: https://allenai.org/blog/tulu-3
+    shows: fully-transparent post-training release -- open data + data mixes, training
+      code/recipe, eval framework, and weights
+    accessed: '2026-06-25'
+  - url: https://github.com/allenai/open-instruct
+    shows: Apache-2.0; Tulu 3 SFT/DPO/RLVR post-training framework + decontamination tools
+    accessed: '2026-06-25'
+adoption:
+  level: 2
+  reach: 10K-100K
+  signal_type: usage_volume
+  confidence: high
+  note: Research/reference traction, not a production endpoint. HF downloads/month ~3.1k
+    (8B), ~493 (70B), ~832 (405B); likes 179/61/112. Aggregate low-thousands monthly.
+    Level 2.
+  sources:
+  - url: https://huggingface.co/allenai/Llama-3.1-Tulu-3-8B
+    shows: ~3,109 downloads last month; 179 likes
+    accessed: '2026-06-25'
+  - url: https://huggingface.co/allenai/Llama-3.1-Tulu-3-405B
+    shows: ~832 downloads last month; 112 likes
+    accessed: '2026-06-25'
+capability:
+  score: 4
+  basis: benchmark:MMLU/GSM8K/IFEval
+  value: Tulu-3-405B MMLU 87.0, GSM8K 95.5, IFEval 86.0, HumanEval 95.9, MATH 67.3
+  confidence: high
+  note: The 405B SKU trades blows with GPT-4o (2024-11) on math/reasoning (GSM8K 95.5
+    vs 91.7) and trails slightly on chat (AlpacaEval) and raw MMLU vs Llama-3.1-405B-Instruct.
+    Strong upper-mid capability; scored 4. The smaller 8B is competitive in its size class
+    (MMLU 68.2, GSM8K 87.6, IFEval 82.4).
+  sources:
+  - url: https://huggingface.co/allenai/Llama-3.1-Tulu-3-405B
+    shows: MMLU 87.0, GSM8K 95.5, IFEval 86.0, HumanEval 95.9, MATH 67.3; vs GPT-4o comparison
+    accessed: '2026-06-25'
+  - url: https://huggingface.co/allenai/Llama-3.1-Tulu-3-8B
+    shows: MMLU 68.2, GSM8K 87.6, IFEval 82.4
+    accessed: '2026-06-25'

--- a/sources/scores/zephyr.yaml
+++ b/sources/scores/zephyr.yaml
@@ -1,0 +1,46 @@
+product: zephyr
+openness:
+  score: 5
+  class: open_source
+  components: weights:open(MIT;base Mistral-7B Apache-2.0);data:open(UltraChat_200k +
+    UltraFeedback_binarized, both MIT, ungated);code:open(alignment-handbook DPO recipe,
+    Apache-2.0);license:MIT(OSI)
+  confidence: high
+  note: 'Genuinely fully-open: MIT weights, the two DPO training datasets are public and
+    MIT, and the end-to-end training code (alignment-handbook) is Apache-2.0 and replicates
+    zephyr-7b-beta. Open_source tier 5. Caveat (does not change the class): upstream
+    UltraChat/UltraFeedback were partly generated with OpenAI model outputs, but the
+    released HF artifacts are open and MIT.'
+  sources:
+  - url: https://huggingface.co/HuggingFaceH4/zephyr-7b-beta
+    shows: License MIT; DPO fine-tune of Mistral-7B on UltraChat/UltraFeedback
+    accessed: '2026-06-25'
+  - url: https://github.com/huggingface/alignment-handbook
+    shows: Apache-2.0; contains all training code to replicate zephyr-7b-beta
+    accessed: '2026-06-25'
+adoption:
+  level: 4
+  reach: 1M-10M
+  signal_type: usage_volume
+  confidence: high
+  note: ~164.9k HF downloads/month on zephyr-7b-beta with 1.85k likes -- a late-2023
+    model still pulling meaningful volume as a lightweight fully-open 7B baseline. The
+    underlying datasets remain active (ultrachat_200k ~57.7k/mo). The 141B ORPO variant
+    is effectively dormant (~52/mo). Level 4 on the leading SKU's sustained monthly volume.
+  sources:
+  - url: https://huggingface.co/HuggingFaceH4/zephyr-7b-beta
+    shows: ~164,917 downloads last month; 1.85k likes
+    accessed: '2026-06-25'
+capability:
+  score: 2
+  basis: benchmark:MT-Bench/AlpacaEval
+  value: zephyr-7b-beta MT-Bench 7.34, AlpacaEval 90.6% win rate, Open LLM Leaderboard
+    avg 52.15
+  confidence: high
+  note: Notable late-2023 capability (a 7B beating much larger chat models on MT-Bench
+    at release), but weak by 2026 standards (GSM8K 12.74, DROP 9.66 on the leaderboard).
+    Low-tier on a scale where 5 = current frontier chat. Scored 2.
+  sources:
+  - url: https://huggingface.co/HuggingFaceH4/zephyr-7b-beta
+    shows: MT-Bench 7.34; AlpacaEval 90.60%; Open LLM Leaderboard avg 52.15
+    accessed: '2026-06-25'


### PR DESCRIPTION
## What & why

`finetuned_chat` had **43 products but only one fully-open-source entry** — `starcoder2`, which is actually a base code model scored low. The genuinely fully-open instruct/chat ecosystem (open weights + open training data + open code/recipe) was entirely absent, so the category read as Stage 1 "Open Experiments" partly as a **curation artifact** rather than a real finding.

This PR adds five prominent open challengers, each verified against primary sources (HF model card + LICENSE + the org's release post). **These are draft proposals — please sanity-check the flagged low-confidence calls.**

## Models added

| Slug | Org | Openness | Adoption | Capability | Fully-open? |
|------|-----|----------|----------|-----------|-------------|
| `olmo-2-instruct` | Ai2 | `open_source` 5 | 3 (~58k DL/mo combined) | 3 (MMLU 77.3, IFEval 85.6 @32B) | **Yes** — Apache-2.0 weights + Dolma data + Tulu 3 recipe + code + checkpoints |
| `olmoe-instruct` | Ai2 | `open_source` 5 | 3 (~37.9k DL/mo) | 2 (MMLU 51.9; SOTA at ~1B-active) | **Yes** — Apache-2.0 MoE, open data/code + 244 checkpoints |
| `zephyr` | Hugging Face | `open_source` 5 | 4 (~165k DL/mo) | 2 (MT-Bench 7.34; late-2023) | **Yes** — MIT weights + open UltraChat/UltraFeedback + alignment-handbook |
| `k2-chat` | LLM360 | `open_source` 5 | 2 (~651 DL/mo, 21k all-time) | 3 (MMLU 69.1, GSM8K 77.1) | **Yes** — Apache-2.0, open data-prep + train code + checkpoints |
| `tulu-3` | Ai2 | `restricted` 3 | 2 (low-thousands DL/mo) | 4 (405B trades blows w/ GPT-4o) | **No** — open recipe/data/code (Apache-2.0) but weights are Llama 3.1 Community License (non-OSI) |

Four are **genuinely fully-open** (`open_source`). **Tulu 3 is honestly classed as restricted, not `open_source`**: its post-training data, code, RLVR recipe and eval framework are fully open and reproducible, but the released weights inherit Meta's Llama 3.1 Community License (700M-MAU cap, non-OSI) — the same calibration the map already applies to Llama-Instruct and Hermes. Scored `restricted` 3 (one notch above bare Llama-Instruct's 2 to reflect the genuinely-open recipe layer). It won't advance the stage, and that's the correct, honest call.

Also: new `sources/organizations/llm360.yaml` (org did not exist); `olmo-2-instruct`/`olmoe-instruct`/`tulu-3` added to the existing `ai2` roster (alongside `olmo-2`); `zephyr` to `hugging-face`.

### Why an `olmo-2-instruct` entry separate from the existing `olmo-2`?
`olmo-2` already exists but lives in `base_pretrained`, scored as the base+instruct *family*. The instruct line has separate HF SKUs, a distinct Tulu 3 post-training pipeline, and a chat-relevant capability axis (IFEval/AlpacaEval) — so it belongs as its own entry in `finetuned_chat`, mirroring how `starcoder2` (instruct) sits in chat while base lives in base_pretrained.

### Candidates skipped
- **Dolly** (Databricks) — `databricks/dolly-v2-12b` model card now 404s on HF; 2023-era. SKIP.
- **OpenHermes / Nous-Hermes** — the Hermes family (4x SKUs) is already in `finetuned_chat`. Not duplicated.

## Stage impact

`finetuned_chat` stage is **unchanged: Stage 1 "Open Experiments" before and after** (43 -> 48 products; category gaps `['maturity', 'openness']`).

This is expected and honest. The stage gate requires a fully-open product to clear the category's *mature* bar (weighted maturity >= 4.5); the strongest new fully-open entry (OLMo 2 Instruct) reaches maturity 3.0. So the additions **materially raise the open floor and remove the curation artifact** — the category no longer reads as "one low-scored base code model is the only open thing here" — without manufacturing a stage jump the data does not support.

## Low-confidence calls flagged for review

- **`k2-chat` adoption (medium)**: ~651 DL/month, 21k all-time, last updated Jan 2025. Niche. Included as a clean fully-open exemplar rather than on popularity. Monthly volume alone would argue level 1; all-time volume puts it at level 2. Borderline include — happy to drop if you would rather keep the bar at "prominent by downloads."
- **`olmoe-instruct` capability (medium)**: exact per-competitor numbers vs TinyLlama/Qwen1.5 live in arXiv 2409.02060 (blog charts are images); the "SOTA at ~1B-active" comparison is directional.
- **`tulu-3` openness data-license (note)**: dataset license is ODC-BY/Apache per Ai2 practice; the precise dataset-card string was not re-fetched. The headline call (open recipe over restricted weights -> `restricted`) is high confidence.
- **OLMo 2 / OLMoE benchmark numbers** are card-reported (primary, but not independently re-run).

## Validation

```
$ uv run python -m build.validate
0 error(s)

$ uv run pytest -q
35 passed in 2.52s
```

Re-synced `build/_frozen_long_tail.json` counts after the batch (`scored` 421 -> 426, `scored_outside` 195 -> 200, `universe` 24821 -> 24826), per the add-product batch step. Did **not** commit `build/notebook_data.json` or `notebooks/ai-stack-map.py` (bot-regenerated; restored to main).
