### PR TITLE
Restyle README hero: stat badges + tighter header

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,7 @@
 
 <a href="https://map.currentai.org/"><img src="assets/hero.png" alt="Open Source AI Stack Gap Map" width="640"></a>
 
-# os-ai-map
-
-**The public data + modeling home behind the [AI Stack Map](https://map.currentai.org/).**
-
-Curated YAML scoring the public-interest AI stack — from base models through orchestration, agents, and deployment — on openness, capability, and adoption.
+**The public data + modeling home behind the [Open Source AI Gap Map](https://map.currentai.org/).**
 
 <p align="center">
   <a href="https://github.com/currentai-org/os-ai-map/actions/workflows/validate.yml"><img src="https://github.com/currentai-org/os-ai-map/actions/workflows/validate.yml/badge.svg" alt="Validate"></a>
@@ -15,11 +11,11 @@ Curated YAML scoring the public-interest AI stack — from base models through o
   <a href="https://map.currentai.org/"><img src="https://img.shields.io/badge/live-map.currentai.org-F0776A.svg" alt="Live map"></a>
 </p>
 
-<table align="center"><tr>
-  <td align="center"><img src="assets/icons/categories.svg" width="40" height="40" alt=""><br><b>15</b><br>categories</td>
-  <td align="center"><img src="assets/icons/organizations.svg" width="40" height="40" alt=""><br><b>249</b><br>organizations</td>
-  <td align="center"><img src="assets/icons/products.svg" width="40" height="40" alt=""><br><b>458</b><br>products</td>
-</tr></table>
+<p align="center">
+  <img src="https://img.shields.io/badge/categories-15-F0776A" alt="15 categories">
+  <img src="https://img.shields.io/badge/organizations-249-F0776A" alt="249 organizations">
+  <img src="https://img.shields.io/badge/products-458-F0776A" alt="458 products">
+</p>
 
 </div>
 
@@ -27,11 +23,7 @@ Curated YAML scoring the public-interest AI stack — from base models through o
 
 Curated YAML in `sources/` feeds a deterministic build pipeline that serializes to
 `build/notebook_data.json`, renders to `notebooks/ai-stack-map.py`, and publishes to
-the OSO platform. There is no front-end in this repo.
-
-```
-sources/*.yaml ──▶ validate ──▶ serialize ──▶ notebook_data.json ──▶ render ──▶ ai-stack-map.py ──▶ OSO platform
-```
+the OSO platform.
 
 ---
 

--- a/assets/icons/categories.svg
+++ b/assets/icons/categories.svg
@@ -1,5 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48" height="48" role="img" aria-label="categories">
-  <rect x="7" y="9" width="34" height="8" rx="4" fill="#F0776A"/>
-  <rect x="7" y="20" width="26" height="8" rx="4" fill="none" stroke="#F0776A" stroke-width="2.5"/>
-  <rect x="7" y="31" width="20" height="8" rx="4" fill="#F0776A"/>
-</svg>

--- a/assets/icons/organizations.svg
+++ b/assets/icons/organizations.svg
@@ -1,8 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48" height="48" role="img" aria-label="organizations">
-  <line x1="24" y1="12" x2="12" y2="35" stroke="#F0776A" stroke-width="2.5"/>
-  <line x1="24" y1="12" x2="36" y2="35" stroke="#F0776A" stroke-width="2.5"/>
-  <line x1="12" y1="35" x2="36" y2="35" stroke="#F0776A" stroke-width="2.5"/>
-  <circle cx="24" cy="12" r="6" fill="#F0776A"/>
-  <circle cx="12" cy="35" r="6" fill="none" stroke="#F0776A" stroke-width="2.5"/>
-  <circle cx="36" cy="35" r="6" fill="none" stroke="#F0776A" stroke-width="2.5"/>
-</svg>

--- a/assets/icons/products.svg
+++ b/assets/icons/products.svg
@@ -1,6 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48" height="48" role="img" aria-label="products">
-  <rect x="7" y="7" width="15" height="15" rx="2.5" fill="#F0776A"/>
-  <rect x="26" y="7" width="15" height="15" rx="2.5" fill="none" stroke="#F0776A" stroke-width="2.5"/>
-  <rect x="7" y="26" width="15" height="15" rx="2.5" fill="none" stroke="#F0776A" stroke-width="2.5"/>
-  <rect x="26" y="26" width="15" height="15" rx="2.5" fill="#F0776A"/>
-</svg>


### PR DESCRIPTION
## Summary

Follow-up polish to the README hero:

- **Counts as badges** — categories / organizations / products move from the icon table to a centered row of coral shield badges, matching the badge row above.
- **Tighter hero** — drop the `# os-ai-map` h1, the secondary tagline, the "no front-end" line, and the ASCII pipeline diagram.
- Rename the map link to **Open Source AI Gap Map**.
- Remove the now-unused icon SVGs.

## Test plan

- [x] Rendered locally and screenshot-verified: both badge rows center, hero is trimmed as intended
- [x] No remaining references to `assets/icons/`
- [ ] Confirm badges resolve on GitHub (shields.io/actions hosts are network-blocked in the dev sandbox)