### PR TITLE
Raise Coop adoption to 3 on new public deployment evidence

### DIFF
--- a/sources/scores/coop.yaml
+++ b/sources/scores/coop.yaml
@@ -10,16 +10,29 @@ openness:
     shows: Apache-2.0; review queues, routing, enforcement rules, REST/GraphQL APIs
     accessed: '2026-07-01'
 adoption:
-  level: 1
-  reach: <10K
-  signal_type: stars_fallback
-  confidence: low
-  note: 62 GitHub stars / 35 forks (July 2026), released V.0 in Feb 2026. Very early; little deployment
-    evidence beyond a coop-integration-example repo.
+  level: 3
+  reach: niche
+  signal_type: reported_traction
+  confidence: medium
+  note: GitHub breadth is modest (~63 stars / 35 forks, July 2026), but Coop is deployed across varied
+    production environments. Coop is the open-sourced productization of the acquired Cove codebase, and
+    former Cove clients carried over as users. Notion is publicly committed and is likely Coop's largest
+    production deployment to date. The v1.0 announcement adds named production feedback from Kyodo (a
+    2-person startup whose platform has sent 150M+ messages; CEO testimonial) and an unnamed large-scale
+    adopter (tens of millions of users, ~95% cut in safety-tooling costs), plus NCMEC as a CSAM-reporting
+    integration partner. Adoption rests on named production deployments rather than community breadth,
+    mirroring sibling Osprey. Now on the v1.0 line (v1.0.2, June 2026), no longer the Feb 2026 V.0.
   sources:
   - url: https://github.com/roostorg/coop
-    shows: 62 stars, 35 forks (July 2026)
-    accessed: '2026-07-01'
+    shows: '"Used in production": Notion, Kyodo, Musubi; v1.0.2 (June 30, 2026); 63 stars, 35 forks'
+    accessed: '2026-07-03'
+  - url: https://roost.tools/blog/coop-1-0-world-s-first-free-open-source-child-safety-infrastructure-for-every-platform/
+    shows: v1.0 (June 2026); Kyodo CEO testimonial (150M+ messages); unnamed adopter with tens of millions
+      of users and ~95% safety-cost reduction; NCMEC reporting integration
+    accessed: '2026-07-03'
+  - url: https://roost.tools/blog/roost-announces-coop-and-osprey-free-open-source-trust-and-safety-infrastructure-for-the-ai-era/
+    shows: Notion (Head of Platform Security, Dan Pyykonen) quoted on running Cove, now evolving into Coop
+    accessed: '2026-07-03'
 capability:
   score: 3
   basis: feature coverage
@@ -27,8 +40,8 @@ capability:
     child-safety workflows (HMA hash matching, NCMEC reporting) and OpenAI Moderation / Google Content
     Safety integrations.
   confidence: low
-  note: Broad moderation-console feature set but explicitly V.0 (Feb 2026); functional and early rather
-    than proven.
+  note: Broad moderation-console feature set, now on the v1.0 line (v1.0.2, June 2026); functional and
+    proven at named deployments but still young.
   sources:
   - url: https://roost.tools/coop/
     shows: review console, queues, routing, enforcement, analytics, integrations


### PR DESCRIPTION
## Summary

Re-scores **Coop** (ROOST's open-source moderation console) in the Safety & Guardrails category. Adoption moves **1 → 3**, maturity **2.0 → 3.0**. Openness (5) and capability (3) are unchanged.

This is a staleness correction driven by new **public** evidence, applied through the existing rubric. It came out of ROOST's feedback on the gap map, but the change rests entirely on public signals so it stays consistent with how every other product is scored.

## Why

When Coop was first scored it was a Feb 2026 **V.0** with ~62 GitHub stars and no public deployment evidence, so it landed at adoption `1` / `stars_fallback` — the floor of the category. Both facts have since changed:

- **v1.0 line shipped** (v1.0.2, June 2026), no longer V.0.
- **Named production adopters are now public**, across varied environments:
  - **Notion** — publicly committed, likely Coop's largest deployment (Cove → Coop lineage; Head of Platform Security quoted).
  - **Kyodo** — a 2-person startup whose platform has sent 150M+ messages; CEO testimonial in the v1 announcement.
  - An **unnamed large-scale adopter** — tens of millions of users, ~95% cut in safety-tooling costs.
  - **NCMEC** CSAM-reporting integration.

Read through the same rubric, `signal_type` becomes `reported_traction` and adoption rises to `3` — the level sibling **Osprey** already holds on marquee-but-not-broad deployment. Kept at 3 (not 4) because Coop lacks the download-breadth of the level-4 guardrail models (Llama Guard, gpt-oss-safeguard, WildGuard).

## Test plan

- [x] `uv run python -m build.validate` → `0 error(s)`
- [x] Serialize dry-run confirms Coop → `maturity 3.0` (adoption 3, capability 3)
- [x] `build/notebook_data.json` and the notebook are **not** committed (bot regenerates on merge)