### PR TITLE
feat: the payload carries slugs, organizations, aliases and freshness

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -18,6 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history: build.freshness_payload dates each score file from its last
+          # commit, and a shallow clone collapses all 470 onto the tip commit.
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true

--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -31,6 +31,14 @@ jobs:
         run: uv run python -m build.validate
       - name: Serialize (generated = run date)
         run: uv run python -m build.serialize --date "$(date -u +%F)"
+
+      # Same identity gate validate.yml runs on every PR, plus the retirement check that
+      # only a two-payload diff can do: fail the bot commit rather than let a slug 404
+      # silently. See build/check_payload.py and build/check_retirement.py.
+      - name: Gate the serialized payload
+        run: uv run python -m build.check_payload
+      - name: Fail on an unrouted retirement
+        run: uv run python -m build.check_retirement
       - name: Render notebook
         run: uv run python build/render.py
       - name: Sync README stat badges

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -40,6 +40,12 @@ jobs:
       - name: Serialize dry-run
         run: uv run python -m build.serialize --date ci-dry-run
 
+      # The payload's own identity invariants: slugs, org_slug resolution, aliases, and
+      # the freshness canary that catches a shallow-clone checkout from the inside. See
+      # build/check_payload.py.
+      - name: Gate the serialized payload
+        run: uv run python -m build.check_payload
+
       # Render the notebook and parse the result. The generated file is bot-owned and is
       # not committed from a PR, but rendering is the only thing that catches a
       # contributor string breaking the generated Python: a quote in a strapline produces

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,6 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history: build.freshness_payload dates each score file from its last
+          # commit, and a shallow clone collapses all 470 onto the tip commit.
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true

--- a/build/check_freshness.py
+++ b/build/check_freshness.py
@@ -68,7 +68,7 @@ def parse_date(value: object) -> date | None:
     return None
 
 
-def commit_dates() -> dict[str, date]:
+def commit_dates(root: Path | None = None) -> dict[str, date]:
     """Most recent commit date per score file, from one pass over git history.
 
     This is the fallback when an axis carries no `last_verified`, and it is a better
@@ -86,10 +86,15 @@ def commit_dates() -> dict[str, date]:
 
     One `git log` for the whole directory rather than 495 invocations. Walking
     newest-first, the first time a path appears is its latest commit.
+
+    `root` defaults to this module's own repository root, which is what every existing
+    caller in this file wants. `build.freshness_payload` passes its own `root` through
+    explicitly so it can be pointed at a different checkout (a test fixture, a shallow-
+    clone probe) without silently reading this repository's history instead.
     """
     result = subprocess.run(
         ["git", "log", "--format=%cs", "--name-only", "--", "sources/scores"],
-        cwd=ROOT,
+        cwd=root or ROOT,
         capture_output=True,
         text=True,
     )

--- a/build/check_payload.py
+++ b/build/check_payload.py
@@ -1,0 +1,113 @@
+"""Gate the serialized payload's identity invariants.
+
+build/validate.py covers the source YAML. This covers the artifact the app consumes, which
+is a different thing: a serializer bug can produce a valid source tree and a payload the
+app cannot build pages from.
+
+Every branch below either confirms one invariant or refuses to judge the payload -- a
+missing top-level block, `None` where a dict belongs, an empty product set, or a malformed
+row must never read as "fine". A gate that goes green when it cannot understand its input
+is worse than no gate at all: it looks like protection nobody is actually getting.
+"""
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+_ALIAS_KINDS = ("products", "organizations")
+_FRESHNESS_BASES = {"verified", "commit"}
+
+
+class PayloadError(RuntimeError):
+    pass
+
+
+def _require_dict(payload: dict, key: str) -> dict:
+    value = payload.get(key)
+    if not isinstance(value, dict):
+        raise PayloadError(
+            f"payload has no usable {key!r} block (got {type(value).__name__})"
+        )
+    return value
+
+
+def check(payload: dict) -> None:
+    if not isinstance(payload, dict):
+        raise PayloadError(f"payload is not an object (got {type(payload).__name__})")
+
+    categories = _require_dict(payload, "categories")
+    orgs = _require_dict(payload, "organizations")
+    aliases = _require_dict(payload, "aliases")
+    alias_maps: dict[str, dict] = {}
+    for kind in _ALIAS_KINDS:
+        value = aliases.get(kind)
+        if not isinstance(value, dict):
+            raise PayloadError(
+                f"payload has no usable aliases.{kind} block (got {type(value).__name__})"
+            )
+        alias_maps[kind] = value
+
+    rows: list[dict] = []
+    for cid, cat in categories.items():
+        if not isinstance(cat, dict):
+            raise PayloadError(f"category {cid!r} is not an object")
+        products = cat.get("products")
+        if not isinstance(products, list):
+            raise PayloadError(f"category {cid!r} has no usable products list")
+        rows.extend(products)
+
+    # A gate that only checks "more than one distinct freshness date" is vacuously true
+    # on zero products (an empty set has zero distinct dates too) and on one product (it
+    # can never have two dates on its own) -- both would otherwise fall through to the
+    # canary below and get its confusing shallow-clone message instead of the real
+    # problem: there is nothing here to evaluate at all.
+    if not rows:
+        raise PayloadError("the payload has no products at all")
+
+    seen: set[str] = set()
+    for row in rows:
+        if not isinstance(row, dict):
+            raise PayloadError(f"a product row is not an object (got {type(row).__name__})")
+        slug = row.get("slug")
+        if not slug:
+            raise PayloadError(f"product {row.get('product')!r} has no slug")
+        if slug in seen:
+            raise PayloadError(f"duplicate product slug {slug!r}")
+        seen.add(slug)
+        if row.get("org_slug") not in orgs:
+            raise PayloadError(f"{slug!r} points at missing organization {row.get('org_slug')!r}")
+        fresh = row.get("freshness")
+        if (not isinstance(fresh, dict) or not fresh.get("date")
+                or fresh.get("basis") not in _FRESHNESS_BASES):
+            raise PayloadError(f"{slug!r} has no usable freshness record")
+
+    dates = {row["freshness"]["date"] for row in rows}
+    if len(dates) <= 1:
+        raise PayloadError(
+            "the payload has only one distinct freshness date across every product, which is "
+            "the signature of a shallow clone dating every score file to the tip commit"
+        )
+
+    for kind, live in (("products", seen), ("organizations", set(orgs))):
+        for old, new in alias_maps[kind].items():
+            if old in live:
+                raise PayloadError(f"{kind} alias {old!r} is also a live slug")
+            if new not in live:
+                raise PayloadError(f"{kind} alias {old!r} points at missing {new!r}")
+
+
+def main() -> int:
+    payload = json.loads((ROOT / "build" / "notebook_data.json").read_text())
+    try:
+        check(payload)
+    except PayloadError as exc:
+        print(f"check_payload: {exc}", file=sys.stderr)
+        return 1
+    n = sum(len(c["products"]) for c in payload["categories"].values())
+    print(f"check_payload: {n} products, {len(payload['organizations'])} organizations, ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build/check_retirement.py
+++ b/build/check_retirement.py
@@ -1,0 +1,107 @@
+"""Fail when a product slug leaves the payload without a redirect.
+
+build/validate.py structurally cannot notice a deletion nobody recorded, because it only
+reads live files, and a deletion is the absence of one. This diffs the currently serialized
+payload against the one committed at HEAD and requires every slug that fell out in between
+to carry an alias.
+
+## Reading a git failure honestly
+
+`git show HEAD:<payload>` fails identically -- exit 128 -- whether the payload was simply
+never committed yet (a legitimate first run, nothing to compare against) or something is
+actually broken: this is not a git repository, HEAD has no commit yet, or git itself is
+missing. Collapsing those into one "skip" is the same failure build/freshness_payload.py was
+rewritten to stop making: reading a failure this code cannot interpret as the one benign
+failure it was hoping for, because both happen to look the same from the outside.
+
+So this asks two separate questions instead of one:
+
+  1. Does HEAD resolve at all (`git rev-parse --verify HEAD`)? If not, there is no history to
+     trust -- not a repository, an unborn branch, or git absent -- and this raises rather than
+     skipping.
+  2. Only once HEAD is known good: does it carry this payload path? Absence here, and only
+     here, means "first run" and returns None.
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PAYLOAD = "build/notebook_data.json"
+
+
+class RetirementCheckError(RuntimeError):
+    """Raised when git history cannot be read well enough to judge retirements safely."""
+
+
+def _run(args: list[str], cwd: Path) -> subprocess.CompletedProcess:
+    try:
+        return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
+    except FileNotFoundError as e:
+        raise RetirementCheckError(
+            "could not check retired slugs: git is not installed or not on PATH."
+        ) from e
+
+
+def _previous_payload(root: Path) -> dict | None:
+    """The payload committed at HEAD, or None if HEAD has genuinely never carried one.
+
+    None answers exactly one question -- does HEAD:<payload> exist -- and nothing else.
+    Every other way this can fail raises, because a check that cannot tell "nothing to
+    compare" apart from "I couldn't ask" and picks the answer that lets it pass through is
+    not protecting anything.
+    """
+    verified = _run(["rev-parse", "--verify", "HEAD"], cwd=root)
+    if verified.returncode != 0:
+        raise RetirementCheckError(
+            "could not check retired slugs: `git rev-parse --verify HEAD` failed "
+            f"({verified.stderr.strip() or 'no stderr'}). A missing HEAD is not the same "
+            "failure as a first run with no previous payload -- that is the payload path "
+            "being absent FROM an existing HEAD, not HEAD itself being unresolvable."
+        )
+    exists = _run(["cat-file", "-e", f"HEAD:{PAYLOAD}"], cwd=root)
+    if exists.returncode != 0:
+        return None
+    show = _run(["show", f"HEAD:{PAYLOAD}"], cwd=root)
+    if show.returncode != 0:
+        raise RetirementCheckError(
+            f"could not check retired slugs: HEAD:{PAYLOAD} exists but `git show` could not "
+            f"read it ({show.stderr.strip() or 'no stderr'})."
+        )
+    try:
+        return json.loads(show.stdout)
+    except json.JSONDecodeError as e:
+        raise RetirementCheckError(
+            f"could not check retired slugs: HEAD:{PAYLOAD} did not parse as JSON ({e})."
+        ) from e
+
+
+def _slugs(payload: dict) -> set[str]:
+    return {p["slug"] for c in payload["categories"].values() for p in c["products"]}
+
+
+def main() -> int:
+    new = json.loads((ROOT / PAYLOAD).read_text())
+    try:
+        previous = _previous_payload(ROOT)
+    except RetirementCheckError as exc:
+        print(f"check_retirement: {exc}", file=sys.stderr)
+        return 1
+    if previous is None:
+        print("check_retirement: no committed payload to compare against, skipping")
+        return 0
+    gone = _slugs(previous) - _slugs(new)
+    unrouted = sorted(s for s in gone if s not in new["aliases"]["products"])
+    if unrouted:
+        print("check_retirement: these slugs left the payload with no alias, so their pages "
+              "would 404:\n  " + "\n  ".join(unrouted), file=sys.stderr)
+        print("Record each in sources/slug_aliases.yaml, or acknowledge the removal.",
+              file=sys.stderr)
+        return 1
+    print(f"check_retirement: {len(gone)} retired, all routed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build/freshness_payload.py
+++ b/build/freshness_payload.py
@@ -21,13 +21,30 @@ class ShallowRepositoryError(RuntimeError):
 
 
 def _is_shallow(root: Path | None) -> bool:
-    out = subprocess.run(["git", "rev-parse", "--is-shallow-repository"],
-                         cwd=root, capture_output=True, text=True)
+    # An ambiguous or failed detection must never default to "not shallow, carry on" --
+    # that is the same silent-wrong-date failure the guard exists to prevent, arriving
+    # through a different door. `root` not being a git repository at all (exit 128, empty
+    # stdout) used to read the same as a clean "false"; it must instead say plainly that
+    # shallowness could not be determined, not that history is known to be shallow.
+    try:
+        out = subprocess.run(["git", "rev-parse", "--is-shallow-repository"],
+                             cwd=root, capture_output=True, text=True)
+    except FileNotFoundError as e:
+        raise ShallowRepositoryError(
+            f"could not determine whether {root} is a shallow git checkout: git is not "
+            "installed or not on PATH."
+        ) from e
+    if out.returncode != 0:
+        raise ShallowRepositoryError(
+            f"could not determine whether {root} is a shallow git checkout: "
+            f"`git rev-parse --is-shallow-repository` exited {out.returncode} "
+            f"({out.stderr.strip() or 'no stderr'})."
+        )
     return out.stdout.strip() == "true"
 
 
 def _commit_dates(root: Path | None) -> dict[str, str]:
-    return {slug: d.isoformat() for slug, d in commit_dates().items()}
+    return {slug: d.isoformat() for slug, d in commit_dates(root).items()}
 
 
 def _last_verified(root: Path | None) -> dict[str, str]:

--- a/build/freshness_payload.py
+++ b/build/freshness_payload.py
@@ -1,0 +1,61 @@
+"""Per-product freshness for the serialized payload.
+
+docs/guides/freshness.md is normative. Two tiers, and the payload says which one it used
+so the page can label the weaker claim rather than passing it off as the stronger one:
+
+  verified  the score file carries last_verified. 6 of 470 today.
+  commit    the git commit date of sources/scores/<slug>.yaml.
+
+A date is NEVER derived from sources[].accessed (freshness.md:30).
+"""
+import subprocess
+from pathlib import Path
+
+import yaml
+
+from build.check_freshness import commit_dates
+
+
+class ShallowRepositoryError(RuntimeError):
+    """Raised when git history is too shallow to date score files honestly."""
+
+
+def _is_shallow(root: Path | None) -> bool:
+    out = subprocess.run(["git", "rev-parse", "--is-shallow-repository"],
+                         cwd=root, capture_output=True, text=True)
+    return out.stdout.strip() == "true"
+
+
+def _commit_dates(root: Path | None) -> dict[str, str]:
+    return {slug: d.isoformat() for slug, d in commit_dates().items()}
+
+
+def _last_verified(root: Path | None) -> dict[str, str]:
+    found: dict[str, str] = {}
+    for path in sorted((Path(root) / "sources" / "scores").glob("*.yaml")):
+        doc = yaml.safe_load(path.read_text()) or {}
+        for axis in ("openness", "adoption", "capability"):
+            value = (doc.get(axis) or {}).get("last_verified")
+            if value:
+                # Most recent confirmation across axes wins; it is the date on which
+                # everything in the score was last standing.
+                current = found.get(path.stem)
+                found[path.stem] = max(current, str(value)) if current else str(value)
+    return found
+
+
+def resolve_freshness(root: Path | None) -> dict[str, dict]:
+    if _is_shallow(root):
+        raise ShallowRepositoryError(
+            "git history is shallow, so score-file commit dates would all collapse to the "
+            "tip commit. Add `fetch-depth: 0` to the checkout step, or run in a full clone."
+        )
+    verified = _last_verified(root)
+    commits = _commit_dates(root)
+    out: dict[str, dict] = {}
+    for slug in sorted(set(verified) | set(commits)):
+        if slug in verified:
+            out[slug] = {"date": verified[slug], "basis": "verified"}
+        else:
+            out[slug] = {"date": commits[slug], "basis": "commit"}
+    return out

--- a/build/serialize.py
+++ b/build/serialize.py
@@ -252,8 +252,8 @@ def _organizations(orgs: dict, product_org: dict) -> dict:
             "display_name": orgs[slug].get("display_name", ""),
             "type": orgs[slug].get("type", "unknown"),
             "homepage": orgs[slug].get("homepage", ""),
-            "github": [e["url"] for e in (orgs[slug].get("github") or [])
-                       if isinstance(e, dict) and e.get("url")],
+            "github": sorted(e["url"] for e in (orgs[slug].get("github") or [])
+                             if isinstance(e, dict) and e.get("url")),
             "country": orgs[slug].get("country", ""),
             "products": sorted(by_org.get(slug, [])),
         }

--- a/build/serialize.py
+++ b/build/serialize.py
@@ -12,9 +12,9 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 
-PRODUCT_KEY_ORDER = ["product", "org", "type", "description",
+PRODUCT_KEY_ORDER = ["slug", "product", "org_slug", "org", "type", "description",
                      "openness", "adoption", "capability", "maturity", "mature",
-                     "version_note", "lineage"]
+                     "freshness", "version_note", "lineage"]
 
 # --- Gap analysis (category-level stage + gaps) -----------------------------
 # Mirrors the open / open-ish / closed verdict in docs/openness-class-map.json
@@ -177,14 +177,17 @@ def _filter_long_tail(frozen: dict, prods: dict) -> dict:
     return lt
 
 
-def _row(prod: dict, org_name: str, score: dict, weights: dict | None,
-         name_map: dict | None = None) -> dict:
+def _row(slug: str, prod: dict, org_slug: str, org_name: str, score: dict,
+         weights: dict | None, name_map: dict | None = None,
+         freshness: dict | None = None) -> dict:
     # Pre-compute the open / open-ish / closed bucket alongside the raw class, so
     # consumers get a stable 3-way verdict that survives changes to the openness.class
     # vocabulary. Same collapse the category gap logic uses (_gap_bucket).
     openness = {**score["openness"], "bucket": _gap_bucket((score["openness"] or {}).get("class"))}
     row = {
+        "slug": slug,
         "product": prod["display_name"],
+        "org_slug": org_slug,
         "org": org_name,
         "type": prod["type"],
         "description": prod.get("description", ""),
@@ -223,10 +226,15 @@ def _row(prod: dict, org_name: str, score: dict, weights: dict | None,
                 resolved[edge] = [nm.get(r, r) for r in refs]
         if resolved:
             row["lineage"] = resolved
+    # Optional so the unit tests can call build_payload with no repo context. Task 5
+    # computes it in __main__ and threads it through.
+    if freshness:
+        row["freshness"] = freshness
     return {k: row[k] for k in PRODUCT_KEY_ORDER if k in row}
 
 
-def build_payload(sources: dict, frozen_long_tail: dict, generated: str | None = None) -> dict:
+def build_payload(sources: dict, frozen_long_tail: dict, generated: str | None = None,
+                  freshness: dict | None = None) -> dict:
     if generated is None:
         generated = date.today().isoformat()
     orgs, cats, prods, scores = (sources["organizations"], sources["categories"],
@@ -274,7 +282,9 @@ def build_payload(sources: dict, frozen_long_tail: dict, generated: str | None =
             # name "Unknown", which is schema-valid; the overlay carries "").
             org_slug = product_org[slug]
             org_name = "" if org_slug == "unknown" else orgs[org_slug]["display_name"]
-            rows.append(_row(p, org_name, scores[slug], cat.get("weights"), name_map))
+            rows.append(_row(slug, p, org_slug, org_name, scores[slug],
+                             cat.get("weights"), name_map,
+                             (freshness or {}).get(slug)))
             n += 1
         sg = _stage_and_gaps(rows, cat.get("weights"), disclosure=cat.get("disclosure_gap", False))
         out_cats[cid] = {"label": cat["display_name"], "arc": cid_arc[cid],

--- a/build/serialize.py
+++ b/build/serialize.py
@@ -261,6 +261,30 @@ def _organizations(orgs: dict, product_org: dict) -> dict:
     }
 
 
+def _aliases(spec: dict) -> dict:
+    """Retired slug -> live slug, for the app's redirects.
+
+    ONLY `aliases` and `organization_aliases`. sources/slug_aliases.yaml has four other
+    top-level keys that look like alias maps and are not:
+      - renamed_before_links records that a slug's PREVIOUS occupant moved elsewhere,
+        not that the slug itself retired. One entry's key (grok) is itself a live
+        product today, so treating it as a redirect would 308 that live page onto a
+        different one; the other's target sits alongside its own still-live sibling
+        (github-copilot-ide next to github-copilot). Its own comment in the YAML says
+        as much: it exists for the audit trail only, because nothing ever linked to
+        the old slug.
+      - version_in_identity and governing_release are documentation (why a slug keeps
+        a version token; which release governs a tier's score), not old-slug -> new-slug
+        pairs, and their values aren't even slugs.
+    Sorted, because this payload feeds a daily automated PR in another repo and
+    unsorted keys would show up there as a phantom diff.
+    """
+    return {
+        "products": dict(sorted((spec.get("aliases") or {}).items())),
+        "organizations": dict(sorted((spec.get("organization_aliases") or {}).items())),
+    }
+
+
 def build_payload(sources: dict, frozen_long_tail: dict, generated: str | None = None,
                   freshness: dict | None = None) -> dict:
     if generated is None:
@@ -268,6 +292,10 @@ def build_payload(sources: dict, frozen_long_tail: dict, generated: str | None =
     orgs, cats, prods, scores = (sources["organizations"], sources["categories"],
                                  sources["products"], sources["scores"])
     taxonomy = sources["taxonomy"]
+    # .get with a default so unit-test fixtures, which build their own source dicts,
+    # keep working without carrying a slug_aliases block. load_sources always supplies
+    # one for the real build (build/validate.py).
+    slug_aliases = sources.get("slug_aliases") or {}
     # Global slug -> display name map, used to resolve lineage references (which
     # point at other on-map products by slug) into readable names at serialize time.
     name_map = {slug: p["display_name"] for slug, p in prods.items()}
@@ -330,6 +358,7 @@ def build_payload(sources: dict, frozen_long_tail: dict, generated: str | None =
     return {"descriptions": descriptions, "layer_order": layer_order,
             "categories": out_cats, "order": order,
             "organizations": _organizations(orgs, product_org),
+            "aliases": _aliases(slug_aliases),
             "n_total": n, "generated": generated,
             "long_tail": _filter_long_tail(frozen_long_tail, prods)}
 

--- a/build/serialize.py
+++ b/build/serialize.py
@@ -366,12 +366,14 @@ def build_payload(sources: dict, frozen_long_tail: dict, generated: str | None =
 if __name__ == "__main__":
     import argparse
     from build.validate import load_sources
+    from build.freshness_payload import resolve_freshness
     parser = argparse.ArgumentParser()
     parser.add_argument("--date", default=None,
                         help="value for the payload 'generated' field (default: today)")
     args = parser.parse_args()
     sources = load_sources(ROOT)
     frozen = json.load(open(ROOT / "build" / "_frozen_long_tail.json"))
-    payload = build_payload(sources, frozen, generated=args.date)
+    payload = build_payload(sources, frozen, generated=args.date,
+                            freshness=resolve_freshness(ROOT))
     (ROOT / "build" / "notebook_data.json").write_text(json.dumps(payload, indent=2, ensure_ascii=False))
     print(f"wrote build/notebook_data.json ({payload['n_total']} products)")

--- a/build/serialize.py
+++ b/build/serialize.py
@@ -233,6 +233,34 @@ def _row(slug: str, prod: dict, org_slug: str, org_name: str, score: dict,
     return {k: row[k] for k in PRODUCT_KEY_ORDER if k in row}
 
 
+def _organizations(orgs: dict, product_org: dict) -> dict:
+    """The organization roster, emitted for the app's /map/org/<slug> pages.
+
+    Sourced from sources/organizations/*.yaml rather than build/registry/organizations.csv:
+    the registry is gitignored, so it never reaches a consumer, and its github column is a
+    stringified Python repr. Here github is a list of {url: ...} mappings, flattened to URLs.
+
+    Everything is sorted. A curator reordering a YAML roster must not produce a payload diff,
+    because a payload diff is a daily bot PR in the app repo.
+    """
+    by_org: dict[str, list[str]] = {}
+    for prod_slug, org_slug in product_org.items():
+        by_org.setdefault(org_slug, []).append(prod_slug)
+    return {
+        slug: {
+            "slug": slug,
+            "display_name": orgs[slug].get("display_name", ""),
+            "type": orgs[slug].get("type", "unknown"),
+            "homepage": orgs[slug].get("homepage", ""),
+            "github": [e["url"] for e in (orgs[slug].get("github") or [])
+                       if isinstance(e, dict) and e.get("url")],
+            "country": orgs[slug].get("country", ""),
+            "products": sorted(by_org.get(slug, [])),
+        }
+        for slug in sorted(orgs)
+    }
+
+
 def build_payload(sources: dict, frozen_long_tail: dict, generated: str | None = None,
                   freshness: dict | None = None) -> dict:
     if generated is None:
@@ -301,6 +329,7 @@ def build_payload(sources: dict, frozen_long_tail: dict, generated: str | None =
     }
     return {"descriptions": descriptions, "layer_order": layer_order,
             "categories": out_cats, "order": order,
+            "organizations": _organizations(orgs, product_org),
             "n_total": n, "generated": generated,
             "long_tail": _filter_long_tail(frozen_long_tail, prods)}
 

--- a/sources/scores/codegemma.yaml
+++ b/sources/scores/codegemma.yaml
@@ -8,7 +8,7 @@ openness:
     Open weights under Google's custom Gemma terms, with no open training data or code. Was 3,
     corrected to 2 on 2026-07-29 on the rule that a use cap lands at 2 in every category, and
     returned to 3 on 2026-08-01 when the universal license scale replaced that rule: a bounded
-    commercial licence caps at 3, and a licence forbidding commerce outright caps at 2. Gemma's
+    commercial license caps at 3, and a license forbidding commerce outright caps at 2. Gemma's
     terms are the former. The 2026-07-29 note cited gemma-2 and gemma-3 as siblings scoring
     2/restricted on the same license. Neither slug exists after the slug migration, and the
     surviving `gemma` records an Apache-2.0 license rather than Gemma terms, so that comparison no
@@ -26,7 +26,7 @@ adoption:
     Open weights under Google's custom Gemma terms, with no open training data or code. Was 3,
     corrected to 2 on 2026-07-29 on the rule that a use cap lands at 2 in every category, and
     returned to 3 on 2026-08-01 when the universal license scale replaced that rule: a bounded
-    commercial licence caps at 3, and a licence forbidding commerce outright caps at 2. Gemma's
+    commercial license caps at 3, and a license forbidding commerce outright caps at 2. Gemma's
     terms are the former. The 2026-07-29 note cited gemma-2 and gemma-3 as siblings scoring
     2/restricted on the same license. Neither slug exists after the slug migration, and the
     surviving `gemma` records an Apache-2.0 license rather than Gemma terms, so that comparison no
@@ -45,7 +45,7 @@ capability:
     Open weights under Google's custom Gemma terms, with no open training data or code. Was 3,
     corrected to 2 on 2026-07-29 on the rule that a use cap lands at 2 in every category, and
     returned to 3 on 2026-08-01 when the universal license scale replaced that rule: a bounded
-    commercial licence caps at 3, and a licence forbidding commerce outright caps at 2. Gemma's
+    commercial license caps at 3, and a license forbidding commerce outright caps at 2. Gemma's
     terms are the former. The 2026-07-29 note cited gemma-2 and gemma-3 as siblings scoring
     2/restricted on the same license. Neither slug exists after the slug migration, and the
     surviving `gemma` records an Apache-2.0 license rather than Gemma terms, so that comparison no

--- a/sources/scores/codellama.yaml
+++ b/sources/scores/codellama.yaml
@@ -8,10 +8,10 @@ openness:
   note: >-
     Weights downloadable under Meta's non-OSI Llama-2 Community license. Marketed as open, which
     the openness class deliberately does not accept at face value. Moved from 2/restricted on
-    2026-08-01 by the universal license scale, which caps a bounded commercial licence at 3 rather
-    than 2. The test at that boundary is whether the licence permits commercial use AT ALL: this
-    one does, for everyone inside the bound. A licence that forbids commerce outright - CC-BY-NC,
-    Mistral Non-Production - stays at 2. Nine other products carry a bounded licence and all now
+    2026-08-01 by the universal license scale, which caps a bounded commercial license at 3 rather
+    than 2. The test at that boundary is whether the license permits commercial use AT ALL: this
+    one does, for everyone inside the bound. A license that forbids commerce outright - CC-BY-NC,
+    Mistral Non-Production - stays at 2. Nine other products carry a bounded license and all now
     score 3; four of them were already recorded there, which is the inconsistency this resolves.
   sources:
   - url: https://huggingface.co/codellama/CodeLlama-13b-Instruct-hf
@@ -25,10 +25,10 @@ adoption:
   note: >-
     Weights downloadable under Meta's non-OSI Llama-2 Community license. Marketed as open, which
     the openness class deliberately does not accept at face value. Moved from 2/restricted on
-    2026-08-01 by the universal license scale, which caps a bounded commercial licence at 3 rather
-    than 2. The test at that boundary is whether the licence permits commercial use AT ALL: this
-    one does, for everyone inside the bound. A licence that forbids commerce outright - CC-BY-NC,
-    Mistral Non-Production - stays at 2. Nine other products carry a bounded licence and all now
+    2026-08-01 by the universal license scale, which caps a bounded commercial license at 3 rather
+    than 2. The test at that boundary is whether the license permits commercial use AT ALL: this
+    one does, for everyone inside the bound. A license that forbids commerce outright - CC-BY-NC,
+    Mistral Non-Production - stays at 2. Nine other products carry a bounded license and all now
     score 3; four of them were already recorded there, which is the inconsistency this resolves.
   sources:
   - url: https://huggingface.co/codellama/CodeLlama-13b-Instruct-hf
@@ -42,10 +42,10 @@ capability:
   note: >-
     Weights downloadable under Meta's non-OSI Llama-2 Community license. Marketed as open, which
     the openness class deliberately does not accept at face value. Moved from 2/restricted on
-    2026-08-01 by the universal license scale, which caps a bounded commercial licence at 3 rather
-    than 2. The test at that boundary is whether the licence permits commercial use AT ALL: this
-    one does, for everyone inside the bound. A licence that forbids commerce outright - CC-BY-NC,
-    Mistral Non-Production - stays at 2. Nine other products carry a bounded licence and all now
+    2026-08-01 by the universal license scale, which caps a bounded commercial license at 3 rather
+    than 2. The test at that boundary is whether the license permits commercial use AT ALL: this
+    one does, for everyone inside the bound. A license that forbids commerce outright - CC-BY-NC,
+    Mistral Non-Production - stays at 2. Nine other products carry a bounded license and all now
     score 3; four of them were already recorded there, which is the inconsistency this resolves.
   sources:
   - url: https://huggingface.co/codellama/CodeLlama-13b-Instruct-hf

--- a/sources/scores/jamba-large.yaml
+++ b/sources/scores/jamba-large.yaml
@@ -10,10 +10,10 @@ openness:
     Weights downloadable under the Jamba Open Model License: non-OSI, with a $50M annual-revenue
     cap that bars large-entity commercial use. The 'Open Model' branding overstates it. Moved from
     2/restricted on 2026-08-01 by the universal license scale, which caps a bounded commercial
-    licence at 3 rather than 2. The test at that boundary is whether the licence permits
-    commercial use AT ALL: this one does, for everyone inside the bound. A licence that forbids
+    license at 3 rather than 2. The test at that boundary is whether the license permits
+    commercial use AT ALL: this one does, for everyone inside the bound. A license that forbids
     commerce outright - CC-BY-NC, Mistral Non-Production - stays at 2. Nine other products carry a
-    bounded licence and all now score 3; four of them were already recorded there, which is the
+    bounded license and all now score 3; four of them were already recorded there, which is the
     inconsistency this resolves.
   sources:
   - url: https://huggingface.co/ai21labs/AI21-Jamba-1.5-Large
@@ -31,10 +31,10 @@ adoption:
     Weights downloadable under the Jamba Open Model License: non-OSI, with a $50M annual-revenue
     cap that bars large-entity commercial use. The 'Open Model' branding overstates it. Moved from
     2/restricted on 2026-08-01 by the universal license scale, which caps a bounded commercial
-    licence at 3 rather than 2. The test at that boundary is whether the licence permits
-    commercial use AT ALL: this one does, for everyone inside the bound. A licence that forbids
+    license at 3 rather than 2. The test at that boundary is whether the license permits
+    commercial use AT ALL: this one does, for everyone inside the bound. A license that forbids
     commerce outright - CC-BY-NC, Mistral Non-Production - stays at 2. Nine other products carry a
-    bounded licence and all now score 3; four of them were already recorded there, which is the
+    bounded license and all now score 3; four of them were already recorded there, which is the
     inconsistency this resolves.
   sources:
   - url: https://huggingface.co/ai21labs/AI21-Jamba-1.5-Large
@@ -50,10 +50,10 @@ capability:
     Weights downloadable under the Jamba Open Model License: non-OSI, with a $50M annual-revenue
     cap that bars large-entity commercial use. The 'Open Model' branding overstates it. Moved from
     2/restricted on 2026-08-01 by the universal license scale, which caps a bounded commercial
-    licence at 3 rather than 2. The test at that boundary is whether the licence permits
-    commercial use AT ALL: this one does, for everyone inside the bound. A licence that forbids
+    license at 3 rather than 2. The test at that boundary is whether the license permits
+    commercial use AT ALL: this one does, for everyone inside the bound. A license that forbids
     commerce outright - CC-BY-NC, Mistral Non-Production - stays at 2. Nine other products carry a
-    bounded licence and all now score 3; four of them were already recorded there, which is the
+    bounded license and all now score 3; four of them were already recorded there, which is the
     inconsistency this resolves.
   sources:
   - url: https://www.ai21.com/blog/announcing-jamba-model-family/

--- a/sources/scores/llama-instruct.yaml
+++ b/sources/scores/llama-instruct.yaml
@@ -8,10 +8,10 @@ openness:
   note: >-
     Weights open under Meta's non-OSI Llama 3.1 Community License, with its 700M-MAU commercial
     cap. Commonly marketed as open. Moved from 2/restricted on 2026-08-01 by the universal license
-    scale, which caps a bounded commercial licence at 3 rather than 2. The test at that boundary
-    is whether the licence permits commercial use AT ALL: this one does, for everyone inside the
-    bound. A licence that forbids commerce outright - CC-BY-NC, Mistral Non-Production - stays at
-    2. Nine other products carry a bounded licence and all now score 3; four of them were already
+    scale, which caps a bounded commercial license at 3 rather than 2. The test at that boundary
+    is whether the license permits commercial use AT ALL: this one does, for everyone inside the
+    bound. A license that forbids commerce outright - CC-BY-NC, Mistral Non-Production - stays at
+    2. Nine other products carry a bounded license and all now score 3; four of them were already
     recorded there, which is the inconsistency this resolves.
   sources:
   - url: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
@@ -25,10 +25,10 @@ adoption:
   note: >-
     Weights open under Meta's non-OSI Llama 3.1 Community License, with its 700M-MAU commercial
     cap. Commonly marketed as open. Moved from 2/restricted on 2026-08-01 by the universal license
-    scale, which caps a bounded commercial licence at 3 rather than 2. The test at that boundary
-    is whether the licence permits commercial use AT ALL: this one does, for everyone inside the
-    bound. A licence that forbids commerce outright - CC-BY-NC, Mistral Non-Production - stays at
-    2. Nine other products carry a bounded licence and all now score 3; four of them were already
+    scale, which caps a bounded commercial license at 3 rather than 2. The test at that boundary
+    is whether the license permits commercial use AT ALL: this one does, for everyone inside the
+    bound. A license that forbids commerce outright - CC-BY-NC, Mistral Non-Production - stays at
+    2. Nine other products carry a bounded license and all now score 3; four of them were already
     recorded there, which is the inconsistency this resolves.
   sources:
   - url: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
@@ -42,10 +42,10 @@ capability:
   note: >-
     Weights open under Meta's non-OSI Llama 3.1 Community License, with its 700M-MAU commercial
     cap. Commonly marketed as open. Moved from 2/restricted on 2026-08-01 by the universal license
-    scale, which caps a bounded commercial licence at 3 rather than 2. The test at that boundary
-    is whether the licence permits commercial use AT ALL: this one does, for everyone inside the
-    bound. A licence that forbids commerce outright - CC-BY-NC, Mistral Non-Production - stays at
-    2. Nine other products carry a bounded licence and all now score 3; four of them were already
+    scale, which caps a bounded commercial license at 3 rather than 2. The test at that boundary
+    is whether the license permits commercial use AT ALL: this one does, for everyone inside the
+    bound. A license that forbids commerce outright - CC-BY-NC, Mistral Non-Production - stays at
+    2. Nine other products carry a bounded license and all now score 3; four of them were already
     recorded there, which is the inconsistency this resolves.
   sources:
   - url: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct

--- a/sources/scores/llama.yaml
+++ b/sources/scores/llama.yaml
@@ -11,10 +11,10 @@ openness:
     acceptable-use policy and naming requirements. No relicensing to record - Llama 3.1 carried
     the equivalent terms, and Llama 4 Scout and Maverick govern as the current release. Moved from
     2/restricted on 2026-08-01 by the universal license scale, which caps a bounded commercial
-    licence at 3 rather than 2. The test at that boundary is whether the licence permits
-    commercial use AT ALL: this one does, for everyone inside the bound. A licence that forbids
+    license at 3 rather than 2. The test at that boundary is whether the license permits
+    commercial use AT ALL: this one does, for everyone inside the bound. A license that forbids
     commerce outright - CC-BY-NC, Mistral Non-Production - stays at 2. Nine other products carry a
-    bounded licence and all now score 3; four of them were already recorded there, which is the
+    bounded license and all now score 3; four of them were already recorded there, which is the
     inconsistency this resolves.
   sources:
   - url: https://huggingface.co/api/models/meta-llama/Llama-4-Scout-17B-16E
@@ -43,10 +43,10 @@ adoption:
     acceptable-use policy and naming requirements. No relicensing to record - Llama 3.1 carried
     the equivalent terms, and Llama 4 Scout and Maverick govern as the current release. Moved from
     2/restricted on 2026-08-01 by the universal license scale, which caps a bounded commercial
-    licence at 3 rather than 2. The test at that boundary is whether the licence permits
-    commercial use AT ALL: this one does, for everyone inside the bound. A licence that forbids
+    license at 3 rather than 2. The test at that boundary is whether the license permits
+    commercial use AT ALL: this one does, for everyone inside the bound. A license that forbids
     commerce outright - CC-BY-NC, Mistral Non-Production - stays at 2. Nine other products carry a
-    bounded licence and all now score 3; four of them were already recorded there, which is the
+    bounded license and all now score 3; four of them were already recorded there, which is the
     inconsistency this resolves.
   sources:
   - url: https://huggingface.co/meta-llama/Llama-3.1-8B
@@ -66,10 +66,10 @@ capability:
     acceptable-use policy and naming requirements. No relicensing to record - Llama 3.1 carried
     the equivalent terms, and Llama 4 Scout and Maverick govern as the current release. Moved from
     2/restricted on 2026-08-01 by the universal license scale, which caps a bounded commercial
-    licence at 3 rather than 2. The test at that boundary is whether the licence permits
-    commercial use AT ALL: this one does, for everyone inside the bound. A licence that forbids
+    license at 3 rather than 2. The test at that boundary is whether the license permits
+    commercial use AT ALL: this one does, for everyone inside the bound. A license that forbids
     commerce outright - CC-BY-NC, Mistral Non-Production - stays at 2. Nine other products carry a
-    bounded licence and all now score 3; four of them were already recorded there, which is the
+    bounded license and all now score 3; four of them were already recorded there, which is the
     inconsistency this resolves.
   sources:
   - url: https://artificialanalysis.ai/models/llama-3-1-instruct-405b

--- a/sources/scores/tulu.yaml
+++ b/sources/scores/tulu.yaml
@@ -7,7 +7,7 @@ openness:
   confidence: high
   note: >-
     The released weights inherit Meta's Llama 3.1 Community License (non-OSI, 700M-MAU cap), so
-    the licence governs what a user downloading THIS checkpoint is bound by, not Ai2's post-
+    the license governs what a user downloading THIS checkpoint is bound by, not Ai2's post-
     training layer. That layer is genuinely open - data, code, RLVR recipe and eval framework, all
     Apache-2.0 - and it is credited where it lives: tulu-3-sft-mixture carries 5/open in
     training_synthetic_datasets, and the same recipe produces olmo-3-instruct at 5/open_source on
@@ -15,7 +15,7 @@ openness:
     corrected to 2 on 2026-07-29, and now 3 again on 2026-08-01 - but not a reversal to the
     original reasoning. The 2026-07-29 correction was right at the time: the 3 it removed was
     3/restricted, a pair no rule in the category ladder could produce. The universal license scale
-    now caps a bounded commercial licence at 3/open_weights, which IS producible, so the score
+    now caps a bounded commercial license at 3/open_weights, which IS producible, so the score
     returns while the objection that removed it stays answered.
   sources:
   - url: https://huggingface.co/allenai/Llama-3.1-Tulu-3-8B
@@ -35,7 +35,7 @@ adoption:
   confidence: high
   note: >-
     The released weights inherit Meta's Llama 3.1 Community License (non-OSI, 700M-MAU cap), so
-    the licence governs what a user downloading THIS checkpoint is bound by, not Ai2's post-
+    the license governs what a user downloading THIS checkpoint is bound by, not Ai2's post-
     training layer. That layer is genuinely open - data, code, RLVR recipe and eval framework, all
     Apache-2.0 - and it is credited where it lives: tulu-3-sft-mixture carries 5/open in
     training_synthetic_datasets, and the same recipe produces olmo-3-instruct at 5/open_source on
@@ -43,7 +43,7 @@ adoption:
     corrected to 2 on 2026-07-29, and now 3 again on 2026-08-01 - but not a reversal to the
     original reasoning. The 2026-07-29 correction was right at the time: the 3 it removed was
     3/restricted, a pair no rule in the category ladder could produce. The universal license scale
-    now caps a bounded commercial licence at 3/open_weights, which IS producible, so the score
+    now caps a bounded commercial license at 3/open_weights, which IS producible, so the score
     returns while the objection that removed it stays answered.
   sources:
   - url: https://huggingface.co/allenai/Llama-3.1-Tulu-3-8B
@@ -59,7 +59,7 @@ capability:
   confidence: high
   note: >-
     The released weights inherit Meta's Llama 3.1 Community License (non-OSI, 700M-MAU cap), so
-    the licence governs what a user downloading THIS checkpoint is bound by, not Ai2's post-
+    the license governs what a user downloading THIS checkpoint is bound by, not Ai2's post-
     training layer. That layer is genuinely open - data, code, RLVR recipe and eval framework, all
     Apache-2.0 - and it is credited where it lives: tulu-3-sft-mixture carries 5/open in
     training_synthetic_datasets, and the same recipe produces olmo-3-instruct at 5/open_source on
@@ -67,7 +67,7 @@ capability:
     corrected to 2 on 2026-07-29, and now 3 again on 2026-08-01 - but not a reversal to the
     original reasoning. The 2026-07-29 correction was right at the time: the 3 it removed was
     3/restricted, a pair no rule in the category ladder could produce. The universal license scale
-    now caps a bounded commercial licence at 3/open_weights, which IS producible, so the score
+    now caps a bounded commercial license at 3/open_weights, which IS producible, so the score
     returns while the objection that removed it stays answered.
   sources:
   - url: https://huggingface.co/allenai/Llama-3.1-Tulu-3-405B

--- a/tests/test_check_payload.py
+++ b/tests/test_check_payload.py
@@ -1,0 +1,157 @@
+import pytest
+
+from build.check_payload import PayloadError, check
+
+
+def _ok():
+    return {
+        "categories": {"c": {"products": [
+            {"slug": "a", "org_slug": "o", "freshness": {"date": "2026-08-01", "basis": "commit"}},
+            {"slug": "b", "org_slug": "o", "freshness": {"date": "2026-07-01", "basis": "verified"}},
+        ]}},
+        "organizations": {"o": {"slug": "o", "products": ["a", "b"]}},
+        "aliases": {"products": {"old-a": "a"}, "organizations": {}},
+    }
+
+
+def test_passes_a_well_formed_payload():
+    check(_ok())
+
+
+def test_fails_when_a_product_has_no_slug():
+    p = _ok(); del p["categories"]["c"]["products"][0]["slug"]
+    with pytest.raises(PayloadError, match="slug"):
+        check(p)
+
+
+def test_fails_when_two_products_share_a_slug():
+    p = _ok(); p["categories"]["c"]["products"][1]["slug"] = "a"
+    with pytest.raises(PayloadError, match="duplicate"):
+        check(p)
+
+
+def test_fails_when_an_org_slug_does_not_resolve():
+    p = _ok(); p["categories"]["c"]["products"][0]["org_slug"] = "ghost"
+    with pytest.raises(PayloadError, match="ghost"):
+        check(p)
+
+
+def test_fails_when_an_alias_key_is_also_a_live_slug():
+    p = _ok(); p["aliases"]["products"]["a"] = "b"
+    with pytest.raises(PayloadError, match="live"):
+        check(p)
+
+
+def test_fails_when_an_alias_target_is_missing():
+    p = _ok(); p["aliases"]["products"]["old-a"] = "ghost"
+    with pytest.raises(PayloadError, match="ghost"):
+        check(p)
+
+
+def test_fails_when_every_product_shares_one_freshness_date():
+    """The shallow-clone canary. A depth-1 checkout dates all 470 to the tip commit, which
+    is not an error anywhere else in the pipeline."""
+    p = _ok()
+    for row in p["categories"]["c"]["products"]:
+        row["freshness"] = {"date": "2026-08-05", "basis": "commit"}
+    with pytest.raises(PayloadError, match="one distinct freshness date"):
+        check(p)
+
+
+# --- Cannot-evaluate paths: a missing or malformed top-level block must refuse to judge
+# the payload, not fall through to a Python TypeError/AttributeError that happens to be
+# non-zero for the wrong reason, and never fall through to a silent pass. ---
+
+def test_fails_when_categories_key_is_missing():
+    p = _ok(); del p["categories"]
+    with pytest.raises(PayloadError, match="categories"):
+        check(p)
+
+
+def test_fails_when_categories_is_none():
+    p = _ok(); p["categories"] = None
+    with pytest.raises(PayloadError, match="categories"):
+        check(p)
+
+
+def test_fails_when_a_category_is_not_an_object():
+    p = _ok(); p["categories"]["c"] = ["not", "a", "dict"]
+    with pytest.raises(PayloadError, match="c"):
+        check(p)
+
+
+def test_fails_when_a_category_has_no_products_list():
+    p = _ok(); p["categories"]["c"]["products"] = None
+    with pytest.raises(PayloadError, match="products"):
+        check(p)
+
+
+def test_fails_when_organizations_key_is_missing():
+    p = _ok(); del p["organizations"]
+    with pytest.raises(PayloadError, match="organizations"):
+        check(p)
+
+
+def test_fails_when_organizations_is_none():
+    p = _ok(); p["organizations"] = None
+    with pytest.raises(PayloadError, match="organizations"):
+        check(p)
+
+
+def test_fails_when_aliases_block_is_missing():
+    p = _ok(); del p["aliases"]
+    with pytest.raises(PayloadError, match="aliases"):
+        check(p)
+
+
+def test_fails_when_aliases_products_is_not_a_dict():
+    p = _ok(); p["aliases"]["products"] = None
+    with pytest.raises(PayloadError, match="aliases"):
+        check(p)
+
+
+def test_fails_when_a_product_row_is_not_an_object():
+    p = _ok(); p["categories"]["c"]["products"][0] = "not-a-dict"
+    with pytest.raises(PayloadError):
+        check(p)
+
+
+def test_fails_on_an_entirely_empty_product_set():
+    """The freshness canary ('more than one distinct date') must not pass vacuously just
+    because there is nothing to compare. Zero products is an absence of evidence, not two
+    distinct dates, and the gate must say so rather than reading as ok."""
+    p = _ok(); p["categories"]["c"]["products"] = []
+    with pytest.raises(PayloadError, match="no products"):
+        check(p)
+
+
+def test_fails_when_a_product_row_has_no_freshness_key_at_all():
+    p = _ok(); del p["categories"]["c"]["products"][0]["freshness"]
+    with pytest.raises(PayloadError, match="freshness"):
+        check(p)
+
+
+def test_fails_when_freshness_is_none():
+    p = _ok(); p["categories"]["c"]["products"][0]["freshness"] = None
+    with pytest.raises(PayloadError, match="freshness"):
+        check(p)
+
+
+def test_fails_when_freshness_basis_is_unrecognized():
+    p = _ok()
+    p["categories"]["c"]["products"][0]["freshness"] = {"date": "2026-08-01", "basis": "guessed"}
+    with pytest.raises(PayloadError, match="freshness"):
+        check(p)
+
+
+def test_fails_when_freshness_date_is_empty():
+    p = _ok()
+    p["categories"]["c"]["products"][0]["freshness"] = {"date": "", "basis": "commit"}
+    with pytest.raises(PayloadError, match="freshness"):
+        check(p)
+
+
+def test_fails_when_org_slug_is_missing_entirely():
+    p = _ok(); del p["categories"]["c"]["products"][0]["org_slug"]
+    with pytest.raises(PayloadError, match="missing organization"):
+        check(p)

--- a/tests/test_check_retirement.py
+++ b/tests/test_check_retirement.py
@@ -1,0 +1,132 @@
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import build.check_retirement as cr
+from build.check_retirement import RetirementCheckError, _previous_payload, main
+
+
+def _init_repo(root: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True, capture_output=True)
+
+
+def _commit(root: Path, message: str, *, allow_empty: bool = False) -> None:
+    args = ["git", "-c", "user.email=test@example.com", "-c", "user.name=test",
+            "commit", "-q", "-m", message]
+    if allow_empty:
+        args.append("--allow-empty")
+    subprocess.run(args, cwd=root, check=True, capture_output=True)
+
+
+def _commit_payload(root: Path, payload: dict, message: str = "payload") -> None:
+    build_dir = root / "build"
+    build_dir.mkdir(parents=True, exist_ok=True)
+    (build_dir / "notebook_data.json").write_text(json.dumps(payload))
+    subprocess.run(["git", "add", "build/notebook_data.json"], cwd=root, check=True, capture_output=True)
+    _commit(root, message)
+
+
+def _write_new_payload(root: Path, payload: dict) -> None:
+    build_dir = root / "build"
+    build_dir.mkdir(parents=True, exist_ok=True)
+    (build_dir / "notebook_data.json").write_text(json.dumps(payload))
+
+
+def _payload(slugs: list[str], aliases: dict | None = None) -> dict:
+    return {
+        "categories": {"c": {"products": [{"slug": s} for s in slugs]}},
+        "aliases": {"products": aliases or {}, "organizations": {}},
+    }
+
+
+# --- _previous_payload: the split this module exists to get right. `git show
+# HEAD:<payload>` fails with the same exit code (128) whether the payload was simply never
+# committed (a legitimate first run) or something is actually broken (no repository, no
+# commit yet, git missing). Only the first of those may read as "skip". ---
+
+def test_returns_none_when_head_has_never_carried_the_payload(tmp_path):
+    _init_repo(tmp_path)
+    _commit(tmp_path, "init", allow_empty=True)
+    assert _previous_payload(tmp_path) is None
+
+
+def test_raises_when_root_is_not_a_git_repository(tmp_path):
+    """Named for the exact confusion the module's docstring calls out: this must not be
+    read the same as 'no previous payload'."""
+    with pytest.raises(RetirementCheckError):
+        _previous_payload(tmp_path)
+
+
+def test_raises_when_head_has_no_commit_yet(tmp_path):
+    """An initialized repo with zero commits: HEAD does not resolve at all. Still not the
+    same failure as 'no previous payload' -- there is no payload path to even ask about."""
+    _init_repo(tmp_path)
+    with pytest.raises(RetirementCheckError):
+        _previous_payload(tmp_path)
+
+
+def test_raises_when_git_binary_is_missing(tmp_path, monkeypatch):
+    def _no_git(*args, **kwargs):
+        raise FileNotFoundError("git")
+    monkeypatch.setattr(cr.subprocess, "run", _no_git)
+    with pytest.raises(RetirementCheckError):
+        _previous_payload(tmp_path)
+
+
+def test_returns_the_committed_payload_when_present(tmp_path):
+    _init_repo(tmp_path)
+    _commit_payload(tmp_path, _payload(["a", "b"]))
+    assert _previous_payload(tmp_path) == _payload(["a", "b"])
+
+
+def test_raises_when_the_committed_payload_is_not_valid_json(tmp_path):
+    _init_repo(tmp_path)
+    (tmp_path / "build").mkdir()
+    (tmp_path / "build" / "notebook_data.json").write_text("{not json")
+    subprocess.run(["git", "add", "build/notebook_data.json"], cwd=tmp_path, check=True, capture_output=True)
+    _commit(tmp_path, "bad json")
+    with pytest.raises(RetirementCheckError):
+        _previous_payload(tmp_path)
+
+
+# --- main(): the retirement/alias behavior itself, plus proof the git-failure paths
+# above actually reach main() rather than being swallowed on the way there. ---
+
+def test_exits_nonzero_when_a_retired_slug_has_no_alias(tmp_path, monkeypatch, capsys):
+    """The failure this file is named after: drop a slug with no alias and watch it go red."""
+    monkeypatch.setattr(cr, "ROOT", tmp_path)
+    _init_repo(tmp_path)
+    _commit_payload(tmp_path, _payload(["a", "b"]))
+    _write_new_payload(tmp_path, _payload(["a"]))
+    assert main() == 1
+    assert "b" in capsys.readouterr().err
+
+
+def test_exits_zero_when_a_retired_slug_is_aliased(tmp_path, monkeypatch):
+    monkeypatch.setattr(cr, "ROOT", tmp_path)
+    _init_repo(tmp_path)
+    _commit_payload(tmp_path, _payload(["a", "b"]))
+    _write_new_payload(tmp_path, _payload(["a"], aliases={"b": "a"}))
+    assert main() == 0
+
+
+def test_exits_zero_on_a_first_run_with_no_committed_payload(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(cr, "ROOT", tmp_path)
+    _init_repo(tmp_path)
+    _commit(tmp_path, "init", allow_empty=True)
+    _write_new_payload(tmp_path, _payload(["a"]))
+    assert main() == 0
+    assert "skipping" in capsys.readouterr().out
+
+
+def test_exits_nonzero_rather_than_skipping_when_root_is_not_a_git_repository(tmp_path, monkeypatch, capsys):
+    """The failure this whole module is designed around: a check that cannot tell 'no
+    history to compare' apart from 'no history I could READ' must not silently pass
+    either way. This must go red, and for the right reason (a git failure it could not
+    interpret), not the accidental red of an unrelated crash."""
+    monkeypatch.setattr(cr, "ROOT", tmp_path)
+    _write_new_payload(tmp_path, _payload(["a"]))
+    assert main() == 1
+    assert "could not check retired slugs" in capsys.readouterr().err

--- a/tests/test_freshness_payload.py
+++ b/tests/test_freshness_payload.py
@@ -1,9 +1,32 @@
+import os
+import subprocess
 from datetime import date
+from pathlib import Path
 
 import pytest
 
 import build.freshness_payload as fp
 from build.freshness_payload import ShallowRepositoryError, resolve_freshness
+
+
+def _git(*args: str, cwd: Path, env: dict | None = None) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True, env=env)
+
+
+def _init_repo_with_one_score(root: Path, slug: str, commit_date: str) -> None:
+    """A throwaway git repository, distinct from this checkout, with exactly one score
+    file committed on a fabricated date. Used to prove root-scoping is real rather than
+    mocked: this slug and this date exist nowhere in os-ai-map's own history."""
+    scores = root / "sources" / "scores"
+    scores.mkdir(parents=True)
+    (scores / f"{slug}.yaml").write_text("openness:\n  score: 3\n")
+    _git("init", "-q", cwd=root)
+    _git("-c", "user.email=test@example.com", "-c", "user.name=test",
+         "add", "sources/scores", cwd=root)
+    env = {**os.environ, "GIT_AUTHOR_DATE": f"{commit_date}T00:00:00",
+           "GIT_COMMITTER_DATE": f"{commit_date}T00:00:00"}
+    _git("-c", "user.email=test@example.com", "-c", "user.name=test",
+         "commit", "-q", "-m", "add score", cwd=root, env=env)
 
 
 def test_refuses_to_emit_dates_in_a_shallow_clone(tmp_path, monkeypatch):
@@ -54,5 +77,43 @@ def test_last_verified_takes_the_most_recent_date_across_axes(tmp_path):
 def test_commit_dates_converts_date_objects_to_isoformat_strings(monkeypatch):
     """`check_freshness.commit_dates()` returns real `date` objects; the payload needs JSON-
     serializable strings, and the conversion must preserve every slug it is handed."""
-    monkeypatch.setattr(fp, "commit_dates", lambda: {"vllm": date(2026, 6, 4), "olmo": date(2026, 7, 30)})
+    monkeypatch.setattr(fp, "commit_dates",
+                        lambda root=None: {"vllm": date(2026, 6, 4), "olmo": date(2026, 7, 30)})
     assert fp._commit_dates(None) == {"vllm": "2026-06-04", "olmo": "2026-07-30"}
+
+
+def test_is_shallow_raises_when_root_is_not_a_git_repository(tmp_path):
+    """`git rev-parse` exits 128 with empty stdout when `root` is not a git repository at
+    all. The old code read that the same as a clean 'false' -- ambiguous or failed
+    detection defaulting to the safe-looking branch is the exact failure the guard exists
+    to prevent, arriving through a different door."""
+    with pytest.raises(ShallowRepositoryError):
+        fp._is_shallow(tmp_path)
+
+
+def test_is_shallow_raises_when_git_binary_is_missing(tmp_path, monkeypatch):
+    """git absent from PATH must fail the same way as git failing: loudly, not as 'false'."""
+    def _no_git(*args, **kwargs):
+        raise FileNotFoundError("git")
+    monkeypatch.setattr(fp.subprocess, "run", _no_git)
+    with pytest.raises(ShallowRepositoryError):
+        fp._is_shallow(tmp_path)
+
+
+def test_resolve_freshness_raises_when_root_is_not_a_git_repository(tmp_path):
+    """The public entry point must surface the same failure, not just the private helper."""
+    (tmp_path / "sources" / "scores").mkdir(parents=True)
+    with pytest.raises(ShallowRepositoryError):
+        resolve_freshness(tmp_path)
+
+
+def test_commit_dates_are_scoped_to_the_given_root_not_this_repository(tmp_path):
+    """`_commit_dates` used to ignore its own `root` argument and read THIS repository's
+    history via check_freshness's module-level ROOT constant. Prove root-scoping is real:
+    a throwaway repo with one score file, committed on a date that appears nowhere in
+    os-ai-map's own history, for a slug that does not exist in os-ai-map at all. If root
+    were ignored, this slug would be missing entirely (real history has no such file)."""
+    _init_repo_with_one_score(tmp_path, "throwaway-product", "2020-01-01")
+    assert resolve_freshness(tmp_path) == {
+        "throwaway-product": {"date": "2020-01-01", "basis": "commit"}
+    }

--- a/tests/test_freshness_payload.py
+++ b/tests/test_freshness_payload.py
@@ -1,0 +1,58 @@
+from datetime import date
+
+import pytest
+
+import build.freshness_payload as fp
+from build.freshness_payload import ShallowRepositoryError, resolve_freshness
+
+
+def test_refuses_to_emit_dates_in_a_shallow_clone(tmp_path, monkeypatch):
+    """Named for the failure it guards: a --depth 1 checkout dates every score file to the
+    tip commit, silently, so all 470 products would publish the same freshness date."""
+    monkeypatch.setattr("build.freshness_payload._is_shallow", lambda root: True)
+    with pytest.raises(ShallowRepositoryError):
+        resolve_freshness(tmp_path)
+
+
+def test_last_verified_outranks_the_commit_date(tmp_path, monkeypatch):
+    monkeypatch.setattr("build.freshness_payload._is_shallow", lambda root: False)
+    monkeypatch.setattr("build.freshness_payload._commit_dates", lambda root: {"apertus": "2026-08-05"})
+    monkeypatch.setattr("build.freshness_payload._last_verified", lambda root: {"apertus": "2026-07-30"})
+    assert resolve_freshness(tmp_path)["apertus"] == {"date": "2026-07-30", "basis": "verified"}
+
+
+def test_falls_back_to_the_commit_date_and_says_so(monkeypatch):
+    """The basis is what lets the page label the weaker claim honestly.
+
+    Uses monkeypatch (not a bare module-attribute assignment) so the substitution is
+    reverted after this test — an unguarded `fp._last_verified = ...` here previously
+    clobbered the real implementation for every test that ran after it in this file.
+    """
+    monkeypatch.setattr(fp, "_is_shallow", lambda root: False)
+    monkeypatch.setattr(fp, "_commit_dates", lambda root: {"vllm": "2026-06-04"})
+    monkeypatch.setattr(fp, "_last_verified", lambda root: {})
+    assert fp.resolve_freshness(None)["vllm"] == {"date": "2026-06-04", "basis": "commit"}
+
+
+def test_last_verified_takes_the_most_recent_date_across_axes(tmp_path):
+    """The three tests above all mock `_last_verified` away, so none of them exercise its
+    real glob-and-aggregate logic. A product with last_verified on more than one axis must
+    report the latest of them, not the first one read or the openness axis specifically."""
+    scores = tmp_path / "sources" / "scores"
+    scores.mkdir(parents=True)
+    (scores / "multi-axis.yaml").write_text(
+        "openness:\n  last_verified: '2026-07-01'\n"
+        "adoption:\n  last_verified: '2026-07-15'\n"
+        "capability:\n  score: 3\n"
+    )
+    (scores / "no-verification.yaml").write_text("openness:\n  score: 2\n")
+    found = fp._last_verified(tmp_path)
+    assert found == {"multi-axis": "2026-07-15"}, \
+        "must take the max across axes, and must not invent a date for an unverified product"
+
+
+def test_commit_dates_converts_date_objects_to_isoformat_strings(monkeypatch):
+    """`check_freshness.commit_dates()` returns real `date` objects; the payload needs JSON-
+    serializable strings, and the conversion must preserve every slug it is handed."""
+    monkeypatch.setattr(fp, "commit_dates", lambda: {"vllm": date(2026, 6, 4), "olmo": date(2026, 7, 30)})
+    assert fp._commit_dates(None) == {"vllm": "2026-06-04", "olmo": "2026-07-30"}

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -312,3 +312,45 @@ def test_organizations_block_sorts_github_urls_and_out_of_order_rosters():
     assert orgs["zeta-labs"]["github"] == [
         "https://github.com/zeta-one", "https://github.com/zeta-two",
     ], "github urls must be sorted, not preserved in source order"
+
+
+def _sources_with_aliases():
+    src = _sources()
+    src["slug_aliases"] = {
+        "version": 1,
+        # Two products, declared out of alphabetical order, so a missing sort call
+        # would leave the payload's key order matching this insertion order instead.
+        "aliases": {"llama-4-scout": "llama-4", "aaa-legacy-name": "llama-4"},
+        # Present in the real file and NOT a redirect map: its key ("llama-4") is a
+        # live product (see _sources()), so merging this in would 308 that live page
+        # onto "something-else".
+        "renamed_before_links": {"llama-4": "something-else"},
+        "version_in_identity": {"raspberry-pi-5": "keeps its 5"},
+        # Two orgs, also out of order, and non-empty so the per-entry loop below
+        # actually runs instead of vacuously passing over an empty dict.
+        "organization_aliases": {"meta-platforms": "meta", "facebook": "meta"},
+        "governing_release": {},
+    }
+    return src
+
+
+def test_alias_map_carries_only_the_two_redirect_safe_blocks():
+    """renamed_before_links is an audit trail, not a redirect map: its key here is a live
+    product, so emitting it would 308 a live page onto a different product."""
+    payload = build_payload(_sources_with_aliases(), frozen_long_tail={}, generated="2026-01-01")
+    aliases = payload["aliases"]
+    assert aliases["products"] == {"aaa-legacy-name": "llama-4", "llama-4-scout": "llama-4"}
+    assert "llama-4" not in aliases["products"], "renamed_before_links leaked into the redirects"
+    assert set(aliases) == {"products", "organizations"}
+    live = {p["slug"] for c in payload["categories"].values() for p in c["products"]}
+    for old, new in aliases["products"].items():
+        assert old not in live, f"alias {old} is also a live product slug"
+        assert new in live, f"alias {old} points at missing product {new}"
+    for old, new in aliases["organizations"].items():
+        assert old not in payload["organizations"], f"alias {old} is also a live org"
+        assert new in payload["organizations"], f"alias {old} points at missing org {new}"
+    assert list(aliases["products"]) == sorted(aliases["products"]), \
+        "product aliases must be sorted, not left in source order"
+    assert list(aliases["organizations"]) == sorted(aliases["organizations"]), \
+        "organization aliases must be sorted, not left in source order"
+    assert aliases["organizations"] == {"facebook": "meta", "meta-platforms": "meta"}

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -204,6 +204,17 @@ def test_unknown_org_renders_empty_string():
     assert payload["categories"]["base_pretrained"]["products"][0]["org"] == ""
 
 
+def test_every_product_carries_its_slug_and_org_slug():
+    """Identity survives PRODUCT_KEY_ORDER — the whitelist at serialize.py:226 silently
+    drops any key not listed, so this fails loudly rather than emitting a slug-less payload."""
+    payload = build_payload(_sources(), frozen_long_tail={}, generated="2026-01-01")
+    rows = [p for c in payload["categories"].values() for p in c["products"]]
+    assert rows, "fixture produced no products"
+    for row in rows:
+        assert row["slug"], f"{row['product']} has no slug"
+        assert row["org_slug"], f"{row['product']} has no org_slug"
+
+
 def _pd(cls, adoption):
     return {"openness": {"class": cls}, "adoption": {"level": adoption},
             "capability": {"score": None}, "type": "dataset"}

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -246,3 +246,20 @@ def test_disclosure_flag_is_independent_of_closed_rows():
     rows = [_pd("open", 4), _pd("closed", None)]
     assert "disclosure" in _stage_and_gaps(rows, {"adopt": 1.0, "cap": 0.0}, disclosure=True)["gaps"]
     assert "disclosure" not in _stage_and_gaps(rows, {"adopt": 1.0, "cap": 0.0})["gaps"]
+
+
+def test_organizations_block_is_complete_and_deterministic():
+    """Every org_slug a product points at must resolve, or the app's org links 404.
+    Sorted because the payload feeds a daily bot PR and unsorted keys are review noise."""
+    payload = build_payload(_sources(), frozen_long_tail={}, generated="2026-01-01")
+    orgs = payload["organizations"]
+    assert list(orgs) == sorted(orgs), "organization keys must be sorted"
+    rows = [p for c in payload["categories"].values() for p in c["products"]]
+    for row in rows:
+        assert row["org_slug"] in orgs, f"{row['slug']} points at missing org {row['org_slug']}"
+    for slug, org in orgs.items():
+        assert org["slug"] == slug
+        assert org["products"] == sorted(org["products"]), f"{slug} roster must be sorted"
+        assert isinstance(org["github"], list)
+        for url in org["github"]:
+            assert isinstance(url, str), f"{slug} github must be flat URL strings"

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -263,3 +263,52 @@ def test_organizations_block_is_complete_and_deterministic():
         assert isinstance(org["github"], list)
         for url in org["github"]:
             assert isinstance(url, str), f"{slug} github must be flat URL strings"
+
+
+def _multi_org_sources():
+    """Two organizations, deliberately unsorted at every level the shared _sources()
+    fixture cannot exercise: zeta-labs owns two products listed out of order and two
+    github entries listed out of order; alpha-labs sorts before it but is declared
+    second. The shared fixture has one org, one product, and no github key at all, so
+    it cannot go red on any of this -- see the review finding this test answers."""
+    return {
+        "organizations": {
+            "zeta-labs": {"name": "zeta-labs", "display_name": "Zeta Labs", "type": "company",
+                         "github": [{"url": "https://github.com/zeta-two"},
+                                    {"url": "https://github.com/zeta-one"}],
+                         "products": ["zeta-b", "zeta-a"]},
+            "alpha-labs": {"name": "alpha-labs", "display_name": "Alpha Labs", "type": "company",
+                          "products": ["alpha-x"]},
+        },
+        "taxonomy": {"arcs": [{"name": "Model components", "layer": "model_components",
+                               "categories": ["base_pretrained"]}]},
+        "categories": {
+            "base_pretrained": {"name": "base_pretrained",
+                                "display_name": "Base / pretrained models",
+                                "products": ["zeta-a", "zeta-b", "alpha-x"], "comments": ""}
+        },
+        "products": {
+            "zeta-a": {"name": "zeta-a", "display_name": "Zeta A", "type": "model", "description": "d"},
+            "zeta-b": {"name": "zeta-b", "display_name": "Zeta B", "type": "model", "description": "d"},
+            "alpha-x": {"name": "alpha-x", "display_name": "Alpha X", "type": "model", "description": "d"},
+        },
+        "scores": {
+            slug: {"product": slug, "openness": {"score": 2, "class": "restricted"},
+                  "adoption": {"level": 3, "signal_type": "usage_volume"},
+                  "capability": {"score": None, "basis": "n/a"}}
+            for slug in ("zeta-a", "zeta-b", "alpha-x")
+        },
+    }
+
+
+def test_organizations_block_sorts_github_urls_and_out_of_order_rosters():
+    """Regression for the finding that github.py:255-256 preserved source order: a
+    cosmetic reorder of a YAML github: list or products: roster must not change the
+    payload, or a curator's harmless edit becomes a phantom daily bot PR."""
+    payload = build_payload(_multi_org_sources(), frozen_long_tail={}, generated="2026-01-01")
+    orgs = payload["organizations"]
+    assert list(orgs) == ["alpha-labs", "zeta-labs"]
+    assert orgs["zeta-labs"]["products"] == ["zeta-a", "zeta-b"]
+    assert orgs["zeta-labs"]["github"] == [
+        "https://github.com/zeta-one", "https://github.com/zeta-two",
+    ], "github urls must be sorted, not preserved in source order"


### PR DESCRIPTION
The gap map front end cannot build a stable per-product URL today. `build/registry/` is gitignored, so `products.csv` never reaches a consumer, and `notebook_data.json` carries display names only — which is why the app currently keys every product on `${org}__${product}`.

`sources/slug_aliases.yaml` puts the deadline plainly: *"the front end keys links on display names today, so nothing pointed at a product slug yet. After links exist, a rename costs an alias forever."* This adds the identity layer before those links are minted.

## What the payload gains

- `slug` and `org_slug` on every product record. Both were already resolved inside `_row`'s caller and thrown away in favour of display names.
- A top-level `organizations` block: 257 entries from `sources/organizations/*.yaml`, with `github` flattened from `[{url}]` to plain strings. Not from `build/registry/organizations.csv`, which is gitignored and whose `github` column is a stringified Python repr.
- A top-level `aliases` block: the 63 product aliases and 2 organization aliases, and deliberately nothing else. `renamed_before_links` is excluded because `grok` is a live product today, so emitting that block as redirects would 308 a working page onto a different one.
- `freshness` per product: `{date, basis}`, where `basis` distinguishes a real `last_verified` (6 of 470) from the commit-date fallback, so a consumer can label the weaker claim honestly instead of passing it off as a verification.

## Why `fetch-depth: 0` moved with it

`regenerate.yml` and `validate.yml` both used a bare `actions/checkout@v4`, which is depth 1. In a shallow clone every score file reports as added at the grafted root commit, so all 470 products come back stamped with the tip commit date. It does not error; it produces a uniform, plausible, wrong date and publishes it as a verification record. `build/freshness_payload.py` now refuses to emit anything when history is shallow — or when it cannot determine whether history is shallow, which is the same hazard through a different door.

## Gates

`build/check_payload.py` covers the serialized artifact rather than the sources: slug present and unique, `org_slug` resolves, alias keys disjoint from live slugs, every alias target live, and more than one distinct freshness date across the corpus — the shallow-clone symptom seen from the inside.

`build/check_retirement.py` fails when a slug leaves the payload without an alias. 69 product files have been deleted since June and 14 have no alias, so this is a live gap rather than a theoretical one. It distinguishes "no previous payload" (a legitimate first-run skip) from "git failed" (an error).

Every gate was injured and observed red for the failure it names before being wired in.

## Also

60 occurrences of "licence" in score-file notes corrected to American English, across 6 files. These are user-visible prose. No key was touched; every changed line is inside a `note:` string.

## Verification

311 tests, up from 266. `validate`, `check_payload` and `check_retirement` all green on the real payload. Two consecutive serializer runs are byte-identical, which matters because this file drives a daily automated PR downstream.