### PR TITLE
Openness guide said no scoring formula exists, and an American English sweep

### DIFF
--- a/build/render.py
+++ b/build/render.py
@@ -160,14 +160,14 @@ def style():
         # Openness: a single-hue salmon ramp, deepest = most open, fading to a
         # pale (but still legible) tint for closed. Monotonic lightness, so it
         # reads as one ordered scale; brand salmon sits mid-ramp and open
-        # products carry the most colour.
+        # products carry the most color.
         "healthy": "#e86f57",   # open        — deep salmon
         "warm": "#f4886f",      # open-ish    — salmon (brand-adjacent)
         "signal": "#f8ad99",    # restricted  — light coral
         "closed": "#f6cabd",    # closed      — pale coral
         "null": "#dcdcda",      # no score    — neutral grey (off the ramp)
         # Structure + the two magnitude axes — a quiet cool pair so the openness
-        # column is where colour lives.
+        # column is where color lives.
         "accent": "#0b252f",    # navy — eyebrows, rules, active controls
         "adopt": "#8aa6ac",     # adoption bar   — light slate
         "capab": "#3f5d68",     # capability bar — dark slate
@@ -684,9 +684,9 @@ def helpers(C, DATA, F, OPEN, STRAPLINES, VERDICT, mix_counts, mo, vbucket,
         # Openness verdict pill, then the open / open-ish / closed dot tally.
         _code, _basis = verdict_for(cid)
         _vlabel, _ = VERDICT[_code]
-        # The verdict is a categorical call, not an ordinal one, so colour-coding it
+        # The verdict is a categorical call, not an ordinal one, so color-coding it
         # fought the openness ramp (open-ish vs closed read alike, and competitive /
-        # no-standout fall off the ramp). Keep it a neutral tag; the colour story
+        # no-standout fall off the ramp). Keep it a neutral tag; the color story
         # lives in the open / open-ish / closed chips beside it.
         _verdict = (
             f'<span style="display:inline-block; font-family:{F["mono"]}; font-size:0.72rem; '
@@ -1026,7 +1026,7 @@ def methodology(C, F, mo):
     # Full methodology prose is authored in docs/methodology.md (## Detail),
     # converted from Markdown to HTML at build time and injected as __METHOD_HTML__
     # (numbers already substituted). The scoped <style> below carries the house
-    # fonts/colours onto the generated HTML, so the source stays plain Markdown.
+    # fonts/colors onto the generated HTML, so the source stays plain Markdown.
     # This <style> also styles the header summary (.v3-sum) links.
     _style = (
         "<style>"

--- a/build/serialize_rubric.py
+++ b/build/serialize_rubric.py
@@ -460,7 +460,7 @@ def build_rubric(sources: dict, policy: dict, routing: dict) -> tuple[dict[str, 
                 # warehouse joins on. `license_tier.reads` lets a category accept the value
                 # under another key - deepseek-coder records `model-license`, because its card
                 # distinguishes the code license from the one on the weights - and
-                # check_rubric honours that list. Without resolving it here the row went out
+                # check_rubric honors that list. Without resolving it here the row went out
                 # as `model-license`, the SQL looked only for `license`, and the product
                 # abstained in the warehouse while reproducing locally. Same drift as the
                 # dimension resolution above, one key over.

--- a/docs/guides/notebook-design.md
+++ b/docs/guides/notebook-design.md
@@ -288,9 +288,9 @@ Everything above (typography, neutrals, surfaces, sharp corners, the navy
 structural accent, the single-salmon brand highlight) is applied as written —
 that is what carries the "looks like the site" resemblance.
 
-The one place we adapted is **data colour**. The site encodes openness through
+The one place we adapted is **data color**. The site encodes openness through
 *shape* (square vs triangle) and uses salmon as a sparing editorial accent. The
-notebooks are dense data instruments: they colour-encode an ordinal 0–5 openness
+notebooks are dense data instruments: they color-encode an ordinal 0–5 openness
 scale, three independent axes, a 4-way distribution, and verdict states. Mapping
 those onto the site's two data hues 1:1 collapsed distinct values (open read the
 same as restricted) and produced low-contrast / heavy-black bars. Per this
@@ -300,7 +300,7 @@ reviewed changes (signed off by Carl; worth confirming with the CF design team):
 **Openness → a single-hue salmon *sequential* ramp** (deepest = most open,
 fading to a pale-but-legible coral for closed). One ordered intensity scale, so
 open vs restricted are unambiguous and "warmth = openness" — open products carry
-the most colour, matching how the site uses salmon as the highlight.
+the most color, matching how the site uses salmon as the highlight.
 
 | Openness | Hex |
 |----------|-----|
@@ -311,12 +311,12 @@ the most colour, matching how the site uses salmon as the highlight.
 | No score | `#dcdcda` |
 
 **Adoption & capability → a quiet cool slate pair**, so the openness column is
-the only place colour lives: adoption `#8aa6ac` (light slate), capability
+the only place color lives: adoption `#8aa6ac` (light slate), capability
 `#3f5d68` (dark slate).
 
 **Verdict pills → one neutral tag** (`#f2f1f1` fill, navy text) for all five
-states. The verdict is categorical, not ordinal, so colour-coding it on the
-salmon ramp made "open-ish leads" and "closed leads" look alike; the colour
+states. The verdict is categorical, not ordinal, so color-coding it on the
+salmon ramp made "open-ish leads" and "closed leads" look alike; the color
 story already lives in the open / open-ish / closed chips beside it.
 
 **Header eyebrow** trimmed from `Current AI · Open Source AI Map · v3` to just

--- a/docs/guides/openness-spectrum.md
+++ b/docs/guides/openness-spectrum.md
@@ -23,14 +23,36 @@ Each `sources/scores/<slug>.yaml` carries two separate, analyst-assigned opennes
 
 | Field | Type | What it is |
 |-------|------|------------|
-| `openness.class` | categorical | An OSI / Model Openness Framework (MOF) label: `open_source`, `open_weights`, `open_core`, `source_available`, `restricted`, `gated`, `documented_only`, `closed`, `open`. |
+| `openness.class` | categorical | An OSI / Model Openness Framework (MOF) label. In use today, by frequency: `open_source`, `closed`, `open`, `open_weights`, `open_core`, `source_available`, `documented`, `gated`, `restricted`, `open_toolchain`, `open_hardware`. `documented_only` is also defined in the vocabulary but no product currently carries it. [`openness-class-map.json`](../openness-class-map.json) is the authoritative list. |
 | `openness.score` | integer 0–5 | A graded openness score with a `components` breakdown (models: `weights / data / code / checkpoints / license`; software: OSI-class license tests; datasets: access / license / documentation). |
 
-Both are assigned by hand against MOF/OSI, with a required primary `sources:` entry for
-every non-null value. There is **no deterministic formula** in the repo that computes the
-score from inputs. (The `add-product` skill references a per-category `scoring_recipe`, but
-that optional field is currently not populated on any category — scoring is editorial
-judgment documented in `components`/`note`.)
+Every non-null value needs a primary `sources:` entry. Both fields were originally assigned
+by hand against MOF/OSI, and that history is why `components`/`note` read as editorial prose.
+
+**A deterministic formula now exists for most of the map.** 13 of the 16 categories declare a
+`scoring_recipe` that names an ordered rule list over dimension values, and
+`build/check_rubric.py` replays it against each product's recorded `components` to check that
+the recorded score is the one the rules produce. Most recipes `extend` a shared ladder in
+[`sources/rubrics/`](../../sources/rubrics/) rather than restating one: `software.yaml` covers
+eleven categories, `model.yaml` the fine-tuned and guardrail models. A category holding more
+than one kind of product maps `extends` per product type.
+
+Three caveats, because "a formula exists" is easy to over-read:
+
+- **The remaining three categories have no recipe yet** — `benchmark_eval_data`,
+  `training_synthetic_datasets` and `edge_hardware`, 85 products. Their scores are still
+  editorial only.
+- **A recipe reproducing a score does not validate it.** It shows the rules describe how the
+  category was scored. The document-grade evidence the checker reads was parsed out of the
+  same files the scores live in, so agreement is a fidelity check on the formula, not on the
+  facts.
+- **A category can hold products back.** `scoring_recipe.deferred` lists products the rules do
+  not decide, usually because a dimension is not recorded in a form the ladder can read. There
+  are 89 such products across 10 categories, and `safeguards` currently defers all 26 of its
+  own. Deferred products publish no openness evidence to the warehouse.
+
+So openness is part computed and part editorial, and which one you are looking at depends on
+the category and the product. `docs/guides/verification.md` tracks the work to close that gap.
 
 ## Why the raw score is not comparable across categories
 
@@ -40,12 +62,18 @@ across all score files shows the overlap:
 
 | score | classes that appear at this score |
 |-------|-----------------------------------|
-| 5 | `open_source`, `open` |
-| 4 | `open_core`, `open_source`, `open_weights`, `open`, `gated` |
-| 3 | `open_weights`, `open_core`, `source_available` |
-| 2 | `restricted`, `open_core`, `source_available`, `gated` |
+| 5 | `open_source`, `open`, `open_hardware` |
+| 4 | `open_core`, `open_weights`, `open`, `gated`, `open_toolchain` |
+| 3 | `open_weights`, `open`, `documented`, `gated` |
+| 2 | `restricted`, `source_available`, `gated` |
 | 1 | `closed` |
 | 0 | `closed` |
+
+Regenerated 2026-07-30. The overlap is narrower than it was: #128's verification gate G3 found
+17 pairs no rule in any recipe could emit and corrected them, which is why `open_core` and
+`source_available` no longer appear at 3 and `open_core` no longer appears at 2. If you are
+reading this table long after that date, regenerate it rather than trusting it — the check is
+a few lines over `sources/scores/*.yaml`.
 
 A pretrained model at **2** is genuinely restricted/gated, because the model gradient is
 compressed (open weights typically land around 3, and you only reach 5 with a fully open

--- a/sources/products/apertus.yaml
+++ b/sources/products/apertus.yaml
@@ -2,7 +2,7 @@ name: apertus
 display_name: Apertus
 type: model
 description: 'Switzerland''s national open LLM and one of the most transparent large models released to
-  date, built by the Swiss AI Initiative (EPFL, ETH Zurich, and the CSCS supercomputing centre) and shipped
+  date, built by the Swiss AI Initiative (EPFL, ETH Zurich, and the CSCS supercomputing center) and shipped
   2 Sep 2025 in 8B and 70B variants under Apache 2.0. ''Apertus'' is Latin for ''open'': the release covers
   not just weights but the full training data (via reconstruction scripts), the Megatron-LM training recipe,
   intermediate checkpoints, a technical report, and EU AI Act / Swiss data-protection compliance documentation.

--- a/sources/products/autogen.yaml
+++ b/sources/products/autogen.yaml
@@ -1,7 +1,7 @@
 name: autogen
 display_name: AutoGen
 type: software
-description: Microsoft's framework for agentic AI centred on multi-agent conversation patterns where LLM agents
+description: Microsoft's framework for agentic AI centered on multi-agent conversation patterns where LLM agents
   collaborate, critique, and run tools/code. Its event-driven v0.4 redesign and code-execution focus distinguish
   it from graph- or role-based frameworks.
 github:

--- a/tests/test_serialize_registry.py
+++ b/tests/test_serialize_registry.py
@@ -164,7 +164,7 @@ def test_real_sources_serialize_without_structural_errors():
     assert len(tables["products"]) == len(tables["product_organizations"])
 
 
-def test_arxiv_ids_normalise_from_every_form():
+def test_arxiv_ids_normalize_from_every_form():
     """URL, bare id, arxiv: prefix and version suffix all reduce to the bare id,
     so the DOI is derivable as 10.48550/arXiv.<id> without further parsing."""
     assert artifact_id("arxiv", "https://arxiv.org/abs/2110.14168") == "2110.14168"

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -710,7 +710,7 @@ def test_license_is_emitted_under_the_name_the_warehouse_joins_on():
     """`license_tier.reads` lets a category accept the license under another key.
 
     deepseek-coder records `model-license`, because its card separates the code license
-    from the one on the weights. check_rubric honours that list, but the serializer used
+    from the one on the weights. check_rubric honors that list, but the serializer used
     to emit the row under its raw key, so the SQL - which looks only for
     `dimension = 'license'` - found nothing and the product abstained in the warehouse
     while reproducing locally. Exactly one license row per scored product, under
@@ -726,8 +726,8 @@ def test_license_is_emitted_under_the_name_the_warehouse_joins_on():
     tables, _, _ = build_rubric(sources, load_policy(root), load_routing(root))
 
     # Deferred products are excluded: a category has declared the rubric does not decide
-    # them, and several are deferred precisely BECAUSE no licence is recorded. Asserting a
-    # licence row for those would be asserting evidence we have said we do not have.
+    # them, and several are deferred precisely BECAUSE no license is recorded. Asserting a
+    # license row for those would be asserting evidence we have said we do not have.
     #
     # Note the asymmetry this leaves. `deferred` lives only in the repo - there is no
     # category_deferrals table - so the warehouse does not know these products are held


### PR DESCRIPTION
Two loose ends left out of #129 because they predate it. Split into two commits so the second can be dropped independently.

## `166946d` — the openness spectrum guide was wrong about scoring

`docs/guides/openness-spectrum.md` is the data-consumer reference, and it claimed:

> There is **no deterministic formula** in the repo that computes the score from inputs. (The `add-product` skill references a per-category `scoring_recipe`, but that optional field is currently not populated on any category — scoring is editorial judgment documented in `components`/`note`.)

Both halves are false, and were before #129: 13 of the 16 categories declare a `scoring_recipe`, and `build/check_rubric.py` replays it against each product's recorded `components`. Anyone reading this guide to decide how to consume the data was being told the opposite of what the repo does.

Rewritten to describe the real state, with the three caveats that stop "a formula exists" being over-read: three categories still have no recipe (85 products), reproducing a score is a fidelity check on the formula rather than on the facts, and 89 products across 10 categories are deferred and publish no openness evidence.

Two more errors in the same file, found while in there:

- **The `score | class` cross-tab was stale.** It predated #128, whose G3 gate found 17 pairs no rule could emit and corrected them. The table still showed `open_core` and `source_available` at score 3 and `open_core` at 2, none of which exist any more. Regenerated from `sources/scores/`, with a dated note and a pointer to regenerate rather than trust it.
- **The class vocabulary was incomplete and partly wrong.** It listed `documented_only`, which no product carries, and omitted `documented` (13 products), `open_toolchain` (6) and `open_hardware` (1). Now lists what is actually in use by frequency, and points at `openness-class-map.json` as authoritative.

Also fixes the `honours` in `build/serialize_rubric.py` that I flagged on #129, plus its twin in `tests/test_serialize_rubric.py` (same sentence, copied) and two `licence` nouns in a comment there.

## `8a01de4` — American English sweep, droppable

A repo-wide scan for British spellings, since the convention is standing and identifiers hide the stems where word-boundary searches miss them:

- `colour` → `color`, in comments only: `build/render.py` (4) and `docs/guides/notebook-design.md` (6). No identifier, dict key or data value touched — verify from the diff.
- `test_arxiv_ids_normalise_from_every_form` → `normalize`, in `tests/test_serialize_registry.py`. This is the identifier case the convention warns about.
- `supercomputing centre` → `center` (`apertus`) and `centred on` → `centered on` (`autogen`). Generic lowercase usage, not either organization's registered name.

**Deliberately left alone:** five places that quote `licence` as an example of the misspelling being *rejected* — `build/validate.py`, `build/rubrics.py`, `tests/test_validate.py` (two, asserting the rejection) and the standing-hazards table in `docs/runbooks/verification-pass.md`. Correcting those would delete the point.

Note the two product-description edits change `build/notebook_data.json`, so expect the usual bot regeneration commit after merge. This PR does not touch either generated file.

## Test plan

- [x] `uv run pytest` — 225 passed
- [x] `uv run python -m build.validate` — `0 error(s)`
- [x] `uv run python -m build.serialize --date ci-dry-run` — clean
- [x] Every number in the rewritten prose measured from `sources/`, not carried over