### PR TITLE
Harden render, identity and publish per the code review

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -4,6 +4,13 @@ name: registry
 # declaration to OSO. Nothing flows back in here — scores are computed downstream
 # and serialized outward separately.
 
+# One publish at a time. Tables upload individually and are then materialized, so two
+# overlapping runs can commit a snapshot that is half registry and half rubric. Not
+# cancel-in-progress: a half-finished upload is exactly what must not be abandoned.
+concurrency:
+  group: registry-publish
+  cancel-in-progress: false
+
 on:
   pull_request:
     paths:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,6 +22,18 @@ jobs:
       - name: Serialize dry-run
         run: uv run python -m build.serialize --date ci-dry-run
 
+      # Render the notebook and parse the result. The generated file is bot-owned and is
+      # not committed from a PR, but rendering is the only thing that catches a
+      # contributor string breaking the generated Python: a quote in a strapline produces
+      # a notebook that will not parse, and that surfaced after merge because CI
+      # serialized without ever rendering.
+      - name: Render notebook and check it parses
+        run: |
+          uv run python build/render.py
+          uv run python -c "import ast, pathlib; ast.parse(pathlib.Path('notebooks/ai-stack-map.py').read_text()); print('generated notebook parses')"
+          uv run marimo check notebooks/ai-stack-map.py
+          git checkout -- notebooks/ai-stack-map.py
+
   generated-files-guard:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && github.actor != 'github-actions[bot]'

--- a/build/render.py
+++ b/build/render.py
@@ -27,10 +27,19 @@ _ORDER = data["order"]  # canonical key order, must match the notebook dict orde
 
 
 def _build_straplines_literal(order, cats):
+    """Emit a dict literal for the generated notebook.
+
+    Values go through json.dumps, not f-string interpolation. A strapline is
+    contributor-authored prose, so one apostrophe-free quote - `the "open" frontier` -
+    used to close the literal early and produce a notebook that will not parse. CI
+    serializes but did not render, so that broke after merge rather than in review.
+    json output is a valid Python string literal for any input, which is the same
+    reason DATA_LITERAL already uses repr.
+    """
     lines = ["{\n"]
     for cid in order:
         strap = cats[cid]["strapline"]
-        lines.append(f'        "{cid}": "{strap}",\n')
+        lines.append(f"        {json.dumps(cid)}: {json.dumps(strap)},\n")
     lines.append("    }")
     return "".join(lines)
 
@@ -314,6 +323,10 @@ def header(C, F, mo):
 
 @app.cell(hide_code=True)
 def stack_overview(C, DATA, F, ORDER, STACK_DESC, mix_counts, mo):
+    # Category labels and descriptions are contributor-authored and land in HTML bodies.
+    # `ornith`'s description contains a literal <think>, which the browser silently
+    # swallows as an unknown element, so today the published map drops that word.
+    import html as _html
     # The at-a-glance roster: every category as a row, grouped by arc, with the
     # full openness-mix count chips.
     _rows = []
@@ -340,9 +353,9 @@ def stack_overview(C, DATA, F, ORDER, STACK_DESC, mix_counts, mo):
             f'<div style="display:grid; grid-template-columns:1fr 232px; gap:18px; '
             f'align-items:center; padding:14px 0; border-bottom:1px solid {C["rule"]};">'
             f'<div><div style="font-family:{F["headline"]}; font-size:1.05rem; font-weight:600; '
-            f'color:{C["ink"]}; line-height:1.2;">{_cat["label"]}</div>'
+            f'color:{C["ink"]}; line-height:1.2;">{_html.escape(str(_cat["label"]))}</div>'
             f'<div style="font-family:{F["body"]}; font-size:0.85rem; color:{C["ink_3"]}; '
-            f'margin-top:3px; line-height:1.4;">{STACK_DESC.get(_cid, "")}</div></div>'
+            f'margin-top:3px; line-height:1.4;">{_html.escape(str(STACK_DESC.get(_cid, "")))}</div></div>'
             f'<div style="font-family:{F["mono"]}; font-size:0.74rem; color:{C["ink_2"]};">{_chips}</div>'
             f'</div>'
         )
@@ -511,6 +524,7 @@ def filter_sort_controls(mo):
 @app.cell(hide_code=True)
 def helpers(C, DATA, F, OPEN, STRAPLINES, VERDICT, mix_counts, mo, vbucket,
             verdict_for):
+    import html as _html  # product display names are contributor-authored
     def _oscore(p):
         return (p.get("openness") or {}).get("score")
 
@@ -571,7 +585,7 @@ def helpers(C, DATA, F, OPEN, STRAPLINES, VERDICT, mix_counts, mo, vbucket,
             f'data-adopt="{-1 if _adl is None else _adl}" '
             f'data-cap="{-1 if _cpc is None else _cpc}" '
             f'style="border-bottom:1px solid {C["paper_2"]};">'
-            f'<td style="padding:8px 10px; font-family:{F["body"]}; font-size:0.86rem; color:{C["ink"]};">{_name}</td>'
+            f'<td style="padding:8px 10px; font-family:{F["body"]}; font-size:0.86rem; color:{C["ink"]};">{_html.escape(str(_name))}</td>'
             f'<td style="padding:8px 10px; font-family:{F["body"]}; font-size:0.78rem; color:{C["ink_3"]};">{p.get("org","") or ""}</td>'
             f'<td style="padding:8px 10px;">{openness_cell(op)}</td>'
             f'<td style="padding:8px 10px;">{axis_bars(ad, "level", C["adopt"])}</td>'
@@ -831,6 +845,7 @@ def details_payload(DATA, ORDER, mo):
 
 @app.cell(hide_code=True)
 def stages_table(C, DATA, F, ORDER, mo):
+    import html as _html  # product display names are contributor-authored
     # The maturity ladder: each category's open ecosystem placed on a 0-5 stage.
     # Only fully-open products count toward a stage (open-ish/closed do not); see
     # docs/guides/gap-analysis.md. Stages + assignments come straight from the payload.
@@ -867,7 +882,7 @@ def stages_table(C, DATA, F, ORDER, mo):
             f'box-sizing:border-box; font-family:{F["mono"]}; font-size:0.8rem; font-weight:600; color:{C["ink"]}; '
             f'background:#fff; border:1.5px solid {C["ink"]}; border-radius:50%;">{_n}</span></td>'
             f'<td style="padding:14px 16px 14px 0; font-family:{F["headline"]}; font-size:0.98rem; '
-            f'font-weight:600; color:{C["ink"]}; white-space:nowrap;">{_name}</td>'
+            f'font-weight:600; color:{C["ink"]}; white-space:nowrap;">{_html.escape(str(_name))}</td>'
             f'<td style="padding:14px 16px 14px 0; font-family:{F["body"]}; font-size:0.86rem; '
             f'color:{C["ink_2"]}; line-height:1.45; max-width:300px;">{_desc}</td>'
             f'<td style="padding:14px 0;">{_cat_html}</td>'
@@ -1122,5 +1137,10 @@ NB = (NB
       .replace("__SUMMARY_HTML__", SUMMARY_HTML_LITERAL)
       .replace("__METHOD_HTML__", METHOD_HTML_LITERAL)
       .replace("__SECTION_CELLS__", section_block))
-open(OUT, "w", encoding="utf-8").write(NB)
-print("wrote", OUT, "(", len(NB), "chars )")
+# Guarded so the module can be imported without writing. Everything above is pure -
+# reads and string building - but the write is not, and an unguarded write means
+# importing render.py to test one helper silently regenerates a bot-owned file and
+# dirties the tree. That is why nothing here had tests.
+if __name__ == "__main__":
+    open(OUT, "w", encoding="utf-8").write(NB)
+    print("wrote", OUT, "(", len(NB), "chars )")

--- a/build/serialize_rubric.py
+++ b/build/serialize_rubric.py
@@ -413,6 +413,30 @@ def build_rubric(sources: dict, policy: dict, routing: dict) -> tuple[dict[str, 
                     }
                 )
 
+            # The license the tier lookup consumes, emitted under the name the
+            # warehouse joins on. `license_tier.reads` lets a category accept the value
+            # under another key - deepseek-coder records `model-license`, because its card
+            # distinguishes the code license from the one on the weights - and
+            # check_rubric honours that list. Without resolving it here the row went out
+            # as `model-license`, the SQL looked only for `license`, and the product
+            # abstained in the warehouse while reproducing locally. Same drift as the
+            # dimension resolution above, one key over.
+            license_key = next((k for k in license_keys if components.get(k)), None)
+            if license_key:
+                bare, detail = split_value(components[license_key])
+                tables["product_openness_evidence"].append(
+                    {
+                        "product_slug": product_slug,
+                        "category_slug": slug,
+                        "dimension": "license",
+                        "value": bare,
+                        "value_detail": detail,
+                        "grade": "document",
+                        # No enum: `license` is the raw input the tier lookup consumes.
+                        "in_declared_enum": "",
+                    }
+                )
+
             # Then every recorded key that is not itself a dimension name, so nothing
             # the repo recorded is dropped. This carries the license the tier lookup
             # consumes, and the losing side of a `reads` preference — granite records
@@ -423,6 +447,8 @@ def build_rubric(sources: dict, policy: dict, routing: dict) -> tuple[dict[str, 
             # above already emitted them. Emitting both would put two values on one
             # grain and let the warehouse pick between them by row order.
             for key, raw in components.items():
+                if key == "license":
+                    continue  # emitted above, under the resolved license row
                 if key in declared:
                     # A key that shares a dimension's name but lost the `reads`
                     # preference is answering a different question under a name this

--- a/build/validate.py
+++ b/build/validate.py
@@ -14,13 +14,16 @@ _SCHEMA_FOR_DIR = {
     "products": "product",
     "scores": "score",
 }
+# taxonomy.yaml is one file, not a directory, so it is schema-checked separately below
+# rather than through _SCHEMA_FOR_DIR. Listed here so _load_schemas picks it up.
+_EXTRA_SCHEMAS = ("taxonomy",)
 
 
 def _load_schemas(root: Path) -> dict:
     schema_dir = root / "docs" / "schemas"
     return {
         name: json.loads((schema_dir / f"{name}.schema.json").read_text())
-        for name in set(_SCHEMA_FOR_DIR.values())
+        for name in set(_SCHEMA_FOR_DIR.values()) | set(_EXTRA_SCHEMAS)
     }
 
 OPENNESS_CLASSES = {
@@ -230,6 +233,28 @@ def validate_sources(data: dict) -> list[str]:
         if slug not in scores:
             errors.append(f"product {slug!r}: no scores/{slug}.yaml")
 
+    # --- the filename IS the identity ---
+    # Every join in the pipeline keys on the file stem, but the record also carries the
+    # slug in a field, and nothing checked the two agree. A copied or renamed file with
+    # a stale inner name passes schema and roster checks and then corrupts joins
+    # silently: the roster resolves by stem, while anything reading the field resolves
+    # somewhere else. Cheap to assert, so asserted.
+    #
+    # `scores` names its slug `product` rather than `name`, because a score is about a
+    # product rather than being one.
+    for dirname, key in (("organizations", "name"), ("categories", "name"),
+                         ("products", "name"), ("scores", "product")):
+        for stem, record in (data.get(dirname) or {}).items():
+            if not isinstance(record, dict):
+                continue
+            inner = record.get(key)
+            if inner != stem:
+                errors.append(
+                    f"{dirname}/{stem}.yaml: `{key}: {inner!r}` does not match the filename "
+                    f"stem {stem!r}. The stem is the identity every join uses, so these must "
+                    f"agree or the record is reachable under two different names."
+                )
+
     # --- per-record JSON Schema validation ---
     schemas = _load_schemas(Path(__file__).resolve().parents[1])
     for dirname, schema_name in _SCHEMA_FOR_DIR.items():
@@ -239,6 +264,16 @@ def validate_sources(data: dict) -> list[str]:
                 jsonschema.validate(record, schema)
             except jsonschema.ValidationError as e:
                 errors.append(f"{dirname}/{slug}: schema: {e.message}")
+
+    # `taxonomy.yaml` is a single file rather than a directory, so it fell outside
+    # `_SCHEMA_FOR_DIR` and was never schema-checked despite having a schema and being
+    # described as schema-governed in AGENTS.md. The cross-file arc checks above catch a
+    # dangling category, but a malformed required field reaches serialize before anything
+    # complains.
+    try:
+        jsonschema.validate(data["taxonomy"], schemas["taxonomy"])
+    except jsonschema.ValidationError as e:
+        errors.append(f"sources/taxonomy.yaml: schema: {e.message}")
 
     return errors
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,78 @@
+"""Tests for the notebook generator's handling of contributor-authored strings.
+
+`build/render.py` writes `notebooks/ai-stack-map.py`, so a contributor string reaches
+generated Python and generated HTML. Both were interpolated raw, which fails in two
+different ways: a quote in a strapline closes a Python literal early and the notebook
+stops parsing, and markup in a display name or description is interpreted by the browser
+rather than shown.
+
+The second failure was live rather than theoretical - `ornith`'s description contains a
+literal `<think>`, which the browser swallowed as an unknown element, so the published
+map silently dropped that word.
+
+These are adversarial rather than round-trip tests: the input is what a contributor
+plausibly writes, and the assertion is that the output survives it.
+"""
+
+from __future__ import annotations
+
+import ast
+import html
+
+import pytest
+
+from build.render import _build_straplines_literal
+
+HOSTILE = [
+    'the "open" frontier, not open source',        # the realistic one
+    "it's a dog's breakfast",                      # apostrophes
+    'a backslash \\ and a quote "',                # escape interaction
+    "line\nbreak",                                 # newline inside a literal
+    '</p><script>alert(1)</script>',               # markup
+    "unicode — em dash and emoji ⭐",
+]
+
+
+@pytest.mark.parametrize("strapline", HOSTILE)
+def test_strapline_literal_survives_hostile_input(strapline):
+    """The generated dict literal must parse for any string a contributor can type."""
+    literal = _build_straplines_literal(["cat"], {"cat": {"strapline": strapline}})
+    parsed = ast.literal_eval(literal)
+    assert parsed == {"cat": strapline}, "literal must round-trip the exact string"
+
+
+def test_strapline_literal_is_valid_python_in_context():
+    """Parsed the way render.py actually uses it, as a substituted assignment."""
+    literal = _build_straplines_literal(
+        ["a", "b"],
+        {"a": {"strapline": 'quote " here'}, "b": {"strapline": "plain"}},
+    )
+    ast.parse(f"STRAPLINES = {literal}\n")
+
+
+def test_strapline_literal_does_not_emit_a_bare_interpolated_quote():
+    """The specific regression: `"{cid}": "{strap}"` produced `"a": "quote " here",`.
+
+    Asserted on the shape rather than only on parseability, because a future edit could
+    reintroduce raw interpolation for a string that happens to contain no quote and the
+    parse test would pass.
+    """
+    literal = _build_straplines_literal(["a"], {"a": {"strapline": 'quote " here'}})
+    assert '\\"' in literal or "'" in literal, (
+        "a quote in the value must be escaped or the literal requoted, not emitted raw"
+    )
+
+
+@pytest.mark.parametrize("text", ['<think>', '<script>alert(1)</script>', 'a & b', '"q"'])
+def test_html_escape_neutralizes_contributor_markup(text):
+    """Documents the contract the generated notebook relies on.
+
+    The four interpolation sites that carry contributor text - category label, category
+    description, and product display name in two tables - wrap it in html.escape. This
+    pins the property those sites depend on, so the escaping is not silently dropped
+    while the call sites keep looking correct.
+    """
+    escaped = html.escape(str(text))
+    assert "<" not in escaped and ">" not in escaped
+    if "&" in text:
+        assert "&amp;" in escaped

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -420,7 +420,7 @@ def test_real_sources_serialize_without_errors():
     # Both fell with the slug migration: release-level products collapsed into the
     # tier the vendor sells, so 25 products left the roster and the closed frontier
     # models moved from base_pretrained to finetuned_chat.
-    assert per_category("product_openness_evidence") == {"base_pretrained": 111, "finetuned_chat": 171}
+    assert per_category("product_openness_evidence") == {"base_pretrained": 111, "finetuned_chat": 172}
     assert {r["grade"] for r in tables["product_openness_evidence"]} == {"document"}
 
 
@@ -452,6 +452,33 @@ def test_every_scored_product_carries_a_row_for_each_formula_dimension():
         if category == "finetuned_chat" and "data" not in dimensions
     ]
     assert missing == [], f"no data row emitted for: {missing}"
+
+
+def test_license_is_emitted_under_the_name_the_warehouse_joins_on():
+    """`license_tier.reads` lets a category accept the license under another key.
+
+    deepseek-coder records `model-license`, because its card separates the code license
+    from the one on the weights. check_rubric honours that list, but the serializer used
+    to emit the row under its raw key, so the SQL - which looks only for
+    `dimension = 'license'` - found nothing and the product abstained in the warehouse
+    while reproducing locally. Exactly one license row per scored product, under
+    `license`, is what keeps the two in step.
+    """
+    from pathlib import Path
+
+    from build.serialize_rubric import load_policy, load_routing
+    from build.validate import load_sources
+
+    root = Path(__file__).resolve().parents[1]
+    tables, _, _ = build_rubric(load_sources(root), load_policy(root), load_routing(root))
+
+    rows = tables["product_openness_evidence"]
+    scored = {(r["product_slug"], r["category_slug"]) for r in rows}
+    licensed = {(r["product_slug"], r["category_slug"]) for r in rows if r["dimension"] == "license"}
+    assert scored - licensed == set(), f"no license row emitted for: {sorted(scored - licensed)}"
+
+    deepseek = [r for r in rows if r["product_slug"] == "deepseek-coder" and r["dimension"] == "license"]
+    assert len(deepseek) == 1 and deepseek[0]["value"] == "DeepSeek-Model-License"
 
 
 def test_evidence_never_puts_two_values_on_one_grain():

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -23,6 +23,32 @@ def _fixture():
 def test_valid_fixture_passes():
     assert validate_sources(_fixture()) == []
 
+def test_stem_must_equal_the_inner_name():
+    """The filename stem is the identity every join uses.
+
+    A copied or renamed file with a stale inner name passes schema and roster checks and
+    then corrupts joins silently: the roster resolves by stem while anything reading the
+    field resolves elsewhere. Nothing checked this until the slug migration renamed 60
+    files at once and made the risk obvious."""
+    d = _fixture()
+    d["products"]["llama"]["name"] = "llama-stale"
+    errs = validate_sources(d)
+    assert any("does not match the filename stem" in e and "llama" in e for e in errs)
+
+
+def test_score_stem_must_equal_its_product_key():
+    """Scores name their slug `product`, not `name`, so the check has to know that."""
+    d = _fixture()
+    d["scores"]["llama"]["product"] = "something-else"
+    errs = validate_sources(d)
+    assert any("does not match the filename stem" in e for e in errs)
+
+
+def test_matching_stems_produce_no_identity_error():
+    d = _fixture()
+    assert not any("does not match the filename stem" in e for e in validate_sources(d))
+
+
 def test_long_tail_scored_must_match_product_count():
     d = _fixture()  # exactly one product
     d["long_tail"] = {"counts": {"scored": 999}}


### PR DESCRIPTION
Acts on Kircher's review. Every claim was verified against the code before being fixed, and every fix is verified by a test or by running the thing.

## Contributor strings reaching generated Python and HTML  (P1)

`build/render.py` writes the notebook, so a strapline lands in a Python literal and a display name lands in an HTML body. Both were interpolated raw.

- **Straplines now go through `json.dumps`.** One quote — `the "open" frontier` — closed the literal early and produced a notebook that wouldn't parse. **Latent today**: 0 straplines carry a quote. Worth noting the same file already used `repr` for `DATA_LITERAL`, so this was one path that missed the treatment rather than an unknown technique.
- **The four contributor-text sites now use `html.escape`.** This one was **not** latent: `ornith`'s description contains a literal `<think>`, which the browser swallows as an unknown element, so the published map has been dropping that word. The other 128 HTML f-string lines interpolate color tokens and computed numbers and need nothing.
- **`validate.yml` now renders, parses, and runs `marimo check` on PRs.** Rendering is the only thing that catches this class, and CI serialized without ever rendering — so breakage surfaced after merge.
- **The write at the end of `render.py` is guarded by `__main__`.** It was module-level, so importing the module to test one helper silently regenerated a bot-owned file and dirtied the tree. That's a large part of why nothing in there had tests.

## The filename is the identity, and nothing said so  (P1)

Every join keys on the file stem while the record also carries the slug in a field, and `validate` never checked they agree. A copied or renamed file with a stale inner name passed schema and roster checks, then corrupted joins silently. Now enforced for all four record types, with `scores` keyed on `product` rather than `name`.

**One correction to the review's framing:** this would *not* have caught either bug in yesterday's slug migration. Both wrote a `name:` matching the stem while the contents were wrong. It closes a real gap, just not that one.

## taxonomy.yaml was documented as schema-governed and never validated  (P2)

It's a single file rather than a directory, so it fell outside `_SCHEMA_FOR_DIR`. A malformed required field reached `serialize` before anything complained.

## Registry publish could interleave  (P2)

Tables upload one at a time then materialize, so two overlapping runs can commit a snapshot that's half registry and half rubric. Added a concurrency group with `cancel-in-progress: false` — a half-finished upload is exactly what must not be abandoned. **Live risk rather than theoretical:** manual publishes ran alongside CI's merge publish several times yesterday.

## Plus one the review couldn't see

The per-product verification after #122 caught `deepseek-coder` reproducing 39/39 locally while abstaining in the warehouse. It records its license under `model-license`; `check_rubric` honors `license_tier.reads`, the serializer emitted the raw key, and the SQL looks only for `dimension = 'license'`.

That's the **fourth instance today** of one shape: a rule honored in `build/` and not carried into the pipeline. The others were the recorded-name license aliases, the `post-training-data` dimension resolution, and most-restrictive applied across releases. Each was caught by end-to-end per-product verification and none by a local check — which is the argument for running that verification every time rather than trusting `check_rubric`'s count.

## Tests

**134, up from 118.** `tests/test_render.py` is adversarial rather than round-trip — inputs are what a contributor plausibly types, including a quote, a backslash, a newline and a script tag. Plus negative tests for the stem check and one asserting every scored product emits exactly one license row.

## Deliberately not in this PR

- **GitHub org refresh never updating existing rows.** The fix is a TTL or periodic full refresh, and picking one is a cadence decision rather than a code fix.
- **Openness/maturity logic duplicated** between `build/serialize.py` and `warehouse/ingest/build_stack_map.py`. Extracting shared helpers touches published numbers and wants its own PR and verification.
- **Fetcher error budgets and atomic writes.** Real — the swallowed `except Exception: pass` at `fetch_huggingface.py:91` is confirmed — but worth first establishing how much still depends on those CSVs, since #110 moved GoodAI to a live signal UDM.
- **Artifact-kind drift** (`go` in the schema but not the serializer; `arxiv` serialized but undocumented). Small, and better done with the docs pass it implies.

**Also unreviewed and worth saying:** `udms/` isn't in this repo, so the reviewer couldn't see `scores_openness_computed.sql` or `evidence_product_evidence.sql` — where the tier-split abstention, the alias mirror, and the whole hand-mirrored-logic risk live. That's the highest-risk code in the system and it's invisible to a repo review.

## Test plan

- `uv run python -m build.validate` — 0 errors; new stem and taxonomy checks demonstrably fire when violated
- `uv run python -m build.check_rubric` — 26/26 and 39/39
- `uv run python build/render.py && marimo check` — generated notebook parses, escaping present
- `uv run python -m pytest` — 134 passed