### PR TITLE
feat(build): add layer_order to notebook_data payload

### DIFF
--- a/build/serialize.py
+++ b/build/serialize.py
@@ -1,7 +1,8 @@
 """Compile sources/ (+ frozen long-tail) into the notebook_data.json payload.
 
 Reproduces the exact structure the live notebook consumes:
-  { categories: {cid: {label, arc, products[]}}, order[], n_total, generated, long_tail }
+  { descriptions, layer_order[], categories: {cid: {label, arc, layer, products[]}},
+    order[], n_total, generated, long_tail }
 """
 from datetime import date
 from pathlib import Path
@@ -213,11 +214,18 @@ def build_payload(sources: dict, frozen_long_tail: dict, generated: str | None =
     order: list[str] = []
     cid_arc: dict[str, str] = {}
     cid_layer: dict[str, str] = {}
+    # layer_order is the Columbia layers in stacking order, taken from the arc
+    # sequence in sources/taxonomy.yaml (one layer per arc). Consumers use it to
+    # render layers in order without re-deriving it from the per-category `layer`.
+    layer_order: list[str] = []
     for arc in taxonomy["arcs"]:
+        lyr = arc.get("layer")
+        if lyr and lyr not in layer_order:
+            layer_order.append(lyr)
         for cid in arc["categories"]:
             order.append(cid)
             cid_arc[cid] = arc["name"]
-            cid_layer[cid] = arc.get("layer")
+            cid_layer[cid] = lyr
     out_cats = {}
     n = 0
     for cid in order:
@@ -246,7 +254,8 @@ def build_payload(sources: dict, frozen_long_tail: dict, generated: str | None =
         "gaps": dict(_GAP_DESC),
         "categories": {cid: cats[cid].get("description", "") for cid in order},
     }
-    return {"descriptions": descriptions, "categories": out_cats, "order": order,
+    return {"descriptions": descriptions, "layer_order": layer_order,
+            "categories": out_cats, "order": order,
             "n_total": n, "generated": generated,
             "long_tail": _filter_long_tail(frozen_long_tail, prods)}
 

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -86,6 +86,15 @@ def test_build_payload_shape_and_order():
     assert row["maturity"] == 4.0
 
 
+def test_layer_order_present_and_in_arc_sequence():
+    # layer_order lists the Columbia layers in taxonomy arc order; the fixture
+    # has a single Model components arc, so it is just that layer.
+    payload = build_payload(_sources(), frozen_long_tail={}, generated="2026-06-10")
+    assert payload["layer_order"] == ["model_components"]
+    # it ships right after descriptions so consumers can read the stack order up top
+    assert list(payload)[:2] == ["descriptions", "layer_order"]
+
+
 def test_null_adoption_serializes_maturity_null():
     src = _sources()
     src["scores"]["llama-4"]["adoption"] = {"level": None, "signal_type": "unknown"}


### PR DESCRIPTION
Adds a top-level **`layer_order`** array to the serialized payload, requested by the front-end so it can fetch how layers stack without re-deriving it from per-category `layer`.

```json
"layer_order": ["model_components", "product_ux", "infrastructure"]
```

- Derived from the arc order in `sources/taxonomy.yaml` (one layer per arc), so it stays in sync with the taxonomy automatically.
- Ships right after `descriptions` (matching the requested placement); `descriptions` stays the first key.
- Confirmed against the deployed data: `https://map.currentai.org/notebook_data.json` currently has `[descriptions, categories, order, n_total, generated, long_tail]` and no `layer_order`.

On merge, the regenerate bot rebuilds `notebook_data.json` with the field; after a republish + the front-end re-copying the JSON, it'll be live for the app.

## Test plan
- `build.validate` → 0 errors
- `pytest -q` → 36 passed (added `test_layer_order_present_and_in_arc_sequence`)
- Serialize dry-run: `layer_order` = `["model_components","product_ux","infrastructure"]`, second key after `descriptions`; bot-owned `notebook_data.json` not committed