### PR TITLE
feat(taxonomy): move Safety & Guardrails to Product / UX layer

### DIFF
--- a/sources/taxonomy.yaml
+++ b/sources/taxonomy.yaml
@@ -20,6 +20,7 @@ arcs:
   - orchestration_agents
   - ui_api
   - telemetry_observability
+  - safeguards
   - agent_tools_protocols
 - name: Infrastructure
   layer: infrastructure
@@ -27,4 +28,3 @@ arcs:
   - ml_frameworks
   - deployment
   - edge_hardware
-  - safeguards


### PR DESCRIPTION
## Summary
- Moves the **Safety & Guardrails** category from the **Infrastructure** arc to **Product / UX** in `sources/taxonomy.yaml`, positioned next to Telemetry & Observability.
- One-line source change; `serialize` derives each category's `layer` slug from its arc, so no other source edits are needed. The bot regenerates `build/notebook_data.json` and the notebook.

## Why
Safety & Guardrails landed in Infrastructure when it was added (#64), but Infrastructure in this map means frameworks / runtimes / deployment / hardware — the layer that runs compute. The safety category's center of gravity is different:
- **Runtime guardrails** (Llama Guard, NeMo Guardrails, LlamaFirewall, LLM Guard, Guardrails AI) are application-layer middleware — they pair with Telemetry & Observability, already in Product / UX.
- **Red-team / safety-eval tools** (PyRIT, garak, HarmBench, DeepTeam, Giskard) are evaluation harnesses.

Product / UX is the better single-layer home.

## Impact
- Categories per layer: model_components 7, product_ux **5**, infrastructure **3**.
- Mature-open counts are **unchanged** (infra 17, product 12) — none of the 24 safety tools reaches the 4.5 maturity bar, so the move shifts no mature-open project between layers.

## Follow-up (not in this PR)
Safety is genuinely cross-cutting (runtime guardrails → product_ux, safety-evals → model_components, safety-classifier models → could be finetuned_chat). A cleaner long-term treatment — split the category or make safety a cross-cutting tag — should be decided alongside open proposal #30 (responsible-AI attributes).

## Test plan
- `uv run python -m build.validate` → 0 errors
- `uv run python -m build.serialize` → 454 products; `categories.safeguards.layer == product_ux`