### PR TITLE
Declare last_verified on scores, and report staleness

### DIFF
--- a/build/check_freshness.py
+++ b/build/check_freshness.py
@@ -1,0 +1,164 @@
+"""Report how stale the map's scores are.
+
+The map's value depends on its numbers being current, and until now there was no
+way to check that without reading 501 files. A score last touched in June looks
+exactly like one touched yesterday.
+
+## Two dates, deliberately not merged
+
+  * **`last_verified`** — layer-2 re-checked this axis against its sources on that
+    date, whether or not the value changed. Currently absent everywhere, because
+    layer-2 does not exist yet. That absence is the honest baseline, and watching
+    it fill in is how we measure the automation landing.
+  * **`max(sources[].accessed)`** — when a source behind the score was last read,
+    by whoever authored it. The best staleness proxy available today, and *not* a
+    verification.
+
+`last_verified` is deliberately NOT backfilled from `accessed`. Someone opening a
+URL is a weaker claim than the conclusion being re-confirmed, and copying one into
+a field whose name asserts the other would overstate the map's freshness across
+1,479 axes at a stroke. It would also be pointless: `accessed` is already in the
+files, so a derived column adds no information, only the stronger claim.
+
+This report therefore labels which signal each number came from, and never lets
+the weaker one be read as the stronger.
+
+Exit status is 0 unless `--max-age-days` is given, so it is safe to run for
+information. Pass a threshold to turn it into a CI gate once layer-2 is keeping
+scores fresh; gating today would only fail on the pre-automation backlog.
+
+Usage:
+    uv run python -m build.check_freshness
+    uv run python -m build.check_freshness --category base_pretrained
+    uv run python -m build.check_freshness --max-age-days 30
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import defaultdict
+from datetime import date, datetime
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+AXES = ("openness", "adoption", "capability")
+
+
+def parse_date(value: object) -> date | None:
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.strptime(value[:10], "%Y-%m-%d").date()
+        except ValueError:
+            return None
+    return None
+
+
+def collect() -> tuple[dict[str, list[tuple[str, str, date, bool]]], list[str]]:
+    """Return (category -> [(product, axis, when, is_verified)], axes with no date).
+
+    `is_verified` separates a real `last_verified` from an `accessed` fallback, so
+    the report can never present the weaker signal as the stronger one.
+    """
+    by_category: dict[str, list[tuple[str, str, date, bool]]] = defaultdict(list)
+    undated: list[str] = []
+
+    for path in sorted((ROOT / "sources" / "categories").glob("*.yaml")):
+        category = yaml.safe_load(path.read_text())
+        for product in category.get("products") or []:
+            score_path = ROOT / "sources" / "scores" / f"{product}.yaml"
+            if not score_path.exists():
+                continue
+            scores = yaml.safe_load(score_path.read_text()) or {}
+            for axis in AXES:
+                block = scores.get(axis)
+                if not isinstance(block, dict):
+                    continue
+
+                verified = parse_date(block.get("last_verified"))
+                if verified is not None:
+                    by_category[category["name"]].append((product, axis, verified, True))
+                    continue
+
+                accessed = [
+                    parse_date(s.get("accessed"))
+                    for s in (block.get("sources") or [])
+                    if isinstance(s, dict)
+                ]
+                accessed = [d for d in accessed if d is not None]
+                if accessed:
+                    by_category[category["name"]].append(
+                        (product, axis, max(accessed), False)
+                    )
+                else:
+                    undated.append(f"{product}.{axis}")
+    return by_category, undated
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--category", help="limit to one category slug")
+    parser.add_argument(
+        "--max-age-days",
+        type=int,
+        help="exit 1 if any category's oldest axis exceeds this. Omit to report only.",
+    )
+    parser.add_argument("--today", help="override today's date, YYYY-MM-DD, for testing")
+    args = parser.parse_args()
+
+    today = parse_date(args.today) or date.today()
+    by_category, undated = collect()
+    if args.category:
+        by_category = {k: v for k, v in by_category.items() if k == args.category}
+
+    rows = [entry for entries in by_category.values() for entry in entries]
+    if not rows:
+        print("no scored axes found")
+        return 0
+
+    print(f"{'category':<30}{'axes':>6}{'median':>9}{'oldest':>9}  oldest product")
+    stalest: list[tuple[int, str, str]] = []
+    for name in sorted(by_category):
+        entries = by_category[name]
+        ages = sorted((today - when).days for _, _, when, _ in entries)
+        median = ages[len(ages) // 2]
+        product, axis, _, _ = max(entries, key=lambda e: (today - e[2]).days)
+        print(f"{name:<30}{len(entries):>6}{median:>8}d{ages[-1]:>8}d  {product}.{axis}")
+        stalest.append((ages[-1], name, f"{product}.{axis}"))
+
+    all_ages = sorted((today - when).days for _, _, when, _ in rows)
+    print(
+        f"\n{len(rows)} axes | median {all_ages[len(all_ages) // 2]}d "
+        f"| oldest {all_ages[-1]}d | newest {all_ages[0]}d"
+    )
+
+    verified_n = sum(1 for _, _, _, is_verified in rows if is_verified)
+    print(
+        f"\n{verified_n} of {len(rows)} axes carry a real last_verified. "
+        f"The other {len(rows) - verified_n} fall back to max(sources.accessed), "
+        "which dates the evidence, not a verification — read those ages as an upper "
+        "bound on freshness."
+    )
+    if undated:
+        print(
+            f"{len(undated)} axes have no date at all: {', '.join(undated[:6])}"
+            + (" ..." if len(undated) > 6 else "")
+        )
+
+    if args.max_age_days is None:
+        return 0
+    over = [(age, cat, what) for age, cat, what in stalest if age > args.max_age_days]
+    if over:
+        print(f"\n{len(over)} categor(ies) exceed {args.max_age_days}d:")
+        for age, cat, what in sorted(over, reverse=True):
+            print(f"  ! {cat:<28} {age}d  ({what})")
+        return 1
+    print(f"\nall categories within {args.max_age_days}d")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/schemas/score.schema.json
+++ b/docs/schemas/score.schema.json
@@ -15,7 +15,8 @@
         "components": { "type": "string" },
         "confidence": { "enum": ["high", "medium", "low"] },
         "note": { "type": "string" },
-        "sources": { "type": "array", "items": { "$ref": "#/definitions/source" } }
+        "sources": { "type": "array", "items": { "$ref": "#/definitions/source" } },
+        "last_verified": { "type": "string", "format": "date", "description": "Date layer-2 last re-verified this axis against its sources. Absent means never verified by the automated process; do not backfill it from source access dates." }
       }
     },
     "adoption": {
@@ -27,7 +28,8 @@
         "signal_type": { "enum": ["active_users", "usage_volume", "reported_traction", "stars_fallback", "unknown"] },
         "confidence": { "enum": ["high", "medium", "low"] },
         "note": { "type": "string" },
-        "sources": { "type": "array", "items": { "$ref": "#/definitions/source" } }
+        "sources": { "type": "array", "items": { "$ref": "#/definitions/source" } },
+        "last_verified": { "type": "string", "format": "date", "description": "Date layer-2 last re-verified this axis against its sources. Absent means never verified by the automated process; do not backfill it from source access dates." }
       }
     },
     "capability": {
@@ -39,7 +41,8 @@
         "value": { "type": ["string", "number", "null"] },
         "confidence": { "enum": ["high", "medium", "low"] },
         "note": { "type": "string" },
-        "sources": { "type": "array", "items": { "$ref": "#/definitions/source" } }
+        "sources": { "type": "array", "items": { "$ref": "#/definitions/source" } },
+        "last_verified": { "type": "string", "format": "date", "description": "Date layer-2 last re-verified this axis against its sources. Absent means never verified by the automated process; do not backfill it from source access dates." }
       }
     }
   },


### PR DESCRIPTION
Groundwork for layer-2, and a measurement we were missing.

## The problem

The map claims its numbers are current. There was no way to check that without reading 501 files, because a score last touched in June looks identical to one touched yesterday.

## What this adds

An optional `last_verified` per axis, written by layer-2 when it re-checks an axis against its sources — **whether or not the value changed**. That distinction is the point: it records *when we last looked*, not *when it last moved*, so a confirmed-unchanged score still leaves a dated trace and the git history of a score file becomes its verification record.

Plus `build/check_freshness.py`, the repo-side counterpart to the platform's `signal_health.py`.

## Why it is not backfilled

The obvious backfill is `max(sources[].accessed)`. I did exactly that, then reverted it.

`accessed: 2026-06-08` means *someone opened this URL that day*. `last_verified: 2026-06-08` asserts *this conclusion was confirmed that day*. Deriving the second from the first mechanically would have upgraded a weaker claim into a stronger one across 1,479 axes. The dates also cluster on a few days — 43 of 47 base models share one — which reads as bulk authoring, not per-product verification.

It would also have added no information, since `accessed` is already in the files. A derived column buys only the overstatement.

**So the field starts empty everywhere.** That is the honest baseline, and watching it fill in is how we measure the automation landing.

## What the report does

Prefers `last_verified`, falls back to `max(sources.accessed)`, and always labels which it used, so the weaker signal can never be read as the stronger. Fallback ages are described as an upper bound on freshness.

```
1479 axes | median 54d | oldest 54d | newest 7d

0 of 1479 axes carry a real last_verified. The other 1479 fall back to
max(sources.accessed), which dates the evidence, not a verification.
24 axes have no date at all.
```

Only `dataset_processing_tools` (7d) and `safeguards` (29d) are inside a month.

## Test plan

- `uv run python -m build.check_freshness` → table above, exit 0
- `--max-age-days 30` → exit 1, listing the 14 categories over threshold
- `uv run python -m build.validate` → 0 errors
- Schema edited as text, not re-dumped: 6 insertions, 3 deletions, formatting preserved

## Notes

- Exits 0 by default so it is safe to run for information. Wire `--max-age-days` into CI once layer-2 is keeping scores fresh; gating now would only fail on the pre-automation backlog.
- Stacks cleanly with #101 — that one adds the rubric, this one the freshness field. No overlap.