### PR TITLE
chore(warehouse): refresh stack_map bridge orgs after #49

### DIFF
--- a/warehouse/catalog/stack_map/repos.csv
+++ b/warehouse/catalog/stack_map/repos.csv
@@ -48,7 +48,7 @@ eleutherai/lm-evaluation-harness,lm-evaluation-harness,lm-evaluation-harness,Ele
 eleutherai/pythia,pythia,Pythia,EleutherAI,base_pretrained,model_components,open_source,open
 explodinggradients/ragas,ragas,Ragas,Exploding Gradients,evaluation_code,model_components,open_source,open
 facebookresearch/cruxeval,cruxeval,CRUXEval,Meta,benchmark_eval_data,model_components,open,open
-firecracker-microvm/firecracker,firecracker,Firecracker,Unknown,deployment,infrastructure,open_source,open
+firecracker-microvm/firecracker,firecracker,Firecracker,Amazon Web Services,deployment,infrastructure,open_source,open
 foundationagents/openmanus,openmanus,OpenManus,FoundationAgents,orchestration_agents,product_ux,open_source,open
 ggml-org/ggml,ggml,GGML,ggml-org (Georgi Gerganov),ml_frameworks,infrastructure,open_source,open
 ggml-org/llama.cpp,llama-cpp,llama.cpp,ggml-org (Georgi Gerganov),inference_code,model_components,open_source,open
@@ -58,7 +58,7 @@ google-coral/libedgetpu,google-coral-dev-board,Google Coral Dev Board,Google,edg
 google-deepmind/code_contests,codecontests,CodeContests,Google DeepMind,benchmark_eval_data,model_components,open,open
 google-gemini/gemini-cli,gemini-cli,Gemini CLI,Google,orchestration_agents,product_ux,open_source,open
 google/flax,flax,Flax,Google DeepMind,ml_frameworks,infrastructure,open_source,open
-google/gvisor,gvisor,gVisor,Unknown,deployment,infrastructure,open_source,open
+google/gvisor,gvisor,gVisor,Google,deployment,infrastructure,open_source,open
 google/sentencepiece,sentencepiece,SentencePiece,Google,ml_frameworks,infrastructure,open_source,open
 gradio-app/gradio,spaces,Spaces,Hugging Face,deployment,infrastructure,open_core,open
 gusye1234/nano-graphrag,nano-graphrag,nano-graphrag,gusye1234,orchestration_agents,product_ux,open_source,open
@@ -85,12 +85,12 @@ huggingface/transformers,transformers,Transformers,Hugging Face,ml_frameworks,in
 huggingface/trl,trl,TRL,Hugging Face,finetuning_code,model_components,open_source,open
 i-am-bee/beeai-framework,beeai,BeeAI Framework,IBM,orchestration_agents,product_ux,open_source,open
 infiniflow/ragflow,ragflow,RAGFlow,InfiniFlow,orchestration_agents,product_ux,open_source,open
-internlm/lmdeploy,lmdeploy,LMDeploy,Unknown,inference_code,model_components,open_source,open
+internlm/lmdeploy,lmdeploy,LMDeploy,Shanghai AI Laboratory,inference_code,model_components,open_source,open
 itzcrazykns/vane,perplexica,Perplexica,ItzCrazyKns,ui_api,product_ux,open_source,open
 janhq/jan,jan,Jan,Jan,ui_api,product_ux,open_source,open
 jax-ml/jax,jax,JAX,Google,ml_frameworks,infrastructure,open_source,open
 jina-ai/reader,jina-reader,Jina Reader,Jina AI,agent_tools_protocols,product_ux,open_source,open
-kata-containers/kata-containers,kata-containers,Kata Containers,Unknown,deployment,infrastructure,open_source,open
+kata-containers/kata-containers,kata-containers,Kata Containers,OpenInfra Foundation,deployment,infrastructure,open_source,open
 kelkalot/simpleaudit,simpleaudit,SimpleAudit,Simula Research Laboratory,evaluation_code,model_components,open_source,open
 keras-team/keras,keras,Keras,Google,ml_frameworks,infrastructure,open_source,open
 khadas/fenix,khadas-edge2,Khadas Edge2,Khadas (Shenzhen Wesion),edge_hardware,infrastructure,open_toolchain,open-ish
@@ -125,7 +125,7 @@ modelcontextprotocol/python-sdk,mcp-python-sdk,MCP Python SDK,Anthropic,agent_to
 modelcontextprotocol/servers,filesystem-mcp,Filesystem MCP Server,Anthropic,agent_tools_protocols,product_ux,open_source,open
 modelcontextprotocol/typescript-sdk,mcp-typescript-sdk,MCP TypeScript SDK,Anthropic,agent_tools_protocols,product_ux,open_source,open
 modsetter/surfsense,surfsense,SurfSense,SurfSense,ui_api,product_ux,open_source,open
-mozilla-ai/llamafile,llamafile,llamafile,Unknown,inference_code,model_components,open_source,open
+mozilla-ai/llamafile,llamafile,llamafile,Mozilla AI,inference_code,model_components,open_source,open
 mudler/localai,localai,LocalAI,Mudler (LocalAI),inference_code,model_components,open_source,open
 n8n-io/n8n,n8n,n8n,n8n,orchestration_agents,product_ux,source_available,open-ish
 nomic-ai/gpt4all,gpt4all,GPT4All,Nomic AI,ui_api,product_ux,open_source,open
@@ -156,12 +156,12 @@ orangepi-xunlong/orangepi-build,orange-pi-5,Orange Pi 5,Orange Pi (Shenzhen Xunl
 pathwaycom/pathway,pathway,Pathway,Pathway,orchestration_agents,product_ux,source_available,open-ish
 prefecthq/fastmcp,fastmcp,FastMCP,Prefect,agent_tools_protocols,product_ux,open_source,open
 princeton-nlp/swe-bench,swe-bench,SWE-bench,Princeton NLP,evaluation_code,model_components,open_source,open
-promptfoo/promptfoo,promptfoo,promptfoo,Unknown,evaluation_code,model_components,open_source,open
+promptfoo/promptfoo,promptfoo,promptfoo,promptfoo,evaluation_code,model_components,open_source,open
 protonlumo/android-lumo,lumo,Proton Lumo,Proton,ui_api,product_ux,open_core,open
 protonlumo/ios-lumo,lumo,Proton Lumo,Proton,ui_api,product_ux,open_core,open
 pydantic/pydantic-ai,pydantic-ai,PydanticAI,Pydantic,orchestration_agents,product_ux,open_core,open
 pytorch/pytorch,pytorch,PyTorch,PyTorch Foundation (Linux Foundation),ml_frameworks,infrastructure,open_source,open
-pytorch/torchtune,torchtune,torchtune,Unknown,finetuning_code,model_components,open_source,open
+pytorch/torchtune,torchtune,torchtune,PyTorch Foundation (Linux Foundation),finetuning_code,model_components,open_source,open
 qdrant/qdrant,qdrant,Qdrant,Qdrant,agent_tools_protocols,product_ux,open_core,open
 radxa-repo/bsp,radxa-rock-5b,Radxa ROCK 5B,Radxa,edge_hardware,infrastructure,open_toolchain,open-ish
 raspberrypi/hailort,raspberry-pi-ai-hat-plus,Raspberry Pi AI HAT+,Raspberry Pi,edge_hardware,infrastructure,open_toolchain,open-ish


### PR DESCRIPTION
Regenerates `warehouse/catalog/stack_map/repos.csv` from `build_stack_map.py` now that #49's org-linking is on main, and re-uploads the static model.

Only the `org` column changed (7 rows: Unknown → real org); category/layer/openness are unchanged, so no chart or published number is affected. `llama-factory` stays Unknown by design.

CI: validate is unaffected (warehouse-only).