### PR TITLE
The warehouse scores thirteen categories it could not see

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -1,0 +1,39 @@
+name: parity
+
+# Gate G5: the repo and the warehouse must compute the same score for every product.
+# `build/check_rubric.py` walks each ladder in Python and
+# `currentai.scores.openness_computed` walks it in Trino, and only this makes the two agree.
+# Every drift this project has shipped was invisible to a count — the reasoning and the four
+# incidents are in build/check_parity.py.
+
+# Deliberately NOT a step in registry.yml, which is where it belongs eventually and cannot
+# go yet. Publishing pushes the static models and materializes those; the user models that
+# read them — evidence.product_evidence, scores.openness_facts, scores.openness_computed —
+# carry no cron and only refresh when something asks them to. So a parity check chained
+# straight onto a publish would compare fresh rules against a warehouse that has not
+# recomputed, and fail for a reason that is not a drift. A gate that cries wolf gets
+# switched off, which is how gates die.
+#
+# Move this into registry.yml's publish job on the day those three models carry crons, or on
+# the day publish_registry triggers the downstream runs and waits for them.
+
+on:
+  schedule:
+    # Daily, well after any working-hours publish has had time to be recomputed.
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+jobs:
+  parity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Install dependencies
+        run: uv sync --locked
+      - name: Compare every product against the warehouse
+        env:
+          OSO_API_KEY: ${{ secrets.OSO_API_KEY }}
+        run: uv run python -m build.check_parity

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,10 +138,17 @@ uv run python -m build.apply_scores --check        # exits non-zero if a score m
 uv run python -m build.apply_scores
 ```
 
-Between those two halves sit two warehouse models, both plain Trino SQL:
-`currentai.evidence.product_evidence` (graded observations) and
+Between those two halves sit three warehouse models, all plain Trino SQL:
+`currentai.evidence.product_evidence` (graded observations),
+`currentai.scores.openness_facts` (one resolved fact per dimension a ladder declares) and
 `currentai.scores.openness_computed` (the ordered-rule walk from `check_rubric.py`).
 Their SQL lives outside this repo, with the maintainer's UDM sources.
+
+None of the three carries a cron, so publishing the registry is only half a refresh: the
+user models recompute when something asks them to, in that order. `check_parity` is what
+tells you whether what the warehouse published still matches what the repo computes, and it
+is a per-product comparison because every drift this project has shipped was invisible to a
+count.
 
 Three rules worth knowing before editing any of it:
 

--- a/build/apply_scores.py
+++ b/build/apply_scores.py
@@ -20,12 +20,12 @@ That is the whole list.
 which EVERYTHING in the score was confirmed still correct, and "everything" means
 every dimension the score records, not only the ones the winning rule happens to read.
 
-This pipeline cannot establish that, for any product, by construction. Of the four
-recorded dimensions, only `license` and `weights` have a dataset route;
+This pipeline cannot establish that, for any product, by construction. Of the recorded
+openness dimensions, only `license` and `weights` have a dataset route;
 `signal_routing.yaml` declares `data` research-only and the GitHub code route carries
-`settles_dimension = false`, so `currentai.scores.openness_computed` hardcodes both to
-document grade. A document is a human's reading of prose that was already in the score
-file. Re-reading the repo is not a confirmation of anything.
+`settles_dimension = false`, so both resolve to document grade in
+`currentai.scores.openness_facts`. A document is a human's reading of prose that was
+already in the score file. Re-reading the repo is not a confirmation of anything.
 
 So there is no date here for the pipeline to write, and it writes none. Two earlier
 attempts wrote one anyway, from a derived aggregate:
@@ -42,11 +42,15 @@ Those were reverted when this writer was removed.
 `last_checked` is still read and reported, because "when did the pipeline last see any
 of this evidence" is a useful diagnostic. It is not written to a file.
 
-**What would have to change for this to write the field again.** A dataset route that
-settles `data` and `code`, and a column counting dimensions the score RECORDS rather
-than `dims_relied_on`, which counts only what the winning rule reads. Until both
-exist, a guarded write-when-fully-confirmed branch could never fire, and a branch that
-cannot fire reads as working code.
+**What would have to change for this to write the field again.** Two things, and one of
+them now exists. `currentai.scores.openness_computed` gained `dims_recorded` and
+`all_recorded_dims_from_dataset`, which count and test every dimension the score RECORDS
+rather than `dims_relied_on`'s narrower "what the winning rule read". Still missing is the
+part that matters: a dataset route that settles `data` and `code`. So the boolean is false
+on essentially every openness axis, and a guarded write-when-fully-confirmed branch would
+still never fire. A branch that cannot fire reads as working code, so there is still no
+branch — but the column it would read is there, and it is queryable if you want to see how
+far off it is.
 
 It will NOT touch `note`, `sources`, `confidence`, `adoption` or `capability`. Those
 are human prose and human judgment. A tool that rewrote them would make its own diffs

--- a/build/check_parity.py
+++ b/build/check_parity.py
@@ -1,0 +1,229 @@
+"""Compare what the repo computes against what the warehouse published, per product.
+
+Gate G5 in `docs/guides/verification.md`. `build/check_rubric.py` walks each category's
+ladder in Python; `currentai.scores.openness_computed` walks the same ladder in Trino. The
+two are separate implementations of one rubric, and nothing but this makes them agree.
+
+## Why a per-product comparison and not a count
+
+Because every drift this project has actually shipped was invisible to a count, and four of
+them landed in a single day:
+
+  * The serializer emitted evidence under the raw component key, so `post-training-data`
+    never matched the formula's `data` condition. Six products would have scored 3 on an
+    absence, with no error.
+  * `check_rubric` resolved `glm-4` through the recorded-name alias table and the SQL, which
+    mirrors `normalize_license` by hand, did not. Local said 47/47; the warehouse said 46/47.
+  * Collapsing releases into tiers made `gemma` declare six SKUs across two license tiers,
+    and most-restrictive-across-all published the family as `restricted` three months after
+    Google relicensed it. `2 / restricted` is a plausible number, which is exactly why only a
+    per-product diff catches it.
+  * `license:none` resolved to a tier named `proprietary` through check_rubric's definitional
+    fallback and to no tier at all through the warehouse's lookup table, so three
+    internal-eval benchmarks scored locally and came back null from the warehouse.
+
+Note what those have in common: the aggregate looked right, or looked wrong by one. A gate
+that asserts "16/16 categories reproduce" passes through all four.
+
+## What it does not check
+
+Whether the scores are RIGHT. Both sides read evidence parsed out of `sources/scores/`, so
+agreement is a fidelity check on two implementations of one formula. `check_verification`
+and the re-read pass are what test the facts.
+
+## Reading the output
+
+Every product falls in exactly one bucket:
+
+  agree            both sides produced the same score and class
+  both abstain     neither scores it - a declared deferral, or a ladder with no matching rung
+  DIVERGE          the two disagree, including one scoring where the other abstains
+
+`DIVERGE` is the only failure. An abstention on both sides is a curation work list, tracked
+in `category_deferrals` and printed by `check_rubric`, not a parity problem.
+
+Requires OSO_API_KEY, and reads through `build/warehouse.py` so the query carries a
+cache-busting nonce. A parity gate that can read a cached result is not a gate: the
+warehouse's SQL API caches on query TEXT, and a fixed verification query returns its first
+answer forever.
+
+Usage:
+    uv run python -m build.check_parity
+    uv run python -m build.check_parity --category safeguards
+    uv run python -m build.check_parity --verbose     # print every product, not just diffs
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+from build.check_rubric import (
+    apply_formula,
+    dimension_value,
+    license_read_keys,
+    license_tier,
+    split_components,
+)
+from build.rubrics import load_product_types, load_shared, recipe_for, resolve_recipe_variants
+from build.warehouse import query
+
+ROOT = Path(__file__).resolve().parents[1]
+TABLE = "currentai.scores.openness_computed"
+
+
+def local_scores(category_filter: str | None) -> tuple[dict, dict]:
+    """(computed, deferred) keyed by (product, category).
+
+    `computed` holds what the ladder produces, or None where it abstains. Deliberately
+    replays `check_category`'s resolution rather than reusing its return value, which is a
+    count: parity needs the per-product verdict, including for products that category has
+    deferred - the warehouse publishes a row for those too and must publish it unscored.
+    """
+    shared = load_shared(ROOT)
+    product_types = load_product_types(ROOT)
+    computed: dict[tuple[str, str], tuple[int, str] | None] = {}
+    deferred: dict[tuple[str, str], str] = {}
+
+    for path in sorted((ROOT / "sources" / "categories").glob("*.yaml")):
+        slug = path.stem
+        if category_filter and slug != category_filter:
+            continue
+        category = yaml.safe_load(path.read_text())
+        variants, errors = resolve_recipe_variants(category, shared)
+        if errors or not variants:
+            continue
+        deferrals = (category.get("scoring_recipe") or {}).get("deferred") or {}
+
+        for product in category.get("products") or []:
+            key = (product, slug)
+            if product in deferrals:
+                because = (deferrals[product] or {}).get("because", "no reason recorded")
+                deferred[key] = " ".join(str(because).split())
+                continue
+            score_path = ROOT / "sources" / "scores" / f"{product}.yaml"
+            if not score_path.exists():
+                continue
+            recipe, _ = recipe_for(variants, product_types.get(product, ""))
+            if recipe is None:
+                computed[key] = None
+                continue
+            openness = (yaml.safe_load(score_path.read_text()) or {}).get("openness") or {}
+            components = split_components(openness.get("components") or "")
+
+            # Same order as check_rubric: the tier first, and only where the ladder declares
+            # one. A tier-free ladder - hardware scores design and toolchain - must not be
+            # asked for a license it never turns on.
+            facts: dict[str, str] = {}
+            has_tiers = bool(((recipe.get("openness") or {}).get("license_tier") or {}).get("values"))
+            if has_tiers:
+                raw = next(
+                    (components[k] for k in license_read_keys(recipe) if components.get(k)), ""
+                )
+                tier = license_tier(raw, recipe)
+                if tier is None:
+                    computed[key] = None
+                    continue
+                facts["license_tier"] = tier
+            declared = ((recipe.get("openness") or {}).get("dimensions")) or {}
+            for name in declared:
+                facts[name] = dimension_value(components, name, recipe)
+            computed[key] = apply_formula(recipe, facts)
+    return computed, deferred
+
+
+def warehouse_scores(category_filter: str | None) -> dict[tuple[str, str], dict]:
+    where = f"WHERE category_slug = '{category_filter}'" if category_filter else ""
+    rows = query(f"""
+        SELECT product_slug, category_slug, openness_score, openness_class, is_deferred,
+               winning_rule_index, dimension_values, scoring_note
+        FROM {TABLE}
+        {where}
+    """)
+    return {(r["product_slug"], r["category_slug"]): r for r in rows}
+
+
+def as_pair(row: dict) -> tuple[int, str] | None:
+    score = row.get("openness_score")
+    if score is None:
+        return None
+    return int(score), row.get("openness_class")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--category", help="one category rather than all of them")
+    parser.add_argument("--verbose", action="store_true", help="print every product")
+    args = parser.parse_args()
+
+    computed, deferred = local_scores(args.category)
+    published = warehouse_scores(args.category)
+
+    agree = abstain = 0
+    diverged: list[str] = []
+
+    for key in sorted(set(computed) | set(deferred) | set(published)):
+        product, category = key
+        row = published.get(key)
+        if row is None:
+            # The warehouse publishes one row per product of every category with rules, so a
+            # missing row is a real divergence rather than a coverage gap - and it is how a
+            # roster built on the wrong table shows up. 36 deferrals were missing when the
+            # roster came from the evidence store, which emits nothing for a deferred product.
+            diverged.append(f"{product} [{category}]: no row in the warehouse at all")
+            continue
+        if key in deferred:
+            if row["is_deferred"] and as_pair(row) is None:
+                abstain += 1
+            elif not row["is_deferred"]:
+                diverged.append(
+                    f"{product} [{category}]: repo defers it, the warehouse does not know"
+                )
+            else:
+                diverged.append(
+                    f"{product} [{category}]: deferred, but the warehouse scored it "
+                    f"{as_pair(row)}"
+                )
+            continue
+        if row["is_deferred"]:
+            diverged.append(f"{product} [{category}]: the warehouse thinks it is deferred")
+            continue
+
+        local = computed.get(key)
+        remote = as_pair(row)
+        if local == remote:
+            if local is None:
+                abstain += 1
+            else:
+                agree += 1
+            if args.verbose:
+                verdict = "abstain" if local is None else f"{local[0]}/{local[1]}"
+                print(f"  ok    {product:34} {category:26} {verdict}")
+            continue
+        diverged.append(
+            f"{product} [{category}]: repo={local or 'abstains'} "
+            f"warehouse={remote or 'abstains'} rule={row['winning_rule_index']} "
+            f"facts=[{row['dimension_values']}] {row['scoring_note'] or ''}".rstrip()
+        )
+
+    print(
+        f"\n{agree} agree, {abstain} abstain on both sides, {len(diverged)} diverge "
+        f"({len(published)} rows published)"
+    )
+    for line in diverged:
+        print(f"  x {line}")
+    if diverged:
+        print(
+            "\nThe repo and the warehouse disagree. Neither is automatically right: fix "
+            "whichever is wrong, and add the case to this file's list if it is a new shape."
+        )
+        return 1
+    print("[OK] repo and warehouse agree on every product")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/serialize_rubric.py
+++ b/build/serialize_rubric.py
@@ -46,6 +46,7 @@ Emitted tables (CSVs into `build/registry/`, alongside the registry's own):
   category_scoring_rules      the ordered formula, one row per rule condition, per category
                               and product type
   category_license_tiers      tier <- example license, per category and product type
+  category_deferrals          products a category has declared its ladder does not decide
   license_aliases             a source's license slug -> canonical license name
   evidence_abstentions        values that mean "this source has no answer"
   product_openness_evidence   per-dimension values parsed from `components`
@@ -106,6 +107,27 @@ TABLES: dict[str, tuple[str, ...]] = {
         "example_license",
         "is_definitional",
     ),
+    # The ladder's dimension vocabulary, so the warehouse does not have to infer it from
+    # which keys the rules happen to test. `openness_computed` needs the declared set for
+    # two different things — which evidence rows are facts rather than traceability, and the
+    # denominator for "every dimension this score records is dataset-grade" — and a rule's
+    # `condition_key` answers neither: a dimension a formula never tests is still recorded,
+    # and `license_tier` is a derived fact rather than a declared dimension.
+    "category_dimensions": (
+        "category_slug",
+        "product_type",
+        "dimension",
+        "reads_keys",
+        "declared_values",
+    ),
+    # Deferrals cross the bridge because silence does not travel. `check_rubric` excludes a
+    # deferred product from reproduction, but the warehouse never heard about it, so a ladder
+    # ending in `otherwise` scored it anyway: `safeguards` published computed openness for
+    # nine guardrail models the repo had explicitly declined to stand behind, and seven of
+    # them disagreed with the recorded score. Emitted per category rather than per variant,
+    # because `deferred` is declared on `scoring_recipe` itself and applies whichever ladder
+    # a product resolves to.
+    "category_deferrals": ("category_slug", "product_slug", "because"),
     "license_aliases": ("source", "license_slug", "license_name"),
     "evidence_abstentions": ("source", "column_name", "abstain_value"),
     "product_openness_evidence": (
@@ -287,6 +309,26 @@ def license_tiers(slug: str, recipe: dict) -> tuple[list[dict], list[str]]:
     return rows, errors
 
 
+def category_dimensions(slug: str, recipe: dict) -> list[dict]:
+    """The ladder's declared dimensions, with the keys each may be recorded under.
+
+    `reads_keys` and `declared_values` are joined with '|' rather than emitted as one row
+    per element: nothing downstream joins on them. They are there so a reader of the
+    warehouse can see what vocabulary a dimension accepts without opening the repo, and so
+    a value arriving outside its enum can be spotted from the warehouse side too.
+    """
+    declared = ((recipe.get("openness") or {}).get("dimensions")) or {}
+    return [
+        {
+            "category_slug": slug,
+            "dimension": name,
+            "reads_keys": "|".join((spec or {}).get("reads") or [name]),
+            "declared_values": "|".join((spec or {}).get("values") or []),
+        }
+        for name, spec in declared.items()
+    ]
+
+
 def license_aliases(routing: dict) -> list[dict]:
     rows: list[dict] = []
     aliases = (((routing.get("dimensions") or {}).get("license") or {}).get("aliases")) or {}
@@ -377,6 +419,21 @@ def build_rubric(sources: dict, policy: dict, routing: dict) -> tuple[dict[str, 
         # `check_category` reads (build/check_rubric.py:240).
         deferred = (category.get("scoring_recipe") or {}).get("deferred") or {}
 
+        # Emitted from the declaration rather than from inside the products loop below,
+        # which only reaches products that have a `sources/scores/` file. The evidence
+        # store's roster is `product_categories`, so a deferred product with no score file
+        # still arrives in the warehouse carrying hub-derived dataset rows, and the filter
+        # that has to stop it needs a row here regardless.
+        for product_slug, spec in sorted(deferred.items()):
+            because = (spec or {}).get("because", "")
+            tables["category_deferrals"].append(
+                {
+                    "category_slug": slug,
+                    "product_slug": product_slug,
+                    "because": " ".join(str(because).split()),
+                }
+            )
+
         for product_type, variant_recipe in sorted(variants.items()):
             rules, rule_errors = scoring_rules(slug, variant_recipe)
             for row in rules:
@@ -389,6 +446,16 @@ def build_rubric(sources: dict, policy: dict, routing: dict) -> tuple[dict[str, 
                 row["product_type"] = product_type
             tables["category_license_tiers"].extend(tier_rows)
             errors.extend(tier_errors)
+
+            dimension_rows = category_dimensions(slug, variant_recipe)
+            for row in dimension_rows:
+                row["product_type"] = product_type
+            tables["category_dimensions"].extend(dimension_rows)
+            if not dimension_rows:
+                errors.append(
+                    f"category '{slug}' ladder for product type '{product_type}' declares no "
+                    f"openness dimensions, so nothing it scores can be traced to a fact"
+                )
 
         for product_slug in category.get("products") or []:
             record = scores.get(product_slug)

--- a/docs/guides/freshness.md
+++ b/docs/guides/freshness.md
@@ -67,6 +67,7 @@ can never be conflated.
 | score file commit date | git | Same question, weaker. Used when `last_verified` is absent. |
 | `sources[].accessed` | `sources/scores/<slug>.yaml`, per source | When was this specific URL read? Evidence provenance. **Not freshness.** |
 | `last_checked` | `currentai.scores.openness_computed` | When did the pipeline last read *any* admitted evidence. Diagnostic. **Not freshness.** |
+| `fact_accessed` | `currentai.scores.openness_facts`, per dimension | When the evidence behind one dimension was read or fetched. Provenance, per fact. **Not freshness.** |
 
 ## What it is for
 
@@ -83,12 +84,19 @@ pre-automation backlog.
 `build/apply_scores.py` is the only thing allowed to change a score file without
 somebody typing the value, and it writes `openness.score` and `openness.class`
 exclusively. It cannot earn `last_verified`, and the reason is structural rather than a
-matter of current coverage: of the four recorded dimensions only `license` and `weights`
-have a dataset route at all. `signal_routing.yaml` declares `data` research-only, and
-the GitHub code route carries `settles_dimension = false`, so
-`currentai.scores.openness_computed` hardcodes both to document grade. Document grade
-means a human read some prose and wrote it into the score file — so for those two
-dimensions the pipeline is reading the repo back to itself, which confirms nothing.
+matter of current coverage: of the recorded openness dimensions only `license` and `weights`
+have a dataset route at all. `signal_routing.yaml` declares `data` research-only, and the
+GitHub code route carries `settles_dimension = false`, so both resolve to document grade in
+`currentai.scores.openness_facts`. Document grade means a human read some prose and wrote it
+into the score file — so for those dimensions the pipeline is reading the repo back to itself,
+which confirms nothing.
+
+Nothing hardcodes that any more, which is worth stating because the older wording said the
+scoring model pinned `data` and `code` to document grade by name. It does not: a dataset row
+wins wherever its route carries `settles_dimension`, and those two routes do not. The
+conclusion is unchanged and now rests on a declaration rather than on a special case.
+`all_recorded_dims_from_dataset` in `currentai.scores.openness_computed` reports the outcome
+per axis, and it is the column a guarded write-when-fully-confirmed branch would have to read.
 
 Since "everything confirmed" can never be true of a pipeline run, there is no date for
 it to write.

--- a/docs/guides/verification.md
+++ b/docs/guides/verification.md
@@ -127,7 +127,7 @@ gate every PR; ones needing the network run periodically.
 | G2 | a claimed date with no fetch digest | required on axes claiming a confirmation | free |
 | G3 | an impossible score/class pair | the pair must be producible by some rule in the recipe | free |
 | G4 | fabricated or rotted sources | sampled re-fetch, digest and `shows` token match | network, weekly |
-| G5 | repo and warehouse drifting apart | per-product differential after every publish | network, per publish |
+| G5 | repo and warehouse drifting apart | `build/check_parity.py`, a per-product differential | network, daily |
 | G6 | a UDM revision that was never released | assert latest revision == latest release | network, per publish |
 
 **They ratchet rather than switch on.** G1 and G2 apply only to axes that carry a
@@ -137,6 +137,13 @@ already taken. A big-bang gate over all 1386 axes would fail on day one and get 
 off, which is how gates die.
 
 G3, G5 and G6 apply in full immediately — nothing has to be populated first.
+
+G5 runs on its own daily schedule rather than inside the publish job, and that placement is
+deliberate rather than a stopgap in disguise. Publishing pushes and materializes the static
+models; the three user models that read them carry no cron and only refresh when something
+asks. Chained onto a publish, the gate would compare fresh rules against a warehouse that has
+not recomputed and fail for a reason that is not a drift. Move it into `registry.yml` on the
+day those models carry crons, and not before.
 
 G3 found 17 impossible pairs on its first run, not the two that were known. `vellum`,
 `whylabs` and `tensorrt-llm` were recorded `4 / open_source`, a pair no rule emits because
@@ -175,8 +182,10 @@ evidence and asks only whether the pair exists in the ladder, so deferring canno
 
 ## Why openness can never be fully automated
 
-By design, not for want of coverage. Of the recorded openness dimensions only `license` and
-`weights` have a dataset route. `signal_routing.yaml` declares `data` research-only, and the
+By design, not for want of coverage. `all_recorded_dims_from_dataset` in
+`currentai.scores.openness_computed` is the column that says so per axis, and it is false
+almost everywhere. Of the recorded openness dimensions only `license` and `weights` have a
+dataset route. `signal_routing.yaml` declares `data` research-only, and the
 GitHub code route carries `settles_dimension: false` because a live repo establishes neither
 a full training pipeline nor an ungated core. For software categories, `core_gated` needs a
 pricing page read.
@@ -267,33 +276,68 @@ evidence recorded under a key the ladder does not read, a couple of judgment cal
 SKU governs a bundled guard model. Correcting those 26 is what remains, through curation
 rather than more machinery.
 
-### 2. Generalize the scoring SQL, once
+### 2. Generalize the scoring SQL, once ✅ **done 2026-08-05**
 
-`currentai.scores.openness_computed` resolves `weights`, `data`, `code` and `license` by
-name in hardcoded UNION branches, so the ten software categories do not score in the
-warehouse at all today. It needs to read the dimensions each recipe DECLARES, exactly as
-`build/check_rubric.py` now does.
+`currentai.scores.openness_computed` resolved `weights`, `data`, `code` and `license` by name
+in hardcoded UNION branches, so 13 of the 16 categories produced no rows at all: their rules
+test `source`, `core_gated`, `availability`, `answers`, `documentation`, `schematics` and
+`toolchain`, nothing built those facts, and with no `otherwise` rung in those ladders every
+product fell out of the join. 74 rows of a possible 470.
 
-Two things ride along:
+It now reads the dimensions each ladder DECLARES, from a new
+`currentai.registry.category_dimensions`, so a seventeenth category scores in the warehouse
+the day its recipe lands. **470 rows, 384 scored, and `check_parity` reports zero divergence
+from `check_rubric` on every one of them.**
 
-- **A per-axis "every recorded dimension is dataset-grade" column.** `dims_relied_on` counts
-  only what the winning rule reads, which is the wrong denominator — `freshness.md` requires
-  every dimension the score *records*. Without this column no tool can ever legitimately
-  write `last_verified`, so it is the precondition for step 3.
-- **A `category_deferrals` table.** `deferred` currently lives only in the repo, so the
-  warehouse does not know which products a category has held back. There are 86 of them now,
-  and no category is without a recipe any more, so deferrals are the whole of it. For the software
-  categories the silence has been safe: with no `otherwise` rule in the software ladder their
-  deferred products fall out of the model's INNER JOIN rather than being scored wrongly.
+What it took, beyond the generic resolution:
 
-  **That safety argument no longer covers every category.** `sources/rubrics/model.yaml` ends
-  in `otherwise: {score: 3, class: open_weights}`, so a deferred product on the model ladder
-  gets a score in the warehouse instead of dropping out. `safeguards` is the first category to
-  pair an `otherwise` ladder with deferrals, and all 26 of its products are deferred. Until
-  this table exists, the warehouse can compute openness for products whose recorded scores the
-  repo has explicitly declined to reproduce, and for seven of the nine guardrail models the
-  computed value disagrees with the published one. That makes the table a correctness fix for
-  `safeguards` rather than only an observability one.
+- **A split into two models.** Generalizing took the query to 174 Trino stages against a
+  ceiling of 150, because the resolution CTEs are read several times each by the rule walk
+  and Trino replans the subtree per reference. `currentai.scores.openness_facts` now holds one
+  row per (product, category, declared dimension) and `openness_computed` walks the rules over
+  it. That is also the audit chain's third link, which this guide describes and which had no
+  table: "which fact did this score rest on, at what grade" is now a select.
+- **The rule join carries the product type.** `rule_index` is unique only within
+  `(category_slug, product_type)`, so `safeguards` — guardrail models on one ladder, guardrail
+  software on another — was the category where joining on the slug alone interleaves two
+  ladders' numbering.
+- **The tier-free allowance.** The unmapped-license guard now fires only for ladders that ask
+  about a license. `sources/rubrics/hardware.yaml` declares no `license_tier` and none of the
+  20 edge products records one, so applied unconditionally the guard nulls all 20.
+- **`dims_recorded` and `all_recorded_dims_from_dataset`.** `dims_relied_on` counts only what
+  the winning rule reads, which is the wrong denominator — this guide requires every dimension
+  the score *records*. The new columns are the precondition for step 3, and for openness the
+  boolean is false almost everywhere, which is the honest answer rather than a gap.
+- **A `category_deferrals` table.** `deferred` lived only in the repo, so the warehouse did
+  not know which products a category had held back. Deferred products now carry a row with a
+  null score and the recorded reason, and the rule walk is skipped for them.
+
+  This was a correctness fix, not observability. `sources/rubrics/model.yaml` ends in
+  `otherwise: {score: 3, class: open_weights}`, so a deferred product on the model ladder was
+  scored rather than dropped: `safeguards` published a computed openness for nine guardrail
+  models the repo had explicitly declined to stand behind, and seven of the nine disagreed
+  with the published value.
+
+Three things this step turned up that the plan did not anticipate:
+
+- **The evidence model was three recipes stale.** `currentai.evidence.product_evidence` last
+  materialized before the dataset, hardware and safeguards recipes landed — and before the
+  slug collapse in #121, so it still held 47 orchestration products where the repo has 36.
+  None of these models carries a cron, so "the repo is ahead of the warehouse" had a second
+  cause underneath the SQL. Crons are step 5 of the plan in `layer2-status`; until then a
+  publish is only half a refresh.
+- **The roster cannot come from the evidence store.** It was
+  `SELECT DISTINCT product_slug, category_slug FROM product_evidence`, which quietly made
+  coverage conditional on evidence existing: `serialize_rubric` emits no document rows for a
+  deferred product, so 36 of the 86 deferrals — the ones with no Hub or GitHub artifact to
+  generate a dataset row either — were absent rather than unscored. It is now
+  `product_categories`, which is what a category claims.
+- **`license:none` resolved two ways.** `check_rubric` maps `none`, `closed` and `proprietary`
+  to a tier NAMED `proprietary` whether or not the ladder declares one; the warehouse joins a
+  real lookup table and found no row, so three internal-eval benchmarks scored locally and
+  came back null. The dataset ladder's `unstated` tier already means exactly this, so the
+  three tokens are now declared there rather than left to a fallback. Precisely the shape of
+  drift `check_parity` exists to catch, and it was caught by the first run of it.
 
 ### 3. The automated freshness pass — roughly 400 axes
 

--- a/docs/runbooks/verification-pass.md
+++ b/docs/runbooks/verification-pass.md
@@ -157,41 +157,64 @@ category's stage or gaps moved (diff the serialized output before and after).
 
 ---
 
-## Phase 2 — Generalize the scoring SQL, once
+## Phase 2 — Generalize the scoring SQL, once ✅ done 2026-08-05
 
-`currentai.scores.openness_computed` resolves `weights`, `data`, `code` and `license` by name
-in hardcoded UNION branches, so the ten software categories do not score in the warehouse at
-all today. It must read the dimensions each recipe DECLARES, as `build/check_rubric.py` now
-does.
+Landed as two models. `docs/guides/verification.md` step 2 carries the full account; this is
+the operational half.
 
-Three things ship together:
+`currentai.scores.openness_computed` resolved `weights`, `data`, `code` and `license` by name,
+so 13 of 16 categories produced no rows. It now reads
+`currentai.registry.category_dimensions`, the ladder's own declaration. **470 rows, 384
+scored, zero divergence from `check_rubric`.**
 
-1. **Dimension-generic resolution**, driven by `category_scoring_rules.condition_key`.
-2. **A per-axis "every RECORDED dimension is dataset-grade" column.** `dims_relied_on` counts
-   only what the winning rule reads, which is the wrong denominator — the rule requires every
-   dimension the score *records*. Without this, Phase 3 cannot legitimately write a date.
-3. **A `category_deferrals` table.** `deferred` lives only in the repo, so the warehouse does
-   not know which 174 products are held back (63 recipe deferrals plus 111 in the four
-   categories with no recipe). With no `otherwise` rule in the software
-   ladder they currently fall out of an INNER JOIN — safe, but silent.
+What shipped:
 
-Deploy per `docs/runbooks/deploy-udms.md`, and note the release step:
+1. **Dimension-generic resolution**, in a new `currentai.scores.openness_facts` — one row per
+   (product, category, declared dimension), which is also the audit chain's dimension link.
+   The split was forced: one query hit 174 Trino stages against a ceiling of 150.
+2. **`dims_recorded` and `all_recorded_dims_from_dataset`**, the denominator Phase 3 needs.
+3. **`category_deferrals`**, plus `category_dimensions`. Deferred products keep a row, carry
+   the recorded reason, and are never walked through the rules.
+
+### The refresh order, which is not optional
+
+Nothing here carries a cron, so a publish is only the first half of a refresh. Getting this
+wrong looks exactly like a code bug: the first run of the generalized SQL reported three
+categories missing entirely, and the cause was `product_evidence` sitting three recipes stale
+— from before the slug collapse in #121, so it still held 47 orchestration products against
+the repo's 36.
 
 ```bash
-# revision -> RELEASE -> run. The middle step is the one that gets forgotten.
+# 1. push the declarations, and wait for the static models to materialize
 uv run python -m build.serialize_rubric && uv run python -m build.publish_registry
-# then create the revision, create the release, then trigger the run
+
+# 2. refresh the user models IN ORDER, waiting for each: they do not cascade
+#    evidence.product_evidence -> scores.openness_facts -> scores.openness_computed
+
+# 3. revision -> RELEASE -> run, for a model whose SQL changed. The middle step is the
+#    one that gets forgotten, and a run without it executes the previous release.
+uv run python tools/deploy_udm.py --dataset scores --model openness_facts \
+    --sql udms/scores_openness_facts.sql
+
+# 4. prove it
+uv run python -m build.check_parity
 ```
 
 ### G5 — the parity gate
 
-Add `build/check_parity.py`: for every scored product, compare `check_rubric`'s local result
-against `currentai.scores.openness_computed` and fail on any divergence. Run it in
-`registry.yml` after the publish step.
+`build/check_parity.py` compares `check_rubric`'s local verdict against
+`currentai.scores.openness_computed` for every product, and fails on any divergence. It runs
+daily in `.github/workflows/parity.yml`.
 
-This is the mechanism for the failure mode that bit four times in one day — `check_rubric`
-and the SQL mirror each other's logic by hand and drift silently. Every one of those four was
-caught by per-product comparison and none by a local check. Automate the thing that worked.
+This is the mechanism for the failure mode that bit four times in one day — `check_rubric` and
+the SQL mirror each other's logic by hand and drift silently. Every one of those four was
+caught by per-product comparison and none by a local check, and the gate's first run caught a
+fifth: `license:none` resolving to a tier through check_rubric's definitional fallback and to
+nothing at all through the warehouse's lookup table.
+
+It is not in `registry.yml`, on purpose. Chained onto a publish it would compare fresh rules
+against the un-recomputed warehouse of step 2 above and fail for a reason that is not a drift.
+Move it there when those three models carry crons.
 
 **Exit criteria:** all 16 categories score in the warehouse, `check_parity` passes, and the
 deferral count in `category_deferrals` matches the repo's.

--- a/sources/rubrics/dataset.yaml
+++ b/sources/rubrics/dataset.yaml
@@ -171,7 +171,17 @@ openness:
         # `cc` is `livecodebench` recording the family without the variant, which names no
         # terms: CC-BY and CC-BY-NC are both `cc`. `undeclared on HF dataset card` is
         # `swe-bench-verified` saying so outright.
-        examples: [not-clearly-stated-on-card, undeclared on HF dataset card, cc]
+        #
+        # `none`, `closed` and `proprietary` are listed here rather than left to
+        # check_rubric's definitional fallback, which resolves all three to a tier NAMED
+        # `proprietary` whether or not the ladder declares one. This ladder does not: an
+        # unpublished eval suite grants nothing, which is what `unstated` already means, and
+        # its definition above says so. Left implicit the two halves disagreed - the local
+        # checker invented the tier and scored the three internal-eval products on their
+        # availability rung, while the warehouse joins a real lookup table, found no row, and
+        # suppressed the score. Declaring it puts both on the same table.
+        examples: [not-clearly-stated-on-card, undeclared on HF dataset card, cc, none,
+          closed, proprietary]
 
   # Ordered, first match wins. There is deliberately NO `otherwise`. Most of the
   # availability vocabulary and the whole `unstated` tier are cases where the ladder either

--- a/tests/test_check_parity.py
+++ b/tests/test_check_parity.py
@@ -1,0 +1,110 @@
+"""Tests for the repo/warehouse parity gate.
+
+No network. The warehouse half is faked, because what needs testing is the comparison: which
+disagreements the gate calls a failure, and which it lets through as a shared abstention.
+
+`local_scores` does read the real `sources/`, on purpose. Its job is to replay what
+`check_rubric` would conclude, and a fixture would let the two drift - which is the exact
+failure mode this gate exists to catch, one level up.
+"""
+
+import build.check_parity as parity
+from build.check_parity import as_pair, local_scores
+
+
+def row(product, category, score=None, klass=None, deferred=False, rule=None):
+    return {
+        "product_slug": product,
+        "category_slug": category,
+        "openness_score": score,
+        "openness_class": klass,
+        "is_deferred": deferred,
+        "winning_rule_index": rule,
+        "dimension_values": "",
+        "scoring_note": None,
+    }
+
+
+def run(monkeypatch, published, category=None, verbose=False):
+    """Drive main() with a faked warehouse. Returns its exit status."""
+    monkeypatch.setattr(parity, "warehouse_scores", lambda _c: published)
+
+    class Args:
+        pass
+
+    args = Args()
+    args.category = category
+    args.verbose = verbose
+    monkeypatch.setattr(parity.argparse.ArgumentParser, "parse_args", lambda self: args)
+    return parity.main()
+
+
+def test_local_scores_matches_check_rubrics_split():
+    """384 products the ladders decide, 86 the categories defer. The same 470 the warehouse
+    publishes, so a change to either number should show up as a failure here first."""
+    computed, deferred = local_scores(None)
+    assert len(deferred) == 86
+    assert len(computed) == 384
+    assert not set(computed) & set(deferred)
+    # Every one of the 384 reproduces today, so none should abstain.
+    assert [key for key, value in computed.items() if value is None] == []
+
+
+def test_agreement_passes(monkeypatch):
+    computed, deferred = local_scores("base_pretrained")
+    published = {
+        key: row(key[0], key[1], value[0], value[1], rule=0) for key, value in computed.items()
+    }
+    published.update({key: row(key[0], key[1], deferred=True) for key in deferred})
+    assert run(monkeypatch, published, "base_pretrained") == 0
+
+
+def test_a_different_score_fails(monkeypatch, capsys):
+    computed, _ = local_scores("base_pretrained")
+    published = {
+        key: row(key[0], key[1], value[0], value[1], rule=0) for key, value in computed.items()
+    }
+    victim = sorted(published)[0]
+    published[victim]["openness_score"] = 1
+    published[victim]["openness_class"] = "closed"
+    assert run(monkeypatch, published, "base_pretrained") == 1
+    assert "1 diverge" in capsys.readouterr().out
+
+
+def test_a_missing_row_fails(monkeypatch, capsys):
+    """The shape that hid 36 deferrals when the roster came from the evidence store: a
+    product the repo knows about and the warehouse never published at all."""
+    computed, _ = local_scores("base_pretrained")
+    published = {
+        key: row(key[0], key[1], value[0], value[1], rule=0) for key, value in computed.items()
+    }
+    del published[sorted(published)[0]]
+    assert run(monkeypatch, published, "base_pretrained") == 1
+    assert "no row in the warehouse at all" in capsys.readouterr().out
+
+
+def test_scoring_a_deferred_product_fails(monkeypatch, capsys):
+    """The safeguards bug: a ladder ending in `otherwise` scoring what the repo declined."""
+    computed, deferred = local_scores("safeguards")
+    published = {
+        key: row(key[0], key[1], value[0], value[1], rule=0) for key, value in computed.items()
+    }
+    published.update({key: row(key[0], key[1], deferred=True) for key in deferred})
+    victim = sorted(deferred)[0]
+    published[victim] = row(victim[0], victim[1], 3, "open_weights", deferred=False, rule=6)
+    assert run(monkeypatch, published, "safeguards") == 1
+    assert "repo defers it, the warehouse does not know" in capsys.readouterr().out
+
+
+def test_a_shared_abstention_is_not_a_divergence(monkeypatch, capsys):
+    """Both sides declining is a curation work list, not a parity failure."""
+    _, deferred = local_scores("ui_api")
+    published = {key: row(key[0], key[1], deferred=True) for key in deferred}
+    assert run(monkeypatch, published, "ui_api") == 1  # the scored products are missing
+    out = capsys.readouterr().out
+    assert f"{len(deferred)} abstain on both sides" in out
+
+
+def test_as_pair_normalizes_the_score_type():
+    assert as_pair(row("x", "y", 4, "open_core")) == (4, "open_core")
+    assert as_pair(row("x", "y")) is None


### PR DESCRIPTION
## What this is

Step 2 of `docs/guides/verification.md` — generalizing the scoring SQL off its hardcoded model dimensions. It was the single biggest correctness item outstanding: `currentai.scores.openness_computed` resolved `weights`, `data`, `code` and `license` by name, so 13 of the 16 categories produced **no rows at all**. Their rules test `source`, `core_gated`, `availability`, `answers`, `documentation`, `schematics` and `toolchain`; nothing built those facts; and with no `otherwise` rung in those ladders every product fell out of the join.

74 rows of a possible 470. **Now 470 rows, 384 scored, zero divergence from `check_rubric` on every one of them.**

The SQL itself lives with the maintainer's UDM sources, not here. This PR is the repo half plus the gate.

## The three tables that cross the bridge

- **`category_dimensions`** — the ladder's own vocabulary. The warehouse now reads what a recipe *declares* rather than inferring it from which keys the rules test, and those differ: `base_pretrained` declares `checkpoints` and `edge_hardware` declares five dimensions where only two are tested. A dimension no formula reads is still recorded, so it still counts toward freshness.
- **`category_deferrals`** — the 86 products a category declares its ladder does not decide. A correctness fix rather than observability: `sources/rubrics/model.yaml` ends in `otherwise: {score: 3, class: open_weights}`, so `safeguards` published a computed openness for nine guardrail models the repo had explicitly declined to stand behind, and seven of the nine disagreed with the published value.
- **`none`, `closed` and `proprietary` on the dataset ladder's `unstated` tier** — they were reaching `check_rubric`'s definitional fallback, which resolves all three to a tier *named* `proprietary` whether or not a ladder declares one. The warehouse joins a real lookup table, found no row, and suppressed the score, so three internal-eval benchmarks scored locally and came back null. `unstated`'s own definition is "no license recorded on the card at all", which is exactly this.

## G5, the parity gate

`build/check_parity.py` compares `check_rubric`'s local verdict against the published score for every product, and `.github/workflows/parity.yml` runs it daily.

Per product, not per count, because every drift this project has shipped was invisible to a count — the `gemma` family read `2/restricted` for three months after Google relicensed, and `2/restricted` is a plausible number. The gate's first run earned its keep by finding the `license:none` divergence above.

**Not** wired into `registry.yml`, on purpose: the three user models behind this carry no cron, so a publish is only half a refresh and a gate chained onto one would fail on the un-recomputed warehouse rather than on a drift. That is how gates get switched off. There is a note saying to move it once those models have crons.

## What this turned up on the way

- **The evidence model was three recipes stale.** `currentai.evidence.product_evidence` had last materialized before the dataset, hardware and safeguards recipes landed, and before the slug collapse in #121 — it still held 47 orchestration products where the repo has 36. So "the repo is ahead of the warehouse" had a second cause underneath the SQL, and anything anyone queried against `currentai.evidence.*` or `currentai.scores.*` in the past week was pre-#121 data.
- **The roster could not come from the evidence store.** It was `SELECT DISTINCT product_slug, category_slug FROM product_evidence`, which quietly made coverage conditional on evidence existing: `serialize_rubric` emits no document rows for a deferred product, so 36 of the 86 deferrals were absent rather than unscored. It is now `product_categories`, which is what a category claims.
- **The query hit Trino's 150-stage ceiling** at 174 stages once generalized, so the model split in two. `currentai.scores.openness_facts` holds one row per (product, category, declared dimension) and `openness_computed` walks the rules over it. That split is also the audit chain's third link, which this guide has described from the start and which had no table.

## Test plan

- `uv run python -m pytest tests/ -q` — 266 pass, 7 of them new
- `uv run python -m build.check_rubric` — 16/16 `[OK]`, unchanged: 384 reproduced, 86 deferred
- `uv run python -m build.check_recipe` — 0 failures
- `uv run python -m build.serialize_rubric --check` — clean
- `uv run python -m build.check_parity` — `384 agree, 86 abstain on both sides, 0 diverge (470 rows published)`
- `uv run python -m build.apply_scores --check` — 470 read, 0 files would change, 0 scores moved

Deployed and verified against the live warehouse, not just locally.

Closes the step-2 item in `docs/guides/verification.md`; `docs/runbooks/verification-pass.md` carries the refresh order, which is not optional.