### PR TITLE
Serialize the registry and push it to OSO

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -52,5 +52,6 @@ jobs:
       - name: Publish to OSO
         env:
           OSO_API_KEY: ${{ secrets.OSO_API_KEY }}
-          OSO_ORG_ID: ${{ secrets.OSO_ORG_ID }}
+          # Org id is not sensitive, so it lives as a repo variable rather than a secret.
+          OSO_ORG_ID: ${{ vars.OSO_ORG_ID }}
         run: uv run python -m build.publish_registry

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -1,0 +1,56 @@
+name: registry
+
+# The "config in" bridge: the repo declares what exists, and CI pushes that
+# declaration to OSO. Nothing flows back in here — scores are computed downstream
+# and serialized outward separately.
+
+on:
+  pull_request:
+    paths:
+      - "sources/**"
+      - "build/serialize_registry.py"
+      - "build/publish_registry.py"
+      - ".github/workflows/registry.yml"
+  push:
+    branches: [main]
+    paths:
+      - "sources/**"
+      - "build/serialize_registry.py"
+      - "build/publish_registry.py"
+  workflow_dispatch:
+
+jobs:
+  # On a PR, prove the registry is internally consistent. Structural problems
+  # (a category listing a product that doesn't exist, a product in no category)
+  # fail here rather than reaching OSO.
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Install dependencies
+        run: uv sync --locked
+      - name: Check registry consistency
+        run: uv run python -m build.serialize_registry --check
+
+  # On main, serialize and push. Static models are created on first run and
+  # reused after, so this is safe to run on every change to sources/.
+  publish:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Install dependencies
+        run: uv sync --locked
+      - name: Serialize registry
+        run: uv run python -m build.serialize_registry
+      - name: Publish to OSO
+        env:
+          OSO_API_KEY: ${{ secrets.OSO_API_KEY }}
+          OSO_ORG_ID: ${{ secrets.OSO_ORG_ID }}
+        run: uv run python -m build.publish_registry

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ notebooks/*.py
 !notebooks/oss-ai-trends.py
 !notebooks/pypi-geo-trends.py
 !notebooks/long-tail-explorer.py
+
+# Serialized registry: pushed to OSO by CI, never committed
+build/registry/

--- a/build/publish_registry.py
+++ b/build/publish_registry.py
@@ -1,0 +1,156 @@
+"""Push the serialized registry CSVs to OSO as static models.
+
+This is the "config in" half of the bridge: the repo declares what exists, CI
+pushes that declaration outward. Nothing is pulled back in, and no generated CSV
+is committed — the repo stays YAML, and OSO gets a flat mirror of it.
+
+Idempotent. Static models are created on first run and reused after, so this can
+run on every push to sources/.
+
+Environment:
+    OSO_API_KEY   required
+    OSO_ORG_ID    required
+    OSO_DATASET   optional, defaults to "registry"
+
+Usage:
+    uv run python -m build.publish_registry
+    uv run python -m build.publish_registry --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from build.serialize_registry import OUT_DIR, TABLES
+
+API = "https://api.oso.xyz/v1/graphql"
+USER_AGENT = "os-ai-map-registry-publisher/1.0"
+DEFAULT_DATASET = "registry"
+
+
+def graphql(query: str, variables: dict, token: str) -> dict:
+    request = urllib.request.Request(
+        API,
+        data=json.dumps({"query": query, "variables": variables}).encode(),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            # The default Python-urllib agent is rejected with a blanket 403.
+            "User-Agent": USER_AGENT,
+        },
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        body = json.load(response)
+    if body.get("errors"):
+        raise RuntimeError(f"GraphQL error: {json.dumps(body['errors'])[:500]}")
+    return body["data"]
+
+
+Q_DATASETS = """query($where: JSON){ datasets(where:$where){ edges{ node{ id name type } } } }"""
+Q_STATIC = """query($where: JSON){ staticModels(where:$where){ edges{ node{ id name } } } }"""
+M_DATASET = """mutation($input: CreateDatasetInput!){
+  createDataset(input:$input){ success dataset{ id name } } }"""
+M_STATIC = """mutation($input: CreateStaticModelInput!){
+  createStaticModel(input:$input){ success staticModel{ id name } } }"""
+M_URL = """mutation($staticModelId: ID!){ createStaticModelUploadUrl(staticModelId:$staticModelId) }"""
+M_RUN = """mutation($input: CreateStaticModelRunRequestInput!){
+  createStaticModelRunRequest(input:$input){ success run{ id status } } }"""
+
+
+def resolve_dataset(name: str, org_id: str, token: str) -> str:
+    found = graphql(Q_DATASETS, {"where": {"org_id": {"eq": org_id}, "name": {"eq": name}}}, token)
+    edges = found["datasets"]["edges"]
+    if edges:
+        return edges[0]["node"]["id"]
+    created = graphql(
+        M_DATASET,
+        {
+            "input": {
+                "orgId": org_id,
+                "name": name,
+                "displayName": "Registry",
+                "type": "STATIC_MODEL",
+                "description": (
+                    "The os-ai-map registry: which products, organizations and categories "
+                    "exist and how they relate. Pushed by CI on every change to sources/. "
+                    "Declarative only — scores are computed downstream, not mirrored here."
+                ),
+            }
+        },
+        token,
+    )
+    return created["createDataset"]["dataset"]["id"]
+
+
+def resolve_static_models(dataset_id: str, org_id: str, token: str) -> dict[str, str]:
+    found = graphql(Q_STATIC, {"where": {"dataset_id": {"eq": dataset_id}}}, token)
+    existing = {n["node"]["name"]: n["node"]["id"] for n in found["staticModels"]["edges"]}
+    for table in TABLES:
+        if table not in existing:
+            created = graphql(
+                M_STATIC, {"input": {"orgId": org_id, "datasetId": dataset_id, "name": table}}, token
+            )
+            existing[table] = created["createStaticModel"]["staticModel"]["id"]
+    return existing
+
+
+def upload(path: Path, url: str) -> None:
+    """Bare PUT. Extra headers are not in the signature and cause a mismatch."""
+    request = urllib.request.Request(
+        url, data=path.read_bytes(), method="PUT", headers={"User-Agent": USER_AGENT}
+    )
+    with urllib.request.urlopen(request, timeout=120) as response:
+        if response.status not in (200, 201):
+            raise RuntimeError(f"upload of {path.name} returned {response.status}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="resolve ids, upload nothing")
+    parser.add_argument("--dir", type=Path, default=OUT_DIR)
+    args = parser.parse_args()
+
+    token = os.environ.get("OSO_API_KEY")
+    org_id = os.environ.get("OSO_ORG_ID")
+    if not token or not org_id:
+        print("OSO_API_KEY and OSO_ORG_ID must both be set", file=sys.stderr)
+        return 2
+    dataset_name = os.environ.get("OSO_DATASET", DEFAULT_DATASET)
+
+    missing = [t for t in TABLES if not (args.dir / f"{t}.csv").exists()]
+    if missing:
+        print(f"missing CSVs: {missing}. Run build.serialize_registry first.", file=sys.stderr)
+        return 2
+
+    dataset_id = resolve_dataset(dataset_name, org_id, token)
+    models = resolve_static_models(dataset_id, org_id, token)
+    print(f"dataset {dataset_name} = {dataset_id}")
+
+    if args.dry_run:
+        for table in TABLES:
+            print(f"  would upload {table}.csv -> {models[table]}")
+        return 0
+
+    for table in TABLES:
+        path = args.dir / f"{table}.csv"
+        url = graphql(M_URL, {"staticModelId": models[table]}, token)["createStaticModelUploadUrl"]
+        upload(path, url)
+        print(f"  uploaded {table}.csv ({path.stat().st_size:,} bytes)")
+
+    run = graphql(
+        M_RUN,
+        {"input": {"datasetId": dataset_id, "selectedModels": [models[t] for t in TABLES]}},
+        token,
+    )["createStaticModelRunRequest"]["run"]
+    print(f"materialization run {run['id']} ({run['status']})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build/serialize_registry.py
+++ b/build/serialize_registry.py
@@ -1,0 +1,280 @@
+"""Serialize the registry — what exists — to flat CSVs for downstream consumers.
+
+This is deliberately NOT `serialize.py`. That module builds the scored payload the
+notebooks render. This one emits only the *declarative* layer: which products,
+organizations and categories exist, and how they relate. Scores are excluded on
+purpose, because scoring is computed downstream and flows back out; if scores
+appeared here the registry would become a scoreboard and the dependency would
+point the wrong way.
+
+Emitted tables (one CSV each, written to build/registry/):
+
+  products              slug, display_name, type, description, comments
+  organizations         slug, display_name, type, homepage, github, country
+  categories            slug, display_name, description, strapline,
+                        weight_adopt, weight_cap, arc_name, layer
+  product_artifacts     product_slug, product_type, artifact_kind, artifact_id, artifact_url
+  product_categories    product_slug, category_slug
+  product_organizations product_slug, org_slug
+  product_lineage       product_slug, relation, target
+
+Two structural notes:
+
+  * Membership is declared on the parent — categories and organizations each list
+    their products — so it is inverted here into join tables.
+  * A category's `layer` is never stored on the category. It is derived from
+    whichever arc contains it in taxonomy.yaml, matching the comment in that file.
+    Storing it twice is how the two drift apart.
+
+Usage:
+    uv run python -m build.serialize_registry            # write CSVs
+    uv run python -m build.serialize_registry --check    # verify, write nothing
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import sys
+from pathlib import Path
+
+from build.validate import load_sources
+
+ROOT = Path(__file__).resolve().parents[1]
+OUT_DIR = ROOT / "build" / "registry"
+
+ARTIFACT_KINDS = ("github", "huggingface_model", "huggingface_dataset", "pypi", "npm", "crates")
+LINEAGE_RELATIONS = ("derived_from", "curated_with", "trains")
+
+TABLES: dict[str, tuple[str, ...]] = {
+    "products": ("slug", "display_name", "type", "description", "comments"),
+    "organizations": ("slug", "display_name", "type", "homepage", "github", "country"),
+    "categories": (
+        "slug",
+        "display_name",
+        "description",
+        "strapline",
+        "weight_adopt",
+        "weight_cap",
+        "arc_name",
+        "layer",
+    ),
+    "product_artifacts": (
+        "product_slug",
+        "product_type",
+        "artifact_kind",
+        "artifact_id",
+        "artifact_url",
+    ),
+    "product_categories": ("product_slug", "category_slug"),
+    "product_organizations": ("product_slug", "org_slug"),
+    "product_lineage": ("product_slug", "relation", "target"),
+}
+
+_ID_PATTERNS = {
+    "github": r"github\.com/([^/]+/[^/]+)",
+    "huggingface_model": r"huggingface\.co/(?!datasets/)(.+)",
+    "huggingface_dataset": r"huggingface\.co/datasets/(.+)",
+    "pypi": r"pypi\.org/project/([^/]+)",
+    "npm": r"npmjs\.com/package/(.+)",
+}
+
+
+def _urls(value: object) -> list[str]:
+    """Artifact values are lists of {url: ...}; tolerate a bare string too."""
+    if isinstance(value, str):
+        return [value]
+    out: list[str] = []
+    if isinstance(value, list):
+        for item in value:
+            if isinstance(item, dict) and isinstance(item.get("url"), str):
+                out.append(item["url"])
+            elif isinstance(item, str):
+                out.append(item)
+    return out
+
+
+def artifact_id(kind: str, url: str) -> str | None:
+    """Reduce a URL to the identifier the relevant API expects.
+
+    Returns None when the URL is not addressable as that artifact kind — an
+    org-level GitHub link, for instance, which names no repo.
+    """
+    trimmed = url.rstrip("/")
+    pattern = _ID_PATTERNS.get(kind)
+    if pattern is None:
+        return trimmed or None
+    match = re.search(pattern, trimmed)
+    if match is None:
+        return None
+    # The github pattern already requires owner/repo, so an org-level link fails
+    # to match above and is reported rather than silently reduced.
+    return match.group(1) or None
+
+
+def category_layers(taxonomy: dict) -> dict[str, tuple[str, str]]:
+    """Map category slug -> (arc name, layer slug), derived from the arcs."""
+    out: dict[str, tuple[str, str]] = {}
+    for arc in taxonomy.get("arcs") or []:
+        if not isinstance(arc, dict):
+            continue
+        name = arc.get("name")
+        layer = arc.get("layer")
+        for slug in arc.get("categories") or []:
+            if isinstance(slug, str) and isinstance(name, str) and isinstance(layer, str):
+                out[slug] = (name, layer)
+    return out
+
+
+def build_registry(sources: dict) -> tuple[dict[str, list[dict]], list[str], list[str]]:
+    """Return (tables, errors, warnings).
+
+    Errors are structural — a reference that points at nothing, a product with no
+    category or no organization. Those break any downstream join, so they fail.
+
+    Warnings are data-quality: an artifact URL that names no addressable resource,
+    such as a GitHub org rather than a repo. Those cost coverage but break nothing,
+    and choosing the right replacement is a curation decision, so they do not fail.
+    """
+    products: dict = sources["products"]
+    organizations: dict = sources["organizations"]
+    categories: dict = sources["categories"]
+    layers = category_layers(sources.get("taxonomy") or {})
+
+    tables: dict[str, list[dict]] = {name: [] for name in TABLES}
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    for slug, product in sorted(products.items()):
+        tables["products"].append(
+            {
+                "slug": slug,
+                "display_name": product.get("display_name", ""),
+                "type": product.get("type", ""),
+                "description": product.get("description", ""),
+                "comments": product.get("comments", ""),
+            }
+        )
+        for kind in ARTIFACT_KINDS:
+            for url in _urls(product.get(kind)):
+                identifier = artifact_id(kind, url)
+                if identifier is None:
+                    warnings.append(f"product '{slug}': {kind} url names no repo: {url}")
+                    continue
+                tables["product_artifacts"].append(
+                    {
+                        "product_slug": slug,
+                        "product_type": product.get("type", ""),
+                        "artifact_kind": kind,
+                        "artifact_id": identifier,
+                        "artifact_url": url,
+                    }
+                )
+        lineage = product.get("lineage")
+        if isinstance(lineage, dict):
+            for relation in LINEAGE_RELATIONS:
+                for target in lineage.get(relation) or []:
+                    if isinstance(target, str):
+                        tables["product_lineage"].append(
+                            {"product_slug": slug, "relation": relation, "target": target}
+                        )
+
+    for slug, org in sorted(organizations.items()):
+        tables["organizations"].append(
+            {
+                "slug": slug,
+                "display_name": org.get("display_name", ""),
+                "type": org.get("type", ""),
+                "homepage": org.get("homepage", ""),
+                "github": org.get("github", ""),
+                "country": org.get("country", ""),
+            }
+        )
+        for product_slug in org.get("products") or []:
+            if product_slug not in products:
+                errors.append(f"organization '{slug}' lists unknown product '{product_slug}'")
+                continue
+            tables["product_organizations"].append(
+                {"product_slug": product_slug, "org_slug": slug}
+            )
+
+    for slug, category in sorted(categories.items()):
+        arc_name, layer = layers.get(slug, ("", ""))
+        if not layer:
+            errors.append(f"category '{slug}' sits in no arc in taxonomy.yaml")
+        weights = category.get("weights") or {}
+        tables["categories"].append(
+            {
+                "slug": slug,
+                "display_name": category.get("display_name", ""),
+                "description": category.get("description", ""),
+                "strapline": category.get("strapline", ""),
+                "weight_adopt": weights.get("adopt", ""),
+                "weight_cap": weights.get("cap", ""),
+                "arc_name": arc_name,
+                "layer": layer,
+            }
+        )
+        for product_slug in category.get("products") or []:
+            if product_slug not in products:
+                errors.append(f"category '{slug}' lists unknown product '{product_slug}'")
+                continue
+            tables["product_categories"].append(
+                {"product_slug": product_slug, "category_slug": slug}
+            )
+
+    placed = {row["product_slug"] for row in tables["product_categories"]}
+    owned = {row["product_slug"] for row in tables["product_organizations"]}
+    for slug in sorted(set(products) - placed):
+        errors.append(f"product '{slug}' is in no category")
+    for slug in sorted(set(products) - owned):
+        errors.append(f"product '{slug}' has no organization")
+
+    return tables, errors, warnings
+
+
+def write_tables(tables: dict[str, list[dict]], out_dir: Path) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for name, columns in TABLES.items():
+        path = out_dir / f"{name}.csv"
+        with path.open("w", newline="", encoding="utf-8") as handle:
+            writer = csv.DictWriter(handle, fieldnames=list(columns))
+            writer.writeheader()
+            writer.writerows(tables[name])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="validate only, write nothing")
+    parser.add_argument("--out", type=Path, default=OUT_DIR, help="output directory")
+    args = parser.parse_args()
+
+    sources = load_sources(ROOT)
+    tables, errors, warnings = build_registry(sources)
+
+    for name in TABLES:
+        print(f"  {name:<22} {len(tables[name]):>5} rows")
+
+    if warnings:
+        print(f"\n{len(warnings)} warning(s) - coverage lost, nothing broken:")
+        for warning in warnings:
+            print(f"  - {warning}")
+
+    if errors:
+        print(f"\n{len(errors)} error(s) - these break downstream joins:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    if args.check:
+        print("\ncheck only: nothing written")
+        return 0
+
+    write_tables(tables, args.out)
+    print(f"\nwrote {len(TABLES)} CSVs to {args.out.relative_to(ROOT)}/")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_serialize_registry.py
+++ b/tests/test_serialize_registry.py
@@ -1,0 +1,124 @@
+"""Tests for the registry serializer.
+
+The registry is the identity layer — what exists — so these tests concentrate on
+the two things that would silently corrupt downstream joins: identifier parsing
+and reference integrity.
+"""
+
+from build.serialize_registry import TABLES, artifact_id, build_registry, category_layers
+
+
+def _sources(products=None, organizations=None, categories=None, taxonomy=None):
+    return {
+        "products": products or {},
+        "organizations": organizations or {},
+        "categories": categories or {},
+        "taxonomy": taxonomy or {"arcs": []},
+    }
+
+
+def test_artifact_id_reduces_urls_to_api_identifiers():
+    assert artifact_id("github", "https://github.com/allenai/OLMo") == "allenai/OLMo"
+    assert artifact_id("github", "https://github.com/allenai/OLMo/") == "allenai/OLMo"
+    assert (
+        artifact_id("huggingface_dataset", "https://huggingface.co/datasets/allenai/c4")
+        == "allenai/c4"
+    )
+    assert (
+        artifact_id("huggingface_model", "https://huggingface.co/allenai/Olmo-3-1025-7B")
+        == "allenai/Olmo-3-1025-7B"
+    )
+    assert artifact_id("pypi", "https://pypi.org/project/accelerate/") == "accelerate"
+
+
+def test_artifact_id_rejects_org_level_github_urls():
+    """An org page names no repo, so it cannot be measured as one."""
+    assert artifact_id("github", "https://github.com/arduino") is None
+    assert artifact_id("github", "https://github.com/lmstudio-ai") is None
+
+
+def test_huggingface_model_pattern_does_not_swallow_datasets():
+    assert artifact_id("huggingface_model", "https://huggingface.co/datasets/allenai/c4") is None
+
+
+def test_category_layer_is_derived_from_the_arc():
+    taxonomy = {
+        "arcs": [
+            {"name": "Model components", "layer": "model_components", "categories": ["base"]},
+            {"name": "Infrastructure", "layer": "infrastructure", "categories": ["deployment"]},
+        ]
+    }
+    layers = category_layers(taxonomy)
+    assert layers["base"] == ("Model components", "model_components")
+    assert layers["deployment"] == ("Infrastructure", "infrastructure")
+
+
+def test_membership_is_inverted_into_join_tables():
+    sources = _sources(
+        products={"olmo": {"display_name": "OLMo", "type": "model"}},
+        organizations={"ai2": {"display_name": "Ai2", "type": "nonprofit", "products": ["olmo"]}},
+        categories={"base": {"display_name": "Base", "weights": {}, "products": ["olmo"]}},
+        taxonomy={"arcs": [{"name": "Model components", "layer": "model_components", "categories": ["base"]}]},
+    )
+    tables, errors, warnings = build_registry(sources)
+    assert errors == []
+    assert warnings == []
+    assert tables["product_categories"] == [{"product_slug": "olmo", "category_slug": "base"}]
+    assert tables["product_organizations"] == [{"product_slug": "olmo", "org_slug": "ai2"}]
+
+
+def test_dangling_references_are_errors():
+    sources = _sources(
+        products={},
+        organizations={"ai2": {"products": ["ghost"]}},
+        categories={"base": {"weights": {}, "products": ["ghost"]}},
+        taxonomy={"arcs": [{"name": "A", "layer": "a", "categories": ["base"]}]},
+    )
+    _, errors, _ = build_registry(sources)
+    assert any("unknown product 'ghost'" in e for e in errors)
+
+
+def test_orphan_products_are_errors():
+    sources = _sources(
+        products={"lonely": {"display_name": "Lonely", "type": "software"}},
+    )
+    _, errors, _ = build_registry(sources)
+    assert any("'lonely' is in no category" in e for e in errors)
+    assert any("'lonely' has no organization" in e for e in errors)
+
+
+def test_category_outside_every_arc_is_an_error():
+    sources = _sources(categories={"floating": {"weights": {}, "products": []}})
+    _, errors, _ = build_registry(sources)
+    assert any("'floating' sits in no arc" in e for e in errors)
+
+
+def test_unaddressable_artifact_is_a_warning_not_an_error():
+    """Coverage is lost but no join breaks, and the fix is a curation decision."""
+    sources = _sources(
+        products={"lm-studio": {"type": "software", "github": [{"url": "https://github.com/lmstudio-ai"}]}},
+        organizations={"lms": {"products": ["lm-studio"]}},
+        categories={"ui": {"weights": {}, "products": ["lm-studio"]}},
+        taxonomy={"arcs": [{"name": "Product / UX", "layer": "product_ux", "categories": ["ui"]}]},
+    )
+    tables, errors, warnings = build_registry(sources)
+    assert errors == []
+    assert any("names no repo" in w for w in warnings)
+    assert tables["product_artifacts"] == []
+
+
+def test_every_declared_table_is_populated_or_present():
+    tables, _, _ = build_registry(_sources())
+    assert set(tables) == set(TABLES)
+
+
+def test_real_sources_serialize_without_structural_errors():
+    from pathlib import Path
+
+    from build.validate import load_sources
+
+    root = Path(__file__).resolve().parents[1]
+    tables, errors, _ = build_registry(load_sources(root))
+    assert errors == [], f"registry has structural errors: {errors[:5]}"
+    assert len(tables["products"]) == len(tables["product_categories"])
+    assert len(tables["products"]) == len(tables["product_organizations"])


### PR DESCRIPTION
Closes CUR-165.

## Why

The registry — which products, organizations and categories exist and how they relate — was only reachable two ways, and neither works for downstream consumers.

Parsing `sources/*.yaml` isn't possible where the consumers run. And the scored notebook payload is *derived* data that is meant to flow outward from the pipeline, not inward from the repo; consuming it would point the dependency the wrong way and make the repo a scoreboard rather than a registry.

So this adds the missing direction: the repo declares what exists, and CI pushes that declaration out.

## What

`build/serialize_registry.py` emits the declarative layer as seven flat CSVs:

| Table | Rows today |
|---|---|
| `products` | 501 |
| `organizations` | 258 |
| `categories` | 16 |
| `product_artifacts` | 478 |
| `product_categories` | 501 |
| `product_organizations` | 501 |
| `product_lineage` | 178 |

`build/publish_registry.py` uploads them and triggers materialization. It's idempotent — static models are created on first run and reused after — so it's safe on every push.

**Scores are excluded on purpose.** `sources/scores/` is not serialized here.

## Design notes

- **Membership is inverted.** Categories and organizations each list their products, so those lists become join tables rather than being duplicated onto the product.
- **`layer` is derived, never stored.** A category's layer is whichever arc contains it in `taxonomy.yaml`, matching the comment in that file. Storing it on the category as well is how the two drift apart.
- **Validation splits severity.** A dangling reference or an orphan product fails, because it breaks any downstream join. An artifact URL that names no addressable resource warns instead — it costs coverage without breaking anything, and choosing the replacement is a curation decision, not a build one.
- **Generated CSVs are gitignored.** The repo stays YAML; only OSO gets the flat mirror.

## Two warnings surfaced

Both are `github` artifacts pointing at an org rather than a repo, so they can't be measured as repos:

- `arduino-uno-q` → `https://github.com/arduino`
- `lm-studio` → `https://github.com/lmstudio-ai`

LM Studio may genuinely have no product repo, in which case the artifact kind is wrong rather than the URL. Left as warnings for a curation call.

## Test plan

- `uv run python -m build.serialize_registry --check` — passes, 2 warnings, 0 errors
- `uv run pytest` — 57 passed (11 new)
- `uv run python -m build.validate` — unchanged, passes
- Publisher exercised end to end against the live API: all seven tables uploaded and materializing under `currentai.registry.*`

## Requires

Two repo secrets before the `publish` job can run on main: `OSO_API_KEY` and `OSO_ORG_ID`.
