### PR TITLE
fix(build): the retirement gate crashed on the first run after slugs landed

### DIFF
--- a/build/check_retirement.py
+++ b/build/check_retirement.py
@@ -21,6 +21,18 @@ So this asks two separate questions instead of one:
      skipping.
   2. Only once HEAD is known good: does it carry this payload path? Absence here, and only
      here, means "first run" and returns None.
+
+## Reading a schema change honestly
+
+The same collapsing mistake shows up one layer down. A committed payload that predates the
+`slug` field entirely carries no 'slug' key on any product -- there is nothing meaningful to
+diff, and that is a legitimate skip, distinct from "no committed payload at all" above. But a
+committed payload where only *some* products carry a slug is not that case: no single
+serializer run produces a half-migrated payload, so that shape is treated as malformed and
+fails loudly rather than silently dropping the unslugged rows from the comparison. Both
+payloads are read through a shape guard rather than indexed into directly, so a missing
+'categories' block, a non-dict category, or a non-dict product row is a clean
+`check_retirement:`-prefixed error, never a raw traceback.
 """
 import json
 import subprocess
@@ -77,8 +89,38 @@ def _previous_payload(root: Path) -> dict | None:
         ) from e
 
 
-def _slugs(payload: dict) -> set[str]:
-    return {p["slug"] for c in payload["categories"].values() for p in c["products"]}
+def _product_rows(payload: dict, label: str) -> list[dict]:
+    """Every product row across every category in `payload`, or raise if the shape can't
+    be trusted enough to read one.
+
+    This is the guard the module was missing: it used to index straight into
+    payload["categories"][...]["products"][...]["slug"] and let a malformed or
+    schema-mismatched payload surface as a raw KeyError. A missing 'categories' block, a
+    non-dict category, a non-list products field, or a non-dict product row all raise
+    here -- deliberately, with a `label` naming which payload (new vs. previous) is at
+    fault -- rather than one unqualified traceback that could be either.
+    """
+    if not isinstance(payload, dict):
+        raise RetirementCheckError(f"the {label} payload is not an object (got {type(payload).__name__})")
+    categories = payload.get("categories")
+    if not isinstance(categories, dict):
+        raise RetirementCheckError(
+            f"the {label} payload has no usable 'categories' block (got {type(categories).__name__})"
+        )
+    rows: list[dict] = []
+    for cid, cat in categories.items():
+        if not isinstance(cat, dict):
+            raise RetirementCheckError(f"{label} payload category {cid!r} is not an object")
+        products = cat.get("products")
+        if not isinstance(products, list):
+            raise RetirementCheckError(f"{label} payload category {cid!r} has no usable products list")
+        for row in products:
+            if not isinstance(row, dict):
+                raise RetirementCheckError(
+                    f"{label} payload has a product row in category {cid!r} that is not an object"
+                )
+            rows.append(row)
+    return rows
 
 
 def main() -> int:
@@ -91,8 +133,53 @@ def main() -> int:
     if previous is None:
         print("check_retirement: no committed payload to compare against, skipping")
         return 0
-    gone = _slugs(previous) - _slugs(new)
-    unrouted = sorted(s for s in gone if s not in new["aliases"]["products"])
+
+    try:
+        new_rows = _product_rows(new, "new")
+        unslugged_new = [r for r in new_rows if not r.get("slug")]
+        if unslugged_new:
+            raise RetirementCheckError(
+                f"the new payload has {len(unslugged_new)} product(s) with no slug"
+            )
+        product_aliases = new.get("aliases", {}).get("products")
+        if not isinstance(product_aliases, dict):
+            raise RetirementCheckError("the new payload has no usable aliases.products block")
+
+        previous_rows = _product_rows(previous, "previous")
+    except RetirementCheckError as exc:
+        print(f"check_retirement: {exc}", file=sys.stderr)
+        return 1
+
+    # The committed payload predates the slug field entirely -- every product in it is
+    # missing 'slug', not just some. There is nothing meaningful to diff across a schema
+    # change like that, so this skips rather than raising or guessing. This is distinct
+    # from the "no committed payload at all" skip above: something WAS committed, it's
+    # just from before slugs existed.
+    previous_slugged = [r for r in previous_rows if r.get("slug")]
+    if previous_rows and not previous_slugged:
+        print(
+            "check_retirement: the committed payload predates slugs (no product in it "
+            "carries one), so there is nothing to diff across that schema change -- skipping"
+        )
+        return 0
+
+    # A mix of slugged and unslugged products in the same committed payload is not the
+    # clean pre-slug case above -- a single serializer run cannot produce that shape. It's
+    # malformed, not merely old, so it fails loudly rather than silently dropping the
+    # unslugged rows from the comparison (which would risk missing a real retirement).
+    if len(previous_slugged) != len(previous_rows):
+        print(
+            "check_retirement: the committed payload has a mix of slugged and unslugged "
+            "products, which should never happen -- refusing to guess which ones were "
+            "retired",
+            file=sys.stderr,
+        )
+        return 1
+
+    new_slugs = {r["slug"] for r in new_rows}
+    previous_slugs = {r["slug"] for r in previous_slugged}
+    gone = previous_slugs - new_slugs
+    unrouted = sorted(s for s in gone if s not in product_aliases)
     if unrouted:
         print("check_retirement: these slugs left the payload with no alias, so their pages "
               "would 404:\n  " + "\n  ".join(unrouted), file=sys.stderr)

--- a/tests/test_check_retirement.py
+++ b/tests/test_check_retirement.py
@@ -130,3 +130,84 @@ def test_exits_nonzero_rather_than_skipping_when_root_is_not_a_git_repository(tm
     _write_new_payload(tmp_path, _payload(["a"]))
     assert main() == 1
     assert "could not check retired slugs" in capsys.readouterr().err
+
+
+# --- the hotfix: a previously committed payload from before slugs existed carries no
+# 'slug' key on any product. There is nothing meaningful to diff across that schema
+# change -- it must be a clean skip, never the KeyError this module shipped with. ---
+
+def test_exits_zero_when_previous_payload_predates_slugs(tmp_path, monkeypatch, capsys):
+    """The exact production crash this hotfix exists for: the payload committed at HEAD
+    predates the slug field entirely, so `previous['slug']` has nothing to read."""
+    monkeypatch.setattr(cr, "ROOT", tmp_path)
+    _init_repo(tmp_path)
+    pre_slug_payload = {
+        "categories": {"c": {"products": [{"product": "a"}, {"product": "b"}]}},
+        "aliases": {"products": {}, "organizations": {}},
+    }
+    _commit_payload(tmp_path, pre_slug_payload)
+    _write_new_payload(tmp_path, _payload(["a", "b"]))
+    assert main() == 0
+    assert "predates slugs" in capsys.readouterr().out
+
+
+def test_pre_slug_skip_message_is_distinct_from_no_previous_payload_skip_message(tmp_path, monkeypatch, capsys):
+    """Both are exit-0 skips but mean different things -- 'nothing has ever been
+    committed' is not 'something was committed but it's from before slugs existed'. A
+    reader must be able to tell them apart from the message alone."""
+    monkeypatch.setattr(cr, "ROOT", tmp_path)
+    _init_repo(tmp_path)
+    pre_slug_payload = {
+        "categories": {"c": {"products": [{"product": "a"}]}},
+        "aliases": {"products": {}, "organizations": {}},
+    }
+    _commit_payload(tmp_path, pre_slug_payload)
+    _write_new_payload(tmp_path, _payload(["a"]))
+    assert main() == 0
+    pre_slug_message = capsys.readouterr().out
+    assert "predates slugs" in pre_slug_message
+    assert "no committed payload to compare against" not in pre_slug_message
+
+
+@pytest.mark.parametrize(
+    "bad_new_payload",
+    [
+        {"aliases": {"products": {}, "organizations": {}}},
+        {"categories": "not-a-dict", "aliases": {"products": {}, "organizations": {}}},
+        {
+            "categories": {"c": {"products": [{"product": "a"}]}},
+            "aliases": {"products": {}, "organizations": {}},
+        },
+    ],
+    ids=["missing-categories", "categories-not-a-dict", "product-missing-slug"],
+)
+def test_exits_nonzero_with_prefixed_error_when_new_payload_is_malformed(
+    tmp_path, monkeypatch, capsys, bad_new_payload
+):
+    """The defect a reviewer flagged on the new-payload side and that got deferred, then
+    bit on the previous-payload side within a day: indexing into an unguarded shape must
+    never surface as a raw traceback, on either side."""
+    monkeypatch.setattr(cr, "ROOT", tmp_path)
+    _init_repo(tmp_path)
+    _commit_payload(tmp_path, _payload(["a", "b"]))
+    _write_new_payload(tmp_path, bad_new_payload)
+    assert main() == 1
+    err = capsys.readouterr().err
+    assert err.startswith("check_retirement:")
+
+
+def test_exits_nonzero_when_previous_payload_mixes_slugged_and_unslugged_products(tmp_path, monkeypatch, capsys):
+    """A previous payload where only some products carry a slug is not the clean
+    'predates slugs entirely' case the tolerance above exists for -- a single serializer
+    run cannot produce that shape, so it is treated as malformed rather than guessed at."""
+    monkeypatch.setattr(cr, "ROOT", tmp_path)
+    _init_repo(tmp_path)
+    mixed_payload = {
+        "categories": {"c": {"products": [{"slug": "a"}, {"product": "b"}]}},
+        "aliases": {"products": {}, "organizations": {}},
+    }
+    _commit_payload(tmp_path, mixed_payload)
+    _write_new_payload(tmp_path, _payload(["a", "b"]))
+    assert main() == 1
+    err = capsys.readouterr().err
+    assert err.startswith("check_retirement:")


### PR DESCRIPTION
`regenerate` has been failing on `main` since #143 merged, at step 8, "Fail on an unrouted retirement":

```
File "build/check_retirement.py", line 81, in _slugs
  return {p["slug"] for c in payload["categories"].values() for p in c["products"]}
KeyError: 'slug'
```

The gate diffs the freshly serialized payload against the previously **committed** one to catch a product slug disappearing without a redirect alias. It assumed both sides carry `slug`. On the first run after #143, the committed payload predated slugs entirely, so the comprehension threw. A bootstrap case the gate was never taught about.

## Why this needs to land before anything else

The failing step aborts the workflow before its "Commit regenerated artifacts" step, so **the payload on `main` never regenerated**. `main` currently pairs the new serializer with a payload built by the old one — `generated: 2026-08-07`, 472 products, no `slug`, no `organizations`, no `aliases`. Every scheduled run will keep failing the same way, and anything downstream waiting on slug-carrying data stays blocked.

## The fix

**A previous payload that predates slugs is skipped, not a crash.** If the committed payload has products and none carry a slug, there is nothing meaningful to diff across that schema change. It exits 0 with a message that is deliberately distinct from the existing "no previous payload" skip and from the git-failure error, because those three states mean different things.

**Both payloads are shape-checked instead of indexed blindly.** A malformed payload on either side now produces a `check_retirement:`-prefixed error and exit 1, never a raw traceback.

A payload where only *some* products carry slugs is treated as malformed rather than tolerated. One serializer run cannot produce that mix, so it is evidence of a bad commit rather than a schema vintage, and silently dropping the unslugged rows would risk a false negative on a real retirement.

## Verification

The sequence that was failing now completes:

```
check_payload: 472 products, 257 organizations, ok
check_retirement: the committed payload predates slugs (no product in it carries one),
                  so there is nothing to diff across that schema change -- skipping
```

317 tests pass, up from 311. The six new ones cover the pre-slug skip, that its message is distinguishable from the no-previous-payload skip, malformed payloads on both sides, and the partial-slug case.

The regression guard matters most here, since the risk in this change is the new tolerance swallowing the real check: disabling retirement detection makes `test_exits_nonzero_when_a_retired_slug_has_no_alias` fail, confirming it is load-bearing.

## Note on the review that predicted this

Task 6's review flagged this class as a Minor — `check_retirement` indexing the new payload without a shape guard and dying on a raw `KeyError`. It was deferred as cosmetic on the reasoning that it fails safe rather than open. That reasoning was wrong for a gate: a gate exists to run against inputs the happy path never produces, so an unguarded `KeyError` in one is a functional defect. Same class, other side of the diff, one day later.