### PR TITLE
feat(warehouse): add gap-map scores to stack_map bridge

### DIFF
--- a/warehouse/catalog/stack_map/repos.csv
+++ b/warehouse/catalog/stack_map/repos.csv
@@ -1,200 +1,206 @@
-repo,product_slug,product_name,org,category,layer,openness_class,openness_bucket
-agent-infra/sandbox,agent-infra-sandbox,Agent Infra Sandbox,Agent Infra,deployment,infrastructure,open_source,open
-agenta-ai/agenta,agenta,Agenta,Agenta AI,telemetry_observability,product_ux,open_core,open
-agentops-ai/agentops,agentops,AgentOps,AgentOps AI,telemetry_observability,product_ux,open_core,open
-aider-ai/aider,aider,Aider,Aider AI,orchestration_agents,product_ux,open_source,open
-airockchip/rknn-toolkit2,rockchip-rk3588,Rockchip RK3588,Rockchip,edge_hardware,infrastructure,documented,closed
-alibaba/opensandbox,opensandbox,OpenSandbox,Alibaba,deployment,infrastructure,open_source,open
-all-hands-ai/openhands,openhands,OpenHands,All Hands AI,orchestration_agents,product_ux,open_core,open
-allenai/dolma,dolma,Dolma,Allen Institute for AI,training_synthetic_datasets,model_components,open,open
-anthropic-experimental/sandbox-runtime,sandbox-runtime,sandbox-runtime,Anthropic,deployment,infrastructure,open_source,open
-anthropics/claude-code,claude-code,Claude Code,Anthropic,orchestration_agents,product_ux,closed,closed
-anthropics/hh-rlhf,hh-rlhf,HH-RLHF (Anthropic Helpful/Harmless),Anthropic,training_synthetic_datasets,model_components,open,open
-antirez/ds4,ds4,ds4,antirez (Salvatore Sanfilippo),inference_code,model_components,open_source,open
-arize-ai/phoenix,phoenix,Phoenix,Arize AI,telemetry_observability,product_ux,source_available,open-ish
-assafelovic/gpt-researcher,gpt-researcher,GPT Researcher,Assaf Elovic,orchestration_agents,product_ux,open_source,open
-axelera-ai-hub/voyager-sdk,axelera-metis-aipu,Axelera Metis AIPU,Axelera AI,edge_hardware,infrastructure,documented,closed
-axolotl-ai-cloud/axolotl,axolotl,Axolotl,Axolotl AI,finetuning_code,model_components,open_source,open
-beagleboard/beagley-ai,beagley-ai,BeagleY-AI,BeagleBoard.org Foundation,edge_hardware,infrastructure,open_hardware,open
-beam-cloud/beta9,beta9,Beta9,Beam Cloud,deployment,infrastructure,open_core,open
-berriai/litellm,litellm,LiteLLM,BerriAI,ui_api,product_ux,open_core,open
-betagouv/comparia,compar-ia,Compar:IA,DINUM / beta.gouv.fr (French Government),evaluation_code,model_components,open_source,open
-bigcode-project/bigcode-evaluation-harness,bigcodebench,BigCodeBench,BigCode Project,evaluation_code,model_components,open_source,open
-bigcode-project/bigcodebench,bigcodebench,BigCodeBench,BigCode Project,evaluation_code,model_components,open_source,open
-blinkdl/rwkv-lm,rwkv,RWKV,RWKV Project,base_pretrained,model_components,open_source,open
-block/goose,goose,Goose,Block,orchestration_agents,product_ux,open_source,open
-browser-use/browser-use,browser-use,Browser Use,Browser Use,agent_tools_protocols,product_ux,open_core,open
-centerforaisafety/hle,humanitys-last-exam,Humanity's Last Exam (HLE),Center for AI Safety,benchmark_eval_data,model_components,gated,open-ish
-cline/cline,cline,Cline,Cline,orchestration_agents,product_ux,open_source,open
-coder/coder,coder-oss,Coder OSS,Coder,deployment,infrastructure,open_core,open
-comet-ml/opik,opik,Opik,Comet ML,telemetry_observability,product_ux,open_source,open
-composiohq/composio,composio,Composio,Composio,agent_tools_protocols,product_ux,open_core,open
-conferlabs/confer-image,confer,Confer,Confer Labs,ui_api,product_ux,source_available,open-ish
-conferlabs/confer-proxy,confer,Confer,Confer Labs,ui_api,product_ux,source_available,open-ish
-confident-ai/deepeval,deepeval,DeepEval,Confident AI,evaluation_code,model_components,open_core,open
-continuedev/continue,continue,Continue,Continue,ui_api,product_ux,open_source,open
-crystaldba/postgres-mcp,postgres-mcp,Postgres MCP Pro,Crystal DBA,agent_tools_protocols,product_ux,open_source,open
-danny-avila/librechat,librechat,LibreChat,LibreChat,ui_api,product_ux,open_source,open
-datasette/datasette-agent,datasette-agent,Datasette Agent,Datasette,orchestration_agents,product_ux,open_source,open
-daytonaio/daytona,daytona-sandbox,Daytona Sandbox,Daytona,deployment,infrastructure,open_core,open
-deepseek-ai/deepseek-v3,deepseek-v3-base,DeepSeek-V3 Base,DeepSeek,base_pretrained,model_components,open_weights,open-ish
-deepset-ai/haystack,haystack,Haystack,deepset,orchestration_agents,product_ux,open_core,open
-deepspeedai/deepspeed,deepspeed,DeepSpeed,Microsoft,ml_frameworks,infrastructure,open_source,open
-docling-project/docling,docling,Docling,IBM,agent_tools_protocols,product_ux,open_source,open
-e2b-dev/e2b,e2b-sandbox,E2B Sandbox,E2B,deployment,infrastructure,open_core,open
-e2b-dev/infra,e2b-sandbox,E2B Sandbox,E2B,deployment,infrastructure,open_core,open
-edgelesssys/privatemode-public,privatemode,Privatemode,Edgeless Systems,ui_api,product_ux,source_available,open-ish
-eleutherai/lm-evaluation-harness,lm-evaluation-harness,lm-evaluation-harness,EleutherAI,evaluation_code,model_components,open_source,open
-eleutherai/pythia,pythia,Pythia,EleutherAI,base_pretrained,model_components,open_source,open
-explodinggradients/ragas,ragas,Ragas,Exploding Gradients,evaluation_code,model_components,open_source,open
-facebookresearch/cruxeval,cruxeval,CRUXEval,Meta,benchmark_eval_data,model_components,open,open
-firecracker-microvm/firecracker,firecracker,Firecracker,Amazon Web Services,deployment,infrastructure,open_source,open
-foundationagents/openmanus,openmanus,OpenManus,FoundationAgents,orchestration_agents,product_ux,open_source,open
-ggml-org/ggml,ggml,GGML,ggml-org (Georgi Gerganov),ml_frameworks,infrastructure,open_source,open
-ggml-org/llama.cpp,llama-cpp,llama.cpp,ggml-org (Georgi Gerganov),inference_code,model_components,open_source,open
-github/github-mcp-server,github-mcp,GitHub MCP Server,GitHub (Microsoft),agent_tools_protocols,product_ux,open_source,open
-github/spec-kit,spec-kit,Spec Kit,GitHub (Microsoft),orchestration_agents,product_ux,open_source,open
-google-coral/libedgetpu,google-coral-dev-board,Google Coral Dev Board,Google,edge_hardware,infrastructure,documented,closed
-google-deepmind/code_contests,codecontests,CodeContests,Google DeepMind,benchmark_eval_data,model_components,open,open
-google-gemini/gemini-cli,gemini-cli,Gemini CLI,Google,orchestration_agents,product_ux,open_source,open
-google/flax,flax,Flax,Google DeepMind,ml_frameworks,infrastructure,open_source,open
-google/gvisor,gvisor,gVisor,Google,deployment,infrastructure,open_source,open
-google/sentencepiece,sentencepiece,SentencePiece,Google,ml_frameworks,infrastructure,open_source,open
-gradio-app/gradio,spaces,Spaces,Hugging Face,deployment,infrastructure,open_core,open
-gusye1234/nano-graphrag,nano-graphrag,nano-graphrag,gusye1234,orchestration_agents,product_ux,open_source,open
-hailo-ai/hailo_model_zoo_genai,hailo-10h,Hailo-10H,Hailo Technologies,edge_hardware,infrastructure,documented,closed
-hailo-ai/hailort,hailo-8,Hailo-8,Hailo Technologies,edge_hardware,infrastructure,documented,closed
-helicone/helicone,helicone,Helicone,Helicone,telemetry_observability,product_ux,open_core,open
-hendrycks/apps,apps,APPS,Hendrycks et al. (UC Berkeley),benchmark_eval_data,model_components,open,open
-hexastack/hexabot,hexabot,Hexabot,Hexastack,orchestration_agents,product_ux,source_available,open-ish
-hiyouga/llama-factory,llama-factory,LLaMA-Factory,Unknown,finetuning_code,model_components,open_source,open
-hkuds/lightrag,lightrag,LightRAG,HKU Data Science Lab,orchestration_agents,product_ux,open_source,open
-huggingface/accelerate,accelerate,Accelerate,Hugging Face,ml_frameworks,infrastructure,open_source,open
-huggingface/chat-ui,huggingchat-chat-ui,HuggingChat / chat-ui,Hugging Face,ui_api,product_ux,open_source,open
-huggingface/datasets,hf-datasets,Datasets,Hugging Face,ml_frameworks,infrastructure,open_source,open
-huggingface/diffusers,diffusers,Diffusers,Hugging Face,ml_frameworks,infrastructure,open_source,open
-huggingface/huggingface_hub,huggingface-hub,huggingface_hub,Hugging Face,ml_frameworks,infrastructure,open_source,open
-huggingface/lighteval,lighteval,lighteval,Hugging Face,evaluation_code,model_components,open_source,open
-huggingface/optimum,optimum,Optimum,Hugging Face,ml_frameworks,infrastructure,open_source,open
-huggingface/peft,peft,PEFT,Hugging Face,finetuning_code,model_components,open_source,open
-huggingface/safetensors,safetensors,Safetensors,Hugging Face,ml_frameworks,infrastructure,open_source,open
-huggingface/smolagents,smolagents,smolagents,Hugging Face,orchestration_agents,product_ux,open_source,open
-huggingface/smollm,smollm2,SmolLM2,Hugging Face,base_pretrained,model_components,open_source,open
-huggingface/tokenizers,tokenizers,Tokenizers,Hugging Face,ml_frameworks,infrastructure,open_source,open
-huggingface/transformers,transformers,Transformers,Hugging Face,ml_frameworks,infrastructure,open_source,open
-huggingface/trl,trl,TRL,Hugging Face,finetuning_code,model_components,open_source,open
-i-am-bee/beeai-framework,beeai,BeeAI Framework,IBM,orchestration_agents,product_ux,open_source,open
-infiniflow/ragflow,ragflow,RAGFlow,InfiniFlow,orchestration_agents,product_ux,open_source,open
-internlm/lmdeploy,lmdeploy,LMDeploy,Shanghai AI Laboratory,inference_code,model_components,open_source,open
-itzcrazykns/vane,perplexica,Perplexica,ItzCrazyKns,ui_api,product_ux,open_source,open
-janhq/jan,jan,Jan,Jan,ui_api,product_ux,open_source,open
-jax-ml/jax,jax,JAX,Google,ml_frameworks,infrastructure,open_source,open
-jina-ai/reader,jina-reader,Jina Reader,Jina AI,agent_tools_protocols,product_ux,open_source,open
-kata-containers/kata-containers,kata-containers,Kata Containers,OpenInfra Foundation,deployment,infrastructure,open_source,open
-kelkalot/simpleaudit,simpleaudit,SimpleAudit,Simula Research Laboratory,evaluation_code,model_components,open_source,open
-keras-team/keras,keras,Keras,Google,ml_frameworks,infrastructure,open_source,open
-khadas/fenix,khadas-edge2,Khadas Edge2,Khadas (Shenzhen Wesion),edge_hardware,infrastructure,open_toolchain,open-ish
-khoj-ai/khoj,khoj,Khoj,Khoj AI,ui_api,product_ux,open_source,open
-korotovsky/slack-mcp-server,slack-mcp,Slack MCP Server,Dmitry Korotovsky,agent_tools_protocols,product_ux,open_source,open
-kortix-ai/suna,suna,Suna,Kortix AI,orchestration_agents,product_ux,source_available,open-ish
-langchain-ai/langgraph,langgraph,LangGraph,LangChain,orchestration_agents,product_ux,open_core,open
-langflow-ai/langflow,langflow,Langflow,Langflow (DataStax),orchestration_agents,product_ux,open_source,open
-langfuse/langfuse,langfuse,Langfuse,Langfuse,telemetry_observability,product_ux,open_core,open
-langwatch/langwatch,langwatch,LangWatch,LangWatch,telemetry_observability,product_ux,open_core,open
-lightning-ai/litgpt,litgpt,LitGPT,Lightning AI,finetuning_code,model_components,open_source,open
-livebench/livebench,livebench,LiveBench,LiveBench,benchmark_eval_data,model_components,open,open
-livecodebench/livecodebench,livecodebench,LiveCodeBench,LiveCodeBench Team,benchmark_eval_data,model_components,open,open
-lm-sys/fastchat,mt-bench,MT-Bench,SGLang (LMSYS / UC Berkeley),benchmark_eval_data,model_components,open,open
-lmnr-ai/lmnr,laminar,Laminar,Laminar AI,telemetry_observability,product_ux,open_source,open
-lobehub/lobehub,lobe-chat,Lobe Chat,LobeHub,ui_api,product_ux,source_available,open-ish
-makenotion/notion-mcp-server,notion-mcp,Notion MCP Server,Notion,agent_tools_protocols,product_ux,open_source,open
-memryx/mxaccl,memryx-mx3,MemryX MX3,MemryX,edge_hardware,infrastructure,documented,closed
-mendableai/firecrawl,firecrawl,Firecrawl,Mendable,agent_tools_protocols,product_ux,open_core,open
-microsoft/autogen,autogen,AutoGen,Microsoft,orchestration_agents,product_ux,open_source,open
-microsoft/graphrag,graphrag,GraphRAG,Microsoft,orchestration_agents,product_ux,open_source,open
-microsoft/markitdown,markitdown,MarkItDown,Microsoft,agent_tools_protocols,product_ux,open_source,open
-microsoft/onnxruntime,onnx-runtime,ONNX Runtime,Microsoft,inference_code,model_components,open_source,open
-microsoft/playwright-mcp,playwright-mcp,Playwright MCP,Microsoft,agent_tools_protocols,product_ux,open_source,open
-microsoft/semantic-kernel,semantic-kernel,Semantic Kernel,Microsoft,orchestration_agents,product_ux,open_source,open
-milvus-io/milvus,milvus,Milvus,Zilliz,agent_tools_protocols,product_ux,open_source,open
-mintplex-labs/anything-llm,anythingllm,AnythingLLM,Mintplex Labs,ui_api,product_ux,open_source,open
-miurla/morphic,morphic,Morphic,Morphic,ui_api,product_ux,open_source,open
-mlfoundations/dclm,dclm-baseline,DCLM-baseline,DataComp-LM (ML Foundations),training_synthetic_datasets,model_components,open,open
-modelcontextprotocol/inspector,mcp-inspector,MCP Inspector,Anthropic,agent_tools_protocols,product_ux,open_source,open
-modelcontextprotocol/python-sdk,mcp-python-sdk,MCP Python SDK,Anthropic,agent_tools_protocols,product_ux,open_source,open
-modelcontextprotocol/servers,filesystem-mcp,Filesystem MCP Server,Anthropic,agent_tools_protocols,product_ux,open_source,open
-modelcontextprotocol/typescript-sdk,mcp-typescript-sdk,MCP TypeScript SDK,Anthropic,agent_tools_protocols,product_ux,open_source,open
-modsetter/surfsense,surfsense,SurfSense,SurfSense,ui_api,product_ux,open_source,open
-mozilla-ai/llamafile,llamafile,llamafile,Mozilla AI,inference_code,model_components,open_source,open
-mudler/localai,localai,LocalAI,Mudler (LocalAI),inference_code,model_components,open_source,open
-n8n-io/n8n,n8n,n8n,n8n,orchestration_agents,product_ux,source_available,open-ish
-nomic-ai/gpt4all,gpt4all,GPT4All,Nomic AI,ui_api,product_ux,open_source,open
-nousresearch/atropos,atropos,Atropos,Nous Research,finetuning_code,model_components,open_source,open
-nousresearch/hermes-agent,hermes-agent,Hermes Agent,Nous Research,orchestration_agents,product_ux,open_source,open
-nuprl/multipl-e,multipl-e,MultiPL-E,Northeastern University / Brown / Wellesley,benchmark_eval_data,model_components,open,open
-nvidia-nemo/rl,nemo-rl,NeMo-RL,NVIDIA,finetuning_code,model_components,open_source,open
-nvidia/tensorrt-llm,tensorrt-llm,TensorRT-LLM,NVIDIA,inference_code,model_components,open_source,open
-oe4t/meta-tegra,nvidia-jetson-orin-nano-super-developer-kit,NVIDIA Jetson Orin Nano Super Developer Kit,NVIDIA,edge_hardware,infrastructure,documented,closed
-ollama/ollama,ollama,Ollama,Ollama,deployment,infrastructure,open_source,open
-onnx/onnx,onnx,ONNX,LF AI & Data (Linux Foundation),ml_frameworks,infrastructure,open_source,open
-open-compass/opencompass,opencompass,OpenCompass,OpenCompass Community,evaluation_code,model_components,open_source,open
-open-thoughts/open-thoughts,openthoughts-114k,OpenThoughts-114k,Open Thoughts,training_synthetic_datasets,model_components,open,open
-open-webui/open-webui,open-webui,Open WebUI,Open WebUI,ui_api,product_ux,source_available,open-ish
-openai/codex,codex-cli,Codex CLI,OpenAI,orchestration_agents,product_ux,open_source,open
-openai/human-eval,humaneval,HumanEval,OpenAI,benchmark_eval_data,model_components,open,open
-openai/simple-evals,simple-evals,simple-evals,OpenAI,evaluation_code,model_components,open_source,open
-openbmb/ultrafeedback,ultrafeedback,UltraFeedback,OpenBMB,training_synthetic_datasets,model_components,open,open
-openclaw/openclaw,openclaw,OpenClaw,OpenClaw Foundation,ui_api,product_ux,open_source,open
-openfn/lightning,openfn,OpenFn,Open Function Group (OpenFn),orchestration_agents,product_ux,open_source,open
-openlit/openlit,openlit,OpenLIT,OpenLIT,telemetry_observability,product_ux,open_source,open
-openmined/pysyft,pysyft,Syft / PySyft,OpenMined,ml_frameworks,infrastructure,open_source,open
-openpcc/openpcc,openpcc,OpenPCC,Confident Security,deployment,infrastructure,open_source,open
-openrlhf/openrlhf,openrlhf,OpenRLHF,OpenRLHF,finetuning_code,model_components,open_source,open
-opensecretcloud/maple,maple-ai,Maple AI,OpenSecret,ui_api,product_ux,open_source,open
-openvinotoolkit/openvino,openvino,OpenVINO,Intel,ml_frameworks,infrastructure,open_source,open
-orangepi-xunlong/orangepi-build,orange-pi-5,Orange Pi 5,Orange Pi (Shenzhen Xunlong),edge_hardware,infrastructure,open_toolchain,open-ish
-pathwaycom/pathway,pathway,Pathway,Pathway,orchestration_agents,product_ux,source_available,open-ish
-prefecthq/fastmcp,fastmcp,FastMCP,Prefect,agent_tools_protocols,product_ux,open_source,open
-princeton-nlp/swe-bench,swe-bench,SWE-bench,Princeton NLP,evaluation_code,model_components,open_source,open
-promptfoo/promptfoo,promptfoo,promptfoo,promptfoo,evaluation_code,model_components,open_source,open
-protonlumo/android-lumo,lumo,Proton Lumo,Proton,ui_api,product_ux,open_core,open
-protonlumo/ios-lumo,lumo,Proton Lumo,Proton,ui_api,product_ux,open_core,open
-pydantic/pydantic-ai,pydantic-ai,PydanticAI,Pydantic,orchestration_agents,product_ux,open_core,open
-pytorch/pytorch,pytorch,PyTorch,PyTorch Foundation (Linux Foundation),ml_frameworks,infrastructure,open_source,open
-pytorch/torchtune,torchtune,torchtune,PyTorch Foundation (Linux Foundation),finetuning_code,model_components,open_source,open
-qdrant/qdrant,qdrant,Qdrant,Qdrant,agent_tools_protocols,product_ux,open_core,open
-radxa-repo/bsp,radxa-rock-5b,Radxa ROCK 5B,Radxa,edge_hardware,infrastructure,open_toolchain,open-ish
-raspberrypi/hailort,raspberry-pi-ai-hat-plus,Raspberry Pi AI HAT+,Raspberry Pi,edge_hardware,infrastructure,open_toolchain,open-ish
-raspberrypi/linux,raspberry-pi-5,Raspberry Pi 5,Raspberry Pi,edge_hardware,infrastructure,open_toolchain,open-ish
-run-llama/llama_index,llama-index,LlamaIndex,LlamaIndex,orchestration_agents,product_ux,open_core,open
-scale3-labs/langtrace,langtrace,Langtrace,Scale3 Labs,telemetry_observability,product_ux,open_core,open
-searxng/searxng,searxng,SearXNG,SearXNG,agent_tools_protocols,product_ux,open_source,open
-sgl-project/sglang,sglang,SGLang,SGLang (LMSYS / UC Berkeley),inference_code,model_components,open_source,open
-significant-gravitas/autogpt,autogpt,AutoGPT,Significant Gravitas,orchestration_agents,product_ux,source_available,open-ish
-sillytavern/sillytavern,sillytavern,SillyTavern,SillyTavern,ui_api,product_ux,open_source,open
-simonw/llm,llm,LLM (Datasette),Datasette,ui_api,product_ux,open_source,open
-sipeed/maixpy,sipeed-maixcam,Sipeed MaixCAM,Sipeed,edge_hardware,infrastructure,open_toolchain,open-ish
-sst/opencode,opencode,OpenCode,SST / Anomaly,orchestration_agents,product_ux,open_source,open
-stackblitz/webcontainer-core,webcontainers,WebContainers,StackBlitz,deployment,infrastructure,source_available,open-ish
-stanford-crfm/helm,helm,HELM,Stanford CRFM,evaluation_code,model_components,open_source,open
-stanfordnlp/dspy,dspy,DSPy,Stanford NLP,orchestration_agents,product_ux,open_source,open
-swe-agent/swe-agent,swe-agent,SWE-agent,Princeton NLP,orchestration_agents,product_ux,open_source,open
-tatsu-lab/alpaca_eval,alpacaeval,AlpacaEval,Tatsu Lab (Stanford),evaluation_code,model_components,open_source,open
-tattle-made/feluda,feluda,Feluda,Tattle,ml_frameworks,infrastructure,open_source,open
-tencent-ailab/persona-hub,personahub,PersonaHub,Tencent AI Lab,training_synthetic_datasets,model_components,open,open
-tensorflow/tensorflow,tensorflow,TensorFlow,Google,ml_frameworks,infrastructure,open_source,open
-texasinstruments/edgeai-tidl-tools,ti-am67a,Texas Instruments AM67A,Texas Instruments,edge_hardware,infrastructure,documented,closed
-thunderbird/thunderbolt,thunderbolt,Thunderbolt,MZLA Technologies,ui_api,product_ux,open_source,open
-togethercomputer/redpajama-data,redpajama-data-v2,RedPajama-Data-v2,Together AI,training_synthetic_datasets,model_components,open,open
-traceloop/openllmetry,openllmetry,OpenLLMetry,Traceloop,telemetry_observability,product_ux,open_source,open
-triton-lang/triton,triton,Triton,Triton (triton-lang),ml_frameworks,infrastructure,open_source,open
-truera/trulens,trulens,TruLens,Snowflake,telemetry_observability,product_ux,open_source,open
-ukgovernmentbeis/inspect_ai,inspect-ai,Inspect AI,UK AI Security Institute,evaluation_code,model_components,open_source,open
-unslothai/unsloth,unsloth,Unsloth,Unsloth AI,finetuning_code,model_components,open_source,open
-vllm-project/vllm,vllm,vLLM,vLLM (UC Berkeley / vLLM team),inference_code,model_components,open_source,open
-volcengine/verl,verl,verl,ByteDance Seed / Volcano Engine,finetuning_code,model_components,open_source,open
-wandb/weave,weave,Weave,Weights & Biases,telemetry_observability,product_ux,open_core,open
-xiaomimimo/mimo,mimo-v2-5-pro,MiMo-V2.5-Pro,Xiaomi,base_pretrained,model_components,open_weights,open-ish
-xlang-ai/osworld,osworld,OSWorld,XLang AI Lab,evaluation_code,model_components,open_source,open
-zai-org/glm-5,glm-5-2,GLM-5.2,Zhipu / Z.ai,base_pretrained,model_components,open_weights,open-ish
-zed-industries/zed,zed,Zed,Zed Industries,orchestration_agents,product_ux,open_core,open
+repo,product_slug,product_name,org,category,layer,openness_class,openness_bucket,adoption,capability,maturity
+agent-infra/sandbox,agent-infra-sandbox,Agent Infra Sandbox,Agent Infra,deployment,infrastructure,open_source,open,1,3,1.8
+agenta-ai/agenta,agenta,Agenta,Agenta AI,telemetry_observability,product_ux,open_core,open,2,4,3.0
+agentops-ai/agentops,agentops,AgentOps,AgentOps AI,telemetry_observability,product_ux,open_core,open,3,3,3.0
+aider-ai/aider,aider,Aider,Aider AI,orchestration_agents,product_ux,open_source,open,3,3,3.0
+airockchip/rknn-toolkit2,rockchip-rk3588,Rockchip RK3588,Rockchip,edge_hardware,infrastructure,documented,closed,5,4,4.5
+alibaba/opensandbox,opensandbox,OpenSandbox,Alibaba,deployment,infrastructure,open_source,open,2,3,2.4
+all-hands-ai/openhands,openhands,OpenHands,All Hands AI,orchestration_agents,product_ux,open_core,open,3,5,4.4
+allenai/dolma,dolma,Dolma,Allen Institute for AI,training_synthetic_datasets,model_components,open,open,1,,1.0
+allenai/olmo,olmo-2-instruct,OLMo 2 Instruct,Ai2,finetuned_chat,model_components,open_source,open,3,3,3.0
+allenai/olmoe,olmoe-instruct,OLMoE Instruct,Ai2,finetuned_chat,model_components,open_source,open,3,2,2.3
+allenai/open-instruct,olmo-2-instruct,OLMo 2 Instruct,Ai2,finetuned_chat,model_components,open_source,open,3,3,3.0
+anthropic-experimental/sandbox-runtime,sandbox-runtime,sandbox-runtime,Anthropic,deployment,infrastructure,open_source,open,2,3,2.4
+anthropics/claude-code,claude-code,Claude Code,Anthropic,orchestration_agents,product_ux,closed,closed,4,5,4.7
+anthropics/hh-rlhf,hh-rlhf,HH-RLHF (Anthropic Helpful/Harmless),Anthropic,training_synthetic_datasets,model_components,open,open,2,,2.0
+antirez/ds4,ds4,ds4,antirez (Salvatore Sanfilippo),inference_code,model_components,open_source,open,2,3,2.5
+arize-ai/phoenix,phoenix,Phoenix,Arize AI,telemetry_observability,product_ux,source_available,open-ish,4,4,4.0
+assafelovic/gpt-researcher,gpt-researcher,GPT Researcher,Assaf Elovic,orchestration_agents,product_ux,open_source,open,3,3,3.0
+axelera-ai-hub/voyager-sdk,axelera-metis-aipu,Axelera Metis AIPU,Axelera AI,edge_hardware,infrastructure,documented,closed,3,4,3.5
+axolotl-ai-cloud/axolotl,axolotl,Axolotl,Axolotl AI,finetuning_code,model_components,open_source,open,2,4,3.0
+beagleboard/beagley-ai,beagley-ai,BeagleY-AI,BeagleBoard.org Foundation,edge_hardware,infrastructure,open_hardware,open,4,3,3.5
+beam-cloud/beta9,beta9,Beta9,Beam Cloud,deployment,infrastructure,open_core,open,2,3,2.4
+berriai/litellm,litellm,LiteLLM,BerriAI,ui_api,product_ux,open_core,open,3,4,3.3
+betagouv/comparia,compar-ia,Compar:IA,DINUM / beta.gouv.fr (French Government),evaluation_code,model_components,open_source,open,3,4,3.5
+bigcode-project/bigcode-evaluation-harness,bigcodebench,BigCodeBench,BigCode Project,evaluation_code,model_components,open_source,open,2,3,2.5
+bigcode-project/bigcodebench,bigcodebench,BigCodeBench,BigCode Project,evaluation_code,model_components,open_source,open,2,3,2.5
+blinkdl/rwkv-lm,rwkv,RWKV,RWKV Project,base_pretrained,model_components,open_source,open,3,4,3.7
+block/goose,goose,Goose,Block,orchestration_agents,product_ux,open_source,open,3,3,3.0
+browser-use/browser-use,browser-use,Browser Use,Browser Use,agent_tools_protocols,product_ux,open_core,open,4,4,4.0
+centerforaisafety/hle,humanitys-last-exam,Humanity's Last Exam (HLE),Center for AI Safety,benchmark_eval_data,model_components,gated,open-ish,4,5,4.4
+cline/cline,cline,Cline,Cline,orchestration_agents,product_ux,open_source,open,4,4,4.0
+coder/coder,coder-oss,Coder OSS,Coder,deployment,infrastructure,open_core,open,3,3,3.0
+comet-ml/opik,opik,Opik,Comet ML,telemetry_observability,product_ux,open_source,open,4,4,4.0
+composiohq/composio,composio,Composio,Composio,agent_tools_protocols,product_ux,open_core,open,4,4,4.0
+conferlabs/confer-image,confer,Confer,Confer Labs,ui_api,product_ux,source_available,open-ish,2,3,2.3
+conferlabs/confer-proxy,confer,Confer,Confer Labs,ui_api,product_ux,source_available,open-ish,2,3,2.3
+confident-ai/deepeval,deepeval,DeepEval,Confident AI,evaluation_code,model_components,open_core,open,4,4,4.0
+continuedev/continue,continue,Continue,Continue,ui_api,product_ux,open_source,open,4,4,4.0
+crystaldba/postgres-mcp,postgres-mcp,Postgres MCP Pro,Crystal DBA,agent_tools_protocols,product_ux,open_source,open,3,4,3.4
+danny-avila/librechat,librechat,LibreChat,LibreChat,ui_api,product_ux,open_source,open,4,5,4.3
+datasette/datasette-agent,datasette-agent,Datasette Agent,Datasette,orchestration_agents,product_ux,open_source,open,1,2,1.7
+daytonaio/daytona,daytona-sandbox,Daytona Sandbox,Daytona,deployment,infrastructure,open_core,open,4,4,4.0
+deepseek-ai/deepseek-v3,deepseek-v3-base,DeepSeek-V3 Base,DeepSeek,base_pretrained,model_components,open_weights,open-ish,4,3,3.3
+deepset-ai/haystack,haystack,Haystack,deepset,orchestration_agents,product_ux,open_core,open,4,5,4.7
+deepspeedai/deepspeed,deepspeed,DeepSpeed,Microsoft,ml_frameworks,infrastructure,open_source,open,3,5,3.8
+docling-project/docling,docling,Docling,IBM,agent_tools_protocols,product_ux,open_source,open,3,5,3.8
+e2b-dev/e2b,e2b-sandbox,E2B Sandbox,E2B,deployment,infrastructure,open_core,open,4,4,4.0
+e2b-dev/infra,e2b-sandbox,E2B Sandbox,E2B,deployment,infrastructure,open_core,open,4,4,4.0
+edgelesssys/privatemode-public,privatemode,Privatemode,Edgeless Systems,ui_api,product_ux,source_available,open-ish,2,4,2.6
+eleutherai/lm-evaluation-harness,lm-evaluation-harness,lm-evaluation-harness,EleutherAI,evaluation_code,model_components,open_source,open,4,5,4.5
+eleutherai/pythia,pythia,Pythia,EleutherAI,base_pretrained,model_components,open_source,open,3,1,1.6
+explodinggradients/ragas,ragas,Ragas,Exploding Gradients,evaluation_code,model_components,open_source,open,4,4,4.0
+facebookresearch/cruxeval,cruxeval,CRUXEval,Meta,benchmark_eval_data,model_components,open,open,3,,3.0
+firecracker-microvm/firecracker,firecracker,Firecracker,Amazon Web Services,deployment,infrastructure,open_source,open,5,5,5.0
+foundationagents/openmanus,openmanus,OpenManus,FoundationAgents,orchestration_agents,product_ux,open_source,open,3,3,3.0
+ggml-org/ggml,ggml,GGML,ggml-org (Georgi Gerganov),ml_frameworks,infrastructure,open_source,open,3,5,3.8
+ggml-org/llama.cpp,llama-cpp,llama.cpp,ggml-org (Georgi Gerganov),inference_code,model_components,open_source,open,4,4,4.0
+github/github-mcp-server,github-mcp,GitHub MCP Server,GitHub (Microsoft),agent_tools_protocols,product_ux,open_source,open,3,5,3.8
+github/spec-kit,spec-kit,Spec Kit,GitHub (Microsoft),orchestration_agents,product_ux,open_source,open,3,4,3.7
+google-coral/libedgetpu,google-coral-dev-board,Google Coral Dev Board,Google,edge_hardware,infrastructure,documented,closed,4,2,3.0
+google-deepmind/code_contests,codecontests,CodeContests,Google DeepMind,benchmark_eval_data,model_components,open,open,3,,3.0
+google-gemini/gemini-cli,gemini-cli,Gemini CLI,Google,orchestration_agents,product_ux,open_source,open,5,5,5.0
+google/flax,flax,Flax,Google DeepMind,ml_frameworks,infrastructure,open_source,open,4,4,4.0
+google/gvisor,gvisor,gVisor,Google,deployment,infrastructure,open_source,open,5,5,5.0
+google/sentencepiece,sentencepiece,SentencePiece,Google,ml_frameworks,infrastructure,open_source,open,5,4,4.6
+gradio-app/gradio,spaces,Spaces,Hugging Face,deployment,infrastructure,open_core,open,5,3,4.2
+gusye1234/nano-graphrag,nano-graphrag,nano-graphrag,gusye1234,orchestration_agents,product_ux,open_source,open,2,3,2.7
+hailo-ai/hailo_model_zoo_genai,hailo-10h,Hailo-10H,Hailo Technologies,edge_hardware,infrastructure,documented,closed,3,4,3.5
+hailo-ai/hailort,hailo-8,Hailo-8,Hailo Technologies,edge_hardware,infrastructure,documented,closed,4,3,3.5
+helicone/helicone,helicone,Helicone,Helicone,telemetry_observability,product_ux,open_core,open,3,4,3.5
+hendrycks/apps,apps,APPS,Hendrycks et al. (UC Berkeley),benchmark_eval_data,model_components,open,open,3,,3.0
+hexastack/hexabot,hexabot,Hexabot,Hexastack,orchestration_agents,product_ux,source_available,open-ish,3,4,3.7
+hiyouga/llama-factory,llama-factory,LLaMA-Factory,Unknown,finetuning_code,model_components,open_source,open,3,4,3.5
+hkuds/lightrag,lightrag,LightRAG,HKU Data Science Lab,orchestration_agents,product_ux,open_source,open,4,4,4.0
+huggingface/accelerate,accelerate,Accelerate,Hugging Face,ml_frameworks,infrastructure,open_source,open,5,4,4.6
+huggingface/alignment-handbook,zephyr,Zephyr,Hugging Face,finetuned_chat,model_components,open_source,open,4,2,2.6
+huggingface/chat-ui,huggingchat-chat-ui,HuggingChat / chat-ui,Hugging Face,ui_api,product_ux,open_source,open,3,3,3.0
+huggingface/datasets,hf-datasets,Datasets,Hugging Face,ml_frameworks,infrastructure,open_source,open,5,4,4.6
+huggingface/diffusers,diffusers,Diffusers,Hugging Face,ml_frameworks,infrastructure,open_source,open,4,4,4.0
+huggingface/huggingface_hub,huggingface-hub,huggingface_hub,Hugging Face,ml_frameworks,infrastructure,open_source,open,5,5,5.0
+huggingface/lighteval,lighteval,lighteval,Hugging Face,evaluation_code,model_components,open_source,open,2,4,3.0
+huggingface/optimum,optimum,Optimum,Hugging Face,ml_frameworks,infrastructure,open_source,open,3,4,3.4
+huggingface/peft,peft,PEFT,Hugging Face,finetuning_code,model_components,open_source,open,5,4,4.5
+huggingface/safetensors,safetensors,Safetensors,Hugging Face,ml_frameworks,infrastructure,open_source,open,5,4,4.6
+huggingface/smolagents,smolagents,smolagents,Hugging Face,orchestration_agents,product_ux,open_source,open,3,3,3.0
+huggingface/smollm,smollm2,SmolLM2,Hugging Face,base_pretrained,model_components,open_source,open,3,3,3.0
+huggingface/tokenizers,tokenizers,Tokenizers,Hugging Face,ml_frameworks,infrastructure,open_source,open,5,5,5.0
+huggingface/transformers,transformers,Transformers,Hugging Face,ml_frameworks,infrastructure,open_source,open,5,5,5.0
+huggingface/trl,trl,TRL,Hugging Face,finetuning_code,model_components,open_source,open,4,4,4.0
+i-am-bee/beeai-framework,beeai,BeeAI Framework,IBM,orchestration_agents,product_ux,open_source,open,3,4,3.7
+infiniflow/ragflow,ragflow,RAGFlow,InfiniFlow,orchestration_agents,product_ux,open_source,open,3,4,3.7
+internlm/lmdeploy,lmdeploy,LMDeploy,Shanghai AI Laboratory,inference_code,model_components,open_source,open,3,4,3.5
+itzcrazykns/vane,perplexica,Perplexica,ItzCrazyKns,ui_api,product_ux,open_source,open,3,4,3.3
+janhq/jan,jan,Jan,Jan,ui_api,product_ux,open_source,open,4,3,3.7
+jax-ml/jax,jax,JAX,Google,ml_frameworks,infrastructure,open_source,open,5,5,5.0
+jina-ai/reader,jina-reader,Jina Reader,Jina AI,agent_tools_protocols,product_ux,open_source,open,3,3,3.0
+kata-containers/kata-containers,kata-containers,Kata Containers,OpenInfra Foundation,deployment,infrastructure,open_source,open,3,4,3.4
+kelkalot/simpleaudit,simpleaudit,SimpleAudit,Simula Research Laboratory,evaluation_code,model_components,open_source,open,2,3,2.5
+keras-team/keras,keras,Keras,Google,ml_frameworks,infrastructure,open_source,open,5,4,4.6
+khadas/fenix,khadas-edge2,Khadas Edge2,Khadas (Shenzhen Wesion),edge_hardware,infrastructure,open_toolchain,open-ish,4,3,3.5
+khoj-ai/khoj,khoj,Khoj,Khoj AI,ui_api,product_ux,open_source,open,3,4,3.3
+korotovsky/slack-mcp-server,slack-mcp,Slack MCP Server,Dmitry Korotovsky,agent_tools_protocols,product_ux,open_source,open,2,4,2.8
+kortix-ai/suna,suna,Suna,Kortix AI,orchestration_agents,product_ux,source_available,open-ish,2,3,2.7
+langchain-ai/langgraph,langgraph,LangGraph,LangChain,orchestration_agents,product_ux,open_core,open,5,5,5.0
+langflow-ai/langflow,langflow,Langflow,Langflow (DataStax),orchestration_agents,product_ux,open_source,open,4,4,4.0
+langfuse/langfuse,langfuse,Langfuse,Langfuse,telemetry_observability,product_ux,open_core,open,3,4,3.5
+langwatch/langwatch,langwatch,LangWatch,LangWatch,telemetry_observability,product_ux,open_core,open,2,4,3.0
+lightning-ai/litgpt,litgpt,LitGPT,Lightning AI,finetuning_code,model_components,open_source,open,3,3,3.0
+livebench/livebench,livebench,LiveBench,LiveBench,benchmark_eval_data,model_components,open,open,4,5,4.4
+livecodebench/livecodebench,livecodebench,LiveCodeBench,LiveCodeBench Team,benchmark_eval_data,model_components,open,open,4,,4.0
+llm360/k2-data-prep,k2-chat,K2 Chat,LLM360,finetuned_chat,model_components,open_source,open,2,3,2.7
+llm360/k2-train,k2-chat,K2 Chat,LLM360,finetuned_chat,model_components,open_source,open,2,3,2.7
+lm-sys/fastchat,mt-bench,MT-Bench,SGLang (LMSYS / UC Berkeley),benchmark_eval_data,model_components,open,open,3,4,3.4
+lmnr-ai/lmnr,laminar,Laminar,Laminar AI,telemetry_observability,product_ux,open_source,open,3,3,3.0
+lobehub/lobehub,lobe-chat,Lobe Chat,LobeHub,ui_api,product_ux,source_available,open-ish,3,4,3.3
+makenotion/notion-mcp-server,notion-mcp,Notion MCP Server,Notion,agent_tools_protocols,product_ux,open_source,open,3,4,3.4
+memryx/mxaccl,memryx-mx3,MemryX MX3,MemryX,edge_hardware,infrastructure,documented,closed,3,3,3.0
+mendableai/firecrawl,firecrawl,Firecrawl,Mendable,agent_tools_protocols,product_ux,open_core,open,3,4,3.4
+microsoft/autogen,autogen,AutoGen,Microsoft,orchestration_agents,product_ux,open_source,open,4,4,4.0
+microsoft/graphrag,graphrag,GraphRAG,Microsoft,orchestration_agents,product_ux,open_source,open,3,4,3.7
+microsoft/markitdown,markitdown,MarkItDown,Microsoft,agent_tools_protocols,product_ux,open_source,open,3,4,3.4
+microsoft/onnxruntime,onnx-runtime,ONNX Runtime,Microsoft,inference_code,model_components,open_source,open,5,4,4.5
+microsoft/playwright-mcp,playwright-mcp,Playwright MCP,Microsoft,agent_tools_protocols,product_ux,open_source,open,4,4,4.0
+microsoft/semantic-kernel,semantic-kernel,Semantic Kernel,Microsoft,orchestration_agents,product_ux,open_source,open,3,4,3.7
+milvus-io/milvus,milvus,Milvus,Zilliz,agent_tools_protocols,product_ux,open_source,open,3,4,3.4
+mintplex-labs/anything-llm,anythingllm,AnythingLLM,Mintplex Labs,ui_api,product_ux,open_source,open,4,4,4.0
+miurla/morphic,morphic,Morphic,Morphic,ui_api,product_ux,open_source,open,3,3,3.0
+mlfoundations/dclm,dclm-baseline,DCLM-baseline,DataComp-LM (ML Foundations),training_synthetic_datasets,model_components,open,open,3,,3.0
+modelcontextprotocol/inspector,mcp-inspector,MCP Inspector,Anthropic,agent_tools_protocols,product_ux,open_source,open,4,4,4.0
+modelcontextprotocol/python-sdk,mcp-python-sdk,MCP Python SDK,Anthropic,agent_tools_protocols,product_ux,open_source,open,3,5,3.8
+modelcontextprotocol/servers,filesystem-mcp,Filesystem MCP Server,Anthropic,agent_tools_protocols,product_ux,open_source,open,3,4,3.4
+modelcontextprotocol/typescript-sdk,mcp-typescript-sdk,MCP TypeScript SDK,Anthropic,agent_tools_protocols,product_ux,open_source,open,5,5,5.0
+modsetter/surfsense,surfsense,SurfSense,SurfSense,ui_api,product_ux,open_source,open,3,4,3.3
+mozilla-ai/llamafile,llamafile,llamafile,Mozilla AI,inference_code,model_components,open_source,open,3,3,3.0
+mudler/localai,localai,LocalAI,Mudler (LocalAI),inference_code,model_components,open_source,open,3,5,4.0
+n8n-io/n8n,n8n,n8n,n8n,orchestration_agents,product_ux,source_available,open-ish,5,4,4.3
+nomic-ai/gpt4all,gpt4all,GPT4All,Nomic AI,ui_api,product_ux,open_source,open,3,3,3.0
+nousresearch/atropos,atropos,Atropos,Nous Research,finetuning_code,model_components,open_source,open,1,3,2.0
+nousresearch/hermes-agent,hermes-agent,Hermes Agent,Nous Research,orchestration_agents,product_ux,open_source,open,4,4,4.0
+nuprl/multipl-e,multipl-e,MultiPL-E,Northeastern University / Brown / Wellesley,benchmark_eval_data,model_components,open,open,3,,3.0
+nvidia-nemo/rl,nemo-rl,NeMo-RL,NVIDIA,finetuning_code,model_components,open_source,open,2,5,3.5
+nvidia/tensorrt-llm,tensorrt-llm,TensorRT-LLM,NVIDIA,inference_code,model_components,open_source,open,3,5,4.0
+oe4t/meta-tegra,nvidia-jetson-orin-nano-super-developer-kit,NVIDIA Jetson Orin Nano Super Developer Kit,NVIDIA,edge_hardware,infrastructure,documented,closed,4,3,3.5
+ollama/ollama,ollama,Ollama,Ollama,deployment,infrastructure,open_source,open,4,4,4.0
+onnx/onnx,onnx,ONNX,LF AI & Data (Linux Foundation),ml_frameworks,infrastructure,open_source,open,5,5,5.0
+open-compass/opencompass,opencompass,OpenCompass,OpenCompass Community,evaluation_code,model_components,open_source,open,3,4,3.5
+open-thoughts/open-thoughts,openthoughts-114k,OpenThoughts-114k,Open Thoughts,training_synthetic_datasets,model_components,open,open,2,,2.0
+open-webui/open-webui,open-webui,Open WebUI,Open WebUI,ui_api,product_ux,source_available,open-ish,4,4,4.0
+openai/codex,codex-cli,Codex CLI,OpenAI,orchestration_agents,product_ux,open_source,open,4,4,4.0
+openai/human-eval,humaneval,HumanEval,OpenAI,benchmark_eval_data,model_components,open,open,4,,4.0
+openai/simple-evals,simple-evals,simple-evals,OpenAI,evaluation_code,model_components,open_source,open,2,2,2.0
+openbmb/ultrafeedback,ultrafeedback,UltraFeedback,OpenBMB,training_synthetic_datasets,model_components,open,open,1,,1.0
+openclaw/openclaw,openclaw,OpenClaw,OpenClaw Foundation,ui_api,product_ux,open_source,open,5,5,5.0
+openfn/lightning,openfn,OpenFn,Open Function Group (OpenFn),orchestration_agents,product_ux,open_source,open,3,4,3.7
+openlit/openlit,openlit,OpenLIT,OpenLIT,telemetry_observability,product_ux,open_source,open,2,4,3.0
+openmined/pysyft,pysyft,Syft / PySyft,OpenMined,ml_frameworks,infrastructure,open_source,open,3,4,3.4
+openpcc/openpcc,openpcc,OpenPCC,Confident Security,deployment,infrastructure,open_source,open,2,4,2.8
+openrlhf/openrlhf,openrlhf,OpenRLHF,OpenRLHF,finetuning_code,model_components,open_source,open,2,4,3.0
+opensecretcloud/maple,maple-ai,Maple AI,OpenSecret,ui_api,product_ux,open_source,open,3,4,3.3
+openvinotoolkit/openvino,openvino,OpenVINO,Intel,ml_frameworks,infrastructure,open_source,open,3,4,3.4
+orangepi-xunlong/orangepi-build,orange-pi-5,Orange Pi 5,Orange Pi (Shenzhen Xunlong),edge_hardware,infrastructure,open_toolchain,open-ish,5,3,4.0
+pathwaycom/pathway,pathway,Pathway,Pathway,orchestration_agents,product_ux,source_available,open-ish,3,4,3.7
+prefecthq/fastmcp,fastmcp,FastMCP,Prefect,agent_tools_protocols,product_ux,open_source,open,5,4,4.6
+princeton-nlp/swe-bench,swe-bench,SWE-bench,Princeton NLP,evaluation_code,model_components,open_source,open,4,5,4.5
+promptfoo/promptfoo,promptfoo,promptfoo,promptfoo,evaluation_code,model_components,open_source,open,4,4,4.0
+protonlumo/android-lumo,lumo,Proton Lumo,Proton,ui_api,product_ux,open_core,open,3,3,3.0
+protonlumo/ios-lumo,lumo,Proton Lumo,Proton,ui_api,product_ux,open_core,open,3,3,3.0
+pydantic/pydantic-ai,pydantic-ai,PydanticAI,Pydantic,orchestration_agents,product_ux,open_core,open,5,4,4.3
+pytorch/pytorch,pytorch,PyTorch,PyTorch Foundation (Linux Foundation),ml_frameworks,infrastructure,open_source,open,5,5,5.0
+pytorch/torchtune,torchtune,torchtune,PyTorch Foundation (Linux Foundation),finetuning_code,model_components,open_source,open,3,3,3.0
+qdrant/qdrant,qdrant,Qdrant,Qdrant,agent_tools_protocols,product_ux,open_core,open,5,4,4.6
+radxa-repo/bsp,radxa-rock-5b,Radxa ROCK 5B,Radxa,edge_hardware,infrastructure,open_toolchain,open-ish,5,4,4.5
+raspberrypi/hailort,raspberry-pi-ai-hat-plus,Raspberry Pi AI HAT+,Raspberry Pi,edge_hardware,infrastructure,open_toolchain,open-ish,4,3,3.5
+raspberrypi/linux,raspberry-pi-5,Raspberry Pi 5,Raspberry Pi,edge_hardware,infrastructure,open_toolchain,open-ish,5,2,3.5
+run-llama/llama_index,llama-index,LlamaIndex,LlamaIndex,orchestration_agents,product_ux,open_core,open,5,5,5.0
+scale3-labs/langtrace,langtrace,Langtrace,Scale3 Labs,telemetry_observability,product_ux,open_core,open,2,3,2.5
+searxng/searxng,searxng,SearXNG,SearXNG,agent_tools_protocols,product_ux,open_source,open,4,4,4.0
+sgl-project/sglang,sglang,SGLang,SGLang (LMSYS / UC Berkeley),inference_code,model_components,open_source,open,4,5,4.5
+significant-gravitas/autogpt,autogpt,AutoGPT,Significant Gravitas,orchestration_agents,product_ux,source_available,open-ish,3,2,2.3
+sillytavern/sillytavern,sillytavern,SillyTavern,SillyTavern,ui_api,product_ux,open_source,open,3,3,3.0
+simonw/llm,llm,LLM (Datasette),Datasette,ui_api,product_ux,open_source,open,3,3,3.0
+sipeed/maixpy,sipeed-maixcam,Sipeed MaixCAM,Sipeed,edge_hardware,infrastructure,open_toolchain,open-ish,3,2,2.5
+sst/opencode,opencode,OpenCode,SST / Anomaly,orchestration_agents,product_ux,open_source,open,4,5,4.7
+stackblitz/webcontainer-core,webcontainers,WebContainers,StackBlitz,deployment,infrastructure,source_available,open-ish,3,3,3.0
+stanford-crfm/helm,helm,HELM,Stanford CRFM,evaluation_code,model_components,open_source,open,3,5,4.0
+stanfordnlp/dspy,dspy,DSPy,Stanford NLP,orchestration_agents,product_ux,open_source,open,4,4,4.0
+swe-agent/swe-agent,swe-agent,SWE-agent,Princeton NLP,orchestration_agents,product_ux,open_source,open,2,3,2.7
+tatsu-lab/alpaca_eval,alpacaeval,AlpacaEval,Tatsu Lab (Stanford),evaluation_code,model_components,open_source,open,3,4,3.5
+tattle-made/feluda,feluda,Feluda,Tattle,ml_frameworks,infrastructure,open_source,open,2,3,2.4
+tencent-ailab/persona-hub,personahub,PersonaHub,Tencent AI Lab,training_synthetic_datasets,model_components,open,open,1,,1.0
+tensorflow/tensorflow,tensorflow,TensorFlow,Google,ml_frameworks,infrastructure,open_source,open,5,5,5.0
+texasinstruments/edgeai-tidl-tools,ti-am67a,Texas Instruments AM67A,Texas Instruments,edge_hardware,infrastructure,documented,closed,3,4,3.5
+thunderbird/thunderbolt,thunderbolt,Thunderbolt,MZLA Technologies,ui_api,product_ux,open_source,open,2,4,2.6
+togethercomputer/redpajama-data,redpajama-data-v2,RedPajama-Data-v2,Together AI,training_synthetic_datasets,model_components,open,open,1,,1.0
+traceloop/openllmetry,openllmetry,OpenLLMetry,Traceloop,telemetry_observability,product_ux,open_source,open,4,3,3.5
+triton-lang/triton,triton,Triton,Triton (triton-lang),ml_frameworks,infrastructure,open_source,open,5,5,5.0
+truera/trulens,trulens,TruLens,Snowflake,telemetry_observability,product_ux,open_source,open,4,4,4.0
+ukgovernmentbeis/inspect_ai,inspect-ai,Inspect AI,UK AI Security Institute,evaluation_code,model_components,open_source,open,4,5,4.5
+unslothai/unsloth,unsloth,Unsloth,Unsloth AI,finetuning_code,model_components,open_source,open,4,4,4.0
+vllm-project/vllm,vllm,vLLM,vLLM (UC Berkeley / vLLM team),inference_code,model_components,open_source,open,4,5,4.5
+volcengine/verl,verl,verl,ByteDance Seed / Volcano Engine,finetuning_code,model_components,open_source,open,4,5,4.5
+wandb/weave,weave,Weave,Weights & Biases,telemetry_observability,product_ux,open_core,open,4,4,4.0
+xiaomimimo/mimo,mimo-v2-5-pro,MiMo-V2.5-Pro,Xiaomi,base_pretrained,model_components,open_weights,open-ish,4,4,4.0
+xlang-ai/osworld,osworld,OSWorld,XLang AI Lab,evaluation_code,model_components,open_source,open,3,5,4.0
+zai-org/glm-5,glm-5-2,GLM-5.2,Zhipu / Z.ai,base_pretrained,model_components,open_weights,open-ish,2,5,4.1
+zed-industries/zed,zed,Zed,Zed Industries,orchestration_agents,product_ux,open_core,open,4,5,4.7

--- a/warehouse/ingest/build_stack_map.py
+++ b/warehouse/ingest/build_stack_map.py
@@ -43,16 +43,29 @@ def _slug(doc: dict, path: str) -> str:
     return (doc or {}).get("name") or os.path.splitext(os.path.basename(path))[0]
 
 
+def _maturity(adoption, capability, w):
+    # Mirror build/serialize.py _maturity_score: per-category adoption/capability blend,
+    # rounded to 2dp; adoption-only when capability is null; null when adoption is missing.
+    if adoption is None:
+        return ""
+    if capability is None:
+        return round(float(adoption), 2)
+    wa, wc = (w or {}).get("adopt", 0.5), (w or {}).get("cap", 0.5)
+    return round((wa * adoption + wc * capability) / ((wa + wc) or 1.0), 2)
+
+
 def build_rows() -> list[list[str]]:
     # category -> layer (taxonomy arcs ARE the Columbia layers)
     tax = yaml.safe_load((SOURCES / "taxonomy.yaml").read_text())
     cat_layer = {cs: arc["layer"] for arc in tax["arcs"] for cs in arc["categories"]}
 
-    # product slug -> category (category rosters own the assignment)
+    # product slug -> category (category rosters own the assignment); category -> weights
     prod_cat = {}
+    cat_weights = {}
     for f in glob.glob(str(SOURCES / "categories" / "*.yaml")):
         cat = yaml.safe_load(open(f)) or {}
         cslug = _slug(cat, f)
+        cat_weights[cslug] = cat.get("weights") or {"adopt": 0.5, "cap": 0.5}
         for ps in cat.get("products") or []:
             prod_cat[ps] = cslug
 
@@ -64,12 +77,14 @@ def build_rows() -> list[list[str]]:
         for ps in o.get("products") or []:
             prod_org[ps] = disp
 
-    # product slug -> openness class/bucket
-    prod_open = {}
+    # product slug -> (openness class/bucket, adoption level, capability score)
+    prod_score = {}
     for f in glob.glob(str(SOURCES / "scores" / "*.yaml")):
         s = yaml.safe_load(open(f)) or {}
         cls = (s.get("openness") or {}).get("class")
-        prod_open[_slug(s, f)] = (cls, _bucket(cls))
+        adoption = (s.get("adoption") or {}).get("level")
+        capability = (s.get("capability") or {}).get("score")
+        prod_score[_slug(s, f)] = (cls, _bucket(cls), adoption, capability)
 
     # product -> repos, joined to the above
     seen: dict[str, list[str]] = {}
@@ -79,14 +94,17 @@ def build_rows() -> list[list[str]]:
         disp = p.get("display_name", slug)
         cat = prod_cat.get(slug)
         layer = cat_layer.get(cat)
-        cls, buck = prod_open.get(slug, (None, "closed"))
+        cls, buck, adoption, capability = prod_score.get(slug, (None, "closed", None, None))
+        maturity = _maturity(adoption, capability, cat_weights.get(cat))
         org = prod_org.get(slug, "")
         for u in p.get("github", []) or []:
             m = re.search(r"github\.com/([^/]+/[^/]+?)(?:\.git)?/?$", u["url"])
             if m and cat:
                 repo = m.group(1).lower()
                 if repo not in seen:
-                    seen[repo] = [repo, slug, disp, org, cat, layer, cls or "unknown", buck]
+                    seen[repo] = [repo, slug, disp, org, cat, layer, cls or "unknown", buck,
+                                  "" if adoption is None else adoption,
+                                  "" if capability is None else capability, maturity]
     return sorted(seen.values())
 
 
@@ -96,7 +114,8 @@ def main() -> None:
     with open(OUTPUT_CSV, "w", newline="") as fh:
         w = csv.writer(fh)
         w.writerow(["repo", "product_slug", "product_name", "org",
-                    "category", "layer", "openness_class", "openness_bucket"])
+                    "category", "layer", "openness_class", "openness_bucket",
+                    "adoption", "capability", "maturity"])
         w.writerows(rows)
     print(f"wrote {OUTPUT_CSV.relative_to(ROOT)}: {len(rows)} rows")
 

--- a/warehouse/models/README.md
+++ b/warehouse/models/README.md
@@ -23,7 +23,7 @@ CSV-based reference data uploaded via scripts. Source CSVs live in `warehouse/ca
 | `currentai.catalog.model_repos` | `warehouse/catalog/huggingface/model_repos.csv` | ~6.3K | HF model → GitHub repo links |
 | `currentai.catalog.foundation_model_repos` | `warehouse/catalog/huggingface/foundation_model_repos.csv` | ~72 | Curated foundation model families → canonical repos |
 | `currentai.catalog.pypi_downloads` | `warehouse/catalog/pypi/pypi_downloads.csv` (gitignored) | ~1.6M | PyPI daily downloads by package × country, 39 AI packages |
-| `currentai.catalog.stack_map` | `warehouse/catalog/stack_map/repos.csv` | 199 | Taxonomy bridge: scored-product repos → stack-map category / layer / openness, generated from `sources/` by `warehouse/ingest/build_stack_map.py` |
+| `currentai.catalog.stack_map` | `warehouse/catalog/stack_map/repos.csv` | 205 | Taxonomy bridge: scored-product repos → stack-map category / layer / openness + gap-map scores (adoption, capability, maturity), generated from `sources/` by `warehouse/ingest/build_stack_map.py` |
 
 ## Entities (User Defined Models)
 


### PR DESCRIPTION
Adds `adoption`, `capability`, and `maturity` columns to `currentai.catalog.stack_map`, generated from `sources/` (maturity mirrors `_maturity_score`, verified 0 mismatches vs the gap map). Re-syncs the bridge to current sources (199→205 rows, incl. the #51 instruct models). Static model re-uploaded via MCP.

Unblocks the launch-insights resilience scatter (y = maturity, joined by repo) and is reusable for any notebook needing gap-map scores per repo.

Test plan: `build.validate` clean; regenerated CSV cross-checked against `notebook_data.json` maturity (0/199 mismatch).