### PR TITLE
Add Ornith 1.0 9B (DeepReinforce) to Fine-tuned / chat models

### DIFF
--- a/build/_frozen_long_tail.json
+++ b/build/_frozen_long_tail.json
@@ -4,11 +4,11 @@
     "models": 6428,
     "packages": 2823,
     "total": 24626,
-    "scored": 458,
+    "scored": 459,
     "overlap": 226,
-    "scored_outside": 232,
+    "scored_outside": 233,
     "uncategorized": 24400,
-    "universe": 24858
+    "universe": 24859
   },
   "top": [
     {

--- a/sources/categories/finetuned_chat.yaml
+++ b/sources/categories/finetuned_chat.yaml
@@ -56,4 +56,5 @@ products:
 - codegemma
 - gemini-3-pro
 - vibethinker
+- ornith
 comments: ''

--- a/sources/organizations/deepreinforce-ai.yaml
+++ b/sources/organizations/deepreinforce-ai.yaml
@@ -1,0 +1,6 @@
+name: deepreinforce-ai
+display_name: DeepReinforce
+type: company
+homepage: https://huggingface.co/deepreinforce-ai
+products:
+- ornith

--- a/sources/products/ornith.yaml
+++ b/sources/products/ornith.yaml
@@ -1,0 +1,13 @@
+name: ornith
+display_name: Ornith 1.0 9B
+type: model
+description: DeepReinforce's open-weights agentic coding model, a 9B dense model built on the Qwen 3.5
+  architecture, with explicit <think> reasoning and tool-calling for terminal-based software-engineering
+  tasks. Optimized for single-GPU deployment (~19GB in bf16).
+huggingface_model:
+- url: https://huggingface.co/deepreinforce-ai/Ornith-1.0-9B
+- url: https://huggingface.co/deepreinforce-ai/Ornith-1.0-9B-GGUF
+comments: MIT-licensed open weights (HF tag license:mit), Qwen 3.5 architecture (qwen3_5), released 2026
+  by DeepReinforce. ~64k downloads/mo on the primary weights repo plus ~288k/mo on the GGUF quant (~352k
+  combined, July 2026); 361 / 407 likes. Reported coding benchmarks include SWE-Bench Verified 69.4, SWE-Bench
+  Pro 42.9, and Terminal-Bench 2.1 ~43.

--- a/sources/scores/ornith.yaml
+++ b/sources/scores/ornith.yaml
@@ -1,0 +1,37 @@
+product: ornith
+openness:
+  score: 3
+  class: open_weights
+  components: weights:open(MIT);base:Qwen3.5;data:closed;recipe:closed;license:MIT(OSI)
+  confidence: high
+  note: MIT-licensed open weights on a Qwen 3.5 base, but no open training data or recipe -> open_weights.
+  sources:
+  - url: https://huggingface.co/deepreinforce-ai/Ornith-1.0-9B
+    shows: license:mit tag; qwen3_5 architecture; safetensors weights
+    accessed: '2026-07-03'
+adoption:
+  level: 3
+  reach: 100k-1M
+  signal_type: usage_volume
+  confidence: medium
+  note: ~352k HF downloads last month combined across the primary weights repo (~64k) and the GGUF quant
+    (~288k), July 2026; 361 + 407 likes. Squarely in the 100k-1M band.
+  sources:
+  - url: https://huggingface.co/deepreinforce-ai/Ornith-1.0-9B
+    shows: 64,051 downloads last month, 361 likes
+    accessed: '2026-07-03'
+  - url: https://huggingface.co/deepreinforce-ai/Ornith-1.0-9B-GGUF
+    shows: 287,942 downloads last month, 407 likes
+    accessed: '2026-07-03'
+capability:
+  score: 4
+  basis: benchmark:SWE-Bench/Terminal-Bench
+  value: SWE-Bench Verified 69.4, SWE-Bench Pro 42.9, Terminal-Bench 2.1 ~43 (Terminus-2) / ~40.6 (Claude
+    Code); agentic coding with reasoning and tool-calling
+  confidence: medium
+  note: Strong agentic-coding scores for a 9B and competitive within the category, but below the frontier
+    coders; benchmarks are vendor-reported on the model card.
+  sources:
+  - url: https://huggingface.co/deepreinforce-ai/Ornith-1.0-9B
+    shows: reported SWE-Bench Verified / Pro and Terminal-Bench results
+    accessed: '2026-07-03'


### PR DESCRIPTION
## Summary

Adds **Ornith 1.0 9B**, DeepReinforce's open-weights agentic coding model, to the `finetuned_chat` category (where the other coders live — qwen3-coder, deepseek-coder, glm-4-6).

Five coordinated edits per the `add-product` recipe: product, score, new org, category roster, and a frozen long-tail count re-sync.

### Scores (all citation-backed to primary HF sources)
- **Openness 3** — `open_weights`. MIT-licensed weights (HF `license:mit` tag) on a Qwen 3.5 base (`qwen3_5` architecture), but no open training data or recipe.
- **Adoption 3** — `usage_volume`, ~352k HF downloads/mo **combined** across the primary weights repo (~64k) and the GGUF quant (~288k). Squarely in the 100k–1M band.
- **Capability 4** — SWE-Bench Verified 69.4, SWE-Bench Pro 42.9, Terminal-Bench 2.1 ~43. Strong for a 9B and competitive in-category, but below the frontier coders; benchmarks are vendor-reported. (Judgment call — happy to move to 5 if you'd rather.)
- Resulting **maturity 3.7**.

### Notes
- Verified against primary metadata: architecture is genuinely **Qwen 3.5** (`Qwen3_5ForConditionalGeneration`, `model_type: qwen3_5`), license is MIT.
- New org **DeepReinforce** (`deepreinforce-ai`).
- `build/_frozen_long_tail.json` scored count re-synced 458 → 459 (with `scored_outside`/`universe` kept coherent), as the recipe requires after adding a product.

## Test plan

- [x] `uv run python -m build.validate` → `0 error(s)`
- [x] Serialize dry-run: Ornith present, openness 3 / adoption 3 / capability 4 / maturity 3.7 under `finetuned_chat`
- [x] Build artifacts (`notebook_data.json`, notebook) not committed — bot regenerates on merge