### PR TITLE
A recipe gate, and the procedure it enforces

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -25,6 +25,14 @@ jobs:
       # product in a category with a recipe. See docs/guides/verification.md.
       - name: Verification gates (G1 invariant, G2 digests, G3 producible pairs)
         run: uv run python -m build.check_verification --verbose
+
+      # Structure of every scoring recipe: a rationale on each rung, a machine_signal on
+      # each dimension, no rule that cannot fire, no product abstained on without a
+      # declared reason, and no evidence the components parser silently discards. Note
+      # check_rubric is not in CI at all; this is what puts the class of check on every PR.
+      # See skills/build-rubric/SKILL.md.
+      - name: Recipe gate (structure, deferral completeness, discarded evidence)
+        run: uv run python -m build.check_recipe --verbose
       - name: Serialize dry-run
         run: uv run python -m build.serialize --date ci-dry-run
 

--- a/build/check_recipe.py
+++ b/build/check_recipe.py
@@ -1,0 +1,471 @@
+"""Assert what a machine can judge about a scoring recipe, and block a merge on failure.
+
+`check_rubric` asks whether a recipe reproduces the recorded scores. This asks whether the
+recipe is well formed enough to be worth reviewing at all — every rung justified, every
+dimension carrying a machine signal, no rule that cannot fire, no product silently abstained
+on, no evidence discarded by the parser. The distinction matters because the two fail for
+different reasons and want different fixes: a reproduction mismatch is a finding about a
+product, while everything here is a defect in the ladder or its wiring.
+
+It exists because `skills/curate-category/SKILL.md` said "edit any of … `scoring_recipe` …"
+and gave no guidance, so every ladder so far was authored from scratch by whoever happened to
+be doing it. The taxonomy expansion event will add roughly twenty-four more categories, each
+born needing a recipe. `skills/build-rubric/SKILL.md` is the procedure; this is the part of it
+a machine can enforce.
+
+Almost everything here composes a signal that already exists somewhere and was not gated:
+`check_rubric` knows about abstentions, `check_verification` G3 knows about impossible pairs,
+and `serialize_rubric --check` knows about undeclared dimensions and out-of-enum values — but
+it emits them as warnings among 282, which is to say invisibly. Gating is the contribution.
+
+WHAT THIS DELIBERATELY DOES NOT ASSERT: any threshold on the reproduction rate, in either
+direction. A ladder tuned until it reproduces every recorded score is a curve fit to the data
+it was supposed to check; it looks rigorous and is worth less than nothing, because it retires
+a check while appearing to pass it. `safeguards` reproduced 0 of 26 and that was the correct
+outcome — the mismatches were the finding. `tests/test_check_recipe.py` asserts this module's
+source contains no such threshold, because the failure mode is someone adding one later in
+good faith.
+
+Usage:
+    uv run python -m build.check_recipe                    # every category with a recipe
+    uv run python -m build.check_recipe --category ui_api
+    uv run python -m build.check_recipe --verbose          # itemize what is reported
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+from build.check_rubric import (
+    ROOT,
+    check_category,
+    dimension_read_map,
+    dimension_value,
+    head,
+    license_read_keys,
+    load_product_types,
+    load_shared,
+    recipe_for,
+    resolve_recipe_variants,
+    split_components,
+)
+from build.check_verification import producible_pairs
+
+
+def split_clauses(text: str) -> list[str]:
+    """Every `;`-separated clause at paren depth zero, INCLUDING the keyless ones.
+
+    `split_components` drops a clause with no colon, silently — which is the thing being
+    checked, so this cannot reuse it. Paren-aware for the same reason it is there: values
+    routinely contain semicolons inside parentheses.
+    """
+    parts: list[str] = []
+    depth = 0
+    current = ""
+    for char in text:
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth = max(0, depth - 1)
+        if char == ";" and depth == 0:
+            parts.append(current)
+            current = ""
+        else:
+            current += char
+    if current.strip():
+        parts.append(current)
+    return [part.strip() for part in parts if part.strip()]
+
+
+def _openness(recipe: dict) -> dict:
+    return recipe.get("openness") or {}
+
+
+def _dimensions(recipe: dict) -> dict:
+    return _openness(recipe).get("dimensions") or {}
+
+
+def _formula(recipe: dict) -> list[dict]:
+    return _openness(recipe).get("formula") or []
+
+
+def every_rung_has_a_because(slug: str, recipe: dict) -> list[str]:
+    """The `because` is the reviewable artifact — what a human reads where a machine cannot judge.
+
+    Strictly `because`. `note` was the other spelling of the same field: `model.yaml` and
+    `base_pretrained` used it exclusively while `software.yaml` and `dataset.yaml` used
+    `because`, and all six `note` rungs read as justifications rather than asides. They were
+    migrated rather than accommodated, because one field under two names is how a required
+    key becomes optional in practice.
+    """
+    problems = []
+    for index, rule in enumerate(_formula(recipe)):
+        if not str(rule.get("because") or "").strip():
+            outcome = rule.get("then") or rule.get("otherwise") or {}
+            problems.append(
+                f"category '{slug}' formula rule {index} "
+                f"({outcome.get('score')}/{outcome.get('class')}) has no `because`"
+            )
+    return problems
+
+
+def every_dimension_has_a_machine_signal(slug: str, recipe: dict) -> list[str]:
+    """What a fetcher could settle later, and what will always need a human read.
+
+    Required even when the answer is `none`, because "nobody has thought about it" and "this
+    needs a human forever" are different facts and the automation roadmap depends on telling
+    them apart.
+    """
+    return [
+        f"category '{slug}' dimension '{name}' declares no `machine_signal`"
+        for name, spec in _dimensions(recipe).items()
+        if not str((spec or {}).get("machine_signal") or "").strip()
+    ]
+
+
+def no_unreachable_rule(slug: str, recipe: dict) -> list[str]:
+    """A rule that cannot fire is where a later edit hides.
+
+    Three ways to be unreachable: declared after an `otherwise`, testing a dimension the
+    recipe never declared, or testing a value outside that dimension's own enum. The last two
+    are already errors inside `serialize_rubric.scoring_rules`; they are recomputed here
+    rather than imported so this module does not depend on the serializer's row shape, and
+    `tests/test_serialize_rubric.py` keeps the other copy honest.
+
+    #133 is what this catches: two rungs in `software.yaml` handed a non-OSI license an
+    open-bucket class and went unnoticed for weeks because the tier's `examples` list was
+    empty, so the rungs could never fire.
+    """
+    problems = []
+    declared = _dimensions(recipe)
+    tiers = ((_openness(recipe).get("license_tier") or {}).get("values") or {}).keys()
+    seen_otherwise = False
+    for index, rule in enumerate(_formula(recipe)):
+        if seen_otherwise:
+            problems.append(
+                f"category '{slug}' formula rule {index} is declared after an `otherwise`, "
+                f"so it can never fire"
+            )
+        if "otherwise" in rule:
+            seen_otherwise = True
+            continue
+        for key, value in (rule.get("when") or {}).items():
+            if key == "license_tier":
+                if value not in tiers:
+                    problems.append(
+                        f"category '{slug}' rule {index} tests license_tier={value!r}, "
+                        f"which is not one of its declared tiers {sorted(tiers)}"
+                    )
+            elif key not in declared:
+                problems.append(
+                    f"category '{slug}' rule {index} tests undeclared dimension {key!r}"
+                )
+            elif value not in ((declared[key] or {}).get("values") or []):
+                problems.append(
+                    f"category '{slug}' rule {index} tests {key}={value!r}, which is not in "
+                    f"its declared values {(declared[key] or {}).get('values')}"
+                )
+    return problems
+
+
+def license_tier_order_is_explicit(slug: str, recipe: dict) -> list[str]:
+    """`tier_rank` is emitted from declaration order, so the order must be load-bearing.
+
+    Only required above one tier: with nothing to compare against, "most restrictive" has
+    nothing to resolve. A ladder with no `license_tier` at all is fine — hardware openness
+    turns on design and toolchain rather than a source license.
+    """
+    spec = _openness(recipe).get("license_tier") or {}
+    values = spec.get("values") or {}
+    if len(values) > 1 and spec.get("ordered_by") != "restrictiveness_ascending":
+        return [
+            f"category '{slug}' declares {len(values)} license tiers but no "
+            f"`ordered_by: restrictiveness_ascending`, so `tier_rank` has no defined meaning"
+        ]
+    return []
+
+
+def _tested_dimensions(recipe: dict) -> set[str]:
+    """Dimensions some rung actually reads. A declared-but-untested dimension is legitimate."""
+    return {
+        key
+        for rule in _formula(recipe)
+        for key in (rule.get("when") or {})
+        if key != "license_tier"
+    }
+
+
+def clauses_parse(
+    slug: str, recipe: dict, components: dict[str, str], deferred: set[str]
+) -> tuple[list[str], list[str], int]:
+    """Return (blocking, reported, total_dropped) for keyless `components` clauses.
+
+    `split_components` discards any clause without a colon, silently. Across the map that is
+    170 of 470 products, and asserting on all of them would fail the gate on day one — which
+    `docs/guides/verification.md` already identifies as how a gate dies. Narrowing by hand
+    found three populations, and only one is a defect:
+
+    - a clause matching nothing in the category's vocabulary: a free-text tail, harmless
+    - a clause restating something already recorded under a proper key: overwhelmingly
+      `no feature-gated core` beside `core-gated:ungated`, left behind when #128's correction
+      pass added the key without removing the prose. Harmless, and failing on it would teach
+      contributors that this gate is noise.
+    - a clause that is the ONLY record of a dimension: the real defect, and what cost
+      `dataset.yaml` five of its eight deferrals
+
+    So a clause blocks only when it is the sole record of a dimension SOME RUNG TESTS and the
+    product is not already deferred. Everything else is reported or counted. That starts at
+    zero blocking failures, which is what makes it a ratchet rather than a backlog.
+    """
+    blocking: list[str] = []
+    reported: list[str] = []
+    total = 0
+    tested = _tested_dimensions(recipe)
+    dimensions = _dimensions(recipe)
+
+    for product, raw in sorted(components.items()):
+        dropped = [clause for clause in split_clauses(raw) if ":" not in clause]
+        if not dropped:
+            continue
+        total += len(dropped)
+        parsed = split_components(raw)
+        for name, spec in dimensions.items():
+            # Already answered under a proper key, so a prose restatement changes nothing.
+            if dimension_value(parsed, name, recipe):
+                continue
+            allowed = {str(value).lower() for value in ((spec or {}).get("values") or [])}
+            for clause in dropped:
+                words = {
+                    word.strip(".,()").lower() for word in clause.replace("-", " ").split()
+                } | {clause.lower()}
+                if not (words & allowed):
+                    continue
+                where = f"category '{slug}' product '{product}': {clause!r}"
+                if name in tested and product not in deferred:
+                    blocking.append(
+                        f"{where} is the only record of dimension '{name}', which the "
+                        f"formula tests, and the clause has no key so the parser discards "
+                        f"it. Record it as `{name}:<value>`."
+                    )
+                else:
+                    why = "deferred" if product in deferred else f"'{name}' is untested"
+                    reported.append(f"{where} holds '{name}' with no key ({why})")
+    return blocking, reported, total
+
+
+def undeclared_keys_holding_evidence(
+    slug: str, recipe: dict, components: dict[str, str], deferred: set[str]
+) -> tuple[list[str], list[str], int]:
+    """Return (blocking, reported, undeclared_key_count) for keys outside the vocabulary.
+
+    An undeclared key is only a defect when it is the ONLY answer to a dimension the formula
+    tests AND its recorded value is inside that dimension's enum. Then the ladder reads the
+    dimension as unrecorded and either abstains or falls through, while the answer was
+    sitting in the file under a different name.
+
+    Scoped the same way and for the same reason as `clauses_parse`. `serialize_rubric --check`
+    already reports every undeclared key as vocabulary drift, and there are 113 distinct ones
+    across 384 recordings — `self-host` alone appears 52 times. Gating that would fail on day
+    one, and the alternative of declaring all 113 as context is a curation project, not a
+    gate: a schema key that needs 113 entries before it asserts anything asserts nothing.
+
+    So the loose warning stays in `serialize_rubric` where it belongs, and this gates the six
+    cases where the key demonstrably holds an answer the ladder wanted. That is a ratchet.
+
+    `ornith` was the one non-deferred instance: it recorded `recipe:closed` and nothing under
+    `code`, so its 3/open_weights came from the `otherwise` rather than from its evidence.
+    Fixed by adding `recipe` to `code`'s `reads` list, which changed no score.
+    """
+    vocabulary = set(dimension_read_map(recipe)) | set(license_read_keys(recipe))
+    dimensions = _dimensions(recipe)
+    tested = _tested_dimensions(recipe)
+
+    blocking: list[str] = []
+    reported: list[str] = []
+    undeclared: set[str] = set()
+
+    for product, raw in sorted(components.items()):
+        parsed = split_components(raw)
+        for key, value in parsed.items():
+            if key in vocabulary:
+                continue
+            undeclared.add(key)
+            for name in sorted(tested):
+                # Already answered under a key the ladder reads, so the synonym is harmless.
+                if dimension_value(parsed, name, recipe):
+                    continue
+                allowed = {
+                    str(item).lower() for item in ((dimensions[name] or {}).get("values") or [])
+                }
+                if head(value).lower() not in allowed:
+                    continue
+                where = f"category '{slug}' product '{product}': '{key}:{head(value)}'"
+                if product in deferred:
+                    reported.append(f"{where} could answer '{name}' (product is deferred)")
+                else:
+                    blocking.append(
+                        f"{where} is the only answer to dimension '{name}', which the "
+                        f"formula tests, under a key the ladder does not read. Add '{key}' "
+                        f"to that dimension's `reads`, or record it under '{name}'."
+                    )
+    return blocking, reported, len(undeclared)
+
+
+def check_one(slug: str, verbose: bool) -> tuple[list[str], list[str]]:
+    """Check one category. Returns (failures, report_lines)."""
+    category = yaml.safe_load(
+        (ROOT / "sources" / "categories" / f"{slug}.yaml").read_text()
+    )
+    variants, errors = resolve_recipe_variants(category, load_shared(ROOT))
+    if errors:
+        return [f"category '{slug}': {error}" for error in errors], []
+
+    product_types = load_product_types(ROOT)
+    deferred = set((category.get("scoring_recipe") or {}).get("deferred") or {})
+    products = category.get("products") or []
+
+    # A mixed category holds one ladder per product type, so structural assertions run per
+    # VARIANT. `safeguards` is the case: a defect in its software half must not be masked by
+    # a clean model half.
+    failures: list[str] = []
+    reported: list[str] = []
+    dimension_count = 0
+    rule_count = 0
+    tier_count = 0
+    for _, recipe in sorted(variants.items()):
+        failures += every_rung_has_a_because(slug, recipe)
+        failures += every_dimension_has_a_machine_signal(slug, recipe)
+        failures += no_unreachable_rule(slug, recipe)
+        failures += license_tier_order_is_explicit(slug, recipe)
+        dimension_count += len(_dimensions(recipe))
+        rule_count += len(_formula(recipe))
+        tier_count += len(
+            (_openness(recipe).get("license_tier") or {}).get("values") or {}
+        )
+
+    # Evidence assertions are per product, against that product's own ladder.
+    by_recipe: dict[int, dict[str, str]] = {}
+    impossible = 0
+    for product in products:
+        path = ROOT / "sources" / "scores" / f"{product}.yaml"
+        if not path.exists():
+            continue
+        openness = (yaml.safe_load(path.read_text()) or {}).get("openness") or {}
+        recipe, _ = recipe_for(variants, product_types.get(product, ""))
+        if recipe is None:
+            continue
+        by_recipe.setdefault(id(recipe), {})[product] = openness.get("components") or ""
+        pair = (openness.get("score"), openness.get("class"))
+        if pair[0] is not None and pair not in producible_pairs(recipe):
+            impossible += 1
+            failures.append(
+                f"category '{slug}' product '{product}': {pair[0]}/{pair[1]} is not an "
+                f"outcome any rule produces"
+            )
+
+    dropped_total = 0
+    undeclared_total = 0
+    for recipe in {id(r): r for r in variants.values()}.values():
+        components = by_recipe.get(id(recipe), {})
+        blocking, reports, dropped = clauses_parse(slug, recipe, components, deferred)
+        failures += blocking
+        reported += reports
+        dropped_total += dropped
+        blocking, reports, undeclared = undeclared_keys_holding_evidence(
+            slug, recipe, components, deferred
+        )
+        failures += blocking
+        reported += reports
+        undeclared_total += undeclared
+
+    # Deferral completeness: a product that neither reproduces nor is declared is a silent
+    # abstention, which is the exact convention violation the safeguards review found -- 11
+    # auto-abstaining products, invisible in the category YAML, while all 41 of their
+    # counterparts elsewhere were declared. Nothing caught it.
+    reproduced, total, problems, deferrals = check_category(slug, verbose=False)
+    silent = [entry for entry in deferrals if "recipe does not decide it" in entry]
+    for entry in silent:
+        failures.append(
+            f"category '{slug}' product '{entry.split(':')[0]}' abstains silently: it is "
+            f"not in `deferred:` and no rung decides it"
+        )
+    for product, block in ((category.get("scoring_recipe") or {}).get("deferred") or {}).items():
+        if not str((block or {}).get("because") or "").strip():
+            failures.append(
+                f"category '{slug}' defers '{product}' with no reason. Deferral is the "
+                f"honest state; silence is not."
+            )
+
+    lines = [
+        f"  dimensions declared ...... {dimension_count:<4}"
+        f"({len(variants)} ladder variant(s))",
+        f"  rules .................... {rule_count:<4}(0 unreachable, 0 missing `because`)"
+        if not failures
+        else f"  rules .................... {rule_count}",
+        f"  license tiers ............ {tier_count}",
+        f"  products ................. {len(products):<4}"
+        f"({reproduced} reproduce, {len(deferrals)} deferred, {len(silent)} silent)",
+        f"  impossible pairs ......... {impossible}",
+        f"  clauses .................. {dropped_total} dropped, "
+        f"{len([f for f in failures if 'has no key so the parser' in f])} blocking",
+        f"  undeclared keys .......... {undeclared_total} "
+        f"(context, reported by serialize_rubric)",
+    ]
+    if verbose:
+        lines += [f"  ~ {line}" for line in reported]
+    # `problems` is check_rubric's reproduction mismatch list. Reported, never gated: a
+    # mismatch is a finding about a product and gating it would pressure someone into
+    # editing a score to make a ladder pass.
+    if verbose and problems:
+        lines += [f"  ! reproduction mismatch: {line}" for line in problems]
+    return failures, lines
+
+
+def check_recipe(slug: str | None = None, verbose: bool = False) -> tuple[list[str], list[str]]:
+    """Check one category, or every category carrying a recipe."""
+    shared = load_shared(ROOT)
+    if slug:
+        slugs = [slug]
+    else:
+        slugs = []
+        for path in sorted((ROOT / "sources" / "categories").glob("*.yaml")):
+            category = yaml.safe_load(path.read_text()) or {}
+            variants, errors = resolve_recipe_variants(category, shared)
+            if variants and not errors:
+                slugs.append(category["name"])
+
+    all_failures: list[str] = []
+    all_lines: list[str] = []
+    for name in slugs:
+        failures, lines = check_one(name, verbose)
+        all_failures += failures
+        all_lines.append(f"\n{name}")
+        all_lines += lines
+        for failure in failures:
+            all_lines.append(f"  FAIL  {failure}")
+        all_lines.append("  [FAIL]" if failures else "  [OK]  ready for human review")
+    return all_failures, all_lines
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--category", help="one category slug; default is every recipe")
+    parser.add_argument("--all", action="store_true", help="every recipe (the default)")
+    parser.add_argument("--verbose", action="store_true", help="itemize reported items")
+    args = parser.parse_args()
+
+    failures, lines = check_recipe(args.category, args.verbose)
+    print("\n".join(lines))
+    if failures:
+        print(f"\n{len(failures)} failure(s)")
+        return 1
+    print("\n0 failure(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/build-rubric/SKILL.md
+++ b/skills/build-rubric/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: build-rubric
+description: Use when a category needs a `scoring_recipe` — deriving an openness ladder from the scores a category already carries, or extending a shared ladder to a new category, in os-ai-map.
+---
+
+# Build a Rubric
+
+A `scoring_recipe` is a machine-readable openness ladder: the dimensions a category asks
+about, the license tiers it recognizes, and an ordered formula that turns recorded evidence
+into a `(score, class)` pair. It lets `check_rubric` re-derive every score in the category from
+the evidence, which is the difference between a score that is documented and a score that is
+checkable.
+
+Ladders live in `sources/rubrics/<name>.yaml` when shared, and inline under
+`scoring_recipe.openness` in a category file when they are not. A category opts in with
+`scoring_recipe: {extends: <name>}`, or `{extends: {model: model, software: software}}` where
+its roster mixes product types.
+
+## The one rule above the others
+
+**Reproduction rate is a diagnostic, never a target.**
+
+A ladder tuned until it reproduces every recorded score is a curve fit to the data it was
+supposed to check. It looks rigorous and is worth less than nothing, because it retires a
+check while appearing to pass it.
+
+- Finding a real mismatch and *lowering* the reproduction rate is a good day's work.
+- `safeguards` reproduced 0 of 26 and that was the correct outcome. The mismatches were the
+  finding.
+- Never add a rung whose only justification is that one product needs it.
+- Never edit a score to make a ladder reproduce. **You do not edit `sources/scores/` at all** —
+  see Boundaries.
+
+`check_recipe` therefore asserts nothing about the rate in either direction.
+
+## Step 0 — check the category can be laddered at all
+
+Do this before anything else. It is a few lines and it has twice been the difference between
+a day's work and a wasted one.
+
+`check_rubric` resolves a dimension by taking `head(value)` — everything before the first `(`
+or `,` — and testing it against the dimension's declared enum. That works when values are
+controlled tokens with an optional parenthetical, which is how most of the map was curated.
+It cannot work when values are sentences. Count them:
+
+```python
+# prose share of components values, for one category
+from build.check_rubric import split_components, head
+prose = sum(1 for v in vals if len(head(v).split()) > 1)
+```
+
+Reference points measured 2026-07-31: `base_pretrained` 0% prose, `training_synthetic_datasets`
+2%, `benchmark_eval_data` 15%, `safeguards` 19%, `deployment` 25%, **`edge_hardware` 71% with
+no product recording a license at all**.
+
+`edge_hardware` was chosen first precisely because 18 of its 20 products record the same five
+keys. Key coverage is not readiness. Its values are prose in the two keys that decide the
+score, so no ladder can read it, and the correct move was to stop and propose a normalization
+rather than build an alias map around it — see
+`plans/reports/2026-07-31-edge-hardware-derivation.md` (local, not in this repo) for the worked
+case.
+
+If the values are prose: **stop and write a proposal.** A per-value alias map is the tempting
+alternative and it is the curve fit relocated from the formula into the value map — a license
+name is a closed external vocabulary where each entry is a fact, but prose is authored per
+product, so an alias list needs an entry per product and the next product invents a new
+phrasing.
+
+## The derivation, nine steps
+
+1. **Inventory the prose.** Dump every `components` key and value across the category with
+   counts. This reveals the questions already being answered and where the spelling drift is.
+   `software.yaml`'s header records about forty phrasings behind two dimensions.
+2. **Cluster into candidate dimensions.** Name the small number of questions the prose is
+   actually answering. Two for software, three for a dataset, three or four for a model.
+   Read the `note:` field on the boundary products — the reasoning that distinguishes a 4 from
+   a 5 is usually there rather than in `components`.
+3. **Name controlled values, and absorb spelling drift with `reads:`.** Never rewrite a score
+   file to match a key you chose. `redistributability` and `redistributable` become one
+   dimension with two `reads`.
+
+   **`reads:` absorbs drift in the KEY only — never in the value, and never in the polarity.**
+   It selects a key and takes its value, so it cannot invert one. `gated: false`,
+   `ungated: yes` and `access: ungated` are one fact three ways. The way out is to make every
+   *positive* spelling a distinct token, test only those in the formula, and let every spelling
+   of "no gate" fall through to the rungs below.
+4. **Build `license_tier` with declaration order = restrictiveness ascending.** `tier_rank` is
+   emitted from that order, so the order is load-bearing rather than cosmetic. List spelling
+   variants literally: whether AGPL is OSI is a fact, and a fact is cheaper to look up than a
+   regex is to get right.
+5. **Write the formula: ordered, first match wins, `because` on every rung.** The `because` is
+   the reviewable artifact — what a human reads where a machine cannot judge. `check_recipe`
+   requires it.
+
+   **Require positive evidence for the top rung.** If a rung fires on the *absence* of bad
+   evidence, a product that recorded nothing scores full marks. `dataset.yaml`'s top rung tests
+   `documentation` for exactly this reason: its gate rungs fire on positive gate tokens, so a
+   product with no gate key is *unrecorded*, not ungated.
+6. **Decide `otherwise` deliberately and record the decision.** `software.yaml` has none on
+   purpose — a third of its products do not record `core-gated`, and an `otherwise` would
+   publish a score for every one of them. `model.yaml` has one, landing on the category's
+   center of gravity. A judgment per ladder, never a default. An `otherwise` must not land in
+   the `open` bucket, or unrecorded evidence counts as open.
+7. **Run `check_rubric`. Every non-reproducing product gets a real per-product deferral reason,
+   or goes in the report.** Never a score edit. The reason must say what is actually wrong with
+   that product. Read two existing `deferred:` blocks before writing yours.
+8. **Record `machine_signal` per dimension.** What a fetcher could settle later, and what will
+   always need a human read. Required even when the answer is `none`: "nobody has thought about
+   it" and "this needs a human forever" are different facts, and the automation roadmap depends
+   on telling them apart.
+9. **Verify against one category before sharing a ladder.** Prove it on one roster, record the
+   counts in that category's `derived_from`, and only then let a second category `extend` it.
+   `software.yaml` was verified against `deployment` 27/27 before ten categories inherited it.
+
+## Two rules about rungs and dimensions
+
+They pull in opposite directions and both matter.
+
+**A declared dimension with no rung is legitimate.** `blobs`, `retail` and `datasheets` in the
+hardware draft; `checkpoints` in `base_pretrained`. Declare it, give it a `machine_signal`, and
+say in a comment that it discriminates nothing yet. Omitting it turns every product recording
+it into a vocabulary-drift warning.
+
+**A rung with no product is not.** A rule that cannot fire is where a later edit hides. #133 is
+what happens when this is ignored: two rungs in `software.yaml` handed a non-OSI license an
+`open`-bucket class, and nothing noticed for weeks because the tier's `examples` list was empty
+so the rungs could never fire. Assigning one license to that tier would have silently activated
+a 5/open_source rung. `check_recipe` now fails on an unreachable rule.
+
+## The `open` bucket needs an externally-open license
+
+The invariant from #133, enforced by `tests/test_openness_buckets.py`:
+
+> A class in the `open` bucket may only be reached through a license tier that is open by an
+> external standard — OSI approval for code and weights, the Open Definition for data.
+
+This is how a 0–5 score stays compatible with frameworks that are binary. The Model Openness
+Framework classes a release under OpenRAIL, a Llama community license or AI2 ImpACT as
+*source-available* rather than open; OSAID requires the freedom to use a system "for any
+purpose". Both lines fall between our `open` and `open-ish` buckets, and levels 4 down to 1
+subdivide what MOF treats as one bucket. A new ladder's top rung must respect it.
+`docs/guides/openness-spectrum.md` has the full reasoning and the two places the map departs
+from MOF deliberately.
+
+## Run the gate
+
+```
+uv run python -m build.check_recipe --category <slug> --verbose
+```
+
+It asserts what a machine can judge: a `because` on every rung, a `machine_signal` on every
+dimension, no unreachable rule, an explicit license-tier order, no impossible `(score, class)`
+pair, no product abstained on without a declared reason, and no evidence the components parser
+silently discards. It runs in CI on every PR.
+
+What it reports rather than fails on is worth reading. `clauses dropped` counts `components`
+clauses with no key — `split_components` discards those silently, and 170 of 470 products have
+at least one. Most are harmless free-text tails or prose restating a properly keyed value, but
+a clause that is the *only* record of a dimension is lost evidence, and that cost
+`dataset.yaml` five of its eight deferrals. Same for `undeclared keys`: 113 exist across the
+map, and the gate fails only when one demonstrably holds an answer the ladder wanted.
+
+Then the human checklist, which is only what a machine cannot judge:
+
+- Is each dimension the right question to ask about **this product type**? A corpus has no
+  runtime to self-host; a tune's data question is the post-training mixture, not the base
+  model's corpus.
+- Does each `because` explain why the rung produces *that score*, rather than restating the
+  condition?
+- Would a contributor reading only this file reach the same score for a product not in the
+  roster?
+
+## Boundaries
+
+- **Never edit anything under `sources/scores/`.** Not one file, for any reason. You author the
+  ladder and the `deferred:` block. A score you believe is wrong goes in a report for a human,
+  batched for review. The verification guide rests on scores being re-derivable rather than
+  asserted, and the first pass of `sources/scores/` was itself agent-authored, so authorship
+  establishes no trust.
+- `components` fields may only ever be edited via `build/components.py`, never by hand.
+- Never hand-edit `build/notebook_data.json` or anything under `notebooks/` — bot-regenerated,
+  and CI blocks PRs that touch them. `build/serialize` writes `notebook_data.json` as a side
+  effect, so check `git status` after running it.
+- Read-only on the warehouse. No uploads, no publish. `currentai.scores.openness_computed`
+  mirrors this formula walk by hand in SQL and does not follow automatically — if you change
+  resolution semantics, say so loudly in the PR.
+- Open a PR. Do not merge.
+
+## Full gate before a final commit
+
+```
+uv run python -m build.validate           # 0 error(s)
+uv run pytest -q
+uv run python -m build.check_recipe       # 0 failure(s)
+uv run python -m build.check_rubric       # diff against a baseline captured BEFORE you start
+uv run python -m build.check_verification
+uv run python -m build.serialize_rubric --check
+```
+
+A new recipe legitimately changes `check_rubric` and `serialize_rubric --check` for its own
+category and nothing else. **If any other category's counts move, stop and report** — you have
+changed shared resolution semantics.

--- a/skills/curate-category/SKILL.md
+++ b/skills/curate-category/SKILL.md
@@ -14,7 +14,9 @@ product roster** (the array order is the display order).
 1. Open `sources/categories/<slug>.yaml`.
 2. Edit any of: `display_name`, `strapline`, `weights.{adopt,cap}`,
    `scoring_recipe`, `comments`, and the `products:` roster. The `name` field is the
-   slug; do not rename it after creation. To regroup or reorder categories across
+   slug; do not rename it after creation. For `scoring_recipe` — deriving a new openness
+   ladder, or extending a shared one to this category — use the `build-rubric` skill; it
+   carries the derivation procedure and the gate that has to pass. To regroup or reorder categories across
    arcs, edit `sources/taxonomy.yaml`: that is the only place arc grouping and
    cross-category display order live (a category file no longer carries `arc` or `order`).
 3. To add a product, it must already have a `sources/products/<slug>.yaml` and a

--- a/sources/categories/base_pretrained.yaml
+++ b/sources/categories/base_pretrained.yaml
@@ -119,20 +119,44 @@ scoring_recipe:
     formula:
     - when: {weights: closed}
       then: {score: 1, class: closed}
+      because: >-
+        No downloadable weights, so there is no artifact for the license or the corpus to be
+        open about. Checked ahead of every license rung: an OSI license on a model nobody can
+        run is not worth a point.
     - when: {license_tier: proprietary}
       then: {score: 1, class: closed}
+      because: >-
+        No public license means no permission to rely on, whatever else was published.
     - when: {license_tier: use_restricted}
       then: {score: 2, class: restricted}
-      note: Open weights behind a use cap. Downloadable is not the same as usable.
+      because: >-
+        Open weights behind a use cap. Downloadable is not the same as usable, and this rung
+        sits ahead of the data and code rungs deliberately: publishing the pretraining corpus
+        does not buy back the right to use the model.
     - when: {data: open, code: open, license_tier: osi}
       then: {score: 5, class: open_source}
+      because: >-
+        The pretraining corpus, the code that consumed it, and an OSI license over the
+        weights. Pythia and the OLMo family are what this rung was written for.
     - when: {data: open, code: open}
       then: {score: 4, class: open_weights}
-      note: Full pipeline but a non-OSI license caps the score at 4.
+      because: >-
+        Full pipeline but a non-OSI license caps the score at 4. MOF would call this
+        source-available rather than open, so it must not reach the `open` bucket; see
+        docs/guides/openness-spectrum.md.
     - when: {data: documented-not-released, code: open}
       then: {score: 4, class: open_weights}
+      because: >-
+        A corpus described in enough detail to audit the mixture, and the code to rebuild
+        against it, but the corpus itself withheld. Level with a non-OSI full release rather
+        than below it, because a reader can check the claims either way. `finetuned_chat`
+        deliberately omits this rung - no tune there pairs a described mixture with an open
+        pipeline, and a rule that cannot fire is a place for a later edit to hide.
     - otherwise: {score: 3, class: open_weights}
-      note: The category's center of gravity — open weights, closed data.
+      because: >-
+        The category's center of gravity - open weights, closed data. A fallthrough rather
+        than a rule because it is what remains once the cases above are spent, and it lands
+        in the open-ish bucket so unrecorded evidence never counts as open.
 
   adoption:
     # Signal choice follows openness: a closed model has no artifact to measure,

--- a/sources/rubrics/dataset.yaml
+++ b/sources/rubrics/dataset.yaml
@@ -159,3 +159,7 @@ openness:
     because: One license covering the release, an open download, and a card. Nothing withheld.
   - when: {license_tier: open_data, documentation: 'yes'}
     then: {score: 5, class: open}
+    because: >-
+      The rung above, for the five products that record the card as `yes` rather than
+      `present`. Two spellings of one value, so two rungs; a components normalization on
+      this category would collapse them back into one.

--- a/sources/rubrics/model.yaml
+++ b/sources/rubrics/model.yaml
@@ -43,6 +43,13 @@ openness:
         vocabulary is issue #106.
     code:
       question: Is the fine-tuning pipeline released, not just inference code?
+      # `recipe` is how two products spell this, and it is the more natural word for a
+      # post-training pipeline. `code` stays first: `tulu` records both, and where a product
+      # answers under either key the more widely used one wins. Found by check_recipe --
+      # `ornith` recorded only `recipe:closed`, so the ladder read `code` as unrecorded and
+      # reproduced its 3/open_weights through the `otherwise` rather than through the
+      # evidence. Same score, and now for the right reason.
+      reads: [code, recipe]
       values: [open, partial, closed]
       evidence:
       - '`open`: the post-training recipe - SFT/DPO/RL configs and scripts'
@@ -120,15 +127,34 @@ openness:
   formula:
   - when: {weights: closed}
     then: {score: 1, class: closed}
+    because: >-
+      No downloadable weights, so there is no artifact for the license or the recipe to be
+      open about. Checked first, ahead of every license rung, because an OSI license on a
+      model nobody can run is not worth a point.
   - when: {license_tier: proprietary}
     then: {score: 1, class: closed}
+    because: >-
+      No public license means no permission to rely on, whatever else was published. Scored
+      beside closed weights rather than above them.
   - when: {license_tier: use_restricted}
     then: {score: 2, class: restricted}
-    note: Open weights behind a use cap. Downloadable is not the same as usable.
+    because: >-
+      Open weights behind a use cap. Downloadable is not the same as usable, and this rung
+      sits ahead of the data and code rungs on purpose: a full open recipe does not buy back
+      the right to use the result.
   - when: {data: open, code: open, license_tier: osi}
     then: {score: 5, class: open_source}
+    because: >-
+      The whole tune is reproducible and the license permits it - post-training mixture, the
+      pipeline that consumed it, and an OSI license over the weights.
   - when: {data: open, code: open}
     then: {score: 4, class: open_weights}
-    note: Full recipe but a non-OSI license caps the score at 4.
+    because: >-
+      Full recipe but a non-OSI license caps the score at 4. The Model Openness Framework
+      would call this source-available rather than open, so it must not reach the `open`
+      bucket; see docs/guides/openness-spectrum.md.
   - otherwise: {score: 3, class: open_weights}
-    note: The category's center of gravity - open weights, closed recipe.
+    because: >-
+      The category's center of gravity - open weights, closed recipe. A fallthrough rather
+      than a rule because it is what remains once the cases above are spent, and it lands in
+      the open-ish bucket so unrecorded evidence never counts as open.

--- a/tests/test_check_recipe.py
+++ b/tests/test_check_recipe.py
@@ -1,0 +1,305 @@
+"""Tests for the recipe gate.
+
+Each assertion gets a synthetic recipe that violates it and one that does not, because a
+gate is only worth having if it has been seen to fail. The last test runs `--all` against
+the repo's real sources and asserts it exits clean: that is the regression guard, and it is
+what fails when someone lands a recipe without a `because`.
+"""
+
+import pytest
+
+from build.check_recipe import (
+    check_recipe,
+    clauses_parse,
+    every_dimension_has_a_machine_signal,
+    every_rung_has_a_because,
+    license_tier_order_is_explicit,
+    no_unreachable_rule,
+    split_clauses,
+    undeclared_keys_holding_evidence,
+)
+
+# A structurally complete, passing recipe. Each test below mutates a copy, so the fixture
+# doubles as the negative control for every assertion.
+GOOD = {
+    "version": 1,
+    "openness": {
+        "dimensions": {
+            "source": {
+                "question": "Is the source published?",
+                "values": ["public", "closed"],
+                "machine_signal": "partial - repo presence from signal_github.repo_state",
+            },
+        },
+        "license_tier": {
+            "ordered_by": "restrictiveness_ascending",
+            "values": {
+                "osi": {"examples": ["MIT"]},
+                "proprietary": {"definition": "no public license"},
+            },
+        },
+        "formula": [
+            {
+                "when": {"source": "closed"},
+                "then": {"score": 1, "class": "closed"},
+                "because": "Nothing published, so the license cannot help.",
+            },
+            {
+                "when": {"source": "public", "license_tier": "osi"},
+                "then": {"score": 5, "class": "open_source"},
+                "because": "The published source is the whole product.",
+            },
+        ],
+    },
+}
+
+
+def _mutate(**openness):
+    recipe = {"version": 1, "openness": {**GOOD["openness"], **openness}}
+    return recipe
+
+
+def test_split_clauses_keeps_the_colonless_ones_the_parser_drops():
+    """`split_components` discards a clause with no colon; this must retain it.
+
+    The whole point of the clause assertion is to see what the parser threw away, so it
+    cannot reuse the parser.
+    """
+    from build.check_rubric import split_components
+
+    text = "license:MIT(OSI; see LICENSE);no feature-gated core;source:public"
+    assert split_components(text) == {"license": "MIT(OSI; see LICENSE)", "source": "public"}
+    assert split_clauses(text) == [
+        "license:MIT(OSI; see LICENSE)",
+        "no feature-gated core",
+        "source:public",
+    ]
+
+
+def test_a_rung_without_a_because_fails():
+    assert every_rung_has_a_because("cat", GOOD) == []
+    formula = [dict(GOOD["openness"]["formula"][0]), {"otherwise": {"score": 3, "class": "x"}}]
+    problems = every_rung_has_a_because("cat", _mutate(formula=formula))
+    assert len(problems) == 1
+    assert "rule 1" in problems[0]
+
+
+def test_a_note_does_not_satisfy_the_because_requirement():
+    """One field, one name. `note` was the other spelling and it has been migrated."""
+    formula = [{"when": {"source": "closed"}, "then": {"score": 1, "class": "closed"},
+                "note": "reads like a justification but is not the declared key"}]
+    assert len(every_rung_has_a_because("cat", _mutate(formula=formula))) == 1
+
+
+def test_an_empty_because_fails_like_a_missing_one():
+    formula = [{"when": {"source": "closed"}, "then": {"score": 1, "class": "closed"},
+                "because": "   "}]
+    assert len(every_rung_has_a_because("cat", _mutate(formula=formula))) == 1
+
+
+def test_a_dimension_without_a_machine_signal_fails():
+    assert every_dimension_has_a_machine_signal("cat", GOOD) == []
+    dimensions = {"source": {"question": "?", "values": ["public"]}}
+    problems = every_dimension_has_a_machine_signal("cat", _mutate(dimensions=dimensions))
+    assert len(problems) == 1
+    assert "source" in problems[0]
+
+
+def test_a_rule_after_an_otherwise_is_unreachable():
+    assert no_unreachable_rule("cat", GOOD) == []
+    formula = [
+        {"otherwise": {"score": 3, "class": "open_weights"}, "because": "fallthrough"},
+        {"when": {"source": "closed"}, "then": {"score": 1, "class": "closed"}, "because": "dead"},
+    ]
+    problems = no_unreachable_rule("cat", _mutate(formula=formula))
+    assert len(problems) == 1
+    assert "rule 1" in problems[0] and "otherwise" in problems[0]
+
+
+def test_a_rule_testing_an_undeclared_dimension_is_unreachable():
+    formula = [
+        {"when": {"governance": "foundation"}, "then": {"score": 4, "class": "x"},
+         "because": "cannot fire"},
+    ]
+    problems = no_unreachable_rule("cat", _mutate(formula=formula))
+    assert any("governance" in p for p in problems)
+
+
+def test_a_rule_testing_a_value_outside_the_declared_enum_is_unreachable():
+    formula = [
+        {"when": {"source": "partial"}, "then": {"score": 2, "class": "source_available"},
+         "because": "partial is not declared"},
+    ]
+    problems = no_unreachable_rule("cat", _mutate(formula=formula))
+    assert any("partial" in p for p in problems)
+
+
+def test_multiple_tiers_without_an_explicit_order_fails():
+    assert license_tier_order_is_explicit("cat", GOOD) == []
+    tier = {"values": GOOD["openness"]["license_tier"]["values"]}  # no ordered_by
+    problems = license_tier_order_is_explicit("cat", _mutate(license_tier=tier))
+    assert len(problems) == 1
+
+
+def test_a_single_tier_needs_no_declared_order():
+    """`tier_rank` is only meaningful when there is something to compare against."""
+    tier = {"values": {"osi": {"examples": ["MIT"]}}}
+    assert license_tier_order_is_explicit("cat", _mutate(license_tier=tier)) == []
+
+
+def test_a_tier_free_ladder_does_not_crash():
+    """Hardware openness turns on design and toolchain, not a source license.
+
+    `check_rubric` cannot yet score such a ladder, but the gate must not be what blocks one
+    from being written.
+    """
+    openness = {k: v for k, v in GOOD["openness"].items() if k != "license_tier"}
+    recipe = {"version": 1, "openness": openness}
+    assert license_tier_order_is_explicit("cat", recipe) == []
+    assert every_rung_has_a_because("cat", recipe) == []
+
+
+class TestClausesParse:
+    """The three-way scoping: fail, report, count.
+
+    Naively asserting that every clause parses fails 166 products, and a gate that fails on
+    day one gets switched off. Only a clause that is the ONLY record of a dimension some rung
+    actually tests can block.
+    """
+
+    def test_a_colonless_clause_holding_a_tested_dimension_blocks(self):
+        blocking, reported, total = clauses_parse(
+            "cat", GOOD, {"p": "no public source shipped"}, deferred=set()
+        )
+        assert total == 1
+        assert len(blocking) == 1 and "p" in blocking[0]
+        assert reported == []
+
+    def test_the_same_clause_only_reports_when_the_product_is_deferred(self):
+        blocking, reported, total = clauses_parse(
+            "cat", GOOD, {"p": "no public source shipped"}, deferred={"p"}
+        )
+        assert blocking == []
+        assert len(reported) == 1
+
+    def test_a_clause_beside_a_properly_keyed_value_is_only_counted(self):
+        """`no feature-gated core;core-gated:ungated` is redundant prose, not lost evidence."""
+        blocking, reported, total = clauses_parse(
+            "cat", GOOD, {"p": "source:public;no source published"}, deferred=set()
+        )
+        assert blocking == [] and reported == []
+        assert total == 1
+
+    def test_the_matcher_reads_declared_values_not_dimension_names(self):
+        """A clause naming the dimension but no value answers nothing.
+
+        The real cases match on the value: `no-feature-gated-core` hits `core_gated`'s
+        `gated`, and `dataset card present` hits `documentation`'s `present`.
+        """
+        blocking, reported, total = clauses_parse(
+            "cat", GOOD, {"p": "source unavailable"}, deferred=set()
+        )
+        assert blocking == [] and reported == []
+        assert total == 1
+
+    def test_a_clause_matching_nothing_is_only_counted(self):
+        blocking, reported, total = clauses_parse(
+            "cat", GOOD, {"p": "source:public;built on ggml"}, deferred=set()
+        )
+        assert blocking == [] and reported == []
+        assert total == 1
+
+    def test_a_clause_holding_a_dimension_no_rung_tests_only_reports(self):
+        """`base_pretrained/ernie` is this shape: `checkpoints` is declared and untested."""
+        dimensions = {
+            **GOOD["openness"]["dimensions"],
+            "checkpoints": {"question": "?", "values": ["released", "none"],
+                            "machine_signal": "none"},
+        }
+        blocking, reported, total = clauses_parse(
+            "cat", _mutate(dimensions=dimensions),
+            {"p": "source:public;no checkpoints released"}, deferred=set(),
+        )
+        assert blocking == []
+        assert len(reported) == 1
+
+
+class TestUndeclaredKeys:
+    """Scoped like the clause check, and for the same reason.
+
+    113 distinct undeclared keys exist across 384 recordings (`self-host` alone appears 52
+    times). Gating all of them fails on day one; declaring all of them is a curation project.
+    Only a key whose VALUE answers a dimension the formula tests, where nothing else does,
+    is a defect — the ladder reads that dimension as unrecorded while the answer sits in the
+    file under another name.
+    """
+
+    def test_a_synonym_holding_the_only_answer_blocks(self):
+        """`ornith` was this: `recipe:closed` and nothing under `code`."""
+        blocking, reported, count = undeclared_keys_holding_evidence(
+            "cat", GOOD, {"p": "src-tree:public"}, deferred=set()
+        )
+        assert len(blocking) == 1 and "src-tree" in blocking[0]
+        assert count == 1
+
+    def test_the_same_synonym_only_reports_when_deferred(self):
+        blocking, reported, _ = undeclared_keys_holding_evidence(
+            "cat", GOOD, {"p": "src-tree:public"}, deferred={"p"}
+        )
+        assert blocking == [] and len(reported) == 1
+
+    def test_a_synonym_beside_a_readable_answer_is_only_counted(self):
+        blocking, reported, count = undeclared_keys_holding_evidence(
+            "cat", GOOD, {"p": "source:public;src-tree:public"}, deferred=set()
+        )
+        assert blocking == [] and reported == []
+        assert count == 1
+
+    def test_a_context_key_whose_value_answers_nothing_is_only_counted(self):
+        """`rows`, `size`, `format`, `github` — context, not openness questions."""
+        blocking, reported, count = undeclared_keys_holding_evidence(
+            "cat", GOOD, {"p": "source:public;rows:1M;size:940MB"}, deferred=set()
+        )
+        assert blocking == [] and reported == []
+        assert count == 2
+
+    def test_a_key_in_a_dimensions_reads_list_is_declared(self):
+        dimensions = {
+            "source": {"question": "?", "values": ["public", "closed"],
+                       "reads": ["source", "src"], "machine_signal": "none"},
+        }
+        blocking, _, count = undeclared_keys_holding_evidence(
+            "cat", _mutate(dimensions=dimensions), {"p": "src:public"}, deferred=set()
+        )
+        assert blocking == [] and count == 0
+
+    def test_the_license_read_keys_are_declared(self):
+        tier = {**GOOD["openness"]["license_tier"], "reads": ["license", "license-terms"]}
+        blocking, _, count = undeclared_keys_holding_evidence(
+            "cat", _mutate(license_tier=tier), {"p": "license-terms:MIT"}, deferred=set()
+        )
+        assert blocking == [] and count == 0
+
+
+def test_reproduction_rate_is_never_asserted():
+    """The one rule above the others.
+
+    A gate that rewards a high reproduction rate turns the ladder into a curve fit to the
+    scores it exists to check. `safeguards` reproduced 0 of 26 and that was correct. Asserted
+    by reading the module source, because the failure mode is someone adding the check later
+    in good faith.
+    """
+    import inspect
+
+    import build.check_recipe as module
+
+    source = inspect.getsource(module)
+    for banned in ("reproduction_rate", "min_reproduced", "MIN_REPRODUCTION", "rate <", "rate >"):
+        assert banned not in source, f"check_recipe must not threshold reproduction ({banned})"
+
+
+@pytest.mark.parametrize("slug", [None])
+def test_the_real_sources_pass_the_gate(slug):
+    """The regression guard. Anything this catches is a real defect or an over-strict rule."""
+    failures, _ = check_recipe(slug)
+    assert failures == [], "\n".join(failures)

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -677,7 +677,10 @@ def test_real_sources_serialize_without_errors():
     # at all now, so `openness_computed` never sees enough rows to score a product the
     # repo declined to stand behind.
     assert per_category("product_openness_evidence") == {
-        "base_pretrained": 111, "finetuned_chat": 172, "deployment": 131,
+        # finetuned_chat rose by 1 when `recipe` joined `code`'s `reads` list: `ornith`
+        # recorded only `recipe:closed`, so its `code` dimension had been reading as
+        # unrecorded and published no evidence row. check_recipe found it.
+        "base_pretrained": 111, "finetuned_chat": 173, "deployment": 131,
         "agent_tools_protocols": 108, "dataset_processing_tools": 86, "evaluation_code": 66,
         "finetuning_code": 119, "inference_code": 47, "ml_frameworks": 80,
         "orchestration_agents": 137, "telemetry_observability": 90, "ui_api": 127,


### PR DESCRIPTION
Phase 2 of the rubric work. Two deliverables: `skills/build-rubric/SKILL.md`, the procedure,
and `build/check_recipe.py`, the part of it a machine can enforce — wired into CI.

`skills/curate-category/SKILL.md` said "edit any of … `scoring_recipe` …" and gave no guidance
on how, which is why every ladder so far was authored from scratch by whoever happened to be
doing it. The taxonomy expansion will add roughly twenty-four more categories, each born needing
a recipe.

## The gate is mostly a ratchet, which is the point

Measured against the 14 existing recipes, most of what the design expected it to expose is
already clean:

| assertion | state |
|---|---|
| no silent abstention | **0** — #129 and #131 declared every one |
| every dimension declares a `machine_signal` | **0 missing** of 11 |
| no rule after an `otherwise`, no unsatisfiable `when` | clean |
| `license_tier` order explicit | clean |
| producible `(score, class)` pairs | clean |
| **every rung carries a rationale** | **8 rungs had neither `because` nor `note`** |
| **no evidence discarded by the parser** | needed scoping — below |

A gate that holds ground already taken is the shape that survives. Note `check_rubric` is not in
CI at all today; this is what puts the whole class of check on every PR.

## The rationale key had drifted

27 rungs. 13 carried `because`, 6 carried `note` and no `because`, 8 carried neither.
`software.yaml` and `dataset.yaml` used `because`; `model.yaml` and `base_pretrained` used `note`
exclusively. Reading all six `note` rungs, every one is a justification rather than an aside —
"Open weights behind a use cap. Downloadable is not the same as usable."

One field under two names, which is the same vocabulary drift this project keeps finding a layer
down. The 6 are migrated, the 8 authored, and the gate now requires `because` strictly. No score
moves; `check_rubric` is byte-identical.

## Two assertions had to be scoped, or the gate would have died on day one

`docs/guides/verification.md` already states the failure mode: "A big-bang gate over all 1386
axes would fail on day one and get switched off, which is how gates die."

**Discarded clauses.** `split_components` silently drops any `components` clause without a
colon. Asserted naively that fails **166 products**. Narrowing by hand found three populations
among 219 keyless clauses:

- **86** match nothing in the category's vocabulary — free-text tails, harmless
- **122** restate something already recorded under a proper key. Overwhelmingly
  `no feature-gated core` sitting beside `core-gated:ungated`, left behind when #128's
  correction pass added the key without removing the prose. Failing on these would teach
  contributors the gate is noise.
- **11** are the *only* record of a dimension. This is the real defect, and it cost
  `dataset.yaml` five of its eight deferrals.

So a clause blocks only when it is the sole record of a dimension **some rung tests** and the
product is not already deferred. **Zero today**, 11 reported as a curation batch.

**Undeclared keys.** Originally scoped as a `descriptive_keys:` schema addition to silence the
ten `rows`/`size`/`format`/`github` warnings that arrived with `dataset.yaml`. Measuring first
killed that design: there are **113 distinct undeclared keys across 384 recordings**, and
`self-host` alone appears 52 times. A schema key needing 113 entries before it asserts anything
asserts nothing, and several of those keys are arguably load-bearing rather than context.

Rescoped to mirror the clause check — a key whose *value* answers a dimension the formula tests,
where nothing else does — it finds 6. The loose warning stays in `serialize_rubric` where it
belongs. **The 282-warning noise is therefore not fixed by this PR**, and is worth its own pass.

## One of those 6 was a real bug

`ornith` records `recipe:closed` and nothing under `code`. `model.yaml`'s `code` dimension does
not read `recipe`, so the ladder saw `code` as unrecorded and produced its `3/open_weights` from
the `otherwise` rather than from the evidence — the right answer for the wrong reason, which is
exactly what a reproduction count cannot see.

Fixed by adding `recipe` to `code`'s `reads` list. `tulu` records both `code:open` and
`recipe:open`, so `code` stays first and nothing changes for it. No score moves. This is the one
extra `product_openness_evidence` row in the pinned counts (`finetuned_chat` 172 → 173):
evidence that was invisible is now published.

## What the skill carries that the design did not anticipate

It leads with a **step 0**: check the category *can* be laddered before deriving anything.
`check_rubric` matches `head(value)` against a declared enum, so a category recording sentences
cannot be read at all. `edge_hardware` has the tidiest keys in the map, 71% prose values and no
license anywhere — stopping to propose a normalization was correct, and the alternative of a
per-value alias map is the curve fit relocated from the formula into the value map.

Also, from actually doing it:

- **`reads:` absorbs drift in the key only** — never the value, never the polarity.
  `gated: false`, `ungated: yes` and `access: ungated` are one fact three ways and no `reads`
  list reconciles them; test the positive tokens and let the negatives fall through.
- **Require positive evidence for the top rung**, or a product that recorded nothing scores full
  marks.
- **A declared dimension with no rung is legitimate; a rung with no product is not.** #133 is
  what happens when the second is ignored.
- **The `open` bucket needs an externally-open license**, with the MOF and OSAID grounding
  from #133.
- **Never edit `sources/scores/`.**

## Verification

```
uv run pytest -q                          254 passed (25 new)
uv run python -m build.validate           0 error(s)
uv run python -m build.check_recipe       0 failure(s) across all 14 recipes
uv run python -m build.check_rubric       byte-identical to pre-branch baseline
uv run python -m build.check_verification G1 G2 G3 [OK]
```

I confirmed the gate fails and exits 1 rather than being decorative, by removing one `because`:

```
FAIL  category 'deployment' formula rule 0 (1/closed) has no `because`
1 failure(s)
```

Sample output — counts, never a rate, because a reproduction percentage invites tuning:

```
training_synthetic_datasets
  dimensions declared ...... 2   (1 ladder variant(s))
  rules .................... 9   (0 unreachable, 0 missing `because`)
  license tiers ............ 4
  products ................. 38  (30 reproduce, 8 deferred, 0 silent)
  impossible pairs ......... 0
  clauses .................. 13 dropped, 0 blocking
  undeclared keys .......... 8 (context, reported by serialize_rubric)
  [OK]  ready for human review
```

`tests/test_check_recipe.py` asserts the module source contains no reproduction threshold, since
the failure mode is someone adding one later in good faith.

**Nothing under `sources/scores/` changed.**
