### PR TITLE
Source the weights claim behind the four closed flagships

### DIFF
--- a/sources/scores/claude-opus-4-7.yaml
+++ b/sources/scores/claude-opus-4-7.yaml
@@ -7,11 +7,15 @@ openness:
   note: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
   sources:
   - url: https://www.anthropic.com/news/claude-opus-4-7
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+    shows: 'launch post states "Opus 4.7 is available today across all Claude products and
+      our API, Amazon Bedrock, Google Cloud''s Vertex AI, and Microsoft Foundry" — every
+      surface named is hosted, and no weight release is mentioned'
+    accessed: '2026-07-28'
   - url: https://aws.amazon.com/blogs/aws/introducing-anthropics-claude-opus-4-7-model-in-amazon-bedrock/
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+    shows: Bedrock access is the managed Anthropic Messages API via bedrock-runtime, invoked
+      through the SDK or the Invoke/Converse APIs; no weights are delivered into the
+      customer account
+    accessed: '2026-07-28'
 adoption:
   level: 4
   reach: null

--- a/sources/scores/gemini-3-5-flash.yaml
+++ b/sources/scores/gemini-3-5-flash.yaml
@@ -7,11 +7,15 @@ openness:
   note: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
   sources:
   - url: https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+    shows: launch post lists the surfaces as the Gemini app, AI Mode in Search, Google
+      Antigravity, the Gemini API in AI Studio and Android Studio, and Gemini Enterprise;
+      all hosted, with no download offered
+    accessed: '2026-07-28'
   - url: https://deepmind.google/models/gemini/
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+    shows: Google's own model index files Gemini under API and app access while placing
+      Gemma separately under a heading of "Open models", so the open-weights line here is
+      drawn by the vendor rather than inferred from silence
+    accessed: '2026-07-28'
 adoption:
   level: 5
   reach: '>10M'

--- a/sources/scores/gpt-5.yaml
+++ b/sources/scores/gpt-5.yaml
@@ -6,12 +6,15 @@ openness:
   confidence: high
   note: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
   sources:
-  - url: https://openai.com/index/introducing-gpt-5/
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+  - url: https://developers.openai.com/api/docs/models/gpt-5
+    shows: 'OpenAI''s own model reference for gpt-5 documents access solely as API endpoints
+      (v1/chat/completions, v1/responses, v1/batch) alongside pricing and rate limits; no
+      weight download or self-hosting path appears anywhere on the page'
+    accessed: '2026-07-28'
   - url: https://en.wikipedia.org/wiki/GPT-5
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+    shows: 'infobox records License: Proprietary, and the article treats the GPT-OSS
+      open-weight models as a separate August 2025 release rather than as GPT-5 weights'
+    accessed: '2026-07-28'
 adoption:
   level: 5
   reach: '>10M'

--- a/sources/scores/grok-4-20.yaml
+++ b/sources/scores/grok-4-20.yaml
@@ -6,12 +6,14 @@ openness:
   confidence: high
   note: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
   sources:
-  - url: https://artificialanalysis.ai/models/grok-4-20
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
   - url: https://docs.x.ai/developers/release-notes
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+    shows: 'xAI release notes record "Grok 4.20 and Grok 4.20 Multi-agent are live" and point
+      at the API docs; no weight release accompanies the entry'
+    accessed: '2026-07-28'
+  - url: https://docs.x.ai/docs/models
+    shows: xAI's own model reference for the Grok 4.x line documents pricing, context limits
+      and model-selection guidance only, and states no distribution or download path
+    accessed: '2026-07-28'
 adoption:
   level: 2
   reach: 10K-100K


### PR DESCRIPTION
`gpt-5`, `claude-opus-4-7`, `gemini-3-5-flash` and `grok-4-20` each score **1/closed** on the strength of `weights:closed` — and every source backing that axis said only `shows: flagship phase-C verification source`. Eight rows of filler under four of the most visible scores on the map.

## Why these four first

They are the ones no machine signal will ever settle. Nothing is distributed, so there is no artifact to measure and no Hub row to read. A document source is the only kind of evidence available here, permanently, which makes it worth getting right rather than leaving as a placeholder.

They are also the clearest case of the gap the layer-2 work surfaced: 111 of the 253 source rows behind the 47 base models cite nothing specific, and these four sit at the top of that list.

## What each page actually shows

I read every page and recorded what it demonstrates, not what I concluded from it.

| product | evidence |
|---|---|
| `gpt-5` | OpenAI's model reference documents access solely as API endpoints (`v1/chat/completions`, `v1/responses`, `v1/batch`) with pricing and rate limits, no download path. Wikipedia's infobox records `License: Proprietary` and treats GPT-OSS as a separate August 2025 release rather than GPT-5 weights. |
| `claude-opus-4-7` | The launch post names the surfaces outright: "Opus 4.7 is available today across all Claude products and our API, Amazon Bedrock, Google Cloud's Vertex AI, and Microsoft Foundry." The Bedrock post shows access is the managed Anthropic Messages API via `bedrock-runtime`, with no weights entering the customer account. |
| `gemini-3-5-flash` | The strongest of the four. Google's own model index files Gemini under API and app access while placing **Gemma** under a separate "Open models" heading — so the open-weights line is drawn by the vendor rather than inferred from silence. |
| `grok-4-20` | xAI's release notes record "Grok 4.20 and Grok 4.20 Multi-agent are live" pointing at the API docs; the model reference covers pricing, context limits and selection guidance and documents no distribution path. |

## Two source swaps, both because the cited page was the wrong instrument

- **`gpt-5`** cited the launch announcement, which returns 403 to us — so nothing could be attested about its contents. Replaced with the API model reference, which is better evidence for how the model is accessed regardless.
- **`grok-4-20`** cited an **Artificial Analysis model page under `openness`**. That measures capability, not how weights are distributed, so it could not support the claim it was attached to. Replaced with xAI's own model docs.

`accessed` moves to 2026-07-28 on all eight rows because these pages were read today rather than carried forward.

## Effect

Once the layer-2 pipeline next runs, all four openness axes become admissible, so each earns a real `last_verified` instead of null — taking base models from **33 of 47** verifiable to **37 of 47**.

**No score moves.** The evidence confirms what was already recorded, which is the outcome to want: the scores were right, they just weren't sourced.

One honest limit: `sources/scores` attributes sources per *axis*, not per dimension, so admitting these rows marks the whole openness axis as sourced even though the pages speak to distribution and licensing rather than to `data` or `code` specifically. The evidence store already records that as `attribution='axis'`. For a closed model the distinction is moot — the formula short-circuits on `weights:closed` at rule 0 and never reads the others.

## Test plan

- `build.validate` — 0 errors
- `build.check_rubric` — 47/47 reproduced, unchanged
- every new `shows` checked against the admission rule in `evidence_policy.yaml` (the declared `verification source` phrase): 8 of 8 admissible, 0 boilerplate remaining on these files
- no overlap with #108's changed files, so the two can merge in either order

Independent of #108, #109, #110 and #111 — pure curation, no tooling.
