### PR TITLE
Fail on a deferral the ladder has since learned to decide

### DIFF
--- a/build/check_recipe.py
+++ b/build/check_recipe.py
@@ -42,11 +42,13 @@ import yaml
 
 from build.check_rubric import (
     ROOT,
+    apply_formula,
     check_category,
     dimension_read_map,
     dimension_value,
     head,
     license_read_keys,
+    license_tier,
     load_product_types,
     load_shared,
     recipe_for,
@@ -315,6 +317,50 @@ def undeclared_keys_holding_evidence(
     return blocking, reported, len(undeclared)
 
 
+def stale_deferrals(
+    slug: str, variants: dict, product_types: dict[str, str], deferred: set[str]
+) -> list[str]:
+    """A product declared `deferred:` that the ladder now reproduces on its own.
+
+    The opposite direction to the silent-abstention check, and the one that rots. A silent
+    abstention is a product nobody declared; a stale deferral is a product declared as
+    undecidable that has since become decidable — because the ladder gained a rung, a license
+    joined a tier, or the evidence was corrected. It looks handled and is not, which is worse:
+    the product is excluded from the reproduction count it would now pass, so the count
+    understates the ladder and the prose reason states something untrue about the file.
+
+    Nothing checked this before. `n8n` was deferred as "source or core-gated is not recorded"
+    while recording `source:public` and a `Sustainable-Use-License` that had since been added
+    to the `competition_restricted` tier, so it produced its recorded 2/source_available
+    exactly. That one went stale in about a week; at forty categories, on prose nobody
+    re-reads, they would accumulate silently.
+    """
+    problems = []
+    for product in sorted(deferred):
+        path = ROOT / "sources" / "scores" / f"{product}.yaml"
+        if not path.exists():
+            continue
+        recipe, _ = recipe_for(variants, product_types.get(product, ""))
+        if recipe is None:
+            continue
+        openness = (yaml.safe_load(path.read_text()) or {}).get("openness") or {}
+        components = split_components(openness.get("components") or "")
+        raw = next((components[k] for k in license_read_keys(recipe) if components.get(k)), "")
+        tier = license_tier(raw, recipe)
+        if tier is None:
+            continue
+        declared = _dimensions(recipe)
+        facts = {name: dimension_value(components, name, recipe) for name in declared}
+        facts["license_tier"] = tier
+        got = apply_formula(recipe, facts)
+        if got is not None and got == (openness.get("score"), openness.get("class")):
+            problems.append(
+                f"category '{slug}' defers '{product}', but the ladder now reproduces its "
+                f"{got[0]}/{got[1]} from the recorded evidence. Remove the deferral."
+            )
+    return problems
+
+
 def check_one(slug: str, verbose: bool) -> tuple[list[str], list[str]]:
     """Check one category. Returns (failures, report_lines)."""
     category = yaml.safe_load(
@@ -399,6 +445,7 @@ def check_one(slug: str, verbose: bool) -> tuple[list[str], list[str]]:
                 f"category '{slug}' defers '{product}' with no reason. Deferral is the "
                 f"honest state; silence is not."
             )
+    failures += stale_deferrals(slug, variants, product_types, deferred)
 
     lines = [
         f"  dimensions declared ...... {dimension_count:<4}"

--- a/sources/categories/orchestration_agents.yaml
+++ b/sources/categories/orchestration_agents.yaml
@@ -61,9 +61,10 @@ scoring_recipe:
   extends: software
   derived_from:
     method: shared software ladder, verified against the hand-authored scores
-    scores_reproduced: 33
+    scores_reproduced: 36
     scores_total: 50
-    verified_on: '2026-07-30'
+    scores_deferred: 14
+    verified_on: '2026-08-01'
     checker: build/check_rubric.py
   # Held back rather than scored. The shared ladder has no `otherwise` rule, so
   # these already abstain; declaring them here records WHY, and keeps the
@@ -125,10 +126,6 @@ scoring_recipe:
         source or core-gated is not recorded in a form the ladder can read; needs a read of
         the repo and pricing page
     zed:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
-    n8n:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of
         the repo and pricing page

--- a/tests/test_check_recipe.py
+++ b/tests/test_check_recipe.py
@@ -281,6 +281,49 @@ class TestUndeclaredKeys:
         assert blocking == [] and count == 0
 
 
+class TestStaleDeferrals:
+    """The direction that rots.
+
+    A silent abstention is a product nobody declared. A stale deferral is a product declared
+    undecidable that has since become decidable, and it is worse because it looks handled:
+    the product is excluded from a reproduction count it would now pass, and the prose reason
+    says something untrue about the file.
+    """
+
+    VARIANTS = {"*": GOOD}
+
+    def _score(self, tmp_path, monkeypatch, components, score, klass):
+        import build.check_recipe as module
+
+        scores = tmp_path / "sources" / "scores"
+        scores.mkdir(parents=True)
+        (scores / "p.yaml").write_text(
+            f"openness:\n  score: {score}\n  class: {klass}\n  components: {components}\n"
+        )
+        monkeypatch.setattr(module, "ROOT", tmp_path)
+
+    def test_a_deferral_the_ladder_now_reproduces_fails(self, tmp_path, monkeypatch):
+        from build.check_recipe import stale_deferrals
+
+        self._score(tmp_path, monkeypatch, "license:MIT;source:public", 5, "open_source")
+        problems = stale_deferrals("cat", self.VARIANTS, {"p": ""}, {"p"})
+        assert len(problems) == 1 and "Remove the deferral" in problems[0]
+
+    def test_a_deferral_the_ladder_still_cannot_decide_passes(self, tmp_path, monkeypatch):
+        from build.check_recipe import stale_deferrals
+
+        # No `source` recorded, so no rung fires and the deferral is still doing work.
+        self._score(tmp_path, monkeypatch, "license:MIT", 5, "open_source")
+        assert stale_deferrals("cat", self.VARIANTS, {"p": ""}, {"p"}) == []
+
+    def test_a_deferral_whose_score_still_disagrees_passes(self, tmp_path, monkeypatch):
+        """Reproducing a DIFFERENT pair is a live mismatch, not a stale deferral."""
+        from build.check_recipe import stale_deferrals
+
+        self._score(tmp_path, monkeypatch, "license:MIT;source:public", 4, "open_core")
+        assert stale_deferrals("cat", self.VARIANTS, {"p": ""}, {"p"}) == []
+
+
 def test_reproduction_rate_is_never_asserted():
     """The one rule above the others.
 

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -683,7 +683,10 @@ def test_real_sources_serialize_without_errors():
         "base_pretrained": 111, "finetuned_chat": 173, "deployment": 131,
         "agent_tools_protocols": 108, "dataset_processing_tools": 86, "evaluation_code": 66,
         "finetuning_code": 119, "inference_code": 47, "ml_frameworks": 80,
-        "orchestration_agents": 137, "telemetry_observability": 90, "ui_api": 127,
+        # orchestration_agents rose by 3 when n8n's stale deferral was removed: a deferred
+        # product publishes no openness evidence, and n8n had been deferred as "not recorded"
+        # while recording everything the ladder needed.
+        "orchestration_agents": 140, "telemetry_observability": 90, "ui_api": 127,
         "training_synthetic_datasets": 158,
     }
     assert {r["grade"] for r in tables["product_openness_evidence"]} == {"document"}


### PR DESCRIPTION
`check_recipe` asserted that no product abstains without a declared reason. It did not assert
that a declared reason is still **true**. That is the direction that rots.

## The instance

`n8n` was deferred in `orchestration_agents` as:

> source or core-gated is not recorded in a form the ladder can read; needs a read of the repo
> and pricing page

It records `source:public` and `license:Sustainable-Use-License(...)`. That license was
subsequently added to the software ladder's `competition_restricted` tier, and the rung
`{license_tier: competition_restricted, source: public}` produces `2/source_available` — which
is exactly its recorded score. The deferral had been false since the tier gained the license,
roughly a week.

A stale deferral is worse than a silent abstention, which is what the gate already caught. A
silent abstention is a product nobody declared. A stale deferral **looks handled**: the product
sits out of a reproduction count it would now pass, so the count understates the ladder, and the
prose states something untrue about the file.

Deferral is not a one-way door. A ladder gains a rung, a license joins a tier, a components
string gets corrected — any of those can retire a deferral written months earlier. At fourteen
categories one went stale unseen. At forty, on prose nobody re-reads, they accumulate.

## The check

`stale_deferrals()` re-runs the formula against each deferred product and fails if the ladder
now produces the recorded pair. Three cases, all tested:

- ladder reproduces the recorded pair → **fail**, remove the deferral
- ladder still cannot decide → pass, the deferral is doing work
- ladder decides a *different* pair → pass, that is a live mismatch and the deferral is correct

## Result

`orchestration_agents` goes from 33 to **36/50 reproduced**, 14 deferred. Three more evidence
rows, because a deferred product publishes none. No score changed and no other category moved.

## How it was found

Not by reading. Carl asked whether the rubric machinery would stay maintainable as the taxonomy
grows from 16 categories to ~40, so I measured the things that would rot rather than answering
from impression. Three probes:

| probe | result |
|---|---|
| deferrals that would now reproduce | **1** — this PR |
| recorded values outside a declared enum on a product that still scores | 0 |
| dimensions a fetcher could ever settle | 1 full, 4 partial, 7 none — see below |

The third is the real scaling constraint and is not addressed here: **68 of 106 deferrals across
the map are "evidence absent, needs a read"**, and that count grows linearly with the product
pool. Only one dimension on any ladder has a `full` machine signal. No rule retires those; they
are research labor, and they are what the discovery pool will multiply.

Also worth noting separately: `machine_signal` is free prose, so "which dimensions could we
automate" cannot be aggregated without reading all twelve strings by hand — one of them,
`model.weights`, does not follow the `full`/`partial`/`none` convention the others use. Cheap to
constrain, but it touches `dataset.yaml`, which #135 is already editing, so it is not in this PR.

```
uv run pytest -q                          257 passed (3 new)
uv run python -m build.validate           0 error(s)
uv run python -m build.check_recipe       0 failures
uv run python -m build.check_verification G1 G2 G3 [OK]
```
