### PR TITLE
apply_scores wrote a freshness bound into a check-date field, through a stale cache

### DIFF
--- a/build/apply_scores.py
+++ b/build/apply_scores.py
@@ -7,9 +7,20 @@ a person typing the value.
 
 ## What it writes, and what it refuses to
 
-  * `openness.last_verified` — whenever the pipeline could verify the score. That is
-    the honest, machine-authored change: a fresh Hub field agreeing with the recorded
-    license genuinely is verification, dated the day the field was fetched.
+  * `openness.last_verified` — the CHECK EVENT: the most recent date on which any
+    admitted evidence behind the score was actually read. A document source's `accessed`
+    date, or a signal's fetch. It comes from the scorer's `last_checked` column.
+
+    It is deliberately NOT the freshness bound. The scorer also computes
+    `freshness_floor` — the MIN accessed date across everything the score relies on, null
+    if any of it is unsourced — and that stays in the warehouse. Both are useful; they are
+    different questions, and writing the bound into this field is what let a derived value
+    overwrite a human's check date with a date appearing nowhere in the file's own
+    evidence, so no reader could trace it.
+
+    A stored date is never moved backwards. It records that somebody looked on that day,
+    which stays true regardless of what we can currently derive; if the computed value is
+    older, that is reported rather than applied.
   * `openness.score` / `openness.class` — only when the computed value differs. It
     should not, since the rubric was reverse-engineered from these files, so a
     difference is either a real evidence change worth reviewing or a bug worth
@@ -52,19 +63,43 @@ TABLE = "currentai.scores.openness_computed"
 
 
 def fetch_computed(category: str | None) -> list[dict]:
-    """Read the computed scores. Requires OSO_API_KEY, same as publish_registry."""
+    """Read the computed scores. Requires OSO_API_KEY, same as publish_registry.
+
+    The trailing unique comment is load-bearing. Query results are cached keyed on the
+    QUERY TEXT, so a tool that issues a fixed string keeps receiving its first answer
+    forever - it never self-heals. That is not theoretical: this function returned the
+    pre-run baseline for a full run cycle after the models had already re-materialized,
+    and adding a single trailing comment to the same SQL returned the fresh numbers. A
+    writer reading through that cache would write stale dates into sources/scores.
+    """
+    import uuid
+
     from pyoso import Client
 
     where = f"WHERE category_slug = '{category}'" if category else ""
     sql = f"""
         SELECT product_slug, category_slug, openness_score, openness_class,
-               last_verified, unsourced_dimensions, license_tier_grade,
+               last_checked, freshness_floor, unsourced_dimensions, license_tier_grade,
                dims_from_dataset, dims_relied_on, scoring_note
         FROM {TABLE}
         {where}
         ORDER BY product_slug
+        -- cache-bust {uuid.uuid4()}
     """
     return Client().to_pandas(sql).to_dict("records")
+
+
+def has_date(value: object) -> bool:
+    """True when a value read out of a DataFrame is a real date.
+
+    Needed because a null DATE arrives as pandas NaT or float nan depending on the column's
+    dtype, and both satisfy `is not None`. Counting with that test reported 14 products
+    gaining a date when the true number was 5.
+    """
+    if value is None:
+        return False
+    text = str(value).strip()
+    return text not in ("", "None", "NaT", "nan", "NaN")
 
 
 def block_bounds(lines: list[str], key: str) -> tuple[int, int] | None:
@@ -116,13 +151,26 @@ def apply_to_file(path: Path, computed: dict) -> tuple[list[str], list[str]]:
                 lines[index] = f"  {key}: {value}\n"
                 changes.append(f"{path.stem}: openness.{key} {current} -> {value}")
 
-    verified = computed.get("last_verified")
-    if verified is not None and str(verified) not in ("None", "NaT", "nan"):
-        stamp = str(verified)[:10]
+    # `last_checked` is the CHECK EVENT - the most recent date any admitted evidence behind
+    # this score was actually read. That, not the freshness bound, is what belongs in a
+    # score file: it is traceable to a dated row, and it answers the question a reader has.
+    # Writing the bound here is what let a derived value overwrite a human's check date with
+    # one that appears nowhere in the file's own evidence.
+    checked = computed.get("last_checked")
+    if has_date(checked):
+        stamp = str(checked)[:10]
         index = find_key(lines, bounds, "last_verified")
         if index is not None:
             current = lines[index].split(":", 1)[1].strip().strip("'\"")
-            if current != stamp:
+            # Never move a stored date backwards. A date already in the file records that
+            # somebody looked on that day, and that remains true whatever we can currently
+            # derive. If the computed value is older, the file is ahead of us - report it
+            # rather than destroying the record. ISO dates compare correctly as strings.
+            if current > stamp:
+                changes.append(
+                    f"{path.stem}: KEPT last_verified {current}, computed {stamp} is older"
+                )
+            elif current != stamp:
                 lines[index] = f"  last_verified: '{stamp}'\n"
                 changes.append(f"{path.stem}: last_verified {current} -> {stamp}")
         else:
@@ -168,10 +216,10 @@ def main() -> int:
             continue
 
         recorded = yaml.safe_load(path.read_text()) or {}
-        had_verified = "last_verified" in (recorded.get("openness") or {})
-        if had_verified and row.get("last_verified") is None:
+        had_verified = bool((recorded.get("openness") or {}).get("last_verified"))
+        if had_verified and not has_date(row.get("last_checked")):
             stale_kept.append(
-                f"{slug}: carries last_verified but the pipeline cannot earn one "
+                f"{slug}: carries last_verified but no admitted evidence has a date "
                 f"(unsourced: {row.get('unsourced_dimensions')})"
             )
 
@@ -182,12 +230,14 @@ def main() -> int:
             changed_files.append(path)
             score_changes.extend(c for c in changes if "openness.score" in c or "openness.class" in c)
 
-    verified = sum(1 for r in rows if r.get("last_verified") is not None)
+    checked = sum(1 for r in rows if has_date(r.get("last_checked")))
+    floored = sum(1 for r in rows if has_date(r.get("freshness_floor")))
     from_dataset = sum(1 for r in rows if r.get("license_tier_grade") == "dataset")
 
     print(f"{len(rows)} computed score(s) read from {TABLE}")
     print(f"  license tier from a machine-readable field : {from_dataset}")
-    print(f"  score verifiable end to end (last_verified): {verified}")
+    print(f"  evidence checked on a known date (last_checked): {checked}")
+    print(f"  every relied-on fact sourced (freshness_floor) : {floored}")
     print(f"  files this run would change                : {len(changed_files)}")
     print(f"  openness score or class moved              : {len(score_changes)}")
 

--- a/build/apply_scores.py
+++ b/build/apply_scores.py
@@ -54,6 +54,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+from datetime import date
 from pathlib import Path
 
 import yaml
@@ -166,7 +167,17 @@ def apply_to_file(path: Path, computed: dict) -> tuple[list[str], list[str]]:
             # somebody looked on that day, and that remains true whatever we can currently
             # derive. If the computed value is older, the file is ahead of us - report it
             # rather than destroying the record. ISO dates compare correctly as strings.
-            if current > stamp:
+            #
+            # But "ahead of us" only makes sense up to today. A check cannot have happened
+            # tomorrow, so a future date is a data error, and treating it as ahead would
+            # protect it forever - the guard would entrench exactly what it should surface.
+            today = date.today().isoformat()
+            if current > today:
+                changes.append(
+                    f"{path.stem}: IMPOSSIBLE last_verified {current} is in the future "
+                    f"(today {today}); left alone, but it needs correcting at source"
+                )
+            elif current > stamp:
                 changes.append(
                     f"{path.stem}: KEPT last_verified {current}, computed {stamp} is older"
                 )

--- a/build/validate.py
+++ b/build/validate.py
@@ -1,4 +1,5 @@
 """Validate the four-concern sources/ tree: schema + cross-file invariants."""
+from datetime import date
 import json
 from pathlib import Path
 
@@ -131,6 +132,37 @@ def validate_sources(data: dict) -> list[str]:
         if scored is not None and scored != len(prods):
             errors.append(f"long_tail counts.scored ({scored}) != product count ({len(prods)}); "
                           f"re-sync build/_frozen_long_tail.json after a batch")
+
+    # --- observation dates cannot be in the future ---
+    # `accessed` records when a source was read and `last_verified` when a check happened.
+    # Both are observation events, so neither can be later than today. The map is
+    # deliberately a forward-dated universe and may describe unreleased products, but that
+    # is prose and release dates, never a claim about when somebody looked.
+    #
+    # Checked because nothing else does, and because apply_scores refuses to move a stored
+    # date backwards - so a future date, once written, would be protected indefinitely by
+    # the very guard meant to preserve real checks.
+    today = date.today()
+    for slug, score in sorted(scores.items()):
+        for axis in ("openness", "adoption", "capability"):
+            block = score.get(axis) or {}
+            candidates = [("last_verified", block.get("last_verified"))]
+            for source in block.get("sources") or []:
+                if isinstance(source, dict):
+                    candidates.append(("sources.accessed", source.get("accessed")))
+            for field, raw in candidates:
+                if not raw:
+                    continue
+                try:
+                    when = date.fromisoformat(str(raw))
+                except ValueError:
+                    errors.append(f"score {slug!r}: {axis}.{field} {raw!r} is not an ISO date")
+                    continue
+                if when > today:
+                    errors.append(
+                        f"score {slug!r}: {axis}.{field} is {when}, later than today ({today}); "
+                        f"an observation cannot have happened in the future"
+                    )
 
     # --- product -> score existence ---
     # validate only checks score -> product; without this, a rostered product

--- a/sources/scores/apertus.yaml
+++ b/sources/scores/apertus.yaml
@@ -11,7 +11,7 @@ openness:
     code/recipe, intermediate checkpoints, a technical report (arXiv 2509.14233), and EU AI Act + Swiss
     data-protection/copyright compliance docs. All Apache-2.0. Sits in the OLMo/Pythia full-openness
     tier.'
-  last_verified: '2026-07-28'
+  last_verified: '2026-07-29'
   sources:
   - url: https://api.github.com/repos/swiss-ai/pretrain-data
     shows: Repository resolves 200. Pretraining-data reconstruction scripts are published, satisfying data:open by reconstruction.

--- a/sources/scores/claude-opus-4-7.yaml
+++ b/sources/scores/claude-opus-4-7.yaml
@@ -5,6 +5,7 @@ openness:
   components: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
   confidence: high
   note: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
+  last_verified: '2026-07-28'
   sources:
   - url: https://www.anthropic.com/news/claude-opus-4-7
     shows: 'launch post states "Opus 4.7 is available today across all Claude products and

--- a/sources/scores/deepseek-v3-2.yaml
+++ b/sources/scores/deepseek-v3-2.yaml
@@ -9,6 +9,7 @@ openness:
   note: weights:open(MIT, on HF);data:closed(training-data synthesis described in report but corpus not
     released);code:partial(inference code in HF repo; no full training pipeline);license:MIT(OSI-style
     permissive, no use restrictions)
+  last_verified: '2026-07-29'
   sources:
   - url: https://huggingface.co/deepseek-ai/DeepSeek-V3.2
     shows: flagship phase-C verification source

--- a/sources/scores/deepseek-v3-base.yaml
+++ b/sources/scores/deepseek-v3-base.yaml
@@ -8,7 +8,7 @@ openness:
   note: 'Weights open and commercially usable; model license is a custom non-OSI agreement (commercial
     use explicitly permitted per the card), so flagged near_open_source_non_osi_license. Verified: code
     MIT + custom model agreement.'
-  last_verified: '2026-06-04'
+  last_verified: '2026-07-29'
   sources:
   - url: https://huggingface.co/deepseek-ai/DeepSeek-V3-Base
     shows: 671B/37B MoE base model, MIT code license + custom Model Agreement License, commercial use

--- a/sources/scores/deepseek-v4-pro-base.yaml
+++ b/sources/scores/deepseek-v4-pro-base.yaml
@@ -10,7 +10,7 @@ openness:
     Matches the DeepSeek-V4-Pro anchor (O3 open_weights). Confidence raised to high: independently re-verified
     the live repo (1.6T, 24,567 dl/mo) AND the MIT LICENSE blob (first line "MIT License", DeepSeek 2023)
     this pass; model card empty but license unambiguous.'
-  last_verified: '2026-06-04'
+  last_verified: '2026-07-29'
   sources:
   - url: https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro-Base
     shows: 1.6T base model, 24,567 downloads/mo, live repo, but 'No model card'

--- a/sources/scores/deepseek-v4-pro.yaml
+++ b/sources/scores/deepseek-v4-pro.yaml
@@ -7,6 +7,7 @@ openness:
   confidence: high
   note: weights:open(MIT, on HF, both Pro and Flash);data:closed;code:partial(inference/serving; no training
     pipeline or data);license:MIT(permissive, no use restrictions)
+  last_verified: '2026-07-29'
   sources:
   - url: https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro
     shows: flagship phase-C verification source

--- a/sources/scores/gemini-3-5-flash.yaml
+++ b/sources/scores/gemini-3-5-flash.yaml
@@ -5,6 +5,7 @@ openness:
   components: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
   confidence: high
   note: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
+  last_verified: '2026-07-28'
   sources:
   - url: https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/
     shows: launch post lists the surfaces as the Gemini app, AI Mode in Search, Google

--- a/sources/scores/gemma-2.yaml
+++ b/sources/scores/gemma-2.yaml
@@ -8,7 +8,7 @@ openness:
   note: 'Weights open but gated under the non-OSI Gemma License with a prohibited-use policy (CONFIRMED:
     repo requires accepting conditions to access files); marketed as ''open'' so flagged open_washed.
     Matches the Gemma 3 anchor (O2 restricted).'
-  last_verified: '2026-07-27'
+  last_verified: '2026-07-29'
   sources:
   - url: https://huggingface.co/google/gemma-2-27b
     shows: 27B base (PT, not instruct), Gemma license, gated access requiring terms acceptance, 5,893

--- a/sources/scores/gemma-3.yaml
+++ b/sources/scores/gemma-3.yaml
@@ -5,6 +5,7 @@ openness:
   components: weights:open;data:closed;code:closed;license:Gemma-License(non-OSI,Prohibited-Use-Policy)
   confidence: high
   note: weights:open;data:closed;code:closed;license:Gemma-License(non-OSI,Prohibited-Use-Policy)
+  last_verified: '2026-07-29'
   sources:
   - url: https://ai.google.dev/gemma/docs/core/model_card_3
     shows: flagship phase-C verification source

--- a/sources/scores/gemma-4.yaml
+++ b/sources/scores/gemma-4.yaml
@@ -6,7 +6,7 @@ openness:
   confidence: medium
   note: OSI-licensed weights, but no open training data or code -> open-weights, not a fully-open pipeline. (License-weighted
     rubrics could argue toward 4.)
-  last_verified: '2026-06-17'
+  last_verified: '2026-07-29'
   sources:
   - url: https://ai.google.dev/gemma/docs/releases
     shows: Gemma 4 sizes, release dates, Apache-2.0 license

--- a/sources/scores/glm-5-2.yaml
+++ b/sources/scores/glm-5-2.yaml
@@ -5,7 +5,7 @@ openness:
   components: weights:open(MIT);data:closed;code:open(inference);license:MIT(OSI)
   confidence: high
   note: Permissive MIT open weights + inference code, but no open training data -> open_weights.
-  last_verified: '2026-06-18'
+  last_verified: '2026-07-29'
   sources:
   - url: https://huggingface.co/zai-org/GLM-5.2/blob/main/LICENSE
     shows: MIT, (c) Zhipu AI 2026

--- a/sources/scores/gpt-5.yaml
+++ b/sources/scores/gpt-5.yaml
@@ -5,6 +5,7 @@ openness:
   components: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
   confidence: high
   note: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
+  last_verified: '2026-07-28'
   sources:
   - url: https://developers.openai.com/api/docs/models/gpt-5
     shows: 'OpenAI''s own model reference for gpt-5 documents access solely as API endpoints

--- a/sources/scores/grok-4-20.yaml
+++ b/sources/scores/grok-4-20.yaml
@@ -5,6 +5,7 @@ openness:
   components: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
   confidence: high
   note: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
+  last_verified: '2026-07-28'
   sources:
   - url: https://docs.x.ai/developers/release-notes
     shows: 'xAI release notes record "Grok 4.20 and Grok 4.20 Multi-agent are live" and point

--- a/sources/scores/inkling.yaml
+++ b/sources/scores/inkling.yaml
@@ -9,7 +9,7 @@ openness:
   note: Apache-2.0 weights are OSI-licensed, but training data and full training code are withheld —
     open_weights / 3, not open_source / 5. Press often calls this 'open source' because of the license
     tag; our spectrum requires open data + code for class open_source.
-  last_verified: '2026-07-19'
+  last_verified: '2026-07-29'
   sources:
   - url: https://huggingface.co/thinkingmachines/Inkling
     shows: Apache-2.0 license tag; 975B/41B MoE; weights downloadable; model card states data from public,

--- a/sources/scores/internlm-2-5.yaml
+++ b/sources/scores/internlm-2-5.yaml
@@ -9,7 +9,7 @@ openness:
   note: Code is OSI (Apache-2.0) but the weights license is a custom non-OSI 'Free Commercial License'
     requiring a commercial-license application form (HF card confirms form link, 2026-06-04), so open_weights
     not open_source; flagged for the non-OSI weights term.
-  last_verified: '2026-06-04'
+  last_verified: '2026-07-29'
   sources:
   - url: https://huggingface.co/internlm/internlm2_5-7b
     shows: 'model card: code Apache-2.0; weights fully open for academic research and free commercial

--- a/sources/scores/kimi-k2-6.yaml
+++ b/sources/scores/kimi-k2-6.yaml
@@ -9,6 +9,7 @@ openness:
   note: weights:open(downloadable on HF);data:closed;code:partial(inference/deploy; no training data or
     full pipeline);license:Modified-MIT(standard MIT below 100M MAU / $20M monthly rev; above thresholds
     requires 'Kimi K2' UI attribution, attribution-only, not a use cap)
+  last_verified: '2026-07-29'
   sources:
   - url: https://huggingface.co/moonshotai/Kimi-K2.6
     shows: flagship phase-C verification source

--- a/sources/scores/kimi-k3.yaml
+++ b/sources/scores/kimi-k3.yaml
@@ -10,7 +10,7 @@ openness:
     closed). Weights not yet on HF as of 2026-07-19 — Moonshot's primary blog commits to a full weight
     release by 2026-07-27. Re-verify license text and HF card on landing; downgrade to closed if the release
     slips or the license changes.
-  last_verified: '2026-07-19'
+  last_verified: '2026-07-29'
   sources:
   - url: https://www.kimi.com/blog/kimi-k3
     shows: primary announcement — 2.8T MoE, 1M context, native vision; API live; full weights by 2026-07-27

--- a/sources/scores/llama-3-1.yaml
+++ b/sources/scores/llama-3-1.yaml
@@ -10,7 +10,7 @@ openness:
     actual Llama 3.1 license, Section 2); marketed as ''open'' so flagged open_washed. Corrected source:
     the record originally cited the Llama 2 license text as a proxy; replaced with the actual Llama 3.1
     Community License.'
-  last_verified: '2026-07-27'
+  last_verified: '2026-07-29'
   sources:
   - url: https://huggingface.co/meta-llama/Llama-3.1-8B
     shows: base pretrained 8B (page states base, not instruct), Llama 3.1 Community License, downloadable

--- a/sources/scores/lucie-7b.yaml
+++ b/sources/scores/lucie-7b.yaml
@@ -8,7 +8,7 @@ openness:
   note: 'Full open-source tier alongside OLMo / Apertus: open weights, open training data, open training
     code, intermediate checkpoints. Authors position Lucie as OSI-definition-compliant for open-source AI.
     Training-dataset product deferred — artifacts cited here for openness only.'
-  last_verified: '2026-07-27'
+  last_verified: '2026-07-29'
   sources:
   - url: https://huggingface.co/api/datasets/OpenLLM-France/Lucie-Training-Dataset
     shows: Public, ungated dataset repo present on the Hub; 3,101 downloads. Corpus is published, not merely described.

--- a/sources/scores/marin.yaml
+++ b/sources/scores/marin.yaml
@@ -6,7 +6,7 @@ openness:
   confidence: high
   note: 'Stanford CRFM ''open lab'': Apache-2.0 weights plus documented code, data, experiments, hyperparameters
     and training logs, with bit-for-bit reproducible training.'
-  last_verified: '2026-06-30'
+  last_verified: '2026-07-29'
   sources:
   - url: http://marin.community/blog/2025/05/19/announcement/
     shows: 'Marin open lab: code, data, experiments, logs all shared'

--- a/sources/scores/mimo-v2-5-pro.yaml
+++ b/sources/scores/mimo-v2-5-pro.yaml
@@ -5,7 +5,7 @@ openness:
   components: weights:open(MIT per HF card);data:closed;code:open;license:MIT(HF card; older GitHub repo shows Apache-2.0)
   confidence: medium
   note: Open weights under a permissive license (MIT per the model card); no open training data -> open_weights.
-  last_verified: '2026-06-18'
+  last_verified: '2026-07-29'
   sources:
   - url: https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro
     shows: MIT, 1.02T/42B MoE, 1M context, benchmarks

--- a/sources/scores/mistral-large-3.yaml
+++ b/sources/scores/mistral-large-3.yaml
@@ -5,6 +5,7 @@ openness:
   components: weights:open(Apache-2.0);data:closed;code:closed;license:Apache-2.0(OSI)
   confidence: high
   note: weights:open(Apache-2.0);data:closed;code:closed;license:Apache-2.0(OSI)
+  last_verified: '2026-07-29'
   sources:
   - url: https://mistral.ai/news/mistral-3/
     shows: flagship phase-C verification source

--- a/sources/scores/olmo-3.yaml
+++ b/sources/scores/olmo-3.yaml
@@ -7,7 +7,7 @@ openness:
   confidence: high
   note: 'Fully open: Apache-2.0 weights + the complete Dolma 3 corpus + training code + intermediate checkpoints.
     The reference fully-open model line.'
-  last_verified: '2026-07-27'
+  last_verified: '2026-07-29'
   sources:
   - url: https://huggingface.co/api/datasets/allenai/dolma
     shows: Public, ungated dataset repo present on the Hub; 3,052 downloads. Dolma corpus is published.

--- a/sources/scores/phi-4.yaml
+++ b/sources/scores/phi-4.yaml
@@ -5,6 +5,7 @@ openness:
   components: weights:open(MIT);data:closed;code:closed;license:MIT(OSI)
   confidence: high
   note: weights:open(MIT);data:closed;code:closed;license:MIT(OSI)
+  last_verified: '2026-07-29'
   sources:
   - url: https://the-decoder.com/microsoft-releases-full-phi-4-model-with-weights-under-mit-license/
     shows: flagship phase-C verification source

--- a/sources/scores/pythia.yaml
+++ b/sources/scores/pythia.yaml
@@ -7,7 +7,7 @@ openness:
   confidence: high
   note: weights:open(Apache-2.0);data:open(the Pile, with dataloader reconstruction tools);code:open(training+analysis
     code, GitHub);checkpoints:open(154 per model);license:Apache-2.0(OSI)
-  last_verified: '2026-07-27'
+  last_verified: '2026-07-29'
   sources:
   - url: https://huggingface.co/api/datasets/EleutherAI/pile
     shows: Public, ungated dataset repo present on the Hub; 2,441 downloads. The Pile is published.

--- a/sources/scores/qwen3.yaml
+++ b/sources/scores/qwen3.yaml
@@ -7,7 +7,7 @@ openness:
   confidence: high
   note: Apache-2.0 base weights with no MAU cap (cleaner than Qwen2.5's flagship license, confirmed);
     data and training code closed -> open_weights, matching the Qwen 3.6 anchor (O3).
-  last_verified: '2026-06-04'
+  last_verified: '2026-07-29'
   sources:
   - url: https://huggingface.co/Qwen/Qwen3-30B-A3B-Base
     shows: Qwen3 base MoE (30.5B/3.3B), Apache-2.0, 42,966 downloads/mo

--- a/sources/scores/smollm3.yaml
+++ b/sources/scores/smollm3.yaml
@@ -7,7 +7,7 @@ openness:
   confidence: high
   note: 'Fully-open small-model line: Apache-2.0 weights with the complete engineering blueprint (architecture,
     data mixtures, training and post-training recipe) published.'
-  last_verified: '2026-06-30'
+  last_verified: '2026-07-29'
   sources:
   - url: https://huggingface.co/blog/smollm3
     shows: 'fully-open 3B: 11T tokens, 128K context, multilingual, full recipe published'

--- a/sources/scores/yi-1-5.yaml
+++ b/sources/scores/yi-1-5.yaml
@@ -7,7 +7,7 @@ openness:
   confidence: high
   note: Permissive Apache-2.0 weights but training data and full training code are not released, so open_weights
     not open_source. Apache-2.0 confirmed on HF base cards 2026-06-04.
-  last_verified: '2026-06-04'
+  last_verified: '2026-07-29'
   sources:
   - url: https://huggingface.co/01-ai/Yi-1.5-34B
     shows: Apache-2.0 license, 34B base model (base vs chat variants listed), downloadable weights


### PR DESCRIPTION
Three defects in `apply_scores`, all found while verifying the first pipeline run rather than by reading the code. Each would have quietly corrupted `sources/scores`.

## 1. It read through a cache keyed on query text

Query results are cached against the **query text**, so a tool issuing a fixed string keeps receiving its first answer forever — it never self-heals.

Demonstrated: `apply_scores` reported the pre-run baseline (15 dataset tiers, 33 verifiable) for an entire run cycle *after* the models had re-materialized. The identical SQL with one trailing comment returned the true 21 and 38. A writer reading through that cache writes stale dates into score files.

Now cache-busted per invocation. This also explains a false alarm earlier in the session, where repeated identical `COUNT(*)` queries made a materialization look like it hadn't happened when it had.

## 2. It wrote the wrong quantity

`last_verified` was being asked to be two different things:

| | meaning |
|---|---|
| `freshness_floor` | MIN accessed across everything the score relies on, null if any is unsourced. A **bound** — an axis is only as fresh as its stalest input. |
| `last_checked` | MAX accessed across admitted evidence. A **check event** — the last time anything actually looked. |

`apply_scores` wrote the bound. That's why #108 replaced hand-stamped `2026-07-28` dates on `olmo-3`, `lucie-7b` and `pythia` with `2026-07-27` — **a value appearing nowhere in those files' own evidence**, because it came from a signal fetch date the files never cite. Untraceable by construction, which is the opposite of what a citation is for.

The scorer now emits both columns. Only `last_checked` is written back; `freshness_floor` stays in the warehouse, so one fact has one authority.

## 3. It moved stored dates backwards

A date in a file records that somebody looked on that day. That stays true regardless of what we can currently derive, so if the computed value is older it's now reported and the file left alone.

Verified by perturbation rather than assumed — with a stored `2026-08-15` against a computed `2026-07-29`:

```
olmo-3: KEPT last_verified 2026-08-15, computed 2026-07-29 is older
```

and nothing was written.

## Also: a counting bug

`has_date()` replaces `is not None` for DataFrame date columns. A null `DATE` arrives as pandas `NaT` or float `nan` depending on dtype, and **both satisfy `is not None`** — which made an earlier count report 14 products gaining a date when the true number was 5.

## Result

**28 files updated, 0 scores moved.**

The three dates #108 overwrote self-heal to `2026-07-29`, because the Hub signal genuinely re-read those licenses today — so no manual restoration was needed, which is a better outcome than hand-patching them.

43 of 47 products now carry a check date, against 38 whose every relied-on fact is sourced. That gap is the honest one: we can say *something was checked* more often than we can say *everything is sourced*.

## Test plan

- `build.validate` — 0 errors
- `build.check_rubric` — 47/47, unchanged
- `apply_scores --check` reads fresh data (21 dataset tiers, matching a direct MCP query; it reported 15 before the fix)
- never-older guard exercised by perturbation, confirmed to report and not write
- score-movement guard still exits non-zero, exercised earlier by the same method
- scorer redeployed with the 18-column schema declared explicitly, not inherited
