### PR TITLE
Use American spelling in build scripts

### DIFF
--- a/build/propose_artifacts.py
+++ b/build/propose_artifacts.py
@@ -15,7 +15,7 @@ like progress.
 Like `propose_arxiv.py`, it writes nothing. It prints candidates with their
 evidence and verdict for a human to accept. The reason is the same: matching by
 name was measured at 2 correct in 10 on this data, and a wrong artifact silently
-attaches another project's licence and download counts to a product. That is
+attaches another project's license and download counts to a product. That is
 indistinguishable from a real score until someone checks.
 
 Candidate sources, in order of trust:

--- a/build/serialize_registry.py
+++ b/build/serialize_registry.py
@@ -93,7 +93,7 @@ _ID_PATTERNS = {
     "huggingface_dataset": r"huggingface\.co/datasets/(.+)",
     "pypi": r"pypi\.org/project/([^/]+)",
     "npm": r"npmjs\.com/package/(.+)",
-    # Accept an abs/pdf URL or a bare id, and normalise to the bare id so the
+    # Accept an abs/pdf URL or a bare id, and normalize to the bare id so the
     # DOI is derivable as 10.48550/arXiv.<id> without further parsing.
     "arxiv": r"(?:arxiv\.org/(?:abs|pdf)/)?(\d{4}\.\d{4,5})(?:v\d+)?",
 }


### PR DESCRIPTION
Repo standard is American English. Two instances of British spelling in comments and docstrings, in files that were already merged:

- `build/serialize_registry.py` — `normalise` → `normalize`
- `build/propose_artifacts.py` — `licence` → `license`

Comment and docstring text only; no identifiers, keys or behavior change.

## Context

Part of a wider sweep. The other instances live on their own branches (#103 for the routing table, #105 for the score notes) and #101's are already merged. The sweep also caught two cases a word-boundary search misses, because the underscore is a word character:

- `normalise_license` → `normalize_license` in `check_rubric.py` (landed with #101)
- the deployed table `repo_catalogue` → `repo_catalog`, redeployed and verified at 17,131 rows, old model deleted

Not included: `build/notebook_data.json` has ~106 hits, but it is generated from score-file prose. Cleaning it means editing source score notes and regenerating, which is a content change rather than a style sweep — worth its own PR if wanted.

## Test plan

- `uv run python -m build.validate` → 0 errors
- `check_freshness`, `propose_artifacts --no-verify`, `propose_arxiv` all run clean