### PR TITLE
Port the scoring rubric to a second category (finetuned_chat)

### DIFF
--- a/build/check_rubric.py
+++ b/build/check_rubric.py
@@ -75,6 +75,31 @@ def head(value: str) -> str:
     return re.split(r"[(,]", value)[0].strip()
 
 
+_RECORDED_ALIASES: dict[str, str] | None = None
+
+
+def recorded_license_aliases() -> dict[str, str]:
+    """Canonical license name for a name as hand-written in a `components` string.
+
+    Read from `sources/signal_routing.yaml`, which already owns the equivalent map
+    for Hub-published slugs. One declaration for both, because they are the same
+    kind of fact — what a license is CALLED — and two copies would drift.
+
+    Deliberately does not carry a tier. Which tier a license belongs to stays a
+    per-category judgment, and a canonical name that appears in no category example
+    still abstains. That abstention is the signal to extend the rubric.
+    """
+    global _RECORDED_ALIASES
+    if _RECORDED_ALIASES is None:
+        routing = yaml.safe_load((ROOT / "sources" / "signal_routing.yaml").read_text()) or {}
+        aliases = ((routing.get("dimensions") or {}).get("license") or {}).get("aliases") or {}
+        _RECORDED_ALIASES = {
+            str(slug).strip().lower(): str(name).strip()
+            for slug, name in (aliases.get("recorded") or {}).items()
+        }
+    return _RECORDED_ALIASES
+
+
 def normalize_license(raw: str) -> str:
     """Reduce a recorded license string to the license that governs the weights.
 
@@ -84,14 +109,19 @@ def normalize_license(raw: str) -> str:
         because it is the one attached to the artifact being scored.
       * `assumed-Modified-MIT` — the `assumed-` prefix marks confidence, not a
         different license.
+
+    Then the recorded-name alias, which resolves spellings of one license to one
+    name. Applied last, so it sees the value after the mechanical steps rather
+    than having to enumerate every prefixed variant.
+
     Purely mechanical. Anything needing judgment is left alone to be flagged.
     """
     value = head(raw)
     if "+" in value and "model" in value.lower():
         value = value.split("+")[-1]
         value = re.sub(r"(?i)^\s*model\s+", "", value)
-    value = re.sub(r"(?i)^assumed-", "", value.strip())
-    return value.strip()
+    value = re.sub(r"(?i)^assumed-", "", value.strip()).strip()
+    return recorded_license_aliases().get(value.lower(), value)
 
 
 def license_tier(raw: str, recipe: dict) -> str | None:
@@ -113,6 +143,63 @@ def license_tier(raw: str, recipe: dict) -> str | None:
     return None
 
 
+def resolve_dimension(components: dict[str, str], dimension: str, recipe: dict) -> str | None:
+    """Which recorded key answers a dimension, or None if nothing does.
+
+    A dimension's `reads` list names the `components` keys that carry its answer,
+    in preference order. It exists because the same question is recorded under
+    different keys in different categories: for a base model the data question is
+    `data`, the pretraining corpus, while for a fine-tune the corpus belongs to
+    somebody else's model and the honest answer lives in `post-training-data`.
+
+    Prefers the first key whose value is in the declared enum, rather than the
+    first key present. A product recording both `data:closed` and
+    `post-training-data:open` is answering two different questions, and taking
+    whichever appeared first in the string would pick between them by accident.
+
+    Falls back to the first present key when none is in the enum, so an
+    unrecognized value surfaces in the mismatch message instead of silently
+    reading as absent.
+
+    Returns the KEY rather than the value, because callers that write evidence out
+    need the parenthetical detail attached to that key too, and re-deriving the
+    preference in a second place is how the two would drift.
+    """
+    spec = (((recipe.get("openness") or {}).get("dimensions") or {}).get(dimension)) or {}
+    keys = spec.get("reads") or [dimension]
+    allowed = set(spec.get("values") or ())
+    present = [key for key in keys if key in components]
+    for key in present:
+        if head(components[key]) in allowed:
+            return key
+    return present[0] if present else None
+
+
+def dimension_value(components: dict[str, str], dimension: str, recipe: dict) -> str:
+    """The bare value the formula reads for a dimension, or '' if unanswered."""
+    key = resolve_dimension(components, dimension, recipe)
+    return head(components[key]) if key is not None else ""
+
+
+def dimension_read_map(recipe: dict) -> dict[str, str]:
+    """Recorded key -> the dimension it can answer.
+
+    A key named in some dimension's `reads` is declared vocabulary even though it is
+    not itself a dimension name, so it must not be reported as vocabulary drift.
+    """
+    declared = ((recipe.get("openness") or {}).get("dimensions")) or {}
+    return {
+        key: name
+        for name, spec in declared.items()
+        for key in ((spec or {}).get("reads") or [name])
+    }
+
+
+def license_read_keys(recipe: dict) -> list[str]:
+    """Recorded keys that may carry the license the tier lookup consumes."""
+    return (((recipe.get("openness") or {}).get("license_tier") or {}).get("reads")) or ["license"]
+
+
 def matches(rule_when: dict, facts: dict) -> bool:
     return all(facts.get(key) == value for key, value in rule_when.items())
 
@@ -129,27 +216,41 @@ def apply_formula(recipe: dict, facts: dict) -> tuple[int, str] | None:
     return None
 
 
-def check_category(slug: str, verbose: bool) -> tuple[int, int, list[str]]:
-    """Return (reproduced, total, problems)."""
+def check_category(slug: str, verbose: bool) -> tuple[int, int, list[str], list[str]]:
+    """Return (reproduced, total, problems, deferred)."""
     category = yaml.safe_load((ROOT / "sources" / "categories" / f"{slug}.yaml").read_text())
     recipe = category.get("scoring_recipe")
     if not recipe:
-        return 0, 0, []
+        return 0, 0, [], []
+
+    # Products the category has declared the rubric does not yet decide, each with
+    # a reason. Deferring is not the same as passing: these are excluded from the
+    # reproduction count rather than counted as reproduced, and printed every run
+    # so the exclusion cannot go quiet. A rubric that reproduces 45 of 45 while
+    # deferring the one product that contradicts it has proved nothing.
+    deferrals = recipe.get("deferred") or {}
 
     reproduced = 0
     total = 0
     problems: list[str] = []
+    deferred: list[str] = []
 
     for product in category.get("products") or []:
         path = ROOT / "sources" / "scores" / f"{product}.yaml"
         if not path.exists():
+            continue
+        if product in deferrals:
+            because = (deferrals[product] or {}).get("because", "no reason recorded")
+            deferred.append(f"{product}: {' '.join(str(because).split())}")
             continue
         scores = yaml.safe_load(path.read_text())
         openness = scores.get("openness") or {}
         components = split_components(openness.get("components") or "")
         total += 1
 
-        raw_license = components.get("license", "")
+        raw_license = next(
+            (components[key] for key in license_read_keys(recipe) if components.get(key)), ""
+        )
         tier = license_tier(raw_license, recipe)
         if tier is None:
             problems.append(
@@ -159,9 +260,9 @@ def check_category(slug: str, verbose: bool) -> tuple[int, int, list[str]]:
             continue
 
         facts = {
-            "weights": head(components.get("weights", "")),
-            "data": head(components.get("data", "")),
-            "code": head(components.get("code", "")),
+            "weights": dimension_value(components, "weights", recipe),
+            "data": dimension_value(components, "data", recipe),
+            "code": dimension_value(components, "code", recipe),
             "license_tier": tier,
         }
         got = apply_formula(recipe, facts)
@@ -178,7 +279,11 @@ def check_category(slug: str, verbose: bool) -> tuple[int, int, list[str]]:
                 f"code={facts['code']} tier={tier}]"
             )
 
-    return reproduced, total, problems
+    unknown = sorted(set(deferrals) - set(category.get("products") or []))
+    for product in unknown:
+        problems.append(f"{product}: deferred by the recipe but not a product of this category")
+
+    return reproduced, total, problems, deferred
 
 
 def main() -> int:
@@ -196,14 +301,17 @@ def main() -> int:
     failed = False
     checked_any = False
     for slug in slugs:
-        reproduced, total, problems = check_category(slug, args.verbose)
-        if total == 0:
+        reproduced, total, problems, deferred = check_category(slug, args.verbose)
+        if total == 0 and not deferred:
             continue
         checked_any = True
         status = "OK" if not problems else "FAIL"
-        print(f"{slug}: {reproduced}/{total} reproduced  [{status}]")
+        suffix = f", {len(deferred)} deferred" if deferred else ""
+        print(f"{slug}: {reproduced}/{total} reproduced{suffix}  [{status}]")
         for problem in problems:
             print(f"  ! {problem}")
+        for entry in deferred:
+            print(f"  ~ deferred  {entry}")
         if problems:
             failed = True
 

--- a/build/serialize_rubric.py
+++ b/build/serialize_rubric.py
@@ -64,7 +64,12 @@ from pathlib import Path
 
 import yaml
 
-from build.check_rubric import split_components
+from build.check_rubric import (
+    dimension_read_map,
+    license_read_keys,
+    resolve_dimension,
+    split_components,
+)
 from build.serialize_registry import write_tables
 from build.validate import load_sources
 
@@ -373,27 +378,28 @@ def build_rubric(sources: dict, policy: dict, routing: dict) -> tuple[dict[str, 
                     f"product '{product_slug}' in '{slug}' records no openness components"
                 )
 
-            for dimension, raw in components.items():
-                bare, detail = split_value(raw)
-                # A component the rubric never declared is vocabulary drift. It cannot
-                # affect a score, because the formula only reads what it declares, so
-                # it is a curation finding rather than a failure - but left unreported
-                # it is an observation nobody will ever act on. `marin` records
-                # `reproducibility:bit-for-bit`, which is a real openness fact the
-                # rubric has no question for.
-                if dimension != "license" and dimension not in declared:
-                    warnings.append(
-                        f"product '{product_slug}' records {dimension!r}, which "
-                        f"'{slug}' does not declare as a dimension"
-                    )
-                allowed = (declared.get(dimension) or {}).get("values")
-                # `license` is not a dimension with an enum; it is the raw input the
-                # license_tier lookup consumes, so it has nothing to be checked against.
-                in_enum = "" if dimension == "license" or not allowed else bare in allowed
+            read_map = dimension_read_map(recipe)
+            license_keys = license_read_keys(recipe)
+
+            # One row per DECLARED DIMENSION, carrying the value the formula will
+            # actually read. Emitted under the dimension name rather than the key it
+            # was recorded under, because the warehouse joins a rule's condition_key
+            # against this column: a row labeled `post-training-data` would leave the
+            # `data` condition unmatched and drop the product into `otherwise`
+            # silently, scoring it 3 on an absence.
+            resolved_keys: dict[str, str] = {}
+            for dimension, spec in declared.items():
+                key = resolve_dimension(components, dimension, recipe)
+                if key is None:
+                    continue
+                resolved_keys[dimension] = key
+                bare, detail = split_value(components[key])
+                allowed = (spec or {}).get("values")
+                in_enum = bare in allowed if allowed else ""
                 if in_enum is False:
                     warnings.append(
-                        f"product '{product_slug}' records {dimension}={bare!r}, which is not in "
-                        f"the rubric's declared values {allowed}"
+                        f"product '{product_slug}' records {key}={bare!r}, which is not in "
+                        f"the rubric's declared values for {dimension} {allowed}"
                     )
                 tables["product_openness_evidence"].append(
                     {
@@ -404,6 +410,60 @@ def build_rubric(sources: dict, policy: dict, routing: dict) -> tuple[dict[str, 
                         "value_detail": detail,
                         "grade": "document",
                         "in_declared_enum": in_enum,
+                    }
+                )
+
+            # Then every recorded key that is not itself a dimension name, so nothing
+            # the repo recorded is dropped. This carries the license the tier lookup
+            # consumes, and the losing side of a `reads` preference — granite records
+            # both a base corpus and an SFT mixture, and only one of them answers the
+            # category's data question.
+            #
+            # Keys that ARE dimension names are skipped here because the resolved pass
+            # above already emitted them. Emitting both would put two values on one
+            # grain and let the warehouse pick between them by row order.
+            for key, raw in components.items():
+                if key in declared:
+                    # A key that shares a dimension's name but lost the `reads`
+                    # preference is answering a different question under a name this
+                    # category has already spent. granite records
+                    # `data:described_not_released` about its BASE corpus while
+                    # `post-training-data` answers the category's data question, so the
+                    # base fact has nowhere to go and would be dropped without a word.
+                    # Reported so it can be relabeled — starcoder2 already uses
+                    # `base-data` for exactly this.
+                    if resolved_keys.get(key) != key:
+                        warnings.append(
+                            f"product '{product_slug}' records {key}={split_value(raw)[0]!r}, but "
+                            f"'{slug}' resolved {key} from {resolved_keys.get(key)!r} instead, so "
+                            f"the recorded value is dropped from the evidence store. Relabel it if "
+                            f"it answers a different question."
+                        )
+                    continue
+                bare, detail = split_value(raw)
+                # A component no dimension declares and no `reads` list names is
+                # vocabulary drift. It cannot affect a score, so it is a curation
+                # finding rather than a failure — but left unreported it is an
+                # observation nobody will ever act on. `marin` records
+                # `reproducibility:bit-for-bit`, a real openness fact the rubric has
+                # no question for.
+                if key not in license_keys and key not in read_map:
+                    warnings.append(
+                        f"product '{product_slug}' records {key!r}, which "
+                        f"'{slug}' does not declare as a dimension"
+                    )
+                tables["product_openness_evidence"].append(
+                    {
+                        "product_slug": product_slug,
+                        "category_slug": slug,
+                        "dimension": key,
+                        "value": bare,
+                        "value_detail": detail,
+                        "grade": "document",
+                        # A traceability row, not the value any rule reads. Left blank
+                        # rather than validated, since the enum it would be checked
+                        # against belongs to the dimension that won.
+                        "in_declared_enum": "",
                     }
                 )
 

--- a/sources/categories/base_pretrained.yaml
+++ b/sources/categories/base_pretrained.yaml
@@ -83,7 +83,7 @@ scoring_recipe:
           definition: >
             Caps or gates use — monthly-active-user ceilings, field-of-use limits,
             research-only terms, or a commercial agreement requirement.
-          examples: [Llama-3.1-Community-License, Llama-4-Community, Gemma-License, Mistral-Research-License, TII-Falcon-License-2.0, glm-4, Qwen-License-Agreement]
+          examples: [Llama-3.1-Community-License, Llama-4-Community, Gemma-License, Mistral-Research-License, TII-Falcon-License-2.0, GLM-4-License, Qwen-License-Agreement]
         proprietary:
           definition: No public license; weights not distributed.
       multi_sku_rule: >

--- a/sources/categories/finetuned_chat.yaml
+++ b/sources/categories/finetuned_chat.yaml
@@ -6,6 +6,198 @@ strapline: Where the closed labs lead. Most chat assistants are API-only; the op
 weights:
   adopt: 0.3
   cap: 0.7
+
+# Second category to carry a machine-readable rubric, and the one that tests
+# whether the first was a general mechanism or a bespoke one. The answer is mostly
+# yes: the tier ladder and the formula below are base_pretrained's, unchanged. What
+# needed adding was vocabulary, not structure - which keys carry the data answer for
+# a fine-tune, and eight more licenses.
+#
+# Ported on 2026-07-29. Three things the port found are recorded here rather than
+# quietly fixed, because they are judgments about published scores:
+#   * `deferred` below - three products whose license restricts CONDUCT rather than
+#     commerce, which this ladder has no tier for.
+#   * codegemma scored 3 while gemma-3 scored 2 on identical facts and the same
+#     license. Corrected to 2 in sources/scores/codegemma.yaml.
+#   * tulu-3 and starcoder2 recorded score/class pairs this ladder cannot emit
+#     (3/restricted, 4/open_source).
+#
+# The formula restates base_pretrained's, less one rule no product here can trigger.
+# Restating is tolerable at two categories and a liability at three - the third one to
+# land should extract the ladder to a shared default that a category overrides rather
+# than copies.
+scoring_recipe:
+  version: 1
+  derived_from:
+    method: ported from base_pretrained, then verified against this category's scores
+    ported_from: base_pretrained
+    scores_reproduced: 43
+    scores_total: 43
+    scores_deferred: 3
+    scores_corrected: 3
+    verified_on: '2026-07-29'
+    checker: build/check_rubric.py
+    note: >
+      43 of 43 reproduce, but only after three recorded scores were corrected -
+      codegemma 3 -> 2, tulu-3 3 -> 2, tinyllama-1-1b-chat-v1-0 4 -> 5. Counting
+      those as reproductions would be circular. 32 of 46 reproduced against the
+      unmodified rubric and unmodified scores, before any alias, any `reads`
+      declaration or any correction; that is the honest measure of how far the pilot
+      rubric traveled on its own.
+
+  openness:
+    dimensions:
+      weights:
+        question: Are the tuned model weights downloadable and runnable locally?
+        values: [open, closed, pending]
+        evidence:
+        - Hugging Face model repo with downloadable weight files (safetensors/GGUF)
+        - vendor download page for weights outside the Hub
+        machine_signal: signal_huggingface.hub_state (gated, private, files)
+      data:
+        question: Is the POST-TRAINING data released - the SFT, DPO or RL sets this
+          tune was built from?
+        # For a base model the data question is the pretraining corpus. For a tune,
+        # that corpus belongs to somebody else's model, and asking about it scores
+        # the base rather than the product. The honest question here is what the
+        # tuner released, which is why `post-training-data` is read first.
+        reads: [post-training-data, data]
+        values: [open, described_not_released, described, partial, closed]
+        evidence:
+        - a released SFT/DPO/RL mixture, or scripts that reconstruct it
+        - '`described` where the mixture is named in the card but not published'
+        - naming the datasets used is NOT sufficient for `open`
+        machine_signal: none - requires research
+        vocabulary_note: >
+          `described_not_released` here is `documented-not-released` in
+          base_pretrained. Same concept, two spellings, and neither category should
+          be the one that unilaterally renames it. Unifying the shared data
+          vocabulary is issue #106.
+      code:
+        question: Is the fine-tuning pipeline released, not just inference code?
+        values: [open, partial, closed]
+        evidence:
+        - '`open`: the post-training recipe - SFT/DPO/RL configs and scripts'
+        - '`partial`: inference, serving or chat-template code only'
+        - '`closed`: no code'
+        machine_signal: partial - repo presence from signal_github.repo_state
+
+    license_tier:
+      # base_pretrained's ladder, unchanged, including the declaration order that
+      # `tier_rank` and the multi-SKU rule depend on. Eight licenses added because
+      # this category ships them and the pilot did not.
+      ordered_by: restrictiveness_ascending
+      # A tune records its license under `license`, except where the card
+      # distinguishes a code license from the one attached to the weights, and then
+      # it lands in `model-license`. The weights license governs either way.
+      reads: [license, model-license]
+      values:
+        osi:
+          definition: OSI-approved license
+          examples: [Apache-2.0, MIT, BSD-3-Clause]
+        permissive_non_osi:
+          definition: >
+            Not OSI-approved but imposes no use restriction. Attribution or
+            naming requirements alone belong here.
+          examples: [Modified-MIT, minimax-community, NVIDIA-Open-Model-License]
+        use_restricted:
+          definition: >
+            Caps or gates use - monthly-active-user ceilings, field-of-use limits,
+            research-only terms, or a commercial agreement requirement.
+          examples: [Llama-2-Community-License, Llama-3-Community-License, Llama-3.1-Community-License,
+            Llama-3.2-Community-License, Llama-4-Community, Gemma-License, GLM-4-License,
+            Qwen-License-Agreement, Mistral-Research-License, Mistral-AI-Non-Production-License,
+            Jamba-Open-Model-License]
+        proprietary:
+          definition: No public license; weights not distributed.
+      multi_sku_rule: >
+        As base_pretrained: where a family ships SKUs under different licenses, the
+        most restrictive license among the SKUs WHOSE WEIGHTS ARE ACTUALLY
+        DISTRIBUTED governs, and API-only tiers are excluded.
+      inherits_from_base: >
+        A tune of a restrictively licensed base carries that restriction, because
+        the license travels with the weights. hermes-4-llama-3-1-405b is
+        use_restricted on account of Meta's terms, not anything Nous did. This needs
+        no rule of its own - the tune records the license it actually ships under,
+        and the ladder does the rest.
+
+        What the ladder deliberately does NOT do is credit the tuner's open method
+        here. A fine-tuning approach generalizes across bases - AI2's Tulu recipe
+        runs on Llama and on OLMo - so scoring the checkpoint would either bury the
+        open method or overstate the artifact. The map already resolves this by
+        scoring the method's artifacts as their own products:
+        tulu-3-sft-mixture is 5/open in training_synthetic_datasets while the
+        Llama-based tulu-3 checkpoint is 2/restricted. That pair is the signal.
+        Recording the checkpoint -> base link so the two can be joined is not yet
+        done; `lineage` exists but is dataset-only and free-text.
+      normalization:
+      - 'compound `code X + model Y`: the MODEL license governs'
+      - 'prefix `assumed-`: same tier, confidence drops to medium'
+      never_use:
+        mixed: Apply multi_sku_rule and store the resolved tier instead.
+        unknown: Research it or defer the product with a reason.
+
+    # Ordered rules, first match wins. base_pretrained's ladder less one rule: it
+    # carries a `data: documented-not-released, code: open -> 4`, and no product here
+    # pairs a described-but-unreleased mixture with an open pipeline. Declaring it
+    # anyway would add a rule that cannot fire, and a dead rule in a first-match-wins
+    # formula is a place for a later edit to hide.
+    formula:
+    - when: {weights: closed}
+      then: {score: 1, class: closed}
+    - when: {license_tier: proprietary}
+      then: {score: 1, class: closed}
+    - when: {license_tier: use_restricted}
+      then: {score: 2, class: restricted}
+      note: Open weights behind a use cap. Downloadable is not the same as usable.
+    - when: {data: open, code: open, license_tier: osi}
+      then: {score: 5, class: open_source}
+    - when: {data: open, code: open}
+      then: {score: 4, class: open_weights}
+      note: Full recipe but a non-OSI license caps the score at 4.
+    - otherwise: {score: 3, class: open_weights}
+      note: The category's center of gravity - open weights, closed recipe.
+
+  # Products this rubric does not decide, each with a reason. All three share one
+  # cause: a license that restricts CONDUCT - no military use, no discrimination,
+  # no commercial use - rather than capping commerce or field of use. The ladder's
+  # `use_restricted` is defined by commercial caps and field-of-use limits, so
+  # these fit no tier honestly.
+  #
+  # Not a quirk of this category. The same licenses are scored three different ways
+  # across the map, including one flat contradiction: DeepSeek-Model-License is
+  # permissive_non_osi in base_pretrained (deepseek-v3-base, 3/open_weights) and
+  # use-restricting here (2/restricted). OpenRAIL lands at 4/open_source here and
+  # 3/open_weights in safeguards. CC-BY-NC is 2/restricted here and 5/open in
+  # training_synthetic_datasets.
+  #
+  # Adding a tier for it would expand the taxonomy on one category's evidence,
+  # which is the thing #106 exists to prevent. Deferring keeps the products visible
+  # and unscored by machine until the tier question is settled in the open.
+  deferred:
+    starcoder2:
+      because: >
+        BigCode-OpenRAIL-M restricts behavior, not commerce. Weights, data and code
+        are all fully open, so the ladder would drop it to 2/restricted on the
+        license alone - harsher than any other reading of this artifact. Recorded
+        4/open_source, a pair the ladder cannot emit at all.
+      license: BigCode-OpenRAIL-M
+    deepseek-coder-v2-instruct:
+      because: >
+        DeepSeek-Model-License carries Attachment A acceptable-use restrictions
+        (military, illegal, discriminatory). base_pretrained tiers this same license
+        permissive_non_osi and scores deepseek-v3-base 3/open_weights; this product
+        is recorded 2/restricted. One of the two is wrong and the rubric should not
+        pick by fiat.
+      license: DeepSeek-Model-License
+    command-r:
+      because: >
+        CC-BY-NC is non-commercial, which is a harder restriction than most entries
+        in use_restricted, yet cc-by-nc-sa-4.0 carries 5/open on personahub in
+        training_synthetic_datasets. Needs one ruling that holds for models and
+        datasets both.
+      license: CC-BY-NC
+
 products:
 - qwen3-coder
 - qwen2-5-coder-instruct

--- a/sources/categories/finetuned_chat.yaml
+++ b/sources/categories/finetuned_chat.yaml
@@ -174,6 +174,9 @@ scoring_recipe:
   # Adding a tier for it would expand the taxonomy on one category's evidence,
   # which is the thing #106 exists to prevent. Deferring keeps the products visible
   # and unscored by machine until the tier question is settled in the open.
+  #
+  # Tracked in issue #117. Whatever lands there has to hold for datasets as well as
+  # models, which is why it is not settled here.
   deferred:
     starcoder2:
       because: >

--- a/sources/scores/codegemma.yaml
+++ b/sources/scores/codegemma.yaml
@@ -1,10 +1,13 @@
 product: codegemma
 openness:
-  score: 3
-  class: open_weights
+  score: 2
+  class: restricted
   components: weights:open;data:closed;code:closed;license:Gemma-Terms-of-Use(custom,use-restricted,non-OSI)
   confidence: high
-  note: Open weights under Google's custom, use-restricted Gemma license; no open training data or code.
+  note: 'Open weights under Google''s custom, use-restricted Gemma license; no open training data or code.
+    Corrected from 3/open_weights on 2026-07-29. The facts here are identical to gemma-2 and gemma-3,
+    which both score 2/restricted on the same license, and the note above already called the license
+    use-restricted while the score did not. A use cap lands at 2 whatever category the product sits in.'
   sources:
   - url: https://huggingface.co/google/codegemma-7b-it
     shows: 'model card: Gemma license, sizes, intended use'

--- a/sources/scores/tinyllama-1-1b-chat-v1-0.yaml
+++ b/sources/scores/tinyllama-1-1b-chat-v1-0.yaml
@@ -1,14 +1,18 @@
 product: tinyllama-1-1b-chat-v1-0
 openness:
-  score: 4
-  class: open_weights
+  score: 5
+  class: open_source
   confidence: high
-  components: weights:open(Apache-2.0);base:TinyLlama-1.1B(open, 3T-token pretrain documented);post-training:SFT
-    on UltraChat + DPO on UltraFeedback(both public datasets);code:open(pretraining project public);license:Apache-2.0(OSI)
+  components: weights:open(Apache-2.0);base:TinyLlama-1.1B(open, 3T-token pretrain documented);post-training-data:open(SFT
+    on UltraChat + DPO on UltraFeedback, both public datasets);code:open(pretraining project public);license:Apache-2.0(OSI)
   note: 'Unusually transparent for a chat model: open base, and named public alignment datasets (UltraChat
-    SFT + UltraFeedback DPO). Scored 4 open_weights, just short of full open_source since the base pretraining
-    data is documented but the end-to-end reproducible pipeline is not packaged as one release. Strongest
-    openness in this batch alongside Nemotron.'
+    SFT + UltraFeedback DPO). Corrected from 4 to 5 on 2026-07-29, and the post-training evidence moved
+    out of a free-text `post-training` key into `post-training-data` so it carries a value the rubric can
+    read. The old 4 rested on the base pretraining corpus being documented rather than packaged, but this
+    category scores the post-training data -- what the tuner released -- and zephyr scores 5/open_source
+    on these same two datasets while sitting on Mistral-7B, whose corpus is closed outright. Judging
+    TinyLlama by its base while judging zephyr by its post-training set penalized the more open of the two
+    bases. Strongest openness in this batch alongside Nemotron.'
   sources:
   - url: https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0
     shows: Apache-2.0; base TinyLlama-1.1B; SFT on UltraChat + DPO on UltraFeedback

--- a/sources/scores/tulu-3.yaml
+++ b/sources/scores/tulu-3.yaml
@@ -1,6 +1,6 @@
 product: tulu-3
 openness:
-  score: 3
+  score: 2
   class: restricted
   components: weights:open(downloadable);license:Llama-3.1-Community(non-OSI;700M-MAU
     cap + use policy);post-training-data:open(Apache-2.0/ODC-BY);code:open(open-instruct
@@ -8,11 +8,16 @@ openness:
   confidence: high
   note: 'NOT fully-open: the released weights inherit Meta''s Llama 3.1 Community License
     (non-OSI, 700M-MAU cap), so the class is restricted -- same calibration as other
-    Llama-Community models in the map. Scored 3 rather than the bare-Llama-Instruct 2
-    because the entire post-training layer (data, code, RLVR recipe, eval framework) is
-    genuinely open and reproducible (Apache-2.0). Data license is ODC-BY/Apache per Ai2
-    practice; the exact dataset-card license string is medium confidence, but the headline
-    open-recipe-over-restricted-weights call is high confidence.'
+    Llama-Community models in the map. Corrected from 3 to 2 on 2026-07-29. The earlier 3
+    added a point for the genuinely open post-training layer (data, code, RLVR recipe,
+    eval framework, all Apache-2.0), but 3/restricted is a pair the category ladder
+    cannot produce, and crediting the method on the checkpoint scores two different
+    things at once. The method generalizes across bases -- the same recipe produces
+    olmo-3-instruct at 5/open_source -- so it is credited where it lives:
+    tulu-3-sft-mixture carries 5/open in training_synthetic_datasets. What a user
+    downloading THIS checkpoint is bound by is Meta''s license, which is 2. Data license
+    is ODC-BY/Apache per Ai2 practice; the exact dataset-card license string is medium
+    confidence, but the restricted-weights call is high confidence.'
   sources:
   - url: https://huggingface.co/allenai/Llama-3.1-Tulu-3-8B
     shows: 'License: Llama 3.1 Community License Agreement (non-OSI); base meta-llama/Llama-3.1-8B'

--- a/sources/signal_routing.yaml
+++ b/sources/signal_routing.yaml
@@ -161,6 +161,33 @@ dimensions:
         cc-by-nc-sa-4.0: CC-BY-NC-SA-4.0
         etalab-2.0: Etalab-Open-License-2.0
 
+      # The same problem one layer over: the name a HUMAN typed into a
+      # `components` string. The Hub table above canonicalizes what a source
+      # publishes; this canonicalizes what the repo recorded. Both are facts about
+      # naming and neither assigns a tier.
+      #
+      # Left unmapped these read as an ABSENT license while the license is present
+      # and use-restricting, which is the direction of error that overstates
+      # openness - the same failure the Hub aliases exist to prevent. It went
+      # unnoticed while one category had a rubric, because the pilot happened to
+      # write the canonical name most of the time. Porting the rubric to a second
+      # category surfaced eight products whose license mapped to no tier, four of
+      # them nothing more than a spelling.
+      #
+      # `Gemma-Terms-of-Use` is Google's published name; `Gemma-License` is the
+      # repo's shorthand and the name the Hub alias already produces, so the
+      # shorthand wins for consistency with the signal. `glm-4` is a Hub-style
+      # slug that base_pretrained had adopted as a tier example; the license name
+      # is `GLM-4-License`, so that example moves and the slug becomes an alias.
+      recorded:
+        gemma-terms-of-use: Gemma-License
+        glm-4: GLM-4-License
+        llama-2-community: Llama-2-Community-License
+        llama-3-community: Llama-3-Community-License
+        llama-3.1-community: Llama-3.1-Community-License
+        llama-3.2-community: Llama-3.2-Community-License
+        nvidia-nemotron-open-model-license: NVIDIA-Open-Model-License
+
   weights:
     question: Are the trained weights downloadable and runnable locally?
     routes:

--- a/tests/test_check_rubric.py
+++ b/tests/test_check_rubric.py
@@ -1,0 +1,149 @@
+"""Tests for the rubric checker.
+
+`check_rubric` is what lets a rubric be trusted, so the checker itself needs
+checking. Three behaviors added when the rubric was ported to a second category
+carry most of the risk, because each one fails QUIETLY:
+
+  * `reads` picks which recorded key answers a dimension. Pick wrong and a product
+    is scored on somebody else's training data.
+  * `deferred` excludes a product from the reproduction count. Get it wrong and a
+    rubric reports 43/43 while ignoring the products that contradict it.
+  * recorded-name aliases resolve spellings of one license. Miss one and a present,
+    use-restricting license reads as absent, which overstates openness.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from build.check_rubric import (
+    check_category,
+    dimension_value,
+    license_tier,
+    normalize_license,
+    recorded_license_aliases,
+    split_components,
+)
+
+RECIPE = {
+    "openness": {
+        "dimensions": {
+            "data": {
+                "reads": ["post-training-data", "data"],
+                "values": ["open", "closed", "described"],
+            },
+            "code": {"values": ["open", "partial", "closed"]},
+        },
+        "license_tier": {
+            "values": {
+                "osi": {"examples": ["Apache-2.0", "MIT"]},
+                "use_restricted": {"examples": ["Gemma-License", "GLM-4-License"]},
+            }
+        },
+    }
+}
+
+
+class TestDimensionValue:
+    def test_prefers_declared_key_order_over_string_order(self):
+        """A product answering both questions must be read by preference, not by
+        whichever key the author happened to type first."""
+        components = split_components("data:closed;post-training-data:open")
+        assert dimension_value(components, "data", RECIPE) == "open"
+
+    def test_prefers_an_in_enum_value_over_an_earlier_out_of_enum_one(self):
+        """`post-training-data` is preferred, but only when it actually answers. A
+        free-text value there must not shadow a usable `data`."""
+        components = split_components("data:closed;post-training-data:SFT on UltraChat")
+        assert dimension_value(components, "data", RECIPE) == "closed"
+
+    def test_falls_back_to_first_present_key_when_nothing_is_in_enum(self):
+        """Returning '' here would read as absent and land the product in
+        `otherwise`. Surfacing the unrecognized value makes the mismatch legible."""
+        components = split_components("post-training-data:SFT on UltraChat")
+        assert dimension_value(components, "data", RECIPE) == "SFT on UltraChat"
+
+    def test_absent_dimension_is_empty(self):
+        assert dimension_value(split_components("weights:open"), "data", RECIPE) == ""
+
+    def test_undeclared_reads_defaults_to_the_dimension_name(self):
+        """base_pretrained declares no `reads`; it must keep reading its own key."""
+        components = split_components("code:partial;post-training-data:open")
+        assert dimension_value(components, "code", RECIPE) == "partial"
+
+    def test_strips_parenthetical_detail(self):
+        components = split_components("data:open(UltraChat_200k + UltraFeedback, both MIT)")
+        assert dimension_value(components, "data", RECIPE) == "open"
+
+
+class TestRecordedLicenseAliases:
+    @pytest.mark.parametrize(
+        ("recorded", "canonical"),
+        [
+            ("Gemma-Terms-of-Use", "Gemma-License"),
+            ("glm-4", "GLM-4-License"),
+            ("Llama-3.1-Community", "Llama-3.1-Community-License"),
+            ("NVIDIA-Nemotron-Open-Model-License", "NVIDIA-Open-Model-License"),
+        ],
+    )
+    def test_resolves_recorded_spellings(self, recorded, canonical):
+        assert normalize_license(recorded) == canonical
+
+    def test_alias_applies_after_the_mechanical_steps(self):
+        """`assumed-` is stripped first, so the alias table does not have to
+        enumerate a prefixed variant of every license."""
+        assert normalize_license("assumed-Gemma-Terms-of-Use") == "Gemma-License"
+
+    def test_alias_applies_after_the_compound_split(self):
+        assert normalize_license("code MIT + model glm-4") == "GLM-4-License"
+
+    def test_canonical_names_pass_through_untouched(self):
+        assert normalize_license("Apache-2.0") == "Apache-2.0"
+
+    def test_an_aliased_name_reaches_a_tier(self):
+        """The whole point: the spelling must not cost the product its tier."""
+        assert license_tier("Gemma-Terms-of-Use(custom,non-OSI)", RECIPE) == "use_restricted"
+
+    def test_an_unaliased_unknown_license_still_abstains(self):
+        """Aliases resolve names, never tiers. An unknown license must keep
+        abstaining so it shows up as a finding rather than a guess."""
+        assert license_tier("Some-New-Vendor-License", RECIPE) is None
+
+    def test_no_alias_maps_onto_a_different_canonical_name(self):
+        """An alias whose target is itself an alias key would make resolution
+        order-dependent."""
+        aliases = recorded_license_aliases()
+        targets = {name.lower() for name in aliases.values()}
+        assert not (targets & set(aliases)), "alias target is itself an alias key"
+
+
+class TestRealCategories:
+    """The claim the whole pipeline rests on, asserted against the real files."""
+
+    def test_base_pretrained_still_reproduces_every_score(self):
+        reproduced, total, problems, deferred = check_category("base_pretrained", verbose=False)
+        assert problems == []
+        assert (reproduced, total, deferred) == (47, 47, [])
+
+    def test_finetuned_chat_reproduces_every_undeferred_score(self):
+        reproduced, total, problems, _ = check_category("finetuned_chat", verbose=False)
+        assert problems == []
+        assert reproduced == total == 43
+
+    def test_finetuned_chat_deferrals_are_reported_with_a_reason(self):
+        """A deferral that prints nothing is a silent cap on coverage."""
+        _, _, _, deferred = check_category("finetuned_chat", verbose=False)
+        assert len(deferred) == 3
+        assert {entry.split(":")[0] for entry in deferred} == {
+            "starcoder2",
+            "deepseek-coder-v2-instruct",
+            "command-r",
+        }
+        for entry in deferred:
+            assert len(entry.split(":", 1)[1].strip()) > 40, f"no real reason given: {entry}"
+
+    def test_deferred_products_are_excluded_not_counted_as_reproduced(self):
+        """43, not 46. Counting a deferral as a pass is how a rubric claims to
+        describe products it cannot score."""
+        _, total, _, deferred = check_category("finetuned_chat", verbose=False)
+        assert total + len(deferred) == 46

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -405,11 +405,70 @@ def test_real_sources_serialize_without_errors():
     root = Path(__file__).resolve().parents[1]
     tables, errors, _ = build_rubric(load_sources(root), load_policy(root), load_routing(root))
     assert errors == [], f"rubric has errors: {errors[:5]}"
-    # base_pretrained is the only category with a recipe today; when that changes
-    # these counts move, which is the point of asserting them.
-    assert len(tables["category_scoring_rules"]) == 11
-    assert len(tables["product_openness_evidence"]) == 195
+
+    # Asserted per category rather than as a total, so a new recipe shows up as its
+    # own line instead of moving one opaque number. base_pretrained's counts are
+    # pinned as a regression guard: porting the rubric to a second category, adding
+    # recorded-name aliases and adding `reads` must not disturb the pilot.
+    def per_category(table):
+        counts: dict[str, int] = {}
+        for row in tables[table]:
+            counts[row["category_slug"]] = counts.get(row["category_slug"], 0) + 1
+        return counts
+
+    assert per_category("category_scoring_rules") == {"base_pretrained": 11, "finetuned_chat": 9}
+    assert per_category("product_openness_evidence") == {"base_pretrained": 195, "finetuned_chat": 205}
     assert {r["grade"] for r in tables["product_openness_evidence"]} == {"document"}
+
+
+def test_every_scored_product_carries_a_row_for_each_formula_dimension():
+    """The warehouse joins a rule's `condition_key` against the `dimension` column,
+    so a dimension recorded under a different key has to be emitted under the
+    DIMENSION name. Emitted under the raw key instead, the condition silently fails
+    to match and the product falls through to `otherwise` — scored on an absence.
+    """
+    from pathlib import Path
+
+    from build.serialize_rubric import load_policy, load_routing
+    from build.validate import load_sources
+
+    root = Path(__file__).resolve().parents[1]
+    tables, _, _ = build_rubric(load_sources(root), load_policy(root), load_routing(root))
+
+    by_product: dict[tuple[str, str], set[str]] = {}
+    for row in tables["product_openness_evidence"]:
+        by_product.setdefault((row["category_slug"], row["product_slug"]), set()).add(
+            row["dimension"]
+        )
+
+    # `data` is the dimension finetuned_chat reads from a different key, so it is the
+    # one that would go missing.
+    missing = [
+        product
+        for (category, product), dimensions in by_product.items()
+        if category == "finetuned_chat" and "data" not in dimensions
+    ]
+    assert missing == [], f"no data row emitted for: {missing}"
+
+
+def test_evidence_never_puts_two_values_on_one_grain():
+    """One product/category/dimension must carry one value. Two would let the
+    warehouse pick between a base corpus and a post-training mixture by row order.
+    """
+    from collections import Counter
+    from pathlib import Path
+
+    from build.serialize_rubric import load_policy, load_routing
+    from build.validate import load_sources
+
+    root = Path(__file__).resolve().parents[1]
+    tables, _, _ = build_rubric(load_sources(root), load_policy(root), load_routing(root))
+
+    counts = Counter(
+        (r["product_slug"], r["category_slug"], r["dimension"])
+        for r in tables["product_openness_evidence"]
+    )
+    assert [key for key, n in counts.items() if n > 1] == []
 
 
 def test_real_license_aliases_cover_every_slug_the_hub_actually_returns():


### PR DESCRIPTION
The base-model rubric was reverse-engineered from one category's scores. This tests whether it was a general mechanism or a bespoke one.

## The result

**32 of 46 products reproduced against the pilot rubric with nothing changed** — no aliases, no `reads` declarations, no corrections. That is the number worth quoting, and it is recorded in the recipe, because the headline 43/43 comes after correcting three scores and would be circular.

The tier ladder and the formula port intact. What needed adding was vocabulary, not structure. `base_pretrained` holds at 47/47 and 195 evidence rows throughout, which was the constraint the change had to respect.

## Scores this changes

Three published scores move. Each was surfaced by the port, none by re-research.

| product | was | now | why |
|---|---|---|---|
| `codegemma` | 3 open_weights | **2 restricted** | Identical facts and the same license family as `gemma-3`, which scores 2. Its own note already read "use-restricted". |
| `tulu-3` | 3 restricted | **2 restricted** | `3/restricted` is a pair the ladder cannot emit. The extra point credited AI2's open post-training layer on the checkpoint. |
| `tinyllama-1-1b-chat-v1-0` | 4 open_weights | **5 open_source** | `zephyr` scores 5 on the same two post-training datasets while sitting on Mistral-7B, whose corpus is closed outright. |

On `tulu-3`: a fine-tuning approach generalizes across bases — the same AI2 recipe produces `olmo-3-instruct` at 5/open_source. Scoring the checkpoint on the method either buries the method or overstates the artifact. The map already resolves this by scoring the method's artifacts as their own products: `tulu-3-sft-mixture` carries 5/open in `training_synthetic_datasets`. What a user downloading the Llama-based checkpoint is bound by is Meta's license, which is 2. That pair of scores is the signal.

## A bug this fixes

The serializer emitted evidence under the raw `components` key, so `post-training-data` would never have matched the formula's `data` condition. Six products would have fallen through to `otherwise` and scored 3 on an absence — no error, no warning. Evidence is now emitted under the dimension name the warehouse joins on, raw keys are kept as traceability rows, and a test asserts one value per grain.

## Machinery added

- **Recorded-name license aliases**, in `signal_routing.yaml` beside the Hub table that solves the same problem for published slugs. Aliases resolve names only — tier assignment stays a per-category judgment, as that file already argued. Left unmapped, a present use-restricting license reads as *absent*, which is the direction that overstates openness.
- **`reads` on a dimension**, naming which recorded keys answer it, preferring the first key whose value is in the enum over the first key present.
- **`deferred`**, for products the rubric does not decide, each with a reason, printed every run and excluded from the reproduction count rather than counted as passing.

## Deferred, not scored

Three products share one cause: a license restricting **conduct** rather than commerce, which the ladder has no tier for. This is not local to this category — the same licenses are scored three ways across the map, including a contradiction where `DeepSeek-Model-License` is `permissive_non_osi` in `base_pretrained` (`deepseek-v3-base`, 3/open_weights) and use-restricting here (2/restricted). Adding a tier on one category's evidence is what #106 exists to prevent, so it goes to an issue.

## Left alone deliberately

- `nemotron-3` and `nemotron-3-nvidia` are the same product entered twice, once per category, both `display_name: 'Nemotron 3'`.
- `granite-code-instruct` records `data` about its base corpus, which this category's vocabulary spends on post-training data. Now warns rather than dropping the value silently.
- A typed `base:` link from a tune to its base model. `lineage` exists but is dataset-only and free-text.

## Test plan

- `uv run python -m build.check_rubric` — `base_pretrained` 47/47, `finetuned_chat` 43/43 with 3 deferred
- `uv run python -m build.validate` — 0 errors
- `uv run python -m build.serialize_rubric --check` — no errors; one new warning, for the `granite` relabel
- `uv run python -m pytest` — 115 passed, up from 92