### PR TITLE
Phase 0: verification gates, and the 17 impossible score pairs G3 caught

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,6 +19,12 @@ jobs:
         run: uv run python -m build.validate
       - name: Run tests
         run: uv run pytest -q
+
+      # G1, G2 and G3. Free, no network, and scoped so they cover exactly what has been
+      # done: G1 and G2 apply only to axes claiming a last_verified, G3 to every scored
+      # product in a category with a recipe. See docs/guides/verification.md.
+      - name: Verification gates (G1 invariant, G2 digests, G3 producible pairs)
+        run: uv run python -m build.check_verification --verbose
       - name: Serialize dry-run
         run: uv run python -m build.serialize --date ci-dry-run
 

--- a/build/apply_scores.py
+++ b/build/apply_scores.py
@@ -72,6 +72,13 @@ import os
 import sys
 from pathlib import Path
 
+# `block_bounds` and `find_key` used to be defined here. They now live beside the
+# components rewriter, which needs the same two primitives and must not have a second
+# copy of them: two implementations of "find this field in this file" is how one of them
+# ends up subtly wrong about folded scalars while the other is right.
+from build.components import block_bounds, find_key
+from build.warehouse import query
+
 ROOT = Path(__file__).resolve().parents[1]
 TABLE = "currentai.scores.openness_computed"
 
@@ -79,28 +86,21 @@ TABLE = "currentai.scores.openness_computed"
 def fetch_computed(category: str | None) -> list[dict]:
     """Read the computed scores. Requires OSO_API_KEY, same as publish_registry.
 
-    The trailing unique comment is load-bearing. Query results are cached keyed on the
-    QUERY TEXT, so a tool that issues a fixed string keeps receiving its first answer
-    forever - it never self-heals. That is not theoretical: this function returned the
-    pre-run baseline for a full run cycle after the models had already re-materialized,
-    and adding a single trailing comment to the same SQL returned the fresh numbers. A
-    writer reading through that cache would write stale dates into sources/scores.
+    The cache-busting nonce this used to append itself now comes from `build.warehouse`,
+    which is the only place that builds a warehouse query and cannot be called without
+    one. Its docstring carries the reasoning and the incident; the short version is that
+    results cache on query TEXT, so a fixed string returns its first answer forever and
+    this function once spent a full run cycle reporting pre-materialization numbers.
     """
-    import uuid
-
-    from pyoso import Client
-
     where = f"WHERE category_slug = '{category}'" if category else ""
-    sql = f"""
+    return query(f"""
         SELECT product_slug, category_slug, openness_score, openness_class,
                last_checked, unsourced_dimensions, license_tier_grade,
                dims_from_dataset, dims_relied_on, scoring_note
         FROM {TABLE}
         {where}
         ORDER BY product_slug
-        -- cache-bust {uuid.uuid4()}
-    """
-    return Client().to_pandas(sql).to_dict("records")
+    """)
 
 
 def has_date(value: object) -> bool:
@@ -114,34 +114,6 @@ def has_date(value: object) -> bool:
         return False
     text = str(value).strip()
     return text not in ("", "None", "NaT", "nan", "NaN")
-
-
-def block_bounds(lines: list[str], key: str) -> tuple[int, int] | None:
-    """Line range [start, end) of the top-level `key:` mapping."""
-    start = None
-    for index, line in enumerate(lines):
-        if line.startswith(f"{key}:") and not line[:1].isspace():
-            start = index
-            break
-    if start is None:
-        return None
-    for index in range(start + 1, len(lines)):
-        if lines[index].strip() and not lines[index][:1].isspace():
-            return start, index
-    return start, len(lines)
-
-
-def find_key(lines: list[str], bounds: tuple[int, int], key: str) -> int | None:
-    """Index of a two-space-indented `key:` inside the block, or None.
-
-    Indent is checked exactly. A `score:` nested deeper — inside a `sources` entry,
-    say — is a different key and must not be mistaken for the axis's own.
-    """
-    for index in range(bounds[0] + 1, bounds[1]):
-        line = lines[index]
-        if line.startswith(f"  {key}:") and not line[2:3].isspace():
-            return index
-    return None
 
 
 def apply_to_file(path: Path, computed: dict) -> tuple[list[str], list[str]]:

--- a/build/check_verification.py
+++ b/build/check_verification.py
@@ -1,0 +1,337 @@
+"""The three free gates: is a claimed confirmation supported, and is a score even possible.
+
+`docs/guides/verification.md` is normative for all three. This module implements them; when
+the two disagree the guide wins. `docs/runbooks/verification-pass.md` has the order of
+operations and why the gates land before any bulk editing of `sources/scores/`.
+
+## G1 — the invariant
+
+> `last_verified: D` is valid only if, for every dimension the score records, at least one
+> source that `establishes` that dimension has `accessed >= D`.
+
+**This validates a claimed date. It never derives one.** The distinction is the whole point
+and it is easy to erode: the invariant mentions `accessed`, so someone will eventually
+"simplify" it into `last_verified = max(accessed)`. That is issue #115 exactly, and between
+#108 and #115 a derived date landed on 19 of the 26 axes that carried one, in six cases
+overwriting a date a person had established by checking. Deriving the date asserts a
+confirmation nobody made; validating it rejects a confirmation nobody could have made.
+
+Note the aggregation direction, which is also load-bearing: the check is over EVERY
+recorded dimension, so the binding constraint is the LEAST recently re-read one.
+`max(accessed)` across an axis would pass an axis where one dimension was re-read today and
+three were last seen in June — and that is not hypothetical, it is what the 2026-07-28 pass
+on the model flagships produced by re-reading only the dataset endpoint.
+
+## G2 — a claimed date needs a fetch to point at
+
+Same scope. Every source read as part of the confirmation carries `http_status` and
+`content_sha256`, because those are what only an actual request produces. The invariant
+alone catches an unsupported date; it cannot catch a source that never said what `shows`
+claims. A missing digest on a newly claimed confirmation means the tool fetched nothing.
+
+## G3 — a score/class pair must be producible
+
+Full scope, immediately, and unlike G1 and G2 it needs nothing to be populated first. For
+every scored product in a category with a `scoring_recipe`, `(score, class)` must be the
+outcome of SOME rule in that recipe. Deliberately weaker than `build/check_rubric.py`,
+which asks whether the recipe reproduces the score from the recorded evidence: G3 ignores
+the evidence and asks only whether the pair exists in the ladder at all. That makes it
+immune to the escape hatch `check_rubric` has, which is `deferred` — a category can defer a
+product out of reproduction, but an impossible pair stays impossible.
+
+Which is how `4 / open_source` survived: no software rule emits 4 with `open_source` (4 is
+`open_core`), and no software rule emits 3 at all, since the ladder's rungs are 1, 2, 4, 5.
+
+## How the gates ratchet
+
+G1 and G2 apply only to axes carrying a `last_verified`, which is a handful today and grows
+as the re-read pass proceeds. The gate therefore covers exactly what has been done, never
+blocks progress, and never permits a regression on ground already taken. A big-bang gate
+over all 1386 axes would fail on day one and get switched off, which is how gates die.
+
+Usage:
+    uv run python -m build.check_verification
+    uv run python -m build.check_verification --gate g3
+    uv run python -m build.check_verification --verbose
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date
+from pathlib import Path
+
+import yaml
+
+from build.check_rubric import license_read_keys, resolve_dimension, split_components
+from build.rubrics import load_shared, resolve_recipe
+
+ROOT = Path(__file__).resolve().parents[1]
+AXES = ("openness", "adoption", "capability")
+
+# Axes exempt from G2 because a digest could not have been recorded when their sources were
+# read. A visible list that shrinks, rather than a date comparison that quietly covers
+# whatever is old.
+#
+# Empty, and worth saying why. The six axes carrying a date when this gate landed all
+# predated it and so would all have qualified; they were re-fetched instead, which took 23
+# requests and produced two findings the exemption would have hidden — a Lucie source URL
+# that had never resolved as cited, and an `rwkv` weights claim with no source behind it at
+# all. Exempting is the cheaper move and it is available; it is not the better one when the
+# set is small.
+#
+# G2 only. An exemption says a digest was unobtainable, which says nothing about whether the
+# sources support the date — that is G1's question, and G1 has no exemptions.
+#
+# Each entry names the axis as `<product>:<axis>` and why. Stale entries are reported.
+DIGEST_EXEMPT: dict[str, str] = {}
+
+
+def load() -> tuple[dict, dict, dict]:
+    """(scores, categories, resolved recipe per category)."""
+    scores = {
+        p.stem: yaml.safe_load(p.read_text()) or {}
+        for p in sorted((ROOT / "sources" / "scores").glob("*.yaml"))
+    }
+    categories = {
+        p.stem: yaml.safe_load(p.read_text()) or {}
+        for p in sorted((ROOT / "sources" / "categories").glob("*.yaml"))
+    }
+    shared = load_shared(ROOT)
+    recipes = {}
+    for slug, category in categories.items():
+        recipe, errors = resolve_recipe(category, shared)
+        if recipe and not errors:
+            recipes[slug] = recipe
+    return scores, categories, recipes
+
+
+def category_of(categories: dict) -> dict[str, str]:
+    """product slug -> its category slug. `validate.py` guarantees exactly one."""
+    return {
+        product: slug
+        for slug, category in categories.items()
+        for product in (category.get("products") or [])
+    }
+
+
+def parse_date(value: object) -> date | None:
+    try:
+        return date.fromisoformat(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def recorded_dimensions(components: dict[str, str], recipe: dict) -> dict[str, str]:
+    """dimension -> the recorded key that answers it, for every dimension this score RECORDS.
+
+    Two things it is deliberately not:
+
+      * not the dimensions the winning rule reads. That is `dims_relied_on` in the
+        warehouse, and it is the wrong denominator — a rule can win on license alone while
+        `data` and `code` sit unconfirmed, so counting only what the rule read would let an
+        axis claim a confirmation of dimensions nobody looked at.
+      * not every key in the components string. Those carry plenty that no ladder scores —
+        `paper`, `model_card`, `self-host` — and demanding an establishing source for
+        `model_card:open` would make the gate expensive and pointless in the same move.
+
+    So: the dimensions the recipe DECLARES, that this product actually records, plus the
+    license, which is recorded rather than derived even though the formula reads the tier.
+
+    Returns the recorded key alongside the dimension name because attribution may use
+    either. `finetuned_chat` answers the data question under `post-training-data`, and a
+    source that says `establishes: [post-training-data]` is being more precise than one
+    saying `[data]`, not less.
+    """
+    declared = ((recipe.get("openness") or {}).get("dimensions")) or {}
+    found: dict[str, str] = {}
+    for name in declared:
+        key = resolve_dimension(components, name, recipe)
+        if key is not None:
+            found[name] = key
+    for key in license_read_keys(recipe):
+        if key in components:
+            found["license"] = key
+            break
+    return found
+
+
+def g1_invariant(scores: dict, categories: dict, recipes: dict) -> list[str]:
+    """Every recorded dimension of a dated axis has an establishing source read since."""
+    problems: list[str] = []
+    owner = category_of(categories)
+    for slug, score in sorted(scores.items()):
+        recipe = recipes.get(owner.get(slug, ""), {})
+        for axis in AXES:
+            block = score.get(axis) or {}
+            claimed = parse_date(block.get("last_verified"))
+            if block.get("last_verified") and claimed is None:
+                problems.append(f"{slug}:{axis}: last_verified {block['last_verified']!r} is not a date")
+                continue
+            if claimed is None:
+                continue
+
+            sources = [s for s in (block.get("sources") or []) if isinstance(s, dict)]
+            fresh = [s for s in sources if (parse_date(s.get("accessed")) or date.min) >= claimed]
+            if not fresh:
+                # The floor, and it is the whole of the check for adoption and capability:
+                # those axes record one banded value rather than a dimension breakdown, so
+                # there is nothing to attribute among, but a confirmation still cannot rest
+                # on zero sources read on or after the day it claims to have happened.
+                problems.append(
+                    f"{slug}:{axis}: claims last_verified {claimed}, but no source was "
+                    f"accessed on or after that date"
+                )
+                continue
+
+            if axis != "openness":
+                continue
+            components = split_components(block.get("components") or "")
+            required = recorded_dimensions(components, recipe)
+            for dimension, key in sorted(required.items()):
+                names = {dimension, key}
+                if not any(names & set(s.get("establishes") or []) for s in fresh):
+                    stale = [
+                        s.get("accessed")
+                        for s in sources
+                        if names & set(s.get("establishes") or [])
+                    ]
+                    detail = (
+                        f"only established by a source last read {min(stale)}"
+                        if stale
+                        else "no source claims to establish it"
+                    )
+                    problems.append(
+                        f"{slug}:{axis}: records {dimension!r} (as {key!r}) but {detail}; "
+                        f"last_verified {claimed} is not supported for that dimension"
+                    )
+    return problems
+
+
+def g2_digests(scores: dict) -> list[str]:
+    """Sources read as part of a claimed confirmation must show they were fetched."""
+    problems: list[str] = []
+    used: set[str] = set()
+    for slug, score in sorted(scores.items()):
+        for axis in AXES:
+            block = score.get(axis) or {}
+            claimed = parse_date(block.get("last_verified"))
+            if claimed is None:
+                continue
+            key = f"{slug}:{axis}"
+            if key in DIGEST_EXEMPT:
+                used.add(key)
+                continue
+            for source in block.get("sources") or []:
+                if not isinstance(source, dict):
+                    continue
+                if (parse_date(source.get("accessed")) or date.min) < claimed:
+                    continue
+                missing = [
+                    field
+                    for field in ("http_status", "content_sha256")
+                    if source.get(field) in (None, "")
+                ]
+                if missing:
+                    problems.append(
+                        f"{key}: source {source.get('url')!r} was read on {source.get('accessed')} "
+                        f"as part of the confirmation but records no {' and no '.join(missing)}; "
+                        f"only an actual fetch produces those"
+                    )
+    # A stale exemption is an exemption that has stopped shrinking, so it is reported.
+    for key, reason in sorted(DIGEST_EXEMPT.items()):
+        if key not in used:
+            problems.append(
+                f"{key}: exempted from G2 ({reason}) but the axis no longer carries a "
+                f"last_verified. Drop the exemption."
+            )
+    return problems
+
+
+def producible_pairs(recipe: dict) -> set[tuple[int, str]]:
+    """Every (score, class) some rule in the recipe can emit."""
+    pairs: set[tuple[int, str]] = set()
+    for rule in (recipe.get("openness") or {}).get("formula") or []:
+        outcome = rule.get("then") or rule.get("otherwise") or {}
+        if "score" in outcome and "class" in outcome:
+            pairs.add((outcome["score"], outcome["class"]))
+    return pairs
+
+
+def g3_producible(scores: dict, categories: dict, recipes: dict) -> list[str]:
+    """A recorded (score, class) must be an outcome the category's ladder can produce."""
+    problems: list[str] = []
+    for slug, recipe in sorted(recipes.items()):
+        pairs = producible_pairs(recipe)
+        if not pairs:
+            continue
+        for product in categories[slug].get("products") or []:
+            openness = (scores.get(product) or {}).get("openness") or {}
+            score, klass = openness.get("score"), openness.get("class")
+            if score is None:
+                continue
+            if (score, klass) not in pairs:
+                problems.append(
+                    f"{product}:openness in {slug}: {score}/{klass} is not an outcome any rule "
+                    f"in the recipe produces (it emits {sorted(pairs)}). One of the two values "
+                    f"is wrong; read the product rather than widening the ladder to admit it."
+                )
+    return problems
+
+
+GATES = {
+    "g1": "a confirmation with no supporting evidence",
+    "g2": "a claimed date with no fetch digest",
+    "g3": "an impossible score/class pair",
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--gate", choices=sorted(GATES), help="run one gate only")
+    parser.add_argument("--verbose", action="store_true", help="show what each gate covered")
+    args = parser.parse_args()
+
+    scores, categories, recipes = load()
+    results = {
+        "g1": g1_invariant(scores, categories, recipes),
+        "g2": g2_digests(scores),
+        "g3": g3_producible(scores, categories, recipes),
+    }
+    if args.gate:
+        results = {args.gate: results[args.gate]}
+
+    dated = sum(
+        1
+        for score in scores.values()
+        for axis in AXES
+        if (score.get(axis) or {}).get("last_verified")
+    )
+    scored = sum(
+        1
+        for slug, recipe in recipes.items()
+        for product in categories[slug].get("products") or []
+        if ((scores.get(product) or {}).get("openness") or {}).get("score") is not None
+    )
+
+    if args.verbose:
+        print(f"{dated} axis/axes carry a last_verified  (G1, G2 scope)")
+        print(f"{scored} scored products in {len(recipes)} categories with a recipe  (G3 scope)")
+        if DIGEST_EXEMPT:
+            print(f"{len(DIGEST_EXEMPT)} G2 exemption(s), each of which should be shrinking")
+        print()
+
+    failed = False
+    for gate, problems in results.items():
+        status = "OK" if not problems else "FAIL"
+        print(f"{gate.upper()}  {GATES[gate]:<44} [{status}]")
+        for problem in problems:
+            print(f"  ! {problem}")
+        if problems:
+            failed = True
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build/components.py
+++ b/build/components.py
@@ -1,0 +1,202 @@
+"""The only supported way to edit an `openness.components` field in place.
+
+## Why a module rather than a `re.sub`
+
+`components` is one long `k:v;k:v` string, and 277 of the 470 score files fold it across
+lines — 57 of them across three or more. So the obvious edit,
+
+    re.sub(r"^  components: (.*)$", ..., text, flags=re.M)
+
+matches the FIRST line of a folded scalar and leaves the continuation lines standing. The
+result parses cleanly and is wrong: the old tail is spliced onto the new value, usually
+mid-key, producing something like `...;core-gated:gatedn(OSI);source:public`. Nothing
+downstream complains, because a components string is only ever split on `;` and `:` and
+those fragments are still shaped like keys. It corrupts silently, which is the one failure
+mode worth building a mechanism against.
+
+Rather than get the regex right, this module does not use one:
+
+  * locate the field by INDENT, taking every following more-indented line as part of it;
+  * re-emit the value with PyYAML, so quoting and folding are the emitter's problem;
+  * re-parse the whole file and assert the new value is what was asked for AND that every
+    other field is unchanged, then assert the bytes outside the span never moved.
+
+Nothing is written unless both assertions hold. A file this cannot handle raises rather
+than producing a plausible-looking edit.
+
+## Why the assertion is the point
+
+A single-line test passes against a single-line regex by accident, so `tests/
+test_components.py` folds a value across three lines. The helper exists so the next
+script cannot re-invent the substitution; the assertion exists because the helper itself
+could have the same bug.
+
+Usage:
+    from build.components import rewrite, set_field
+    rewrite(Path("sources/scores/mastra.yaml"), "license:Apache-2.0(OSI);source:public")
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+
+import yaml
+
+# PyYAML's `width` is a soft target: it breaks at the first space AFTER the column is
+# exceeded, so 100 yields lines in the 100-115 range. That matches what the score files
+# already contain (the folded blocks peak at columns 102-103), so an edit does not reflow
+# the whole field and bury the real change in a whitespace diff.
+WIDTH = 100
+INDENT = "  "
+
+
+def block_bounds(lines: list[str], key: str) -> tuple[int, int] | None:
+    """Line range [start, end) of the top-level `key:` mapping.
+
+    Shared with `build/apply_scores.py`, which used to define its own copy. One
+    definition, because both are locating a block in the same file format.
+    """
+    start = None
+    for index, line in enumerate(lines):
+        if line.startswith(f"{key}:") and not line[:1].isspace():
+            start = index
+            break
+    if start is None:
+        return None
+    for index in range(start + 1, len(lines)):
+        if lines[index].strip() and not lines[index][:1].isspace():
+            return start, index
+    return start, len(lines)
+
+
+def find_key(lines: list[str], bounds: tuple[int, int], key: str) -> int | None:
+    """Index of a two-space-indented `key:` inside the block, or None.
+
+    Indent is checked exactly. A `score:` nested deeper — inside a `sources` entry, say —
+    is a different key and must not be mistaken for the axis's own.
+    """
+    for index in range(bounds[0] + 1, bounds[1]):
+        line = lines[index]
+        if line.startswith(f"  {key}:") and not line[2:3].isspace():
+            return index
+    return None
+
+
+def field_span(lines: list[str], bounds: tuple[int, int], key: str) -> tuple[int, int] | None:
+    """[start, end) covering `  key:` AND every folded continuation line.
+
+    The continuation test is indentation, not content. A sibling key sits at the same
+    indent as `key`, a `sources:` list item likewise, so anything MORE indented belongs to
+    this field's value. That is the entire reason this is not a line-oriented regex.
+
+    A blank line ends the span. Nothing in `sources/scores/` puts one inside a scalar, and
+    treating it as a terminator fails loudly via the reparse assertion if that ever stops
+    being true, rather than swallowing the rest of the block.
+    """
+    start = find_key(lines, bounds, key)
+    if start is None:
+        return None
+    end = start + 1
+    while end < bounds[1]:
+        line = lines[end]
+        if not line.strip():
+            break
+        if len(line) - len(line.lstrip()) <= len(INDENT):
+            break
+        end += 1
+    return start, end
+
+
+def render(key: str, value: object, width: int = WIDTH) -> list[str]:
+    """The `  key: ...` lines for a value, quoted and folded by PyYAML.
+
+    Emitting through the YAML dumper rather than by hand is what makes an arbitrary value
+    safe: `vellum`'s components contains `vellum-assistant: gateway+clients`, and a bare
+    `: ` inside a plain scalar changes the parse. The dumper quotes it; a format string
+    would not have known to.
+    """
+    dumped = yaml.safe_dump(
+        {key: value},
+        default_flow_style=False,
+        allow_unicode=True,
+        width=width,
+        sort_keys=False,
+    )
+    return [f"{INDENT}{line}\n" if line.strip() else "\n" for line in dumped.splitlines()]
+
+
+def set_field(text: str, value: object, axis: str = "openness", key: str = "components") -> str:
+    """Return `text` with `axis.key` replaced by `value`. Raises rather than guessing.
+
+    Generic over the field, though `components` is the motivating case and the default.
+    `score` and `class` go through the same path, which is what makes a score correction
+    and a components edit the same operation with the same reparse assertion behind it -
+    and `value` is typed loosely because `score` is an int.
+
+    Three checks before returning, in order of what they catch:
+
+      1. the re-parsed field equals `value` — the edit did what was asked;
+      2. the re-parsed document equals the original with only that one field changed —
+         nothing else was spliced, reflowed or swallowed. This is the check that catches
+         folded-scalar corruption, because a spliced tail lands in a NEIGHBORING key;
+      3. the bytes before and after the span are identical — true by construction, so a
+         failure here means the span itself was computed wrong.
+    """
+    lines = text.splitlines(keepends=True)
+    bounds = block_bounds(lines, axis)
+    if bounds is None:
+        raise ValueError(f"no top-level {axis!r} block")
+    span = field_span(lines, bounds, key)
+    if span is None:
+        raise ValueError(f"{axis} has no {key!r} field to rewrite")
+
+    rendered = render(key, value)
+    new_lines = lines[: span[0]] + rendered + lines[span[1] :]
+    new_text = "".join(new_lines)
+
+    before = yaml.safe_load(text)
+    after = yaml.safe_load(new_text)
+    got = ((after or {}).get(axis) or {}).get(key)
+    if got != value:
+        raise ValueError(f"{axis}.{key} re-parsed as {got!r}, not the value asked for")
+    expected = copy.deepcopy(before)
+    expected[axis][key] = value
+    if after != expected:
+        raise ValueError(
+            f"rewriting {axis}.{key} changed something else in the document; refusing to write"
+        )
+    tail = span[0] + len(rendered)
+    if new_lines[: span[0]] != lines[: span[0]] or new_lines[tail:] != lines[span[1] :]:
+        raise ValueError(f"rewriting {axis}.{key} moved bytes outside its own span")
+
+    return new_text
+
+
+def rewrite(path: Path, value: object, axis: str = "openness", key: str = "components") -> bool:
+    """Write the new value into the file. True when the file changed."""
+    text = path.read_text()
+    new_text = set_field(text, value, axis=axis, key=key)
+    if new_text == text:
+        return False
+    path.write_text(new_text)
+    return True
+
+
+def parse(value: str) -> dict[str, str]:
+    """`k:v;k:v` -> dict, paren-aware. Re-exported from the checker that owns it.
+
+    Editing a components string almost always means reading it first, and there must be
+    exactly one parser or a writer and a reader can disagree about what a value says.
+    """
+    from build.check_rubric import split_components
+
+    return split_components(value)
+
+
+def format(fields: dict[str, str]) -> str:  # noqa: A001 - the inverse of `parse`, so named for it
+    """dict -> `k:v;k:v`, preserving insertion order.
+
+    No spaces after the separators, matching what the 470 files already contain.
+    """
+    return ";".join(f"{key}:{val}" for key, val in fields.items())

--- a/build/rubrics.py
+++ b/build/rubrics.py
@@ -64,3 +64,43 @@ def resolve_recipe(category: dict, shared: dict[str, dict]) -> tuple[dict | None
     merged.update({key: value for key, value in recipe.items() if key != "extends"})
     merged["extends"] = base_name
     return merged, []
+
+
+def recipe_vocabulary(recipe: dict) -> set[str]:
+    """Every dimension name a source may claim to establish, for one resolved recipe.
+
+    Three things belong in it, and the third is the one that is easy to leave out:
+
+      * the declared dimension names — `weights`, `source`, `core_gated`;
+      * the recorded keys those dimensions `read`, since `post-training-data` and
+        `core-gated` are how the evidence is actually written down and attributing to
+        the recorded key is more precise than attributing to the dimension;
+      * the license keys. `license_tier` is derived rather than recorded, so a source
+        establishes the LICENSE, which is what `docs/guides/verification.md` writes in
+        its worked example. Omitting it would reject the guide's own illustration.
+    """
+    openness = (recipe.get("openness") or {}) if recipe else {}
+    names: set[str] = set()
+    for name, spec in (openness.get("dimensions") or {}).items():
+        names.add(name)
+        names.update((spec or {}).get("reads") or [])
+    names.update(((openness.get("license_tier") or {}).get("reads")) or ["license"])
+    return names
+
+
+def dimension_vocabulary(categories: dict[str, dict], shared: dict[str, dict]) -> set[str]:
+    """The union of every recipe's vocabulary, across every category.
+
+    Deliberately a union rather than per-category. A source is cited by an axis, and an
+    axis belongs to a product, which belongs to one category — so a per-category check
+    would be tighter. It would also reject a correct `establishes: [license]` written on
+    a product in one of the four categories that has no recipe yet, and those are exactly
+    the products Phase 4 will re-read. The union still catches the failure this exists to
+    catch, which is a typo: `licence`, `weight`, `core_gate` name nothing anywhere.
+    """
+    names: set[str] = set()
+    for category in (categories or {}).values():
+        recipe, errors = resolve_recipe(category or {}, shared or {})
+        if recipe and not errors:
+            names |= recipe_vocabulary(recipe)
+    return names

--- a/build/validate.py
+++ b/build/validate.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import jsonschema
 import yaml
 
+from build.rubrics import dimension_vocabulary
+
 # Maps each sources/ subdir to its docs/schemas/<name>.schema.json basename.
 _SCHEMA_FOR_DIR = {
     "organizations": "organization",
@@ -195,6 +197,29 @@ def validate_sources(data: dict) -> list[str]:
         if scored is not None and scored != len(prods):
             errors.append(f"long_tail counts.scored ({scored}) != product count ({len(prods)}); "
                           f"re-sync build/_frozen_long_tail.json after a batch")
+
+    # --- `establishes` must name a real dimension ---
+    # A source's `establishes` list is what makes a re-check claim checkable: it records
+    # which source settles which dimension, so check_verification can require a fresh read
+    # per dimension rather than one fresh read per axis. That only works if the names mean
+    # something. A typo'd `licence` or `weight` establishes nothing at all while reading
+    # like attribution, and the gate that consumes it would then pass an axis whose
+    # dimension has no supporting source. Cross-file because the vocabulary lives in the
+    # category recipes, not in the schema.
+    vocabulary = dimension_vocabulary(cats, data.get("rubrics") or {})
+    if vocabulary:
+        for slug, score in sorted(scores.items()):
+            for axis in ("openness", "adoption", "capability"):
+                for source in (score.get(axis) or {}).get("sources") or []:
+                    if not isinstance(source, dict):
+                        continue
+                    for name in source.get("establishes") or []:
+                        if name not in vocabulary:
+                            errors.append(
+                                f"score {slug!r}: {axis} source {source.get('url')!r} claims to "
+                                f"establish {name!r}, which no scoring_recipe declares as a "
+                                f"dimension or reads as a recorded key"
+                            )
 
     # --- observation dates cannot be in the future ---
     # `accessed` records when a source was read and `last_verified` when a check happened.

--- a/build/warehouse.py
+++ b/build/warehouse.py
@@ -1,0 +1,72 @@
+"""The only supported way to read the OSO warehouse from `build/`.
+
+## Why a helper for one line of SQL
+
+Warehouse query results are cached keyed on the QUERY TEXT. A tool that issues a fixed
+string therefore keeps receiving its FIRST answer for that string, and it never self-heals:
+re-running it, waiting, or re-materializing the model changes nothing, because the text is
+still the same text. There is no cache-control knob to reach for from the client side.
+
+This has already cost real time. `build/apply_scores.py` returned the pre-run baseline for
+a full run cycle after the models had re-materialized, and adding a single trailing comment
+to the same SQL returned the fresh numbers. The failure is silent and confidence-inspiring
+in the wrong direction: the tool reports success, against data from before the change it
+was checking.
+
+Verification tooling is the worst possible place for that, because a stale read there
+writes a stale date into `sources/scores/` under a field whose name asserts a fresh check.
+So the nonce lives here rather than in each caller's discipline. `query()` cannot be called
+without one — there is no parameter to switch it off.
+
+Note that this defeats the cache on purpose and therefore costs a real query every time.
+That is the intended trade: these are low-frequency build and verification reads, and a
+wrong answer is far more expensive than a slow one.
+
+Usage:
+    from build.warehouse import query
+    rows = query("SELECT product_slug FROM currentai.scores.openness_computed")
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+MARKER = "-- cache-bust"
+
+
+def cache_busted(sql: str) -> str:
+    """`sql` with a unique trailing comment, so no two calls share a cache key.
+
+    A comment rather than anything semantic: it changes the text, which is what the cache
+    keys on, while leaving the query plan and the result identical. A `WHERE 1=1 AND
+    '<uuid>' = '<uuid>'` would also work and would be a real predicate the planner has to
+    carry, which is a worse trade.
+    """
+    return f"{sql.rstrip()}\n{MARKER} {uuid.uuid4()}\n"
+
+
+def has_nonce(sql: str) -> bool:
+    """Whether a query text already carries a nonce. For tests and for asserting callers."""
+    return MARKER in sql
+
+
+def require_api_key() -> str:
+    """The key, or a clear failure. Every caller here needs it, so it is asked for once."""
+    token = os.environ.get("OSO_API_KEY")
+    if not token:
+        raise RuntimeError("OSO_API_KEY must be set to read the warehouse")
+    return token
+
+
+def query(sql: str) -> list[dict]:
+    """Run `sql` with a forced nonce and return rows as plain dicts.
+
+    Returns dicts rather than a DataFrame so callers do not have to think about pandas
+    null sentinels. `build/apply_scores.has_date` exists because a null DATE arrives as
+    NaT or float nan depending on the column dtype, and both satisfy `is not None`.
+    """
+    from pyoso import Client
+
+    require_api_key()
+    return Client().to_pandas(cache_busted(sql)).to_dict("records")

--- a/docs/guides/verification.md
+++ b/docs/guides/verification.md
@@ -136,21 +136,42 @@ exactly what has been done, never blocks progress, and never permits a regressio
 already taken. A big-bang gate over all 1386 axes would fail on day one and get switched
 off, which is how gates die.
 
-G3, G5 and G6 apply in full immediately — nothing has to be populated first. G3 already has
-a known catch: `vellum` and `whylabs` are recorded `4 / open_source`, a pair no ladder here
-can produce.
+G3, G5 and G6 apply in full immediately — nothing has to be populated first.
+
+G3 found 17 impossible pairs on its first run, not the two that were known. `vellum`,
+`whylabs` and `tensorrt-llm` were recorded `4 / open_source`, a pair no rule emits because
+4 is `open_core`; five more were `2 / open_core`, which no rule emits either; and nine
+carried a score of 3, which the software ladder cannot produce **at all**, its rungs being
+1, 2, 4 and 5. All 17 were corrected by reading the products, in three groups:
+
+- `2 / open_core` → `2 / source_available`. The class was wrong. `open_core` in this ladder
+  means an OSI core with functionality withheld for a paid tier; these five have an open
+  periphery around a closed engine, which is `source: partial`.
+- score 3 → 2. The score was wrong. Every one of the nine is "you can read it and not run
+  it freely" — a non-OSI restrictive license over public source, or a client standing in
+  for a closed service — which the ladder scores at 2.
+- `4 / open_source` → `5 / open_source`. The score was wrong. Each of the three publishes
+  the whole self-hostable product under an OSI license with nothing withheld. The 4s
+  encoded maturity or scepticism about the vendor's marketing, both of which belong on the
+  adoption and capability axes and were already recorded there.
+
+Worth noting what G3 caught that `check_rubric` could not: 16 of the 17 were sitting in a
+category's `deferred` block, which excludes a product from reproduction. G3 ignores the
+evidence and asks only whether the pair exists in the ladder, so deferring cannot hide it.
 
 ### Two shared utilities, so the mechanism cannot be bypassed
 
 - **`build/components.py`** — the only supported way to edit a `components` field. The
-  block-safe rewriter with the reparse assertion, extracted. 21 of deployment's 27 files
-  fold that scalar across lines, so any hand-rolled `^  components: (.*)$` substitution
-  splices keys mid-string and corrupts the value silently. A shared helper means the next
-  script cannot re-invent that.
-- **A query helper that forces a cache-busting nonce.** Warehouse results cache on query
-  TEXT, so a fixed verification query returns its first answer forever and a tool reading
-  through that cache reports success against stale data. It has already happened. The nonce
-  belongs in the helper, not in each caller's discipline.
+  block-safe rewriter with the reparse assertion. 277 of the 470 score files fold that
+  scalar across lines, 57 of them across three or more, so any hand-rolled
+  `^  components: (.*)$` substitution splices keys mid-string and corrupts the value
+  silently. A shared helper means the next script cannot re-invent that. Generic over the
+  field, so a score correction and a components edit are the same operation with the same
+  assertion behind them.
+- **`build/warehouse.py`** — the only supported way to read the warehouse, and it forces a
+  cache-busting nonce. Results cache on query TEXT, so a fixed verification query returns
+  its first answer forever and a tool reading through that cache reports success against
+  stale data. It has already happened. `query()` has no parameter to switch the nonce off.
 
 ## Why openness can never be fully automated
 
@@ -172,10 +193,20 @@ different in kind and can be automated — see the table below.
 | **real claims to verify** | **1386** |
 | of those, citing at least one source URL | 1386 |
 | carrying a real `last_verified` | 6 (once #124 lands; 26 before it, 19 of them tool-written) |
+| of those 6, satisfying G1 and G2 | 6, after the Phase 0 re-read |
 | distinct source URLs behind all of it | 1099 (450 cited more than once) |
 
 Every real claim already cites a source. The work is not finding evidence; it is re-reading
 what is cited. And the re-read surface is 1099 fetches, not 1386, because sources are shared.
+
+**None of the 6 satisfied G1 as first written**, which is worth recording because it is the
+clearest evidence that the invariant does something. `establishes` did not exist when those
+dates were set, and beyond that the 2026-07-28 pass on the four model flagships re-read only
+the dataset endpoint: `apertus`, `olmo`, `pythia` and `lucie-7b` all claimed a whole-axis
+confirmation while citing 2026-06 reads for weights, code, checkpoints and license. Refetching
+the 23 cited sources cleared it and turned up two things an exemption would have hidden — a
+Lucie source URL that had never resolved as cited (missing the `/datasets/` segment, so the
+Hub answered 401), and an `rwkv` `weights:open` claim with no source behind it at all.
 
 ### What automation can and cannot earn, per axis
 
@@ -229,9 +260,10 @@ Two things ride along:
   every dimension the score *records*. Without this column no tool can ever legitimately
   write `last_verified`, so it is the precondition for step 3.
 - **A `category_deferrals` table.** `deferred` currently lives only in the repo, so the
-  warehouse does not know which products a category has held back. There are ~180 of them
-  now. With no `otherwise` rule in the software ladder they fall out of the model's INNER
-  JOIN rather than being scored wrongly — the safe direction, but silent.
+  warehouse does not know which products a category has held back. There are 63 of them now,
+  alongside the 111 products in the four categories with no recipe at all. With no
+  `otherwise` rule in the software ladder they fall out of the model's INNER JOIN rather than
+  being scored wrongly — the safe direction, but silent.
 
 ### 3. The automated freshness pass — roughly 400 axes
 
@@ -246,13 +278,16 @@ than clearing it first.** Reading a product's sources to determine `core-gated` 
 re-check that earns its `last_verified`; done as two passes it is the same pages fetched
 twice, and it re-verifies scores that are about to change.
 
-That backlog is currently ~180 products: 59 whose prose does not settle their dimensions, 11
-where the ladder and the recorded score disagree, plus the model-category gaps.
+That backlog is currently 174 products: 49 whose prose does not settle `source` or
+`core-gated`, 10 whose recorded license maps to no tier in the ladder, 4 where the ladder and
+the recorded score still disagree (`jina-reader`, `openhands`, `maple-ai`, `privatemode` — all
+producible pairs, so G3 passes them and only `check_rubric` objects), plus the 111 products in
+the four categories that have no recipe yet.
 
 **Expect scores to move.** Verification is not a formality: the RWKV correction in #105 came
-out of a pass like this, and the 11 ladder conflicts already say some recorded scores are
-wrong — `vellum` and `whylabs` are recorded `4 / open_source`, which is not a pair any ladder
-here can produce. `apply_scores --check` exits non-zero on a moved score for this reason.
+out of a pass like this, and G3's first run moved 17 openness scores or classes before the
+gate could land at all. `apply_scores --check` exits non-zero on a moved score for this
+reason.
 
 ### 5. Turn on the age gate
 

--- a/docs/runbooks/verification-pass.md
+++ b/docs/runbooks/verification-pass.md
@@ -27,6 +27,23 @@ corrupted twice already.
 Do this first. Everything after it is bulk edits to `sources/scores/`, and gates written
 afterwards would be gates written to fit whatever the bulk edits happened to produce.
 
+> **0.1 to 0.4 have landed.** `build/check_verification.py` runs in `validate.yml`, and all
+> three gates pass. Two things went differently from what is written below and are worth
+> knowing before following it:
+>
+> - **G3 caught 17 impossible pairs, not 2.** `vellum` and `whylabs` were the known ones;
+>   `tensorrt-llm` made a third `4 / open_source`, five products were `2 / open_core`, and
+>   nine carried a score of 3, which the software ladder cannot emit at all. All were fixed
+>   as score corrections. `docs/guides/verification.md` has the three groups and the
+>   reasoning; the ladder was not touched.
+> - **The G2 exemption list is empty.** All 6 dated axes qualified for it, and none of them
+>   satisfied G1 either, because the 2026-07-28 pass on the model flagships re-read only the
+>   dataset endpoint. Re-fetching the 23 cited sources was 23 requests and it turned up two
+>   defects the exemption would have hidden. Exempting stays the cheaper move and the
+>   mechanism is still there; it is not the better move when the set is small.
+>
+> **0.5 (G6) has NOT landed.** It is the one Phase 0 item still open.
+
 ### 0.1 Schema: `establishes`, `http_status`, `content_sha256`
 
 Add all three to `docs/schemas/score.schema.json` under `definitions.source`, **all
@@ -154,7 +171,8 @@ Three things ship together:
    only what the winning rule reads, which is the wrong denominator — the rule requires every
    dimension the score *records*. Without this, Phase 3 cannot legitimately write a date.
 3. **A `category_deferrals` table.** `deferred` lives only in the repo, so the warehouse does
-   not know which ~180 products are held back. With no `otherwise` rule in the software
+   not know which 174 products are held back (63 recipe deferrals plus 111 in the four
+   categories with no recipe). With no `otherwise` rule in the software
    ladder they currently fall out of an INNER JOIN — safe, but silent.
 
 Deploy per `docs/runbooks/deploy-udms.md`, and note the release step:
@@ -203,7 +221,7 @@ them as `verified` rather than `commit`.
 
 ## Phase 4 — The re-read pass, ~1099 URLs
 
-Everything else, all of openness included. **Fold the ~180 deferrals in rather than clearing
+Everything else, all of openness included. **Fold the 174 held-back products in rather than clearing
 them first** — reading a product's sources to settle `core-gated` *is* the re-check that earns
 its date. Two passes means the same pages fetched twice, on scores about to change.
 

--- a/docs/schemas/score.schema.json
+++ b/docs/schemas/score.schema.json
@@ -53,7 +53,25 @@
       "properties": {
         "url": { "type": "string", "pattern": "^https?://" },
         "shows": { "type": "string", "minLength": 1 },
-        "accessed": { "type": "string", "minLength": 1 }
+        "accessed": { "type": "string", "minLength": 1 },
+        "establishes": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Which dimensions of this axis's score THIS source settles. `sources` is a flat list per axis, so without it nothing records which source establishes which dimension, and a re-check claim cannot be checked. Every name must be a dimension some category's scoring_recipe declares, or a recorded key one of those dimensions reads; build/validate.py enforces that cross-file, because a typo'd name would establish nothing while looking like attribution. Optional and forward-populated: build/check_verification.py requires it only on axes that claim a last_verified. Normative definition in docs/guides/verification.md."
+        },
+        "http_status": {
+          "type": "integer",
+          "minimum": 100,
+          "maximum": 599,
+          "description": "HTTP status the fetch at `accessed` returned. Present means something actually made a request. A 404 at re-check time says the URL was either never real or has rotted."
+        },
+        "content_sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$",
+          "description": "SHA-256 of the fetched response body at `accessed` time. A changed digest says the page moved under a claim that still cites it — a reason to re-check rather than a failure on its own, since pages legitimately change. A MISSING digest on a newly claimed confirmation is a hard failure, because it means the tool fetched nothing."
+        }
       }
     }
   }

--- a/sources/categories/agent_tools_protocols.yaml
+++ b/sources/categories/agent_tools_protocols.yaml
@@ -66,8 +66,10 @@ scoring_recipe:
         the repo and pricing page
     apify:
       because: >-
-        ladder computes 1/closed from the recorded evidence but the score says 2/open_core;
-        one of the two is wrong and it needs a human
+        the license is recorded as `mixed(platform closed, SDK open)`, which names no license and
+        so maps to no tier. The deciding rule reads `source` alone, but check_rubric resolves a
+        license tier before applying the formula, so it abstains. Adding the license to a tier is
+        a rubric change, held for Phase 1.
     yomo:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of

--- a/sources/categories/dataset_processing_tools.yaml
+++ b/sources/categories/dataset_processing_tools.yaml
@@ -47,8 +47,12 @@ scoring_recipe:
   deferred:
     txt360-pipeline:
       because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
+        the license is recorded as prose - `Apache-2.0 asserted in README only, no LICENSE file in
+        repo` - so the tier lookup reads a sentence rather than a license name. Confirmed
+        2026-07-30: the repo still ships no LICENSE file and the GitHub license endpoint 404s. The
+        deciding rule reads `source` alone, but check_rubric resolves a license tier before
+        applying the formula, so it abstains. Adding the license to a tier is a rubric change,
+        held for Phase 1.
     nemo-data-designer:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of

--- a/sources/categories/evaluation_code.yaml
+++ b/sources/categories/evaluation_code.yaml
@@ -56,20 +56,26 @@ scoring_recipe:
         the repo and pricing page
     chatbot-arena:
       because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
+        no `license` key is recorded at all; the components describe the platform and its OSS
+        heritage without naming the license the product ships under. The deciding rule reads
+        `source` alone, but check_rubric resolves a license tier before applying the formula, so
+        it abstains. Adding the license to a tier is a rubric change, held for Phase 1.
     patronus-evaluation-platform:
       because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
+        no `license` key is recorded at all - the SDK repo page does not display one, which the
+        note already flags. The deciding rule reads `source` alone, but check_rubric resolves a
+        license tier before applying the formula, so it abstains. Adding the license to a tier is
+        a rubric change, held for Phase 1.
     scale-evaluation:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of
         the repo and pricing page
     artificial-analysis-intelligence-index:
       because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
+        no `license` key is recorded at all; only Stirrup's MIT is named, and Stirrup is one eval
+        harness rather than the Index. The deciding rule reads `source` alone, but check_rubric
+        resolves a license tier before applying the formula, so it abstains. Adding the license to
+        a tier is a rubric change, held for Phase 1.
     epoch-ai-benchmarks:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of

--- a/sources/categories/finetuning_code.yaml
+++ b/sources/categories/finetuning_code.yaml
@@ -56,10 +56,6 @@ scoring_recipe:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of
         the repo and pricing page
-    predibase:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
     anyscale-fine-tuning:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of

--- a/sources/categories/inference_code.yaml
+++ b/sources/categories/inference_code.yaml
@@ -46,8 +46,12 @@ scoring_recipe:
         the repo and pricing page
     max:
       because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
+        `Modular-Community-License` appears in no tier's examples. Read 2026-07-30: it licenses
+        per discrete device and grants a limited redistribution right over certain components
+        only, which is competition_restricted in substance - but recording that means adding it to
+        the tier list. The deciding rule reads `source` alone, but check_rubric resolves a license
+        tier before applying the formula, so it abstains. Adding the license to a tier is a rubric
+        change, held for Phase 1.
     aws-neuron:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of
@@ -73,10 +77,6 @@ scoring_recipe:
         source or core-gated is not recorded in a form the ladder can read; needs a read of
         the repo and pricing page
     sglang:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
-    tensorrt-llm:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of
         the repo and pricing page

--- a/sources/categories/orchestration_agents.yaml
+++ b/sources/categories/orchestration_agents.yaml
@@ -76,12 +76,11 @@ scoring_recipe:
         the repo and pricing page
     autogpt:
       because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
-    suna:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
+        the license is recorded as `DUAL, autogpt_platform/ under PolyForm Shield ...`, so the
+        tier lookup reads `DUAL`. PolyForm Shield is an anti-compete license and governs the
+        active product, which is why the score is 2. The deciding rule reads `source` alone, but
+        check_rubric resolves a license tier before applying the formula, so it abstains. Adding
+        the license to a tier is a rubric change, held for Phase 1.
     claude-code:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of
@@ -90,14 +89,13 @@ scoring_recipe:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of
         the repo and pricing page
-    vellum:
-      because: >-
-        ladder computes 4/open_core from the recorded evidence but the score says
-        4/open_source; one of the two is wrong and it needs a human
     dify:
       because: >-
-        ladder computes 4/open_core from the recorded evidence but the score says
-        3/source_available; one of the two is wrong and it needs a human
+        `Dify-Open-Source-License` appears in no tier's examples. Its multi-tenant and branding
+        conditions on top of Apache-2.0 make it competition_restricted in substance. The deciding
+        rule reads `source` alone, but check_rubric resolves a license tier before applying the
+        formula, so it abstains. Adding the license to a tier is a rubric change, held for Phase
+        1.
     openhands:
       because: >-
         ladder computes 5/open_source from the recorded evidence but the score says

--- a/sources/categories/telemetry_observability.yaml
+++ b/sources/categories/telemetry_observability.yaml
@@ -46,10 +46,6 @@ scoring_recipe:
   # reproduction count honest by excluding them from it rather than counting
   # them as passes.
   deferred:
-    phoenix:
-      because: >-
-        ladder computes 2/source_available from the recorded evidence but the score says
-        3/source_available; one of the two is wrong and it needs a human
     agentops:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of
@@ -62,10 +58,6 @@ scoring_recipe:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of
         the repo and pricing page
-    whylabs:
-      because: >-
-        ladder computes 4/open_core from the recorded evidence but the score says
-        4/open_source; one of the two is wrong and it needs a human
     langfuse:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of

--- a/sources/categories/ui_api.yaml
+++ b/sources/categories/ui_api.yaml
@@ -66,12 +66,18 @@ scoring_recipe:
   deferred:
     open-webui:
       because: >-
-        ladder computes 4/open_core from the recorded evidence but the score says
-        3/source_available; one of the two is wrong and it needs a human
+        `Open-WebUI-License` appears in no tier's examples. Its branding-retention clause above 50
+        end-users/30d charges for a class of use, which is competition_restricted in substance.
+        The deciding rule reads `source` alone, but check_rubric resolves a license tier before
+        applying the formula, so it abstains. Adding the license to a tier is a rubric change,
+        held for Phase 1.
     lobe-chat:
       because: >-
-        ladder computes 4/open_core from the recorded evidence but the score says
-        3/source_available; one of the two is wrong and it needs a human
+        `LobeHub-Community-License` appears in no tier's examples. Requiring a commercial license
+        to distribute a derivative work is a restriction Apache-2.0 does not carry. The deciding
+        rule reads `source` alone, but check_rubric resolves a license tier before applying the
+        formula, so it abstains. Adding the license to a tier is a rubric change, held for Phase
+        1.
     nextchat:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of
@@ -81,10 +87,6 @@ scoring_recipe:
         source or core-gated is not recorded in a form the ladder can read; needs a read of
         the repo and pricing page
     thunderbolt:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
-    lumo:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of
         the repo and pricing page

--- a/sources/scores/apertus.yaml
+++ b/sources/scores/apertus.yaml
@@ -11,22 +11,39 @@ openness:
     code/recipe, intermediate checkpoints, a technical report (arXiv 2509.14233), and EU AI Act + Swiss
     data-protection/copyright compliance docs. All Apache-2.0. Sits in the OLMo/Pythia full-openness
     tier.'
-  last_verified: '2026-07-28'
+  last_verified: '2026-07-30'
   sources:
   - url: https://api.github.com/repos/swiss-ai/pretrain-data
-    shows: Repository resolves 200. Pretraining-data reconstruction scripts are published, satisfying data:open by reconstruction.
-    accessed: '2026-07-28'
+    shows: '`private: false`, `archived: false`, license `Apache-2.0`, description "Pretraining data
+      reconstruction scripts for Apertus". The reconstruction scripts are published, which is what
+      satisfies data:open by reconstruction rather than by a released corpus.'
+    accessed: '2026-07-30'
+    http_status: 200
+    content_sha256: 22e9345c0f44c7324c2929ca38e9408ec556575ea2ff4c4b7ebb538fe1d69e2e
+    establishes: [data]
   - url: https://huggingface.co/swiss-ai/Apertus-70B-2509
-    shows: Apache-2.0; BF16 safetensors weights; training checkpoints on branches; data reconstruction
-      scripts; EU AI Act docs; 15T tokens; 4,096 GH200 GPUs; Megatron-LM
-    accessed: '2026-06-08'
+    shows: 'Model card: "Fully open model: open weights + open data + full training details including
+      all data and training recipes"; "Training Framework: Megatron-LM" linking github.com/swiss-ai/Megatron-LM;
+      "The training intermediate checkpoints are available on the different branches of this same
+      repository"; license apache-2.0; BF16 safetensors.'
+    accessed: '2026-07-30'
+    http_status: 200
+    content_sha256: e8de05e747aaf6672a8eb9207609722e7b7f310340f30af75bf22fdd6daa489a
+    establishes: [weights, license, code, checkpoints]
   - url: https://ethz.ch/en/news-and-events/eth-news/news/2025/09/press-release-apertus-a-fully-open-transparent-multilingual-language-model.html
-    shows: 'ETH Zurich press release: fully open weights + data + training recipe; Swiss data-protection/copyright
-      + EU AI Act compliance; released 2 Sep 2025 by EPFL/ETH/CSCS'
-    accessed: '2026-06-08'
+    shows: 'ETH Zurich press release, title "Apertus: a fully open, transparent, multilingual language
+      model", dated 2 September 2025 (EPFL/ETH/CSCS). Corroborates the release framing; establishes
+      no dimension on its own, since a press release describes rather than exhibits the artifacts.'
+    accessed: '2026-07-30'
+    http_status: 200
+    content_sha256: fbd3f61a6bbf347b973e0bab0b366ba30fbf24002de216fc1a9e5d3ff458be3b
   - url: https://github.com/swiss-ai/pretrain-data
-    shows: open pretraining-data reconstruction scripts
-    accessed: '2026-06-08'
+    shows: Repository page for the pretraining-data reconstruction scripts; "reconstruction" appears
+      throughout the tree and README.
+    accessed: '2026-07-30'
+    http_status: 200
+    content_sha256: 713a1393fe21e68bf2fffbcd11d9f4d395aacf16b55fc9852f511ee4549cb579
+    establishes: [data]
 adoption:
   level: 2
   reach: 10K-100K

--- a/sources/scores/apify.yaml
+++ b/sources/scores/apify.yaml
@@ -1,13 +1,17 @@
 product: apify
 openness:
   score: 2
-  class: open_core
-  components: platform:proprietary(Apify-Cloud,Actor-store,managed);oss-sdk:Crawlee(Apache-2.0,OSI, JS+Python);license:mixed(platform
+  class: source_available
+  components: platform:proprietary(Apify-Cloud,Actor-store,managed);source:partial(Crawlee SDK published,
+    the platform that runs Actors is not);oss-sdk:Crawlee(Apache-2.0,OSI, JS+Python);license:mixed(platform
     closed, SDK open)
   confidence: high
-  note: 'The product proper (Apify platform/Actor store) is proprietary SaaS; Apify also maintains the
-    OSS Crawlee scraping library (Apache-2.0). Scored open_core but low (2): the open piece is an adjacent
-    SDK, not the platform core, so most value is gated behind the managed cloud.'
+  note: The product proper (Apify platform/Actor store) is proprietary SaaS; Apify also maintains the OSS
+    Crawlee scraping library (Apache-2.0). Crawlee is an adjacent SDK rather than the platform core, so
+    most value stays behind the managed cloud. Class corrected from open_core on 2026-07-30. In this ladder
+    open_core means an OSI core with functionality withheld for a paid tier, and there is no open core here,
+    only an open periphery. A repo that exists while the runtime does not ship is source:partial, which
+    the ladder scores 2/source_available. The score itself was already 2.
   sources:
   - url: https://apify.com
     shows: proprietary full-stack scraping platform with 35,000+ Actors; Crawlee called out as their OSS

--- a/sources/scores/artificial-analysis-intelligence-index.yaml
+++ b/sources/scores/artificial-analysis-intelligence-index.yaml
@@ -1,16 +1,21 @@
 product: artificial-analysis-intelligence-index
 openness:
   score: 2
-  class: open_core
-  components: platform:closed(proprietary benchmarking site + methodology); methodology:documented(public
-    methodology page, per-eval breakdown, temp/token params); datasets:closed(maintains internal copies
-    of all eval datasets); harness:partial-open(Stirrup MIT, used for the agentic GDPval-AA eval only,
-    413 stars); the full Intelligence Index harness is not open
+  class: source_available
+  components: platform:closed(proprietary benchmarking site + methodology); source:partial(Stirrup covers
+    one of ten evals; the Index pipeline does not ship); methodology:documented(public methodology page,
+    per-eval breakdown, temp/token params); datasets:closed(maintains internal copies of all eval datasets);
+    harness:partial-open(Stirrup MIT, used for the agentic GDPval-AA eval only, 413 stars); the full Intelligence
+    Index harness is not open
   confidence: high
-  note: Methodology is well-documented and one component harness (Stirrup) is MIT-OSS, but the Index itself
-    (pipeline, internal dataset copies, grader config) is proprietary => open_core (closed-leaning with
-    a documented methodology + one OSS sub-tool). Not pure closed given Stirrup + transparent methodology;
-    not source_available since the core isn't published.
+  note: 'Methodology is well documented and one component harness (Stirrup) is MIT, but the Index itself
+    (pipeline, internal dataset copies, grader config) is proprietary. The earlier note reasoned "not source_available
+    since the core isn''t published", which reads source_available as a stronger claim than this ladder
+    makes: source:partial covers a repo existing while the runtime does not ship, and Stirrup covers one
+    of ten evals. Class corrected from open_core on 2026-07-30. In this ladder open_core means an OSI core
+    with functionality withheld for a paid tier, and there is no open core here, only an open periphery.
+    A repo that exists while the runtime does not ship is source:partial, which the ladder scores 2/source_available.
+    The score itself was already 2.'
   sources:
   - url: https://artificialanalysis.ai/methodology/intelligence-benchmarking
     shows: v4.0.4 (Mar 2026), 10-eval composite, internal copies of all datasets, standardized params

--- a/sources/scores/autogpt.yaml
+++ b/sources/scores/autogpt.yaml
@@ -1,13 +1,15 @@
 product: autogpt
 openness:
-  score: 3
+  score: 2
   class: source_available
   confidence: high
   components: license:DUAL, autogpt_platform/ under PolyForm Shield (non-OSI, source-available, anti-compete);
     everything else (Classic, Forge, agbenchmark) MIT(OSI);source:public
   note: 'Verified dual license: the current flagship, the AutoGPT Platform, is PolyForm Shield (source-available,
-    non-OSI), while legacy components stay MIT. Mixed-tier: scored source_available because the active
-    product is non-OSI. Confirmed via primary GitHub source.'
+    non-OSI, anti-compete), while legacy components (Classic, Forge, agbenchmark) stay MIT. Scored on the
+    active product. Score corrected from 3 to 2 on 2026-07-30. The software ladder has rungs at 1, 2, 4
+    and 5 and none at 3, so 3/source_available was not a pair any rule could produce; the ladder scores
+    "you can read it and not run it freely" at 2.'
   sources:
   - url: https://github.com/Significant-Gravitas/AutoGPT
     shows: 'dual license: PolyForm Shield for autogpt_platform, MIT for the rest (verified); 185k stars;

--- a/sources/scores/chatbot-arena.yaml
+++ b/sources/scores/chatbot-arena.yaml
@@ -1,15 +1,21 @@
 product: chatbot-arena
 openness:
   score: 2
-  class: open_core
-  components: platform:closed(hosted arena.ai, proprietary live leaderboard + private vote data); reference-code:FastChat
-    Apache-2.0 (powers Chatbot Arena but stale, last release Feb 2024, 39.5k stars); aux-OSS:Arena-Hard-Auto
-    Apache-2.0 (automatic LLM eval, highest correlation to LMArena); ranking methodology + crowd-vote
-    dataset not fully open
+  class: source_available
+  components: platform:closed(hosted arena.ai, proprietary live leaderboard + private vote data); source:partial(FastChat
+    is a real arena implementation but stale relative to the operating platform; the current ranking pipeline
+    does not ship); reference-code:FastChat Apache-2.0 (powers Chatbot Arena but stale, last release Feb
+    2024, 39.5k stars); aux-OSS:Arena-Hard-Auto Apache-2.0 (automatic LLM eval, highest correlation to LMArena);
+    ranking methodology + crowd-vote dataset not fully open
   confidence: medium
-  note: 'Scored as the hosted platform: the live evaluation product, its vote stream, and current ranking
-    pipeline are closed; substantial OSS heritage (FastChat) and an OSS automatic-eval companion exist,
-    so open_core not closed. The OSS code is stale relative to the operating platform.'
+  note: 'Scored as the hosted platform: the live evaluation product, its vote stream and the current ranking
+    pipeline are closed, while substantial OSS heritage (FastChat) and an OSS automatic-eval companion (Arena-Hard-Auto)
+    exist. The OSS code is stale relative to the operating platform, which is what makes this source_available
+    rather than closed: FastChat is a real arena implementation, just not the one running. Class corrected
+    from open_core on 2026-07-30. In this ladder open_core means an OSI core with functionality withheld
+    for a paid tier, and there is no open core here, only an open periphery. A repo that exists while the
+    runtime does not ship is source:partial, which the ladder scores 2/source_available. The score itself
+    was already 2.'
   sources:
   - url: https://github.com/lm-sys/FastChat
     shows: Apache-2.0; 'FastChat powers Chatbot Arena (lmarena.ai), serving over 10M chat requests for

--- a/sources/scores/dify.yaml
+++ b/sources/scores/dify.yaml
@@ -1,10 +1,15 @@
 product: dify
 openness:
-  score: 3
+  score: 2
   class: source_available
   components: license:Dify-Open-Source-License(Apache-2.0-based,non-OSI,added-conditions:multi-tenant/branding-restrictions);source:public;cloud+enterprise-tiers
   confidence: high
-  note: license:Dify-Open-Source-License(Apache-2.0-based,non-OSI,added-conditions:multi-tenant/branding-restrictions);source:public;cloud+enterprise-tiers
+  note: 'The Dify Open Source License is Apache-2.0 with added conditions: a multi-tenant service restriction
+    and branding requirements. That puts it outside OSI approval and charges for a class of use, so the
+    public source does not make the product freely runnable. Cloud and enterprise tiers sit alongside it.
+    Score corrected from 3 to 2 on 2026-07-30. The software ladder has rungs at 1, 2, 4 and 5 and none at
+    3, so 3/source_available was not a pair any rule could produce; the ladder scores "you can read it and
+    not run it freely" at 2.'
   sources:
   - url: https://github.com/langgenius/dify
     shows: flagship phase-C verification source

--- a/sources/scores/lobe-chat.yaml
+++ b/sources/scores/lobe-chat.yaml
@@ -1,13 +1,16 @@
 product: lobe-chat
 openness:
-  score: 3
+  score: 2
   class: source_available
   components: 'license:LobeHub-Community-License(Apache-2.0-based, non-OSI: commercial license required
     to develop+distribute a derivative work; CLA lets LobeHub relicense contributions for cloud editions);source:public;cloud-tier:LobeHub
     Cloud'
   confidence: high
-  note: 'Source-available, not OSI: the derivative-work commercial-license requirement and contributor
-    relicensing terms exceed Apache-2.0; still presented publicly as open source.'
+  note: 'Source-available, not OSI: distributing a derivative work requires a commercial license, and the
+    CLA lets LobeHub relicense contributions for its cloud editions. Both exceed Apache-2.0, though it is
+    still presented publicly as open source. Score corrected from 3 to 2 on 2026-07-30. The software ladder
+    has rungs at 1, 2, 4 and 5 and none at 3, so 3/source_available was not a pair any rule could produce;
+    the ladder scores "you can read it and not run it freely" at 2.'
   sources:
   - url: https://github.com/lobehub/lobe-chat/blob/main/LICENSE
     shows: LobeHub Community License (Apache-2.0 based) requiring a commercial license to distribute derivative

--- a/sources/scores/lucie-7b.yaml
+++ b/sources/scores/lucie-7b.yaml
@@ -7,24 +7,50 @@ openness:
   confidence: high
   note: 'Full open-source tier alongside OLMo / Apertus: open weights, open training data, open training
     code, intermediate checkpoints. Authors position Lucie as OSI-definition-compliant for open-source AI.
-    Training-dataset product deferred — artifacts cited here for openness only.'
-  last_verified: '2026-07-28'
+    Training-dataset product deferred — artifacts cited here for openness only. Caveat found on the
+    2026-07-30 re-read: Lucie-Training-Dataset carries `cc-by-nc-sa-4.0`, so the corpus is published
+    and ungated but NOT commercially reusable. The `data` dimension asks whether the corpus is released,
+    not under what terms, so the score is unchanged — but the authors'' OSI-compliance claim does not
+    survive a strict reading, and Lucie is a weaker full-openness exemplar than OLMo, whose Dolma is
+    `odc-by`.'
+  last_verified: '2026-07-30'
   sources:
   - url: https://huggingface.co/api/datasets/OpenLLM-France/Lucie-Training-Dataset
-    shows: Public, ungated dataset repo present on the Hub; 3,101 downloads. Corpus is published, not merely described.
-    accessed: '2026-07-28'
+    shows: '`gated: false`, `private: false`, 2,823 downloads, 38 likes. Card license is `cc-by-nc-sa-4.0`
+      - the corpus is published and ungated, but non-commercial. See the note.'
+    accessed: '2026-07-30'
+    http_status: 200
+    content_sha256: 45eb931a751bf23f6b1483d7e9f36de370f6d97f8c16c385a8ccae2acd8c6164
+    establishes: [data]
   - url: https://huggingface.co/OpenLLM-France/Lucie-7B
-    shows: Apache-2.0 weights; links to Lucie-Training-Dataset; intermediate checkpoints; Llama-3.1 arch
-    accessed: '2026-07-19'
-  - url: https://huggingface.co/OpenLLM-France/Lucie-Training-Dataset
-    shows: redistributable multilingual pretraining corpus used for Lucie-7B
-    accessed: '2026-07-19'
+    shows: 'License apache-2.0, safetensors weights, links to Lucie-Training-Dataset, and intermediate
+      checkpoints as repo branches (`step0005000`, `step0010000`, ...); `isGated: false`.'
+    accessed: '2026-07-30'
+    http_status: 200
+    content_sha256: a5fe19f486e453fa8ff6a2f528a7b4f7855809cd39442d25c5b590af6f855198
+    establishes: [weights, license, checkpoints]
+  - url: https://huggingface.co/datasets/OpenLLM-France/Lucie-Training-Dataset
+    shows: 'Dataset page for the multilingual pretraining corpus: `isGated: false`, `isPrivate: false`,
+      Parquet format present. Cited previously WITHOUT the `/datasets/` path segment, which the Hub
+      resolves as a model repo and answers 401; the URL was corrected on re-read rather than the
+      dataset having become gated.'
+    accessed: '2026-07-30'
+    http_status: 200
+    content_sha256: ab497f71443c15c8e810967bc042d412b3c4fea042b835021e318998a48874f0
+    establishes: [data]
   - url: https://github.com/OpenLLM-France/Lucie-Training
-    shows: open training code (Megatron-DeepSpeed fork)
-    accessed: '2026-07-19'
+    shows: Repository described as "Code for continual pretraining of LUCIE" - the Megatron-DeepSpeed
+      fork used for the run.
+    accessed: '2026-07-30'
+    http_status: 200
+    content_sha256: b7f84d33bcf5b837dab128ddfabf07d5111127bb8f434f8ddf86ebf5942e26f3
+    establishes: [code]
   - url: https://arxiv.org/abs/2503.12294
-    shows: paper claiming OSI-compliant open resources for multilingual generation
-    accessed: '2026-07-19'
+    shows: Paper claiming OSI-compliant open resources for multilingual generation. The claim is the
+      authors', which is why it establishes no dimension by itself.
+    accessed: '2026-07-30'
+    http_status: 200
+    content_sha256: 2943dcf52d6e8f8ff3a631bb99bc6b48bb75c5015eac8c5fc7f29d9f0848dc41
 adoption:
   level: 2
   reach: 10K-100K

--- a/sources/scores/lumo.yaml
+++ b/sources/scores/lumo.yaml
@@ -1,13 +1,17 @@
 product: lumo
 openness:
-  score: 3
-  class: open_core
-  components: clients:open(GPLv3 - web in ProtonMail/WebClients, iOS/Android in ProtonLumo);service:closed(backend,
-    routing, model-serving not public);license:GPLv3(clients)
+  score: 2
+  class: source_available
+  components: source:partial(GPLv3 clients only; backend, routing and model-serving are not published);clients:open(GPLv3
+    - web in ProtonMail/WebClients, iOS/Android in ProtonLumo);service:closed(backend, routing, model-serving
+    not public);license:GPLv3(clients)
   confidence: high
-  note: Open clients (GPLv3) over a proprietary hosted service - the backend, routing, and model-serving
-    layer are not published. Marketed as "fully open source," but support and third-party reviews note
-    that only the clients are open, so open_core is the honest class.
+  note: 'Open clients (GPLv3) over a proprietary hosted service: the backend, routing and model-serving
+    layer are not published. Marketed as "fully open source", but support pages and third-party reviews
+    note that only the clients are open. Corrected from 3/open_core on 2026-07-30, and both values were
+    wrong: the ladder has no rung at 3, and a published client standing in for an unpublished engine is
+    source:partial, which it scores 2/source_available. open_core would mean an OSI core with a paid tier
+    withheld.'
   sources:
   - url: https://github.com/ProtonLumo/ios-lumo
     shows: iOS client source under GPLv3

--- a/sources/scores/mastra.yaml
+++ b/sources/scores/mastra.yaml
@@ -9,23 +9,37 @@ openness:
     OSI license, not fair-code. LICENSE.md scopes the commercial carve-out narrowly to `ee/` auth directories,
     so the agent, workflow, memory and eval surfaces a user actually builds on are Apache-2.0. Not 5 because
     the enterprise auth code is source-available and the managed platform is closed.
-  last_verified: '2026-07-29'
+  last_verified: '2026-07-30'
   sources:
   - url: https://github.com/mastra-ai/mastra/blob/main/LICENSE.md
-    shows: 'LICENSE.md states content outside `ee/` directories is "available under the Apache License 2.0",
-      Copyright 2025 Kepler Software, Inc., while `ee/` paths (packages/core/src/auth/ee/,
-      packages/server/src/server/auth/ee/) fall under the license in ee/LICENSE. This preamble ahead of the
-      Apache text is why GitHub''s classifier reports NOASSERTION for the repo.'
-    accessed: '2026-07-29'
-  - url: https://www.npmjs.com/package/@mastra/core
-    shows: published package metadata declares license Apache-2.0 at v1.54.0, confirming the framework ships
-      to consumers under the OSI license rather than only being licensed that way in-repo
-    accessed: '2026-07-29'
+    shows: 'LICENSE.md: "All content that resides under any directory named ''ee/'' within this repository"
+      - listing packages/core/src/auth/ee/ and packages/server/src/server/auth/ee/ - "is licensed under
+      the license defined in ee/LICENSE", while everything "not mentioned" in those directories or
+      restrictions "is available under the ''Apache License 2.0''". This preamble ahead of the Apache
+      text is why GitHub''s classifier reports NOASSERTION for the repo.'
+    accessed: '2026-07-30'
+    http_status: 200
+    content_sha256: f3e088854ab54991f81a9b4a0b8343d33a80124c091dfb5c962e67b589f0e1bd
+    establishes: [license, core-gated]
+  - url: https://registry.npmjs.org/@mastra/core
+    shows: 'Registry metadata declares `license: Apache-2.0`, latest 1.55.0 (was 1.54.0 on 2026-07-29),
+      confirming the framework ships to consumers under the OSI license rather than only being licensed
+      that way in-repo. Cited previously as the npmjs.com package page, which answers 403 to any
+      non-browser fetch behind a Cloudflare interstitial; the registry endpoint serves the same fact
+      and can actually be re-checked.'
+    accessed: '2026-07-30'
+    http_status: 200
+    content_sha256: 374b1995706041a57a638521d51bfef0ea265ca0acfd323e412b3b3d90e9980f
+    establishes: [license]
   - url: https://mastra.ai/
-    shows: 'site FAQ states "Mastra''s core framework is open source under the Apache 2.0 license. Enterprise
-      features are source-available under the Mastra Enterprise License", and describes Mastra Platform as a
-      hosted commercial tier'
-    accessed: '2026-07-29'
+    shows: 'Site FAQ states "Mastra''s core framework is open source under the Apache 2.0 license.
+      Enterprise features are source-available under the Mastra Enterprise License", and describes
+      Mastra Cloud as the hosted commercial tier you can "deploy the same app to" after running it
+      locally - so the published framework is what self-hosts.'
+    accessed: '2026-07-30'
+    http_status: 200
+    content_sha256: c1458faa3a17755659530882810b981eaa4849f8e2135f48e2c7efe7cc8ce82b
+    establishes: [source, core-gated]
 adoption:
   level: 4
   reach: 1M-10M

--- a/sources/scores/max.yaml
+++ b/sources/scores/max.yaml
@@ -1,14 +1,20 @@
 product: max
 openness:
-  score: 3
+  score: 2
   class: source_available
-  components: license:Modular-Community-License(non-OSI; Apache-2.0-w/-LLVM-exceptions only for some components);source:public(~450k
-    LOC incl MAX kernels + inference server + Mojo stdlib);commercial-tier:Modular enterprise/managed
-    deployment
+  components: license:Modular-Community-License(non-OSI, per-device licensing and a limited redistribution
+    grant, governs MAX/Mojo usage+distribution);repo-license:Apache-2.0-WITH-LLVM-exception(the source in
+    modular/modular);source:public(~450k LOC incl MAX kernels + inference server + Mojo stdlib);commercial-tier:Modular
+    enterprise/managed deployment
   confidence: high
-  note: Large public codebase but MAX/Mojo usage and distribution are governed by the non-OSI Modular
-    Community License (not OSI-approved), plus a commercial tier -> source_available, not open_source.
-    Marketed as 'open'; flag open_washed (non-OSI license presented as open).
+  note: 'Large public codebase, and the repo''s own LICENSE is now Apache-2.0 with LLVM Exceptions. The
+    README is explicit that "Modular, MAX and Mojo usage and distribution are licensed under the Modular
+    Community License", which is not OSI approved: read 2026-07-30, it licenses per discrete physical device,
+    grants only a limited right to redistribute certain components, and provides the community variant free
+    of charge subject to withdrawal at any time. So the source is readable and not freely runnable at scale.
+    Marketed as "open"; flag open_washed. Score corrected from 3 to 2 on 2026-07-30. The software ladder
+    has rungs at 1, 2, 4 and 5 and none at 3, so 3/source_available was not a pair any rule could produce;
+    the ladder scores "you can read it and not run it freely" at 2.'
   sources:
   - url: https://github.com/modular/modular
     shows: Modular Community License (non-OSI) governs MAX/Mojo usage+distribution; ~450k LOC public;

--- a/sources/scores/olmo.yaml
+++ b/sources/scores/olmo.yaml
@@ -6,17 +6,30 @@ openness:
   confidence: high
   note: 'Fully open: Apache-2.0 weights + the complete Dolma 3 corpus + training code + intermediate checkpoints.
     The reference fully-open model line.'
-  last_verified: '2026-07-28'
+  last_verified: '2026-07-30'
   sources:
   - url: https://huggingface.co/api/datasets/allenai/dolma
-    shows: Public, ungated dataset repo present on the Hub; 3,052 downloads. Dolma corpus is published.
-    accessed: '2026-07-28'
+    shows: '`gated: false`, `private: false`, 2,767 downloads, 1,064 likes, card license `odc-by`.
+      The Dolma corpus is published and ungated.'
+    accessed: '2026-07-30'
+    http_status: 200
+    content_sha256: 6f3da060ba808471df1fcbbf40725022dc3778c4b994ec1ed490991230ff869a
+    establishes: [data]
   - url: https://allenai.org/blog/olmo3
-    shows: 'fully-open release: weights, Dolma 3 data, code, recipes, checkpoints; Nov 2025 / Dec 2025 3.1 update'
-    accessed: '2026-06-30'
+    shows: '"Olmo 3 is pretrained on Dolma 3, a new ~9.3-trillion-token corpus"; "Because the Olmo 3
+      data recipes, training pipeline, and checkpoints are open, independent teams can connect model
+      behavior back to measurable" training decisions; "Olmo 3-Base delivers the strongest performance
+      among fully open base models - where training data, code, and weights are all publicly available".'
+    accessed: '2026-07-30'
+    http_status: 200
+    content_sha256: fc5d9ecb2b5ed673bac303a0a171c28183c19c3a4805d26e4676b6d112ceb94b
+    establishes: [data, code, checkpoints]
   - url: https://huggingface.co/allenai/Olmo-3-1025-7B
-    shows: OLMo 3 7B base on HF; Apache-2.0
-    accessed: '2026-06-30'
+    shows: 'OLMo 3 7B base model card: License apache-2.0, safetensors weight files, `isGated: false`.'
+    accessed: '2026-07-30'
+    http_status: 200
+    content_sha256: e8e02a24fb65c9b97ede3bc582e78689a9a12c0ca7f16effc953e5a57bbd24f3
+    establishes: [weights, license]
 adoption:
   level: 4
   reach: 1M-10M

--- a/sources/scores/open-webui.yaml
+++ b/sources/scores/open-webui.yaml
@@ -1,13 +1,17 @@
 product: open-webui
 openness:
-  score: 3
+  score: 2
   class: source_available
   components: 'license:Open-WebUI-License(BSD-3-Clause-based + non-OSI branding clause: branding may not
     be removed above 50 end-users/30d without enterprise license or written permission);source:public;enterprise-tier:commercial
     license to remove branding'
   confidence: high
-  note: 'Source-available, not OSI: a branding-retention clause caps free branding removal at <=50 users/30d,
-    which fails the OSS Definition; widely marketed as open source.'
+  note: 'Source-available, not OSI: a branding-retention clause caps free branding removal at 50 end-users
+    per 30 days, above which an enterprise license or written permission is required. That charges for a
+    class of use and fails the OSS Definition, though it is widely marketed as open source. Score corrected
+    from 3 to 2 on 2026-07-30. The software ladder has rungs at 1, 2, 4 and 5 and none at 3, so 3/source_available
+    was not a pair any rule could produce; the ladder scores "you can read it and not run it freely" at
+    2.'
   sources:
   - url: https://github.com/open-webui/open-webui/blob/main/LICENSE
     shows: BSD-3-Clause-derived license with Section 4 branding-retention clause (<=50 users/30d), non-OSI

--- a/sources/scores/patronus-evaluation-platform.yaml
+++ b/sources/scores/patronus-evaluation-platform.yaml
@@ -1,14 +1,17 @@
 product: patronus-evaluation-platform
 openness:
   score: 2
-  class: open_core
-  components: platform:closed(hosted SaaS; remote Judge/Lynx/Glider evaluators run on Patronus infrastructure);
-    client-SDKs:open(patronus-py public on GitHub, v0.1.25, but only 7 stars and wires to the hosted API);
-    eval engine + proprietary evaluators not self-hostable
+  class: source_available
+  components: platform:closed(hosted SaaS; remote Judge/Lynx/Glider evaluators run on Patronus infrastructure);source:partial(patronus-py
+    is a client wiring to the hosted API, not the engine);client-SDKs:open(patronus-py public on GitHub,
+    v0.1.25, but only 7 stars and wires to the hosted API);eval engine + proprietary evaluators not self-hostable
   confidence: medium
-  note: Open-source SDK is a thin client to a closed hosted evaluation backend; the core scoring engine
-    and managed evaluators are proprietary => open_core, low end (the OSS surface is a connector, not
-    the product). License text not displayed on the SDK repo page (note).
+  note: The open-source SDK is a thin client to a closed hosted evaluation backend; the core scoring engine
+    and the managed Lynx/Glider evaluators are proprietary and not self-hostable. License text is not displayed
+    on the SDK repo page. Class corrected from open_core on 2026-07-30. In this ladder open_core means an
+    OSI core with functionality withheld for a paid tier, and there is no open core here, only an open periphery.
+    A repo that exists while the runtime does not ship is source:partial, which the ladder scores 2/source_available.
+    The score itself was already 2.
   sources:
   - url: https://github.com/patronus-ai/patronus-py
     shows: Python SDK whose remote evaluators 'run remotely on Patronus infrastructure'; v0.1.25 Jan 2026;

--- a/sources/scores/phoenix.yaml
+++ b/sources/scores/phoenix.yaml
@@ -1,12 +1,15 @@
 product: phoenix
 openness:
-  score: 3
+  score: 2
   class: source_available
   components: 'license:Elastic-License-2.0(ELv2, non-OSI: prohibits offering as a managed/hosted service
     to third parties);source:public;self-hostable;commercial:Arize-AX-SaaS-is-separate-closed-product'
   confidence: high
-  note: LICENSE file is ELv2 verbatim, not an OSI license; Arize markets Phoenix as 'the open source platform'
-    (open_washed). Source-available + self-hostable, but not OSI open_source.
+  note: The LICENSE file is ELv2 verbatim, which is not an OSI license, while Arize markets Phoenix as "the
+    open source platform" (open_washed). Source-available and self-hostable, with Arize AX as a separate
+    closed SaaS product. Score corrected from 3 to 2 on 2026-07-30. The software ladder has rungs at 1,
+    2, 4 and 5 and none at 3, so 3/source_available was not a pair any rule could produce; the ladder scores
+    "you can read it and not run it freely" at 2.
   sources:
   - url: https://github.com/Arize-ai/phoenix/blob/main/LICENSE
     shows: Elastic License 2.0 (ELv2) full text

--- a/sources/scores/predibase.yaml
+++ b/sources/scores/predibase.yaml
@@ -1,15 +1,18 @@
 product: predibase
 openness:
   score: 2
-  class: open_core
-  components: core-platform:closed(proprietary post-training stack + turbo serving);OSS-components:LoRAX(open source
+  class: source_available
+  components: core-platform:closed(proprietary post-training stack + turbo serving);source:partial(LoRAX
+    and Ludwig are adjacent OSS; the fine-tuning platform does not ship);OSS-components:LoRAX(open source
     multi-LoRA serving)+Ludwig(open source);runs-on:Predibase-SaaS-or-customer-VPC;license:Proprietary(managed)
     with Apache-licensed LoRAX/Ludwig adjuncts
   confidence: high
-  note: 'Open-core: the founders created and maintain OSS LoRAX (multi-LoRA serving) and Ludwig, but the
-    Predibase fine-tuning/RFT platform itself is proprietary managed SaaS. Scored 2 (open-core leaning
-    closed) because the FT product - the thing being scored - is the proprietary platform, with OSS only
-    at the serving/declarative-ML edges.'
+  note: The founders created and maintain OSS LoRAX (multi-LoRA serving) and Ludwig, but the Predibase fine-tuning/RFT
+    platform, which is the thing being scored, is proprietary managed SaaS running on Predibase's own cloud
+    or a customer VPC. The OSS sits at the serving and declarative-ML edges. Class corrected from open_core
+    on 2026-07-30. In this ladder open_core means an OSI core with functionality withheld for a paid tier,
+    and there is no open core here, only an open periphery. A repo that exists while the runtime does not
+    ship is source:partial, which the ladder scores 2/source_available. The score itself was already 2.
   sources:
   - url: https://docs.predibase.com/
     shows: managed platform to fine-tune & serve open source LLMs; SFT/RFT/continued-pretraining; built

--- a/sources/scores/pythia.yaml
+++ b/sources/scores/pythia.yaml
@@ -10,20 +10,38 @@ openness:
     GitHub, and 154 intermediate checkpoints per model size. Every dimension the rubric asks about is answered by
     something downloadable, which is what separates 5 from the open-weights tier: the run is reproducible, not merely
     the model usable.'
-  last_verified: '2026-07-28'
+  last_verified: '2026-07-30'
   sources:
   - url: https://huggingface.co/api/datasets/EleutherAI/pile
-    shows: Public, ungated dataset repo present on the Hub; 2,441 downloads. The Pile is published.
-    accessed: '2026-07-28'
+    shows: '`gated: false`, `private: false`, 2,308 downloads, 502 likes. The Pile is published and
+      ungated on the Hub.'
+    accessed: '2026-07-30'
+    http_status: 200
+    content_sha256: 9371eeb13e004a16509da436da0b3ef00eed76096078a82766cb980dc657c9ca
+    establishes: [data]
   - url: https://arxiv.org/abs/2304.01373
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+    shows: 'Abstract: "We provide public access to 154 checkpoints for each one of the 16 models,
+      alongside tools to download and reconstruct their exact training dataloaders" - which is both
+      the checkpoint claim and the reconstruction tooling that makes the corpus reproducible in token
+      order.'
+    accessed: '2026-07-30'
+    http_status: 200
+    content_sha256: 4a9c75245714d244bd57fdac23e8cc59ccf7b12a72594e32941b7e9c26de3983
+    establishes: [checkpoints, data]
   - url: https://github.com/EleutherAI/pythia
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+    shows: 'Repository page, described as "The hub for EleutherAI''s work on interpretability and
+      learning dynamics" - training and analysis code, public.'
+    accessed: '2026-07-30'
+    http_status: 200
+    content_sha256: 34d20875f3ddcdae5b25e04fb188e300e5faf94eddfc1b59cd4002b846f1866e
+    establishes: [code]
   - url: https://huggingface.co/EleutherAI/pythia-12b/blob/main/README.md
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+    shows: 'Model card front matter: `license: apache-2.0`, `datasets: [EleutherAI/pile]`; License
+      apache-2.0 in the repo sidebar.'
+    accessed: '2026-07-30'
+    http_status: 200
+    content_sha256: e5da5801a6a437bf051cdaa442810bf7d832b3b3b7a8af62546755322fdb2a0f
+    establishes: [weights, license]
 adoption:
   level: 3
   reach: 100K-1M

--- a/sources/scores/rwkv.yaml
+++ b/sources/scores/rwkv.yaml
@@ -6,7 +6,7 @@ openness:
     index with resolvable links to public datasets, but no released corpus and no reconstruction
     pipeline);code:open(github.com/BlinkDL/RWKV-LM);license:Apache-2.0(OSI)
   confidence: high
-  last_verified: '2026-07-28'
+  last_verified: '2026-07-30'
   note: 'Corrected from 5/open_source on 2026-07-28, then re-examined the same day after challenge.
     The correction stands but it is a close call, and RWKV published more than a first look suggests.
     What IS released: an itemized, machine-readable index (index/train.jsonl, train.csv) naming every
@@ -27,22 +27,45 @@ openness:
     the nine products checked fall between the available values.'
   sources:
   - url: https://huggingface.co/datasets/RWKV/RWKV-World-Listing/raw/main/train.csv
-    shows: 'Component table: Dataset;Category;Citation;Version;URL;Notes. Every source named with a
-      resolvable link. Notes defer exact sampling to unpublished supplementary material and include the
-      unresolved question "peS2o - Which version out of the 3?".'
-    accessed: '2026-07-28'
+    shows: 'Header `Dataset;Category;Categories;Citation;Version;URL;Notes`; every source named with a
+      resolvable link. Notes defer exact sampling to unpublished supplementary material ("see wiki.txt
+      in the supplementary material for exact" amounts) and include the unresolved question "peS2o -
+      Which version out of the 3?".'
+    accessed: '2026-07-30'
+    http_status: 200
+    content_sha256: b017936cd892fab763f650c6d9ee11cb375faaa0240f4ee313866960310ab03d
+    establishes: [data]
   - url: https://huggingface.co/api/datasets/Goose-World/RWKV-World-v3
-    shows: '10 files, 8.17GB: index/train.jsonl, train.csv, 100k and 1M preview subsamples, READMEs,
-      one figure. No corpus shards.'
-    accessed: '2026-07-28'
+    shows: '`gated: false`, `private: false`, 217 downloads. Files are `index/train.jsonl`, `train.csv`,
+      `100k/subsample_100k.jsonl`, `1m/subsample_1m.jsonl`, two READMEs and one figure. No corpus
+      shards, which is what holds `data` at documented-not-released.'
+    accessed: '2026-07-30'
+    http_status: 200
+    content_sha256: d5d229aa8e6b2381fd7cc987d6f9203b3bc3a8e7837ccab9fe2055f036ed6db0
+    establishes: [data]
   - url: https://api.github.com/repos/BlinkDL/RWKV-LM
-    shows: Model and training code by version (RWKV-v1..v8) plus figures. No data-prep or corpus
-      reconstruction directory.
-    accessed: '2026-07-28'
+    shows: '`private: false`, license `Apache-2.0`, 14,642 stars, pushed 2026-07-23. Model and training
+      code by version (RWKV-v1..v8). No data-prep or corpus-reconstruction directory.'
+    accessed: '2026-07-30'
+    http_status: 200
+    content_sha256: 756686a7592173285002c7f9a7315216e500ff3aecebd1bea8a9b950804eec9a
+    establishes: [code]
+  - url: https://huggingface.co/api/models/BlinkDL/rwkv-7-world
+    shows: '`gated: false`, `private: false`, card license `apache-2.0`, 4,537 downloads. Weight files
+      downloadable as `RWKV-x070-World-{0.1B,0.4B,1.5B}-*.pth`. Added on the 2026-07-30 re-read: the
+      axis recorded `weights:open(Apache-2.0)` while citing only the code repo and the dataset, so
+      nothing on file actually established the weights.'
+    accessed: '2026-07-30'
+    http_status: 200
+    content_sha256: ed3f89200a3bfc477a6e76310016fee4adeafc7577883f6b1e5a12906c3dbe7d
+    establishes: [weights, license]
   - url: https://arxiv.org/abs/2503.14456
-    shows: 'RWKV-7 Goose paper: claims a 3.1T open corpus. No arXiv ancillary files are attached, so
-      the supplementary material the dataset notes point to is not obtainable from the paper either.'
-    accessed: '2026-07-28'
+    shows: 'RWKV-7 Goose paper abstract: "we also present an extended open source 3.1 trillion token
+      multilingual corpus". No arXiv ancillary files are attached, so the supplementary material the
+      dataset notes point to is not obtainable from the paper either.'
+    accessed: '2026-07-30'
+    http_status: 200
+    content_sha256: ead02dec46f813c10d8ff4b7884f5d83f41d05a27ce94edbbaaaee2f18212d68
 adoption:
   level: 3
   signal_type: stars_fallback

--- a/sources/scores/suna.yaml
+++ b/sources/scores/suna.yaml
@@ -1,13 +1,15 @@
 product: suna
 openness:
-  score: 3
+  score: 2
   class: source_available
   confidence: high
   components: license:Elastic License 2.0(non-OSI, source-available, restricts hosting as a managed service);source:public;managed
     cloud + self-host tiers
-  note: Verified Elastic License 2.0 in the LICENSE file, source-available, NOT OSI; restricts providing
-    the software as a hosted/managed service. Marketed as 'open source' but carries managed-service restrictions;
-    flagged open_washed.
+  note: 'Verified Elastic License 2.0 in the LICENSE file: source-available, not OSI approved, and restricts
+    providing the software as a hosted or managed service. Marketed as "open source" while carrying managed-service
+    restrictions; flagged open_washed. Score corrected from 3 to 2 on 2026-07-30. The software ladder has
+    rungs at 1, 2, 4 and 5 and none at 3, so 3/source_available was not a pair any rule could produce; the
+    ladder scores "you can read it and not run it freely" at 2.'
   sources:
   - url: https://github.com/kortix-ai/suna/blob/main/LICENSE
     shows: Elastic License 2.0 text (verified, non-OSI)

--- a/sources/scores/tensorrt-llm.yaml
+++ b/sources/scores/tensorrt-llm.yaml
@@ -1,12 +1,18 @@
 product: tensorrt-llm
 openness:
-  score: 4
+  score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;caveat:runs only on NVIDIA GPUs (vendor-hardware lock,
-    not a license restriction)
-  confidence: high
-  note: license:Apache-2.0(OSI);source:public;caveat:runs only on NVIDIA GPUs (vendor-hardware lock, not
+  components: license:Apache-2.0(OSI, stated in LICENSE; GitHub reports NOASSERTION because of the bundled-dependency
+    appendix);source:public;core-gated:ungated;caveat:runs only on NVIDIA GPUs (vendor-hardware lock, not
     a license restriction)
+  confidence: high
+  note: 'Apache-2.0 across the repo. The LICENSE opens "This project is licensed under the Apache 2.0 license"
+    and then appends the terms of the third-party code it bundles, which is why GitHub''s classifier reports
+    NOASSERTION. Nothing is withheld from the published source: NVIDIA sells NIM and enterprise support
+    as separate products rather than gating features out of this one. Score corrected from 4 to 5 on 2026-07-30.
+    In this ladder 4 pairs with open_core and never with open_source, and the recorded 4 was carrying the
+    NVIDIA-GPU-only caveat, which is a hardware lock rather than a license restriction and answers no openness
+    dimension.'
   sources:
   - url: https://github.com/NVIDIA/TensorRT-LLM
     shows: flagship phase-C verification source

--- a/sources/scores/txt360-pipeline.yaml
+++ b/sources/scores/txt360-pipeline.yaml
@@ -1,13 +1,16 @@
 product: txt360-pipeline
 openness:
-  score: 3
+  score: 2
   class: source_available
   components: license:Apache-2.0 asserted in README only, no LICENSE file in repo (GitHub reports null);
     source:public(LLM360/TxT360)
   confidence: low
-  note: The README badge asserts Apache-2.0 but the repo ships no LICENSE file, so there is no actual
-    redistribution grant. Scored source_available until a LICENSE lands, rather than assuming OSI open
-    source from a badge.
+  note: 'The README badge asserts Apache-2.0 but the repo ships no LICENSE file, so there is no actual redistribution
+    grant. Re-checked 2026-07-30: still no LICENSE file, and the GitHub license endpoint returns 404 while
+    the repo API reports a null license. Scored on that rather than on the badge. Score corrected from 3
+    to 2 on 2026-07-30. The software ladder has rungs at 1, 2, 4 and 5 and none at 3, so 3/source_available
+    was not a pair any rule could produce; the ladder scores "you can read it and not run it freely" at
+    2.'
   sources:
   - url: https://github.com/LLM360/TxT360
     shows: README asserts Apache-2.0; no LICENSE file in repo (GitHub reports null license)

--- a/sources/scores/vellum.yaml
+++ b/sources/scores/vellum.yaml
@@ -1,18 +1,21 @@
 product: vellum
 openness:
-  score: 4
+  score: 5
   class: open_source
-  components: 'license:MIT(OSI, Copyright 2025 Vellum AI);source:public+full-agent(github.com/vellum-ai/vellum-assistant:
-    gateway+clients+skill-framework+memory);self-host:yes(by design);managed-cloud:optional-add-on(memory/security)'
+  components: 'license:MIT(OSI, Copyright 2025 Vellum AI);source:public(the full agent - gateway, clients,
+    skill framework, memory - in github.com/vellum-ai/vellum-assistant);core-gated:ungated(README: managed
+    runtime on Vellum Platform or self-hosted, "Same codebase, same data model");self-host:yes(by design);managed-cloud:hosting
+    convenience, not a feature tier'
   confidence: high
-  note: 'CORRECTED from record''s ''closed/score 1''. Primary check disproves it: the agent''s complete
-    source is public and MIT-licensed (LICENSE file: ''Copyright (c) 2025 Vellum AI'', full app incl.
-    backend gateway, Mac/Slack/Telegram clients, sandboxed skill framework, memory system), self-hostable
-    by design, not a client/SDK stub. Vendor''s own marketing comparison table paradoxically labels Vellum
-    ''Proprietary'' (vs MIT for Hermes/OpenClaw) because it sells a managed cloud tier; but the core agent
-    is genuinely open source. Class=open_source; score 4 rather than 5 because the differentiated managed
-    memory/security layer is a hosted add-on and the vendor markets the primary offering as proprietary
-    cloud.'
+  note: 'CORRECTED from the record''s "closed/score 1". The agent''s complete source is public and MIT-licensed
+    (LICENSE: "Copyright (c) 2025 Vellum AI"), covering the backend gateway, the Mac/Slack/Telegram clients,
+    the sandboxed skill framework and the memory system, and it is self-hostable by design rather than a
+    client stub. The vendor''s own marketing comparison table labels Vellum "Proprietary" against MIT for
+    Hermes/OpenClaw, because it sells a managed cloud tier. Score corrected from 4 to 5 on 2026-07-30. The
+    earlier 4 rested on the managed memory/security layer being a differentiator, but the README states
+    the managed runtime and the self-hosted one are the "Same codebase, same data model", so hosting is
+    convenience rather than a feature tier. The ladder''s core_gated note is explicit that a hosted offering
+    alongside an ungated core is not gating, and 4 pairs with open_core in any case.'
   sources:
   - url: https://www.vellum.ai
     shows: personal AI assistant 'AI layer for your life'; comparison table labels Vellum 'Proprietary'

--- a/sources/scores/whylabs.yaml
+++ b/sources/scores/whylabs.yaml
@@ -1,14 +1,17 @@
 product: whylabs
 openness:
-  score: 4
+  score: 5
   class: open_source
-  components: license:Apache-2.0(OSI, whylogs + LangKit + open sourced platform);source:public(github.com/whylabs);hosted-SaaS:discontinued;status:company-ceased-ops,
+  components: license:Apache-2.0(OSI, whylogs + LangKit + open sourced platform);source:public(github.com/whylabs);core-gated:ungated(nothing
+    is withheld - the company ceased operations and open sourced the platform on closure);hosted-SaaS:discontinued;status:company-ceased-ops,
     platform open sourced on closure
   confidence: high
-  note: 'Scored on what remains accessible: the OSS stack. whylogs (data logging) + LangKit (LLM monitoring)
-    are Apache-2.0 OSI, and WhyLabs open sourced its platform on shutdown. Not 5 because the hosted monitoring
-    backend is no longer maintained/operating and the OSS pieces are libraries rather than a turnkey live
-    observability product.'
+  note: 'Scored on what remains accessible: the OSS stack. whylogs (data logging) and LangKit (LLM monitoring)
+    are Apache-2.0, and WhyLabs open sourced its platform on shutdown. Score corrected from 4 to 5 on 2026-07-30.
+    The earlier 4 was justified by the hosted backend no longer operating and the OSS pieces being libraries
+    rather than a turnkey observability product, which are maturity judgments and are already recorded as
+    adoption 2 and capability 2. On the openness question the published source is the whole product, because
+    there is no longer anything else, and 4 pairs with open_core rather than open_source.'
   sources:
   - url: https://whylabs.ai/langkit
     shows: '''WhyLabs, Inc. is discontinuing operations''; platform/whylogs/LangKit open sourced'

--- a/tests/test_check_verification.py
+++ b/tests/test_check_verification.py
@@ -1,0 +1,283 @@
+"""Tests for G1, G2 and G3.
+
+The one that matters most is `test_g1_fails_when_one_dimension_is_stale`. G1's aggregation
+direction is load-bearing — it is over EVERY recorded dimension, so the binding constraint
+is the least recently re-read one — and the tempting simplification to `max(accessed)` would
+pass exactly that fixture. The failure mode has shipped twice (#108, #115), so it is pinned.
+"""
+
+import pytest
+import yaml
+
+from build.check_verification import (
+    DIGEST_EXEMPT,
+    g1_invariant,
+    g2_digests,
+    g3_producible,
+    producible_pairs,
+    recorded_dimensions,
+)
+
+RECIPE = {
+    "openness": {
+        "dimensions": {
+            "weights": {"values": ["open", "closed"]},
+            "data": {"values": ["open", "closed"], "reads": ["data", "post-training-data"]},
+            "code": {"values": ["open", "partial", "closed"]},
+        },
+        "license_tier": {"reads": ["license"], "values": {}},
+        "formula": [
+            {"when": {"weights": "closed"}, "then": {"score": 1, "class": "closed"}},
+            {"when": {"weights": "open"}, "then": {"score": 5, "class": "open_source"}},
+        ],
+    }
+}
+CATEGORIES = {"models": {"name": "models", "products": ["m"], "scoring_recipe": RECIPE}}
+RECIPES = {"models": RECIPE}
+
+
+def _score(**openness):
+    block = {
+        "score": 5,
+        "class": "open_source",
+        "components": "weights:open;data:open;code:open;license:Apache-2.0(OSI)",
+    }
+    block.update(openness)
+    return {"m": {"product": "m", "openness": block}}
+
+
+def _src(url, accessed, establishes=None, fetched=True):
+    source = {"url": url, "shows": "x", "accessed": accessed}
+    if establishes is not None:
+        source["establishes"] = establishes
+    if fetched:
+        source["http_status"] = 200
+        source["content_sha256"] = "a" * 64
+    return source
+
+
+FULL = [
+    _src("https://a", "2026-07-30", ["weights", "license"]),
+    _src("https://b", "2026-07-30", ["data"]),
+    _src("https://c", "2026-07-30", ["code"]),
+]
+
+
+# --- what counts as a recorded dimension ---
+
+def test_recorded_dimensions_are_the_declared_ones_plus_license():
+    found = recorded_dimensions(
+        {"weights": "open", "data": "open", "code": "open", "license": "Apache-2.0(OSI)"}, RECIPE
+    )
+    assert found == {"weights": "weights", "data": "data", "code": "code", "license": "license"}
+
+
+def test_undeclared_components_keys_are_not_dimensions():
+    """`paper` and `model_card` are recorded but no ladder scores them, so demanding an
+    establishing source for each would make the gate expensive and pointless at once."""
+    found = recorded_dimensions(
+        {"weights": "open", "paper": "open", "model_card": "open", "license": "MIT"}, RECIPE
+    )
+    assert set(found) == {"weights", "license"}
+
+
+def test_a_dimension_answered_under_a_reads_alias_keeps_the_alias():
+    """`finetuned_chat` answers the data question under `post-training-data`, and a source
+    attributing to that key is being more precise than one attributing to `data`."""
+    found = recorded_dimensions({"post-training-data": "open", "license": "MIT"}, RECIPE)
+    assert found["data"] == "post-training-data"
+
+
+# --- G1 ---
+
+def test_g1_passes_when_every_dimension_has_a_fresh_establishing_source():
+    scores = _score(last_verified="2026-07-30", sources=FULL)
+    assert g1_invariant(scores, CATEGORIES, RECIPES) == []
+
+
+def test_g1_ignores_an_axis_with_no_date():
+    """The ratchet: an axis claiming nothing is not asked to prove anything."""
+    assert g1_invariant(_score(sources=[_src("https://a", "2020-01-01")]), CATEGORIES, RECIPES) == []
+
+
+def test_g1_fails_when_a_dimension_has_no_establishing_source():
+    scores = _score(last_verified="2026-07-30", sources=FULL[:2])  # code unattributed
+    problems = g1_invariant(scores, CATEGORIES, RECIPES)
+    assert any("records 'code'" in p and "no source claims to establish it" in p for p in problems)
+
+
+def test_g1_fails_when_one_dimension_is_stale():
+    """The aggregation direction. Three dimensions re-read today, one last seen in June: a
+    `max(accessed)` check passes this, and the invariant must not."""
+    scores = _score(
+        last_verified="2026-07-30",
+        sources=[
+            _src("https://a", "2026-07-30", ["weights", "license"]),
+            _src("https://b", "2026-07-30", ["data"]),
+            _src("https://c", "2026-06-01", ["code"]),
+        ],
+    )
+    problems = g1_invariant(scores, CATEGORIES, RECIPES)
+    assert len(problems) == 1
+    assert "records 'code'" in problems[0]
+    assert "only established by a source last read 2026-06-01" in problems[0]
+
+
+def test_g1_fails_when_no_source_was_read_on_or_after_the_claimed_date():
+    scores = _score(
+        last_verified="2026-07-30",
+        sources=[_src("https://a", "2026-06-01", ["weights", "data", "code", "license"])],
+    )
+    problems = g1_invariant(scores, CATEGORIES, RECIPES)
+    assert any("no source was accessed on or after that date" in p for p in problems)
+
+
+def test_g1_never_derives_a_date_it_only_validates_one():
+    """Guards against the #115 'simplification'. A fully-attributed axis with no
+    `last_verified` must stay silent rather than acquiring one."""
+    scores = _score(sources=FULL)
+    assert g1_invariant(scores, CATEGORIES, RECIPES) == []
+    assert "last_verified" not in scores["m"]["openness"]
+
+
+def test_g1_floor_applies_to_adoption_where_there_are_no_dimensions():
+    """Adoption records one banded value, so there is nothing to attribute among - but a
+    confirmation still cannot rest on zero sources read on or after the date it claims."""
+    scores = {"m": {"product": "m", "adoption": {"level": 4, "last_verified": "2026-07-30",
+                                                "sources": [_src("https://a", "2026-06-01")]}}}
+    assert any("no source was accessed on or after" in p for p in g1_invariant(scores, {}, {}))
+
+
+def test_g1_accepts_adoption_with_one_fresh_source_and_no_attribution():
+    scores = {"m": {"product": "m", "adoption": {"level": 4, "last_verified": "2026-07-30",
+                                                "sources": [_src("https://a", "2026-07-30")]}}}
+    assert g1_invariant(scores, {}, {}) == []
+
+
+def test_g1_rejects_a_last_verified_that_is_not_a_date():
+    scores = _score(last_verified="last week", sources=FULL)
+    assert any("is not a date" in p for p in g1_invariant(scores, CATEGORIES, RECIPES))
+
+
+def test_g1_falls_back_to_the_floor_for_a_category_with_no_recipe():
+    """Four categories have no recipe yet, so there is no declared vocabulary to check
+    against. The gate degrades to the floor rather than passing vacuously or erroring."""
+    scores = _score(last_verified="2026-07-30", sources=[_src("https://a", "2026-06-01")])
+    assert any("no source was accessed on or after" in p for p in g1_invariant(scores, {}, {}))
+
+
+# --- G2 ---
+
+def test_g2_passes_when_every_fresh_source_records_a_fetch():
+    assert g2_digests(_score(last_verified="2026-07-30", sources=FULL)) == []
+
+
+def test_g2_fails_on_a_missing_digest():
+    scores = _score(
+        last_verified="2026-07-30",
+        sources=[_src("https://a", "2026-07-30", ["weights"], fetched=False)],
+    )
+    problems = g2_digests(scores)
+    assert any("no http_status and no content_sha256" in p for p in problems)
+
+
+def test_g2_ignores_sources_read_before_the_claimed_date():
+    """Those were not part of this confirmation, so they are out of scope. Otherwise every
+    new date would demand re-fetching evidence it never relied on."""
+    scores = _score(
+        last_verified="2026-07-30",
+        sources=FULL + [_src("https://old", "2026-01-01", fetched=False)],
+    )
+    assert g2_digests(scores) == []
+
+
+def test_g2_reports_a_stale_exemption(monkeypatch):
+    monkeypatch.setitem(DIGEST_EXEMPT, "ghost:openness", "pre-runbook date")
+    problems = g2_digests(_score(last_verified="2026-07-30", sources=FULL))
+    assert any("Drop the exemption" in p for p in problems)
+
+
+def test_g2_honors_a_live_exemption(monkeypatch):
+    monkeypatch.setitem(DIGEST_EXEMPT, "m:openness", "pre-runbook date")
+    scores = _score(
+        last_verified="2026-07-30",
+        sources=[_src("https://a", "2026-07-30", ["weights"], fetched=False)],
+    )
+    assert g2_digests(scores) == []
+
+
+def test_the_shipped_exemption_list_is_empty():
+    """Not a style preference. An exemption is a claim that a digest was unobtainable, and
+    every axis dated so far was re-fetched instead."""
+    assert DIGEST_EXEMPT == {}
+
+
+# --- G3 ---
+
+def test_producible_pairs_reads_then_and_otherwise():
+    recipe = {"openness": {"formula": [
+        {"when": {"a": "b"}, "then": {"score": 2, "class": "source_available"}},
+        {"otherwise": {"score": 1, "class": "closed"}},
+    ]}}
+    assert producible_pairs(recipe) == {(2, "source_available"), (1, "closed")}
+
+
+def test_g3_passes_on_a_producible_pair():
+    assert g3_producible(_score(), CATEGORIES, RECIPES) == []
+
+
+def test_g3_fails_on_a_class_no_rule_pairs_with_that_score():
+    """`4/open_source` in software: 4 exists and `open_source` exists, never together."""
+    scores = _score(score=1, **{"class": "open_source"})
+    problems = g3_producible(scores, CATEGORIES, RECIPES)
+    assert any("1/open_source is not an outcome" in p for p in problems)
+
+
+def test_g3_fails_on_a_score_no_rule_emits():
+    """The software ladder's rungs are 1, 2, 4, 5. A software product scored 3 is impossible
+    by construction, however plausible the class looks beside it."""
+    scores = _score(score=3, **{"class": "open_source"})
+    assert any("3/open_source is not an outcome" in p for p in g3_producible(scores, CATEGORIES, RECIPES))
+
+
+def test_g3_ignores_an_unscored_product():
+    assert g3_producible(_score(score=None), CATEGORIES, RECIPES) == []
+
+
+def test_g3_is_not_escapable_by_deferring_the_product():
+    """`check_rubric` excludes a deferred product from reproduction. G3 must not, or a
+    category could defer its way out of an impossible pair - which is how `4/open_source`
+    survived a checker that reported 33/33."""
+    categories = {"models": dict(CATEGORIES["models"])}
+    recipes = {"models": dict(RECIPE, deferred={"m": {"because": "needs a human, at length"}})}
+    scores = _score(score=3, **{"class": "open_source"})
+    assert g3_producible(scores, categories, recipes)
+
+
+# --- the repo itself ---
+
+def test_the_repo_passes_all_three_gates():
+    from build.check_verification import load
+
+    scores, categories, recipes = load()
+    assert g1_invariant(scores, categories, recipes) == []
+    assert g2_digests(scores) == []
+    assert g3_producible(scores, categories, recipes) == []
+
+
+@pytest.mark.parametrize("axis", ["openness", "adoption", "capability"])
+def test_every_dated_axis_in_the_repo_carries_establishing_evidence(axis):
+    """Restates G1's scope as data rather than logic: whatever carries a date must be
+    covered, so a new date cannot land without the gate having an opinion about it."""
+    from build.check_verification import ROOT
+
+    for path in sorted((ROOT / "sources" / "scores").glob("*.yaml")):
+        block = (yaml.safe_load(path.read_text()) or {}).get(axis) or {}
+        if not block.get("last_verified"):
+            continue
+        fresh = [
+            s for s in block.get("sources") or []
+            if str(s.get("accessed")) >= str(block["last_verified"])
+        ]
+        assert fresh, f"{path.name}:{axis}"
+        assert all(s.get("content_sha256") for s in fresh), f"{path.name}:{axis}"

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -1,0 +1,206 @@
+"""Tests for the block-safe components rewriter.
+
+The load-bearing test is `test_rewrites_a_value_folded_across_three_lines`. A single-line
+fixture passes against a naive `^  components: (.*)$` substitution by accident, so a
+single-line test proves nothing about the bug this module exists to prevent. Every fixture
+here that matters folds.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from build.components import field_span, format, parse, render, rewrite, set_field
+
+# `granite-code-instruct`'s real components value, which folds across four lines in the
+# repo. Real rather than invented on purpose: what makes a value fold is spaces inside the
+# parentheticals, and a hand-written fixture is liable to have too few of them and quietly
+# stop folding. `test_the_folded_fixture_really_folds` asserts it still does.
+GRANITE = (
+    "weights:open(Apache-2.0,on HF);code:partial(inference + fine-tune sample scripts via "
+    "Dolomite Engine; no full training pipeline in repo);data:described_not_released("
+    "CommitPackFT/MathInstruct/Glaive/HelpSteer/Open-Platypus named in card but processed corpus "
+    "not redistributable);post-training-data:described(SFT mixture named, not released);"
+    "paper:open(arXiv 2405.04324);model_card:open;license:Apache-2.0(OSI)"
+)
+
+FOLDED_THREE = f"""product: granite-code-instruct
+openness:
+  score: 4
+  class: open_weights
+  components: {GRANITE}
+  confidence: high
+  note: 'Open-core in the LangGraph shape: the framework itself is a real OSI license.'
+  last_verified: '2026-07-29'
+  sources:
+  - url: https://github.com/mastra-ai/mastra/blob/main/LICENSE.md
+    shows: LICENSE.md scopes the carve-out to `ee/` directories
+    accessed: '2026-07-29'
+adoption:
+  level: 4
+  reach: 1M-10M
+capability:
+  score: 4
+  basis: feature_matrix
+"""
+
+SINGLE_LINE = """product: olmo
+openness:
+  score: 5
+  class: open_source
+  components: weights:open;data:open;license:Apache-2.0(OSI)
+  confidence: high
+adoption:
+  level: 4
+capability:
+  score: 4
+  basis: benchmark
+"""
+
+
+def _fold(text: str) -> str:
+    """Re-emit the fixture so `components` really is folded, not just long."""
+    lines = text.splitlines(keepends=True)
+    for index, line in enumerate(lines):
+        if line.startswith("  components:"):
+            value = yaml.safe_load(text)["openness"]["components"]
+            return "".join(lines[:index] + render("components", value) + lines[index + 1 :])
+    raise AssertionError("fixture has no components field")
+
+
+def test_the_folded_fixture_really_folds_across_three_lines():
+    """Guards the guard. If this fixture stopped folding, every test below would still
+    pass while testing nothing, which is exactly the accident being defended against."""
+    text = _fold(FOLDED_THREE)
+    lines = text.splitlines(keepends=True)
+    start, end = field_span(lines, (1, len(lines)), "components")
+    assert end - start >= 3, text
+
+
+def test_rewrites_a_value_folded_across_three_lines():
+    text = _fold(FOLDED_THREE)
+    new = set_field(text, "license:MIT(OSI);source:public;core-gated:ungated")
+    parsed = yaml.safe_load(new)
+    assert parsed["openness"]["components"] == "license:MIT(OSI);source:public;core-gated:ungated"
+
+
+def test_a_fold_leaves_no_continuation_line_behind():
+    """The actual corruption: a regex replaces line one and the old tail survives, so the
+    parsed value ends with a fragment of the value that was supposed to be replaced."""
+    text = _fold(FOLDED_THREE)
+    parsed = yaml.safe_load(set_field(text, "source:closed"))
+    assert parsed["openness"]["components"] == "source:closed"
+    assert "training pipeline" not in parsed["openness"]["components"]
+
+
+def test_neighboring_fields_survive_a_fold_rewrite():
+    text = _fold(FOLDED_THREE)
+    before = yaml.safe_load(text)
+    after = yaml.safe_load(set_field(text, "source:public;core-gated:ungated"))
+    for key in ("score", "class", "confidence", "note", "last_verified", "sources"):
+        assert after["openness"][key] == before["openness"][key], key
+    assert after["adoption"] == before["adoption"]
+    assert after["capability"] == before["capability"]
+    assert after["product"] == before["product"]
+
+
+def test_single_line_value_also_rewrites():
+    parsed = yaml.safe_load(set_field(SINGLE_LINE, "weights:open;data:closed"))
+    assert parsed["openness"]["components"] == "weights:open;data:closed"
+
+
+def test_a_value_needing_quotes_round_trips():
+    """`vellum` records `vellum-assistant: gateway+clients`, and a bare `: ` inside a plain
+    scalar changes the parse. The dumper has to quote it and does."""
+    value = "license:MIT(OSI);source:public+full-agent(vellum-assistant: gateway+clients)"
+    parsed = yaml.safe_load(set_field(SINGLE_LINE, value))
+    assert parsed["openness"]["components"] == value
+
+
+def test_a_long_value_folds_at_its_spaces():
+    value = format({f"dimension-{n}": f"value {n} with some detail" for n in range(20)})
+    text = set_field(SINGLE_LINE, value)
+    assert len(text.splitlines()) > len(SINGLE_LINE.splitlines())
+    assert yaml.safe_load(text)["openness"]["components"] == value
+
+
+def test_a_long_value_with_no_spaces_stays_on_one_line():
+    """YAML folds at spaces, so a `k:v;k:v` run with none cannot be folded and correctly
+    is not. Worth pinning: it means line length alone never tells you whether a value
+    folds, which is why `field_span` tests indentation instead of guessing from width."""
+    value = format({f"dimension-{n}": f"value-{n}-detail" for n in range(20)})
+    text = set_field(SINGLE_LINE, value)
+    assert len(text.splitlines()) == len(SINGLE_LINE.splitlines())
+    assert yaml.safe_load(text)["openness"]["components"] == value
+
+
+def test_rewriting_is_idempotent():
+    once = set_field(_fold(FOLDED_THREE), "source:public;core-gated:gated")
+    assert set_field(once, "source:public;core-gated:gated") == once
+
+
+def test_missing_axis_raises():
+    with pytest.raises(ValueError, match="no top-level"):
+        set_field(SINGLE_LINE, "x:y", axis="hardware")
+
+
+def test_missing_field_raises_rather_than_inventing_one():
+    text = SINGLE_LINE.replace("  components: weights:open;data:open;license:Apache-2.0(OSI)\n", "")
+    with pytest.raises(ValueError, match="no 'components' field"):
+        set_field(text, "x:y")
+
+
+def test_rewrite_writes_the_file_and_reports_change(tmp_path: Path):
+    path = tmp_path / "mastra.yaml"
+    path.write_text(_fold(FOLDED_THREE))
+    assert rewrite(path, "source:public;core-gated:ungated") is True
+    assert yaml.safe_load(path.read_text())["openness"]["components"] == (
+        "source:public;core-gated:ungated"
+    )
+    assert rewrite(path, "source:public;core-gated:ungated") is False
+
+
+def test_parse_and_format_round_trip():
+    value = "weights:open(Apache-2.0, safetensors);data:closed;license:MIT(OSI)"
+    assert format(parse(value)) == value
+
+
+def test_parse_is_paren_aware():
+    """One parser, shared with check_rubric: a `;` inside parentheses is not a separator."""
+    assert parse("license:Apache-2.0(OSI; see LICENSE);source:public") == {
+        "license": "Apache-2.0(OSI; see LICENSE)",
+        "source": "public",
+    }
+
+
+def test_every_real_score_file_round_trips():
+    """The corpus is the fixture. Setting each file's components to its own current value
+    must be a no-op, which exercises the span logic against all 277 folded fields."""
+    root = Path(__file__).resolve().parents[1]
+    checked = 0
+    for path in sorted((root / "sources" / "scores").glob("*.yaml")):
+        text = path.read_text()
+        current = ((yaml.safe_load(text) or {}).get("openness") or {}).get("components")
+        if current is None:
+            continue
+        checked += 1
+        assert yaml.safe_load(set_field(text, current)) == yaml.safe_load(text), path.name
+    assert checked > 400
+
+
+def test_the_naive_regex_corrupts_the_same_fixture():
+    """Not a test of this module, but of the substitution it replaces.
+
+    Pinned so the reason the module exists cannot be argued away later: the same edit done
+    with a line regex parses fine and yields a value with the old tail spliced onto it.
+    """
+    import re
+
+    text = _fold(FOLDED_THREE)
+    naive = re.sub(r"^  components: .*$", "  components: source:closed", text, count=1, flags=re.M)
+    corrupted = yaml.safe_load(naive)["openness"]["components"]
+    # The old value's tail survives and is spliced onto the new one mid-key, so the parsed
+    # result reads as a key called `source` whose value trails off into the previous value.
+    assert corrupted.startswith("source:closed Engine; no full training pipeline")
+    assert "license:Apache-2.0(OSI)" in corrupted

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -430,11 +430,17 @@ def test_real_sources_serialize_without_errors():
     # Both fell with the slug migration: release-level products collapsed into the
     # tier the vendor sells, so 25 products left the roster and the closed frontier
     # models moved from base_pretrained to finetuned_chat.
+    #
+    # Eight software categories then rose by 1-3 rows when the G3 score corrections landed:
+    # fixing an impossible score/class pair means recording the dimension that decides it, so
+    # products that had described their gating in prose gained a readable `source:` or
+    # `core-gated:` key. The two model categories are untouched, which is what the pilot
+    # counts are pinned to catch.
     assert per_category("product_openness_evidence") == {
         "base_pretrained": 111, "finetuned_chat": 172, "deployment": 131,
-        "agent_tools_protocols": 122, "dataset_processing_tools": 88, "evaluation_code": 92,
-        "finetuning_code": 131, "inference_code": 77, "ml_frameworks": 84,
-        "orchestration_agents": 176, "telemetry_observability": 100, "ui_api": 168,
+        "agent_tools_protocols": 123, "dataset_processing_tools": 88, "evaluation_code": 95,
+        "finetuning_code": 132, "inference_code": 80, "ml_frameworks": 84,
+        "orchestration_agents": 178, "telemetry_observability": 102, "ui_api": 169,
     }
     assert {r["grade"] for r in tables["product_openness_evidence"]} == {"document"}
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -170,3 +170,89 @@ def test_product_lineage_rejects_unknown_keys():
     d["products"]["llama"]["lineage"] = {"forked_from": ["x"]}
     errs = validate_sources(d)
     assert any("lineage" in e or "forked_from" in e or "additional" in e.lower() for e in errs)
+
+
+def _with_recipe(d):
+    """Give the fixture a category recipe, so `establishes` has a vocabulary to check.
+
+    Without one the cross-file check has nothing to check against and skips, which is the
+    correct behavior for a hand-built fixture but makes it useless for these tests.
+    """
+    d["categories"]["base_pretrained"]["scoring_recipe"] = {
+        "openness": {
+            "dimensions": {
+                "weights": {"values": ["open", "closed"]},
+                "data": {"values": ["open", "closed"], "reads": ["data", "post-training-data"]},
+            },
+            "formula": [{"when": {"weights": "closed"}, "then": {"score": 1, "class": "closed"}}],
+        }
+    }
+    return d
+
+
+def test_establishes_accepts_a_declared_dimension():
+    d = _with_recipe(_fixture())
+    d["scores"]["llama"]["openness"]["sources"][0]["establishes"] = ["weights"]
+    assert validate_sources(d) == []
+
+
+def test_establishes_accepts_a_recorded_key_a_dimension_reads():
+    """`post-training-data` is not a dimension name, but it is declared vocabulary."""
+    d = _with_recipe(_fixture())
+    d["scores"]["llama"]["openness"]["sources"][0]["establishes"] = ["post-training-data"]
+    assert validate_sources(d) == []
+
+
+def test_establishes_accepts_license_though_it_is_a_derived_tier():
+    """A source establishes the license; the recipe derives the tier from it."""
+    d = _with_recipe(_fixture())
+    d["scores"]["llama"]["openness"]["sources"][0]["establishes"] = ["license"]
+    assert validate_sources(d) == []
+
+
+def test_establishes_rejects_a_typo():
+    """The whole point: a misspelled dimension establishes nothing while looking like it does."""
+    d = _with_recipe(_fixture())
+    d["scores"]["llama"]["openness"]["sources"][0]["establishes"] = ["weight"]
+    errs = validate_sources(d)
+    assert any("establish 'weight'" in e for e in errs)
+
+
+def test_establishes_rejects_a_british_spelling_of_license():
+    d = _with_recipe(_fixture())
+    d["scores"]["llama"]["openness"]["sources"][0]["establishes"] = ["licence"]
+    assert any("establish 'licence'" in e for e in validate_sources(d))
+
+
+def test_establishes_checked_on_adoption_and_capability_too():
+    d = _with_recipe(_fixture())
+    d["scores"]["llama"]["adoption"]["sources"][0]["establishes"] = ["nonsense"]
+    assert any("adoption source" in e and "nonsense" in e for e in validate_sources(d))
+
+
+def test_establishes_skipped_when_no_recipe_declares_anything():
+    """No vocabulary means no basis to reject a name, so the check abstains rather than
+    failing every source in a repo whose categories have no recipes yet."""
+    d = _fixture()  # deliberately no scoring_recipe
+    d["scores"]["llama"]["openness"]["sources"][0]["establishes"] = ["weight"]
+    assert not any("establish" in e for e in validate_sources(d))
+
+
+def test_digest_must_be_a_sha256():
+    d = _fixture()
+    d["scores"]["llama"]["openness"]["sources"][0]["content_sha256"] = "deadbeef"
+    assert any("schema" in e for e in validate_sources(d))
+
+
+def test_http_status_must_be_a_real_status_code():
+    d = _fixture()
+    d["scores"]["llama"]["openness"]["sources"][0]["http_status"] = 20
+    assert any("schema" in e for e in validate_sources(d))
+
+
+def test_a_fetched_source_with_status_and_digest_validates():
+    d = _fixture()
+    d["scores"]["llama"]["openness"]["sources"][0].update(
+        {"http_status": 200, "content_sha256": "a" * 64}
+    )
+    assert validate_sources(d) == []

--- a/tests/test_warehouse.py
+++ b/tests/test_warehouse.py
@@ -1,0 +1,77 @@
+"""Tests for the nonce-forcing query helper.
+
+No network here. What matters is that the nonce cannot be skipped and that two calls with
+the same SQL do not produce the same query text, since the cache keys on exactly that.
+"""
+
+import pytest
+
+from build.apply_scores import fetch_computed
+from build.warehouse import cache_busted, has_nonce, query, require_api_key
+
+
+def test_a_nonce_is_appended():
+    assert has_nonce(cache_busted("SELECT 1"))
+
+
+def test_two_calls_on_identical_sql_differ():
+    """The whole point. Identical text hits the cache, so the text must not be identical."""
+    assert cache_busted("SELECT 1") != cache_busted("SELECT 1")
+
+
+def test_the_nonce_is_a_trailing_comment():
+    """A comment leaves the plan and the result untouched; a predicate would not."""
+    busted = cache_busted("SELECT 1 FROM t")
+    body, _, nonce = busted.partition("-- cache-bust")
+    assert body.strip() == "SELECT 1 FROM t"
+    assert len(nonce.strip()) == 36  # a uuid4
+
+
+def test_query_requires_a_key_before_it_tries_the_network(monkeypatch):
+    monkeypatch.delenv("OSO_API_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="OSO_API_KEY"):
+        require_api_key()
+
+
+def test_fetch_computed_goes_through_the_helper(monkeypatch):
+    """apply_scores must not build its own SQL string. Asserted by capturing what reaches
+    the helper: if the port were reverted, the captured text would have no nonce."""
+    seen: list[str] = []
+
+    def fake_query(sql: str) -> list[dict]:
+        seen.append(sql)
+        return []
+
+    monkeypatch.setattr("build.apply_scores.query", fake_query)
+    fetch_computed("base_pretrained")
+    assert len(seen) == 1
+    assert "currentai.scores.openness_computed" in seen[0]
+    assert "WHERE category_slug = 'base_pretrained'" in seen[0]
+    # The nonce is added inside `query`, so what apply_scores hands over must NOT carry one -
+    # a nonce here would mean a second, hand-rolled implementation had crept back in.
+    assert not has_nonce(seen[0])
+    assert has_nonce(cache_busted(seen[0]))
+
+
+def test_query_is_the_only_entry_point_and_always_busts(monkeypatch):
+    captured: list[str] = []
+
+    class FakeFrame:
+        def to_dict(self, _how):
+            return [{"ok": 1}]
+
+    class FakeClient:
+        def to_pandas(self, sql):
+            captured.append(sql)
+            return FakeFrame()
+
+    import sys
+    import types
+
+    module = types.ModuleType("pyoso")
+    module.Client = FakeClient
+    monkeypatch.setitem(sys.modules, "pyoso", module)
+    monkeypatch.setenv("OSO_API_KEY", "test-key")
+
+    assert query("SELECT 1") == [{"ok": 1}]
+    assert has_nonce(captured[0])


### PR DESCRIPTION
Phase 0 of `docs/runbooks/verification-pass.md`. The gates land before any bulk editing of `sources/scores/`, so they cannot be written to fit whatever the bulk edits happen to produce.

## The four mechanisms

**0.1 — `establishes`, `http_status`, `content_sha256`** on a source, all optional. `establishes` is what makes a re-check claim checkable: `sources` is a flat list per axis, so without it nothing records which source settles which dimension. Cross-validated in `build/validate.py` against the vocabulary the recipes declare — 11 names today — because a typo'd `licence` establishes nothing while reading like attribution.

**0.2 — `build/components.py`**, the only supported way to edit a `components` field. Locates the field by indent, re-emits through the YAML dumper so quoting and folding are its problem, then re-parses and asserts the new value plus that every other field is unchanged, then that no bytes outside the span moved. Nothing is written unless all three hold.

277 of the 470 score files fold that scalar, 57 across three or more lines. `tests/test_components.py` uses a real four-line value as its fixture, round-trips all 470 files, and pins the naive regex *failing* on the same input, so the reason the module exists cannot be argued away. `apply_scores` is ported onto its `block_bounds`/`find_key` rather than keeping a second copy.

**0.3 — `build/check_verification.py`** with G1, G2 and G3, wired into `validate.yml` beside the test step. G1 and G2 are scoped to axes carrying a `last_verified` (6 today), G3 to every scored product in a category with a recipe (359).

**0.4 — `build/warehouse.py`**, the only place that builds a warehouse query, and it appends `-- cache-bust <uuid4>` with no parameter to switch it off. `apply_scores.fetch_computed` ported onto it.

## G3 caught 17, not 2

`vellum` and `whylabs` were the known pair. `tensorrt-llm` made a third `4 / open_source`, five products were `2 / open_core`, and nine carried a score of 3, which the software ladder cannot emit at all — its rungs are 1, 2, 4, 5.

**16 of the 17 were sitting in a category's `deferred` block.** That excludes a product from `check_rubric` reproduction, which is why the checker reported 12/12 `[OK]` throughout. G3 ignores the evidence and asks only whether the pair exists in the ladder, so deferring cannot hide it.

All fixed by reading the product. The ladder is untouched.

| | from | to | wrong value |
|---|---|---|---|
| `apify`, `chatbot-arena`, `patronus-evaluation-platform`, `artificial-analysis-intelligence-index`, `predibase` | `2 / open_core` | `2 / source_available` | class |
| `txt360-pipeline`, `max`, `autogpt`, `suna`, `dify`, `phoenix`, `open-webui`, `lobe-chat` | `3 / source_available` | `2 / source_available` | score |
| `lumo` | `3 / open_core` | `2 / source_available` | both |
| `tensorrt-llm`, `vellum`, `whylabs` | `4 / open_source` | `5 / open_source` | score |

- **`open_core` was being used to mean "some open part exists".** In this ladder it means an OSI core with functionality withheld for a paid tier. These five have an open *periphery* around a closed engine — Crawlee beside the Apify platform, `patronus-py` wiring to a hosted backend, Stirrup covering one of ten evals — which is `source: partial`, scored 2.
- **There is no rung at 3.** Every one of the nine is "you can read it and not run it freely": a non-OSI restrictive license over public source, or a client standing in for a closed service. That is what the ladder scores at 2.
- **4 pairs with `open_core`, never with `open_source`.** Each of the three publishes the whole self-hostable product under an OSI license with nothing withheld. `vellum`'s README states the managed runtime and the self-hosted one are the "Same codebase, same data model"; `whylabs` open sourced its platform on closure. The 4s encoded maturity and scepticism about vendor marketing, both already recorded on the adoption and capability axes.

Seven of the seventeen now reproduce through the ladder and left `deferred` (296/296 reproduced, up from 289). The ten stale deferral reasons are rewritten to name the license value that actually blocks each, rather than "source or core-gated is not recorded", which had stopped being true.

## G1 failed on all 6 dated axes, and that was the useful part

`establishes` did not exist when those dates were written. Beyond that, the 2026-07-28 pass on the model flagships re-read only the dataset endpoint: `apertus`, `olmo`, `pythia` and `lucie-7b` each claimed a whole-axis confirmation while citing 2026-06 reads for weights, code, checkpoints and license. That is exactly what the invariant exists to catch, and what `max(accessed)` would have waved through.

Refetched all 23 cited sources rather than exempting them, so `DIGEST_EXEMPT` ships empty. Two defects an exemption would have hidden:

- `lucie-7b` cited `huggingface.co/OpenLLM-France/Lucie-Training-Dataset` without the `/datasets/` segment, which the Hub resolves as a model repo and answers **401**. The URL had never resolved as cited. Corrected; the dataset is ungated.
- `rwkv` recorded `weights:open(Apache-2.0)` while citing only the code repo, the dataset and the paper. **Nothing on file established the weights.** Added `api/models/BlinkDL/rwkv-7-world`.

And one finding worth flagging: **Lucie's training corpus is `cc-by-nc-sa-4.0`**, so it is published and ungated but not commercially reusable. The `data` dimension asks whether the corpus is released rather than under what terms, so the score is unchanged — but the paper's OSI-compliance claim does not survive a strict reading, and it makes Lucie a weaker full-openness exemplar than OLMo, whose Dolma is `odc-by`. Recorded in the note.

`mastra`'s npmjs.com citation returns **403** to any non-browser fetch behind a Cloudflare interstitial; repointed at `registry.npmjs.org/@mastra/core`, which serves the same fact and can actually be re-checked.

## Verification

```
build.validate                0 errors
pytest                        209 passed
build.check_verification      G1 [OK]  G2 [OK]  G3 [OK]
build.check_rubric            12/12 [OK], 296/296 reproduced, 63 deferred
serialize + render + marimo   clean
```

Serialized output diffed before and after: the only changes are those 17 products. **No category's stage or gaps moved.** Six products move openness `bucket` from `open` to `open-ish`, which is the visible consequence of the `open_core` → `source_available` corrections.

`build/notebook_data.json` and `notebooks/ai-stack-map.py` are untouched.

## Still open

- **0.5, G6** — the release assertion in `publish_registry`. Not in this PR.
- **Four ladder conflicts remain** — `jina-reader`, `openhands`, `maple-ai`, `privatemode`. All producible pairs, so G3 passes them; only `check_rubric` objects. Phase 4 work.
- **`check_rubric` requires a mappable license tier before applying the formula**, even for rules that never read the license. Ten deferrals are blocked purely by that, several now recording a readable `source:partial` that rule 2 would decide on its own. A checker fix, held for Phase 1 rather than smuggled in here.