### PR TITLE
feat(sources): add Otari (Mozilla AI LLM gateway) to UI & API

### DIFF
--- a/build/_frozen_long_tail.json
+++ b/build/_frozen_long_tail.json
@@ -4,11 +4,11 @@
     "models": 6428,
     "packages": 2823,
     "total": 24626,
-    "scored": 456,
+    "scored": 457,
     "overlap": 226,
-    "scored_outside": 230,
+    "scored_outside": 231,
     "uncategorized": 24400,
-    "universe": 24856
+    "universe": 24857
   },
   "top": [
     {

--- a/sources/categories/ui_api.yaml
+++ b/sources/categories/ui_api.yaml
@@ -45,6 +45,7 @@ products:
 - glean-assistant
 - glean-workplace-search-ai
 - litellm
+- otari
 - lm-studio
 - gpt4all
 - openclaw

--- a/sources/organizations/mozilla-ai.yaml
+++ b/sources/organizations/mozilla-ai.yaml
@@ -7,4 +7,5 @@ github:
 - url: https://github.com/mozilla-ai
 products:
 - llamafile
-comments: Mozilla's AI venture; maintains llamafile (originally released under Mozilla Ocho).
+- otari
+comments: Mozilla's AI venture; maintains llamafile (originally released under Mozilla Ocho) and the Otari LLM gateway.

--- a/sources/products/otari.yaml
+++ b/sources/products/otari.yaml
@@ -1,0 +1,11 @@
+name: otari
+display_name: Otari
+type: software
+description: An open, self-hosted OpenAI-compatible LLM gateway from Mozilla AI. It puts one endpoint in
+  front of 40+ providers with virtual API keys, budget enforcement, and usage tracking, and ships
+  server-side, model-agnostic tools including sandboxed code execution via a Docker-isolated Python REPL.
+  Built on Mozilla AI's any-llm; a hosted platform (Otari.ai) runs on the same core.
+github:
+- url: https://github.com/mozilla-ai/otari
+comments: Otari LLM gateway, Apache-2.0, from Mozilla AI; ~63 GitHub stars (July 2026), created April 2026.
+  Built on Mozilla AI's any-llm. Verified live July 2026.

--- a/sources/scores/otari.yaml
+++ b/sources/scores/otari.yaml
@@ -1,0 +1,41 @@
+product: otari
+openness:
+  score: 4
+  class: open_core
+  components: license:Apache-2.0(OSI, core);source:public;self-host:yes(Docker Compose);service:hosted
+    Otari.ai platform on the same core
+  confidence: high
+  note: Apache-2.0 self-hostable gateway (github.com/mozilla-ai/otari) with a hosted Otari.ai platform on
+    the same core; classed open_core alongside peer gateways such as LiteLLM. Would be open_source (5) if
+    the hosted platform is not a commercial tier.
+  sources:
+  - url: https://github.com/mozilla-ai/otari
+    shows: Apache-2.0; OpenAI-compatible gateway; self-host via Docker Compose
+    accessed: '2026-07-01'
+  - url: https://blog.mozilla.ai/otari-own-your-ai-stack/
+    shows: OSS gateway plus hosted Otari.ai platform on the same foundation
+    accessed: '2026-07-01'
+adoption:
+  level: 1
+  reach: <10K
+  signal_type: stars_fallback
+  confidence: low
+  note: 63 GitHub stars / 6 forks (July 2026), created April 2026. Very new; limited adoption signal so
+    far. (Mozilla AI's underlying any-llm library is far more adopted at ~2.1K stars, but is a separate
+    product.)
+  sources:
+  - url: https://github.com/mozilla-ai/otari
+    shows: 63 stars, 6 forks (July 2026)
+    accessed: '2026-07-01'
+capability:
+  score: 3
+  basis: feature_matrix
+  value: null
+  confidence: medium
+  note: OpenAI-compatible gateway to 40+ providers with virtual keys, budgets, usage tracking, and
+    sandboxed server-side code-execution tools. Solid feature set, but narrower provider coverage and less
+    proven than LiteLLM (140+ providers). No standard benchmark applies to a gateway.
+  sources:
+  - url: https://github.com/mozilla-ai/otari
+    shows: 40+ providers, virtual keys, budgets, usage tracking, sandboxed code execution
+    accessed: '2026-07-01'


### PR DESCRIPTION
## Summary
Adds **Otari**, Mozilla AI's open OpenAI-compatible **LLM gateway** (`mozilla-ai/otari`, Apache-2.0) — one endpoint in front of 40+ providers with virtual keys, budget enforcement, usage tracking, and sandboxed server-side code-execution tools. Placed in **UI & API**, alongside its direct peers **LiteLLM** and **OpenRouter**.

## Scoring (calibrated against LiteLLM)
| | Openness | Adoption | Capability | Maturity | Mature? |
|---|---|---|---|---|---|
| Otari | 4 (open_core) | 1 (63★, created Apr 2026) | 3 (feature matrix) | **1.6** | No |
| LiteLLM (peer) | 4 (open_core) | 3 (49K★, 21K dependents) | 4 | 3.3 | No |

UI & API uses 0.7 adoption / 0.3 capability weights, so a 3-month-old gateway with 63 stars lands low. Not mature → the mature-open set and insights are unchanged.

## Notes
- **Openness 4 (open_core):** Apache-2.0 self-hostable core + a hosted Otari.ai platform on the same foundation, matching LiteLLM's classification. Would be open_source (5) if the hosted platform is not a commercial tier — flagged in the score note.
- Mozilla AI's underlying **any-llm** library (~2.1K stars) is far more adopted and a plausible stronger addition, but is a separate product — not included here.

## Files
- New: `products/otari.yaml`, `scores/otari.yaml`
- Modified: `organizations/mozilla-ai.yaml` (roster), `categories/ui_api.yaml` (roster)
- `build/_frozen_long_tail.json` counts re-synced (+1); `notebook_data.json` left for the bot.

## Test plan
- `uv run python -m build.validate` → 0 errors
- `uv run python -m build.serialize` → 457 products; Otari lands openness 4, maturity 1.6, `mature=False`.