### PR TITLE
Merge duplicate Zhipu org into Z.ai

### DIFF
--- a/sources/organizations/zhipu-ai.yaml
+++ b/sources/organizations/zhipu-ai.yaml
@@ -1,8 +1,0 @@
-name: zhipu-ai
-display_name: Zhipu AI
-type: company
-homepage: https://www.zhipuai.cn
-products:
-- glm-4-9b
-- glm-4
-- glm-4-6

--- a/sources/organizations/zhipu-z-ai.yaml
+++ b/sources/organizations/zhipu-z-ai.yaml
@@ -1,8 +1,11 @@
 name: zhipu-z-ai
-display_name: Zhipu / Z.ai
+display_name: Z.ai
 type: company
 homepage: https://z.ai
 products:
+- glm-4-9b
+- glm-4
+- glm-4-6
 - glm-5-1
 - glm-5-2
-comments: International brand of zhipu-ai; merge candidate.
+comments: Z.ai is the international brand of Zhipu AI; the separate zhipu-ai org entry was merged in here (July 2026).


### PR DESCRIPTION
## Summary

The repo carried two org entries for the same company:

- `zhipu-ai` (Zhipu AI) — GLM-4, GLM-4.6, GLM-4-9B
- `zhipu-z-ai` (Z.ai, the international brand) — GLM-5.1, GLM-5.2, already flagged "merge candidate"

Consolidates on **`zhipu-z-ai`** since Z.ai is the better-known brand:

- Move GLM-4, GLM-4.6, and GLM-4-9B into the `zhipu-z-ai` roster (all five GLM models now under one org)
- Rename its `display_name` to **Z.ai**
- Delete the duplicate `zhipu-ai.yaml`

All five GLM products now resolve to a single org in the serialized output.

## Scope check

- Only `sources/organizations/` is affected. The one other `zhipu-ai` hit in `sources/` is an article URL in `glm-5-1.yaml` (left as-is).
- The warehouse `stack_map` bridge joins on repos, not our org slugs, so it's unaffected.

## Test plan

- [x] `uv run python -m build.validate` → `0 error(s)` (confirms each product is in exactly one org roster)
- [x] Serialize dry-run: GLM-4 / GLM-4-9B / GLM-4.6 / GLM-5.1 / GLM-5.2 all → `Z.ai`