### PR TITLE
feat(sources): add nono (nolabs-ai) to deployment

### DIFF
--- a/build/_frozen_long_tail.json
+++ b/build/_frozen_long_tail.json
@@ -4,11 +4,11 @@
     "models": 6428,
     "packages": 2823,
     "total": 24626,
-    "scored": 427,
+    "scored": 428,
     "overlap": 226,
-    "scored_outside": 201,
+    "scored_outside": 202,
     "uncategorized": 24400,
-    "universe": 24827
+    "universe": 24828
   },
   "top": [
     {

--- a/sources/categories/deployment.yaml
+++ b/sources/categories/deployment.yaml
@@ -30,4 +30,5 @@ products:
 - ollama
 - ray
 - openpcc
+- nono
 comments: ''

--- a/sources/organizations/nolabs-ai.yaml
+++ b/sources/organizations/nolabs-ai.yaml
@@ -1,0 +1,8 @@
+name: nolabs-ai
+display_name: nolabs.ai
+type: company
+homepage: https://nono.sh
+github:
+  - url: https://github.com/nolabs-ai
+products:
+  - nono

--- a/sources/products/nono.yaml
+++ b/sources/products/nono.yaml
@@ -1,0 +1,16 @@
+name: nono
+display_name: nono
+type: software
+description: "An open-source, zero-setup sandbox that runs AI agents (Claude Code, Copilot, and others)
+  with least-privilege isolation on macOS, Linux, and Windows. Written in Rust by nolabs-ai (built by
+  members of the Sigstore team), it wraps agent processes in a least-privilege sandbox with near-zero
+  startup latency, ships FFI bindings for Rust, Python, TypeScript, and Go, and hosts an agent registry.
+  Fully open source (Apache-2.0) and self-hostable as a standalone CLI or library, with no proprietary
+  backend, distributed via curl, Homebrew, and Linux package managers."
+github:
+  - url: https://github.com/nolabs-ai/nono
+comments: "nono (nono.sh) — least-privilege agent sandbox in Rust by nolabs-ai (built by members of the
+  Sigstore team). Apache-2.0, fully self-hostable, no proprietary service. ~2,900 GitHub stars (June 2026).
+  Installable via curl, Homebrew, and Linux package managers (Debian/Ubuntu, Fedora, Arch, RHEL, openSUSE,
+  Nix, WSL2); FFI bindings nono-py / nono-ts / nono-go; agent registry at registry.nono.sh. Verified live
+  June 2026."

--- a/sources/scores/nono.yaml
+++ b/sources/scores/nono.yaml
@@ -1,0 +1,42 @@
+product: nono
+openness:
+  score: 5
+  class: open_source
+  components: license:Apache-2.0(OSI);source:public(full Rust implementation, self-hostable);distribution:curl
+    / Homebrew / Debian-Ubuntu-Fedora-Arch-RHEL-openSUSE-Nix + FFI bindings (nono-py, nono-ts, nono-go);service:none(standalone
+    CLI/library, no proprietary backend)
+  confidence: high
+  note: 'Fully open source: an Apache-2.0 Rust implementation that is self-hostable as a standalone CLI
+    or library with no proprietary service tier. A clean contrast with the managed sandbox clouds (Vercel,
+    Cloudflare, Modal), which publish only a client SDK over a closed runtime.'
+  sources:
+  - url: https://github.com/nolabs-ai/nono
+    shows: Apache-2.0 license; full Rust source; self-hostable; install via curl / Homebrew / Linux package
+      managers; FFI bindings nono-py / nono-ts / nono-go
+    accessed: '2026-06-29'
+adoption:
+  level: 2
+  reach: 1K-10K
+  signal_type: stars_fallback
+  confidence: low
+  note: '~2,900 GitHub stars (June 2026) for a 2026 release, with multi-platform packages and FFI bindings
+    published. Stars are the only public proxy here, so this is capped per the methodology and read as
+    early but real traction rather than scaled adoption.'
+  sources:
+  - url: https://github.com/nolabs-ai/nono
+    shows: ~2,900 stars (June 2026)
+    accessed: '2026-06-29'
+capability:
+  score: 3
+  basis: feature coverage (cross-platform least-privilege agent sandboxing)
+  value: Least-privilege agent sandboxing across macOS / Linux / Windows with near-zero startup, FFI bindings
+    for Rust / Python / TypeScript / Go, and an agent registry. Lighter-weight than the microVM-based sandboxes
+    (E2B, Firecracker) but with the widest local-platform coverage and lowest setup friction.
+  confidence: medium
+  note: 'Solid, cross-platform sandbox with very low setup friction; scored mid-range for the category
+    -- below the heavier microVM / OS-isolation options on hard isolation depth, but broad and easy to
+    adopt locally.'
+  sources:
+  - url: https://nono.sh
+    shows: zero-setup, cross-platform least-privilege agent sandboxing; agent registry
+    accessed: '2026-06-29'


### PR DESCRIPTION
Adds **nono** (nono.sh) — an open-source, zero-setup least-privilege agent sandbox in Rust by nolabs-ai (built by members of the Sigstore team).

- **Openness: open_source (5)** — Apache-2.0, full Rust source, self-hostable as a standalone CLI/library, **no proprietary backend**. A clean contrast to the managed sandbox clouds (Vercel/Cloudflare/Modal), which only open a client SDK.
- **Adoption: 2** (`stars_fallback`, ~2,900 GitHub stars, June 2026 release) — stars-only proxy, capped per methodology.
- **Capability: 3** — cross-platform (macOS/Linux/Windows) least-privilege sandboxing, FFI bindings for Rust/Python/TS/Go, agent registry.

Adds the product, score, the `nolabs-ai` org, the deployment roster entry, and re-syncs the frozen long-tail count (427 → 428).

Note: org `display_name` set to `nolabs.ai` — worth confirming the exact brand name.

Test plan: `build.validate` → 0 errors; `pytest -q` → 35 passed; serialize confirms nono lands in deployment as open_source/5, maturity 2.4; bot-owned `notebook_data.json` not committed.