### PR TITLE
Signal-backed Nemotron adoption, and citations for the nine unverifiable base models

### DIFF
--- a/sources/products/glm-5-1.yaml
+++ b/sources/products/glm-5-1.yaml
@@ -3,5 +3,7 @@ display_name: GLM-5.1
 type: model
 description: GLM-5.1 released 7 Apr 2026 by Z.ai (formerly Zhipu AI). Post-training upgrade on GLM-5 base;
   744B-param MoE. Weights on Hugging Face under MIT.
+huggingface_model:
+- url: https://huggingface.co/zai-org/GLM-5.1
 comments: GLM-5.1 released 7 Apr 2026 by Z.ai (formerly Zhipu AI). Post-training upgrade on GLM-5 base;
   744B-param MoE. Weights on Hugging Face under MIT.

--- a/sources/products/qwen-3-6.yaml
+++ b/sources/products/qwen-3-6.yaml
@@ -6,6 +6,9 @@ description: 'Qwen3.6 series, released early-mid 2026: open-weight variants incl
   (Preview) that are proprietary/API-only. GitHub QwenLM/Qwen3.6 verified live June 2026.'
 github:
 - url: https://github.com/QwenLM/Qwen3.6
+huggingface_model:
+- url: https://huggingface.co/Qwen/Qwen3.6-27B
+- url: https://huggingface.co/Qwen/Qwen3.6-35B-A3B
 comments: 'Qwen3.6 series, released early-mid 2026: open-weight variants incl Qwen3.6-35B-A3B (MoE, Apr
   16 2026) and dense Qwen3.6-27B (Apr 22 2026), plus hosted flagship tiers Qwen3.6-Plus and Qwen3.6-Max
   (Preview) that are proprietary/API-only. GitHub QwenLM/Qwen3.6 verified live June 2026.'

--- a/sources/scores/deepseek-v3-2.yaml
+++ b/sources/scores/deepseek-v3-2.yaml
@@ -11,6 +11,9 @@ openness:
     permissive, no use restrictions)
   last_verified: '2026-07-29'
   sources:
+  - url: https://huggingface.co/api/models/deepseek-ai/DeepSeek-V3.2
+    shows: license mit, ungated, 689.5GB of weight files, 1,277,394 downloads last month
+    accessed: '2026-07-29'
   - url: https://huggingface.co/deepseek-ai/DeepSeek-V3.2
     shows: flagship phase-C verification source
     accessed: '2026-06-04'

--- a/sources/scores/deepseek-v4-pro.yaml
+++ b/sources/scores/deepseek-v4-pro.yaml
@@ -9,6 +9,9 @@ openness:
     pipeline or data);license:MIT(permissive, no use restrictions)
   last_verified: '2026-07-29'
   sources:
+  - url: https://huggingface.co/api/models/deepseek-ai/DeepSeek-V4-Pro
+    shows: license mit, ungated, 864.8GB of weight files, 1,635,092 downloads last month
+    accessed: '2026-07-29'
   - url: https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro
     shows: flagship phase-C verification source
     accessed: '2026-06-04'

--- a/sources/scores/falcon-3.yaml
+++ b/sources/scores/falcon-3.yaml
@@ -6,6 +6,10 @@ openness:
   confidence: high
   note: weights:open;data:closed;code:closed;license:TII-Falcon-License-2.0(Apache-based+AUP,non-OSI)
   sources:
+  - url: https://huggingface.co/api/models/tiiuae/Falcon3-10B-Base
+    shows: ungated, 41.2GB of weight files, 7,688 downloads last month; cardData.license is `other`, so the Hub
+      does not name the license and the tier rests on the TII text
+    accessed: '2026-07-29'
   - url: https://huggingface.co/blog/falcon3
     shows: flagship phase-C verification source
     accessed: '2026-06-04'

--- a/sources/scores/glm-5-1.yaml
+++ b/sources/scores/glm-5-1.yaml
@@ -6,6 +6,9 @@ openness:
   confidence: high
   note: weights:open(MIT);data:closed;code:closed;license:MIT(OSI)
   sources:
+  - url: https://huggingface.co/api/models/zai-org/GLM-5.1
+    shows: license mit, ungated, 1,507.8GB of weight files, 84,623 downloads last month
+    accessed: '2026-07-29'
   - url: https://www.buildfastwithai.com/blogs/glm-5-1-open-source-review-2026
     shows: flagship phase-C verification source
     accessed: '2026-06-04'

--- a/sources/scores/kimi-k2-6.yaml
+++ b/sources/scores/kimi-k2-6.yaml
@@ -11,6 +11,10 @@ openness:
     requires 'Kimi K2' UI attribution, attribution-only, not a use cap)
   last_verified: '2026-07-29'
   sources:
+  - url: https://huggingface.co/api/models/moonshotai/Kimi-K2.6
+    shows: ungated, 595.3GB of weight files, 884,375 downloads last month; cardData.license is `other`, so the
+      Modified-MIT tier rests on the repo's own license file
+    accessed: '2026-07-29'
   - url: https://huggingface.co/moonshotai/Kimi-K2.6
     shows: flagship phase-C verification source
     accessed: '2026-06-04'

--- a/sources/scores/llama-4-scout-maverick.yaml
+++ b/sources/scores/llama-4-scout-maverick.yaml
@@ -10,6 +10,10 @@ openness:
     training code);license:Llama-4-Community(non-OSI: 700M MAU commercial cap as of Apr 2025 + no-compete/no-train-competing-LLM
     clause)'
   sources:
+  - url: https://huggingface.co/api/models/meta-llama/Llama-4-Scout-17B-16E
+    shows: gated (manual approval), 217.3GB of weight files, 32,527 downloads last month; cardData.license is
+      `other`, so the Llama-4-Community tier rests on Meta's text
+    accessed: '2026-07-29'
   - url: https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E
     shows: flagship phase-C verification source
     accessed: '2026-06-04'

--- a/sources/scores/mistral-large-3.yaml
+++ b/sources/scores/mistral-large-3.yaml
@@ -7,6 +7,10 @@ openness:
   note: weights:open(Apache-2.0);data:closed;code:closed;license:Apache-2.0(OSI)
   last_verified: '2026-07-29'
   sources:
+  - url: https://huggingface.co/api/models/mistralai/Mistral-Large-3-675B-Base-2512
+    shows: license apache-2.0, ungated, 1,352.0GB of weight files; the base checkpoint, distinct from the
+      -Instruct-2512 sibling
+    accessed: '2026-07-29'
   - url: https://mistral.ai/news/mistral-3/
     shows: flagship phase-C verification source
     accessed: '2026-06-04'

--- a/sources/scores/nemotron-3.yaml
+++ b/sources/scores/nemotron-3.yaml
@@ -30,21 +30,32 @@ openness:
       the code corpus, not the corpus itself
     accessed: '2026-07-28'
 adoption:
-  level: 3
-  reach: 100K-1M
-  signal_type: reported_traction
-  confidence: medium
-  note: Distributed free via OpenRouter (nemotron-3-super-120b-a12b:free), NVIDIA build/NIM, and Hugging
-    Face; positioned for agentic/enterprise use. Level 3 on reported multi-platform distribution. The
-    earlier note said no hard download count was available because the HF repo was gated; the shipped
-    repos are in fact ungated and carry ~1.0M monthly downloads on Nano BF16, 855K on Super BF16 and 339K
-    on Ultra BF16, which is 1M-10M territory. Left at 3 pending a signal-backed recount rather than
-    re-banded on a hand-read figure -- the Hub artifacts are now declared, so signal_huggingface will
-    answer this directly.
+  level: 4
+  reach: 1M-10M
+  signal_type: usage_volume
+  confidence: high
+  note: 'Corrected from 3/reported_traction to 4/usage_volume on 2026-07-29, and this is the first score
+    on the map re-banded off a machine signal rather than a hand-read figure. The record previously said
+    no hard download count was available because the instruct repo was gated; all three shipped repos
+    resolve ungated at HTTP 200. Summing the family''s distributed SKUs, which is what the category''s
+    adoption recipe specifies: Nano BF16 994,374 + Super BF16 855,265 + Ultra BF16 339,360 = 2,188,999
+    monthly downloads, squarely in the 1M-10M band. The NVFP4/FP8/GGUF quantizations are excluded to
+    avoid double counting the same weights. Also distributed free via OpenRouter
+    (nemotron-3-super-120b-a12b:free) and NVIDIA build/NIM, which the band does not capture, so 4 is a
+    floor.'
   sources:
   - url: https://research.nvidia.com/labs/nemotron/Nemotron-3/
     shows: official distribution via NVIDIA build/NIM + HF for agentic use
     accessed: '2026-06-04'
+  - url: https://huggingface.co/api/models/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
+    shows: 994,374 downloads last month, ungated, 63.2GB of weight files, HTTP 200
+    accessed: '2026-07-29'
+  - url: https://huggingface.co/api/models/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
+    shows: 855,265 downloads last month, ungated, 247.2GB of weight files, HTTP 200
+    accessed: '2026-07-29'
+  - url: https://huggingface.co/api/models/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16
+    shows: 339,360 downloads last month, ungated, 2,242.1GB of weight files, HTTP 200
+    accessed: '2026-07-29'
 capability:
   score: 5
   basis: benchmark:SWE-bench/AIME/GPQA/MMLU-Pro

--- a/sources/scores/phi-4.yaml
+++ b/sources/scores/phi-4.yaml
@@ -7,6 +7,9 @@ openness:
   note: weights:open(MIT);data:closed;code:closed;license:MIT(OSI)
   last_verified: '2026-07-29'
   sources:
+  - url: https://huggingface.co/api/models/microsoft/phi-4
+    shows: license mit, ungated, 29.3GB of weight files, 712,912 downloads last month
+    accessed: '2026-07-29'
   - url: https://the-decoder.com/microsoft-releases-full-phi-4-model-with-weights-under-mit-license/
     shows: flagship phase-C verification source
     accessed: '2026-06-04'

--- a/sources/scores/qwen-3-6.yaml
+++ b/sources/scores/qwen-3-6.yaml
@@ -10,6 +10,9 @@ openness:
     code on GitHub; no training pipeline/data);license:mixed(open variants Apache-2.0; Plus/Max flagship
     tiers proprietary, commercial-restricted/API-only)
   sources:
+  - url: https://huggingface.co/api/models/Qwen/Qwen3.6-27B
+    shows: license apache-2.0, ungated, 55.6GB of weight files, 6,232,995 downloads last month
+    accessed: '2026-07-29'
   - url: https://github.com/QwenLM/Qwen3.6
     shows: flagship phase-C verification source
     accessed: '2026-06-04'


### PR DESCRIPTION
Steps 5 and 6 of the post-#118 plan. Two commits, and **one finding that should probably gate the second one** — see the last section.

## 1. Nemotron 3 adoption, re-banded off the Hub signal

First score on the map moved by a machine signal rather than a hand-read figure, which is what declaring artifacts was for. The record claimed no hard download count was available because the instruct repo was gated; all three shipped repos resolve ungated at HTTP 200.

```
Nano BF16    994,374
Super BF16   855,265
Ultra BF16   339,360
---------------------
             2,188,999   -> 1M-10M, level 4
```

`3/reported_traction/medium` → `4/usage_volume/high`. Quantizations excluded so the same weights aren't counted twice. Free distribution via OpenRouter and NVIDIA build/NIM isn't captured by a download band at all, so 4 is a floor.

## 2. Citations for the nine base models with no freshness floor

All nine scored every dimension on `flagship phase-C verification source`. The fix is ~10 citations rather than 36, because document-grade `admitted` is computed per **axis**:

```sql
COALESCE(s.sources_admitted, 0) > 0 AS admitted
```

Each new `shows` records what the Hub API actually returns — license slug, gating, weight-file size, 30-day downloads — so it's re-derivable by re-requesting the URL. Existing filler rows are left in place; the policy keeps them with a `reject_reason` on purpose so they stay a queryable work list.

Two of the nine declared **no Hub artifact at all**, and were exactly the two with zero of four dimensions sourced. Now declared, verified live, and both agree with what the score files already claimed:

```
glm-5-1    zai-org/GLM-5.1          license mit
qwen-3-6   Qwen/Qwen3.6-27B         license apache-2.0
           Qwen/Qwen3.6-35B-A3B     license apache-2.0
```

`falcon-3`, `kimi-k2-6` and `llama-4-scout-maverick` report `other` as their Hub license, which is in the abstain list, so those tiers still rest on document evidence — each citation says so rather than implying the Hub settled it.

Admissible sources 325/418 → 337/430. No score changes; `check_rubric` stays 44/44 and 43/43.

## The finding: freshness_floor takes the NEWEST source date, not the oldest

`scores_openness_computed` documents the opposite of what it does:

> `last_verified` … is the MIN accessed date across the evidence the winning rule depends on … **An axis is only as verified as its stalest input.** Nothing here stamps CURRENT_DATE: a recompute must never make stale evidence look freshly checked.

The MIN runs across *dimensions*, but `evidence.product_evidence` gives every document dimension the axis's **MAX** admitted date:

```sql
MAX(CASE WHEN admitted THEN NULLIF(source_accessed, '') END) AS last_admitted
```

so the MIN has nothing to choose between. Measured on current data — four products already affected:

```
product      oldest admitted   newest admitted   stamped on document rows
apertus      2026-06-08        2026-07-28        2026-07-28
olmo-3       2026-06-30        2026-07-28        2026-07-28
nemotron-3   2026-06-04        2026-07-28        2026-07-28
lucie-7b     2026-07-19        2026-07-28        2026-07-28
```

**This PR would widen it from 4 products to 13.** Each of the nine gets a 2026-07-29 citation, which would stamp its whole openness axis as verified today while the `data` and `code` judgments still date from 2026-06-04. Those two dimensions are the ones I could not verify from a machine source, so they are precisely the ones that should keep an old date.

The predecessor bug is in the warehouse model, not in this diff, and `udms/` is outside this repo. The fix is one line — `MAX` → `MIN` on `last_admitted` — which also walks the four products above back to their true stalest date. I have not made that change: it moves published freshness dates and deserves a decision rather than being smuggled in alongside a citation pass.

**So this PR is honest about provenance and not yet honest about recency.** Reviewing the citations is safe; merging before the `MAX`/`MIN` call means nine products briefly claim a freshness they haven't earned.

## Test plan

- `uv run python -m build.validate` — 0 errors
- `uv run python -m build.check_rubric` — `base_pretrained` 44/44, `finetuned_chat` 43/43 with 3 deferred
- `uv run python -m build.serialize_rubric --check` — admissible 337/430, no errors
- `uv run python -m pytest` — 117 passed
- Every `shows` re-derivable by re-requesting its `huggingface.co/api/models/...` URL