### PR TITLE
Add Mastra to orchestration & agents

### DIFF
--- a/build/_frozen_long_tail.json
+++ b/build/_frozen_long_tail.json
@@ -4,10 +4,10 @@
     "models": 6428,
     "packages": 2823,
     "total": 24626,
-    "scored": 501,
-    "overlap": 244,
+    "scored": 502,
+    "overlap": 245,
     "scored_outside": 257,
-    "uncategorized": 24382,
+    "uncategorized": 24381,
     "universe": 24883
   },
   "top": [
@@ -21,7 +21,7 @@
       "name": "ultraworkers/claw-code",
       "type": "repo",
       "usage_label": "188,924 stars",
-      "description": "The repo is finally unlocked. enjoy the party! The fastest repo in history to surpass 100K stars \u2b50. Join Discord: https:"
+      "description": "The repo is finally unlocked. enjoy the party! The fastest repo in history to surpass 100K stars ⭐. Join Discord: https:"
     },
     {
       "name": "obra/superpowers",
@@ -45,91 +45,91 @@
       "name": "f/prompts.chat",
       "type": "repo",
       "usage_label": "160,986 stars",
-      "description": "f.k.a. Awesome ChatGPT Prompts. Share, discover, and collect prompts from the community. Free and open source \u2014 self-hos"
+      "description": "f.k.a. Awesome ChatGPT Prompts. Share, discover, and collect prompts from the community. Free and open source — self-hos"
     },
     {
       "name": "huggingface/transformers",
       "type": "repo",
       "usage_label": "160,031 stars",
-      "description": "\ud83e\udd17 Transformers: the model-definition framework for state-of-the-art machine learning models in text, vision, audio, and "
+      "description": "🤗 Transformers: the model-definition framework for state-of-the-art machine learning models in text, vision, audio, and "
     },
     {
       "name": "Snailclimb/JavaGuide",
       "type": "repo",
       "usage_label": "155,279 stars",
-      "description": "Java \u9762\u8bd5 & \u540e\u7aef\u901a\u7528\u9762\u8bd5\u6307\u5357\uff0c\u8986\u76d6\u8ba1\u7b97\u673a\u57fa\u7840\u3001\u6570\u636e\u5e93\u3001\u5206\u5e03\u5f0f\u3001\u9ad8\u5e76\u53d1\u3001\u7cfb\u7edf\u8bbe\u8ba1\u4e0e AI \u5e94\u7528\u5f00\u53d1"
+      "description": "Java 面试 & 后端通用面试指南，覆盖计算机基础、数据库、分布式、高并发、系统设计与 AI 应用开发"
     },
     {
       "name": "cross-encoder/ms-marco-MiniLM-L6-v2",
       "type": "model",
       "usage_label": "31.2M downloads",
-      "description": "cross-encoder \u00b7 text-ranking"
+      "description": "cross-encoder · text-ranking"
     },
     {
       "name": "BAAI/bge-small-en-v1.5",
       "type": "model",
       "usage_label": "27.9M downloads",
-      "description": "BAAI \u00b7 feature-extraction"
+      "description": "BAAI · feature-extraction"
     },
     {
       "name": "Falconsai/nsfw_image_detection",
       "type": "model",
       "usage_label": "27.1M downloads",
-      "description": "Falconsai \u00b7 image-classification"
+      "description": "Falconsai · image-classification"
     },
     {
       "name": "amazon/chronos-2",
       "type": "model",
       "usage_label": "20.9M downloads",
-      "description": "amazon \u00b7 time-series-forecasting"
+      "description": "amazon · time-series-forecasting"
     },
     {
       "name": "BAAI/bge-m3",
       "type": "model",
       "usage_label": "18.7M downloads",
-      "description": "BAAI \u00b7 sentence-similarity"
+      "description": "BAAI · sentence-similarity"
     },
     {
       "name": "FacebookAI/roberta-base",
       "type": "model",
       "usage_label": "17.9M downloads",
-      "description": "FacebookAI \u00b7 fill-mask"
+      "description": "FacebookAI · fill-mask"
     },
     {
       "name": "FacebookAI/xlm-roberta-base",
       "type": "model",
       "usage_label": "17.3M downloads",
-      "description": "FacebookAI \u00b7 fill-mask"
+      "description": "FacebookAI · fill-mask"
     },
     {
       "name": "FacebookAI/roberta-large",
       "type": "model",
       "usage_label": "16.3M downloads",
-      "description": "FacebookAI \u00b7 fill-mask"
+      "description": "FacebookAI · fill-mask"
     },
     {
       "name": "Bingsu/adetailer",
       "type": "model",
       "usage_label": "14.8M downloads",
-      "description": "Bingsu \u00b7 model"
+      "description": "Bingsu · model"
     },
     {
       "name": "colbert-ir/colbertv2.0",
       "type": "model",
       "usage_label": "14.1M downloads",
-      "description": "colbert-ir \u00b7 model"
+      "description": "colbert-ir · model"
     },
     {
       "name": "BAAI/bge-large-en-v1.5",
       "type": "model",
       "usage_label": "12.9M downloads",
-      "description": "BAAI \u00b7 feature-extraction"
+      "description": "BAAI · feature-extraction"
     },
     {
       "name": "apple/DFN5B-CLIP-ViT-H-14-378",
       "type": "model",
       "usage_label": "12.0M downloads",
-      "description": "apple \u00b7 model"
+      "description": "apple · model"
     },
     {
       "name": "huggingface/documentation-images",

--- a/sources/categories/orchestration_agents.yaml
+++ b/sources/categories/orchestration_agents.yaml
@@ -55,4 +55,5 @@ products:
 - datasette-agent
 - openfn
 - hexabot
+- mastra
 comments: ''

--- a/sources/organizations/mastra.yaml
+++ b/sources/organizations/mastra.yaml
@@ -1,0 +1,11 @@
+name: mastra
+display_name: Mastra
+type: company
+homepage: https://mastra.ai
+country: USA
+github:
+- url: https://github.com/mastra-ai
+products:
+- mastra
+comments: Legal entity is Kepler Software, Inc., per the Apache-2.0 copyright line in the repo's LICENSE.md;
+  the product and org trade as Mastra.

--- a/sources/products/mastra.yaml
+++ b/sources/products/mastra.yaml
@@ -1,0 +1,20 @@
+name: mastra
+display_name: Mastra
+type: software
+description: TypeScript-native framework for building AI agents and agentic applications. Covers agents with
+  tools and instructions, graph-based workflows with explicit control flow, conversation memory with semantic
+  recall, model routing across 90+ providers, and built-in evals, tracing and human-in-the-loop. Runs on Node.js,
+  integrates with React and Next.js, or deploys as a standalone server. The framework is Apache-2.0; enterprise
+  auth code under `ee/` directories carries a separate source-available license, and the hosted Mastra Platform
+  is commercial - open-core in the same shape as LangGraph and LlamaIndex. Notable as the most-used TypeScript
+  agent framework in a category whose open frameworks are otherwise almost entirely Python.
+github:
+- url: https://github.com/mastra-ai/mastra
+npm:
+- url: https://www.npmjs.com/package/@mastra/core
+- url: https://www.npmjs.com/package/mastra
+comments: Apache-2.0 framework by Kepler Software, Inc., trading as Mastra. LICENSE.md splits the repo - everything
+  outside `ee/` directories is Apache-2.0 (Copyright 2025 Kepler Software, Inc.), while `ee/` paths such as
+  packages/core/src/auth/ee/ fall under the Mastra Enterprise License. GitHub's classifier reports NOASSERTION
+  because of that preamble, so the license was read from the LICENSE.md body and confirmed against npm package
+  metadata (both @mastra/core and mastra declare Apache-2.0). Verified live 2026-07-29; @mastra/core at v1.54.0.

--- a/sources/scores/mastra.yaml
+++ b/sources/scores/mastra.yaml
@@ -1,0 +1,61 @@
+product: mastra
+openness:
+  score: 4
+  class: open_core
+  components: license:Apache-2.0(OSI, everything outside `ee/`);source:public;ee/-auth-directories-under-Mastra-Enterprise-License;Mastra-Platform-hosted-tier-commercial
+  confidence: high
+  note: Open-core in the LangGraph/LlamaIndex shape rather than the n8n one - the framework itself is a real
+    OSI license, not fair-code. LICENSE.md scopes the commercial carve-out narrowly to `ee/` auth directories,
+    so the agent, workflow, memory and eval surfaces a user actually builds on are Apache-2.0. Not 5 because
+    the enterprise auth code is source-available and the managed platform is closed.
+  last_verified: '2026-07-29'
+  sources:
+  - url: https://github.com/mastra-ai/mastra/blob/main/LICENSE.md
+    shows: 'LICENSE.md states content outside `ee/` directories is "available under the Apache License 2.0",
+      Copyright 2025 Kepler Software, Inc., while `ee/` paths (packages/core/src/auth/ee/,
+      packages/server/src/server/auth/ee/) fall under the license in ee/LICENSE. This preamble ahead of the
+      Apache text is why GitHub''s classifier reports NOASSERTION for the repo.'
+    accessed: '2026-07-29'
+  - url: https://www.npmjs.com/package/@mastra/core
+    shows: published package metadata declares license Apache-2.0 at v1.54.0, confirming the framework ships
+      to consumers under the OSI license rather than only being licensed that way in-repo
+    accessed: '2026-07-29'
+  - url: https://mastra.ai/
+    shows: 'site FAQ states "Mastra''s core framework is open source under the Apache 2.0 license. Enterprise
+      features are source-available under the Mastra Enterprise License", and describes Mastra Platform as a
+      hosted commercial tier'
+    accessed: '2026-07-29'
+adoption:
+  level: 4
+  reach: 1M-10M
+  signal_type: usage_volume
+  confidence: high
+  note: '@mastra/core at 4,931,561 downloads in the last month, which places it in the 1-10M band. Deliberately
+    NOT summed with the `mastra` package (2,151,411/mo): npm counts increment for transitively fetched
+    dependencies, and `mastra` pulls @mastra/core through @mastra/deployer, so adding them double-counts the
+    same installs. @mastra/core is the package everything resolves to and is the better single proxy. The band
+    is the same either way. Raw download volume includes CI and mirror traffic, so this is install volume rather
+    than a user count.'
+  sources:
+  - url: https://api.npmjs.org/downloads/point/last-month/@mastra/core
+    shows: npm registry download API returns 4,931,561 downloads for @mastra/core over the trailing month
+    accessed: '2026-07-29'
+  - url: https://github.com/mastra-ai/mastra
+    shows: 26,669 stars, 2,523 forks and 100 contributors, last pushed 2026-07-29 - corroborating activity,
+      not the adoption basis
+    accessed: '2026-07-29'
+capability:
+  score: 4
+  basis: feature_matrix
+  value: null
+  confidence: medium
+  note: Feature coverage comparable to LangChain and Pydantic-AI (both 4) - agents with tools, graph workflows
+    with explicit control flow, memory with semantic recall, model routing across 90+ providers, evals, tracing
+    and human-in-the-loop. Not 5 like LangGraph or LlamaIndex, which have deeper ecosystems and longer track
+    records. Confidence is medium rather than high because no first-party SWE-bench or GAIA result exists for
+    the framework itself, so this is a feature-matrix judgment rather than a measurement.
+  sources:
+  - url: https://mastra.ai/
+    shows: documents agents, graph-based workflows with control flow, memory with semantic recall, model routing
+      across 90+ providers, built-in evals and tracing, and human-in-the-loop
+    accessed: '2026-07-29'


### PR DESCRIPTION
TypeScript-native agent framework. The category's open frameworks were otherwise almost entirely Python — only 11 of 501 products declared an npm package and none was a general-purpose agent SDK — so this fills a coverage gap rather than adding a 50th peer.

It was already in our own discovery roster: the GoodAI List carries `mastra-ai/mastra` under "Build agent workflow (SDK)", the same subcategory as `langchain`. It had just never been promoted to a scored product.

| signal | value |
|---|---|
| GitHub | `mastra-ai/mastra` — 26,669 stars, 2,523 forks, 100 contributors, pushed 2026-07-29 |
| npm | `@mastra/core` 4,931,561/mo · `mastra` 2,151,411/mo |
| license | Apache-2.0 outside `ee/`; `ee/` auth under the Mastra Enterprise License |
| org | Mastra (legal entity Kepler Software, Inc.) |

## Openness 4 / open_core — license read from the body, not the classifier

GitHub reports `NOASSERTION`, which is exactly the case the `add-product` skill warns about, so I read `LICENSE.md` rather than trusting it. The repo is split: everything outside `ee/` directories is Apache-2.0 (© 2025 Kepler Software, Inc.), while `ee/` auth paths — `packages/core/src/auth/ee/`, `packages/server/src/server/auth/ee/` — fall under the Mastra Enterprise License. A preamble ahead of the Apache text is what defeats the classifier. Cross-checked against npm metadata, where both packages declare `Apache-2.0` at the published version.

That's the **LangGraph/LlamaIndex shape, not the n8n one** — a genuine OSI license on the framework rather than fair-code — and the commercial carve-out is scoped narrowly to auth, so the agent, workflow, memory and eval surfaces users actually build on are Apache-2.0. Not 5 because the enterprise auth code is source-available and the managed platform is closed.

## Adoption 4, with a deliberate refusal to sum

`@mastra/core` at 4.93M downloads/month puts it in the 1–10M band, alongside `crewai`, `haystack`, `dspy` and `autogen`.

I did **not** sum it with the `mastra` package (2.15M/mo). npm increments counts for transitively fetched dependencies, and `mastra` pulls `@mastra/core` through `@mastra/deployer`, so adding them double-counts the same installs. The band is 4 either way, so nothing hinges on it — but the note records the reasoning so the next person doesn't "fix" it by summing.

Raw download volume includes CI and mirror traffic, so this is install volume rather than a user count. Said so in the note.

## Capability 4, `feature_matrix`, confidence **medium**

Feature coverage comparable to LangChain and Pydantic-AI, both 4. Not 5 like LangGraph, LlamaIndex or Haystack, which have deeper ecosystems and longer track records.

Confidence is medium rather than high because no first-party SWE-bench or GAIA result exists for the framework itself, so this is a feature-matrix judgment rather than a measurement. Several peers record `high` on exactly that basis; I'd rather this one be honest than consistent with them.

## Two things worth noting

**Every source row states what the page specifically shows**, with today's accessed date — no `flagship phase-C verification source` filler. Worth flagging because `crewai`, the nearest peer, has that placeholder on all five of its rows, so the pattern isn't confined to base models.

**Mastra's license will not route from the GitHub signal.** `NOASSERTION` is an abstain value per `signal_routing.yaml`, so this product counts as "routed" in `check_routing` (it has a declared artifact) while producing no usable license evidence. It's a clean live example of the coverage overstatement we found earlier: routed counts declared artifacts, not usable values.

## Test plan

- `build.validate` — 0 errors
- `build.check_rubric` — 47/47, unaffected (Mastra isn't `base_pretrained`)
- `build.serialize_registry --check` — products 501 → 502, artifacts 518 → 521, no new warnings
- `build.serialize --date ci-dry-run` — writes cleanly at 502 products
- license verified against `LICENSE.md` body **and** npm package metadata; stars/downloads verified against the GitHub and npm APIs today
- frozen long-tail counts re-synced with the three internal identities asserted before writing: `scored` 501→502, `overlap` 244→245, `uncategorized` 24,382→24,381; `scored_outside` and `universe` unchanged
- `build/notebook_data.json` regenerated for the dry run and reverted, not committed
