### PR TITLE
Close the layer-2 loop for base models: evidence store, scoring model, snapshot-out

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - "sources/**"
       - "build/serialize_registry.py"
+      - "build/serialize_rubric.py"
       - "build/publish_registry.py"
       - ".github/workflows/registry.yml"
   push:
@@ -16,6 +17,7 @@ on:
     paths:
       - "sources/**"
       - "build/serialize_registry.py"
+      - "build/serialize_rubric.py"
       - "build/publish_registry.py"
   workflow_dispatch:
 
@@ -34,6 +36,11 @@ jobs:
         run: uv sync --locked
       - name: Check registry consistency
         run: uv run python -m build.serialize_registry --check
+      # A formula rule that can never match — one testing an undeclared dimension
+      # or a value outside its own enum — does not raise. It silently pushes
+      # products into `otherwise`, so it has to fail here.
+      - name: Check rubric consistency
+        run: uv run python -m build.serialize_rubric --check
 
   # On main, serialize and push. Static models are created on first run and
   # reused after, so this is safe to run on every change to sources/.
@@ -49,6 +56,8 @@ jobs:
         run: uv sync --locked
       - name: Serialize registry
         run: uv run python -m build.serialize_registry
+      - name: Serialize rubric and evidence
+        run: uv run python -m build.serialize_rubric
       - name: Publish to OSO
         env:
           OSO_API_KEY: ${{ secrets.OSO_API_KEY }}

--- a/build/apply_scores.py
+++ b/build/apply_scores.py
@@ -1,0 +1,227 @@
+"""Write computed scores back into `sources/scores/`, so a human reviews rather than writes.
+
+This is the one place where data flows INTO the repo. Everything else in `build/`
+pushes declarations outward. That direction matters: the repo is the source of truth
+for what the map SAYS, and this tool is the only thing allowed to change it without
+a person typing the value.
+
+## What it writes, and what it refuses to
+
+  * `openness.last_verified` — whenever the pipeline could verify the score. That is
+    the honest, machine-authored change: a fresh Hub field agreeing with the recorded
+    license genuinely is verification, dated the day the field was fetched.
+  * `openness.score` / `openness.class` — only when the computed value differs. It
+    should not, since the rubric was reverse-engineered from these files, so a
+    difference is either a real evidence change worth reviewing or a bug worth
+    finding. Either way it must be loud, so `--check` exits non-zero on one.
+
+It will NOT remove an existing `last_verified` when the pipeline can no longer earn
+one. That case is reported instead. Deleting a date because provenance got stricter
+is destructive, and the fix is to source the evidence, not to erase the record.
+
+It will NOT touch `note`, `sources`, `confidence`, `adoption` or `capability`. Those
+are human prose and human judgment. A tool that rewrote them would make its own diffs
+unreviewable, which is the whole value of the review step.
+
+## Why line editing rather than a YAML round trip
+
+`yaml.safe_load` then `yaml.dump` reformats every string in the file — folded scalars
+collapse, quoting changes, key order moves. The diff would be 501 files of noise with
+the real change buried in it. So this edits the specific lines and leaves every other
+byte alone. `last_verified` is replaced where it already sits, since its position
+varies across the six files that carry one, and otherwise inserted before `sources:`,
+which is where most of them put it.
+
+Usage:
+    uv run python -m build.apply_scores --check      # report, write nothing
+    uv run python -m build.apply_scores              # write
+    uv run python -m build.apply_scores --category base_pretrained
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+TABLE = "currentai.scores.openness_computed"
+
+
+def fetch_computed(category: str | None) -> list[dict]:
+    """Read the computed scores. Requires OSO_API_KEY, same as publish_registry."""
+    from pyoso import Client
+
+    where = f"WHERE category_slug = '{category}'" if category else ""
+    sql = f"""
+        SELECT product_slug, category_slug, openness_score, openness_class,
+               last_verified, unsourced_dimensions, license_tier_grade,
+               dims_from_dataset, dims_relied_on, scoring_note
+        FROM {TABLE}
+        {where}
+        ORDER BY product_slug
+    """
+    return Client().to_pandas(sql).to_dict("records")
+
+
+def block_bounds(lines: list[str], key: str) -> tuple[int, int] | None:
+    """Line range [start, end) of the top-level `key:` mapping."""
+    start = None
+    for index, line in enumerate(lines):
+        if line.startswith(f"{key}:") and not line[:1].isspace():
+            start = index
+            break
+    if start is None:
+        return None
+    for index in range(start + 1, len(lines)):
+        if lines[index].strip() and not lines[index][:1].isspace():
+            return start, index
+    return start, len(lines)
+
+
+def find_key(lines: list[str], bounds: tuple[int, int], key: str) -> int | None:
+    """Index of a two-space-indented `key:` inside the block, or None.
+
+    Indent is checked exactly. A `score:` nested deeper — inside a `sources` entry,
+    say — is a different key and must not be mistaken for the axis's own.
+    """
+    for index in range(bounds[0] + 1, bounds[1]):
+        line = lines[index]
+        if line.startswith(f"  {key}:") and not line[2:3].isspace():
+            return index
+    return None
+
+
+def apply_to_file(path: Path, computed: dict) -> tuple[list[str], list[str]]:
+    """Return (new_lines, changes). Empty changes means the file is already correct."""
+    lines = path.read_text().splitlines(keepends=True)
+    bounds = block_bounds(lines, "openness")
+    if bounds is None:
+        return lines, [f"{path.stem}: no openness block"]
+
+    changes: list[str] = []
+    score = computed.get("openness_score")
+    klass = computed.get("openness_class")
+
+    if score is not None:
+        for key, value in (("score", int(score)), ("class", klass)):
+            index = find_key(lines, bounds, key)
+            if index is None:
+                continue
+            current = lines[index].split(":", 1)[1].strip()
+            if current != str(value):
+                lines[index] = f"  {key}: {value}\n"
+                changes.append(f"{path.stem}: openness.{key} {current} -> {value}")
+
+    verified = computed.get("last_verified")
+    if verified is not None and str(verified) not in ("None", "NaT", "nan"):
+        stamp = str(verified)[:10]
+        index = find_key(lines, bounds, "last_verified")
+        if index is not None:
+            current = lines[index].split(":", 1)[1].strip().strip("'\"")
+            if current != stamp:
+                lines[index] = f"  last_verified: '{stamp}'\n"
+                changes.append(f"{path.stem}: last_verified {current} -> {stamp}")
+        else:
+            anchor = find_key(lines, bounds, "sources")
+            insert_at = anchor if anchor is not None else bounds[1]
+            lines.insert(insert_at, f"  last_verified: '{stamp}'\n")
+            changes.append(f"{path.stem}: last_verified + {stamp}")
+
+    return lines, changes
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="report only, write nothing")
+    parser.add_argument("--category", help="limit to one category slug")
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+
+    if not os.environ.get("OSO_API_KEY"):
+        print("OSO_API_KEY must be set", file=sys.stderr)
+        return 2
+
+    rows = fetch_computed(args.category)
+    if not rows:
+        print(f"no computed scores in {TABLE}", file=sys.stderr)
+        return 2
+
+    changed_files: list[Path] = []
+    all_changes: list[str] = []
+    score_changes: list[str] = []
+    stale_kept: list[str] = []
+    unscored: list[str] = []
+    pending: dict[Path, list[str]] = {}
+
+    for row in rows:
+        slug = row["product_slug"]
+        path = ROOT / "sources" / "scores" / f"{slug}.yaml"
+        if not path.exists():
+            continue
+
+        if row.get("openness_score") is None:
+            unscored.append(f"{slug}: {row.get('scoring_note')}")
+            continue
+
+        recorded = yaml.safe_load(path.read_text()) or {}
+        had_verified = "last_verified" in (recorded.get("openness") or {})
+        if had_verified and row.get("last_verified") is None:
+            stale_kept.append(
+                f"{slug}: carries last_verified but the pipeline cannot earn one "
+                f"(unsourced: {row.get('unsourced_dimensions')})"
+            )
+
+        new_lines, changes = apply_to_file(path, row)
+        if changes:
+            pending[path] = new_lines
+            all_changes.extend(changes)
+            changed_files.append(path)
+            score_changes.extend(c for c in changes if "openness.score" in c or "openness.class" in c)
+
+    verified = sum(1 for r in rows if r.get("last_verified") is not None)
+    from_dataset = sum(1 for r in rows if r.get("license_tier_grade") == "dataset")
+
+    print(f"{len(rows)} computed score(s) read from {TABLE}")
+    print(f"  license tier from a machine-readable field : {from_dataset}")
+    print(f"  score verifiable end to end (last_verified): {verified}")
+    print(f"  files this run would change                : {len(changed_files)}")
+    print(f"  openness score or class moved              : {len(score_changes)}")
+
+    if score_changes:
+        print("\nSCORE CHANGES — each one needs a human to look at it:")
+        for change in score_changes:
+            print(f"  ! {change}")
+
+    if unscored:
+        print(f"\n{len(unscored)} product(s) the rubric declined to score:")
+        for item in unscored:
+            print(f"  - {item}")
+
+    if stale_kept:
+        print(f"\n{len(stale_kept)} product(s) keep a last_verified the pipeline cannot re-earn:")
+        for item in stale_kept:
+            print(f"  - {item}")
+        print("  (left alone on purpose — source the evidence rather than erase the date)")
+
+    if args.verbose and all_changes:
+        print(f"\nall {len(all_changes)} change(s):")
+        for change in all_changes:
+            print(f"  {change}")
+
+    if args.check:
+        print("\ncheck only: nothing written")
+        # A moved score is the one thing CI must not wave through.
+        return 1 if score_changes else 0
+
+    for path, new_lines in pending.items():
+        path.write_text("".join(new_lines))
+    print(f"\nwrote {len(pending)} file(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build/publish_registry.py
+++ b/build/publish_registry.py
@@ -1,8 +1,13 @@
-"""Push the serialized registry CSVs to OSO as static models.
+"""Push the serialized registry and rubric CSVs to OSO as static models.
 
-This is the "config in" half of the bridge: the repo declares what exists, CI
-pushes that declaration outward. Nothing is pulled back in, and no generated CSV
-is committed — the repo stays YAML, and OSO gets a flat mirror of it.
+This is the "config in" half of the bridge: the repo declares what exists and how
+to score it, CI pushes that declaration outward. Nothing is pulled back in here,
+and no generated CSV is committed — the repo stays YAML, and OSO gets a flat mirror
+of it.
+
+Two serializers feed this. `serialize_registry` emits identity; `serialize_rubric`
+emits each category's scoring rules plus the evidence currently on record. Layer-2
+cannot compute a score without both, so they publish together.
 
 Idempotent. Static models are created on first run and reused after, so this can
 run on every push to sources/.
@@ -27,7 +32,15 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
-from build.serialize_registry import OUT_DIR, TABLES
+from build.serialize_registry import OUT_DIR
+from build.serialize_registry import TABLES as REGISTRY_TABLES
+from build.serialize_rubric import TABLES as RUBRIC_TABLES
+
+# One dataset, two serializers. `serialize_registry` declares what exists;
+# `serialize_rubric` declares how to score it and what evidence is on record.
+# Both are configuration flowing outward, so they share the `registry` dataset
+# and this publisher. Order is stable so the materialization run is reproducible.
+TABLES: tuple[str, ...] = tuple(REGISTRY_TABLES) + tuple(RUBRIC_TABLES)
 
 API = "https://api.oso.xyz/v1/graphql"
 USER_AGENT = "os-ai-map-registry-publisher/1.0"
@@ -125,7 +138,11 @@ def main() -> int:
 
     missing = [t for t in TABLES if not (args.dir / f"{t}.csv").exists()]
     if missing:
-        print(f"missing CSVs: {missing}. Run build.serialize_registry first.", file=sys.stderr)
+        print(
+            f"missing CSVs: {missing}. Run build.serialize_registry and "
+            f"build.serialize_rubric first.",
+            file=sys.stderr,
+        )
         return 2
 
     dataset_id = resolve_dataset(dataset_name, org_id, token)

--- a/build/serialize_registry.py
+++ b/build/serialize_registry.py
@@ -252,9 +252,19 @@ def build_registry(sources: dict) -> tuple[dict[str, list[dict]], list[str], lis
     return tables, errors, warnings
 
 
-def write_tables(tables: dict[str, list[dict]], out_dir: Path) -> None:
+def write_tables(
+    tables: dict[str, list[dict]],
+    out_dir: Path,
+    spec: dict[str, tuple[str, ...]] | None = None,
+) -> None:
+    """Write one CSV per declared table. `spec` defaults to the registry's own.
+
+    Shared with build/serialize_rubric.py, which emits a different table set into
+    the same directory, so the column order comes from the caller's spec rather
+    than from this module's TABLES.
+    """
     out_dir.mkdir(parents=True, exist_ok=True)
-    for name, columns in TABLES.items():
+    for name, columns in (spec or TABLES).items():
         path = out_dir / f"{name}.csv"
         with path.open("w", newline="", encoding="utf-8") as handle:
             writer = csv.DictWriter(handle, fieldnames=list(columns))

--- a/build/serialize_rubric.py
+++ b/build/serialize_rubric.py
@@ -287,25 +287,41 @@ def license_aliases(routing: dict) -> list[dict]:
     return rows
 
 
-def evidence_abstentions(policy: dict) -> list[dict]:
-    """Flatten the per-source abstention lists declared in evidence_policy.yaml.
+def evidence_abstentions(routing: dict) -> list[dict]:
+    """Flatten every route's `abstain_values` from signal_routing.yaml.
+
+    Read from the ROUTE rather than from evidence_policy.yaml, because a value that
+    means "no answer" is a fact about a source and signal_routing.yaml is what owns
+    source semantics. An earlier draft declared GitHub's NOASSERTION in both files,
+    which is the drift this bridge exists to prevent.
 
     These cross the bridge rather than being written into the warehouse SQL for the
-    same reason the components parser stays here: a policy implemented in two places
-    is a policy that will drift. The `_note` keys alongside each list are prose for
-    a reader and are skipped.
+    same reason the components parser stays in the repo: one declaration, or they
+    diverge. `source` is the route's source name — `huggingface_model`, not
+    `huggingface` — so an abstention attached to model licenses cannot be read as
+    applying to dataset licenses.
     """
     rows: list[dict] = []
-    for source, columns in (policy.get("abstentions") or {}).items():
-        if not isinstance(columns, dict):
+    seen: set[tuple[str, str, str]] = set()
+    for dimension in (routing.get("dimensions") or {}).values():
+        if not isinstance(dimension, dict):
             continue
-        for column, values in columns.items():
-            if column.endswith("_note") or not isinstance(values, list):
+        for route in dimension.get("routes") or []:
+            if not isinstance(route, dict):
                 continue
-            for value in values:
-                rows.append(
-                    {"source": source, "column_name": column, "abstain_value": str(value)}
-                )
+            source = route.get("source")
+            column = route.get("column")
+            if not source or not column:
+                continue
+            for value in route.get("abstain_values") or []:
+                key = (str(source), str(column), str(value))
+                # The same source/column pair can be routed by more than one
+                # dimension, and the lookup table wants one row per value.
+                if key not in seen:
+                    seen.add(key)
+                    rows.append(
+                        {"source": source, "column_name": column, "abstain_value": str(value)}
+                    )
     return rows
 
 
@@ -325,9 +341,9 @@ def build_rubric(sources: dict, policy: dict, routing: dict) -> tuple[dict[str, 
     warnings: list[str] = []
 
     tables["license_aliases"] = license_aliases(routing)
-    tables["evidence_abstentions"] = evidence_abstentions(policy)
+    tables["evidence_abstentions"] = evidence_abstentions(routing)
     if not tables["evidence_abstentions"]:
-        warnings.append("evidence_policy.yaml declares no abstentions")
+        warnings.append("signal_routing.yaml declares no route abstain_values")
 
     scored_categories = 0
     for slug, category in sorted(categories.items()):

--- a/build/serialize_rubric.py
+++ b/build/serialize_rubric.py
@@ -1,0 +1,472 @@
+"""Serialize each category's scoring rubric and its recorded evidence to flat CSVs.
+
+Companion to `serialize_registry.py`, and deliberately a separate module. That one
+emits IDENTITY — which products, organizations and categories exist. This one emits
+the two things layer-2 needs in order to compute a score: the rubric that says how
+to score, and the evidence recorded against each product.
+
+They are kept apart because their claims differ. The registry is authoritative
+about what exists. This module is authoritative about the rubric and explicitly
+NOT authoritative about the evidence — it reports what `sources/scores/` currently
+records, including the places where that record cites nothing specific. Merging the
+two would let a serializer that ships unverified assertions borrow the registry's
+credibility.
+
+## Why evidence flows outward when scores do not
+
+`serialize_registry.py` excludes scores on purpose: scoring is computed downstream
+and flows back, so mirroring scores outward would point the dependency the wrong
+way. Evidence is not a score. It is the input a score is computed FROM, and it has
+to reach the scorer somehow.
+
+There is a circularity here worth stating plainly: for the base-model pilot the
+document-grade evidence is parsed out of the very files the pipeline writes back
+to. That makes the first run a fidelity test of the formula and nothing more. It
+can prove the rubric describes how the category was scored; it cannot show the
+scores are right. Steady state is evidence from datasets and fresh research, with
+these rows surviving only where nothing better exists.
+
+## Parsing stays in the repo
+
+`components` strings are parsed by `build/check_rubric.py`, which is tested and
+which CI already gates on. Shipping a second copy of that parser into a warehouse
+model would leave two implementations to keep in step, and they would drift. So the
+repo emits pre-split dimensions and the warehouse consumes flat facts.
+
+## Grain, and an honest limit
+
+`components` gives a value per dimension. `sources` is a list per AXIS, with no
+attribution of a particular source to a particular dimension. So evidence comes out
+at dimension grain and sources come out at axis grain, and the two cannot be joined
+more tightly than that. The evidence-store design wants source-per-dimension; today's
+files do not carry it. Recording the limit beats inventing an attribution.
+
+Emitted tables (CSVs into `build/registry/`, alongside the registry's own):
+
+  category_scoring_rules      the ordered formula, one row per rule condition
+  category_license_tiers      tier <- example license, per category
+  license_aliases             a source's license slug -> canonical license name
+  evidence_abstentions        values that mean "this source has no answer"
+  product_openness_evidence   per-dimension values parsed from `components`
+  product_score_sources       per-axis sources, each with an admission verdict
+
+Usage:
+    uv run python -m build.serialize_rubric            # write CSVs
+    uv run python -m build.serialize_rubric --check    # validate, write nothing
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+from build.check_rubric import split_components
+from build.serialize_registry import write_tables
+from build.validate import load_sources
+
+ROOT = Path(__file__).resolve().parents[1]
+OUT_DIR = ROOT / "build" / "registry"
+
+AXES = ("openness", "adoption", "capability")
+
+# `license_tier()` in check_rubric defines the proprietary tier by MEANING rather
+# than by an example list, because no vendor publishes a license called
+# "proprietary". Those tokens are emitted as definitional examples so the warehouse
+# gets one lookup table instead of a lookup table plus a hardcoded special case.
+DEFINITIONAL_TIERS = {"proprietary": ("proprietary", "closed", "none")}
+
+TABLES: dict[str, tuple[str, ...]] = {
+    "category_scoring_rules": (
+        "category_slug",
+        "recipe_version",
+        "rule_index",
+        "is_otherwise",
+        "condition_key",
+        "condition_value",
+        "then_score",
+        "then_class",
+    ),
+    "category_license_tiers": (
+        "category_slug",
+        "tier",
+        "tier_rank",
+        "example_license",
+        "is_definitional",
+    ),
+    "license_aliases": ("source", "license_slug", "license_name"),
+    "evidence_abstentions": ("source", "column_name", "abstain_value"),
+    "product_openness_evidence": (
+        "product_slug",
+        "category_slug",
+        "dimension",
+        "value",
+        "value_detail",
+        "grade",
+        "in_declared_enum",
+    ),
+    "product_score_sources": (
+        "product_slug",
+        "category_slug",
+        "axis",
+        "source_url",
+        "source_shows",
+        "source_accessed",
+        "grade",
+        "admitted",
+        "reject_reason",
+    ),
+}
+
+
+def load_policy(root: Path) -> dict:
+    return yaml.safe_load((root / "sources" / "evidence_policy.yaml").read_text()) or {}
+
+
+def load_routing(root: Path) -> dict:
+    return yaml.safe_load((root / "sources" / "signal_routing.yaml").read_text()) or {}
+
+
+def split_value(raw: str) -> tuple[str, str]:
+    """Split a recorded component into its bare value and its trailing detail.
+
+    'open(downloadable on HF, gated)' -> ('open', 'downloadable on HF, gated')
+    The bare half matches `check_rubric.head` exactly, which is what the formula
+    consumes; the detail half is what a reviewer needs and the formula ignores.
+    """
+    text = (raw or "").strip()
+    parts = re.split(r"[(,]", text, maxsplit=1)
+    bare = parts[0].strip()
+    rest = parts[1].strip() if len(parts) > 1 else ""
+    return bare, rest.rstrip(")").strip()
+
+
+def admit(shows: str, policy: dict) -> tuple[bool, str]:
+    """Decide whether a recorded source is admissible evidence.
+
+    Rejection is not deletion. The row is still emitted, carrying its reason, so
+    that unsourced assertions become a queryable work list instead of quietly
+    passing for provenance.
+    """
+    rules = policy.get("admission") or {}
+    text = (shows or "").strip()
+    if rules.get("require_nonempty_shows", True) and not text:
+        return False, "no `shows` recorded"
+    lowered = text.lower()
+    for phrase in rules.get("boilerplate_shows") or []:
+        if str(phrase).lower() in lowered:
+            return False, f"boilerplate `shows`: {phrase!r}"
+    return True, ""
+
+
+def scoring_rules(slug: str, recipe: dict) -> tuple[list[dict], list[str]]:
+    """Flatten the ordered formula into one row per condition.
+
+    Long form rather than a column per dimension: dimensions differ by category,
+    and a wide table would need reshaping every time a new rubric lands.
+    `rule_index` preserves the order, which is load-bearing — the formula is
+    first-match-wins, so a reordering silently changes scores.
+    """
+    rows: list[dict] = []
+    errors: list[str] = []
+    openness = recipe.get("openness") or {}
+    declared = openness.get("dimensions") or {}
+    tiers = ((openness.get("license_tier") or {}).get("values") or {}).keys()
+    version = recipe.get("version", "")
+
+    for index, rule in enumerate(openness.get("formula") or []):
+        if "otherwise" in rule:
+            result = rule["otherwise"]
+            rows.append(
+                {
+                    "category_slug": slug,
+                    "recipe_version": version,
+                    "rule_index": index,
+                    "is_otherwise": True,
+                    "condition_key": "",
+                    "condition_value": "",
+                    "then_score": result.get("score", ""),
+                    "then_class": result.get("class", ""),
+                }
+            )
+            continue
+
+        when = rule.get("when") or {}
+        then = rule.get("then") or {}
+        if not when or not then:
+            errors.append(f"category '{slug}' formula rule {index} has neither a when/then nor an otherwise")
+            continue
+
+        for key, value in when.items():
+            # A condition naming a dimension that the rubric never declared, or a
+            # tier that its own tier list does not define, cannot ever match. It
+            # would not raise; it would just make the rule dead and push products
+            # into `otherwise`. That is exactly the failure a checker has to catch.
+            if key == "license_tier":
+                if value not in tiers:
+                    errors.append(
+                        f"category '{slug}' rule {index} tests license_tier={value!r}, "
+                        f"which is not one of its declared tiers {sorted(tiers)}"
+                    )
+            elif key not in declared:
+                errors.append(
+                    f"category '{slug}' rule {index} tests undeclared dimension {key!r}"
+                )
+            elif value not in (declared[key].get("values") or []):
+                errors.append(
+                    f"category '{slug}' rule {index} tests {key}={value!r}, which is not in "
+                    f"its declared values {declared[key].get('values')}"
+                )
+            rows.append(
+                {
+                    "category_slug": slug,
+                    "recipe_version": version,
+                    "rule_index": index,
+                    "is_otherwise": False,
+                    "condition_key": key,
+                    "condition_value": value,
+                    "then_score": then.get("score", ""),
+                    "then_class": then.get("class", ""),
+                }
+            )
+    return rows, errors
+
+
+def license_tiers(slug: str, recipe: dict) -> tuple[list[dict], list[str]]:
+    """Emit tier <- example license, carrying the declared restrictiveness rank.
+
+    `tier_rank` is the position of the tier in the recipe's `values` mapping. That
+    is only meaningful if the category says its declaration order encodes
+    restrictiveness, so `ordered_by` is required whenever there is more than one
+    tier to compare. Without it the multi-SKU rule would be resolving "most
+    restrictive" against whatever order the YAML happened to be written in.
+    """
+    rows: list[dict] = []
+    errors: list[str] = []
+    spec_root = ((recipe.get("openness") or {}).get("license_tier")) or {}
+    values = spec_root.get("values") or {}
+    if len(values) > 1 and spec_root.get("ordered_by") != "restrictiveness_ascending":
+        errors.append(
+            f"category '{slug}' declares {len(values)} license tiers but no "
+            f"`ordered_by: restrictiveness_ascending`, so the most-restrictive rule "
+            f"has no defined ordering to resolve against"
+        )
+    for rank, (tier, spec) in enumerate(values.items()):
+        for example in (spec or {}).get("examples") or []:
+            rows.append(
+                {
+                    "category_slug": slug,
+                    "tier": tier,
+                    "tier_rank": rank,
+                    "example_license": example,
+                    "is_definitional": False,
+                }
+            )
+        for token in DEFINITIONAL_TIERS.get(tier, ()):
+            rows.append(
+                {
+                    "category_slug": slug,
+                    "tier": tier,
+                    "tier_rank": rank,
+                    "example_license": token,
+                    "is_definitional": True,
+                }
+            )
+    return rows, errors
+
+
+def license_aliases(routing: dict) -> list[dict]:
+    rows: list[dict] = []
+    aliases = (((routing.get("dimensions") or {}).get("license") or {}).get("aliases")) or {}
+    for source, mapping in aliases.items():
+        for slug, name in (mapping or {}).items():
+            rows.append({"source": source, "license_slug": str(slug), "license_name": name})
+    return rows
+
+
+def evidence_abstentions(policy: dict) -> list[dict]:
+    """Flatten the per-source abstention lists declared in evidence_policy.yaml.
+
+    These cross the bridge rather than being written into the warehouse SQL for the
+    same reason the components parser stays here: a policy implemented in two places
+    is a policy that will drift. The `_note` keys alongside each list are prose for
+    a reader and are skipped.
+    """
+    rows: list[dict] = []
+    for source, columns in (policy.get("abstentions") or {}).items():
+        if not isinstance(columns, dict):
+            continue
+        for column, values in columns.items():
+            if column.endswith("_note") or not isinstance(values, list):
+                continue
+            for value in values:
+                rows.append(
+                    {"source": source, "column_name": column, "abstain_value": str(value)}
+                )
+    return rows
+
+
+def build_rubric(sources: dict, policy: dict, routing: dict) -> tuple[dict[str, list[dict]], list[str], list[str]]:
+    """Return (tables, errors, warnings).
+
+    Errors are things that would make scoring wrong rather than merely incomplete:
+    a malformed rule, or a rule that can never match. Warnings are coverage and
+    data-quality facts — a category with no rubric yet, a recorded value outside
+    its own declared enum, a source that cites nothing.
+    """
+    categories: dict = sources["categories"]
+    scores: dict = sources.get("scores") or {}
+
+    tables: dict[str, list[dict]] = {name: [] for name in TABLES}
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    tables["license_aliases"] = license_aliases(routing)
+    tables["evidence_abstentions"] = evidence_abstentions(policy)
+    if not tables["evidence_abstentions"]:
+        warnings.append("evidence_policy.yaml declares no abstentions")
+
+    scored_categories = 0
+    for slug, category in sorted(categories.items()):
+        recipe = category.get("scoring_recipe")
+        if not recipe:
+            warnings.append(f"category '{slug}' declares no scoring_recipe")
+            continue
+        scored_categories += 1
+
+        rules, rule_errors = scoring_rules(slug, recipe)
+        tables["category_scoring_rules"].extend(rules)
+        errors.extend(rule_errors)
+        tier_rows, tier_errors = license_tiers(slug, recipe)
+        tables["category_license_tiers"].extend(tier_rows)
+        errors.extend(tier_errors)
+
+        declared = ((recipe.get("openness") or {}).get("dimensions")) or {}
+
+        for product_slug in category.get("products") or []:
+            record = scores.get(product_slug)
+            if record is None:
+                continue
+            openness = record.get("openness") or {}
+            components = split_components(openness.get("components") or "")
+            if not components:
+                warnings.append(
+                    f"product '{product_slug}' in '{slug}' records no openness components"
+                )
+
+            for dimension, raw in components.items():
+                bare, detail = split_value(raw)
+                # A component the rubric never declared is vocabulary drift. It cannot
+                # affect a score, because the formula only reads what it declares, so
+                # it is a curation finding rather than a failure - but left unreported
+                # it is an observation nobody will ever act on. `marin` records
+                # `reproducibility:bit-for-bit`, which is a real openness fact the
+                # rubric has no question for.
+                if dimension != "license" and dimension not in declared:
+                    warnings.append(
+                        f"product '{product_slug}' records {dimension!r}, which "
+                        f"'{slug}' does not declare as a dimension"
+                    )
+                allowed = (declared.get(dimension) or {}).get("values")
+                # `license` is not a dimension with an enum; it is the raw input the
+                # license_tier lookup consumes, so it has nothing to be checked against.
+                in_enum = "" if dimension == "license" or not allowed else bare in allowed
+                if in_enum is False:
+                    warnings.append(
+                        f"product '{product_slug}' records {dimension}={bare!r}, which is not in "
+                        f"the rubric's declared values {allowed}"
+                    )
+                tables["product_openness_evidence"].append(
+                    {
+                        "product_slug": product_slug,
+                        "category_slug": slug,
+                        "dimension": dimension,
+                        "value": bare,
+                        "value_detail": detail,
+                        "grade": "document",
+                        "in_declared_enum": in_enum,
+                    }
+                )
+
+            rejected = 0
+            for axis in AXES:
+                for source in (record.get(axis) or {}).get("sources") or []:
+                    if not isinstance(source, dict):
+                        continue
+                    shows = source.get("shows") or ""
+                    admitted, reason = admit(shows, policy)
+                    rejected += 0 if admitted else 1
+                    accessed = source.get("accessed")
+                    tables["product_score_sources"].append(
+                        {
+                            "product_slug": product_slug,
+                            "category_slug": slug,
+                            "axis": axis,
+                            "source_url": source.get("url", ""),
+                            "source_shows": shows,
+                            "source_accessed": str(accessed) if accessed else "",
+                            "grade": "document",
+                            "admitted": admitted,
+                            "reject_reason": reason,
+                        }
+                    )
+            if rejected:
+                warnings.append(
+                    f"product '{product_slug}': {rejected} source row(s) cite nothing specific"
+                )
+
+    if scored_categories == 0:
+        errors.append("no category declares a scoring_recipe, so there is nothing to score with")
+
+    return tables, errors, warnings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="validate only, write nothing")
+    parser.add_argument("--out", type=Path, default=OUT_DIR, help="output directory")
+    parser.add_argument("--verbose", action="store_true", help="print every warning")
+    args = parser.parse_args()
+
+    sources = load_sources(ROOT)
+    tables, errors, warnings = build_rubric(sources, load_policy(ROOT), load_routing(ROOT))
+
+    for name in TABLES:
+        print(f"  {name:<27} {len(tables[name]):>5} rows")
+
+    admitted = sum(1 for r in tables["product_score_sources"] if r["admitted"])
+    total_sources = len(tables["product_score_sources"])
+    if total_sources:
+        print(
+            f"\n  admissible sources: {admitted}/{total_sources} "
+            f"({admitted / total_sources:.0%}); {total_sources - admitted} cite nothing specific"
+        )
+
+    if warnings:
+        print(f"\n{len(warnings)} warning(s) — coverage and data quality, nothing broken")
+        shown = warnings if args.verbose else warnings[:8]
+        for warning in shown:
+            print(f"  - {warning}")
+        if len(shown) < len(warnings):
+            print(f"  ... {len(warnings) - len(shown)} more (--verbose)")
+
+    if errors:
+        print(f"\n{len(errors)} error(s) — these would make scoring wrong:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    if args.check:
+        print("\ncheck only: nothing written")
+        return 0
+
+    write_tables(tables, args.out, TABLES)
+    print(f"\nwrote {len(TABLES)} CSVs to {args.out.relative_to(ROOT)}/")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sources/categories/base_pretrained.yaml
+++ b/sources/categories/base_pretrained.yaml
@@ -64,6 +64,12 @@ scoring_recipe:
     # alone is too blunt: several non-OSI licenses are permissive in substance.
     # The line is whether the license restricts USE, not whether OSI blessed it.
     license_tier:
+      # Declaration order below IS restrictiveness order, least restrictive first.
+      # `multi_sku_rule` resolves a family to the most restrictive tier among its
+      # distributed SKUs, which is meaningless without an ordering. Declared here
+      # and emitted as `tier_rank` by build/serialize_rubric.py so the scorer reads
+      # the order rather than inferring it from how the YAML happens to be written.
+      ordered_by: restrictiveness_ascending
       values:
         osi:
           definition: OSI-approved license

--- a/sources/evidence_policy.yaml
+++ b/sources/evidence_policy.yaml
@@ -1,0 +1,93 @@
+# What counts as evidence, and what counts as an absence of information.
+#
+# ## Evidence is graded by re-derivability, not by author
+#
+# The first pass of `sources/scores/` was agent-authored, so recording whether a
+# human or a model produced a value tells you nothing about whether anyone can
+# check it. What matters is whether the value can be arrived at again. Two grades:
+#
+#   dataset    A named field in a machine-readable source. Re-derived by running
+#              a query. Carries the table, the column and the transform.
+#   document   A specific URL whose content asserts the value. Re-derived by
+#              reading it again. Carries the url, what it shows, and when it was
+#              read.
+#
+# `dataset` is preferred wherever it can answer, because a document is an
+# interpretation of prose and a dataset field is a lookup. RWKV is the case that
+# settled it: its data-openness 5 rested on a paper's claim of a 3.1T open
+# corpus, and what corrected it to 4 was the Hugging Face datasets API showing
+# the published repos hold a component index and 100k/1M previews, no corpus.
+# The document was plausible, traceable and wrong. The dataset was neither
+# plausible nor implausible, it was just checkable.
+#
+# This file is the policy half. `signal_routing.yaml` decides WHICH source is
+# authoritative per dimension; this decides WHETHER a given observation is
+# admissible at all.
+version: 1
+verified_on: '2026-07-28'
+
+# A value with no re-derivation path is not evidence. A rejected observation is
+# still recorded, with its reason, so the gap is queryable rather than invisible
+# - the point is to turn unsourced assertions into a work list.
+admission:
+  # `shows` has to say what the source specifically demonstrates. This phrase was
+  # used as filler during the first pass and asserts nothing: it appears on 199 of
+  # the 1,950 source rows in the repo, and on 111 of the 253 rows behind the 47
+  # base models. 13 base-model products have no other kind of source.
+  boilerplate_shows:
+  - verification source
+  boilerplate_note: >
+    Declared as the shortest phrase that matches all 199 rows. The full string is
+    'flagship phase-C verification source'; matching on the fragment catches the
+    same set with no over-reach. Add a phrase here only after counting how many
+    rows it hits and confirming none of them are real.
+
+  # There is deliberately NO minimum length rule. It was tried and rejected: a
+  # 25-character floor would have thrown out 'MIT License text' and
+  # '13,834 monthly downloads', which are short and completely specific, while
+  # keeping every one of the 199 filler rows, which are long. Length measures
+  # verbosity, not specificity.
+  require_nonempty_shows: true
+
+# Values that mean "this source has no answer". Falling through to a less
+# authoritative source here is how a refresh silently corrupts good data, so the
+# rule is to produce no evidence and leave the dimension to research.
+abstentions:
+  huggingface:
+    license: [other, cc]
+    license_note: >
+      `other` is the Hub's escape hatch for "read the repo". It is an absence of
+      information, not evidence of a permissive or a restrictive license. 12 of
+      147 live Hub rows carry it, including 4 base models. Bare `cc` is the same
+      problem in a different costume: it names a license family with no version
+      and no terms, so it settles nothing.
+  github:
+    license_spdx_id: [NOASSERTION]
+    license_spdx_id_note: >
+      GitHub could not classify the LICENSE file. 25 products hit this. Already
+      declared in signal_routing.yaml as an abstain_when; repeated here so the
+      whole abstention policy reads in one place.
+  # A null license is an abstention everywhere, and is not listed per source
+  # because it needs no interpretation.
+  null_is_abstention: true
+
+  # A declared artifact that does not resolve is not a signal. Five base-model
+  # artifacts are in this state: gemma-3 (both SKUs 404), mistral-large-3 (404),
+  # gemma-4 (307), olmo-3's 32B SKU (404), and rwkv, whose artifact_id is `RWKV`,
+  # an organization rather than a repository.
+  usable_http_status: [200]
+
+# Where a family ships several SKUs and the rubric resolves them with an
+# aggregate rule - most-restrictive-license is the one in use today - the
+# aggregate is only computable when EVERY distributed SKU yields a mapped value.
+partial_coverage:
+  rule: abstain
+  why: >
+    max(restrictiveness) over a subset can only fall, so partial coverage biases
+    a family toward permissive. It overstates openness, which is the worst
+    direction for this map to be wrong in. Measured on qwen-2-5: Qwen2.5-72B
+    reports `other` and Qwen2.5-7B reports apache-2.0, so scoring from the SKUs
+    that answered would move the family from 2/restricted to 3/open_weights on
+    the strength of the SKU that is not the restrictive one. The recipe's
+    multi_sku_rule states that per-SKU licenses come from the Hub and are
+    therefore derivable rather than judged; for this family they are not.

--- a/sources/evidence_policy.yaml
+++ b/sources/evidence_policy.yaml
@@ -49,32 +49,24 @@ admission:
   # verbosity, not specificity.
   require_nonempty_shows: true
 
-# Values that mean "this source has no answer". Falling through to a less
-# authoritative source here is how a refresh silently corrupts good data, so the
-# rule is to produce no evidence and leave the dimension to research.
+# Values that mean "this source has no answer" are NOT declared here. They are a
+# fact about a source, so they live on the route in `signal_routing.yaml` as
+# `abstain_values`, and build/serialize_rubric.py reads them from there into the
+# registry.evidence_abstentions table.
+#
+# An earlier draft of this file declared GitHub's NOASSERTION as well, alongside
+# the `abstain_when` that signal_routing.yaml already had. Two declarations of one
+# rule is precisely the drift the config bridge exists to prevent, so there is now
+# one. What stays here is the policy that is NOT source-specific:
 abstentions:
-  huggingface:
-    license: [other, cc]
-    license_note: >
-      `other` is the Hub's escape hatch for "read the repo". It is an absence of
-      information, not evidence of a permissive or a restrictive license. 12 of
-      147 live Hub rows carry it, including 4 base models. Bare `cc` is the same
-      problem in a different costume: it names a license family with no version
-      and no terms, so it settles nothing.
-  github:
-    license_spdx_id: [NOASSERTION]
-    license_spdx_id_note: >
-      GitHub could not classify the LICENSE file. 25 products hit this. Already
-      declared in signal_routing.yaml as an abstain_when; repeated here so the
-      whole abstention policy reads in one place.
-  # A null license is an abstention everywhere, and is not listed per source
+  # A null value is an abstention from every source, and needs no per-source list
   # because it needs no interpretation.
   null_is_abstention: true
 
-  # A declared artifact that does not resolve is not a signal. Five base-model
-  # artifacts are in this state: gemma-3 (both SKUs 404), mistral-large-3 (404),
-  # gemma-4 (307), olmo-3's 32B SKU (404), and rwkv, whose artifact_id is `RWKV`,
-  # an organization rather than a repository.
+  # A declared artifact that does not resolve is not a signal, whichever source it
+  # came from. Five base-model artifacts were in this state before PR #109: gemma-3
+  # (both SKUs 404), mistral-large-3 (404), gemma-4 (307), olmo-3's 32B SKU (404),
+  # and rwkv, whose artifact_id was `RWKV`, an organization rather than a repository.
   usable_http_status: [200]
 
 # Where a family ships several SKUs and the rubric resolves them with an

--- a/sources/scores/alia-40b.yaml
+++ b/sources/scores/alia-40b.yaml
@@ -11,6 +11,7 @@ openness:
     documented (60+ named sources) rather than released or reconstructable. That missing open-data component
     is the bright line that keeps it at open_weights (4) rather than the OLMo/Pythia/Apertus open_source
     (5) tier, where Apertus reaches 5 by shipping data-reconstruction scripts. No intermediate checkpoints.'
+  last_verified: '2026-06-26'
   sources:
   - url: https://huggingface.co/BSC-LT/ALIA-40b
     shows: Apache-2.0 license; downloadable safetensors weights; 40.4B params; 9.37T training tokens; corpus

--- a/sources/scores/amazon-nova.yaml
+++ b/sources/scores/amazon-nova.yaml
@@ -6,6 +6,7 @@ openness:
   confidence: high
   note: Closed proprietary models served only via AWS Bedrock/SageMaker; no downloadable weights. Confirmed
     on live vendor page.
+  last_verified: '2026-06-04'
   sources:
   - url: https://aws.amazon.com/nova/models/
     shows: Nova 2 Lite/Pro(Preview)/Sonic + Multimodal Embedding via Bedrock/SageMaker, proprietary

--- a/sources/scores/claude-fable-5.yaml
+++ b/sources/scores/claude-fable-5.yaml
@@ -5,6 +5,7 @@ openness:
   components: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
   confidence: high
   note: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
+  last_verified: '2026-06-11'
   sources:
   - url: https://www.anthropic.com/news/claude-fable-5-mythos-5
     shows: Mythos-class flagship, proprietary, claude-fable-5 via API and cloud marketplaces only

--- a/sources/scores/deepseek-v3-base.yaml
+++ b/sources/scores/deepseek-v3-base.yaml
@@ -8,6 +8,7 @@ openness:
   note: 'Weights open and commercially usable; model license is a custom non-OSI agreement (commercial
     use explicitly permitted per the card), so flagged near_open_source_non_osi_license. Verified: code
     MIT + custom model agreement.'
+  last_verified: '2026-06-04'
   sources:
   - url: https://huggingface.co/deepseek-ai/DeepSeek-V3-Base
     shows: 671B/37B MoE base model, MIT code license + custom Model Agreement License, commercial use

--- a/sources/scores/deepseek-v4-pro-base.yaml
+++ b/sources/scores/deepseek-v4-pro-base.yaml
@@ -10,6 +10,7 @@ openness:
     Matches the DeepSeek-V4-Pro anchor (O3 open_weights). Confidence raised to high: independently re-verified
     the live repo (1.6T, 24,567 dl/mo) AND the MIT LICENSE blob (first line "MIT License", DeepSeek 2023)
     this pass; model card empty but license unambiguous.'
+  last_verified: '2026-06-04'
   sources:
   - url: https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro-Base
     shows: 1.6T base model, 24,567 downloads/mo, live repo, but 'No model card'

--- a/sources/scores/ernie-5-1.yaml
+++ b/sources/scores/ernie-5-1.yaml
@@ -6,6 +6,7 @@ openness:
     open, 5.x flagship closed)
   confidence: high
   note: No weights distributed for the 5.x flagship; closed API model.
+  last_verified: '2026-06-18'
   sources:
   - url: https://huggingface.co/baidu
     shows: Baidu HF org lists only ERNIE 4.5 + Image open, no 5.x weights

--- a/sources/scores/gemma-2.yaml
+++ b/sources/scores/gemma-2.yaml
@@ -8,6 +8,7 @@ openness:
   note: 'Weights open but gated under the non-OSI Gemma License with a prohibited-use policy (CONFIRMED:
     repo requires accepting conditions to access files); marketed as ''open'' so flagged open_washed.
     Matches the Gemma 3 anchor (O2 restricted).'
+  last_verified: '2026-07-27'
   sources:
   - url: https://huggingface.co/google/gemma-2-27b
     shows: 27B base (PT, not instruct), Gemma license, gated access requiring terms acceptance, 5,893

--- a/sources/scores/gemma-4.yaml
+++ b/sources/scores/gemma-4.yaml
@@ -6,6 +6,7 @@ openness:
   confidence: medium
   note: OSI-licensed weights, but no open training data or code -> open-weights, not a fully-open pipeline. (License-weighted
     rubrics could argue toward 4.)
+  last_verified: '2026-06-17'
   sources:
   - url: https://ai.google.dev/gemma/docs/releases
     shows: Gemma 4 sizes, release dates, Apache-2.0 license

--- a/sources/scores/glm-4-9b.yaml
+++ b/sources/scores/glm-4-9b.yaml
@@ -9,6 +9,7 @@ openness:
   note: Weights downloadable but glm-4 license is non-OSI with registration-gated commercial use + use
     restrictions, restricted, not open_weights. HF card confirms a custom glm-4 LICENSE file (full restriction
     text in the linked LICENSE).
+  last_verified: '2026-06-04'
   sources:
   - url: https://huggingface.co/THUDM/glm-4-9b-hf
     shows: base GLM-4-9B, 8K context, glm-4 custom license, downloadable weights

--- a/sources/scores/glm-5-2.yaml
+++ b/sources/scores/glm-5-2.yaml
@@ -5,6 +5,7 @@ openness:
   components: weights:open(MIT);data:closed;code:open(inference);license:MIT(OSI)
   confidence: high
   note: Permissive MIT open weights + inference code, but no open training data -> open_weights.
+  last_verified: '2026-06-18'
   sources:
   - url: https://huggingface.co/zai-org/GLM-5.2/blob/main/LICENSE
     shows: MIT, (c) Zhipu AI 2026

--- a/sources/scores/gpt-4-1.yaml
+++ b/sources/scores/gpt-4-1.yaml
@@ -6,6 +6,7 @@ openness:
   confidence: high
   note: No downloadable weights; API-only, like the GPT-5 anchor (O1 closed). Confirmed API-only with
     1M context (1,047,576) on OpenAI docs 2026-06-04.
+  last_verified: '2026-06-04'
   sources:
   - url: https://developers.openai.com/api/docs/models/gpt-4.1
     shows: GPT-4.1 API-only model, 1,047,576 context window, no open weights

--- a/sources/scores/gpt-4o.yaml
+++ b/sources/scores/gpt-4o.yaml
@@ -6,6 +6,7 @@ openness:
   confidence: high
   note: No downloadable weights; API/ChatGPT-only, like the GPT-5 anchor (O1 closed). Confirmed API-only
     with 128K context and Oct 2023 cutoff on OpenAI docs 2026-06-04.
+  last_verified: '2026-06-04'
   sources:
   - url: https://developers.openai.com/api/docs/models/gpt-4o
     shows: GPT-4o API-only model, 128K context, text+image input, no open weights, Oct 2023 cutoff

--- a/sources/scores/inflection-3-0.yaml
+++ b/sources/scores/inflection-3-0.yaml
@@ -6,6 +6,7 @@ openness:
   confidence: high
   note: Closed proprietary models via API + enterprise licensing; no downloadable weights; fine-tuned
     models are the customer's alone. Confirmed via primary Intel Newsroom press release (2026-06-04).
+  last_verified: '2026-06-04'
   sources:
   - url: https://www.maginative.com/article/inflection-ai-unveils-enterprise-offering-with-new-inflection-3-0-models-2/
     shows: Inflection 3.0 (Pi + Productivity), enterprise/API, proprietary (aggregator source)

--- a/sources/scores/inkling.yaml
+++ b/sources/scores/inkling.yaml
@@ -9,6 +9,7 @@ openness:
   note: Apache-2.0 weights are OSI-licensed, but training data and full training code are withheld —
     open_weights / 3, not open_source / 5. Press often calls this 'open source' because of the license
     tag; our spectrum requires open data + code for class open_source.
+  last_verified: '2026-07-19'
   sources:
   - url: https://huggingface.co/thinkingmachines/Inkling
     shows: Apache-2.0 license tag; 975B/41B MoE; weights downloadable; model card states data from public,

--- a/sources/scores/internlm-2-5.yaml
+++ b/sources/scores/internlm-2-5.yaml
@@ -9,6 +9,7 @@ openness:
   note: Code is OSI (Apache-2.0) but the weights license is a custom non-OSI 'Free Commercial License'
     requiring a commercial-license application form (HF card confirms form link, 2026-06-04), so open_weights
     not open_source; flagged for the non-OSI weights term.
+  last_verified: '2026-06-04'
   sources:
   - url: https://huggingface.co/internlm/internlm2_5-7b
     shows: 'model card: code Apache-2.0; weights fully open for academic research and free commercial

--- a/sources/scores/kimi-k3.yaml
+++ b/sources/scores/kimi-k3.yaml
@@ -10,6 +10,7 @@ openness:
     closed). Weights not yet on HF as of 2026-07-19 — Moonshot's primary blog commits to a full weight
     release by 2026-07-27. Re-verify license text and HF card on landing; downgrade to closed if the release
     slips or the license changes.
+  last_verified: '2026-07-19'
   sources:
   - url: https://www.kimi.com/blog/kimi-k3
     shows: primary announcement — 2.8T MoE, 1M context, native vision; API live; full weights by 2026-07-27

--- a/sources/scores/llama-3-1.yaml
+++ b/sources/scores/llama-3-1.yaml
@@ -10,6 +10,7 @@ openness:
     actual Llama 3.1 license, Section 2); marketed as ''open'' so flagged open_washed. Corrected source:
     the record originally cited the Llama 2 license text as a proxy; replaced with the actual Llama 3.1
     Community License.'
+  last_verified: '2026-07-27'
   sources:
   - url: https://huggingface.co/meta-llama/Llama-3.1-8B
     shows: base pretrained 8B (page states base, not instruct), Llama 3.1 Community License, downloadable

--- a/sources/scores/lucie-7b.yaml
+++ b/sources/scores/lucie-7b.yaml
@@ -8,7 +8,7 @@ openness:
   note: 'Full open-source tier alongside OLMo / Apertus: open weights, open training data, open training
     code, intermediate checkpoints. Authors position Lucie as OSI-definition-compliant for open-source AI.
     Training-dataset product deferred — artifacts cited here for openness only.'
-  last_verified: '2026-07-28'
+  last_verified: '2026-07-27'
   sources:
   - url: https://huggingface.co/api/datasets/OpenLLM-France/Lucie-Training-Dataset
     shows: Public, ungated dataset repo present on the Hub; 3,101 downloads. Corpus is published, not merely described.

--- a/sources/scores/marin.yaml
+++ b/sources/scores/marin.yaml
@@ -6,6 +6,7 @@ openness:
   confidence: high
   note: 'Stanford CRFM ''open lab'': Apache-2.0 weights plus documented code, data, experiments, hyperparameters
     and training logs, with bit-for-bit reproducible training.'
+  last_verified: '2026-06-30'
   sources:
   - url: http://marin.community/blog/2025/05/19/announcement/
     shows: 'Marin open lab: code, data, experiments, logs all shared'

--- a/sources/scores/mimo-v2-5-pro.yaml
+++ b/sources/scores/mimo-v2-5-pro.yaml
@@ -5,6 +5,7 @@ openness:
   components: weights:open(MIT per HF card);data:closed;code:open;license:MIT(HF card; older GitHub repo shows Apache-2.0)
   confidence: medium
   note: Open weights under a permissive license (MIT per the model card); no open training data -> open_weights.
+  last_verified: '2026-06-18'
   sources:
   - url: https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro
     shows: MIT, 1.02T/42B MoE, 1M context, benchmarks

--- a/sources/scores/minimax-m3.yaml
+++ b/sources/scores/minimax-m3.yaml
@@ -8,6 +8,7 @@ openness:
   note: Weights released publicly on Hugging Face after the 2026-06-04 scoring (then announced-not-yet-released);
     ungated download under a custom minimax-community license. Data and training pipeline closed, so
     open_weights not open_source. Matches the MiniMax-M2.5 sibling precedent.
+  last_verified: '2026-06-23'
   sources:
   - url: https://huggingface.co/api/models/MiniMaxAI/MiniMax-M3
     shows: Public ungated weights repo (safetensors/MoE), license=minimax-community, created 2026-06-02

--- a/sources/scores/mistral-large-2.yaml
+++ b/sources/scores/mistral-large-2.yaml
@@ -9,6 +9,7 @@ openness:
     card explicitly restricts to personal/scientific/academic non-profit use; commercial requires contacting
     Mistral). Notable contrast with Mistral Large 3''s Apache-2.0. No base-only weights published; public
     SKU is instruct.'
+  last_verified: '2026-06-04'
   sources:
   - url: https://huggingface.co/mistralai/Mistral-Large-Instruct-2407
     shows: 123B instruct model, Mistral AI Research License (research/non-commercial only), 7,455 downloads/mo,

--- a/sources/scores/olmo-3.yaml
+++ b/sources/scores/olmo-3.yaml
@@ -7,7 +7,7 @@ openness:
   confidence: high
   note: 'Fully open: Apache-2.0 weights + the complete Dolma 3 corpus + training code + intermediate checkpoints.
     The reference fully-open model line.'
-  last_verified: '2026-07-28'
+  last_verified: '2026-07-27'
   sources:
   - url: https://huggingface.co/api/datasets/allenai/dolma
     shows: Public, ungated dataset repo present on the Hub; 3,052 downloads. Dolma corpus is published.

--- a/sources/scores/pythia.yaml
+++ b/sources/scores/pythia.yaml
@@ -7,7 +7,7 @@ openness:
   confidence: high
   note: weights:open(Apache-2.0);data:open(the Pile, with dataloader reconstruction tools);code:open(training+analysis
     code, GitHub);checkpoints:open(154 per model);license:Apache-2.0(OSI)
-  last_verified: '2026-07-28'
+  last_verified: '2026-07-27'
   sources:
   - url: https://huggingface.co/api/datasets/EleutherAI/pile
     shows: Public, ungated dataset repo present on the Hub; 2,441 downloads. The Pile is published.

--- a/sources/scores/qwen-2-5.yaml
+++ b/sources/scores/qwen-2-5.yaml
@@ -9,6 +9,7 @@ openness:
   note: 'Flagship 72B base carries the Qwen License with a 100M MAU cap (CONFIRMED in license Section
     4: >100M MAU commercial requires separate authorization), non-OSI, so the headline SKU is restricted;
     smaller sizes are Apache. Mixed-tier across the family.'
+  last_verified: '2026-06-04'
   sources:
   - url: https://huggingface.co/Qwen/Qwen2.5-72B/blob/main/LICENSE
     shows: Qwen License Agreement Section 4, 100M MAU commercial cap requiring separate authorization

--- a/sources/scores/qwen-3-7-max.yaml
+++ b/sources/scores/qwen-3-7-max.yaml
@@ -6,6 +6,7 @@ openness:
     from Qwen open-weights line)
   confidence: high
   note: Alibaba's own announcement calls it a proprietary model; no weights distributed.
+  last_verified: '2026-06-18'
   sources:
   - url: https://www.alibabacloud.com/blog/qwen3-7-the-agent-frontier_603154
     shows: 'official: ''proprietary'', Model Studio API-only'

--- a/sources/scores/qwen3.yaml
+++ b/sources/scores/qwen3.yaml
@@ -7,6 +7,7 @@ openness:
   confidence: high
   note: Apache-2.0 base weights with no MAU cap (cleaner than Qwen2.5's flagship license, confirmed);
     data and training code closed -> open_weights, matching the Qwen 3.6 anchor (O3).
+  last_verified: '2026-06-04'
   sources:
   - url: https://huggingface.co/Qwen/Qwen3-30B-A3B-Base
     shows: Qwen3 base MoE (30.5B/3.3B), Apache-2.0, 42,966 downloads/mo

--- a/sources/scores/reka-core.yaml
+++ b/sources/scores/reka-core.yaml
@@ -7,6 +7,7 @@ openness:
   confidence: high
   note: Proprietary multimodal model; API/on-prem/on-device deployment but no downloadable weights. Confirmed
     on launch page.
+  last_verified: '2026-06-04'
   sources:
   - url: https://reka.ai/news/reka-core-our-frontier-class-multimodal-language-model
     shows: Reka Core via API/on-prem/on-device, proprietary, no open weights

--- a/sources/scores/smollm3.yaml
+++ b/sources/scores/smollm3.yaml
@@ -7,6 +7,7 @@ openness:
   confidence: high
   note: 'Fully-open small-model line: Apache-2.0 weights with the complete engineering blueprint (architecture,
     data mixtures, training and post-training recipe) published.'
+  last_verified: '2026-06-30'
   sources:
   - url: https://huggingface.co/blog/smollm3
     shows: 'fully-open 3B: 11T tokens, 128K context, multilingual, full recipe published'

--- a/sources/scores/yi-1-5.yaml
+++ b/sources/scores/yi-1-5.yaml
@@ -7,6 +7,7 @@ openness:
   confidence: high
   note: Permissive Apache-2.0 weights but training data and full training code are not released, so open_weights
     not open_source. Apache-2.0 confirmed on HF base cards 2026-06-04.
+  last_verified: '2026-06-04'
   sources:
   - url: https://huggingface.co/01-ai/Yi-1.5-34B
     shows: Apache-2.0 license, 34B base model (base vs chat variants listed), downloadable weights

--- a/sources/signal_routing.yaml
+++ b/sources/signal_routing.yaml
@@ -88,20 +88,35 @@ dimensions:
 
   license:
     question: Which license governs the artifact being scored?
+    # `abstain_values` is the authoritative list of values that mean "this source
+    # has no answer for this column". It lives here, on the route, because
+    # abstention is a fact about a SOURCE, and this file is what owns source
+    # semantics. `evidence_policy.yaml` owns the separate question of whether a
+    # DOCUMENT is admissible. Keeping the two apart is deliberate: an earlier draft
+    # declared NOASSERTION in both files, which is exactly the drift this bridge
+    # exists to prevent. build/serialize_rubric.py reads these into the
+    # registry.evidence_abstentions table, so the warehouse never hardcodes them.
     routes:
     - source: huggingface_model
       column: license
       governs: weights
       confidence: high
+      abstain_values: [other, cc]
+      abstain_note: >
+        `other` is the Hub's escape hatch for "read the repo", and bare `cc` names
+        a license family with no version and no terms. Both are an absence of
+        information, not evidence of a permissive or a restrictive license. 12 of
+        147 live Hub rows carry one, including 4 base models.
     - source: huggingface_dataset
       column: license
       governs: dataset
       confidence: high
+      abstain_values: [other, cc]
     - source: github
       column: license_spdx_id
       governs: code
       confidence: high
-      abstain_when: license_spdx_id = 'NOASSERTION'
+      abstain_values: [NOASSERTION]
       abstain_note: >
         GitHub could not classify the LICENSE file. It is an absence of
         information, not evidence of a non-standard license. 25 products hit

--- a/sources/signal_routing.yaml
+++ b/sources/signal_routing.yaml
@@ -116,6 +116,36 @@ dimensions:
     - strip a leading `app=` / `code=` / `model=` qualifier
     - '`assumed-X` keeps tier X but caps confidence at medium'
 
+    # Hugging Face publishes a license SLUG, not the license name a rubric's tier
+    # examples use. Without this map `gemma` and `llama3.1` match no tier and the
+    # signal reads as ABSENT while it is in fact present and use-restricting -
+    # which is the failure that overstates openness. 12 of the 47 base models
+    # depend on an alias to route their license at all.
+    #
+    # These are aliases only. They say what a slug is CALLED, which is a fact
+    # about the Hub. They deliberately do NOT say what tier it belongs to, which
+    # is a judgment each category's `scoring_recipe` makes for itself. A slug that
+    # aliases to a name absent from the category's license_tier examples abstains,
+    # and that abstention is the signal to extend the rubric rather than to guess.
+    aliases:
+      huggingface:
+        apache-2.0: Apache-2.0
+        mit: MIT
+        bsd-3-clause: BSD-3-Clause
+        gemma: Gemma-License
+        llama2: Llama-2-Community-License
+        llama3: Llama-3-Community-License
+        llama3.1: Llama-3.1-Community-License
+        llama3.2: Llama-3.2-Community-License
+        llama4: Llama-4-Community
+        bigcode-openrail-m: BigCode-OpenRAIL-M
+        odc-by: ODC-By-1.0
+        cc0-1.0: CC0-1.0
+        cc-by-4.0: CC-BY-4.0
+        cc-by-sa-4.0: CC-BY-SA-4.0
+        cc-by-nc-sa-4.0: CC-BY-NC-SA-4.0
+        etalab-2.0: Etalab-Open-License-2.0
+
   weights:
     question: Are the trained weights downloadable and runnable locally?
     routes:

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -202,33 +202,68 @@ def test_license_aliases_come_out_per_source():
     ]
 
 
-def test_abstentions_flatten_and_skip_their_prose_notes():
-    """The policy crosses the bridge instead of being written into warehouse SQL, so
-    that one declaration drives both. The `_note` keys are for a reader."""
-    policy = {
-        "abstentions": {
-            "huggingface": {"license": ["other", "cc"], "license_note": "prose for a human"},
-            "github": {"license_spdx_id": ["NOASSERTION"]},
-            "null_is_abstention": True,
+def test_abstentions_come_from_the_route_and_keep_the_source_specific():
+    """Read from signal_routing.yaml, not evidence_policy.yaml. `source` is the route
+    name so a model-license abstention cannot be read as a dataset-license one."""
+    routing = {
+        "dimensions": {
+            "license": {
+                "routes": [
+                    {"source": "huggingface_model", "column": "license",
+                     "abstain_values": ["other", "cc"], "abstain_note": "prose for a human"},
+                    {"source": "github", "column": "license_spdx_id",
+                     "abstain_values": ["NOASSERTION"]},
+                    {"source": "huggingface_dataset", "column": "license"},
+                ]
+            }
         }
     }
-    rows = evidence_abstentions(policy)
-    assert rows == [
-        {"source": "huggingface", "column_name": "license", "abstain_value": "other"},
-        {"source": "huggingface", "column_name": "license", "abstain_value": "cc"},
+    assert evidence_abstentions(routing) == [
+        {"source": "huggingface_model", "column_name": "license", "abstain_value": "other"},
+        {"source": "huggingface_model", "column_name": "license", "abstain_value": "cc"},
         {"source": "github", "column_name": "license_spdx_id", "abstain_value": "NOASSERTION"},
     ]
 
 
-def test_real_abstentions_cover_the_two_escape_hatches_seen_in_the_data():
+def test_the_same_source_column_routed_twice_yields_one_row_per_value():
+    """A lookup table with duplicate keys would fan out the evidence join."""
+    routing = {
+        "dimensions": {
+            "license": {"routes": [{"source": "github", "column": "license_spdx_id",
+                                    "abstain_values": ["NOASSERTION"]}]},
+            "code": {"routes": [{"source": "github", "column": "license_spdx_id",
+                                 "abstain_values": ["NOASSERTION"]}]},
+        }
+    }
+    assert len(evidence_abstentions(routing)) == 1
+
+
+def test_real_abstentions_cover_the_escape_hatches_seen_in_the_data():
+    from pathlib import Path
+
+    from build.serialize_rubric import load_routing
+
+    rows = evidence_abstentions(load_routing(Path(__file__).resolve().parents[1]))
+    pairs = {(r["source"], r["abstain_value"]) for r in rows}
+    assert ("huggingface_model", "other") in pairs
+    assert ("huggingface_model", "cc") in pairs
+    assert ("github", "NOASSERTION") in pairs
+
+
+def test_abstentions_are_declared_in_exactly_one_file():
+    """Regression guard. NOASSERTION was once declared in both signal_routing.yaml and
+    evidence_policy.yaml; a reader fixing one would have missed the other."""
     from pathlib import Path
 
     from build.serialize_rubric import load_policy
 
-    rows = evidence_abstentions(load_policy(Path(__file__).resolve().parents[1]))
-    pairs = {(r["source"], r["abstain_value"]) for r in rows}
-    assert ("huggingface", "other") in pairs
-    assert ("github", "NOASSERTION") in pairs
+    policy_abstentions = load_policy(Path(__file__).resolve().parents[1]).get("abstentions") or {}
+    # Only non-source-specific policy belongs here, and those are scalars/flags.
+    for key, value in policy_abstentions.items():
+        assert not isinstance(value, dict), (
+            f"evidence_policy.yaml declares per-source abstentions under {key!r}; "
+            f"those belong on the route in signal_routing.yaml"
+        )
 
 
 def test_admission_rejects_the_declared_boilerplate():

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -1,0 +1,394 @@
+"""Tests for the rubric and evidence serializer.
+
+Two things here would corrupt scores silently rather than loudly, so they get the
+attention: the ORDER of the formula rules, because the formula is first-match-wins
+and a reordering changes scores without changing any value, and the ADMISSION rule,
+because a filler source that passes for evidence is worse than no source at all.
+"""
+
+import pytest
+
+from build.serialize_rubric import (
+    TABLES,
+    admit,
+    build_rubric,
+    evidence_abstentions,
+    license_aliases,
+    license_tiers,
+    scoring_rules,
+    split_value,
+)
+
+RECIPE = {
+    "version": 1,
+    "openness": {
+        "dimensions": {
+            "weights": {"question": "?", "values": ["open", "closed", "pending"]},
+            "data": {"question": "?", "values": ["open", "documented-not-released", "closed"]},
+            "code": {"question": "?", "values": ["open", "partial", "closed"]},
+        },
+        "license_tier": {
+            "ordered_by": "restrictiveness_ascending",
+            "values": {
+                "osi": {"examples": ["Apache-2.0", "MIT"]},
+                "use_restricted": {"examples": ["Gemma-License"]},
+                "proprietary": {"definition": "no public license"},
+            },
+        },
+        "formula": [
+            {"when": {"weights": "closed"}, "then": {"score": 1, "class": "closed"}},
+            {"when": {"license_tier": "use_restricted"}, "then": {"score": 2, "class": "restricted"}},
+            {
+                "when": {"data": "open", "code": "open", "license_tier": "osi"},
+                "then": {"score": 5, "class": "open_source"},
+            },
+            {"otherwise": {"score": 3, "class": "open_weights"}},
+        ],
+    },
+}
+
+POLICY = {"admission": {"boilerplate_shows": ["verification source"], "require_nonempty_shows": True}}
+
+
+def _sources(categories=None, scores=None):
+    return {"categories": categories or {}, "scores": scores or {}}
+
+
+def test_split_value_separates_the_bare_value_from_its_detail():
+    assert split_value("open(downloadable on HF, gated)") == ("open", "downloadable on HF, gated")
+    assert split_value("Apache-2.0(OSI)") == ("Apache-2.0", "OSI")
+    assert split_value("closed") == ("closed", "")
+    assert split_value("") == ("", "")
+
+
+def test_split_value_bare_half_matches_what_the_formula_consumes():
+    """The formula reads check_rubric.head; the two must not diverge."""
+    from build.check_rubric import head
+
+    for raw in [
+        "open(downloadable on HF, gated/terms acceptance)",
+        "code MIT + model DeepSeek-Model-License",
+        "documented-not-released",
+        "Llama-3.1-Community-License(non-OSI: 700M MAU cap)",
+    ]:
+        assert split_value(raw)[0] == head(raw)
+
+
+def test_formula_order_is_preserved_because_first_match_wins():
+    rows, errors = scoring_rules("base", RECIPE)
+    assert errors == []
+    indexes = [r["rule_index"] for r in rows]
+    assert indexes == sorted(indexes)
+    # The `weights: closed` short circuit has to stay ahead of the tier rules, or a
+    # closed model with a restrictive license scores 2 instead of 1.
+    assert rows[0] == {
+        "category_slug": "base",
+        "recipe_version": 1,
+        "rule_index": 0,
+        "is_otherwise": False,
+        "condition_key": "weights",
+        "condition_value": "closed",
+        "then_score": 1,
+        "then_class": "closed",
+    }
+
+
+def test_multi_condition_rule_becomes_several_rows_sharing_a_rule_index():
+    rows, _ = scoring_rules("base", RECIPE)
+    rule_2 = [r for r in rows if r["rule_index"] == 2]
+    assert len(rule_2) == 3
+    assert {r["condition_key"] for r in rule_2} == {"data", "code", "license_tier"}
+    assert {r["then_score"] for r in rule_2} == {5}
+
+
+def test_otherwise_rule_carries_no_condition():
+    rows, _ = scoring_rules("base", RECIPE)
+    fallthrough = [r for r in rows if r["is_otherwise"]]
+    assert len(fallthrough) == 1
+    assert fallthrough[0]["condition_key"] == ""
+    assert fallthrough[0]["then_score"] == 3
+
+
+def test_rule_testing_an_undeclared_dimension_is_an_error():
+    """A dead rule does not raise, it just pushes products into `otherwise`."""
+    recipe = {
+        "version": 1,
+        "openness": {
+            "dimensions": {"weights": {"values": ["open"]}},
+            "license_tier": {"values": {"osi": {"examples": ["MIT"]}}},
+            "formula": [{"when": {"governance": "foundation"}, "then": {"score": 4, "class": "x"}}],
+        },
+    }
+    _, errors = scoring_rules("base", recipe)
+    assert any("undeclared dimension 'governance'" in e for e in errors)
+
+
+def test_rule_testing_a_value_outside_the_declared_enum_is_an_error():
+    recipe = {
+        "version": 1,
+        "openness": {
+            "dimensions": {"data": {"values": ["open", "closed"]}},
+            "license_tier": {"values": {"osi": {"examples": ["MIT"]}}},
+            "formula": [{"when": {"data": "components-listed"}, "then": {"score": 4, "class": "x"}}],
+        },
+    }
+    _, errors = scoring_rules("base", recipe)
+    assert any("components-listed" in e for e in errors)
+
+
+def test_rule_testing_an_undefined_tier_is_an_error():
+    recipe = {
+        "version": 1,
+        "openness": {
+            "dimensions": {"data": {"values": ["open"]}},
+            "license_tier": {"values": {"osi": {"examples": ["MIT"]}}},
+            "formula": [{"when": {"license_tier": "copyleft"}, "then": {"score": 4, "class": "x"}}],
+        },
+    }
+    _, errors = scoring_rules("base", recipe)
+    assert any("copyleft" in e for e in errors)
+
+
+def test_proprietary_tier_is_emitted_definitionally():
+    """No vendor publishes a license called 'proprietary', so the tier is defined by
+    meaning. Emitting the tokens keeps the warehouse to one lookup table."""
+    rows, errors = license_tiers("base", RECIPE)
+    assert errors == []
+    proprietary = [r for r in rows if r["tier"] == "proprietary"]
+    assert {r["example_license"] for r in proprietary} == {"proprietary", "closed", "none"}
+    assert all(r["is_definitional"] for r in proprietary)
+    osi = [r for r in rows if r["tier"] == "osi"]
+    assert not any(r["is_definitional"] for r in osi)
+
+
+def test_tier_rank_follows_declaration_order():
+    """`most restrictive SKU governs` needs an ordering, and it has to be the
+    declared one rather than whatever order the YAML happens to use."""
+    rows, _ = license_tiers("base", RECIPE)
+    rank_of = {r["tier"]: r["tier_rank"] for r in rows}
+    assert rank_of["osi"] < rank_of["use_restricted"] < rank_of["proprietary"]
+
+
+def test_several_tiers_without_a_declared_ordering_is_an_error():
+    recipe = {
+        "version": 1,
+        "openness": {
+            "dimensions": {},
+            "license_tier": {
+                "values": {"osi": {"examples": ["MIT"]}, "use_restricted": {"examples": ["Gemma"]}}
+            },
+            "formula": [],
+        },
+    }
+    _, errors = license_tiers("base", recipe)
+    assert any("ordered_by" in e for e in errors)
+
+
+def test_a_single_tier_needs_no_declared_ordering():
+    """Nothing to compare, so requiring the key would be noise."""
+    recipe = {
+        "version": 1,
+        "openness": {"license_tier": {"values": {"osi": {"examples": ["MIT"]}}}},
+    }
+    rows, errors = license_tiers("base", recipe)
+    assert errors == []
+    assert rows[0]["tier_rank"] == 0
+
+
+def test_license_aliases_come_out_per_source():
+    routing = {"dimensions": {"license": {"aliases": {"huggingface": {"gemma": "Gemma-License"}}}}}
+    assert license_aliases(routing) == [
+        {"source": "huggingface", "license_slug": "gemma", "license_name": "Gemma-License"}
+    ]
+
+
+def test_abstentions_flatten_and_skip_their_prose_notes():
+    """The policy crosses the bridge instead of being written into warehouse SQL, so
+    that one declaration drives both. The `_note` keys are for a reader."""
+    policy = {
+        "abstentions": {
+            "huggingface": {"license": ["other", "cc"], "license_note": "prose for a human"},
+            "github": {"license_spdx_id": ["NOASSERTION"]},
+            "null_is_abstention": True,
+        }
+    }
+    rows = evidence_abstentions(policy)
+    assert rows == [
+        {"source": "huggingface", "column_name": "license", "abstain_value": "other"},
+        {"source": "huggingface", "column_name": "license", "abstain_value": "cc"},
+        {"source": "github", "column_name": "license_spdx_id", "abstain_value": "NOASSERTION"},
+    ]
+
+
+def test_real_abstentions_cover_the_two_escape_hatches_seen_in_the_data():
+    from pathlib import Path
+
+    from build.serialize_rubric import load_policy
+
+    rows = evidence_abstentions(load_policy(Path(__file__).resolve().parents[1]))
+    pairs = {(r["source"], r["abstain_value"]) for r in rows}
+    assert ("huggingface", "other") in pairs
+    assert ("github", "NOASSERTION") in pairs
+
+
+def test_admission_rejects_the_declared_boilerplate():
+    ok, reason = admit("flagship phase-C verification source", POLICY)
+    assert not ok
+    assert "boilerplate" in reason
+
+
+def test_admission_rejects_an_empty_shows():
+    ok, reason = admit("", POLICY)
+    assert not ok
+    assert "no `shows`" in reason
+
+
+@pytest.mark.parametrize(
+    "shows",
+    [
+        "MIT License text",
+        "13,834 monthly downloads",
+        "~1,996 stars",
+        "AA Intelligence Index 17, rank #29/43",
+    ],
+)
+def test_admission_keeps_short_but_specific_sources(shows):
+    """A length floor was tried and rejected. These are all under 40 characters and
+    every one of them names a fact; the 199 filler rows are longer than all of them."""
+    ok, reason = admit(shows, POLICY)
+    assert ok, reason
+
+
+def test_rejected_sources_are_emitted_not_dropped():
+    """Rejection turns an unsourced assertion into a work item. Dropping it would
+    make the gap invisible, which is the failure mode being fixed."""
+    sources = _sources(
+        categories={"base": {"scoring_recipe": RECIPE, "products": ["m"]}},
+        scores={
+            "m": {
+                "openness": {
+                    "score": 3,
+                    "class": "open_weights",
+                    "components": "weights:open;data:closed",
+                    "sources": [
+                        {"url": "https://x.test/a", "shows": "flagship phase-C verification source", "accessed": "2026-06-04"},
+                        {"url": "https://x.test/b", "shows": "Apache-2.0 in the model card", "accessed": "2026-06-04"},
+                    ],
+                }
+            }
+        },
+    )
+    tables, errors, warnings = build_rubric(sources, POLICY, {})
+    assert errors == []
+    rows = tables["product_score_sources"]
+    assert len(rows) == 2
+    assert [r["admitted"] for r in rows] == [False, True]
+    assert any("cite nothing specific" in w for w in warnings)
+
+
+def test_evidence_comes_out_at_dimension_grain():
+    sources = _sources(
+        categories={"base": {"scoring_recipe": RECIPE, "products": ["m"]}},
+        scores={"m": {"openness": {"components": "weights:open(on HF);data:closed;license:MIT(OSI)"}}},
+    )
+    tables, errors, _ = build_rubric(sources, POLICY, {})
+    assert errors == []
+    by_dimension = {r["dimension"]: r for r in tables["product_openness_evidence"]}
+    assert set(by_dimension) == {"weights", "data", "license"}
+    assert by_dimension["weights"]["value"] == "open"
+    assert by_dimension["weights"]["value_detail"] == "on HF"
+    assert by_dimension["weights"]["grade"] == "document"
+    # `license` feeds the tier lookup rather than an enum, so it has nothing to check.
+    assert by_dimension["license"]["in_declared_enum"] == ""
+    assert by_dimension["data"]["in_declared_enum"] is True
+
+
+def test_value_outside_the_declared_enum_is_a_warning_not_an_error():
+    """The rubric being too coarse for the data is a curation finding, and it must
+    not block a build."""
+    sources = _sources(
+        categories={"base": {"scoring_recipe": RECIPE, "products": ["m"]}},
+        scores={"m": {"openness": {"components": "data:components-listed"}}},
+    )
+    tables, errors, warnings = build_rubric(sources, POLICY, {})
+    assert errors == []
+    assert any("components-listed" in w for w in warnings)
+    assert tables["product_openness_evidence"][0]["in_declared_enum"] is False
+
+
+def test_undeclared_component_dimension_is_a_warning():
+    """`marin` records reproducibility:bit-for-bit, which is a real openness fact the
+    base-model rubric has no question for. It cannot move a score, but it should not
+    pass through unremarked either."""
+    sources = _sources(
+        categories={"base": {"scoring_recipe": RECIPE, "products": ["m"]}},
+        scores={"m": {"openness": {"components": "weights:open;reproducibility:bit-for-bit"}}},
+    )
+    tables, errors, warnings = build_rubric(sources, POLICY, {})
+    assert errors == []
+    assert any("'reproducibility'" in w and "does not declare" in w for w in warnings)
+    # Still emitted: the scorer ignores it, a curator should not have to.
+    assert {r["dimension"] for r in tables["product_openness_evidence"]} == {
+        "weights",
+        "reproducibility",
+    }
+
+
+def test_license_is_not_treated_as_an_undeclared_dimension():
+    """It feeds the tier lookup rather than being a dimension with an enum."""
+    sources = _sources(
+        categories={"base": {"scoring_recipe": RECIPE, "products": ["m"]}},
+        scores={"m": {"openness": {"components": "license:MIT(OSI)"}}},
+    )
+    _, _, warnings = build_rubric(sources, POLICY, {})
+    assert not any("does not declare" in w for w in warnings)
+
+
+def test_a_category_with_no_recipe_is_a_warning():
+    sources = _sources(categories={"base": {"scoring_recipe": RECIPE, "products": []}, "other": {}})
+    _, errors, warnings = build_rubric(sources, POLICY, {})
+    assert errors == []
+    assert any("'other' declares no scoring_recipe" in w for w in warnings)
+
+
+def test_no_recipe_anywhere_is_an_error():
+    _, errors, _ = build_rubric(_sources(categories={"other": {}}), POLICY, {})
+    assert any("nothing to score with" in e for e in errors)
+
+
+def test_every_declared_table_is_present():
+    tables, _, _ = build_rubric(_sources(categories={"base": {"scoring_recipe": RECIPE}}), POLICY, {})
+    assert set(tables) == set(TABLES)
+
+
+def test_real_sources_serialize_without_errors():
+    from pathlib import Path
+
+    from build.serialize_rubric import load_policy, load_routing
+    from build.validate import load_sources
+
+    root = Path(__file__).resolve().parents[1]
+    tables, errors, _ = build_rubric(load_sources(root), load_policy(root), load_routing(root))
+    assert errors == [], f"rubric has errors: {errors[:5]}"
+    # base_pretrained is the only category with a recipe today; when that changes
+    # these counts move, which is the point of asserting them.
+    assert len(tables["category_scoring_rules"]) == 11
+    assert len(tables["product_openness_evidence"]) == 195
+    assert {r["grade"] for r in tables["product_openness_evidence"]} == {"document"}
+
+
+def test_real_license_aliases_cover_every_slug_the_hub_actually_returns():
+    """Slugs observed live in signal_huggingface.hub_state on 2026-07-28. A slug with
+    no alias reads as an ABSENT license rather than a present one, which is the
+    direction that overstates openness."""
+    from pathlib import Path
+
+    from build.serialize_rubric import load_routing
+
+    observed_models = {"apache-2.0", "mit", "llama3.1", "gemma", "llama2", "llama3", "bigcode-openrail-m"}
+    aliased = {
+        r["license_slug"]
+        for r in license_aliases(load_routing(Path(__file__).resolve().parents[1]))
+        if r["source"] == "huggingface"
+    }
+    assert observed_models <= aliased, f"unaliased Hub license slugs: {observed_models - aliased}"


### PR DESCRIPTION
Scores can now be computed from stored evidence and written back to `sources/scores/`, so a reviewer checks a score rather than authoring one. Proven end to end on `base_pretrained`: the warehouse reproduces all 47 hand-authored openness scores.

The objective test for layer-2 was never "is the data fresh". It was **did a score change without anyone hand-writing it?** This PR is the first change to `sources/scores/` that no person typed.

## What was missing

`serialize_registry` emits identity only, so each category's `scoring_recipe` never reached OSO and there was nothing for a scorer to apply. `serialize_rubric` adds it, as a separate module: the registry's claim ("this is what exists") and this one's ("this is what we currently record, including where it cites nothing specific") are different claims, and merging them would let a serializer that ships unverified assertions borrow the registry's credibility.

| table | rows | what it carries |
|---|---|---|
| `category_scoring_rules` | 11 | the ordered formula, one row per condition |
| `category_license_tiers` | 17 | tier ← example license, with a declared rank |
| `license_aliases` | 16 | a source's license slug → canonical name |
| `evidence_abstentions` | 3 | values meaning "this source has no answer" |
| `product_openness_evidence` | 195 | per-dimension values parsed from `components` |
| `product_score_sources` | 253 | per-axis sources, each with an admission verdict |

Two warehouse models consume it, both plain Trino SQL:

- **`currentai.evidence.product_evidence`** (275 rows) — graded observations, one row per product/category/dimension/grade/artifact.
- **`currentai.scores.openness_computed`** (47 rows) — the ordered-rule walk from `build/check_rubric.py:apply_formula`, applying rules that arrive from the bridge rather than any written here. Editing a threshold in the repo re-scores without touching the model.

## Evidence is graded by re-derivability, not by author

The first pass of `sources/scores/` was itself agent-authored, so recording whether a human or a model produced a value says nothing about whether anyone can check it. Two grades: **`dataset`** (a named field in a machine-readable source, re-derived by running a query) and **`document`** (a URL whose content asserts it, re-derived by reading it). `dataset` is preferred wherever it can answer.

RWKV is why the preference runs that way. Its data-openness 5 rested on a paper's *claim* of a 3.1T open corpus; what corrected it to 4 was the Hub showing the published repos hold a component index and previews. The document was plausible, traceable and wrong.

`sources/evidence_policy.yaml` declares the policy, and it crosses the bridge rather than being written into the SQL, because a policy implemented in two places drifts.

## Three bugs measurement caught before they shipped

**Partial SKU coverage cannot be trusted.** `Qwen2.5-72B` reports its license as `other` (the Hub's "read the repo" escape hatch) and `Qwen2.5-7B` as `apache-2.0`. Resolving most-restrictive over the SKUs that answered moves `qwen-2-5` from 2/restricted to 3/open_weights — on the strength of the SKU that is not the restrictive one. `max(restrictiveness)` over a subset can only fall, so partial coverage *always* biases toward permissive. It overstates openness, which is the worst direction for this map to be wrong in. The rule is now to abstain at the family level. The weights aggregate needs no such guard and doesn't get one: one downloadable SKU makes the family downloadable, so an unreachable SKU could only add openness.

**Hub license slugs need aliases.** `gemma` and `llama3.1` match none of the rubric's tier examples, so without the map a present, use-restricting license reads as *absent* — the same direction of error. 12 of the 47 base models depend on an alias to route their license at all.

**A minimum length was the wrong way to spot filler evidence.** I tried a 25-character floor on `shows`. It would have rejected `'MIT License text'` and `'13,834 monthly downloads'` — short and completely specific — while keeping all 199 filler rows, which are long. Length measures verbosity, not specificity. One declared phrase does the job.

## Coverage is thinner than `check_routing` reports

`check_routing` counts a *declared artifact*, not a *usable value*. For base models only **15 of 47** license tiers come from a machine-readable field: 6 abstain (`other` or null) and 26 have no signal at all. Worth knowing before trusting the 335 figure repo-wide.

**111 of the 253 source rows** behind these 47 products say only `shows: flagship phase-C verification source`, which asserts nothing. Those are recorded as inadmissible *with a reason* rather than dropped, so unsourced assertions become a queryable work list instead of passing for provenance.

Five declared Hub artifacts don't resolve — `gemma-3` (both SKUs 404), `mistral-large-3` (404), `gemma-4` (307), `olmo-3`'s 32B (404), and `rwkv`, whose `artifact_id` is `RWKV`, an organization rather than a repository. Those get their own PR.

## What landed in `sources/scores/`

**No openness score or class moved.** That is the expected result: the rubric was reverse-engineered from these files, so agreement is a fidelity check on the formula, not a validation of the facts. What changed is that 30 openness axes now carry a date the pipeline can defend, taking the repo from **6 real `last_verified` values to 33**.

`last_verified` is the MIN accessed date across the evidence the winning rule depends on, and absent whenever any of that evidence cites nothing specific. An axis is only as verified as its stalest input. Nothing stamps the current date, so a recompute cannot make old evidence look freshly checked.

`lucie-7b`, `olmo-3` and `pythia` move back one day, 2026-07-28 → 2026-07-27: their stalest input is the Hugging Face signal, fetched on the 27th, so the earlier date is the accurate one.

14 products get no date. Four closed flagships — `gpt-5`, `claude-opus-4-7`, `gemini-3-5-flash`, `grok-4-20` — score 1 entirely on an unsourced `weights` claim.

## Guard rails

- An unmapped license tier is **reported, not scored** — the score comes out null with a reason. Falling through to `otherwise` would silently record every unrecognized license as 3/open_weights.
- `apply_scores --check` exits non-zero if a score or class moves, so CI cannot wave one through.
- `apply_scores` edits lines rather than round-tripping YAML, so folded scalars aren't reflowed and the diff stays reviewable. It never touches `note`, `sources`, `confidence`, `adoption` or `capability`.
- It will not delete a `last_verified` the pipeline can no longer earn; that case is reported, because the fix is to source the evidence rather than erase the record.
- CI now fails on a formula rule that can never match — one testing an undeclared dimension, a value outside its own enum, or an undefined tier. Such a rule doesn't raise; it silently pushes products into `otherwise`.
- A multi-tier rubric without `ordered_by: restrictiveness_ascending` is an error. "Most restrictive SKU governs" needs an ordering, and it must be the declared one rather than whatever order the YAML happens to use.

## Test plan

- `build.check_rubric` — 47/47 reproduced, unchanged
- `currentai.scores.openness_computed` reproduces the same 47/47 through the platform; a mismatch would mean the bridge isn't carrying the recipe
- `build.validate` — 0 errors
- `pytest` — 91 passed, 24 new covering formula order, admission, tier rank and the abstention flattening
- `build.serialize_rubric --check` and `build.serialize_registry --check` both clean
- grain check on both models returns no duplicate keys
- `build.apply_scores --check` reports 0 score movements

## Deliberately not in this PR

15 more rubrics (issue #106 shows the shared `data` vocabulary is already too coarse; revise it against all 16 at once, after the loop works), crons, the AA/LMArena capability bridges, and the append-only evidence history. Document and dataset evidence are both projections of git and the signal tables, so `FULL` models suffice and the read-modify-write loop with its truncation risk stays off the critical path until stage 1 does real research.

Refs CUR-166.
