### PR TITLE
The sweep decisions, in the guides the sweep agents read

### DIFF
--- a/docs/guides/product-info.md
+++ b/docs/guides/product-info.md
@@ -82,6 +82,39 @@ see "The division of labor" below. When a fact could sit in either, it goes here
   commit counts, "fastest-growing", and the product's current version number. See
   "Volatile facts" below; they go stale the day they are written and prose has no
   freshness gate to catch it.
+- **Curator rationale** — why the map includes the product. See below.
+
+### Curator rationale is not description content
+
+A description describes. A clause explaining why the map picked something up — "Picked when
+hardware is constrained", "Chosen because it is the only OSI-licensed option in the category" —
+is a note about our selection rather than about the product, and it reads as a recommendation
+in a field that is meant to be a catalog entry.
+
+It is also where the content this guide already bans has collected. Surveying the corpus on
+2026-08-08, every hardcoded star count in a product carrying such a clause sat inside the
+clause, as did nearly every superlative, while the descriptive half of the same field was
+clean. Removing the clause is mostly a deletion, not a rewrite.
+
+Find them with:
+
+```
+\b(picked|chosen|included|selected)\s+(because|when|by|for|as|if)\b
+```
+
+Rewrite in this order:
+
+1. **Salvage the facts trapped inside.** The clause often carries the most concrete thing in
+   the entry — "powers the Hugging Face Open LLM Leaderboard", "the execution layer behind
+   Vercel Open Agents", "Anyscale's founders created Ray at UC Berkeley's RISELab in 2019".
+   Those are product facts. Move them into the description proper.
+2. **Drop counts, funding and superlatives.** Banned elsewhere in this guide already, so no
+   judgment call is involved.
+3. **Delete the recommendation framing.** What is left of "Picked when hardware is
+   constrained" after steps 1 and 2 is our opinion, and it goes.
+
+If a selection judgment genuinely needs recording — a product admitted on a borderline reading,
+say — it is a footnote about *our reading*, so it belongs in `comments` under the rules below.
 
 ## `comments` — verification details and methodology footnotes
 
@@ -156,7 +189,33 @@ Examples:
 4. **Keep judgments on the axes.** Adoption and openness are scored, sourced fields. An
    *openness verdict* ("truly open") and the **license it rests on** belong in the score
    file, where they carry evidence. See "Scored fields" below.
-5. **Do not embed volatile facts** — counts or current version numbers. See below.
+5. **Do not embed volatile facts** — counts, current version numbers, or corporate events.
+   See below.
+
+## How far to verify a claim
+
+A prose refresh runs *inside* the score re-read — one pass per product, described in
+`docs/runbooks/verification-pass.md` Phase 4. The same repository, model card and vendor docs
+are opened once and both halves are written from what they show. So prose carries no separate
+research budget, and the only question left is what to do with the claims that sit outside the
+score's evidence.
+
+| claim class | policy |
+|---|---|
+| what the product is and does | **verify** — the score re-read establishes it anyway |
+| comparative positioning ("Where MCP …, A2A …") | **verify** — the same pages settle it |
+| superlative or unsourced ranking | **delete** — already against this guide |
+| corporate event (acquired / raised / IPO) | **omit** unless identity-bearing |
+| curator rationale ("Picked when …") | **remove from `description`** |
+
+Three of the five resolve to delete or omit rather than research, which is most of the reason
+the prose half adds little to the cost of a re-read. A claim that the sources opened for the
+score do not settle, and that none of the rules above disposes of, comes **out** of the prose.
+It is never left in unverified on the grounds that it was already there.
+
+This is also why the coupling matters. A prose pass run on its own does not open primary
+sources, and the result is a provenance line naming a method — `Verified 2026-08-08 via web
+search` — which is precisely what the canonical form below forbids.
 
 ## Scored fields — don't restate them
 
@@ -239,6 +298,18 @@ Three cases are **durable** and stay:
 3. **A statement of absence.** `Created 6 May 2026; no tagged releases (built from source)`
    describes how the project ships, not where it currently is.
 
+### Corporate events
+
+An acquisition, a funding round, or an IPO fails the same test. It is true on the day it is
+written, the next event makes it incomplete rather than wrong, and nothing in the repo is
+watching. **Omit it by default.**
+
+The exception is when the event is *identity-bearing* — it establishes who ships the product
+now, and a reader who did not know it would go looking for the wrong vendor. `Predibase, now
+part of Rubrik` earns its clause on those grounds. `Raised a $50M Series B in 2025` does not,
+and neither does an acquisition recounted as company history. Funding in particular is a
+proxy for traction, which is what the `adoption` axis is for.
+
 The tell for the volatile case is a word like "latest", "current", or "as of". A tier
 product states this outright — see `claude-sonnet`: *"Anthropic ships a new Sonnet roughly
 every few months, so a versioned entry goes stale faster than it can be reviewed; the slug
@@ -276,7 +347,9 @@ Use this to refresh an existing product's prose (the `verify-product` skill auto
    but to confirm the project is alive and that neither has moved a score. A version goes in
    only under one of the three durable cases above; a license does not go in at all.
 3. **Rewrite `description`** to the format above if anything material changed, keeping it
-   neutral and within the length band. Leave it alone if nothing moved.
+   neutral and within the length band. Leave it alone if nothing moved. Strip a curator
+   rationale clause and a corporate event wherever you find one, salvaging any product fact
+   inside first; both are edits worth making on their own, with nothing else moving.
 4. **Update `comments`**: strip any stale count, "latest version" clause, or license
    restatement, and move any surviving *product* fact into `description`. Keep only
    footnotes about the reading itself. Set the verification line to today's date and the
@@ -296,6 +369,8 @@ Use this to refresh an existing product's prose (the `verify-product` skill auto
 - [ ] No hardcoded star/download/contributor counts — rely on the artifact links and the
       `adoption` axis instead.
 - [ ] No "latest/current version" clause, unless it is identity, terminal, or an absence.
+- [ ] No curator rationale — no "Picked when …" / "Chosen because …" clause in `description`.
+- [ ] No funding round, acquisition, or IPO, unless it says who ships the product now.
 - [ ] No license restatement — it is `openness.components` in the score file.
 - [ ] `comments` says nothing `description` already says — no product facts, footnotes only.
 - [ ] Verification line in canonical form: `Verified <YYYY-MM-DD> via <source>.`

--- a/docs/guides/verification.md
+++ b/docs/guides/verification.md
@@ -133,7 +133,7 @@ gate every PR; ones needing the network run periodically.
 **They ratchet rather than switch on.** G1 and G2 apply only to axes that carry a
 `last_verified`, which is 6 today and grows as the re-read pass proceeds. So the gate covers
 exactly what has been done, never blocks progress, and never permits a regression on ground
-already taken. A big-bang gate over all 1386 axes would fail on day one and get switched
+already taken. A big-bang gate over all 1370 axes would fail on day one and get switched
 off, which is how gates die.
 
 G3, G5 and G6 apply in full immediately — nothing has to be populated first.
@@ -202,20 +202,30 @@ pricing page read.
 So every openness axis needs at least one read, permanently. Adoption and capability are
 different in kind and can be automated — see the table below.
 
-## Current state, 2026-07-30
+## Current state, 2026-08-08
 
 | | count |
 |---|---|
-| axes total (470 products × 3) | 1410 |
-| deliberately null — capability on datasets and a wire protocol, not claims | 24 |
-| **real claims to verify** | **1386** |
-| of those, citing at least one source URL | 1386 |
-| carrying a real `last_verified` | 6 (once #124 lands; 26 before it, 19 of them tool-written) |
+| axes total (472 products × 3) | 1416 |
+| deliberately null — not claims | 46 (26 capability, 20 adoption) |
+| **real claims to verify** | **1370** |
+| of those, citing at least one source URL | 1370 |
+| carrying a real `last_verified` | 6 |
 | of those 6, satisfying G1 and G2 | 6, after the Phase 0 re-read |
-| distinct source URLs behind all of it | 1099 (450 cited more than once) |
+| distinct source URLs behind all of it | 1106 |
+
+Regenerate these rather than trusting them; the corpus grows most weeks.
+
+The null axes are two different abstentions and both are deliberate. Capability is null where
+the axis does not apply — datasets and a wire protocol are not capable of anything a benchmark
+measures. Adoption is null where **no usage figure exists to band**, which is mostly the hosted
+fine-tuning and evaluation features of a larger platform — Azure, OpenAI, Mistral, Together,
+Vertex, Bedrock — none of which publishes a standalone number, plus the internal eval suites,
+which have no users outside the lab that wrote them. Banding those on vendor prose would be
+inventing the number, so the axis abstains instead.
 
 Every real claim already cites a source. The work is not finding evidence; it is re-reading
-what is cited. And the re-read surface is 1099 fetches, not 1386, because sources are shared.
+what is cited. And the re-read surface is 1106 fetches, not 1370, because sources are shared.
 
 **None of the 6 satisfied G1 as first written**, which is worth recording because it is the
 clearest evidence that the invariant does something. `establishes` did not exist when those
@@ -227,6 +237,9 @@ Lucie source URL that had never resolved as cited (missing the `/datasets/` segm
 Hub answered 401), and an `rwkv` `weights:open` claim with no source behind it at all.
 
 ### What automation can and cannot earn, per axis
+
+Counted 2026-07-30, before the corpus reached 472 products. The per-axis totals have moved a
+little since; the split has not.
 
 | axis | axes | all sources signal-backed | can a fetch earn the date? |
 |---|---|---|---|
@@ -354,12 +367,20 @@ Adoption and capability, restricted to axes where every recorded dimension is si
 The date is the signal fetch date. No reading and no judgment, which is exactly why it can
 run unattended and why it must be fenced to those axes only.
 
-### 4. The re-read pass — roughly 1099 URLs
+### 4. The re-read pass — roughly 1106 URLs
 
 Everything else, all of openness included. **Fold the deferral backlog into this pass rather
 than clearing it first.** Reading a product's sources to determine `core-gated` *is* the
 re-check that earns its `last_verified`; done as two passes it is the same pages fetched
 twice, and it re-verifies scores that are about to change.
+
+**The prose refresh folds in on the same argument.** A product's `description` and `comments`
+are brought up to `docs/guides/product-info.md` in the same read, because refreshing them means
+opening the pages this pass already fetches, and because a prose pass run on its own does not
+open primary sources at all. One PR per category carries both halves. The runbook's Phase 4 has
+the unit of work; the split of authority is unchanged — this guide governs the score and the
+date, `product-info.md` governs the prose, and the `comments` verification line still earns no
+`last_verified`.
 
 That backlog is currently the 86 declared deferrals. Every category has a recipe now, and
 `safeguards` — which used to contribute all 26 of its products here — is down to 5. The

--- a/docs/runbooks/verification-pass.md
+++ b/docs/runbooks/verification-pass.md
@@ -111,7 +111,7 @@ corrections.
 
 ---
 
-## Phase 1 — Finish the recipes: 16/16 categories, 470/470 products
+## Phase 1 — Finish the recipes: 16/16 categories, 472/472 products
 
 111 products, four categories. Do this before Phase 2 or the SQL generalization gets done
 twice.
@@ -213,6 +213,19 @@ uv run python tools/deploy_udm.py --dataset scores --model openness_facts \
 uv run python -m build.check_parity
 ```
 
+Two things about step 2 that are easy to get wrong, both of which cost hours on 2026-08-08:
+
+- **Per-model refresh is not reachable over MCP without the model UUIDs.**
+  `createUserModelRunRequest.selectedModels` takes UUIDs, not names: passing
+  `"openness_facts"` fails with `invalid input syntax for type uuid`. Without the IDs to hand,
+  the only path is a whole-dataset run, which does work and preserves topological order, but
+  pulls in eight unrelated `scores` models and takes about four minutes against roughly ten
+  seconds targeted.
+- **Verify a run from the data, not from the run status.** A `scores` run reports RUNNING for
+  minutes after its early models have already committed. Query `MAX(last_checked)` through
+  `build/warehouse.py` — which forces the nonce, without which you read the pre-materialization
+  answer back out of the query-text cache.
+
 ### G5 — the parity gate
 
 `build/check_parity.py` compares `check_rubric`'s local verdict against
@@ -255,24 +268,44 @@ them as `verified` rather than `commit`.
 
 ---
 
-## Phase 4 — The re-read pass, ~1099 URLs
+## Phase 4 — The re-read pass, ~1106 URLs
 
-Everything else, all of openness included. **Fold the 174 held-back products in rather than clearing
+Everything else, all of openness included. **Fold the 86 held-back products in rather than clearing
 them first** — reading a product's sources to settle `core-gated` *is* the re-check that earns
 its date. Two passes means the same pages fetched twice, on scores about to change.
+(`check_recipe` prints the current deferral count per category; regenerate it rather than
+trusting the number here.)
 
-Per axis, the unit of work:
+**The prose comes with it.** The pass refreshes a product's `description` and `comments` to
+`docs/guides/product-info.md` in the same unit of work, for the same reason the deferral
+backlog folds in: refreshing the prose means opening the repository, model card and vendor docs
+this phase already fetches. Run separately it is the same pages twice — and worse, a prose pass
+that does not open primary sources produces a provenance line naming a *method*
+(`Verified 2026-08-08 via web search`), which is how seven products acquired one in #147.
 
-1. Fetch each cited URL; record `http_status`, `content_sha256`, and a `shows` extract that
-   actually appears in the body.
-2. Re-derive each recorded dimension and attribute it: `establishes: [...]`.
-3. If a value moved, that is the valuable output — fix the score and say why in `note`.
-4. Stamp `last_verified` only once every recorded dimension has an establishing source.
+The unit of work is therefore per product, not per axis:
+
+1. **Read what the warehouse already has** before fetching anything — the signal row carries
+   `http_status`, `license_*`, `is_archived`, `is_gated`, `downloads_30d` and `fetched_at`.
+2. Fetch each cited URL a signal does not already cover; record `http_status`,
+   `content_sha256`, and a `shows` extract that actually appears in the body. A cited URL that
+   404s is a finding, not something to paper over.
+3. Re-derive each recorded dimension and attribute it: `establishes: [...]`.
+4. **Rewrite the prose** per `product-info.md` — `description` load-bearing and within the
+   length band, `comments` a footnote ending in the canonical verification line. Delete rather
+   than research a superlative, a corporate event, or a curator rationale clause; the guide's
+   claim-class table is the rule.
+5. If a value moved, that is the valuable output — fix the score and say why in `note`.
+6. Stamp `last_verified` only once every recorded dimension has an establishing source.
+   Otherwise `deferred` with a real reason. Never both, and never silently absent.
 
 Batch by category so `check_rubric` gives a clean signal per batch, and run
-`check_verification` after each batch rather than at the end.
+`check_verification` after each batch rather than at the end. One PR per category, prose and
+scores together, with every moved score itemized against its evidence. Categories go in order
+of **worst signal coverage first**, so no manual reading duplicates what Phase 3's write-back
+would have earned for free.
 
-**On agent execution.** This is 1099 fetches and it is the step most exposed to
+**On agent execution.** This is 1106 fetches and it is the step most exposed to
 rubber-stamping — an agent that "confirms" without reading would reproduce #108's failure at
 fifty times the scale while looking legitimate. Three things make that not work: G1 requires
 the `accessed` bump on every dimension, G2 requires a digest that only fetching produces, and
@@ -282,8 +315,9 @@ G4 re-fetches a sample and compares. Do not relax any of the three to make a bat
 is the return on the work, not a problem with it — `apply_scores --check` exits non-zero on a
 moved score deliberately.
 
-**Exit criteria:** every one of the 1386 real claims either carries a confirmed
-`last_verified` or sits in `deferred` with a reason. Zero silently absent.
+**Exit criteria:** every one of the 1370 real claims either carries a confirmed
+`last_verified` or sits in `deferred` with a reason, and every product's prose satisfies
+`product-info.md`. Zero silently absent.
 
 ---
 
@@ -293,9 +327,14 @@ moved score deliberately.
 uv run python -m build.check_freshness --max-age-days 90     # tune, then gate
 ```
 
-Add G4 (sampled re-fetch) as a weekly scheduled workflow, reporting drift rather than hard
-failing, since pages legitimately change. Turn `--max-age-days` into a CI gate once coverage
-makes it fail on genuine staleness rather than on backlog. Drop the G2 exemption list.
+**G4 landed early**, in #148, because Phase 4 is the step it exists to police and running that
+without it would be the rubber-stamp risk with nothing underneath it. `build/check_refetch.py`
+re-fetches a sample and compares digests, weekly in `.github/workflows/refetch.yml`, reporting
+drift rather than hard failing since pages legitimately change. A digest that **matches** is
+the proof — one that differs proves nothing on its own.
+
+What remains here: turn `--max-age-days` into a CI gate once coverage makes it fail on genuine
+staleness rather than on backlog, and drop the G2 exemption list.
 
 **Exit criteria:** the five definition-of-done conditions hold, and each is enforced by
 something that runs without being remembered.

--- a/skills/verify-product/SKILL.md
+++ b/skills/verify-product/SKILL.md
@@ -15,6 +15,18 @@ openness/adoption/capability value.
 > and the source of the rules below. This skill is the procedure; the guide is the
 > authority.
 
+**Where this runs.** In the category sweep the prose refresh happens *inside* the score
+re-read (`docs/runbooks/verification-pass.md`, Phase 4): one agent opens a product's sources
+once and writes both halves from them, and one PR carries the category. This skill stays the
+prose half, and the boundary below still holds — the score half follows
+`docs/guides/verification.md`, which is gated and evidence-attributed. Run standalone, the
+skill is unchanged.
+
+**How far to verify.** The guide's claim-class table is the rule. Two consequences worth
+having in front of you: a superlative, a corporate event, and a curator rationale clause are
+**deleted or omitted, never researched**, and a claim the product's own sources do not settle
+comes out of the prose rather than staying in on the grounds that it was already written.
+
 ## Steps
 
 1. **Locate the product**: `sources/products/<slug>.yaml`. Note its `type` and its
@@ -43,6 +55,18 @@ openness/adoption/capability value.
    `description` is the **load-bearing** field: everything a reader needs about the product
    lives here, including who builds or stewards it. Avoid three sentences in a row opening
    "It …" — recast one around its real subject.
+
+   **Strip the curator rationale clause.** Find it with
+   `\b(picked|chosen|included|selected)\s+(because|when|by|for|as|if)\b`. A description
+   describes; why the map picked the product up is not a product fact. Work in this order:
+   salvage the concrete facts trapped inside the clause and move them into the description
+   proper ("powers the Hugging Face Open LLM Leaderboard"), drop the counts, funding and
+   superlatives that have collected there, then delete the recommendation framing. Like a
+   stale count, this is a valid reason to edit with nothing else moving.
+
+   **Strip corporate events** — acquired, raised, IPO'd. Keep one only when it establishes who
+   ships the product today ("Predibase, now part of Rubrik"); never as company history, and
+   never funding, which is a proxy for the `adoption` axis.
 5. **Rewrite `comments` as a footnote.** It is not a second description. Anything about the
    *product* — what it does, who builds it, what it runs on — moves to `description`; what
    stays is about *the reading*: an evidence gap, a judgment call a score rests on, or


### PR DESCRIPTION
Step 1 of the verification sweep. The prose pass and the score re-read are one pass from here, so the rules that govern both have to live in the guides an agent doing that pass actually reads. Nothing here changes data — docs and one skill.

## What changed

**`docs/guides/product-info.md`**
- **A claim-class table.** What it is/does and comparative positioning get verified by the score re-read anyway. Superlatives, corporate events and curator rationale resolve to *delete or omit*, not research. A claim the product's own sources don't settle comes out of the prose rather than staying in because it was already written.
- **Curator rationale is not description content.** A description describes. The "Picked when hardware is constrained" clause is also where the already-banned content had collected — surveying on 2026-08-08, every hardcoded star count in an affected product sat inside the clause while the descriptive half was clean. Rewrite order is salvage the trapped facts first, then drop counts/funding/superlatives, then delete the recommendation framing.
- **Corporate events.** Omit by default; keep only when identity-bearing ("Predibase, now part of Rubrik"). Funding is a proxy for the `adoption` axis.

**`skills/verify-product/SKILL.md`** — the same three rules in the per-product procedure, plus where the skill now sits inside the merged pass. Its boundary is unchanged: prose only, never `last_verified`.

**`docs/runbooks/verification-pass.md`**
- Phase 4's unit of work never mentioned prose. It is half the job now, so the unit is per product, not per axis.
- Two things that cost hours on 2026-08-08: `createUserModelRunRequest.selectedModels` takes model UUIDs rather than names, and a `scores` run reports RUNNING for minutes after its early models have committed — so verify from `MAX(last_checked)`, not from run status.
- G4 landed early in #148; Phase 5 says so rather than still listing it as future work.

**`docs/guides/verification.md`** — the current-state table, re-derived rather than edited. Also spells out why 46 axes are deliberately null, which the old table asserted without explaining.

## Corrected counts

Recomputed from `sources/`, not copied forward:

| | was | is |
|---|---|---|
| products | 470 | **472** |
| axes | 1410 | **1416** |
| deliberately null | 24 | **46** (26 capability, 20 adoption) |
| real claims | 1386 | **1370** |
| distinct source URLs | 1099 | **1106** |
| held-back products, Phase 4 | 174 | **86** |

Historical measurements keep their original numbers and their dates — the automation table is now labeled 2026-07-30 rather than silently refreshed with a host set I could not reproduce exactly.

## Test plan

- `build.validate` → `0 error(s)`
- `build.check_verification` → G1/G2/G3 `[OK]`
- `build.check_recipe` → 16 categories, 0 failures, 86 deferrals (the source of the corrected number)
- `pytest tests/ -q` → 337 passed

## Note

The rules are deliberately in the guides only. Copying them into a sweep workflow prompt would create a second copy that drifts, which is the exact failure this sweep exists to fix.