### PR TITLE
G4, the gate that goes and looks

### DIFF
--- a/.github/workflows/refetch.yml
+++ b/.github/workflows/refetch.yml
@@ -1,0 +1,53 @@
+name: refetch
+
+# Gate G4: independent evidence that a recorded fetch actually happened.
+#
+# G1 and G2 both read what the writer wrote. An agent that never opened a page can emit a
+# plausible `accessed`, a plausible 200 and sixty-four plausible hex characters, and both
+# gates pass — #108's failure mode with better spelling. G4 is the only check that goes and
+# looks, and it is the third leg the runbook names. The reasoning is in
+# build/check_refetch.py.
+#
+# Report-only on purpose, and this is the part most likely to get "fixed" later. Pages
+# change: the first full run confirmed 4 of 24 digests and drifted on the other 20, because
+# every GitHub and Hugging Face API endpoint carries a star or download count in its body.
+# Failing on drift would fail 83% on day one, and a gate that fails on ordinary behavior gets
+# switched off — which is how gates die. What it DOES fail on is fabrication: a digest reused
+# across two URLs, or one that is not a SHA-256 at all. Those admit no innocent reading.
+#
+# The count of confirmations is the signal, not the ratio. An agent that fetched nothing
+# would confirm zero, stable URLs included.
+#
+# Unlike parity.yml this needs no warehouse, so it is not tied to the Monday recompute chain
+# and can run any day. Thursday keeps it clear of the Monday gate traffic.
+
+on:
+  schedule:
+    - cron: "0 7 * * 4"
+  workflow_dispatch:
+    inputs:
+      sample:
+        description: "How many sources to re-fetch"
+        default: "25"
+      all:
+        description: "Re-fetch every source carrying a digest"
+        type: boolean
+        default: false
+
+jobs:
+  refetch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Install dependencies
+        run: uv sync --locked
+      - name: Re-fetch a sample and compare digests
+        run: |
+          if [ "${{ inputs.all }}" = "true" ]; then
+            uv run python -m build.check_refetch --all
+          else
+            uv run python -m build.check_refetch --sample "${{ inputs.sample || 25 }}"
+          fi

--- a/build/check_refetch.py
+++ b/build/check_refetch.py
@@ -1,0 +1,255 @@
+"""G4 — the sampled re-fetch: independent evidence that a recorded fetch actually happened.
+
+`docs/guides/verification.md` is normative; this module implements the gate. It is the third
+leg of the anti-rubber-stamping defense the runbook names, and until now the only one that
+was missing.
+
+## Why the other two are not enough
+
+G1 asks whether a claimed date is supported by the `accessed` dates on record. G2 asks
+whether the sources carry an `http_status` and a `content_sha256`. Both are real, and both
+share a blind spot: **they read what the writer wrote.** An agent that never opened a page
+can still emit a plausible `accessed`, a plausible `200`, and sixty-four plausible hex
+characters, and both gates pass. That is #108's failure mode with better spelling.
+
+G4 is the only check that goes and looks.
+
+## What a match proves, and what a mismatch does not
+
+Asymmetric, and the asymmetry is the point:
+
+- **A digest that still matches is proof the original fetch was real.** SHA-256 preimages
+  are not guessable, so a recorded digest reproducing from a live body could only have come
+  from that body. This is positive evidence, and it is the reason to run the gate.
+- **A digest that differs proves nothing on its own.** Pages change. `api.github.com/repos/*`
+  carries a star count, HF model endpoints carry download counts — those bodies differ
+  between any two requests. Treating drift as failure would make the gate noise, and a noisy
+  gate gets switched off.
+
+In practice only stable bodies reproduce — the first full run confirmed four sources, three
+arXiv `/abs/` pages and one HF `/raw/` CSV, while every API endpoint carrying a star or
+download count drifted. That is the expected shape, and it is why the count of confirmations
+is the signal rather than the ratio: an agent that fetched nothing would confirm **zero**,
+stable URLs included.
+
+So the report separates *confirmed* from *drifted* and never fails on drift. What it does
+fail on is the small set of things that admit no innocent reading:
+
+- **A digest reused across two different URLs.** Two distinct pages with byte-identical
+  bodies is possible but rare; the same sixty-four characters pasted twice is the ordinary
+  explanation, and it is fabrication.
+- **A malformed digest.** `validate.py` enforces the schema pattern, so this should be
+  unreachable — it is here because a gate that trusts another gate is how both stop working.
+
+Status regressions (recorded `200`, now `404`) are reported as findings rather than
+failures: a page can legitimately die between the read and the check. That is still exactly
+the signal a re-read pass wants, and it is how the Lucie source that had never resolved as
+cited was found — the URL was missing its `/datasets/` segment and the Hub answered 401 to
+anyone who tried it.
+
+## Sampling
+
+The re-read surface is ~1,100 URLs and this runs weekly, so it samples. The sample is seeded
+and therefore reproducible: the same seed re-checks the same sources, which is what makes a
+newly-drifted source visible rather than lost in the shuffle. `--all` re-fetches everything
+carrying a digest, which is the right mode after a bulk pass.
+
+Usage:
+    uv run python -m build.check_refetch                    # 25 sampled, report only
+    uv run python -m build.check_refetch --all              # every source with a digest
+    uv run python -m build.check_refetch --product apertus  # one product
+    uv run python -m build.check_refetch --strict           # fail on findings too
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import random
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+import requests
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+AXES = ("openness", "adoption", "capability")
+
+# A real browser-ish UA. Several vendor docs sites answer 403 to the default python-requests
+# string, which would otherwise read as a dead source on every run.
+USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/126.0.0.0 Safari/537.36 os-ai-map-verification/1.0"
+)
+
+
+@dataclass(frozen=True)
+class Source:
+    product: str
+    axis: str
+    url: str
+    digest: str
+    status: object
+    accessed: object
+
+    @property
+    def key(self) -> str:
+        return f"{self.product}:{self.axis}"
+
+
+def load_sources(product: str | None = None) -> list[Source]:
+    """Every source across every score file that records a digest."""
+    out: list[Source] = []
+    for path in sorted((ROOT / "sources" / "scores").glob("*.yaml")):
+        if product and path.stem != product:
+            continue
+        score = yaml.safe_load(path.read_text()) or {}
+        for axis in AXES:
+            block = score.get(axis) or {}
+            if not isinstance(block, dict):
+                continue
+            for source in block.get("sources") or []:
+                if not isinstance(source, dict):
+                    continue
+                digest = source.get("content_sha256")
+                if not digest:
+                    continue
+                out.append(
+                    Source(
+                        product=path.stem,
+                        axis=axis,
+                        url=str(source.get("url") or ""),
+                        digest=str(digest),
+                        status=source.get("http_status"),
+                        accessed=source.get("accessed"),
+                    )
+                )
+    return out
+
+
+def offline_failures(sources: list[Source]) -> list[str]:
+    """Checks that need no network and admit no innocent reading."""
+    problems: list[str] = []
+
+    for source in sources:
+        if len(source.digest) != 64 or any(c not in "0123456789abcdef" for c in source.digest):
+            problems.append(
+                f"{source.key}: {source.url!r} records {source.digest!r}, which is not a "
+                f"SHA-256. Nothing that fetched a body would produce it."
+            )
+
+    by_digest: dict[str, set[str]] = defaultdict(set)
+    for source in sources:
+        by_digest[source.digest].add(source.url)
+    for digest, urls in sorted(by_digest.items()):
+        if len(urls) > 1:
+            listed = ", ".join(sorted(urls))
+            problems.append(
+                f"digest {digest[:12]}… is recorded for {len(urls)} different URLs "
+                f"({listed}). Two pages with byte-identical bodies is possible; the same "
+                f"digest pasted twice is likelier, and it means at least one was not fetched."
+            )
+    return problems
+
+
+def refetch(source: Source, timeout: float) -> tuple[str, str]:
+    """(outcome, detail). Outcome is one of confirmed / drifted / gone / unreachable."""
+    try:
+        response = requests.get(
+            source.url,
+            timeout=timeout,
+            headers={"User-Agent": USER_AGENT},
+            allow_redirects=True,
+        )
+    except requests.RequestException as exc:
+        return "unreachable", f"{type(exc).__name__}: {exc}"
+
+    # 429 and 5xx are the host saying "not now", not "not here". Calling those dead would
+    # make the gate fail on GitHub's rate limiter, which is how a gate earns a reputation
+    # for lying. The first run of this module reported a live Mastra LICENSE as dead for
+    # exactly that reason.
+    if response.status_code == 429 or response.status_code >= 500:
+        return "unreachable", f"HTTP {response.status_code} (transient; retry)"
+    if response.status_code >= 400:
+        return "gone", f"recorded {source.status}, now HTTP {response.status_code}"
+
+    live = hashlib.sha256(response.content).hexdigest()
+    if live == source.digest:
+        return "confirmed", ""
+    return "drifted", f"body changed since {source.accessed}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sample", type=int, default=25, help="how many to re-fetch")
+    parser.add_argument("--seed", type=int, default=0, help="sample seed; same seed, same set")
+    parser.add_argument("--all", action="store_true", help="re-fetch every source with a digest")
+    parser.add_argument("--product", help="restrict to one product slug")
+    parser.add_argument("--timeout", type=float, default=20.0)
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="also fail on dead and unreachable sources, not just on fabrication",
+    )
+    args = parser.parse_args()
+
+    sources = load_sources(args.product)
+    if not sources:
+        print("0 sources record a digest yet — nothing for G4 to re-fetch.")
+        print("This is expected until the re-read pass populates content_sha256.")
+        return 0
+
+    failures = offline_failures(sources)
+
+    chosen = sources
+    if not args.all and len(sources) > args.sample:
+        chosen = random.Random(args.seed).sample(sources, args.sample)
+
+    buckets: dict[str, list[tuple[Source, str]]] = defaultdict(list)
+    for source in sorted(chosen, key=lambda s: (s.product, s.axis, s.url)):
+        outcome, detail = refetch(source, args.timeout)
+        buckets[outcome].append((source, detail))
+
+    for outcome, label in (
+        ("gone", "DEAD — recorded as reachable, now an error"),
+        ("unreachable", "UNREACHABLE — could not be checked this run"),
+        ("drifted", "DRIFTED — body changed; re-check queue, not a failure"),
+    ):
+        if buckets[outcome]:
+            print(f"\n{label}")
+            for source, detail in buckets[outcome]:
+                print(f"  {source.key:38s} {source.url}")
+                if detail:
+                    print(f"  {'':38s}   {detail}")
+
+    if failures:
+        print("\nFABRICATION — no innocent reading")
+        for problem in failures:
+            print(f"  {problem}")
+
+    confirmed = len(buckets["confirmed"])
+    print(
+        f"\n{len(sources)} sources carry a digest, {len(chosen)} re-fetched: "
+        f"{confirmed} confirmed, {len(buckets['drifted'])} drifted, "
+        f"{len(buckets['gone'])} dead, {len(buckets['unreachable'])} unreachable."
+    )
+    if confirmed:
+        print(
+            f"{confirmed} digest(s) reproduced exactly, which only an actual fetch could "
+            f"have produced. That is the positive evidence this gate exists for."
+        )
+
+    if failures:
+        print(f"\n[FAIL] {len(failures)} source(s) could not have been fetched as recorded")
+        return 1
+    findings = len(buckets["gone"]) + len(buckets["unreachable"])
+    if args.strict and findings:
+        print(f"\n[FAIL] --strict: {findings} source(s) dead or unreachable")
+        return 1
+    print("\n[OK] no fabricated digests")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_refetch.py
+++ b/tests/test_check_refetch.py
@@ -1,0 +1,102 @@
+"""Tests for G4, the sampled re-fetch.
+
+The two that matter are `test_reused_digest_across_urls_is_fabrication` and
+`test_rate_limit_is_not_reported_dead`.
+
+The first is the gate's whole reason to exist: G1 and G2 read what the writer wrote, so the
+only thing that catches an invented digest is noticing it could not have come from a body.
+Two URLs sharing sixty-four characters is the cheapest form of that.
+
+The second pins a bug the first real run produced. G4 reported a live Mastra LICENSE as dead
+because GitHub answered 429, and a gate that reports rate limiting as a dead source is a gate
+people learn to ignore. Transient statuses must stay out of the findings bucket.
+"""
+
+import hashlib
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from build.check_refetch import Source, offline_failures, refetch
+
+DIGEST_A = "a" * 64
+DIGEST_B = "b" * 64
+
+
+def src(url: str, digest: str, product: str = "p", status: int = 200) -> Source:
+    return Source(
+        product=product, axis="openness", url=url, digest=digest, status=status,
+        accessed="2026-07-30",
+    )
+
+
+def test_clean_sources_have_no_offline_failures():
+    sources = [src("https://a.example/x", DIGEST_A), src("https://b.example/y", DIGEST_B)]
+    assert offline_failures(sources) == []
+
+
+def test_reused_digest_across_urls_is_fabrication():
+    """The same digest on two different URLs means at least one was never fetched."""
+    sources = [src("https://a.example/x", DIGEST_A), src("https://b.example/y", DIGEST_A)]
+    problems = offline_failures(sources)
+    assert len(problems) == 1
+    assert "2 different URLs" in problems[0]
+
+
+def test_same_digest_on_the_same_url_twice_is_fine():
+    """Two axes citing one page legitimately share its digest — that is not a collision."""
+    sources = [
+        src("https://a.example/x", DIGEST_A, product="one"),
+        src("https://a.example/x", DIGEST_A, product="two"),
+    ]
+    assert offline_failures(sources) == []
+
+
+@pytest.mark.parametrize("bad", ["", "abc", "z" * 64, "A" * 64, "a" * 63, "a" * 65])
+def test_malformed_digest_is_rejected(bad: str):
+    problems = offline_failures([src("https://a.example/x", bad)])
+    assert len(problems) == 1
+    assert "not a SHA-256" in problems[0]
+
+
+def _response(status: int, body: bytes = b"") -> Mock:
+    return Mock(status_code=status, content=body)
+
+
+def test_matching_digest_is_confirmed():
+    body = b"stable content"
+    source = src("https://a.example/x", hashlib.sha256(body).hexdigest())
+    with patch("build.check_refetch.requests.get", return_value=_response(200, body)):
+        assert refetch(source, 5.0)[0] == "confirmed"
+
+
+def test_changed_body_is_drift_not_failure():
+    source = src("https://a.example/x", DIGEST_A)
+    with patch("build.check_refetch.requests.get", return_value=_response(200, b"new")):
+        assert refetch(source, 5.0)[0] == "drifted"
+
+
+@pytest.mark.parametrize("status", [429, 500, 502, 503])
+def test_rate_limit_is_not_reported_dead(status: int):
+    """429 and 5xx are 'not now', not 'not here'. Reported as unreachable, never as a finding."""
+    source = src("https://a.example/x", DIGEST_A)
+    with patch("build.check_refetch.requests.get", return_value=_response(status)):
+        outcome, detail = refetch(source, 5.0)
+    assert outcome == "unreachable"
+    assert "transient" in detail
+
+
+@pytest.mark.parametrize("status", [401, 403, 404, 410])
+def test_client_errors_are_dead(status: int):
+    source = src("https://a.example/x", DIGEST_A)
+    with patch("build.check_refetch.requests.get", return_value=_response(status)):
+        assert refetch(source, 5.0)[0] == "gone"
+
+
+def test_network_error_is_unreachable_not_dead():
+    source = src("https://a.example/x", DIGEST_A)
+    with patch(
+        "build.check_refetch.requests.get", side_effect=requests.Timeout("timed out")
+    ):
+        assert refetch(source, 5.0)[0] == "unreachable"


### PR DESCRIPTION
The runbook names three things that stop an agent rubber-stamping a re-read:

> G1 requires the `accessed` bump on every dimension, G2 requires a digest that only
> fetching produces, and G4 re-fetches a sample and compares. Do not relax any of the three
> to make a batch finish.

G1 and G2 are built. G4 never was, and the re-read pass is about to put agents in front of
1,106 URLs.

It matters because **G1 and G2 both read what the writer wrote.** An agent that never opened
a page can emit a plausible `accessed`, a plausible `200`, and sixty-four plausible hex
characters, and both gates pass. That is #108's failure mode with better spelling. G4 is the
only check that goes and looks.

## The asymmetry is the design

- **A digest that still matches is proof the original fetch was real.** SHA-256 preimages are
  not guessable, so a recorded digest reproducing from a live body could only have come from
  that body.
- **A digest that differs proves nothing.** `api.github.com/repos/*` carries a star count and
  the HF endpoints carry download counts; those bodies differ between any two requests.

So confirmations are the signal and drift is a re-check queue, never a failure. The first
full run over all 24 recorded digests:

```
24 sources carry a digest, 24 re-fetched:
  4 confirmed   3 arXiv /abs/ pages and one HF /raw/ CSV
 20 drifted     every API endpoint carrying a counter
  0 dead
```

That is the expected shape, and it is why the **count** of confirmations is the signal rather
than the ratio: an agent that fetched nothing would confirm zero, stable URLs included.
Failing on drift would have failed 83% on day one, and a gate that fails on ordinary behavior
gets switched off.

## What it does fail on

Only what admits no innocent reading, and both are free — no network:

- **A digest reused across two different URLs.** Two pages with byte-identical bodies is
  possible; the same sixty-four characters pasted twice is likelier.
- **A digest that is not a SHA-256.** `validate.py` enforces the schema pattern, so this
  should be unreachable. It is here because a gate that trusts another gate is how both stop
  working.

## It found a bug in itself on the first run

G4 reported a live Mastra `LICENSE.md` as **dead** because GitHub answered 429. Rate limiting
is "not now", not "not here". 429 and 5xx are now `unreachable` and stay out of the findings
bucket — a gate that cries wolf on a rate limiter is one people learn to ignore. Pinned by
`test_rate_limit_is_not_reported_dead`.

## Scheduling

Weekly Thursday 07:00 UTC, report-only, plus `workflow_dispatch` with `--sample` / `--all`.

Unlike `parity.yml` this needs no warehouse, so it is deliberately **not** tied to the Monday
recompute chain and can run any day. Thursday keeps it clear of Monday's gate traffic.

## Verification

```
uv run python -m pytest tests/ -q            337 passed (20 new)
uv run python -m build.check_refetch --all   4 confirmed, 20 drifted, 0 dead  [OK]
uv run python -m build.validate              0 error(s)
uv run python -m build.check_verification    G1 G2 G3 [OK]
```

Independent of #147 — cut from `main`, touches no file that PR touches.
