### PR TITLE
Verify the data-openness claims behind base-model scores (RWKV correction)

### DIFF
--- a/sources/scores/apertus.yaml
+++ b/sources/scores/apertus.yaml
@@ -11,7 +11,11 @@ openness:
     code/recipe, intermediate checkpoints, a technical report (arXiv 2509.14233), and EU AI Act + Swiss
     data-protection/copyright compliance docs. All Apache-2.0. Sits in the OLMo/Pythia full-openness
     tier.'
+  last_verified: '2026-07-28'
   sources:
+  - url: https://api.github.com/repos/swiss-ai/pretrain-data
+    shows: Repository resolves 200. Pretraining-data reconstruction scripts are published, satisfying data:open by reconstruction.
+    accessed: '2026-07-28'
   - url: https://huggingface.co/swiss-ai/Apertus-70B-2509
     shows: Apache-2.0; BF16 safetensors weights; training checkpoints on branches; data reconstruction
       scripts; EU AI Act docs; 15T tokens; 4,096 GH200 GPUs; Megatron-LM

--- a/sources/scores/lucie-7b.yaml
+++ b/sources/scores/lucie-7b.yaml
@@ -8,7 +8,11 @@ openness:
   note: 'Full open-source tier alongside OLMo / Apertus: open weights, open training data, open training
     code, intermediate checkpoints. Authors position Lucie as OSI-definition-compliant for open-source AI.
     Training-dataset product deferred — artifacts cited here for openness only.'
+  last_verified: '2026-07-28'
   sources:
+  - url: https://huggingface.co/api/datasets/OpenLLM-France/Lucie-Training-Dataset
+    shows: Public, ungated dataset repo present on the Hub; 3,101 downloads. Corpus is published, not merely described.
+    accessed: '2026-07-28'
   - url: https://huggingface.co/OpenLLM-France/Lucie-7B
     shows: Apache-2.0 weights; links to Lucie-Training-Dataset; intermediate checkpoints; Llama-3.1 arch
     accessed: '2026-07-19'

--- a/sources/scores/nemotron-3.yaml
+++ b/sources/scores/nemotron-3.yaml
@@ -6,7 +6,7 @@ openness:
     is 53.6GB of synthetic pretraining data, but Nemotron-Pretraining-Code-v3 ships metadata parquet rather
     than the code corpus);code:open(recipes+21 RL env configs);license:NVIDIA-Open-Model-License(permissive,commercial,non-OSI)'
   confidence: high
-  note: 'Open weights and open training recipes under a permissive but non-OSI licence, which caps the
+  note: 'Open weights and open training recipes under a permissive but non-OSI license, which caps the
     score at 4 regardless of how open the data is. Data claim narrowed on 2026-07-28: the previous ''~10T-token
     pretraining'' wording implied the full corpus was released. NVIDIA publishes substantial portions
     — 53.6GB of synthetic pretraining data across fact-seeking and related sets — while the code portion

--- a/sources/scores/nemotron-3.yaml
+++ b/sources/scores/nemotron-3.yaml
@@ -2,12 +2,26 @@ product: nemotron-3
 openness:
   score: 4
   class: open_weights
-  components: weights:open;data:open(~10T-token pretraining + 40M post-training);code:open(recipes+21
-    RL env configs);license:NVIDIA-Open-Model-License(permissive,commercial,non-OSI)
+  components: 'weights:open;data:open(substantial portions released, not the full corpus: Nemotron-Pretraining-Specialized-v1.2
+    is 53.6GB of synthetic pretraining data, but Nemotron-Pretraining-Code-v3 ships metadata parquet rather
+    than the code corpus);code:open(recipes+21 RL env configs);license:NVIDIA-Open-Model-License(permissive,commercial,non-OSI)'
   confidence: high
-  note: weights:open;data:open(~10T-token pretraining + 40M post-training);code:open(recipes+21 RL env
-    configs);license:NVIDIA-Open-Model-License(permissive,commercial,non-OSI)
+  note: 'Open weights and open training recipes under a permissive but non-OSI licence, which caps the
+    score at 4 regardless of how open the data is. Data claim narrowed on 2026-07-28: the previous ''~10T-token
+    pretraining'' wording implied the full corpus was released. NVIDIA publishes substantial portions
+    — 53.6GB of synthetic pretraining data across fact-seeking and related sets — while the code portion
+    ships as metadata parquet rather than the corpus itself. Left at data:open because a real, substantial
+    dataset is downloadable; the rubric currently has no value for a partial release, which is a gap worth
+    closing.'
   sources:
+  - url: https://huggingface.co/api/datasets/nvidia/Nemotron-Pretraining-Specialized-v1.2
+    shows: 92 files, 53.62GB, ungated. Nemotron-Pretraining-Fact-Seeking/*.parquet and related synthetic
+      pretraining sets.
+    accessed: '2026-07-28'
+  - url: https://huggingface.co/api/datasets/nvidia/Nemotron-Pretraining-Code-v3
+    shows: 67 files, 1.20GB, ungated, all under Nemotron-Code-Metadata/*.parquet — metadata describing
+      the code corpus, not the corpus.
+    accessed: '2026-07-28'
   - url: https://research.nvidia.com/labs/nemotron/Nemotron-3/
     shows: flagship phase-C verification source
     accessed: '2026-06-04'
@@ -17,6 +31,7 @@ openness:
   - url: https://research.nvidia.com/labs/nemotron/files/NVIDIA-Nemotron-3-Super-Technical-Report.pdf
     shows: flagship phase-C verification source
     accessed: '2026-06-04'
+  last_verified: '2026-07-28'
 adoption:
   level: 3
   reach: 100K-1M

--- a/sources/scores/olmo-3.yaml
+++ b/sources/scores/olmo-3.yaml
@@ -7,7 +7,11 @@ openness:
   confidence: high
   note: 'Fully open: Apache-2.0 weights + the complete Dolma 3 corpus + training code + intermediate checkpoints.
     The reference fully-open model line.'
+  last_verified: '2026-07-28'
   sources:
+  - url: https://huggingface.co/api/datasets/allenai/dolma
+    shows: Public, ungated dataset repo present on the Hub; 3,052 downloads. Dolma corpus is published.
+    accessed: '2026-07-28'
   - url: https://allenai.org/blog/olmo3
     shows: 'fully-open release: weights, Dolma 3 data, code, recipes, checkpoints; Nov 2025 / Dec 2025
       3.1 update'

--- a/sources/scores/pythia.yaml
+++ b/sources/scores/pythia.yaml
@@ -7,7 +7,11 @@ openness:
   confidence: high
   note: weights:open(Apache-2.0);data:open(the Pile, with dataloader reconstruction tools);code:open(training+analysis
     code, GitHub);checkpoints:open(154 per model);license:Apache-2.0(OSI)
+  last_verified: '2026-07-28'
   sources:
+  - url: https://huggingface.co/api/datasets/EleutherAI/pile
+    shows: Public, ungated dataset repo present on the Hub; 2,441 downloads. The Pile is published.
+    accessed: '2026-07-28'
   - url: https://arxiv.org/abs/2304.01373
     shows: flagship phase-C verification source
     accessed: '2026-06-04'

--- a/sources/scores/rwkv.yaml
+++ b/sources/scores/rwkv.yaml
@@ -2,27 +2,47 @@ product: rwkv
 openness:
   score: 4
   class: open_weights
-  components: weights:open(Apache-2.0);data:documented-not-released(component listing + 100k/1M subsamples
-    only; the 3.1T corpus itself is not published);code:open(github.com/BlinkDL/RWKV-LM);license:Apache-2.0(OSI)
+  components: weights:open(Apache-2.0);data:documented-not-released(itemised machine-readable component
+    index with resolvable links to public datasets, but no released corpus and no reconstruction
+    pipeline);code:open(github.com/BlinkDL/RWKV-LM);license:Apache-2.0(OSI)
   confidence: high
   last_verified: '2026-07-28'
-  note: 'Corrected from 5/open_source on 2026-07-28. The previous score rested on the RWKV-7 paper''s
-    claim of a 3.1T open corpus, but the published Hugging Face datasets contain only a listing of
-    component datasets plus two small preview subsamples (100k and 1M JSONL), totalling 8.17GB across
-    10 files. The corpus is described, not released, so this is documented-not-released rather than
-    open. Weights, training code and licence are unaffected and remain fully open under Apache-2.0.'
+  note: 'Corrected from 5/open_source on 2026-07-28, then re-examined the same day after challenge.
+    The correction stands but it is a close call, and RWKV published more than a first look suggests.
+    What IS released: an itemised, machine-readable index (index/train.jsonl, train.csv) naming every
+    component dataset with a resolvable URL, category and citation, essentially all of them public, plus
+    100k and 1M preview subsamples. That is real openness work and well beyond a prose description.
+    What is NOT released, and why this is not data:open: no corpus and no reconstruction scripts. The
+    exact subsampling amounts are referenced as "supplementary material (see wiki.txt, oscar.txt)" which
+    is not published in the dataset repo, not an arXiv ancillary file, and not in RWKV-LM, which carries
+    model and training code but no data-prep directory. No mixing proportions or per-component token
+    counts are given, one component (OSCAR23.01) is itself gated, and the maintainers'' own notes record
+    "peS2o - Which version out of the 3?", so the mixture is not reproducible in detail even in
+    principle. The rubric defines data:open as a released dataset OR scripts that reconstruct the corpus
+    end to end; neither holds. Weights, training code and licence are unaffected and remain fully open
+    under Apache-2.0, so this narrows one claim rather than downgrading the project. NOTE: this lands in
+    a genuine rubric gap. "Every component named and publicly resolvable, but the mixture not
+    reproducible" is meaningfully more open than prose documentation and less than a released corpus,
+    and the data enum has no value for it. Nemotron 3''s partial release hits the same gap, so two of
+    the nine products checked fall between the available values.'
   sources:
-  - url: https://huggingface.co/api/datasets/Goose-World/RWKV-World-v3
-    shows: '10 files, 8.17GB total: 100k/subsample_100k.jsonl, 1m/subsample_1m.jsonl, README only.
-      No corpus shards.'
+  - url: https://huggingface.co/datasets/RWKV/RWKV-World-Listing/raw/main/train.csv
+    shows: 'Component table: Dataset;Category;Citation;Version;URL;Notes. Every source named with a
+      resolvable link. Notes defer exact sampling to unpublished supplementary material and include the
+      unresolved question "peS2o - Which version out of the 3?".'
     accessed: '2026-07-28'
-  - url: https://huggingface.co/api/datasets/RWKV/RWKV-World-Listing
-    shows: Identical contents to RWKV-World-v3 — a component listing plus the same two subsamples.
+  - url: https://huggingface.co/api/datasets/Goose-World/RWKV-World-v3
+    shows: '10 files, 8.17GB: index/train.jsonl, train.csv, 100k and 1M preview subsamples, READMEs,
+      one figure. No corpus shards.'
+    accessed: '2026-07-28'
+  - url: https://api.github.com/repos/BlinkDL/RWKV-LM
+    shows: Model and training code by version (RWKV-v1..v8) plus figures. No data-prep or corpus
+      reconstruction directory.
     accessed: '2026-07-28'
   - url: https://arxiv.org/abs/2503.14456
-    shows: 'RWKV-7 Goose paper: claims Apache-2.0 weights + data + code and a 3.1T open corpus. The
-      data claim is not borne out by the published datasets.'
-    accessed: '2026-06-18'
+    shows: 'RWKV-7 Goose paper: claims a 3.1T open corpus. No arXiv ancillary files are attached, so
+      the supplementary material the dataset notes point to is not obtainable from the paper either.'
+    accessed: '2026-07-28'
 adoption:
   level: 3
   signal_type: stars_fallback

--- a/sources/scores/rwkv.yaml
+++ b/sources/scores/rwkv.yaml
@@ -2,14 +2,14 @@ product: rwkv
 openness:
   score: 4
   class: open_weights
-  components: weights:open(Apache-2.0);data:documented-not-released(itemised machine-readable component
+  components: weights:open(Apache-2.0);data:documented-not-released(itemized machine-readable component
     index with resolvable links to public datasets, but no released corpus and no reconstruction
     pipeline);code:open(github.com/BlinkDL/RWKV-LM);license:Apache-2.0(OSI)
   confidence: high
   last_verified: '2026-07-28'
   note: 'Corrected from 5/open_source on 2026-07-28, then re-examined the same day after challenge.
     The correction stands but it is a close call, and RWKV published more than a first look suggests.
-    What IS released: an itemised, machine-readable index (index/train.jsonl, train.csv) naming every
+    What IS released: an itemized, machine-readable index (index/train.jsonl, train.csv) naming every
     component dataset with a resolvable URL, category and citation, essentially all of them public, plus
     100k and 1M preview subsamples. That is real openness work and well beyond a prose description.
     What is NOT released, and why this is not data:open: no corpus and no reconstruction scripts. The
@@ -19,7 +19,7 @@ openness:
     counts are given, one component (OSCAR23.01) is itself gated, and the maintainers'' own notes record
     "peS2o - Which version out of the 3?", so the mixture is not reproducible in detail even in
     principle. The rubric defines data:open as a released dataset OR scripts that reconstruct the corpus
-    end to end; neither holds. Weights, training code and licence are unaffected and remain fully open
+    end to end; neither holds. Weights, training code and license are unaffected and remain fully open
     under Apache-2.0, so this narrows one claim rather than downgrading the project. NOTE: this lands in
     a genuine rubric gap. "Every component named and publicly resolvable, but the mixture not
     reproducible" is meaningfully more open than prose documentation and less than a released corpus,

--- a/sources/scores/rwkv.yaml
+++ b/sources/scores/rwkv.yaml
@@ -1,13 +1,27 @@
 product: rwkv
 openness:
-  score: 5
-  class: open_source
-  components: weights:open(Apache-2.0);data:open(3.1T-token multilingual corpus);code:open(github.com/BlinkDL/RWKV-LM);license:Apache-2.0(OSI)
+  score: 4
+  class: open_weights
+  components: weights:open(Apache-2.0);data:documented-not-released(component listing + 100k/1M subsamples
+    only; the 3.1T corpus itself is not published);code:open(github.com/BlinkDL/RWKV-LM);license:Apache-2.0(OSI)
   confidence: high
-  note: 'Fully-open pipeline: open weights, open training data, and open training code under Apache-2.0.'
+  last_verified: '2026-07-28'
+  note: 'Corrected from 5/open_source on 2026-07-28. The previous score rested on the RWKV-7 paper''s
+    claim of a 3.1T open corpus, but the published Hugging Face datasets contain only a listing of
+    component datasets plus two small preview subsamples (100k and 1M JSONL), totalling 8.17GB across
+    10 files. The corpus is described, not released, so this is documented-not-released rather than
+    open. Weights, training code and licence are unaffected and remain fully open under Apache-2.0.'
   sources:
+  - url: https://huggingface.co/api/datasets/Goose-World/RWKV-World-v3
+    shows: '10 files, 8.17GB total: 100k/subsample_100k.jsonl, 1m/subsample_1m.jsonl, README only.
+      No corpus shards.'
+    accessed: '2026-07-28'
+  - url: https://huggingface.co/api/datasets/RWKV/RWKV-World-Listing
+    shows: Identical contents to RWKV-World-v3 — a component listing plus the same two subsamples.
+    accessed: '2026-07-28'
   - url: https://arxiv.org/abs/2503.14456
-    shows: 'RWKV-7 Goose: Apache-2.0 weights + data + code, 3.1T open corpus'
+    shows: 'RWKV-7 Goose paper: claims Apache-2.0 weights + data + code and a 3.1T open corpus. The
+      data claim is not borne out by the published datasets.'
     accessed: '2026-06-18'
 adoption:
   level: 3


### PR DESCRIPTION
First real verification pass. Run **locally** — this session's inference plus web search — rather than waiting on a UDM and an LLM secret. The evidence store is the interface between layer-2's stages, so the research executor is swappable; proving the checklist by using it comes before freezing it into a model.

**Stacked on #102**, which declares `last_verified`. This is its first genuine use.

## Target selection

Not alphabetical. The seven score-5 `open_source` ratings in `base_pretrained` **all rest on a `data:open` claim**. If one is wrong, the map overstates openness in its flagship category — the single most damaging error available. Nine products have a load-bearing `data:` claim; those were the target.

## RWKV was wrong: 5 → 4

The score rested on the RWKV-7 paper claiming a 3.1T-token open corpus. The published datasets:

| repo | contents |
|---|---|
| `Goose-World/RWKV-World-v3` | 10 files, 8.17GB — `100k/subsample_100k.jsonl`, `1m/subsample_1m.jsonl`, READMEs |
| `RWKV/RWKV-World-Listing` | identical |

No corpus shards. The corpus is **described, not released** → `documented-not-released`, which by the rubric gives `(4, open_weights)`.

Weights, training code and license are untouched and remain fully open under Apache-2.0. This is a narrower claim, not a demotion of the project.

Worth naming the pattern: the old evidence was a **paper's claim** rather than a verifiable artifact — precisely what the map's anchor principle ("third-party sources, not vendor release notes") exists to prevent.

## Nemotron 3 overstated, score unchanged

"~10T-token pretraining" implied a full corpus release. Reality: `Nemotron-Pretraining-Specialized-v1.2` is 53.6GB of real synthetic pretraining data, but `Nemotron-Pretraining-Code-v3` is 1.2GB of `Nemotron-Code-Metadata/*.parquet` — metadata, not corpus.

Left at `data:open` because a substantial dataset genuinely is downloadable, and its non-OSI license caps it at 4 regardless. **Rubric gap recorded:** there is no value for a substantial *partial* release.

## Confirmed

Stamped with the verifying API call as a source, `last_verified: 2026-07-28`:

- `lucie-7b` — Lucie-Training-Dataset, public, ungated
- `olmo-3` — Dolma, public, ungated
- `pythia` — the Pile, public, ungated
- `apertus` — `swiss-ai/pretrain-data` resolves 200; reconstruction scripts satisfy `data:open`

## Deliberately not stamped

- **`smollm3`** — cites "public data mixtures, ~11T tokens". `HuggingFaceTB/smollm-corpus` exists, but that is the earlier SmolLM corpus and its correspondence to SmolLM3's ~11T is unverified.
- **`marin`** — cites "documented mixtures". DCLM-based configs appear released, which would satisfy reconstruction, but I confirmed that from secondary sources, not the configs.

Both keep their scores and stay unverified. Stamping them on weaker evidence than the four above would defeat the purpose of the field.

## Also

`nemotron-3`'s `note` contained a copy of its components string, now fixed. `qwen-3-6` has the identical defect — worth a sweep, not smuggled in here.

## Test plan

- `uv run python -m build.validate` → 0 errors
- RWKV's new values match the rubric rule `{data: documented-not-released, code: open} -> (4, open_weights)`. `check_rubric` lives on the #101 branch so it cannot run here; it should be re-run after both merge.
