### PR TITLE
fix(products): mark Atropos repo as archived

### DIFF
--- a/sources/products/atropos.yaml
+++ b/sources/products/atropos.yaml
@@ -3,11 +3,12 @@ display_name: Atropos
 type: software
 description: Language-model reinforcement-learning environments framework for collecting and evaluating
   LLM trajectories across diverse environments. Nous positions it as part of the post-training stack,
-  and the GitHub repo has 1.2K stars, 362 forks, and active 2026 development, which makes it a meaningful
-  open source training primitive.
+  and the GitHub repo has 1.2K stars and 362 forks. The repo was archived (read-only) on 2026-07-04 and
+  is no longer actively developed.
 github:
 - url: https://github.com/NousResearch/atropos
 comments: 'Atropos, Nous Research LLM RL-environments framework for collecting/evaluating trajectories
   and driving RL training (RLHF/RLAIF, GRPO-style). v0.4.0 (Mar 10, 2026), confirmed live on GitHub June
   2026. Integrates with trainers Axolotl and Tinker. Borderline: it is the RL-environment/orchestration
-  layer that feeds a fine-tuning trainer.'
+  layer that feeds a fine-tuning trainer. Repo archived read-only on 2026-07-04 (last release v0.4.0,
+  Mar 10 2026); no longer actively maintained.'

--- a/sources/scores/atropos.yaml
+++ b/sources/scores/atropos.yaml
@@ -9,8 +9,9 @@ openness:
     layer (RLHF/RLAIF/GRPO).
   sources:
   - url: https://github.com/NousResearch/atropos
-    shows: MIT license; LLM RL-environments framework; v0.4.0 (Mar 10 2026); Axolotl/Tinker trainer integrations
-    accessed: '2026-06-04'
+    shows: MIT license; LLM RL-environments framework; v0.4.0 (Mar 10 2026); Axolotl/Tinker trainer integrations;
+      repo archived read-only 2026-07-04
+    accessed: '2026-07-21'
 adoption:
   level: 1
   reach: <10K


### PR DESCRIPTION
NousResearch/atropos was archived (read-only) on 2026-07-04, surfaced during the #85 verification sweep. This corrects the "active 2026 development" line in the description and notes the archived status in the comments and openness source. Openness (MIT, open_source) is unchanged — only the maintenance status.

## Test plan
- `python -m build.validate` → 0 errors