### PR TITLE
Stop apply_scores writing last_verified, and revert the dates it wrote

### DIFF
--- a/build/apply_scores.py
+++ b/build/apply_scores.py
@@ -5,30 +5,48 @@ pushes declarations outward. That direction matters: the repo is the source of t
 for what the map SAYS, and this tool is the only thing allowed to change it without
 a person typing the value.
 
-## What it writes, and what it refuses to
+## What it writes
 
-  * `openness.last_verified` — the CHECK EVENT: the most recent date on which any
-    admitted evidence behind the score was actually read. A document source's `accessed`
-    date, or a signal's fetch. It comes from the scorer's `last_checked` column.
-
-    It is deliberately NOT the freshness bound. The scorer also computes
-    `freshness_floor` — the MIN accessed date across everything the score relies on, null
-    if any of it is unsourced — and that stays in the warehouse. Both are useful; they are
-    different questions, and writing the bound into this field is what let a derived value
-    overwrite a human's check date with a date appearing nowhere in the file's own
-    evidence, so no reader could trace it.
-
-    A stored date is never moved backwards. It records that somebody looked on that day,
-    which stays true regardless of what we can currently derive; if the computed value is
-    older, that is reported rather than applied.
   * `openness.score` / `openness.class` — only when the computed value differs. It
     should not, since the rubric was reverse-engineered from these files, so a
     difference is either a real evidence change worth reviewing or a bug worth
     finding. Either way it must be loud, so `--check` exits non-zero on one.
 
-It will NOT remove an existing `last_verified` when the pipeline can no longer earn
-one. That case is reported instead. Deleting a date because provenance got stricter
-is destructive, and the fix is to source the evidence, not to erase the record.
+That is the whole list.
+
+## Why it does not write `last_verified`
+
+`docs/guides/freshness.md` is normative: `last_verified` is the most recent date on
+which EVERYTHING in the score was confirmed still correct, and "everything" means
+every dimension the score records, not only the ones the winning rule happens to read.
+
+This pipeline cannot establish that, for any product, by construction. Of the four
+recorded dimensions, only `license` and `weights` have a dataset route;
+`signal_routing.yaml` declares `data` research-only and the GitHub code route carries
+`settles_dimension = false`, so `currentai.scores.openness_computed` hardcodes both to
+document grade. A document is a human's reading of prose that was already in the score
+file. Re-reading the repo is not a confirmation of anything.
+
+So there is no date here for the pipeline to write, and it writes none. Two earlier
+attempts wrote one anyway, from a derived aggregate:
+
+  * #108 wrote the freshness BOUND, the MIN `accessed` across the score's evidence.
+  * #115 replaced it with `last_checked`, the MAX over the same dates.
+
+Both are the mistake the guide names: any aggregate of access dates is still a
+confirmation claim computed from readings, and changing the aggregation does not fix
+the category error. Between them they put a derived date on 19 of the 26 axes that
+carried one, in six cases overwriting a date a person had established by checking.
+Those were reverted when this writer was removed.
+
+`last_checked` is still read and reported, because "when did the pipeline last see any
+of this evidence" is a useful diagnostic. It is not written to a file.
+
+**What would have to change for this to write the field again.** A dataset route that
+settles `data` and `code`, and a column counting dimensions the score RECORDS rather
+than `dims_relied_on`, which counts only what the winning rule reads. Until both
+exist, a guarded write-when-fully-confirmed branch could never fire, and a branch that
+cannot fire reads as working code.
 
 It will NOT touch `note`, `sources`, `confidence`, `adoption` or `capability`. Those
 are human prose and human judgment. A tool that rewrote them would make its own diffs
@@ -39,9 +57,7 @@ unreviewable, which is the whole value of the review step.
 `yaml.safe_load` then `yaml.dump` reformats every string in the file — folded scalars
 collapse, quoting changes, key order moves. The diff would be 501 files of noise with
 the real change buried in it. So this edits the specific lines and leaves every other
-byte alone. `last_verified` is replaced where it already sits, since its position
-varies across the six files that carry one, and otherwise inserted before `sources:`,
-which is where most of them put it.
+byte alone.
 
 Usage:
     uv run python -m build.apply_scores --check      # report, write nothing
@@ -54,10 +70,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
-from datetime import date
 from pathlib import Path
-
-import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 TABLE = "currentai.scores.openness_computed"
@@ -80,7 +93,7 @@ def fetch_computed(category: str | None) -> list[dict]:
     where = f"WHERE category_slug = '{category}'" if category else ""
     sql = f"""
         SELECT product_slug, category_slug, openness_score, openness_class,
-               last_checked, freshness_floor, unsourced_dimensions, license_tier_grade,
+               last_checked, unsourced_dimensions, license_tier_grade,
                dims_from_dataset, dims_relied_on, scoring_note
         FROM {TABLE}
         {where}
@@ -152,44 +165,9 @@ def apply_to_file(path: Path, computed: dict) -> tuple[list[str], list[str]]:
                 lines[index] = f"  {key}: {value}\n"
                 changes.append(f"{path.stem}: openness.{key} {current} -> {value}")
 
-    # `last_checked` is the CHECK EVENT - the most recent date any admitted evidence behind
-    # this score was actually read. That, not the freshness bound, is what belongs in a
-    # score file: it is traceable to a dated row, and it answers the question a reader has.
-    # Writing the bound here is what let a derived value overwrite a human's check date with
-    # one that appears nowhere in the file's own evidence.
-    checked = computed.get("last_checked")
-    if has_date(checked):
-        stamp = str(checked)[:10]
-        index = find_key(lines, bounds, "last_verified")
-        if index is not None:
-            current = lines[index].split(":", 1)[1].strip().strip("'\"")
-            # Never move a stored date backwards. A date already in the file records that
-            # somebody looked on that day, and that remains true whatever we can currently
-            # derive. If the computed value is older, the file is ahead of us - report it
-            # rather than destroying the record. ISO dates compare correctly as strings.
-            #
-            # But "ahead of us" only makes sense up to today. A check cannot have happened
-            # tomorrow, so a future date is a data error, and treating it as ahead would
-            # protect it forever - the guard would entrench exactly what it should surface.
-            today = date.today().isoformat()
-            if current > today:
-                changes.append(
-                    f"{path.stem}: IMPOSSIBLE last_verified {current} is in the future "
-                    f"(today {today}); left alone, but it needs correcting at source"
-                )
-            elif current > stamp:
-                changes.append(
-                    f"{path.stem}: KEPT last_verified {current}, computed {stamp} is older"
-                )
-            elif current != stamp:
-                lines[index] = f"  last_verified: '{stamp}'\n"
-                changes.append(f"{path.stem}: last_verified {current} -> {stamp}")
-        else:
-            anchor = find_key(lines, bounds, "sources")
-            insert_at = anchor if anchor is not None else bounds[1]
-            lines.insert(insert_at, f"  last_verified: '{stamp}'\n")
-            changes.append(f"{path.stem}: last_verified + {stamp}")
-
+    # No `last_verified` write. See the module docstring: the pipeline cannot confirm
+    # every recorded dimension, so it has no date to offer, and every date it has offered
+    # so far was an aggregate of access dates wearing a confirmation's name.
     return lines, changes
 
 
@@ -212,7 +190,6 @@ def main() -> int:
     changed_files: list[Path] = []
     all_changes: list[str] = []
     score_changes: list[str] = []
-    stale_kept: list[str] = []
     unscored: list[str] = []
     pending: dict[Path, list[str]] = {}
 
@@ -226,14 +203,6 @@ def main() -> int:
             unscored.append(f"{slug}: {row.get('scoring_note')}")
             continue
 
-        recorded = yaml.safe_load(path.read_text()) or {}
-        had_verified = bool((recorded.get("openness") or {}).get("last_verified"))
-        if had_verified and not has_date(row.get("last_checked")):
-            stale_kept.append(
-                f"{slug}: carries last_verified but no admitted evidence has a date "
-                f"(unsourced: {row.get('unsourced_dimensions')})"
-            )
-
         new_lines, changes = apply_to_file(path, row)
         if changes:
             pending[path] = new_lines
@@ -242,15 +211,23 @@ def main() -> int:
             score_changes.extend(c for c in changes if "openness.score" in c or "openness.class" in c)
 
     checked = sum(1 for r in rows if has_date(r.get("last_checked")))
-    floored = sum(1 for r in rows if has_date(r.get("freshness_floor")))
     from_dataset = sum(1 for r in rows if r.get("license_tier_grade") == "dataset")
+    # How far automation actually reaches: the winning rule rested entirely on facts read
+    # out of a machine-readable field. Reported because it is the number that has to grow
+    # before this tool could ever write last_verified, and it is NOT sufficient on its own -
+    # a rule can win on license alone while `data` and `code` stay document-grade.
+    all_machine = sum(
+        1 for r in rows
+        if r.get("dims_relied_on") and r.get("dims_from_dataset") == r.get("dims_relied_on")
+    )
 
     print(f"{len(rows)} computed score(s) read from {TABLE}")
-    print(f"  license tier from a machine-readable field : {from_dataset}")
-    print(f"  evidence checked on a known date (last_checked): {checked}")
-    print(f"  every relied-on fact sourced (freshness_floor) : {floored}")
-    print(f"  files this run would change                : {len(changed_files)}")
-    print(f"  openness score or class moved              : {len(score_changes)}")
+    print(f"  license tier from a machine-readable field  : {from_dataset}")
+    print(f"  winning rule rested only on dataset grade   : {all_machine}")
+    print(f"  pipeline last saw evidence on a known date  : {checked}")
+    print(f"  files this run would change                 : {len(changed_files)}")
+    print(f"  openness score or class moved               : {len(score_changes)}")
+    print("  last_verified written                       : 0, always (see the docstring)")
 
     if score_changes:
         print("\nSCORE CHANGES — each one needs a human to look at it:")
@@ -261,12 +238,6 @@ def main() -> int:
         print(f"\n{len(unscored)} product(s) the rubric declined to score:")
         for item in unscored:
             print(f"  - {item}")
-
-    if stale_kept:
-        print(f"\n{len(stale_kept)} product(s) keep a last_verified the pipeline cannot re-earn:")
-        for item in stale_kept:
-            print(f"  - {item}")
-        print("  (left alone on purpose — source the evidence rather than erase the date)")
 
     if args.verbose and all_changes:
         print(f"\nall {len(all_changes)} change(s):")

--- a/docs/guides/freshness.md
+++ b/docs/guides/freshness.md
@@ -72,18 +72,51 @@ product, and takes `--max-age-days` to become a CI gate once enough axes carry a
 `last_verified` that gating would fail on genuine staleness rather than on the
 pre-automation backlog.
 
-## Known divergences, as of 2026-07-29
+## Who may write `last_verified`
 
-Recorded so nobody mistakes the current data for the rule.
+**A person, and only a person.** No tool in this repo writes the field.
 
-- **`build/apply_scores.py` writes `last_verified` from the pipeline's `last_checked`**,
-  which is the max over any admitted evidence. That contradicts the rule twice over: it
-  is derived from access dates, and it takes the newest rather than requiring everything
-  to have been confirmed. Consequences in the data today: 6 axes carry a date newer than
-  some of their own evidence (`deepseek-v3-2`, `deepseek-v4-pro`, `phi-4`, `kimi-k2-6`,
-  `mistral-large-3`, `minimax-m3`), and 4 carry a date that no source in the file was
-  read on, because it came from a signal fetch (`pythia`, `apertus`, `olmo-3`,
-  `lucie-7b`). Both need fixing in `apply_scores`, not by reinterpreting the rule.
-- **`freshness_floor` in `currentai.scores.openness_computed`** is a per-dimension
-  aggregate of access dates. It is the reverted backfill under another name and should
-  be removed rather than refined.
+`build/apply_scores.py` is the only thing allowed to change a score file without
+somebody typing the value, and it writes `openness.score` and `openness.class`
+exclusively. It cannot earn `last_verified`, and the reason is structural rather than a
+matter of current coverage: of the four recorded dimensions only `license` and `weights`
+have a dataset route at all. `signal_routing.yaml` declares `data` research-only, and
+the GitHub code route carries `settles_dimension = false`, so
+`currentai.scores.openness_computed` hardcodes both to document grade. Document grade
+means a human read some prose and wrote it into the score file — so for those two
+dimensions the pipeline is reading the repo back to itself, which confirms nothing.
+
+Since "everything confirmed" can never be true of a pipeline run, there is no date for
+it to write.
+
+## Both earlier divergences, and how they were closed
+
+Kept because the mistake is easy to re-invent, and was, twice.
+
+- **`apply_scores` wrote a derived date into the field.** #108 wrote the freshness bound
+  (MIN `accessed`); #115 replaced it with `last_checked` (MAX over the same dates).
+  Between them they put a derived date on **19 of the 26 axes** that carried one. Six
+  overwrote a date a person had established: `apertus`, `lucie-7b`, `olmo` and `pythia`
+  each lost their #105 verification date to a signal fetch one day later.
+
+  Closed by deleting the writer, and reverting what it had written. Tracing every stored
+  date to the commit that set it put the 26 into three groups: **2** set by hand (#105
+  `rwkv`, #113 `mastra`) and kept; **4** restored to the #105 date the tool had
+  overwritten; **20** removed, because no constituent had ever been hand-confirmed. The
+  20 are 15 the tool wrote outright plus 5 the #121 tier merge carried forward from
+  tool-written release files — a merge confirms nothing, so it cannot originate a date.
+
+  Coverage went 26 → 6 axes, which is the honest number: six axes have actually been
+  checked by somebody. The other 20 fall back to their commit date, correctly labeled
+  `commit` rather than `verified`.
+
+  Restoring rather than keeping was the right call because these were never confirmation
+  records. The rule that a stored date is never moved backwards protects a person's
+  observation; it does not protect a tool's arithmetic.
+- **`freshness_floor`** was a per-dimension aggregate of access dates — the reverted
+  backfill under another name. Removed from the model rather than refined.
+
+Where a tier had absorbed several release-level products, the restored date is the
+**oldest** constituent confirmation, because the tier's score covers all of them and one
+stale member bounds the whole thing. That is an aggregate over confirmations, not over
+readings, so it is consistent with the rule above.

--- a/sources/scores/alia-40b.yaml
+++ b/sources/scores/alia-40b.yaml
@@ -11,7 +11,6 @@ openness:
     documented (60+ named sources) rather than released or reconstructable. That missing open-data component
     is the bright line that keeps it at open_weights (4) rather than the OLMo/Pythia/Apertus open_source
     (5) tier, where Apertus reaches 5 by shipping data-reconstruction scripts. No intermediate checkpoints.'
-  last_verified: '2026-06-26'
   sources:
   - url: https://huggingface.co/BSC-LT/ALIA-40b
     shows: Apache-2.0 license; downloadable safetensors weights; 40.4B params; 9.37T training tokens; corpus

--- a/sources/scores/apertus.yaml
+++ b/sources/scores/apertus.yaml
@@ -11,7 +11,7 @@ openness:
     code/recipe, intermediate checkpoints, a technical report (arXiv 2509.14233), and EU AI Act + Swiss
     data-protection/copyright compliance docs. All Apache-2.0. Sits in the OLMo/Pythia full-openness
     tier.'
-  last_verified: '2026-07-29'
+  last_verified: '2026-07-28'
   sources:
   - url: https://api.github.com/repos/swiss-ai/pretrain-data
     shows: Repository resolves 200. Pretraining-data reconstruction scripts are published, satisfying data:open by reconstruction.

--- a/sources/scores/claude-fable.yaml
+++ b/sources/scores/claude-fable.yaml
@@ -7,7 +7,6 @@ openness:
   note: 'No weights, data or code released. Served through the Anthropic API only, so 1/closed on every dimension.
     Recorded here rather than in base_pretrained because a closed model has no observable base checkpoint to score,
     which is the convention #114 settled.'
-  last_verified: '2026-06-11'
   sources:
   - url: https://www.anthropic.com/news/claude-fable-5-mythos-5
     shows: Mythos-class flagship, proprietary, claude-fable-5 via API and cloud marketplaces only

--- a/sources/scores/deepseek.yaml
+++ b/sources/scores/deepseek.yaml
@@ -10,7 +10,6 @@ openness:
     retired deepseek-v3-base record carried a compound `code MIT + model DeepSeek-Model-License`, and whether that
     license''s acceptable-use restrictions count as use-restricting is open in issue #117. The tier does not depend
     on that ruling. Adoption 5 is carried from V3.2, the most downloaded release.'
-  last_verified: '2026-07-29'
   sources:
   - url: https://huggingface.co/api/models/deepseek-ai/DeepSeek-V4-Pro
     shows: license mit, ungated, 864.8GB of weight files, 1,635,092 downloads last month

--- a/sources/scores/ernie.yaml
+++ b/sources/scores/ernie.yaml
@@ -6,7 +6,6 @@ openness:
     open, 5.x flagship closed)
   confidence: high
   note: No weights distributed for the 5.x flagship; closed API model.
-  last_verified: '2026-06-18'
   sources:
   - url: https://huggingface.co/baidu
     shows: Baidu HF org lists only ERNIE 4.5 + Image open, no 5.x weights

--- a/sources/scores/gemma.yaml
+++ b/sources/scores/gemma.yaml
@@ -10,7 +10,6 @@ openness:
     the Hub on 2026-07-29. The current release governs, so a family that becomes more open is recorded as such rather
     than pinned to its worst historical release. Adoption 5 is carried from Gemma 2, which still out-downloads Gemma
     4.'
-  last_verified: '2026-07-29'
   sources:
   - url: https://ai.google.dev/gemma/docs/releases
     shows: Gemma 4 sizes, release dates, Apache-2.0 license

--- a/sources/scores/glm.yaml
+++ b/sources/scores/glm.yaml
@@ -8,7 +8,6 @@ openness:
     through the family: GLM-4 and GLM-4-9B carried the GLM-4 License, which requires commercial-use registration
     and a ''Built with GLM'' attribution and scored 2, while GLM-4.6, GLM-5.1 and GLM-5.2 are plain MIT. GLM-5.2
     governs as the current release. Capability 5 comes from the GLM-5 line; the GLM-4 line scored 2.'
-  last_verified: '2026-07-29'
   sources:
   - url: https://huggingface.co/zai-org/GLM-5.2/blob/main/LICENSE
     shows: MIT, (c) Zhipu AI 2026

--- a/sources/scores/gpt-4o.yaml
+++ b/sources/scores/gpt-4o.yaml
@@ -6,7 +6,6 @@ openness:
   confidence: high
   note: No downloadable weights; API/ChatGPT-only, like the GPT-5 anchor (O1 closed). Confirmed API-only
     with 128K context and Oct 2023 cutoff on OpenAI docs 2026-06-04.
-  last_verified: '2026-06-04'
   sources:
   - url: https://developers.openai.com/api/docs/models/gpt-4o
     shows: GPT-4o API-only model, 128K context, text+image input, no open weights, Oct 2023 cutoff

--- a/sources/scores/grok.yaml
+++ b/sources/scores/grok.yaml
@@ -7,7 +7,6 @@ openness:
   note: Proprietary, served through the xAI API, grok.com and X, with no downloadable weights, so 1/closed. Grok
     4.20 governs and contributes capability 4; adoption 3 is carried from Grok 3, which had wider reach. The bare
     `grok` slug names this model line - the consumer chat app is a separate product recorded as grok-app.
-  last_verified: '2026-07-28'
   sources:
   - url: https://docs.x.ai/developers/release-notes
     shows: xAI release notes record "Grok 4.20 and Grok 4.20 Multi-agent are live" and point at the API docs; no

--- a/sources/scores/inflection.yaml
+++ b/sources/scores/inflection.yaml
@@ -6,7 +6,6 @@ openness:
   confidence: high
   note: Closed proprietary models via API + enterprise licensing; no downloadable weights; fine-tuned models are
     the customer's alone. Confirmed via primary Intel Newsroom press release (2026-06-04).
-  last_verified: '2026-06-04'
   sources:
   - url: https://www.maginative.com/article/inflection-ai-unveils-enterprise-offering-with-new-inflection-3-0-models-2/
     shows: Inflection 3.0 (Pi + Productivity), enterprise/API, proprietary (aggregator source)

--- a/sources/scores/inkling.yaml
+++ b/sources/scores/inkling.yaml
@@ -9,7 +9,6 @@ openness:
   note: Apache-2.0 weights are OSI-licensed, but training data and full training code are withheld —
     open_weights / 3, not open_source / 5. Press often calls this 'open source' because of the license
     tag; our spectrum requires open data + code for class open_source.
-  last_verified: '2026-07-29'
   sources:
   - url: https://huggingface.co/thinkingmachines/Inkling
     shows: Apache-2.0 license tag; 975B/41B MoE; weights downloadable; model card states data from public,

--- a/sources/scores/internlm.yaml
+++ b/sources/scores/internlm.yaml
@@ -9,7 +9,6 @@ openness:
   note: Code is OSI (Apache-2.0) but the weights license is a custom non-OSI 'Free Commercial License' requiring
     a commercial-license application form (HF card confirms form link, 2026-06-04), so open_weights not open_source;
     flagged for the non-OSI weights term.
-  last_verified: '2026-07-29'
   sources:
   - url: https://huggingface.co/internlm/internlm2_5-7b
     shows: 'model card: code Apache-2.0; weights fully open for academic research and free commercial usage via

--- a/sources/scores/kimi.yaml
+++ b/sources/scores/kimi.yaml
@@ -11,7 +11,6 @@ openness:
     is recorded as `assumed-Modified-MIT` by continuity with K2.x rather than confirmed against a published file.
     K2.6''s Modified-MIT is confirmed, so the tier''s openness firms up as soon as K3''s terms are read directly.
     Adoption 4 is carried from K2.6.'
-  last_verified: '2026-07-29'
   sources:
   - url: https://www.kimi.com/blog/kimi-k3
     shows: primary announcement — 2.8T MoE, 1M context, native vision; API live; full weights by 2026-07-27

--- a/sources/scores/lucie-7b.yaml
+++ b/sources/scores/lucie-7b.yaml
@@ -8,7 +8,7 @@ openness:
   note: 'Full open-source tier alongside OLMo / Apertus: open weights, open training data, open training
     code, intermediate checkpoints. Authors position Lucie as OSI-definition-compliant for open-source AI.
     Training-dataset product deferred — artifacts cited here for openness only.'
-  last_verified: '2026-07-29'
+  last_verified: '2026-07-28'
   sources:
   - url: https://huggingface.co/api/datasets/OpenLLM-France/Lucie-Training-Dataset
     shows: Public, ungated dataset repo present on the Hub; 3,101 downloads. Corpus is published, not merely described.

--- a/sources/scores/marin.yaml
+++ b/sources/scores/marin.yaml
@@ -6,7 +6,6 @@ openness:
   confidence: high
   note: 'Stanford CRFM ''open lab'': Apache-2.0 weights plus documented code, data, experiments, hyperparameters
     and training logs, with bit-for-bit reproducible training.'
-  last_verified: '2026-07-29'
   sources:
   - url: http://marin.community/blog/2025/05/19/announcement/
     shows: 'Marin open lab: code, data, experiments, logs all shared'

--- a/sources/scores/mimo-pro.yaml
+++ b/sources/scores/mimo-pro.yaml
@@ -5,7 +5,6 @@ openness:
   components: weights:open(MIT per HF card);data:closed;code:open;license:MIT(HF card; older GitHub repo shows Apache-2.0)
   confidence: medium
   note: Open weights under a permissive license (MIT per the model card); no open training data -> open_weights.
-  last_verified: '2026-07-29'
   sources:
   - url: https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro
     shows: MIT, 1.02T/42B MoE, 1M context, benchmarks

--- a/sources/scores/minimax.yaml
+++ b/sources/scores/minimax.yaml
@@ -9,7 +9,6 @@ openness:
     the current release. Capability 5 is carried from M2.5 because M3 records no capability score at all, so the
     tier's capability describes the older release and should be re-read when M3 is benchmarked - it is the one axis
     here not sourced to the governing release.
-  last_verified: '2026-06-23'
   sources:
   - url: https://huggingface.co/api/models/MiniMaxAI/MiniMax-M3
     shows: Public ungated weights repo (safetensors/MoE), license=minimax-community, created 2026-06-02

--- a/sources/scores/mistral-large.yaml
+++ b/sources/scores/mistral-large.yaml
@@ -8,7 +8,6 @@ openness:
     2 shipped under the Mistral Research License, which permits research and non-commercial use only and scored
     2, and Large 3 is Apache-2.0. Large 3 governs, so the tier records the relicensing rather than the family''s
     worst historical terms.'
-  last_verified: '2026-07-29'
   sources:
   - url: https://huggingface.co/api/models/mistralai/Mistral-Large-3-675B-Base-2512
     shows: license apache-2.0, ungated, 1,352.0GB of weight files; the base checkpoint, distinct from the -Instruct-2512

--- a/sources/scores/olmo.yaml
+++ b/sources/scores/olmo.yaml
@@ -6,7 +6,7 @@ openness:
   confidence: high
   note: 'Fully open: Apache-2.0 weights + the complete Dolma 3 corpus + training code + intermediate checkpoints.
     The reference fully-open model line.'
-  last_verified: '2026-07-29'
+  last_verified: '2026-07-28'
   sources:
   - url: https://huggingface.co/api/datasets/allenai/dolma
     shows: Public, ungated dataset repo present on the Hub; 3,052 downloads. Dolma corpus is published.

--- a/sources/scores/phi.yaml
+++ b/sources/scores/phi.yaml
@@ -8,7 +8,6 @@ openness:
     the training pipeline is published - Microsoft describes the synthetic data mix without releasing it. So 3/open_weights:
     the artifact is free to use and the recipe is not reproducible. Reaching 4 or 5 would need the data or the pipeline,
     not a more permissive license.'
-  last_verified: '2026-07-29'
   sources:
   - url: https://huggingface.co/api/models/microsoft/phi-4
     shows: license mit, ungated, 29.3GB of weight files, 712,912 downloads last month

--- a/sources/scores/pythia.yaml
+++ b/sources/scores/pythia.yaml
@@ -10,7 +10,7 @@ openness:
     GitHub, and 154 intermediate checkpoints per model size. Every dimension the rubric asks about is answered by
     something downloadable, which is what separates 5 from the open-weights tier: the run is reproducible, not merely
     the model usable.'
-  last_verified: '2026-07-29'
+  last_verified: '2026-07-28'
   sources:
   - url: https://huggingface.co/api/datasets/EleutherAI/pile
     shows: Public, ungated dataset repo present on the Hub; 2,441 downloads. The Pile is published.

--- a/sources/scores/reka-core.yaml
+++ b/sources/scores/reka-core.yaml
@@ -7,7 +7,6 @@ openness:
   confidence: high
   note: Proprietary multimodal model; API/on-prem/on-device deployment but no downloadable weights. Confirmed
     on launch page.
-  last_verified: '2026-06-04'
   sources:
   - url: https://reka.ai/news/reka-core-our-frontier-class-multimodal-language-model
     shows: Reka Core via API/on-prem/on-device, proprietary, no open weights

--- a/sources/scores/smollm.yaml
+++ b/sources/scores/smollm.yaml
@@ -7,7 +7,6 @@ openness:
   confidence: high
   note: 'Fully-open small-model line: Apache-2.0 weights with the complete engineering blueprint (architecture,
     data mixtures, training and post-training recipe) published.'
-  last_verified: '2026-07-29'
   sources:
   - url: https://huggingface.co/blog/smollm3
     shows: 'fully-open 3B: 11T tokens, 128K context, multilingual, full recipe published'

--- a/sources/scores/yi.yaml
+++ b/sources/scores/yi.yaml
@@ -7,7 +7,6 @@ openness:
   confidence: high
   note: Permissive Apache-2.0 weights but training data and full training code are not released, so open_weights
     not open_source. Apache-2.0 confirmed on HF base cards 2026-06-04.
-  last_verified: '2026-07-29'
   sources:
   - url: https://huggingface.co/01-ai/Yi-1.5-34B
     shows: Apache-2.0 license, 34B base model (base vs chat variants listed), downloadable weights

--- a/tests/test_apply_scores.py
+++ b/tests/test_apply_scores.py
@@ -1,0 +1,132 @@
+"""Tests for the one tool that writes into `sources/scores/`.
+
+`build/apply_scores.py` is the only thing allowed to change a score file without a
+person typing the value, which makes what it will NOT touch as much a part of its
+contract as what it will.
+
+The regression these pin is not hypothetical. Two separate releases taught the tool to
+write `openness.last_verified` from an aggregate of source access dates — #108 the MIN,
+#115 the MAX — and between them they put a derived date on 19 of the 26 axes that
+carried one, in six cases overwriting a date a person had established by checking. The
+normative rule is in `docs/guides/freshness.md`: `last_verified` is a human's
+confirmation that everything in the score is still correct, and no aggregation of
+readings produces it.
+
+So the first test asserts an absence, deliberately. It fails the moment anyone
+reintroduces the write, whatever aggregate they reach for and however plausible the
+column name.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from build.apply_scores import apply_to_file, block_bounds, find_key, has_date
+
+SCORE = """\
+product: demo
+openness:
+  score: 3
+  class: open_weights
+  components: weights:open;data:closed;code:partial;license:Apache-2.0
+  confidence: high
+  note: A demo product.
+  last_verified: '2026-06-01'
+  sources:
+  - url: https://example.invalid/model
+    shows: Apache-2.0 in the model card
+    accessed: '2026-07-29'
+adoption:
+  level: 3
+"""
+
+
+def write(tmp_path: Path, text: str = SCORE) -> Path:
+    path = tmp_path / "demo.yaml"
+    path.write_text(text)
+    return path
+
+
+@pytest.mark.parametrize(
+    "computed",
+    [
+        {"openness_score": 3, "openness_class": "open_weights", "last_checked": "2026-07-29"},
+        # The shapes the two regressions actually arrived in.
+        {"openness_score": 3, "openness_class": "open_weights", "freshness_floor": "2026-07-29"},
+        {"openness_score": 3, "openness_class": "open_weights", "last_checked": "2026-12-31"},
+    ],
+)
+def test_never_writes_last_verified(tmp_path, computed):
+    """No computed date, under any column name, may reach the file."""
+    path = write(tmp_path)
+    new_lines, changes = apply_to_file(path, computed)
+    assert "".join(new_lines).count("last_verified") == 1, "must not add a second one"
+    assert "  last_verified: '2026-06-01'\n" in new_lines, "the human's date is untouched"
+    assert not any("last_verified" in c for c in changes), f"reported a date change: {changes}"
+
+
+def test_does_not_add_last_verified_to_a_file_without_one():
+    """The earlier writer INSERTED the key before `sources:`. That must not happen."""
+    text = SCORE.replace("  last_verified: '2026-06-01'\n", "")
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        path = write(Path(tmp), text)
+        new_lines, _ = apply_to_file(
+            path, {"openness_score": 3, "openness_class": "open_weights",
+                   "last_checked": "2026-07-29"}
+        )
+        assert "last_verified" not in "".join(new_lines)
+
+
+def test_writes_score_and_class_when_they_move(tmp_path):
+    """The half of the contract that is a write, so the absence tests cannot pass vacuously."""
+    path = write(tmp_path)
+    new_lines, changes = apply_to_file(
+        path, {"openness_score": 2, "openness_class": "restricted"}
+    )
+    joined = "".join(new_lines)
+    assert "  score: 2\n" in joined and "  class: restricted\n" in joined
+    assert len(changes) == 2, changes
+
+
+def test_leaves_human_prose_alone(tmp_path):
+    """note, components, confidence and sources are human judgment."""
+    path = write(tmp_path)
+    new_lines, _ = apply_to_file(
+        path, {"openness_score": 2, "openness_class": "restricted",
+               "last_checked": "2026-07-29"}
+    )
+    joined = "".join(new_lines)
+    for line in ("  note: A demo product.\n",
+                 "  components: weights:open;data:closed;code:partial;license:Apache-2.0\n",
+                 "  confidence: high\n",
+                 "    accessed: '2026-07-29'\n"):
+        assert line in joined, f"rewrote {line.strip()!r}"
+
+
+def test_null_score_changes_nothing(tmp_path):
+    """A product the rubric declined to score must not be edited toward a guess."""
+    path = write(tmp_path)
+    new_lines, changes = apply_to_file(path, {"openness_score": None, "openness_class": None})
+    assert "".join(new_lines) == SCORE and not changes
+
+
+def test_find_key_ignores_deeper_indentation(tmp_path):
+    """`accessed` sits under a sources entry; a nested key is a different key."""
+    lines = SCORE.splitlines(keepends=True)
+    bounds = block_bounds(lines, "openness")
+    assert bounds is not None
+    assert find_key(lines, bounds, "accessed") is None
+    assert find_key(lines, bounds, "score") is not None
+
+
+@pytest.mark.parametrize("value,expected", [
+    (None, False), ("", False), ("NaT", False), ("nan", False), ("None", False),
+    ("2026-07-29", True),
+])
+def test_has_date_rejects_the_dataframe_nulls(value, expected):
+    """A null DATE arrives as NaT or nan depending on dtype, and both pass `is not None`."""
+    assert has_date(value) is expected


### PR DESCRIPTION
## What this fixes

`docs/guides/freshness.md` is normative: **`last_verified` is the most recent date on
which everything in the score was confirmed still correct.** `apply_scores` was writing
it from `last_checked`, the MAX over source access dates. That breaks the rule twice —
derived from readings rather than confirmations, and newest-wins rather than
everything-confirmed.

## Why the pipeline can never write this field

Not "cannot yet". Cannot, structurally. Of the four recorded openness dimensions only
`license` and `weights` have a dataset route. `signal_routing.yaml` declares `data`
research-only and the GitHub code route carries `settles_dimension = false`, so
`currentai.scores.openness_computed` hardcodes both to document grade — meaning a human
read some prose and wrote it into the score file. For those two dimensions the pipeline
is reading the repo back to itself, which confirms nothing.

So the writer is gone rather than tightened. A guarded write-when-fully-confirmed branch
could never fire, and a branch that cannot fire reads as working code.

## What happened to the 26 stored dates

Every one was traced to the commit that set its current value, which splits them three
ways:

| | n | action |
|---|---|---|
| set by hand | 2 | kept — `rwkv` (#105), `mastra` (#113) |
| tool-written over a human date | 4 | restored to the #105 date |
| never hand-confirmed | 20 | removed |

The 20 are 15 the tool wrote outright, plus 5 the #121 tier merge carried forward from
tool-written release files. A merge confirms nothing, so it cannot originate a date.

The four restorations are the ones worth looking at, because each lost a real
confirmation to a signal fetch one day later:

```
apertus    2026-07-29 -> 2026-07-28
lucie-7b   2026-07-29 -> 2026-07-28
olmo       2026-07-29 -> 2026-07-28
pythia     2026-07-29 -> 2026-07-28
```

**Coverage goes 26 → 6 axes of 1410.** That is the honest number: six axes have actually
been checked by a person. The other 20 now fall back to their commit date, which
`check_freshness` labels `commit` rather than `verified`, so the weaker claim is visible
as weaker. Report-level medians are unchanged (35d median, 50d oldest) because the
fallback was already doing this work.

Removing rather than keeping was the call because these were never confirmation records.
The rule that a stored date is never moved backwards protects a person's observation; it
does not protect a tool's arithmetic.

## `freshness_floor` is gone

`currentai.scores.openness_computed` revision 8 drops it. It was a MIN over the same
access dates — the backfill #102 reverted, under another name — and its only consumer
was the write this PR removes. The `last_checked` column stays, as a diagnostic, with its
description rewritten to say it must never be written into a score file.

## Test plan

- `tests/test_apply_scores.py`, new: asserts the **absence**, parameterized over the
  three shapes the regression has actually arrived in (`last_checked`, `freshness_floor`,
  a future date). Two separate releases have now taught this tool to write a derived
  date, so the absence needs a test that fails on the third attempt.
- 148 tests pass (was 134).
- `build.validate` → 0 errors.
- `marimo check` on the regenerated notebook → clean.
- `currentai.scores.openness_computed` rev 8 released and materialized: 65 rows, 0 null
  scores, and `freshness_floor` no longer resolves. Rev 10 (released) is the same logic
  with a corrected header comment.

  Worth knowing for the next model change: **a run materializes the latest RELEASED
  revision, not the latest revision.** Creating a revision changes nothing until
  `createDataModelRelease` points at it. Three runs went into concluding that dropping a
  column had broken materialization, when the runs were still executing the previous
  release and the new SQL had never executed at all.

Closes the two divergences that `docs/guides/freshness.md` recorded on 2026-07-29.
