### PR TITLE
feat(sources): add ROOST safety tools (Osprey, Coop) to Safety & Guardrails

### DIFF
--- a/build/_frozen_long_tail.json
+++ b/build/_frozen_long_tail.json
@@ -4,11 +4,11 @@
     "models": 6428,
     "packages": 2823,
     "total": 24626,
-    "scored": 454,
+    "scored": 456,
     "overlap": 226,
-    "scored_outside": 228,
+    "scored_outside": 230,
     "uncategorized": 24400,
-    "universe": 24854
+    "universe": 24856
   },
   "top": [
     {

--- a/sources/categories/safeguards.yaml
+++ b/sources/categories/safeguards.yaml
@@ -29,8 +29,13 @@ products:
 - llm-guard
 - pyrit
 - garak
+- osprey
+- coop
 - openai-moderation
 - azure-content-safety
 - bedrock-guardrails
 - lakera-guard
-comments: ''
+comments: 'Osprey and Coop are Trust & Safety operational tooling — a real-time rules engine and a moderation/review
+  console — that orchestrate AI safety signals rather than acting as guardrail models themselves. Folded
+  into this category for now, but they are strong candidates for a future stand-alone Trust & Safety
+  operations category.'

--- a/sources/organizations/roost.yaml
+++ b/sources/organizations/roost.yaml
@@ -1,0 +1,9 @@
+name: roost
+display_name: ROOST
+type: foundation
+homepage: https://roost.tools
+github:
+- url: https://github.com/roostorg
+products:
+- osprey
+- coop

--- a/sources/products/coop.yaml
+++ b/sources/products/coop.yaml
@@ -1,0 +1,12 @@
+name: coop
+display_name: Coop
+type: software
+description: An open, self-hosted review and moderation console from ROOST. It provides review queues,
+  routing, automated enforcement rules, analytics, and REST/GraphQL integrations, with child-safety
+  workflows (HMA hash matching, NCMEC reporting) and integrations with the OpenAI Moderation and Google
+  Content Safety APIs. Trust & Safety operational tooling that orchestrates AI safety signals rather than
+  an AI guardrail model.
+github:
+- url: https://github.com/roostorg/coop
+comments: Coop review/moderation console, Apache-2.0, from ROOST; ~62 GitHub stars (July 2026), released
+  V.0 in Feb 2026. Verified live July 2026.

--- a/sources/products/osprey.yaml
+++ b/sources/products/osprey.yaml
@@ -1,0 +1,13 @@
+name: osprey
+display_name: Osprey
+type: software
+description: An open, high-performance safety rules engine for real-time abuse mitigation, originally
+  built at Discord and donated to ROOST. It evaluates events and their properties in real time using a
+  Python-based rules DSL (SML), ingesting signals — including ML classifier outputs — to automatically
+  detect and action spam, abuse, and policy violations at scale. Trust & Safety operational
+  infrastructure rather than an AI guardrail model.
+github:
+- url: https://github.com/roostorg/osprey
+comments: Osprey safety rules engine, Apache-2.0, donated by Discord to ROOST; ~446 GitHub stars (July
+  2026). In production at Discord (400M daily actions, 2.3M rules/sec), Bluesky, and Matrix. Verified live
+  July 2026.

--- a/sources/scores/coop.yaml
+++ b/sources/scores/coop.yaml
@@ -1,0 +1,35 @@
+product: coop
+openness:
+  score: 5
+  class: open_source
+  components: license:Apache-2.0(OSI);source:public(github.com/roostorg/coop);self-host:yes;service:none
+  confidence: high
+  note: 'Fully open source: Apache-2.0 self-hosted moderation review console from ROOST.'
+  sources:
+  - url: https://github.com/roostorg/coop
+    shows: Apache-2.0; review queues, routing, enforcement rules, REST/GraphQL APIs
+    accessed: '2026-07-01'
+adoption:
+  level: 1
+  reach: <10K
+  signal_type: stars_fallback
+  confidence: low
+  note: 62 GitHub stars / 35 forks (July 2026), released V.0 in Feb 2026. Very early; little deployment
+    evidence beyond a coop-integration-example repo.
+  sources:
+  - url: https://github.com/roostorg/coop
+    shows: 62 stars, 35 forks (July 2026)
+    accessed: '2026-07-01'
+capability:
+  score: 3
+  basis: feature coverage
+  value: Review queues, routing, automated enforcement rules, analytics, and REST/GraphQL APIs, plus
+    child-safety workflows (HMA hash matching, NCMEC reporting) and OpenAI Moderation / Google Content
+    Safety integrations.
+  confidence: low
+  note: Broad moderation-console feature set but explicitly V.0 (Feb 2026); functional and early rather
+    than proven.
+  sources:
+  - url: https://roost.tools/coop/
+    shows: review console, queues, routing, enforcement, analytics, integrations
+    accessed: '2026-07-01'

--- a/sources/scores/osprey.yaml
+++ b/sources/scores/osprey.yaml
@@ -1,0 +1,35 @@
+product: osprey
+openness:
+  score: 5
+  class: open_source
+  components: license:Apache-2.0(OSI);source:public;self-host:yes;service:none
+  confidence: high
+  note: 'Fully open source: Apache-2.0 real-time safety rules engine, self-hostable, no proprietary tier.
+    Donated by Discord to ROOST.'
+  sources:
+  - url: https://github.com/roostorg/osprey
+    shows: Apache-2.0; Rust coordinator + stateless Python workers; SML rules DSL
+    accessed: '2026-07-01'
+adoption:
+  level: 3
+  reach: niche
+  signal_type: reported_traction
+  confidence: medium
+  note: 446 GitHub stars / 52 forks (July 2026) is a modest community signal, but Osprey is in production
+    at Discord (400M daily actions, 2.3M rules/sec), Bluesky, and Matrix. Adoption rests on marquee
+    deployments rather than breadth; open-sourced under ROOST in Sep 2025.
+  sources:
+  - url: https://roost.tools/blog/introducing-osprey-v1-0-open-source-infrastructure-for-real-time-abuse-mitigation/
+    shows: v1.0 release; production users (Discord, Bluesky, Matrix)
+    accessed: '2026-07-01'
+capability:
+  score: 4
+  basis: throughput / rules coverage
+  value: High-performance real-time event-decisioning engine with a Python rules DSL (SML); ~2.3M rules/sec
+    and 400M daily actions at Discord.
+  confidence: medium
+  note: Battle-tested at Discord scale; single-purpose Trust & Safety rules engine, not an AI-native guardrail.
+  sources:
+  - url: https://github.com/roostorg/osprey
+    shows: Rust coordinator, stateless Python workers, SML DSL
+    accessed: '2026-07-01'


### PR DESCRIPTION
## Summary
Adds two open **ROOST** Trust & Safety tools to the **Safety & Guardrails** category:
- **Osprey** — real-time safety rules engine, built at Discord and donated to ROOST (`roostorg/osprey`, Apache-2.0).
- **Coop** — self-hosted moderation/review console (`roostorg/coop`, Apache-2.0).

## Scoring
| | Openness | Adoption | Capability | Maturity | Mature? |
|---|---|---|---|---|---|
| Osprey | 5 (open_source) | 3 (`reported_traction` — prod use at Discord/Bluesky/Matrix; 446★) | 4 | **3.5** | No |
| Coop | 5 (open_source) | 1 (`stars_fallback` — 62★, V.0 Feb 2026) | 3 | **2.0** | No |

Neither clears the 4.5 maturity bar, so **the mature-open set (38) and the stewardship insight are unchanged**. This adds 2 open products to the category.

Adoption is scored on the merits (marquee deployments lift Osprey above its modest star count; Coop is early), not on repository popularity — GitHub stars cap at level 3 per methodology.

## Scope note
Osprey and Coop are Trust & Safety *operational* tooling — a rules engine and a moderation console — that orchestrate AI safety signals (Coop integrates the OpenAI Moderation and Google Content Safety APIs; Osprey ingests ML classifier outputs) rather than acting as guardrail models themselves. They're folded into Safety & Guardrails for now, with a `comments` note flagging them as candidates for a future stand-alone **Trust & Safety operations** category.

## Files
- New: `organizations/roost.yaml`, `products/{osprey,coop}.yaml`, `scores/{osprey,coop}.yaml`
- Modified: `categories/safeguards.yaml` (roster + scope comment)
- `build/_frozen_long_tail.json` counts re-synced (+2 net-new scored products); `notebook_data.json` left for the bot to regenerate.

## Test plan
- `uv run python -m build.validate` → 0 errors
- `uv run python -m build.serialize` → 456 products; both land at openness 5, maturity 3.5 / 2.0, `mature=False`; safeguards mature-open still empty.