### PR TITLE
feat(products): add YoMo to agent tools & protocols

### DIFF
--- a/build/_frozen_long_tail.json
+++ b/build/_frozen_long_tail.json
@@ -4,10 +4,10 @@
     "models": 6428,
     "packages": 2823,
     "total": 24626,
-    "scored": 479,
-    "overlap": 243,
+    "scored": 480,
+    "overlap": 244,
     "scored_outside": 236,
-    "uncategorized": 24383,
+    "uncategorized": 24382,
     "universe": 24862
   },
   "top": [

--- a/sources/categories/agent_tools_protocols.yaml
+++ b/sources/categories/agent_tools_protocols.yaml
@@ -37,4 +37,5 @@ products:
 - postgres-mcp
 - docling
 - markitdown
+- yomo
 comments: ''

--- a/sources/organizations/vivgrid.yaml
+++ b/sources/organizations/vivgrid.yaml
@@ -1,0 +1,8 @@
+name: vivgrid
+display_name: Vivgrid
+type: company
+homepage: https://vivgrid.com
+github:
+- url: https://github.com/yomorun
+products:
+- yomo

--- a/sources/products/yomo.yaml
+++ b/sources/products/yomo.yaml
@@ -1,0 +1,15 @@
+name: yomo
+display_name: YoMo
+type: software
+description: Open-source LLM function-calling framework for building serverless AI agents on geo-distributed
+  edge infrastructure. Developers write strongly-typed tools/skills (TypeScript, Go) that YoMo deploys
+  and runs across edge nodes, exposed through an OpenAI-compatible chat completions API. Rust core with
+  QUIC transport and TLS 1.3; integrates MCP and A2A for agent tooling.
+github:
+- url: https://github.com/yomorun/yomo
+crates:
+- url: https://crates.io/crates/yomo
+comments: Apache-2.0 framework/runtime for the agent-tooling layer (function calling, skill deployment,
+  edge orchestration), not a model. Maintained since 2020; v2.0.4 released 7 Jul 2026 (Rust rewrite).
+  Backed by Vivgrid (https://vivgrid.com), which operates it as a managed geo-distributed platform. Added
+  from contributor issue #89. Verified live July 2026.

--- a/sources/scores/yomo.yaml
+++ b/sources/scores/yomo.yaml
@@ -1,0 +1,49 @@
+product: yomo
+openness:
+  score: 5
+  class: open_source
+  components: license:Apache-2.0(declared in Cargo.toml+README);source:public;full-runtime-in-repo(Rust
+    core+QUIC+multi-language SDKs);managed-hosting-by-Vivgrid-optional
+  confidence: medium
+  note: Cargo.toml declares license = "Apache-2.0" and the README states Apache License 2.0, but no LICENSE
+    file is committed at the repo root, so GitHub's detector reports no license. The full runtime (Rust
+    core, QUIC transport, serverless SDKs) is in the open repo; Vivgrid's managed platform is optional
+    hosting of the same open framework rather than a gated core. Scored open_source with medium confidence
+    pending a committed LICENSE file.
+  sources:
+  - url: https://github.com/yomorun/yomo/blob/main/Cargo.toml
+    shows: license = "Apache-2.0", name = "yomo", version = "2.0.4"
+    accessed: '2026-07-09'
+  - url: https://github.com/yomorun/yomo
+    shows: README License section links Apache License 2.0; Rust core, QUIC, serverless SDKs public
+    accessed: '2026-07-09'
+adoption:
+  level: 3
+  reach: null
+  signal_type: stars_fallback
+  confidence: medium
+  note: Established niche project — 1.9k GitHub stars, 144 forks, maintained since 2020 across 30 releases,
+    actively pushed (Jul 2026), company-backed (Vivgrid). No mass-market usage volume — crates.io shows
+    ~250 downloads/month and there is no matching high-volume npm/PyPI package. Stars are the only real
+    signal, so adoption is capped at level 3.
+  sources:
+  - url: https://github.com/yomorun/yomo
+    shows: 1,914 stars, 144 forks, created 2020-07-01, pushed 2026-07-09, latest release v2.0.4
+    accessed: '2026-07-09'
+  - url: https://crates.io/crates/yomo
+    shows: ~253 recent-month downloads (7,631 all-time), max_version 2.0.4
+    accessed: '2026-07-09'
+capability:
+  score: 3
+  basis: feature_matrix
+  value: strongly-typed LLM function calling/skills, serverless deployment across geo-distributed edge
+    nodes, QUIC transport + TLS 1.3, OpenAI-compatible chat completions API, MCP and A2A integration,
+    TypeScript and Go SDKs
+  confidence: medium
+  note: Distinctive full agent runtime with an edge/geo-distributed angle and multi-language SDKs. Functional
+    and coherent feature set for the agent-tooling layer but narrower ecosystem and integration surface
+    than the category leaders (MCP itself, FastMCP). Rated 3 on feature breadth from repo/README review.
+  sources:
+  - url: https://github.com/yomorun/yomo
+    shows: 'feature set: function calling/skills, serverless edge deployment, QUIC, OpenAI-compatible API, MCP/A2A'
+    accessed: '2026-07-09'


### PR DESCRIPTION
Adds **YoMo** (maintainer: Vivgrid) to the map, from contributor issue #89.

YoMo is an Apache-2.0 LLM function-calling framework for building serverless AI agents on geo-distributed edge infrastructure — Rust core with QUIC transport and TLS 1.3, an OpenAI-compatible chat completions API, and MCP + A2A integration. It sits in the agent-tooling layer (a framework/runtime, not a model), so it's rostered under `agent_tools_protocols`.

## Files
- `sources/products/yomo.yaml`, `sources/scores/yomo.yaml`, `sources/organizations/vivgrid.yaml`
- rostered under `agent_tools_protocols`
- `build/_frozen_long_tail.json` counts re-synced (+1 `scored`/`scored_outside`/`universe`)

## Scoring (honest, mostly medium confidence)
- **Openness 5 / open_source (confidence: medium).** `Cargo.toml` declares `license = "Apache-2.0"` and the README states Apache License 2.0, but there is no committed root LICENSE file, so GitHub's detector reports no license. Full runtime (Rust core, QUIC, serverless SDKs) is in the open repo; Vivgrid's managed platform is optional hosting of the same open framework, not a gated core. Flagging the openness call for review — happy to drop to `open_core` (4) if you'd rather treat the Vivgrid managed tier like browser-use's cloud.
- **Adoption 3 (stars_fallback).** 1.9k stars, 144 forks, maintained since 2020 across 30 releases, active. No mass-market usage volume (crates.io ~250 dl/month; no matching high-volume npm/PyPI package), so capped at the stars ceiling.
- **Capability 3 (feature_matrix).** Distinctive edge/geo-distributed runtime with multi-language SDKs, but narrower ecosystem than the category leaders (MCP, FastMCP).

Derived **maturity 3.0, not mature** — present and enriched in the dataset, correctly below the mature tier.

## Verification
- Primary sources: `gh api repos/yomorun/yomo` (1,914 stars, v2.0.4 2026-07-07), `Cargo.toml` license field, README, crates.io downloads
- `python -m build.validate` → 0 errors
- `pytest` → 43 passed

Closes #89