### PR TITLE
The guides still said three categories had no scoring recipe

### DIFF
--- a/docs/guides/freshness.md
+++ b/docs/guides/freshness.md
@@ -19,8 +19,9 @@ That is the whole definition. Three consequences follow from it, and no other re
 is intended:
 
 1. **"Everything" means every dimension the score records**, not only the ones the
-   winning rule happens to read. `falcon-3` scores 2 the moment its license resolves
-   to `use_restricted`, so its `data` and `code` values never affect the outcome — but
+   winning rule happens to read. A model scores the moment its license resolves to a
+   capped tier — `use_bounded` or `commercial_forbidden` — so its `data` and `code`
+   values never affect the outcome, but
    they are still published claims, so they still have to be confirmed. A fresh
    license cannot carry a stale corpus claim.
 2. **Confirmation means the axis was re-checked against its sources**, whether or not

--- a/docs/guides/openness-spectrum.md
+++ b/docs/guides/openness-spectrum.md
@@ -39,9 +39,10 @@ than one kind of product maps `extends` per product type.
 
 Three caveats, because "a formula exists" is easy to over-read:
 
-- **The remaining three categories have no recipe yet** — `benchmark_eval_data`,
-  `training_synthetic_datasets` and `edge_hardware`, 85 products. Their scores are still
-  editorial only.
+- **A recipe covers a category, not every product in it.** All sixteen categories carry one as
+  of 2026-08-01, but 86 products are declared in a `deferred:` block, meaning the category has
+  said the ladder does not decide them. Those scores remain editorial. `check_recipe` prints
+  the per-category split and fails if a product abstains without being declared.
 - **A recipe reproducing a score does not validate it.** It shows the rules describe how the
   category was scored. The document-grade evidence the checker reads was parsed out of the
   same files the scores live in, so agreement is a fidelity check on the formula, not on the

--- a/docs/guides/verification.md
+++ b/docs/guides/verification.md
@@ -224,23 +224,33 @@ automatically: the HF hub, GitHub, PyPI, LMArena, Artificial Analysis, OpenRoute
 The order matters more than usual here, because two of the steps get cheaper by waiting and
 one gets done twice if rushed.
 
-### 1. Finish the recipes — 16/16 categories, 470/470 products
+### 1. Finish the recipes — 16/16 categories ✅ **done 2026-08-01**
 
-85 products across three categories still have no `scoring_recipe`:
+All sixteen categories carry a `scoring_recipe`. The last three landed as PRs #131, #135 and
+#137, and `safeguards` was corrected from 0/26 to 21/26 in #138 and #139.
 
-| category | n | product type |
-|---|---|---|
-| `benchmark_eval_data` | 27 | dataset |
-| `training_synthetic_datasets` | 38 | dataset |
-| `edge_hardware` | 20 | hardware |
+Four shared ladders now exist — `software` (ten categories), `model` (two), `dataset` (two)
+and `hardware` (one) — plus `base_pretrained`'s own. `build/check_recipe.py` gates the
+structure of every one of them on every PR, and `skills/build-rubric/SKILL.md` is the
+procedure for the next one.
 
-**Do this before step 2.** Step 2 generalizes the scoring SQL off its hardcoded model
-dimensions, and that generalization should be driven by the complete dimension vocabulary.
-Generalize it now for software alone and it gets redone when `dataset` and `hardware` arrive
-with dimensions of their own.
+Two things this step turned out to depend on, neither of which the plan anticipated:
 
-Both are cheap: one dataset ladder covers the 65 products in `benchmark_eval_data` and
-`training_synthetic_datasets`, hardware is `edge_hardware`'s 20.
+- **A category can only be laddered if its `components` VALUES are controlled tokens.**
+  `check_rubric` matches `head(value)` against a declared enum, so a category recording
+  sentences cannot be read at all. `edge_hardware` had the tidiest key coverage of the three
+  and 71% prose values, which is why it went last and needed a normalization pass first. Key
+  coverage is not readiness; measuring the prose share is now step 0 of the guide.
+- **"One dataset ladder covers both dataset categories" was optimistic.** Applied unchanged to
+  `benchmark_eval_data` the ladder reproduced 0 of 27, because that category spells the card
+  key `datasheet` and because a benchmark may not be published at all — an internal eval suite
+  or a held-out test set — which `gate` had no rung for. The shared ladder widened rather than
+  forking, and `training_synthetic_datasets` came through identical.
+
+**This had to precede step 2**, and still does for anyone re-reading the order: step 2
+generalizes the scoring SQL off its hardcoded model dimensions, and that generalization is
+driven by the complete dimension vocabulary. Doing it before `dataset` and `hardware` existed
+would have meant doing it twice.
 
 `safeguards` is no longer on this list, and it is why `extends` now accepts two forms. It
 holds 9 products typed `model` and 17 typed `software`, so a single shared ladder could not
@@ -271,8 +281,8 @@ Two things ride along:
   every dimension the score *records*. Without this column no tool can ever legitimately
   write `last_verified`, so it is the precondition for step 3.
 - **A `category_deferrals` table.** `deferred` currently lives only in the repo, so the
-  warehouse does not know which products a category has held back. There are 89 of them now,
-  alongside the 85 products in the three categories with no recipe at all. For the software
+  warehouse does not know which products a category has held back. There are 86 of them now,
+  and no category is without a recipe any more, so deferrals are the whole of it. For the software
   categories the silence has been safe: with no `otherwise` rule in the software ladder their
   deferred products fall out of the model's INNER JOIN rather than being scored wrongly.
 
@@ -298,12 +308,15 @@ than clearing it first.** Reading a product's sources to determine `core-gated` 
 re-check that earns its `last_verified`; done as two passes it is the same pages fetched
 twice, and it re-verifies scores that are about to change.
 
-That backlog is currently 174 products: 49 whose prose does not settle `source` or
-`core-gated`, 10 whose recorded license maps to no tier in the ladder, 4 where the ladder and
-the recorded score still disagree (`jina-reader`, `openhands`, `maple-ai`, `privatemode` — all
-producible pairs, so G3 passes them and only `check_rubric` objects), plus the 85 products in
-the three categories that have no recipe yet and the 26 in `safeguards`, which has a recipe but
-reproduces none of them.
+That backlog is currently the 86 declared deferrals. Every category has a recipe now, and
+`safeguards` — which used to contribute all 26 of its products here — is down to 5. The
+composition is roughly: products whose prose does not settle a dimension the ladder reads,
+products whose recorded license maps to no tier, and a handful where the ladder and the
+recorded score genuinely disagree (`jina-reader`, `openhands`, `maple-ai`, `privatemode`, all
+producible pairs, so G3 passes them and only `check_rubric` objects).
+
+Regenerate the number rather than trusting it — `check_recipe` prints per-category counts, and
+the figure has moved several times in a week.
 
 **Expect scores to move.** Verification is not a formality: the RWKV correction in #105 came
 out of a pass like this, and G3's first run moved 17 openness scores or classes before the

--- a/skills/build-rubric/SKILL.md
+++ b/skills/build-rubric/SKILL.md
@@ -25,8 +25,11 @@ supposed to check. It looks rigorous and is worth less than nothing, because it 
 check while appearing to pass it.
 
 - Finding a real mismatch and *lowering* the reproduction rate is a good day's work.
-- `safeguards` reproduced 0 of 26 and that was the correct outcome. The mismatches were the
-  finding.
+- `safeguards` reproduced 0 of 26 and that was the correct outcome at the time: the mismatches
+  were the finding. It is 21/26 now, and the way it got there is the more useful lesson —
+  sixteen of the seventeen fixes were transcription, not curation. The evidence was in the
+  files under keys the ladders do not read. Check for that before assuming a low rate means
+  research is owed.
 - Never add a rung whose only justification is that one product needs it.
 - Never edit a score to make a ladder reproduce. **You do not edit `sources/scores/` at all** —
   see Boundaries.

--- a/sources/scores/falcon.yaml
+++ b/sources/scores/falcon.yaml
@@ -7,7 +7,7 @@ openness:
   note: 'Weights downloadable and freely usable commercially at any scale, corpus not released, no training code,
     so 3/open_weights. Corrected from 2/restricted on 2026-07-29 under issue #117: TII-Falcon-License-2.0 is Apache-based
     with an acceptable-use policy, and a conduct restriction caps neither who may use the model nor at what scale.
-    It therefore sits in permissive_non_osi beside attribution requirements rather than in use_restricted beside
+    It therefore sits in permissive_non_osi beside attribution requirements rather than in the capped tier beside
     Llama''s 700M-MAU ceiling. Not 4 or 5: the corpus and the pipeline are both closed, and the license is non-OSI
     regardless, since the OSD forbids discriminating against a field of endeavor. The Hub reports this license as
     `other`, an abstention rather than an answer, so the tier rests on TII''s published text.'


### PR DESCRIPTION
Housekeeping after the rubric work. All sixteen categories have carried a `scoring_recipe`
since 2026-08-01, and three places in the docs said otherwise.

This is the same failure **#130** fixed two days ago — the openness guide asserting no scoring
formula existed after one had shipped. Worth naming as a pattern rather than a one-off: **a
guide that quotes a count goes stale the moment the count moves, and nothing checks prose.**

## Corrected

- **`verification.md` step 1** claimed 85 products across three categories had no recipe, with
  a table listing them. Rewritten as done — and it now records the two things the step turned
  out to depend on that the plan hadn't anticipated: a category is only ladderable if its
  `components` **values** are controlled tokens, and "one dataset ladder covers both dataset
  categories" was optimistic (applied unchanged to `benchmark_eval_data` it reproduced 0 of 27).
- **`verification.md`'s deferral backlog** said 174 products, counting the 85 and all 26 of
  `safeguards`. It's the **86 declared deferrals** now. The text also now says to regenerate
  the number rather than trust it, since it has moved several times in a week.
- **`openness-spectrum.md`'s caveat** listed the same three categories. Replaced with the
  caveat that actually applies: a recipe covers a category, not every product in it.

## Also

Three stale references to `use_restricted`, which #139 renamed to `use_bounded` **specifically
so stale references would be visible** — one in `freshness.md`, one in `falcon`'s note. The
historical mentions in `model.yaml` and `base_pretrained.yaml` stay on purpose (they explain
the rename). Test fixtures keep their own synthetic `use_restricted` tier, which is
self-contained.

And `skills/build-rubric/SKILL.md` cited `safeguards` at 0/26 as the
reproduction-is-a-diagnostic example. That was right on 2026-07-30 and reads as wrong at 21/26,
so it keeps the history and gains the more useful lesson: sixteen of the seventeen fixes were
**transcription, not curation**, so check for evidence recorded under an unread key before
assuming a low rate means research is owed.

## Not changed

No score, class or `components` value. `falcon` stays 3/open_weights.

The `build/registry/*.csv` files are stale locally but they are gitignored build artifacts —
CI regenerates and republishes them on every push to `sources/`, and that workflow went green
after #139.

```
uv run pytest -q                          259 passed
uv run python -m build.validate           0 error(s)
uv run python -m build.check_recipe       0 failures
uv run python -m build.check_verification G1 G2 G3 [OK]
```
