### PR TITLE
feat(sources): add SyftHub (OpenMined federated RAG) to Orchestration & agents

### DIFF
--- a/build/_frozen_long_tail.json
+++ b/build/_frozen_long_tail.json
@@ -4,11 +4,11 @@
     "models": 6428,
     "packages": 2823,
     "total": 24626,
-    "scored": 457,
+    "scored": 458,
     "overlap": 226,
-    "scored_outside": 231,
+    "scored_outside": 232,
     "uncategorized": 24400,
-    "universe": 24857
+    "universe": 24858
   },
   "top": [
     {

--- a/sources/categories/orchestration_agents.yaml
+++ b/sources/categories/orchestration_agents.yaml
@@ -41,6 +41,7 @@ products:
 - graphrag
 - lightrag
 - nano-graphrag
+- syfthub
 - pathway
 - opencode
 - semantic-kernel

--- a/sources/organizations/openmined.yaml
+++ b/sources/organizations/openmined.yaml
@@ -3,3 +3,4 @@ display_name: OpenMined
 type: foundation
 products:
 - pysyft
+- syfthub

--- a/sources/products/syfthub.yaml
+++ b/sources/products/syfthub.yaml
@@ -1,0 +1,13 @@
+name: syfthub
+display_name: SyftHub
+type: software
+description: An open, privacy-preserving federated RAG framework from OpenMined. Instead of centralizing
+  documents, a query is broadcast across a network of peers; each peer searches its own private index and
+  returns only the most relevant snippets, which are aggregated, ranked, and synthesized by an LLM into a
+  grounded answer. The SyftHub SDK loads data sources from the network, selects an LLM, and runs federated
+  RAG pipelines. Built on OpenMined's Syft privacy stack.
+github:
+- url: https://github.com/OpenMined/syft-hub-sdk
+comments: SyftHub federated RAG SDK, Apache-2.0, from OpenMined; ~2 GitHub stars (July 2026), created Aug
+  2025. Early-stage; part of OpenMined's federated-RAG work (alongside local-rag / local-rag-router) and
+  built on the Syft privacy stack (PySyft is tracked separately). Verified live July 2026.

--- a/sources/scores/syfthub.yaml
+++ b/sources/scores/syfthub.yaml
@@ -1,0 +1,35 @@
+product: syfthub
+openness:
+  score: 5
+  class: open_source
+  components: license:Apache-2.0(OSI);source:public(github.com/OpenMined/syft-hub-sdk);self-host:yes;service:none
+  confidence: high
+  note: 'Fully open source: Apache-2.0 SDK, self-hostable, no proprietary tier. Built on OpenMined''s
+    open Syft privacy stack.'
+  sources:
+  - url: https://github.com/OpenMined/syft-hub-sdk
+    shows: Apache-2.0; federated RAG client SDK
+    accessed: '2026-07-01'
+adoption:
+  level: 1
+  reach: <10K
+  signal_type: stars_fallback
+  confidence: low
+  note: ~2 GitHub stars (July 2026), created Aug 2025 — pre-adoption. Part of OpenMined's federated-RAG
+    effort (also local-rag, local-rag-router). Included as an emerging entry, not on adoption merit.
+  sources:
+  - url: https://github.com/OpenMined/syft-hub-sdk
+    shows: 2 stars (July 2026)
+    accessed: '2026-07-01'
+capability:
+  score: 2
+  basis: feature_matrix
+  value: null
+  confidence: low
+  note: Implements a full federated RAG pipeline — distributed private indexing, federated query broadcast,
+    local top-k retrieval, global aggregation/ranking, and LLM synthesis. A distinctive privacy-preserving
+    approach (nothing else on the map does federated RAG), but early-stage and narrow.
+  sources:
+  - url: https://openmined.org/syfthub/
+    shows: federated RAG architecture — distributed indexing, federated query, aggregation, synthesis
+    accessed: '2026-07-01'


### PR DESCRIPTION
## Summary
Adds **SyftHub**, OpenMined's open privacy-preserving **federated RAG** framework (`OpenMined/syft-hub-sdk`, Apache-2.0), to **Orchestration & agents** (with GraphRAG, LightRAG, RAGFlow). A query is broadcast across a network of peers; each searches its own *private* index and returns only relevant snippets, which are aggregated and synthesized — a distinctive approach with no other federated-RAG entry on the map.

## Scoring
| Openness | Adoption | Capability | Maturity | Mature? |
|---|---|---|---|---|
| 5 (open_source, Apache-2.0) | 1 (~2 stars, created Aug 2025) | 2 (full federated-RAG pipeline, early-stage) | **1.7** | No |

Orchestration & agents is capability-weighted (0.3 adoption / 0.7 capability). SyftHub is added as an **emerging entry on the merits of the approach, not adoption** — it's pre-adoption (~2 stars) but implements a novel, fully-open privacy-preserving RAG pipeline. Not mature → no headline sets change. OpenMined is already on the map via `Syft / PySyft`; this is a separate sub-project added to its roster.

## Files
- New: `products/syfthub.yaml`, `scores/syfthub.yaml`
- Modified: `organizations/openmined.yaml` (roster), `categories/orchestration_agents.yaml` (roster)
- `build/_frozen_long_tail.json` counts re-synced (+1); `notebook_data.json` left for the bot.

## Test plan
- `uv run python -m build.validate` → 0 errors
- `uv run python -m build.serialize` → 458 products; SyftHub lands openness 5, maturity 1.7, `mature=False`.