### PR TITLE
fix(sources): correct nolabs org display name

### DIFF
--- a/sources/organizations/nolabs-ai.yaml
+++ b/sources/organizations/nolabs-ai.yaml
@@ -1,5 +1,5 @@
 name: nolabs-ai
-display_name: nolabs.ai
+display_name: nolabs
 type: company
 homepage: https://nono.sh
 github:


### PR DESCRIPTION
Set the `nolabs-ai` org `display_name` to **nolabs** (was the placeholder `nolabs.ai`). Confirmed by the maintainer.