### PR TITLE
Verification: enforcement design, gates, and the runbook to auditable scores

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,11 @@ sources/taxonomy.yaml  Arc grouping + cross-category display order
 sources/signal_routing.yaml  Which machine signal is authoritative per dimension, and
                        which values mean "this source has no answer" (abstain_values)
 sources/evidence_policy.yaml  When an observation is admissible as evidence
+sources/rubrics/       Shared scoring ladders. A category inherits one with
+                       `scoring_recipe: {extends: <name>}` rather than copying it;
+                       build/rubrics.py resolves that. license-to-tier lives here,
+                       because whether AGPL is `osi` is a fact about AGPL, not
+                       about one category.
 warehouse/models/      UDM SQL (entities, events, metrics, scores)
 warehouse/ingest/      Python fetchers that write CSVs to warehouse/catalog/
 warehouse/catalog/     Raw external CSVs (HF benchmarks, incidents, GitHub orgs)
@@ -29,7 +34,7 @@ warehouse/sources.yaml Manifest: each external source declares EITHER a fetcher
 build/                 Python pipeline, see below
 notebooks/             Generated ai-stack-map.py and standalone companion notebooks (pypi-geo-trends, oss-ai-trends, long-tail-explorer)
 docs/methodology.md    Canonical methodology copy, rendered into the notebook (a build input)
-docs/guides/           Query conventions and notebook style guide
+docs/guides/           Query conventions, notebook style, freshness and verification
 docs/runbooks/         Maintainer deploy runbooks
 docs/schemas/          JSON Schemas for the source files (four concerns + taxonomy)
 skills/                Agent skills for common editor workflows
@@ -53,7 +58,10 @@ Config bridge out   serialize_registry.py  identity: what exists
                     publish_registry.py    pushes both table sets to OSO as static models
 
 Scores back in      apply_scores.py   reads computed scores from OSO, writes
-                                      sources/scores/. The ONLY inbound data path.
+                                      openness.score and openness.class into
+                                      sources/scores/ and nothing else. The ONLY
+                                      inbound data path. It writes no dates -- see
+                                      docs/guides/verification.md.
 
 Checkers (CI)       check_rubric.py    does the rubric reproduce the hand-authored scores
                     check_routing.py   which dimensions have a usable machine signal
@@ -142,10 +150,15 @@ Three rules worth knowing before editing any of it:
 - **Declare a rule once.** Abstention values live on the route in `signal_routing.yaml`,
   admission policy in `evidence_policy.yaml`, the formula in the category's
   `scoring_recipe`. The warehouse hardcodes none of them; it reads them across the bridge.
-- **`apply_scores` never invents a date.** `last_verified` is the oldest accessed date among
-  the evidence a score depends on, and absent if any of that evidence cites nothing
-  specific. Nothing stamps the current date, so a recompute cannot make stale evidence look
-  freshly checked.
+- **`apply_scores` writes no date at all.** It writes `openness.score` and
+  `openness.class`, and that is the whole list. `last_verified` means a person or an agent
+  re-read the cited sources and re-derived the value; this pipeline reads values back out of
+  `sources/scores/`, which confirms nothing. Two releases taught it to write the field from
+  an aggregate of `sources[].accessed` anyway — #108 the MIN, #115 the MAX — and between
+  them they put a derived date on 19 of the 26 axes that carried one. **Do not reintroduce
+  it**, under any aggregation or column name; `tests/test_apply_scores.py` asserts the
+  absence. The rule is in `docs/guides/freshness.md`, who may write it in
+  `docs/guides/verification.md`.
 
 `notebooks/pypi-geo-trends.py`, `notebooks/oss-ai-trends.py`, and `notebooks/long-tail-explorer.py`
 are **fully standalone**: no build-pipeline coupling, no generated payload. Each queries

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,6 +209,9 @@ and walk through validation + preview steps.
 
 After a PR merges, a maintainer (OSO MCP write access) may need to:
 
+- `docs/runbooks/verification-pass.md`: the plan for getting every score auditable --
+  gates first, then coverage, then the re-read pass. Start here for score-verification
+  work; it names the failure modes each step is guarding against.
 - `docs/runbooks/deploy-udms.md`: revise, release, and run UDM SQL changes.
 - `docs/runbooks/refresh-data.md`: run fetchers and reload static models.
 - `docs/runbooks/publish-notebook.md`: serialize, render, upload, and publish the live

--- a/docs/guides/freshness.md
+++ b/docs/guides/freshness.md
@@ -6,6 +6,9 @@ look like they answer it but do not.
 > This is the data-consumer / query reference, and it is normative. For the
 > reader-facing methodology see `docs/methodology.md`. When the rule below changes,
 > change it here first and make the code follow.
+>
+> This guide defines what `last_verified` MEANS. For who may write one, how an axis earns
+> it, and the plan for populating every axis, see `docs/guides/verification.md`.
 
 ## The rule
 

--- a/docs/guides/verification.md
+++ b/docs/guides/verification.md
@@ -38,6 +38,120 @@ No tool that computes over already-recorded values. `build/apply_scores.py` writ
 `openness.score` and `openness.class` and deliberately writes no date at all; the reasoning
 is in its module docstring and in the divergence history in `freshness.md`.
 
+## The audit chain, and where it currently breaks
+
+For a score to be auditable, a reader must be able to walk it back to something outside the
+repo:
+
+```
+score  <-  the rule that fired      (category scoring_recipe)
+       <-  the dimension values     (openness.components)
+       <-  the evidence             (openness.sources[].shows)
+       <-  a source                 (openness.sources[].url)
+```
+
+Three of those four links hold today. **The third does not.** `sources` is a flat list per
+axis, so nothing records WHICH source establishes WHICH dimension. Measured on 2026-07-30:
+324 of 470 openness axes cite exactly one source, asserted to establish `weights`, `data`,
+`code` and `license` together. A reader cannot check that, and neither can a tool.
+
+That is the gap that makes a re-check unfalsifiable, and closing it is what makes everything
+below possible.
+
+### `establishes`: per-dimension attribution
+
+A source item gains an optional list naming the dimensions it settles:
+
+```yaml
+sources:
+- url: https://huggingface.co/org/model
+  shows: Apache-2.0 in the model card; safetensors weights downloadable
+  accessed: '2026-07-30'
+  establishes: [license, weights]
+- url: https://github.com/org/model
+  shows: pretraining configs and data-prep scripts in the repo
+  accessed: '2026-07-30'
+  establishes: [code, data]
+```
+
+Optional and forward-populated, so existing data is not retroactively invalid. The re-check
+tooling writes it; the gates below apply only to axes that claim a confirmation.
+
+### The invariant that makes a rubber stamp fail
+
+> **`last_verified: D` is valid only if, for every dimension the score records, at least one
+> source that `establishes` that dimension has `accessed >= D`.**
+
+This is the mechanism, not a convention. Claiming a confirmation you did not perform now
+requires also back-dating the `accessed` field of every dimension's source — and those are
+what the content check below verifies.
+
+**This validates a claimed date. It never derives one.** The distinction is the whole point
+and it is easy to erode: someone will eventually notice that the invariant mentions
+`accessed` and "simplify" it into `last_verified = max(accessed)`, which is #115 exactly.
+Deriving the date asserts a confirmation nobody made; validating it rejects a confirmation
+nobody could have made. `freshness.md` forbids the first and requires the second.
+
+Note the aggregation direction, which is also load-bearing: the check is over EVERY recorded
+dimension, so the binding constraint is the *least* recently re-read one. `max(accessed)`
+across an axis would pass an axis where one dimension was re-read today and three were last
+seen in June.
+
+### Catching fabrication rather than just inconsistency
+
+The invariant catches unsupported dates. It cannot catch a source that never said what
+`shows` claims, or a URL that never existed. For that, the re-check tool records what it
+actually fetched:
+
+```yaml
+- url: https://…
+  accessed: '2026-07-30'
+  http_status: 200
+  content_sha256: 3f9a…          # of the fetched body at accessed time
+```
+
+A digest makes two later audits possible: a URL that 404s at re-check time was either never
+real or has rotted, and a changed digest tells you the page moved under a claim that still
+cites it. Neither is a hard failure on its own — pages legitimately change — but both are
+reasons to re-check, and a *missing* digest on a newly claimed confirmation is a hard
+failure, because it means the tool did not fetch anything.
+
+## The gates, and why they ratchet
+
+Every failure mode this project has actually hit gets a mechanism, not a note. Cheap ones
+gate every PR; ones needing the network run periodically.
+
+| # | failure mode | mechanism | cost |
+|---|---|---|---|
+| G1 | a confirmation with no supporting evidence | the invariant above | free |
+| G2 | a claimed date with no fetch digest | required on axes claiming a confirmation | free |
+| G3 | an impossible score/class pair | the pair must be producible by some rule in the recipe | free |
+| G4 | fabricated or rotted sources | sampled re-fetch, digest and `shows` token match | network, weekly |
+| G5 | repo and warehouse drifting apart | per-product differential after every publish | network, per publish |
+| G6 | a UDM revision that was never released | assert latest revision == latest release | network, per publish |
+
+**They ratchet rather than switch on.** G1 and G2 apply only to axes that carry a
+`last_verified`, which is 6 today and grows as the re-read pass proceeds. So the gate covers
+exactly what has been done, never blocks progress, and never permits a regression on ground
+already taken. A big-bang gate over all 1386 axes would fail on day one and get switched
+off, which is how gates die.
+
+G3, G5 and G6 apply in full immediately — nothing has to be populated first. G3 already has
+a known catch: `vellum` and `whylabs` are recorded `4 / open_source`, a pair no ladder here
+can produce.
+
+### Two shared utilities, so the mechanism cannot be bypassed
+
+- **`build/components.py`** — the only supported way to edit a `components` field. The
+  block-safe rewriter with the reparse assertion, extracted. 21 of deployment's 27 files
+  fold that scalar across lines, so any hand-rolled `^  components: (.*)$` substitution
+  splices keys mid-string and corrupts the value silently. A shared helper means the next
+  script cannot re-invent that.
+- **A query helper that forces a cache-busting nonce.** Warehouse results cache on query
+  TEXT, so a fixed verification query returns its first answer forever and a tool reading
+  through that cache reports success against stale data. It has already happened. The nonce
+  belongs in the helper, not in each caller's discipline.
+
 ## Why openness can never be fully automated
 
 By design, not for want of coverage. Of the recorded openness dimensions only `license` and
@@ -149,6 +263,8 @@ staleness.
 
 ## Related
 
+- `docs/runbooks/verification-pass.md` — the executable plan: gate order, commands, exit
+  criteria per phase, and the standing-hazards table
 - `docs/guides/freshness.md` — what `last_verified` means, and the two divergences already
   closed
 - `docs/guides/openness-spectrum.md` — the openness ladders themselves

--- a/docs/guides/verification.md
+++ b/docs/guides/verification.md
@@ -1,0 +1,156 @@
+# Verification Guide
+
+How a score earns a `last_verified` date, and the plan for getting one onto every axis.
+
+> Companion to `docs/guides/freshness.md`, which defines what `last_verified` *means*.
+> This guide covers who may write one and how. Both are normative. When either changes,
+> change the guide first and make the code follow.
+
+## How an axis earns its date
+
+**An axis earns `last_verified` when someone re-read its cited sources and re-derived its
+value.** Not when a tool aggregated dates. Not when a value was copied forward.
+
+Three consequences, and no other reading is intended:
+
+1. **A re-check must be evidence-producing.** It records what was read and what that
+   source showed, the way `sources[].shows` already does. A date that cannot be traced to
+   a fresh observation is indistinguishable from a rubber stamp, and we have twice shipped
+   the rubber stamp by accident (#108, #115).
+2. **An agent re-reading a cited URL is a confirmation. The pipeline reading recorded
+   values is not.** This is the distinction the whole plan below rests on, so it is worth
+   stating precisely. When an agent fetches `https://…/model-card` and re-derives that the
+   license is Apache-2.0, something outside the repo was consulted and the conclusion was
+   re-established. When `apply_scores` reads `license:Apache-2.0` out of
+   `sources/scores/foo.yaml`, computes on it, and writes a date back, the repo has been
+   read to itself and nothing was confirmed.
+
+   Who performed the re-check is not the test — re-derivability is. The first pass of
+   `sources/scores/` was agent-authored, so authorship never established trust here and
+   does not now. See the grading rule in `AGENTS.md`.
+3. **A re-check that changes nothing still earns the date.** Confirming a value is
+   unchanged is the normal outcome and the main point. Only recording the ones that moved
+   would make the field a change log rather than a freshness measure.
+
+### What may never write it
+
+No tool that computes over already-recorded values. `build/apply_scores.py` writes
+`openness.score` and `openness.class` and deliberately writes no date at all; the reasoning
+is in its module docstring and in the divergence history in `freshness.md`.
+
+## Why openness can never be fully automated
+
+By design, not for want of coverage. Of the recorded openness dimensions only `license` and
+`weights` have a dataset route. `signal_routing.yaml` declares `data` research-only, and the
+GitHub code route carries `settles_dimension: false` because a live repo establishes neither
+a full training pipeline nor an ungated core. For software categories, `core_gated` needs a
+pricing page read.
+
+So every openness axis needs at least one read, permanently. Adoption and capability are
+different in kind and can be automated — see the table below.
+
+## Current state, 2026-07-30
+
+| | count |
+|---|---|
+| axes total (470 products × 3) | 1410 |
+| deliberately null — capability on datasets and a wire protocol, not claims | 24 |
+| **real claims to verify** | **1386** |
+| of those, citing at least one source URL | 1386 |
+| carrying a real `last_verified` | 6 (once #124 lands; 26 before it, 19 of them tool-written) |
+| distinct source URLs behind all of it | 1099 (450 cited more than once) |
+
+Every real claim already cites a source. The work is not finding evidence; it is re-reading
+what is cited. And the re-read surface is 1099 fetches, not 1386, because sources are shared.
+
+### What automation can and cannot earn, per axis
+
+| axis | axes | all sources signal-backed | can a fetch earn the date? |
+|---|---|---|---|
+| adoption | 470 | 204 (+68 partial) | **Yes** — the score IS a banded signal, so re-fetching re-derives it |
+| capability | 446 | 198 (+55 partial) | **Yes where a benchmark row exists**; feature and internal-eval judgments need a read |
+| openness | 470 | 272 (+86 partial) | **Never fully** — see above |
+
+"Signal-backed" means every source the axis cites is on a host a fetcher already re-derives
+automatically: the HF hub, GitHub, PyPI, LMArena, Artificial Analysis, OpenRouter.
+
+## The plan, in order
+
+The order matters more than usual here, because two of the steps get cheaper by waiting and
+one gets done twice if rushed.
+
+### 1. Finish the recipes — 16/16 categories, 470/470 products
+
+111 products across four categories still have no `scoring_recipe`:
+
+| category | n | product type |
+|---|---|---|
+| `benchmark_eval_data` | 27 | dataset |
+| `training_synthetic_datasets` | 38 | dataset |
+| `edge_hardware` | 20 | hardware |
+| `safeguards` | 26 | **mixed** — 9 model, 17 software |
+
+**Do this before step 2.** Step 2 generalizes the scoring SQL off its hardcoded model
+dimensions, and that generalization should be driven by the complete dimension vocabulary.
+Generalize it now for software alone and it gets redone when `dataset` and `hardware` arrive
+with dimensions of their own.
+
+Two of the four are cheap: one dataset ladder covers 65 products, hardware is 20 products.
+`safeguards` is the one that changes the machinery — it is the only mixed-type category, so
+`extends` has to become per-product-type rather than per-category. That in turn forces the
+other half of the ladder extraction: pulling the model ladder out to
+`sources/rubrics/model.yaml` so `safeguards` can reference both it and `software.yaml`.
+
+### 2. Generalize the scoring SQL, once
+
+`currentai.scores.openness_computed` resolves `weights`, `data`, `code` and `license` by
+name in hardcoded UNION branches, so the ten software categories do not score in the
+warehouse at all today. It needs to read the dimensions each recipe DECLARES, exactly as
+`build/check_rubric.py` now does.
+
+Two things ride along:
+
+- **A per-axis "every recorded dimension is dataset-grade" column.** `dims_relied_on` counts
+  only what the winning rule reads, which is the wrong denominator — `freshness.md` requires
+  every dimension the score *records*. Without this column no tool can ever legitimately
+  write `last_verified`, so it is the precondition for step 3.
+- **A `category_deferrals` table.** `deferred` currently lives only in the repo, so the
+  warehouse does not know which products a category has held back. There are ~180 of them
+  now. With no `otherwise` rule in the software ladder they fall out of the model's INNER
+  JOIN rather than being scored wrongly — the safe direction, but silent.
+
+### 3. The automated freshness pass — roughly 400 axes
+
+Adoption and capability, restricted to axes where every recorded dimension is signal-derived.
+The date is the signal fetch date. No reading and no judgment, which is exactly why it can
+run unattended and why it must be fenced to those axes only.
+
+### 4. The re-read pass — roughly 1099 URLs
+
+Everything else, all of openness included. **Fold the deferral backlog into this pass rather
+than clearing it first.** Reading a product's sources to determine `core-gated` *is* the
+re-check that earns its `last_verified`; done as two passes it is the same pages fetched
+twice, and it re-verifies scores that are about to change.
+
+That backlog is currently ~180 products: 59 whose prose does not settle their dimensions, 11
+where the ladder and the recorded score disagree, plus the model-category gaps.
+
+**Expect scores to move.** Verification is not a formality: the RWKV correction in #105 came
+out of a pass like this, and the 11 ladder conflicts already say some recorded scores are
+wrong — `vellum` and `whylabs` are recorded `4 / open_source`, which is not a pair any ladder
+here can produce. `apply_scores --check` exits non-zero on a moved score for this reason.
+
+### 5. Turn on the age gate
+
+`build/check_freshness.py --max-age-days` becomes a CI gate. This is the entire point of
+having the field: a category whose oldest axis is 50 days old is a category to go and look
+at. Gating earlier would only fail on the pre-automation backlog rather than on genuine
+staleness.
+
+## Related
+
+- `docs/guides/freshness.md` — what `last_verified` means, and the two divergences already
+  closed
+- `docs/guides/openness-spectrum.md` — the openness ladders themselves
+- `sources/rubrics/` — shared ladders; `build/rubrics.py` for how `extends` resolves (#126)
+- `AGENTS.md` — the layer-2 loop and the evidence grading rule

--- a/docs/runbooks/verification-pass.md
+++ b/docs/runbooks/verification-pass.md
@@ -1,0 +1,271 @@
+# Runbook: getting every score auditable
+
+Executable plan for reaching the state where every score can be re-derived from evidence, and
+the failure modes this project has actually hit are prevented by a mechanism rather than by
+remembering.
+
+> **Read `docs/guides/verification.md` first.** It is normative: what `last_verified` means,
+> who may write one, the `establishes` invariant, and the gate table. This runbook is only
+> the order of operations and the commands.
+
+**Definition of done.** Not "every axis has a date." It is:
+
+1. Every axis claiming a confirmation satisfies the invariant — every recorded dimension has
+   an establishing source re-read on or after the claimed date. Gated.
+2. Every score/class pair is producible by its category's rubric. Gated.
+3. `check_rubric` reproduces 16/16 categories, and the warehouse agrees per product. Gated.
+4. Every date traces to a fetch with a status and a digest. Gated.
+5. The remaining gaps are enumerated in `deferred` with reasons, not silently absent.
+
+A date on every axis is the *by-product*. Chasing coverage first is how the field got
+corrupted twice already.
+
+---
+
+## Phase 0 — Build the gates, before any volume work
+
+Do this first. Everything after it is bulk edits to `sources/scores/`, and gates written
+afterwards would be gates written to fit whatever the bulk edits happened to produce.
+
+### 0.1 Schema: `establishes`, `http_status`, `content_sha256`
+
+Add all three to `docs/schemas/score.schema.json` under `definitions.source`, **all
+optional**. `establishes` is an array whose items must be dimension names declared by some
+recipe — validate that cross-file in `build/validate.py`, or a typo'd dimension name silently
+establishes nothing.
+
+```bash
+uv run python -m build.validate        # 0 errors, nothing populated yet
+uv run pytest -q
+```
+
+### 0.2 `build/components.py` — the only supported components editor
+
+Extract the block-safe rewriter: locate the `  components:` block including folded
+continuation lines, rebuild it, re-parse the file, and assert both the new value and that
+every other field is byte-identical. Port the callers.
+
+Test it against a file whose `components` folds across three lines. A single-line regex
+passes such a test only by accident, which is why the test matters more than the helper.
+
+### 0.3 The three free gates
+
+Put all three in `build/check_verification.py`, one command, wired into `validate.yml` next
+to the existing test step.
+
+- **G1, the invariant.** For each axis carrying `last_verified: D`: every dimension the score
+  records has ≥1 source with `establishes` naming it and `accessed >= D`. Scope: axes with a
+  date only.
+- **G2, digest present.** Same scope: every establishing source has `http_status` and
+  `content_sha256`. Exempt dates predating this runbook by listing them explicitly, so the
+  exemption is visible and shrinks.
+- **G3, producible pair.** For every scored product in a category with a recipe, `(score,
+  class)` must equal the outcome of some rule in that recipe. Full scope, immediately.
+
+```bash
+uv run python -m build.check_verification          # expect G3 to FAIL first run
+```
+
+G3 will fail on `vellum` and `whylabs` (`4 / open_source`) and possibly others. **Fix those
+scores before landing the gate**; each is a real error, and one of the two recorded values is
+wrong in each case. Resolve by reading the product, not by adjusting the rubric to admit the
+pair.
+
+### 0.4 The nonce-forcing query helper
+
+One place that builds warehouse queries and appends `-- cache-bust <uuid4>`. Warehouse
+results cache on query text, so a fixed verification query returns its first answer forever;
+this has already caused a tool to report success against pre-materialization data. Port
+`apply_scores.fetch_computed` and any verification script onto it.
+
+### 0.5 G6 — the release assertion
+
+`build/publish_registry.py` (or the runbook step around it) asserts, for every UDM it depends
+on, that `latestRevision.revisionNumber == latestRelease.revision.revisionNumber`.
+
+A run materializes the latest **released** revision. Creating a revision changes nothing
+until `createDataModelRelease` points at it, and the symptom is "my change had no effect"
+rather than an error — three runs were spent on that, concluding a column drop had broken
+materialization when the new SQL had never executed. See `docs/runbooks/deploy-udms.md`.
+
+**Exit criteria for Phase 0:** `check_verification` passes, `validate.yml` runs it, the
+components helper has the folded-scalar test, and G3's catches are fixed as score
+corrections.
+
+---
+
+## Phase 1 — Finish the recipes: 16/16 categories, 470/470 products
+
+111 products, four categories. Do this before Phase 2 or the SQL generalization gets done
+twice.
+
+| category | n | type | notes |
+|---|---|---|---|
+| `benchmark_eval_data` | 27 | dataset | one new ladder covers both dataset categories |
+| `training_synthetic_datasets` | 38 | dataset | |
+| `edge_hardware` | 20 | hardware | own ladder; version-in-identity applies |
+| `safeguards` | 26 | **mixed** 9 model + 17 software | do last, changes the machinery |
+
+Method per category, the one proven on `deployment` and the nine software categories:
+
+```bash
+# 1. Survey what is actually recorded before designing anything.
+#    Software components turned out to be prose with 213 distinct keys; the model
+#    categories were structured. Do not assume which you have.
+uv run python -m build.check_rubric --category <slug>
+
+# 2. Derive each dimension from the recorded prose WITHOUT looking at the score, apply
+#    the ladder, compare. Agreement is corroboration; normalize only those.
+# 3. Hold the rest in `deferred` with a real reason (>40 chars; a test enforces it).
+# 4. Verify.
+uv run python -m build.check_rubric && uv run python -m build.validate && uv run pytest -q
+```
+
+Two rules learned the hard way:
+
+- **Never trust a regex classification.** A first pass got 3 of deployment's 27 wrong:
+  `sandbox-runtime` says "no managed/**proprietary** tier", `openpcc` calls its commercial
+  service "**separate**", `webcontainers` publishes a repo but no runtime source. Most
+  gated-sounding words in this corpus sit inside negations. Use the regex to triage, read to
+  decide.
+- **Use `build/components.py`.** See 0.2.
+
+`safeguards` is the interesting one: being the only mixed-type category, `extends` must become
+per-product-type rather than per-category. That forces extracting the model ladder to
+`sources/rubrics/model.yaml`, which finishes the de-duplication that
+`sources/rubrics/software.yaml` started.
+
+**Exit criteria:** `check_rubric` reports 16/16 `[OK]`, every deferral carries a reason, no
+category's stage or gaps moved (diff the serialized output before and after).
+
+---
+
+## Phase 2 — Generalize the scoring SQL, once
+
+`currentai.scores.openness_computed` resolves `weights`, `data`, `code` and `license` by name
+in hardcoded UNION branches, so the ten software categories do not score in the warehouse at
+all today. It must read the dimensions each recipe DECLARES, as `build/check_rubric.py` now
+does.
+
+Three things ship together:
+
+1. **Dimension-generic resolution**, driven by `category_scoring_rules.condition_key`.
+2. **A per-axis "every RECORDED dimension is dataset-grade" column.** `dims_relied_on` counts
+   only what the winning rule reads, which is the wrong denominator — the rule requires every
+   dimension the score *records*. Without this, Phase 3 cannot legitimately write a date.
+3. **A `category_deferrals` table.** `deferred` lives only in the repo, so the warehouse does
+   not know which ~180 products are held back. With no `otherwise` rule in the software
+   ladder they currently fall out of an INNER JOIN — safe, but silent.
+
+Deploy per `docs/runbooks/deploy-udms.md`, and note the release step:
+
+```bash
+# revision -> RELEASE -> run. The middle step is the one that gets forgotten.
+uv run python -m build.serialize_rubric && uv run python -m build.publish_registry
+# then create the revision, create the release, then trigger the run
+```
+
+### G5 — the parity gate
+
+Add `build/check_parity.py`: for every scored product, compare `check_rubric`'s local result
+against `currentai.scores.openness_computed` and fail on any divergence. Run it in
+`registry.yml` after the publish step.
+
+This is the mechanism for the failure mode that bit four times in one day — `check_rubric`
+and the SQL mirror each other's logic by hand and drift silently. Every one of those four was
+caught by per-product comparison and none by a local check. Automate the thing that worked.
+
+**Exit criteria:** all 16 categories score in the warehouse, `check_parity` passes, and the
+deferral count in `category_deferrals` matches the repo's.
+
+---
+
+## Phase 3 — The automated pass, ~400 axes
+
+Adoption and capability only, and only where every recorded dimension is signal-derived
+(needs Phase 2's column). The date is the signal fetch date; the establishing source is the
+signal's URL, with the digest captured at fetch time.
+
+No reading and no judgment, which is why it can run unattended — and exactly why it must be
+fenced to those axes. Openness is excluded permanently: `data` is research-only in
+`signal_routing.yaml`, the GitHub code route is `settles_dimension: false`, and software
+`core_gated` needs a pricing page.
+
+```bash
+uv run python -m build.check_verification    # G1/G2 now cover ~400 more axes
+uv run python -m build.check_freshness       # coverage should jump
+```
+
+**Exit criteria:** every axis it touched satisfies G1 and G2, and `check_freshness` reports
+them as `verified` rather than `commit`.
+
+---
+
+## Phase 4 — The re-read pass, ~1099 URLs
+
+Everything else, all of openness included. **Fold the ~180 deferrals in rather than clearing
+them first** — reading a product's sources to settle `core-gated` *is* the re-check that earns
+its date. Two passes means the same pages fetched twice, on scores about to change.
+
+Per axis, the unit of work:
+
+1. Fetch each cited URL; record `http_status`, `content_sha256`, and a `shows` extract that
+   actually appears in the body.
+2. Re-derive each recorded dimension and attribute it: `establishes: [...]`.
+3. If a value moved, that is the valuable output — fix the score and say why in `note`.
+4. Stamp `last_verified` only once every recorded dimension has an establishing source.
+
+Batch by category so `check_rubric` gives a clean signal per batch, and run
+`check_verification` after each batch rather than at the end.
+
+**On agent execution.** This is 1099 fetches and it is the step most exposed to
+rubber-stamping — an agent that "confirms" without reading would reproduce #108's failure at
+fifty times the scale while looking legitimate. Three things make that not work: G1 requires
+the `accessed` bump on every dimension, G2 requires a digest that only fetching produces, and
+G4 re-fetches a sample and compares. Do not relax any of the three to make a batch finish.
+
+**Expect scores to move.** The RWKV correction in #105 came out of a pass like this. Movement
+is the return on the work, not a problem with it — `apply_scores --check` exits non-zero on a
+moved score deliberately.
+
+**Exit criteria:** every one of the 1386 real claims either carries a confirmed
+`last_verified` or sits in `deferred` with a reason. Zero silently absent.
+
+---
+
+## Phase 5 — Close the ratchet
+
+```bash
+uv run python -m build.check_freshness --max-age-days 90     # tune, then gate
+```
+
+Add G4 (sampled re-fetch) as a weekly scheduled workflow, reporting drift rather than hard
+failing, since pages legitimately change. Turn `--max-age-days` into a CI gate once coverage
+makes it fail on genuine staleness rather than on backlog. Drop the G2 exemption list.
+
+**Exit criteria:** the five definition-of-done conditions hold, and each is enforced by
+something that runs without being remembered.
+
+---
+
+## Standing hazards
+
+Every one of these has happened. They are not hypotheticals.
+
+| hazard | tell | guard |
+|---|---|---|
+| Derived date sold as a confirmation | any aggregate of `accessed` reaching `last_verified` | `tests/test_apply_scores.py`; G1 validates, never derives |
+| Stale warehouse read | identical query text returning a pre-materialization answer | the nonce helper (0.4) |
+| Unreleased revision | "my SQL change had no effect", no error | G6 (0.5) |
+| Repo/warehouse drift | local reproduces, warehouse abstains | G5 (Phase 2) |
+| Folded-scalar corruption | a components value with a key spliced mid-string | `build/components.py` (0.2) |
+| Partial coverage overstating openness | most-restrictive over a subset of SKUs | already in the SQL: `skus_mapped = skus_reachable AND tiers_seen <= 1` |
+| Bot-owned files in a PR | `generated-files-guard` fails | edit `sources/` only; the bot regenerates on merge |
+| British spelling | `licence`, `penalised`, `labelled` | American English everywhere, including identifiers |
+
+## Related
+
+- `docs/guides/verification.md` — normative: the invariant, the gates, who may write a date
+- `docs/guides/freshness.md` — normative: what `last_verified` means
+- `docs/runbooks/deploy-udms.md` — revision → release → run
+- `AGENTS.md` — the layer-2 loop and the evidence grading rule


### PR DESCRIPTION
Written so this survives a context reset, and so the riskiest step is protected by a
mechanism rather than by remembering.

**Merge after #126** — merges clean (verified), but the guide references `sources/rubrics/`
and `build/rubrics.py`, which arrive with #126.

## The problem this actually solves

The plan's biggest step asks an agent to re-check ~1099 URLs. An agent that rubber-stamps
them reproduces #108's failure at fifty times the scale **while looking entirely
legitimate** — which a convention cannot prevent. Making that impossible needed a gap closed
first.

`sources` is a flat list per axis, so nothing records *which* source establishes *which*
dimension. Measured: **324 of 470 openness axes cite exactly one source**, asserted to
establish `weights`, `data`, `code` and `license` together. Neither a reader nor a tool can
check that, so a re-check is currently unfalsifiable.

## The mechanism

A source item gains an optional `establishes: [dimension, …]`, and with it:

> **`last_verified: D` is valid only if, for every dimension the score records, at least one
> source that `establishes` that dimension has `accessed >= D`.**

Claiming a confirmation nobody performed now requires back-dating the `accessed` date of
every dimension's source — and a `content_sha256` + `http_status` captured at fetch time is
what makes *those* falsifiable in turn. A missing digest on a newly claimed confirmation is a
hard failure, because it means the tool fetched nothing.

Two things the guide states loudly, because both are easy to erode:

- **This validates a claimed date; it never derives one.** Someone will eventually notice the
  invariant mentions `accessed` and "simplify" it into `max(accessed)` — that is #115 exactly.
- **The aggregation direction is load-bearing.** It is over *every* recorded dimension, so the
  binding constraint is the least recently re-read one. `max(accessed)` would pass an axis
  where one dimension was re-read today and three were last seen in June.

## Six gates, and they ratchet

| | failure mode | mechanism | cost |
|---|---|---|---|
| G1 | confirmation with no supporting evidence | the invariant | free |
| G2 | claimed date with no fetch digest | required where a date is claimed | free |
| G3 | impossible score/class pair | pair must be producible by the recipe | free |
| G4 | fabricated or rotted sources | sampled re-fetch | network, weekly |
| G5 | repo/warehouse drift | per-product differential after publish | network, per publish |
| G6 | revision never released | latest revision == latest release | network, per publish |

G1 and G2 are **scoped to axes that claim a confirmation** — 6 today, growing as the pass
proceeds. The gate covers exactly what has been done, never blocks progress, and never
permits a regression on ground already taken. A big-bang gate over 1386 axes would fail on
day one and get switched off, which is how gates die.

G3 applies immediately and already has a catch: `vellum` and `whylabs` are recorded
`4 / open_source`, a pair no ladder here can produce. Both are real errors to fix as score
corrections, not by widening the rubric to admit the pair.

G5 is the mechanism for the failure that bit **four times in one day** — `check_rubric` and
the scoring SQL mirror each other by hand and drift silently. All four were caught by
per-product comparison and none by a local check, so that comparison becomes a gate.

## `docs/runbooks/verification-pass.md`

Phase 0 builds the gates **before** any bulk editing, because gates written afterwards get
written to fit whatever the bulk edits happened to produce. Then coverage (16/16 categories),
then the SQL generalization once, then the automated pass, then the re-read pass with the
~180 deferrals folded in.

Definition of done is deliberately **not** "every axis has a date" — that is the by-product.
Chasing coverage first is how the field got corrupted twice.

It also carries a standing-hazards table where every entry has actually happened, each paired
with the guard that now prevents it: stale warehouse reads, unreleased revisions, folded-scalar
corruption, bot-owned files in a PR, British spelling.

## `AGENTS.md`, corrected

It still asserted the #108 behavior — "`last_verified` is the oldest accessed date among the
evidence a score depends on" — in the file an agent reads first. Replaced with what the code
does, plus an explicit "do not reintroduce it under any aggregation or column name" pointing
at the test that asserts the absence. Also documents `sources/rubrics/` and `extends`, and
links the runbook.

## Test plan

Docs only; no code paths touched. 148 tests pass, `build.validate` clean, test-merges clean
against #126. Every repo path cited resolves or is labeled with the PR it arrives in — the two
that resolve to nothing are `sources/rubrics/model.yaml` (future work, named in Phase 1) and
`sources/scores/foo.yaml` (illustrative prose).