### PR TITLE
Per-product-type scoring recipes, and the safeguards wiring they unlock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,9 +23,11 @@ sources/signal_routing.yaml  Which machine signal is authoritative per dimension
 sources/evidence_policy.yaml  When an observation is admissible as evidence
 sources/rubrics/       Shared scoring ladders. A category inherits one with
                        `scoring_recipe: {extends: <name>}` rather than copying it;
-                       build/rubrics.py resolves that. license-to-tier lives here,
-                       because whether AGPL is `osi` is a fact about AGPL, not
-                       about one category.
+                       or, for a category whose products don't all climb the same
+                       ladder, `{extends: {<product type>: <name>, ...}}` (safeguards
+                       is the example). build/rubrics.py resolves either form.
+                       license-to-tier lives here, because whether AGPL is `osi` is
+                       a fact about AGPL, not about one category.
 warehouse/models/      UDM SQL (entities, events, metrics, scores)
 warehouse/ingest/      Python fetchers that write CSVs to warehouse/catalog/
 warehouse/catalog/     Raw external CSVs (HF benchmarks, incidents, GitHub orgs)

--- a/build/check_rubric.py
+++ b/build/check_rubric.py
@@ -221,9 +221,10 @@ def apply_formula(recipe: dict, facts: dict) -> tuple[int, str] | None:
 def check_category(slug: str, verbose: bool) -> tuple[int, int, list[str], list[str]]:
     """Return (reproduced, total, problems, deferred)."""
     category = yaml.safe_load((ROOT / "sources" / "categories" / f"{slug}.yaml").read_text())
-    # `extends: software` pulls the shared ladder in. Resolution errors are returned as
-    # problems rather than raising, so one broken category cannot stop the others being
-    # checked - and cannot pass silently either.
+    # `extends: software` pulls in one shared ladder for every product; `extends: {model:
+    # ..., software: ...}` pulls in one per product type, as `safeguards` does. Resolution
+    # errors are returned as problems rather than raising, so one broken category cannot
+    # stop the others being checked - and cannot pass silently either.
     variants, recipe_errors = resolve_recipe_variants(category, load_shared(ROOT))
     if recipe_errors:
         return 0, 0, [f"{slug}: {e}" for e in recipe_errors], []

--- a/build/check_rubric.py
+++ b/build/check_rubric.py
@@ -230,14 +230,13 @@ def check_category(slug: str, verbose: bool) -> tuple[int, int, list[str], list[
     if not variants:
         return 0, 0, [], []
     product_types = load_product_types(ROOT)
-    # Deferrals are a property of the category's declaration, not of any one ladder.
+    # Deferrals are a property of the category's declaration, not of any one ladder:
+    # products the category has declared the rubric does not yet decide, each with a
+    # reason. Deferring is not the same as passing: these are excluded from the
+    # reproduction count rather than counted as reproduced, and printed every run so
+    # the exclusion cannot go quiet. A rubric that reproduces 45 of 45 while deferring
+    # the one product that contradicts it has proved nothing.
     deferrals = (category.get("scoring_recipe") or {}).get("deferred") or {}
-
-    # Products the category has declared the rubric does not yet decide, each with
-    # a reason. Deferring is not the same as passing: these are excluded from the
-    # reproduction count rather than counted as reproduced, and printed every run
-    # so the exclusion cannot go quiet. A rubric that reproduces 45 of 45 while
-    # deferring the one product that contradicts it has proved nothing.
 
     reproduced = 0
     total = 0
@@ -339,7 +338,7 @@ def main() -> int:
     checked_any = False
     for slug in slugs:
         reproduced, total, problems, deferred = check_category(slug, args.verbose)
-        if total == 0 and not deferred:
+        if total == 0 and not deferred and not problems:
             continue
         checked_any = True
         status = "OK" if not problems else "FAIL"

--- a/build/check_rubric.py
+++ b/build/check_rubric.py
@@ -35,7 +35,7 @@ from pathlib import Path
 
 import yaml
 
-from build.rubrics import load_shared, resolve_recipe
+from build.rubrics import load_product_types, load_shared, recipe_for, resolve_recipe_variants
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -224,18 +224,20 @@ def check_category(slug: str, verbose: bool) -> tuple[int, int, list[str], list[
     # `extends: software` pulls the shared ladder in. Resolution errors are returned as
     # problems rather than raising, so one broken category cannot stop the others being
     # checked - and cannot pass silently either.
-    recipe, recipe_errors = resolve_recipe(category, load_shared(ROOT))
+    variants, recipe_errors = resolve_recipe_variants(category, load_shared(ROOT))
     if recipe_errors:
         return 0, 0, [f"{slug}: {e}" for e in recipe_errors], []
-    if not recipe:
+    if not variants:
         return 0, 0, [], []
+    product_types = load_product_types(ROOT)
+    # Deferrals are a property of the category's declaration, not of any one ladder.
+    deferrals = (category.get("scoring_recipe") or {}).get("deferred") or {}
 
     # Products the category has declared the rubric does not yet decide, each with
     # a reason. Deferring is not the same as passing: these are excluded from the
     # reproduction count rather than counted as reproduced, and printed every run
     # so the exclusion cannot go quiet. A rubric that reproduces 45 of 45 while
     # deferring the one product that contradicts it has proved nothing.
-    deferrals = recipe.get("deferred") or {}
 
     reproduced = 0
     total = 0
@@ -249,6 +251,10 @@ def check_category(slug: str, verbose: bool) -> tuple[int, int, list[str], list[
         if product in deferrals:
             because = (deferrals[product] or {}).get("because", "no reason recorded")
             deferred.append(f"{product}: {' '.join(str(because).split())}")
+            continue
+        recipe, why = recipe_for(variants, product_types.get(product, ""))
+        if recipe is None:
+            problems.append(f"{product}: {why}")
             continue
         scores = yaml.safe_load(path.read_text())
         openness = scores.get("openness") or {}

--- a/build/check_verification.py
+++ b/build/check_verification.py
@@ -262,24 +262,26 @@ def producible_pairs(recipe: dict) -> set[tuple[int, str]]:
     return pairs
 
 
-def g3_producible(scores: dict, categories: dict, recipes: dict) -> list[str]:
+def g3_producible(
+    scores: dict, categories: dict, recipes: dict, product_types: dict[str, str]
+) -> list[str]:
     """A recorded (score, class) must be an outcome the category's ladder can produce.
 
-    A mixed category has one ladder per product type, so a pair is possible for the
-    category if ANY of its ladders can produce it — the union across variants.
+    A mixed category has one ladder per product type. Each product is checked against
+    its OWN ladder via `recipe_for` — the same selection G1, `check_rubric` and
+    `serialize_rubric` all use — not the union of every variant in the category. A
+    software product recording a pair only the model ladder can emit must still fail
+    here, even though some ladder in the category could have produced it.
     """
     problems: list[str] = []
     for slug, variants in sorted(recipes.items()):
-        pairs: set[tuple[int, str]] = set()
-        for recipe in variants.values():
-            pairs |= producible_pairs(recipe)
-        if not pairs:
-            continue
         for product in categories[slug].get("products") or []:
             openness = (scores.get(product) or {}).get("openness") or {}
             score, klass = openness.get("score"), openness.get("class")
             if score is None:
                 continue
+            recipe, _ = recipe_for(variants, product_types.get(product, ""))
+            pairs = producible_pairs(recipe or {})
             if (score, klass) not in pairs:
                 problems.append(
                     f"{product}:openness in {slug}: {score}/{klass} is not an outcome any rule "
@@ -307,7 +309,7 @@ def main() -> int:
     results = {
         "g1": g1_invariant(scores, categories, recipes, product_types),
         "g2": g2_digests(scores),
-        "g3": g3_producible(scores, categories, recipes),
+        "g3": g3_producible(scores, categories, recipes, product_types),
     }
     if args.gate:
         results = {args.gate: results[args.gate]}

--- a/build/check_verification.py
+++ b/build/check_verification.py
@@ -157,15 +157,14 @@ def recorded_dimensions(components: dict[str, str], recipe: dict) -> dict[str, s
 
 
 def g1_invariant(
-    scores: dict, categories: dict, recipes: dict, product_types: dict[str, str] | None = None
+    scores: dict, categories: dict, recipes: dict, product_types: dict[str, str]
 ) -> list[str]:
     """Every recorded dimension of a dated axis has an establishing source read since."""
     problems: list[str] = []
     owner = category_of(categories)
-    product_types = product_types or {}
     for slug, score in sorted(scores.items()):
         variants = recipes.get(owner.get(slug, ""), {})
-        recipe, _ = recipe_for(variants, product_types.get(slug, "")) if variants else (None, None)
+        recipe, _ = recipe_for(variants, product_types.get(slug, ""))
         recipe = recipe or {}
         for axis in AXES:
             block = score.get(axis) or {}

--- a/build/check_verification.py
+++ b/build/check_verification.py
@@ -64,7 +64,7 @@ from pathlib import Path
 import yaml
 
 from build.check_rubric import license_read_keys, resolve_dimension, split_components
-from build.rubrics import load_shared, resolve_recipe
+from build.rubrics import load_product_types, load_shared, recipe_for, resolve_recipe_variants
 
 ROOT = Path(__file__).resolve().parents[1]
 AXES = ("openness", "adoption", "capability")
@@ -88,7 +88,7 @@ DIGEST_EXEMPT: dict[str, str] = {}
 
 
 def load() -> tuple[dict, dict, dict]:
-    """(scores, categories, resolved recipe per category)."""
+    """(scores, categories, resolved recipe variants per category)."""
     scores = {
         p.stem: yaml.safe_load(p.read_text()) or {}
         for p in sorted((ROOT / "sources" / "scores").glob("*.yaml"))
@@ -100,9 +100,9 @@ def load() -> tuple[dict, dict, dict]:
     shared = load_shared(ROOT)
     recipes = {}
     for slug, category in categories.items():
-        recipe, errors = resolve_recipe(category, shared)
-        if recipe and not errors:
-            recipes[slug] = recipe
+        variants, errors = resolve_recipe_variants(category, shared)
+        if variants and not errors:
+            recipes[slug] = variants
     return scores, categories, recipes
 
 
@@ -156,12 +156,17 @@ def recorded_dimensions(components: dict[str, str], recipe: dict) -> dict[str, s
     return found
 
 
-def g1_invariant(scores: dict, categories: dict, recipes: dict) -> list[str]:
+def g1_invariant(
+    scores: dict, categories: dict, recipes: dict, product_types: dict[str, str] | None = None
+) -> list[str]:
     """Every recorded dimension of a dated axis has an establishing source read since."""
     problems: list[str] = []
     owner = category_of(categories)
+    product_types = product_types or {}
     for slug, score in sorted(scores.items()):
-        recipe = recipes.get(owner.get(slug, ""), {})
+        variants = recipes.get(owner.get(slug, ""), {})
+        recipe, _ = recipe_for(variants, product_types.get(slug, "")) if variants else (None, None)
+        recipe = recipe or {}
         for axis in AXES:
             block = score.get(axis) or {}
             claimed = parse_date(block.get("last_verified"))
@@ -259,10 +264,16 @@ def producible_pairs(recipe: dict) -> set[tuple[int, str]]:
 
 
 def g3_producible(scores: dict, categories: dict, recipes: dict) -> list[str]:
-    """A recorded (score, class) must be an outcome the category's ladder can produce."""
+    """A recorded (score, class) must be an outcome the category's ladder can produce.
+
+    A mixed category has one ladder per product type, so a pair is possible for the
+    category if ANY of its ladders can produce it — the union across variants.
+    """
     problems: list[str] = []
-    for slug, recipe in sorted(recipes.items()):
-        pairs = producible_pairs(recipe)
+    for slug, variants in sorted(recipes.items()):
+        pairs: set[tuple[int, str]] = set()
+        for recipe in variants.values():
+            pairs |= producible_pairs(recipe)
         if not pairs:
             continue
         for product in categories[slug].get("products") or []:
@@ -293,8 +304,9 @@ def main() -> int:
     args = parser.parse_args()
 
     scores, categories, recipes = load()
+    product_types = load_product_types(ROOT)
     results = {
-        "g1": g1_invariant(scores, categories, recipes),
+        "g1": g1_invariant(scores, categories, recipes, product_types),
         "g2": g2_digests(scores),
         "g3": g3_producible(scores, categories, recipes),
     }
@@ -309,7 +321,7 @@ def main() -> int:
     )
     scored = sum(
         1
-        for slug, recipe in recipes.items()
+        for slug in recipes
         for product in categories[slug].get("products") or []
         if ((scores.get(product) or {}).get("openness") or {}).get("score") is not None
     )

--- a/build/rubrics.py
+++ b/build/rubrics.py
@@ -1,7 +1,15 @@
 """Shared scoring ladders, and how a category inherits one.
 
 A category's `scoring_recipe` may either spell out its own `openness` block or point at a
-shared ladder in `sources/rubrics/<name>.yaml` with `extends: <name>`.
+shared ladder in `sources/rubrics/<name>.yaml` with `extends: <name>`. `extends` can also be
+a mapping of product type to ladder name, for a category whose products do not all climb the
+same ladder — `safeguards` holds guardrail models and guardrail software, so it declares
+`extends: {model: model, software: software}` rather than a single name. The key `"*"` means
+one ladder covers every type; `resolve_recipe_variants` returns that as its only entry when
+`extends` is a plain string, so callers do not need to branch on which form a category used.
+`recipe_for(variants, product_type)` then picks the recipe that governs one product, reading
+its `type:` field from `sources/products/<slug>.yaml` (see `load_product_types`), and reports
+why when no ladder in the mapping covers that type.
 
 ## Why this exists
 

--- a/build/rubrics.py
+++ b/build/rubrics.py
@@ -153,8 +153,8 @@ def dimension_vocabulary(categories: dict[str, dict], shared: dict[str, dict]) -
     """
     names: set[str] = set()
     for category in (categories or {}).values():
-        recipe, errors = resolve_recipe(category or {}, shared or {})
-        if recipe and not errors:
+        variants, _ = resolve_recipe_variants(category or {}, shared or {})
+        for recipe in variants.values():
             names |= recipe_vocabulary(recipe)
     return names
 

--- a/build/rubrics.py
+++ b/build/rubrics.py
@@ -50,6 +50,11 @@ def resolve_recipe(category: dict, shared: dict[str, dict]) -> tuple[dict | None
         return None, []
 
     base_name = recipe.get("extends")
+    if isinstance(base_name, dict):
+        return None, [
+            "scoring_recipe extends per product type; call resolve_recipe_variants "
+            "and select with recipe_for"
+        ]
     if not base_name:
         return recipe, []
 
@@ -64,6 +69,54 @@ def resolve_recipe(category: dict, shared: dict[str, dict]) -> tuple[dict | None
     merged.update({key: value for key, value in recipe.items() if key != "extends"})
     merged["extends"] = base_name
     return merged, []
+
+
+def resolve_recipe_variants(
+    category: dict, shared: dict[str, dict]
+) -> tuple[dict[str, dict], list[str]]:
+    """({product type: resolved recipe}, errors). The key "*" covers every type.
+
+    `extends` is a string for a uniform category and a mapping of product type ->
+    ladder name for a mixed one (`safeguards` holds guardrail models and software
+    libraries, which climb different ladders). The category's own keys merge into
+    every variant under the same whole-key-replace rule as `resolve_recipe`.
+    """
+    recipe = category.get("scoring_recipe")
+    if not recipe:
+        return {}, []
+    base_name = recipe.get("extends")
+    if not isinstance(base_name, dict):
+        resolved, errors = resolve_recipe(category, shared)
+        return ({"*": resolved} if resolved else {}), errors
+
+    variants: dict[str, dict] = {}
+    errors: list[str] = []
+    for product_type, ladder_name in sorted(base_name.items()):
+        base = shared.get(ladder_name)
+        if base is None:
+            errors.append(
+                f"scoring_recipe extends {ladder_name!r} for type {product_type!r}, "
+                f"which is not a file in sources/rubrics/ "
+                f"(have: {', '.join(sorted(shared)) or 'none'})"
+            )
+            continue
+        merged = dict(base)
+        merged.update({key: value for key, value in recipe.items() if key != "extends"})
+        merged["extends"] = ladder_name
+        variants[product_type] = merged
+    return variants, errors
+
+
+def recipe_for(variants: dict[str, dict], product_type: str) -> tuple[dict | None, str | None]:
+    """The recipe governing one product, or (None, why not)."""
+    if "*" in variants:
+        return variants["*"], None
+    if product_type in variants:
+        return variants[product_type], None
+    return None, (
+        f"no ladder for product type {product_type!r} "
+        f"(recipe covers: {', '.join(sorted(variants)) or 'nothing'})"
+    )
 
 
 def recipe_vocabulary(recipe: dict) -> set[str]:

--- a/build/rubrics.py
+++ b/build/rubrics.py
@@ -157,3 +157,16 @@ def dimension_vocabulary(categories: dict[str, dict], shared: dict[str, dict]) -
         if recipe and not errors:
             names |= recipe_vocabulary(recipe)
     return names
+
+
+def load_product_types(root: Path) -> dict[str, str]:
+    """slug -> `type` for every product file. The slug is the filename stem —
+    that identity rule is enforced by validate, so it is safe to rely on here."""
+    directory = root / "sources" / "products"
+    if not directory.is_dir():
+        return {}
+    types: dict[str, str] = {}
+    for path in sorted(directory.glob("*.yaml")):
+        record = yaml.safe_load(path.read_text()) or {}
+        types[path.stem] = str(record.get("type") or "")
+    return types

--- a/build/serialize_rubric.py
+++ b/build/serialize_rubric.py
@@ -371,6 +371,12 @@ def build_rubric(sources: dict, policy: dict, routing: dict) -> tuple[dict[str, 
             continue
         scored_categories += 1
 
+        # Deferrals are a property of the category's declaration, not of any one
+        # resolved ladder variant, so they are read off `scoring_recipe` directly
+        # rather than through `resolve_recipe` — the same source `check_rubric.py`'s
+        # `check_category` reads (build/check_rubric.py:240).
+        deferred = (category.get("scoring_recipe") or {}).get("deferred") or {}
+
         for product_type, variant_recipe in sorted(variants.items()):
             rules, rule_errors = scoring_rules(slug, variant_recipe)
             for row in rules:
@@ -394,7 +400,16 @@ def build_rubric(sources: dict, policy: dict, routing: dict) -> tuple[dict[str, 
             # that runs unconditionally after this block (see
             # test_recipe_miss_still_emits_score_sources_for_other_axes).
             recipe, why = recipe_for(variants, product_types.get(product_slug, ""))
-            if recipe is None:
+            if product_slug in deferred:
+                # `openness_computed` builds its roster with SELECT DISTINCT product_slug,
+                # category_slug FROM product_evidence, so any row emitted here is enough for
+                # that downstream model to compute a score. `deferred` means the repo has
+                # declared it will NOT stand behind the ladder reproducing this product's
+                # recorded score, so no openness evidence goes out and no score is ever
+                # computed for it — the safe silence, instead of a computed score nobody
+                # signed off on.
+                pass
+            elif recipe is None:
                 warnings.append(f"product '{product_slug}' in '{slug}': {why}")
             else:
                 declared = ((recipe.get("openness") or {}).get("dimensions")) or {}

--- a/build/serialize_rubric.py
+++ b/build/serialize_rubric.py
@@ -70,6 +70,7 @@ from build.check_rubric import (
     resolve_dimension,
     split_components,
 )
+from build.rubrics import load_product_types, recipe_for, resolve_recipe_variants
 from build.serialize_registry import write_tables
 from build.validate import load_sources
 
@@ -84,11 +85,10 @@ AXES = ("openness", "adoption", "capability")
 # gets one lookup table instead of a lookup table plus a hardcoded special case.
 DEFINITIONAL_TIERS = {"proprietary": ("proprietary", "closed", "none")}
 
-from build.rubrics import resolve_recipe
-
 TABLES: dict[str, tuple[str, ...]] = {
     "category_scoring_rules": (
         "category_slug",
+        "product_type",
         "recipe_version",
         "rule_index",
         "is_otherwise",
@@ -99,6 +99,7 @@ TABLES: dict[str, tuple[str, ...]] = {
     ),
     "category_license_tiers": (
         "category_slug",
+        "product_type",
         "tier",
         "tier_rank",
         "example_license",
@@ -355,29 +356,44 @@ def build_rubric(sources: dict, policy: dict, routing: dict) -> tuple[dict[str, 
     if not tables["evidence_abstentions"]:
         warnings.append("signal_routing.yaml declares no route abstain_values")
 
+    # Slug -> declared `type`, threaded through `sources` rather than read here so
+    # `build_rubric` stays a pure function of its inputs (see `test_rubric_rows_carry_product_type`).
+    product_types: dict[str, str] = sources.get("product_types") or {}
+
     scored_categories = 0
     for slug, category in sorted(categories.items()):
-        recipe, recipe_errors = resolve_recipe(category, shared_rubrics)
+        variants, recipe_errors = resolve_recipe_variants(category, shared_rubrics)
         errors.extend(f"category '{slug}' {e}" for e in recipe_errors)
-        if not recipe:
+        if not variants:
             if not recipe_errors:
                 warnings.append(f"category '{slug}' declares no scoring_recipe")
             continue
         scored_categories += 1
 
-        rules, rule_errors = scoring_rules(slug, recipe)
-        tables["category_scoring_rules"].extend(rules)
-        errors.extend(rule_errors)
-        tier_rows, tier_errors = license_tiers(slug, recipe)
-        tables["category_license_tiers"].extend(tier_rows)
-        errors.extend(tier_errors)
+        for product_type, variant_recipe in sorted(variants.items()):
+            rules, rule_errors = scoring_rules(slug, variant_recipe)
+            for row in rules:
+                row["product_type"] = product_type
+            tables["category_scoring_rules"].extend(rules)
+            errors.extend(rule_errors)
 
-        declared = ((recipe.get("openness") or {}).get("dimensions")) or {}
+            tier_rows, tier_errors = license_tiers(slug, variant_recipe)
+            for row in tier_rows:
+                row["product_type"] = product_type
+            tables["category_license_tiers"].extend(tier_rows)
+            errors.extend(tier_errors)
 
         for product_slug in category.get("products") or []:
             record = scores.get(product_slug)
             if record is None:
                 continue
+            recipe, why = recipe_for(variants, product_types.get(product_slug, ""))
+            if recipe is None:
+                warnings.append(f"product '{product_slug}' in '{slug}': {why}")
+                continue
+
+            declared = ((recipe.get("openness") or {}).get("dimensions")) or {}
+
             openness = record.get("openness") or {}
             components = split_components(openness.get("components") or "")
             if not components:
@@ -541,6 +557,7 @@ def main() -> int:
     args = parser.parse_args()
 
     sources = load_sources(ROOT)
+    sources["product_types"] = load_product_types(ROOT)
     tables, errors, warnings = build_rubric(sources, load_policy(ROOT), load_routing(ROOT))
 
     for name in TABLES:

--- a/build/serialize_rubric.py
+++ b/build/serialize_rubric.py
@@ -43,8 +43,9 @@ files do not carry it. Recording the limit beats inventing an attribution.
 
 Emitted tables (CSVs into `build/registry/`, alongside the registry's own):
 
-  category_scoring_rules      the ordered formula, one row per rule condition
-  category_license_tiers      tier <- example license, per category
+  category_scoring_rules      the ordered formula, one row per rule condition, per category
+                              and product type
+  category_license_tiers      tier <- example license, per category and product type
   license_aliases             a source's license slug -> canonical license name
   evidence_abstentions        values that mean "this source has no answer"
   product_openness_evidence   per-dimension values parsed from `components`

--- a/build/serialize_rubric.py
+++ b/build/serialize_rubric.py
@@ -387,134 +387,138 @@ def build_rubric(sources: dict, policy: dict, routing: dict) -> tuple[dict[str, 
             record = scores.get(product_slug)
             if record is None:
                 continue
+            # A missing/unmapped product type only forfeits the recipe-dependent
+            # openness evidence below — it says nothing about whether adoption and
+            # capability sources exist, so it must not skip the axis-source loop
+            # that runs unconditionally after this block (see
+            # test_recipe_miss_still_emits_score_sources_for_other_axes).
             recipe, why = recipe_for(variants, product_types.get(product_slug, ""))
             if recipe is None:
                 warnings.append(f"product '{product_slug}' in '{slug}': {why}")
-                continue
+            else:
+                declared = ((recipe.get("openness") or {}).get("dimensions")) or {}
 
-            declared = ((recipe.get("openness") or {}).get("dimensions")) or {}
-
-            openness = record.get("openness") or {}
-            components = split_components(openness.get("components") or "")
-            if not components:
-                warnings.append(
-                    f"product '{product_slug}' in '{slug}' records no openness components"
-                )
-
-            read_map = dimension_read_map(recipe)
-            license_keys = license_read_keys(recipe)
-
-            # One row per DECLARED DIMENSION, carrying the value the formula will
-            # actually read. Emitted under the dimension name rather than the key it
-            # was recorded under, because the warehouse joins a rule's condition_key
-            # against this column: a row labeled `post-training-data` would leave the
-            # `data` condition unmatched and drop the product into `otherwise`
-            # silently, scoring it 3 on an absence.
-            resolved_keys: dict[str, str] = {}
-            for dimension, spec in declared.items():
-                key = resolve_dimension(components, dimension, recipe)
-                if key is None:
-                    continue
-                resolved_keys[dimension] = key
-                bare, detail = split_value(components[key])
-                allowed = (spec or {}).get("values")
-                in_enum = bare in allowed if allowed else ""
-                if in_enum is False:
+                openness = record.get("openness") or {}
+                components = split_components(openness.get("components") or "")
+                if not components:
                     warnings.append(
-                        f"product '{product_slug}' records {key}={bare!r}, which is not in "
-                        f"the rubric's declared values for {dimension} {allowed}"
+                        f"product '{product_slug}' in '{slug}' records no openness components"
                     )
-                tables["product_openness_evidence"].append(
-                    {
-                        "product_slug": product_slug,
-                        "category_slug": slug,
-                        "dimension": dimension,
-                        "value": bare,
-                        "value_detail": detail,
-                        "grade": "document",
-                        "in_declared_enum": in_enum,
-                    }
-                )
 
-            # The license the tier lookup consumes, emitted under the name the
-            # warehouse joins on. `license_tier.reads` lets a category accept the value
-            # under another key - deepseek-coder records `model-license`, because its card
-            # distinguishes the code license from the one on the weights - and
-            # check_rubric honours that list. Without resolving it here the row went out
-            # as `model-license`, the SQL looked only for `license`, and the product
-            # abstained in the warehouse while reproducing locally. Same drift as the
-            # dimension resolution above, one key over.
-            license_key = next((k for k in license_keys if components.get(k)), None)
-            if license_key:
-                bare, detail = split_value(components[license_key])
-                tables["product_openness_evidence"].append(
-                    {
-                        "product_slug": product_slug,
-                        "category_slug": slug,
-                        "dimension": "license",
-                        "value": bare,
-                        "value_detail": detail,
-                        "grade": "document",
-                        # No enum: `license` is the raw input the tier lookup consumes.
-                        "in_declared_enum": "",
-                    }
-                )
+                read_map = dimension_read_map(recipe)
+                license_keys = license_read_keys(recipe)
 
-            # Then every recorded key that is not itself a dimension name, so nothing
-            # the repo recorded is dropped. This carries the license the tier lookup
-            # consumes, and the losing side of a `reads` preference — granite records
-            # both a base corpus and an SFT mixture, and only one of them answers the
-            # category's data question.
-            #
-            # Keys that ARE dimension names are skipped here because the resolved pass
-            # above already emitted them. Emitting both would put two values on one
-            # grain and let the warehouse pick between them by row order.
-            for key, raw in components.items():
-                if key == "license":
-                    continue  # emitted above, under the resolved license row
-                if key in declared:
-                    # A key that shares a dimension's name but lost the `reads`
-                    # preference is answering a different question under a name this
-                    # category has already spent. granite records
-                    # `data:described_not_released` about its BASE corpus while
-                    # `post-training-data` answers the category's data question, so the
-                    # base fact has nowhere to go and would be dropped without a word.
-                    # Reported so it can be relabeled — starcoder2 already uses
-                    # `base-data` for exactly this.
-                    if resolved_keys.get(key) != key:
+                # One row per DECLARED DIMENSION, carrying the value the formula will
+                # actually read. Emitted under the dimension name rather than the key it
+                # was recorded under, because the warehouse joins a rule's condition_key
+                # against this column: a row labeled `post-training-data` would leave the
+                # `data` condition unmatched and drop the product into `otherwise`
+                # silently, scoring it 3 on an absence.
+                resolved_keys: dict[str, str] = {}
+                for dimension, spec in declared.items():
+                    key = resolve_dimension(components, dimension, recipe)
+                    if key is None:
+                        continue
+                    resolved_keys[dimension] = key
+                    bare, detail = split_value(components[key])
+                    allowed = (spec or {}).get("values")
+                    in_enum = bare in allowed if allowed else ""
+                    if in_enum is False:
                         warnings.append(
-                            f"product '{product_slug}' records {key}={split_value(raw)[0]!r}, but "
-                            f"'{slug}' resolved {key} from {resolved_keys.get(key)!r} instead, so "
-                            f"the recorded value is dropped from the evidence store. Relabel it if "
-                            f"it answers a different question."
+                            f"product '{product_slug}' records {key}={bare!r}, which is not in "
+                            f"the rubric's declared values for {dimension} {allowed}"
                         )
-                    continue
-                bare, detail = split_value(raw)
-                # A component no dimension declares and no `reads` list names is
-                # vocabulary drift. It cannot affect a score, so it is a curation
-                # finding rather than a failure — but left unreported it is an
-                # observation nobody will ever act on. `marin` records
-                # `reproducibility:bit-for-bit`, a real openness fact the rubric has
-                # no question for.
-                if key not in license_keys and key not in read_map:
-                    warnings.append(
-                        f"product '{product_slug}' records {key!r}, which "
-                        f"'{slug}' does not declare as a dimension"
+                    tables["product_openness_evidence"].append(
+                        {
+                            "product_slug": product_slug,
+                            "category_slug": slug,
+                            "dimension": dimension,
+                            "value": bare,
+                            "value_detail": detail,
+                            "grade": "document",
+                            "in_declared_enum": in_enum,
+                        }
                     )
-                tables["product_openness_evidence"].append(
-                    {
-                        "product_slug": product_slug,
-                        "category_slug": slug,
-                        "dimension": key,
-                        "value": bare,
-                        "value_detail": detail,
-                        "grade": "document",
-                        # A traceability row, not the value any rule reads. Left blank
-                        # rather than validated, since the enum it would be checked
-                        # against belongs to the dimension that won.
-                        "in_declared_enum": "",
-                    }
-                )
+
+                # The license the tier lookup consumes, emitted under the name the
+                # warehouse joins on. `license_tier.reads` lets a category accept the value
+                # under another key - deepseek-coder records `model-license`, because its card
+                # distinguishes the code license from the one on the weights - and
+                # check_rubric honours that list. Without resolving it here the row went out
+                # as `model-license`, the SQL looked only for `license`, and the product
+                # abstained in the warehouse while reproducing locally. Same drift as the
+                # dimension resolution above, one key over.
+                license_key = next((k for k in license_keys if components.get(k)), None)
+                if license_key:
+                    bare, detail = split_value(components[license_key])
+                    tables["product_openness_evidence"].append(
+                        {
+                            "product_slug": product_slug,
+                            "category_slug": slug,
+                            "dimension": "license",
+                            "value": bare,
+                            "value_detail": detail,
+                            "grade": "document",
+                            # No enum: `license` is the raw input the tier lookup consumes.
+                            "in_declared_enum": "",
+                        }
+                    )
+
+                # Then every recorded key that is not itself a dimension name, so nothing
+                # the repo recorded is dropped. This carries the license the tier lookup
+                # consumes, and the losing side of a `reads` preference — granite records
+                # both a base corpus and an SFT mixture, and only one of them answers the
+                # category's data question.
+                #
+                # Keys that ARE dimension names are skipped here because the resolved pass
+                # above already emitted them. Emitting both would put two values on one
+                # grain and let the warehouse pick between them by row order.
+                for key, raw in components.items():
+                    if key == "license":
+                        continue  # emitted above, under the resolved license row
+                    if key in declared:
+                        # A key that shares a dimension's name but lost the `reads`
+                        # preference is answering a different question under a name this
+                        # category has already spent. granite records
+                        # `data:described_not_released` about its BASE corpus while
+                        # `post-training-data` answers the category's data question, so the
+                        # base fact has nowhere to go and would be dropped without a word.
+                        # Reported so it can be relabeled — starcoder2 already uses
+                        # `base-data` for exactly this.
+                        if resolved_keys.get(key) != key:
+                            warnings.append(
+                                f"product '{product_slug}' records {key}={split_value(raw)[0]!r}, but "
+                                f"'{slug}' resolved {key} from {resolved_keys.get(key)!r} instead, so "
+                                f"the recorded value is dropped from the evidence store. Relabel it if "
+                                f"it answers a different question."
+                            )
+                        continue
+                    bare, detail = split_value(raw)
+                    # A component no dimension declares and no `reads` list names is
+                    # vocabulary drift. It cannot affect a score, so it is a curation
+                    # finding rather than a failure — but left unreported it is an
+                    # observation nobody will ever act on. `marin` records
+                    # `reproducibility:bit-for-bit`, a real openness fact the rubric has
+                    # no question for.
+                    if key not in license_keys and key not in read_map:
+                        warnings.append(
+                            f"product '{product_slug}' records {key!r}, which "
+                            f"'{slug}' does not declare as a dimension"
+                        )
+                    tables["product_openness_evidence"].append(
+                        {
+                            "product_slug": product_slug,
+                            "category_slug": slug,
+                            "dimension": key,
+                            "value": bare,
+                            "value_detail": detail,
+                            "grade": "document",
+                            # A traceability row, not the value any rule reads. Left blank
+                            # rather than validated, since the enum it would be checked
+                            # against belongs to the dimension that won.
+                            "in_declared_enum": "",
+                        }
+                    )
 
             rejected = 0
             for axis in AXES:

--- a/docs/guides/verification.md
+++ b/docs/guides/verification.md
@@ -271,10 +271,19 @@ Two things ride along:
   every dimension the score *records*. Without this column no tool can ever legitimately
   write `last_verified`, so it is the precondition for step 3.
 - **A `category_deferrals` table.** `deferred` currently lives only in the repo, so the
-  warehouse does not know which products a category has held back. There are 63 of them now,
-  alongside the 111 products in the four categories with no recipe at all. With no
-  `otherwise` rule in the software ladder they fall out of the model's INNER JOIN rather than
-  being scored wrongly — the safe direction, but silent.
+  warehouse does not know which products a category has held back. There are 89 of them now,
+  alongside the 85 products in the three categories with no recipe at all. For the software
+  categories the silence has been safe: with no `otherwise` rule in the software ladder their
+  deferred products fall out of the model's INNER JOIN rather than being scored wrongly.
+
+  **That safety argument no longer covers every category.** `sources/rubrics/model.yaml` ends
+  in `otherwise: {score: 3, class: open_weights}`, so a deferred product on the model ladder
+  gets a score in the warehouse instead of dropping out. `safeguards` is the first category to
+  pair an `otherwise` ladder with deferrals, and all 26 of its products are deferred. Until
+  this table exists, the warehouse can compute openness for products whose recorded scores the
+  repo has explicitly declined to reproduce, and for seven of the nine guardrail models the
+  computed value disagrees with the published one. That makes the table a correctness fix for
+  `safeguards` rather than only an observability one.
 
 ### 3. The automated freshness pass — roughly 400 axes
 
@@ -292,8 +301,9 @@ twice, and it re-verifies scores that are about to change.
 That backlog is currently 174 products: 49 whose prose does not settle `source` or
 `core-gated`, 10 whose recorded license maps to no tier in the ladder, 4 where the ladder and
 the recorded score still disagree (`jina-reader`, `openhands`, `maple-ai`, `privatemode` — all
-producible pairs, so G3 passes them and only `check_rubric` objects), plus the 111 products in
-the four categories that have no recipe yet.
+producible pairs, so G3 passes them and only `check_rubric` objects), plus the 85 products in
+the three categories that have no recipe yet and the 26 in `safeguards`, which has a recipe but
+reproduces none of them.
 
 **Expect scores to move.** Verification is not a formality: the RWKV correction in #105 came
 out of a pass like this, and G3's first run moved 17 openness scores or classes before the

--- a/docs/guides/verification.md
+++ b/docs/guides/verification.md
@@ -226,25 +226,36 @@ one gets done twice if rushed.
 
 ### 1. Finish the recipes — 16/16 categories, 470/470 products
 
-111 products across four categories still have no `scoring_recipe`:
+85 products across three categories still have no `scoring_recipe`:
 
 | category | n | product type |
 |---|---|---|
 | `benchmark_eval_data` | 27 | dataset |
 | `training_synthetic_datasets` | 38 | dataset |
 | `edge_hardware` | 20 | hardware |
-| `safeguards` | 26 | **mixed** — 9 model, 17 software |
 
 **Do this before step 2.** Step 2 generalizes the scoring SQL off its hardcoded model
 dimensions, and that generalization should be driven by the complete dimension vocabulary.
 Generalize it now for software alone and it gets redone when `dataset` and `hardware` arrive
 with dimensions of their own.
 
-Two of the four are cheap: one dataset ladder covers 65 products, hardware is 20 products.
-`safeguards` is the one that changes the machinery — it is the only mixed-type category, so
-`extends` has to become per-product-type rather than per-category. That in turn forces the
-other half of the ladder extraction: pulling the model ladder out to
-`sources/rubrics/model.yaml` so `safeguards` can reference both it and `software.yaml`.
+Both are cheap: one dataset ladder covers the 65 products in `benchmark_eval_data` and
+`training_synthetic_datasets`, hardware is `edge_hardware`'s 20.
+
+`safeguards` is no longer on this list, and it is why `extends` now accepts two forms. It
+holds 9 products typed `model` and 17 typed `software`, so a single shared ladder could not
+cover it. `scoring_recipe.extends` can now be a mapping of product type to ladder name —
+`safeguards` declares `model: model, software: software` — resolved per product by the
+`type:` field in `sources/products/<slug>.yaml`, through `build/rubrics.py`'s
+`resolve_recipe_variants` and `recipe_for`. That forced the other half of the extraction
+too: the fine-tuned model ladder moved out of `finetuned_chat.yaml` into a shared
+`sources/rubrics/model.yaml`, so `safeguards` could reference it alongside `software.yaml`.
+
+The machinery landed; the scores did not. `safeguards` reproduces none of its 26 products.
+All 26 sit in the category's `deferred` block: a license resolving to the wrong tier,
+evidence recorded under a key the ladder does not read, a couple of judgment calls on which
+SKU governs a bundled guard model. Correcting those 26 is what remains, through curation
+rather than more machinery.
 
 ### 2. Generalize the scoring SQL, once
 

--- a/sources/categories/finetuned_chat.yaml
+++ b/sources/categories/finetuned_chat.yaml
@@ -22,12 +22,13 @@ weights:
 #   * tulu-3 and starcoder2 recorded score/class pairs this ladder cannot emit
 #     (3/restricted, 4/open_source).
 #
-# The formula restates base_pretrained's, less one rule no product here can trigger.
-# Restating is tolerable at two categories and a liability at three - the third one to
-# land should extract the ladder to a shared default that a category overrides rather
-# than copies.
+# The formula restated base_pretrained's, less one rule no product here can trigger.
+# Restating was tolerable at two categories and a liability at three, so as of this
+# extraction the ladder itself lives in sources/rubrics/model.yaml and this category
+# extends it rather than copying it.
 scoring_recipe:
   version: 1
+  extends: model
   derived_from:
     method: ported from base_pretrained, then verified against this category's scores
     ported_from: base_pretrained
@@ -45,130 +46,11 @@ scoring_recipe:
       declaration or any correction; that is the honest measure of how far the pilot
       rubric traveled on its own.
 
-  openness:
-    dimensions:
-      weights:
-        question: Are the tuned model weights downloadable and runnable locally?
-        values: [open, closed, pending]
-        evidence:
-        - Hugging Face model repo with downloadable weight files (safetensors/GGUF)
-        - vendor download page for weights outside the Hub
-        machine_signal: signal_huggingface.hub_state (gated, private, files)
-      data:
-        question: Is the POST-TRAINING data released - the SFT, DPO or RL sets this
-          tune was built from?
-        # For a base model the data question is the pretraining corpus. For a tune,
-        # that corpus belongs to somebody else's model, and asking about it scores
-        # the base rather than the product. The honest question here is what the
-        # tuner released, which is why `post-training-data` is read first.
-        reads: [post-training-data, data]
-        values: [open, described_not_released, described, partial, closed]
-        evidence:
-        - a released SFT/DPO/RL mixture, or scripts that reconstruct it
-        - '`described` where the mixture is named in the card but not published'
-        - naming the datasets used is NOT sufficient for `open`
-        machine_signal: none - requires research
-        vocabulary_note: >
-          `described_not_released` here is `documented-not-released` in
-          base_pretrained. Same concept, two spellings, and neither category should
-          be the one that unilaterally renames it. Unifying the shared data
-          vocabulary is issue #106.
-      code:
-        question: Is the fine-tuning pipeline released, not just inference code?
-        values: [open, partial, closed]
-        evidence:
-        - '`open`: the post-training recipe - SFT/DPO/RL configs and scripts'
-        - '`partial`: inference, serving or chat-template code only'
-        - '`closed`: no code'
-        machine_signal: partial - repo presence from signal_github.repo_state
-
-    license_tier:
-      # base_pretrained's ladder, unchanged, including the declaration order that
-      # `tier_rank` and the multi-SKU rule depend on. Eight licenses added because
-      # this category ships them and the pilot did not.
-      ordered_by: restrictiveness_ascending
-      # A tune records its license under `license`, except where the card
-      # distinguishes a code license from the one attached to the weights, and then
-      # it lands in `model-license`. The weights license governs either way.
-      reads: [license, model-license]
-      values:
-        osi:
-          definition: OSI-approved license
-          examples: [Apache-2.0, MIT, BSD-3-Clause]
-        permissive_non_osi:
-          definition: >
-            Not OSI-approved, but imposes no restriction on WHO may use the artifact or
-            AT WHAT SCALE. Attribution, naming and CONDUCT requirements belong here: an
-            acceptable-use policy forbidding military, illegal or discriminatory use caps
-            neither commerce nor reach, so it sits beside attribution rather than beside a
-            monthly-active-user ceiling. Non-OSI by construction, since the OSD forbids
-            discriminating against a field of endeavor. Settled in issue #117, which was
-            opened because the same OpenRAIL family had been scored 3 in one category and
-            4 in another.
-          examples: [Modified-MIT, minimax-community, NVIDIA-Open-Model-License, BigCode-OpenRAIL-M,
-            DeepSeek-Model-License, TII-Falcon-License-2.0]
-        use_restricted:
-          definition: >
-            Caps or gates use - monthly-active-user ceilings, field-of-use limits,
-            research-only terms, or a commercial agreement requirement.
-          examples: [Llama-2-Community-License, Llama-3-Community-License, Llama-3.1-Community-License,
-            Llama-3.2-Community-License, Llama-4-Community, Gemma-License, GLM-4-License,
-            Qwen-License-Agreement, Mistral-Research-License, Mistral-AI-Non-Production-License,
-            Jamba-Open-Model-License, CC-BY-NC]
-        proprietary:
-          definition: No public license; weights not distributed.
-      multi_sku_rule: >
-        As base_pretrained: where a family ships SKUs under different licenses, the
-        most restrictive license among the SKUs WHOSE WEIGHTS ARE ACTUALLY
-        DISTRIBUTED governs, and API-only tiers are excluded.
-      inherits_from_base: >
-        A tune of a restrictively licensed base carries that restriction, because
-        the license travels with the weights. hermes-4-llama-3-1-405b is
-        use_restricted on account of Meta's terms, not anything Nous did. This needs
-        no rule of its own - the tune records the license it actually ships under,
-        and the ladder does the rest.
-
-        What the ladder deliberately does NOT do is credit the tuner's open method
-        here. A fine-tuning approach generalizes across bases - AI2's Tulu recipe
-        runs on Llama and on OLMo - so scoring the checkpoint would either bury the
-        open method or overstate the artifact. The map already resolves this by
-        scoring the method's artifacts as their own products:
-        tulu-3-sft-mixture is 5/open in training_synthetic_datasets while the
-        Llama-based tulu-3 checkpoint is 2/restricted. That pair is the signal.
-        Recording the checkpoint -> base link so the two can be joined is not yet
-        done; `lineage` exists but is dataset-only and free-text.
-      normalization:
-      - 'compound `code X + model Y`: the MODEL license governs'
-      - 'prefix `assumed-`: same tier, confidence drops to medium'
-      never_use:
-        mixed: Apply multi_sku_rule and store the resolved tier instead.
-        unknown: Research it or defer the product with a reason.
-
-    # Ordered rules, first match wins. base_pretrained's ladder less one rule: it
-    # carries a `data: documented-not-released, code: open -> 4`, and no product here
-    # pairs a described-but-unreleased mixture with an open pipeline. Declaring it
-    # anyway would add a rule that cannot fire, and a dead rule in a first-match-wins
-    # formula is a place for a later edit to hide.
-    formula:
-    - when: {weights: closed}
-      then: {score: 1, class: closed}
-    - when: {license_tier: proprietary}
-      then: {score: 1, class: closed}
-    - when: {license_tier: use_restricted}
-      then: {score: 2, class: restricted}
-      note: Open weights behind a use cap. Downloadable is not the same as usable.
-    - when: {data: open, code: open, license_tier: osi}
-      then: {score: 5, class: open_source}
-    - when: {data: open, code: open}
-      then: {score: 4, class: open_weights}
-      note: Full recipe but a non-OSI license caps the score at 4.
-    - otherwise: {score: 3, class: open_weights}
-      note: The category's center of gravity - open weights, closed recipe.
-
   # Nothing deferred. The three products that were - starcoder2, deepseek-coder and
   # command-r - are decided by the conduct-versus-commerce distinction settled in issue
-  # #117 and written into permissive_non_osi above. Keeping the key with an empty map
-  # would read as "we defer nothing yet"; removing it says the question was answered.
+  # #117 and written into permissive_non_osi in sources/rubrics/model.yaml. Keeping the
+  # key with an empty map would read as "we defer nothing yet"; removing it says the
+  # question was answered.
 
 products:
 - qwen-coder

--- a/sources/categories/finetuned_chat.yaml
+++ b/sources/categories/finetuned_chat.yaml
@@ -9,9 +9,9 @@ weights:
 
 # Second category to carry a machine-readable rubric, and the one that tests
 # whether the first was a general mechanism or a bespoke one. The answer is mostly
-# yes: the tier ladder and the formula below are base_pretrained's, unchanged. What
-# needed adding was vocabulary, not structure - which keys carry the data answer for
-# a fine-tune, and eight more licenses.
+# yes: the tier ladder and the formula, now in sources/rubrics/model.yaml, are
+# base_pretrained's, unchanged. What needed adding was vocabulary, not structure -
+# which keys carry the data answer for a fine-tune, and eight more licenses.
 #
 # Ported on 2026-07-29. Three things the port found are recorded here rather than
 # quietly fixed, because they are judgments about published scores:

--- a/sources/categories/safeguards.yaml
+++ b/sources/categories/safeguards.yaml
@@ -25,8 +25,9 @@ scoring_recipe:
         recorded weights:adapter-open and data:Aegis safety dataset documented values also
         fall outside the ladder's declared enums. See the 2026-07-30 reproduction report.
     openguardrails:
-      because: source or core-gated is not recorded in a form the ladder can read; needs a
-        read of the repo and pricing page
+      because: >-
+        source or core-gated is not recorded in a form the ladder can read; needs a read of
+        the repo and pricing page
     zentropi-cope:
       because: >-
         License zentropi-openrail-m appears in no tier's examples and has no alias in
@@ -55,14 +56,17 @@ scoring_recipe:
         use-restricted Llama license the harness's own license does not cover; which SKU
         governs 5/open_source is a curation call. See the 2026-07-30 reproduction report.
     harmbench:
-      because: source or core-gated is not recorded in a form the ladder can read; needs a
-        read of the repo and pricing page
+      because: >-
+        source or core-gated is not recorded in a form the ladder can read; needs a read of
+        the repo and pricing page
     giskard:
-      because: source or core-gated is not recorded in a form the ladder can read; needs a
-        read of the repo and pricing page
+      because: >-
+        source or core-gated is not recorded in a form the ladder can read; needs a read of
+        the repo and pricing page
     deepteam:
-      because: source or core-gated is not recorded in a form the ladder can read; needs a
-        read of the repo and pricing page
+      because: >-
+        source or core-gated is not recorded in a form the ladder can read; needs a read of
+        the repo and pricing page
     perspective-api:
       because: >-
         No source or license key is recorded, only a service:proprietary... prose
@@ -90,26 +94,33 @@ scoring_recipe:
         evidence (data:not-released) but the score says 4/open_weights. See the 2026-07-30
         reproduction report.
     nemo-guardrails:
-      because: source or core-gated is not recorded in a form the ladder can read; needs a
-        read of the repo and pricing page
+      because: >-
+        source or core-gated is not recorded in a form the ladder can read; needs a read of
+        the repo and pricing page
     guardrails-ai:
-      because: source or core-gated is not recorded in a form the ladder can read; needs a
-        read of the repo and pricing page
+      because: >-
+        source or core-gated is not recorded in a form the ladder can read; needs a read of
+        the repo and pricing page
     llm-guard:
-      because: source or core-gated is not recorded in a form the ladder can read; needs a
-        read of the repo and pricing page
+      because: >-
+        source or core-gated is not recorded in a form the ladder can read; needs a read of
+        the repo and pricing page
     pyrit:
-      because: source or core-gated is not recorded in a form the ladder can read; needs a
-        read of the repo and pricing page
+      because: >-
+        source or core-gated is not recorded in a form the ladder can read; needs a read of
+        the repo and pricing page
     garak:
-      because: source or core-gated is not recorded in a form the ladder can read; needs a
-        read of the repo and pricing page
+      because: >-
+        source or core-gated is not recorded in a form the ladder can read; needs a read of
+        the repo and pricing page
     osprey:
-      because: source or core-gated is not recorded in a form the ladder can read; needs a
-        read of the repo and pricing page
+      because: >-
+        source or core-gated is not recorded in a form the ladder can read; needs a read of
+        the repo and pricing page
     coop:
-      because: source or core-gated is not recorded in a form the ladder can read; needs a
-        read of the repo and pricing page
+      because: >-
+        source or core-gated is not recorded in a form the ladder can read; needs a read of
+        the repo and pricing page
     openai-moderation:
       because: >-
         No source or license key is recorded, only a service:proprietary... prose

--- a/sources/categories/safeguards.yaml
+++ b/sources/categories/safeguards.yaml
@@ -19,35 +19,117 @@ scoring_recipe:
     checker: build/check_rubric.py
   deferred:
     aegis-guard:
-      because: 'pending P1a-prime curation — see 2026-07-30 reproduction report'
+      because: >-
+        License Llama-2-Community resolves to use_restricted; the ladder computes
+        2/restricted from the recorded evidence but the score says 3/open_weights. The
+        recorded weights:adapter-open and data:Aegis safety dataset documented values also
+        fall outside the ladder's declared enums. See the 2026-07-30 reproduction report.
+    openguardrails:
+      because: source or core-gated is not recorded in a form the ladder can read; needs a
+        read of the repo and pricing page
     zentropi-cope:
-      because: 'pending P1a-prime curation — see 2026-07-30 reproduction report'
+      because: >-
+        License zentropi-openrail-m appears in no tier's examples and has no alias in
+        signal_routing.yaml, so the tier lookup fails before the formula runs even though
+        the components note already calls it use-restricted. See the 2026-07-30
+        reproduction report.
     qwen3guard:
-      because: 'pending P1a-prime curation — see 2026-07-30 reproduction report'
+      because: >-
+        License resolves to osi; the ladder computes 3/open_weights from the recorded
+        evidence (data:not-released) but the score says 4/open_weights. See the 2026-07-30
+        reproduction report.
     wildguard:
-      because: 'pending P1a-prime curation — see 2026-07-30 reproduction report'
+      because: >-
+        data:open is recorded but code was never recorded at all, so the 4-rule's second
+        condition is unmet; the ladder computes 3/open_weights from the recorded evidence
+        but the score says 4/open_weights. See the 2026-07-30 reproduction report.
     llama-prompt-guard:
-      because: 'pending P1a-prime curation — see 2026-07-30 reproduction report'
+      because: >-
+        License Llama-4-Community resolves to use_restricted; the ladder computes
+        2/restricted from the recorded evidence but the score says 3/open_weights. See the
+        2026-07-30 reproduction report.
     llamafirewall:
-      because: 'pending P1a-prime curation — see 2026-07-30 reproduction report'
+      because: >-
+        The MIT-licensed framework facts are recorded under framework and self-host, keys
+        the software ladder does not read, and the bundled guard models carry a
+        use-restricted Llama license the harness's own license does not cover; which SKU
+        governs 5/open_source is a curation call. See the 2026-07-30 reproduction report.
+    harmbench:
+      because: source or core-gated is not recorded in a form the ladder can read; needs a
+        read of the repo and pricing page
+    giskard:
+      because: source or core-gated is not recorded in a form the ladder can read; needs a
+        read of the repo and pricing page
+    deepteam:
+      because: source or core-gated is not recorded in a form the ladder can read; needs a
+        read of the repo and pricing page
     perspective-api:
-      because: 'pending P1a-prime curation — see 2026-07-30 reproduction report'
+      because: >-
+        No source or license key is recorded, only a service:proprietary... prose
+        description the software ladder's reads list does not check. See the 2026-07-30
+        reproduction report.
     llama-guard:
-      because: 'pending P1a-prime curation — see 2026-07-30 reproduction report'
+      because: >-
+        License Llama-3.1-Community resolves to use_restricted (the >700M-MAU clause); the
+        ladder computes 2/restricted from the recorded evidence but the score says
+        3/open_weights. See the 2026-07-30 reproduction report.
     shieldgemma:
-      because: 'pending P1a-prime curation — see 2026-07-30 reproduction report'
+      because: >-
+        License Gemma matches no tier in model.yaml's examples; an alias exists
+        (gemma: Gemma-License) but only in signal_routing.yaml's huggingface: sub-table,
+        which the license-alias lookup does not read. See the 2026-07-30 reproduction
+        report.
     granite-guardian:
-      because: 'pending P1a-prime curation — see 2026-07-30 reproduction report'
+      because: >-
+        License resolves to osi; the ladder computes 3/open_weights from the recorded
+        evidence (data:not-released) but the score says 4/open_weights. See the 2026-07-30
+        reproduction report.
     gpt-oss-safeguard:
-      because: 'pending P1a-prime curation — see 2026-07-30 reproduction report'
+      because: >-
+        License resolves to osi; the ladder computes 3/open_weights from the recorded
+        evidence (data:not-released) but the score says 4/open_weights. See the 2026-07-30
+        reproduction report.
+    nemo-guardrails:
+      because: source or core-gated is not recorded in a form the ladder can read; needs a
+        read of the repo and pricing page
+    guardrails-ai:
+      because: source or core-gated is not recorded in a form the ladder can read; needs a
+        read of the repo and pricing page
+    llm-guard:
+      because: source or core-gated is not recorded in a form the ladder can read; needs a
+        read of the repo and pricing page
+    pyrit:
+      because: source or core-gated is not recorded in a form the ladder can read; needs a
+        read of the repo and pricing page
+    garak:
+      because: source or core-gated is not recorded in a form the ladder can read; needs a
+        read of the repo and pricing page
+    osprey:
+      because: source or core-gated is not recorded in a form the ladder can read; needs a
+        read of the repo and pricing page
+    coop:
+      because: source or core-gated is not recorded in a form the ladder can read; needs a
+        read of the repo and pricing page
     openai-moderation:
-      because: 'pending P1a-prime curation — see 2026-07-30 reproduction report'
+      because: >-
+        No source or license key is recorded, only a service:proprietary... prose
+        description the software ladder's reads list does not check. See the 2026-07-30
+        reproduction report.
     azure-content-safety:
-      because: 'pending P1a-prime curation — see 2026-07-30 reproduction report'
+      because: >-
+        No source or license key is recorded, only a service:proprietary... prose
+        description the software ladder's reads list does not check. See the 2026-07-30
+        reproduction report.
     bedrock-guardrails:
-      because: 'pending P1a-prime curation — see 2026-07-30 reproduction report'
+      because: >-
+        No source or license key is recorded, only a service:proprietary... prose
+        description the software ladder's reads list does not check. See the 2026-07-30
+        reproduction report.
     lakera-guard:
-      because: 'pending P1a-prime curation — see 2026-07-30 reproduction report'
+      because: >-
+        No source or license key is recorded, only a service:proprietary... prose
+        description the software ladder's reads list does not check. See the 2026-07-30
+        reproduction report.
 products:
 - aegis-guard
 - openguardrails

--- a/sources/categories/safeguards.yaml
+++ b/sources/categories/safeguards.yaml
@@ -8,6 +8,46 @@ strapline: 'Open guardrail models and libraries are strong here, but the commerc
 weights:
   adopt: 0.5
   cap: 0.5
+scoring_recipe:
+  version: 1
+  extends:
+    model: model
+    software: software
+  derived_from:
+    method: per-type extends over the shared ladders; reproduction pending curation
+    verified_on: '2026-07-30'
+    checker: build/check_rubric.py
+  deferred:
+    aegis-guard:
+      because: 'pending P1a-prime curation — see 2026-07-30 reproduction report'
+    zentropi-cope:
+      because: 'pending P1a-prime curation — see 2026-07-30 reproduction report'
+    qwen3guard:
+      because: 'pending P1a-prime curation — see 2026-07-30 reproduction report'
+    wildguard:
+      because: 'pending P1a-prime curation — see 2026-07-30 reproduction report'
+    llama-prompt-guard:
+      because: 'pending P1a-prime curation — see 2026-07-30 reproduction report'
+    llamafirewall:
+      because: 'pending P1a-prime curation — see 2026-07-30 reproduction report'
+    perspective-api:
+      because: 'pending P1a-prime curation — see 2026-07-30 reproduction report'
+    llama-guard:
+      because: 'pending P1a-prime curation — see 2026-07-30 reproduction report'
+    shieldgemma:
+      because: 'pending P1a-prime curation — see 2026-07-30 reproduction report'
+    granite-guardian:
+      because: 'pending P1a-prime curation — see 2026-07-30 reproduction report'
+    gpt-oss-safeguard:
+      because: 'pending P1a-prime curation — see 2026-07-30 reproduction report'
+    openai-moderation:
+      because: 'pending P1a-prime curation — see 2026-07-30 reproduction report'
+    azure-content-safety:
+      because: 'pending P1a-prime curation — see 2026-07-30 reproduction report'
+    bedrock-guardrails:
+      because: 'pending P1a-prime curation — see 2026-07-30 reproduction report'
+    lakera-guard:
+      because: 'pending P1a-prime curation — see 2026-07-30 reproduction report'
 products:
 - aegis-guard
 - openguardrails

--- a/sources/categories/safeguards.yaml
+++ b/sources/categories/safeguards.yaml
@@ -15,6 +15,9 @@ scoring_recipe:
     software: software
   derived_from:
     method: per-type extends over the shared ladders; reproduction pending curation
+    scores_reproduced: 0
+    scores_total: 26
+    scores_deferred: 26
     verified_on: '2026-07-30'
     checker: build/check_rubric.py
   deferred:

--- a/sources/rubrics/model.yaml
+++ b/sources/rubrics/model.yaml
@@ -1,0 +1,133 @@
+# Shared openness ladder for FINE-TUNED / GUARDRAIL model categories.
+#
+# Inherited via `scoring_recipe: {extends: model}`. See build/rubrics.py for the merge
+# rules and why the ladder is shared rather than copied per category.
+#
+# Three dimensions carry a tune's openness question: weights, post-training data, code.
+# That is deliberately not base_pretrained's questionnaire — a base model asks about the
+# pretraining corpus and (optionally) checkpoints, which is a different set of facts about
+# a different artifact. base_pretrained does not extend this ladder for exactly that
+# reason: the merge rule replaces a whole key rather than merging into it, so sharing only
+# the license tiers and not the dimensions would buy nothing — the category would still
+# have to restate its own `dimensions` and `formula` in full.
+#
+# As of this extraction, `finetuned_chat` extends this ladder.
+openness:
+  dimensions:
+    weights:
+      question: Are the tuned model weights downloadable and runnable locally?
+      values: [open, closed, pending]
+      evidence:
+      - Hugging Face model repo with downloadable weight files (safetensors/GGUF)
+      - vendor download page for weights outside the Hub
+      machine_signal: signal_huggingface.hub_state (gated, private, files)
+    data:
+      question: Is the POST-TRAINING data released - the SFT, DPO or RL sets this
+        tune was built from?
+      # For a base model the data question is the pretraining corpus. For a tune,
+      # that corpus belongs to somebody else's model, and asking about it scores
+      # the base rather than the product. The honest question here is what the
+      # tuner released, which is why `post-training-data` is read first.
+      reads: [post-training-data, data]
+      values: [open, described_not_released, described, partial, closed]
+      evidence:
+      - a released SFT/DPO/RL mixture, or scripts that reconstruct it
+      - '`described` where the mixture is named in the card but not published'
+      - naming the datasets used is NOT sufficient for `open`
+      machine_signal: none - requires research
+      vocabulary_note: >
+        `described_not_released` here is `documented-not-released` in
+        base_pretrained. Same concept, two spellings, and neither category should
+        be the one that unilaterally renames it. Unifying the shared data
+        vocabulary is issue #106.
+    code:
+      question: Is the fine-tuning pipeline released, not just inference code?
+      values: [open, partial, closed]
+      evidence:
+      - '`open`: the post-training recipe - SFT/DPO/RL configs and scripts'
+      - '`partial`: inference, serving or chat-template code only'
+      - '`closed`: no code'
+      machine_signal: partial - repo presence from signal_github.repo_state
+
+  license_tier:
+    # base_pretrained's ladder, unchanged, including the declaration order that
+    # `tier_rank` and the multi-SKU rule depend on. Eight licenses added because
+    # this category ships them and the pilot did not.
+    ordered_by: restrictiveness_ascending
+    # A tune records its license under `license`, except where the card
+    # distinguishes a code license from the one attached to the weights, and then
+    # it lands in `model-license`. The weights license governs either way.
+    reads: [license, model-license]
+    values:
+      osi:
+        definition: OSI-approved license
+        examples: [Apache-2.0, MIT, BSD-3-Clause]
+      permissive_non_osi:
+        definition: >
+          Not OSI-approved, but imposes no restriction on WHO may use the artifact or
+          AT WHAT SCALE. Attribution, naming and CONDUCT requirements belong here: an
+          acceptable-use policy forbidding military, illegal or discriminatory use caps
+          neither commerce nor reach, so it sits beside attribution rather than beside a
+          monthly-active-user ceiling. Non-OSI by construction, since the OSD forbids
+          discriminating against a field of endeavor. Settled in issue #117, which was
+          opened because the same OpenRAIL family had been scored 3 in one category and
+          4 in another.
+        examples: [Modified-MIT, minimax-community, NVIDIA-Open-Model-License, BigCode-OpenRAIL-M,
+          DeepSeek-Model-License, TII-Falcon-License-2.0]
+      use_restricted:
+        definition: >
+          Caps or gates use - monthly-active-user ceilings, field-of-use limits,
+          research-only terms, or a commercial agreement requirement.
+        examples: [Llama-2-Community-License, Llama-3-Community-License, Llama-3.1-Community-License,
+          Llama-3.2-Community-License, Llama-4-Community, Gemma-License, GLM-4-License,
+          Qwen-License-Agreement, Mistral-Research-License, Mistral-AI-Non-Production-License,
+          Jamba-Open-Model-License, CC-BY-NC]
+      proprietary:
+        definition: No public license; weights not distributed.
+    multi_sku_rule: >
+      As base_pretrained: where a family ships SKUs under different licenses, the
+      most restrictive license among the SKUs WHOSE WEIGHTS ARE ACTUALLY
+      DISTRIBUTED governs, and API-only tiers are excluded.
+    inherits_from_base: >
+      A tune of a restrictively licensed base carries that restriction, because
+      the license travels with the weights. hermes-4-llama-3-1-405b is
+      use_restricted on account of Meta's terms, not anything Nous did. This needs
+      no rule of its own - the tune records the license it actually ships under,
+      and the ladder does the rest.
+
+      What the ladder deliberately does NOT do is credit the tuner's open method
+      here. A fine-tuning approach generalizes across bases - AI2's Tulu recipe
+      runs on Llama and on OLMo - so scoring the checkpoint would either bury the
+      open method or overstate the artifact. The map already resolves this by
+      scoring the method's artifacts as their own products:
+      tulu-3-sft-mixture is 5/open in training_synthetic_datasets while the
+      Llama-based tulu-3 checkpoint is 2/restricted. That pair is the signal.
+      Recording the checkpoint -> base link so the two can be joined is not yet
+      done; `lineage` exists but is dataset-only and free-text.
+    normalization:
+    - 'compound `code X + model Y`: the MODEL license governs'
+    - 'prefix `assumed-`: same tier, confidence drops to medium'
+    never_use:
+      mixed: Apply multi_sku_rule and store the resolved tier instead.
+      unknown: Research it or defer the product with a reason.
+
+  # Ordered rules, first match wins. base_pretrained's ladder less one rule: it
+  # carries a `data: documented-not-released, code: open -> 4`, and no product here
+  # pairs a described-but-unreleased mixture with an open pipeline. Declaring it
+  # anyway would add a rule that cannot fire, and a dead rule in a first-match-wins
+  # formula is a place for a later edit to hide.
+  formula:
+  - when: {weights: closed}
+    then: {score: 1, class: closed}
+  - when: {license_tier: proprietary}
+    then: {score: 1, class: closed}
+  - when: {license_tier: use_restricted}
+    then: {score: 2, class: restricted}
+    note: Open weights behind a use cap. Downloadable is not the same as usable.
+  - when: {data: open, code: open, license_tier: osi}
+    then: {score: 5, class: open_source}
+  - when: {data: open, code: open}
+    then: {score: 4, class: open_weights}
+    note: Full recipe but a non-OSI license caps the score at 4.
+  - otherwise: {score: 3, class: open_weights}
+    note: The category's center of gravity - open weights, closed recipe.

--- a/sources/rubrics/model.yaml
+++ b/sources/rubrics/model.yaml
@@ -11,7 +11,8 @@
 # the license tiers and not the dimensions would buy nothing — the category would still
 # have to restate its own `dimensions` and `formula` in full.
 #
-# As of this extraction, `finetuned_chat` extends this ladder.
+# As of this extraction, `finetuned_chat` and `safeguards` (its guardrail-model half)
+# extend this ladder.
 openness:
   dimensions:
     weights:

--- a/sources/rubrics/software.yaml
+++ b/sources/rubrics/software.yaml
@@ -5,9 +5,9 @@
 #
 # Software openness does not turn on a model's questions. There are no weights and no
 # training corpus; what matters is whether the thing you run is the thing that was
-# published. Ten categories ask that same question of the same four license tiers, so the
-# ladder lives here and the license-to-tier mapping has one home: whether AGPL is `osi` is
-# a fact about AGPL, not about telemetry versus deployment.
+# published. Eleven categories ask that same question of the same four license tiers, so
+# the ladder lives here and the license-to-tier mapping has one home: whether AGPL is `osi`
+# is a fact about AGPL, not about telemetry versus deployment.
 #
 # Verified against deployment first, 27/27. Each inheriting category records its own
 # `derived_from` counts.

--- a/tests/test_check_rubric.py
+++ b/tests/test_check_rubric.py
@@ -212,6 +212,11 @@ def test_mixed_type_category_scores_each_product_on_its_own_ladder(tmp_path, mon
         "openness": {"score": 5, "class": "open_source", "components": "source:public;license:Apache-2.0"}
     })
     monkeypatch.setattr("build.check_rubric.ROOT", tmp_path)
+    # Cold cache: reset the module-level alias cache so this test does not depend on an
+    # earlier test in the file having already warmed it against the real ROOT. Without
+    # this, `recorded_license_aliases()` reads `tmp_path/sources/signal_routing.yaml`,
+    # which does not exist, and the test's pass/fail depends on suite ordering.
+    monkeypatch.setattr("build.check_rubric._RECORDED_ALIASES", {})
 
     reproduced, total, problems, deferred = check_category("mixed", verbose=False)
 

--- a/tests/test_check_rubric.py
+++ b/tests/test_check_rubric.py
@@ -15,6 +15,7 @@ carry most of the risk, because each one fails QUIETLY:
 from __future__ import annotations
 
 import pytest
+import yaml
 
 from build.check_rubric import (
     ROOT,
@@ -25,6 +26,11 @@ from build.check_rubric import (
     recorded_license_aliases,
     split_components,
 )
+
+
+def write_yaml(path, payload):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload, sort_keys=False))
 
 RECIPE = {
     "openness": {
@@ -166,3 +172,48 @@ class TestRealCategories:
         even while the deferral count is zero."""
         _, total, _, deferred = check_category("finetuned_chat", verbose=False)
         assert total + len(deferred) == 39
+
+
+def test_mixed_type_category_scores_each_product_on_its_own_ladder(tmp_path, monkeypatch):
+    # Arrange a category holding one model and one software product, a shared
+    # ladder for each, and score files that reproduce only if the right ladder
+    # is applied to the right product.
+    write_yaml(tmp_path / "sources/rubrics/model.yaml", {
+        "openness": {
+            "license_tier": {"reads": ["license"], "values": {"osi": {"examples": ["Apache-2.0"]}}},
+            "dimensions": {"weights": {"values": ["open", "closed"]}},
+            "formula": [
+                {"when": {"weights": "open"}, "then": {"score": 5, "class": "open_source"}},
+                {"otherwise": {"score": 1, "class": "closed"}},
+            ],
+        }
+    })
+    write_yaml(tmp_path / "sources/rubrics/software.yaml", {
+        "openness": {
+            "license_tier": {"reads": ["license"], "values": {"osi": {"examples": ["Apache-2.0"]}}},
+            "dimensions": {"source": {"values": ["public", "closed"]}},
+            "formula": [
+                {"when": {"source": "public", "license_tier": "osi"},
+                 "then": {"score": 5, "class": "open_source"}},
+            ],
+        }
+    })
+    write_yaml(tmp_path / "sources/categories/mixed.yaml", {
+        "name": "mixed",
+        "products": ["a-model", "a-tool"],
+        "scoring_recipe": {"extends": {"model": "model", "software": "software"}},
+    })
+    write_yaml(tmp_path / "sources/products/a-model.yaml", {"name": "a-model", "type": "model"})
+    write_yaml(tmp_path / "sources/products/a-tool.yaml", {"name": "a-tool", "type": "software"})
+    write_yaml(tmp_path / "sources/scores/a-model.yaml", {
+        "openness": {"score": 5, "class": "open_source", "components": "weights:open;license:Apache-2.0"}
+    })
+    write_yaml(tmp_path / "sources/scores/a-tool.yaml", {
+        "openness": {"score": 5, "class": "open_source", "components": "source:public;license:Apache-2.0"}
+    })
+    monkeypatch.setattr("build.check_rubric.ROOT", tmp_path)
+
+    reproduced, total, problems, deferred = check_category("mixed", verbose=False)
+
+    assert problems == []
+    assert (reproduced, total) == (2, 2)

--- a/tests/test_check_verification.py
+++ b/tests/test_check_verification.py
@@ -95,17 +95,17 @@ def test_a_dimension_answered_under_a_reads_alias_keeps_the_alias():
 
 def test_g1_passes_when_every_dimension_has_a_fresh_establishing_source():
     scores = _score(last_verified="2026-07-30", sources=FULL)
-    assert g1_invariant(scores, CATEGORIES, RECIPES) == []
+    assert g1_invariant(scores, CATEGORIES, RECIPES, {}) == []
 
 
 def test_g1_ignores_an_axis_with_no_date():
     """The ratchet: an axis claiming nothing is not asked to prove anything."""
-    assert g1_invariant(_score(sources=[_src("https://a", "2020-01-01")]), CATEGORIES, RECIPES) == []
+    assert g1_invariant(_score(sources=[_src("https://a", "2020-01-01")]), CATEGORIES, RECIPES, {}) == []
 
 
 def test_g1_fails_when_a_dimension_has_no_establishing_source():
     scores = _score(last_verified="2026-07-30", sources=FULL[:2])  # code unattributed
-    problems = g1_invariant(scores, CATEGORIES, RECIPES)
+    problems = g1_invariant(scores, CATEGORIES, RECIPES, {})
     assert any("records 'code'" in p and "no source claims to establish it" in p for p in problems)
 
 
@@ -120,7 +120,7 @@ def test_g1_fails_when_one_dimension_is_stale():
             _src("https://c", "2026-06-01", ["code"]),
         ],
     )
-    problems = g1_invariant(scores, CATEGORIES, RECIPES)
+    problems = g1_invariant(scores, CATEGORIES, RECIPES, {})
     assert len(problems) == 1
     assert "records 'code'" in problems[0]
     assert "only established by a source last read 2026-06-01" in problems[0]
@@ -131,7 +131,7 @@ def test_g1_fails_when_no_source_was_read_on_or_after_the_claimed_date():
         last_verified="2026-07-30",
         sources=[_src("https://a", "2026-06-01", ["weights", "data", "code", "license"])],
     )
-    problems = g1_invariant(scores, CATEGORIES, RECIPES)
+    problems = g1_invariant(scores, CATEGORIES, RECIPES, {})
     assert any("no source was accessed on or after that date" in p for p in problems)
 
 
@@ -139,7 +139,7 @@ def test_g1_never_derives_a_date_it_only_validates_one():
     """Guards against the #115 'simplification'. A fully-attributed axis with no
     `last_verified` must stay silent rather than acquiring one."""
     scores = _score(sources=FULL)
-    assert g1_invariant(scores, CATEGORIES, RECIPES) == []
+    assert g1_invariant(scores, CATEGORIES, RECIPES, {}) == []
     assert "last_verified" not in scores["m"]["openness"]
 
 
@@ -148,25 +148,25 @@ def test_g1_floor_applies_to_adoption_where_there_are_no_dimensions():
     confirmation still cannot rest on zero sources read on or after the date it claims."""
     scores = {"m": {"product": "m", "adoption": {"level": 4, "last_verified": "2026-07-30",
                                                 "sources": [_src("https://a", "2026-06-01")]}}}
-    assert any("no source was accessed on or after" in p for p in g1_invariant(scores, {}, {}))
+    assert any("no source was accessed on or after" in p for p in g1_invariant(scores, {}, {}, {}))
 
 
 def test_g1_accepts_adoption_with_one_fresh_source_and_no_attribution():
     scores = {"m": {"product": "m", "adoption": {"level": 4, "last_verified": "2026-07-30",
                                                 "sources": [_src("https://a", "2026-07-30")]}}}
-    assert g1_invariant(scores, {}, {}) == []
+    assert g1_invariant(scores, {}, {}, {}) == []
 
 
 def test_g1_rejects_a_last_verified_that_is_not_a_date():
     scores = _score(last_verified="last week", sources=FULL)
-    assert any("is not a date" in p for p in g1_invariant(scores, CATEGORIES, RECIPES))
+    assert any("is not a date" in p for p in g1_invariant(scores, CATEGORIES, RECIPES, {}))
 
 
 def test_g1_falls_back_to_the_floor_for_a_category_with_no_recipe():
     """Four categories have no recipe yet, so there is no declared vocabulary to check
     against. The gate degrades to the floor rather than passing vacuously or erroring."""
     scores = _score(last_verified="2026-07-30", sources=[_src("https://a", "2026-06-01")])
-    assert any("no source was accessed on or after" in p for p in g1_invariant(scores, {}, {}))
+    assert any("no source was accessed on or after" in p for p in g1_invariant(scores, {}, {}, {}))
 
 
 # --- G2 ---
@@ -260,10 +260,12 @@ def test_g3_is_not_escapable_by_deferring_the_product():
 # --- the repo itself ---
 
 def test_the_repo_passes_all_three_gates():
-    from build.check_verification import load
+    from build.check_verification import ROOT, load
+    from build.rubrics import load_product_types
 
     scores, categories, recipes = load()
-    assert g1_invariant(scores, categories, recipes) == []
+    product_types = load_product_types(ROOT)
+    assert g1_invariant(scores, categories, recipes, product_types) == []
     assert g2_digests(scores) == []
     assert g3_producible(scores, categories, recipes) == []
 

--- a/tests/test_check_verification.py
+++ b/tests/test_check_verification.py
@@ -226,13 +226,13 @@ def test_producible_pairs_reads_then_and_otherwise():
 
 
 def test_g3_passes_on_a_producible_pair():
-    assert g3_producible(_score(), CATEGORIES, RECIPES) == []
+    assert g3_producible(_score(), CATEGORIES, RECIPES, {}) == []
 
 
 def test_g3_fails_on_a_class_no_rule_pairs_with_that_score():
     """`4/open_source` in software: 4 exists and `open_source` exists, never together."""
     scores = _score(score=1, **{"class": "open_source"})
-    problems = g3_producible(scores, CATEGORIES, RECIPES)
+    problems = g3_producible(scores, CATEGORIES, RECIPES, {})
     assert any("1/open_source is not an outcome" in p for p in problems)
 
 
@@ -240,11 +240,11 @@ def test_g3_fails_on_a_score_no_rule_emits():
     """The software ladder's rungs are 1, 2, 4, 5. A software product scored 3 is impossible
     by construction, however plausible the class looks beside it."""
     scores = _score(score=3, **{"class": "open_source"})
-    assert any("3/open_source is not an outcome" in p for p in g3_producible(scores, CATEGORIES, RECIPES))
+    assert any("3/open_source is not an outcome" in p for p in g3_producible(scores, CATEGORIES, RECIPES, {}))
 
 
 def test_g3_ignores_an_unscored_product():
-    assert g3_producible(_score(score=None), CATEGORIES, RECIPES) == []
+    assert g3_producible(_score(score=None), CATEGORIES, RECIPES, {}) == []
 
 
 def test_g3_is_not_escapable_by_deferring_the_product():
@@ -254,7 +254,38 @@ def test_g3_is_not_escapable_by_deferring_the_product():
     categories = {"models": dict(CATEGORIES["models"])}
     recipes = {"models": {"*": dict(RECIPE, deferred={"m": {"because": "needs a human, at length"}})}}
     scores = _score(score=3, **{"class": "open_source"})
-    assert g3_producible(scores, categories, recipes)
+    assert g3_producible(scores, categories, recipes, {})
+
+
+def test_g3_checks_a_mixed_category_product_against_its_own_ladder_not_the_union():
+    """G1, `check_rubric` and `serialize_rubric` all select per product with `recipe_for`.
+    G3 used to test each recorded pair against the UNION of every variant in the
+    category instead, so a software product recording a pair only the model ladder can
+    emit would have passed - even though the software ladder, the one that actually
+    governs it, cannot produce that pair. That is exactly the class of failure this gate
+    exists to catch (see the module docstring's `4/open_source` story), so the union was
+    the one place the escape hatch stayed open.
+    """
+    model_recipe = {"openness": {"formula": [
+        {"when": {"weights": "open"}, "then": {"score": 3, "class": "open_weights"}},
+        {"otherwise": {"score": 1, "class": "closed"}},
+    ]}}
+    software_recipe = {"openness": {"formula": [
+        {"when": {"source": "public"}, "then": {"score": 5, "class": "open_source"}},
+        {"otherwise": {"score": 1, "class": "closed"}},
+    ]}}
+    categories = {"mixed": {"name": "mixed", "products": ["a-tool"]}}
+    recipes = {"mixed": {"model": model_recipe, "software": software_recipe}}
+    product_types = {"a-tool": "software"}
+    scores = {"a-tool": {"product": "a-tool", "openness": {"score": 3, "class": "open_weights"}}}
+
+    # The union of both ladders WOULD have admitted this pair (the model ladder emits
+    # it), which is why the old implementation passed it.
+    union_pairs = producible_pairs(model_recipe) | producible_pairs(software_recipe)
+    assert (3, "open_weights") in union_pairs
+
+    problems = g3_producible(scores, categories, recipes, product_types)
+    assert any("3/open_weights is not an outcome" in p for p in problems)
 
 
 # --- the repo itself ---
@@ -267,7 +298,7 @@ def test_the_repo_passes_all_three_gates():
     product_types = load_product_types(ROOT)
     assert g1_invariant(scores, categories, recipes, product_types) == []
     assert g2_digests(scores) == []
-    assert g3_producible(scores, categories, recipes) == []
+    assert g3_producible(scores, categories, recipes, product_types) == []
 
 
 @pytest.mark.parametrize("axis", ["openness", "adoption", "capability"])

--- a/tests/test_check_verification.py
+++ b/tests/test_check_verification.py
@@ -33,7 +33,10 @@ RECIPE = {
     }
 }
 CATEGORIES = {"models": {"name": "models", "products": ["m"], "scoring_recipe": RECIPE}}
-RECIPES = {"models": RECIPE}
+# `recipes` maps a category to its resolved variants ("*" for a uniform category, or one
+# key per product type for a mixed one) - the same shape build.check_verification.load()
+# produces via resolve_recipe_variants.
+RECIPES = {"models": {"*": RECIPE}}
 
 
 def _score(**openness):
@@ -249,7 +252,7 @@ def test_g3_is_not_escapable_by_deferring_the_product():
     category could defer its way out of an impossible pair - which is how `4/open_source`
     survived a checker that reported 33/33."""
     categories = {"models": dict(CATEGORIES["models"])}
-    recipes = {"models": dict(RECIPE, deferred={"m": {"because": "needs a human, at length"}})}
+    recipes = {"models": {"*": dict(RECIPE, deferred={"m": {"because": "needs a human, at length"}})}}
     scores = _score(score=3, **{"class": "open_source"})
     assert g3_producible(scores, categories, recipes)
 

--- a/tests/test_rubrics.py
+++ b/tests/test_rubrics.py
@@ -1,0 +1,64 @@
+"""Per-product-type recipe resolution.
+
+A mixed-type category (safeguards: 9 models, 17 software) declares
+`extends: {model: model, software: software}`. Everything else keeps
+`extends: <name>` and resolves exactly as before.
+"""
+
+from build.rubrics import recipe_for, resolve_recipe, resolve_recipe_variants
+
+SHARED = {
+    "software": {"openness": {"formula": [{"otherwise": {"score": 1, "class": "closed"}}]}},
+    "model": {"openness": {"formula": [{"otherwise": {"score": 5, "class": "open_source"}}]}},
+}
+
+
+def test_string_extends_resolves_to_star():
+    category = {"scoring_recipe": {"extends": "software", "version": 1}}
+    variants, errors = resolve_recipe_variants(category, SHARED)
+    assert errors == []
+    assert set(variants) == {"*"}
+    assert variants["*"]["openness"] == SHARED["software"]["openness"]
+    assert variants["*"]["version"] == 1  # category keys ride along
+
+
+def test_no_recipe_resolves_to_empty():
+    assert resolve_recipe_variants({}, SHARED) == ({}, [])
+
+
+def test_mapping_extends_resolves_per_type():
+    category = {"scoring_recipe": {"extends": {"model": "model", "software": "software"}}}
+    variants, errors = resolve_recipe_variants(category, SHARED)
+    assert errors == []
+    assert set(variants) == {"model", "software"}
+    assert variants["model"]["openness"] == SHARED["model"]["openness"]
+    assert variants["software"]["openness"] == SHARED["software"]["openness"]
+
+
+def test_mapping_extends_unknown_ladder_is_an_error():
+    category = {"scoring_recipe": {"extends": {"model": "nonexistent"}}}
+    variants, errors = resolve_recipe_variants(category, SHARED)
+    assert variants == {}
+    assert len(errors) == 1 and "nonexistent" in errors[0]
+
+
+def test_recipe_for_star_covers_every_type():
+    variants, _ = resolve_recipe_variants({"scoring_recipe": {"extends": "software"}}, SHARED)
+    recipe, why = recipe_for(variants, "model")
+    assert recipe is not None and why is None
+
+
+def test_recipe_for_missing_type_returns_reason():
+    variants, _ = resolve_recipe_variants(
+        {"scoring_recipe": {"extends": {"model": "model"}}}, SHARED
+    )
+    recipe, why = recipe_for(variants, "dataset")
+    assert recipe is None
+    assert "dataset" in why and "model" in why
+
+
+def test_resolve_recipe_rejects_mapping_extends():
+    category = {"scoring_recipe": {"extends": {"model": "model"}}}
+    recipe, errors = resolve_recipe(category, SHARED)
+    assert recipe is None
+    assert errors and "resolve_recipe_variants" in errors[0]

--- a/tests/test_rubrics.py
+++ b/tests/test_rubrics.py
@@ -5,7 +5,9 @@ A mixed-type category (safeguards: 9 models, 17 software) declares
 `extends: <name>` and resolves exactly as before.
 """
 
-from build.rubrics import recipe_for, resolve_recipe, resolve_recipe_variants
+from pathlib import Path
+
+from build.rubrics import recipe_for, resolve_recipe, resolve_recipe_variants, load_product_types
 
 SHARED = {
     "software": {"openness": {"formula": [{"otherwise": {"score": 1, "class": "closed"}}]}},
@@ -62,3 +64,17 @@ def test_resolve_recipe_rejects_mapping_extends():
     recipe, errors = resolve_recipe(category, SHARED)
     assert recipe is None
     assert errors and "resolve_recipe_variants" in errors[0]
+
+
+def test_load_product_types(tmp_path: Path):
+    d = tmp_path / "sources" / "products"
+    d.mkdir(parents=True)
+    (d / "some-model.yaml").write_text("name: some-model\ntype: model\n")
+    (d / "some-tool.yaml").write_text("name: some-tool\ntype: software\n")
+    (d / "broken.yaml").write_text("name: broken\n")
+    types = load_product_types(tmp_path)
+    assert types == {"some-model": "model", "some-tool": "software", "broken": ""}
+
+
+def test_load_product_types_missing_dir(tmp_path: Path):
+    assert load_product_types(tmp_path) == {}

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -584,7 +584,7 @@ def test_real_sources_serialize_without_errors():
                 "evaluation_code", "finetuning_code", "inference_code", "ml_frameworks",
                 "orchestration_agents", "telemetry_observability", "ui_api"]
     assert per_category("category_scoring_rules") == {
-        "base_pretrained": 11, "finetuned_chat": 9, **{c: 16 for c in SOFTWARE},
+        "base_pretrained": 11, "finetuned_chat": 9, "safeguards": 25, **{c: 16 for c in SOFTWARE},
     }
     # Both fell with the slug migration: release-level products collapsed into the
     # tier the vendor sells, so 25 products left the roster and the closed frontier

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -74,6 +74,34 @@ SHARED_RUBRICS_FIXTURE = {
 }
 
 
+# Dedicated to test_recipe_for_selects_the_matching_ladder_for_a_scored_product only.
+# Unlike SHARED_RUBRICS_FIXTURE, the two ladders here declare DISJOINT `weights` enums,
+# so scoring a product against the wrong ladder is visible: the recorded value falls
+# outside the other ladder's declared values and trips `in_declared_enum`.
+DISJOINT_WEIGHTS_RUBRICS_FIXTURE = {
+    "software": {
+        "openness": {
+            "dimensions": {"weights": {"question": "?", "values": ["closed-source", "source-available"]}},
+            "license_tier": {
+                "ordered_by": "restrictiveness_ascending",
+                "values": {"osi": {"examples": ["MIT"]}, "proprietary": {"definition": "no public license"}},
+            },
+            "formula": [{"otherwise": {"score": 3, "class": "open_weights"}}],
+        },
+    },
+    "model": {
+        "openness": {
+            "dimensions": {"weights": {"question": "?", "values": ["open", "closed"]}},
+            "license_tier": {
+                "ordered_by": "restrictiveness_ascending",
+                "values": {"osi": {"examples": ["MIT"]}, "proprietary": {"definition": "no public license"}},
+            },
+            "formula": [{"otherwise": {"score": 3, "class": "open_weights"}}],
+        },
+    },
+}
+
+
 def _sources(categories=None, scores=None, rubrics=None, product_types=None):
     return {
         "categories": categories or {},
@@ -453,9 +481,15 @@ def test_rubric_rows_carry_product_type():
 
 
 def test_recipe_for_selects_the_matching_ladder_for_a_scored_product():
-    """A scored product in a mixed-type category picks up the openness evidence
-    for its OWN type's ladder, not the other one — `weights` differs between the
-    two fixture ladders so a mismatch would be visible in the emitted value.
+    """A scored product in a mixed-type category is scored against its OWN type's
+    ladder, not the other one. `DISJOINT_WEIGHTS_RUBRICS_FIXTURE`'s two ladders
+    declare non-overlapping `weights` enums (model: open/closed; software:
+    closed-source/source-available), so picking the wrong ladder for a product
+    is visible: the recorded value falls outside the other ladder's declared
+    values, flipping `in_declared_enum` to False and firing a "not in the
+    rubric's declared values" warning. A `recipe_for` that ignored `product_type`
+    and always returned one ladder for both products would trip that check on
+    whichever product does not match the ladder it hard-coded.
     """
     sources = _sources(
         categories={
@@ -464,19 +498,22 @@ def test_recipe_for_selects_the_matching_ladder_for_a_scored_product():
         },
         scores={
             "m1": {"openness": {"components": "weights:open"}},
-            "s1": {"openness": {"components": "weights:closed"}},
+            "s1": {"openness": {"components": "weights:source-available"}},
         },
-        rubrics=SHARED_RUBRICS_FIXTURE,
+        rubrics=DISJOINT_WEIGHTS_RUBRICS_FIXTURE,
         product_types={"m1": "model", "s1": "software"},
     )
     tables, errors, warnings = build_rubric(sources, policy={}, routing={})
     assert errors == []
     assert not any("in 'mixed':" in w for w in warnings)
+    assert not any("not in the rubric's declared values" in w for w in warnings)
     evidence = {
-        (r["product_slug"], r["dimension"]): r["value"] for r in tables["product_openness_evidence"]
+        (r["product_slug"], r["dimension"]): r for r in tables["product_openness_evidence"]
     }
-    assert evidence[("m1", "weights")] == "open"
-    assert evidence[("s1", "weights")] == "closed"
+    assert evidence[("m1", "weights")]["value"] == "open"
+    assert evidence[("m1", "weights")]["in_declared_enum"] is True
+    assert evidence[("s1", "weights")]["value"] == "source-available"
+    assert evidence[("s1", "weights")]["in_declared_enum"] is True
 
 
 def test_recipe_miss_still_emits_score_sources_for_other_axes():

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -565,6 +565,59 @@ def test_recipe_miss_still_emits_score_sources_for_other_axes():
     assert sources_by_axis["capability"]["admitted"] is True
 
 
+def test_deferred_product_emits_no_openness_evidence():
+    """`openness_computed` builds its product roster with `SELECT DISTINCT
+    product_slug, category_slug FROM product_evidence` — so a deferred product must
+    not appear in `product_openness_evidence` at all, or that downstream model
+    computes a score for a product the repo has explicitly declined to stand behind.
+    """
+    sources = _sources(
+        categories={
+            "base": {
+                "scoring_recipe": {**RECIPE, "deferred": {"m1": {"because": "test reason"}}},
+                "products": ["m1", "m2"],
+            }
+        },
+        scores={
+            "m1": {"openness": {"components": "weights:open;data:open;code:open;license:MIT(OSI)"}},
+            "m2": {"openness": {"components": "weights:open;data:open;code:open;license:MIT(OSI)"}},
+        },
+    )
+    tables, errors, _ = build_rubric(sources, POLICY, {})
+    assert errors == []
+    assert not any(r["product_slug"] == "m1" for r in tables["product_openness_evidence"])
+    # The non-deferred product in the same category is unaffected.
+    assert any(r["product_slug"] == "m2" for r in tables["product_openness_evidence"])
+
+
+def test_deferred_product_still_emits_score_sources():
+    """`deferred` is scoped to the openness axis only. `product_score_sources` covers
+    all three axes, including adoption and capability, which have nothing to do with
+    a deferred openness score — a body-wide `continue` here would silently drop them,
+    which is exactly the regression `c151452` had to repair.
+    """
+    sources = _sources(
+        categories={
+            "base": {
+                "scoring_recipe": {**RECIPE, "deferred": {"m1": {"because": "test reason"}}},
+                "products": ["m1"],
+            }
+        },
+        scores={
+            "m1": {
+                "openness": {"components": "weights:open;data:open;code:open;license:MIT(OSI)"},
+                "adoption": {"sources": [{"url": "https://x.test/a", "shows": "1.2M monthly downloads"}]},
+                "capability": {"sources": [{"url": "https://x.test/b", "shows": "AA Intelligence Index 17"}]},
+            },
+        },
+    )
+    tables, errors, _ = build_rubric(sources, POLICY, {})
+    assert errors == []
+    assert not any(r["product_slug"] == "m1" for r in tables["product_openness_evidence"])
+    sources_by_axis = {r["axis"]: r for r in tables["product_score_sources"] if r["product_slug"] == "m1"}
+    assert set(sources_by_axis) == {"adoption", "capability"}
+
+
 def test_every_declared_table_is_present():
     tables, _, _ = build_rubric(_sources(categories={"base": {"scoring_recipe": RECIPE}}), POLICY, {})
     assert set(tables) == set(TABLES)
@@ -609,11 +662,17 @@ def test_real_sources_serialize_without_errors():
     # products that had described their gating in prose gained a readable `source:` or
     # `core-gated:` key. The two model categories are untouched, which is what the pilot
     # counts are pinned to catch.
+    # `safeguards` disappears from this dict entirely: all 26 of its products are
+    # deferred, so it now contributes zero product_openness_evidence rows. Nine other
+    # categories drop too, by however many rows their own deferred products used to
+    # carry (1-3 rows per product) — a deferred product publishes no openness evidence
+    # at all now, so `openness_computed` never sees enough rows to score a product the
+    # repo declined to stand behind.
     assert per_category("product_openness_evidence") == {
-        "base_pretrained": 111, "finetuned_chat": 172, "safeguards": 87, "deployment": 131,
-        "agent_tools_protocols": 123, "dataset_processing_tools": 88, "evaluation_code": 95,
-        "finetuning_code": 132, "inference_code": 80, "ml_frameworks": 84,
-        "orchestration_agents": 178, "telemetry_observability": 102, "ui_api": 169,
+        "base_pretrained": 111, "finetuned_chat": 172, "deployment": 131,
+        "agent_tools_protocols": 108, "dataset_processing_tools": 86, "evaluation_code": 66,
+        "finetuning_code": 119, "inference_code": 47, "ml_frameworks": 80,
+        "orchestration_agents": 137, "telemetry_observability": 90, "ui_api": 127,
     }
     assert {r["grade"] for r in tables["product_openness_evidence"]} == {"document"}
 

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -421,9 +421,13 @@ def test_no_recipe_anywhere_is_an_error():
 
 
 def test_rubric_rows_carry_product_type():
-    """A uniform category's rows are stamped `*`; a mixed category's rows are
-    stamped with the product type of the ladder that produced them, and each
-    scored product picks up the row for its own type via `recipe_for`.
+    """A uniform category's rubric rows are stamped `*`; a mixed category's rubric
+    rows are stamped with the product type of the ladder that produced them. This
+    test supplies no `scores`, so it exercises only the per-category rubric-table
+    stamping (`category_scoring_rules` and `category_license_tiers`) — the
+    per-product `recipe_for` selection is covered separately by
+    `test_recipe_for_selects_the_matching_ladder_for_a_scored_product` and
+    `test_recipe_miss_still_emits_score_sources_for_other_axes`.
     """
     sources = _sources(
         categories={
@@ -437,10 +441,76 @@ def test_rubric_rows_carry_product_type():
     )
     tables, errors, _ = build_rubric(sources, policy={}, routing={})
     assert errors == []
-    uniform_rows = [r for r in tables["category_scoring_rules"] if r["category_slug"] == "uniform"]
-    mixed_rows = [r for r in tables["category_scoring_rules"] if r["category_slug"] == "mixed"]
-    assert {r["product_type"] for r in uniform_rows} == {"*"}
-    assert {r["product_type"] for r in mixed_rows} == {"model", "software"}
+    uniform_rules = [r for r in tables["category_scoring_rules"] if r["category_slug"] == "uniform"]
+    mixed_rules = [r for r in tables["category_scoring_rules"] if r["category_slug"] == "mixed"]
+    assert {r["product_type"] for r in uniform_rules} == {"*"}
+    assert {r["product_type"] for r in mixed_rules} == {"model", "software"}
+
+    uniform_tiers = [r for r in tables["category_license_tiers"] if r["category_slug"] == "uniform"]
+    mixed_tiers = [r for r in tables["category_license_tiers"] if r["category_slug"] == "mixed"]
+    assert {r["product_type"] for r in uniform_tiers} == {"*"}
+    assert {r["product_type"] for r in mixed_tiers} == {"model", "software"}
+
+
+def test_recipe_for_selects_the_matching_ladder_for_a_scored_product():
+    """A scored product in a mixed-type category picks up the openness evidence
+    for its OWN type's ladder, not the other one — `weights` differs between the
+    two fixture ladders so a mismatch would be visible in the emitted value.
+    """
+    sources = _sources(
+        categories={
+            "mixed": {"name": "mixed", "products": ["m1", "s1"],
+                      "scoring_recipe": {"extends": {"model": "model", "software": "software"}}},
+        },
+        scores={
+            "m1": {"openness": {"components": "weights:open"}},
+            "s1": {"openness": {"components": "weights:closed"}},
+        },
+        rubrics=SHARED_RUBRICS_FIXTURE,
+        product_types={"m1": "model", "s1": "software"},
+    )
+    tables, errors, warnings = build_rubric(sources, policy={}, routing={})
+    assert errors == []
+    assert not any("in 'mixed':" in w for w in warnings)
+    evidence = {
+        (r["product_slug"], r["dimension"]): r["value"] for r in tables["product_openness_evidence"]
+    }
+    assert evidence[("m1", "weights")] == "open"
+    assert evidence[("s1", "weights")] == "closed"
+
+
+def test_recipe_miss_still_emits_score_sources_for_other_axes():
+    """A product whose declared `type` does not match any ladder (missing, or not
+    one of the mapped keys) loses its openness evidence — `recipe_for` has nothing
+    to hand back — but its adoption and capability source rows must still be
+    emitted. Those axes read only `record` and `policy`, never `recipe`, so a
+    `recipe_for` miss has no bearing on them. This pins Finding 1: narrowing the
+    `continue` to skip only the recipe-dependent block, not the whole per-product
+    body.
+    """
+    sources = _sources(
+        categories={
+            "mixed": {"name": "mixed", "products": ["m1"],
+                      "scoring_recipe": {"extends": {"model": "model", "software": "software"}}},
+        },
+        scores={
+            "m1": {
+                "openness": {"components": "weights:open"},
+                "adoption": {"sources": [{"url": "https://x.test/a", "shows": "13,834 monthly downloads"}]},
+                "capability": {"sources": [{"url": "https://x.test/b", "shows": "AA Intelligence Index 17"}]},
+            },
+        },
+        rubrics=SHARED_RUBRICS_FIXTURE,
+        product_types={"m1": "unmapped-type"},
+    )
+    tables, errors, warnings = build_rubric(sources, policy=POLICY, routing={})
+    assert errors == []
+    assert any("in 'mixed':" in w for w in warnings)
+    assert not any(r["product_slug"] == "m1" for r in tables["product_openness_evidence"])
+    sources_by_axis = {r["axis"]: r for r in tables["product_score_sources"] if r["product_slug"] == "m1"}
+    assert set(sources_by_axis) == {"adoption", "capability"}
+    assert sources_by_axis["adoption"]["admitted"] is True
+    assert sources_by_axis["capability"]["admitted"] is True
 
 
 def test_every_declared_table_is_present():

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -111,6 +111,21 @@ def _sources(categories=None, scores=None, rubrics=None, product_types=None):
     }
 
 
+def _real_sources(root):
+    """The repo's real sources, with `product_types` threaded through the way `main()`
+    does it (`build/serialize_rubric.py:564`). Without this key every product's `type`
+    reads as `""`, which for a mixed category (`extends` mapping product type -> ladder)
+    means `recipe_for` resolves to None for every product rather than to its real ladder
+    — a test that omits it exercises a path no production run takes.
+    """
+    from build.rubrics import load_product_types
+    from build.validate import load_sources
+
+    sources = load_sources(root)
+    sources["product_types"] = load_product_types(root)
+    return sources
+
+
 def test_split_value_separates_the_bare_value_from_its_detail():
     assert split_value("open(downloadable on HF, gated)") == ("open", "downloadable on HF, gated")
     assert split_value("Apache-2.0(OSI)") == ("Apache-2.0", "OSI")
@@ -559,10 +574,9 @@ def test_real_sources_serialize_without_errors():
     from pathlib import Path
 
     from build.serialize_rubric import load_policy, load_routing
-    from build.validate import load_sources
 
     root = Path(__file__).resolve().parents[1]
-    tables, errors, _ = build_rubric(load_sources(root), load_policy(root), load_routing(root))
+    tables, errors, _ = build_rubric(_real_sources(root), load_policy(root), load_routing(root))
     assert errors == [], f"rubric has errors: {errors[:5]}"
 
     # Asserted per category rather than as a total, so a new recipe shows up as its
@@ -596,7 +610,7 @@ def test_real_sources_serialize_without_errors():
     # `core-gated:` key. The two model categories are untouched, which is what the pilot
     # counts are pinned to catch.
     assert per_category("product_openness_evidence") == {
-        "base_pretrained": 111, "finetuned_chat": 172, "deployment": 131,
+        "base_pretrained": 111, "finetuned_chat": 172, "safeguards": 87, "deployment": 131,
         "agent_tools_protocols": 123, "dataset_processing_tools": 88, "evaluation_code": 95,
         "finetuning_code": 132, "inference_code": 80, "ml_frameworks": 84,
         "orchestration_agents": 178, "telemetry_observability": 102, "ui_api": 169,
@@ -613,10 +627,9 @@ def test_every_scored_product_carries_a_row_for_each_formula_dimension():
     from pathlib import Path
 
     from build.serialize_rubric import load_policy, load_routing
-    from build.validate import load_sources
 
     root = Path(__file__).resolve().parents[1]
-    tables, _, _ = build_rubric(load_sources(root), load_policy(root), load_routing(root))
+    tables, _, _ = build_rubric(_real_sources(root), load_policy(root), load_routing(root))
 
     by_product: dict[tuple[str, str], set[str]] = {}
     for row in tables["product_openness_evidence"]:
@@ -646,12 +659,12 @@ def test_license_is_emitted_under_the_name_the_warehouse_joins_on():
     """
     from pathlib import Path
 
-    from build.rubrics import resolve_recipe
+    from build.rubrics import resolve_recipe_variants
     from build.serialize_rubric import load_policy, load_routing
-    from build.validate import load_sources
 
     root = Path(__file__).resolve().parents[1]
-    tables, _, _ = build_rubric(load_sources(root), load_policy(root), load_routing(root))
+    sources = _real_sources(root)
+    tables, _, _ = build_rubric(sources, load_policy(root), load_routing(root))
 
     # Deferred products are excluded: a category has declared the rubric does not decide
     # them, and several are deferred precisely BECAUSE no licence is recorded. Asserting a
@@ -662,12 +675,17 @@ def test_license_is_emitted_under_the_name_the_warehouse_joins_on():
     # back. With no `otherwise` rule in the software ladder they currently fall out of the
     # scoring model's INNER JOIN rather than being scored wrongly, which is the safe
     # direction but a silent one. Bridging the list is tracked separately.
-    sources = load_sources(root)
+    #
+    # Deferrals are a property of the category's declaration, not of any one resolved
+    # ladder — `resolve_recipe_variants` only screens out a category whose `extends` is
+    # broken, matching `build/check_rubric.py`'s `check_category`.
     shared = sources.get("rubrics") or {}
     deferred = set()
     for slug, category in sources["categories"].items():
-        recipe, _ = resolve_recipe(category, shared)
-        for product in ((recipe or {}).get("deferred") or {}):
+        variants, _ = resolve_recipe_variants(category, shared)
+        if not variants:
+            continue
+        for product in ((category.get("scoring_recipe") or {}).get("deferred") or {}):
             deferred.add((product, slug))
 
     rows = tables["product_openness_evidence"]
@@ -687,10 +705,9 @@ def test_evidence_never_puts_two_values_on_one_grain():
     from pathlib import Path
 
     from build.serialize_rubric import load_policy, load_routing
-    from build.validate import load_sources
 
     root = Path(__file__).resolve().parents[1]
-    tables, _, _ = build_rubric(load_sources(root), load_policy(root), load_routing(root))
+    tables, _, _ = build_rubric(_real_sources(root), load_policy(root), load_routing(root))
 
     counts = Counter(
         (r["product_slug"], r["category_slug"], r["dimension"])

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -49,9 +49,38 @@ RECIPE = {
 
 POLICY = {"admission": {"boilerplate_shows": ["verification source"], "require_nonempty_shows": True}}
 
+# Two shared ladders, minimal but structurally valid, for the product-type variant test.
+SHARED_RUBRICS_FIXTURE = {
+    "software": {
+        "openness": {
+            "dimensions": {"weights": {"question": "?", "values": ["open", "closed"]}},
+            "license_tier": {
+                "ordered_by": "restrictiveness_ascending",
+                "values": {"osi": {"examples": ["MIT"]}, "proprietary": {"definition": "no public license"}},
+            },
+            "formula": [{"otherwise": {"score": 3, "class": "open_weights"}}],
+        },
+    },
+    "model": {
+        "openness": {
+            "dimensions": {"weights": {"question": "?", "values": ["open", "closed"]}},
+            "license_tier": {
+                "ordered_by": "restrictiveness_ascending",
+                "values": {"osi": {"examples": ["MIT"]}, "proprietary": {"definition": "no public license"}},
+            },
+            "formula": [{"otherwise": {"score": 3, "class": "open_weights"}}],
+        },
+    },
+}
 
-def _sources(categories=None, scores=None):
-    return {"categories": categories or {}, "scores": scores or {}}
+
+def _sources(categories=None, scores=None, rubrics=None, product_types=None):
+    return {
+        "categories": categories or {},
+        "scores": scores or {},
+        "rubrics": rubrics or {},
+        "product_types": product_types or {},
+    }
 
 
 def test_split_value_separates_the_bare_value_from_its_detail():
@@ -389,6 +418,29 @@ def test_a_category_with_no_recipe_is_a_warning():
 def test_no_recipe_anywhere_is_an_error():
     _, errors, _ = build_rubric(_sources(categories={"other": {}}), POLICY, {})
     assert any("nothing to score with" in e for e in errors)
+
+
+def test_rubric_rows_carry_product_type():
+    """A uniform category's rows are stamped `*`; a mixed category's rows are
+    stamped with the product type of the ladder that produced them, and each
+    scored product picks up the row for its own type via `recipe_for`.
+    """
+    sources = _sources(
+        categories={
+            "uniform": {"name": "uniform", "products": ["p1"],
+                        "scoring_recipe": {"extends": "software"}},
+            "mixed": {"name": "mixed", "products": ["m1", "s1"],
+                      "scoring_recipe": {"extends": {"model": "model", "software": "software"}}},
+        },
+        rubrics=SHARED_RUBRICS_FIXTURE,
+        product_types={"p1": "software", "m1": "model", "s1": "software"},
+    )
+    tables, errors, _ = build_rubric(sources, policy={}, routing={})
+    assert errors == []
+    uniform_rows = [r for r in tables["category_scoring_rules"] if r["category_slug"] == "uniform"]
+    mixed_rows = [r for r in tables["category_scoring_rules"] if r["category_slug"] == "mixed"]
+    assert {r["product_type"] for r in uniform_rows} == {"*"}
+    assert {r["product_type"] for r in mixed_rows} == {"model", "software"}
 
 
 def test_every_declared_table_is_present():


### PR DESCRIPTION
## Summary

- `scoring_recipe.extends` now accepts a mapping of product type to ladder, resolved per product by its `type:` field. String `extends` is unchanged and every uniform category produces byte-identical output.
- The fine-tuned model ladder moves to `sources/rubrics/model.yaml`. `finetuned_chat` reproduction is unchanged at 39/39; `base_pretrained` stays standalone by design, because its questionnaire is pretraining corpus plus checkpoints and whole-key-replace merging would make partial sharing worthless.
- `safeguards` gains its first recipe (`model` + `software` per type), making it the 13th category with one and the first mixed-type one.
- Rubric CSVs gain a `product_type` column so the warehouse resolves recipes exactly as the repo does.
- A deferred product no longer publishes openness evidence. See the warehouse section below — this one is load-bearing.

## `safeguards` reproduces 0 of 26, and that is the honest state

All 26 products are deferred, each with the specific reason it failed. Nothing was corrected here by design: the mismatches are the curation backlog, and a reproduction count improved by editing scores would be worthless. No file under `sources/scores/` changed anywhere on this branch.

The shapes, for the curation session:

- Three guardrail models (`aegis-guard`, `llama-guard`, `llama-prompt-guard`) record `3/open_weights` on Llama-family licenses. Those licenses are `use_restricted` everywhere else in the map, which caps at `2/restricted`.
- Four (`qwen3guard`, `wildguard`, `granite-guardian`, `gpt-oss-safeguard`) record `4` where the ladder computes `3`, because a `data` or `code` dimension is not recorded as open.
- Two (`zentropi-cope`, `shieldgemma`) carry license strings that map to no tier. `shieldgemma`'s is a one-line fix: `gemma` is aliased under `huggingface:` in `signal_routing.yaml` but not under `recorded:`, which is the only sub-table the checker reads.
- Eleven software products abstain because `source` or `core-gated` is not recorded in a readable form. They now sit in `deferred:` with a stated reason, matching what all twelve other categories already do.

## The warehouse problem this branch had, and how it is closed

Platform lineage shows two **released** UDMs depend on the rubric static models: `currentai.scores.openness_computed` on both, and `currentai.evidence.product_evidence` on `category_scoring_rules`.

`openness_computed` reads its rules generically from `category_scoring_rules`, but joins them on `category_slug` alone with no `product_type` filter. Both of `safeguards`' ladders emit `rule_index` 0,1,2… under the same `category_slug`, so their rule indices collide: `rule_size` sums `conditions_required` across both ladders and `otherwise_rule` takes `MIN(rule_index)` over both. The nine guardrail models resolve exactly the four dimensions that model handles (`weights`, `data`, `code`, `license`), so they would have been scored from interleaved rules on the first materialization after merge, contradicting the published score for seven of them.

The fix is upstream of the SQL: **a deferred product now publishes no `product_openness_evidence` rows.** `openness_computed` builds its roster with `SELECT DISTINCT product_slug, category_slug FROM product_evidence`, so `safeguards` contributes nothing, its roster is empty, and no `safeguards` row is computed at all. The collision cannot fire.

This is also the right semantics independent of the bug: where the repo has declined to reproduce a score, it should not hand the warehouse the evidence to recompute one.

Evidence rows drop 1552 → 1274, covering 89 deferrals across 10 categories. Most of those products never computed a score anyway, because the software ladder deliberately has no `otherwise` rule and their `source`/`core-gated` dimensions do not resolve. Four exceptions did resolve and did compute — `jina-reader`, `openhands`, `maple-ai`, `privatemode`, the known score-vs-ladder disagreements — and they now compute nothing rather than something the repo does not stand behind.

Still owed to P2b, and now written down in `docs/guides/verification.md`: the generalized scoring SQL must join `rules.product_type IN ('*', products.type)`, and `rule_index` is only unique within `(category_slug, product_type)`.

## Pre-merge step, already done

The two rubric static models were deleted from `currentai/registry` on 2026-07-30 (`category_scoring_rules` `cdad20a5-…`, `category_license_tiers` `b7888bc1-…`), because the new `product_type` column cannot be added to a live static model. CI recreates them with the new schema on the merge push.

**`openness_computed` and `product_evidence` are broken until that push lands**, so this wants merging rather than sitting.

## Test plan

- [x] `uv run pytest` — 225 passed
- [x] `uv run python -m build.validate` — `0 error(s)`
- [x] `uv run python -m build.check_rubric` — every pre-existing category's counts unchanged (`base_pretrained 26/26`, `finetuned_chat 39/39`), one addition: `safeguards: 0/0 reproduced, 26 deferred`
- [x] `uv run python -m build.check_verification` — byte-identical to pre-branch, so G1/G2/G3 all still pass with `safeguards` newly in G3's scope
- [x] `uv run python -m build.serialize_rubric --check` — exit 0
- [x] Static models deleted so CI recreates them with the new column
- [ ] After merge: confirm the `registry` publish job recreated both tables, then re-materialize `openness_computed` and `product_evidence`

## Review notes

A whole-branch review caught two defects that cancelled each other out, which is why the per-task suites stayed green: a surviving `resolve_recipe` caller in the serializer tests swallowed the mapping-`extends` error, dropping all 26 `safeguards` deferrals from a test's exclusion set (63 pairs collected, none from `safeguards`); and four real-source tests omitted `product_types`, so the per-product half of the new category was asserted vacuously. Both are fixed in `b89f87e`, and the deferred exclusion set is now 89. `a0e2f9c` tightens G3, which was unioning across variants where every other consumer selects per product.

Note that commit `94503d5`'s message claims `safeguards` emits no `product_openness_evidence` rows. That was wrong at the time: it emitted 87, and the test only saw zero because it omitted `product_types`. `b89f87e`'s body corrects the record rather than rewriting history. As of `9730707` the count really is zero, for a different and deliberate reason.

Part of verification roadmap step 1 (docs/guides/verification.md); Kariba tracking: OSO-3643.