### PR TITLE
feat(sources): add Kimi K3, Inkling, and Lucie 7B

### DIFF
--- a/build/_frozen_long_tail.json
+++ b/build/_frozen_long_tail.json
@@ -4,10 +4,10 @@
     "models": 6428,
     "packages": 2823,
     "total": 24626,
-    "scored": 474,
+    "scored": 477,
     "overlap": 241,
-    "scored_outside": 233,
-    "uncategorized": 24385,
+    "scored_outside": 236,
+    "uncategorized": 24382,
     "universe": 24859
   },
   "top": [

--- a/sources/categories/base_pretrained.yaml
+++ b/sources/categories/base_pretrained.yaml
@@ -23,6 +23,9 @@ products:
 - inflection-3-0
 - glm-4-9b
 - kimi-k2-6
+- kimi-k3
+- inkling
+- lucie-7b
 - olmo-3
 - pythia
 - llama-4-scout-maverick

--- a/sources/organizations/linagora.yaml
+++ b/sources/organizations/linagora.yaml
@@ -1,0 +1,6 @@
+name: linagora
+display_name: Linagora
+type: company
+homepage: https://linagora.com
+products:
+- lucie-7b

--- a/sources/organizations/moonshot-ai.yaml
+++ b/sources/organizations/moonshot-ai.yaml
@@ -4,3 +4,4 @@ type: company
 homepage: https://www.moonshot.ai
 products:
 - kimi-k2-6
+- kimi-k3

--- a/sources/organizations/thinking-machines-lab.yaml
+++ b/sources/organizations/thinking-machines-lab.yaml
@@ -4,3 +4,4 @@ type: company
 homepage: https://thinkingmachines.ai
 products:
 - tinker
+- inkling

--- a/sources/products/inkling.yaml
+++ b/sources/products/inkling.yaml
@@ -1,0 +1,14 @@
+name: inkling
+display_name: Inkling
+type: model
+description: Thinking Machines Lab's first open-weight foundation model, released 2026-07-15. A natively
+  multimodal MoE (975B total / 41B active) that accepts text, image, and audio inputs with a 1M-token
+  context window, trained on 45T tokens. Apache-2.0 weights on Hugging Face; positioned as a customizable
+  base (via Tinker LoRA) rather than the strongest overall open or closed model. Family also includes
+  Inkling-Small (276B / 12B active), folded into this entry.
+huggingface_model:
+- url: https://huggingface.co/thinkingmachines/Inkling
+- url: https://huggingface.co/thinkingmachines/Inkling-NVFP4
+comments: Inkling, 975B total / 41B active MoE (6-of-256 + 2 shared experts), hybrid local/global attention,
+  native text/image/audio. Released 15 Jul 2026 under Apache-2.0. Inkling-Small (276B/12B) is a sibling
+  preview in the same family — not a separate map entry. Training data not redistributed.

--- a/sources/products/kimi-k3.yaml
+++ b/sources/products/kimi-k3.yaml
@@ -1,0 +1,12 @@
+name: kimi-k3
+display_name: Kimi K3
+type: model
+description: Moonshot AI's flagship 2.8T-parameter MoE (activating 16 of 896 experts) with native vision
+  and a 1M-token context window, announced 2026-07-16. Positioned as the world's first open 3T-class model;
+  live on kimi.com / Kimi Work / Kimi Code / the Kimi API at launch, with full weights scheduled for 2026-07-27.
+  Built on Kimi Delta Attention and Attention Residuals; Moonshot reports frontier-tier long-horizon coding
+  and agentic knowledge-work results trailing only Claude Fable 5 and GPT-5.6 Sol among tested models.
+comments: Kimi K3, 2.8T total MoE, Stable LatentMoE (16/896 experts), 1M context, native multimodal. API
+  live 16 Jul 2026; weights promised by 27 Jul 2026. Openness scored assuming continuity with the Kimi
+  K2.x Modified-MIT open-weight license (same family pattern as kimi-k2-6); confirm against the HF card
+  once weights land. No HF URL yet — add when the checkpoint is published.

--- a/sources/products/lucie-7b.yaml
+++ b/sources/products/lucie-7b.yaml
@@ -1,0 +1,16 @@
+name: lucie-7b
+display_name: Lucie 7B
+type: model
+description: Linagora / OpenLLM-France's fully open multilingual 7B foundation model (Llama 3.1 architecture),
+  trained on ~3T tokens with roughly equal French and English shares plus German, Spanish, Italian, and
+  code. Apache-2.0 weights, redistributable Lucie Training Dataset, Megatron-DeepSpeed training code, and
+  intermediate checkpoints — one of the few European releases that clears the full open-source bar.
+  Instruct variants (v1.1 and human-data) are folded into this entry.
+github:
+- url: https://github.com/OpenLLM-France/Lucie-Training
+huggingface_model:
+- url: https://huggingface.co/OpenLLM-France/Lucie-7B
+- url: https://huggingface.co/OpenLLM-France/Lucie-7B-Instruct-v1.1
+comments: Lucie-7B base + Instruct-v1.1 / Instruct-human-data. Apache-2.0 weights; training data at
+  OpenLLM-France/Lucie-Training-Dataset (not a separate map product for now); training code AGPL/community
+  stack on GitHub. Paper arXiv:2503.12294. Collection https://huggingface.co/collections/OpenLLM-France/lucie-llm.

--- a/sources/scores/inkling.yaml
+++ b/sources/scores/inkling.yaml
@@ -1,0 +1,49 @@
+product: inkling
+openness:
+  score: 3
+  class: open_weights
+  components: weights:open(Apache-2.0 on HF, BF16 + NVFP4);data:closed(public+third-party+synthetic, not
+    redistributed);code:partial(day-0 transformers/SGLang/vLLM/llama.cpp; no training pipeline);license:Apache-2.0(OSI
+    for weights only)
+  confidence: high
+  note: Apache-2.0 weights are OSI-licensed, but training data and full training code are withheld —
+    open_weights / 3, not open_source / 5. Press often calls this 'open source' because of the license
+    tag; our spectrum requires open data + code for class open_source.
+  sources:
+  - url: https://huggingface.co/thinkingmachines/Inkling
+    shows: Apache-2.0 license tag; 975B/41B MoE; weights downloadable; model card states data from public,
+      third-party, and synthetic sources (not released)
+    accessed: '2026-07-19'
+  - url: https://thinkingmachines.ai/news/introducing-inkling/
+    shows: primary announcement — open weights on HF, Tinker availability, Inkling-Small sibling
+    accessed: '2026-07-19'
+adoption:
+  level: 3
+  reach: 100K-1M
+  signal_type: usage_volume
+  confidence: medium
+  note: HF card shows ~13K downloads in the first days and 1K+ likes; day-0 serving via Tinker plus
+    partners (Together, Modal, Fireworks, etc.). Early but broad distribution for a ~1T open-weight model;
+    level 3 until cumulative usage settles.
+  sources:
+  - url: https://huggingface.co/thinkingmachines/Inkling
+    shows: ~13.5K downloads last month, 1129 likes (as of 2026-07-19)
+    accessed: '2026-07-19'
+  - url: https://thinkingmachines.ai/news/introducing-inkling/
+    shows: Tinker availability and third-party inference partner rollout
+    accessed: '2026-07-19'
+capability:
+  score: 4
+  basis: benchmark:SWE-bench/GPQA/AIME
+  value: 'SWE-bench Verified 77.6%; SWE-bench Pro 54.3%; GPQA Diamond 87.2%; AIME 2026 97.1% (effort=0.99)'
+  confidence: high
+  note: Strong open-weight multimodal base — beats Nemotron 3 Ultra on SWE Verified (77.6 vs 70.7) but
+    trails Kimi K2.6 (80.2) and DeepSeek-V4-Pro (80.6). Vendor card is explicit that Inkling is not the
+    strongest overall model; scored 4 (high open-weight tier, not frontier-defining 5).
+  sources:
+  - url: https://huggingface.co/thinkingmachines/Inkling
+    shows: vendor eval table vs Nemotron 3 Ultra / Kimi K2.6 / DeepSeek V4 Pro / closed frontier peers
+    accessed: '2026-07-19'
+  - url: https://thinkingmachines.ai/model-card/inkling/
+    shows: model card with architecture and evaluation details
+    accessed: '2026-07-19'

--- a/sources/scores/kimi-k3.yaml
+++ b/sources/scores/kimi-k3.yaml
@@ -1,0 +1,45 @@
+product: kimi-k3
+openness:
+  score: 3
+  class: open_weights
+  components: weights:pending(scheduled 2026-07-27; API live today);data:closed;code:partial(inference/deploy
+    expected; no training data or full pipeline);license:assumed-Modified-MIT(continuity with Kimi K2.x;
+    confirm on weight release)
+  confidence: medium
+  note: Scored open_weights / 3 on continuity with Kimi K2.6 (Modified MIT, weights downloadable, data
+    closed). Weights not yet on HF as of 2026-07-19 — Moonshot's primary blog commits to a full weight
+    release by 2026-07-27. Re-verify license text and HF card on landing; downgrade to closed if the release
+    slips or the license changes.
+  sources:
+  - url: https://www.kimi.com/blog/kimi-k3
+    shows: primary announcement — 2.8T MoE, 1M context, native vision; API live; full weights by 2026-07-27
+    accessed: '2026-07-19'
+  - url: https://huggingface.co/moonshotai/Kimi-K2.6
+    shows: prior Kimi open-weight release under Modified MIT (assumed continuity for K3 license class)
+    accessed: '2026-07-19'
+adoption:
+  level: 3
+  reach: 100K-1M
+  signal_type: reported_traction
+  confidence: medium
+  note: Day-0 distribution across kimi.com, Kimi app, Kimi Work, Kimi Code, and the official Kimi API
+    (kimi-k3). Early post-launch; inherits the Kimi consumer/API channel from K2.6. Level 3 until independent
+    download/usage counts after the weight drop.
+  sources:
+  - url: https://www.kimi.com/blog/kimi-k3
+    shows: availability on kimi.com, Kimi Work, Kimi Code, and Kimi API (kimi-k3) at launch
+    accessed: '2026-07-19'
+capability:
+  score: 5
+  basis: benchmark:vendor-suite/coding+agentic
+  value: null
+  confidence: medium
+  note: Vendor evaluation (max thinking effort) places K3 at frontier open-weight tier for long-horizon
+    coding and agentic knowledge work, trailing Claude Fable 5 and GPT-5.6 Sol overall but competitive
+    or ahead of other open and several closed peers on DeepSWE / Terminal-Bench / SWE Marathon-style
+    tasks. Capability 5 on reported frontier coding/agentic profile; re-check against independent third-party
+    leaderboards after weight release.
+  sources:
+  - url: https://www.kimi.com/blog/kimi-k3
+    shows: vendor benchmark suite and case studies (kernel opt, MiniTriton, SWE-style agentic coding)
+    accessed: '2026-07-19'

--- a/sources/scores/lucie-7b.yaml
+++ b/sources/scores/lucie-7b.yaml
@@ -1,0 +1,54 @@
+product: lucie-7b
+openness:
+  score: 5
+  class: open_source
+  components: weights:open(Apache-2.0);data:open(Lucie-Training-Dataset on HF, redistributed in training
+    form);code:open(Lucie-Training Megatron-DeepSpeed fork);checkpoints:open(intermediate HF revisions);license:Apache-2.0(OSI)
+  confidence: high
+  note: 'Full open-source tier alongside OLMo / Apertus: open weights, open training data, open training
+    code, intermediate checkpoints. Authors position Lucie as OSI-definition-compliant for open-source AI.
+    Training-dataset product deferred — artifacts cited here for openness only.'
+  sources:
+  - url: https://huggingface.co/OpenLLM-France/Lucie-7B
+    shows: Apache-2.0 weights; links to Lucie-Training-Dataset; intermediate checkpoints; Llama-3.1 arch
+    accessed: '2026-07-19'
+  - url: https://huggingface.co/OpenLLM-France/Lucie-Training-Dataset
+    shows: redistributable multilingual pretraining corpus used for Lucie-7B
+    accessed: '2026-07-19'
+  - url: https://github.com/OpenLLM-France/Lucie-Training
+    shows: open training code (Megatron-DeepSpeed fork)
+    accessed: '2026-07-19'
+  - url: https://arxiv.org/abs/2503.12294
+    shows: paper claiming OSI-compliant open resources for multilingual generation
+    accessed: '2026-07-19'
+adoption:
+  level: 2
+  reach: 10K-100K
+  signal_type: usage_volume
+  confidence: medium
+  note: Niche sovereign/French open-LLM audience. HF Lucie-7B ~780 downloads/month and 31 likes (Jul
+    2026); collection upvotes modest. Comparable adoption tier to Apertus / Falcon-class fully-open
+    European releases rather than Llama/Qwen scale.
+  sources:
+  - url: https://huggingface.co/OpenLLM-France/Lucie-7B
+    shows: ~780 downloads/month, 31 likes (as of 2026-07-19)
+    accessed: '2026-07-19'
+  - url: https://huggingface.co/collections/OpenLLM-France/lucie-llm
+    shows: official Lucie LLM collection (base, instruct, dataset, paper)
+    accessed: '2026-07-19'
+capability:
+  score: 2
+  basis: benchmark:multilingual-pretrain-suite
+  value: null
+  confidence: medium
+  note: 7B multilingual base prioritizing French cultural representation and data-rights constraints —
+    competitive for its size/language mix on French/English evals in the paper, but well below the 2026
+    open-weight frontier (trillion-param MoEs). Capability 2 reflects small-scale fully-open sovereign
+    model, not frontier performance. Value is openness + FR/EU language coverage.
+  sources:
+  - url: https://arxiv.org/abs/2503.12294
+    shows: Lucie-7B / Instruct eval narrative vs contemporary open baselines
+    accessed: '2026-07-19'
+  - url: https://huggingface.co/OpenLLM-France/Lucie-7B
+    shows: training/eval learning curves and multilingual benchmark plots on the model card
+    accessed: '2026-07-19'


### PR DESCRIPTION
## Summary
- Add **Kimi K3** (Moonshot) to `base_pretrained` — 2.8T MoE; openness scored as `open_weights`/3 assuming Modified-MIT continuity with K2.6 (weights scheduled 2026-07-27; medium confidence until HF lands)
- Add **Inkling** (Thinking Machines Lab) — 975B/41B multimodal MoE under Apache-2.0 weights; `open_weights`/3 because training data is closed
- Add **Lucie 7B** (new `linagora` org) — fully open European 7B; `open_source`/5; model-only (training dataset deferred)
- Sync `build/_frozen_long_tail.json` scored count 474 → 477

## Test plan
- [x] `uv run python -m build.validate` → `0 error(s)`
- [ ] Spot-check product/score YAML and org/category roster membership
- [ ] After Jul 27: confirm Kimi K3 HF URL + license text and update if needed


Made with [Cursor](https://cursor.com)