### PR TITLE
Signal routing table: which source is authoritative per dimension

### DIFF
--- a/build/check_routing.py
+++ b/build/check_routing.py
@@ -1,0 +1,165 @@
+"""Report how much of the map `sources/signal_routing.yaml` can actually answer.
+
+The routing table declares which machine signal is authoritative for which
+scoring dimension. This measures what that buys: for every product, which
+dimensions have a usable route, and which fall through to research.
+
+Two things it protects against:
+
+  * **Overstating automation.** A routing table looks comprehensive until you
+    count coverage. Capability has two declared anchors and neither is joinable,
+    so on paper it is routed and in practice it is not. This prints that.
+  * **Silent drift.** A route naming a table or column that no longer exists
+    should fail here, not halfway through a research run.
+
+Coverage is computed from the registry's artifacts rather than from the signal
+tables directly, so it runs offline against the repo and answers "what could be
+routed" — the live tables then determine what actually resolves.
+
+Usage:
+    uv run python -m build.check_routing
+    uv run python -m build.check_routing --category base_pretrained
+    uv run python -m build.check_routing --unrouted     # list products with no route at all
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import defaultdict
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Which artifact key in a product YAML satisfies which routing source.
+SOURCE_ARTIFACT = {
+    "github": "github",
+    "huggingface_model": "huggingface_model",
+    "huggingface_dataset": "huggingface_dataset",
+    "pypi": "pypi",
+    "semanticscholar": "arxiv",  # citations are reached via the paper id
+}
+
+
+def artifacts_of(product: dict) -> set[str]:
+    """Which artifact kinds this product declares."""
+    found: set[str] = set()
+    for key in ("github", "huggingface_model", "huggingface_dataset", "pypi", "npm", "crates", "arxiv"):
+        value = product.get(key)
+        if value:
+            found.add(key)
+    return found
+
+
+def load() -> tuple[dict, dict, dict, dict]:
+    routing = yaml.safe_load((ROOT / "sources" / "signal_routing.yaml").read_text())
+    products = {
+        p.stem: yaml.safe_load(p.read_text())
+        for p in sorted((ROOT / "sources" / "products").glob("*.yaml"))
+    }
+    categories = {
+        p.stem: yaml.safe_load(p.read_text())
+        for p in sorted((ROOT / "sources" / "categories").glob("*.yaml"))
+    }
+    category_of = {}
+    for name, cat in categories.items():
+        for slug in cat.get("products") or []:
+            category_of[slug] = cat["name"]
+    return routing, products, categories, category_of
+
+
+def route_usable(route: dict, sources: dict) -> tuple[bool, str]:
+    """Is this route executable at all, before considering any product?"""
+    source = sources.get(route.get("source")) or {}
+    if route.get("blocked_by") == "bridge" or source.get("bridged") is False:
+        return False, "unbridged"
+    if not source:
+        return False, "unknown source"
+    return True, ""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--category", help="limit to one category slug")
+    parser.add_argument("--unrouted", action="store_true", help="list products with no route")
+    args = parser.parse_args()
+
+    routing, products, _, category_of = load()
+    sources = routing.get("sources") or {}
+    dimensions = routing.get("dimensions") or {}
+
+    # Structural check first: a route pointing at nothing is a bug in the table.
+    problems: list[str] = []
+    for dim, spec in dimensions.items():
+        for route in spec.get("routes") or []:
+            name = route.get("source")
+            if name not in sources:
+                problems.append(f"{dim}: route names unknown source {name!r}")
+                continue
+            # An unbridged source can never resolve to a product, so it needs no
+            # artifact mapping. Only a source claiming to be usable must have one.
+            if sources[name].get("bridged") and name not in SOURCE_ARTIFACT:
+                problems.append(f"{dim}: bridged source {name!r} has no artifact mapping in this checker")
+    if problems:
+        print("ROUTING TABLE PROBLEMS")
+        for p in problems:
+            print(f"  ! {p}")
+        return 1
+
+    slugs = [s for s in products if not args.category or category_of.get(s) == args.category]
+
+    covered: dict[str, int] = defaultdict(int)
+    blocked: dict[str, int] = defaultdict(int)
+    per_product_routed: dict[str, int] = {}
+
+    for slug in slugs:
+        arts = artifacts_of(products[slug])
+        cat = category_of.get(slug)
+        n_routed = 0
+        for dim, spec in dimensions.items():
+            hit = False
+            was_blocked = False
+            for route in spec.get("routes") or []:
+                only = route.get("applies_to_categories")
+                if only and cat not in only:
+                    continue
+                usable, _ = route_usable(route, sources)
+                if not usable:
+                    was_blocked = True
+                    continue
+                if SOURCE_ARTIFACT.get(route["source"]) in arts:
+                    hit = True
+                    break
+            if hit:
+                covered[dim] += 1
+                n_routed += 1
+            elif was_blocked:
+                blocked[dim] += 1
+        per_product_routed[slug] = n_routed
+
+    total = len(slugs)
+    print(f"{total} products\n")
+    print(f"{'dimension':<14}{'routed':>8}{'':>3}{'blocked by bridge':>19}{'':>3}{'research':>10}")
+    for dim in dimensions:
+        c = covered[dim]
+        b = blocked[dim]
+        print(f"{dim:<14}{c:>8}{'':>3}{b:>19}{'':>3}{total - c:>10}")
+
+    research_only = routing.get("research_only") or {}
+    if research_only:
+        print(f"\nresearch-only by declaration: {', '.join(research_only)}")
+
+    none_routed = [s for s, n in per_product_routed.items() if n == 0]
+    print(f"\n{len(none_routed)} of {total} products have NO routable dimension at all")
+    if args.unrouted:
+        for slug in sorted(none_routed):
+            print(f"  {slug:<34}{category_of.get(slug, '?')}")
+    elif none_routed:
+        print(f"  e.g. {', '.join(sorted(none_routed)[:8])} ...  (--unrouted for the full list)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sources/signal_routing.yaml
+++ b/sources/signal_routing.yaml
@@ -1,0 +1,215 @@
+# Which machine signal is authoritative for which scoring dimension.
+#
+# Layer-2 research uses this to answer what it can from cached, dated,
+# traceable sources before spending an LLM on anything. It is the difference
+# between a refresh that is cheap and defensible and one that quietly
+# corrupts good data.
+#
+# ## Routing is by ARTIFACT KIND, not by product
+#
+# This is the whole reason the file exists. A model's code repository and its
+# weights routinely carry different licences, and the code repo is the wrong
+# answer for the weights dimension.
+#
+# Measured on 2026-07-28 against the 239 products with a GitHub licence signal:
+# 175 agreed exactly with the recorded value, 5 differed only in formatting,
+# 25 returned NOASSERTION, and 13 genuinely disagreed. In every model case
+# among those 13, Hugging Face agreed with the recorded value and GitHub was
+# the outlier — glm-5-2 (recorded MIT, HF mit, GitHub Apache-2.0), lucie-7b
+# (recorded Apache-2.0, HF apache-2.0, GitHub GPL-3.0), and likewise mimo-v2-5-pro,
+# zephyr and tulu-3.
+#
+# So a naive "refresh licence from GitHub" pass would have overwritten six
+# correct model scores with the wrong licence, each change looking like a
+# well-sourced improvement. Route by artifact kind and that class of error
+# cannot occur.
+#
+# ## Abstain rather than substitute
+#
+# When the authoritative signal for a dimension is missing or unusable, the
+# rule is to produce NO evidence and leave the dimension to research. Falling
+# through to a less authoritative signal is how the failure above happens.
+
+version: 1
+verified_on: '2026-07-28'
+
+# Where each artifact kind's facts live. `key` is the join column back to the
+# registry; a source with no key cannot be used until a bridge exists.
+sources:
+  github:
+    table: currentai.signal_github.repo_state
+    key: product_slug
+    evidence_url: https://github.com/{repo}
+    bridged: true
+  huggingface_model:
+    table: currentai.signal_huggingface.hub_state
+    key: product_slug
+    filter: artifact_kind = 'huggingface_model'
+    evidence_url: https://huggingface.co/{artifact_id}
+    bridged: true
+  huggingface_dataset:
+    table: currentai.signal_huggingface.hub_state
+    key: product_slug
+    filter: artifact_kind = 'huggingface_dataset'
+    evidence_url: https://huggingface.co/datasets/{artifact_id}
+    bridged: true
+  pypi:
+    table: currentai.signal_pypi.package_downloads
+    key: product_slug
+    evidence_url: https://pypistats.org/packages/{package}
+    bridged: true
+  semanticscholar:
+    table: currentai.signal_semanticscholar.paper_citations
+    key: product_slug
+    evidence_url: https://www.semanticscholar.org/paper/{paper_id}
+    bridged: true
+  artificialanalysis:
+    table: currentai.signal_artificialanalysis.model_evaluations
+    key: null
+    evidence_url: https://artificialanalysis.ai/models/{aa_slug}
+    bridged: false
+    bridge_note: >
+      Keyed on `aa_slug`, with no product_slug column. A product -> aa_slug
+      bridge must exist before capability can be routed here. Until then this
+      source is declared but unusable, and capability stays hand-authored.
+  lmarena:
+    table: currentai.signal_lmarena.text_leaderboard
+    key: null
+    evidence_url: https://lmarena.ai/leaderboard
+    bridged: false
+    bridge_note: >
+      Keyed on `model_name` as published by the arena, which does not match our
+      slugs. Same bridge problem as artificialanalysis.
+
+# Ordered routes per dimension. First route whose artifact the product actually
+# has, wins. `governs` records what the value is a fact ABOUT, so a licence
+# attached to code is never read as a licence attached to weights.
+dimensions:
+
+  license:
+    question: Which licence governs the artifact being scored?
+    routes:
+    - source: huggingface_model
+      column: license
+      governs: weights
+      confidence: high
+    - source: huggingface_dataset
+      column: license
+      governs: dataset
+      confidence: high
+    - source: github
+      column: license_spdx_id
+      governs: code
+      confidence: high
+      abstain_when: license_spdx_id = 'NOASSERTION'
+      abstain_note: >
+        GitHub could not classify the LICENSE file. It is an absence of
+        information, not evidence of a non-standard licence. 25 products hit
+        this. Leave it to research.
+    never:
+    - route: github licence -> the weights dimension
+      because: >
+        Measured wrong for 6 of 6 models where the two disagreed. The code repo
+        licence is a fact about the code, not the weights.
+    normalisation:
+    - GPLv3 -> GPL-3.0, AGPLv3 -> AGPL-3.0, case-insensitive
+    - strip a leading `app=` / `code=` / `model=` qualifier
+    - '`assumed-X` keeps tier X but caps confidence at medium'
+
+  weights:
+    question: Are the trained weights downloadable and runnable locally?
+    routes:
+    - source: huggingface_model
+      columns: [is_gated, gated_mode, is_private, is_disabled, used_storage_bytes]
+      governs: weights
+      derivation: >
+        open when the repo is public, not disabled, and carries weight files;
+        gating is recorded in value_detail rather than closing the dimension,
+        since a click-through gate is not the same as withheld weights.
+      confidence: high
+    unroutable_note: >
+      A model distributed outside the Hub has no signal here. Research it.
+
+  code:
+    question: Is the source released, and is the project still alive?
+    routes:
+    - source: github
+      columns: [is_archived, is_disabled, pushed_at, html_url]
+      governs: code
+      derivation: >
+        Presence and liveness only. Whether the code constitutes a full training
+        pipeline versus inference-only is a judgment the API cannot make, so this
+        route informs `code` but does not settle it.
+      settles_dimension: false
+      confidence: high
+
+  adoption:
+    question: How widely is this actually used?
+    routes:
+    - source: huggingface_model
+      column: downloads_30d
+      signal_type: usage_volume
+      confidence: high
+    - source: huggingface_dataset
+      column: downloads_30d
+      signal_type: usage_volume
+      confidence: high
+    - source: pypi
+      column: downloads_30d
+      signal_type: usage_volume
+      confidence: high
+    - source: semanticscholar
+      column: citation_count
+      signal_type: usage_volume
+      applies_to_categories: [benchmark_eval_data]
+      confidence: high
+      note: >
+        For a benchmark, citations measure reach better than downloads: the
+        question is how many papers evaluate against it.
+    - source: github
+      column: stargazers_count
+      signal_type: stars_fallback
+      confidence: low
+      note: >
+        Last resort, and explicitly last. Stars measure attention, not use, and
+        the rubric already ranks this below every real usage signal.
+    sum_across_artifacts: true
+    sum_note: >
+      A model family ships several SKUs. The map's unit is the family, so
+      downloads sum across its artifacts rather than taking the largest.
+
+  capability:
+    question: How good is it, measured independently?
+    routes:
+    - source: artificialanalysis
+      column: artificial_analysis_intelligence_index
+      applies_to_categories: [base_pretrained, finetuned_chat]
+      blocked_by: bridge
+    - source: lmarena
+      column: rating
+      applies_to_categories: [finetuned_chat]
+      blocked_by: bridge
+    - source: semanticscholar
+      column: citation_count
+      applies_to_categories: [benchmark_eval_data]
+      confidence: medium
+      note: >
+        Citations are a reach signal, not a quality one. Usable as corroboration
+        for a benchmark's standing, not as the capability score itself.
+    status: >
+      Effectively unroutable today. The two real capability anchors are both
+      unbridged, and no category's scoring_recipe has calibrated 1-5 thresholds
+      against them. Capability stays hand-authored until both are fixed.
+
+# Dimensions with no machine signal at all, listed so their absence is a
+# recorded decision rather than an oversight.
+research_only:
+  data:
+    why: >
+      Whether a pretraining corpus is released, or reconstructible from released
+      scripts, is not exposed by any API. A dataset card describing sources does
+      not answer it.
+  checkpoints:
+    why: Intermediate checkpoints on HF branches are not surfaced in the Hub API summary.
+  governance:
+    why: Who controls the roadmap is a question about an organisation, not an artifact.

--- a/sources/signal_routing.yaml
+++ b/sources/signal_routing.yaml
@@ -8,10 +8,10 @@
 # ## Routing is by ARTIFACT KIND, not by product
 #
 # This is the whole reason the file exists. A model's code repository and its
-# weights routinely carry different licences, and the code repo is the wrong
+# weights routinely carry different licenses, and the code repo is the wrong
 # answer for the weights dimension.
 #
-# Measured on 2026-07-28 against the 239 products with a GitHub licence signal:
+# Measured on 2026-07-28 against the 239 products with a GitHub license signal:
 # 175 agreed exactly with the recorded value, 5 differed only in formatting,
 # 25 returned NOASSERTION, and 13 genuinely disagreed. In every model case
 # among those 13, Hugging Face agreed with the recorded value and GitHub was
@@ -19,8 +19,8 @@
 # (recorded Apache-2.0, HF apache-2.0, GitHub GPL-3.0), and likewise mimo-v2-5-pro,
 # zephyr and tulu-3.
 #
-# So a naive "refresh licence from GitHub" pass would have overwritten six
-# correct model scores with the wrong licence, each change looking like a
+# So a naive "refresh license from GitHub" pass would have overwritten six
+# correct model scores with the wrong license, each change looking like a
 # well-sourced improvement. Route by artifact kind and that class of error
 # cannot occur.
 #
@@ -82,12 +82,12 @@ sources:
       slugs. Same bridge problem as artificialanalysis.
 
 # Ordered routes per dimension. First route whose artifact the product actually
-# has, wins. `governs` records what the value is a fact ABOUT, so a licence
-# attached to code is never read as a licence attached to weights.
+# has, wins. `governs` records what the value is a fact ABOUT, so a license
+# attached to code is never read as a license attached to weights.
 dimensions:
 
   license:
-    question: Which licence governs the artifact being scored?
+    question: Which license governs the artifact being scored?
     routes:
     - source: huggingface_model
       column: license
@@ -104,14 +104,14 @@ dimensions:
       abstain_when: license_spdx_id = 'NOASSERTION'
       abstain_note: >
         GitHub could not classify the LICENSE file. It is an absence of
-        information, not evidence of a non-standard licence. 25 products hit
+        information, not evidence of a non-standard license. 25 products hit
         this. Leave it to research.
     never:
-    - route: github licence -> the weights dimension
+    - route: github license -> the weights dimension
       because: >
         Measured wrong for 6 of 6 models where the two disagreed. The code repo
-        licence is a fact about the code, not the weights.
-    normalisation:
+        license is a fact about the code, not the weights.
+    normalization:
     - GPLv3 -> GPL-3.0, AGPLv3 -> AGPL-3.0, case-insensitive
     - strip a leading `app=` / `code=` / `model=` qualifier
     - '`assumed-X` keeps tier X but caps confidence at medium'
@@ -212,4 +212,4 @@ research_only:
   checkpoints:
     why: Intermediate checkpoints on HF branches are not surfaced in the Hub API summary.
   governance:
-    why: Who controls the roadmap is a question about an organisation, not an artifact.
+    why: Who controls the roadmap is a question about an organization, not an artifact.


### PR DESCRIPTION
Prerequisite for the layer-2 freshness pass. Before refreshing anything from machine signals, we need a rule for which signal is authoritative for which dimension — and measuring it showed the naive rule would have corrupted good data.

## The finding that shaped it

Compared every recorded license against the GitHub signal, for the 239 products that have one:

| | n |
|---|---|
| agreed exactly | 175 |
| formatting only (`GPLv3` vs `GPL-3.0`) | 5 |
| GitHub returned `NOASSERTION` | 25 |
| compound `code X + model Y` | 3 |
| **genuine disagreement** | **13** |
| no recorded license | 18 |

**In every model case among the 13, Hugging Face agreed with the recorded value and GitHub was the outlier.** `glm-5-2`: recorded MIT, HF mit, GitHub Apache-2.0. `lucie-7b`: recorded Apache-2.0, HF apache-2.0, GitHub GPL-3.0. Also `mimo-v2-5-pro`, `zephyr`, `tulu-3`.

Those are not errors in the map. They are the **code repo's license differing from the artifact's license** — the distinction the rubric's separate `weights` and `code` dimensions already encode.

So a "refresh license from GitHub" pass would have overwritten six correct model scores with the wrong license, every change looking like a well-sourced improvement. Route by artifact kind and that class of error cannot happen.

The measurement is recorded in the table as a `never` route with its reasoning, so it survives the next person who reaches for the obvious approach.

## Two other rules

**Abstain rather than substitute.** `NOASSERTION` means GitHub could not parse the LICENSE file — an absence of information, not evidence of an unusual license. Falling through to a weaker source is how the failure above happens. Those 25 go to research.

**Sources declare whether they are bridged.** Artificial Analysis and LMArena are keyed on their own model names with no `product_slug`, so capability is declared but unroutable. Recording it as blocked beats leaving it quietly absent, and it explains why `base_pretrained`'s capability bands were left uncalibrated in #101.

## Coverage, as a number

`build/check_routing.py`:

```
501 products

dimension       routed     blocked by bridge     research
license            335                     0          166
adoption           342                     0          159
code               250                     0          251
weights             62                     0          439
capability          23                    97          478
```

## It surfaced a gap worth chasing

159 products have no routable dimension — but some are open-weights models that should route fine. `apertus`, `glm-4-9b` and `kimi-k3` each **cite a Hugging Face id in their own score sources while declaring no `huggingface_model` artifact**. The signal exists; the registry just doesn't point at it.

That's mechanically recoverable from evidence already in the files, the same way `propose_arxiv.py` mines arXiv ids. Worth doing before the freshness pass, since it directly widens coverage. Not in this PR.

## Test plan

- `uv run python -m build.check_routing` → table above, exit 0
- `--category base_pretrained` → 25/47 license, 0/47 capability (47 bridge-blocked)
- `--unrouted` → lists the 159
- Structural check fails the run if a route names an unknown source, so the table can't rot silently
- `uv run python -m build.validate` → 0 errors

## Stacking

Independent of #101 (rubric) and #102 (last_verified). No file overlap.
