### PR TITLE
Add arxiv artifact kind and a candidate proposer

### DIFF
--- a/build/propose_arxiv.py
+++ b/build/propose_arxiv.py
@@ -1,0 +1,171 @@
+"""Propose arXiv identifiers for products, from evidence we already hold.
+
+Citation counts need an exact identifier. Matching papers by product name was
+measured at 2 correct out of 10: APPS resolved to a medical software paper with
+25k citations, MATH to a psychology paper with 3.4k. Both would have looked
+entirely credible in a table, which is the dangerous kind of wrong.
+
+So this proposes rather than decides. It gathers candidate arXiv ids from two
+places we already have and prints them with their evidence for review. Nothing is
+written to sources/ — a human picks the canonical paper and adds it.
+
+Two evidence routes:
+  1. arXiv links already present in a product's own yaml or its score sources.
+  2. `arxiv:` tags on the product's Hugging Face artifact. The Hub carries these
+     as first-class tags.
+
+Neither is authoritative. Route 2 in particular lists *cited* papers as well as
+the paper describing the artifact — cais/mmlu tags four, only one of which is the
+MMLU paper. Anything with more than one candidate is flagged REVIEW and needs a
+person to choose.
+
+Usage:
+    uv run python -m build.propose_arxiv                 # every product
+    uv run python -m build.propose_arxiv --category benchmark_eval_data
+    uv run python -m build.propose_arxiv --format yaml   # paste-ready snippets
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from build.validate import load_sources
+
+ROOT = Path(__file__).resolve().parents[1]
+HF_API = "https://huggingface.co/api"
+USER_AGENT = "os-ai-map-arxiv-proposer/1.0"
+
+ARXIV_RE = re.compile(r"(?:arxiv\.org/(?:abs|pdf)/|arxiv:)(\d{4}\.\d{4,5})", re.I)
+
+
+def _hf_ids(product: dict) -> list[tuple[str, str]]:
+    """Return (kind, hf_id) for the product's Hugging Face artifacts."""
+    out: list[tuple[str, str]] = []
+    for key, segment in (("huggingface_model", "models"), ("huggingface_dataset", "datasets")):
+        value = product.get(key)
+        entries = [value] if isinstance(value, str) else (value or [])
+        for entry in entries:
+            url = entry.get("url") if isinstance(entry, dict) else entry
+            if not isinstance(url, str):
+                continue
+            match = re.search(r"huggingface\.co/(?:datasets/)?(.+)", url.rstrip("/"))
+            if match:
+                out.append((segment, match.group(1)))
+    return out
+
+
+def _fetch_hf_tags(segment: str, hf_id: str, token: str | None) -> list[str]:
+    """arXiv ids from the Hub's tags. Returns [] on any failure — this is a hint,
+    not a dependency, so a Hub hiccup must not fail the whole proposal."""
+    headers = {"User-Agent": USER_AGENT}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(f"{HF_API}/{segment}/{hf_id}", headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=25) as response:
+            payload = json.load(response)
+    except (urllib.error.URLError, TimeoutError, ValueError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    tags = payload.get("tags")
+    if not isinstance(tags, list):
+        return []
+    return [t.split(":", 1)[1] for t in tags if isinstance(t, str) and t.startswith("arxiv:")]
+
+
+def propose(sources: dict, category: str | None, token: str | None) -> list[dict]:
+    products: dict = sources["products"]
+    categories: dict = sources["categories"]
+
+    wanted = set(products)
+    if category:
+        cat = categories.get(category)
+        if cat is None:
+            raise SystemExit(f"no such category: {category}")
+        wanted = {s for s in (cat.get("products") or []) if s in products}
+
+    rows: list[dict] = []
+    for slug in sorted(wanted):
+        product = products[slug]
+        if product.get("arxiv"):
+            continue  # already declared
+
+        from_yaml: list[str] = []
+        for text in (
+            (ROOT / "sources" / "products" / f"{slug}.yaml").read_text(),
+            (ROOT / "sources" / "scores" / f"{slug}.yaml").read_text()
+            if (ROOT / "sources" / "scores" / f"{slug}.yaml").exists()
+            else "",
+        ):
+            from_yaml.extend(ARXIV_RE.findall(text))
+
+        from_hub: list[str] = []
+        for segment, hf_id in _hf_ids(product):
+            from_hub.extend(_fetch_hf_tags(segment, hf_id, token))
+
+        candidates: list[str] = []
+        for value in from_yaml + from_hub:
+            if value not in candidates:
+                candidates.append(value)
+
+        if not candidates:
+            verdict = "NONE"
+        elif len(candidates) == 1:
+            verdict = "single"
+        else:
+            verdict = "REVIEW"
+
+        rows.append(
+            {
+                "slug": slug,
+                "display_name": product.get("display_name", slug),
+                "candidates": candidates,
+                "from_yaml": from_yaml,
+                "from_hub": from_hub,
+                "verdict": verdict,
+            }
+        )
+    return rows
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--category", help="limit to one category slug")
+    parser.add_argument("--format", choices=("table", "yaml"), default="table")
+    args = parser.parse_args()
+
+    token = os.environ.get("HUGGING_FACE_TOKEN") or os.environ.get("HF_TOKEN")
+    rows = propose(load_sources(ROOT), args.category, token)
+
+    if args.format == "yaml":
+        for row in rows:
+            if row["verdict"] == "single":
+                print(f"# {row['slug']} — {row['display_name']}")
+                print("arxiv:")
+                print(f"- url: https://arxiv.org/abs/{row['candidates'][0]}")
+                print()
+        print(f"# {sum(1 for r in rows if r['verdict'] == 'REVIEW')} products need a human choice")
+        print(f"# {sum(1 for r in rows if r['verdict'] == 'NONE')} have no candidate")
+        return 0
+
+    print(f"{'product':<26} {'verdict':<8} candidates (yaml | hub)")
+    for row in rows:
+        cands = ", ".join(row["candidates"]) or "-"
+        print(f"  {row['display_name'][:24]:<24} {row['verdict']:<8} {cands[:60]}")
+    counts = {v: sum(1 for r in rows if r["verdict"] == v) for v in ("single", "REVIEW", "NONE")}
+    print(f"\nsingle candidate (safe to accept): {counts['single']}")
+    print(f"multiple candidates (pick one):    {counts['REVIEW']}")
+    print(f"no candidate found:                {counts['NONE']}")
+    print("\nNothing written. Review, then add an `arxiv:` block to the product yaml.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build/serialize_registry.py
+++ b/build/serialize_registry.py
@@ -14,9 +14,16 @@ Emitted tables (one CSV each, written to build/registry/):
   categories            slug, display_name, description, strapline,
                         weight_adopt, weight_cap, arc_name, layer
   product_artifacts     product_slug, product_type, artifact_kind, artifact_id, artifact_url
+                        (kinds: github, huggingface_model, huggingface_dataset,
+                         pypi, npm, crates, arxiv)
   product_categories    product_slug, category_slug
   product_organizations product_slug, org_slug
   product_lineage       product_slug, relation, target
+
+`arxiv` exists so citation lookups join on an exact identifier. Matching papers
+by product name was measured at 2 correct out of 10 — APPS resolved to a medical
+software paper with 25k citations and MATH to a psychology paper with 3.4k, both
+of which would have looked entirely credible in a table.
 
 Two structural notes:
 
@@ -44,7 +51,15 @@ from build.validate import load_sources
 ROOT = Path(__file__).resolve().parents[1]
 OUT_DIR = ROOT / "build" / "registry"
 
-ARTIFACT_KINDS = ("github", "huggingface_model", "huggingface_dataset", "pypi", "npm", "crates")
+ARTIFACT_KINDS = (
+    "github",
+    "huggingface_model",
+    "huggingface_dataset",
+    "pypi",
+    "npm",
+    "crates",
+    "arxiv",
+)
 LINEAGE_RELATIONS = ("derived_from", "curated_with", "trains")
 
 TABLES: dict[str, tuple[str, ...]] = {
@@ -78,6 +93,9 @@ _ID_PATTERNS = {
     "huggingface_dataset": r"huggingface\.co/datasets/(.+)",
     "pypi": r"pypi\.org/project/([^/]+)",
     "npm": r"npmjs\.com/package/(.+)",
+    # Accept an abs/pdf URL or a bare id, and normalise to the bare id so the
+    # DOI is derivable as 10.48550/arXiv.<id> without further parsing.
+    "arxiv": r"(?:arxiv\.org/(?:abs|pdf)/)?(\d{4}\.\d{4,5})(?:v\d+)?",
 }
 
 

--- a/docs/schemas/product.schema.json
+++ b/docs/schemas/product.schema.json
@@ -2,38 +2,123 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Product",
   "type": "object",
-  "required": ["name", "display_name", "type"],
+  "required": [
+    "name",
+    "display_name",
+    "type"
+  ],
   "additionalProperties": false,
   "properties": {
-    "name": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
-    "display_name": { "type": "string", "minLength": 1 },
-    "type": { "enum": ["model", "software", "dataset", "hardware"] },
-    "description": { "type": "string" },
-    "comments": { "type": "string" },
-    "github": { "type": "array", "items": { "$ref": "#/definitions/url" } },
-    "npm": { "type": "array", "items": { "$ref": "#/definitions/url" } },
-    "pypi": { "type": "array", "items": { "$ref": "#/definitions/url" } },
-    "crates": { "type": "array", "items": { "$ref": "#/definitions/url" } },
-    "go": { "type": "array", "items": { "$ref": "#/definitions/url" } },
-    "huggingface_model": { "type": "array", "items": { "$ref": "#/definitions/url" } },
-    "huggingface_dataset": { "type": "array", "items": { "$ref": "#/definitions/url" } },
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]*$"
+    },
+    "display_name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "type": {
+      "enum": [
+        "model",
+        "software",
+        "dataset",
+        "hardware"
+      ]
+    },
+    "description": {
+      "type": "string"
+    },
+    "comments": {
+      "type": "string"
+    },
+    "github": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/url"
+      }
+    },
+    "npm": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/url"
+      }
+    },
+    "pypi": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/url"
+      }
+    },
+    "crates": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/url"
+      }
+    },
+    "go": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/url"
+      }
+    },
+    "huggingface_model": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/url"
+      }
+    },
+    "huggingface_dataset": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/url"
+      }
+    },
+    "arxiv": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/url"
+      }
+    },
     "lineage": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "derived_from": { "type": "array", "items": { "type": "string", "minLength": 1 } },
-        "curated_with": { "type": "array", "items": { "type": "string", "minLength": 1 } },
-        "trains": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+        "derived_from": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "curated_with": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "trains": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
       }
     }
   },
   "definitions": {
     "url": {
       "type": "object",
-      "required": ["url"],
+      "required": [
+        "url"
+      ],
       "additionalProperties": false,
       "properties": {
-        "url": { "type": "string", "pattern": "^https?://" }
+        "url": {
+          "type": "string",
+          "pattern": "^https?://"
+        }
       }
     }
   }

--- a/sources/products/ai2-arc.yaml
+++ b/sources/products/ai2-arc.yaml
@@ -10,3 +10,5 @@ comments: 'AI2 Reasoning Challenge (ARC), Allen Institute for AI (Clark et al. 2
   7,787 grade-school science multiple-choice questions: ARC-Challenge (2,590) + ARC-Easy (5,197). Foundational
   LLM commonsense/reasoning benchmark, still a standard in 2026 model release reports. Verified live June
   2026 on huggingface.co/datasets/allenai/ai2_arc.'
+arxiv:
+- url: https://arxiv.org/abs/1803.05457

--- a/sources/products/apps.yaml
+++ b/sources/products/apps.yaml
@@ -13,3 +13,5 @@ huggingface_dataset:
 comments: 'APPS (Hendrycks et al., NeurIPS 2021, arXiv 2105.09938): 10,000 coding problems (5,000 train
   / 5,000 test) with 131,777 test cases, Introductory/Interview/Competition difficulty, Python solutions.
   HF dataset (codeparrot/apps) verified live June 2026 (13,834 monthly downloads, MIT).'
+arxiv:
+- url: https://arxiv.org/abs/2105.09938

--- a/sources/products/codecontests.yaml
+++ b/sources/products/codecontests.yaml
@@ -15,3 +15,5 @@ comments: 'CodeContests (deepmind/code_contests), competitive-programming datase
   with public/private/generated test cases and correct+incorrect human solutions in multiple languages.
   Verified live on HF June 2026 (~56k downloads last month). [Verifier note: original record stated 13,328
   train; HF dataset viewer shows 3,760 train / 4,044 total; corrected.]'
+arxiv:
+- url: https://arxiv.org/abs/2203.07814

--- a/sources/products/cruxeval.yaml
+++ b/sources/products/cruxeval.yaml
@@ -17,3 +17,5 @@ comments: 'CRUXEval (Code Reasoning, Understanding, and eXecution Evaluation) by
   Leather, Solar-Lezama, Synnaeve, Wang; arXiv 2401.03065, 2024). 800 Python functions with input/output
   pairs; two tasks: CRUXEval-I (input prediction) + CRUXEval-O (output prediction). Verified live June
   2026 on github.com/facebookresearch/cruxeval.'
+arxiv:
+- url: https://arxiv.org/abs/2401.03065

--- a/sources/products/evalplus.yaml
+++ b/sources/products/evalplus.yaml
@@ -9,3 +9,5 @@ description: HumanEval+ and MBPP+ extend the original benchmarks with 80x and 35
 comments: 'EvalPlus framework + datasets: HumanEval+ (164 problems, 80x more tests than original HumanEval)
   and MBPP+ (35x more tests than original MBPP), plus EvalPerf. Apache-2.0. HumanEval+ HF dataset verified
   live June 2026 (25,817 monthly downloads). Published NeurIPS 2023 (EvalPlus) / COLM 2024 (EvalPerf).'
+arxiv:
+- url: https://arxiv.org/abs/2305.01210

--- a/sources/products/gaia.yaml
+++ b/sources/products/gaia.yaml
@@ -9,3 +9,5 @@ huggingface_dataset:
 - url: https://huggingface.co/datasets/gaia-benchmark/GAIA
 comments: 'Double-gated: test-set answers held out (server-side scoring) AND the HF dataset is access-gated (accept
   terms, anti-resharing clause). ~42k monthly downloads.'
+arxiv:
+- url: https://arxiv.org/abs/2311.12983

--- a/sources/products/gpqa.yaml
+++ b/sources/products/gpqa.yaml
@@ -9,3 +9,5 @@ huggingface_dataset:
 comments: GPQA (Graduate-Level Google-Proof Q&A), 448 expert-written multiple-choice questions in biology/physics/chemistry;
   the 198-question 'GPQA Diamond' high-quality subset is the headline benchmark cited in most 2025-2026
   frontier model reports. Paper arXiv:2311.12022. HF dataset Idavidrein/gpqa verified live June 2026.
+arxiv:
+- url: https://arxiv.org/abs/2311.12022

--- a/sources/products/gsm8k.yaml
+++ b/sources/products/gsm8k.yaml
@@ -9,3 +9,5 @@ huggingface_dataset:
 comments: GSM8K (openai/gsm8k), 8.5K grade-school math word problems (7,473 train / 1,319 test), ~5.9
   MB, 'main' + 'socratic' configs. From 'Training Verifiers to Solve Math Word Problems' (arXiv:2110.14168).
   Verified live on HF June 2026 (~948k downloads last month).
+arxiv:
+- url: https://arxiv.org/abs/2110.14168

--- a/sources/products/hellaswag.yaml
+++ b/sources/products/hellaswag.yaml
@@ -10,3 +10,5 @@ comments: HellaSwag (Zellers et al., ACL 2019), commonsense NLI sentence-complet
   examples (39,905 train / 10,042 val / 10,003 test); 4-way multiple-choice over ActivityNet-derived contexts.
   Canonical commonsense benchmark reported in nearly every LLM release. Verified live June 2026 on huggingface.co/datasets/Rowan/hellaswag.
   Registry attributes to AI2/Allen Institute; primary authors are UW/AI2 (Rowan Zellers).
+arxiv:
+- url: https://arxiv.org/abs/1905.07830

--- a/sources/products/humaneval.yaml
+++ b/sources/products/humaneval.yaml
@@ -12,3 +12,5 @@ huggingface_dataset:
 comments: HumanEval (openai/openai_humaneval), 164 hand-written Python problems (prompt + canonical solution
   + unit tests), single test split, ~92 kB. From 'Evaluating LLMs Trained on Code' (Codex paper, arXiv:2107.03374).
   Verified live on HF June 2026 (~287k downloads last month).
+arxiv:
+- url: https://arxiv.org/abs/2107.03374

--- a/sources/products/humanitys-last-exam.yaml
+++ b/sources/products/humanitys-last-exam.yaml
@@ -12,3 +12,5 @@ huggingface_dataset:
 comments: The 2,500 public questions include answers under MIT, but the HF dataset is access-gated (accept conditions,
   no-redistribution + canary string) and a separate private held-out set detects overfitting -> scored gated (a
   license-weighted reading could argue open). ~35k monthly downloads.
+arxiv:
+- url: https://arxiv.org/abs/2501.14249

--- a/sources/products/ifeval.yaml
+++ b/sources/products/ifeval.yaml
@@ -9,3 +9,5 @@ huggingface_dataset:
 comments: IFEval (Instruction-Following Eval), 541 prompts with ~25 verifiable instruction types for programmatic
   (rule-based) scoring of LLM instruction-following. Paper arXiv:2311.07911. A core component of the HF
   Open LLM Leaderboard. HF dataset google/IFEval verified live June 2026.
+arxiv:
+- url: https://arxiv.org/abs/2311.07911

--- a/sources/products/livebench.yaml
+++ b/sources/products/livebench.yaml
@@ -9,3 +9,5 @@ github:
 - url: https://github.com/livebench/livebench
 comments: Questions and ground-truth answers public (Apache-2.0/MIT). ~1.2k stars; multi-category HF dataset downloads.
   Monthly rotation is freshness management, not gating.
+arxiv:
+- url: https://arxiv.org/abs/2406.19314

--- a/sources/products/livecodebench.yaml
+++ b/sources/products/livecodebench.yaml
@@ -15,3 +15,5 @@ comments: LiveCodeBench code_generation_lite, release_v5 = 880 problems (May 202
   continuously-updated contamination-free coding benchmark (problems from LeetCode/AtCoder/Codeforces)
   covering code generation, self-repair, test-output prediction, execution. HF dataset verified live June
   2026 (71,393 monthly downloads).
+arxiv:
+- url: https://arxiv.org/abs/2403.07974

--- a/sources/products/math.yaml
+++ b/sources/products/math.yaml
@@ -10,3 +10,5 @@ comments: 'MATH (Hendrycks et al., NeurIPS 2021, arXiv 2103.03874): 12,500 compe
   train / 5,000 test) with step-by-step LaTeX solutions, Level 1-5, 7 subjects. Original HF dataset (hendrycks/competition_math)
   verified June 2026 but ACCESS DISABLED via DMCA takedown; no longer redistributable from the canonical
   registry; license tag is MIT.'
+arxiv:
+- url: https://arxiv.org/abs/2103.03874

--- a/sources/products/mbpp.yaml
+++ b/sources/products/mbpp.yaml
@@ -11,3 +11,5 @@ huggingface_dataset:
 comments: MBPP (google-research-datasets/mbpp), ~974 crowd-sourced basic Python problems (full) + 427
   hand-verified (sanitized); splits train/test/validation/prompt. From 'Program Synthesis with LLMs' (Austin
   et al., arXiv:2108.07732). Verified live on HF June 2026 (~198k downloads last month).
+arxiv:
+- url: https://arxiv.org/abs/2108.07732

--- a/sources/products/mmlu-pro.yaml
+++ b/sources/products/mmlu-pro.yaml
@@ -9,3 +9,5 @@ huggingface_dataset:
 comments: MMLU-Pro, ~12,032 questions across 14 disciplines with 10 answer options (vs MMLU's 4), expert-reviewed
   and contamination-hardened; test split (12,000) + small validation (70). Paper arXiv:2406.01574. HF
   dataset TIGER-Lab/MMLU-Pro verified live June 2026.
+arxiv:
+- url: https://arxiv.org/abs/2406.01574

--- a/sources/products/mmlu.yaml
+++ b/sources/products/mmlu.yaml
@@ -10,3 +10,5 @@ comments: 'MMLU (Massive Multitask Language Understanding; Hendrycks et al., ICL
   57 subjects, ~14,042 test questions (231,400 total rows incl. auxiliary_train), 4-option multiple choice.
   HF dataset (cais/mmlu) verified live June 2026 (541,723 monthly downloads, MIT). Note: now largely saturated
   (top models 88-94%) and largely superseded by MMLU-Pro for frontier differentiation.'
+arxiv:
+- url: https://arxiv.org/abs/2009.03300

--- a/sources/products/mmmu.yaml
+++ b/sources/products/mmmu.yaml
@@ -13,3 +13,5 @@ comments: 'MMMU (Massive Multi-discipline Multimodal Understanding), ~11,550 col
   900 / test 10,500. Test-set answers were previously held out behind EvalAI but were RELEASED on 2026-02-12,
   so all splits are now publicly answerable. CVPR 2024, paper arXiv:2311.16502. HF dataset MMMU/MMMU verified
   live June 2026.'
+arxiv:
+- url: https://arxiv.org/abs/2311.16502

--- a/sources/products/mt-bench.yaml
+++ b/sources/products/mt-bench.yaml
@@ -10,3 +10,5 @@ huggingface_dataset:
 - url: https://huggingface.co/datasets/lmsys/mt_bench_human_judgments
 comments: Questions + GPT-4 reference answers public in FastChat (Apache-2.0); companion human-judgments dataset
   is CC-BY-4.0. Small (80 Q) and partly saturated now.
+arxiv:
+- url: https://arxiv.org/abs/2306.05685

--- a/sources/products/multipl-e.yaml
+++ b/sources/products/multipl-e.yaml
@@ -13,3 +13,5 @@ comments: 'MultiPL-E: translations of HumanEval (161 problems) and MBPP (397 pro
   languages (Ada, Clojure, C++, C#, D, Dart, Elixir, Go, Haskell, Java, Julia, JS, Lua, OCaml, PHP, Perl,
   R, Ruby, Racket, Rust, Scala, Shell, Swift, TS). HF dataset (nuprl/MultiPL-E, 47 subsets) verified live
   June 2026; integrated into the BigCode evaluation harness. arXiv 2208.08227 (IEEE TSE).'
+arxiv:
+- url: https://arxiv.org/abs/2208.08227

--- a/sources/products/swe-bench-verified.yaml
+++ b/sources/products/swe-bench-verified.yaml
@@ -15,3 +15,5 @@ huggingface_dataset:
 comments: SWE-bench Verified (princeton-nlp/SWE-bench_Verified), 500 human-validated GitHub issue-resolution
   task instances (~2.1 MB) curated by OpenAI from the SWE-bench test set. Leaderboard at swebench.com.
   Verified live on HF June 2026 (~914k downloads last month).
+arxiv:
+- url: https://arxiv.org/abs/2310.06770

--- a/sources/products/truthfulqa.yaml
+++ b/sources/products/truthfulqa.yaml
@@ -11,3 +11,5 @@ comments: TruthfulQA, 817 questions across 38 categories crafted to elicit imita
   generation + multiple_choice configs. Paper arXiv:2109.07958 (2021). Now relatively dated and saturated
   by frontier models but still a widely-cited truthfulness benchmark. HF dataset truthfulqa/truthful_qa
   verified live June 2026.
+arxiv:
+- url: https://arxiv.org/abs/2109.07958

--- a/tests/test_serialize_registry.py
+++ b/tests/test_serialize_registry.py
@@ -122,3 +122,43 @@ def test_real_sources_serialize_without_structural_errors():
     assert errors == [], f"registry has structural errors: {errors[:5]}"
     assert len(tables["products"]) == len(tables["product_categories"])
     assert len(tables["products"]) == len(tables["product_organizations"])
+
+
+def test_arxiv_ids_normalise_from_every_form():
+    """URL, bare id, arxiv: prefix and version suffix all reduce to the bare id,
+    so the DOI is derivable as 10.48550/arXiv.<id> without further parsing."""
+    assert artifact_id("arxiv", "https://arxiv.org/abs/2110.14168") == "2110.14168"
+    assert artifact_id("arxiv", "https://arxiv.org/pdf/2009.03300v3") == "2009.03300"
+    assert artifact_id("arxiv", "arxiv:1803.05457") == "1803.05457"
+    assert artifact_id("arxiv", "2311.12022") == "2311.12022"
+
+
+def test_arxiv_rejects_non_identifiers():
+    assert artifact_id("arxiv", "https://arxiv.org/abs/not-an-id") is None
+    assert artifact_id("arxiv", "") is None
+
+
+def test_arxiv_artifacts_serialize_like_any_other_kind():
+    sources = _sources(
+        products={
+            "gsm8k": {
+                "display_name": "GSM8K",
+                "type": "dataset",
+                "arxiv": [{"url": "https://arxiv.org/abs/2110.14168"}],
+            }
+        },
+        organizations={"openai": {"products": ["gsm8k"]}},
+        categories={"bench": {"weights": {}, "products": ["gsm8k"]}},
+        taxonomy={"arcs": [{"name": "Model components", "layer": "model_components", "categories": ["bench"]}]},
+    )
+    tables, errors, _ = build_registry(sources)
+    assert errors == []
+    assert tables["product_artifacts"] == [
+        {
+            "product_slug": "gsm8k",
+            "product_type": "dataset",
+            "artifact_kind": "arxiv",
+            "artifact_id": "2110.14168",
+            "artifact_url": "https://arxiv.org/abs/2110.14168",
+        }
+    ]


### PR DESCRIPTION
Follows #98. Unblocks citation-based capability scoring for the benchmark/eval datasets category, which today has no capability basis at all — 23 of its 27 products are scored `n/a`.

## Why an identifier, not a name

I tested matching benchmark papers to OpenAlex by product name across 10 products. **Two were correct.** The failures were not near-misses:

| Product | Top match by name | Cites |
|---|---|---|
| **APPS** | "Rayyan—a web and mobile app for systematic reviews" | 25,313 |
| **MATH** | "Stereotype Threat and Women's Math Performance" | 3,405 |
| HumanEval | "CodeGeeX: A Pre-Trained Model for Code Generation" | 236 |
| GSM8K | a paper *about* GSM8K, not GSM8K | 11 |

Short generic names are hopeless by title, and the wrong answers carry large citation counts that look entirely plausible downstream. So the fix is an exact identifier in the registry.

## What's here

**`arxiv` as an artifact kind.** Accepts `https://arxiv.org/abs/2110.14168`, `https://arxiv.org/pdf/2009.03300v3`, `arxiv:1803.05457` or a bare `2311.12022`, and normalises to the bare id. That makes the DOI derivable as `10.48550/arXiv.<id>`, which OpenAlex resolves exactly.

**`build/propose_arxiv.py`**, which does the legwork without making the call. It pulls candidates from two sources we already hold:

1. arXiv links already in a product's yaml or its score sources
2. `arxiv:` tags on the product's Hugging Face artifact — the Hub carries these as first-class tags

Run against `benchmark_eval_data`:

```
single candidate (safe to accept): 16
multiple candidates (pick one):     4
no candidate found:                 7
```

Spot-checking the singles: HumanEval → 2107.03374, GSM8K → 2110.14168, SWE-bench → 2310.06770, MMLU-Pro → 2406.01574, TruthfulQA → 2109.07958. All correct.

## It proposes, it does not decide

Hub tags list *cited* papers alongside the describing paper. `cais/mmlu` tags four ids, only one of which is the MMLU paper. So multi-candidate products are flagged `REVIEW` rather than guessed at, and the script writes nothing to `sources/`.

The four needing a human: APPS, CodeContests, MMLU, MultiPL-E.

Of the seven with no candidate, three look **legitimately paperless** — Anthropic Internal Coding Evals, OpenAI Internal Evals, Scale SEAL Leaderboard. That is a fact about them rather than missing data, and arguably a signal in itself: an eval nobody can cite is a different artifact from one with thousands of citations. The other four (MATH, HLE, EvalPlus, Compar:IA Datasets) likely do have papers and need a manual lookup.

Hub lookups fail soft — a Hub outage degrades a hint rather than failing the run.

## Test plan

- `uv run pytest` — 60 passed (3 new, covering id normalisation, rejection of non-ids, and end-to-end serialization of an arxiv artifact)
- `uv run python -m build.serialize_registry --check` — passes, same 2 pre-existing warnings, 0 errors
- `uv run python -m build.propose_arxiv --category benchmark_eval_data` — output above

## Next

Once ids are added to `sources/`, the OpenAlex UDM is a lookup by DOI with no fuzzy matching, and the benchmark/eval category gets its first capability basis.
