### PR TITLE
Add Luciole and OpenRAG (OpenLLM-France / Linagora)

### DIFF
--- a/build/_frozen_long_tail.json
+++ b/build/_frozen_long_tail.json
@@ -4,11 +4,11 @@
     "models": 6428,
     "packages": 2823,
     "total": 24626,
-    "scored": 471,
+    "scored": 472,
     "overlap": 245,
-    "scored_outside": 226,
+    "scored_outside": 227,
     "uncategorized": 24381,
-    "universe": 24852
+    "universe": 24853
   },
   "top": [
     {

--- a/build/_frozen_long_tail.json
+++ b/build/_frozen_long_tail.json
@@ -4,11 +4,11 @@
     "models": 6428,
     "packages": 2823,
     "total": 24626,
-    "scored": 470,
+    "scored": 471,
     "overlap": 245,
-    "scored_outside": 225,
+    "scored_outside": 226,
     "uncategorized": 24381,
-    "universe": 24851
+    "universe": 24852
   },
   "top": [
     {

--- a/sources/categories/base_pretrained.yaml
+++ b/sources/categories/base_pretrained.yaml
@@ -237,6 +237,7 @@ products:
 - kimi
 - inkling
 - lucie-7b
+- luciole
 - olmo
 - pythia
 - phi

--- a/sources/categories/orchestration_agents.yaml
+++ b/sources/categories/orchestration_agents.yaml
@@ -51,6 +51,7 @@ products:
 - spec-kit
 - langflow
 - ragflow
+- openrag
 - n8n
 - datasette-agent
 - openfn

--- a/sources/organizations/linagora.yaml
+++ b/sources/organizations/linagora.yaml
@@ -5,3 +5,4 @@ homepage: https://linagora.com
 products:
 - lucie-7b
 - luciole
+- openrag

--- a/sources/organizations/linagora.yaml
+++ b/sources/organizations/linagora.yaml
@@ -4,3 +4,4 @@ type: company
 homepage: https://linagora.com
 products:
 - lucie-7b
+- luciole

--- a/sources/products/luciole.yaml
+++ b/sources/products/luciole.yaml
@@ -1,0 +1,29 @@
+name: luciole
+display_name: Luciole
+type: model
+description: Linagora / OpenLLM-France's fully open multilingual (French–English) LLM family and the
+  successor to Lucie, released in 1B, 8B, and 23B sizes (base + Instruct-1.1). Apache-2.0 weights, the
+  redistributable Luciole-Training-Dataset (~4.65T tokens drawn only from openly licensed corpora), the
+  Luciole-Training pipeline on GitHub, and intermediate + final pretraining checkpoints — clearing the
+  full open-source bar. Base models are pretrained on roughly 30% French data (English 53%, French 16%,
+  plus German/Spanish/Italian/Portuguese/Dutch/Arabic and regional languages); the Instruct-1.1 models are
+  SFT + DPO aligned on math, science, coding, chat, RAG, and translation. Built by LINAGORA and the
+  OpenLLM-France consortium, funded by BPI France through the France 2030 program.
+github:
+- url: https://github.com/OpenLLM-France/Luciole-Training
+huggingface_model:
+- url: https://huggingface.co/OpenLLM-France/Luciole-23B-Base
+- url: https://huggingface.co/OpenLLM-France/Luciole-23B-Instruct-1.1
+- url: https://huggingface.co/OpenLLM-France/Luciole-8B-Base
+- url: https://huggingface.co/OpenLLM-France/Luciole-8B-Instruct-1.1
+- url: https://huggingface.co/OpenLLM-France/Luciole-1B-Base
+- url: https://huggingface.co/OpenLLM-France/Luciole-1B-Instruct-1.1
+huggingface_dataset:
+- url: https://huggingface.co/datasets/OpenLLM-France/Luciole-Training-Dataset
+comments: "Luciole family (1B / 8B / 23B, base + Instruct-1.1) from LINAGORA / OpenLLM-France, successor to
+  Lucie-7B. Apache-2.0 weights; open Luciole-Training-Dataset (~4.65T tokens, open-licensed corpora only —
+  cleaner terms than Lucie's cc-by-nc-sa corpus); Luciole-Training pipeline on GitHub (GPL-3.0); intermediate
+  + final checkpoints published. Funded by BPI France / France 2030. Collection:
+  https://huggingface.co/collections/OpenLLM-France/luciole-llm. Verified via primary model/dataset cards,
+  August 2026 (HF direct fetch blocked by egress proxy; figures cross-checked via search snippets of the
+  live cards)."

--- a/sources/products/openrag.yaml
+++ b/sources/products/openrag.yaml
@@ -1,0 +1,16 @@
+name: openrag
+display_name: OpenRAG
+type: software
+description: Linagora's lightweight, modular, and extensible retrieval-augmented generation (RAG) framework —
+  a batteries-included, self-hostable application stack rather than a bare library. It ingests multiple
+  document formats (PDFs, documents, audio, and images with AI captioning), organizes knowledge into
+  partitions, performs hybrid semantic + keyword search with multilingual reranking, and exposes indexed
+  content through a bundled web chat interface, an admin UI, and an OpenAI-compatible REST API. Backend in
+  Python with a TypeScript/JavaScript frontend; scales across machines and GPUs via Ray and deploys via
+  Docker Compose. AGPL-3.0, fully open source with no vendor lock-in.
+github:
+- url: https://github.com/linagora/openrag
+comments: "OpenRAG by Linagora, AGPL-3.0. Full application stack (admin UI + chat UI + OpenAI-compatible REST
+  API), Python backend / TS-JS frontend, Ray-based distributed processing, GPU acceleration, Docker Compose
+  deployment. ~237 GitHub stars (Aug 2026). No first-party PyPI/npm package; self-host is the primary
+  distribution. Verified live on GitHub, August 2026."

--- a/sources/scores/luciole.yaml
+++ b/sources/scores/luciole.yaml
@@ -1,0 +1,64 @@
+product: luciole
+openness:
+  score: 5
+  class: open_source
+  components: weights:open(Apache-2.0, safetensors on HF for 1B/8B/23B base + Instruct-1.1);data:open(Luciole-Training-Dataset
+    on HF, ~4.65T tokens, "only corpora under open licenses");code:open(Luciole-Training pretraining +
+    data-processing pipeline on GitHub, GPL-3.0);checkpoints:open(intermediate + final pretraining checkpoints
+    released);license:Apache-2.0(OSI)
+  confidence: high
+  note: 'Full open-source tier alongside Lucie / OLMo / Apertus: open weights, open training data, open
+    training code, and intermediate checkpoints. Notably a cleaner full-openness exemplar than its Lucie
+    predecessor — the Luciole-Training-Dataset is described as containing only openly licensed corpora,
+    where Lucie-Training-Dataset carried a non-commercial cc-by-nc-sa license. The weights are Apache-2.0
+    (OSI) across every distributed size, so the data + code + OSI-license rule lands at 5.'
+  sources:
+  - url: https://huggingface.co/OpenLLM-France/Luciole-23B-Instruct-1.1
+    shows: Apache-2.0 license; downloadable safetensors weights; fine-tuned + DPO-aligned version of
+      Luciole-23B-Base; developed by LINAGORA and the OpenLLM-France consortium (France 2030 / BPI France)
+    accessed: '2026-08-07'
+  - url: https://huggingface.co/datasets/OpenLLM-France/Luciole-Training-Dataset
+    shows: released multilingual pretraining corpus (~4.65T tokens; EN 53.4% / FR 16.3% / DE / ES / IT /
+      PT / NL / AR + regional), "contains only corpora under open licenses"
+    accessed: '2026-08-07'
+  - url: https://github.com/OpenLLM-France/Luciole-Training
+    shows: training pipeline for the Luciole series — data prep, training recipe, and configs (GPL-3.0)
+    accessed: '2026-08-07'
+  - url: https://huggingface.co/collections/OpenLLM-France/luciole-llm
+    shows: official Luciole LLM collection (1B/8B/23B base + Instruct-1.1, training dataset), with final
+      and intermediate pretraining checkpoints shared for research and continual pretraining
+    accessed: '2026-08-07'
+adoption:
+  level: 1
+  reach: <10K
+  signal_type: usage_volume
+  confidence: medium
+  note: 'Niche sovereign / French open-LLM audience, and newer and smaller-reach than Lucie-7B (level 2).
+    Summed monthly HF downloads across the shipped sizes sit in the low thousands (23B ~640, 8B ~944, 1B
+    ~842 as of Aug 2026), well under the 10K level-2 threshold. Adoption may be recomputed from the linked
+    artifacts by the warehouse.'
+  sources:
+  - url: https://huggingface.co/OpenLLM-France/Luciole-23B-Instruct-1.1
+    shows: ~640 downloads/month, 13 likes (as of 2026-08-07)
+    accessed: '2026-08-07'
+  - url: https://huggingface.co/collections/OpenLLM-France/luciole-llm
+    shows: family of 1B / 8B / 23B (base + Instruct-1.1); per-size monthly downloads in the hundreds
+    accessed: '2026-08-07'
+capability:
+  score: 2
+  basis: benchmark:multilingual-pretrain-suite
+  value: null
+  confidence: low
+  note: Multilingual French–English family up to 23B, prioritizing French cultural representation and open
+    data rights over frontier performance. Larger than Lucie-7B (capability 2) but the same sovereign-model
+    tier — mid-scale and well below the 2026 open-weight frontier (trillion-param MoEs). Positioned like
+    Alia-40b (capability 2); kept conservative pending published benchmarks. Value is openness + FR/EU
+    language coverage.
+  sources:
+  - url: https://huggingface.co/OpenLLM-France/Luciole-23B-Base
+    shows: 23B multilingual base model, ~30% French pretraining data, French/English focus
+    accessed: '2026-08-07'
+  - url: https://huggingface.co/collections/OpenLLM-France/luciole-llm
+    shows: 1B / 8B / 23B base + Instruct-1.1 lineup; Instruct trained via SFT + DPO on math, science,
+      coding, chat, RAG, and translation
+    accessed: '2026-08-07'

--- a/sources/scores/openrag.yaml
+++ b/sources/scores/openrag.yaml
@@ -1,0 +1,40 @@
+product: openrag
+openness:
+  score: 5
+  class: open_source
+  components: license:AGPL-3.0(OSI);source:public;self-host:primary(Docker Compose);core-gated:ungated;commercial:none
+  confidence: high
+  note: Fully open AGPL-3.0 RAG application stack — the published source is the whole product, self-hosted
+    via Docker Compose, with no feature-gated enterprise tier and no vendor lock-in. AGPL is OSI-approved and
+    sits beside Apache on the software ladder, so osi + public + ungated lands at 5.
+  sources:
+  - url: https://github.com/linagora/openrag
+    shows: AGPL-3.0 license; full source for backend (Python) + frontend (TS/JS); self-hostable via Docker
+      Compose; admin UI, chat UI, and OpenAI-compatible REST API bundled; no paid/enterprise tier
+    accessed: '2026-08-07'
+adoption:
+  level: 1
+  signal_type: stars_fallback
+  confidence: medium
+  note: '~237 GitHub stars, 55 forks (Aug 2026) — early-stage. No download metric available (Docker-distributed,
+    no first-party PyPI/npm), so adoption falls back to stars, which the ladder caps at 3; 237 stars places
+    it in the lowest band.'
+  sources:
+  - url: https://github.com/linagora/openrag
+    shows: ~237 stars, 55 forks, 88 open issues (as of 2026-08-07)
+    accessed: '2026-08-07'
+capability:
+  score: 3
+  basis: feature_matrix
+  value: multimodal ingestion (PDF / document / audio / image with AI captioning); knowledge partitions;
+    hybrid semantic + keyword search with multilingual reranking; bundled chat UI + admin UI; OpenAI-compatible
+    REST API; Ray-based distributed processing; GPU acceleration; Docker Compose deployment
+  confidence: medium
+  note: Feature-complete, batteries-included general RAG stack with a broad ingestion + retrieval surface and
+    a bundled UI/API. A notch below RAGFlow (capability 4), whose distinctive layout-aware deep document
+    understanding and larger, more mature community set the ceiling for this category.
+  sources:
+  - url: https://github.com/linagora/openrag
+    shows: 'feature set: multimodal ingestion, hybrid search + multilingual reranking, chat/admin UI,
+      OpenAI-compatible API, Ray distribution, GPU acceleration'
+    accessed: '2026-08-07'

--- a/tests/test_check_parity.py
+++ b/tests/test_check_parity.py
@@ -40,13 +40,15 @@ def run(monkeypatch, published, category=None, verbose=False):
 
 
 def test_local_scores_matches_check_rubrics_split():
-    """384 products the ladders decide, 86 the categories defer. The same 470 the warehouse
-    publishes, so a change to either number should show up as a failure here first."""
+    """386 products the ladders decide, 86 the categories defer. The same 472 the warehouse
+    publishes, so a change to either number should show up as a failure here first. Was 384
+    before Luciole (base_pretrained) and OpenRAG (orchestration_agents) were added, both
+    computed rather than deferred."""
     computed, deferred = local_scores(None)
     assert len(deferred) == 86
-    assert len(computed) == 384
+    assert len(computed) == 386
     assert not set(computed) & set(deferred)
-    # Every one of the 384 reproduces today, so none should abstain.
+    # Every one of the 386 reproduces today, so none should abstain.
     assert [key for key, value in computed.items() if value is None] == []
 
 

--- a/tests/test_check_rubric.py
+++ b/tests/test_check_rubric.py
@@ -128,13 +128,14 @@ class TestRealCategories:
     """The claim the whole pipeline rests on, asserted against the real files."""
 
     def test_base_pretrained_still_reproduces_every_score(self):
-        """26, down from 44: the slug migration collapsed release-level products into
-        the tier the vendor sells, and moved the closed frontier models to
-        finetuned_chat. The point of pinning this is that the count only ever moves for
-        a reason recorded in a commit."""
+        """27, down from 44 then up 1: the slug migration collapsed release-level products
+        into the tier the vendor sells and moved the closed frontier models to
+        finetuned_chat (44 -> 26); adding the fully-open Luciole family took it to 27. The
+        point of pinning this is that the count only ever moves for a reason recorded in a
+        commit."""
         reproduced, total, problems, deferred = check_category("base_pretrained", verbose=False)
         assert problems == []
-        assert (reproduced, total, deferred) == (26, 26, [])
+        assert (reproduced, total, deferred) == (27, 27, [])
 
     def test_finetuned_chat_reproduces_every_undeferred_score(self):
         reproduced, total, problems, _ = check_category("finetuned_chat", verbose=False)

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -697,13 +697,18 @@ def test_real_sources_serialize_without_errors():
         # finetuned_chat rose by 1 when `recipe` joined `code`'s `reads` list: `ornith`
         # recorded only `recipe:closed`, so its `code` dimension had been reading as
         # unrecorded and published no evidence row. check_recipe found it.
-        "base_pretrained": 111, "finetuned_chat": 173, "deployment": 131,
+        # base_pretrained rose by 5 (111 -> 116) when the fully-open Luciole family was
+        # added: five openness dimensions recorded (weights, data, code, checkpoints, license).
+        "base_pretrained": 116, "finetuned_chat": 173, "deployment": 131,
         "agent_tools_protocols": 108, "dataset_processing_tools": 86, "evaluation_code": 66,
         "finetuning_code": 119, "inference_code": 47, "ml_frameworks": 80,
         # orchestration_agents rose by 3 when n8n's stale deferral was removed: a deferred
         # product publishes no openness evidence, and n8n had been deferred as "not recorded"
-        # while recording everything the ladder needed.
-        "orchestration_agents": 140, "telemetry_observability": 90, "ui_api": 127,
+        # while recording everything the ladder needed. Then by 6 more (140 -> 146) when
+        # OpenRAG was added: it records source, core-gated, license, self-host, commercial,
+        # and the normalized core_gated the ladder reads from core-gated — the same six-row
+        # shape RAGFlow already contributes.
+        "orchestration_agents": 146, "telemetry_observability": 90, "ui_api": 127,
         # training_synthetic_datasets is unchanged at 158 across the ladder widening, which
         # is the check that mattered: benchmark_eval_data's new dimensions and rungs did not
         # disturb the category the ladder was derived from.


### PR DESCRIPTION
## What

Adds two OpenLLM-France / Linagora products to the map:

- **Luciole** (`base_pretrained`) — the fully-open multilingual (FR–EN) LLM family and successor to Lucie-7B, in 1B / 8B / 23B sizes (base + Instruct-1.1). Openness **5 / open_source**: Apache-2.0 weights, the released open-licensed Luciole-Training-Dataset (~4.65T tokens), the Luciole-Training pipeline on GitHub, and published intermediate + final checkpoints. Adoption 1, capability 2.
- **OpenRAG** (`orchestration_agents`) — Linagora's AGPL-3.0 retrieval-augmented generation application stack (multimodal ingestion, hybrid search + multilingual reranking, bundled chat/admin UI, OpenAI-compatible API, Ray distribution). Openness **5 / open_source** (AGPL is OSI, self-host is the whole product, no gated tier). Adoption 1, capability 3.

Both are added to the existing `linagora` org roster (now `lucie-7b`, `luciole`, `openrag`). The category rubrics reproduce both hand-authored scores (`base_pretrained: 27/27`, `orchestration_agents: 37/37`). `build/_frozen_long_tail.json` dedup counts re-synced (scored 470 → 472).

> Note: this environment's egress proxy blocks huggingface.co, so the Luciole HF model/dataset cards could not be fetched directly for `content_sha256` verification. Every claim was cross-checked against live search snippets of the cards dated 2026-08-07 and the primary URLs are cited; a maintainer with HF access may want a standard re-read pass before stamping `last_verified`.

## Checklist

- [x] `uv run python -m build.validate` prints `0 error(s)`
- [x] New/changed scores cite sources (`url`, `shows`, `accessed`)
- [x] I did not edit `build/notebook_data.json` or `notebooks/ai-stack-map.py`
      (a bot regenerates them on merge)
- [x] Product appears in exactly one category roster and one org roster

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSF4TWAoPvNK7igDAqhLUo)_