### PR TITLE
ci(regenerate): allow a manual re-run

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -9,6 +9,13 @@ on:
       - "build/serialize.py"
       - "build/render.py"
       - "build/_frozen_long_tail.json"
+  # Manual re-run. The path filter above is right for the normal case — regenerate when the
+  # inputs change — but it leaves no way to re-run after a fix to something the filter does not
+  # watch. On 2026-08-07 a bug in build/check_retirement.py aborted this workflow before its
+  # commit step, so the payload on main went stale; the fix touched only that gate and its tests,
+  # neither of which is a trigger path, so nothing re-ran and the staleness persisted with no way
+  # to clear it. A gate that can block regeneration needs a way to unblock it.
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Adds `workflow_dispatch` to `regenerate.yml`. Three lines plus a comment; no other change.

## Why

`regenerate` fires on pushes to `main` touching `sources/**`, `docs/methodology.md`, `build/serialize.py`, `build/render.py` or `build/_frozen_long_tail.json`. That filter is right for the normal case, but it leaves no way to re-run the workflow after fixing something the filter does not watch.

That gap bit today. #143 introduced `build/check_retirement.py`, which crashed on its first run against a payload that predated slugs. The crash aborted the workflow **before** its "Commit regenerated artifacts" step, so `build/notebook_data.json` on `main` never regenerated. #145 fixed the crash — but it touched only that gate and its tests, neither of which is a trigger path, so nothing re-ran.

The result is the current state of `main`: the new serializer paired with a payload built by the old one, `generated: 2026-08-07`, 472 products, no `slug`, no `organizations`, no `aliases`. There is no way to clear it short of pushing an unrelated change to a watched path, and `gh workflow run` returns:

```
HTTP 422: Workflow does not have 'workflow_dispatch' trigger
```

A gate that can block regeneration needs a way to unblock it.

## Scope

Deliberately minimal. No cron added — the push trigger is the right primary mechanism and a schedule would be a different decision. The path filter is unchanged, and `.github/workflows/**` is deliberately **not** added to it, so merging this does not itself fire a run.

## Verification

The workflow parses with both triggers present, all five path filters intact, and the `regenerate` job unchanged:

```
triggers: ['push', 'workflow_dispatch']
workflow_dispatch present: True
push paths still intact: 5 entries
jobs: ['regenerate']
```

Once merged I will dispatch a run and confirm the payload comes back carrying `slug`, `organizations` and `aliases` — a dispatchable workflow only proves it can be started, not that it completes.