### PR TITLE
safeguards: 0/26 was mostly a reading problem, not a scoring one

### DIFF
--- a/sources/categories/safeguards.yaml
+++ b/sources/categories/safeguards.yaml
@@ -14,136 +14,91 @@ scoring_recipe:
     model: model
     software: software
   derived_from:
-    method: per-type extends over the shared ladders; reproduction pending curation
-    scores_reproduced: 0
+    method: per-type extends over the shared ladders; evidence transcribed into the keys the
+      ladders read, then verified
+    scores_reproduced: 17
     scores_total: 26
-    scores_deferred: 26
-    verified_on: '2026-07-30'
+    scores_deferred: 9
+    verified_on: '2026-08-01'
     checker: build/check_rubric.py
+  note: >-
+    Was 0/26. Sixteen products were not disagreeing with the ladders at all - they recorded the
+    deciding evidence under keys the ladders do not read, or in prose. Eleven software products
+    recorded `self-host:yes;service:none`, which is `core-gated:ungated` said another way; five
+    hosted services recorded `service:proprietary ...(no self-host)`, which is `source:closed`
+    plus `license:proprietary`. Transcribing those moved no score, and none of it was research.
+    Two more were license-lookup misses with settled precedent: a bare `gemma` alias, and a
+    vendor-prefixed OpenRAIL-M that #117 already governs.
+
+    What remains is nine real disagreements, in three shapes. Four are the license cap: a
+    use-restricted model is capped at 2 by the current ladders and all four are recorded 3,
+    which is what the agreed universal license scale sets that tier to - they resolve when it is
+    built, not by curation. Four are scored 4 where the recorded evidence supports 3. One needs
+    a decision about which artifact a bundled product is scored on.
   deferred:
     aegis-guard:
       because: >-
-        License Llama-2-Community resolves to use_restricted; the ladder computes
-        2/restricted from the recorded evidence but the score says 3/open_weights. The
-        recorded weights:adapter-open and data:Aegis safety dataset documented values also
-        fall outside the ladder's declared enums. See the 2026-07-30 reproduction report.
-    openguardrails:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
-    zentropi-cope:
-      because: >-
-        License zentropi-openrail-m appears in no tier's examples and has no alias in
-        signal_routing.yaml, so the tier lookup fails before the formula runs even though
-        the components note already calls it use-restricted. See the 2026-07-30
-        reproduction report.
-    qwen3guard:
-      because: >-
-        License resolves to osi; the ladder computes 3/open_weights from the recorded
-        evidence (data:not-released) but the score says 4/open_weights. See the 2026-07-30
-        reproduction report.
-    wildguard:
-      because: >-
-        data:open is recorded but code was never recorded at all, so the 4-rule's second
-        condition is unmet; the ladder computes 3/open_weights from the recorded evidence
-        but the score says 4/open_weights. See the 2026-07-30 reproduction report.
-    llama-prompt-guard:
-      because: >-
-        License Llama-4-Community resolves to use_restricted; the ladder computes
-        2/restricted from the recorded evidence but the score says 3/open_weights. See the
-        2026-07-30 reproduction report.
-    llamafirewall:
-      because: >-
-        The MIT-licensed framework facts are recorded under framework and self-host, keys
-        the software ladder does not read, and the bundled guard models carry a
-        use-restricted Llama license the harness's own license does not cover; which SKU
-        governs 5/open_source is a curation call. See the 2026-07-30 reproduction report.
-    harmbench:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
-    giskard:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
-    deepteam:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
-    perspective-api:
-      because: >-
-        No source or license key is recorded, only a service:proprietary... prose
-        description the software ladder's reads list does not check. See the 2026-07-30
-        reproduction report.
+        Recorded 3/open_weights; the ladders compute 2/restricted. Llama-2-Community resolves to
+        `use_restricted`, which model.yaml caps at 2. This is one of four products in the
+        category recorded at exactly the 3 the agreed universal license scale assigns that tier,
+        so it resolves when the scale is built rather than by curation. Separately, its
+        `weights:adapter-open` and `data:Aegis safety dataset documented` are both outside
+        model.yaml's declared enums, so the record needs a rewrite of its own either way - the
+        adapter weights are public while the base LlamaGuard model is gated behind Meta's
+        access request, which no single `weights` value currently expresses.
     llama-guard:
       because: >-
-        License Llama-3.1-Community resolves to use_restricted (the >700M-MAU clause); the
-        ladder computes 2/restricted from the recorded evidence but the score says
-        3/open_weights. See the 2026-07-30 reproduction report.
+        Recorded 3/open_weights; the ladders compute 2/restricted. Llama-3.1-Community resolves
+        to `use_restricted` on the >700M-MAU clause. Resolves with the universal license scale,
+        which sets that tier to 3. Note `code:inference recipe public` is also outside the
+        declared enum, though it does not affect the outcome.
+    llama-prompt-guard:
+      because: >-
+        Recorded 3/open_weights; the ladders compute 2/restricted. Llama-4-Community resolves to
+        `use_restricted`. Resolves with the universal license scale.
     shieldgemma:
       because: >-
-        License Gemma matches no tier in model.yaml's examples; an alias exists
-        (gemma: Gemma-License) but only in signal_routing.yaml's huggingface: sub-table,
-        which the license-alias lookup does not read. See the 2026-07-30 reproduction
-        report.
+        Recorded 3/open_weights; the ladders compute 2/restricted. This one changed shape in
+        this pass: it used to abstain because the bare `gemma` license string matched no alias,
+        and the alias is now recorded, so the real disagreement is visible - Gemma-License
+        resolves to `use_restricted` and the ladder caps it at 2. Resolves with the universal
+        license scale. Surfacing a mismatch where there was an abstention is the point of
+        fixing a lookup.
+    qwen3guard:
+      because: >-
+        Recorded 4/open_weights; the ladders compute 3/open_weights. Apache-2.0, so the license
+        is not the constraint: model.yaml's 4-rung needs BOTH post-training data and the
+        fine-tuning pipeline released, and this records `data:not-released` with no `code` at
+        all. Either the 4 is crediting a recipe the product's own record says is not published,
+        or the 4-rung is the wrong test for a guardrail model. Same shape as `granite-guardian`
+        and `gpt-oss-safeguard`; one reading should settle all three.
     granite-guardian:
       because: >-
-        License resolves to osi; the ladder computes 3/open_weights from the recorded
-        evidence (data:not-released) but the score says 4/open_weights. See the 2026-07-30
-        reproduction report.
+        Recorded 4/open_weights; the ladders compute 3/open_weights. As `qwen3guard`: an
+        OSI license, `data:not-released`, no `code` recorded, and the 4-rung needs both.
     gpt-oss-safeguard:
       because: >-
-        License resolves to osi; the ladder computes 3/open_weights from the recorded
-        evidence (data:not-released) but the score says 4/open_weights. See the 2026-07-30
-        reproduction report.
-    nemo-guardrails:
+        Recorded 4/open_weights; the ladders compute 3/open_weights. As `qwen3guard`: an
+        OSI license, `data:not-released`, no `code` recorded, and the 4-rung needs both.
+    wildguard:
       because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
-    guardrails-ai:
+        Recorded 4/open_weights; the ladders compute 3/open_weights. Different cause from the
+        three above: `data:open` is genuinely correct, since the WildGuardMix corpus is public,
+        but `code` was never recorded and the 4-rung needs both. This is the one of the four
+        that a repo read could settle rather than a judgment call - if the fine-tuning pipeline
+        is published, recording it makes the 4 reproduce.
+    llamafirewall:
       because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
-    llm-guard:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
-    pyrit:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
-    garak:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
-    osprey:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
-    coop:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
-    openai-moderation:
-      because: >-
-        No source or license key is recorded, only a service:proprietary... prose
-        description the software ladder's reads list does not check. See the 2026-07-30
-        reproduction report.
-    azure-content-safety:
-      because: >-
-        No source or license key is recorded, only a service:proprietary... prose
-        description the software ladder's reads list does not check. See the 2026-07-30
-        reproduction report.
-    bedrock-guardrails:
-      because: >-
-        No source or license key is recorded, only a service:proprietary... prose
-        description the software ladder's reads list does not check. See the 2026-07-30
-        reproduction report.
-    lakera-guard:
-      because: >-
-        No source or license key is recorded, only a service:proprietary... prose
-        description the software ladder's reads list does not check. See the 2026-07-30
-        reproduction report.
+        Recorded 5/open_source; the ladders abstain, because neither `source` nor `license` is
+        recorded under a key the software ladder reads - the MIT framework facts sit under
+        `framework` and `self-host`. Deliberately left untranscribed, unlike the other sixteen:
+        the same components string records that the bundled guard models (Prompt Guard 2, Llama
+        Guard) carry the use-restricted Llama Community License, so transcribing only the
+        favourable half would manufacture a 5 while ignoring the question. Which artifact a
+        bundled product is scored on is the multi-SKU rule applied to a case where "SKU" is
+        arguable - the harness is MIT and runs against whatever model you point it at.
+        Needs a human.
+
 products:
 - aegis-guard
 - openguardrails

--- a/sources/rubrics/model.yaml
+++ b/sources/rubrics/model.yaml
@@ -80,8 +80,13 @@ openness:
           discriminating against a field of endeavor. Settled in issue #117, which was
           opened because the same OpenRAIL family had been scored 3 in one category and
           4 in another.
+        # `zentropi-openrail-m` is a vendor-prefixed OpenRAIL-M, so #117 governs it exactly
+        # as it governs BigCode-OpenRAIL-M. Note the product's own components string calls
+        # it "use-restricted", which is looser language than the tier names use: an
+        # acceptable-use policy is not a use CAP, and #117 was opened precisely because that
+        # conflation had scored one OpenRAIL family two different ways.
         examples: [Modified-MIT, minimax-community, NVIDIA-Open-Model-License, BigCode-OpenRAIL-M,
-          DeepSeek-Model-License, TII-Falcon-License-2.0]
+          zentropi-openrail-m, DeepSeek-Model-License, TII-Falcon-License-2.0]
       use_restricted:
         definition: >
           Caps or gates use - monthly-active-user ceilings, field-of-use limits,

--- a/sources/scores/azure-content-safety.yaml
+++ b/sources/scores/azure-content-safety.yaml
@@ -2,8 +2,8 @@ product: azure-content-safety
 openness:
   score: 1
   class: closed
-  components: service:proprietary managed Azure service(no self-host);features:text/image moderation,
-    prompt shields, groundedness
+  components: service:proprietary managed Azure service(no self-host);features:text/image moderation, prompt
+    shields, groundedness;source:closed;license:proprietary
   confidence: high
   note: Closed managed cloud service; no weights or source.
   sources:

--- a/sources/scores/bedrock-guardrails.yaml
+++ b/sources/scores/bedrock-guardrails.yaml
@@ -3,7 +3,7 @@ openness:
   score: 1
   class: closed
   components: service:proprietary managed AWS service(no self-host);features:denied topics, content filters,
-    PII redaction, contextual grounding
+    PII redaction, contextual grounding;source:closed;license:proprietary
   confidence: high
   note: Closed managed cloud service; no weights or source.
   sources:

--- a/sources/scores/coop.yaml
+++ b/sources/scores/coop.yaml
@@ -2,7 +2,7 @@ product: coop
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(github.com/roostorg/coop);self-host:yes;service:none
+  components: license:Apache-2.0(OSI);source:public(github.com/roostorg/coop);self-host:yes;service:none;core-gated:ungated
   confidence: high
   note: 'Fully open source: Apache-2.0 self-hosted moderation review console from ROOST.'
   sources:

--- a/sources/scores/deepteam.yaml
+++ b/sources/scores/deepteam.yaml
@@ -2,7 +2,7 @@ product: deepteam
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;self-host:yes;service:none
+  components: license:Apache-2.0(OSI);source:public;self-host:yes;service:none;core-gated:ungated
   confidence: high
   note: 'Fully open source: Apache-2.0 red-teaming framework, self-hostable.'
   sources:

--- a/sources/scores/garak.yaml
+++ b/sources/scores/garak.yaml
@@ -2,7 +2,7 @@ product: garak
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;self-host:yes;service:none
+  components: license:Apache-2.0(OSI);source:public;self-host:yes;service:none;core-gated:ungated
   confidence: high
   note: 'Fully open source: Apache-2.0 scanner, self-hostable, no proprietary tier.'
   sources:

--- a/sources/scores/giskard.yaml
+++ b/sources/scores/giskard.yaml
@@ -2,7 +2,7 @@ product: giskard
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;self-host:yes;service:none(per the repo)
+  components: license:Apache-2.0(OSI);source:public;self-host:yes;service:none(per the repo);core-gated:ungated
   confidence: high
   note: 'Fully open source: Apache-2.0 Python library, self-hostable; no commercial tier mentioned on
     the repo.'

--- a/sources/scores/guardrails-ai.yaml
+++ b/sources/scores/guardrails-ai.yaml
@@ -3,7 +3,7 @@ openness:
   score: 4
   class: open_core
   components: license:Apache-2.0(OSI) for the framework;source:public;hub:Guardrails Hub validator registry;commercial:hosted/enterprise
-    tier
+    tier;core-gated:gated
   confidence: medium
   note: Apache-2.0 framework that is fully self-hostable, with a Hub of validators and a commercial tier
     on top; classed open_core alongside other OSS-core-plus-commercial tools.

--- a/sources/scores/harmbench.yaml
+++ b/sources/scores/harmbench.yaml
@@ -2,7 +2,7 @@ product: harmbench
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public;self-host:yes;service:none
+  components: license:MIT(OSI);source:public;self-host:yes;service:none;core-gated:ungated
   confidence: high
   note: 'Fully open source: MIT-licensed standardized red-teaming evaluation framework, self-hostable.'
   sources:

--- a/sources/scores/lakera-guard.yaml
+++ b/sources/scores/lakera-guard.yaml
@@ -3,7 +3,7 @@ openness:
   score: 1
   class: closed
   components: service:proprietary SaaS API(no self-host);note:vendor Lakera acquired by Check Point Nov
-    2025
+    2025;source:closed;license:proprietary
   confidence: high
   note: Closed SaaS security product; no weights or source. (Lakera also runs the public Gandalf prompt-injection
     game, but Guard itself is proprietary.)

--- a/sources/scores/llm-guard.yaml
+++ b/sources/scores/llm-guard.yaml
@@ -3,7 +3,7 @@ openness:
   score: 5
   class: open_source
   components: license:MIT(OSI);source:public(full Python implementation);self-host:yes;service:none(the
-    OSS toolkit; Protect AI's platform is separate)
+    OSS toolkit; Protect AI's platform is separate);core-gated:ungated
   confidence: high
   note: 'Fully open source: MIT-licensed, complete source, self-hostable. (Protect AI''s commercial platform
     is a separate product; this is the standalone OSS toolkit.)'

--- a/sources/scores/nemo-guardrails.yaml
+++ b/sources/scores/nemo-guardrails.yaml
@@ -2,7 +2,7 @@ product: nemo-guardrails
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(full Python implementation);self-host:yes(library/CLI/Docker/server);service:none
+  components: license:Apache-2.0(OSI);source:public(full Python implementation);self-host:yes(library/CLI/Docker/server);service:none;core-gated:ungated
   confidence: high
   note: 'Fully open source: Apache-2.0, complete source, self-hostable with no proprietary tier.'
   sources:

--- a/sources/scores/openai-moderation.yaml
+++ b/sources/scores/openai-moderation.yaml
@@ -2,7 +2,7 @@ product: openai-moderation
 openness:
   score: 1
   class: closed
-  components: service:proprietary hosted API(no weights, no self-host);access:free moderation endpoint
+  components: service:proprietary hosted API(no weights, no self-host);access:free moderation endpoint;source:closed;license:proprietary
   confidence: high
   note: Closed, API-only hosted classifier; no weights or source.
   sources:

--- a/sources/scores/openguardrails.yaml
+++ b/sources/scores/openguardrails.yaml
@@ -3,7 +3,7 @@ openness:
   score: 5
   class: open_source
   components: license:Apache-2.0(OSI) for both platform and model;source:public;self-host:yes(on-prem/private);model:OpenGuardrails-Text-2510
-    open weights Apache-2.0
+    open weights Apache-2.0;core-gated:ungated
   confidence: high
   note: 'Fully open source: both the guardrails platform and the safety model are Apache-2.0 and self-hostable,
     including on-prem deployment.'

--- a/sources/scores/osprey.yaml
+++ b/sources/scores/osprey.yaml
@@ -2,7 +2,7 @@ product: osprey
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;self-host:yes;service:none
+  components: license:Apache-2.0(OSI);source:public;self-host:yes;service:none;core-gated:ungated
   confidence: high
   note: 'Fully open source: Apache-2.0 real-time safety rules engine, self-hostable, no proprietary tier.
     Donated by Discord to ROOST.'

--- a/sources/scores/perspective-api.yaml
+++ b/sources/scores/perspective-api.yaml
@@ -3,7 +3,7 @@ openness:
   score: 1
   class: closed
   components: service:proprietary hosted API by Jigsaw/Google(no weights, no self-host);access:free with
-    quota;scores:toxicity + related attributes
+    quota;scores:toxicity + related attributes;source:closed;license:proprietary
   confidence: high
   note: Closed, API-only hosted classifier; no weights or source. Long-standing and influential, but proprietary.
   sources:

--- a/sources/scores/pyrit.yaml
+++ b/sources/scores/pyrit.yaml
@@ -2,7 +2,7 @@ product: pyrit
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public(full Python framework);self-host:yes;service:none
+  components: license:MIT(OSI);source:public(full Python framework);self-host:yes;service:none;core-gated:ungated
   confidence: high
   note: 'Fully open source: MIT-licensed automation framework, self-hostable, no proprietary tier.'
   sources:

--- a/sources/signal_routing.yaml
+++ b/sources/signal_routing.yaml
@@ -180,6 +180,10 @@ dimensions:
       # slug that base_pretrained had adopted as a tier example; the license name
       # is `GLM-4-License`, so that example moves and the slug becomes an alias.
       recorded:
+        # `shieldgemma` records the bare family name. The alias already existed two tables
+        # up under `huggingface:`, which `recorded_license_aliases()` does not read, so the
+        # product abstained on a lookup miss rather than on anything about its license.
+        gemma: Gemma-License
         gemma-terms-of-use: Gemma-License
         glm-4: GLM-4-License
         llama-2-community: Llama-2-Community-License

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -681,8 +681,10 @@ def test_real_sources_serialize_without_errors():
     # products that had described their gating in prose gained a readable `source:` or
     # `core-gated:` key. The two model categories are untouched, which is what the pilot
     # counts are pinned to catch.
-    # `safeguards` disappears from this dict entirely: all 26 of its products are
-    # deferred, so it now contributes zero product_openness_evidence rows. Nine other
+    # `safeguards` is back at 90 rows. It had disappeared from this dict entirely when all
+    # 26 of its products were deferred; 17 now reproduce, because sixteen of them were
+    # recording the deciding evidence under keys the ladders do not read rather than
+    # disagreeing with the ladders. Nine other
     # categories drop too, by however many rows their own deferred products used to
     # carry (1-3 rows per product) — a deferred product publishes no openness evidence
     # at all now, so `openness_computed` never sees enough rows to score a product the
@@ -702,6 +704,7 @@ def test_real_sources_serialize_without_errors():
         # is the check that mattered: benchmark_eval_data's new dimensions and rungs did not
         # disturb the category the ladder was derived from.
         "training_synthetic_datasets": 158, "benchmark_eval_data": 111,
+        "safeguards": 90,
         # 17 scored hardware products across the five recorded dimensions, less the keys
         # individual products do not record. No license row among them, by design -
         # `edge_hardware` is the only category whose ladder declares no `license_tier`.


### PR DESCRIPTION
The last rubric phase. **`safeguards` goes from 0/26 reproduced to 17/26.**

The 2026-07-30 reproduction report framed most of this as curation debt. Re-reading the
evidence, most of it wasn't: **sixteen of the seventeen were not disagreeing with the ladders
at all.** They recorded the deciding evidence under keys the ladders don't read, or in prose.
None of it needed research.

## What was actually wrong

**Eleven software products** record `self-host:yes;service:none` — which is `core-gated:ungated`
said another way. `guardrails-ai` records `commercial:hosted/enterprise tier`, and its note
already says "classed open_core alongside other OSS-core-plus-commercial tools" — that's
`core-gated:gated`.

**Five hosted services** record `service:proprietary …(no self-host)`. That is two facts at
once: `source:closed` and `license:proprietary`. The software ladder reaches their recorded
`1/closed` through `source:closed`.

This is the third time the same shape has come up — `ornith`'s `recipe`/`code`, the dataset
category's `datasheet`/`dataset_card`, and now this. The evidence is in the file; the ladder
is looking under a different name.

Every added value is a transcription of something the same file already states, every prior
key is untouched, and **no score, class or note changed anywhere**. All three asserted
mechanically, not assumed.

## Two license-lookup misses, both with settled precedent

- **`shieldgemma`** records a bare `gemma`. The alias existed — but in `signal_routing.yaml`'s
  `huggingface:` sub-table, which `recorded_license_aliases()` doesn't read. Moved to
  `recorded:`, one line.
- **`zentropi-cope`** records `zentropi-openrail-m`, a vendor-prefixed OpenRAIL-M. #117 already
  governs that family exactly as it governs `BigCode-OpenRAIL-M`, so it joins
  `permissive_non_osi` and reproduces at 3. Worth noting its own components string calls it
  "use-restricted", which is looser language than the tier names use — and that conflation is
  precisely what #117 was opened to settle.

**The `shieldgemma` fix turns an abstention into a mismatch, not a reproduction — and that is
the point.** It was abstaining on a lookup miss, and what the miss was hiding is a real
disagreement about the Gemma license cap.

## The nine that remain, in three shapes

**Four are the license cap** — `aegis-guard`, `llama-guard`, `llama-prompt-guard`,
`shieldgemma`. A use-restricted model is capped at 2 by the current ladders, and all four are
recorded 3, which is exactly what the agreed universal license scale assigns that tier. **These
resolve when the scale is built, not by curation.** That's a useful data point for the scale:
four hand-authored scores already agree with it.

**Four are recorded 4 where the evidence supports 3.** Three are the same case — an
OSI-licensed guardrail model with `data:not-released` and no `code`, where `model.yaml`'s
4-rung needs both — so one reading settles `qwen3guard`, `granite-guardian` and
`gpt-oss-safeguard` together. Either the 4 credits a recipe the product's own record says isn't
published, or the 4-rung is the wrong test for a guardrail model. `wildguard` is the fourth and
differs: its `data:open` is genuinely correct (WildGuardMix is public) and only `code` is
missing, so a repo read could settle that one rather than a judgment call.

**`llamafirewall` needs a decision** about which artifact a bundled product is scored on. I
left it deliberately untranscribed, unlike the other sixteen: its MIT framework facts sit under
`framework` and `self-host`, but the same string records that the bundled guard models (Prompt
Guard 2, Llama Guard) carry the use-restricted Llama Community License. Transcribing only the
favourable half would manufacture a 5 while ignoring the question. It's the multi-SKU rule
applied to a case where "SKU" is arguable — the harness is MIT and runs against whatever model
you point it at.

## Also worth knowing

Three records carry values outside their declared enums, which don't change any outcome but
mean the files say something the vocabulary can't express: `aegis-guard`'s
`weights:adapter-open` (its adapter is public while the base LlamaGuard model is gated behind
Meta's access request — no single `weights` value says that), its `data:Aegis safety dataset
documented`, and `llama-guard`'s `code:inference recipe public`.

`data:not-released` is a third spelling of a concept `model.yaml` calls
`described_not_released` and `base_pretrained` calls `documented-not-released`. That's issue
#106, still open, and this category is now a third witness to it.

## Verification

```
uv run pytest -q                          259 passed
uv run python -m build.validate           0 error(s)
uv run python -m build.check_recipe       0 failures across all 16 recipes
uv run python -m build.check_verification G1 G2 G3 [OK]
uv run python -m build.check_rubric       safeguards 0/26 -> 17/26; no other category moves
```
