### PR TITLE
fix(sources): drop misleading kernel-fork artifact from Raspberry Pi 5

### DIFF
--- a/sources/products/raspberry-pi-5.yaml
+++ b/sources/products/raspberry-pi-5.yaml
@@ -6,7 +6,8 @@ description: A credit-card-sized single-board computer (SBC) built on the Broadc
   has no dedicated NPU, so on-device AI runs on the CPU/GPU or via add-on accelerators (e.g. the AI HAT+).
   Made by Raspberry Pi, it is the most ubiquitous hobbyist/edge SBC and the de facto reference platform
   for community edge-AI projects.
-github:
-- url: https://github.com/raspberrypi/linux
-comments: Verified live 2026-06-22 via primary sources. Open Linux kernel tree and published datasheets/reduced
-  schematics, globally purchasable, though full board design files and some firmware remain closed.
+comments: Verified live 2026-06-22 via primary sources. Runs an open Linux kernel tree
+  (github.com/raspberrypi/linux) and ships published datasheets/reduced schematics, globally purchasable,
+  though full board design files and some firmware remain closed. No representative GitHub artifact: the
+  product is hardware, and the kernel fork is a general-purpose OS mirror whose commit/contributor signal
+  is unrelated to the board as an AI platform (see issue #54).

--- a/sources/products/raspberry-pi-5.yaml
+++ b/sources/products/raspberry-pi-5.yaml
@@ -8,6 +8,6 @@ description: A credit-card-sized single-board computer (SBC) built on the Broadc
   for community edge-AI projects.
 comments: Verified live 2026-06-22 via primary sources. Runs an open Linux kernel tree
   (github.com/raspberrypi/linux) and ships published datasheets/reduced schematics, globally purchasable,
-  though full board design files and some firmware remain closed. No representative GitHub artifact: the
-  product is hardware, and the kernel fork is a general-purpose OS mirror whose commit/contributor signal
-  is unrelated to the board as an AI platform (see issue #54).
+  though full board design files and some firmware remain closed. No representative GitHub artifact is
+  declared; the product is hardware, and the kernel fork is a general-purpose OS mirror whose commit and
+  contributor signal is unrelated to the board as an AI platform (tracked in issue 54).


### PR DESCRIPTION
Closes #54. The `raspberrypi/linux` artifact on `raspberry-pi-5` is the Linux kernel fork (35k+ commits, ~590 kernel-maintainer contributors), which polluted the edge_hardware contributor/bus-factor analysis. Hardware products may legitimately have no representative repo, so the `github:` artifact is dropped (kernel-tree reference kept in comments). Openness/adoption/capability scores are unchanged. `build.validate` → 0 errors.