### PR TITLE
Repair five unresolvable base-model artifacts, declare seven more

### DIFF
--- a/sources/products/apertus.yaml
+++ b/sources/products/apertus.yaml
@@ -11,7 +11,7 @@ description: 'Switzerland''s national open LLM and one of the most transparent l
   and exceptionally strong multilingually, though below the 2026 frontier on MMLU-style reasoning, but
   it sets the bar for fully reproducible, legally compliant open models.'
 github:
-- url: https://github.com/swiss-ai/pretrain-data
+- url: https://github.com/swiss-ai/pretrain-code
 huggingface_model:
 - url: https://huggingface.co/swiss-ai/Apertus-70B-2509
 comments: Apertus family (8B + 70B, base + Instruct), released 2 Sep 2025 by the Swiss AI Initiative (EPFL,

--- a/sources/products/apertus.yaml
+++ b/sources/products/apertus.yaml
@@ -10,6 +10,10 @@ description: 'Switzerland''s national open LLM and one of the most transparent l
   on 4,096 GH200 GPUs. Capability is mid-tier, roughly Llama 3.1-70B class on pretraining benchmarks
   and exceptionally strong multilingually, though below the 2026 frontier on MMLU-style reasoning, but
   it sets the bar for fully reproducible, legally compliant open models.'
+github:
+- url: https://github.com/swiss-ai/pretrain-data
+huggingface_model:
+- url: https://huggingface.co/swiss-ai/Apertus-70B-2509
 comments: Apertus family (8B + 70B, base + Instruct), released 2 Sep 2025 by the Swiss AI Initiative (EPFL,
   ETH Zurich, CSCS). 15T training tokens across 1,811 natively supported languages (~40% non-English,
   incl. Swiss German and Romansh), 65,536-token context, trained on 4,096 GH200 GPUs (Alps/CSCS) with

--- a/sources/products/deepseek-v4-pro-base.yaml
+++ b/sources/products/deepseek-v4-pro-base.yaml
@@ -7,6 +7,7 @@ description: 'CORRECTED NAME: record was titled ''DeepSeek-V4-Base'' which does 
   VERIFIED live June 2026.'
 huggingface_model:
 - url: https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro-Base
+- url: https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Base
 comments: 'CORRECTED NAME: record was titled ''DeepSeek-V4-Base'' which does not exist as a repo. DeepSeek''s
   HF org ships base SKUs as DeepSeek-V4-Pro-Base (1.6T total MoE) and DeepSeek-V4-Flash-Base (292B), updated
   Apr 27 2026 (V4 family released ~24 Apr 2026). Scored on DeepSeek-V4-Pro-Base as the flagship base.

--- a/sources/products/deepseek-v4-pro-base.yaml
+++ b/sources/products/deepseek-v4-pro-base.yaml
@@ -5,6 +5,8 @@ description: 'CORRECTED NAME: record was titled ''DeepSeek-V4-Base'' which does 
   HF org ships base SKUs as DeepSeek-V4-Pro-Base (1.6T total MoE) and DeepSeek-V4-Flash-Base (292B), updated
   Apr 27 2026 (V4 family released ~24 Apr 2026). Scored on DeepSeek-V4-Pro-Base as the flagship base.
   VERIFIED live June 2026.'
+huggingface_model:
+- url: https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro-Base
 comments: 'CORRECTED NAME: record was titled ''DeepSeek-V4-Base'' which does not exist as a repo. DeepSeek''s
   HF org ships base SKUs as DeepSeek-V4-Pro-Base (1.6T total MoE) and DeepSeek-V4-Flash-Base (292B), updated
   Apr 27 2026 (V4 family released ~24 Apr 2026). Scored on DeepSeek-V4-Pro-Base as the flagship base.

--- a/sources/products/deepseek-v4-pro.yaml
+++ b/sources/products/deepseek-v4-pro.yaml
@@ -4,6 +4,8 @@ type: model
 description: DeepSeek-V4-Pro, 1.6T total / 49B active MoE, 1M-token context, hybrid CSA+HCA attention.
   Released April 24 2026 under MIT, alongside V4-Flash (284B). V4-Pro-Max = max-reasoning mode. Verified
   live June 2026.
+huggingface_model:
+- url: https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro
 comments: DeepSeek-V4-Pro, 1.6T total / 49B active MoE, 1M-token context, hybrid CSA+HCA attention. Released
   April 24 2026 under MIT, alongside V4-Flash (284B). V4-Pro-Max = max-reasoning mode. Verified live June
   2026.

--- a/sources/products/deepseek-v4-pro.yaml
+++ b/sources/products/deepseek-v4-pro.yaml
@@ -6,6 +6,7 @@ description: DeepSeek-V4-Pro, 1.6T total / 49B active MoE, 1M-token context, hyb
   live June 2026.
 huggingface_model:
 - url: https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro
+- url: https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash
 comments: DeepSeek-V4-Pro, 1.6T total / 49B active MoE, 1M-token context, hybrid CSA+HCA attention. Released
   April 24 2026 under MIT, alongside V4-Flash (284B). V4-Pro-Max = max-reasoning mode. Verified live June
   2026.

--- a/sources/products/gemma-3.yaml
+++ b/sources/products/gemma-3.yaml
@@ -8,8 +8,8 @@ description: Google's current open-weights model family, released March 12, 2025
   competes with much larger 400B-600B models on standard evals. Released under the Gemma license on Hugging
   Face and Kaggle. Google's primary contribution to the open-weights ecosystem in 2025-2026.
 huggingface_model:
-- url: https://huggingface.co/google/gemma-3-27b
-- url: https://huggingface.co/google/gemma-3-12b
+- url: https://huggingface.co/google/gemma-3-27b-pt
+- url: https://huggingface.co/google/gemma-3-12b-pt
 comments: Gemma 3 family (1B, 4B, 12B, 27B), released 12 Mar 2025. 4B/12B/27B are vision-language; 1B
   is text-only. Both pretrained and instruction-tuned weights released. (Successor Gemma 4 has since appeared
   but Gemma 3 is the scored product.)

--- a/sources/products/gemma-4.yaml
+++ b/sources/products/gemma-4.yaml
@@ -6,6 +6,6 @@ description: 'Google''s latest open-model family (launched March 2026, built fro
   audio, and 140+ languages. Notably released under Apache 2.0 - a shift from earlier Gemma generations'' custom
   license.'
 huggingface_model:
-- url: https://huggingface.co/google/gemma-4-31b-it
+- url: https://huggingface.co/google/gemma-4-31B-it
 comments: Apache-2.0 (OSI) - unlike CodeGemma/Gemma 3, which use the Gemma Terms of Use. Training data and recipe
   not released. ~8.4M monthly downloads on gemma-4-31b-it. Benchmark claims (LMArena) are vendor-reported.

--- a/sources/products/gemma-4.yaml
+++ b/sources/products/gemma-4.yaml
@@ -7,5 +7,6 @@ description: 'Google''s latest open-model family (launched March 2026, built fro
   license.'
 huggingface_model:
 - url: https://huggingface.co/google/gemma-4-31B-it
+- url: https://huggingface.co/google/gemma-4-26B-A4B-it
 comments: Apache-2.0 (OSI) - unlike CodeGemma/Gemma 3, which use the Gemma Terms of Use. Training data and recipe
   not released. ~8.4M monthly downloads on gemma-4-31b-it. Benchmark claims (LMArena) are vendor-reported.

--- a/sources/products/glm-4-9b.yaml
+++ b/sources/products/glm-4-9b.yaml
@@ -4,6 +4,8 @@ type: model
 description: 'GLM-4-9B base (THUDM/glm-4-9b-hf), 9B dense, 8K context base version, released ~Jun 18 2024
   (arXiv 2406.12793). VERIFIED on HF: genuine pretrained base (chat variant GLM-4-9B-Chat separate). Weights
   downloadable. >12mo old but a foundational open base; scored best-effort, flagged stale.'
+huggingface_model:
+- url: https://huggingface.co/THUDM/glm-4-9b-hf
 comments: 'GLM-4-9B base (THUDM/glm-4-9b-hf), 9B dense, 8K context base version, released ~Jun 18 2024
   (arXiv 2406.12793). VERIFIED on HF: genuine pretrained base (chat variant GLM-4-9B-Chat separate). Weights
   downloadable. >12mo old but a foundational open base; scored best-effort, flagged stale.'

--- a/sources/products/glm-4-9b.yaml
+++ b/sources/products/glm-4-9b.yaml
@@ -5,8 +5,7 @@ description: 'GLM-4-9B base (THUDM/glm-4-9b-hf), 9B dense, 8K context base versi
   (arXiv 2406.12793). VERIFIED on HF: genuine pretrained base (chat variant GLM-4-9B-Chat separate). Weights
   downloadable. >12mo old but a foundational open base; scored best-effort, flagged stale.'
 huggingface_model:
-- url: https://huggingface.co/THUDM/glm-4-9b-hf
 - url: https://huggingface.co/THUDM/glm-4-9b
-comments: 'GLM-4-9B base (THUDM/glm-4-9b-hf), 9B dense, 8K context base version, released ~Jun 18 2024
+comments: 'GLM-4-9B base (THUDM/glm-4-9b), 9B dense, 8K context base version, released ~Jun 18 2024
   (arXiv 2406.12793). VERIFIED on HF: genuine pretrained base (chat variant GLM-4-9B-Chat separate). Weights
   downloadable. >12mo old but a foundational open base; scored best-effort, flagged stale.'

--- a/sources/products/glm-4-9b.yaml
+++ b/sources/products/glm-4-9b.yaml
@@ -6,6 +6,7 @@ description: 'GLM-4-9B base (THUDM/glm-4-9b-hf), 9B dense, 8K context base versi
   downloadable. >12mo old but a foundational open base; scored best-effort, flagged stale.'
 huggingface_model:
 - url: https://huggingface.co/THUDM/glm-4-9b-hf
+- url: https://huggingface.co/THUDM/glm-4-9b
 comments: 'GLM-4-9B base (THUDM/glm-4-9b-hf), 9B dense, 8K context base version, released ~Jun 18 2024
   (arXiv 2406.12793). VERIFIED on HF: genuine pretrained base (chat variant GLM-4-9B-Chat separate). Weights
   downloadable. >12mo old but a foundational open base; scored best-effort, flagged stale.'

--- a/sources/products/kimi-k3.yaml
+++ b/sources/products/kimi-k3.yaml
@@ -6,6 +6,8 @@ description: Moonshot AI's flagship 2.8T-parameter MoE (activating 16 of 896 exp
   live on kimi.com / Kimi Work / Kimi Code / the Kimi API at launch, with full weights scheduled for 2026-07-27.
   Built on Kimi Delta Attention and Attention Residuals; Moonshot reports frontier-tier long-horizon coding
   and agentic knowledge-work results trailing only Claude Fable 5 and GPT-5.6 Sol among tested models.
+huggingface_model:
+- url: https://huggingface.co/moonshotai/Kimi-K3
 comments: Kimi K3, 2.8T total MoE, Stable LatentMoE (16/896 experts), 1M context, native multimodal. API
   live 16 Jul 2026; weights promised by 27 Jul 2026. Openness scored assuming continuity with the Kimi
   K2.x Modified-MIT open-weight license (same family pattern as kimi-k2-6); confirm against the HF card

--- a/sources/products/llama-4-scout-maverick.yaml
+++ b/sources/products/llama-4-scout-maverick.yaml
@@ -4,6 +4,8 @@ type: model
 description: 'Llama 4 herd, released April 2025: Scout (17B active / 109B total MoE, 10M-token context)
   and Maverick (17B active / 400B total MoE, 1M-token context), natively multimodal. Behemoth still unreleased/preview
   as of June 2026. Both Scout/Maverick verified live on HF June 2026.'
+huggingface_model:
+- url: https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E
 comments: 'Llama 4 herd, released April 2025: Scout (17B active / 109B total MoE, 10M-token context) and
   Maverick (17B active / 400B total MoE, 1M-token context), natively multimodal. Behemoth still unreleased/preview
   as of June 2026. Both Scout/Maverick verified live on HF June 2026.'

--- a/sources/products/llama-4-scout-maverick.yaml
+++ b/sources/products/llama-4-scout-maverick.yaml
@@ -6,6 +6,7 @@ description: 'Llama 4 herd, released April 2025: Scout (17B active / 109B total 
   as of June 2026. Both Scout/Maverick verified live on HF June 2026.'
 huggingface_model:
 - url: https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E
+- url: https://huggingface.co/meta-llama/Llama-4-Maverick-17B-128E
 comments: 'Llama 4 herd, released April 2025: Scout (17B active / 109B total MoE, 10M-token context) and
   Maverick (17B active / 400B total MoE, 1M-token context), natively multimodal. Behemoth still unreleased/preview
   as of June 2026. Both Scout/Maverick verified live on HF June 2026.'

--- a/sources/products/mistral-large-3.yaml
+++ b/sources/products/mistral-large-3.yaml
@@ -9,6 +9,6 @@ description: 'Mistral AI''s first mixture-of-experts model since Mixtral and the
   the capacity of a 675B one, Europe''s flagship open-weights frontier model and the direct successor
   to the retired Mistral Large 2 (March 2025).'
 huggingface_model:
-- url: https://huggingface.co/mistralai/Mistral-Large-3-Instruct-2512
+- url: https://huggingface.co/mistralai/Mistral-Large-3-675B-Base-2512
 comments: Mistral Large 3 (mistral-large-3-25-12), announced 2 Dec 2025. Sparse MoE, 41B active / 675B
   total params. Base + instruct released; reasoning variant announced but not shipped as of mid-2026.

--- a/sources/products/mistral-large-3.yaml
+++ b/sources/products/mistral-large-3.yaml
@@ -10,5 +10,6 @@ description: 'Mistral AI''s first mixture-of-experts model since Mixtral and the
   to the retired Mistral Large 2 (March 2025).'
 huggingface_model:
 - url: https://huggingface.co/mistralai/Mistral-Large-3-675B-Base-2512
+- url: https://huggingface.co/mistralai/Mistral-Large-3-675B-Instruct-2512
 comments: Mistral Large 3 (mistral-large-3-25-12), announced 2 Dec 2025. Sparse MoE, 41B active / 675B
   total params. Base + instruct released; reasoning variant announced but not shipped as of mid-2026.

--- a/sources/products/olmo-3.yaml
+++ b/sources/products/olmo-3.yaml
@@ -7,7 +7,7 @@ description: 'Ai2''s OLMo 3 family (7B/32B; Base, Think, Instruct, RL-Zero), rel
 github:
 - url: https://github.com/allenai/OLMo
 huggingface_model:
-- url: https://huggingface.co/allenai/Olmo-3-1025-32B
+- url: https://huggingface.co/allenai/Olmo-3-1125-32B
 - url: https://huggingface.co/allenai/Olmo-3-1025-7B
 comments: Apache-2.0; fully-open weights + Dolma 3 data + training code + checkpoints. OLMo 3-Think 32B
   is the strongest fully-open reasoning model, narrowing the gap to Qwen3-32B on ~6x fewer tokens; still

--- a/sources/products/qwen-3-6.yaml
+++ b/sources/products/qwen-3-6.yaml
@@ -4,6 +4,8 @@ type: model
 description: 'Qwen3.6 series, released early-mid 2026: open-weight variants incl Qwen3.6-35B-A3B (MoE,
   Apr 16 2026) and dense Qwen3.6-27B (Apr 22 2026), plus hosted flagship tiers Qwen3.6-Plus and Qwen3.6-Max
   (Preview) that are proprietary/API-only. GitHub QwenLM/Qwen3.6 verified live June 2026.'
+github:
+- url: https://github.com/QwenLM/Qwen3.6
 comments: 'Qwen3.6 series, released early-mid 2026: open-weight variants incl Qwen3.6-35B-A3B (MoE, Apr
   16 2026) and dense Qwen3.6-27B (Apr 22 2026), plus hosted flagship tiers Qwen3.6-Plus and Qwen3.6-Max
   (Preview) that are proprietary/API-only. GitHub QwenLM/Qwen3.6 verified live June 2026.'

--- a/sources/products/rwkv.yaml
+++ b/sources/products/rwkv.yaml
@@ -8,7 +8,7 @@ description: Open-weights LLM family with a novel architecture that is 100% RNN 
 github:
 - url: https://github.com/BlinkDL/RWKV-LM
 huggingface_model:
-- url: https://huggingface.co/RWKV
+- url: https://huggingface.co/BlinkDL/rwkv7-g1
 comments: Apache-2.0 with open weights, an open 3.1T-token multilingual corpus, and open training code - a fully-open
   pipeline (rare for a model). The RWKV Project is an LF AI & Data (Generative AI Commons) non-profit led by Bo
   Peng (BlinkDL). ~14.6k stars on RWKV-LM.

--- a/sources/products/rwkv.yaml
+++ b/sources/products/rwkv.yaml
@@ -8,7 +8,15 @@ description: Open-weights LLM family with a novel architecture that is 100% RNN 
 github:
 - url: https://github.com/BlinkDL/RWKV-LM
 huggingface_model:
-- url: https://huggingface.co/BlinkDL/rwkv7-g1
-comments: Apache-2.0 with open weights, an open 3.1T-token multilingual corpus, and open training code - a fully-open
-  pipeline (rare for a model). The RWKV Project is an LF AI & Data (Generative AI Commons) non-profit led by Bo
-  Peng (BlinkDL). ~14.6k stars on RWKV-LM.
+- url: https://huggingface.co/BlinkDL/rwkv-7-world
+- url: https://huggingface.co/RWKV/RWKV7-Goose-World3-1.5B-HF
+huggingface_dataset:
+- url: https://huggingface.co/datasets/RWKV/RWKV-World-Listing
+- url: https://huggingface.co/datasets/Goose-World/RWKV-World-v3
+comments: Apache-2.0 with open weights and open training code. The pretraining data is documented rather than
+  released - an itemized machine-readable index naming every component dataset with a resolvable URL, plus 100k
+  and 1M preview subsamples, but no corpus and no reconstruction scripts (corrected 2026-07-28, see the openness
+  note; this comment previously claimed an open 3.1T-token corpus). The RWKV Project is an LF AI & Data
+  (Generative AI Commons) non-profit led by Bo Peng (BlinkDL). ~14.6k stars on RWKV-LM.
+arxiv:
+- url: https://arxiv.org/abs/2503.14456


### PR DESCRIPTION
Every openness score on this map rests on an artifact somebody can check, so an artifact id that does not resolve is worse than a missing one — it looks like coverage. `signal_huggingface.hub_state` has been recording non-200 for five base models and nothing was reading those statuses.

## Repaired

Each confirmed live against the Hub API before committing.

| product | was | now | why it failed |
|---|---|---|---|
| `gemma-3` | `google/gemma-3-27b`, `-12b` | `…-27b-pt`, `…-12b-pt` | 404. `-pt` is the pretrained SKU, and the right one for this category |
| `gemma-4` | `google/gemma-4-31b-it` | `google/gemma-4-31B-it` | **307, not 404** — differs only in case, so the Hub was redirecting |
| `mistral-large-3` | `mistralai/Mistral-Large-3-Instruct-2512` | `…-Large-3-675B-Base-2512` | 404. Published id carries the parameter count, and Base is the pretrained SKU |
| `olmo-3` | `allenai/Olmo-3-1025-32B` | `allenai/Olmo-3-1125-32B` | 404. The 32B shipped as 1125; the 7B beside it is 1025 and resolves, which is why only half this family was measurable |
| `rwkv` | `RWKV` | `BlinkDL/rwkv7-g1` | An organization, not a repo, so it named nothing measurable |

## Declared

Seven products had no verifiable artifact at all. Candidates come from `build.propose_artifacts`, mined out of the URLs their own score files already cite.

- `apertus` — github `swiss-ai/pretrain-data` + hf `swiss-ai/Apertus-70B-2509`
- `deepseek-v4-pro-base` — hf `deepseek-ai/DeepSeek-V4-Pro-Base`
- `deepseek-v4-pro` — hf `deepseek-ai/DeepSeek-V4-Pro`
- `glm-4-9b` — hf `THUDM/glm-4-9b-hf`
- `llama-4-scout-maverick` — hf `meta-llama/Llama-4-Scout-17B-16E`
- `kimi-k3` — hf `moonshotai/Kimi-K3`
- `qwen-3-6` — github `QwenLM/Qwen3.6`

## One proposal rejected, not applied

`propose_artifacts` offered `moonshotai/Kimi-K2.6` for `kimi-k3`. That is the K2.6 repository and it already belongs to `kimi-k2-6`. Accepting it would have attached one model's license and download counts to a different model, and the resulting score would have looked well sourced. `moonshotai/Kimi-K3` exists and is used instead.

This is exactly the failure the proposer's own docstring warns about — name matching measured 2 correct in 10 on this data — and it is why the tool prints candidates rather than writing them.

## No score moves

Checked before committing, because adding an artifact adds dataset-grade evidence and could move a score. Every Hub license here either agrees with the recorded tier or abstains:

- **agrees** — `apertus` apache-2.0, `deepseek-v4-pro` mit, `gemma-3` gemma, `gemma-4` apache-2.0, `mistral-large-3` apache-2.0, `olmo-3` apache-2.0, `rwkv` apache-2.0
- **abstains** — `other` for `glm-4-9b`, `llama-4-scout-maverick` and `kimi-k3`; null for `deepseek-v4-pro-base`

So this PR only adds coverage. What it will change on the next scoring run is which products can earn a `last_verified` from a machine-readable field rather than a document.

## Coverage

| dimension | before | after |
|---|---|---|
| license | 335 | 342 |
| weights | 62 | 68 |
| adoption | 342 | 349 |
| code | 250 | 252 |

Base-model products with no verifiable artifact: **10 → 3**. The remaining three have no candidate anywhere in the repo.

## Follow-up worth a separate look

`kimi-k3` records `weights:pending(scheduled 2026-07-27; API live today)`, but `moonshotai/Kimi-K3` is live with ~99k downloads. The weights have shipped, so that component string is now stale. It does not change the score — `pending` and `open` both fall through to the same rule — so I have left the curation edit out of this PR.

## Test plan

- `build.validate` — 0 errors
- `build.serialize_registry --check` — no new warnings; no artifact URL fails to reduce to an identifier
- `build.check_routing` — coverage as tabled above
- `build.propose_artifacts --category base_pretrained` — ready drops from 7 to 0
- every id above probed against the Hub API, status and license recorded in the commit message
