### PR TITLE
A shared dataset openness ladder, and why it came from the datasets and not the hardware

### DIFF
--- a/sources/categories/training_synthetic_datasets.yaml
+++ b/sources/categories/training_synthetic_datasets.yaml
@@ -9,6 +9,81 @@ weights:
   adopt: 0.5
   cap: 0.5
 disclosure_gap: true
+scoring_recipe:
+  version: 1
+  derived_from:
+    method: reverse-engineered from hand-authored scores, then verified
+    scores_reproduced: 30
+    scores_total: 38
+    scores_deferred: 8
+    verified_on: '2026-07-31'
+    checker: build/check_rubric.py
+  note: >-
+    First DATASET category, and the source the shared ladder was derived from. Chosen over
+    benchmark_eval_data because its recorded evidence is the cleanest in the map: 38 of 38
+    name a license and almost every value is a controlled token rather than a sentence. Eight
+    products are deferred below and none of the eight is deferred for being awkward - five
+    record their evidence in clauses the components parser discards, one is the only
+    non-commercial license on the ladder, one records no license at all, and one hides the
+    fact that decides it inside a parenthetical.
+
+  extends: dataset
+  deferred:
+    smoltalk:
+      because: >-
+        The ladder computes 5/open and the score says 4/open. The 4 rests on
+        `license:apache-2.0(new-subsets)+per-component` - newly created subsets are
+        Apache-2.0 while incorporated datasets keep their own terms - but `head()` splits the
+        license value at the first parenthesis, so the ladder reads a clean `apache-2.0` and
+        the qualifier that justifies the 4 never reaches it. Either the per-component scope
+        belongs in a key of its own or the score is a level high; it needs a human.
+    personahub:
+      because: >-
+        `cc-by-nc-sa-4.0` resolves to the `noncommercial` tier, which carries no rung on
+        purpose. model.yaml puts the same license family in `use_restricted` and caps a model
+        at 2/restricted; this is recorded 5/open on the reasoning that a corpus's openness
+        question is redistributability, which non-commercial terms still permit. Both readings
+        are defensible and the map cannot hold both. Deferred until the question is settled
+        the way issue #117 settled OpenRAIL for models.
+    openhermes-2-5:
+      because: >-
+        License `not-clearly-stated-on-card` resolves to the `unstated` tier, which carries no
+        rung: absent a grant there is no permission to rely on, however freely the files
+        download. Recorded 5/open with the note conceding no explicit license string exists.
+        Either the license is findable, in which case record it, or a 5 is not supportable.
+    cosmopedia:
+      because: >-
+        Records `ungated` and `dataset card present` as clauses with no key, which
+        split_components discards, so neither the gate nor the documentation dimension has a
+        value and no rung can fire. The evidence is present and correct; only the keys are
+        missing. Fixed by recording `gated:false;dataset_card:present`.
+    openthoughts-114k:
+      because: >-
+        Records `ungated` and `dataset card present` as clauses with no key, which
+        split_components discards, so neither the gate nor the documentation dimension has a
+        value and no rung can fire. The evidence is present and correct; only the keys are
+        missing. Fixed by recording `gated:false;dataset_card:present`.
+    synth:
+      because: >-
+        Records `ungated` and `dataset card present` as clauses with no key, which
+        split_components discards, so neither the gate nor the documentation dimension has a
+        value and no rung can fire. The evidence is present and correct; only the keys are
+        missing. Fixed by recording `gated:false;dataset_card:present`.
+    tulu-3-sft-mixture:
+      because: >-
+        Records `ungated` and `dataset card present` as clauses with no key, which
+        split_components discards, so neither the gate nor the documentation dimension has a
+        value and no rung can fire. The evidence is present and correct; only the keys are
+        missing. Fixed by recording `gated:false;dataset_card:present`. Note the recorded
+        license carries `(mixed subset licenses incl CC-BY-NC)`, so once the keys are fixed
+        this product raises the same question `personahub` is deferred for.
+    wildchat-1m:
+      because: >-
+        Records `dataset card present` as a clause with no key, so the documentation dimension
+        has no value. Separately its gate reads `false per HF API`, whose `head()` is the whole
+        phrase rather than `false`, so the value sits outside the declared enum too. Both are
+        recording defects rather than missing research: `gated:false;dataset_card:present`
+        settles it.
 products:
 - fineweb
 - fineweb-edu

--- a/sources/rubrics/dataset.yaml
+++ b/sources/rubrics/dataset.yaml
@@ -1,0 +1,161 @@
+# Shared openness ladder for DATASET categories.
+#
+# Inherited via `scoring_recipe: {extends: dataset}`. See build/rubrics.py for the merge
+# rules and why the ladder is shared rather than copied per category.
+#
+# A corpus asks neither the software question nor the model question. There is no runtime to
+# self-host and no weights to download, so `source` and `core-gated` have nothing to bind to.
+# What decides a dataset's openness is whether you can get it, whether the license that
+# covers it covers all of it, and whether anything documents what is inside. Three
+# dimensions, in that order of weight.
+#
+# Verified against training_synthetic_datasets first, 30/38. That category records the
+# cleanest evidence in the map - 38 of 38 name a license and almost every value is a
+# controlled token - which is why the ladder was derived from it rather than from
+# benchmark_eval_data. Each inheriting category records its own `derived_from` counts.
+openness:
+  dimensions:
+    gate:
+      question: Is download gated - terms to accept, contact details to hand over, or an
+        approval to wait for?
+      # Three keys and two polarities record one fact. `gated: false`, `ungated: yes` and
+      # `access: ungated` are the same statement three ways, and `reads:` cannot reconcile
+      # them because it selects a key and takes its value: it has no way to invert one.
+      #
+      # The ladder does not need it to. Every way of saying "there is a gate" is a distinct
+      # positive token, so the rules test only those, and all three spellings of "no gate"
+      # fall through to the license rungs below. They are declared here anyway, because they
+      # ARE the recorded vocabulary and a reader of this file should see what the data says
+      # rather than what it ought to say.
+      #
+      # `'yes'` and `'false'` are quoted deliberately. YAML 1.1 parses both bare, and a
+      # `values:` list holding [True, False] stops matching the strings the formula sees.
+      reads: [access, gated, ungated]
+      values: [ungated, 'yes', 'false', auto, manual, terms-acceptance,
+        terms-acceptance+contact-info]
+      evidence:
+      - '`manual`: a maintainer approves each request, so access depends on a human'
+      - '`auto`: the gate grants automatically but still takes contact details - `culturax`
+        is the case, auto-approved against a contact-info agreement'
+      - '`terms-acceptance`: a click-through license gate, no contact details'
+      - '`terms-acceptance+contact-info`: both, which is `the-stack-v2`'
+      - '`ungated`, `yes` and `false`: three recordings of an open download'
+      machine_signal: full - signal_huggingface.hub_state carries the gate state directly,
+        and it is the only dimension on this ladder a fetcher can settle without a human
+    documentation:
+      question: Is there a dataset card describing provenance, composition and limits?
+      # `present` and `yes` are one value with two spellings, under two keys. Unlike the
+      # gate above the polarity is consistent, so `reads:` handles the keys and both
+      # spellings are declared - but the drift does reach the formula, which carries the
+      # top rung twice, once per spelling. That is the honest cost of not rewriting 5
+      # score files to agree with the other 25, and it is the first thing a components
+      # normalization on this category would remove.
+      #
+      # The top rung tests this dimension rather than resting on gate and license alone,
+      # which is deliberate. The gate rungs fire on POSITIVE gate evidence, so a product
+      # recording no gate key at all is not thereby ungated - it is unrecorded. Requiring a
+      # card at the top rung is what stops "no evidence" from resolving as "nothing wrong".
+      reads: [dataset_card, card]
+      values: [present, 'yes', partial, legacy-repo-only]
+      evidence:
+      - '`partial`: a card exists but does not describe the release being scored -
+        `flan-collection` documents the recipe, not the conversion people actually download'
+      - '`legacy-repo-only`: the card lives on a superseded repo whose loader or mirrors are
+        dead, which is `the-pile`'
+      machine_signal: partial - the Hub API establishes that a card file exists, never that
+        it describes provenance
+
+  # Declaration order IS restrictiveness order, least restrictive first, and `tier_rank` is
+  # emitted from it.
+  license_tier:
+    reads: [license]
+    ordered_by: restrictiveness_ascending
+    values:
+      open_data:
+        definition: >-
+          One license, covering the whole release, permitting redistribution and reuse.
+          Attribution and share-alike obligations belong here: they bind whoever
+          redistributes without capping who may use the corpus, which is the line this
+          ladder draws, exactly as the software ladder puts AGPL beside Apache.
+        # Spelling and case variants are listed literally rather than normalized, following
+        # software.yaml: whether ODC-BY permits redistribution is a fact, and a fact is
+        # cheaper to look up than a regex is to get right.
+        #
+        # `permissive` and `open` are NOT license names. They are a curator's conclusion
+        # recorded where the license goes, and they are listed because they are what four
+        # products actually record. Replacing them with the licenses they stand for is a
+        # curation fix, not a rubric one.
+        examples: [ODC-BY, odc-by, ODC-BY-1.0, CC-BY-4.0, cc0-1.0, Apache-2.0, apache-2.0,
+          MIT, mit, permissive, open, NVIDIA-Open-Data, CommonCrawl-ToU+Apache-2.0]
+      noncommercial:
+        definition: >-
+          Permits redistribution but forbids commercial use. Deliberately carries NO rung in
+          the formula below, which is the one place this ladder declines to decide: the same
+          license family resolves to `use_restricted` in model.yaml and caps a model at
+          2/restricted, while `personahub` is recorded 5/open here on the reasoning that a
+          corpus's openness question is redistributability and non-commercial terms still
+          permit it. Both readings are defensible and they cannot both be right across the
+          map. Until one is chosen, a product landing here abstains and says so, rather than
+          having whichever answer the ladder happened to encode published on its behalf.
+          Issue #117 settled the analogous question for OpenRAIL on models.
+        examples: [cc-by-nc-sa-4.0]
+      deferred_to_components:
+        definition: >-
+          The card grants no license of its own and defers to the terms of whatever the
+          corpus was assembled from. Below the noncommercial tier because a bounded
+          restriction you can read is a smaller problem than an unbounded one you have to
+          audit per subset, and above `unstated` because at least the obligation is
+          locatable.
+        examples: [mixed-per-subset, inherits-the-stack-v2, follows mC4 + OSCAR-2301 terms]
+      unstated:
+        definition: >-
+          No license recorded on the card at all. The most restrictive tier, because absent
+          a grant there is no permission to rely on, however freely the files download.
+        examples: [not-clearly-stated-on-card]
+
+  # Ordered, first match wins. There is deliberately NO `otherwise`. Two thirds of the
+  # gate-positive vocabulary and the whole `noncommercial` tier are cases where the ladder
+  # either has a rule or should abstain, and an `otherwise` would publish 5/open for a
+  # dataset whose license nobody recorded.
+  formula:
+  # A gate comes first and outranks everything below it. A permissively licensed corpus you
+  # cannot download without a maintainer's approval is not more open than one you can,
+  # whatever the license says, so no license tier can lift a gated product past 3.
+  - when: {gate: manual}
+    then: {score: 3, class: gated}
+    because: A maintainer approves each request, so access depends on someone answering.
+  - when: {gate: auto}
+    then: {score: 3, class: gated}
+    because: >-
+      The gate grants automatically, but it still collects contact details before it does.
+      Scored beside manual approval because the barrier is the disclosure, not the wait.
+  - when: {gate: terms-acceptance}
+    then: {score: 3, class: gated}
+    because: A click-through license gate. Downloadable, not freely downloadable.
+  - when: {gate: terms-acceptance+contact-info}
+    then: {score: 3, class: gated}
+    because: Both barriers at once, which is the most gated shape the category records.
+  # Ungated from here down, so the license is what decides.
+  - when: {license_tier: deferred_to_components, documentation: legacy-repo-only}
+    then: {score: 3, class: open}
+    because: >-
+      No license of its own AND no live card. `the-pile` is the case: per-subset terms, a
+      superseded repo, and Books3 withdrawn from circulation. Open in the sense that it
+      downloads, and in no other sense.
+  - when: {license_tier: deferred_to_components, documentation: present}
+    then: {score: 4, class: open}
+    because: >-
+      A documented, ungated release whose license points somewhere else. Not 5, because
+      establishing what you may do with it means reading another corpus's terms - and for
+      `stack-edu` those terms are The Stack v2's, which is itself gated.
+  - when: {license_tier: open_data, documentation: partial}
+    then: {score: 4, class: open}
+    because: >-
+      A clean license and an ungated download, but the card does not describe the artifact
+      people actually use. `flan-collection` documents the Apache-2.0 recipe while the
+      widely used conversion is documented by whoever converted it.
+  - when: {license_tier: open_data, documentation: present}
+    then: {score: 5, class: open}
+    because: One license covering the release, an open download, and a card. Nothing withheld.
+  - when: {license_tier: open_data, documentation: 'yes'}
+    then: {score: 5, class: open}

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -650,8 +650,12 @@ def test_real_sources_serialize_without_errors():
     SOFTWARE = ["agent_tools_protocols", "dataset_processing_tools", "deployment",
                 "evaluation_code", "finetuning_code", "inference_code", "ml_frameworks",
                 "orchestration_agents", "telemetry_observability", "ui_api"]
+    # `training_synthetic_datasets` is the first DATASET category and inherits
+    # sources/rubrics/dataset.yaml. Its 14 rows are 4 single-condition gate rungs plus 5
+    # rungs pairing a license tier with a documentation state.
     assert per_category("category_scoring_rules") == {
-        "base_pretrained": 11, "finetuned_chat": 9, "safeguards": 25, **{c: 16 for c in SOFTWARE},
+        "base_pretrained": 11, "finetuned_chat": 9, "safeguards": 25,
+        "training_synthetic_datasets": 14, **{c: 16 for c in SOFTWARE},
     }
     # Both fell with the slug migration: release-level products collapsed into the
     # tier the vendor sells, so 25 products left the roster and the closed frontier
@@ -673,6 +677,7 @@ def test_real_sources_serialize_without_errors():
         "agent_tools_protocols": 108, "dataset_processing_tools": 86, "evaluation_code": 66,
         "finetuning_code": 119, "inference_code": 47, "ml_frameworks": 80,
         "orchestration_agents": 137, "telemetry_observability": 90, "ui_api": 127,
+        "training_synthetic_datasets": 158,
     }
     assert {r["grade"] for r in tables["product_openness_evidence"]} == {"document"}
 


### PR DESCRIPTION
The first DATASET ladder, `sources/rubrics/dataset.yaml`, plus
`training_synthetic_datasets` extending it at **30/38 reproduced, 8 deferred**.

## What the ladder asks

A corpus asks neither the software question nor the model question. There is no runtime to
self-host and no weights to download, so `source` and `core-gated` have nothing to bind to.
Three dimensions carry it instead:

- **`gate`** — terms to accept, contact details to hand over, or an approval to wait for. A
  gate outranks every license rung below it: a permissively licensed corpus you cannot
  download without a maintainer's approval is not more open than one you can.
- **`documentation`** — is there a card describing provenance and limits.
- **`license_tier`** — four tiers, `open_data` → `noncommercial` → `deferred_to_components`
  → `unstated`, declaration order encoding restrictiveness as the other two ladders do.

No `otherwise`, following `software.yaml`. Two thirds of the gate vocabulary and the whole
`noncommercial` tier are cases where the ladder either has a rule or should abstain, and an
`otherwise` would publish 5/open for a corpus whose license nobody recorded.

## The 8 deferrals are the interesting half

None is deferred for being awkward.

**Five are a parser defect, not missing research.** `cosmopedia`, `openthoughts-114k`,
`synth`, `tulu-3-sft-mixture` and `wildchat-1m` record `ungated` and `dataset card present`
as clauses with *no key*. `split_components` drops any clause without a colon, silently, so
the evidence is present, correct, and unreadable. Recording
`gated:false;dataset_card:present` would lift reproduction to 35/38 with no research and no
score change. Across the whole map 170 of 470 products lose at least one clause this way,
and three lose the entire string.

**One is a cross-category inconsistency the map cannot keep.** `personahub` carries
`cc-by-nc-sa-4.0`. `model.yaml` puts that family in `use_restricted` and caps a model at
2/restricted; this is recorded 5/open, on the reasoning that a corpus's openness question is
redistributability and non-commercial terms still permit it. Both readings are defensible.
The `noncommercial` tier therefore carries **no rung on purpose** — the ladder abstains and
says so rather than publishing whichever answer I happened to encode. This wants settling
the way #117 settled OpenRAIL for models.

**One is a score that may not be supportable.** `openhermes-2-5` records
`license:not-clearly-stated-on-card` and is scored 5/open, its own note conceding no explicit
license string exists. The `unstated` tier declines to score it: absent a grant there is no
permission to rely on, however freely the files download.

**One is a discarded qualifier.** `smoltalk` is scored 4 on
`license:apache-2.0(new-subsets)+per-component`, but `head()` splits the license at the first
parenthesis, so the ladder reads a clean `apache-2.0` and computes 5. Either the
per-component scope needs a key of its own or the score is a level high.

## Why this category and not `edge_hardware`

The plan had `edge_hardware` first, on the grounds that 18 of its 20 products already record
the same five keys. Coverage of *keys* is tidy; the *values* are not, and the machinery reads
values. Measured across every category, counting `components` values only:

| category | products | records a license | prose values |
|---|---|---|---|
| `base_pretrained` | 26 | 26/26 | 0% |
| `training_synthetic_datasets` | 38 | 38/38 | 2% |
| `benchmark_eval_data` | 27 | 25/27 | 15% |
| `safeguards` | 26 | 20/26 | 19% |
| `deployment` | 27 | 27/27 | 25% |
| `edge_hardware` | 20 | **0/20** | **71%** |

`check_rubric` resolves a dimension by testing `head(value)` against a declared enum, so
`schematics:reduced published` yields `reduced published` and matches nothing. In the four
comparison categories the residual prose sits in keys no formula reads — `size`,
`contamination`, `governance`. In `edge_hardware` it sits in the two keys that decide the
score, and no product records a license at all, which `check_rubric` currently treats as a
hard failure rather than an abstention.

So `edge_hardware` is the least readable category in the repo, not the tidiest. The ladder
for it is drafted and reaches 18/20 against a proposed normalization, and it is held until
that normalization is decided. Deriving the guide here instead means the derivation exercises
the machinery rather than fighting it, which is what verifying a shared ladder against one
roster is for.

## Verification

```
uv run pytest -q                          225 passed
uv run python -m build.validate           0 error(s)
uv run python -m build.check_rubric       +1 line; no other category's counts move
uv run python -m build.check_verification G1 G2 G3 all [OK]
uv run python -m build.serialize_rubric --check   14 rule rows, 158 evidence rows
```

G3 now applies to all 38 products in the category and passes: every recorded
`(score, class)` pair is producible by some rung.

Two assertions in `tests/test_serialize_rubric.py` gain a line, which is what that test is
built for — it pins counts per category so a new recipe shows up as its own number.

`serialize_rubric --check` goes from 273 warnings to 282: one "declares no scoring_recipe"
disappears and ten "records `format`/`rows`/`size`/`github`, which the category does not
declare as a dimension" appear. Those keys are descriptive metadata, not openness questions,
so declaring them as dimensions would be wrong. There is no way today to say "recorded key
that answers no openness question", which is worth fixing when `check_recipe` lands — it is
the difference between a real vocabulary drift and a row count.

**Nothing under `sources/scores/` changed.** No score, class or components string was edited
to produce any number here.
