### PR TITLE
A standard for the two prose fields, and the duplication it found in both directions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,10 @@ Invariants (validated in CI):
    Artifact keys (include only the ones that exist): `github`, `npm`, `pypi`,
    `crates`, `go`, `huggingface_model`, `huggingface_dataset`. Do **not** add an
    `org:` field — org membership lives in the org file.
+
+   For the style, length, and tone of `description`/`comments` — and the canonical
+   `Verified <YYYY-MM-DD> via <source>.` line — see `docs/guides/product-info.md`.
+   To refresh those fields on an existing product, use the `verify-product` skill.
 3. **Create `sources/scores/<slug>.yaml`** (see scoring rubric below). The file
    starts with `product: <slug>`; openness requires both `score` and `class`,
    and capability requires `score` and `basis`. If you can't score an axis yet,

--- a/docs/guides/product-info.md
+++ b/docs/guides/product-info.md
@@ -34,7 +34,7 @@ mechanism (see "Provenance vs. `last_verified`").
 | `name` | required, kebab-case | the slug/identity; see `add-product` | machine |
 | `display_name` | required | the human label | reader |
 | `description` | string | what the product IS and DOES, neutral | reader (payload `description`) |
-| `comments` | string | provenance: ownership, hosting, lifecycle, caveats, and the verification line | reader (payload `version_note`) |
+| `comments` | string | footnote: how the entry was verified, and any judgment call behind it | reader (payload `version_note`) |
 
 Both prose fields are optional in the schema, but in practice every product carries a
 `description` and almost every one carries `comments`. Write both.
@@ -44,15 +44,23 @@ Both prose fields are optional in the schema, but in practice every product carr
 **Purpose.** Tell a reader what the product is and what it does, in the neutral register
 of a catalog entry. It is not a pitch and not a review.
 
+**`description` is the load-bearing field.** Everything a reader needs about the product
+belongs here: what it is, what it does, what distinguishes it, and who builds or stewards
+it. `comments` is a footnote about *how we know*, not a second place to put product facts —
+see "The division of labour" below. When a fact could sit in either, it goes here.
+
 **Format.**
 - **Length: 2–4 sentences, ~35–70 words.** The corpus median is 3 sentences / 55 words;
   treat 1 sentence as too thin for a scored product and 6 as too long. A long tail entry
   may be a single clause.
-- **Lead with the product doing something**, not with its vendor or its license. Good:
-  "Accelerate is a Hugging Face PyTorch library that lets users run raw PyTorch training
-  scripts across CPUs, multi-GPU, and TPU…". The org and license belong in `comments`, not
-  in the first sentence, unless the org name is genuinely load-bearing for identity (e.g.
-  "NVIDIA's content-safety classifier").
+- **Lead with the product doing something**, not with its vendor. Good: "Accelerate is a
+  Hugging Face PyTorch library that lets users run raw PyTorch training scripts across
+  CPUs, multi-GPU, and TPU…". Who builds it belongs in the description, but usually in a
+  closing clause rather than the opening one, unless the org is load-bearing for identity
+  (e.g. "NVIDIA's content-safety classifier").
+- **Vary the sentence openings.** Three sentences in a row beginning "It …" reads as a
+  generated list. Recast one around its real subject ("A graph compiler optimizes…",
+  "Modular develops and distributes it").
 - **Present tense, third person, declarative.** No second person ("you can"), no imperative.
 - **First mention uses the display name**, then a natural short form.
 - **Spell out an acronym once** if the category reader would not know it.
@@ -75,19 +83,37 @@ of a catalog entry. It is not a pitch and not a review.
   "Volatile facts" below; they go stale the day they are written and prose has no
   freshness gate to catch it.
 
-## `comments` — provenance and notes
+## `comments` — verification details and methodology footnotes
 
-**Purpose.** The provenance notes a reader or the next editor needs but that are not the
-product's description: identity and aliases, ownership and hosting, gating caveats,
-lifecycle state (archived, superseded), and the verification line.
+**Purpose.** How we know what the entry says, and anything a reader or the next editor
+needs about the *treatment* rather than the product. In practice: the verification line,
+plus the occasional footnote about a judgment call or an evidence gap.
 
-**Format.** One compact paragraph, up to ~45 words. Semicolon- or period-separated clauses
-are both fine. Order, loosely: identity/aka → ownership/hosting → caveats → verification
-line.
+### The division of labour
 
-There is no lower bound. With the license and the current version both out, a product whose
-durable provenance is just "who maintains it" gets one clause and the verification line, and
-that is a complete entry. Do not pad to reach a length.
+`description` is load-bearing; `comments` is a footnote. The test is the subject of the
+sentence:
+
+| the sentence is about… | field |
+|---|---|
+| the product — what it is, does, runs on, who builds it | `description` |
+| our reading of it — what was checked, what was ambiguous, what a score followed | `comments` |
+
+Both fields render in the same product detail panel, one directly above the other. A fact
+stated twice is read twice, so the split is not cosmetic. Before writing a clause in
+`comments`, check it is not already in `description`; if it belongs to the product, move it
+rather than repeat it.
+
+Footnotes that earn their place:
+- an evidence gap — "no tagged releases, so this is verified against the repository head"
+- a judgment call the score rests on — "the repository source and usage terms carry
+  different licenses; the openness score follows the usage terms"
+- something in a source that would mislead the next reader — "the LICENSE file also bundles
+  third-party code under separate terms"
+
+**Format.** Up to ~45 words, and no lower bound. Most products need only the verification
+line, and one line is a complete entry. Do not pad, and do not invent a footnote to fill
+the field.
 
 **Do not state the license here.** It is a scored field — see "Scored fields" below.
 
@@ -102,13 +128,20 @@ Verified <YYYY-MM-DD> via <source>.
 
 - **ISO date**, matching the `accessed:` format in score files. A month-year ("June 2026")
   is acceptable only when the exact day is genuinely unknown; prefer the full date.
-- **`<source>`** names what was read: `primary sources`, `HF model card`, `GitHub`,
-  `PyPI`, `vendor docs`, `LICENSE body`. Name the host when one source settled it.
+- **`<source>` names the document you read, not the method you used.** `GitHub`, `PyPI`,
+  `the LICENSE body`, `the HF model card`, `the AWS Neuron documentation`, `Groq's LPU
+  architecture blog` are all good. This list is **illustrative, not closed** — name the
+  source specifically enough that the next editor can open the same page. Where several
+  sources were needed, name them.
+- **Never name a method.** `web search`, `research`, and the bare `primary sources` describe
+  how you looked rather than what settled it, and leave the next editor nothing to re-open.
+  If a search led you to a vendor page, the vendor page is the source.
 - Capital "V". One line, at the end of `comments`.
 
 Examples:
-- `Hosted by the Linux Foundation; originated at UC Berkeley. Verified 2026-06-22 via GitHub.`
-- `Adapter weights public on HF, base gated by Meta. Verified 2026-06-14 via HF model card.`
+- `Verified 2026-06-22 via GitHub and the LICENSE body.`
+- `No tagged releases, so this is verified against the repository head. Verified 2026-06-22 via GitHub.`
+- `The base weights are gated, so openness was read from the model card rather than a download. Verified 2026-06-14 via the HF model card.`
 
 ## Global rules
 
@@ -244,9 +277,10 @@ Use this to refresh an existing product's prose (the `verify-product` skill auto
    only under one of the three durable cases above; a license does not go in at all.
 3. **Rewrite `description`** to the format above if anything material changed, keeping it
    neutral and within the length band. Leave it alone if nothing moved.
-4. **Update `comments`**: correct the ownership, hosting, and caveat clauses; strip any
-   stale count, "latest version" clause, or license restatement; then set the verification
-   line to today's date and the source you read.
+4. **Update `comments`**: strip any stale count, "latest version" clause, or license
+   restatement, and move any surviving *product* fact into `description`. Keep only
+   footnotes about the reading itself. Set the verification line to today's date and the
+   document you read.
 5. **If a fact moves a score**, do not touch the score file here — record it and hand off
    to the `verification.md` flow.
 6. **Validate:** `uv run python -m build.validate` prints `0 error(s)`. Preview only; do
@@ -256,13 +290,16 @@ Use this to refresh an existing product's prose (the `verify-product` skill auto
 
 - [ ] `description`: 2–4 sentences, ~35–70 words, leads with the product doing something,
       present tense, neutral register.
-- [ ] No marketing words; no unsourced superlatives; judgments left on the axes.
+- [ ] No marketing words; no unsourced superlatives; judgments left on the axes. Watch
+      "high-performance" and "high-throughput" — say what the product does instead.
+- [ ] No three consecutive sentences opening "It …".
 - [ ] No hardcoded star/download/contributor counts — rely on the artifact links and the
       `adoption` axis instead.
 - [ ] No "latest/current version" clause, unless it is identity, terminal, or an absence.
 - [ ] No license restatement — it is `openness.components` in the score file.
-- [ ] `comments`: identity/aka; ownership/hosting; caveats; lifecycle state.
+- [ ] `comments` says nothing `description` already says — no product facts, footnotes only.
 - [ ] Verification line in canonical form: `Verified <YYYY-MM-DD> via <source>.`
+- [ ] `<source>` names a document someone could reopen, never a method ("web search").
 - [ ] American English throughout.
 - [ ] Every factual claim confirmed against a primary source, not memory.
 - [ ] `uv run python -m build.validate` → `0 error(s)`.

--- a/docs/guides/product-info.md
+++ b/docs/guides/product-info.md
@@ -70,19 +70,20 @@ of a catalog entry. It is not a pitch and not a review.
   measured, forthright about limitations.*
 - **Unsourced superlatives and rankings** ("the best", "the leading", "the de facto
   standard") unless they are a plain, checkable fact stated as one.
-- **Point-in-time metrics** — star counts, download/install/pull counts, contributor and
-  commit counts, "fastest-growing". See "Volatile metrics" below; they go stale the day
-  they are written and prose has no freshness gate to catch it.
+- **Point-in-time facts** — star counts, download/install/pull counts, contributor and
+  commit counts, "fastest-growing", and the product's current version number. See
+  "Volatile facts" below; they go stale the day they are written and prose has no
+  freshness gate to catch it.
 
 ## `comments` — provenance and notes
 
 **Purpose.** The scoring/provenance notes a reader or the next editor needs but that are
-not the product's description: license (with OSI/OSI-not call), version and release date,
-ownership/hosting nuance, gating caveats, and the verification line.
+not the product's description: license (with OSI/OSI-not call), ownership/hosting nuance,
+gating caveats, lifecycle state (archived, superseded), and the verification line.
 
 **Format.** One compact paragraph, ~15–45 words (corpus median ~30). Semicolon- or
-period-separated clauses are both fine. Order, loosely: identity/aka → license → version
-& date → caveats → verification line.
+period-separated clauses are both fine. Order, loosely: identity/aka → license →
+caveats → verification line.
 
 **Always state the license explicitly, and flag the non-obvious call**, because the
 license is what the openness score turns on and the classifier lies (see
@@ -106,7 +107,7 @@ Verified <YYYY-MM-DD> via <source>.
 - Capital "V". One line, at the end of `comments`.
 
 Examples:
-- `Apache 2.0 (unmodified LICENSE body). v1.9.3 released 2026-05-29. Verified 2026-06-22 via GitHub.`
+- `Apache 2.0 (unmodified LICENSE body). Hosted by the Linux Foundation. Verified 2026-06-22 via GitHub.`
 - `Llama 2 Community License (not OSI); adapter weights public on HF, base gated by Meta. Verified 2026-06-14 via HF model card.`
 
 ## Global rules
@@ -123,14 +124,22 @@ Examples:
    *openness verdict* ("truly open") belongs in the score file, where it carries evidence,
    not in prose. When in doubt, describe what the product is and let the axis carry the
    judgment.
-5. **Do not embed volatile metrics** — see below.
+5. **Do not embed volatile facts** — counts or current version numbers. See below.
 
-## Volatile metrics — link, don't embed
+## Volatile facts — link, don't embed
 
-A star count, download count, or contributor count is stale the moment it is written, and
-prose carries no freshness mechanism — `last_verified` gates *scores*, not `description`
-text. So a hardcoded "24K GitHub stars" or "~4.8k stars, actively maintained" is a
-liability with no owner. Do not write it.
+Prose carries no freshness mechanism. `last_verified` gates *scores*, not `description`
+text, so any fact in prose that a later event can invalidate is a liability with no owner.
+
+**The test: would a future release make this sentence wrong?** If yes, it is volatile and
+does not belong in prose. If a future release would instead be a *different product entry*,
+or if there will be no future release, the fact is durable and can stay.
+
+### Counts
+
+A star count, download count, or contributor count is stale the moment it is written. A
+hardcoded "24K GitHub stars" or "~4.8k stars, actively maintained" fails the test. Do not
+write it.
 
 The actuals already have two homes, and neither is the prose:
 
@@ -149,6 +158,34 @@ as a stand-in for a count. If a number matters, it is an `adoption` score, not a
 > Forward direction: as the notebook renders live/computed counts from the linked artifacts
 > and the `adoption` axis, prose should carry none. Treat every metric you would type as a
 > link you should rely on instead.
+
+### Current version and release date
+
+A "latest version" clause fails the same test for the same reason: the next release makes
+it wrong, and nothing in the repo will notice. `v0.26.0 released 2026-07-25` and
+`Latest stable v1.2.1 ...; 1.3.0 release candidates in progress` are both promises the map
+cannot keep across several hundred products. The `github`/`pypi`/`huggingface_*` links
+already point at the page showing the current release. Do not restate it.
+
+Three cases are **durable** and stay:
+
+1. **The version is the entry's identity.** For a named model release — `Apertus family
+   (8B + 70B), released 2 Sep 2025` — the date is a historical fact about *this* product,
+   and the next release is a different entry (or a different rung; see
+   `slug_aliases.yaml`). Keep it.
+2. **There will be no future release.** `Latest release v3.3.7 (2025-12-19). Repo archived
+   2026-03-21 and placed in maintenance mode` is durable precisely because the project
+   stopped. Keep it — an archived project's last release is a lifecycle fact.
+3. **A statement of absence.** `Created 6 May 2026; no tagged releases (built from source)`
+   describes how the project ships, not where it currently is.
+
+The tell for the volatile case is a word like "latest", "current", or "as of". A tier
+product states this outright — see `claude-sonnet`: *"Anthropic ships a new Sonnet roughly
+every few months, so a versioned entry goes stale faster than it can be reviewed; the slug
+is stable."* That reasoning generalizes; it is why the rule exists.
+
+Where a version genuinely bears on a *score* — a relicense at v2, weights pulled in a
+later release — it is score evidence with a `sources[].accessed` date, not a prose clause.
 
 ## Provenance vs. `last_verified`
 
@@ -174,12 +211,15 @@ Use this to refresh an existing product's prose (the `verify-product` skill auto
 1. **Open the primary source(s)** the product points at — its `github`/`huggingface_*`/
    `pypi` URLs, and the vendor blog or registry. Never refresh from memory or a secondary
    summary.
-2. **Re-derive the checkable facts**: current version and release date, license (read the
-   LICENSE body, not the GitHub classifier), what it bundles/does, ownership/hosting.
+2. **Re-derive the checkable facts**: license (read the LICENSE body, not the GitHub
+   classifier), what it bundles/does, ownership/hosting, lifecycle state. Check the current
+   release to confirm the project is alive and that nothing moved a score, but do not write
+   the version into prose unless it is one of the three durable cases above.
 3. **Rewrite `description`** to the format above if anything material changed, keeping it
    neutral and within the length band. Leave it alone if nothing moved.
-4. **Update `comments`**: correct the license/version/date clauses, then set the
-   verification line to today's date and the source you read.
+4. **Update `comments`**: correct the license and caveat clauses, strip any stale count or
+   "latest version" clause, then set the verification line to today's date and the source
+   you read.
 5. **If a fact moves a score**, do not touch the score file here — record it and hand off
    to the `verification.md` flow.
 6. **Validate:** `uv run python -m build.validate` prints `0 error(s)`. Preview only; do
@@ -192,7 +232,8 @@ Use this to refresh an existing product's prose (the `verify-product` skill auto
 - [ ] No marketing words; no unsourced superlatives; judgments left on the axes.
 - [ ] No hardcoded star/download/contributor counts — rely on the artifact links and the
       `adoption` axis instead.
-- [ ] `comments`: license stated with the OSI call; version + release date; caveats.
+- [ ] No "latest/current version" clause, unless it is identity, terminal, or an absence.
+- [ ] `comments`: license stated with the OSI call; ownership/hosting; caveats.
 - [ ] Verification line in canonical form: `Verified <YYYY-MM-DD> via <source>.`
 - [ ] American English throughout.
 - [ ] Every factual claim confirmed against a primary source, not memory.

--- a/docs/guides/product-info.md
+++ b/docs/guides/product-info.md
@@ -47,7 +47,7 @@ of a catalog entry. It is not a pitch and not a review.
 **`description` is the load-bearing field.** Everything a reader needs about the product
 belongs here: what it is, what it does, what distinguishes it, and who builds or stewards
 it. `comments` is a footnote about *how we know*, not a second place to put product facts —
-see "The division of labour" below. When a fact could sit in either, it goes here.
+see "The division of labor" below. When a fact could sit in either, it goes here.
 
 **Format.**
 - **Length: 2–4 sentences, ~35–70 words.** The corpus median is 3 sentences / 55 words;
@@ -67,7 +67,7 @@ see "The division of labour" below. When a fact could sit in either, it goes her
 
 **Content — include:**
 - The product's *kind* (library / model / protocol / dataset / board) and its one-line job.
-- What distinguishes it from the obvious neighbour, factually ("Where MCP connects agents
+- What distinguishes it from the obvious neighbor, factually ("Where MCP connects agents
   to tools, A2A connects agents to other agents").
 - Concrete, checkable specifics: parameter class, modality, what it bundles, what standard
   it implements.
@@ -89,7 +89,7 @@ see "The division of labour" below. When a fact could sit in either, it goes her
 needs about the *treatment* rather than the product. In practice: the verification line,
 plus the occasional footnote about a judgment call or an evidence gap.
 
-### The division of labour
+### The division of labor
 
 `description` is load-bearing; `comments` is a footnote. The test is the subject of the
 sentence:

--- a/docs/guides/product-info.md
+++ b/docs/guides/product-info.md
@@ -34,7 +34,7 @@ mechanism (see "Provenance vs. `last_verified`").
 | `name` | required, kebab-case | the slug/identity; see `add-product` | machine |
 | `display_name` | required | the human label | reader |
 | `description` | string | what the product IS and DOES, neutral | reader (payload `description`) |
-| `comments` | string | provenance: license, version, release date, and the verification line | reader (payload `version_note`) |
+| `comments` | string | provenance: ownership, hosting, lifecycle, caveats, and the verification line | reader (payload `version_note`) |
 
 Both prose fields are optional in the schema, but in practice every product carries a
 `description` and almost every one carries `comments`. Write both.

--- a/docs/guides/product-info.md
+++ b/docs/guides/product-info.md
@@ -1,0 +1,208 @@
+# Product Info Guide
+
+The style, format, and tone of a product's **prose** fields — `description` and
+`comments` — and the procedure for keeping them current.
+
+> This guide governs the two hand-authored strings in `sources/products/<slug>.yaml`.
+> It is the prose companion to the scoring machinery, which is a different thing: how a
+> *score* earns a `last_verified` date, its evidence, and its gates live in
+> `docs/guides/verification.md` and `docs/guides/freshness.md`, and this guide never
+> overrides them. When a rule here changes, change the guide first and make the reviewer
+> (and the `verify-product` skill) follow.
+
+Both fields are reader-facing. `serialize.py` emits `description` into the payload as
+`description` and `comments` as `version_note`; both render in the notebook. So neither is
+a scratchpad — they are published copy.
+
+## Scope, and what this is NOT
+
+In scope: the free-text prose an editor writes by hand — `description` and `comments` —
+plus the two label fields around them (`display_name`, and how they relate to `name`).
+
+Out of scope, and deliberately: **anything a score records.** `openness`, `adoption`,
+`capability`, their `sources[]`, and `last_verified` live in
+`sources/scores/<slug>.yaml`, are governed by `verification.md`/`freshness.md`, and are
+partly machine-written (`build/apply_scores.py`). Do not encode a score judgment in the
+prose (see "Keep judgments on the axes" below), and do not treat the `comments`
+verification line as a freshness date — the two are related in spirit and separate in
+mechanism (see "Provenance vs. `last_verified`").
+
+## The fields at a glance
+
+| field | schema | what it is | audience |
+|---|---|---|---|
+| `name` | required, kebab-case | the slug/identity; see `add-product` | machine |
+| `display_name` | required | the human label | reader |
+| `description` | string | what the product IS and DOES, neutral | reader (payload `description`) |
+| `comments` | string | provenance: license, version, release date, and the verification line | reader (payload `version_note`) |
+
+Both prose fields are optional in the schema, but in practice every product carries a
+`description` and almost every one carries `comments`. Write both.
+
+## `description` — what it is and does
+
+**Purpose.** Tell a reader what the product is and what it does, in the neutral register
+of a catalog entry. It is not a pitch and not a review.
+
+**Format.**
+- **Length: 2–4 sentences, ~35–70 words.** The corpus median is 3 sentences / 55 words;
+  treat 1 sentence as too thin for a scored product and 6 as too long. A long tail entry
+  may be a single clause.
+- **Lead with the product doing something**, not with its vendor or its license. Good:
+  "Accelerate is a Hugging Face PyTorch library that lets users run raw PyTorch training
+  scripts across CPUs, multi-GPU, and TPU…". The org and license belong in `comments`, not
+  in the first sentence, unless the org name is genuinely load-bearing for identity (e.g.
+  "NVIDIA's content-safety classifier").
+- **Present tense, third person, declarative.** No second person ("you can"), no imperative.
+- **First mention uses the display name**, then a natural short form.
+- **Spell out an acronym once** if the category reader would not know it.
+
+**Content — include:**
+- The product's *kind* (library / model / protocol / dataset / board) and its one-line job.
+- What distinguishes it from the obvious neighbour, factually ("Where MCP connects agents
+  to tools, A2A connects agents to other agents").
+- Concrete, checkable specifics: parameter class, modality, what it bundles, what standard
+  it implements.
+
+**Content — exclude:**
+- **Marketing cadence.** No "powerful", "cutting-edge", "seamless", "revolutionary",
+  "blazing-fast". Borrow the register named in `docs/methodology.md`: *precise, defined,
+  measured, forthright about limitations.*
+- **Unsourced superlatives and rankings** ("the best", "the leading", "the de facto
+  standard") unless they are a plain, checkable fact stated as one.
+- **Point-in-time metrics** — star counts, download/install/pull counts, contributor and
+  commit counts, "fastest-growing". See "Volatile metrics" below; they go stale the day
+  they are written and prose has no freshness gate to catch it.
+
+## `comments` — provenance and notes
+
+**Purpose.** The scoring/provenance notes a reader or the next editor needs but that are
+not the product's description: license (with OSI/OSI-not call), version and release date,
+ownership/hosting nuance, gating caveats, and the verification line.
+
+**Format.** One compact paragraph, ~15–45 words (corpus median ~30). Semicolon- or
+period-separated clauses are both fine. Order, loosely: identity/aka → license → version
+& date → caveats → verification line.
+
+**Always state the license explicitly, and flag the non-obvious call**, because the
+license is what the openness score turns on and the classifier lies (see
+`add-product` and `openness-spectrum.md`): "Llama 2 Community License (not OSI)",
+"Gemma license is not OSI", "BSL 1.1 → source_available", "LICENSE file is the standard,
+unmodified Apache 2.0 text."
+
+### The verification line — canonical form
+
+The corpus carries this idiom 227 ways ("Verified live June 2026", "verified live on HF
+June 2026", "Verified live 2026-06-22 via primary sources", …). Standardize on:
+
+```
+Verified <YYYY-MM-DD> via <source>.
+```
+
+- **ISO date**, matching the `accessed:` format in score files. A month-year ("June 2026")
+  is acceptable only when the exact day is genuinely unknown; prefer the full date.
+- **`<source>`** names what was read: `primary sources`, `HF model card`, `GitHub`,
+  `PyPI`, `vendor docs`, `LICENSE body`. Name the host when one source settled it.
+- Capital "V". One line, at the end of `comments`.
+
+Examples:
+- `Apache 2.0 (unmodified LICENSE body). v1.9.3 released 2026-05-29. Verified 2026-06-22 via GitHub.`
+- `Llama 2 Community License (not OSI); adapter weights public on HF, base gated by Meta. Verified 2026-06-14 via HF model card.`
+
+## Global rules
+
+1. **American English everywhere** — `license` not `licence`, `penalized`, `labeled`,
+   `behavior`. This is a standing hazard in `verification-pass.md` and applies to prose
+   too, not just identifiers.
+2. **No marketing cadence.** Same register as the methodology copy.
+3. **Never assert from memory.** Any factual claim — version, release date, license,
+   what it bundles — is confirmed against a PRIMARY source before it is written. A
+   plausible claim that does not survive a check is not written. (This is the same rule
+   `add-product` step 7 states for adding.)
+4. **Keep judgments on the axes.** Adoption and openness are scored, sourced fields. An
+   *openness verdict* ("truly open") belongs in the score file, where it carries evidence,
+   not in prose. When in doubt, describe what the product is and let the axis carry the
+   judgment.
+5. **Do not embed volatile metrics** — see below.
+
+## Volatile metrics — link, don't embed
+
+A star count, download count, or contributor count is stale the moment it is written, and
+prose carries no freshness mechanism — `last_verified` gates *scores*, not `description`
+text. So a hardcoded "24K GitHub stars" or "~4.8k stars, actively maintained" is a
+liability with no owner. Do not write it.
+
+The actuals already have two homes, and neither is the prose:
+
+- **The artifact URLs are the live link.** A product's `github`/`pypi`/`huggingface_*`
+  entries point at the page that shows the current number. A reader who wants the count
+  follows the link; a tool reads it from the source.
+- **Adoption is a computed axis.** Magnitude of use is scored on the `adoption` axis from
+  those artifacts by the warehouse (`docs/methodology.md`: "real usage, not stars"), which
+  is where the number belongs *with* a date and a signal type.
+
+What prose may still say is the **durable, qualitative** shape of adoption when it is a
+structural fact rather than a number — "the distributed-training backbone for other Hugging
+Face libraries", "hosted by the Linux Foundation". Prefer even these sparingly, and never
+as a stand-in for a count. If a number matters, it is an `adoption` score, not a sentence.
+
+> Forward direction: as the notebook renders live/computed counts from the linked artifacts
+> and the `adoption` axis, prose should carry none. Treat every metric you would type as a
+> link you should rely on instead.
+
+## Provenance vs. `last_verified`
+
+These look alike and are not the same, and conflating them is the exact error
+`freshness.md` exists to prevent. Keep them straight:
+
+- The **`comments` verification line** is *editorial provenance for the prose* in the
+  product file. It says "an editor last confirmed these descriptive facts on this day." It
+  is not gated, not machine-read for freshness, and carries no per-dimension evidence.
+- **`last_verified`** lives in the *score* file, per axis, and is a confirmation that a
+  *score* is still correct, re-derivable from `sources[].establishes`, and gated (G1/G2).
+  Only a person writes it, and only per the rules in `verification.md`.
+
+Writing the `comments` line **does not** earn a `last_verified`, and updating a product's
+prose is not a score re-check. If a prose re-read turns up a fact that moves a *score* (a
+relicense, weights pulled, a dataset gated), that is a score change: stop, and follow
+`verification.md` — do not edit the score from the product file.
+
+## Updating a product — procedure
+
+Use this to refresh an existing product's prose (the `verify-product` skill automates it):
+
+1. **Open the primary source(s)** the product points at — its `github`/`huggingface_*`/
+   `pypi` URLs, and the vendor blog or registry. Never refresh from memory or a secondary
+   summary.
+2. **Re-derive the checkable facts**: current version and release date, license (read the
+   LICENSE body, not the GitHub classifier), what it bundles/does, ownership/hosting.
+3. **Rewrite `description`** to the format above if anything material changed, keeping it
+   neutral and within the length band. Leave it alone if nothing moved.
+4. **Update `comments`**: correct the license/version/date clauses, then set the
+   verification line to today's date and the source you read.
+5. **If a fact moves a score**, do not touch the score file here — record it and hand off
+   to the `verification.md` flow.
+6. **Validate:** `uv run python -m build.validate` prints `0 error(s)`. Preview only; do
+   not commit `build/notebook_data.json` or `notebooks/ai-stack-map.py` (bot-owned).
+
+## Checklist
+
+- [ ] `description`: 2–4 sentences, ~35–70 words, leads with the product doing something,
+      present tense, neutral register.
+- [ ] No marketing words; no unsourced superlatives; judgments left on the axes.
+- [ ] No hardcoded star/download/contributor counts — rely on the artifact links and the
+      `adoption` axis instead.
+- [ ] `comments`: license stated with the OSI call; version + release date; caveats.
+- [ ] Verification line in canonical form: `Verified <YYYY-MM-DD> via <source>.`
+- [ ] American English throughout.
+- [ ] Every factual claim confirmed against a primary source, not memory.
+- [ ] `uv run python -m build.validate` → `0 error(s)`.
+
+## Related
+
+- `skills/verify-product/SKILL.md` — the procedure above, as an agent-runnable skill
+- `skills/add-product/SKILL.md` — creating a product (step 7 is the same primary-source rule)
+- `docs/guides/verification.md` — normative: how a *score* earns `last_verified`
+- `docs/guides/freshness.md` — normative: what `last_verified` means
+- `docs/methodology.md` — the register these fields borrow ("no marketing cadence")
+- `docs/schemas/product.schema.json` — the field definitions

--- a/docs/guides/product-info.md
+++ b/docs/guides/product-info.md
@@ -77,19 +77,19 @@ of a catalog entry. It is not a pitch and not a review.
 
 ## `comments` — provenance and notes
 
-**Purpose.** The scoring/provenance notes a reader or the next editor needs but that are
-not the product's description: license (with OSI/OSI-not call), ownership/hosting nuance,
-gating caveats, lifecycle state (archived, superseded), and the verification line.
+**Purpose.** The provenance notes a reader or the next editor needs but that are not the
+product's description: identity and aliases, ownership and hosting, gating caveats,
+lifecycle state (archived, superseded), and the verification line.
 
-**Format.** One compact paragraph, ~15–45 words (corpus median ~30). Semicolon- or
-period-separated clauses are both fine. Order, loosely: identity/aka → license →
-caveats → verification line.
+**Format.** One compact paragraph, up to ~45 words. Semicolon- or period-separated clauses
+are both fine. Order, loosely: identity/aka → ownership/hosting → caveats → verification
+line.
 
-**Always state the license explicitly, and flag the non-obvious call**, because the
-license is what the openness score turns on and the classifier lies (see
-`add-product` and `openness-spectrum.md`): "Llama 2 Community License (not OSI)",
-"Gemma license is not OSI", "BSL 1.1 → source_available", "LICENSE file is the standard,
-unmodified Apache 2.0 text."
+There is no lower bound. With the license and the current version both out, a product whose
+durable provenance is just "who maintains it" gets one clause and the verification line, and
+that is a complete entry. Do not pad to reach a length.
+
+**Do not state the license here.** It is a scored field — see "Scored fields" below.
 
 ### The verification line — canonical form
 
@@ -107,8 +107,8 @@ Verified <YYYY-MM-DD> via <source>.
 - Capital "V". One line, at the end of `comments`.
 
 Examples:
-- `Apache 2.0 (unmodified LICENSE body). Hosted by the Linux Foundation. Verified 2026-06-22 via GitHub.`
-- `Llama 2 Community License (not OSI); adapter weights public on HF, base gated by Meta. Verified 2026-06-14 via HF model card.`
+- `Hosted by the Linux Foundation; originated at UC Berkeley. Verified 2026-06-22 via GitHub.`
+- `Adapter weights public on HF, base gated by Meta. Verified 2026-06-14 via HF model card.`
 
 ## Global rules
 
@@ -121,10 +121,37 @@ Examples:
    plausible claim that does not survive a check is not written. (This is the same rule
    `add-product` step 7 states for adding.)
 4. **Keep judgments on the axes.** Adoption and openness are scored, sourced fields. An
-   *openness verdict* ("truly open") belongs in the score file, where it carries evidence,
-   not in prose. When in doubt, describe what the product is and let the axis carry the
-   judgment.
+   *openness verdict* ("truly open") and the **license it rests on** belong in the score
+   file, where they carry evidence. See "Scored fields" below.
 5. **Do not embed volatile facts** — counts or current version numbers. See below.
+
+## Scored fields — don't restate them
+
+The license is the clearest case, and the one this guide used to get backwards. It is not
+merely descriptive: it *is* the openness score's basis, recorded in
+`sources/scores/<slug>.yaml` as `openness.components` (`license:Apache-2.0(OSI);…`) with
+`sources[].accessed` behind it and the G1/G2 gates in front of it.
+
+Restating it in `comments` creates a second copy with none of that. The two then drift in
+one direction only: a relicense flows correctly through `verification.md`, the score
+updates, and the prose is quietly left wrong with nothing to catch it. That is the same
+"liability with no owner" the volatile-facts rule names, made worse by the copy *looking*
+authoritative.
+
+It also buys the reader nothing. `build/serialize.py` emits the whole `openness` dict into
+the payload, and the front end already renders `openness.components` in the product detail
+panel — in larger type than the prose `version_note` directly above it. The license is on
+screen either way; only one copy carries evidence.
+
+So: **read the LICENSE body, and do not write it into prose.** Reading it stays essential —
+the GitHub classifier lies (a custom copyright line makes a genuine MIT/Apache repo report
+`NOASSERTION`), and the OSI / not-OSI call is exactly what the score turns on. But when the
+body disagrees with the recorded score, that is a **score** finding: stop and follow
+`verification.md`. Do not reconcile it by editing the product file.
+
+The same applies to any other scored dimension. Adoption, capability, and the openness
+class are axes with evidence; prose describes what the product is and lets them carry the
+judgment.
 
 ## Volatile facts — link, don't embed
 
@@ -211,15 +238,15 @@ Use this to refresh an existing product's prose (the `verify-product` skill auto
 1. **Open the primary source(s)** the product points at — its `github`/`huggingface_*`/
    `pypi` URLs, and the vendor blog or registry. Never refresh from memory or a secondary
    summary.
-2. **Re-derive the checkable facts**: license (read the LICENSE body, not the GitHub
-   classifier), what it bundles/does, ownership/hosting, lifecycle state. Check the current
-   release to confirm the project is alive and that nothing moved a score, but do not write
-   the version into prose unless it is one of the three durable cases above.
+2. **Re-derive the checkable facts**: what it bundles/does, ownership/hosting, lifecycle
+   state. Read the LICENSE body and the current release too — not to write them into prose,
+   but to confirm the project is alive and that neither has moved a score. A version goes in
+   only under one of the three durable cases above; a license does not go in at all.
 3. **Rewrite `description`** to the format above if anything material changed, keeping it
    neutral and within the length band. Leave it alone if nothing moved.
-4. **Update `comments`**: correct the license and caveat clauses, strip any stale count or
-   "latest version" clause, then set the verification line to today's date and the source
-   you read.
+4. **Update `comments`**: correct the ownership, hosting, and caveat clauses; strip any
+   stale count, "latest version" clause, or license restatement; then set the verification
+   line to today's date and the source you read.
 5. **If a fact moves a score**, do not touch the score file here — record it and hand off
    to the `verification.md` flow.
 6. **Validate:** `uv run python -m build.validate` prints `0 error(s)`. Preview only; do
@@ -233,7 +260,8 @@ Use this to refresh an existing product's prose (the `verify-product` skill auto
 - [ ] No hardcoded star/download/contributor counts — rely on the artifact links and the
       `adoption` axis instead.
 - [ ] No "latest/current version" clause, unless it is identity, terminal, or an absence.
-- [ ] `comments`: license stated with the OSI call; ownership/hosting; caveats.
+- [ ] No license restatement — it is `openness.components` in the score file.
+- [ ] `comments`: identity/aka; ownership/hosting; caveats; lifecycle state.
 - [ ] Verification line in canonical form: `Verified <YYYY-MM-DD> via <source>.`
 - [ ] American English throughout.
 - [ ] Every factual claim confirmed against a primary source, not memory.

--- a/docs/guides/verification.md
+++ b/docs/guides/verification.md
@@ -390,5 +390,7 @@ staleness.
 - `docs/guides/freshness.md` — what `last_verified` means, and the two divergences already
   closed
 - `docs/guides/openness-spectrum.md` — the openness ladders themselves
+- `docs/guides/product-info.md` — the prose companion: style/tone for a product's
+  `description`/`comments`, and why the `comments` verification line is NOT a `last_verified`
 - `sources/rubrics/` — shared ladders; `build/rubrics.py` for how `extends` resolves (#126)
 - `AGENTS.md` — the layer-2 loop and the evidence grading rule

--- a/skills/add-product/SKILL.md
+++ b/skills/add-product/SKILL.md
@@ -107,5 +107,9 @@ research agents work well). **After a batch, two hand-authored things drift and 
 re-checked:** category **straplines** (see the `curate-category` skill) and the
 `build/_frozen_long_tail.json` dedup counts (`scored` / `overlap` / `uncategorized`).
 
+## Related
+- `docs/guides/product-info.md` — style/format/tone for the `description` and `comments`
+  prose written in step 2; `skills/verify-product` refreshes those fields later.
+
 ## Boundaries
 - Read-only on the warehouse. No MCP, no uploads.

--- a/skills/verify-product/SKILL.md
+++ b/skills/verify-product/SKILL.md
@@ -39,7 +39,16 @@ openness/adoption/capability value.
    go stale with no freshness gate; the artifact links and the `adoption` axis carry the
    actuals (see the guide's "Volatile facts" section). This applies even when nothing
    else moved: removing a stale count IS a valid reason to edit.
-5. **Update `comments`:** correct the identity, ownership/hosting, and caveat clauses.
+
+   `description` is the **load-bearing** field: everything a reader needs about the product
+   lives here, including who builds or stewards it. Avoid three sentences in a row opening
+   "It …" — recast one around its real subject.
+5. **Rewrite `comments` as a footnote.** It is not a second description. Anything about the
+   *product* — what it does, who builds it, what it runs on — moves to `description`; what
+   stays is about *the reading*: an evidence gap, a judgment call a score rests on, or
+   something in a source that would mislead the next editor. Most products need only the
+   verification line, and that alone is a complete entry — do not pad.
+
    **Strip any "latest / current version" clause** — the next release makes it wrong and
    nothing will notice. Keep a version only when it is the entry's identity (a named model
    release), terminal (the project is archived), or a statement of absence ("no tagged
@@ -49,8 +58,10 @@ openness/adoption/capability value.
    ```
    Verified <YYYY-MM-DD> via <source>.
    ```
-   ISO date (today's), `<source>` naming what you read (`primary sources`, `HF model
-   card`, `GitHub`, `PyPI`, `vendor docs`, `LICENSE body`). Capital V, one line, at the end.
+   ISO date (today's). `<source>` names **a document someone could reopen** — `GitHub`,
+   `PyPI`, `the LICENSE body`, `the HF model card`, `the AWS Neuron documentation`. Never a
+   method: `web search` and a bare `primary sources` say how you looked, not what settled
+   it. If a search led you to a vendor page, cite the vendor page. Capital V, one line, last.
 6. **American English** throughout — `license`, not `licence`; `behavior`, `labeled`.
 7. **Validate:** `uv run python -m build.validate` must print `0 error(s)`.
 8. Rebuild + preview, then open a PR. Preview only: do not commit the regenerated
@@ -74,11 +85,24 @@ freshness date and earns no `last_verified`. Keeping these separate is the whole
 ## Verifying in batches
 
 For many products, drive research with parallel agents (one per product, each reading that
-product's own primary sources), then apply the edits with a small script that rewrites only
-the `description` and `comments` keys with
-`yaml.safe_dump(..., sort_keys=False, allow_unicode=True)` — preserving every other field
-byte-for-byte. Run `build.validate` after each batch, not just at the end. A plausible
-release that cannot be confirmed against any primary source is SKIPPED, not guessed.
+product's own primary sources), then apply the edits with a small script.
+
+**Do not load-modify-dump the whole file.** These YAMLs are hand-wrapped and do not
+round-trip: no single `yaml.dump` width reproduces them, so a whole-document rewrite
+rewraps every plain scalar in the file and buries a two-field edit in a corpus-wide diff.
+Splice the one key instead — take the lines before it, emit just that key, and keep the
+rest byte-for-byte:
+
+```python
+lines = path.read_text().splitlines(keepends=True)
+i = next(n for n, l in enumerate(lines) if l.startswith('comments:'))
+block = yaml.dump({'comments': new_text}, width=105, allow_unicode=True,
+                  default_flow_style=False, sort_keys=False)
+path.write_text(''.join(lines[:i]) + block)   # comments is the last key
+```
+
+Run `build.validate` after each batch, not just at the end. A plausible release that cannot
+be confirmed against any primary source is SKIPPED, not guessed.
 
 ## Boundaries
 

--- a/skills/verify-product/SKILL.md
+++ b/skills/verify-product/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: verify-product
+description: Use when an editor wants to verify or refresh an existing product's prose in the AI Stack Map — its description and comments — against primary sources, applying a consistent format and tone. Updates only the product file; does not touch scores or last_verified.
+---
+
+# Verify a Product
+
+Re-checks and rewrites the two hand-authored prose fields of
+`sources/products/<slug>.yaml` — `description` and `comments` — against primary sources,
+applying the house style. This is a **prose** refresh, not a score re-check: it never
+writes `last_verified`, never edits `sources/scores/<slug>.yaml`, and never adjusts an
+openness/adoption/capability value.
+
+> Read `docs/guides/product-info.md` first — it is the normative style/format/tone spec
+> and the source of the rules below. This skill is the procedure; the guide is the
+> authority.
+
+## Steps
+
+1. **Locate the product**: `sources/products/<slug>.yaml`. Note its `type` and its
+   artifact URLs (`github`, `huggingface_model`, `huggingface_dataset`, `pypi`, `npm`,
+   `crates`, `go`, `arxiv`).
+2. **Read the PRIMARY sources.** Fetch the product's own artifact URLs plus the vendor
+   blog / registry. Never refresh from memory or a secondary summary. If a cited URL 404s
+   or has moved, that is a finding — note it; do not paper over it.
+3. **Re-derive the checkable facts:**
+   - current version + release date;
+   - license — **read the LICENSE body**, not the GitHub classifier (a custom copyright
+     line makes a genuine MIT/Apache repo report `NOASSERTION`); make the OSI / not-OSI
+     call (Gemma, Llama Community, BSL 1.1, fair-code are all NOT OSI);
+   - what it is / does / bundles, and ownership + hosting.
+4. **Rewrite `description`** to the guide's format only if something material changed:
+   2–4 sentences (~35–70 words), lead with the product doing something, present tense,
+   neutral register, no marketing cadence, no unsourced superlatives. Leave it untouched
+   if nothing moved. **Strip any hardcoded star / download / contributor count** — those
+   go stale with no freshness gate; the artifact links and the `adoption` axis carry the
+   actuals (see the guide's "Volatile metrics" section). This applies even when nothing
+   else moved: removing a stale count IS a valid reason to edit.
+5. **Update `comments`:** correct the license / version / date clauses and caveats, then
+   set the verification line to the canonical form:
+   ```
+   Verified <YYYY-MM-DD> via <source>.
+   ```
+   ISO date (today's), `<source>` naming what you read (`primary sources`, `HF model
+   card`, `GitHub`, `PyPI`, `vendor docs`, `LICENSE body`). Capital V, one line, at the end.
+6. **American English** throughout — `license`, not `licence`; `behavior`, `labeled`.
+7. **Validate:** `uv run python -m build.validate` must print `0 error(s)`.
+8. Rebuild + preview, then open a PR. Preview only: do not commit the regenerated
+   `build/notebook_data.json` or `notebooks/ai-stack-map.py` (bot-owned; CI blocks
+   hand-edits).
+
+## When a re-read moves a score
+
+If the primary source shows something that changes an **openness / adoption / capability**
+value — a relicense, weights pulled, a dataset newly gated, an OSI call that was wrong —
+**stop.** That is a score change, not a prose edit.
+
+- Do NOT edit `sources/scores/<slug>.yaml` from here, and do NOT write `last_verified`.
+- Record the finding (in the PR description, or as a note), and hand off to the flow in
+  `docs/guides/verification.md`, which is gated and evidence-attributed.
+
+The `comments` verification line is editorial provenance for the *prose*; it is not a
+freshness date and earns no `last_verified`. Keeping these separate is the whole point
+(see `freshness.md`).
+
+## Verifying in batches
+
+For many products, drive research with parallel agents (one per product, each reading that
+product's own primary sources), then apply the edits with a small script that rewrites only
+the `description` and `comments` keys with
+`yaml.safe_dump(..., sort_keys=False, allow_unicode=True)` — preserving every other field
+byte-for-byte. Run `build.validate` after each batch, not just at the end. A plausible
+release that cannot be confirmed against any primary source is SKIPPED, not guessed.
+
+## Boundaries
+
+- Edits `sources/products/<slug>.yaml` only. Never `sources/scores/`, never `last_verified`.
+- Read-only on the warehouse. No MCP, no uploads.
+- Never assert a fact from memory; primary sources only.

--- a/skills/verify-product/SKILL.md
+++ b/skills/verify-product/SKILL.md
@@ -24,19 +24,24 @@ openness/adoption/capability value.
    blog / registry. Never refresh from memory or a secondary summary. If a cited URL 404s
    or has moved, that is a finding — note it; do not paper over it.
 3. **Re-derive the checkable facts:**
-   - current version + release date;
    - license — **read the LICENSE body**, not the GitHub classifier (a custom copyright
      line makes a genuine MIT/Apache repo report `NOASSERTION`); make the OSI / not-OSI
      call (Gemma, Llama Community, BSL 1.1, fair-code are all NOT OSI);
-   - what it is / does / bundles, and ownership + hosting.
+   - what it is / does / bundles, and ownership + hosting;
+   - lifecycle state — archived, maintenance mode, superseded;
+   - the current release, to confirm the project is alive and that nothing moved a score.
+     Read it; do not write it into prose (see step 5).
 4. **Rewrite `description`** to the guide's format only if something material changed:
    2–4 sentences (~35–70 words), lead with the product doing something, present tense,
    neutral register, no marketing cadence, no unsourced superlatives. Leave it untouched
    if nothing moved. **Strip any hardcoded star / download / contributor count** — those
    go stale with no freshness gate; the artifact links and the `adoption` axis carry the
-   actuals (see the guide's "Volatile metrics" section). This applies even when nothing
+   actuals (see the guide's "Volatile facts" section). This applies even when nothing
    else moved: removing a stale count IS a valid reason to edit.
-5. **Update `comments`:** correct the license / version / date clauses and caveats, then
+5. **Update `comments`:** correct the license and caveat clauses. **Strip any "latest /
+   current version" clause** — the next release makes it wrong and nothing will notice.
+   Keep a version only when it is the entry's identity (a named model release), terminal
+   (the project is archived), or a statement of absence ("no tagged releases"). Then
    set the verification line to the canonical form:
    ```
    Verified <YYYY-MM-DD> via <source>.

--- a/skills/verify-product/SKILL.md
+++ b/skills/verify-product/SKILL.md
@@ -24,13 +24,14 @@ openness/adoption/capability value.
    blog / registry. Never refresh from memory or a secondary summary. If a cited URL 404s
    or has moved, that is a finding — note it; do not paper over it.
 3. **Re-derive the checkable facts:**
-   - license — **read the LICENSE body**, not the GitHub classifier (a custom copyright
-     line makes a genuine MIT/Apache repo report `NOASSERTION`); make the OSI / not-OSI
-     call (Gemma, Llama Community, BSL 1.1, fair-code are all NOT OSI);
    - what it is / does / bundles, and ownership + hosting;
    - lifecycle state — archived, maintenance mode, superseded;
+   - the license — **read the LICENSE body**, not the GitHub classifier (a custom copyright
+     line makes a genuine MIT/Apache repo report `NOASSERTION`); make the OSI / not-OSI
+     call (Gemma, Llama Community, BSL 1.1, fair-code are all NOT OSI). Read it to check it
+     against the recorded score; **do not write it into prose** (see step 5);
    - the current release, to confirm the project is alive and that nothing moved a score.
-     Read it; do not write it into prose (see step 5).
+     Read it; do not write it into prose either.
 4. **Rewrite `description`** to the guide's format only if something material changed:
    2–4 sentences (~35–70 words), lead with the product doing something, present tense,
    neutral register, no marketing cadence, no unsourced superlatives. Leave it untouched
@@ -38,11 +39,13 @@ openness/adoption/capability value.
    go stale with no freshness gate; the artifact links and the `adoption` axis carry the
    actuals (see the guide's "Volatile facts" section). This applies even when nothing
    else moved: removing a stale count IS a valid reason to edit.
-5. **Update `comments`:** correct the license and caveat clauses. **Strip any "latest /
-   current version" clause** — the next release makes it wrong and nothing will notice.
-   Keep a version only when it is the entry's identity (a named model release), terminal
-   (the project is archived), or a statement of absence ("no tagged releases"). Then
-   set the verification line to the canonical form:
+5. **Update `comments`:** correct the identity, ownership/hosting, and caveat clauses.
+   **Strip any "latest / current version" clause** — the next release makes it wrong and
+   nothing will notice. Keep a version only when it is the entry's identity (a named model
+   release), terminal (the project is archived), or a statement of absence ("no tagged
+   releases"). **Strip any license restatement** — the license is `openness.components` in
+   the score file, where it carries evidence and a gate; a second copy in prose only drifts.
+   Then set the verification line to the canonical form:
    ```
    Verified <YYYY-MM-DD> via <source>.
    ```

--- a/sources/products/apple-core-ml-runtime.yaml
+++ b/sources/products/apple-core-ml-runtime.yaml
@@ -5,6 +5,6 @@ description: Apple Core ML is an on-device inference runtime that executes model
   and Neural Engine on iPhone, iPad, Mac, and Vision Pro. It partitions model graphs across the available
   hardware and runs .mlpackage and .mlmodel files. It underpins on-device machine learning features across
   Apple's operating systems, including Apple Intelligence.
-comments: Proprietary Apple system framework (iOS/macOS/watchOS/tvOS/visionOS; Neural Engine + GPU + CPU);
-  the companion coremltools conversion package is open source (3-Clause BSD). Verified 2026-08-08 via Apple
+comments: Apple system framework shipped with iOS/macOS/watchOS/tvOS/visionOS, running on the Neural Engine,
+  GPU, and CPU; the coremltools conversion package is distributed separately. Verified 2026-08-08 via Apple
   Developer docs.

--- a/sources/products/apple-core-ml-runtime.yaml
+++ b/sources/products/apple-core-ml-runtime.yaml
@@ -1,11 +1,10 @@
 name: apple-core-ml-runtime
 display_name: Apple Core ML Runtime
 type: software
-description: On-device inference runtime that executes models across Apple's heterogeneous compute (CPU,
-  GPU, and Neural Engine) on iPhone, iPad, Mac, and Vision Pro. The compiler automatically partitions
-  model graphs across available hardware for optimal latency and power efficiency. Powers Siri, on-device
-  autocorrect, image recognition, and Apple Intelligence features. The most widely deployed on-device
-  inference runtime by install base (2B+ active Apple devices).
-comments: Apple Core ML on-device inference runtime (iOS/macOS/watchOS/tvOS, Neural Engine + GPU + CPU).
-  Proprietary system framework; companion coremltools (conversion) is open (BSD-3-Clause). Confirmed live
-  June 2026 via Apple Developer docs.
+description: Apple Core ML is an on-device inference runtime that executes models across Apple's CPU, GPU,
+  and Neural Engine on iPhone, iPad, Mac, and Vision Pro. It partitions model graphs across the available
+  hardware and runs .mlpackage and .mlmodel files. It underpins on-device machine learning features across
+  Apple's operating systems, including Apple Intelligence.
+comments: Proprietary Apple system framework (iOS/macOS/watchOS/tvOS/visionOS; Neural Engine + GPU + CPU);
+  the companion coremltools conversion package is open source (3-Clause BSD). Verified 2026-08-08 via Apple
+  Developer docs.

--- a/sources/products/apple-core-ml-runtime.yaml
+++ b/sources/products/apple-core-ml-runtime.yaml
@@ -2,9 +2,8 @@ name: apple-core-ml-runtime
 display_name: Apple Core ML Runtime
 type: software
 description: Apple Core ML is an on-device inference runtime that executes models across Apple's CPU, GPU,
-  and Neural Engine on iPhone, iPad, Mac, and Vision Pro. It partitions model graphs across the available
-  hardware and runs .mlpackage and .mlmodel files. It underpins on-device machine learning features across
-  Apple's operating systems, including Apple Intelligence.
-comments: Apple system framework shipped with iOS/macOS/watchOS/tvOS/visionOS, running on the Neural Engine,
-  GPU, and CPU; the coremltools conversion package is distributed separately. Verified 2026-08-08 via Apple
-  Developer docs.
+  and Neural Engine, shipped as a system framework with iOS, macOS, watchOS, tvOS, and visionOS. It partitions
+  model graphs across the available hardware and runs .mlpackage and .mlmodel files, which the separately distributed
+  coremltools package produces. Apple's own on-device features, including Apple Intelligence, are built on
+  it.
+comments: Verified 2026-08-08 via Apple Developer docs.

--- a/sources/products/aws-neuron.yaml
+++ b/sources/products/aws-neuron.yaml
@@ -5,6 +5,6 @@ description: AWS Neuron is the SDK and runtime for running machine learning on A
   and Trainium accelerators (Inf1/Inf2 and Trn1/Trn2/Trn3 instances). Its compiler converts models from
   PyTorch and JAX into executables for the custom silicon, and it supports model serving through a vLLM
   plugin alongside a kernel-authoring interface (NKI).
-comments: Proprietary AWS SDK (closed-source compiler and runtime), distributed by AWS; samples and some
-  tooling are published on GitHub. Neuron SDK 2.31.0 released 2026-07-07, targeting Inferentia and Trainium
-  (Inf1/Inf2, Trn1/Trn2/Trn3). Verified 2026-08-08 via AWS Neuron documentation.
+comments: Proprietary AWS SDK (closed-source compiler and runtime), distributed by AWS; samples and some tooling
+  are published on GitHub. Targets Inferentia and Trainium (Inf1/Inf2, Trn1/Trn2/Trn3). Verified 2026-08-08
+  via AWS Neuron documentation.

--- a/sources/products/aws-neuron.yaml
+++ b/sources/products/aws-neuron.yaml
@@ -1,9 +1,8 @@
 name: aws-neuron
 display_name: AWS Neuron
 type: software
-description: AWS Neuron is the SDK and runtime for running machine learning on AWS's custom Inferentia
-  and Trainium accelerators (Inf1/Inf2 and Trn1/Trn2/Trn3 instances). Its compiler converts models from
-  PyTorch and JAX into executables for the custom silicon, and it supports model serving through a vLLM
-  plugin alongside a kernel-authoring interface (NKI).
-comments: Distributed by AWS as a separate SDK download; samples and some tooling are published on GitHub.
-  Targets Inferentia and Trainium (Inf1/Inf2, Trn1/Trn2/Trn3). Verified 2026-08-08 via AWS Neuron documentation.
+description: AWS Neuron is the SDK and runtime for running machine learning on AWS's custom Inferentia and
+  Trainium accelerators (Inf1/Inf2 and Trn1/Trn2/Trn3 instances). Its compiler converts models from PyTorch
+  and JAX into executables for the custom silicon, with serving through a vLLM plugin and a kernel-authoring
+  interface (NKI). AWS distributes it as a separate SDK, publishing samples and some tooling on GitHub.
+comments: Verified 2026-08-08 via the AWS Neuron documentation and its release notes.

--- a/sources/products/aws-neuron.yaml
+++ b/sources/products/aws-neuron.yaml
@@ -5,6 +5,5 @@ description: AWS Neuron is the SDK and runtime for running machine learning on A
   and Trainium accelerators (Inf1/Inf2 and Trn1/Trn2/Trn3 instances). Its compiler converts models from
   PyTorch and JAX into executables for the custom silicon, and it supports model serving through a vLLM
   plugin alongside a kernel-authoring interface (NKI).
-comments: Proprietary AWS SDK (closed-source compiler and runtime), distributed by AWS; samples and some tooling
-  are published on GitHub. Targets Inferentia and Trainium (Inf1/Inf2, Trn1/Trn2/Trn3). Verified 2026-08-08
-  via AWS Neuron documentation.
+comments: Distributed by AWS as a separate SDK download; samples and some tooling are published on GitHub.
+  Targets Inferentia and Trainium (Inf1/Inf2, Trn1/Trn2/Trn3). Verified 2026-08-08 via AWS Neuron documentation.

--- a/sources/products/aws-neuron.yaml
+++ b/sources/products/aws-neuron.yaml
@@ -1,10 +1,10 @@
 name: aws-neuron
 display_name: AWS Neuron
 type: software
-description: Proprietary SDK and runtime for running inference on AWS's custom Inferentia2 and Trainium
-  chips. The Neuron Compiler converts models from PyTorch/JAX into optimized executables for AWS custom
-  silicon. Offers significant cost savings vs GPU instances for supported model architectures. Integrated
-  with SageMaker and EC2. AWS's play to break NVIDIA GPU dependency for inference workloads, custom silicon
-  with a proprietary software stack.
-comments: Neuron SDK 2.30.0 (released ~May 22, 2026; 86 releases on GitHub). Serves LLM/DL inference on
-  AWS Inferentia/Trainium accelerators (Inf2/Trn instances). Confirmed live June 2026.
+description: AWS Neuron is the SDK and runtime for running machine learning on AWS's custom Inferentia
+  and Trainium accelerators (Inf2 and Trn instances). Its compiler converts models from PyTorch and JAX
+  into executables for the custom silicon, and it supports model serving through vLLM alongside a kernel-authoring
+  interface (NKI). It runs on EC2 and Amazon SageMaker.
+comments: Proprietary AWS SDK (closed-source compiler and runtime), distributed by AWS; samples and some
+  tooling are published on GitHub. Neuron SDK 2.30.0 (released ~May 2026), targeting Inferentia/Trainium
+  (Inf2/Trn) accelerators. Verified 2026-08-08 via web search.

--- a/sources/products/aws-neuron.yaml
+++ b/sources/products/aws-neuron.yaml
@@ -2,9 +2,9 @@ name: aws-neuron
 display_name: AWS Neuron
 type: software
 description: AWS Neuron is the SDK and runtime for running machine learning on AWS's custom Inferentia
-  and Trainium accelerators (Inf2 and Trn instances). Its compiler converts models from PyTorch and JAX
-  into executables for the custom silicon, and it supports model serving through vLLM alongside a kernel-authoring
-  interface (NKI). It runs on EC2 and Amazon SageMaker.
+  and Trainium accelerators (Inf1/Inf2 and Trn1/Trn2/Trn3 instances). Its compiler converts models from
+  PyTorch and JAX into executables for the custom silicon, and it supports model serving through a vLLM
+  plugin alongside a kernel-authoring interface (NKI).
 comments: Proprietary AWS SDK (closed-source compiler and runtime), distributed by AWS; samples and some
-  tooling are published on GitHub. Neuron SDK 2.30.0 (released ~May 2026), targeting Inferentia/Trainium
-  (Inf2/Trn) accelerators. Verified 2026-08-08 via web search.
+  tooling are published on GitHub. Neuron SDK 2.31.0 released 2026-07-07, targeting Inferentia and Trainium
+  (Inf1/Inf2, Trn1/Trn2/Trn3). Verified 2026-08-08 via AWS Neuron documentation.

--- a/sources/products/cerebras-inference.yaml
+++ b/sources/products/cerebras-inference.yaml
@@ -5,6 +5,6 @@ description: Cerebras Inference runs on the Cerebras Wafer-Scale Engine (WSE-3),
   with 4 trillion transistors and 44GB of on-chip SRAM that avoids off-chip memory access. It keeps entire
   models on one wafer to serve large models at high throughput, and is available through an OpenAI-compatible
   API.
-comments: 'Cerebras Inference: proprietary cloud inference on the Wafer-Scale Engine (WSE-3); OpenAI-compatible
-  API, serves open models (gpt-oss and others). Closed, managed service; Cerebras Systems listed on Nasdaq
-  (CBRS) 2026-05-14. Verified 2026-08-08 via Cerebras docs, chip page, and IPO press release.'
+comments: 'Cerebras Inference: managed cloud inference on the Wafer-Scale Engine (WSE-3); OpenAI-compatible
+  API, serves open models (gpt-oss and others). Cerebras Systems listed on Nasdaq (CBRS) 2026-05-14. Verified
+  2026-08-08 via Cerebras docs, chip page, and IPO press release.'

--- a/sources/products/cerebras-inference.yaml
+++ b/sources/products/cerebras-inference.yaml
@@ -2,9 +2,9 @@ name: cerebras-inference
 display_name: Cerebras Inference
 type: software
 description: Cerebras Inference runs on the Cerebras Wafer-Scale Engine (WSE-3), a single wafer-sized chip
-  with roughly 4 trillion transistors and 44GB of on-chip SRAM that avoids off-chip memory access. It keeps
-  entire models on one wafer to serve large models at high throughput, and is available through an OpenAI-compatible
+  with 4 trillion transistors and 44GB of on-chip SRAM that avoids off-chip memory access. It keeps entire
+  models on one wafer to serve large models at high throughput, and is available through an OpenAI-compatible
   API.
 comments: 'Cerebras Inference: proprietary cloud inference on the Wafer-Scale Engine (WSE-3); OpenAI-compatible
-  API, serves open models (Llama, gpt-oss, GLM, etc.). Closed, managed service; Cerebras Systems went public
-  on Nasdaq in 2026. Verified 2026-08-08 via web search.'
+  API, serves open models (gpt-oss and others). Closed, managed service; Cerebras Systems listed on Nasdaq
+  (CBRS) 2026-05-14. Verified 2026-08-08 via Cerebras docs, chip page, and IPO press release.'

--- a/sources/products/cerebras-inference.yaml
+++ b/sources/products/cerebras-inference.yaml
@@ -1,10 +1,8 @@
 name: cerebras-inference
 display_name: Cerebras Inference
 type: software
-description: Cerebras Inference runs on the Cerebras Wafer-Scale Engine (WSE-3), a single wafer-sized chip
-  with 4 trillion transistors and 44GB of on-chip SRAM that avoids off-chip memory access. It keeps entire
-  models on one wafer to serve large models at high throughput, and is available through an OpenAI-compatible
-  API.
-comments: 'Cerebras Inference: managed cloud inference on the Wafer-Scale Engine (WSE-3); OpenAI-compatible
-  API, serves open models (gpt-oss and others). Cerebras Systems listed on Nasdaq (CBRS) 2026-05-14. Verified
-  2026-08-08 via Cerebras docs, chip page, and IPO press release.'
+description: Cerebras Inference runs on the Cerebras Wafer-Scale Engine (WSE-3), a wafer-sized chip with 4
+  trillion transistors and 44GB of on-chip SRAM. Models small enough to fit are held entirely in on-chip memory;
+  larger ones are split at layer boundaries across multiple CS-3 systems, avoiding off-chip memory in either
+  case. Cerebras, listed on Nasdaq since May 2026, serves open models through an OpenAI-compatible API.
+comments: Verified 2026-08-08 via the Cerebras inference docs, chip page, and IPO pricing release.

--- a/sources/products/cerebras-inference.yaml
+++ b/sources/products/cerebras-inference.yaml
@@ -1,11 +1,10 @@
 name: cerebras-inference
 display_name: Cerebras Inference
 type: software
-description: Inference service running on the Cerebras Wafer-Scale Engine (WSE-3), a single chip containing
-  4 trillion transistors with 44GB of on-chip SRAM, eliminating off-chip memory bottlenecks entirely.
-  Achieves extremely high throughput on large models by keeping the entire model on a single wafer. Available
-  via API. Positioned as the fastest inference for large models where the entire model fits on one wafer.
-  Raised $4.3B+, filed for IPO.
-comments: 'Cerebras Inference: proprietary cloud inference on Wafer-Scale Engine (WSE); OpenAI-compatible
-  API, serves open models (GLM 4.7, gpt-oss-120b, Llama 4 Scout). Closed/managed service. Confirmed live
-  June 2026 (cerebras.ai).'
+description: Cerebras Inference runs on the Cerebras Wafer-Scale Engine (WSE-3), a single wafer-sized chip
+  with roughly 4 trillion transistors and 44GB of on-chip SRAM that avoids off-chip memory access. It keeps
+  entire models on one wafer to serve large models at high throughput, and is available through an OpenAI-compatible
+  API.
+comments: 'Cerebras Inference: proprietary cloud inference on the Wafer-Scale Engine (WSE-3); OpenAI-compatible
+  API, serves open models (Llama, gpt-oss, GLM, etc.). Closed, managed service; Cerebras Systems went public
+  on Nasdaq in 2026. Verified 2026-08-08 via web search.'

--- a/sources/products/ds4.yaml
+++ b/sources/products/ds4.yaml
@@ -1,13 +1,13 @@
 name: ds4
 display_name: ds4
 type: software
-description: Native local LLM inference engine by antirez (Salvatore Sanfilippo), optimized first for DeepSeek V4
-  Flash (with DeepSeek V4 PRO support on very-high-memory machines). Self-contained C/CUDA/Objective-C engine built
-  on llama.cpp/GGML with DeepSeek-specific loading, prompt rendering, tool calling, and KV state streaming (RAM
-  and on-disk SSD). Ships an HTTP server with OpenAI-compatible endpoints and an integrated coding agent, across
-  Metal (Apple Silicon), NVIDIA CUDA/DGX Spark, and AMD Strix Halo (ROCm) backends.
+description: ds4 (DwarfStar 4) is a native local LLM inference engine by antirez (Salvatore Sanfilippo), optimized
+  first for DeepSeek V4 Flash, with DeepSeek V4 PRO on very-high-memory machines and GLM 5.2 also supported. The
+  self-contained C/CUDA/Objective-C engine builds on llama.cpp/GGML, adding model loading, prompt rendering, tool
+  calling, and KV state streaming to RAM and on-disk SSD. It ships an HTTP server with OpenAI-compatible endpoints
+  and an integrated coding agent across Metal (Apple Silicon), NVIDIA CUDA/DGX Spark, and AMD Strix Halo (ROCm) backends.
 github:
 - url: https://github.com/antirez/ds4
-comments: MIT-licensed (LICENSE body, (c) 2026 The ds4.c authors + ggml authors). Created 6 May 2026, ~332 commits,
-  last push 17 Jun 2026; ~14.6k stars, no tagged releases (built from source). Deliberately narrow 'one model at
-  a time' design. Verified 2026-06-19.
+comments: MIT (LICENSE body, (c) 2026 The ds4.c authors + (c) 2023-2026 the ggml authors). Created 6 May 2026;
+  no tagged releases (built from source). Deliberately narrow 'one model at a time' design. Verified 2026-08-08
+  via GitHub and LICENSE body.

--- a/sources/products/ds4.yaml
+++ b/sources/products/ds4.yaml
@@ -1,12 +1,11 @@
 name: ds4
 display_name: ds4
 type: software
-description: ds4 (DwarfStar 4) is a native local LLM inference engine by antirez (Salvatore Sanfilippo),
-  optimized first for DeepSeek V4 Flash. The self-contained C/CUDA/Objective-C engine builds on llama.cpp/GGML,
-  adding model loading, prompt rendering, tool calling, and KV state streaming to RAM and on-disk SSD. It ships
-  an HTTP server with OpenAI-compatible endpoints and an integrated coding agent across Metal (Apple Silicon),
-  NVIDIA CUDA, and AMD ROCm backends.
+description: 'ds4 (DwarfStar 4) is a native local LLM inference engine by antirez (Salvatore Sanfilippo), optimized
+  first for DeepSeek V4 Flash and deliberately narrow: it serves one model at a time. The self-contained C/CUDA/Objective-C
+  engine builds on llama.cpp/GGML, adding model loading, prompt rendering, tool calling, and KV state streaming
+  to RAM and SSD. It ships an HTTP server with OpenAI-compatible endpoints and a coding agent.'
 github:
 - url: https://github.com/antirez/ds4
-comments: Created 6 May 2026; no tagged releases (built from source). Deliberately narrow 'one model at a time'
-  design, built on ggml/llama.cpp. Verified 2026-08-08 via GitHub and LICENSE body.
+comments: The project has no tagged releases and is built from source, so this entry is verified against the
+  repository head rather than a release. Verified 2026-08-08 via GitHub and the LICENSE body.

--- a/sources/products/ds4.yaml
+++ b/sources/products/ds4.yaml
@@ -1,11 +1,11 @@
 name: ds4
 display_name: ds4
 type: software
-description: ds4 (DwarfStar 4) is a native local LLM inference engine by antirez (Salvatore Sanfilippo), optimized
-  first for DeepSeek V4 Flash, with DeepSeek V4 PRO on very-high-memory machines and GLM 5.2 also supported. The
-  self-contained C/CUDA/Objective-C engine builds on llama.cpp/GGML, adding model loading, prompt rendering, tool
-  calling, and KV state streaming to RAM and on-disk SSD. It ships an HTTP server with OpenAI-compatible endpoints
-  and an integrated coding agent across Metal (Apple Silicon), NVIDIA CUDA/DGX Spark, and AMD Strix Halo (ROCm) backends.
+description: ds4 (DwarfStar 4) is a native local LLM inference engine by antirez (Salvatore Sanfilippo),
+  optimized first for DeepSeek V4 Flash. The self-contained C/CUDA/Objective-C engine builds on llama.cpp/GGML,
+  adding model loading, prompt rendering, tool calling, and KV state streaming to RAM and on-disk SSD. It ships
+  an HTTP server with OpenAI-compatible endpoints and an integrated coding agent across Metal (Apple Silicon),
+  NVIDIA CUDA, and AMD ROCm backends.
 github:
 - url: https://github.com/antirez/ds4
 comments: MIT (LICENSE body, (c) 2026 The ds4.c authors + (c) 2023-2026 the ggml authors). Created 6 May 2026;

--- a/sources/products/ds4.yaml
+++ b/sources/products/ds4.yaml
@@ -8,6 +8,5 @@ description: ds4 (DwarfStar 4) is a native local LLM inference engine by antirez
   NVIDIA CUDA, and AMD ROCm backends.
 github:
 - url: https://github.com/antirez/ds4
-comments: MIT (LICENSE body, (c) 2026 The ds4.c authors + (c) 2023-2026 the ggml authors). Created 6 May 2026;
-  no tagged releases (built from source). Deliberately narrow 'one model at a time' design. Verified 2026-08-08
-  via GitHub and LICENSE body.
+comments: Created 6 May 2026; no tagged releases (built from source). Deliberately narrow 'one model at a time'
+  design, built on ggml/llama.cpp. Verified 2026-08-08 via GitHub and LICENSE body.

--- a/sources/products/fireworks-inference.yaml
+++ b/sources/products/fireworks-inference.yaml
@@ -1,10 +1,8 @@
 name: fireworks-inference
 display_name: Fireworks Inference
 type: software
-description: Fireworks Inference serves open models on its FireAttention engine, built from handwritten
-  CUDA kernels and adaptive speculative decoding, running on NVIDIA and AMD GPUs. It serves many models and
-  LoRA adapters concurrently and supports function calling, and offers both serverless per-token endpoints
-  and dedicated GPU deployments. It was founded by former Meta PyTorch engineers.
-comments: Fireworks AI cloud inference on its FireAttention kernels and FireOptimizer tuning stack, running
-  on NVIDIA and AMD GPUs; OpenAI-compatible API, serves 100+ open models. Verified 2026-08-08 via Fireworks
-  docs, engineering blog, and team page.
+description: Fireworks Inference runs open models on the FireAttention engine, built from handwritten CUDA
+  kernels and adaptive speculative decoding, across NVIDIA and AMD GPUs. It hosts many models and LoRA adapters
+  concurrently, supports function calling, and offers both serverless per-token endpoints and dedicated GPU
+  deployments. Its vendor, Fireworks AI, was founded by former Meta PyTorch engineers.
+comments: Verified 2026-08-08 via the Fireworks docs, engineering blog, and team page.

--- a/sources/products/fireworks-inference.yaml
+++ b/sources/products/fireworks-inference.yaml
@@ -1,10 +1,10 @@
 name: fireworks-inference
 display_name: Fireworks Inference
 type: software
-description: Fireworks Inference serves open models on a proprietary FireAttention engine tuned for multi-tenant
-  model serving on NVIDIA GPUs. It serves many models and LoRA adapters concurrently and supports function
-  calling, and offers both serverless per-token endpoints and on-demand GPU deployments. Founded by former
-  Meta PyTorch engineers.
-comments: Fireworks AI cloud inference (proprietary FireAttention kernels, FireOptimizer) on NVIDIA GPUs;
-  OpenAI-compatible API, serves many open models (DeepSeek, Qwen, GLM, Kimi, Gemma, Llama, etc.). Closed,
-  managed service. Verified 2026-08-08 via web search.
+description: Fireworks Inference serves open models on a proprietary FireAttention engine built from handwritten
+  CUDA kernels and adaptive speculative decoding, running on NVIDIA and AMD GPUs. It serves many models and
+  LoRA adapters concurrently and supports function calling, and offers both serverless per-token endpoints
+  and dedicated GPU deployments. It was founded by former Meta PyTorch engineers.
+comments: Fireworks AI cloud inference (proprietary FireAttention kernels, FireOptimizer tuning stack) on
+  NVIDIA and AMD GPUs; OpenAI-compatible API, serves 100+ open models. Closed, managed service. Verified
+  2026-08-08 via Fireworks docs, engineering blog, and team page.

--- a/sources/products/fireworks-inference.yaml
+++ b/sources/products/fireworks-inference.yaml
@@ -1,10 +1,10 @@
 name: fireworks-inference
 display_name: Fireworks Inference
 type: software
-description: Fireworks Inference serves open models on a proprietary FireAttention engine built from handwritten
+description: Fireworks Inference serves open models on its FireAttention engine, built from handwritten
   CUDA kernels and adaptive speculative decoding, running on NVIDIA and AMD GPUs. It serves many models and
   LoRA adapters concurrently and supports function calling, and offers both serverless per-token endpoints
   and dedicated GPU deployments. It was founded by former Meta PyTorch engineers.
-comments: Fireworks AI cloud inference (proprietary FireAttention kernels, FireOptimizer tuning stack) on
-  NVIDIA and AMD GPUs; OpenAI-compatible API, serves 100+ open models. Closed, managed service. Verified
-  2026-08-08 via Fireworks docs, engineering blog, and team page.
+comments: Fireworks AI cloud inference on its FireAttention kernels and FireOptimizer tuning stack, running
+  on NVIDIA and AMD GPUs; OpenAI-compatible API, serves 100+ open models. Verified 2026-08-08 via Fireworks
+  docs, engineering blog, and team page.

--- a/sources/products/fireworks-inference.yaml
+++ b/sources/products/fireworks-inference.yaml
@@ -1,11 +1,10 @@
 name: fireworks-inference
 display_name: Fireworks Inference
 type: software
-description: High-performance inference platform built on a proprietary FireAttention engine optimized
-  for multi-tenant model serving on commodity GPUs. Specializes in efficiently serving many models and
-  LoRA adapters simultaneously with minimal overhead. Supports open models (Llama, Mixtral, Qwen) and
-  function calling. Founded by ex-Meta PyTorch team members. Competitive pricing and low latency have
-  made it a popular choice for startups building on open models.
-comments: Fireworks AI cloud inference (proprietary FireAttention kernels) on NVIDIA GPUs; OpenAI-compatible
-  API, serves many open models (DeepSeek V3.2/V4-Pro, Qwen 3.6, GLM-5.1, Kimi K2.6, Gemma 4, Llama, etc.).
-  Closed/managed service. Confirmed live June 2026 (fireworks.ai).
+description: Fireworks Inference serves open models on a proprietary FireAttention engine tuned for multi-tenant
+  model serving on NVIDIA GPUs. It serves many models and LoRA adapters concurrently and supports function
+  calling, and offers both serverless per-token endpoints and on-demand GPU deployments. Founded by former
+  Meta PyTorch engineers.
+comments: Fireworks AI cloud inference (proprietary FireAttention kernels, FireOptimizer) on NVIDIA GPUs;
+  OpenAI-compatible API, serves many open models (DeepSeek, Qwen, GLM, Kimi, Gemma, Llama, etc.). Closed,
+  managed service. Verified 2026-08-08 via web search.

--- a/sources/products/google-cloud-tpu-inference.yaml
+++ b/sources/products/google-cloud-tpu-inference.yaml
@@ -5,7 +5,6 @@ description: Google Cloud TPU Inference serves models on Google's Tensor Process
   the v5e, v6e (Trillium), and Ironwood (TPU7x) generations. The Pathways distributed runtime and the
   JetStream serving engine partition and serve models across multi-host TPU pods, with disaggregated serving
   for large language models. It is offered as a managed service through Vertex AI and GKE.
-comments: Proprietary managed cloud offering; the Pathways runtime (from Google DeepMind) and JetStream
-  are Google-developed and integrated for multi-host TPU serving under AI Hypercomputer. Available on Cloud
-  TPU generations up to Ironwood (TPU7x) and Trillium (v6e), via Vertex AI / GKE. Verified 2026-08-08 via
-  vendor docs.
+comments: Managed cloud offering; the Pathways runtime (from Google DeepMind) and JetStream are Google-developed
+  and integrated for multi-host TPU serving under AI Hypercomputer. Available on Cloud TPU generations up to
+  Ironwood (TPU7x) and Trillium (v6e), via Vertex AI / GKE. Verified 2026-08-08 via vendor docs.

--- a/sources/products/google-cloud-tpu-inference.yaml
+++ b/sources/products/google-cloud-tpu-inference.yaml
@@ -1,11 +1,11 @@
 name: google-cloud-tpu-inference
 display_name: Google Cloud TPU Inference
 type: software
-description: Proprietary inference runtime for Google's Tensor Processing Units (TPUs), now in v5e/v6e
-  generations. The Pathways system enables efficient model serving across TPU pods with automatic model
-  partitioning. Powers Google's own production inference for Gemini and internal models. Available via
-  Vertex AI and GKE for external customers. The most mature custom-silicon inference stack, developed
-  over 8+ years of TPU generations.
-comments: Pathways runtime (Google DeepMind distributed runtime) made available on Google Cloud and integrated
-  into JetStream for multi-host/disaggregated TPU serving (2026, AI Hypercomputer). Proprietary managed
-  cloud offering on Trillium v6 / Ironwood TPUs. Confirmed live June 2026.
+description: Google Cloud TPU Inference serves models on Google's Tensor Processing Units (TPUs), spanning
+  the v5e, v6e (Trillium), and Ironwood (TPU7x) generations. The Pathways distributed runtime and the
+  JetStream serving engine partition and serve models across multi-host TPU pods, with disaggregated serving
+  for large language models. It is offered as a managed service through Vertex AI and GKE.
+comments: Proprietary managed cloud offering; the Pathways runtime (from Google DeepMind) and JetStream
+  are Google-developed and integrated for multi-host TPU serving under AI Hypercomputer. Available on Cloud
+  TPU generations up to Ironwood (TPU7x) and Trillium (v6e), via Vertex AI / GKE. Verified 2026-08-08 via
+  vendor docs.

--- a/sources/products/google-cloud-tpu-inference.yaml
+++ b/sources/products/google-cloud-tpu-inference.yaml
@@ -2,9 +2,7 @@ name: google-cloud-tpu-inference
 display_name: Google Cloud TPU Inference
 type: software
 description: Google Cloud TPU Inference serves models on Google's Tensor Processing Units (TPUs), spanning
-  the v5e, v6e (Trillium), and Ironwood (TPU7x) generations. The Pathways distributed runtime and the
-  JetStream serving engine partition and serve models across multi-host TPU pods, with disaggregated serving
-  for large language models. It is offered as a managed service through Vertex AI and GKE.
-comments: Managed cloud offering; the Pathways runtime (from Google DeepMind) and JetStream are Google-developed
-  and integrated for multi-host TPU serving under AI Hypercomputer. Available on Cloud TPU generations up to
-  Ironwood (TPU7x) and Trillium (v6e), via Vertex AI / GKE. Verified 2026-08-08 via vendor docs.
+  the v5e, v6e (Trillium), and Ironwood (TPU7x) generations. The Pathways distributed runtime and the JetStream
+  serving engine partition and serve models across multi-host TPU pods, with disaggregated serving for large
+  language models. Google offers it as a managed service under AI Hypercomputer, through Vertex AI and GKE.
+comments: Verified 2026-08-08 via the Google Cloud TPU documentation.

--- a/sources/products/groq-inference.yaml
+++ b/sources/products/groq-inference.yaml
@@ -1,11 +1,10 @@
 name: groq-inference
 display_name: Groq Inference
 type: software
-description: Inference service running on custom Language Processing Unit (LPU) hardware designed from
-  the ground up for sequential token generation. Achieves industry-leading token throughput, widely benchmarked
-  at 500-800 tokens/sec for Llama-class models, far exceeding GPU-based alternatives. Deterministic, SRAM-based
-  architecture eliminates memory bottlenecks. Available via API with OpenAI-compatible endpoints. The
-  company that put 'inference speed' in the mainstream conversation in early 2024.
+description: Groq Inference runs open models on Groq's custom Language Processing Unit (LPU) hardware,
+  designed for sequential token generation rather than repurposed from training accelerators. Its deterministic,
+  SRAM-based architecture keeps model weights on-chip to reduce memory bottlenecks. The GroqCloud service
+  exposes the models through an API with OpenAI-compatible endpoints.
 comments: GroqCloud proprietary cloud inference on Groq LPU (Language Processing Unit) hardware; OpenAI-compatible
-  API, serves open models (gpt-oss, Llama, etc.). Closed/managed-only service. Confirmed live June 2026
-  (groq.com).
+  API, serves open models (gpt-oss, Llama, Whisper, etc.). Closed, managed-only service. Verified 2026-08-08
+  via web search.

--- a/sources/products/groq-inference.yaml
+++ b/sources/products/groq-inference.yaml
@@ -3,8 +3,9 @@ display_name: Groq Inference
 type: software
 description: Groq Inference runs open models on Groq's custom Language Processing Unit (LPU) hardware,
   designed for sequential token generation rather than repurposed from training accelerators. Its deterministic,
-  SRAM-based architecture keeps model weights on-chip to reduce memory bottlenecks. The GroqCloud service
-  exposes the models through an API with OpenAI-compatible endpoints.
+  statically scheduled architecture holds model weights in hundreds of megabytes of on-chip SRAM rather than
+  cache, avoiding off-chip memory access. The GroqCloud service exposes the models through an API with
+  OpenAI-compatible endpoints.
 comments: GroqCloud proprietary cloud inference on Groq LPU (Language Processing Unit) hardware; OpenAI-compatible
   API, serves open models (gpt-oss, Llama, Whisper, etc.). Closed, managed-only service. Verified 2026-08-08
-  via web search.
+  via Groq API docs and LPU architecture blog.

--- a/sources/products/groq-inference.yaml
+++ b/sources/products/groq-inference.yaml
@@ -6,6 +6,6 @@ description: Groq Inference runs open models on Groq's custom Language Processin
   statically scheduled architecture holds model weights in hundreds of megabytes of on-chip SRAM rather than
   cache, avoiding off-chip memory access. The GroqCloud service exposes the models through an API with
   OpenAI-compatible endpoints.
-comments: GroqCloud proprietary cloud inference on Groq LPU (Language Processing Unit) hardware; OpenAI-compatible
-  API, serves open models (gpt-oss, Llama, Whisper, etc.). Closed, managed-only service. Verified 2026-08-08
-  via Groq API docs and LPU architecture blog.
+comments: GroqCloud managed cloud inference on Groq LPU (Language Processing Unit) hardware; OpenAI-compatible
+  API, serves open models (gpt-oss, Llama, Whisper, etc.). Verified 2026-08-08 via Groq API docs and LPU architecture
+  blog.

--- a/sources/products/groq-inference.yaml
+++ b/sources/products/groq-inference.yaml
@@ -1,11 +1,9 @@
 name: groq-inference
 display_name: Groq Inference
 type: software
-description: Groq Inference runs open models on Groq's custom Language Processing Unit (LPU) hardware,
-  designed for sequential token generation rather than repurposed from training accelerators. Its deterministic,
-  statically scheduled architecture holds model weights in hundreds of megabytes of on-chip SRAM rather than
-  cache, avoiding off-chip memory access. The GroqCloud service exposes the models through an API with
-  OpenAI-compatible endpoints.
-comments: GroqCloud managed cloud inference on Groq LPU (Language Processing Unit) hardware; OpenAI-compatible
-  API, serves open models (gpt-oss, Llama, Whisper, etc.). Verified 2026-08-08 via Groq API docs and LPU architecture
-  blog.
+description: Groq Inference runs open models on Groq's custom Language Processing Unit (LPU) hardware, designed
+  for sequential token generation rather than repurposed from training accelerators. Its deterministic, statically
+  scheduled architecture holds model weights in hundreds of megabytes of on-chip SRAM rather than cache, avoiding
+  off-chip memory access. The GroqCloud service exposes open models, including gpt-oss, Llama, and Whisper,
+  through an OpenAI-compatible API.
+comments: Verified 2026-08-08 via the Groq API docs and Groq's LPU architecture blog.

--- a/sources/products/llama-cpp.yaml
+++ b/sources/products/llama-cpp.yaml
@@ -7,5 +7,5 @@ description: llama.cpp runs LLM and VLM inference in portable C/C++ with no exte
   and phones without CUDA or Python, and underpins tools including Ollama, LM Studio, and GPT4All.
 github:
 - url: https://github.com/ggml-org/llama.cpp
-comments: MIT license (unmodified LICENSE body, "The ggml authors"). ggml.ai team joined Hugging Face full-time
-  Feb 2026; project remains open. Verified 2026-08-08 via GitHub and LICENSE body.
+comments: The ggml.ai team joined Hugging Face full-time in Feb 2026; the project continues under the ggml-org
+  organization. Verified 2026-08-08 via GitHub and LICENSE body.

--- a/sources/products/llama-cpp.yaml
+++ b/sources/products/llama-cpp.yaml
@@ -7,6 +7,5 @@ description: llama.cpp runs LLM and VLM inference in portable C/C++ with no exte
   and phones without CUDA or Python, and underpins tools including Ollama, LM Studio, and GPT4All.
 github:
 - url: https://github.com/ggml-org/llama.cpp
-comments: MIT license (unmodified LICENSE body, "The ggml authors"). Latest release tag b10326 (2026-08-07,
-  GitHub). ggml.ai team joined Hugging Face full-time Feb 2026; project remains open. Verified 2026-08-08 via
-  GitHub and LICENSE body.
+comments: MIT license (unmodified LICENSE body, "The ggml authors"). ggml.ai team joined Hugging Face full-time
+  Feb 2026; project remains open. Verified 2026-08-08 via GitHub and LICENSE body.

--- a/sources/products/llama-cpp.yaml
+++ b/sources/products/llama-cpp.yaml
@@ -1,12 +1,12 @@
 name: llama-cpp
 display_name: llama.cpp
 type: software
-description: CPU and GPU inference engine for LLMs written in portable C/C++. Pioneered the GGUF quantization
-  format (2-8 bit) that became the ecosystem standard for local model distribution. Runs on consumer hardware
-  (laptops, phones, Raspberry Pi) without requiring CUDA or Python. 112K+ GitHub stars make it the most-starred
-  inference project; foundational infrastructure that powers Ollama, LM Studio, GPT4All, and dozens of
-  other tools.
+description: llama.cpp runs LLM and VLM inference in portable C/C++ with no external dependencies, targeting
+  CPUs and GPUs across a wide range of hardware. It supports 1.5-bit through 8-bit integer quantization and
+  the GGUF model format used widely for local model distribution. It runs on consumer hardware such as laptops
+  and phones without CUDA or Python, and underpins tools including Ollama, LM Studio, and GPT4All.
 github:
 - url: https://github.com/ggml-org/llama.cpp
-comments: Active 2026; latest release tag b9518 (June 4, 2026, GitHub). ggml.ai team joined Hugging Face
-  full-time Feb 20, 2026; project stays open. Confirmed live June 2026.
+comments: MIT license (unmodified LICENSE body, "The ggml authors"). Latest release tag b10326 (2026-08-07,
+  GitHub). ggml.ai team joined Hugging Face full-time Feb 2026; project remains open. Verified 2026-08-08 via
+  GitHub and LICENSE body.

--- a/sources/products/llama-cpp.yaml
+++ b/sources/products/llama-cpp.yaml
@@ -1,11 +1,11 @@
 name: llama-cpp
 display_name: llama.cpp
 type: software
-description: llama.cpp runs LLM and VLM inference in portable C/C++ with no external dependencies, targeting
-  CPUs and GPUs across a wide range of hardware. It supports 1.5-bit through 8-bit integer quantization and
-  the GGUF model format used widely for local model distribution. It runs on consumer hardware such as laptops
-  and phones without CUDA or Python, and underpins tools including Ollama, LM Studio, and GPT4All.
+description: llama.cpp runs LLM and VLM inference in portable C/C++ with no external dependencies, on CPUs
+  and GPUs across a wide range of hardware. It supports 1.5-bit through 8-bit integer quantization and the
+  GGUF format used widely for local model distribution, running on laptops and phones without CUDA or Python.
+  Maintained under ggml-org, whose ggml.ai team joined Hugging Face in February 2026, it underpins Ollama,
+  LM Studio, and GPT4All.
 github:
 - url: https://github.com/ggml-org/llama.cpp
-comments: The ggml.ai team joined Hugging Face full-time in Feb 2026; the project continues under the ggml-org
-  organization. Verified 2026-08-08 via GitHub and LICENSE body.
+comments: Verified 2026-08-08 via GitHub and the LICENSE body.

--- a/sources/products/llamafile.yaml
+++ b/sources/products/llamafile.yaml
@@ -7,5 +7,5 @@ description: llamafile packages a large language model and the software to run i
   whisperfile, provides the same single-file distribution for speech-to-text built on whisper.cpp.
 github:
 - url: https://github.com/mozilla-ai/llamafile
-comments: Apache 2.0 (OSI; MIT for llama.cpp/whisper.cpp changes; standard LICENSE body, Mozilla Foundation
-  copyright). Mozilla.ai (Mozilla Builders) project. Verified 2026-08-08 via GitHub and LICENSE body.
+comments: A Mozilla.ai (Mozilla Builders) project; incorporates its own changes to llama.cpp and whisper.cpp.
+  Verified 2026-08-08 via GitHub and LICENSE body.

--- a/sources/products/llamafile.yaml
+++ b/sources/products/llamafile.yaml
@@ -8,5 +8,4 @@ description: llamafile packages a large language model and the software to run i
 github:
 - url: https://github.com/mozilla-ai/llamafile
 comments: Apache 2.0 (OSI; MIT for llama.cpp/whisper.cpp changes; standard LICENSE body, Mozilla Foundation
-  copyright). v0.10.5 released 2026-08-03 (GitHub). Mozilla.ai (Mozilla Builders) project. Verified 2026-08-08
-  via GitHub and LICENSE body.
+  copyright). Mozilla.ai (Mozilla Builders) project. Verified 2026-08-08 via GitHub and LICENSE body.

--- a/sources/products/llamafile.yaml
+++ b/sources/products/llamafile.yaml
@@ -1,11 +1,12 @@
 name: llamafile
 display_name: llamafile
 type: software
-description: llamafile v0.10.3 (released June 2, 2026, GitHub); Apache-2.0 (MIT for llama.cpp/whisper.cpp
-  changes). Single-file cross-platform LLM executable (llama.cpp + Cosmopolitan Libc). Mozilla Builders
-  initiative, actively maintained June 2026.
+description: llamafile packages a large language model and the software to run it into a single cross-platform
+  executable that runs without installation on macOS, Linux, BSD, and Windows. It combines llama.cpp with
+  Cosmopolitan Libc to produce one file that works across operating systems and CPU architectures. A companion,
+  whisperfile, provides the same single-file distribution for speech-to-text built on whisper.cpp.
 github:
 - url: https://github.com/mozilla-ai/llamafile
-comments: llamafile v0.10.3 (released June 2, 2026, GitHub); Apache-2.0 (MIT for llama.cpp/whisper.cpp
-  changes). Single-file cross-platform LLM executable (llama.cpp + Cosmopolitan Libc). Mozilla Builders
-  initiative, actively maintained June 2026.
+comments: Apache 2.0 (OSI; MIT for llama.cpp/whisper.cpp changes; standard LICENSE body, Mozilla Foundation
+  copyright). v0.10.5 released 2026-08-03 (GitHub). Mozilla.ai (Mozilla Builders) project. Verified 2026-08-08
+  via GitHub and LICENSE body.

--- a/sources/products/llamafile.yaml
+++ b/sources/products/llamafile.yaml
@@ -2,10 +2,9 @@ name: llamafile
 display_name: llamafile
 type: software
 description: llamafile packages a large language model and the software to run it into a single cross-platform
-  executable that runs without installation on macOS, Linux, BSD, and Windows. It combines llama.cpp with
-  Cosmopolitan Libc to produce one file that works across operating systems and CPU architectures. A companion,
-  whisperfile, provides the same single-file distribution for speech-to-text built on whisper.cpp.
+  executable that runs without installation on macOS, Linux, BSD, and Windows. It combines llama.cpp with Cosmopolitan
+  Libc to produce one file that works across operating systems and CPU architectures. A Mozilla Builders project,
+  it has a companion, whisperfile, providing the same single-file distribution for speech-to-text.
 github:
 - url: https://github.com/mozilla-ai/llamafile
-comments: A Mozilla.ai (Mozilla Builders) project; incorporates its own changes to llama.cpp and whisper.cpp.
-  Verified 2026-08-08 via GitHub and LICENSE body.
+comments: Verified 2026-08-08 via GitHub and the LICENSE body.

--- a/sources/products/lmdeploy.yaml
+++ b/sources/products/lmdeploy.yaml
@@ -8,6 +8,5 @@ description: LMDeploy is a toolkit for compressing, deploying, and serving large
   models such as InternVL.
 github:
 - url: https://github.com/InternLM/lmdeploy
-comments: Apache 2.0 (OSI; standard LICENSE body, Shanghai AI Laboratory copyright). v0.15.0 released
-  2026-07-31 (GitHub/PyPI). Maintained by the InternLM team / Shanghai AI Laboratory. Verified 2026-08-08 via
-  GitHub, PyPI, and LICENSE body.
+comments: Apache 2.0 (OSI; standard LICENSE body, Shanghai AI Laboratory copyright). Maintained by the InternLM
+  team / Shanghai AI Laboratory. Verified 2026-08-08 via GitHub, PyPI, and LICENSE body.

--- a/sources/products/lmdeploy.yaml
+++ b/sources/products/lmdeploy.yaml
@@ -1,9 +1,13 @@
 name: lmdeploy
 display_name: LMDeploy
 type: software
-description: LMDeploy v0.13.0 (released May 12, 2026, GitHub); Apache-2.0 OSS inference/serving toolkit
-  (TurboMind + PyTorch engines). Confirmed live on GitHub + PyPI June 2026.
+description: LMDeploy is a toolkit for compressing, deploying, and serving large language models, built by
+  the InternLM team. It provides two inference engines — TurboMind, focused on performance with persistent
+  batching, blocked KV cache, and custom CUDA kernels, and a pure-Python PyTorch engine — plus weight-only and
+  KV-cache quantization. It supports model families including Llama, Qwen, and DeepSeek, and vision-language
+  models such as InternVL.
 github:
 - url: https://github.com/InternLM/lmdeploy
-comments: LMDeploy v0.13.0 (released May 12, 2026, GitHub); Apache-2.0 OSS inference/serving toolkit (TurboMind
-  + PyTorch engines). Confirmed live on GitHub + PyPI June 2026.
+comments: Apache 2.0 (OSI; standard LICENSE body, Shanghai AI Laboratory copyright). v0.15.0 released
+  2026-07-31 (GitHub/PyPI). Maintained by the InternLM team / Shanghai AI Laboratory. Verified 2026-08-08 via
+  GitHub, PyPI, and LICENSE body.

--- a/sources/products/lmdeploy.yaml
+++ b/sources/products/lmdeploy.yaml
@@ -2,11 +2,10 @@ name: lmdeploy
 display_name: LMDeploy
 type: software
 description: LMDeploy is a toolkit for compressing, deploying, and serving large language models, built by
-  the InternLM team. It provides two inference engines — TurboMind, focused on performance with persistent
-  batching, blocked KV cache, and custom CUDA kernels, and a pure-Python PyTorch engine — plus weight-only and
-  KV-cache quantization. It supports model families including Llama, Qwen, and DeepSeek, and vision-language
+  the InternLM team at Shanghai AI Laboratory. It provides two inference engines — TurboMind, focused on performance
+  with persistent batching, blocked KV cache, and custom CUDA kernels, and a pure-Python PyTorch engine — plus
+  weight-only and KV-cache quantization. Supported families include Llama, Qwen, DeepSeek, and vision-language
   models such as InternVL.
 github:
 - url: https://github.com/InternLM/lmdeploy
-comments: Maintained by the InternLM team at Shanghai AI Laboratory. Verified 2026-08-08 via GitHub, PyPI,
-  and LICENSE body.
+comments: Verified 2026-08-08 via GitHub, PyPI, and the LICENSE body.

--- a/sources/products/lmdeploy.yaml
+++ b/sources/products/lmdeploy.yaml
@@ -8,5 +8,5 @@ description: LMDeploy is a toolkit for compressing, deploying, and serving large
   models such as InternVL.
 github:
 - url: https://github.com/InternLM/lmdeploy
-comments: Apache 2.0 (OSI; standard LICENSE body, Shanghai AI Laboratory copyright). Maintained by the InternLM
-  team / Shanghai AI Laboratory. Verified 2026-08-08 via GitHub, PyPI, and LICENSE body.
+comments: Maintained by the InternLM team at Shanghai AI Laboratory. Verified 2026-08-08 via GitHub, PyPI,
+  and LICENSE body.

--- a/sources/products/localai.yaml
+++ b/sources/products/localai.yaml
@@ -4,7 +4,7 @@ type: software
 description: LocalAI is a self-hosted, OpenAI-compatible inference engine that runs LLMs plus vision, image,
   audio, and video models on commodity hardware, with no GPU required. A modular multi-backend architecture
   (60+ backends including llama.cpp, vLLM, whisper.cpp, diffusers, and MLX) sits behind one unified API, with
-  built-in agents, RAG, and Model Context Protocol support.
+  built-in agents, RAG, and Model Context Protocol support. Ettore Di Giacinto created and maintains it.
 github:
 - url: https://github.com/mudler/LocalAI
-comments: Created and maintained by Ettore Di Giacinto. Verified 2026-08-08 via GitHub and LICENSE body.
+comments: Verified 2026-08-08 via GitHub and the LICENSE body.

--- a/sources/products/localai.yaml
+++ b/sources/products/localai.yaml
@@ -1,9 +1,11 @@
 name: localai
 display_name: LocalAI
 type: software
-description: Self-hosted, OpenAI-compatible inference engine that runs LLMs, vision, image, audio, and video models
-  on commodity hardware (CPU or any GPU). A modular multi-backend architecture (36+ backends incl. llama.cpp, vLLM,
-  transformers, whisper.cpp, diffusers) behind one unified API, with built-in agents, RAG, and MCP.
+description: LocalAI is a self-hosted, OpenAI-compatible inference engine that runs LLMs plus vision, image,
+  audio, and video models on commodity hardware, with no GPU required. A modular multi-backend architecture
+  (60+ backends including llama.cpp, vLLM, whisper.cpp, diffusers, and MLX) sits behind one unified API, with
+  built-in agents, RAG, and Model Context Protocol support.
 github:
 - url: https://github.com/mudler/LocalAI
-comments: MIT, no feature-gated core. ~47k stars. Broadest model-type coverage of the local inference engines.
+comments: MIT (LICENSE body, (c) 2023-2025 Ettore Di Giacinto); no feature-gated core. v4.8.2 released
+  2026-08-07. Verified 2026-08-08 via GitHub and LICENSE body.

--- a/sources/products/localai.yaml
+++ b/sources/products/localai.yaml
@@ -7,5 +7,5 @@ description: LocalAI is a self-hosted, OpenAI-compatible inference engine that r
   built-in agents, RAG, and Model Context Protocol support.
 github:
 - url: https://github.com/mudler/LocalAI
-comments: MIT (LICENSE body, (c) 2023-2025 Ettore Di Giacinto); no feature-gated core. v4.8.2 released
-  2026-08-07. Verified 2026-08-08 via GitHub and LICENSE body.
+comments: MIT (LICENSE body, (c) 2023-2025 Ettore Di Giacinto); no feature-gated core. Verified 2026-08-08
+  via GitHub and LICENSE body.

--- a/sources/products/localai.yaml
+++ b/sources/products/localai.yaml
@@ -7,5 +7,4 @@ description: LocalAI is a self-hosted, OpenAI-compatible inference engine that r
   built-in agents, RAG, and Model Context Protocol support.
 github:
 - url: https://github.com/mudler/LocalAI
-comments: MIT (LICENSE body, (c) 2023-2025 Ettore Di Giacinto); no feature-gated core. Verified 2026-08-08
-  via GitHub and LICENSE body.
+comments: Created and maintained by Ettore Di Giacinto. Verified 2026-08-08 via GitHub and LICENSE body.

--- a/sources/products/max.yaml
+++ b/sources/products/max.yaml
@@ -1,8 +1,9 @@
 name: max
 display_name: MAX
 type: software
-description: MAX is an inference engine built on the Mojo programming language that serves LLMs and other
-  models across NVIDIA, AMD, and Apple GPUs plus CPUs from a single codebase. A graph compiler optimizes
-  model execution for the target hardware, and it serves PyTorch and Hugging Face models through OpenAI-compatible
-  endpoints. Developed by Modular, the company founded by LLVM and Swift creator Chris Lattner.
-comments: Built and distributed by Modular alongside the Mojo language. Verified 2026-08-08 via GitHub.
+description: MAX is an inference engine built on the Mojo programming language that serves LLMs and other models
+  across NVIDIA, AMD, and Apple GPUs plus CPUs from a single codebase. A graph compiler optimizes model execution
+  for the target hardware, and it serves PyTorch and Hugging Face models through OpenAI-compatible endpoints.
+  Modular, the company founded by LLVM and Swift creator Chris Lattner, develops and distributes it.
+comments: The repository source and MAX/Mojo usage carry different licenses; the openness score follows the
+  usage terms rather than the repository file. Verified 2026-08-08 via GitHub.

--- a/sources/products/max.yaml
+++ b/sources/products/max.yaml
@@ -5,7 +5,6 @@ description: MAX is an inference engine built on the Mojo programming language t
   models across NVIDIA, AMD, and Apple GPUs plus CPUs from a single codebase. A graph compiler optimizes
   model execution for the target hardware, and it serves PyTorch and Hugging Face models through OpenAI-compatible
   endpoints. Developed by Modular, the company founded by LLVM and Swift creator Chris Lattner.
-comments: MAX 26.4 (Mojo 1.0.0b2), released 2026-06-18. Inference-serving framework with OpenAI-compatible
-  endpoints on NVIDIA, AMD, and Apple GPUs plus CPU. Repository source is Apache 2.0 with LLVM Exceptions,
-  but MAX and Mojo usage and distribution are governed by the non-OSI Modular Community License. Verified
-  2026-08-08 via GitHub.
+comments: Inference-serving framework with OpenAI-compatible endpoints on NVIDIA, AMD, and Apple GPUs plus
+  CPU. Repository source is Apache 2.0 with LLVM Exceptions, but MAX and Mojo usage and distribution are governed
+  by the non-OSI Modular Community License. Verified 2026-08-08 via GitHub.

--- a/sources/products/max.yaml
+++ b/sources/products/max.yaml
@@ -1,11 +1,11 @@
 name: max
 display_name: MAX
 type: software
-description: Unified inference engine built on the Mojo programming language that targets multiple hardware
-  backends (NVIDIA, AMD, Intel, Apple) from a single codebase. Includes a graph compiler that automatically
-  optimizes model execution for the target hardware. Supports PyTorch and Hugging Face models with claimed
-  performance matching or exceeding TensorRT-LLM on NVIDIA GPUs while also running on non-NVIDIA hardware.
-  Founded by former LLVM/Swift creator Chris Lattner. 26K+ stars on the combined Modular repo.
-comments: MAX 26.3 (stable, released May 7, 2026; Mojo 1.0.0b1). High-performance inference-serving framework
-  (500+ open models, OpenAI-compatible endpoints) on NVIDIA/AMD/Apple GPUs + CPU. Source largely public
-  (github.com/modular/modular) but under the non-OSI Modular Community License.
+description: MAX is an inference engine built on the Mojo programming language that serves LLMs and other
+  models across NVIDIA, AMD, and Apple GPUs plus CPUs from a single codebase. A graph compiler optimizes
+  model execution for the target hardware, and it serves PyTorch and Hugging Face models through OpenAI-compatible
+  endpoints. Developed by Modular, the company founded by LLVM and Swift creator Chris Lattner.
+comments: MAX 26.4 (Mojo 1.0.0b2), released 2026-06-18. Inference-serving framework with OpenAI-compatible
+  endpoints on NVIDIA, AMD, and Apple GPUs plus CPU. Repository source is Apache 2.0 with LLVM Exceptions,
+  but MAX and Mojo usage and distribution are governed by the non-OSI Modular Community License. Verified
+  2026-08-08 via GitHub.

--- a/sources/products/max.yaml
+++ b/sources/products/max.yaml
@@ -5,6 +5,4 @@ description: MAX is an inference engine built on the Mojo programming language t
   models across NVIDIA, AMD, and Apple GPUs plus CPUs from a single codebase. A graph compiler optimizes
   model execution for the target hardware, and it serves PyTorch and Hugging Face models through OpenAI-compatible
   endpoints. Developed by Modular, the company founded by LLVM and Swift creator Chris Lattner.
-comments: Inference-serving framework with OpenAI-compatible endpoints on NVIDIA, AMD, and Apple GPUs plus
-  CPU. Repository source is Apache 2.0 with LLVM Exceptions, but MAX and Mojo usage and distribution are governed
-  by the non-OSI Modular Community License. Verified 2026-08-08 via GitHub.
+comments: Built and distributed by Modular alongside the Mojo language. Verified 2026-08-08 via GitHub.

--- a/sources/products/onnx-runtime.yaml
+++ b/sources/products/onnx-runtime.yaml
@@ -1,12 +1,13 @@
 name: onnx-runtime
 display_name: ONNX Runtime
 type: software
-description: 'Cross-platform inference accelerator supporting models from PyTorch, TensorFlow, and other
-  frameworks via the ONNX interchange format. Runs on CPUs, GPUs, NPUs, and custom accelerators with hardware-specific
-  execution providers. Used in production across Microsoft products (Windows, Office, Azure). Unique differentiator:
-  hardware-agnostic: one runtime targets NVIDIA, AMD, Intel, Qualcomm, and Apple silicon. 20K+ stars,
-  steady development over 7+ years.'
+description: ONNX Runtime is a cross-platform accelerator for machine learning inference and training, running
+  models exported from PyTorch, TensorFlow/Keras, and classical ML libraries via the ONNX interchange format.
+  It executes on CPUs, GPUs, NPUs, and custom accelerators through hardware-specific execution providers that
+  target NVIDIA, AMD, Intel, Qualcomm, and Apple silicon. Microsoft uses it in production across Windows,
+  Office, and Azure.
 github:
 - url: https://github.com/microsoft/onnxruntime
-comments: Latest release v1.26.0 (May 8, 2026, GitHub). Cross-platform inference + training accelerator
-  for ONNX models (PyTorch/TF export + classical ML). Confirmed live June 2026.
+comments: MIT license (Microsoft Corporation; unmodified LICENSE body). Latest release v1.28.0 (2026-07-25,
+  GitHub/PyPI). Cross-platform inference + training accelerator for ONNX models. Verified 2026-08-08 via
+  GitHub, PyPI, and LICENSE body.

--- a/sources/products/onnx-runtime.yaml
+++ b/sources/products/onnx-runtime.yaml
@@ -4,8 +4,8 @@ type: software
 description: ONNX Runtime is a cross-platform accelerator for machine learning inference and training, running
   models exported from PyTorch, TensorFlow/Keras, and classical ML libraries via the ONNX interchange format.
   It executes on CPUs, GPUs, NPUs, and custom accelerators through hardware-specific execution providers that
-  target NVIDIA, AMD, Intel, Qualcomm, and Apple silicon. Microsoft uses it in production across Windows,
-  Office, and Azure.
+  target NVIDIA, AMD, Intel, Qualcomm, and Apple silicon. Microsoft develops it and uses it in production across
+  Windows, Office, and Azure.
 github:
 - url: https://github.com/microsoft/onnxruntime
-comments: Developed and maintained by Microsoft. Verified 2026-08-08 via GitHub, PyPI, and LICENSE body.
+comments: Verified 2026-08-08 via GitHub, PyPI, and the LICENSE body.

--- a/sources/products/onnx-runtime.yaml
+++ b/sources/products/onnx-runtime.yaml
@@ -8,5 +8,4 @@ description: ONNX Runtime is a cross-platform accelerator for machine learning i
   Office, and Azure.
 github:
 - url: https://github.com/microsoft/onnxruntime
-comments: MIT license (Microsoft Corporation; unmodified LICENSE body). Cross-platform inference + training
-  accelerator for ONNX models. Verified 2026-08-08 via GitHub, PyPI, and LICENSE body.
+comments: Developed and maintained by Microsoft. Verified 2026-08-08 via GitHub, PyPI, and LICENSE body.

--- a/sources/products/onnx-runtime.yaml
+++ b/sources/products/onnx-runtime.yaml
@@ -8,6 +8,5 @@ description: ONNX Runtime is a cross-platform accelerator for machine learning i
   Office, and Azure.
 github:
 - url: https://github.com/microsoft/onnxruntime
-comments: MIT license (Microsoft Corporation; unmodified LICENSE body). Latest release v1.28.0 (2026-07-25,
-  GitHub/PyPI). Cross-platform inference + training accelerator for ONNX models. Verified 2026-08-08 via
-  GitHub, PyPI, and LICENSE body.
+comments: MIT license (Microsoft Corporation; unmodified LICENSE body). Cross-platform inference + training
+  accelerator for ONNX models. Verified 2026-08-08 via GitHub, PyPI, and LICENSE body.

--- a/sources/products/qualcomm-ai-engine-direct.yaml
+++ b/sources/products/qualcomm-ai-engine-direct.yaml
@@ -1,10 +1,9 @@
 name: qualcomm-ai-engine-direct
 display_name: Qualcomm AI Engine Direct
 type: software
-description: Qualcomm AI Engine Direct is an on-device inference runtime and SDK (also called the Qualcomm
-  AI Runtime, QAIRT or QNN) for Snapdragon processors. It provides a unified low-level API over the Hexagon
-  NPU/HTP, Adreno GPU, and Kryo CPU, dispatching work to the chosen backend. Runtimes including TensorFlow
-  Lite/LiteRT, ONNX Runtime, and ExecuTorch delegate to it, with quantization down to 4-bit weights.
-comments: Qualcomm SDK distributed as a separate EULA download from the Qualcomm software center (aka Qualcomm
-  AI Runtime / QAIRT / QNN); a convenience wrapper, quic/ai-engine-direct-helper, is published on GitHub. Verified
-  2026-08-08 via Qualcomm developer docs, ExecuTorch docs, and GitHub LICENSE.
+description: Qualcomm AI Engine Direct (also called the Qualcomm AI Runtime, QAIRT or QNN) is an on-device
+  inference runtime and SDK for Snapdragon processors, distributed as a separate EULA download. It provides
+  a unified low-level API over the Hexagon NPU/HTP, Adreno GPU, and Kryo CPU. TensorFlow Lite/LiteRT, ONNX
+  Runtime, and ExecuTorch delegate to it, with quantization down to 4-bit weights; a convenience wrapper, quic/ai-engine-direct-helper,
+  is on GitHub.
+comments: Verified 2026-08-08 via the Qualcomm developer docs, the ExecuTorch Qualcomm backend docs, and GitHub.

--- a/sources/products/qualcomm-ai-engine-direct.yaml
+++ b/sources/products/qualcomm-ai-engine-direct.yaml
@@ -2,10 +2,10 @@ name: qualcomm-ai-engine-direct
 display_name: Qualcomm AI Engine Direct
 type: software
 description: Qualcomm AI Engine Direct is an on-device inference runtime and SDK (also called the Qualcomm
-  AI Runtime, QNN) for Snapdragon processors across mobile, automotive, IoT, and PC. It provides a unified
-  low-level API over the Hexagon NPU/HTP, Adreno GPU, and Kryo CPU, dispatching work to the chosen backend.
-  It supports models from PyTorch, TensorFlow, and ONNX, including quantization down to INT4.
-comments: Proprietary Qualcomm SDK (separate download; aka Qualcomm AI Runtime / QAIRT / QNN) for on-device
-  inference on Snapdragon NPU/HTP (Hexagon), GPU (Adreno), and CPU (Kryo); an open-source helper wrapper
-  (quic/ai-engine-direct-helper, 3-Clause BSD) exists. Serves as a backend for LiteRT and ExecuTorch. Verified
-  2026-08-08 via web search.
+  AI Runtime, QAIRT or QNN) for Snapdragon processors. It provides a unified low-level API over the Hexagon
+  NPU/HTP, Adreno GPU, and Kryo CPU, dispatching work to the chosen backend. Runtimes including TensorFlow
+  Lite/LiteRT, ONNX Runtime, and ExecuTorch delegate to it, with quantization down to 4-bit weights.
+comments: Proprietary Qualcomm SDK (separate download; aka Qualcomm AI Runtime / QAIRT / QNN), v2.49.0.260730,
+  for on-device inference on Snapdragon Hexagon NPU/HTP, Adreno GPU, and Kryo CPU. The open-source helper
+  wrapper quic/ai-engine-direct-helper is BSD 3-Clause. Verified 2026-08-08 via Qualcomm developer docs,
+  ExecuTorch docs, and GitHub LICENSE.

--- a/sources/products/qualcomm-ai-engine-direct.yaml
+++ b/sources/products/qualcomm-ai-engine-direct.yaml
@@ -5,6 +5,6 @@ description: Qualcomm AI Engine Direct is an on-device inference runtime and SDK
   AI Runtime, QAIRT or QNN) for Snapdragon processors. It provides a unified low-level API over the Hexagon
   NPU/HTP, Adreno GPU, and Kryo CPU, dispatching work to the chosen backend. Runtimes including TensorFlow
   Lite/LiteRT, ONNX Runtime, and ExecuTorch delegate to it, with quantization down to 4-bit weights.
-comments: Proprietary Qualcomm SDK (separate download; aka Qualcomm AI Runtime / QAIRT / QNN) for on-device
-  inference on Snapdragon Hexagon NPU/HTP, Adreno GPU, and Kryo CPU. The open-source helper wrapper quic/ai-engine-direct-helper
-  is BSD 3-Clause. Verified 2026-08-08 via Qualcomm developer docs, ExecuTorch docs, and GitHub LICENSE.
+comments: Qualcomm SDK distributed as a separate EULA download from the Qualcomm software center (aka Qualcomm
+  AI Runtime / QAIRT / QNN); a convenience wrapper, quic/ai-engine-direct-helper, is published on GitHub. Verified
+  2026-08-08 via Qualcomm developer docs, ExecuTorch docs, and GitHub LICENSE.

--- a/sources/products/qualcomm-ai-engine-direct.yaml
+++ b/sources/products/qualcomm-ai-engine-direct.yaml
@@ -5,7 +5,6 @@ description: Qualcomm AI Engine Direct is an on-device inference runtime and SDK
   AI Runtime, QAIRT or QNN) for Snapdragon processors. It provides a unified low-level API over the Hexagon
   NPU/HTP, Adreno GPU, and Kryo CPU, dispatching work to the chosen backend. Runtimes including TensorFlow
   Lite/LiteRT, ONNX Runtime, and ExecuTorch delegate to it, with quantization down to 4-bit weights.
-comments: Proprietary Qualcomm SDK (separate download; aka Qualcomm AI Runtime / QAIRT / QNN), v2.49.0.260730,
-  for on-device inference on Snapdragon Hexagon NPU/HTP, Adreno GPU, and Kryo CPU. The open-source helper
-  wrapper quic/ai-engine-direct-helper is BSD 3-Clause. Verified 2026-08-08 via Qualcomm developer docs,
-  ExecuTorch docs, and GitHub LICENSE.
+comments: Proprietary Qualcomm SDK (separate download; aka Qualcomm AI Runtime / QAIRT / QNN) for on-device
+  inference on Snapdragon Hexagon NPU/HTP, Adreno GPU, and Kryo CPU. The open-source helper wrapper quic/ai-engine-direct-helper
+  is BSD 3-Clause. Verified 2026-08-08 via Qualcomm developer docs, ExecuTorch docs, and GitHub LICENSE.

--- a/sources/products/qualcomm-ai-engine-direct.yaml
+++ b/sources/products/qualcomm-ai-engine-direct.yaml
@@ -1,12 +1,11 @@
 name: qualcomm-ai-engine-direct
 display_name: Qualcomm AI Engine Direct
 type: software
-description: On-device inference runtime for Qualcomm's Snapdragon processors targeting mobile, automotive,
-  IoT, and PC. Provides unified API across Qualcomm's Hexagon NPU, Adreno GPU, and Kryo CPU with automatic
-  hardware dispatch for optimal performance and power. Powers on-device AI in billions of Android phones
-  and Copilot+ PCs. Supports transformer models with quantization down to INT4. The dominant inference
-  runtime for Android on-device AI workloads.
-comments: Qualcomm AI Engine Direct SDK (aka Qualcomm AI Runtime / QNN) for on-device inference on Snapdragon
-  NPU/HTP (Hexagon), GPU (Adreno), CPU (Kryo). Distributed as a proprietary SDK (separate Qualcomm download);
-  open source helper wrapper (quic/ai-engine-direct-helper, BSD-3) exists. Integrated as backend for LiteRT
-  and ExecuTorch. Confirmed live June 2026.
+description: Qualcomm AI Engine Direct is an on-device inference runtime and SDK (also called the Qualcomm
+  AI Runtime, QNN) for Snapdragon processors across mobile, automotive, IoT, and PC. It provides a unified
+  low-level API over the Hexagon NPU/HTP, Adreno GPU, and Kryo CPU, dispatching work to the chosen backend.
+  It supports models from PyTorch, TensorFlow, and ONNX, including quantization down to INT4.
+comments: Proprietary Qualcomm SDK (separate download; aka Qualcomm AI Runtime / QAIRT / QNN) for on-device
+  inference on Snapdragon NPU/HTP (Hexagon), GPU (Adreno), and CPU (Kryo); an open-source helper wrapper
+  (quic/ai-engine-direct-helper, 3-Clause BSD) exists. Serves as a backend for LiteRT and ExecuTorch. Verified
+  2026-08-08 via web search.

--- a/sources/products/sambanova-cloud.yaml
+++ b/sources/products/sambanova-cloud.yaml
@@ -1,10 +1,10 @@
 name: sambanova-cloud
 display_name: SambaNova Cloud
 type: software
-description: Inference service running on custom Reconfigurable Dataflow Architecture (RDA) chips, the
-  SN40L processor with 1TB+ on-chip memory. Designed for large models that don't fit in GPU memory without
-  tensor parallelism. Offers both cloud API and on-premise appliance (DataScale) for enterprise deployments.
-  Competitive with Groq and Cerebras on throughput for large models. Raised $1.5B+, primarily targeting
-  enterprise and government customers.
-comments: SambaNova Cloud, proprietary managed inference service on SN40L RDU hardware (cloud.sambanova.ai).
-  Serves Llama / open models at high token/s. Confirmed as live commercial cloud offering June 2026.
+description: SambaNova Cloud is an inference service running on SambaNova's custom Reconfigurable Dataflow
+  Unit (RDU) chips, the SN40L, whose three-tier memory system (on-chip SRAM, HBM, and DDR DRAM) is designed
+  to fit large models without tensor parallelism. It exposes OpenAI-compatible API endpoints, and the same
+  hardware is offered as an on-premise appliance for enterprise deployments.
+comments: Proprietary managed inference service on SN40L RDU hardware (cloud.sambanova.ai); serves Llama
+  and other open-weight models via OpenAI-compatible APIs. On-premise and managed-appliance options also
+  offered. Verified 2026-08-08 via web search.

--- a/sources/products/sambanova-cloud.yaml
+++ b/sources/products/sambanova-cloud.yaml
@@ -5,6 +5,6 @@ description: SambaNova Cloud is an inference service running on SambaNova's cust
   Unit (RDU) chips, the SN40L. Its three-tier memory system pairs on-chip SRAM for hot local work with HBM
   to stream model weights and DDR DRAM for prompt caching and multi-model workloads. It exposes OpenAI-compatible
   API endpoints.
-comments: Proprietary managed inference service (SambaCloud) on SN40L RDU hardware; serves open-weight models
-  via OpenAI-compatible APIs. On-premise deployment offered as SambaStack. Verified 2026-08-08 via SambaNova
-  docs and technology pages.
+comments: Managed inference service (SambaCloud) on SN40L RDU hardware; serves open-weight models via OpenAI-compatible
+  APIs. On-premise deployment offered as SambaStack. Verified 2026-08-08 via SambaNova docs and technology
+  pages.

--- a/sources/products/sambanova-cloud.yaml
+++ b/sources/products/sambanova-cloud.yaml
@@ -3,8 +3,6 @@ display_name: SambaNova Cloud
 type: software
 description: SambaNova Cloud is an inference service running on SambaNova's custom Reconfigurable Dataflow
   Unit (RDU) chips, the SN40L. Its three-tier memory system pairs on-chip SRAM for hot local work with HBM
-  to stream model weights and DDR DRAM for prompt caching and multi-model workloads. It exposes OpenAI-compatible
-  API endpoints.
-comments: Managed inference service (SambaCloud) on SN40L RDU hardware; serves open-weight models via OpenAI-compatible
-  APIs. On-premise deployment offered as SambaStack. Verified 2026-08-08 via SambaNova docs and technology
-  pages.
+  to stream model weights and DDR DRAM for prompt caching and multi-model workloads. It serves open-weight
+  models through OpenAI-compatible endpoints as SambaCloud, with SambaStack offered for on-premise deployment.
+comments: Verified 2026-08-08 via the SambaNova Cloud docs and dataflow architecture pages.

--- a/sources/products/sambanova-cloud.yaml
+++ b/sources/products/sambanova-cloud.yaml
@@ -2,9 +2,9 @@ name: sambanova-cloud
 display_name: SambaNova Cloud
 type: software
 description: SambaNova Cloud is an inference service running on SambaNova's custom Reconfigurable Dataflow
-  Unit (RDU) chips, the SN40L, whose three-tier memory system (on-chip SRAM, HBM, and DDR DRAM) is designed
-  to fit large models without tensor parallelism. It exposes OpenAI-compatible API endpoints, and the same
-  hardware is offered as an on-premise appliance for enterprise deployments.
-comments: Proprietary managed inference service on SN40L RDU hardware (cloud.sambanova.ai); serves Llama
-  and other open-weight models via OpenAI-compatible APIs. On-premise and managed-appliance options also
-  offered. Verified 2026-08-08 via web search.
+  Unit (RDU) chips, the SN40L. Its three-tier memory system pairs on-chip SRAM for hot local work with HBM
+  to stream model weights and DDR DRAM for prompt caching and multi-model workloads. It exposes OpenAI-compatible
+  API endpoints.
+comments: Proprietary managed inference service (SambaCloud) on SN40L RDU hardware; serves open-weight models
+  via OpenAI-compatible APIs. On-premise deployment offered as SambaStack. Verified 2026-08-08 via SambaNova
+  docs and technology pages.

--- a/sources/products/sglang.yaml
+++ b/sources/products/sglang.yaml
@@ -7,5 +7,5 @@ description: SGLang is a high-performance serving engine for large language and 
   AMD, Intel, and TPU hardware from a single GPU to distributed clusters.
 github:
 - url: https://github.com/sgl-project/sglang
-comments: Apache-2.0 (standard LICENSE text, "SGLang Team" copyright). Hosted by the LMSYS non-profit and part
-  of the PyTorch ecosystem. Verified 2026-08-08 via GitHub and LICENSE body.
+comments: Hosted by the LMSYS non-profit and part of the PyTorch ecosystem. Verified 2026-08-08 via GitHub
+  and LICENSE body.

--- a/sources/products/sglang.yaml
+++ b/sources/products/sglang.yaml
@@ -7,5 +7,5 @@ description: SGLang is a high-performance serving engine for large language and 
   AMD, Intel, and TPU hardware from a single GPU to distributed clusters.
 github:
 - url: https://github.com/sgl-project/sglang
-comments: Apache-2.0 (standard LICENSE text, "SGLang Team" copyright). v0.5.17 released 2026-08-08. Hosted
-  by the LMSYS non-profit and part of the PyTorch ecosystem. Verified 2026-08-08 via GitHub and LICENSE body.
+comments: Apache-2.0 (standard LICENSE text, "SGLang Team" copyright). Hosted by the LMSYS non-profit and part
+  of the PyTorch ecosystem. Verified 2026-08-08 via GitHub and LICENSE body.

--- a/sources/products/sglang.yaml
+++ b/sources/products/sglang.yaml
@@ -1,12 +1,11 @@
 name: sglang
 display_name: SGLang
 type: software
-description: High-performance LLM/VLM serving engine built around RadixAttention for automatic prefix-KV
-  reuse, with structured-generation, speculative decoding, and disaggregated-prefill support. Deployed
-  on 400K+ GPUs worldwide and serving trillions of tokens/day; xAI uses it to serve Grok 3, Microsoft
-  Azure to serve DeepSeek R1 on AMD, and adopters include AMD, NVIDIA, AWS, Oracle Cloud, LinkedIn, and
-  Cursor. Joined the PyTorch ecosystem in March 2025; 28K GitHub stars with 450+ contributors.
+description: SGLang is a high-performance serving engine for large language and multimodal models, built
+  around RadixAttention for automatic prefix-KV cache reuse. It adds zero-overhead scheduling, speculative
+  decoding, structured-output generation, disaggregated prefill, and quantization, and runs across NVIDIA,
+  AMD, Intel, and TPU hardware from a single GPU to distributed clusters.
 github:
 - url: https://github.com/sgl-project/sglang
-comments: v0.5.12.post1, released May 26, 2026 (GitHub). Hosted under LMSYS / PyTorch ecosystem. Confirmed
-  to exist as of June 2026.
+comments: Apache-2.0 (standard LICENSE text, "SGLang Team" copyright). v0.5.17 released 2026-08-08. Hosted
+  by the LMSYS non-profit and part of the PyTorch ecosystem. Verified 2026-08-08 via GitHub and LICENSE body.

--- a/sources/products/sglang.yaml
+++ b/sources/products/sglang.yaml
@@ -1,11 +1,10 @@
 name: sglang
 display_name: SGLang
 type: software
-description: SGLang is a high-performance serving engine for large language and multimodal models, built
-  around RadixAttention for automatic prefix-KV cache reuse. It adds zero-overhead scheduling, speculative
-  decoding, structured-output generation, disaggregated prefill, and quantization, and runs across NVIDIA,
-  AMD, Intel, and TPU hardware from a single GPU to distributed clusters.
+description: SGLang is a serving engine for large language and multimodal models, built around RadixAttention
+  for automatic prefix-KV cache reuse. It adds zero-overhead scheduling, speculative decoding, structured-output
+  generation, disaggregated prefill, and quantization, and runs across NVIDIA, AMD, Intel, and TPU hardware
+  from a single GPU to distributed clusters. The LMSYS non-profit hosts it, and it sits in the PyTorch ecosystem.
 github:
 - url: https://github.com/sgl-project/sglang
-comments: Hosted by the LMSYS non-profit and part of the PyTorch ecosystem. Verified 2026-08-08 via GitHub
-  and LICENSE body.
+comments: Verified 2026-08-08 via GitHub and the LICENSE body.

--- a/sources/products/tensorrt-llm.yaml
+++ b/sources/products/tensorrt-llm.yaml
@@ -8,6 +8,6 @@ description: TensorRT-LLM is NVIDIA's inference library for optimizing and servi
   hardware and the CUDA ecosystem.
 github:
 - url: https://github.com/NVIDIA/TensorRT-LLM
-comments: Apache-2.0 (standard LICENSE text, NVIDIA copyright; the LICENSE file also bundles third-party
-  MIT/BSD code and a custom LTX-2 Community License for optional model support). Latest stable v1.2.1 released
-  2026-04-20 (PyPI); 1.3.0 release candidates in progress. Verified 2026-08-08 via PyPI and LICENSE body.
+comments: Apache-2.0 (standard LICENSE text, NVIDIA copyright; the LICENSE file also bundles third-party MIT/BSD
+  code and a custom LTX-2 Community License for optional model support). Verified 2026-08-08 via PyPI and LICENSE
+  body.

--- a/sources/products/tensorrt-llm.yaml
+++ b/sources/products/tensorrt-llm.yaml
@@ -1,11 +1,12 @@
 name: tensorrt-llm
 display_name: TensorRT-LLM
 type: software
-description: TensorRT-LLM is NVIDIA's inference library for optimizing and serving LLMs on NVIDIA GPUs,
-  using custom kernels, in-flight batching, FP8/INT4 quantization, speculative decoding, and multi-GPU
-  tensor parallelism. It exposes a PyTorch-native Python API for defining and compiling models and integrates
-  with Triton Inference Server and NVIDIA Dynamo. It is tightly coupled to NVIDIA hardware and the CUDA
-  ecosystem.
+description: TensorRT-LLM is NVIDIA's inference library for optimizing and serving LLMs on NVIDIA GPUs, using
+  custom kernels, in-flight batching, FP8/INT4 quantization, speculative decoding, and multi-GPU tensor parallelism.
+  It exposes a PyTorch-native Python API for defining and compiling models and integrates with Triton Inference
+  Server and NVIDIA Dynamo. Being built on CUDA, it is tightly coupled to NVIDIA hardware.
 github:
 - url: https://github.com/NVIDIA/TensorRT-LLM
-comments: Developed by NVIDIA and runs only on NVIDIA GPUs. Verified 2026-08-08 via PyPI and LICENSE body.
+comments: The LICENSE file also bundles third-party MIT/BSD code and an LTX-2 Community License covering optional
+  model support; the openness score follows the primary repository license. Verified 2026-08-08 via PyPI and
+  the LICENSE body.

--- a/sources/products/tensorrt-llm.yaml
+++ b/sources/products/tensorrt-llm.yaml
@@ -4,10 +4,8 @@ type: software
 description: TensorRT-LLM is NVIDIA's inference library for optimizing and serving LLMs on NVIDIA GPUs,
   using custom kernels, in-flight batching, FP8/INT4 quantization, speculative decoding, and multi-GPU
   tensor parallelism. It exposes a PyTorch-native Python API for defining and compiling models and integrates
-  with Triton Inference Server and NVIDIA Dynamo. The source is Apache-2.0 but tightly coupled to NVIDIA
-  hardware and the CUDA ecosystem.
+  with Triton Inference Server and NVIDIA Dynamo. It is tightly coupled to NVIDIA hardware and the CUDA
+  ecosystem.
 github:
 - url: https://github.com/NVIDIA/TensorRT-LLM
-comments: Apache-2.0 (standard LICENSE text, NVIDIA copyright; the LICENSE file also bundles third-party MIT/BSD
-  code and a custom LTX-2 Community License for optional model support). Verified 2026-08-08 via PyPI and LICENSE
-  body.
+comments: Developed by NVIDIA and runs only on NVIDIA GPUs. Verified 2026-08-08 via PyPI and LICENSE body.

--- a/sources/products/tensorrt-llm.yaml
+++ b/sources/products/tensorrt-llm.yaml
@@ -1,12 +1,13 @@
 name: tensorrt-llm
 display_name: TensorRT-LLM
 type: software
-description: NVIDIA's optimized LLM inference library providing maximum throughput on NVIDIA GPUs through
-  kernel fusion, in-flight batching, FP8/INT4 quantization, and multi-GPU tensor parallelism. Python API
-  for defining and compiling models into optimized TensorRT engines. Used by major cloud providers and
-  inference services as the backend for NVIDIA GPU deployments. Source code is Apache-2.0, but the value
-  proposition is tightly coupled to NVIDIA hardware and CUDA ecosystem.
+description: TensorRT-LLM is NVIDIA's inference library for optimizing and serving LLMs on NVIDIA GPUs,
+  using custom kernels, in-flight batching, FP8/INT4 quantization, speculative decoding, and multi-GPU
+  tensor parallelism. It exposes a PyTorch-native Python API for defining and compiling models and integrates
+  with Triton Inference Server and NVIDIA Dynamo. The source is Apache-2.0 but tightly coupled to NVIDIA
+  hardware and the CUDA ecosystem.
 github:
 - url: https://github.com/NVIDIA/TensorRT-LLM
-comments: Actively maintained; repo last updated 2026-06-01 with ongoing releases (AutoDeploy Q2/Q3 milestone).
-  Confirmed to exist as of June 2026.
+comments: Apache-2.0 (standard LICENSE text, NVIDIA copyright; the LICENSE file also bundles third-party
+  MIT/BSD code and a custom LTX-2 Community License for optional model support). Latest stable v1.2.1 released
+  2026-04-20 (PyPI); 1.3.0 release candidates in progress. Verified 2026-08-08 via PyPI and LICENSE body.

--- a/sources/products/text-generation-inference.yaml
+++ b/sources/products/text-generation-inference.yaml
@@ -6,6 +6,5 @@ description: Text Generation Inference (TGI) is Hugging Face's LLM serving toolk
   Attention, token streaming, and quantization (GPTQ, AWQ, EETQ), and has powered Hugging Face's Inference
   Endpoints and Hugging Chat. The project is now in maintenance mode, with Hugging Face pointing new deployments
   to vLLM, SGLang, llama.cpp, and MLX.
-comments: Apache-2.0 (LICENSE body, "Copyright 2022 Hugging Face"). Latest release v3.3.7 (2025-12-19). Repo
-  archived 2026-03-21 and placed in maintenance mode; HF recommends vLLM/SGLang/llama.cpp/MLX going forward.
-  Verified 2026-08-08 via GitHub and LICENSE body.
+comments: Latest release v3.3.7 (2025-12-19). Repo archived 2026-03-21 and placed in maintenance mode; HF recommends
+  vLLM/SGLang/llama.cpp/MLX going forward. Verified 2026-08-08 via GitHub and LICENSE body.

--- a/sources/products/text-generation-inference.yaml
+++ b/sources/products/text-generation-inference.yaml
@@ -1,10 +1,11 @@
 name: text-generation-inference
 display_name: Text Generation Inference
 type: software
-description: Hugging Face's production LLM serving solution, purpose-built for the HF model ecosystem.
-  Supports continuous batching, tensor parallelism, Flash Attention, and quantization (GPTQ, AWQ, EETQ).
-  Powers Hugging Face Inference Endpoints and is the default backend when deploying models from the Hub.
-  Tight integration with the transformers library makes it the path of least resistance for HF users going
-  to production.
-comments: Latest release v3.3.7 (Dec 19, 2025). Repo ARCHIVED Mar 21, 2026 and placed in maintenance mode;
-  HF now recommends vLLM/SGLang/llama.cpp/MLX going forward. Verified live (archived) June 2026.
+description: Text Generation Inference (TGI) is Hugging Face's LLM serving toolkit, a Rust, Python, and gRPC
+  server purpose-built for the HF model ecosystem. It supports continuous batching, tensor parallelism, Flash
+  Attention, token streaming, and quantization (GPTQ, AWQ, EETQ), and has powered Hugging Face's Inference
+  Endpoints and Hugging Chat. The project is now in maintenance mode, with Hugging Face pointing new deployments
+  to vLLM, SGLang, llama.cpp, and MLX.
+comments: Apache-2.0 (LICENSE body, "Copyright 2022 Hugging Face"). Latest release v3.3.7 (2025-12-19). Repo
+  archived 2026-03-21 and placed in maintenance mode; HF recommends vLLM/SGLang/llama.cpp/MLX going forward.
+  Verified 2026-08-08 via GitHub and LICENSE body.

--- a/sources/products/text-generation-inference.yaml
+++ b/sources/products/text-generation-inference.yaml
@@ -6,5 +6,5 @@ description: Text Generation Inference (TGI) is Hugging Face's LLM serving toolk
   Attention, token streaming, and quantization (GPTQ, AWQ, EETQ), and has powered Hugging Face's Inference
   Endpoints and Hugging Chat. The project is now in maintenance mode, with Hugging Face pointing new deployments
   to vLLM, SGLang, llama.cpp, and MLX.
-comments: Latest release v3.3.7 (2025-12-19). Repo archived 2026-03-21 and placed in maintenance mode; HF recommends
-  vLLM/SGLang/llama.cpp/MLX going forward. Verified 2026-08-08 via GitHub and LICENSE body.
+comments: Final release v3.3.7 (2025-12-19); the repository was archived 2026-03-21, so no later release exists.
+  Verified 2026-08-08 via GitHub and the LICENSE body.

--- a/sources/products/together-inference-engine.yaml
+++ b/sources/products/together-inference-engine.yaml
@@ -1,10 +1,10 @@
 name: together-inference-engine
 display_name: Together Inference Engine
 type: software
-description: Together Inference Engine is a proprietary stack that serves open models with FlashAttention,
+description: Together Inference Engine is a serving stack that runs open models with FlashAttention,
   adaptive speculative decoding, and custom CUDA kernels. It offers serverless endpoints across a large
   catalog of open models alongside dedicated instances that reserve GPU capacity for a single model. It is
   built by Together AI, whose team also publishes open kernel research including FlashAttention and ThunderKittens.
-comments: 'Together AI Inference Engine: proprietary cloud inference (serverless and dedicated) for open
-  models, OpenAI-compatible; built on Together''s kernel stack (FlashAttention, ThunderKittens, ATLAS
-  speculative decoding). Closed, managed service. Verified 2026-08-08 via Together docs and engineering blog.'
+comments: 'Together AI Inference Engine: managed cloud inference (serverless and dedicated) for open models,
+  OpenAI-compatible; built on Together''s kernel stack (FlashAttention, ThunderKittens, ATLAS speculative decoding).
+  Verified 2026-08-08 via Together docs and engineering blog.'

--- a/sources/products/together-inference-engine.yaml
+++ b/sources/products/together-inference-engine.yaml
@@ -1,10 +1,8 @@
 name: together-inference-engine
 display_name: Together Inference Engine
 type: software
-description: Together Inference Engine is a serving stack that runs open models with FlashAttention,
-  adaptive speculative decoding, and custom CUDA kernels. It offers serverless endpoints across a large
-  catalog of open models alongside dedicated instances that reserve GPU capacity for a single model. It is
-  built by Together AI, whose team also publishes open kernel research including FlashAttention and ThunderKittens.
-comments: 'Together AI Inference Engine: managed cloud inference (serverless and dedicated) for open models,
-  OpenAI-compatible; built on Together''s kernel stack (FlashAttention, ThunderKittens, ATLAS speculative decoding).
-  Verified 2026-08-08 via Together docs and engineering blog.'
+description: Together Inference Engine is a serving stack that runs open models with FlashAttention, adaptive
+  speculative decoding (ATLAS), and custom CUDA kernels. It offers serverless endpoints across a large catalog
+  of open models alongside dedicated instances that reserve GPU capacity for a single model. Together AI builds
+  it, and its team also publishes open kernel research including FlashAttention and ThunderKittens.
+comments: Verified 2026-08-08 via the Together docs and engineering blog.

--- a/sources/products/together-inference-engine.yaml
+++ b/sources/products/together-inference-engine.yaml
@@ -1,11 +1,10 @@
 name: together-inference-engine
 display_name: Together Inference Engine
 type: software
-description: Proprietary inference engine optimized for serving open source models at scale with Flash
-  Attention, speculative decoding, and custom CUDA kernels. Supports a wide catalog of open models with
-  fast switching. Also offers a dedicated endpoints product for reserved GPU capacity. Founded by researchers
-  from Stanford, Berkeley, and CMU. Differentiated by combining inference speed with strong research output
-  (RedPajama, Together MoE research).
-comments: 'Together AI Inference Engine: proprietary cloud inference (serverless/dedicated) for open models,
-  OpenAI-compatible; built on Together''s research stack (FlashAttention, ThunderKittens, ATLAS accelerators).
-  Closed/managed service. Confirmed live June 2026 (together.ai).'
+description: Together Inference Engine is a proprietary stack that serves open models with FlashAttention,
+  speculative decoding, and custom CUDA kernels. It offers serverless endpoints across a large catalog of
+  open models alongside dedicated instances that reserve GPU capacity for a single model. Built by Together
+  AI, whose team also publishes open research such as FlashAttention and RedPajama.
+comments: 'Together AI Inference Engine: proprietary cloud inference (serverless and dedicated) for open
+  models, OpenAI-compatible; built on Together''s research stack (FlashAttention, ThunderKittens). Closed,
+  managed service. Verified 2026-08-08 via web search.'

--- a/sources/products/together-inference-engine.yaml
+++ b/sources/products/together-inference-engine.yaml
@@ -2,9 +2,9 @@ name: together-inference-engine
 display_name: Together Inference Engine
 type: software
 description: Together Inference Engine is a proprietary stack that serves open models with FlashAttention,
-  speculative decoding, and custom CUDA kernels. It offers serverless endpoints across a large catalog of
-  open models alongside dedicated instances that reserve GPU capacity for a single model. Built by Together
-  AI, whose team also publishes open research such as FlashAttention and RedPajama.
+  adaptive speculative decoding, and custom CUDA kernels. It offers serverless endpoints across a large
+  catalog of open models alongside dedicated instances that reserve GPU capacity for a single model. It is
+  built by Together AI, whose team also publishes open kernel research including FlashAttention and ThunderKittens.
 comments: 'Together AI Inference Engine: proprietary cloud inference (serverless and dedicated) for open
-  models, OpenAI-compatible; built on Together''s research stack (FlashAttention, ThunderKittens). Closed,
-  managed service. Verified 2026-08-08 via web search.'
+  models, OpenAI-compatible; built on Together''s kernel stack (FlashAttention, ThunderKittens, ATLAS
+  speculative decoding). Closed, managed service. Verified 2026-08-08 via Together docs and engineering blog.'

--- a/sources/products/vllm.yaml
+++ b/sources/products/vllm.yaml
@@ -7,5 +7,6 @@ description: vLLM is a high-throughput serving engine for large language models 
   wide range of model architectures. It exposes an OpenAI-compatible API server for self-hosted deployment.
 github:
 - url: https://github.com/vllm-project/vllm
-comments: Apache 2.0 (OSI; unmodified LICENSE body). v0.26.0 released 2026-07-25 (GitHub/PyPI). Verified
-  2026-08-08 via GitHub, PyPI, and LICENSE body.
+comments: Apache 2.0 (OSI; unmodified LICENSE body). Originated in the Sky Computing Lab at UC Berkeley;
+  community-governed under the vllm-project organization, with no foundation affiliation. Verified 2026-08-08
+  via GitHub and LICENSE body.

--- a/sources/products/vllm.yaml
+++ b/sources/products/vllm.yaml
@@ -1,11 +1,11 @@
 name: vllm
 display_name: vLLM
 type: software
-description: vLLM is a high-throughput serving engine for large language models built on PagedAttention,
-  which manages the KV cache as virtual memory pages to reduce memory waste during batched inference. It
-  supports continuous batching, tensor and pipeline parallelism, speculative decoding, quantization, and a
-  wide range of model architectures. It exposes an OpenAI-compatible API server for self-hosted deployment.
+description: vLLM is a serving engine for large language models built on PagedAttention, which manages the
+  KV cache as virtual memory pages to reduce memory waste during batched inference. It supports continuous
+  batching, tensor and pipeline parallelism, speculative decoding, and quantization, exposing an OpenAI-compatible
+  API server for self-hosted deployment. It originated in the Sky Computing Lab at UC Berkeley and is community-governed
+  under vllm-project.
 github:
 - url: https://github.com/vllm-project/vllm
-comments: Originated in the Sky Computing Lab at UC Berkeley; community-governed under the vllm-project organization,
-  with no foundation affiliation. Verified 2026-08-08 via GitHub and LICENSE body.
+comments: Verified 2026-08-08 via GitHub and the LICENSE body.

--- a/sources/products/vllm.yaml
+++ b/sources/products/vllm.yaml
@@ -1,10 +1,11 @@
 name: vllm
 display_name: vLLM
 type: software
-description: High-throughput LLM serving engine built on PagedAttention, which treats KV cache as virtual
-  memory pages to near-eliminate memory waste during batched inference. Supports continuous batching,
-  tensor parallelism, speculative decoding, and 40+ model architectures. The de facto standard for self-hosted
-  production model serving, used by Anyscale, Databricks, and most open source inference deployments.
+description: vLLM is a high-throughput serving engine for large language models built on PagedAttention,
+  which manages the KV cache as virtual memory pages to reduce memory waste during batched inference. It
+  supports continuous batching, tensor and pipeline parallelism, speculative decoding, quantization, and a
+  wide range of model architectures. It exposes an OpenAI-compatible API server for self-hosted deployment.
 github:
 - url: https://github.com/vllm-project/vllm
-comments: v0.22.0, released May 29, 2026 (GitHub releases). Confirmed to exist as of June 2026.
+comments: Apache 2.0 (OSI; unmodified LICENSE body). v0.26.0 released 2026-07-25 (GitHub/PyPI). Verified
+  2026-08-08 via GitHub, PyPI, and LICENSE body.

--- a/sources/products/vllm.yaml
+++ b/sources/products/vllm.yaml
@@ -7,6 +7,5 @@ description: vLLM is a high-throughput serving engine for large language models 
   wide range of model architectures. It exposes an OpenAI-compatible API server for self-hosted deployment.
 github:
 - url: https://github.com/vllm-project/vllm
-comments: Apache 2.0 (OSI; unmodified LICENSE body). Originated in the Sky Computing Lab at UC Berkeley;
-  community-governed under the vllm-project organization, with no foundation affiliation. Verified 2026-08-08
-  via GitHub and LICENSE body.
+comments: Originated in the Sky Computing Lab at UC Berkeley; community-governed under the vllm-project organization,
+  with no foundation affiliation. Verified 2026-08-08 via GitHub and LICENSE body.


### PR DESCRIPTION
`description` and `comments` are the only two hand-authored strings in a product file, and
they had no written standard. The corpus shows it: the verification idiom alone appears 227
ways — `Verified live June 2026`, `verified live on HF June 2026`, `Verified live 2026-06-22
via primary sources`.

Both are published copy. `serialize.py` emits `description` as `description` and `comments`
as `version_note`, and `product-detail.svelte` renders them one directly above the other in
the detail panel. Neither is a scratchpad.

This adds `docs/guides/product-info.md`, the standard, and `skills/verify-product/SKILL.md`,
the procedure as a runnable skill. Both are applied to all 20 `inference_code` products.

## What each field is for

**`description` is load-bearing.** Everything about the product goes there — what it is, what
it does, who builds it. **`comments` is a footnote on how we know**: the verification line,
plus the occasional note on an evidence gap or a judgment call a score rests on.

The test is the subject of the sentence. About the product, it is a description. About our
reading of the product, it is a comment.

That split is not cosmetic, because both render in the same panel. `google-cloud-tpu-inference`
stated Pathways, JetStream, Vertex AI/GKE, Ironwood and Trillium in both fields. `max`,
`onnx-runtime` and `lmdeploy` said nothing in `comments` their descriptions had not already
said.

## The license was in the wrong file

The guide's first draft said to *always* state the license in `comments`. That was backwards.

The license is not descriptive. It is the openness score's basis, recorded in
`sources/scores/<slug>.yaml` as `openness.components`, with `sources[].accessed` behind it and
the G1/G2 gates in front. A prose copy carries none of that, and the two drift one way only: a
relicense flows through `verification.md`, the score updates, and the prose is left quietly
wrong with nothing to catch it.

It also buys a reader nothing.

| | products |
|---|---|
| license in both prose and the openness score | 333 |
| prose only, so the score would lose it | **0** |
| score only, prose already omits it | 136 |

`serialize.py` emits the whole `openness` dict, and `product-detail.svelte` renders
`openness.components` at 14px directly below `version_note` at 11px. The license is on screen
either way. Only one copy carries evidence.

Reading the LICENSE body stays essential — the GitHub classifier reports `NOASSERTION` on
genuine Apache repos, and the OSI call is what the score turns on. It is now read to check the
score rather than to write prose, and a disagreement is a score finding for `verification.md`.

## Volatile facts, generalized

The rule started as "no star counts" and generalizes to a test: **would a future release make
this sentence wrong?**

Counts fail it. So does a current version number, which 59 products carry as a real release
clause and which nothing in the repo will ever notice going wrong. Three cases pass and stay:
the version is the entry's identity (a named model release, where the next release is a
different entry), there will be no future release (an archived project), or it is a statement
of absence ("no tagged releases, built from source").

`claude-sonnet` had already worked this out in its own comments, before any rule existed:

> Tier product. Anthropic ships a new Sonnet roughly every few months, so a versioned entry
> goes stale faster than it can be reviewed; the slug is stable.

## Naming a source

`<source>` names a document someone can reopen — `GitHub`, `the LICENSE body`, `the AWS Neuron
documentation`. Never a method. `web search` and a bare `primary sources` say how you looked
rather than what settled it, which is how a corpus grows 227 idioms.

That rule exists because the first pass wrote `via web search` on seven products, all of them
closed vendor services with no repo or LICENSE body to read. Re-reading those seven against the
vendors' own documentation turned up four real errors:

| product | was | actually |
|---|---|---|
| `aws-neuron` | SDK 2.30.0, ~May 2026 | 2.31.0, released 2026-07-07; targets Inf1/Inf2 and Trn1/Trn2/Trn3 |
| `fireworks-inference` | NVIDIA GPUs | FireAttention V3 is an AMD implementation |
| `qualcomm-ai-engine-direct` | direct PyTorch support | PyTorch reaches the runtime via ExecuTorch |
| `sambanova-cloud` | generic cloud and on-prem | the products are SambaCloud and SambaStack |

Claims the vendor docs would not settle were dropped rather than relabeled: SageMaker support,
the Cerebras and SambaNova model lists, RedPajama, and Qualcomm's device-segment list.

## Self-review found four more

Re-reading the finished twenty as a set caught what no check did.

- **`cerebras-inference` was factually wrong.** It claimed to keep entire models on one wafer
  to serve large models. Cerebras says the opposite for exactly that case: past 44GB, models
  split at layer boundaries across systems, and 70B needs four of them.
- **`fireworks-inference` had the product founded** by former Meta PyTorch engineers, rather
  than the company.
- **`tensorrt-llm` lost the bundled LTX-2 Community License** when the license restatement
  went. It appears in no score file, so "the score is a superset" did not hold for it — that
  check was a keyword regex over license names, not over content. It returns as a footnote.
- **`text-generation-inference` said "Latest release"**, where the guide names "latest" as the
  tell for a volatile clause. It is "Final". The repo is archived, which is the only reason
  the version may stay at all.

Also gone: the marketing register that survived the first pass (`high-performance`,
`high-throughput`), and three-in-a-row sentences opening "It".

## Not in this PR

314 products still restate a license and 59 carry a version clause. That sweep is
deliberately separate — this sets the rule and does one category to it.

One thing worth settling before it starts. The guide does not say what "verified enough" means
for a long-tail product nobody has looked at. These twenty took several primary-source reads
each, and that bar decides whether a 314-product sweep is feasible or just aspirational.

## Verification

```
uv run python -m build.validate                    0 error(s)
20 descriptions, 55-68 words                       all inside the 35-70 band
20 verification lines                              all canonical, none naming a method
license restatements outside the source clause     0
comments restating a description fact              0
marketing register, "It" chains                    0
```

No score file is touched, so no `last_verified` moves. `build/notebook_data.json` and
`notebooks/ai-stack-map.py` are left to the bot.
