### PR TITLE
feat(warehouse): stack_map taxonomy bridge + stack_contributors model

### DIFF
--- a/warehouse/catalog/stack_map/repos.csv
+++ b/warehouse/catalog/stack_map/repos.csv
@@ -1,0 +1,200 @@
+repo,product_slug,product_name,org,category,layer,openness_class,openness_bucket
+agent-infra/sandbox,agent-infra-sandbox,Agent Infra Sandbox,Agent Infra,deployment,infrastructure,open_source,open
+agenta-ai/agenta,agenta,Agenta,Agenta AI,telemetry_observability,product_ux,open_core,open
+agentops-ai/agentops,agentops,AgentOps,AgentOps AI,telemetry_observability,product_ux,open_core,open
+aider-ai/aider,aider,Aider,Aider AI,orchestration_agents,product_ux,open_source,open
+airockchip/rknn-toolkit2,rockchip-rk3588,Rockchip RK3588,Rockchip,edge_hardware,infrastructure,documented,closed
+alibaba/opensandbox,opensandbox,OpenSandbox,Alibaba,deployment,infrastructure,open_source,open
+all-hands-ai/openhands,openhands,OpenHands,All Hands AI,orchestration_agents,product_ux,open_core,open
+allenai/dolma,dolma,Dolma,Allen Institute for AI,training_synthetic_datasets,model_components,open,open
+anthropic-experimental/sandbox-runtime,sandbox-runtime,sandbox-runtime,Anthropic,deployment,infrastructure,open_source,open
+anthropics/claude-code,claude-code,Claude Code,Anthropic,orchestration_agents,product_ux,closed,closed
+anthropics/hh-rlhf,hh-rlhf,HH-RLHF (Anthropic Helpful/Harmless),Anthropic,training_synthetic_datasets,model_components,open,open
+antirez/ds4,ds4,ds4,antirez (Salvatore Sanfilippo),inference_code,model_components,open_source,open
+arize-ai/phoenix,phoenix,Phoenix,Arize AI,telemetry_observability,product_ux,source_available,open-ish
+assafelovic/gpt-researcher,gpt-researcher,GPT Researcher,Assaf Elovic,orchestration_agents,product_ux,open_source,open
+axelera-ai-hub/voyager-sdk,axelera-metis-aipu,Axelera Metis AIPU,Axelera AI,edge_hardware,infrastructure,documented,closed
+axolotl-ai-cloud/axolotl,axolotl,Axolotl,Axolotl AI,finetuning_code,model_components,open_source,open
+beagleboard/beagley-ai,beagley-ai,BeagleY-AI,BeagleBoard.org Foundation,edge_hardware,infrastructure,open_hardware,open
+beam-cloud/beta9,beta9,Beta9,Beam Cloud,deployment,infrastructure,open_core,open
+berriai/litellm,litellm,LiteLLM,BerriAI,ui_api,product_ux,open_core,open
+betagouv/comparia,compar-ia,Compar:IA,DINUM / beta.gouv.fr (French Government),evaluation_code,model_components,open_source,open
+bigcode-project/bigcode-evaluation-harness,bigcodebench,BigCodeBench,BigCode Project,evaluation_code,model_components,open_source,open
+bigcode-project/bigcodebench,bigcodebench,BigCodeBench,BigCode Project,evaluation_code,model_components,open_source,open
+blinkdl/rwkv-lm,rwkv,RWKV,RWKV Project,base_pretrained,model_components,open_source,open
+block/goose,goose,Goose,Block,orchestration_agents,product_ux,open_source,open
+browser-use/browser-use,browser-use,Browser Use,Browser Use,agent_tools_protocols,product_ux,open_core,open
+centerforaisafety/hle,humanitys-last-exam,Humanity's Last Exam (HLE),Center for AI Safety,benchmark_eval_data,model_components,gated,open-ish
+cline/cline,cline,Cline,Cline,orchestration_agents,product_ux,open_source,open
+coder/coder,coder-oss,Coder OSS,Coder,deployment,infrastructure,open_core,open
+comet-ml/opik,opik,Opik,Comet ML,telemetry_observability,product_ux,open_source,open
+composiohq/composio,composio,Composio,Composio,agent_tools_protocols,product_ux,open_core,open
+conferlabs/confer-image,confer,Confer,Confer Labs,ui_api,product_ux,source_available,open-ish
+conferlabs/confer-proxy,confer,Confer,Confer Labs,ui_api,product_ux,source_available,open-ish
+confident-ai/deepeval,deepeval,DeepEval,Confident AI,evaluation_code,model_components,open_core,open
+continuedev/continue,continue,Continue,Continue,ui_api,product_ux,open_source,open
+crystaldba/postgres-mcp,postgres-mcp,Postgres MCP Pro,Crystal DBA,agent_tools_protocols,product_ux,open_source,open
+danny-avila/librechat,librechat,LibreChat,LibreChat,ui_api,product_ux,open_source,open
+datasette/datasette-agent,datasette-agent,Datasette Agent,Datasette,orchestration_agents,product_ux,open_source,open
+daytonaio/daytona,daytona-sandbox,Daytona Sandbox,Daytona,deployment,infrastructure,open_core,open
+deepseek-ai/deepseek-v3,deepseek-v3-base,DeepSeek-V3 Base,DeepSeek,base_pretrained,model_components,open_weights,open-ish
+deepset-ai/haystack,haystack,Haystack,deepset,orchestration_agents,product_ux,open_core,open
+deepspeedai/deepspeed,deepspeed,DeepSpeed,Microsoft,ml_frameworks,infrastructure,open_source,open
+docling-project/docling,docling,Docling,IBM,agent_tools_protocols,product_ux,open_source,open
+e2b-dev/e2b,e2b-sandbox,E2B Sandbox,E2B,deployment,infrastructure,open_core,open
+e2b-dev/infra,e2b-sandbox,E2B Sandbox,E2B,deployment,infrastructure,open_core,open
+edgelesssys/privatemode-public,privatemode,Privatemode,Edgeless Systems,ui_api,product_ux,source_available,open-ish
+eleutherai/lm-evaluation-harness,lm-evaluation-harness,lm-evaluation-harness,EleutherAI,evaluation_code,model_components,open_source,open
+eleutherai/pythia,pythia,Pythia,EleutherAI,base_pretrained,model_components,open_source,open
+explodinggradients/ragas,ragas,Ragas,Exploding Gradients,evaluation_code,model_components,open_source,open
+facebookresearch/cruxeval,cruxeval,CRUXEval,Meta,benchmark_eval_data,model_components,open,open
+firecracker-microvm/firecracker,firecracker,Firecracker,Unknown,deployment,infrastructure,open_source,open
+foundationagents/openmanus,openmanus,OpenManus,FoundationAgents,orchestration_agents,product_ux,open_source,open
+ggml-org/ggml,ggml,GGML,ggml-org (Georgi Gerganov),ml_frameworks,infrastructure,open_source,open
+ggml-org/llama.cpp,llama-cpp,llama.cpp,ggml-org (Georgi Gerganov),inference_code,model_components,open_source,open
+github/github-mcp-server,github-mcp,GitHub MCP Server,GitHub (Microsoft),agent_tools_protocols,product_ux,open_source,open
+github/spec-kit,spec-kit,Spec Kit,GitHub (Microsoft),orchestration_agents,product_ux,open_source,open
+google-coral/libedgetpu,google-coral-dev-board,Google Coral Dev Board,Google,edge_hardware,infrastructure,documented,closed
+google-deepmind/code_contests,codecontests,CodeContests,Google DeepMind,benchmark_eval_data,model_components,open,open
+google-gemini/gemini-cli,gemini-cli,Gemini CLI,Google,orchestration_agents,product_ux,open_source,open
+google/flax,flax,Flax,Google DeepMind,ml_frameworks,infrastructure,open_source,open
+google/gvisor,gvisor,gVisor,Unknown,deployment,infrastructure,open_source,open
+google/sentencepiece,sentencepiece,SentencePiece,Google,ml_frameworks,infrastructure,open_source,open
+gradio-app/gradio,spaces,Spaces,Hugging Face,deployment,infrastructure,open_core,open
+gusye1234/nano-graphrag,nano-graphrag,nano-graphrag,gusye1234,orchestration_agents,product_ux,open_source,open
+hailo-ai/hailo_model_zoo_genai,hailo-10h,Hailo-10H,Hailo Technologies,edge_hardware,infrastructure,documented,closed
+hailo-ai/hailort,hailo-8,Hailo-8,Hailo Technologies,edge_hardware,infrastructure,documented,closed
+helicone/helicone,helicone,Helicone,Helicone,telemetry_observability,product_ux,open_core,open
+hendrycks/apps,apps,APPS,Hendrycks et al. (UC Berkeley),benchmark_eval_data,model_components,open,open
+hexastack/hexabot,hexabot,Hexabot,Hexastack,orchestration_agents,product_ux,source_available,open-ish
+hiyouga/llama-factory,llama-factory,LLaMA-Factory,Unknown,finetuning_code,model_components,open_source,open
+hkuds/lightrag,lightrag,LightRAG,HKU Data Science Lab,orchestration_agents,product_ux,open_source,open
+huggingface/accelerate,accelerate,Accelerate,Hugging Face,ml_frameworks,infrastructure,open_source,open
+huggingface/chat-ui,huggingchat-chat-ui,HuggingChat / chat-ui,Hugging Face,ui_api,product_ux,open_source,open
+huggingface/datasets,hf-datasets,Datasets,Hugging Face,ml_frameworks,infrastructure,open_source,open
+huggingface/diffusers,diffusers,Diffusers,Hugging Face,ml_frameworks,infrastructure,open_source,open
+huggingface/huggingface_hub,huggingface-hub,huggingface_hub,Hugging Face,ml_frameworks,infrastructure,open_source,open
+huggingface/lighteval,lighteval,lighteval,Hugging Face,evaluation_code,model_components,open_source,open
+huggingface/optimum,optimum,Optimum,Hugging Face,ml_frameworks,infrastructure,open_source,open
+huggingface/peft,peft,PEFT,Hugging Face,finetuning_code,model_components,open_source,open
+huggingface/safetensors,safetensors,Safetensors,Hugging Face,ml_frameworks,infrastructure,open_source,open
+huggingface/smolagents,smolagents,smolagents,Hugging Face,orchestration_agents,product_ux,open_source,open
+huggingface/smollm,smollm2,SmolLM2,Hugging Face,base_pretrained,model_components,open_source,open
+huggingface/tokenizers,tokenizers,Tokenizers,Hugging Face,ml_frameworks,infrastructure,open_source,open
+huggingface/transformers,transformers,Transformers,Hugging Face,ml_frameworks,infrastructure,open_source,open
+huggingface/trl,trl,TRL,Hugging Face,finetuning_code,model_components,open_source,open
+i-am-bee/beeai-framework,beeai,BeeAI Framework,IBM,orchestration_agents,product_ux,open_source,open
+infiniflow/ragflow,ragflow,RAGFlow,InfiniFlow,orchestration_agents,product_ux,open_source,open
+internlm/lmdeploy,lmdeploy,LMDeploy,Unknown,inference_code,model_components,open_source,open
+itzcrazykns/vane,perplexica,Perplexica,ItzCrazyKns,ui_api,product_ux,open_source,open
+janhq/jan,jan,Jan,Jan,ui_api,product_ux,open_source,open
+jax-ml/jax,jax,JAX,Google,ml_frameworks,infrastructure,open_source,open
+jina-ai/reader,jina-reader,Jina Reader,Jina AI,agent_tools_protocols,product_ux,open_source,open
+kata-containers/kata-containers,kata-containers,Kata Containers,Unknown,deployment,infrastructure,open_source,open
+kelkalot/simpleaudit,simpleaudit,SimpleAudit,Simula Research Laboratory,evaluation_code,model_components,open_source,open
+keras-team/keras,keras,Keras,Google,ml_frameworks,infrastructure,open_source,open
+khadas/fenix,khadas-edge2,Khadas Edge2,Khadas (Shenzhen Wesion),edge_hardware,infrastructure,open_toolchain,open-ish
+khoj-ai/khoj,khoj,Khoj,Khoj AI,ui_api,product_ux,open_source,open
+korotovsky/slack-mcp-server,slack-mcp,Slack MCP Server,Dmitry Korotovsky,agent_tools_protocols,product_ux,open_source,open
+kortix-ai/suna,suna,Suna,Kortix AI,orchestration_agents,product_ux,source_available,open-ish
+langchain-ai/langgraph,langgraph,LangGraph,LangChain,orchestration_agents,product_ux,open_core,open
+langflow-ai/langflow,langflow,Langflow,Langflow (DataStax),orchestration_agents,product_ux,open_source,open
+langfuse/langfuse,langfuse,Langfuse,Langfuse,telemetry_observability,product_ux,open_core,open
+langwatch/langwatch,langwatch,LangWatch,LangWatch,telemetry_observability,product_ux,open_core,open
+lightning-ai/litgpt,litgpt,LitGPT,Lightning AI,finetuning_code,model_components,open_source,open
+livebench/livebench,livebench,LiveBench,LiveBench,benchmark_eval_data,model_components,open,open
+livecodebench/livecodebench,livecodebench,LiveCodeBench,LiveCodeBench Team,benchmark_eval_data,model_components,open,open
+lm-sys/fastchat,mt-bench,MT-Bench,SGLang (LMSYS / UC Berkeley),benchmark_eval_data,model_components,open,open
+lmnr-ai/lmnr,laminar,Laminar,Laminar AI,telemetry_observability,product_ux,open_source,open
+lobehub/lobehub,lobe-chat,Lobe Chat,LobeHub,ui_api,product_ux,source_available,open-ish
+makenotion/notion-mcp-server,notion-mcp,Notion MCP Server,Notion,agent_tools_protocols,product_ux,open_source,open
+memryx/mxaccl,memryx-mx3,MemryX MX3,MemryX,edge_hardware,infrastructure,documented,closed
+mendableai/firecrawl,firecrawl,Firecrawl,Mendable,agent_tools_protocols,product_ux,open_core,open
+microsoft/autogen,autogen,AutoGen,Microsoft,orchestration_agents,product_ux,open_source,open
+microsoft/graphrag,graphrag,GraphRAG,Microsoft,orchestration_agents,product_ux,open_source,open
+microsoft/markitdown,markitdown,MarkItDown,Microsoft,agent_tools_protocols,product_ux,open_source,open
+microsoft/onnxruntime,onnx-runtime,ONNX Runtime,Microsoft,inference_code,model_components,open_source,open
+microsoft/playwright-mcp,playwright-mcp,Playwright MCP,Microsoft,agent_tools_protocols,product_ux,open_source,open
+microsoft/semantic-kernel,semantic-kernel,Semantic Kernel,Microsoft,orchestration_agents,product_ux,open_source,open
+milvus-io/milvus,milvus,Milvus,Zilliz,agent_tools_protocols,product_ux,open_source,open
+mintplex-labs/anything-llm,anythingllm,AnythingLLM,Mintplex Labs,ui_api,product_ux,open_source,open
+miurla/morphic,morphic,Morphic,Morphic,ui_api,product_ux,open_source,open
+mlfoundations/dclm,dclm-baseline,DCLM-baseline,DataComp-LM (ML Foundations),training_synthetic_datasets,model_components,open,open
+modelcontextprotocol/inspector,mcp-inspector,MCP Inspector,Anthropic,agent_tools_protocols,product_ux,open_source,open
+modelcontextprotocol/python-sdk,mcp-python-sdk,MCP Python SDK,Anthropic,agent_tools_protocols,product_ux,open_source,open
+modelcontextprotocol/servers,filesystem-mcp,Filesystem MCP Server,Anthropic,agent_tools_protocols,product_ux,open_source,open
+modelcontextprotocol/typescript-sdk,mcp-typescript-sdk,MCP TypeScript SDK,Anthropic,agent_tools_protocols,product_ux,open_source,open
+modsetter/surfsense,surfsense,SurfSense,SurfSense,ui_api,product_ux,open_source,open
+mozilla-ai/llamafile,llamafile,llamafile,Unknown,inference_code,model_components,open_source,open
+mudler/localai,localai,LocalAI,Mudler (LocalAI),inference_code,model_components,open_source,open
+n8n-io/n8n,n8n,n8n,n8n,orchestration_agents,product_ux,source_available,open-ish
+nomic-ai/gpt4all,gpt4all,GPT4All,Nomic AI,ui_api,product_ux,open_source,open
+nousresearch/atropos,atropos,Atropos,Nous Research,finetuning_code,model_components,open_source,open
+nousresearch/hermes-agent,hermes-agent,Hermes Agent,Nous Research,orchestration_agents,product_ux,open_source,open
+nuprl/multipl-e,multipl-e,MultiPL-E,Northeastern University / Brown / Wellesley,benchmark_eval_data,model_components,open,open
+nvidia-nemo/rl,nemo-rl,NeMo-RL,NVIDIA,finetuning_code,model_components,open_source,open
+nvidia/tensorrt-llm,tensorrt-llm,TensorRT-LLM,NVIDIA,inference_code,model_components,open_source,open
+oe4t/meta-tegra,nvidia-jetson-orin-nano-super-developer-kit,NVIDIA Jetson Orin Nano Super Developer Kit,NVIDIA,edge_hardware,infrastructure,documented,closed
+ollama/ollama,ollama,Ollama,Ollama,deployment,infrastructure,open_source,open
+onnx/onnx,onnx,ONNX,LF AI & Data (Linux Foundation),ml_frameworks,infrastructure,open_source,open
+open-compass/opencompass,opencompass,OpenCompass,OpenCompass Community,evaluation_code,model_components,open_source,open
+open-thoughts/open-thoughts,openthoughts-114k,OpenThoughts-114k,Open Thoughts,training_synthetic_datasets,model_components,open,open
+open-webui/open-webui,open-webui,Open WebUI,Open WebUI,ui_api,product_ux,source_available,open-ish
+openai/codex,codex-cli,Codex CLI,OpenAI,orchestration_agents,product_ux,open_source,open
+openai/human-eval,humaneval,HumanEval,OpenAI,benchmark_eval_data,model_components,open,open
+openai/simple-evals,simple-evals,simple-evals,OpenAI,evaluation_code,model_components,open_source,open
+openbmb/ultrafeedback,ultrafeedback,UltraFeedback,OpenBMB,training_synthetic_datasets,model_components,open,open
+openclaw/openclaw,openclaw,OpenClaw,OpenClaw Foundation,ui_api,product_ux,open_source,open
+openfn/lightning,openfn,OpenFn,Open Function Group (OpenFn),orchestration_agents,product_ux,open_source,open
+openlit/openlit,openlit,OpenLIT,OpenLIT,telemetry_observability,product_ux,open_source,open
+openmined/pysyft,pysyft,Syft / PySyft,OpenMined,ml_frameworks,infrastructure,open_source,open
+openpcc/openpcc,openpcc,OpenPCC,Confident Security,deployment,infrastructure,open_source,open
+openrlhf/openrlhf,openrlhf,OpenRLHF,OpenRLHF,finetuning_code,model_components,open_source,open
+opensecretcloud/maple,maple-ai,Maple AI,OpenSecret,ui_api,product_ux,open_source,open
+openvinotoolkit/openvino,openvino,OpenVINO,Intel,ml_frameworks,infrastructure,open_source,open
+orangepi-xunlong/orangepi-build,orange-pi-5,Orange Pi 5,Orange Pi (Shenzhen Xunlong),edge_hardware,infrastructure,open_toolchain,open-ish
+pathwaycom/pathway,pathway,Pathway,Pathway,orchestration_agents,product_ux,source_available,open-ish
+prefecthq/fastmcp,fastmcp,FastMCP,Prefect,agent_tools_protocols,product_ux,open_source,open
+princeton-nlp/swe-bench,swe-bench,SWE-bench,Princeton NLP,evaluation_code,model_components,open_source,open
+promptfoo/promptfoo,promptfoo,promptfoo,Unknown,evaluation_code,model_components,open_source,open
+protonlumo/android-lumo,lumo,Proton Lumo,Proton,ui_api,product_ux,open_core,open
+protonlumo/ios-lumo,lumo,Proton Lumo,Proton,ui_api,product_ux,open_core,open
+pydantic/pydantic-ai,pydantic-ai,PydanticAI,Pydantic,orchestration_agents,product_ux,open_core,open
+pytorch/pytorch,pytorch,PyTorch,PyTorch Foundation (Linux Foundation),ml_frameworks,infrastructure,open_source,open
+pytorch/torchtune,torchtune,torchtune,Unknown,finetuning_code,model_components,open_source,open
+qdrant/qdrant,qdrant,Qdrant,Qdrant,agent_tools_protocols,product_ux,open_core,open
+radxa-repo/bsp,radxa-rock-5b,Radxa ROCK 5B,Radxa,edge_hardware,infrastructure,open_toolchain,open-ish
+raspberrypi/hailort,raspberry-pi-ai-hat-plus,Raspberry Pi AI HAT+,Raspberry Pi,edge_hardware,infrastructure,open_toolchain,open-ish
+raspberrypi/linux,raspberry-pi-5,Raspberry Pi 5,Raspberry Pi,edge_hardware,infrastructure,open_toolchain,open-ish
+run-llama/llama_index,llama-index,LlamaIndex,LlamaIndex,orchestration_agents,product_ux,open_core,open
+scale3-labs/langtrace,langtrace,Langtrace,Scale3 Labs,telemetry_observability,product_ux,open_core,open
+searxng/searxng,searxng,SearXNG,SearXNG,agent_tools_protocols,product_ux,open_source,open
+sgl-project/sglang,sglang,SGLang,SGLang (LMSYS / UC Berkeley),inference_code,model_components,open_source,open
+significant-gravitas/autogpt,autogpt,AutoGPT,Significant Gravitas,orchestration_agents,product_ux,source_available,open-ish
+sillytavern/sillytavern,sillytavern,SillyTavern,SillyTavern,ui_api,product_ux,open_source,open
+simonw/llm,llm,LLM (Datasette),Datasette,ui_api,product_ux,open_source,open
+sipeed/maixpy,sipeed-maixcam,Sipeed MaixCAM,Sipeed,edge_hardware,infrastructure,open_toolchain,open-ish
+sst/opencode,opencode,OpenCode,SST / Anomaly,orchestration_agents,product_ux,open_source,open
+stackblitz/webcontainer-core,webcontainers,WebContainers,StackBlitz,deployment,infrastructure,source_available,open-ish
+stanford-crfm/helm,helm,HELM,Stanford CRFM,evaluation_code,model_components,open_source,open
+stanfordnlp/dspy,dspy,DSPy,Stanford NLP,orchestration_agents,product_ux,open_source,open
+swe-agent/swe-agent,swe-agent,SWE-agent,Princeton NLP,orchestration_agents,product_ux,open_source,open
+tatsu-lab/alpaca_eval,alpacaeval,AlpacaEval,Tatsu Lab (Stanford),evaluation_code,model_components,open_source,open
+tattle-made/feluda,feluda,Feluda,Tattle,ml_frameworks,infrastructure,open_source,open
+tencent-ailab/persona-hub,personahub,PersonaHub,Tencent AI Lab,training_synthetic_datasets,model_components,open,open
+tensorflow/tensorflow,tensorflow,TensorFlow,Google,ml_frameworks,infrastructure,open_source,open
+texasinstruments/edgeai-tidl-tools,ti-am67a,Texas Instruments AM67A,Texas Instruments,edge_hardware,infrastructure,documented,closed
+thunderbird/thunderbolt,thunderbolt,Thunderbolt,MZLA Technologies,ui_api,product_ux,open_source,open
+togethercomputer/redpajama-data,redpajama-data-v2,RedPajama-Data-v2,Together AI,training_synthetic_datasets,model_components,open,open
+traceloop/openllmetry,openllmetry,OpenLLMetry,Traceloop,telemetry_observability,product_ux,open_source,open
+triton-lang/triton,triton,Triton,Triton (triton-lang),ml_frameworks,infrastructure,open_source,open
+truera/trulens,trulens,TruLens,Snowflake,telemetry_observability,product_ux,open_source,open
+ukgovernmentbeis/inspect_ai,inspect-ai,Inspect AI,UK AI Security Institute,evaluation_code,model_components,open_source,open
+unslothai/unsloth,unsloth,Unsloth,Unsloth AI,finetuning_code,model_components,open_source,open
+vllm-project/vllm,vllm,vLLM,vLLM (UC Berkeley / vLLM team),inference_code,model_components,open_source,open
+volcengine/verl,verl,verl,ByteDance Seed / Volcano Engine,finetuning_code,model_components,open_source,open
+wandb/weave,weave,Weave,Weights & Biases,telemetry_observability,product_ux,open_core,open
+xiaomimimo/mimo,mimo-v2-5-pro,MiMo-V2.5-Pro,Xiaomi,base_pretrained,model_components,open_weights,open-ish
+xlang-ai/osworld,osworld,OSWorld,XLang AI Lab,evaluation_code,model_components,open_source,open
+zai-org/glm-5,glm-5-2,GLM-5.2,Zhipu / Z.ai,base_pretrained,model_components,open_weights,open-ish
+zed-industries/zed,zed,Zed,Zed Industries,orchestration_agents,product_ux,open_core,open

--- a/warehouse/ingest/build_stack_map.py
+++ b/warehouse/ingest/build_stack_map.py
@@ -1,0 +1,105 @@
+"""
+Build the stack-map taxonomy bridge CSV from curated sources/.
+
+Unlike the other fetchers (which pull from external APIs), this derives a CSV
+purely from the curated YAML in sources/: it maps every scored product's GitHub
+repo to its stack-map taxonomy (category, layer, openness). The OSO warehouse
+entities/repos catalog carries goodailist categories, NOT the curated
+sources/categories taxonomy, so this bridge is what lets warehouse models
+(e.g. currentai.scores.stack_contributors) roll up by stack-map category.
+
+Output: warehouse/catalog/stack_map/repos.csv  (one row per scored repo)
+Upload as the currentai.catalog.stack_map static model (see warehouse/models/README.md).
+
+Usage:
+    uv run python warehouse/ingest/build_stack_map.py
+"""
+
+import csv
+import glob
+import os
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SOURCES = ROOT / "sources"
+OUTPUT_CSV = ROOT / "warehouse" / "catalog" / "stack_map" / "repos.csv"
+
+OPEN = {"open_source", "open", "open_core", "open_hardware"}
+OPENISH = {"open_weights", "source_available", "gated", "open_toolchain"}
+
+
+def _bucket(cls: str) -> str:
+    if cls in OPEN:
+        return "open"
+    if cls in OPENISH:
+        return "open-ish"
+    return "closed"
+
+
+def _slug(doc: dict, path: str) -> str:
+    return (doc or {}).get("name") or os.path.splitext(os.path.basename(path))[0]
+
+
+def build_rows() -> list[list[str]]:
+    # category -> layer (taxonomy arcs ARE the Columbia layers)
+    tax = yaml.safe_load((SOURCES / "taxonomy.yaml").read_text())
+    cat_layer = {cs: arc["layer"] for arc in tax["arcs"] for cs in arc["categories"]}
+
+    # product slug -> category (category rosters own the assignment)
+    prod_cat = {}
+    for f in glob.glob(str(SOURCES / "categories" / "*.yaml")):
+        cat = yaml.safe_load(open(f)) or {}
+        cslug = _slug(cat, f)
+        for ps in cat.get("products") or []:
+            prod_cat[ps] = cslug
+
+    # product slug -> org display name (org rosters own membership)
+    prod_org = {}
+    for f in glob.glob(str(SOURCES / "organizations" / "*.yaml")):
+        o = yaml.safe_load(open(f)) or {}
+        disp = o.get("display_name") or _slug(o, f)
+        for ps in o.get("products") or []:
+            prod_org[ps] = disp
+
+    # product slug -> openness class/bucket
+    prod_open = {}
+    for f in glob.glob(str(SOURCES / "scores" / "*.yaml")):
+        s = yaml.safe_load(open(f)) or {}
+        cls = (s.get("openness") or {}).get("class")
+        prod_open[_slug(s, f)] = (cls, _bucket(cls))
+
+    # product -> repos, joined to the above
+    seen: dict[str, list[str]] = {}
+    for f in glob.glob(str(SOURCES / "products" / "*.yaml")):
+        p = yaml.safe_load(open(f)) or {}
+        slug = _slug(p, f)
+        disp = p.get("display_name", slug)
+        cat = prod_cat.get(slug)
+        layer = cat_layer.get(cat)
+        cls, buck = prod_open.get(slug, (None, "closed"))
+        org = prod_org.get(slug, "")
+        for u in p.get("github", []) or []:
+            m = re.search(r"github\.com/([^/]+/[^/]+?)(?:\.git)?/?$", u["url"])
+            if m and cat:
+                repo = m.group(1).lower()
+                if repo not in seen:
+                    seen[repo] = [repo, slug, disp, org, cat, layer, cls or "unknown", buck]
+    return sorted(seen.values())
+
+
+def main() -> None:
+    rows = build_rows()
+    OUTPUT_CSV.parent.mkdir(parents=True, exist_ok=True)
+    with open(OUTPUT_CSV, "w", newline="") as fh:
+        w = csv.writer(fh)
+        w.writerow(["repo", "product_slug", "product_name", "org",
+                    "category", "layer", "openness_class", "openness_bucket"])
+        w.writerows(rows)
+    print(f"wrote {OUTPUT_CSV.relative_to(ROOT)}: {len(rows)} rows")
+
+
+if __name__ == "__main__":
+    main()

--- a/warehouse/models/README.md
+++ b/warehouse/models/README.md
@@ -23,6 +23,7 @@ CSV-based reference data uploaded via scripts. Source CSVs live in `warehouse/ca
 | `currentai.catalog.model_repos` | `warehouse/catalog/huggingface/model_repos.csv` | ~6.3K | HF model → GitHub repo links |
 | `currentai.catalog.foundation_model_repos` | `warehouse/catalog/huggingface/foundation_model_repos.csv` | ~72 | Curated foundation model families → canonical repos |
 | `currentai.catalog.pypi_downloads` | `warehouse/catalog/pypi/pypi_downloads.csv` (gitignored) | ~1.6M | PyPI daily downloads by package × country, 39 AI packages |
+| `currentai.catalog.stack_map` | `warehouse/catalog/stack_map/repos.csv` | 199 | Taxonomy bridge: scored-product repos → stack-map category / layer / openness, generated from `sources/` by `warehouse/ingest/build_stack_map.py` |
 
 ## Entities (User Defined Models)
 
@@ -66,6 +67,7 @@ The OSAI/Raffi v2 taxonomy layer (scores.taxonomy, scores.investment_ranking) wa
 | `currentai.scores.project_summary` | [scores_project_summary.sql](scores_project_summary.sql) | Daily 7am | ~14K | Rolled-up snapshot per project |
 | `currentai.scores.repos_summary` | [scores_repos_summary.sql](scores_repos_summary.sql) | Daily 7am | ~15K | Per-repo snapshot: catalog metadata + 90-day activity + contributors |
 | `currentai.scores.ossd_coverage` | [scores_ossd_coverage.sql](scores_ossd_coverage.sql) | Daily 6am | ~10K | Per-org oss-directory match rates |
+| `currentai.scores.stack_contributors` | [scores_stack_contributors.sql](scores_stack_contributors.sql) | @manual | ~68K | Distinct GitHub code committers (12mo, bots excluded) per scored product, bridged to stack-map category/layer/openness via `catalog.stack_map` |
 
 ## Subscribed External Datasets
 

--- a/warehouse/models/scores_stack_contributors.sql
+++ b/warehouse/models/scores_stack_contributors.sql
@@ -1,0 +1,42 @@
+-- currentai.scores.stack_contributors
+-- Distinct GitHub code contributors to the curated AI Stack Map products, with the
+-- stack-map taxonomy (category / layer / openness) bridged in via currentai.catalog.stack_map.
+-- Grain: one row per (developer, repo). Window: trailing 365 days of COMMIT_CODE.
+-- Bots are excluded. The repo->taxonomy bridge is regenerated from sources/ (the OSO
+-- entities catalog does not carry stack-map categories).
+
+WITH commits AS (
+  SELECT
+    e.from_artifact_id AS developer_id,
+    e.from_artifact_name AS developer_login,
+    LOWER(e.to_artifact_namespace || '/' || e.to_artifact_name) AS repo,
+    COUNT(*) AS commits_12mo,
+    MAX(e.time) AS last_commit
+  FROM oso.int_events__github_unified e
+  WHERE e.event_type = 'COMMIT_CODE'
+    AND e.time >= CURRENT_DATE - INTERVAL '365' DAY
+    AND LOWER(e.to_artifact_namespace || '/' || e.to_artifact_name) IN (SELECT repo FROM currentai.catalog.stack_map)
+    AND e.from_artifact_name IS NOT NULL
+    AND NOT (
+      LOWER(e.from_artifact_name) LIKE '%[bot]%'
+      OR LOWER(e.from_artifact_name) LIKE '%-bot'
+      OR LOWER(e.from_artifact_name) LIKE 'bot-%'
+      OR LOWER(e.from_artifact_name) IN ('github-actions','dependabot','renovate','renovate-bot','mergify','copybara')
+    )
+  GROUP BY 1, 2, 3
+)
+SELECT
+  c.developer_id,
+  c.developer_login,
+  c.repo,
+  m.product_slug,
+  m.product_name,
+  m.org,
+  m.category,
+  m.layer,
+  m.openness_class,
+  m.openness_bucket,
+  c.commits_12mo,
+  c.last_commit
+FROM commits c
+JOIN currentai.catalog.stack_map m ON c.repo = m.repo

--- a/warehouse/sources.yaml
+++ b/warehouse/sources.yaml
@@ -42,3 +42,10 @@ sources:
     provides: Safety / safeguards incidents
     fetcher: warehouse/ingest/fetch_incidents.py
     refresh: quarterly
+
+  - id: stack_map
+    name: Stack-map taxonomy bridge (internal)
+    homepage: https://github.com/currentai-org/os-ai-map
+    provides: Scored-product repos mapped to stack-map category/layer/openness (derived from sources/, not an external API)
+    fetcher: warehouse/ingest/build_stack_map.py
+    refresh: on-curation-change


### PR DESCRIPTION
## Summary

Bridges the curated `sources/` taxonomy into the warehouse and adds a distinct-contributor model, to power the gap-map launch insights (OSO-3002). The OSO entities/repos catalog carries `goodailist` categories, **not** the curated `sources/categories` taxonomy — so there was no way to roll warehouse activity up by stack-map category/layer/openness. This fixes that.

### Models (deployed to `currentai` via MCP)
- **`currentai.catalog.stack_map`** (static, 199 rows) — scored-product repos → `category / layer / openness_class / openness_bucket / org`, generated from `sources/` by `warehouse/ingest/build_stack_map.py`. Regenerate + re-upload on curation changes.
- **`currentai.scores.stack_contributors`** (UDM, ~68K rows) — one row per (developer, repo): distinct GitHub `COMMIT_CODE` committers to the 199 repos (bots excluded, trailing 365 days), joined to the bridge. Source is `oso.int_events__github_unified` (note: `currentai.events.github_events` has no actor column, so actor-level dedup must use the public unified events table).

### Why a model (not a live query)
`COUNT(DISTINCT from_artifact_id)` over int_events for 190+ repos × 365d blows the pyoso/API 15GB interactive limit (times out). Materializing server-side is the fix.

### Headline result (OSO-3002)
Distinct open-stack developers, last 12 months: **57,618** any-commit (45,234 ex-OpenClaw) / **26,374** ≥10 commits / **9,877** core ≥50 commits.

## Test plan
- `uv run python -m build.validate` → `0 error(s)`
- `uv run pytest -q` → `35 passed`
- `warehouse/ingest/build_stack_map.py` reproduces the uploaded CSV byte-identically
- Both models materialized and queried successfully in `currentai`

Draft: the models are already live in the warehouse; this PR tracks their source so they don't drift.