### PR TITLE
fix(scores): reclassify proprietary sandbox services as closed

### DIFF
--- a/sources/products/cloudflare-sandboxes.yaml
+++ b/sources/products/cloudflare-sandboxes.yaml
@@ -4,9 +4,8 @@ type: software
 description: 'Cloudflare''s two-tier sandboxing for AI agents, shipped during Agents Week 2026: Dynamic
   Workers (V8 isolates, ms-scale cold start, ~100x faster and more memory-efficient than containers, open
   beta April 2026) and Sandboxes (persistent Linux environments, GA April 2026 for full-OS workloads).
-  Picked when latency, edge distribution, and isolation density matter; distributed across Cloudflare''s
-  global edge network and available to all paid Workers users, the company''s headline agent infrastructure
-  release of 2026.'
+  Runs on Cloudflare''s global edge network and is available to paid Workers users. Execution is tied
+  to Cloudflare''s proprietary platform; only the Sandbox SDK is open source.'
 comments: 'Two related 2026 offerings: (a) Cloudflare Sandbox SDK (cloudflare/sandbox-sdk, @cloudflare/sandbox
   v0.11.0, 1 Jun 2026) - container-backed sandboxes on Workers/Durable Objects; (b) Dynamic Workers /
   Worker Loader (open beta announced 24 Mar 2026) - V8-isolate-based per-runtime sandboxing, ~100x faster

--- a/sources/products/gvisor.yaml
+++ b/sources/products/gvisor.yaml
@@ -2,8 +2,8 @@ name: gvisor
 display_name: gVisor
 type: software
 description: gVisor application-kernel sandbox; repo live June 2026 (rolling date-tagged releases, no
-  GitHub Releases page). Go userspace kernel intercepting syscalls (Sentry + Gofer); powers Google Cloud
-  Run.
+  GitHub Releases page). Go userspace kernel intercepting syscalls (Sentry + Gofer); used as the
+  sandbox runtime behind Google Cloud Run and GKE Sandbox.
 github:
 - url: https://github.com/google/gvisor
 comments: gVisor application-kernel sandbox; repo live June 2026 (rolling date-tagged releases, no GitHub

--- a/sources/scores/cloudflare-sandboxes.yaml
+++ b/sources/scores/cloudflare-sandboxes.yaml
@@ -1,14 +1,14 @@
 product: cloudflare-sandboxes
 openness:
-  score: 3
-  class: open_core
-  components: sdk:open (@cloudflare/sandbox Apache-2.0, cloudflare/sandbox-sdk on GitHub);runtime/platform:proprietary
-    Cloudflare edge (Workers/Durable Objects/Dynamic Worker Loader - no self-host);pricing:Workers paid
-    plan, Dynamic Workers $0.002/unique-worker/day post-beta
+  score: 1
+  class: closed
+  components: service:proprietary Cloudflare edge (Workers/Durable Objects/Dynamic Worker Loader - no
+    self-host of the isolate/container plane);open-part:Sandbox SDK only (@cloudflare/sandbox Apache-2.0,
+    cloudflare/sandbox-sdk on GitHub);pricing:Workers paid plan, Dynamic Workers $0.002/unique-worker/day
   confidence: high
-  note: 'open_core: the Sandbox SDK is Apache-2.0 and public, but execution requires Cloudflare''s proprietary
-    managed edge network (no self-host of the isolate/container plane). Calibrated as open_core alongside
-    Modal/Vercel.'
+  note: 'Closed managed service. The Sandbox SDK is Apache-2.0, but execution requires Cloudflare''s proprietary
+    managed edge network (no self-host of the isolate/container plane); an open client SDK over a closed
+    runtime is not open_core. Reclassified from open_core.'
   sources:
   - url: https://github.com/cloudflare/sandbox-sdk
     shows: Apache-2.0 SDK; runs on Cloudflare Containers/Workers/Durable Objects (managed edge)

--- a/sources/scores/modal-sandboxes.yaml
+++ b/sources/scores/modal-sandboxes.yaml
@@ -1,14 +1,14 @@
 product: modal-sandboxes
 openness:
-  score: 3
-  class: open_core
-  components: sdk:open (modal Python/JS client libraries public);runtime/platform:proprietary managed
-    cloud (no self-host of the gVisor execution plane);pricing:pay-as-you-go usage, free starter credits
-  confidence: medium
-  note: 'Treated as open_core per the recipe''s explicit example (E2B, Modal = open_core: OSS runtime/SDK
-    + managed cloud). The SDK is open but the execution substrate is a proprietary managed service; calibrated
-    below the Ollama/full-OSS anchors. Confidence medium - the managed plane dominates the value and is
-    closed.'
+  score: 1
+  class: closed
+  components: service:proprietary Modal managed cloud (no self-host of the gVisor execution plane);open-part:client
+    SDK only (modal Python/JS client libraries);pricing:pay-as-you-go usage, free starter credits
+  confidence: high
+  note: 'Closed managed service. The client SDK is open, but the execution substrate is a proprietary
+    managed cloud with no self-host; an open client over a closed runtime is not open_core. Corrects a
+    prior mis-calibration that grouped Modal with the genuinely self-hostable E2B (E2B ships self-hostable
+    infra; Modal does not).'
   sources:
   - url: https://modal.com/pricing
     shows: Modal is a managed proprietary cloud platform, pay-per-CPU-cycle, $30/mo free credits

--- a/sources/scores/replit-agent-code-execution-api.yaml
+++ b/sources/scores/replit-agent-code-execution-api.yaml
@@ -1,15 +1,15 @@
 product: replit-agent-code-execution-api
 openness:
-  score: 2
-  class: open_core
-  components: service:proprietary(Replit managed Autoscale Deployments);sandbox-runtime:omegajail(open source,
-    github.com/omegaup/omegajail unprivileged container);client:replit-code-exec(PyPI / github.com/replit/replit-code-exec,
-    ISC, ARCHIVED 2025-02-11);no self-hostable execution service
+  score: 1
+  class: closed
+  components: service:proprietary(Replit managed Autoscale Deployments, no self-host);open-part:third-party
+    isolation primitive omegajail(github.com/omegaup/omegajail) + an ARCHIVED thin client (replit-code-exec,
+    ISC, read-only since 2025-02-11);no self-hostable execution service
   confidence: medium
-  note: The isolation primitive (omegajail, from omegaUp) is open source and a thin client was published,
-    but the code-execution service is a proprietary managed offering, and the client repo is now archived
-    (read-only since 2025-02-11). Closest to open_core (open primitive under a closed service); no feature-gated
-    OSS core product to self-host.
+  note: 'Closed managed service. The sandbox primitive (omegajail) is open source but it is a third-party
+    dependency, not Replit''s own open core, and the thin client is archived; there is no self-hostable
+    open product, so an open dependency under a closed service is not open_core. Reclassified from open_core
+    (borderline).'
   sources:
   - url: https://replit.com/blog/ai-agents-code-execution
     shows: Code Execution API uses omegajail (open source unprivileged container sandbox) on Replit's

--- a/sources/scores/spaces.yaml
+++ b/sources/scores/spaces.yaml
@@ -1,13 +1,14 @@
 product: spaces
 openness:
-  score: 2
-  class: open_core
-  components: platform:proprietary(HF-managed hosting);SDKs:Gradio(Apache-2.0 OSS), Streamlit(OSS), Docker;runtime/control-plane:closed(no
-    self-hostable Spaces);hardware-tiers:CPU free + paid GPU upgrades
+  score: 1
+  class: closed
+  components: platform:proprietary(HF-managed hosting/orchestration, no self-hostable Spaces);open-part:app
+    SDKs only (Gradio Apache-2.0, Streamlit) which are separate, portable OSS products;hardware-tiers:CPU
+    free + paid GPU upgrades
   confidence: medium
-  note: The app SDKs (Gradio etc.) are OSS and apps run as arbitrary Docker, but the Spaces hosting/orchestration
-    platform is a closed managed service; open SDKs over a proprietary host = open_core-ish. Not self-hostable
-    as Spaces.
+  note: 'Closed managed hosting service. Apps are built with OSS SDKs (Gradio etc.) that run anywhere,
+    but Spaces itself - the managed host/orchestration - is proprietary and not self-hostable; those SDKs
+    are separate products, not a Spaces open core. Reclassified from open_core (borderline).'
   sources:
   - url: https://huggingface.co/docs/hub/spaces
     shows: Spaces hosts apps via Gradio (OSS SDK), Streamlit, arbitrary Dockerfile, or static HTML on

--- a/sources/scores/vercel-sandbox.yaml
+++ b/sources/scores/vercel-sandbox.yaml
@@ -1,12 +1,15 @@
 product: vercel-sandbox
 openness:
-  score: 3
-  class: open_core
-  components: sdk:open (@vercel/sandbox JS + Python SDK + CLI, GitHub vercel/sandbox);runtime/platform:proprietary
-    Vercel Fluid-compute managed cloud (no self-host);pricing:pay-for-active-CPU-time managed service
-  confidence: medium
-  note: 'open_core: SDK + CLI are public on GitHub, but sandboxes only execute on Vercel''s proprietary
-    Fluid-compute cloud (no self-host of the microVM plane). Calibrated alongside Modal as open_core.'
+  score: 1
+  class: closed
+  components: service:proprietary Vercel Fluid-compute managed cloud (no self-host of the Firecracker
+    microVM plane);open-part:client SDK/CLI only (@vercel/sandbox JS + Python, vercel/sandbox on GitHub);license:proprietary
+    service
+  confidence: high
+  note: 'Closed managed service. The SDK/CLI are open, but they are only a client for Vercel''s proprietary
+    microVM cloud, which cannot be self-hosted; an open client over a closed runtime is not open_core (the
+    core is proprietary). Reclassified from open_core; sits with the other proprietary sandbox clouds (Google
+    Cloud Run, Fly Sprites, Northflank).'
   sources:
   - url: https://vercel.com/docs/sandbox
     shows: Firecracker microVM isolation; SDK/CLI on GitHub vercel/sandbox; managed Vercel cloud, pay-for-active-CPU


### PR DESCRIPTION
## Summary
Several proprietary managed sandbox services in the **Deployment** category were classed `open_core` on the basis that their *client SDK* is open. But `open_core` requires a self-hostable OSS **core** — an open client over a closed runtime is not open-core (boto3 doesn't make AWS open-core). Corrected to `closed`.

### Clear-cut (open client SDK over a proprietary runtime, no self-host) → `closed` (was `open_core` 3)
- **Vercel Sandbox** — only `@vercel/sandbox` SDK is open; microVM plane is proprietary Vercel cloud
- **Cloudflare Sandboxes** — only the Apache-2.0 Sandbox SDK is open; execution is Cloudflare's edge
- **Modal Sandboxes** — only the `modal` client is open; runtime is Modal's managed cloud (corrects a prior mis-calibration that grouped Modal with the genuinely self-hostable E2B)

### Borderline (open dependency/SDK under a closed service) → `closed` (was `open_core` 2)
- **Replit Code Execution API** — uses OSS omegajail (third-party) + an archived thin client; service is proprietary
- **HF Spaces** — apps use OSS Gradio/Streamlit (separate, portable products); the Spaces host/orchestration is closed

*(If you'd rather keep these two at `source_available` (2), easy to dial back — flagging them as the judgment calls.)*

### Unchanged — genuinely open-core (self-hostable OSS core + managed tier)
E2B (Apache, self-host via Terraform), Daytona (AGPL), beta9 (AGPL), Coder OSS (AGPL CE).

### Editorial
De-marketed two descriptions: gVisor ("powers Google Cloud Run" → "used as the sandbox runtime behind Google Cloud Run and GKE Sandbox") and Cloudflare (removed "the company's headline … release of 2026"). A broader marketing-language pass across the catalog is a separate follow-up.

## Test plan
- `uv run python -m build.validate` → 0 error(s)
- `uv run pytest -q` → 35 passed
- Serialize confirms all five now read `class=closed`, `bucket=closed`; bot-owned `notebook_data.json` not committed