### PR TITLE
Machine-readable scoring rubric: base / pretrained models (pilot)

### DIFF
--- a/build/check_rubric.py
+++ b/build/check_rubric.py
@@ -1,0 +1,217 @@
+"""Verify a category's `scoring_recipe` reproduces its hand-authored scores.
+
+The rubric in each category YAML was reverse-engineered from scores humans wrote.
+That only stays true if something checks it. This replays the rubric's formula
+against every product's recorded evidence and compares the result to the recorded
+score.
+
+Two ways this earns its place:
+
+  * **Before layer-2 exists**, it proves the rubric is a faithful description of
+    how the category was actually scored, rather than a plausible-looking
+    invention. A rubric that cannot reproduce the past should not be trusted to
+    write the future.
+  * **After layer-2 exists**, it is the regression test for rubric edits. Changing
+    a threshold should produce a small, explainable diff. If a one-line change
+    moves 30 products, that is the signal to stop.
+
+It reads the openness `components` string, which is the evidence the human
+recorded. It does NOT re-research anything — this checks the formula, not the
+facts.
+
+Exit status is 1 on any mismatch, so CI can gate on it.
+
+Usage:
+    uv run python -m build.check_rubric                        # every category with a recipe
+    uv run python -m build.check_rubric --category base_pretrained
+    uv run python -m build.check_rubric --verbose              # show every product
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def split_components(text: str) -> dict[str, str]:
+    """Parse the `k:v;k:v` components string into a dict.
+
+    Splits on `;` only at paren depth zero. Values routinely contain semicolons
+    inside parentheses — 'license:Apache-2.0(OSI; see LICENSE)' — and a naive
+    split silently invents dimensions out of the fragments.
+    """
+    parts: list[str] = []
+    depth = 0
+    current = ""
+    for char in text:
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth = max(0, depth - 1)
+        if char == ";" and depth == 0:
+            parts.append(current)
+            current = ""
+        else:
+            current += char
+    if current.strip():
+        parts.append(current)
+
+    out: dict[str, str] = {}
+    for part in parts:
+        if ":" not in part:
+            continue
+        key, value = part.split(":", 1)
+        out[key.strip()] = value.strip()
+    return out
+
+
+def head(value: str) -> str:
+    """The bare value, before any parenthetical or comma-separated detail."""
+    return re.split(r"[(,]", value)[0].strip()
+
+
+def normalise_license(raw: str) -> str:
+    """Reduce a recorded licence string to the licence that governs the weights.
+
+    Two forms in the data need flattening, both spelled out in the recipe's
+    `normalisation` list:
+      * `code MIT + model DeepSeek-Model-License` — the model licence governs,
+        because it is the one attached to the artifact being scored.
+      * `assumed-Modified-MIT` — the `assumed-` prefix marks confidence, not a
+        different licence.
+    Purely mechanical. Anything needing judgment is left alone to be flagged.
+    """
+    value = head(raw)
+    if "+" in value and "model" in value.lower():
+        value = value.split("+")[-1]
+        value = re.sub(r"(?i)^\s*model\s+", "", value)
+    value = re.sub(r"(?i)^assumed-", "", value.strip())
+    return value.strip()
+
+
+def license_tier(raw: str, recipe: dict) -> str | None:
+    """Map a licence string onto a tier from the recipe's own examples.
+
+    Returns None when the licence is unmapped, which is a finding rather than an
+    error — an unmapped licence means the rubric has not yet been told how to
+    treat it, and `mixed` means the evidence never recorded the outcome.
+    """
+    tiers = ((recipe.get("openness") or {}).get("license_tier") or {}).get("values") or {}
+    needle = normalise_license(raw).lower()
+    for name, spec in tiers.items():
+        for example in (spec or {}).get("examples") or []:
+            if example.lower() == needle:
+                return name
+    # Proprietary is the one tier defined by meaning rather than an example list.
+    if needle in ("proprietary", "closed", "none"):
+        return "proprietary"
+    return None
+
+
+def matches(rule_when: dict, facts: dict) -> bool:
+    return all(facts.get(key) == value for key, value in rule_when.items())
+
+
+def apply_formula(recipe: dict, facts: dict) -> tuple[int, str] | None:
+    """Walk the ordered rules, first match wins."""
+    for rule in (recipe.get("openness") or {}).get("formula") or []:
+        if "otherwise" in rule:
+            result = rule["otherwise"]
+            return result["score"], result["class"]
+        if matches(rule.get("when") or {}, facts):
+            result = rule["then"]
+            return result["score"], result["class"]
+    return None
+
+
+def check_category(slug: str, verbose: bool) -> tuple[int, int, list[str]]:
+    """Return (reproduced, total, problems)."""
+    category = yaml.safe_load((ROOT / "sources" / "categories" / f"{slug}.yaml").read_text())
+    recipe = category.get("scoring_recipe")
+    if not recipe:
+        return 0, 0, []
+
+    reproduced = 0
+    total = 0
+    problems: list[str] = []
+
+    for product in category.get("products") or []:
+        path = ROOT / "sources" / "scores" / f"{product}.yaml"
+        if not path.exists():
+            continue
+        scores = yaml.safe_load(path.read_text())
+        openness = scores.get("openness") or {}
+        components = split_components(openness.get("components") or "")
+        total += 1
+
+        raw_license = components.get("license", "")
+        tier = license_tier(raw_license, recipe)
+        if tier is None:
+            problems.append(
+                f"{product}: licence {raw_license!r} maps to no tier "
+                f"(recorded {openness.get('score')} {openness.get('class')})"
+            )
+            continue
+
+        facts = {
+            "weights": head(components.get("weights", "")),
+            "data": head(components.get("data", "")),
+            "code": head(components.get("code", "")),
+            "license_tier": tier,
+        }
+        got = apply_formula(recipe, facts)
+        expected = (openness.get("score"), openness.get("class"))
+
+        if got == expected:
+            reproduced += 1
+            if verbose:
+                print(f"  ok    {product:<24} {expected[0]} {expected[1]}")
+        else:
+            problems.append(
+                f"{product}: rubric says {got}, scores say {expected} "
+                f"[weights={facts['weights']} data={facts['data']} "
+                f"code={facts['code']} tier={tier}]"
+            )
+
+    return reproduced, total, problems
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--category", help="limit to one category slug")
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+
+    slugs = (
+        [args.category]
+        if args.category
+        else sorted(p.stem for p in (ROOT / "sources" / "categories").glob("*.yaml"))
+    )
+
+    failed = False
+    checked_any = False
+    for slug in slugs:
+        reproduced, total, problems = check_category(slug, args.verbose)
+        if total == 0:
+            continue
+        checked_any = True
+        status = "OK" if not problems else "FAIL"
+        print(f"{slug}: {reproduced}/{total} reproduced  [{status}]")
+        for problem in problems:
+            print(f"  ! {problem}")
+        if problems:
+            failed = True
+
+    if not checked_any:
+        print("no category defines a scoring_recipe yet")
+        return 0
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build/check_rubric.py
+++ b/build/check_rubric.py
@@ -75,15 +75,15 @@ def head(value: str) -> str:
     return re.split(r"[(,]", value)[0].strip()
 
 
-def normalise_license(raw: str) -> str:
-    """Reduce a recorded licence string to the licence that governs the weights.
+def normalize_license(raw: str) -> str:
+    """Reduce a recorded license string to the license that governs the weights.
 
     Two forms in the data need flattening, both spelled out in the recipe's
-    `normalisation` list:
-      * `code MIT + model DeepSeek-Model-License` — the model licence governs,
+    `normalization` list:
+      * `code MIT + model DeepSeek-Model-License` — the model license governs,
         because it is the one attached to the artifact being scored.
       * `assumed-Modified-MIT` — the `assumed-` prefix marks confidence, not a
-        different licence.
+        different license.
     Purely mechanical. Anything needing judgment is left alone to be flagged.
     """
     value = head(raw)
@@ -95,14 +95,14 @@ def normalise_license(raw: str) -> str:
 
 
 def license_tier(raw: str, recipe: dict) -> str | None:
-    """Map a licence string onto a tier from the recipe's own examples.
+    """Map a license string onto a tier from the recipe's own examples.
 
-    Returns None when the licence is unmapped, which is a finding rather than an
-    error — an unmapped licence means the rubric has not yet been told how to
+    Returns None when the license is unmapped, which is a finding rather than an
+    error — an unmapped license means the rubric has not yet been told how to
     treat it, and `mixed` means the evidence never recorded the outcome.
     """
     tiers = ((recipe.get("openness") or {}).get("license_tier") or {}).get("values") or {}
-    needle = normalise_license(raw).lower()
+    needle = normalize_license(raw).lower()
     for name, spec in tiers.items():
         for example in (spec or {}).get("examples") or []:
             if example.lower() == needle:
@@ -153,7 +153,7 @@ def check_category(slug: str, verbose: bool) -> tuple[int, int, list[str]]:
         tier = license_tier(raw_license, recipe)
         if tier is None:
             problems.append(
-                f"{product}: licence {raw_license!r} maps to no tier "
+                f"{product}: license {raw_license!r} maps to no tier "
                 f"(recorded {openness.get('score')} {openness.get('class')})"
             )
             continue

--- a/sources/categories/base_pretrained.yaml
+++ b/sources/categories/base_pretrained.yaml
@@ -6,6 +6,172 @@ strapline: The frontier is open-weights, not open source. Only a handful of fami
 weights:
   adopt: 0.3
   cap: 0.7
+
+# Machine-readable rubric for this category. Drives layer-2: the evidence
+# checklist tells the research stage what to hunt for, the formula turns stored
+# evidence into a score. Not hand-designed — reverse-engineered from the 47
+# hand-authored scores in sources/scores/ on 2026-07-28 and verified to reproduce
+# all 47 exactly (build/check_rubric.py). Changing it should produce an
+# explainable diff, so change the rubric here rather than editing scores directly.
+scoring_recipe:
+  version: 1
+  derived_from:
+    method: reverse-engineered from hand-authored scores, then verified
+    scores_reproduced: 47
+    scores_total: 47
+    verified_on: '2026-07-28'
+    checker: build/check_rubric.py
+
+  openness:
+    # Four dimensions were asked of all 47 products; checkpoints of 6. These are
+    # the questions, taken from what the category has actually been scoring.
+    dimensions:
+      weights:
+        question: Are the trained model weights downloadable and runnable locally?
+        values: [open, closed, pending]
+        evidence:
+        - Hugging Face model repo with downloadable weight files (safetensors/GGUF)
+        - vendor download page or torrent for weights outside the Hub
+        - '`pending` only where a release is announced with a date but not yet shipped'
+        machine_signal: signal_huggingface.hub_state (gated, private, files)
+      data:
+        question: Is the pretraining corpus released, or reconstructible from released scripts?
+        values: [open, documented-not-released, closed]
+        evidence:
+        - a released dataset, or scripts that reconstruct the corpus end to end
+        - '`documented-not-released` where composition is fully described but no
+          data or scripts ship'
+        - a data card describing sources is NOT sufficient for `open`
+        machine_signal: none — requires research
+      code:
+        question: Is the training pipeline released, not just inference code?
+        values: [open, partial, closed]
+        evidence:
+        - '`open`: full pretraining pipeline (data prep, training recipe, configs)'
+        - '`partial`: inference or fine-tuning code only, which is the common case'
+        - '`closed`: no code, or evaluation harness only'
+        machine_signal: partial — repo presence from signal_github.repo_state
+      checkpoints:
+        question: Are intermediate training checkpoints published?
+        values: [open, not-released]
+        optional: true
+        note: Scored for only 6 of 47. Absence is not evidence of `not-released`.
+        evidence:
+        - intermediate checkpoints on HF branches or a public mirror
+        machine_signal: none — requires research
+
+    # The discriminator that decides restricted vs open_weights. OSI approval
+    # alone is too blunt: several non-OSI licences are permissive in substance.
+    # The line is whether the licence restricts USE, not whether OSI blessed it.
+    license_tier:
+      values:
+        osi:
+          definition: OSI-approved licence
+          examples: [Apache-2.0, MIT, BSD-3-Clause]
+        permissive_non_osi:
+          definition: >
+            Not OSI-approved but imposes no use restriction. Attribution or
+            naming requirements alone belong here.
+          examples: [Modified-MIT, DeepSeek-Model-License, minimax-community, NVIDIA-Open-Model-License]
+        use_restricted:
+          definition: >
+            Caps or gates use — monthly-active-user ceilings, field-of-use limits,
+            research-only terms, or a commercial agreement requirement.
+          examples: [Llama-3.1-Community-License, Llama-4-Community, Gemma-License, Mistral-Research-License, TII-Falcon-License-2.0, glm-4, Qwen-License-Agreement]
+        proprietary:
+          definition: No public licence; weights not distributed.
+      multi_sku_rule: >
+        Where a family ships SKUs under different licences, the most restrictive
+        licence among the SKUs WHOSE WEIGHTS ARE ACTUALLY DISTRIBUTED governs.
+        API-only and hosted-only tiers are excluded: they are a different product
+        surface, and this axis scores the artifact you can download. That
+        distinction is what separates the two families previously both recorded
+        as `mixed` — Qwen 2.5 distributes 3B/72B under the Qwen License, which
+        caps the family at use_restricted, while Qwen 3's restrictive Plus/Max
+        tiers are never distributed at all, leaving the distributed set Apache.
+        Per-SKU licences come from signal_huggingface.hub_state, so this is
+        derivable rather than judged.
+      normalisation:
+      - 'compound `code X + model Y`: the MODEL licence governs, since it is the
+        one attached to the weights'
+      - 'prefix `assumed-`: same tier as the licence named, but confidence drops
+        to medium until the release confirms it'
+      never_use:
+        mixed: >
+          Records that SKUs differ without recording the outcome, so the score
+          cannot be reproduced from the evidence. Apply multi_sku_rule and store
+          the resolved tier instead.
+        unknown: Research it or leave the product unscored.
+
+    # Ordered rules, first match wins.
+    formula:
+    - when: {weights: closed}
+      then: {score: 1, class: closed}
+    - when: {license_tier: proprietary}
+      then: {score: 1, class: closed}
+    - when: {license_tier: use_restricted}
+      then: {score: 2, class: restricted}
+      note: Open weights behind a use cap. Downloadable is not the same as usable.
+    - when: {data: open, code: open, license_tier: osi}
+      then: {score: 5, class: open_source}
+    - when: {data: open, code: open}
+      then: {score: 4, class: open_weights}
+      note: Full pipeline but a non-OSI licence caps the score at 4.
+    - when: {data: documented-not-released, code: open}
+      then: {score: 4, class: open_weights}
+    - otherwise: {score: 3, class: open_weights}
+      note: The category's centre of gravity — open weights, closed data.
+
+  adoption:
+    # Signal choice follows openness: a closed model has no artifact to measure,
+    # so the axis falls back to reported figures. 29 of 47 are usage_volume,
+    # 14 reported_traction, 3 active_users, 1 stars_fallback.
+    signal_preference:
+    - signal_type: usage_volume
+      source: Hugging Face downloads, summed across the family's shipped SKUs
+      machine_signal: signal_huggingface.hub_state
+    - signal_type: active_users
+      source: vendor-disclosed MAU or seat counts
+    - signal_type: reported_traction
+      source: >
+        Credible third-party or vendor-reported reach where no artifact exists.
+        Directional only — set confidence to medium at best.
+    - signal_type: stars_fallback
+      source: GitHub stars, last resort
+      machine_signal: signal_github.repo_state
+    bands:
+    - {level: 1, reach: <10K}
+    - {level: 2, reach: 10K-100K}
+    - {level: 3, reach: 100K-1M}
+    - {level: 4, reach: 1M-10M}
+    - {level: 5, reach: '>10M'}
+    reach_is_monthly: true
+    note: >
+      Bands are monthly figures. Sum across the family's SKUs, base and instruct,
+      because the map's unit is the model family, not a single repo.
+
+  capability:
+    # 46 of 47 are already benchmark-based, so this axis has a real anchor.
+    basis: benchmark
+    anchor:
+      primary: Artificial Analysis Intelligence Index
+      machine_signal: signal_artificialanalysis.model_evaluations
+      fallback: >
+        Published pretraining-suite average (ARC/HellaSwag/WinoGrande/PIQA and
+        similar) where the model is absent from Artificial Analysis.
+    bands: null
+    bands_status: >
+      NOT YET CALIBRATED. The 1-5 thresholds must be fitted against the Artificial
+      Analysis index using the 47 existing capability scores, which is a separate
+      step from this rubric. Until fitted, capability stays hand-authored and the
+      layer-2 scorer must not write it.
+
+  # Confidence stops being a per-file judgment call and becomes derived.
+  confidence_rule:
+    high: a direct measured signal or a primary source states the fact outright
+    medium: a proxy signal, or a reported figure that could not be independently confirmed
+    low: inferred from indirect evidence, or the source is older than 90 days
+
 products:
 - llama-3-1
 - deepseek-v3-base

--- a/sources/categories/base_pretrained.yaml
+++ b/sources/categories/base_pretrained.yaml
@@ -61,12 +61,12 @@ scoring_recipe:
         machine_signal: none — requires research
 
     # The discriminator that decides restricted vs open_weights. OSI approval
-    # alone is too blunt: several non-OSI licences are permissive in substance.
-    # The line is whether the licence restricts USE, not whether OSI blessed it.
+    # alone is too blunt: several non-OSI licenses are permissive in substance.
+    # The line is whether the license restricts USE, not whether OSI blessed it.
     license_tier:
       values:
         osi:
-          definition: OSI-approved licence
+          definition: OSI-approved license
           examples: [Apache-2.0, MIT, BSD-3-Clause]
         permissive_non_osi:
           definition: >
@@ -79,22 +79,22 @@ scoring_recipe:
             research-only terms, or a commercial agreement requirement.
           examples: [Llama-3.1-Community-License, Llama-4-Community, Gemma-License, Mistral-Research-License, TII-Falcon-License-2.0, glm-4, Qwen-License-Agreement]
         proprietary:
-          definition: No public licence; weights not distributed.
+          definition: No public license; weights not distributed.
       multi_sku_rule: >
-        Where a family ships SKUs under different licences, the most restrictive
-        licence among the SKUs WHOSE WEIGHTS ARE ACTUALLY DISTRIBUTED governs.
+        Where a family ships SKUs under different licenses, the most restrictive
+        license among the SKUs WHOSE WEIGHTS ARE ACTUALLY DISTRIBUTED governs.
         API-only and hosted-only tiers are excluded: they are a different product
         surface, and this axis scores the artifact you can download. That
         distinction is what separates the two families previously both recorded
         as `mixed` — Qwen 2.5 distributes 3B/72B under the Qwen License, which
         caps the family at use_restricted, while Qwen 3's restrictive Plus/Max
         tiers are never distributed at all, leaving the distributed set Apache.
-        Per-SKU licences come from signal_huggingface.hub_state, so this is
+        Per-SKU licenses come from signal_huggingface.hub_state, so this is
         derivable rather than judged.
-      normalisation:
-      - 'compound `code X + model Y`: the MODEL licence governs, since it is the
+      normalization:
+      - 'compound `code X + model Y`: the MODEL license governs, since it is the
         one attached to the weights'
-      - 'prefix `assumed-`: same tier as the licence named, but confidence drops
+      - 'prefix `assumed-`: same tier as the license named, but confidence drops
         to medium until the release confirms it'
       never_use:
         mixed: >
@@ -116,11 +116,11 @@ scoring_recipe:
       then: {score: 5, class: open_source}
     - when: {data: open, code: open}
       then: {score: 4, class: open_weights}
-      note: Full pipeline but a non-OSI licence caps the score at 4.
+      note: Full pipeline but a non-OSI license caps the score at 4.
     - when: {data: documented-not-released, code: open}
       then: {score: 4, class: open_weights}
     - otherwise: {score: 3, class: open_weights}
-      note: The category's centre of gravity — open weights, closed data.
+      note: The category's center of gravity — open weights, closed data.
 
   adoption:
     # Signal choice follows openness: a closed model has no artifact to measure,

--- a/sources/scores/qwen-2-5.yaml
+++ b/sources/scores/qwen-2-5.yaml
@@ -2,9 +2,9 @@ product: qwen-2-5
 openness:
   score: 2
   class: restricted
-  components: weights:open(downloadable on HF);data:closed;code:partial(inference; no training pipeline);license:mixed,
-    0.5B-14B Apache-2.0, but flagship 72B & 3B under Qwen-License-Agreement(non-OSI, 100M MAU commercial
-    cap)
+  components: 'weights:open(downloadable on HF);data:closed;code:partial(inference; no training pipeline);license:Qwen-License-Agreement(most
+    restrictive distributed SKU: 0.5B-14B ship Apache-2.0, but the distributed 72B & 3B carry a non-OSI
+    100M MAU commercial cap)'
   confidence: high
   note: 'Flagship 72B base carries the Qwen License with a 100M MAU cap (CONFIRMED in license Section
     4: >100M MAU commercial requires separate authorization), non-OSI, so the headline SKU is restricted;

--- a/sources/scores/qwen-3-6.yaml
+++ b/sources/scores/qwen-3-6.yaml
@@ -3,8 +3,8 @@ openness:
   score: 3
   class: open_weights
   components: weights:open(Apache-2.0 for open variants e.g. 27B/35B-A3B);data:closed;code:partial(inference/usage
-    code on GitHub; no training pipeline/data);license:mixed(open variants Apache-2.0; Plus/Max flagship
-    tiers proprietary, commercial-restricted/API-only)
+    code on GitHub; no training pipeline/data);license:Apache-2.0(most restrictive distributed SKU; the
+    proprietary Plus/Max tiers are API-only and never distributed, so they fall outside this axis)
   confidence: high
   note: weights:open(Apache-2.0 for open variants e.g. 27B/35B-A3B);data:closed;code:partial(inference/usage
     code on GitHub; no training pipeline/data);license:mixed(open variants Apache-2.0; Plus/Max flagship
@@ -27,10 +27,10 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: 'ATOM Report (Apr 2026): Qwen family ~942.1M cumulative HF downloads (>50% of all global open source
-    downloads), overtook Llama in Sept 2025; >113,000 derivative models (>200,000 incl tagged); 69% of
-    new fine-tunes by Feb 2026 build on Qwen. Qwen 3.6 is the current flagship generation of that dominant
-    family, unambiguously >10M reach.'
+  note: 'ATOM Report (Apr 2026): Qwen family ~942.1M cumulative HF downloads (>50% of all global open
+    source downloads), overtook Llama in Sept 2025; >113,000 derivative models (>200,000 incl tagged);
+    69% of new fine-tunes by Feb 2026 build on Qwen. Qwen 3.6 is the current flagship generation of that
+    dominant family, unambiguously >10M reach.'
   sources:
   - url: https://arxiv.org/html/2604.07190v1
     shows: flagship phase-C verification source


### PR DESCRIPTION
**Pilot for one category, deliberately.** `scoring_recipe.version: 1`, `base_pretrained` only. Fifteen categories still have no machine-readable rubric; this establishes the shape and the verification method before that gets multiplied by sixteen.

## What this adds

A `scoring_recipe` block in `base_pretrained.yaml`, filling a slot reserved in the category schema and unused by every category. Layer-2 needs it twice: the evidence checklist tells the research stage what to hunt for, the formula turns stored evidence into a score.

**Derived, not designed.** Every part came out of the 47 hand-authored scores:

| Finding | Evidence |
|---|---|
| Openness asks exactly four questions | `weights`, `data`, `code`, `license` present 47/47; `checkpoints` 6/47 |
| Capability has a real anchor | 46/47 already `benchmark`-based |
| Adoption signal follows openness | 29 `usage_volume`, 14 `reported_traction` — the 14 are the closed models |

## Two things the derivation turned up

**OSI approval is the wrong discriminator.** `(weights:open, data:closed, code:partial)` produced both `2/restricted` and `3/open_weights` with no recorded reason. The real line is whether the license restricts *use*: Llama caps you at 700M MAU, Kimi's Modified-MIT only asks for UI attribution. Hence three open tiers rather than a boolean.

**`mixed` was hiding the answer.** Two products recorded `license:mixed` and scored differently, 2 and 3, with nothing explaining why. Resolved by the multi-SKU rule: most restrictive among SKUs whose weights are *actually distributed*. Qwen 2.5 distributes 72B/3B under a capped license; Qwen 3's restrictive Plus/Max tiers are API-only and never shipped, so they fall outside an axis that scores what you can download. **Both scores unchanged** — only the evidence became explicit.

I got that rule wrong on the first attempt ("most restrictive SKU", which would have scored Qwen 3 as closed) and `check_rubric` caught it.

## Capability is deliberately unfinished

`bands: null`, with `bands_status` saying why. #103 later confirmed the harder reason: Artificial Analysis and LMArena have **no `product_slug`**, so the anchors aren't joinable yet. The thresholds couldn't have been fitted even if I'd tried.

## The checker

`build/check_rubric.py` replays the formula against each product's recorded evidence and compares to the recorded score. **47/47**, exit 1 on mismatch so CI can gate.

It earns its place twice. Now: proof the rubric describes how the category was really scored, rather than being a plausible invention. Later: the regression test for rubric edits — a one-line threshold change that moves 30 products is the signal to stop.

## Known limitation, tracked separately in #106

Reproducing 47/47 proves the rubric matches what humans did. It does **not** prove the vocabulary is adequate — and it isn't. Verifying the nine load-bearing `data:` claims found **two products that land between the available `data` values**: RWKV (full component index, no reconstruction pipeline) and Nemotron 3 (substantial partial release).

**Not patched here on purpose.** Fixing a shared vocabulary from one category's evidence is the mistake to avoid; the other fifteen categories will surface their own gaps, and the enum should be revised once against all of them. See #106.

## Test plan

- `uv run python -m build.check_rubric` → `base_pretrained: 47/47 reproduced [OK]`, exit 0
- `uv run python -m build.validate` → 0 errors
- Rebased on current `main` (post #102, #104); both checks re-run clean
- Score files round-trip through the YAML dumper with a zero-line diff, verified before editing that way

## Merge order

Best merged **before #105**, so `check_rubric` exists on `main` and can verify #105's RWKV change (`data: documented-not-released` + `code: open` → `4, open_weights`) rather than relying on my hand-verification.
