### PR TITLE
State the freshness rule once, and fix the fallback to match it

### DIFF
--- a/build/check_freshness.py
+++ b/build/check_freshness.py
@@ -6,22 +6,27 @@ exactly like one touched yesterday.
 
 ## Two dates, deliberately not merged
 
-  * **`last_verified`** — layer-2 re-checked this axis against its sources on that
-    date, whether or not the value changed. Currently absent everywhere, because
-    layer-2 does not exist yet. That absence is the honest baseline, and watching
-    it fill in is how we measure the automation landing.
-  * **`max(sources[].accessed)`** — when a source behind the score was last read,
-    by whoever authored it. The best staleness proxy available today, and *not* a
-    verification.
+  * **`last_verified`** — the most recent date on which everything in the score was
+    confirmed still correct. Written when an axis is re-checked against its sources,
+    whether or not the value changed. 41 of 1,485 axes carry one, up from zero when
+    the field landed, and watching that fill in is how we measure the automation.
+  * **The score file's last commit date** — the fallback. Somebody committed this
+    file on that date and left the score standing, which git records and nobody can
+    inflate. Weaker than a re-check and *not* presented as one.
 
-`last_verified` is deliberately NOT backfilled from `accessed`. Someone opening a
-URL is a weaker claim than the conclusion being re-confirmed, and copying one into
-a field whose name asserts the other would overstate the map's freshness across
-1,479 axes at a stroke. It would also be pointless: `accessed` is already in the
-files, so a derived column adds no information, only the stronger claim.
+`last_verified` is deliberately NOT backfilled from `sources[].accessed`. Someone
+opening a URL is a weaker claim than the conclusion being re-confirmed, and copying
+one into a field whose name asserts the other would overstate freshness across every
+axis at a stroke. It also adds nothing, since `accessed` is already in the files.
 
-This report therefore labels which signal each number came from, and never lets
-the weaker one be read as the stronger.
+The commit date is the better fallback for the same reason it is honest: it dates a
+review rather than a reading. `max(accessed)` read a median 55d when the files had in
+fact been revised a median 35d ago, so it was both the stronger claim and the wronger
+number. Its one limit, stated in the output: for a file untouched since it was added
+the commit date dates the import, which still answers "has anyone revisited this".
+
+This report labels which signal each number came from, and never lets the weaker one
+be read as the stronger.
 
 Exit status is 0 unless `--max-age-days` is given, so it is safe to run for
 information. Pass a threshold to turn it into a CI gate once layer-2 is keeping
@@ -36,6 +41,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import subprocess
 from collections import defaultdict
 from datetime import date, datetime
 from pathlib import Path
@@ -57,12 +63,54 @@ def parse_date(value: object) -> date | None:
     return None
 
 
+def commit_dates() -> dict[str, date]:
+    """Most recent commit date per score file, from one pass over git history.
+
+    This is the fallback when an axis carries no `last_verified`, and it is a better
+    one than `max(sources[].accessed)`. Committing a score file is somebody asserting
+    the file is right as of that date, which is why #102 put it as "the git history of
+    a score file becomes its verification record". An `accessed` date only says a URL
+    was opened; copying that into a freshness figure is the overstatement that PR
+    reverted, and it reads 20 days staler than the truth because it dates the reading
+    rather than the review.
+
+    Honest about what it is not: for a file untouched since it was added, this dates
+    the import, not a review. That still answers the question the report exists for -
+    nobody has revisited this - which is why the label says `commit` and not
+    `verified`.
+
+    One `git log` for the whole directory rather than 495 invocations. Walking
+    newest-first, the first time a path appears is its latest commit.
+    """
+    result = subprocess.run(
+        ["git", "log", "--format=%cs", "--name-only", "--", "sources/scores"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    latest: dict[str, date] = {}
+    current: date | None = None
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        # A `%cs` line parses as a date; a path line does not. That is the whole
+        # discriminator, so no state machine is needed.
+        parsed = parse_date(line)
+        if parsed is not None:
+            current = parsed
+        elif current is not None and line.startswith("sources/scores/") and line.endswith(".yaml"):
+            latest.setdefault(line[len("sources/scores/") : -len(".yaml")], current)
+    return latest
+
+
 def collect() -> tuple[dict[str, list[tuple[str, str, date, bool]]], list[str]]:
     """Return (category -> [(product, axis, when, is_verified)], axes with no date).
 
-    `is_verified` separates a real `last_verified` from an `accessed` fallback, so
+    `is_verified` separates a real `last_verified` from a commit-date fallback, so
     the report can never present the weaker signal as the stronger one.
     """
+    committed = commit_dates()
     by_category: dict[str, list[tuple[str, str, date, bool]]] = defaultdict(list)
     undated: list[str] = []
 
@@ -83,17 +131,12 @@ def collect() -> tuple[dict[str, list[tuple[str, str, date, bool]]], list[str]]:
                     by_category[category["name"]].append((product, axis, verified, True))
                     continue
 
-                accessed = [
-                    parse_date(s.get("accessed"))
-                    for s in (block.get("sources") or [])
-                    if isinstance(s, dict)
-                ]
-                accessed = [d for d in accessed if d is not None]
-                if accessed:
-                    by_category[category["name"]].append(
-                        (product, axis, max(accessed), False)
-                    )
+                when = committed.get(product)
+                if when is not None:
+                    by_category[category["name"]].append((product, axis, when, False))
                 else:
+                    # Only reachable for a file git has never seen, so in practice an
+                    # uncommitted local addition rather than a data problem.
                     undated.append(f"{product}.{axis}")
     return by_category, undated
 
@@ -138,9 +181,10 @@ def main() -> int:
     verified_n = sum(1 for _, _, _, is_verified in rows if is_verified)
     print(
         f"\n{verified_n} of {len(rows)} axes carry a real last_verified. "
-        f"The other {len(rows) - verified_n} fall back to max(sources.accessed), "
-        "which dates the evidence, not a verification — read those ages as an upper "
-        "bound on freshness."
+        f"The other {len(rows) - verified_n} fall back to the score file's last commit "
+        "date, which dates the last time somebody committed the file and left the score "
+        "standing. For a file untouched since it was added that dates the import, not a "
+        "review, so read those ages as 'nobody has revisited this'."
     )
     if undated:
         print(

--- a/build/check_freshness.py
+++ b/build/check_freshness.py
@@ -4,6 +4,11 @@ The map's value depends on its numbers being current, and until now there was no
 way to check that without reading 501 files. A score last touched in June looks
 exactly like one touched yesterday.
 
+**`docs/guides/freshness.md` is the normative definition.** The rule is one sentence:
+`last_verified` is the most recent date on which everything in the score was confirmed
+still correct. This module implements the report; that guide owns the meaning, and
+when the two disagree the guide wins.
+
 ## Two dates, deliberately not merged
 
   * **`last_verified`** — the most recent date on which everything in the score was

--- a/docs/guides/freshness.md
+++ b/docs/guides/freshness.md
@@ -1,0 +1,89 @@
+# Score Freshness Guide
+
+What it means for a score to be current, which date answers that, and which dates
+look like they answer it but do not.
+
+> This is the data-consumer / query reference, and it is normative. For the
+> reader-facing methodology see `docs/methodology.md`. When the rule below changes,
+> change it here first and make the code follow.
+
+## The rule
+
+**`last_verified` is the most recent date on which everything in the score was
+confirmed still correct.**
+
+That is the whole definition. Three consequences follow from it, and no other reading
+is intended:
+
+1. **"Everything" means every dimension the score records**, not only the ones the
+   winning rule happens to read. `falcon-3` scores 2 the moment its license resolves
+   to `use_restricted`, so its `data` and `code` values never affect the outcome — but
+   they are still published claims, so they still have to be confirmed. A fresh
+   license cannot carry a stale corpus claim.
+2. **Confirmation means the axis was re-checked against its sources**, whether or not
+   the value moved. A re-check that changes nothing is still a confirmation and still
+   earns the date. This is what makes the field fill in as automation lands.
+3. **A date is never derived from `sources[].accessed`.** See below.
+
+## Why freshness is not `max(sources[].accessed)`
+
+`accessed: 2026-06-08` says somebody opened that URL that day. `last_verified:
+2026-06-08` says the conclusion was confirmed that day. The second is a stronger
+claim, and deriving it from the first upgrades weak evidence into strong evidence
+across every axis at once.
+
+This was tried and reverted deliberately (#102). It is worth restating because the
+mistake is easy to re-invent: any aggregate of access dates — max, min, per-dimension
+min — is still a confirmation claim computed from readings. Changing the aggregation
+does not fix the category error.
+
+It is also, as it happens, the less accurate number. `max(accessed)` reported a median
+staleness of 55 days when the files had in fact been revised a median of 35 days ago.
+
+## The fallback: the score file's last commit date
+
+Most axes carry no `last_verified` yet. For those, freshness falls back to **the last
+commit date of `sources/scores/<slug>.yaml`**.
+
+Somebody committed that file on that date and left the score standing, which is a
+review rather than a reading. Git records it, and nobody can inflate it. As #102 put
+it, the git history of a score file *is* its verification record.
+
+**What the fallback does not claim.** For a file untouched since it was added, the
+commit date dates the import, not a review. That is still the answer to the question
+the report exists to ask — has anyone revisited this — but it is not a confirmation,
+and `build/check_freshness.py` labels it `commit` rather than `verified` so the two
+can never be conflated.
+
+## Which date to use
+
+| field | where | what it answers |
+|---|---|---|
+| `last_verified` | `sources/scores/<slug>.yaml`, per axis | Is this score still right? Authoritative. |
+| score file commit date | git | Same question, weaker. Used when `last_verified` is absent. |
+| `sources[].accessed` | `sources/scores/<slug>.yaml`, per source | When was this specific URL read? Evidence provenance. **Not freshness.** |
+| `last_checked` | `currentai.scores.openness_computed` | When did the pipeline last read *any* admitted evidence. Diagnostic. **Not freshness.** |
+
+## What it is for
+
+Triage. A category whose oldest axis is 50 days old is a category to go and look at.
+`build/check_freshness.py` reports per-category median and oldest, names the stalest
+product, and takes `--max-age-days` to become a CI gate once enough axes carry a real
+`last_verified` that gating would fail on genuine staleness rather than on the
+pre-automation backlog.
+
+## Known divergences, as of 2026-07-29
+
+Recorded so nobody mistakes the current data for the rule.
+
+- **`build/apply_scores.py` writes `last_verified` from the pipeline's `last_checked`**,
+  which is the max over any admitted evidence. That contradicts the rule twice over: it
+  is derived from access dates, and it takes the newest rather than requiring everything
+  to have been confirmed. Consequences in the data today: 6 axes carry a date newer than
+  some of their own evidence (`deepseek-v3-2`, `deepseek-v4-pro`, `phi-4`, `kimi-k2-6`,
+  `mistral-large-3`, `minimax-m3`), and 4 carry a date that no source in the file was
+  read on, because it came from a signal fetch (`pythia`, `apertus`, `olmo-3`,
+  `lucie-7b`). Both need fixing in `apply_scores`, not by reinterpreting the rule.
+- **`freshness_floor` in `currentai.scores.openness_computed`** is a per-dimension
+  aggregate of access dates. It is the reverted backfill under another name and should
+  be removed rather than refined.

--- a/docs/schemas/score.schema.json
+++ b/docs/schemas/score.schema.json
@@ -16,7 +16,7 @@
         "confidence": { "enum": ["high", "medium", "low"] },
         "note": { "type": "string" },
         "sources": { "type": "array", "items": { "$ref": "#/definitions/source" } },
-        "last_verified": { "type": "string", "format": "date", "description": "Date layer-2 last re-verified this axis against its sources. Absent means never verified by the automated process; do not backfill it from source access dates." }
+        "last_verified": { "type": "string", "format": "date", "description": "The most recent date on which everything in this axis's score was confirmed still correct. Written when the axis is re-checked against its sources, whether or not the value changed. Absent means never confirmed, in which case freshness falls back to the score file's last commit date. Never backfill it from source access dates: opening a URL is a weaker claim than re-confirming a conclusion, and no aggregation of accessed dates fixes that. Normative definition in docs/guides/freshness.md." }
       }
     },
     "adoption": {
@@ -29,7 +29,7 @@
         "confidence": { "enum": ["high", "medium", "low"] },
         "note": { "type": "string" },
         "sources": { "type": "array", "items": { "$ref": "#/definitions/source" } },
-        "last_verified": { "type": "string", "format": "date", "description": "Date layer-2 last re-verified this axis against its sources. Absent means never verified by the automated process; do not backfill it from source access dates." }
+        "last_verified": { "type": "string", "format": "date", "description": "The most recent date on which everything in this axis's score was confirmed still correct. Written when the axis is re-checked against its sources, whether or not the value changed. Absent means never confirmed, in which case freshness falls back to the score file's last commit date. Never backfill it from source access dates: opening a URL is a weaker claim than re-confirming a conclusion, and no aggregation of accessed dates fixes that. Normative definition in docs/guides/freshness.md." }
       }
     },
     "capability": {
@@ -42,7 +42,7 @@
         "confidence": { "enum": ["high", "medium", "low"] },
         "note": { "type": "string" },
         "sources": { "type": "array", "items": { "$ref": "#/definitions/source" } },
-        "last_verified": { "type": "string", "format": "date", "description": "Date layer-2 last re-verified this axis against its sources. Absent means never verified by the automated process; do not backfill it from source access dates." }
+        "last_verified": { "type": "string", "format": "date", "description": "The most recent date on which everything in this axis's score was confirmed still correct. Written when the axis is re-checked against its sources, whether or not the value changed. Absent means never confirmed, in which case freshness falls back to the score file's last commit date. Never backfill it from source access dates: opening a URL is a weaker claim than re-confirming a conclusion, and no aggregation of accessed dates fixes that. Normative definition in docs/guides/freshness.md." }
       }
     }
   },


### PR DESCRIPTION
Five readings of "freshness" were in play across the repo today and none was written down as *the* definition, so it got re-derived every time it came up. This writes it down and fixes the one place the code was straightforwardly wrong.

## The rule

> **`last_verified` is the most recent date on which everything in the score was confirmed still correct.**

`docs/guides/freshness.md` now owns that, as a peer of `openness-spectrum.md` and in the same normative register. Three things follow, spelled out because each one had been argued separately:

1. **"Everything" means every dimension the score records**, not just the ones the winning rule reads. `falcon-3` scores 2 as soon as its license resolves to `use_restricted`, so `data` and `code` never affect the outcome — but they are still published claims, so a fresh license can't carry a stale corpus claim.
2. **A re-check that changes nothing still counts.** That's what makes the field fill in as automation lands.
3. **Never derived from `sources[].accessed`.** #102 tried that and reverted it. Worth restating because the mistake is easy to re-invent: max, min, per-dimension min — any aggregate of *readings* is still a confirmation claim computed from readings. Changing the aggregation doesn't fix the category error.

`check_freshness.py` and all three axes of `score.schema.json` now point at the guide rather than restating it.

## The fix: the fallback is the commit date

#102 already said what the fallback should be — *"the git history of a score file becomes its verification record"* — and the code didn't do it.

```
before   1461 axes | median 55d | oldest 55d | 24 axes with no date at all
after    1485 axes | median 35d | oldest 55d | 0 undated
```

Committing a score file is somebody asserting the file is right as of that date, which is a review rather than a reading, recorded in a form nobody can inflate. It's also simply the more accurate number: `max(accessed)` reported a median 55d staleness when the files had in fact been revised a median 35d ago.

The 24 previously undated axes were all `capability` on benchmark products, which record no sources. Every committed file has a commit date, so they're covered.

Still labeled `commit`, not `verified`. For a file untouched since it was added the commit date dates the import, so those ages read as "nobody has revisited this" — which is the question the report exists to ask.

One `git log` over `sources/scores` rather than 495 invocations.

## Recorded, not fixed here

The guide lists two places the current data diverges from the rule, so nobody mistakes today's values for the definition:

- **`apply_scores` writes `last_verified` from the pipeline's `last_checked`**, a max over any admitted evidence. That's the prohibited derivation, live. Six axes carry a date newer than some of their own evidence (`deepseek-v3-2`, `deepseek-v4-pro`, `phi-4`, `kimi-k2-6`, `mistral-large-3`, `minimax-m3`); four carry a date no source in the file was read on, because it came from a signal fetch (`pythia`, `apertus`, `olmo-3`, `lucie-7b`). Five of the six overstating ones were caused by the citation pass in #119 pushing the max forward.
- **`freshness_floor` in `currentai.scores.openness_computed`** is the reverted backfill under another name. Should be removed rather than refined.

Both belong in `apply_scores` and the warehouse model respectively, not in another reinterpretation of the rule.

## Test plan

- `uv run python -m build.check_freshness` — table above, exit 0
- `--max-age-days 30` → exit 1; `--max-age-days 60` → exit 0
- `uv run python -m build.validate` — 0 errors
- `uv run python -m pytest` — 117 passed
- `score.schema.json` edited as text and re-parsed as JSON; description updated on all three axes