### PR TITLE
feat(deployment): incorporate ComputeSDK sandbox benchmarks

### DIFF
--- a/build/_frozen_long_tail.json
+++ b/build/_frozen_long_tail.json
@@ -4,11 +4,11 @@
     "models": 6428,
     "packages": 2823,
     "total": 24626,
-    "scored": 477,
-    "overlap": 241,
+    "scored": 479,
+    "overlap": 243,
     "scored_outside": 236,
-    "uncategorized": 24382,
-    "universe": 24859
+    "uncategorized": 24383,
+    "universe": 24862
   },
   "top": [
     {

--- a/sources/categories/deployment.yaml
+++ b/sources/categories/deployment.yaml
@@ -31,4 +31,6 @@ products:
 - ray
 - openpcc
 - nono
+- tensorlake-sandbox
+- blaxel-sandbox
 comments: ''

--- a/sources/organizations/blaxel.yaml
+++ b/sources/organizations/blaxel.yaml
@@ -1,0 +1,8 @@
+name: blaxel
+display_name: Blaxel
+type: company
+homepage: https://blaxel.ai
+github:
+- url: https://github.com/blaxel-ai
+products:
+- blaxel-sandbox

--- a/sources/organizations/tensorlake.yaml
+++ b/sources/organizations/tensorlake.yaml
@@ -1,0 +1,8 @@
+name: tensorlake
+display_name: Tensorlake
+type: company
+homepage: https://www.tensorlake.ai
+github:
+- url: https://github.com/tensorlakeai
+products:
+- tensorlake-sandbox

--- a/sources/products/blaxel-sandbox.yaml
+++ b/sources/products/blaxel-sandbox.yaml
@@ -1,0 +1,13 @@
+name: blaxel-sandbox
+display_name: Blaxel Sandbox
+type: software
+description: MicroVM-based code-execution sandboxes for AI agents that stay in standby indefinitely at
+  zero compute cost and resume in under 25ms with full filesystem and memory state. The sandbox API is
+  MIT-licensed and self-hostable via Docker Compose; the managed perpetual-standby platform is the commercial
+  layer. Built by an ex-OVH/ForePaaS team (YC S2025); raised a $7.3M seed led by First Round in 2025.
+  ~22 stars on the sandbox repo.
+github:
+- url: https://github.com/blaxel-ai/sandbox
+comments: Blaxel sandbox API (MIT, self-hostable via Docker Compose on port 8080) over a proprietary managed
+  standby platform; microVM isolation, sub-25ms resume from standby. Sandbox repo ~22 stars June/July
+  2026.

--- a/sources/products/tensorlake-sandbox.yaml
+++ b/sources/products/tensorlake-sandbox.yaml
@@ -1,0 +1,12 @@
+name: tensorlake-sandbox
+display_name: Tensorlake Sandbox
+type: software
+description: Serverless Firecracker-microVM sandbox runtime with durable-execution orchestration for agentic
+  apps, offering snapshot/suspend/resume and scale to thousands of sandboxes. The runtime and SDK are
+  Apache-2.0 with a bring-your-own-cloud self-host path (run sandboxes inside your own AWS/GCP/Azure account);
+  the managed scheduler is the hosted layer. Backed by Redpoint and Amplify Partners; the company repositioned
+  from document ingestion to a sandbox-native cloud. ~959 stars on GitHub.
+github:
+- url: https://github.com/tensorlakeai/tensorlake
+comments: Tensorlake sandbox-native cloud for AI agents; repo Apache-2.0 (Python + Rust), CLI v0.5.65
+  live on GitHub July 2026. Firecracker microVMs with BYOC self-host; managed scheduler (Lattice) proprietary.

--- a/sources/scores/beta9.yaml
+++ b/sources/scores/beta9.yaml
@@ -32,9 +32,14 @@ capability:
   confidence: medium
   note: Capable serverless container runtime with GPU support, volumes, autoscaling and sandbox primitives,
     but container-level (not VM/microVM) isolation places it below the VM-grade peers on the isolation-strength
-    dimension; mid-tier.
+    dimension; mid-tier. Independent ComputeSDK TTI benchmarks of Beam (the managed beta9 cloud) corroborate
+    the fast container launch (~380ms median cold-start, 8th of 19 sandbox providers).
   sources:
   - url: https://github.com/beam-cloud/beta9
     shows: 'serverless runtime: rapid container launches, parallelize across hundreds of containers, GPU
       support, volume storage, sandboxes'
     accessed: '2026-06-04'
+  - url: https://www.computesdk.com/benchmarks/sandboxes/
+    shows: 'ComputeSDK TTI leaderboard (independent, 100 iters/day, 2026-07-09 run): Beam (managed beta9)
+      median time-to-interactive ~380ms sequential / ~810ms burst @100 concurrent; 8th of 19 providers'
+    accessed: '2026-07-09'

--- a/sources/scores/blaxel-sandbox.yaml
+++ b/sources/scores/blaxel-sandbox.yaml
@@ -1,0 +1,49 @@
+product: blaxel-sandbox
+openness:
+  score: 4
+  class: open_core
+  components: license:MIT(OSI);source:public(sandbox API, self-hostable via Docker Compose);managed-tier:Blaxel
+    proprietary perpetual-standby platform
+  confidence: medium
+  note: MIT sandbox API that is self-hostable via Docker Compose, with a proprietary managed perpetual-standby
+    platform, so open-core. The open component carries a maximally permissive MIT license; the standby/scale
+    platform is the closed value-add. Open surface is narrower than E2B's full self-hostable infra.
+  sources:
+  - url: https://github.com/blaxel-ai/sandbox
+    shows: MIT license; sandbox API self-hostable via Docker Compose (port 8080)
+    accessed: '2026-07-09'
+  - url: https://blaxel.ai/sandbox
+    shows: perpetual sandbox platform for AI agents; standby at zero compute cost, sub-25ms resume
+    accessed: '2026-07-09'
+adoption:
+  level: 1
+  reach: null
+  signal_type: stars_fallback
+  confidence: low
+  note: 'Very nascent: ~22 stars on the sandbox repo, a $7.3M seed (First Round, YC S2025), and an unverified
+    vendor claim of billions of agent requests. No usage or download signal. stars_fallback with a low-double-digit
+    star base places this at 1. Added on openness and mission-fit grounds despite the low prominence;
+    scored honestly. Low confidence.'
+  sources:
+  - url: https://github.com/blaxel-ai/sandbox
+    shows: ~22 stars / 11 forks; MIT sandbox API
+    accessed: '2026-07-09'
+capability:
+  score: 3
+  basis: feature_matrix
+  value: isolation:microVM (strong); cold-start:sub-second fresh, sub-25ms resume from standby; runtime
+    breadth:agent code execution; persistence:perpetual standby with full FS/memory state; scale:vendor-claimed
+    billions of agent requests (unverified)
+  confidence: medium
+  note: MicroVM isolation and the perpetual-standby resume model are a genuinely strong, distinctive feature
+    set, but proven scale is unverified and the product is early, so held at 3 rather than level with
+    the proven microVM 4s. Independent ComputeSDK TTI benchmarks measure ~450ms median fresh cold-start
+    (11th of 19 sandbox providers), mid-pack.
+  sources:
+  - url: https://blaxel.ai/sandbox
+    shows: microVM sandboxes, perpetual standby, sub-25ms resume with full FS/memory state
+    accessed: '2026-07-09'
+  - url: https://www.computesdk.com/benchmarks/sandboxes/
+    shows: 'ComputeSDK TTI leaderboard (independent, 100 iters/day, 2026-07-09 run): median time-to-interactive
+      ~450ms sequential / ~910ms burst @100 concurrent; 11th of 19 providers'
+    accessed: '2026-07-09'

--- a/sources/scores/cloudflare-sandboxes.yaml
+++ b/sources/scores/cloudflare-sandboxes.yaml
@@ -41,10 +41,15 @@ capability:
     container sandbox; persistence:Durable Objects-backed state; scale:edge-global, unlimited dynamic
     workers
   confidence: medium
-  note: Distinctive isolate-based approach gives best-in-class cold-start and density, plus a container
-    path for arbitrary code; held at 4 because isolate sandboxing is JS/TS-centric (narrower than microVM
-    any-image), Dynamic Workers is still open beta, and overall scale evidence is per-customer rather
-    than category-leading. Scored as a combined product per the registry name.
+  note: Distinctive isolate-based approach gives best-in-class cold-start and density on the JS/TS isolate
+    path, plus a container path for arbitrary code; held at 4 because isolate sandboxing is JS/TS-centric
+    (narrower than microVM any-image), Dynamic Workers is still open beta, and overall scale evidence is
+    per-customer rather than category-leading. Scored as a combined product per the registry name.
+    Independent ComputeSDK TTI benchmarks measure the container-backed sandbox path (what runs arbitrary
+    code) at ~1.8s median cold-start, 18th of 19 sandbox providers, degrading to ~4.3s under 100-concurrent
+    burst; the sub-ms figures apply to the JS/TS Dynamic Workers path, not the arbitrary-code sandbox the
+    benchmark exercises. On measured full-sandbox latency alone this would be a 3; held at 4 on the strength
+    of the dual isolate-plus-container isolation model.
   sources:
   - url: https://blog.cloudflare.com/dynamic-workers/
     shows: V8 isolate sandboxing, ~ms start, 100x faster/100x more memory-efficient than containers
@@ -52,3 +57,7 @@ capability:
   - url: https://github.com/cloudflare/sandbox-sdk
     shows: 'container-backed sandbox: run commands, manage files, background processes, expose services'
     accessed: '2026-06-04'
+  - url: https://www.computesdk.com/benchmarks/sandboxes/
+    shows: 'ComputeSDK TTI leaderboard (independent, 100 iters/day, 2026-07-09 run): container-backed sandbox
+      median time-to-interactive ~1760ms sequential / ~4290ms burst @100 concurrent; 18th of 19 providers'
+    accessed: '2026-07-09'

--- a/sources/scores/daytona-sandbox.yaml
+++ b/sources/scores/daytona-sandbox.yaml
@@ -33,8 +33,13 @@ capability:
   confidence: high
   note: Strong isolation (dedicated kernel + isolated net/fs, allocated vCPU/RAM/disk) with sub-90ms cold-start
     and persistent sessions; among the strongest agent-runtime feature sets, just below the kernel/microVM
-    frontier-definers.
+    frontier-definers. Independent ComputeSDK TTI benchmarks corroborate the sub-100ms-class cold-start
+    (~140ms median, 4th-fastest of 19 sandbox providers).
   sources:
   - url: https://github.com/daytonaio/daytona
     shows: dedicated kernel/filesystem/network stack per sandbox; <90ms spin-up; persistent state; Python/TS/JS
     accessed: '2026-06-04'
+  - url: https://www.computesdk.com/benchmarks/sandboxes/
+    shows: 'ComputeSDK TTI leaderboard (independent, 100 iters/day, 2026-07-09 run): median time-to-interactive
+      ~140ms sequential / ~710ms burst @100 concurrent; 4th-fastest of 19 providers'
+    accessed: '2026-07-09'

--- a/sources/scores/e2b-sandbox.yaml
+++ b/sources/scores/e2b-sandbox.yaml
@@ -35,8 +35,13 @@ capability:
   confidence: high
   note: VM-grade isolation (Firecracker) is the strongest tier in the feature matrix; broad SDK/runtime
     support and proven scale. Below the frontier-definer Firecracker itself (which it builds on), so 4
-    not 5.
+    not 5. Independent ComputeSDK TTI benchmarks corroborate the sub-second cold-start (~370ms median
+    time-to-interactive, mid-pack of 19 sandbox providers).
   sources:
   - url: https://e2b.dev/
     shows: each sandbox powered by Firecracker microVM; 1B+ sandboxes started
     accessed: '2026-06-04'
+  - url: https://www.computesdk.com/benchmarks/sandboxes/
+    shows: 'ComputeSDK TTI leaderboard (independent, 100 iters/day, 2026-07-09 run): median time-to-interactive
+      ~370ms sequential / ~470ms burst @100 concurrent; 7th-fastest of 19 providers'
+    accessed: '2026-07-09'

--- a/sources/scores/google-cloud-run.yaml
+++ b/sources/scores/google-cloud-run.yaml
@@ -40,7 +40,8 @@ capability:
   note: Very broad runtime/language coverage and hyperscaler scale; new agent `sandbox` tool (announced
     Next '26, 'coming soon') adds first-class AI-code-execution via a `sandbox do --` command. gVisor
     isolation is process/syscall-level rather than full microVM (Sprites/Northflank), so not the top isolation
-    tier. Strong but not the single frontier-definer.
+    tier. Strong but not the single frontier-definer. Independent ComputeSDK TTI benchmarks corroborate
+    the sub-second cold-start (~430ms median, 10th of 19 sandbox providers).
   sources:
   - url: https://cloud.google.com/blog/products/serverless/whats-new-for-cloud-run-at-next26
     shows: built-in `sandbox` tool for agents to run AI-generated code in ephemeral isolated envs; container
@@ -49,3 +50,7 @@ capability:
   - url: https://cloud.google.com/run
     shows: OCI container deploy, scale-to-zero, broad runtime support
     accessed: '2026-06-04'
+  - url: https://www.computesdk.com/benchmarks/sandboxes/
+    shows: 'ComputeSDK TTI leaderboard (independent, 100 iters/day, 2026-07-09 run): median time-to-interactive
+      ~430ms sequential / ~510ms burst @100 concurrent; 10th of 19 providers'
+    accessed: '2026-07-09'

--- a/sources/scores/modal-sandboxes.yaml
+++ b/sources/scores/modal-sandboxes.yaml
@@ -39,7 +39,8 @@ capability:
   confidence: medium
   note: 'Strong, purpose-built agent sandbox: gVisor isolation + arbitrary images + high concurrency.
     Sits just below the Firecracker-microVM frontier (Lambda/Vercel) on isolation strength; scored 4,
-    level with the Ray/Ollama capability anchors.'
+    level with the Ray/Ollama capability anchors. Independent ComputeSDK TTI benchmarks measure ~470ms
+    median cold-start (13th of 19 sandbox providers), consistent with the fast-container-stack claim.'
   sources:
   - url: https://modal.com/docs/guide/sandbox
     shows: sandbox lifecycle, custom images, timeouts up to 24h, untrusted-code execution
@@ -47,3 +48,7 @@ capability:
   - url: https://modal.com/resources/best-code-execution-sandboxes-ai-agents
     shows: gVisor user-space kernel isolation, 50,000+ concurrent sessions (corroborating)
     accessed: '2026-06-04'
+  - url: https://www.computesdk.com/benchmarks/sandboxes/
+    shows: 'ComputeSDK TTI leaderboard (independent, 100 iters/day, 2026-07-09 run): median time-to-interactive
+      ~470ms sequential / ~570ms burst @100 concurrent; 13th of 19 providers'
+    accessed: '2026-07-09'

--- a/sources/scores/northflank-sandboxes.yaml
+++ b/sources/scores/northflank-sandboxes.yaml
@@ -33,8 +33,14 @@ capability:
   confidence: medium
   note: 'Strong: microVM isolation, ~200ms cold-start, broad runtime support, multi-cloud scale, and explicit
     support for untrusted code-gen at scale. Just below frontier on proven sandbox-specific scale vs the
-    dedicated leaders; isolation+latency are top-tier.'
+    dedicated leaders; isolation+latency are top-tier. Independent ComputeSDK TTI benchmarks confirm the
+    top-tier latency, measuring ~100ms median cold-start (3rd-fastest of 19 sandbox providers), beating
+    the ~200ms spec.'
   sources:
   - url: https://northflank.com/
     shows: microVM 200ms isolation, untrusted code at scale, millions of containers, 330+ AZs
     accessed: '2026-06-04'
+  - url: https://www.computesdk.com/benchmarks/sandboxes/
+    shows: 'ComputeSDK TTI leaderboard (independent, 100 iters/day, 2026-07-09 run): median time-to-interactive
+      ~100ms sequential / ~190ms burst @100 concurrent; 3rd-fastest of 19 providers'
+    accessed: '2026-07-09'

--- a/sources/scores/tensorlake-sandbox.yaml
+++ b/sources/scores/tensorlake-sandbox.yaml
@@ -1,0 +1,48 @@
+product: tensorlake-sandbox
+openness:
+  score: 4
+  class: open_core
+  components: license:Apache-2.0(OSI);source:public(runtime+SDK, BYOC self-host in your own AWS/GCP/Azure);managed-tier:Tensorlake
+    hosted cloud + proprietary Lattice scheduler
+  confidence: medium
+  note: Apache-2.0 runtime and SDK with a genuine bring-your-own-cloud self-host path, plus a proprietary
+    managed scheduler, so open-core on par with the permissive-Apache peers (E2B). The open part is permissive
+    and self-hostable; the managed scheduler is the closed value-add.
+  sources:
+  - url: https://github.com/tensorlakeai/tensorlake
+    shows: Apache-2.0 license; sandbox runtime + SDK (Python + Rust); BYOC self-host
+    accessed: '2026-07-09'
+  - url: https://www.tensorlake.ai/
+    shows: sandbox-native cloud for AI agents; run sandboxes in your own cloud account
+    accessed: '2026-07-09'
+adoption:
+  level: 2
+  reach: 10K-100K
+  signal_type: stars_fallback
+  confidence: low
+  note: No published usage or download figure for the runtime; ~959 GitHub stars is the available signal,
+    alongside Redpoint and Amplify backing and a free tier. stars_fallback caps the level at 3; placed
+    at 2 on a low-thousands star base absent any volume signal. Low confidence.
+  sources:
+  - url: https://github.com/tensorlakeai/tensorlake
+    shows: ~959 stars / 138 forks; no published usage figures
+    accessed: '2026-07-09'
+capability:
+  score: 4
+  basis: feature_matrix
+  value: isolation:Firecracker microVM (top tier); cold-start:sub-second; runtime breadth:arbitrary agent
+    sandboxes; persistence:snapshot/suspend/resume + durable-execution orchestration; scale:reported thousands
+    of concurrent sandboxes
+  confidence: medium
+  note: Firecracker microVM isolation plus durable-execution orchestration and snapshot/resume make for
+    a rich agent-runtime feature set, level with the microVM peers. Independent ComputeSDK TTI benchmarks
+    measure ~460ms median cold-start (12th of 19 sandbox providers), mid-pack and consistent with the
+    sub-second claim.
+  sources:
+  - url: https://www.tensorlake.ai/
+    shows: Firecracker microVM sandboxes, snapshot/suspend/resume, durable execution, scale to thousands
+    accessed: '2026-07-09'
+  - url: https://www.computesdk.com/benchmarks/sandboxes/
+    shows: 'ComputeSDK TTI leaderboard (independent, 100 iters/day, 2026-07-09 run): median time-to-interactive
+      ~460ms sequential / ~960ms burst @100 concurrent; 12th of 19 providers'
+    accessed: '2026-07-09'

--- a/sources/scores/vercel-sandbox.yaml
+++ b/sources/scores/vercel-sandbox.yaml
@@ -40,8 +40,15 @@ capability:
   note: Firecracker microVM isolation (top tier) + ms cold-start + persistence/snapshots make it a strong
     agent sandbox; held at 4 rather than 5 because the managed-runtime breadth is narrower (Node/Python
     first-class) than Lambda's any-runtime/any-image frontier and scale is not at Lambda's proven level.
+    Independent ComputeSDK TTI benchmarks measure ~390ms median cold-start (9th of 19 sandbox providers);
+    the vendor's 'ms startup' framing is optimistic versus the measured hundreds of ms, though still solidly
+    sub-second.
   sources:
   - url: https://vercel.com/docs/sandbox
     shows: Firecracker microVM per sandbox, ms startup, persistent+snapshot, node/python runtimes, up
       to 45m
     accessed: '2026-06-04'
+  - url: https://www.computesdk.com/benchmarks/sandboxes/
+    shows: 'ComputeSDK TTI leaderboard (independent, 100 iters/day, 2026-07-09 run): median time-to-interactive
+      ~390ms sequential / ~490ms burst @100 concurrent; 9th of 19 providers'
+    accessed: '2026-07-09'


### PR DESCRIPTION
## Summary

Incorporates the [ComputeSDK sandbox benchmark leaderboard](https://www.computesdk.com/benchmarks/sandboxes/) (`computesdk/benchmarks`, MIT, daily runs) into the map for both capability measurement and product discovery.

**Capability anchors — corroborating only.** ComputeSDK measures Time to Interactive (TTI, wall-clock create→first-command, 100 iters/day). Added it as an extra source on 8 mapped sandboxes; `basis: feature_matrix` and all scores are unchanged. Where measured TTI agrees with the vendor claim the note says so; where it doesn't, it's flagged.

| Product | Median TTI (seq) | Rank /19 |
|---|--:|--:|
| northflank-sandboxes | ~100ms | 3rd (beats its ~200ms spec) |
| daytona-sandbox | ~140ms | 4th |
| e2b-sandbox | ~370ms | 7th |
| beta9 (Beam) | ~380ms | 8th |
| vercel-sandbox | ~390ms | 9th |
| google-cloud-run | ~430ms | 10th |
| modal-sandboxes | ~470ms | 13th |
| cloudflare-sandboxes | ~1760ms | **18th** |

Cloudflare's "best-in-class cold-start" note is qualified: the container-backed sandbox path (what runs arbitrary code) is near the bottom on measured TTI; the sub-ms figure is the JS/TS Dynamic Workers isolate path, not what the benchmark exercises. Held at capability 4 on the isolation model.

**Two new open sandboxes** surfaced by the leaderboard:
- `tensorlake-sandbox` — open_core (Apache-2.0 runtime + BYOC self-host), adoption 2 / capability 4
- `blaxel-sandbox` — open_core (MIT, self-hostable sandbox API), adoption 1 / capability 3 (scored honestly low; added on openness/mission-fit grounds)

Frozen long-tail counts re-synced (scored 474→476). The other 10 leaderboard providers were triaged out: archil is a filesystem (not a sandbox), beam is beta9 (already mapped), and the rest are closed/nascent (OSI-licensed client SDK over a proprietary hosted runtime = closed).

## Test plan
- `uv run python -m build.validate` → 0 errors
- `uv run pytest -q` → 43 passed
- `uv run python -m build.serialize --date 2026-07-09` → 476 products, no error
- Bot-owned `notebook_data.json` / `ai-stack-map.py` left untouched (regen bot rebuilds on merge)