### PR TITLE
Refresh GLM-5.2 adoption on current HF usage

### DIFF
--- a/sources/products/glm-5-2.yaml
+++ b/sources/products/glm-5-2.yaml
@@ -9,5 +9,5 @@ github:
 - url: https://github.com/zai-org/GLM-5
 huggingface_model:
 - url: https://huggingface.co/zai-org/GLM-5.2
-comments: MIT-licensed open weights (HF model card + LICENSE, (c) Zhipu AI 2026). ~753B-param MoE, 1M context. Model
-  only days old at audit (~666 HF downloads/month, volatile).
+comments: MIT-licensed open weights (HF model card + LICENSE, (c) Zhipu AI 2026). ~753B-param MoE, 1M context.
+  ~191k HF downloads/month and 3.32k likes as of July 2026 (up sharply from ~666 when days old at the June audit).

--- a/sources/scores/glm-5-2.yaml
+++ b/sources/scores/glm-5-2.yaml
@@ -10,14 +10,16 @@ openness:
     shows: MIT, (c) Zhipu AI 2026
     accessed: '2026-06-18'
 adoption:
-  level: 2
+  level: 3
+  reach: 100k-1M
   signal_type: usage_volume
-  confidence: low
-  note: ~666 HF downloads last month (model was days old at audit; volatile/low).
+  confidence: medium
+  note: ~191k HF downloads last month and 3.32k likes (July 2026), up sharply from ~666 when the model
+    was days old at the June audit. Now firmly in the 100k-1M band.
   sources:
   - url: https://huggingface.co/zai-org/GLM-5.2
-    shows: 666 downloads last month, 753B MoE, 1M context
-    accessed: '2026-06-18'
+    shows: 191,462 downloads last month, 3.32k likes, 753B MoE, 1M context
+    accessed: '2026-07-03'
 capability:
   score: 5
   basis: benchmark:LMArena/FrontierSWE/Terminal-Bench


### PR DESCRIPTION
## Summary

Refreshes **GLM-5.2** adoption, which was scored days after release and is now stale.

- The June 18 audit caught the model when it was days old: ~666 HF downloads/month, landing adoption at level **2**.
- Current Hugging Face stats: **191,462 downloads last month, 3.32k likes** — firmly in the 100k–1M band.
- Bump **adoption 2 → 3** (`usage_volume`, confidence low → medium), add `reach: 100k-1M`, and refresh the note + product comment.
- Maturity moves **4.1 → 4.4** (still under the 4.5 mature bar; `open_weights` so no effect on the category stage).

Applied through the existing rubric — [the adoption bands](CONTRIBUTING.md) put 100k–1M/mo at level 3.

## Test plan

- [x] `uv run python -m build.validate` → `0 error(s)`
- [x] Confirmed maturity recomputes to 4.4 (base_pretrained weights 0.3 adopt / 0.7 cap)