### PR TITLE
edge_hardware's level 5 required something no product can meet

### DIFF
--- a/sources/categories/edge_hardware.yaml
+++ b/sources/categories/edge_hardware.yaml
@@ -30,9 +30,17 @@ products:
 - sipeed-maixcam
 comments: 'Physical AI hardware (issue #24): SBCs, system-on-modules, accelerator modules,
   and chipsets used to run inference at the edge. Hardware openness vocabulary, scored on
-  design + toolchain + availability rather than source license: open_hardware (open
-  schematics + open toolchain, no blobs) = 5; open_toolchain (proprietary silicon, open
-  SDK/datasheets, globally purchasable) = 4; documented (datasheets public + buyable, but
-  closed/limited SDK or firmware blobs) = 3; restricted (NDA/design-win/private-sale only) =
-  1. Adoption = retail availability + community; capability = TOPS / RAM / runnable model
-  size.'
+  design + toolchain + availability rather than source license: open_hardware (board design
+  files published under a license permitting reuse + open toolchain) = 5; open_toolchain
+  (schematics readable but not reusable, open SDK/datasheets, globally purchasable) = 4;
+  documented (datasheets public + buyable, but no design files of its own, or a closed or
+  registration-gated SDK) = 3; restricted (NDA/design-win/private-sale only) = 1. Adoption =
+  retail availability + community; capability = TOPS / RAM / runnable model size.
+
+  Level 5 previously read "open schematics + open toolchain, no blobs". The no-blobs
+  condition is dropped because it is unreachable: every part in this category runs on a
+  proprietary SoC needing firmware blobs, beagley-ai included, and beagley-ai is the only
+  product scored 5. What separates it from the 4s is that its design files carry a license
+  permitting reuse (CC-BY/CC-BY-SA, OSHWA-certified US002616) where radxa-rock-5b, for one,
+  publishes PDFs and explicitly withholds editable PCB source. Blobs remain a documented
+  caveat on every product rather than a discriminator between any two.'


### PR DESCRIPTION
A one-field correction to `sources/categories/edge_hardware.yaml`'s `comments`.

## The problem

The prose ladder defined the top tier as:

> open_hardware (open schematics + open toolchain, **no blobs**) = 5

Every part in this category runs on a proprietary SoC that needs firmware blobs. That
includes `beagley-ai`, the only product in the category scored 5, whose own recorded evidence
says "TI DSP/WiFi firmware blobs a caveat". So the rung was unreachable as written, and its
single occupant did not meet it.

## What actually separates 5 from 4

Not blobs. `beagley-ai`'s board design files carry a license that permits reuse — CC-BY /
CC-BY-SA, OSHWA-certified US002616. The six products at 4 publish schematics you can read but
not reuse: `radxa-rock-5b` ships PDFs, SMD maps, DXF and 3D STP and its note states plainly
that editable PCB source is not released.

The tier definitions now say that, and blobs are described as what they are — a caveat that
applies to every product in the category, so a discriminator between none of them.

## Scope

`comments` only. No score, class or `components` string changed, and `edge_hardware` still has
no `scoring_recipe`; that is held pending a separate decision about its recorded evidence.

Found while deriving a hardware scoring recipe, which is how the contradiction surfaced.

```
uv run python -m build.validate    0 error(s)
uv run pytest -q                   225 passed
```
