### PR TITLE
feat(sources): dataset provenance sweep and lineage capture

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,6 +176,23 @@ documented reuse and winning controlled ablations are capability evidence. Keep
 adoption to verified download volume and record reuse and ablation results under
 `capability`.
 
+#### Dataset lineage
+
+Dataset products may carry an optional `lineage` block recording filiation — how
+corpora derive from one another, what tooling curated them, and which models they
+verifiably trained:
+
+```yaml
+lineage:
+  derived_from: [fineweb]          # upstream data sources
+  curated_with: [datatrove]        # curation/processing tooling
+  trains: [smollm3, apertus]       # models documented as trained on it
+```
+
+Use map product slugs where the referent is on the map, otherwise a plain name
+(e.g. `Common Crawl`, `datatrove`). Entries must be documented in the product's
+primary sources (model cards, technical reports, dataset cards), not inferred.
+
 ## Suggesting without writing YAML
 
 Open an issue instead — there are structured forms for **suggest a product**,

--- a/build/_frozen_long_tail.json
+++ b/build/_frozen_long_tail.json
@@ -4,10 +4,10 @@
     "models": 6428,
     "packages": 2823,
     "total": 24626,
-    "scored": 459,
-    "overlap": 226,
+    "scored": 474,
+    "overlap": 241,
     "scored_outside": 233,
-    "uncategorized": 24400,
+    "uncategorized": 24385,
     "universe": 24859
   },
   "top": [

--- a/docs/schemas/product.schema.json
+++ b/docs/schemas/product.schema.json
@@ -16,7 +16,16 @@
     "crates": { "type": "array", "items": { "$ref": "#/definitions/url" } },
     "go": { "type": "array", "items": { "$ref": "#/definitions/url" } },
     "huggingface_model": { "type": "array", "items": { "$ref": "#/definitions/url" } },
-    "huggingface_dataset": { "type": "array", "items": { "$ref": "#/definitions/url" } }
+    "huggingface_dataset": { "type": "array", "items": { "$ref": "#/definitions/url" } },
+    "lineage": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "derived_from": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+        "curated_with": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+        "trains": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+      }
+    }
   },
   "definitions": {
     "url": {

--- a/sources/categories/training_synthetic_datasets.yaml
+++ b/sources/categories/training_synthetic_datasets.yaml
@@ -2,9 +2,9 @@ name: training_synthetic_datasets
 display_name: Training & synthetic datasets
 description: "Corpora for pre-training and post-training models."
 strapline: Open training data is a monoculture. The only mature fully-open corpora —
-  FineWeb-Edu and DCLM — are filtered Common-Crawl English web text; open multilingual,
-  preference, and reasoning data lag well behind. Meanwhile the frontier's own recipe —
-  its proprietary and licensed data and exact mix — stays invisible.
+  FineWeb-Edu, DCLM, and Dolma 3 — are filtered Common-Crawl English web text; open
+  multilingual, preference, and reasoning data lag well behind. Meanwhile the frontier's
+  own recipe — its proprietary and licensed data and exact mix — stays invisible.
 weights:
   adopt: 0.5
   cap: 0.5

--- a/sources/categories/training_synthetic_datasets.yaml
+++ b/sources/categories/training_synthetic_datasets.yaml
@@ -33,6 +33,21 @@ products:
 - ultrafeedback
 - hh-rlhf
 - synth
+- the-pile
+- ultrachat-200k
+- starcoderdata
+- dolma-3
+- dolci
+- txt360
+- nemotron-cc
+- finemath
+- stack-edu
+- smoltalk
+- oasst1
+- flan-collection
+- pes2o
+- openwebmath
+- hermes-3-dataset
 comments: 'Pre-training corpora + post-training/synthetic/preference data: everything
   consumed to BUILD a model, as opposed to benchmark_eval_data which scores one. Dataset
   openness vocabulary (open / gated / documented_only / closed). Proposed in issue #10.'

--- a/sources/organizations/allen-institute-for-ai.yaml
+++ b/sources/organizations/allen-institute-for-ai.yaml
@@ -10,3 +10,6 @@ products:
 - madlad-400
 - wildchat-1m
 - tulu-3-sft-mixture
+- dolma-3
+- dolci
+- pes2o

--- a/sources/organizations/bigcode-project.yaml
+++ b/sources/organizations/bigcode-project.yaml
@@ -8,3 +8,4 @@ products:
 - bigcodebench
 - the-stack-v2
 - starcoder2
+- starcoderdata

--- a/sources/organizations/eleutherai.yaml
+++ b/sources/organizations/eleutherai.yaml
@@ -7,3 +7,4 @@ github:
 products:
 - pythia
 - lm-evaluation-harness
+- the-pile

--- a/sources/organizations/google-research.yaml
+++ b/sources/organizations/google-research.yaml
@@ -4,3 +4,4 @@ type: company
 homepage: https://research.google
 products:
 - mbpp
+- flan-collection

--- a/sources/organizations/hugging-face.yaml
+++ b/sources/organizations/hugging-face.yaml
@@ -28,3 +28,7 @@ products:
 - huggingface-hub
 - optimum
 - zephyr
+- ultrachat-200k
+- finemath
+- stack-edu
+- smoltalk

--- a/sources/organizations/llm360.yaml
+++ b/sources/organizations/llm360.yaml
@@ -6,3 +6,4 @@ github:
 - url: https://github.com/LLM360
 products:
 - k2-v2
+- txt360

--- a/sources/organizations/nous-research.yaml
+++ b/sources/organizations/nous-research.yaml
@@ -11,3 +11,4 @@ products:
 - hermes-4-14b
 - atropos
 - hermes-agent
+- hermes-3-dataset

--- a/sources/organizations/nvidia.yaml
+++ b/sources/organizations/nvidia.yaml
@@ -16,3 +16,4 @@ products:
 - nvidia-jetson-agx-orin
 - nvidia-jetson-orin-nx
 - megatron-lm
+- nemotron-cc

--- a/sources/organizations/open-web-math.yaml
+++ b/sources/organizations/open-web-math.yaml
@@ -1,0 +1,8 @@
+name: open-web-math
+display_name: OpenWebMath project
+type: lab
+homepage: https://github.com/keirp/OpenWebMath
+github:
+- url: https://github.com/keirp/OpenWebMath
+products:
+- openwebmath

--- a/sources/organizations/openassistant.yaml
+++ b/sources/organizations/openassistant.yaml
@@ -1,0 +1,8 @@
+name: openassistant
+display_name: OpenAssistant
+type: foundation
+homepage: https://open-assistant.io
+github:
+- url: https://github.com/LAION-AI/Open-Assistant
+products:
+- oasst1

--- a/sources/products/aya-collection.yaml
+++ b/sources/products/aya-collection.yaml
@@ -7,5 +7,9 @@ description: The Aya Collection is a large multilingual instruction-tuning datas
   collection holds hundreds of millions of examples across 64 subsets.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/CohereLabs/aya_collection
+lineage:
+  derived_from:
+  - Aya crowdsourced annotations
+  - templated NLP datasets
 comments: Verified live 2026-06-22 via primary sources. Ungated, Apache-2.0 licensed, with a complete
   dataset card.

--- a/sources/products/c4.yaml
+++ b/sources/products/c4.yaml
@@ -7,5 +7,13 @@ description: C4 (Colossal Clean Crawled Corpus) is a cleaned version of Common C
   English pretraining corpora.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/allenai/c4
+lineage:
+  derived_from:
+  - Common Crawl
+  curated_with:
+  - TensorFlow Datasets C4 pipeline
+  trains:
+  - T5
+  - UL2
 comments: Verified live 2026-06-22 via primary sources. Permissively licensed (ODC-BY) and ungated with
   a full dataset card.

--- a/sources/products/common-corpus.yaml
+++ b/sources/products/common-corpus.yaml
@@ -8,5 +8,10 @@ description: Common Corpus is a multilingual pretraining dataset of roughly 2.27
   filtering. It is one of the largest openly licensed text corpora for LLM training.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/PleIAs/common_corpus
+lineage:
+  derived_from:
+  - public domain and openly licensed sources
+  trains:
+  - Pleias models
 comments: Verified live 2026-06-22 via primary sources. Ungated with a full dataset card and built exclusively
   from uncopyrighted or openly licensed sources.

--- a/sources/products/cosmopedia.yaml
+++ b/sources/products/cosmopedia.yaml
@@ -8,5 +8,10 @@ description: Cosmopedia is a large-scale synthetic dataset of over 31 million te
   It is a reference corpus for synthetic-data pretraining recipes.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/HuggingFaceTB/cosmopedia
+lineage:
+  derived_from:
+  - Mixtral-8x7B synthetic generation
+  trains:
+  - rwkv
 comments: Verified live 2026-06-22 via primary sources. Permissive Apache-2.0 license, ungated, full dataset
   card and downloadable parquet files.

--- a/sources/products/culturax.yaml
+++ b/sources/products/culturax.yaml
@@ -7,5 +7,9 @@ description: CulturaX is a multilingual web corpus for LLM pretraining containin
   cleaning, document refinement, and MinHash fuzzy deduplication. Distributed as ~16TB of parquet.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/uonlp/CulturaX
+lineage:
+  derived_from:
+  - mC4
+  - OSCAR
 comments: Verified live 2026-06-22 via primary sources. Dataset card is rich but downloads require agreeing
   to share contact information (auto gate).

--- a/sources/products/dclm-baseline.yaml
+++ b/sources/products/dclm-baseline.yaml
@@ -10,5 +10,15 @@ github:
 - url: https://github.com/mlfoundations/dclm
 huggingface_dataset:
 - url: https://huggingface.co/datasets/mlfoundations/dclm-baseline-1.0
+lineage:
+  derived_from:
+  - Common Crawl
+  curated_with:
+  - DCLM pipeline
+  trains:
+  - smollm3
+  - olmoe-instruct
+  - marin
+  - rwkv
 comments: Verified live 2026-06-22 via primary sources. Permissive CC-BY-4.0 license, ungated download,
   with open code repo and dataset card.

--- a/sources/products/dolci.yaml
+++ b/sources/products/dolci.yaml
@@ -1,0 +1,21 @@
+name: dolci
+display_name: Dolci
+type: dataset
+description: 'Dolci is Ai2''s post-training data suite for OLMo 3: SFT, DPO preference, and RLVR sets
+  for both Instruct and Think variants, released under ODC-BY. It is the successor to the Tulu mixtures,
+  folding in OpenThoughts3, FLAN v2, OpenAssistant, WildChat, and new Ai2 synthetic data.'
+huggingface_dataset:
+- url: https://huggingface.co/datasets/allenai/Dolci-Instruct-SFT
+lineage:
+  derived_from:
+  - OpenThoughts3-1.2M
+  - flan-collection
+  - oasst1
+  - wildchat-1m
+  - Tulu 3 persona sets
+  - Aya dataset
+  curated_with:
+  - open-instruct
+  trains:
+  - olmo-3-instruct
+comments: 'Family bucket: Dolci-Instruct and Dolci-Think SFT/DPO/RL sets.'

--- a/sources/products/dolma-3.yaml
+++ b/sources/products/dolma-3.yaml
@@ -1,0 +1,27 @@
+name: dolma-3
+display_name: Dolma 3
+type: dataset
+description: 'Dolma 3 is Ai2''s ODC-BY pretraining data release behind OLMo 3: a ~9T-token pool from Common
+  Crawl, olmOCR-processed scientific PDFs, Stack-Edu code, and FineMath, plus the exact quality-upsampled
+  mixes (Dolma 3 Mix, Dolmino mid-training, Longmino long-context) used in training. The full pool, every
+  mix, and the curation tooling are public.'
+huggingface_dataset:
+- url: https://huggingface.co/datasets/allenai/dolma3_pool
+lineage:
+  derived_from:
+  - Common Crawl
+  - stack-edu
+  - finemath
+  - olmOCR-processed science PDFs
+  - RedPajama v1 arXiv
+  - dolma
+  curated_with:
+  - olmOCR
+  - datamap-rs
+  - duplodocus
+  - decon
+  trains:
+  - olmo-3
+  - olmo-3-instruct
+comments: 'Family bucket: dolma3_pool plus the Mix/Dolmino/Longmino training mixes. Successor to the map''s
+  dolma entry (Dolma 1.x).'

--- a/sources/products/dolma.yaml
+++ b/sources/products/dolma.yaml
@@ -9,5 +9,18 @@ github:
 - url: https://github.com/allenai/dolma
 huggingface_dataset:
 - url: https://huggingface.co/datasets/allenai/dolma
+lineage:
+  derived_from:
+  - Common Crawl
+  - pes2o
+  - Project Gutenberg
+  - Wikipedia
+  curated_with:
+  - Dolma toolkit
+  trains:
+  - OLMo 1/2
+  - olmoe-instruct
+  - marin
+  - rwkv
 comments: Verified live 2026-06-22 via primary sources. Permissively licensed (ODC-BY), ungated download
   with a full dataset card and replication toolkit.

--- a/sources/products/finemath.yaml
+++ b/sources/products/finemath.yaml
@@ -1,0 +1,18 @@
+name: finemath
+display_name: FineMath
+type: dataset
+description: FineMath is Hugging Face's classifier-filtered mathematical web corpus extracted from Common
+  Crawl (tens of billions of tokens at the 3+/4+ quality tiers), released under ODC-BY. It is a documented
+  pretraining component of SmolLM3, Apertus, Marin, and OLMo 3's Dolma 3 pool.
+huggingface_dataset:
+- url: https://huggingface.co/datasets/HuggingFaceTB/finemath
+lineage:
+  derived_from:
+  - Common Crawl
+  curated_with:
+  - datatrove
+  trains:
+  - smollm3
+  - apertus
+  - marin
+  - olmo-3

--- a/sources/products/fineweb-2.yaml
+++ b/sources/products/fineweb-2.yaml
@@ -8,5 +8,14 @@ description: FineWeb-2 is the multilingual successor to FineWeb, covering over 1
   LLM training.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/HuggingFaceFW/fineweb-2
+lineage:
+  derived_from:
+  - Common Crawl
+  curated_with:
+  - datatrove
+  trains:
+  - apertus
+  - smollm3
+  - alia-40b
 comments: Verified live 2026-06-22 via primary sources. Permissive ODC-BY license, ungated, with a dataset
   card spanning 1000+ languages.

--- a/sources/products/fineweb-edu.yaml
+++ b/sources/products/fineweb-edu.yaml
@@ -7,5 +7,15 @@ description: FineWeb-Edu is an educational subset of FineWeb (~1.3 trillion toke
   performance on knowledge- and reasoning-heavy benchmarks relative to unfiltered web data.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/HuggingFaceFW/fineweb-edu
+lineage:
+  derived_from:
+  - fineweb
+  curated_with:
+  - datatrove
+  trains:
+  - apertus
+  - smollm3
+  - alia-40b
+  - rwkv
 comments: Verified live 2026-06-22 via primary sources. Permissive ODC-BY license with ungated download
   and full dataset card.

--- a/sources/products/fineweb.yaml
+++ b/sources/products/fineweb.yaml
@@ -8,5 +8,10 @@ description: FineWeb is a large-scale English pretraining dataset of over 18.5 t
   widely cited reference in the open-data pretraining community.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/HuggingFaceFW/fineweb
+lineage:
+  derived_from:
+  - Common Crawl
+  curated_with:
+  - datatrove
 comments: Verified live 2026-06-22 via primary sources. Permissive ODC-BY license with ungated download
   and a full dataset card.

--- a/sources/products/flan-collection.yaml
+++ b/sources/products/flan-collection.yaml
@@ -1,0 +1,20 @@
+name: flan-collection
+display_name: FLAN Collection (v2)
+type: dataset
+description: The FLAN Collection (v2) is Google Research's instruction-tuning compilation of 1,800+ tasks
+  (P3, Super-NaturalInstructions, chain-of-thought data) that trained Flan-T5 and Flan-PaLM. It remains
+  a canonical instruction-data building block, folded into Tulu 3, OLMo 3's Dolci, and Marin's Dolmino
+  mixes.
+github:
+- url: https://github.com/google-research/FLAN
+huggingface_dataset:
+- url: https://huggingface.co/datasets/ai2-adapt-dev/flan_v2_converted
+lineage:
+  derived_from:
+  - P3
+  - Super-NaturalInstructions
+  - chain-of-thought collections
+  trains:
+  - tulu-3
+  - olmo-3-instruct
+  - marin

--- a/sources/products/hermes-3-dataset.yaml
+++ b/sources/products/hermes-3-dataset.yaml
@@ -1,0 +1,15 @@
+name: hermes-3-dataset
+display_name: Hermes 3 Dataset
+type: dataset
+description: The Hermes 3 Dataset is Nous Research's Apache-2.0 release of the instruction and chat corpus
+  behind Hermes 3, mixing synthetic generation with curated community data. It seeds the (unreleased)
+  Hermes 4 corpus and documents the Hermes line's data recipe.
+huggingface_dataset:
+- url: https://huggingface.co/datasets/NousResearch/Hermes-3-Dataset
+lineage:
+  derived_from:
+  - Nous synthetic instruction generation
+  trains:
+  - hermes-4-3-36b
+  - hermes-4-14b
+  - hermes-4-llama-3-1-405b

--- a/sources/products/hh-rlhf.yaml
+++ b/sources/products/hh-rlhf.yaml
@@ -9,5 +9,8 @@ github:
 - url: https://github.com/anthropics/hh-rlhf
 huggingface_dataset:
 - url: https://huggingface.co/datasets/Anthropic/hh-rlhf
+lineage:
+  derived_from:
+  - human preference annotations (Anthropic crowdworkers)
 comments: Verified live 2026-06-22 via primary sources. Publicly downloadable and ungated under the permissive
   MIT license.

--- a/sources/products/madlad-400.yaml
+++ b/sources/products/madlad-400.yaml
@@ -7,5 +7,8 @@ description: MADLAD-400 is a document-level multilingual web corpus derived from
   of low-resource languages. It underpins the MADLAD-400 machine-translation models.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/allenai/MADLAD-400
+lineage:
+  derived_from:
+  - Common Crawl
 comments: Verified live 2026-06-22 via primary sources. Ungated with a permissive open-data license and
   a complete dataset card.

--- a/sources/products/nemotron-cc.yaml
+++ b/sources/products/nemotron-cc.yaml
@@ -1,0 +1,20 @@
+name: nemotron-cc
+display_name: Nemotron-CC
+type: dataset
+description: Nemotron-CC is NVIDIA's Common Crawl-derived pretraining corpus family (v1/v2 plus Math,
+  Code, and Specialized sets), spanning trillions of tokens with synthetic rephrasing, released under
+  the NVIDIA Open Data License with gated access. It backs the Nemotron model line and is a documented
+  component of Marin 8B.
+huggingface_dataset:
+- url: https://huggingface.co/datasets/nvidia/Nemotron-CC-v2
+lineage:
+  derived_from:
+  - Common Crawl
+  curated_with:
+  - NeMo Curator
+  - Lynx + LLM math pipeline
+  trains:
+  - nemotron-3
+  - nemotron-3-nvidia
+  - marin
+comments: 'Family bucket: Nemotron-CC v1/v2, Nemotron-CC-Math, Nemotron-Pretraining-Code, and Nemotron-Pretraining-Specialized.'

--- a/sources/products/oasst1.yaml
+++ b/sources/products/oasst1.yaml
@@ -1,0 +1,16 @@
+name: oasst1
+display_name: OpenAssistant Conversations (OASST1)
+type: dataset
+description: OpenAssistant Conversations (OASST1) is the LAION-community crowdsourced human dialogue corpus
+  (161k messages in 35 languages, Apache-2.0) from the 2023 OpenAssistant project. It remains a staple
+  human-data ingredient in open post-training mixes, from Guanaco to Tulu 3 and OLMo 3's Dolci.
+github:
+- url: https://github.com/LAION-AI/Open-Assistant
+huggingface_dataset:
+- url: https://huggingface.co/datasets/OpenAssistant/oasst1
+lineage:
+  derived_from:
+  - crowdsourced human conversations
+  trains:
+  - tulu-3
+  - olmo-3-instruct

--- a/sources/products/openhermes-2-5.yaml
+++ b/sources/products/openhermes-2-5.yaml
@@ -7,5 +7,11 @@ description: OpenHermes 2.5 is a large synthetic instruction-following dataset o
   2.5 fine-tunes and is widely used as a base SFT mix for open instruction-tuned models.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/teknium/OpenHermes-2.5
+lineage:
+  derived_from:
+  - GPT-4 synthetic instruction data
+  - community datasets
+  trains:
+  - smollm3
 comments: Verified live 2026-06-22 via primary sources. Publicly downloadable and ungated with a full
   card, though an explicit license string is not stated on the card.

--- a/sources/products/openthoughts-114k.yaml
+++ b/sources/products/openthoughts-114k.yaml
@@ -9,5 +9,12 @@ github:
 - url: https://github.com/open-thoughts/open-thoughts
 huggingface_dataset:
 - url: https://huggingface.co/datasets/open-thoughts/OpenThoughts-114k
+lineage:
+  derived_from:
+  - DeepSeek-R1 reasoning traces
+  curated_with:
+  - open-thoughts pipeline
+  trains:
+  - marin
 comments: Verified live 2026-06-22 via primary sources. Apache-2.0 licensed, ungated, with dataset card,
   code repo, and paper.

--- a/sources/products/openwebmath.yaml
+++ b/sources/products/openwebmath.yaml
@@ -1,0 +1,17 @@
+name: openwebmath
+display_name: OpenWebMath
+type: dataset
+description: OpenWebMath is a 14.7B-token corpus of mathematical web text extracted from Common Crawl
+  with LaTeX preserved, released under ODC-BY by researchers from the University of Toronto and collaborators.
+  It appears in Proof-Pile-2 (Llemma), OLMoE, Nemotron 3, and StarCoder2's math supplements.
+github:
+- url: https://github.com/keirp/OpenWebMath
+huggingface_dataset:
+- url: https://huggingface.co/datasets/open-web-math/open-web-math
+lineage:
+  derived_from:
+  - Common Crawl
+  trains:
+  - olmoe-instruct
+  - nemotron-3
+  - starcoder2

--- a/sources/products/oscar-2301.yaml
+++ b/sources/products/oscar-2301.yaml
@@ -8,5 +8,10 @@ description: OSCAR-2301 is a multilingual web corpus extracted and filtered from
   metadata is CC0-1.0.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/oscar-corpus/OSCAR-2301
+lineage:
+  derived_from:
+  - Common Crawl
+  curated_with:
+  - Ungoliant
 comments: Verified live 2026-06-22 via primary sources. Manually gated and the card states access is temporarily
   suspended pending clarification.

--- a/sources/products/personahub.yaml
+++ b/sources/products/personahub.yaml
@@ -10,5 +10,8 @@ github:
 - url: https://github.com/tencent-ailab/persona-hub
 huggingface_dataset:
 - url: https://huggingface.co/datasets/proj-persona/PersonaHub
+lineage:
+  derived_from:
+  - persona-driven synthesis (GPT-4o)
 comments: Verified live 2026-06-22 via primary sources. Publicly downloadable and ungated under CC-BY-NC-SA-4.0,
   which permits redistribution for non-commercial research.

--- a/sources/products/pes2o.yaml
+++ b/sources/products/pes2o.yaml
@@ -1,0 +1,17 @@
+name: pes2o
+display_name: peS2o
+type: dataset
+description: peS2o is Ai2's ODC-BY corpus of ~40M cleaned academic papers derived from S2ORC (Semantic
+  Scholar). It is a standard open scientific-text component, documented in OLMoE, Marin, and NVIDIA's
+  Nemotron 3 pretraining data.
+huggingface_dataset:
+- url: https://huggingface.co/datasets/allenai/peS2o
+lineage:
+  derived_from:
+  - S2ORC (Semantic Scholar)
+  curated_with:
+  - Dolma toolkit
+  trains:
+  - olmoe-instruct
+  - marin
+  - nemotron-3

--- a/sources/products/redpajama-data-v2.yaml
+++ b/sources/products/redpajama-data-v2.yaml
@@ -9,5 +9,10 @@ github:
 - url: https://github.com/togethercomputer/RedPajama-Data
 huggingface_dataset:
 - url: https://huggingface.co/datasets/togethercomputer/RedPajama-Data-V2
+lineage:
+  derived_from:
+  - Common Crawl
+  curated_with:
+  - CCNet
 comments: Verified live 2026-06-22 via primary sources. Ungated with a full dataset card; redistributable
   per Common Crawl ToU with Apache-2.0 processing code.

--- a/sources/products/refinedweb.yaml
+++ b/sources/products/refinedweb.yaml
@@ -7,5 +7,12 @@ description: Falcon RefinedWeb is a large English web dataset (~968M rows, ~2.8T
   that rigorously filtered web data alone can match or beat curated corpora for LLM pretraining.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/tiiuae/falcon-refinedweb
+lineage:
+  derived_from:
+  - Common Crawl
+  curated_with:
+  - Macrodata Refinement pipeline
+  trains:
+  - Falcon 1/2
 comments: Verified live 2026-06-22 via primary sources. Permissive ODC-BY 1.0 license, ungated download,
   with a dataset card (a public extract of the full corpus).

--- a/sources/products/smoltalk.yaml
+++ b/sources/products/smoltalk.yaml
@@ -1,0 +1,21 @@
+name: smoltalk
+display_name: SmolTalk
+type: dataset
+description: SmolTalk (and SmolTalk2) is Hugging Face's open SFT mixture behind the SmolLM instruct models,
+  combining new Apache-2.0 synthetic sets (Smol-Magpie-Ultra and others) with established public datasets.
+  Marin 8B Instruct also trains on it; component licenses follow their sources.
+huggingface_dataset:
+- url: https://huggingface.co/datasets/HuggingFaceTB/smoltalk
+lineage:
+  derived_from:
+  - openhermes-2-5
+  - MetaMathQA
+  - NuminaMath-CoT
+  - OpenThoughts3-1.2M
+  - Llama-Nemotron-Post-Training-Dataset
+  curated_with:
+  - distilabel
+  trains:
+  - smollm3
+  - marin
+comments: 'Family bucket: SmolTalk and SmolTalk2.'

--- a/sources/products/stack-edu.yaml
+++ b/sources/products/stack-edu.yaml
@@ -1,0 +1,17 @@
+name: stack-edu
+display_name: Stack-Edu
+type: dataset
+description: Stack-Edu is Hugging Face's education-filtered slice of StarCoder2Data (~125B tokens of high-quality
+  code), scored by an educational-value classifier. It is a documented component of SmolLM3 and OLMo 3's
+  Dolma 3 pool; licensing defers to The Stack v2's terms.
+huggingface_dataset:
+- url: https://huggingface.co/datasets/HuggingFaceTB/stack-edu
+lineage:
+  derived_from:
+  - starcoderdata
+  - the-stack-v2
+  curated_with:
+  - datatrove
+  trains:
+  - smollm3
+  - olmo-3

--- a/sources/products/starcoderdata.yaml
+++ b/sources/products/starcoderdata.yaml
@@ -1,0 +1,23 @@
+name: starcoderdata
+display_name: StarCoderData
+type: dataset
+description: StarCoderData is the BigCode project's ~250B-token filtered code corpus drawn from The Stack
+  v1 (permissively licensed GitHub code plus issues and notebooks), used to train StarCoder. It became
+  a standard open code-pretraining component, documented in TinyLlama, IBM Granite Code, ALIA, Apertus,
+  Marin, and OLMoE.
+huggingface_dataset:
+- url: https://huggingface.co/datasets/bigcode/starcoderdata
+lineage:
+  derived_from:
+  - the-stack-v2
+  curated_with:
+  - bigcode-dataset tooling
+  trains:
+  - tinyllama-1-1b-chat-v1-0
+  - granite-code-instruct
+  - alia-40b
+  - apertus
+  - marin
+  - olmoe-instruct
+comments: Derived from The Stack v1 (the map's the-stack-v2 entry covers the Stack family's current version;
+  v1 is its direct predecessor).

--- a/sources/products/synth.yaml
+++ b/sources/products/synth.yaml
@@ -8,5 +8,10 @@ description: SYNTH is a large-scale synthetic dataset from PleIAs (released with
   traces and seed attribution, and roughly 20% covers non-English European languages.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/PleIAs/SYNTH
+lineage:
+  derived_from:
+  - open seed corpora (synthetic generation)
+  trains:
+  - Pleias models
 comments: Verified live 2026-06-22 via primary sources. Permissively licensed, ungated dataset with a
   documented card.

--- a/sources/products/the-pile.yaml
+++ b/sources/products/the-pile.yaml
@@ -1,0 +1,28 @@
+name: the-pile
+display_name: The Pile
+type: dataset
+description: The Pile is EleutherAI's 825 GiB, 22-source English pretraining corpus (2020), spanning web
+  text, academic papers, code, books, and forums. It set the template for documented open pretraining
+  data and trained Pythia, GPT-NeoX-20B, GPT-J, and Cerebras-GPT among others. The original mirrors are
+  offline; data is now served through the deduplicated Hugging Face repo, and component licenses vary
+  by subset.
+github:
+- url: https://github.com/EleutherAI/the-pile
+huggingface_dataset:
+- url: https://huggingface.co/datasets/EleutherAI/the_pile_deduplicated
+lineage:
+  derived_from:
+  - Common Crawl
+  - PubMed Central
+  - arXiv
+  - GitHub
+  - StackExchange
+  - Wikipedia
+  - FreeLaw
+  - Project Gutenberg
+  curated_with:
+  - the-pile pipeline
+  trains:
+  - pythia
+comments: Covers the Pile family (original + deduplicated). Verified live 2026-07-04; canonical hosting
+  moved to the deduplicated repo after the original mirrors went offline.

--- a/sources/products/the-stack-v2.yaml
+++ b/sources/products/the-stack-v2.yaml
@@ -7,5 +7,14 @@ description: The Stack v2 is a large source-code dataset of 3.28B unique files (
   but access requires accepting terms of use tied to Software Heritage principles.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/bigcode/the-stack-v2
+lineage:
+  derived_from:
+  - Software Heritage archive
+  - GitHub issues and pull requests
+  curated_with:
+  - bigcode-dataset tooling
+  trains:
+  - starcoder2
+  - smollm3
 comments: Verified live 2026-06-22 via primary sources. Requires acceptance of terms and sharing contact
   info before download, so access is gated.

--- a/sources/products/tulu-3-sft-mixture.yaml
+++ b/sources/products/tulu-3-sft-mixture.yaml
@@ -8,5 +8,20 @@ description: The Tulu 3 SFT Mixture is a supervised fine-tuning dataset of rough
   the open Tulu 3 model family.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/allenai/tulu-3-sft-mixture
+lineage:
+  derived_from:
+  - flan-collection
+  - oasst1
+  - wildchat-1m
+  - NuminaMath-TIR
+  - Evol CodeAlpaca
+  - Aya dataset
+  curated_with:
+  - open-instruct
+  trains:
+  - tulu-3
+  - apertus
+  - marin
+  - smollm3
 comments: Verified live 2026-06-22 via primary sources. ODC-BY licensed and ungated with a full dataset
   card, though some subsets carry non-commercial licenses.

--- a/sources/products/txt360.yaml
+++ b/sources/products/txt360.yaml
@@ -1,0 +1,24 @@
+name: txt360
+display_name: TxT360
+type: dataset
+description: TxT360 is LLM360's globally deduplicated pretraining corpus combining 99 Common Crawl snapshots
+  with 14 curated high-quality sources (FreeLaw, PG-19, arXiv, Wikipedia, StackExchange, and more) under
+  ODC-BY. It trains K2-V2 together with the TxT360-Midas mid-training and 3efforts SFT extensions.
+github:
+- url: https://github.com/LLM360/TxT360
+huggingface_dataset:
+- url: https://huggingface.co/datasets/LLM360/TxT360
+lineage:
+  derived_from:
+  - Common Crawl
+  - FreeLaw
+  - Project Gutenberg (PG-19)
+  - arXiv
+  - Wikipedia
+  - StackExchange
+  - HackerNews
+  curated_with:
+  - TxT360 pipeline
+  trains:
+  - k2-v2
+comments: 'Family bucket: TxT360 plus the Midas mid-training and 3efforts SFT extensions.'

--- a/sources/products/ultrachat-200k.yaml
+++ b/sources/products/ultrachat-200k.yaml
@@ -1,0 +1,14 @@
+name: ultrachat-200k
+display_name: UltraChat 200k
+type: dataset
+description: UltraChat 200k is Hugging Face H4's filtered 200k-dialogue slice of the ChatGPT-distilled
+  UltraChat corpus, released under MIT for supervised fine-tuning. It anchored the Zephyr recipe and became
+  a default open SFT set for chat alignment, also used by TinyLlama-Chat.
+huggingface_dataset:
+- url: https://huggingface.co/datasets/HuggingFaceH4/ultrachat_200k
+lineage:
+  derived_from:
+  - UltraChat (ChatGPT-distilled dialogues)
+  trains:
+  - zephyr
+  - tinyllama-1-1b-chat-v1-0

--- a/sources/products/ultrafeedback.yaml
+++ b/sources/products/ultrafeedback.yaml
@@ -10,5 +10,12 @@ github:
 - url: https://github.com/OpenBMB/UltraFeedback
 huggingface_dataset:
 - url: https://huggingface.co/datasets/openbmb/UltraFeedback
+lineage:
+  derived_from:
+  - GPT-4 preference annotations over multi-model completions
+  trains:
+  - zephyr
+  - tinyllama-1-1b-chat-v1-0
+  - olmoe-instruct
 comments: Verified live 2026-06-22 via primary sources. Publicly downloadable and ungated under the permissive
   MIT license.

--- a/sources/products/wildchat-1m.yaml
+++ b/sources/products/wildchat-1m.yaml
@@ -7,5 +7,11 @@ description: WildChat-1M is a corpus of around 838k real user-chatbot conversati
   used, and moderation scores. It is a widely cited source of naturalistic instruction and chat data.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/allenai/WildChat-1M
+lineage:
+  derived_from:
+  - real user-ChatGPT conversations
+  trains:
+  - tulu-3
+  - olmo-3-instruct
 comments: Verified live 2026-06-22 via primary sources. ODC-BY licensed and reported ungated by the HF
   API, though Ai2 datasets sometimes show an access notice.

--- a/sources/scores/dolci.yaml
+++ b/sources/scores/dolci.yaml
@@ -1,0 +1,28 @@
+product: dolci
+openness:
+  score: 5
+  class: open
+  components: license:ODC-BY;gated:false;dataset_card:present
+  confidence: high
+  note: ODC-BY, ungated, per-stage dataset cards.
+  sources:
+  - url: https://huggingface.co/datasets/allenai/Dolci-Instruct-SFT
+    shows: ODC-BY license, ungated, dataset card
+    accessed: '2026-07-04'
+adoption:
+  level: 3
+  reach: 10k-100k
+  signal_type: usage_volume
+  confidence: high
+  note: 12,526 monthly downloads on the Instruct-SFT artifact, graded on the training-corpus bands.
+  sources:
+  - url: https://huggingface.co/api/datasets/allenai/Dolci-Instruct-SFT
+    shows: downloads field = 12,526 (30-day)
+    accessed: '2026-07-04'
+capability:
+  score: null
+  basis: n/a
+  value: null
+  confidence: high
+  note: a dataset is not 'capable'
+  sources: []

--- a/sources/scores/dolci.yaml
+++ b/sources/scores/dolci.yaml
@@ -14,15 +14,23 @@ adoption:
   reach: 10k-100k
   signal_type: usage_volume
   confidence: high
-  note: 12,526 monthly downloads on the Instruct-SFT artifact, graded on the training-corpus bands.
+  note: 12,526 monthly downloads on Hugging Face, graded on the training-corpus bands.
   sources:
   - url: https://huggingface.co/api/datasets/allenai/Dolci-Instruct-SFT
     shows: downloads field = 12,526 (30-day)
     accessed: '2026-07-04'
 capability:
-  score: null
-  basis: n/a
+  score: 5
+  basis: training_value:downstream
   value: null
   confidence: high
-  note: a dataset is not 'capable'
-  sources: []
+  note: The current fully-open frontier post-training suite; OLMo 3-Think 32B leads the fully-open thinking-model
+    class in documented benchmarks.
+  sources:
+  - url: https://allenai.org/blog/olmo3
+    shows: 'OLMo 3-Think 32B (trained with Dolci) is the strongest fully-open thinking model: MATH 96.1,
+      HumanEval+ 91.4, IFEval 89.0'
+    accessed: '2026-07-04'
+  - url: https://huggingface.co/datasets/allenai/Dolci-Instruct-SFT
+    shows: Dolci is Ai2's OLMo 3 post-training suite, successor to the Tulu mixtures
+    accessed: '2026-07-04'

--- a/sources/scores/dolma-3.yaml
+++ b/sources/scores/dolma-3.yaml
@@ -14,19 +14,19 @@ adoption:
   reach: 100k-1M
   signal_type: usage_volume
   confidence: high
-  note: 158,294 monthly downloads on the flagship Dolma 3 Mix artifact (pool at 26,433), graded on the
-    training-corpus bands.
+  note: 158,294 monthly downloads on Hugging Face, graded on the training-corpus bands.
   sources:
   - url: https://huggingface.co/api/datasets/allenai/dolma3_mix-6T-1025-7B
     shows: downloads field = 158,294 (30-day)
     accessed: '2026-07-04'
-  - url: https://huggingface.co/api/datasets/allenai/dolma3_pool
-    shows: downloads field = 26,433 (30-day)
-    accessed: '2026-07-04'
 capability:
-  score: null
-  basis: n/a
+  score: 5
+  basis: training_value:downstream
   value: null
   confidence: high
-  note: a dataset is not 'capable'
-  sources: []
+  note: The current (2025) corpus behind OLMo 3, the strongest fully-open base and thinking models; uses
+    documented quality-aware upsampling and data-mix ablations.
+  sources:
+  - url: https://allenai.org/blog/olmo3
+    shows: Dolma 3 trains all OLMo 3 variants; OLMo 3-Base 32B is the strongest fully-open base model
+    accessed: '2026-07-04'

--- a/sources/scores/dolma-3.yaml
+++ b/sources/scores/dolma-3.yaml
@@ -1,0 +1,32 @@
+product: dolma-3
+openness:
+  score: 5
+  class: open
+  components: license:ODC-BY;gated:false;dataset_card:present
+  confidence: high
+  note: ODC-BY, ungated, fully documented pool and training mixes.
+  sources:
+  - url: https://huggingface.co/datasets/allenai/dolma3_pool
+    shows: ODC-BY license, ungated, dataset card
+    accessed: '2026-07-04'
+adoption:
+  level: 4
+  reach: 100k-1M
+  signal_type: usage_volume
+  confidence: high
+  note: 158,294 monthly downloads on the flagship Dolma 3 Mix artifact (pool at 26,433), graded on the
+    training-corpus bands.
+  sources:
+  - url: https://huggingface.co/api/datasets/allenai/dolma3_mix-6T-1025-7B
+    shows: downloads field = 158,294 (30-day)
+    accessed: '2026-07-04'
+  - url: https://huggingface.co/api/datasets/allenai/dolma3_pool
+    shows: downloads field = 26,433 (30-day)
+    accessed: '2026-07-04'
+capability:
+  score: null
+  basis: n/a
+  value: null
+  confidence: high
+  note: a dataset is not 'capable'
+  sources: []

--- a/sources/scores/finemath.yaml
+++ b/sources/scores/finemath.yaml
@@ -1,0 +1,41 @@
+product: finemath
+openness:
+  score: 5
+  class: open
+  components: license:ODC-BY;gated:false;dataset_card:present
+  confidence: high
+  note: ODC-BY, ungated, full dataset card.
+  sources:
+  - url: https://huggingface.co/datasets/HuggingFaceTB/finemath
+    shows: ODC-BY license, ungated, dataset card
+    accessed: '2026-07-04'
+adoption:
+  level: 4
+  reach: 100k-1M
+  signal_type: documented_reuse
+  confidence: high
+  note: 24,077 monthly downloads on Hugging Face (level 3 on the corpus bands), promoted one level for
+    documented reuse. Documented pretraining component of SmolLM3, Apertus, Marin, and OLMo 3.
+  sources:
+  - url: https://huggingface.co/api/datasets/HuggingFaceTB/finemath
+    shows: downloads field = 24,077 (30-day)
+    accessed: '2026-07-04'
+  - url: https://huggingface.co/blog/smollm3
+    shows: SmolLM3 pretraining mix includes FineMath
+    accessed: '2026-07-04'
+  - url: https://arxiv.org/abs/2509.14233
+    shows: Apertus pretraining corpus includes FineMath
+    accessed: '2026-07-04'
+  - url: https://huggingface.co/marin-community/marin-8b-base
+    shows: 'Marin mixture: FineMath 3+'
+    accessed: '2026-07-04'
+  - url: https://huggingface.co/datasets/allenai/dolma3_pool
+    shows: Dolma 3 pool includes FineMath 3+
+    accessed: '2026-07-04'
+capability:
+  score: null
+  basis: n/a
+  value: null
+  confidence: high
+  note: a dataset is not 'capable'
+  sources: []

--- a/sources/scores/finemath.yaml
+++ b/sources/scores/finemath.yaml
@@ -10,32 +10,26 @@ openness:
     shows: ODC-BY license, ungated, dataset card
     accessed: '2026-07-04'
 adoption:
-  level: 4
-  reach: 100k-1M
-  signal_type: documented_reuse
+  level: 3
+  reach: 10k-100k
+  signal_type: usage_volume
   confidence: high
-  note: 24,077 monthly downloads on Hugging Face (level 3 on the corpus bands), promoted one level for
-    documented reuse. Documented pretraining component of SmolLM3, Apertus, Marin, and OLMo 3.
+  note: 24,077 monthly downloads on Hugging Face, graded on the training-corpus bands.
   sources:
   - url: https://huggingface.co/api/datasets/HuggingFaceTB/finemath
     shows: downloads field = 24,077 (30-day)
     accessed: '2026-07-04'
-  - url: https://huggingface.co/blog/smollm3
-    shows: SmolLM3 pretraining mix includes FineMath
-    accessed: '2026-07-04'
-  - url: https://arxiv.org/abs/2509.14233
-    shows: Apertus pretraining corpus includes FineMath
-    accessed: '2026-07-04'
-  - url: https://huggingface.co/marin-community/marin-8b-base
-    shows: 'Marin mixture: FineMath 3+'
-    accessed: '2026-07-04'
-  - url: https://huggingface.co/datasets/allenai/dolma3_pool
-    shows: Dolma 3 pool includes FineMath 3+
-    accessed: '2026-07-04'
 capability:
-  score: null
-  basis: n/a
+  score: 5
+  basis: training_value:ablation
   value: null
   confidence: high
-  note: a dataset is not 'capable'
-  sources: []
+  note: Leads controlled math ablations (FineMath-4+ ~2x GSM8K and ~6x MATH over InfiMM-WebMath, beats
+    OpenWebMath); current 2025 default in SmolLM3, Apertus, Marin, and OLMo 3.
+  sources:
+  - url: https://huggingface.co/datasets/HuggingFaceTB/finemath
+    shows: FineMath-4+ achieves ~2x GSM8K and ~6x MATH over InfiMM-WebMath and beats OpenWebMath
+    accessed: '2026-07-04'
+  - url: https://arxiv.org/html/2502.02737v1
+    shows: SmolLM2 paper details the FineMath ablation vs OpenWebMath/InfiMM-WebMath
+    accessed: '2026-07-04'

--- a/sources/scores/flan-collection.yaml
+++ b/sources/scores/flan-collection.yaml
@@ -1,0 +1,43 @@
+product: flan-collection
+openness:
+  score: 4
+  class: open
+  components: access:ungated(conversion);license:Apache-2.0(recipe)+per-task;dataset_card:partial
+  confidence: medium
+  note: Released as an Apache-2.0 recipe/repo; the widely used HF conversion (ai2-adapt-dev) is ungated.
+    Underlying task datasets keep their own licenses.
+  sources:
+  - url: https://github.com/google-research/FLAN
+    shows: Apache-2.0 FLAN v2 recipe
+    accessed: '2026-07-04'
+  - url: https://huggingface.co/datasets/ai2-adapt-dev/flan_v2_converted
+    shows: ungated HF conversion used by Tulu/OLMo mixes
+    accessed: '2026-07-04'
+adoption:
+  level: 2
+  reach: 1k-10k
+  signal_type: documented_reuse
+  confidence: high
+  note: 924 monthly downloads on the HF conversion (level 1 on the corpus bands; the collection is consumed
+    via mirrors and folded mixtures), promoted one level for documented reuse. Documented in Flan-T5/Flan-PaLM,
+    Tulu 3, OLMo 3's Dolci, and Marin's Dolmino mix.
+  sources:
+  - url: https://huggingface.co/api/datasets/ai2-adapt-dev/flan_v2_converted
+    shows: downloads field = 924 (30-day)
+    accessed: '2026-07-04'
+  - url: https://arxiv.org/abs/2301.13688
+    shows: The Flan Collection paper (Flan-T5/Flan-PaLM)
+    accessed: '2026-07-04'
+  - url: https://arxiv.org/abs/2411.15124
+    shows: Tulu 3 SFT mixture includes FLAN v2
+    accessed: '2026-07-04'
+  - url: https://huggingface.co/marin-community/marin-8b-base
+    shows: Marin Dolmino mid-training includes FLAN
+    accessed: '2026-07-04'
+capability:
+  score: null
+  basis: n/a
+  value: null
+  confidence: high
+  note: a dataset is not 'capable'
+  sources: []

--- a/sources/scores/flan-collection.yaml
+++ b/sources/scores/flan-collection.yaml
@@ -14,30 +14,26 @@ openness:
     shows: ungated HF conversion used by Tulu/OLMo mixes
     accessed: '2026-07-04'
 adoption:
-  level: 2
-  reach: 1k-10k
-  signal_type: documented_reuse
+  level: 1
+  reach: <1k
+  signal_type: usage_volume
   confidence: high
-  note: 924 monthly downloads on the HF conversion (level 1 on the corpus bands; the collection is consumed
-    via mirrors and folded mixtures), promoted one level for documented reuse. Documented in Flan-T5/Flan-PaLM,
-    Tulu 3, OLMo 3's Dolci, and Marin's Dolmino mix.
+  note: 924 monthly downloads on Hugging Face, graded on the training-corpus bands.
   sources:
   - url: https://huggingface.co/api/datasets/ai2-adapt-dev/flan_v2_converted
     shows: downloads field = 924 (30-day)
     accessed: '2026-07-04'
-  - url: https://arxiv.org/abs/2301.13688
-    shows: The Flan Collection paper (Flan-T5/Flan-PaLM)
-    accessed: '2026-07-04'
-  - url: https://arxiv.org/abs/2411.15124
-    shows: Tulu 3 SFT mixture includes FLAN v2
-    accessed: '2026-07-04'
-  - url: https://huggingface.co/marin-community/marin-8b-base
-    shows: Marin Dolmino mid-training includes FLAN
-    accessed: '2026-07-04'
 capability:
-  score: null
-  basis: n/a
+  score: 3
+  basis: training_value:superseded
   value: null
   confidence: high
-  note: a dataset is not 'capable'
-  sources: []
+  note: Strong historical comparative ablations (Flan 2022 beats P3/T0/SNI on the same T5-XL) and still
+    a component in Tulu 3, Dolci, and Marin's mixes, but dated as a standalone chat-era recipe.
+  sources:
+  - url: https://arxiv.org/abs/2301.13688
+    shows: 'The Flan Collection: Flan 2022 leads P3++/Super-NatInst on MMLU/BBH (same T5-XL)'
+    accessed: '2026-07-04'
+  - url: https://huggingface.co/datasets/allenai/Dolci-Instruct-SFT
+    shows: OLMo 3 Dolci still consumes FLAN v2 (89,981 prompts)
+    accessed: '2026-07-04'

--- a/sources/scores/hermes-3-dataset.yaml
+++ b/sources/scores/hermes-3-dataset.yaml
@@ -1,0 +1,32 @@
+product: hermes-3-dataset
+openness:
+  score: 5
+  class: open
+  components: license:Apache-2.0;gated:false;dataset_card:present
+  confidence: high
+  note: Apache-2.0, ungated, dataset card.
+  sources:
+  - url: https://huggingface.co/datasets/NousResearch/Hermes-3-Dataset
+    shows: Apache-2.0 license, ungated, dataset card
+    accessed: '2026-07-04'
+adoption:
+  level: 2
+  reach: 1k-10k
+  signal_type: usage_volume
+  confidence: high
+  note: 1,414 monthly downloads on Hugging Face, graded on the training-corpus bands. Documented component
+    of the Hermes 4 post-training corpus.
+  sources:
+  - url: https://huggingface.co/api/datasets/NousResearch/Hermes-3-Dataset
+    shows: downloads field = 1,414 (30-day)
+    accessed: '2026-07-04'
+  - url: https://arxiv.org/abs/2508.18255
+    shows: 'Hermes 4 report: Hermes 3 data folded into the corpus'
+    accessed: '2026-07-04'
+capability:
+  score: null
+  basis: n/a
+  value: null
+  confidence: high
+  note: a dataset is not 'capable'
+  sources: []

--- a/sources/scores/hermes-3-dataset.yaml
+++ b/sources/scores/hermes-3-dataset.yaml
@@ -14,19 +14,22 @@ adoption:
   reach: 1k-10k
   signal_type: usage_volume
   confidence: high
-  note: 1,414 monthly downloads on Hugging Face, graded on the training-corpus bands. Documented component
-    of the Hermes 4 post-training corpus.
+  note: 1,414 monthly downloads on Hugging Face, graded on the training-corpus bands.
   sources:
   - url: https://huggingface.co/api/datasets/NousResearch/Hermes-3-Dataset
     shows: downloads field = 1,414 (30-day)
     accessed: '2026-07-04'
-  - url: https://arxiv.org/abs/2508.18255
-    shows: 'Hermes 4 report: Hermes 3 data folded into the corpus'
-    accessed: '2026-07-04'
 capability:
-  score: null
-  basis: n/a
+  score: 4
+  basis: training_value:downstream
   value: null
   confidence: high
-  note: a dataset is not 'capable'
-  sources: []
+  note: Proven value with documented Hermes 3 results and explicitly folded into Hermes 4 (2025), but
+    independent reuse is limited to community quantizers.
+  sources:
+  - url: https://arxiv.org/pdf/2508.18255
+    shows: 'Hermes 4 report: a significant portion of the Hermes 3 dataset was retained'
+    accessed: '2026-07-04'
+  - url: https://arxiv.org/pdf/2408.11857
+    shows: Hermes 3 beats Llama 3.1 Instruct on most benchmarks at 405B/70B/8B
+    accessed: '2026-07-04'

--- a/sources/scores/nemotron-cc.yaml
+++ b/sources/scores/nemotron-cc.yaml
@@ -1,0 +1,30 @@
+product: nemotron-cc
+openness:
+  score: 3
+  class: gated
+  components: license:NVIDIA-Open-Data;gated:manual(model-training-use);dataset_card:present
+  confidence: high
+  note: Manually gated behind the NVIDIA Data Agreement for Model Training; synthetic portions may inherit
+    generator-model license terms.
+  sources:
+  - url: https://huggingface.co/datasets/nvidia/Nemotron-CC-v2
+    shows: gated (manual), NVIDIA Open Data License, dataset card
+    accessed: '2026-07-04'
+adoption:
+  level: 3
+  reach: 10k-100k
+  signal_type: usage_volume
+  confidence: high
+  note: 16,100 monthly downloads on the v2 artifact, graded on the training-corpus bands. Documented pretraining
+    data for Nemotron 3 and Marin 8B.
+  sources:
+  - url: https://huggingface.co/api/datasets/nvidia/Nemotron-CC-v2
+    shows: downloads field = 16,100 (30-day)
+    accessed: '2026-07-04'
+capability:
+  score: null
+  basis: n/a
+  value: null
+  confidence: high
+  note: a dataset is not 'capable'
+  sources: []

--- a/sources/scores/nemotron-cc.yaml
+++ b/sources/scores/nemotron-cc.yaml
@@ -15,16 +15,23 @@ adoption:
   reach: 10k-100k
   signal_type: usage_volume
   confidence: high
-  note: 16,100 monthly downloads on the v2 artifact, graded on the training-corpus bands. Documented pretraining
-    data for Nemotron 3 and Marin 8B.
+  note: 16,100 monthly downloads on Hugging Face, graded on the training-corpus bands.
   sources:
   - url: https://huggingface.co/api/datasets/nvidia/Nemotron-CC-v2
     shows: downloads field = 16,100 (30-day)
     accessed: '2026-07-04'
 capability:
-  score: null
-  basis: n/a
+  score: 5
+  basis: training_value:ablation
   value: null
   confidence: high
-  note: a dataset is not 'capable'
-  sources: []
+  note: Wins vs DCLM at a long token horizon (Nemotron-CC-HQ +5.6 MMLU over DCLM; a 15T-token 8B beats
+    Llama 3.1 8B); current default for NVIDIA Nemotron models and Marin 8B late phases.
+  sources:
+  - url: https://arxiv.org/abs/2412.02595
+    shows: Nemotron-CC-HQ improves MMLU by 5.6 over DCLM; an 8B on 15T tokens beats Llama 3.1 8B by +5
+      MMLU
+    accessed: '2026-07-04'
+  - url: https://marin.readthedocs.io/en/latest/reports/marin-8b-retro/
+    shows: Marin 8B adopted Nemotron-CC as its primary source in later phases
+    accessed: '2026-07-04'

--- a/sources/scores/oasst1.yaml
+++ b/sources/scores/oasst1.yaml
@@ -10,29 +10,26 @@ openness:
     shows: Apache-2.0 license, ungated, dataset card
     accessed: '2026-07-04'
 adoption:
-  level: 4
-  reach: 100k-1M
-  signal_type: documented_reuse
+  level: 3
+  reach: 10k-100k
+  signal_type: usage_volume
   confidence: high
-  note: 15,736 monthly downloads on Hugging Face (level 3 on the corpus bands), promoted one level for
-    documented reuse. Documented post-training data for Guanaco, Tulu 3, and OLMo 3's Dolci.
+  note: 15,736 monthly downloads on Hugging Face, graded on the training-corpus bands.
   sources:
   - url: https://huggingface.co/api/datasets/OpenAssistant/oasst1
     shows: downloads field = 15,736 (30-day)
     accessed: '2026-07-04'
-  - url: https://arxiv.org/abs/2305.14314
-    shows: QLoRA/Guanaco fine-tuned on OASST1
-    accessed: '2026-07-04'
-  - url: https://arxiv.org/abs/2411.15124
-    shows: Tulu 3 SFT mixture includes OASST1 (Guanaco subset)
-    accessed: '2026-07-04'
-  - url: https://huggingface.co/datasets/allenai/Dolci-Instruct-SFT
-    shows: Dolci SFT includes OpenAssistant Guanaco
-    accessed: '2026-07-04'
 capability:
-  score: null
-  basis: n/a
+  score: 3
+  basis: training_value:downstream
   value: null
   confidence: high
-  note: a dataset is not 'capable'
-  sources: []
+  note: Proven with ongoing downstream use (Guanaco, Tulu 3, OLMo 3 Dolci) but dated, reduced to a fractional
+    ingredient, with no comparative results isolating its value.
+  sources:
+  - url: https://arxiv.org/abs/2305.14314
+    shows: Guanaco/QLoRA fine-tuned on OASST1
+    accessed: '2026-07-04'
+  - url: https://huggingface.co/datasets/allenai/Dolci-Instruct-SFT
+    shows: OpenAssistant Guanaco appears as a small fraction of OLMo 3 Dolci SFT
+    accessed: '2026-07-04'

--- a/sources/scores/oasst1.yaml
+++ b/sources/scores/oasst1.yaml
@@ -1,0 +1,38 @@
+product: oasst1
+openness:
+  score: 5
+  class: open
+  components: license:Apache-2.0;gated:false;dataset_card:present
+  confidence: high
+  note: Apache-2.0, ungated, full dataset card.
+  sources:
+  - url: https://huggingface.co/datasets/OpenAssistant/oasst1
+    shows: Apache-2.0 license, ungated, dataset card
+    accessed: '2026-07-04'
+adoption:
+  level: 4
+  reach: 100k-1M
+  signal_type: documented_reuse
+  confidence: high
+  note: 15,736 monthly downloads on Hugging Face (level 3 on the corpus bands), promoted one level for
+    documented reuse. Documented post-training data for Guanaco, Tulu 3, and OLMo 3's Dolci.
+  sources:
+  - url: https://huggingface.co/api/datasets/OpenAssistant/oasst1
+    shows: downloads field = 15,736 (30-day)
+    accessed: '2026-07-04'
+  - url: https://arxiv.org/abs/2305.14314
+    shows: QLoRA/Guanaco fine-tuned on OASST1
+    accessed: '2026-07-04'
+  - url: https://arxiv.org/abs/2411.15124
+    shows: Tulu 3 SFT mixture includes OASST1 (Guanaco subset)
+    accessed: '2026-07-04'
+  - url: https://huggingface.co/datasets/allenai/Dolci-Instruct-SFT
+    shows: Dolci SFT includes OpenAssistant Guanaco
+    accessed: '2026-07-04'
+capability:
+  score: null
+  basis: n/a
+  value: null
+  confidence: high
+  note: a dataset is not 'capable'
+  sources: []

--- a/sources/scores/openwebmath.yaml
+++ b/sources/scores/openwebmath.yaml
@@ -10,29 +10,26 @@ openness:
     shows: ODC-BY 1.0 license, ungated, dataset card
     accessed: '2026-07-04'
 adoption:
-  level: 4
-  reach: 100k-1M
-  signal_type: documented_reuse
+  level: 3
+  reach: 10k-100k
+  signal_type: usage_volume
   confidence: high
-  note: 31,502 monthly downloads on Hugging Face (level 3 on the corpus bands), promoted one level for
-    documented reuse. Documented in Proof-Pile-2/Llemma, OLMoE, Nemotron 3, and StarCoder2.
+  note: 31,502 monthly downloads on Hugging Face, graded on the training-corpus bands.
   sources:
   - url: https://huggingface.co/api/datasets/open-web-math/open-web-math
     shows: downloads field = 31,502 (30-day)
     accessed: '2026-07-04'
-  - url: https://arxiv.org/abs/2310.10631
-    shows: Llemma/Proof-Pile-2 built on OpenWebMath
-    accessed: '2026-07-04'
-  - url: https://huggingface.co/datasets/allenai/OLMoE-mix-0924
-    shows: 'OLMoE mix: 12.7B OpenWebMath tokens'
-    accessed: '2026-07-04'
-  - url: https://arxiv.org/abs/2402.19173
-    shows: StarCoder2 pretraining supplements include OpenWebMath
-    accessed: '2026-07-04'
 capability:
-  score: null
-  basis: n/a
+  score: 3
+  basis: training_value:superseded
   value: null
   confidence: high
-  note: a dataset is not 'capable'
-  sources: []
+  note: Proven math corpus (Llemma/Proof-Pile-2, OLMoE, StarCoder2 math supplement) but Oct-2023 vintage
+    and now the baseline that FineMath, MegaMath, and Nemotron-CC-Math beat in ablations.
+  sources:
+  - url: https://arxiv.org/html/2508.15096v1
+    shows: Nemotron-CC-Math surpasses all prior open math datasets including OpenWebMath
+    accessed: '2026-07-04'
+  - url: https://huggingface.co/datasets/HuggingFaceTB/finemath
+    shows: FineMath-3+ outperforms OpenWebMath on GSM8k and MATH
+    accessed: '2026-07-04'

--- a/sources/scores/openwebmath.yaml
+++ b/sources/scores/openwebmath.yaml
@@ -1,0 +1,38 @@
+product: openwebmath
+openness:
+  score: 5
+  class: open
+  components: license:ODC-BY;gated:false;dataset_card:present
+  confidence: high
+  note: ODC-BY 1.0, ungated, full dataset card.
+  sources:
+  - url: https://huggingface.co/datasets/open-web-math/open-web-math
+    shows: ODC-BY 1.0 license, ungated, dataset card
+    accessed: '2026-07-04'
+adoption:
+  level: 4
+  reach: 100k-1M
+  signal_type: documented_reuse
+  confidence: high
+  note: 31,502 monthly downloads on Hugging Face (level 3 on the corpus bands), promoted one level for
+    documented reuse. Documented in Proof-Pile-2/Llemma, OLMoE, Nemotron 3, and StarCoder2.
+  sources:
+  - url: https://huggingface.co/api/datasets/open-web-math/open-web-math
+    shows: downloads field = 31,502 (30-day)
+    accessed: '2026-07-04'
+  - url: https://arxiv.org/abs/2310.10631
+    shows: Llemma/Proof-Pile-2 built on OpenWebMath
+    accessed: '2026-07-04'
+  - url: https://huggingface.co/datasets/allenai/OLMoE-mix-0924
+    shows: 'OLMoE mix: 12.7B OpenWebMath tokens'
+    accessed: '2026-07-04'
+  - url: https://arxiv.org/abs/2402.19173
+    shows: StarCoder2 pretraining supplements include OpenWebMath
+    accessed: '2026-07-04'
+capability:
+  score: null
+  basis: n/a
+  value: null
+  confidence: high
+  note: a dataset is not 'capable'
+  sources: []

--- a/sources/scores/pes2o.yaml
+++ b/sources/scores/pes2o.yaml
@@ -1,0 +1,38 @@
+product: pes2o
+openness:
+  score: 5
+  class: open
+  components: license:ODC-BY;gated:false;dataset_card:present
+  confidence: high
+  note: ODC-BY, ungated, full dataset card.
+  sources:
+  - url: https://huggingface.co/datasets/allenai/peS2o
+    shows: ODC-BY license, ungated, dataset card
+    accessed: '2026-07-04'
+adoption:
+  level: 4
+  reach: 100k-1M
+  signal_type: documented_reuse
+  confidence: high
+  note: 11,347 monthly downloads on Hugging Face (level 3 on the corpus bands), promoted one level for
+    documented reuse. Documented pretraining component of OLMoE, Marin, and Nemotron 3.
+  sources:
+  - url: https://huggingface.co/api/datasets/allenai/peS2o
+    shows: downloads field = 11,347 (30-day)
+    accessed: '2026-07-04'
+  - url: https://huggingface.co/datasets/allenai/OLMoE-mix-0924
+    shows: 'OLMoE mix: 57.2B peS2o tokens'
+    accessed: '2026-07-04'
+  - url: https://huggingface.co/marin-community/marin-8b-base
+    shows: Marin mixture includes peS2o
+    accessed: '2026-07-04'
+  - url: https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
+    shows: Nemotron 3 Nano card lists peS2o among pretraining sources
+    accessed: '2026-07-04'
+capability:
+  score: null
+  basis: n/a
+  value: null
+  confidence: high
+  note: a dataset is not 'capable'
+  sources: []

--- a/sources/scores/pes2o.yaml
+++ b/sources/scores/pes2o.yaml
@@ -10,29 +10,26 @@ openness:
     shows: ODC-BY license, ungated, dataset card
     accessed: '2026-07-04'
 adoption:
-  level: 4
-  reach: 100k-1M
-  signal_type: documented_reuse
+  level: 3
+  reach: 10k-100k
+  signal_type: usage_volume
   confidence: high
-  note: 11,347 monthly downloads on Hugging Face (level 3 on the corpus bands), promoted one level for
-    documented reuse. Documented pretraining component of OLMoE, Marin, and Nemotron 3.
+  note: 11,347 monthly downloads on Hugging Face, graded on the training-corpus bands.
   sources:
   - url: https://huggingface.co/api/datasets/allenai/peS2o
     shows: downloads field = 11,347 (30-day)
     accessed: '2026-07-04'
-  - url: https://huggingface.co/datasets/allenai/OLMoE-mix-0924
-    shows: 'OLMoE mix: 57.2B peS2o tokens'
-    accessed: '2026-07-04'
-  - url: https://huggingface.co/marin-community/marin-8b-base
-    shows: Marin mixture includes peS2o
-    accessed: '2026-07-04'
-  - url: https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
-    shows: Nemotron 3 Nano card lists peS2o among pretraining sources
-    accessed: '2026-07-04'
 capability:
-  score: null
-  basis: n/a
+  score: 4
+  basis: training_value:downstream
   value: null
   confidence: high
-  note: a dataset is not 'capable'
-  sources: []
+  note: The standard open science corpus with documented multi-model reuse (OLMoE 57B tokens, Marin, Nemotron
+    3), but no ablation leadership, and OLMo 3 replaced it with a new academic-PDF dataset.
+  sources:
+  - url: https://huggingface.co/datasets/allenai/OLMoE-mix-0924
+    shows: peS2o contributes 57.2B tokens to the OLMoE mix and is used in Marin and Nemotron 3
+    accessed: '2026-07-04'
+  - url: https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
+    shows: Nemotron 3 Nano lists peS2o among pretraining sources
+    accessed: '2026-07-04'

--- a/sources/scores/smoltalk.yaml
+++ b/sources/scores/smoltalk.yaml
@@ -1,0 +1,32 @@
+product: smoltalk
+openness:
+  score: 4
+  class: open
+  components: access:ungated;license:apache-2.0(new-subsets)+per-component;dataset_card:present
+  confidence: high
+  note: Ungated; newly created subsets are Apache-2.0, incorporated public datasets keep their own licenses.
+  sources:
+  - url: https://huggingface.co/datasets/HuggingFaceTB/smoltalk
+    shows: ungated, mixed licensing documented on card
+    accessed: '2026-07-04'
+adoption:
+  level: 3
+  reach: 10k-100k
+  signal_type: usage_volume
+  confidence: high
+  note: 17,489 monthly downloads on SmolTalk (SmolTalk2 at 10,783), graded on the training-corpus bands.
+    Documented SFT data for SmolLM2/3 and Marin 8B Instruct.
+  sources:
+  - url: https://huggingface.co/api/datasets/HuggingFaceTB/smoltalk
+    shows: downloads field = 17,489 (30-day)
+    accessed: '2026-07-04'
+  - url: https://huggingface.co/api/datasets/HuggingFaceTB/smoltalk2
+    shows: downloads field = 10,783 (30-day)
+    accessed: '2026-07-04'
+capability:
+  score: null
+  basis: n/a
+  value: null
+  confidence: high
+  note: a dataset is not 'capable'
+  sources: []

--- a/sources/scores/smoltalk.yaml
+++ b/sources/scores/smoltalk.yaml
@@ -14,19 +14,22 @@ adoption:
   reach: 10k-100k
   signal_type: usage_volume
   confidence: high
-  note: 17,489 monthly downloads on SmolTalk (SmolTalk2 at 10,783), graded on the training-corpus bands.
-    Documented SFT data for SmolLM2/3 and Marin 8B Instruct.
+  note: 17,489 monthly downloads on Hugging Face, graded on the training-corpus bands.
   sources:
   - url: https://huggingface.co/api/datasets/HuggingFaceTB/smoltalk
     shows: downloads field = 17,489 (30-day)
     accessed: '2026-07-04'
-  - url: https://huggingface.co/api/datasets/HuggingFaceTB/smoltalk2
-    shows: downloads field = 10,783 (30-day)
-    accessed: '2026-07-04'
 capability:
-  score: null
-  basis: n/a
+  score: 5
+  basis: training_value:ablation
   value: null
   confidence: high
-  note: a dataset is not 'capable'
-  sources: []
+  note: Leads head-to-head SFT-mixture ablations (beats OpenHermes-2.5, UltraChat, MagPie-Pro) and is
+    the current default across SmolLM2/3 and Marin 8B Instruct.
+  sources:
+  - url: https://arxiv.org/html/2502.02737v1
+    shows: 'SmolLM2 paper: SmolTalk surpasses OpenHermes-2.5, UltraChat, and MagPie-Pro'
+    accessed: '2026-07-04'
+  - url: https://huggingface.co/marin-community/marin-8b-instruct
+    shows: Marin 8B Instruct lists SmolTalk in its SFT mix
+    accessed: '2026-07-04'

--- a/sources/scores/stack-edu.yaml
+++ b/sources/scores/stack-edu.yaml
@@ -14,16 +14,22 @@ adoption:
   reach: 1k-10k
   signal_type: usage_volume
   confidence: high
-  note: 3,892 monthly downloads on Hugging Face, graded on the training-corpus bands. Documented component
-    of SmolLM3 and OLMo 3's Dolma 3 pool.
+  note: 3,892 monthly downloads on Hugging Face, graded on the training-corpus bands.
   sources:
   - url: https://huggingface.co/api/datasets/HuggingFaceTB/stack-edu
     shows: downloads field = 3,892 (30-day)
     accessed: '2026-07-04'
 capability:
-  score: null
-  basis: n/a
+  score: 5
+  basis: training_value:ablation
   value: null
   confidence: high
-  note: a dataset is not 'capable'
-  sources: []
+  note: Leads controlled classifier ablations, beating StarCoder2Data on MultiPL-E across all languages
+    (SmolLM2 paper); current default in SmolLM3 and OLMo 3's Dolma 3.
+  sources:
+  - url: https://arxiv.org/html/2502.02737v1
+    shows: Stack-Edu consistently outperforms StarCoder2Data on MultiPL-E (Python 25.6 vs 20.7, etc.)
+    accessed: '2026-07-04'
+  - url: https://huggingface.co/blog/smollm3
+    shows: Stack-Edu included in the SmolLM3 pretraining mixture
+    accessed: '2026-07-04'

--- a/sources/scores/stack-edu.yaml
+++ b/sources/scores/stack-edu.yaml
@@ -1,0 +1,29 @@
+product: stack-edu
+openness:
+  score: 4
+  class: open
+  components: access:ungated;license:inherits-the-stack-v2;dataset_card:present
+  confidence: medium
+  note: Ungated download with a card; the card defers the data license to The Stack v2's terms.
+  sources:
+  - url: https://huggingface.co/datasets/HuggingFaceTB/stack-edu
+    shows: ungated access, card defers license to the-stack-v2
+    accessed: '2026-07-04'
+adoption:
+  level: 2
+  reach: 1k-10k
+  signal_type: usage_volume
+  confidence: high
+  note: 3,892 monthly downloads on Hugging Face, graded on the training-corpus bands. Documented component
+    of SmolLM3 and OLMo 3's Dolma 3 pool.
+  sources:
+  - url: https://huggingface.co/api/datasets/HuggingFaceTB/stack-edu
+    shows: downloads field = 3,892 (30-day)
+    accessed: '2026-07-04'
+capability:
+  score: null
+  basis: n/a
+  value: null
+  confidence: high
+  note: a dataset is not 'capable'
+  sources: []

--- a/sources/scores/starcoderdata.yaml
+++ b/sources/scores/starcoderdata.yaml
@@ -10,33 +10,26 @@ openness:
     shows: gated (auto) access with terms, dataset card
     accessed: '2026-07-04'
 adoption:
-  level: 4
-  reach: 100k-1M
-  signal_type: documented_reuse
+  level: 3
+  reach: 10k-100k
+  signal_type: usage_volume
   confidence: high
-  note: 20,254 monthly downloads on Hugging Face (level 3 on the corpus bands), promoted one level for
-    documented reuse. Documented pretraining component of TinyLlama, Granite Code, ALIA-40b, Apertus,
-    Marin, and OLMoE.
+  note: 20,254 monthly downloads on Hugging Face, graded on the training-corpus bands.
   sources:
   - url: https://huggingface.co/api/datasets/bigcode/starcoderdata
     shows: downloads field = 20,254 (30-day)
     accessed: '2026-07-04'
-  - url: https://github.com/jzhang38/TinyLlama
-    shows: 'TinyLlama pretrain mix: StarCoderData'
-    accessed: '2026-07-04'
-  - url: https://arxiv.org/abs/2509.14233
-    shows: Apertus pretraining corpus includes StarCoderData
-    accessed: '2026-07-04'
-  - url: https://huggingface.co/BSC-LT/ALIA-40b
-    shows: 'ALIA-40b: StarCoder training data is 13.67% of tokens'
-    accessed: '2026-07-04'
-  - url: https://huggingface.co/datasets/allenai/OLMoE-mix-0924
-    shows: 'OLMoE mix: 101B StarCoder tokens'
-    accessed: '2026-07-04'
 capability:
-  score: null
-  basis: n/a
+  score: 3
+  basis: training_value:superseded
   value: null
   confidence: high
-  note: a dataset is not 'capable'
-  sources: []
+  note: Proven pretraining component (TinyLlama, Granite Code, ALIA, OLMoE) but drawn from The Stack v1
+    and functionally superseded by The Stack v2 / Stack-Edu.
+  sources:
+  - url: https://huggingface.co/datasets/allenai/OLMoE-mix-0924
+    shows: StarCoderData is a documented component of TinyLlama, Granite Code, ALIA, Apertus, Marin, OLMoE
+    accessed: '2026-07-04'
+  - url: https://arxiv.org/abs/2402.19173
+    shows: The Stack v2/StarCoder2 is the successor to the Stack v1 lineage
+    accessed: '2026-07-04'

--- a/sources/scores/starcoderdata.yaml
+++ b/sources/scores/starcoderdata.yaml
@@ -1,0 +1,42 @@
+product: starcoderdata
+openness:
+  score: 3
+  class: gated
+  components: license:permissive(SPDX per file);gated:terms-acceptance;dataset_card:present
+  confidence: high
+  note: Terms-gated like its parent The Stack v1; permissively licensed source files.
+  sources:
+  - url: https://huggingface.co/datasets/bigcode/starcoderdata
+    shows: gated (auto) access with terms, dataset card
+    accessed: '2026-07-04'
+adoption:
+  level: 4
+  reach: 100k-1M
+  signal_type: documented_reuse
+  confidence: high
+  note: 20,254 monthly downloads on Hugging Face (level 3 on the corpus bands), promoted one level for
+    documented reuse. Documented pretraining component of TinyLlama, Granite Code, ALIA-40b, Apertus,
+    Marin, and OLMoE.
+  sources:
+  - url: https://huggingface.co/api/datasets/bigcode/starcoderdata
+    shows: downloads field = 20,254 (30-day)
+    accessed: '2026-07-04'
+  - url: https://github.com/jzhang38/TinyLlama
+    shows: 'TinyLlama pretrain mix: StarCoderData'
+    accessed: '2026-07-04'
+  - url: https://arxiv.org/abs/2509.14233
+    shows: Apertus pretraining corpus includes StarCoderData
+    accessed: '2026-07-04'
+  - url: https://huggingface.co/BSC-LT/ALIA-40b
+    shows: 'ALIA-40b: StarCoder training data is 13.67% of tokens'
+    accessed: '2026-07-04'
+  - url: https://huggingface.co/datasets/allenai/OLMoE-mix-0924
+    shows: 'OLMoE mix: 101B StarCoder tokens'
+    accessed: '2026-07-04'
+capability:
+  score: null
+  basis: n/a
+  value: null
+  confidence: high
+  note: a dataset is not 'capable'
+  sources: []

--- a/sources/scores/synth.yaml
+++ b/sources/scores/synth.yaml
@@ -23,7 +23,7 @@ capability:
   score: 4
   basis: training_value:results
   value: null
-  confidence: high
+  confidence: medium
   note: A novel fully-open synthetic reasoning corpus with real first-party end-to-end results (Baguettotron
     best-in-class sub-350M), but single-lab evidence.
   sources:

--- a/sources/scores/the-pile.yaml
+++ b/sources/scores/the-pile.yaml
@@ -15,29 +15,26 @@ openness:
     shows: 'legacy card: per-subset licensing, loading script only'
     accessed: '2026-07-04'
 adoption:
-  level: 3
-  reach: 10k-100k
-  signal_type: documented_reuse
+  level: 2
+  reach: 1k-10k
+  signal_type: usage_volume
   confidence: high
-  note: 9,980 monthly downloads on the deduplicated repo (level 2 on the corpus bands), promoted one level
-    for documented reuse. Canonical pretraining corpus of Pythia, GPT-NeoX-20B, and Cerebras-GPT.
+  note: 9,980 monthly downloads on Hugging Face, graded on the training-corpus bands.
   sources:
   - url: https://huggingface.co/api/datasets/EleutherAI/the_pile_deduplicated
     shows: downloads field = 9,980 (30-day)
     accessed: '2026-07-04'
-  - url: https://arxiv.org/abs/2304.01373
-    shows: 'Pythia: all 16 models trained on the Pile'
-    accessed: '2026-07-04'
-  - url: https://arxiv.org/abs/2204.06745
-    shows: GPT-NeoX-20B trained on the Pile
-    accessed: '2026-07-04'
-  - url: https://arxiv.org/abs/2304.03208
-    shows: Cerebras-GPT trained on the (deduplicated) Pile
-    accessed: '2026-07-04'
 capability:
-  score: null
-  basis: n/a
+  score: 3
+  basis: training_value:superseded
   value: null
   confidence: high
-  note: a dataset is not 'capable'
-  sources: []
+  note: The foundational 2020-era template, proven for a wide 2022-23 family (Pythia, GPT-NeoX-20B, GPT-J,
+    Cerebras-GPT), but dated and beaten by modern web corpora in FineWeb ablations.
+  sources:
+  - url: https://arxiv.org/pdf/2304.03208
+    shows: The Pile trained GPT-NeoX-20B, GPT-J, Pythia, and Cerebras-GPT
+    accessed: '2026-07-04'
+  - url: https://arxiv.org/html/2406.17557v1
+    shows: FineWeb outperforms The Pile in its ablation
+    accessed: '2026-07-04'

--- a/sources/scores/the-pile.yaml
+++ b/sources/scores/the-pile.yaml
@@ -1,0 +1,43 @@
+product: the-pile
+openness:
+  score: 3
+  class: open
+  components: access:ungated;license:mixed-per-subset;dataset_card:legacy-repo-only
+  confidence: medium
+  note: Ungated download via the deduplicated HF repo; the original EleutherAI/pile repo is a loading
+    script whose mirrors are dead. The card defers licensing to per-subset terms and Books3 has been withdrawn
+    from circulation.
+  sources:
+  - url: https://huggingface.co/datasets/EleutherAI/the_pile_deduplicated
+    shows: hosts the working parquet data (451 GB), ungated
+    accessed: '2026-07-04'
+  - url: https://huggingface.co/datasets/EleutherAI/pile
+    shows: 'legacy card: per-subset licensing, loading script only'
+    accessed: '2026-07-04'
+adoption:
+  level: 3
+  reach: 10k-100k
+  signal_type: documented_reuse
+  confidence: high
+  note: 9,980 monthly downloads on the deduplicated repo (level 2 on the corpus bands), promoted one level
+    for documented reuse. Canonical pretraining corpus of Pythia, GPT-NeoX-20B, and Cerebras-GPT.
+  sources:
+  - url: https://huggingface.co/api/datasets/EleutherAI/the_pile_deduplicated
+    shows: downloads field = 9,980 (30-day)
+    accessed: '2026-07-04'
+  - url: https://arxiv.org/abs/2304.01373
+    shows: 'Pythia: all 16 models trained on the Pile'
+    accessed: '2026-07-04'
+  - url: https://arxiv.org/abs/2204.06745
+    shows: GPT-NeoX-20B trained on the Pile
+    accessed: '2026-07-04'
+  - url: https://arxiv.org/abs/2304.03208
+    shows: Cerebras-GPT trained on the (deduplicated) Pile
+    accessed: '2026-07-04'
+capability:
+  score: null
+  basis: n/a
+  value: null
+  confidence: high
+  note: a dataset is not 'capable'
+  sources: []

--- a/sources/scores/txt360.yaml
+++ b/sources/scores/txt360.yaml
@@ -1,0 +1,29 @@
+product: txt360
+openness:
+  score: 5
+  class: open
+  components: license:ODC-BY;gated:false;dataset_card:present
+  confidence: high
+  note: ODC-BY, ungated, documented pipeline on GitHub.
+  sources:
+  - url: https://huggingface.co/datasets/LLM360/TxT360
+    shows: ODC-BY license, ungated, dataset card
+    accessed: '2026-07-04'
+adoption:
+  level: 2
+  reach: 1k-10k
+  signal_type: usage_volume
+  confidence: high
+  note: 4,218 monthly downloads on Hugging Face, graded on the training-corpus bands. Documented pretraining
+    corpus of K2-V2.
+  sources:
+  - url: https://huggingface.co/api/datasets/LLM360/TxT360
+    shows: downloads field = 4,218 (30-day)
+    accessed: '2026-07-04'
+capability:
+  score: null
+  basis: n/a
+  value: null
+  confidence: high
+  note: a dataset is not 'capable'
+  sources: []

--- a/sources/scores/txt360.yaml
+++ b/sources/scores/txt360.yaml
@@ -14,16 +14,19 @@ adoption:
   reach: 1k-10k
   signal_type: usage_volume
   confidence: high
-  note: 4,218 monthly downloads on Hugging Face, graded on the training-corpus bands. Documented pretraining
-    corpus of K2-V2.
+  note: 4,218 monthly downloads on Hugging Face, graded on the training-corpus bands.
   sources:
   - url: https://huggingface.co/api/datasets/LLM360/TxT360
     shows: downloads field = 4,218 (30-day)
     accessed: '2026-07-04'
 capability:
-  score: null
-  basis: n/a
+  score: 4
+  basis: training_value:ablation
   value: null
   confidence: high
-  note: a dataset is not 'capable'
-  sources: []
+  note: A self-reported controlled ablation beats FineWeb (8x8B MoE, 1.5T tokens) but without published
+    numeric scores; trains K2 / K2-V2 (LLM360, 2024-25).
+  sources:
+  - url: https://huggingface.co/datasets/LLM360/TxT360
+    shows: 5.7T deduplicated tokens upsampled to 15T+, claimed to outperform FineWeb 15T; trains K2/K2-V2
+    accessed: '2026-07-04'

--- a/sources/scores/txt360.yaml
+++ b/sources/scores/txt360.yaml
@@ -23,7 +23,7 @@ capability:
   score: 4
   basis: training_value:ablation
   value: null
-  confidence: high
+  confidence: medium
   note: A self-reported controlled ablation beats FineWeb (8x8B MoE, 1.5T tokens) but without published
     numeric scores; trains K2 / K2-V2 (LLM360, 2024-25).
   sources:

--- a/sources/scores/ultrachat-200k.yaml
+++ b/sources/scores/ultrachat-200k.yaml
@@ -14,16 +14,22 @@ adoption:
   reach: 10k-100k
   signal_type: usage_volume
   confidence: high
-  note: 57,823 monthly downloads on Hugging Face, graded on the training-corpus bands. Documented SFT
-    data for Zephyr and TinyLlama-Chat.
+  note: 57,823 monthly downloads on Hugging Face, graded on the training-corpus bands.
   sources:
   - url: https://huggingface.co/api/datasets/HuggingFaceH4/ultrachat_200k
     shows: downloads field = 57,823 (30-day)
     accessed: '2026-07-04'
 capability:
-  score: null
-  basis: n/a
+  score: 3
+  basis: training_value:superseded
   value: null
   confidence: high
-  note: a dataset is not 'capable'
-  sources: []
+  note: Clean SFT before/after in the Zephyr paper (MT-Bench ~6.64), but dropped from 2024-25 default
+    SFT mixes (absent from SmolTalk and Tulu 3).
+  sources:
+  - url: https://ar5iv.labs.arxiv.org/html/2310.16944
+    shows: 'Zephyr: dSFT on UltraChat reaches MT-Bench 6.64'
+    accessed: '2026-07-04'
+  - url: https://huggingface.co/datasets/allenai/tulu-3-sft-mixture
+    shows: UltraChat-200k is not used as an SFT source in Tulu 3
+    accessed: '2026-07-04'

--- a/sources/scores/ultrachat-200k.yaml
+++ b/sources/scores/ultrachat-200k.yaml
@@ -1,0 +1,29 @@
+product: ultrachat-200k
+openness:
+  score: 5
+  class: open
+  components: license:MIT;gated:false;dataset_card:present
+  confidence: high
+  note: MIT-licensed, ungated, full dataset card.
+  sources:
+  - url: https://huggingface.co/datasets/HuggingFaceH4/ultrachat_200k
+    shows: MIT license, ungated access, dataset card
+    accessed: '2026-07-04'
+adoption:
+  level: 3
+  reach: 10k-100k
+  signal_type: usage_volume
+  confidence: high
+  note: 57,823 monthly downloads on Hugging Face, graded on the training-corpus bands. Documented SFT
+    data for Zephyr and TinyLlama-Chat.
+  sources:
+  - url: https://huggingface.co/api/datasets/HuggingFaceH4/ultrachat_200k
+    shows: downloads field = 57,823 (30-day)
+    accessed: '2026-07-04'
+capability:
+  score: null
+  basis: n/a
+  value: null
+  confidence: high
+  note: a dataset is not 'capable'
+  sources: []

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -127,3 +127,20 @@ def test_unknown_signal_type_still_fails():
     d = _fixture()
     d["scores"]["llama-4"]["adoption"]["signal_type"] = "vibes"
     assert any("signal_type" in e for e in validate_sources(d))
+
+
+def test_product_lineage_block_validates():
+    d = _fixture()
+    d["products"]["llama-4"]["lineage"] = {
+        "derived_from": ["Common Crawl"],
+        "curated_with": ["datatrove"],
+        "trains": ["llama-4"],
+    }
+    assert validate_sources(d) == []
+
+
+def test_product_lineage_rejects_unknown_keys():
+    d = _fixture()
+    d["products"]["llama-4"]["lineage"] = {"forked_from": ["x"]}
+    errs = validate_sources(d)
+    assert any("lineage" in e or "forked_from" in e or "additional" in e.lower() for e in errs)


### PR DESCRIPTION
## Summary

Implements the discovery and filiation additions from @yjernite's comment on #58, and extends the two-axis dataset scoring from #83 to the corpora added here. Stacked on #83.

- **Provenance sweep.** Researched the training-data documentation (model cards + technical reports) of all 52 open, open-weights, and data-documenting models on the map: 16 fully document/release their data, 29 partial, 7 none. This is the evidence base for both the new corpora and the capability scores.
- **15 new corpora added**, each verified against its HF page/API and the documenting model reports (accessed 2026-07-04): The Pile, UltraChat 200k, StarCoderData, Dolma 3, Dolci, TxT360, Nemotron-CC, FineMath, Stack-Edu, SmolTalk, OASST1, FLAN v2, peS2o, OpenWebMath, Hermes 3 Dataset. Two new orgs (OpenAssistant, OpenWebMath project). Category grows 23 → 38.
- **Capability (training value) on all 38 corpora.** Each new corpus is scored on both axes per the #83 design — adoption = download volume, capability = training value from ablations and downstream models. **Dolma 3 joins FineWeb-Edu and DCLM as a mature open corpus** (it is the current corpus behind OLMo 3). The ablation-leading corpora (Stack-Edu, FineMath, SmolTalk, Nemotron-CC) score capability 5; dated baselines (The Pile, OSCAR, older mixes) score 3.
- **Lineage block.** New optional `lineage` field (`derived_from` / `curated_with` / `trains`; map slugs where the referent is on the map, plain names otherwise), populated on all 38 dataset products from the sweep evidence. Source-side only.

Category stays **Stage 4 [maturity, disclosure]**.

## Held / not added (overrule welcome)

- **SlimPajama-627B** — HF repo now returns 401 and is absent from Cerebras' public listing (made private/disabled); openness and adoption unverifiable. Referenced in lineage strings instead.
- Model-specific aggregation mixes whose components are already covered: OLMoE-mix, RWKV World v3, Dolmino-Mix-1124, Proof-Pile 2.
- Single-family or niche post-training sets (MetaMathQA, MathInstruct, CommitPackFT, Glaive sets, HelpSteer, NuminaMath, No Robots, Self-OSS-Instruct, FinePersonas, MegaMath, OpenMathReasoning, AceCode, Bespoke-Stratos, Dolphin R1, Natural Reasoning, MegaWika, Capybara).
- Version successors folded into existing entries: OpenThoughts3-1.2M, Colossal OSCAR, FineWeb2-HQ.

## Test plan

- `uv run python -m build.validate` — 0 errors (474 products; frozen long-tail counts re-synced +15)
- `uv run pytest -q` — 43 passed (2 lineage schema tests)
- `uv run python -m build.serialize` — category renders 38 products, Stage 4; bot-owned files untouched

Refs #58