### PR TITLE
Settle #117: conduct restrictions are not commercial restrictions

### DIFF
--- a/sources/categories/base_pretrained.yaml
+++ b/sources/categories/base_pretrained.yaml
@@ -76,14 +76,20 @@ scoring_recipe:
           examples: [Apache-2.0, MIT, BSD-3-Clause]
         permissive_non_osi:
           definition: >
-            Not OSI-approved but imposes no use restriction. Attribution or
-            naming requirements alone belong here.
-          examples: [Modified-MIT, DeepSeek-Model-License, minimax-community, NVIDIA-Open-Model-License]
+            Not OSI-approved, but imposes no restriction on WHO may use the artifact or
+            AT WHAT SCALE. Attribution, naming and CONDUCT requirements belong here: an
+            acceptable-use policy forbidding military, illegal or discriminatory use caps
+            neither commerce nor reach, so it sits beside attribution rather than beside a
+            monthly-active-user ceiling. Non-OSI by construction, since the OSD forbids
+            discriminating against a field of endeavor. Settled in issue #117, which was
+            opened because the same OpenRAIL family had been scored 3 in one category and
+            4 in another.
+          examples: [Modified-MIT, DeepSeek-Model-License, TII-Falcon-License-2.0, minimax-community, NVIDIA-Open-Model-License]
         use_restricted:
           definition: >
             Caps or gates use — monthly-active-user ceilings, field-of-use limits,
             research-only terms, or a commercial agreement requirement.
-          examples: [Llama-3.1-Community-License, Llama-4-Community, Gemma-License, Mistral-Research-License, TII-Falcon-License-2.0, GLM-4-License, Qwen-License-Agreement]
+          examples: [Llama-3.1-Community-License, Llama-4-Community, Gemma-License, Mistral-Research-License, GLM-4-License, Qwen-License-Agreement]
         proprietary:
           definition: No public license; weights not distributed.
       multi_sku_rule: >

--- a/sources/categories/finetuned_chat.yaml
+++ b/sources/categories/finetuned_chat.yaml
@@ -31,9 +31,9 @@ scoring_recipe:
   derived_from:
     method: ported from base_pretrained, then verified against this category's scores
     ported_from: base_pretrained
-    scores_reproduced: 37
-    scores_total: 37
-    scores_deferred: 3
+    scores_reproduced: 39
+    scores_total: 39
+    scores_deferred: 0
     scores_corrected: 3
     verified_on: '2026-07-29'
     checker: build/check_rubric.py
@@ -97,9 +97,16 @@ scoring_recipe:
           examples: [Apache-2.0, MIT, BSD-3-Clause]
         permissive_non_osi:
           definition: >
-            Not OSI-approved but imposes no use restriction. Attribution or
-            naming requirements alone belong here.
-          examples: [Modified-MIT, minimax-community, NVIDIA-Open-Model-License]
+            Not OSI-approved, but imposes no restriction on WHO may use the artifact or
+            AT WHAT SCALE. Attribution, naming and CONDUCT requirements belong here: an
+            acceptable-use policy forbidding military, illegal or discriminatory use caps
+            neither commerce nor reach, so it sits beside attribution rather than beside a
+            monthly-active-user ceiling. Non-OSI by construction, since the OSD forbids
+            discriminating against a field of endeavor. Settled in issue #117, which was
+            opened because the same OpenRAIL family had been scored 3 in one category and
+            4 in another.
+          examples: [Modified-MIT, minimax-community, NVIDIA-Open-Model-License, BigCode-OpenRAIL-M,
+            DeepSeek-Model-License, TII-Falcon-License-2.0]
         use_restricted:
           definition: >
             Caps or gates use - monthly-active-user ceilings, field-of-use limits,
@@ -107,7 +114,7 @@ scoring_recipe:
           examples: [Llama-2-Community-License, Llama-3-Community-License, Llama-3.1-Community-License,
             Llama-3.2-Community-License, Llama-4-Community, Gemma-License, GLM-4-License,
             Qwen-License-Agreement, Mistral-Research-License, Mistral-AI-Non-Production-License,
-            Jamba-Open-Model-License]
+            Jamba-Open-Model-License, CC-BY-NC]
         proprietary:
           definition: No public license; weights not distributed.
       multi_sku_rule: >
@@ -158,48 +165,10 @@ scoring_recipe:
     - otherwise: {score: 3, class: open_weights}
       note: The category's center of gravity - open weights, closed recipe.
 
-  # Products this rubric does not decide, each with a reason. All three share one
-  # cause: a license that restricts CONDUCT - no military use, no discrimination,
-  # no commercial use - rather than capping commerce or field of use. The ladder's
-  # `use_restricted` is defined by commercial caps and field-of-use limits, so
-  # these fit no tier honestly.
-  #
-  # Not a quirk of this category. The same licenses are scored three different ways
-  # across the map, including one flat contradiction: DeepSeek-Model-License is
-  # permissive_non_osi in base_pretrained (the deepseek tier, 3/open_weights) and
-  # use-restricting here (2/restricted). OpenRAIL lands at 4/open_source here and
-  # 3/open_weights in safeguards. CC-BY-NC is 2/restricted here and 5/open in
-  # training_synthetic_datasets.
-  #
-  # Adding a tier for it would expand the taxonomy on one category's evidence,
-  # which is the thing #106 exists to prevent. Deferring keeps the products visible
-  # and unscored by machine until the tier question is settled in the open.
-  #
-  # Tracked in issue #117. Whatever lands there has to hold for datasets as well as
-  # models, which is why it is not settled here.
-  deferred:
-    starcoder2:
-      because: >
-        BigCode-OpenRAIL-M restricts behavior, not commerce. Weights, data and code
-        are all fully open, so the ladder would drop it to 2/restricted on the
-        license alone - harsher than any other reading of this artifact. Recorded
-        4/open_source, a pair the ladder cannot emit at all.
-      license: BigCode-OpenRAIL-M
-    deepseek-coder:
-      because: >
-        DeepSeek-Model-License carries Attachment A acceptable-use restrictions
-        (military, illegal, discriminatory). base_pretrained tiers this same license
-        permissive_non_osi and scores the deepseek tier 3/open_weights; this product
-        is recorded 2/restricted. One of the two is wrong and the rubric should not
-        pick by fiat.
-      license: DeepSeek-Model-License
-    command-r:
-      because: >
-        CC-BY-NC is non-commercial, which is a harder restriction than most entries
-        in use_restricted, yet cc-by-nc-sa-4.0 carries 5/open on personahub in
-        training_synthetic_datasets. Needs one ruling that holds for models and
-        datasets both.
-      license: CC-BY-NC
+  # Nothing deferred. The three products that were - starcoder2, deepseek-coder and
+  # command-r - are decided by the conduct-versus-commerce distinction settled in issue
+  # #117 and written into permissive_non_osi above. Keeping the key with an empty map
+  # would read as "we defer nothing yet"; removing it says the question was answered.
 
 products:
 - qwen-coder

--- a/sources/scores/deepseek-coder.yaml
+++ b/sources/scores/deepseek-coder.yaml
@@ -1,14 +1,17 @@
 product: deepseek-coder
 openness:
-  score: 2
-  class: restricted
+  score: 3
+  class: open_weights
   components: weights:open(downloadable on HF);data:closed;code:open(MIT, repo code);model-license:DeepSeek-Model-License(non-OSI;
     Attachment A acceptable-use restrictions - military/illegal/discrimination/etc.; commercial allowed but use-based
     restrictions must propagate to derivatives)
   confidence: high
-  note: 'Mixed tier: repo CODE is MIT, but the WEIGHTS are governed by the non-OSI DeepSeek Model License with use-based
-    restrictions (Attachment A) -> restricted class for the model, not open_weights. Distinct from newer DeepSeek
-    models (R1/V3.2/V4) which ship weights under plain MIT.'
+  note: 'MIT-licensed inference code with downloadable weights under the DeepSeek Model License, corpus not released,
+    so 3/open_weights. Corrected from 2/restricted on 2026-07-29 under issue #117. The license''s Attachment A forbids
+    military, illegal and discriminatory use and requires those terms to propagate to derivatives, but permits commercial
+    use at any scale - a conduct restriction, not a commercial one. This also removes the contradiction that opened
+    #117: base_pretrained already tiered the same license permissive_non_osi, so the same terms were producing a
+    3 in one category and a 2 in another. Now consistent with the `deepseek` tier, which reaches 3 under plain MIT.'
   sources:
   - url: https://huggingface.co/deepseek-ai/DeepSeek-Coder-V2-Instruct
     shows: model license = 'DeepSeek Model Agreement', code license = MIT, 236B-A21B MoE instruct coder

--- a/sources/scores/falcon.yaml
+++ b/sources/scores/falcon.yaml
@@ -1,14 +1,16 @@
 product: falcon
 openness:
-  score: 2
-  class: restricted
+  score: 3
+  class: open_weights
   components: weights:open;data:closed;code:closed;license:TII-Falcon-License-2.0(Apache-based+AUP,non-OSI)
   confidence: high
-  note: 'Weights downloadable, corpus not released, no training code, and licensed under TII-Falcon-License-2.0
-    - Apache-based but carrying an acceptable-use policy, so non-OSI and use-restricting. That license is what caps
-    the tier at 2 rather than 3: downloadable is not the same as usable without conditions. The Hub reports the
-    license as `other`, which is an abstention rather than an answer, so the tier rests on TII''s published text
-    rather than on a machine-readable field.'
+  note: 'Weights downloadable and freely usable commercially at any scale, corpus not released, no training code,
+    so 3/open_weights. Corrected from 2/restricted on 2026-07-29 under issue #117: TII-Falcon-License-2.0 is Apache-based
+    with an acceptable-use policy, and a conduct restriction caps neither who may use the model nor at what scale.
+    It therefore sits in permissive_non_osi beside attribution requirements rather than in use_restricted beside
+    Llama''s 700M-MAU ceiling. Not 4 or 5: the corpus and the pipeline are both closed, and the license is non-OSI
+    regardless, since the OSD forbids discriminating against a field of endeavor. The Hub reports this license as
+    `other`, an abstention rather than an answer, so the tier rests on TII''s published text.'
   sources:
   - url: https://huggingface.co/api/models/tiiuae/Falcon3-10B-Base
     shows: ungated, 41.2GB of weight files, 7,688 downloads last month; cardData.license is `other`, so the Hub

--- a/sources/scores/starcoder2.yaml
+++ b/sources/scores/starcoder2.yaml
@@ -1,14 +1,18 @@
 product: starcoder2
 openness:
   score: 4
-  class: open_source
-  components: weights:open;data:open(self-oss-instruct-sc2-exec-filter-50k + 7 documented intermediate
-    datasets);code:open(starcoder2-self-align pipeline on GitHub);base-data:open(The Stack v2);license:BigCode-OpenRAIL-M(open
-    but RAIL behavioral-use restrictions, not OSI)
+  class: open_weights
+  components: weights:open;data:open(self-oss-instruct-sc2-exec-filter-50k + 7 documented intermediate datasets);code:open(starcoder2-self-align
+    pipeline on GitHub);base-data:open(The Stack v2);license:BigCode-OpenRAIL-M(open but RAIL behavioral-use restrictions,
+    not OSI)
   confidence: high
-  note: Fully reproducible self-alignment pipeline (open weights + open instruct data + open code + open
-    base corpus) -> open_source tier; held to 4 rather than 5 because OpenRAIL-M carries non-OSI behavioral-use
-    restrictions.
+  note: 'The most open artifact in this category by evidence: weights, the full training corpus (The Stack v2) and
+    the self-align pipeline are all published. Held to 4 rather than 5 because BigCode-OpenRAIL-M is not OSI-approved
+    - its behavioral-use clauses discriminate against fields of endeavor, which the OSD forbids - and rule 5 of
+    the ladder reserves the top score for an OSI license. Class corrected from open_source to open_weights on 2026-07-29:
+    the score was right but 4/open_source is a pair this ladder cannot emit, and the mismatch is what flagged it.
+    Resolved under issue #117 by tiering RAIL as a conduct restriction, which is what keeps a fully-open pipeline
+    off the 2/restricted floor it would otherwise have hit on the license alone.'
   sources:
   - url: https://huggingface.co/bigcode/starcoder2-15b-instruct-v0.1
     shows: self-aligned; open dataset + open self-align code + OpenRAIL-M license
@@ -21,9 +25,8 @@ adoption:
   reach: <10K
   signal_type: usage_volume
   confidence: medium
-  note: Instruct SKU ~1.1k downloads/last-month; base StarCoder2-15B ~9.4k/last-month. Research-significant
-    (fully-open self-alignment recipe) but low production reach; placed at 1 on the instruct SKU's measured
-    volume.
+  note: Instruct SKU ~1.1k downloads/last-month; base StarCoder2-15B ~9.4k/last-month. Research-significant (fully-open
+    self-alignment recipe) but low production reach; placed at 1 on the instruct SKU's measured volume.
   sources:
   - url: https://huggingface.co/bigcode/starcoder2-15b-instruct-v0.1
     shows: ~1,120 downloads last month
@@ -36,9 +39,8 @@ capability:
   basis: benchmark:HumanEval
   value: StarCoder2-15B-Instruct-v0.1 HumanEval pass@1 72.6% (HumanEval+ 63.4%)
   confidence: high
-  note: Strong HumanEval for a fully-open 16B in 2024 (best fully-self-aligned code model at release),
-    but HumanEval is saturated and the model is below 2026 frontier coders on harder agentic benchmarks
-    (SWE-bench). Mid-tier.
+  note: Strong HumanEval for a fully-open 16B in 2024 (best fully-self-aligned code model at release), but HumanEval
+    is saturated and the model is below 2026 frontier coders on harder agentic benchmarks (SWE-bench). Mid-tier.
   sources:
   - url: https://huggingface.co/bigcode/starcoder2-15b-instruct-v0.1
     shows: HumanEval pass@1 72.6%, HumanEval+ 63.4%

--- a/tests/test_check_rubric.py
+++ b/tests/test_check_rubric.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pytest
 
 from build.check_rubric import (
+    ROOT,
     check_category,
     dimension_value,
     license_tier,
@@ -132,22 +133,36 @@ class TestRealCategories:
     def test_finetuned_chat_reproduces_every_undeferred_score(self):
         reproduced, total, problems, _ = check_category("finetuned_chat", verbose=False)
         assert problems == []
-        assert reproduced == total == 36
+        assert reproduced == total == 39
 
-    def test_finetuned_chat_deferrals_are_reported_with_a_reason(self):
-        """A deferral that prints nothing is a silent cap on coverage."""
+    def test_no_category_defers_without_a_substantive_reason(self):
+        """A deferral that prints nothing is a silent cap on coverage.
+
+        Written as an invariant over every category rather than a fixed list, because
+        the list is currently empty: issue #117 settled conduct-versus-commerce, which
+        decided the three products finetuned_chat used to defer. Asserting "3 deferred"
+        would have to be edited every time the count moves; asserting "any deferral
+        carries a reason" holds at zero and bites the moment one is added."""
+        import yaml
+
+        for path in sorted((ROOT / "sources" / "categories").glob("*.yaml")):
+            category = yaml.safe_load(path.read_text())
+            if not category.get("scoring_recipe"):
+                continue
+            _, _, problems, deferred = check_category(category["name"], verbose=False)
+            assert problems == [], f"{category['name']}: {problems}"
+            for entry in deferred:
+                reason = entry.split(":", 1)[1].strip()
+                assert len(reason) > 40, f"{category['name']}: no real reason given: {entry}"
+
+    def test_finetuned_chat_currently_defers_nothing(self):
+        """The count itself, pinned separately so a new deferral is visible in a diff."""
         _, _, _, deferred = check_category("finetuned_chat", verbose=False)
-        assert len(deferred) == 3
-        assert {entry.split(":")[0] for entry in deferred} == {
-            "starcoder2",
-            "deepseek-coder",
-            "command-r",
-        }
-        for entry in deferred:
-            assert len(entry.split(":", 1)[1].strip()) > 40, f"no real reason given: {entry}"
+        assert deferred == []
 
     def test_deferred_products_are_excluded_not_counted_as_reproduced(self):
-        """36, not 39. Counting a deferral as a pass is how a rubric claims to
-        describe products it cannot score."""
+        """39 scored and 0 deferred. Counting a deferral as a pass is how a rubric
+        claims to describe products it cannot score, so the identity is worth keeping
+        even while the deferral count is zero."""
         _, total, _, deferred = check_category("finetuned_chat", verbose=False)
         assert total + len(deferred) == 39


### PR DESCRIPTION
Closes #117.

The openness ladder's tiers are about **commercial reach** — who may use an artifact and at what scale. Licenses that restrict *conduct* instead, forbidding military, illegal or discriminatory use, cap neither, and the ladder had nowhere to put them. So the same OpenRAIL family scored 3 in `safeguards` and 4 in `finetuned_chat`, and the DeepSeek Model License scored 3 in `base_pretrained` and 2 in `finetuned_chat` off identical terms.

## The distinction

Written into `permissive_non_osi`'s definition in both recipes:

```
conduct / acceptable-use  ->  permissive_non_osi   caps neither commerce nor reach, so it
                                                   sits beside attribution requirements
commercial prohibition    ->  use_restricted       non-commercial blocks most downstream use
commercial cap or gate    ->  use_restricted       unchanged: MAU ceilings, revenue caps,
                                                   registration, research-only
```

Non-OSI either way, because the OSD forbids discriminating against a field of endeavor — so a RAIL-licensed model can reach 4 but never 5. **No new tier**, so `tier_rank` and `multi_sku_rule` are untouched.

Re-tiered to `permissive_non_osi`: `BigCode-OpenRAIL-M`, `DeepSeek-Model-License`, `TII-Falcon-License-2.0`. And `CC-BY-NC` is now declared under `use_restricted`, where it had never been declared at all — which is why `command-r` was deferred rather than scored.

## Scores that move

Simulated before editing, so these were verified rather than predicted:

```
falcon           2 restricted   -> 3 open_weights   Apache-based license plus an AUP;
                                                    freely commercial at any scale
deepseek-coder   2 restricted   -> 3 open_weights   now agrees with the `deepseek` tier,
                                                    which reaches 3 under plain MIT
starcoder2       4 open_source  -> 4 open_weights   score was right, but 4/open_source is
                                                    a pair the ladder cannot emit
command-r        2 restricted   -> 2 restricted     resolves with no change
```

`starcoder2` is the case that makes the rule worth having. Its weights, the full Stack v2 corpus and the self-align pipeline are all published — folding RAIL into `use_restricted` would have scored it **2**, level with a research-only license, on the license alone.

`falcon` is the one change to a product that wasn't deferred, so it's the one a reader might notice.

## finetuned_chat now defers nothing

39/39 reproduce, up from 36/36 with three deferred. `base_pretrained` holds at 26/26.

The `deferred` block is removed rather than left empty — an empty map reads as "nothing deferred yet", while its absence records that the question was answered.

**The deferral test became an invariant.** It asserted a fixed list of three products; it's now `test_no_category_defers_without_a_substantive_reason` over every category with a recipe, which holds at zero and bites the moment a deferral is added. The count is pinned separately so a new one shows up in a diff.

## Reported to #117 rather than fixed here

`personahub` carries **CC-BY-NC-SA at 5/open** in `training_synthetic_datasets`. The dataset classes are `open / gated / documented_only / closed`, and `gated` means *access* friction — `the-stack-v2` and `nemotron-cc` are gated because they require accepting terms, while `personahub` is explicitly ungated and downloadable. There is no class for "freely downloadable but non-commercial", which is this same gap on the dataset side. Forcing it into `gated` would be wrong, and that category has no recipe yet, so nothing is blocked.

## Test plan

- `uv run python -m build.check_rubric` — `base_pretrained` 26/26, `finetuned_chat` 39/39, no deferrals
- `uv run python -m build.validate` — 0 errors
- `uv run python -m build.serialize_rubric --check` — no errors, `category_license_tiers` 37 → 41 rows
- `uv run python -m pytest` — 118 passed