### PR TITLE
The three scoring models are on weekly crons now, so say what that does and does not buy

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -6,21 +6,29 @@ name: parity
 # Every drift this project has shipped was invisible to a count — the reasoning and the four
 # incidents are in build/check_parity.py.
 
-# Deliberately NOT a step in registry.yml, which is where it belongs eventually and cannot
-# go yet. Publishing pushes the static models and materializes those; the user models that
-# read them — evidence.product_evidence, scores.openness_facts, scores.openness_computed —
-# carry no cron and only refresh when something asks them to. So a parity check chained
-# straight onto a publish would compare fresh rules against a warehouse that has not
-# recomputed, and fail for a reason that is not a drift. A gate that cries wolf gets
-# switched off, which is how gates die.
+# Deliberately NOT a step in registry.yml. Publishing pushes the static models and
+# materializes those, but the user models that read them recompute on a WEEKLY cron —
+# evidence.product_evidence Monday 03:00 UTC, scores.openness_facts 04:00,
+# scores.openness_computed 05:00. So a parity check chained onto a publish would compare
+# fresh rules against a warehouse that has not recomputed yet, and fail for a reason that is
+# not a drift. A gate that cries wolf gets switched off, which is how gates die.
 #
-# Move this into registry.yml's publish job on the day those three models carry crons, or on
-# the day publish_registry triggers the downstream runs and waits for them.
+# Crons do not fix that, which is worth being precise about: they bound how stale the
+# warehouse gets, not how quickly a publish reaches it. On a weekly schedule a Tuesday merge
+# waits six days to be scored. This moves into registry.yml on the day publish_registry
+# triggers the three downstream runs and waits for them, and not before.
+#
+# This schedule is why the gate is weekly rather than daily, and the two must move together.
+# A daily gate over a weekly chain fails every day between a merge and the next Monday — six
+# false alarms per real one, all of them saying "the warehouse has not caught up yet", which
+# is not what a parity gate is for. Anyone wanting a check sooner should refresh the three
+# models and then run this by hand: workflow_dispatch is here for exactly that.
 
 on:
   schedule:
-    # Daily, well after any working-hours publish has had time to be recomputed.
-    - cron: "0 6 * * *"
+    # Monday 06:00 UTC, one hour behind scores.openness_computed, so it grades a warehouse
+    # that has just recomputed against the rules CI pushed during the week.
+    - cron: "0 6 * * 1"
   workflow_dispatch:
 
 jobs:

--- a/docs/guides/verification.md
+++ b/docs/guides/verification.md
@@ -138,12 +138,21 @@ off, which is how gates die.
 
 G3, G5 and G6 apply in full immediately — nothing has to be populated first.
 
-G5 runs on its own daily schedule rather than inside the publish job, and that placement is
+G5 runs on its own weekly schedule rather than inside the publish job, and that placement is
 deliberate rather than a stopgap in disguise. Publishing pushes and materializes the static
-models; the three user models that read them carry no cron and only refresh when something
-asks. Chained onto a publish, the gate would compare fresh rules against a warehouse that has
-not recomputed and fail for a reason that is not a drift. Move it into `registry.yml` on the
-day those models carry crons, and not before.
+models; the three user models that read them recompute on Monday at 03:00, 04:00 and 05:00 UTC,
+upstream first, and G5 grades the result at 06:00. Chained onto a publish instead, the gate would
+compare fresh rules against a warehouse that has not recomputed and fail for a reason that is
+not a drift.
+
+**The gate's schedule has to match the chain's.** A daily gate over a weekly chain fails every
+day between a merge and the following Monday, always saying "the warehouse has not caught up",
+which is not what a parity gate is for and is how a gate earns its way into being ignored. If
+you want a check sooner, refresh the three models and run `check_parity` by hand.
+
+The crons bound how stale the warehouse gets; they do not make a publish arrive any faster, so a
+Tuesday merge is scored the following Monday. Move G5 into `registry.yml` on the day
+`publish_registry` triggers those three runs and waits for them.
 
 G3 found 17 impossible pairs on its first run, not the two that were known. `vellum`,
 `whylabs` and `tensorrt-llm` were recorded `4 / open_source`, a pair no rule emits because

--- a/docs/runbooks/verification-pass.md
+++ b/docs/runbooks/verification-pass.md
@@ -178,11 +178,24 @@ What shipped:
 
 ### The refresh order, which is not optional
 
-Nothing here carries a cron, so a publish is only the first half of a refresh. Getting this
-wrong looks exactly like a code bug: the first run of the generalized SQL reported three
-categories missing entirely, and the cause was `product_evidence` sitting three recipes stale
-— from before the slug collapse in #121, so it still held 47 orchestration products against
-the repo's 36.
+The three user models now carry weekly crons — `evidence.product_evidence` Monday 03:00 UTC,
+`scores.openness_facts` 04:00, `scores.openness_computed` 05:00, with G5 grading at 06:00 — so
+the warehouse is at most a week behind the repo on its own. **A publish is still only the first
+half of a refresh**, and on a weekly cadence that matters more rather than less: merge on
+Tuesday and the map carries the old numbers until the following Monday unless you walk the chain
+below. Do that whenever a merge changes a score, rather than waiting.
+
+Getting this wrong looks exactly like a code bug: the first run of the generalized SQL reported
+three categories missing entirely, and the cause was `product_evidence` sitting three recipes
+stale — from before the slug collapse in #121, so it still held 47 orchestration products
+against the repo's 36. That was with nothing scheduled at all; a weekly cron caps that at a week,
+and changes nothing about the next ten minutes.
+
+**What the crons do NOT refresh: the signals themselves.** `signal_huggingface.hub_state` and
+`signal_github.repo_state` are still `@manual`, so the chain recomputes the same fetched facts
+every Monday. Scheduling those is a bigger decision than a cron expression — it is the point at
+which scores start moving on their own, which is what `apply_scores --check` exits non-zero
+for and what the review digest in the autopilot design exists to handle.
 
 ```bash
 # 1. push the declarations, and wait for the static models to materialize


### PR DESCRIPTION
Follow-up to #141, which shipped a workflow comment and a guide paragraph asserting these models carry no cron. True when it merged; not true now.

```
evidence.product_evidence   Mon 03:00 UTC   rev #7
scores.openness_facts       Mon 04:00       rev #6
scores.openness_computed    Mon 05:00       rev #14
check_parity (G5)           Mon 06:00       parity.yml
```

Upstream first, so the gate grades a warehouse that has just recomputed against the rules CI pushed during the week. Crons are set on the platform, each revision released; the SQL is unchanged, only the schedule.

**G5 moves from daily to weekly with them, and the coupling is the point.** A daily gate over a weekly chain fails every day between a merge and the following Monday, always saying "the warehouse has not caught up yet" — six false alarms per real one, which is how a gate earns its way into being ignored. This guide makes that argument about other gates; it applies here. `workflow_dispatch` stays for anyone who wants an answer sooner, and the runbook says to refresh the three models first.

**The condition for moving G5 into `registry.yml` was wrong, not merely stale.** It said "on the day those models carry crons" — that day has arrived and moving it would still be wrong. A cron bounds how stale the warehouse gets; it does not make a publish arrive faster. On a weekly cadence a Tuesday merge waits six days, so a parity check chained onto that publish still compares fresh rules against a warehouse that has not recomputed. The real condition is `publish_registry` triggering the three downstream runs and waiting for them.

Weekly also raises the stakes on the manual path, so the runbook now says to walk the chain after any merge that moves a score rather than waiting for Monday.

**What the crons do not cover:** `signal_huggingface.hub_state` and `signal_github.repo_state` are still `@manual`, so the chain recomputes the same fetched facts every Monday. The map cannot yet notice that a repo was archived or a model relicensed. Scheduling those is the point at which scores start moving without anyone touching the repo — what `apply_scores --check` exits non-zero for, and what the review digest in the autopilot design exists to handle. Worth deciding deliberately rather than as a side effect of this.

## Test plan

- `uv run python -m pytest tests/ -q` — 266 pass
- `uv run python -m build.check_parity` — `384 agree, 86 abstain on both sides, 0 diverge` against the freshly released revisions
- Crons verified on the platform: all three report `0 {3,4,5} * * 1`, `kind=FULL`, and latest revision == latest release

Docs and one workflow schedule. No SQL, no scoring behavior.