### PR TITLE
Name the gates instead of numbering them

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -1,6 +1,6 @@
 name: parity
 
-# Gate G5: the repo and the warehouse must compute the same score for every product.
+# The parity gate: the repo and the warehouse must compute the same score for every product.
 # `build/check_rubric.py` walks each ladder in Python and
 # `currentai.scores.openness_computed` walks it in Trino, and only this makes the two agree.
 # Every drift this project has shipped was invisible to a count — the reasoning and the four

--- a/.github/workflows/refetch.yml
+++ b/.github/workflows/refetch.yml
@@ -1,12 +1,12 @@
 name: refetch
 
-# Gate G4: independent evidence that a recorded fetch actually happened.
+# The sampled re-fetch: independent evidence that a recorded fetch actually happened.
 #
-# G1 and G2 both read what the writer wrote. An agent that never opened a page can emit a
-# plausible `accessed`, a plausible 200 and sixty-four plausible hex characters, and both
-# gates pass — #108's failure mode with better spelling. G4 is the only check that goes and
-# looks, and it is the third leg the runbook names. The reasoning is in
-# build/check_refetch.py.
+# The invariant and the digest requirement both read what the writer wrote. An agent that
+# never opened a page can emit a plausible `accessed`, a plausible 200 and sixty-four
+# plausible hex characters, and both gates pass — #108's failure mode with better spelling.
+# The sampled re-fetch is the only check that goes and looks, and it is the third leg the
+# runbook names. The reasoning is in build/check_refetch.py.
 #
 # Report-only on purpose, and this is the part most likely to get "fixed" later. Pages
 # change: the first full run confirmed 4 of 24 digests and drifted on the other 20, because

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,10 +24,11 @@ jobs:
       - name: Run tests
         run: uv run pytest -q
 
-      # G1, G2 and G3. Free, no network, and scoped so they cover exactly what has been
-      # done: G1 and G2 apply only to axes claiming a last_verified, G3 to every scored
-      # product in a category with a recipe. See docs/guides/verification.md.
-      - name: Verification gates (G1 invariant, G2 digests, G3 producible pairs)
+      # The invariant, the digest requirement and the producible-pair check. Free, no
+      # network, and scoped so they cover exactly what has been done: invariant and digests
+      # apply only to axes claiming a last_verified, producible-pairs to every scored product
+      # in a category with a recipe. See docs/guides/verification.md.
+      - name: Verification gates (invariant, digests, producible-pairs)
         run: uv run python -m build.check_verification --verbose
 
       # Structure of every scoring recipe: a rationale on each rung, a machine_signal on

--- a/build/check_parity.py
+++ b/build/check_parity.py
@@ -1,8 +1,9 @@
 """Compare what the repo computes against what the warehouse published, per product.
 
-Gate G5 in `docs/guides/verification.md`. `build/check_rubric.py` walks each category's
-ladder in Python; `currentai.scores.openness_computed` walks the same ladder in Trino. The
-two are separate implementations of one rubric, and nothing but this makes them agree.
+The parity gate in `docs/guides/verification.md`. `build/check_rubric.py` walks each
+category's ladder in Python. `currentai.scores.openness_computed` walks the same ladder in
+Trino. The two are separate implementations of one rubric, and nothing but this makes them
+agree.
 
 ## Why a per-product comparison and not a count
 

--- a/build/check_recipe.py
+++ b/build/check_recipe.py
@@ -14,9 +14,10 @@ born needing a recipe. `skills/build-rubric/SKILL.md` is the procedure; this is 
 a machine can enforce.
 
 Almost everything here composes a signal that already exists somewhere and was not gated:
-`check_rubric` knows about abstentions, `check_verification` G3 knows about impossible pairs,
-and `serialize_rubric --check` knows about undeclared dimensions and out-of-enum values — but
-it emits them as warnings among 282, which is to say invisibly. Gating is the contribution.
+`check_rubric` knows about abstentions, `check_verification`'s producible-pair check knows
+about impossible pairs, and `serialize_rubric --check` knows about undeclared dimensions and
+out-of-enum values — but it emits them as warnings among 282, which is to say invisibly.
+Gating is the contribution.
 
 WHAT THIS DELIBERATELY DOES NOT ASSERT: any threshold on the reproduction rate, in either
 direction. A ladder tuned until it reproduces every recorded score is a curve fit to the data
@@ -55,7 +56,7 @@ from build.check_rubric import (
     resolve_recipe_variants,
     split_components,
 )
-from build.check_verification import producible_pairs
+from build.check_verification import rule_outcomes
 
 
 def split_clauses(text: str) -> list[str]:
@@ -406,7 +407,7 @@ def check_one(slug: str, verbose: bool) -> tuple[list[str], list[str]]:
             continue
         by_recipe.setdefault(id(recipe), {})[product] = openness.get("components") or ""
         pair = (openness.get("score"), openness.get("class"))
-        if pair[0] is not None and pair not in producible_pairs(recipe):
+        if pair[0] is not None and pair not in rule_outcomes(recipe):
             impossible += 1
             failures.append(
                 f"category '{slug}' product '{product}': {pair[0]}/{pair[1]} is not an "

--- a/build/check_refetch.py
+++ b/build/check_refetch.py
@@ -1,18 +1,19 @@
-"""G4 — the sampled re-fetch: independent evidence that a recorded fetch actually happened.
+"""The sampled re-fetch: independent evidence that a recorded fetch actually happened.
 
-`docs/guides/verification.md` is normative; this module implements the gate. It is the third
+`docs/guides/verification.md` is normative. This module implements the gate. It is the third
 leg of the anti-rubber-stamping defense the runbook names, and until now the only one that
 was missing.
 
 ## Why the other two are not enough
 
-G1 asks whether a claimed date is supported by the `accessed` dates on record. G2 asks
-whether the sources carry an `http_status` and a `content_sha256`. Both are real, and both
-share a blind spot: **they read what the writer wrote.** An agent that never opened a page
-can still emit a plausible `accessed`, a plausible `200`, and sixty-four plausible hex
-characters, and both gates pass. That is #108's failure mode with better spelling.
+The invariant asks whether a claimed date is supported by the `accessed` dates on record.
+The digest requirement asks whether the sources carry an `http_status` and a
+`content_sha256`. Both are real, and both share a blind spot: **they read what the writer
+wrote.** An agent that never opened a page can still emit a plausible `accessed`, a plausible
+`200`, and sixty-four plausible hex characters, and both gates pass. That is #108's failure
+mode with better spelling.
 
-G4 is the only check that goes and looks.
+The sampled re-fetch is the only check that goes and looks.
 
 ## What a match proves, and what a mismatch does not
 
@@ -196,7 +197,7 @@ def main() -> int:
 
     sources = load_sources(args.product)
     if not sources:
-        print("0 sources record a digest yet — nothing for G4 to re-fetch.")
+        print("0 sources record a digest yet — nothing to re-fetch.")
         print("This is expected until the re-read pass populates content_sha256.")
         return 0
 

--- a/build/check_verification.py
+++ b/build/check_verification.py
@@ -4,7 +4,7 @@
 the two disagree the guide wins. `docs/runbooks/verification-pass.md` has the order of
 operations and why the gates land before any bulk editing of `sources/scores/`.
 
-## G1 — the invariant
+## The invariant
 
 > `last_verified: D` is valid only if, for every dimension the score records, at least one
 > source that `establishes` that dimension has `accessed >= D`.
@@ -22,36 +22,38 @@ recorded dimension, so the binding constraint is the LEAST recently re-read one.
 three were last seen in June — and that is not hypothetical, it is what the 2026-07-28 pass
 on the model flagships produced by re-reading only the dataset endpoint.
 
-## G2 — a claimed date needs a fetch to point at
+## The digest requirement — a claimed date needs a fetch to point at
 
 Same scope. Every source read as part of the confirmation carries `http_status` and
 `content_sha256`, because those are what only an actual request produces. The invariant
-alone catches an unsupported date; it cannot catch a source that never said what `shows`
+alone catches an unsupported date. It cannot catch a source that never said what `shows`
 claims. A missing digest on a newly claimed confirmation means the tool fetched nothing.
 
-## G3 — a score/class pair must be producible
+## The producible-pair check — a score/class pair must be producible
 
-Full scope, immediately, and unlike G1 and G2 it needs nothing to be populated first. For
-every scored product in a category with a `scoring_recipe`, `(score, class)` must be the
-outcome of SOME rule in that recipe. Deliberately weaker than `build/check_rubric.py`,
-which asks whether the recipe reproduces the score from the recorded evidence: G3 ignores
-the evidence and asks only whether the pair exists in the ladder at all. That makes it
-immune to the escape hatch `check_rubric` has, which is `deferred` — a category can defer a
-product out of reproduction, but an impossible pair stays impossible.
+Full scope, immediately, and unlike the invariant and the digest requirement it needs
+nothing to be populated first. For every scored product in a category with a
+`scoring_recipe`, `(score, class)` must be the outcome of SOME rule in that recipe.
+Deliberately weaker than `build/check_rubric.py`, which asks whether the recipe reproduces
+the score from the recorded evidence: producible-pairs ignores the evidence and asks only
+whether the pair exists in the ladder at all. That makes it immune to the escape hatch
+`check_rubric` has, which is `deferred` — a category can defer a product out of
+reproduction, but an impossible pair stays impossible.
 
 Which is how `4 / open_source` survived: no software rule emits 4 with `open_source` (4 is
 `open_core`), and no software rule emits 3 at all, since the ladder's rungs are 1, 2, 4, 5.
 
 ## How the gates ratchet
 
-G1 and G2 apply only to axes carrying a `last_verified`, which is a handful today and grows
-as the re-read pass proceeds. The gate therefore covers exactly what has been done, never
-blocks progress, and never permits a regression on ground already taken. A big-bang gate
-over all 1386 axes would fail on day one and get switched off, which is how gates die.
+The invariant and the digest requirement apply only to axes carrying a `last_verified`,
+which is a handful today and grows as the re-read pass proceeds. They therefore cover
+exactly what has been done, never block progress, and never permit a regression on ground
+already taken. A big-bang gate over all 1370 axes would fail on day one and get switched
+off, which is how gates die.
 
 Usage:
     uv run python -m build.check_verification
-    uv run python -m build.check_verification --gate g3
+    uv run python -m build.check_verification --gate producible-pairs
     uv run python -m build.check_verification --verbose
 """
 
@@ -69,19 +71,20 @@ from build.rubrics import load_product_types, load_shared, recipe_for, resolve_r
 ROOT = Path(__file__).resolve().parents[1]
 AXES = ("openness", "adoption", "capability")
 
-# Axes exempt from G2 because a digest could not have been recorded when their sources were
-# read. A visible list that shrinks, rather than a date comparison that quietly covers
-# whatever is old.
+# Axes exempt from the digest requirement because a digest could not have been recorded when
+# their sources were read. A visible list that shrinks, rather than a date comparison that
+# quietly covers whatever is old.
 #
 # Empty, and worth saying why. The six axes carrying a date when this gate landed all
-# predated it and so would all have qualified; they were re-fetched instead, which took 23
+# predated it and so would all have qualified. They were re-fetched instead, which took 23
 # requests and produced two findings the exemption would have hidden — a Lucie source URL
 # that had never resolved as cited, and an `rwkv` weights claim with no source behind it at
-# all. Exempting is the cheaper move and it is available; it is not the better one when the
+# all. Exempting is the cheaper move and it is available. It is not the better one when the
 # set is small.
 #
-# G2 only. An exemption says a digest was unobtainable, which says nothing about whether the
-# sources support the date — that is G1's question, and G1 has no exemptions.
+# Digests only. An exemption says a digest was unobtainable, which says nothing about whether
+# the sources support the date. That is the invariant's question, and the invariant has no
+# exemptions.
 #
 # Each entry names the axis as `<product>:<axis>` and why. Stale entries are reported.
 DIGEST_EXEMPT: dict[str, str] = {}
@@ -156,7 +159,7 @@ def recorded_dimensions(components: dict[str, str], recipe: dict) -> dict[str, s
     return found
 
 
-def g1_invariant(
+def invariant(
     scores: dict, categories: dict, recipes: dict, product_types: dict[str, str]
 ) -> list[str]:
     """Every recorded dimension of a dated axis has an establishing source read since."""
@@ -212,7 +215,7 @@ def g1_invariant(
     return problems
 
 
-def g2_digests(scores: dict) -> list[str]:
+def digests(scores: dict) -> list[str]:
     """Sources read as part of a claimed confirmation must show they were fetched."""
     problems: list[str] = []
     used: set[str] = set()
@@ -246,13 +249,13 @@ def g2_digests(scores: dict) -> list[str]:
     for key, reason in sorted(DIGEST_EXEMPT.items()):
         if key not in used:
             problems.append(
-                f"{key}: exempted from G2 ({reason}) but the axis no longer carries a "
-                f"last_verified. Drop the exemption."
+                f"{key}: exempted from the digest requirement ({reason}) but the axis no "
+                f"longer carries a last_verified. Drop the exemption."
             )
     return problems
 
 
-def producible_pairs(recipe: dict) -> set[tuple[int, str]]:
+def rule_outcomes(recipe: dict) -> set[tuple[int, str]]:
     """Every (score, class) some rule in the recipe can emit."""
     pairs: set[tuple[int, str]] = set()
     for rule in (recipe.get("openness") or {}).get("formula") or []:
@@ -262,13 +265,13 @@ def producible_pairs(recipe: dict) -> set[tuple[int, str]]:
     return pairs
 
 
-def g3_producible(
+def producible_pairs(
     scores: dict, categories: dict, recipes: dict, product_types: dict[str, str]
 ) -> list[str]:
     """A recorded (score, class) must be an outcome the category's ladder can produce.
 
     A mixed category has one ladder per product type. Each product is checked against
-    its OWN ladder via `recipe_for` — the same selection G1, `check_rubric` and
+    its OWN ladder via `recipe_for` — the same selection the invariant, `check_rubric` and
     `serialize_rubric` all use — not the union of every variant in the category. A
     software product recording a pair only the model ladder can emit must still fail
     here, even though some ladder in the category could have produced it.
@@ -281,7 +284,7 @@ def g3_producible(
             if score is None:
                 continue
             recipe, _ = recipe_for(variants, product_types.get(product, ""))
-            pairs = producible_pairs(recipe or {})
+            pairs = rule_outcomes(recipe or {})
             if (score, klass) not in pairs:
                 problems.append(
                     f"{product}:openness in {slug}: {score}/{klass} is not an outcome any rule "
@@ -292,10 +295,11 @@ def g3_producible(
 
 
 GATES = {
-    "g1": "a confirmation with no supporting evidence",
-    "g2": "a claimed date with no fetch digest",
-    "g3": "an impossible score/class pair",
+    "invariant": "a confirmation with no supporting evidence",
+    "digests": "a claimed date with no fetch digest",
+    "producible-pairs": "an impossible score/class pair",
 }
+NAME_WIDTH = max(len(name) for name in GATES)
 
 
 def main() -> int:
@@ -307,9 +311,9 @@ def main() -> int:
     scores, categories, recipes = load()
     product_types = load_product_types(ROOT)
     results = {
-        "g1": g1_invariant(scores, categories, recipes, product_types),
-        "g2": g2_digests(scores),
-        "g3": g3_producible(scores, categories, recipes, product_types),
+        "invariant": invariant(scores, categories, recipes, product_types),
+        "digests": digests(scores),
+        "producible-pairs": producible_pairs(scores, categories, recipes, product_types),
     }
     if args.gate:
         results = {args.gate: results[args.gate]}
@@ -328,16 +332,19 @@ def main() -> int:
     )
 
     if args.verbose:
-        print(f"{dated} axis/axes carry a last_verified  (G1, G2 scope)")
-        print(f"{scored} scored products in {len(recipes)} categories with a recipe  (G3 scope)")
+        print(f"{dated} axis/axes carry a last_verified  (invariant, digests scope)")
+        print(
+            f"{scored} scored products in {len(recipes)} categories with a recipe  "
+            f"(producible-pairs scope)"
+        )
         if DIGEST_EXEMPT:
-            print(f"{len(DIGEST_EXEMPT)} G2 exemption(s), each of which should be shrinking")
+            print(f"{len(DIGEST_EXEMPT)} digest exemption(s), each of which should be shrinking")
         print()
 
     failed = False
     for gate, problems in results.items():
         status = "OK" if not problems else "FAIL"
-        print(f"{gate.upper()}  {GATES[gate]:<44} [{status}]")
+        print(f"{gate:<{NAME_WIDTH}}  {GATES[gate]:<44} [{status}]")
         for problem in problems:
             print(f"  ! {problem}")
         if problems:

--- a/docs/guides/openness-spectrum.md
+++ b/docs/guides/openness-spectrum.md
@@ -70,8 +70,8 @@ across all score files shows the overlap:
 | 1 | `closed` |
 | 0 | `closed` |
 
-Regenerated 2026-07-30. The overlap is narrower than it was: #128's verification gate G3 found
-17 pairs no rule in any recipe could emit and corrected them, which is why `open_core` and
+Regenerated 2026-07-30. The overlap is narrower than it was: the producible-pair check added in
+#128 found 17 pairs no rule in any recipe could emit, and correcting them is why `open_core` and
 `source_available` no longer appear at 3 and `open_core` no longer appears at 2. If you are
 reading this table long after that date, regenerate it rather than trusting it — the check is
 a few lines over `sources/scores/*.yaml`.
@@ -175,7 +175,7 @@ restriction disqualifies. Under MOF, a release under OpenRAIL, a Llama community
 AI2 ImpACT is *source-available*, not open.
 
 This map is a 0–5 score, which is a different instrument. The 2024 Columbia Convening
-catalogues three families of approach — gradient, score, and binary — and adopts none; the
+catalogs three families of approach — gradient, score, and binary — and adopts none; the
 score family is the one the map belongs to.
 
 The two stay compatible through one rule:

--- a/docs/guides/product-info.md
+++ b/docs/guides/product-info.md
@@ -222,7 +222,7 @@ search` — which is precisely what the canonical form below forbids.
 The license is the clearest case, and the one this guide used to get backwards. It is not
 merely descriptive: it *is* the openness score's basis, recorded in
 `sources/scores/<slug>.yaml` as `openness.components` (`license:Apache-2.0(OSI);…`) with
-`sources[].accessed` behind it and the G1/G2 gates in front of it.
+`sources[].accessed` behind it and the invariant and the digest requirement in front of it.
 
 Restating it in `comments` creates a second copy with none of that. The two then drift in
 one direction only: a relicense flows correctly through `verification.md`, the score
@@ -327,8 +327,9 @@ These look alike and are not the same, and conflating them is the exact error
   product file. It says "an editor last confirmed these descriptive facts on this day." It
   is not gated, not machine-read for freshness, and carries no per-dimension evidence.
 - **`last_verified`** lives in the *score* file, per axis, and is a confirmation that a
-  *score* is still correct, re-derivable from `sources[].establishes`, and gated (G1/G2).
-  Only a person writes it, and only per the rules in `verification.md`.
+  *score* is still correct, re-derivable from `sources[].establishes`, and gated by the
+  invariant and the digest requirement. Only a person writes it, and only per the rules in
+  `verification.md`.
 
 Writing the `comments` line **does not** earn a `last_verified`, and updating a product's
 prose is not a score re-check. If a prose re-read turns up a fact that moves a *score* (a

--- a/docs/guides/verification.md
+++ b/docs/guides/verification.md
@@ -119,45 +119,48 @@ failure, because it means the tool did not fetch anything.
 ## The gates, and why they ratchet
 
 Every failure mode this project has actually hit gets a mechanism, not a note. Cheap ones
-gate every PR; ones needing the network run periodically.
+gate every PR. The ones needing the network run periodically.
 
-| # | failure mode | mechanism | cost |
+| gate | failure mode | mechanism | cost |
 |---|---|---|---|
-| G1 | a confirmation with no supporting evidence | the invariant above | free |
-| G2 | a claimed date with no fetch digest | required on axes claiming a confirmation | free |
-| G3 | an impossible score/class pair | the pair must be producible by some rule in the recipe | free |
-| G4 | fabricated or rotted sources | sampled re-fetch, digest and `shows` token match | network, weekly |
-| G5 | repo and warehouse drifting apart | `build/check_parity.py`, a per-product differential | network, daily |
-| G6 | a UDM revision that was never released | assert latest revision == latest release | network, per publish |
+| invariant | a confirmation with no supporting evidence | the invariant above | free |
+| digests | a claimed date with no fetch digest | required on axes claiming a confirmation | free |
+| producible-pairs | an impossible score/class pair | the pair must be producible by some rule in the recipe | free |
+| refetch | fabricated or rotted sources | sampled re-fetch, digest and `shows` token match | network, weekly |
+| parity | repo and warehouse drifting apart | `build/check_parity.py`, a per-product differential | network, weekly |
+| release | a UDM revision that was never released | assert latest revision == latest release | network, per publish |
 
-**They ratchet rather than switch on.** G1 and G2 apply only to axes that carry a
-`last_verified`, which is 6 today and grows as the re-read pass proceeds. So the gate covers
-exactly what has been done, never blocks progress, and never permits a regression on ground
-already taken. A big-bang gate over all 1370 axes would fail on day one and get switched
+These were numbered G1-G6 until 2026-08-08. Older PRs and commit messages use the numbers.
+
+**They ratchet rather than switch on.** The invariant and the digest requirement apply only to
+axes that carry a `last_verified`, which is 6 today and grows as the re-read pass proceeds. So
+they cover exactly what has been done, never block progress, and never permit a regression on
+ground already taken. A big-bang gate over all 1370 axes would fail on day one and get switched
 off, which is how gates die.
 
-G3, G5 and G6 apply in full immediately — nothing has to be populated first.
+The producible-pair check, the parity gate and the release assertion apply in full immediately —
+nothing has to be populated first.
 
-G5 runs on its own weekly schedule rather than inside the publish job, and that placement is
-deliberate rather than a stopgap in disguise. Publishing pushes and materializes the static
-models; the three user models that read them recompute on Monday at 03:00, 04:00 and 05:00 UTC,
-upstream first, and G5 grades the result at 06:00. Chained onto a publish instead, the gate would
-compare fresh rules against a warehouse that has not recomputed and fail for a reason that is
-not a drift.
+The parity gate runs on its own weekly schedule rather than inside the publish job, and that
+placement is deliberate rather than a stopgap in disguise. Publishing pushes and materializes the
+static models. The three user models that read them recompute on Monday at 03:00, 04:00 and 05:00
+UTC, upstream first, and parity grades the result at 06:00. If it were chained onto a publish
+instead, the gate would compare fresh rules against a warehouse that has not recomputed and fail
+for a reason that is not a drift.
 
 **The gate's schedule has to match the chain's.** A daily gate over a weekly chain fails every
 day between a merge and the following Monday, always saying "the warehouse has not caught up",
 which is not what a parity gate is for and is how a gate earns its way into being ignored. If
 you want a check sooner, refresh the three models and run `check_parity` by hand.
 
-The crons bound how stale the warehouse gets; they do not make a publish arrive any faster, so a
-Tuesday merge is scored the following Monday. Move G5 into `registry.yml` on the day
+The crons bound how stale the warehouse gets. They do not make a publish arrive any faster, so a
+Tuesday merge is scored the following Monday. Move parity into `registry.yml` on the day
 `publish_registry` triggers those three runs and waits for them.
 
-G3 found 17 impossible pairs on its first run, not the two that were known. `vellum`,
-`whylabs` and `tensorrt-llm` were recorded `4 / open_source`, a pair no rule emits because
-4 is `open_core`; five more were `2 / open_core`, which no rule emits either; and nine
-carried a score of 3, which the software ladder cannot produce **at all**, its rungs being
+The producible-pair check found 17 impossible pairs on its first run, not the two that were
+known. `vellum`, `whylabs` and `tensorrt-llm` were recorded `4 / open_source`, a pair no rule
+emits because 4 is `open_core`; five more were `2 / open_core`, which no rule emits either; and
+nine carried a score of 3, which the software ladder cannot produce **at all**, its rungs being
 1, 2, 4 and 5. All 17 were corrected by reading the products, in three groups:
 
 - `2 / open_core` → `2 / source_available`. The class was wrong. `open_core` in this ladder
@@ -168,12 +171,12 @@ carried a score of 3, which the software ladder cannot produce **at all**, its r
   for a closed service — which the ladder scores at 2.
 - `4 / open_source` → `5 / open_source`. The score was wrong. Each of the three publishes
   the whole self-hostable product under an OSI license with nothing withheld. The 4s
-  encoded maturity or scepticism about the vendor's marketing, both of which belong on the
+  encoded maturity or skepticism about the vendor's marketing, both of which belong on the
   adoption and capability axes and were already recorded there.
 
-Worth noting what G3 caught that `check_rubric` could not: 16 of the 17 were sitting in a
-category's `deferred` block, which excludes a product from reproduction. G3 ignores the
-evidence and asks only whether the pair exists in the ladder, so deferring cannot hide it.
+The producible-pair check caught something `check_rubric` could not: 16 of the 17 were sitting
+in a category's `deferred` block, which excludes a product from reproduction. The check ignores
+the evidence and asks only whether the pair exists in the ladder, so deferring cannot hide it.
 
 ### Two shared utilities, so the mechanism cannot be bypassed
 
@@ -211,7 +214,7 @@ different in kind and can be automated — see the table below.
 | **real claims to verify** | **1370** |
 | of those, citing at least one source URL | 1370 |
 | carrying a real `last_verified` | 6 |
-| of those 6, satisfying G1 and G2 | 6, after the Phase 0 re-read |
+| of those 6, satisfying the invariant and the digest requirement | 6, after the Phase 0 re-read |
 | distinct source URLs behind all of it | 1106 |
 
 Regenerate these rather than trusting them; the corpus grows most weeks.
@@ -227,8 +230,8 @@ inventing the number, so the axis abstains instead.
 Every real claim already cites a source. The work is not finding evidence; it is re-reading
 what is cited. And the re-read surface is 1106 fetches, not 1370, because sources are shared.
 
-**None of the 6 satisfied G1 as first written**, which is worth recording because it is the
-clearest evidence that the invariant does something. `establishes` did not exist when those
+**None of the 6 satisfied the invariant as first written**, which is worth recording because it
+is the clearest evidence the invariant does something. `establishes` did not exist when those
 dates were set, and beyond that the 2026-07-28 pass on the four model flagships re-read only
 the dataset endpoint: `apertus`, `olmo`, `pythia` and `lucie-7b` all claimed a whole-axis
 confirmation while citing 2026-06 reads for weights, code, checkpoints and license. Refetching
@@ -387,15 +390,15 @@ That backlog is currently the 86 declared deferrals. Every category has a recipe
 composition is roughly: products whose prose does not settle a dimension the ladder reads,
 products whose recorded license maps to no tier, and a handful where the ladder and the
 recorded score genuinely disagree (`jina-reader`, `openhands`, `maple-ai`, `privatemode`, all
-producible pairs, so G3 passes them and only `check_rubric` objects).
+pairs some rule can produce, so producible-pairs passes them and only `check_rubric` objects).
 
 Regenerate the number rather than trusting it — `check_recipe` prints per-category counts, and
 the figure has moved several times in a week.
 
 **Expect scores to move.** Verification is not a formality: the RWKV correction in #105 came
-out of a pass like this, and G3's first run moved 17 openness scores or classes before the
-gate could land at all. `apply_scores --check` exits non-zero on a moved score for this
-reason.
+out of a pass like this, and the first run of producible-pairs moved 17 openness scores or
+classes before the gate could land at all. `apply_scores --check` exits non-zero on a moved
+score for this reason.
 
 ### 5. Turn on the age gate
 

--- a/docs/runbooks/verification-pass.md
+++ b/docs/runbooks/verification-pass.md
@@ -31,18 +31,19 @@ afterwards would be gates written to fit whatever the bulk edits happened to pro
 > three gates pass. Two things went differently from what is written below and are worth
 > knowing before following it:
 >
-> - **G3 caught 17 impossible pairs, not 2.** `vellum` and `whylabs` were the known ones;
->   `tensorrt-llm` made a third `4 / open_source`, five products were `2 / open_core`, and
->   nine carried a score of 3, which the software ladder cannot emit at all. All were fixed
->   as score corrections. `docs/guides/verification.md` has the three groups and the
->   reasoning; the ladder was not touched.
-> - **The G2 exemption list is empty.** All 6 dated axes qualified for it, and none of them
->   satisfied G1 either, because the 2026-07-28 pass on the model flagships re-read only the
->   dataset endpoint. Re-fetching the 23 cited sources was 23 requests and it turned up two
->   defects the exemption would have hidden. Exempting stays the cheaper move and the
->   mechanism is still there; it is not the better move when the set is small.
+> - **The producible-pair check caught 17 impossible pairs, not 2.** `vellum` and `whylabs`
+>   were the known ones. `tensorrt-llm` made a third `4 / open_source`, five products were
+>   `2 / open_core`, and nine carried a score of 3, which the software ladder cannot emit at
+>   all. All were fixed as score corrections. `docs/guides/verification.md` has the three
+>   groups and the reasoning. The ladder was not touched.
+> - **The exemption list for the digest requirement is empty.** All 6 dated axes qualified
+>   for it, and none of them satisfied the invariant either, because the 2026-07-28 pass on
+>   the model flagships re-read only the dataset endpoint. Re-fetching the 23 cited sources
+>   was 23 requests and it turned up two defects the exemption would have hidden. Exempting
+>   stays the cheaper move and the mechanism is still there. It is not the better move when
+>   the set is small.
 >
-> **0.5 (G6) has NOT landed.** It is the one Phase 0 item still open.
+> **0.5, the release assertion, has NOT landed.** It is the one Phase 0 item still open.
 
 ### 0.1 Schema: `establishes`, `http_status`, `content_sha256`
 
@@ -70,23 +71,24 @@ passes such a test only by accident, which is why the test matters more than the
 Put all three in `build/check_verification.py`, one command, wired into `validate.yml` next
 to the existing test step.
 
-- **G1, the invariant.** For each axis carrying `last_verified: D`: every dimension the score
+- **The invariant.** For each axis carrying `last_verified: D`: every dimension the score
   records has ≥1 source with `establishes` naming it and `accessed >= D`. Scope: axes with a
   date only.
-- **G2, digest present.** Same scope: every establishing source has `http_status` and
+- **The digest requirement.** Same scope: every establishing source has `http_status` and
   `content_sha256`. Exempt dates predating this runbook by listing them explicitly, so the
   exemption is visible and shrinks.
-- **G3, producible pair.** For every scored product in a category with a recipe, `(score,
-  class)` must equal the outcome of some rule in that recipe. Full scope, immediately.
+- **The producible-pair check.** For every scored product in a category with a recipe,
+  `(score, class)` must equal the outcome of some rule in that recipe. Full scope,
+  immediately.
 
 ```bash
-uv run python -m build.check_verification          # expect G3 to FAIL first run
+uv run python -m build.check_verification          # expect producible-pairs to FAIL first run
 ```
 
-G3 will fail on `vellum` and `whylabs` (`4 / open_source`) and possibly others. **Fix those
-scores before landing the gate**; each is a real error, and one of the two recorded values is
-wrong in each case. Resolve by reading the product, not by adjusting the rubric to admit the
-pair.
+The producible-pair check will fail on `vellum` and `whylabs` (`4 / open_source`) and possibly
+others. **Fix those scores before landing the gate.** Each is a real error, and one of the two
+recorded values is wrong in each case. Resolve by reading the product, not by adjusting the
+rubric to admit the pair.
 
 ### 0.4 The nonce-forcing query helper
 
@@ -95,7 +97,7 @@ results cache on query text, so a fixed verification query returns its first ans
 this has already caused a tool to report success against pre-materialization data. Port
 `apply_scores.fetch_computed` and any verification script onto it.
 
-### 0.5 G6 — the release assertion
+### 0.5 The release assertion
 
 `build/publish_registry.py` (or the runbook step around it) asserts, for every UDM it depends
 on, that `latestRevision.revisionNumber == latestRelease.revision.revisionNumber`.
@@ -106,8 +108,8 @@ rather than an error — three runs were spent on that, concluding a column drop
 materialization when the new SQL had never executed. See `docs/runbooks/deploy-udms.md`.
 
 **Exit criteria for Phase 0:** `check_verification` passes, `validate.yml` runs it, the
-components helper has the folded-scalar test, and G3's catches are fixed as score
-corrections.
+components helper has the folded-scalar test, and what the producible-pair check caught is
+fixed as score corrections.
 
 ---
 
@@ -179,11 +181,11 @@ What shipped:
 ### The refresh order, which is not optional
 
 The three user models now carry weekly crons — `evidence.product_evidence` Monday 03:00 UTC,
-`scores.openness_facts` 04:00, `scores.openness_computed` 05:00, with G5 grading at 06:00 — so
-the warehouse is at most a week behind the repo on its own. **A publish is still only the first
-half of a refresh**, and on a weekly cadence that matters more rather than less: merge on
-Tuesday and the map carries the old numbers until the following Monday unless you walk the chain
-below. Do that whenever a merge changes a score, rather than waiting.
+`scores.openness_facts` 04:00, `scores.openness_computed` 05:00, with the parity gate grading at
+06:00 — so the warehouse is at most a week behind the repo on its own. **A publish is still only
+the first half of a refresh**, and on a weekly cadence that matters more rather than less: merge
+on Tuesday and the map carries the old numbers until the following Monday unless you walk the
+chain below. Do that whenever a merge changes a score, rather than waiting.
 
 Getting this wrong looks exactly like a code bug: the first run of the generalized SQL reported
 three categories missing entirely, and the cause was `product_evidence` sitting three recipes
@@ -226,11 +228,11 @@ Two things about step 2 that are easy to get wrong, both of which cost hours on 
   `build/warehouse.py` — which forces the nonce, without which you read the pre-materialization
   answer back out of the query-text cache.
 
-### G5 — the parity gate
+### The parity gate
 
 `build/check_parity.py` compares `check_rubric`'s local verdict against
 `currentai.scores.openness_computed` for every product, and fails on any divergence. It runs
-daily in `.github/workflows/parity.yml`.
+weekly in `.github/workflows/parity.yml`, Monday at 06:00 UTC, behind the three models it grades.
 
 This is the mechanism for the failure mode that bit four times in one day — `check_rubric` and
 the SQL mirror each other's logic by hand and drift silently. Every one of those four was
@@ -259,12 +261,12 @@ fenced to those axes. Openness is excluded permanently: `data` is research-only 
 `core_gated` needs a pricing page.
 
 ```bash
-uv run python -m build.check_verification    # G1/G2 now cover ~400 more axes
+uv run python -m build.check_verification    # invariant and digests now cover ~400 more axes
 uv run python -m build.check_freshness       # coverage should jump
 ```
 
-**Exit criteria:** every axis it touched satisfies G1 and G2, and `check_freshness` reports
-them as `verified` rather than `commit`.
+**Exit criteria:** every axis it touched satisfies the invariant and the digest requirement,
+and `check_freshness` reports them as `verified` rather than `commit`.
 
 ---
 
@@ -307,9 +309,10 @@ would have earned for free.
 
 **On agent execution.** This is 1106 fetches and it is the step most exposed to
 rubber-stamping — an agent that "confirms" without reading would reproduce #108's failure at
-fifty times the scale while looking legitimate. Three things make that not work: G1 requires
-the `accessed` bump on every dimension, G2 requires a digest that only fetching produces, and
-G4 re-fetches a sample and compares. Do not relax any of the three to make a batch finish.
+fifty times the scale while looking legitimate. Three things make that not work: the invariant
+requires the `accessed` bump on every dimension, the digest requirement requires a digest that
+only fetching produces, and the sampled re-fetch goes back to the network for a sample and
+compares. Do not relax any of the three to make a batch finish.
 
 **Expect scores to move.** The RWKV correction in #105 came out of a pass like this. Movement
 is the return on the work, not a problem with it — `apply_scores --check` exits non-zero on a
@@ -327,14 +330,15 @@ moved score deliberately.
 uv run python -m build.check_freshness --max-age-days 90     # tune, then gate
 ```
 
-**G4 landed early**, in #148, because Phase 4 is the step it exists to police and running that
-without it would be the rubber-stamp risk with nothing underneath it. `build/check_refetch.py`
-re-fetches a sample and compares digests, weekly in `.github/workflows/refetch.yml`, reporting
-drift rather than hard failing since pages legitimately change. A digest that **matches** is
-the proof — one that differs proves nothing on its own.
+**The sampled re-fetch landed early**, in #148, because Phase 4 is the step it exists to police
+and running that without it would be the rubber-stamp risk with nothing underneath it.
+`build/check_refetch.py` re-fetches a sample and compares digests, weekly in
+`.github/workflows/refetch.yml`. It reports drift rather than hard failing, since pages
+legitimately change. A digest that **matches** is the proof — one that differs proves nothing on
+its own.
 
 What remains here: turn `--max-age-days` into a CI gate once coverage makes it fail on genuine
-staleness rather than on backlog, and drop the G2 exemption list.
+staleness rather than on backlog, and drop the digest requirement's exemption list.
 
 **Exit criteria:** the five definition-of-done conditions hold, and each is enforced by
 something that runs without being remembered.
@@ -347,10 +351,10 @@ Every one of these has happened. They are not hypotheticals.
 
 | hazard | tell | guard |
 |---|---|---|
-| Derived date sold as a confirmation | any aggregate of `accessed` reaching `last_verified` | `tests/test_apply_scores.py`; G1 validates, never derives |
+| Derived date sold as a confirmation | any aggregate of `accessed` reaching `last_verified` | `tests/test_apply_scores.py`; the invariant validates, never derives |
 | Stale warehouse read | identical query text returning a pre-materialization answer | the nonce helper (0.4) |
-| Unreleased revision | "my SQL change had no effect", no error | G6 (0.5) |
-| Repo/warehouse drift | local reproduces, warehouse abstains | G5 (Phase 2) |
+| Unreleased revision | "my SQL change had no effect", no error | the release assertion (0.5) |
+| Repo/warehouse drift | local reproduces, warehouse abstains | the parity gate (Phase 2) |
 | Folded-scalar corruption | a components value with a key spliced mid-string | `build/components.py` (0.2) |
 | Partial coverage overstating openness | most-restrictive over a subset of SKUs | already in the SQL: `skus_mapped = skus_reachable AND tiers_seen <= 1` |
 | Bot-owned files in a PR | `generated-files-guard` fails | edit `sources/` only; the bot regenerates on merge |

--- a/sources/categories/benchmark_eval_data.yaml
+++ b/sources/categories/benchmark_eval_data.yaml
@@ -31,8 +31,8 @@ scoring_recipe:
 
     A tenth, `gpqa`, was corrected rather than deferred: it recorded 4/gated, a pair no rung
     produces, and the ladder's answer of 3 is what the other nine gated corpora on the map
-    already carry. G3 caught it, which is what G3 is for - the pair was unfalsifiable until a
-    ladder existed to falsify it.
+    already carry. The producible-pair check caught it, which is what that check is for - the
+    pair was unfalsifiable until a ladder existed to falsify it.
 
   extends: dataset
   deferred:

--- a/tests/test_check_refetch.py
+++ b/tests/test_check_refetch.py
@@ -1,15 +1,17 @@
-"""Tests for G4, the sampled re-fetch.
+"""Tests for the sampled re-fetch.
 
 The two that matter are `test_reused_digest_across_urls_is_fabrication` and
 `test_rate_limit_is_not_reported_dead`.
 
-The first is the gate's whole reason to exist: G1 and G2 read what the writer wrote, so the
-only thing that catches an invented digest is noticing it could not have come from a body.
-Two URLs sharing sixty-four characters is the cheapest form of that.
+The first is the gate's whole reason to exist: the invariant and the digest requirement read
+what the writer wrote, so the only thing that catches an invented digest is noticing it could
+not have come from a body. Two URLs sharing sixty-four characters is the cheapest form of
+that.
 
-The second pins a bug the first real run produced. G4 reported a live Mastra LICENSE as dead
-because GitHub answered 429, and a gate that reports rate limiting as a dead source is a gate
-people learn to ignore. Transient statuses must stay out of the findings bucket.
+The second pins a bug the first real run produced. The sampled re-fetch reported a live
+Mastra LICENSE as dead because GitHub answered 429, and a gate that reports rate limiting as
+a dead source is a gate people learn to ignore. Transient statuses must stay out of the
+findings bucket.
 """
 
 import hashlib

--- a/tests/test_check_verification.py
+++ b/tests/test_check_verification.py
@@ -1,9 +1,10 @@
-"""Tests for G1, G2 and G3.
+"""Tests for invariant, digests and producible-pairs.
 
-The one that matters most is `test_g1_fails_when_one_dimension_is_stale`. G1's aggregation
-direction is load-bearing — it is over EVERY recorded dimension, so the binding constraint
-is the least recently re-read one — and the tempting simplification to `max(accessed)` would
-pass exactly that fixture. The failure mode has shipped twice (#108, #115), so it is pinned.
+The one that matters most is `test_invariant_fails_when_one_dimension_is_stale`. The
+invariant's aggregation direction is load-bearing — it is over EVERY recorded dimension, so
+the binding constraint is the least recently re-read one — and the tempting simplification
+to `max(accessed)` would pass exactly that fixture. The failure mode has shipped twice
+(#108, #115), so it is pinned.
 """
 
 import pytest
@@ -11,11 +12,11 @@ import yaml
 
 from build.check_verification import (
     DIGEST_EXEMPT,
-    g1_invariant,
-    g2_digests,
-    g3_producible,
+    digests,
+    invariant,
     producible_pairs,
     recorded_dimensions,
+    rule_outcomes,
 )
 
 RECIPE = {
@@ -91,25 +92,25 @@ def test_a_dimension_answered_under_a_reads_alias_keeps_the_alias():
     assert found["data"] == "post-training-data"
 
 
-# --- G1 ---
+# --- the invariant ---
 
-def test_g1_passes_when_every_dimension_has_a_fresh_establishing_source():
+def test_invariant_passes_when_every_dimension_has_a_fresh_establishing_source():
     scores = _score(last_verified="2026-07-30", sources=FULL)
-    assert g1_invariant(scores, CATEGORIES, RECIPES, {}) == []
+    assert invariant(scores, CATEGORIES, RECIPES, {}) == []
 
 
-def test_g1_ignores_an_axis_with_no_date():
+def test_invariant_ignores_an_axis_with_no_date():
     """The ratchet: an axis claiming nothing is not asked to prove anything."""
-    assert g1_invariant(_score(sources=[_src("https://a", "2020-01-01")]), CATEGORIES, RECIPES, {}) == []
+    assert invariant(_score(sources=[_src("https://a", "2020-01-01")]), CATEGORIES, RECIPES, {}) == []
 
 
-def test_g1_fails_when_a_dimension_has_no_establishing_source():
+def test_invariant_fails_when_a_dimension_has_no_establishing_source():
     scores = _score(last_verified="2026-07-30", sources=FULL[:2])  # code unattributed
-    problems = g1_invariant(scores, CATEGORIES, RECIPES, {})
+    problems = invariant(scores, CATEGORIES, RECIPES, {})
     assert any("records 'code'" in p and "no source claims to establish it" in p for p in problems)
 
 
-def test_g1_fails_when_one_dimension_is_stale():
+def test_invariant_fails_when_one_dimension_is_stale():
     """The aggregation direction. Three dimensions re-read today, one last seen in June: a
     `max(accessed)` check passes this, and the invariant must not."""
     scores = _score(
@@ -120,93 +121,93 @@ def test_g1_fails_when_one_dimension_is_stale():
             _src("https://c", "2026-06-01", ["code"]),
         ],
     )
-    problems = g1_invariant(scores, CATEGORIES, RECIPES, {})
+    problems = invariant(scores, CATEGORIES, RECIPES, {})
     assert len(problems) == 1
     assert "records 'code'" in problems[0]
     assert "only established by a source last read 2026-06-01" in problems[0]
 
 
-def test_g1_fails_when_no_source_was_read_on_or_after_the_claimed_date():
+def test_invariant_fails_when_no_source_was_read_on_or_after_the_claimed_date():
     scores = _score(
         last_verified="2026-07-30",
         sources=[_src("https://a", "2026-06-01", ["weights", "data", "code", "license"])],
     )
-    problems = g1_invariant(scores, CATEGORIES, RECIPES, {})
+    problems = invariant(scores, CATEGORIES, RECIPES, {})
     assert any("no source was accessed on or after that date" in p for p in problems)
 
 
-def test_g1_never_derives_a_date_it_only_validates_one():
+def test_invariant_never_derives_a_date_it_only_validates_one():
     """Guards against the #115 'simplification'. A fully-attributed axis with no
     `last_verified` must stay silent rather than acquiring one."""
     scores = _score(sources=FULL)
-    assert g1_invariant(scores, CATEGORIES, RECIPES, {}) == []
+    assert invariant(scores, CATEGORIES, RECIPES, {}) == []
     assert "last_verified" not in scores["m"]["openness"]
 
 
-def test_g1_floor_applies_to_adoption_where_there_are_no_dimensions():
+def test_invariant_floor_applies_to_adoption_where_there_are_no_dimensions():
     """Adoption records one banded value, so there is nothing to attribute among - but a
     confirmation still cannot rest on zero sources read on or after the date it claims."""
     scores = {"m": {"product": "m", "adoption": {"level": 4, "last_verified": "2026-07-30",
                                                 "sources": [_src("https://a", "2026-06-01")]}}}
-    assert any("no source was accessed on or after" in p for p in g1_invariant(scores, {}, {}, {}))
+    assert any("no source was accessed on or after" in p for p in invariant(scores, {}, {}, {}))
 
 
-def test_g1_accepts_adoption_with_one_fresh_source_and_no_attribution():
+def test_invariant_accepts_adoption_with_one_fresh_source_and_no_attribution():
     scores = {"m": {"product": "m", "adoption": {"level": 4, "last_verified": "2026-07-30",
                                                 "sources": [_src("https://a", "2026-07-30")]}}}
-    assert g1_invariant(scores, {}, {}, {}) == []
+    assert invariant(scores, {}, {}, {}) == []
 
 
-def test_g1_rejects_a_last_verified_that_is_not_a_date():
+def test_invariant_rejects_a_last_verified_that_is_not_a_date():
     scores = _score(last_verified="last week", sources=FULL)
-    assert any("is not a date" in p for p in g1_invariant(scores, CATEGORIES, RECIPES, {}))
+    assert any("is not a date" in p for p in invariant(scores, CATEGORIES, RECIPES, {}))
 
 
-def test_g1_falls_back_to_the_floor_for_a_category_with_no_recipe():
+def test_invariant_falls_back_to_the_floor_for_a_category_with_no_recipe():
     """Four categories have no recipe yet, so there is no declared vocabulary to check
     against. The gate degrades to the floor rather than passing vacuously or erroring."""
     scores = _score(last_verified="2026-07-30", sources=[_src("https://a", "2026-06-01")])
-    assert any("no source was accessed on or after" in p for p in g1_invariant(scores, {}, {}, {}))
+    assert any("no source was accessed on or after" in p for p in invariant(scores, {}, {}, {}))
 
 
-# --- G2 ---
+# --- the digest requirement ---
 
-def test_g2_passes_when_every_fresh_source_records_a_fetch():
-    assert g2_digests(_score(last_verified="2026-07-30", sources=FULL)) == []
+def test_digests_passes_when_every_fresh_source_records_a_fetch():
+    assert digests(_score(last_verified="2026-07-30", sources=FULL)) == []
 
 
-def test_g2_fails_on_a_missing_digest():
+def test_digests_fails_on_a_missing_digest():
     scores = _score(
         last_verified="2026-07-30",
         sources=[_src("https://a", "2026-07-30", ["weights"], fetched=False)],
     )
-    problems = g2_digests(scores)
+    problems = digests(scores)
     assert any("no http_status and no content_sha256" in p for p in problems)
 
 
-def test_g2_ignores_sources_read_before_the_claimed_date():
+def test_digests_ignores_sources_read_before_the_claimed_date():
     """Those were not part of this confirmation, so they are out of scope. Otherwise every
     new date would demand re-fetching evidence it never relied on."""
     scores = _score(
         last_verified="2026-07-30",
         sources=FULL + [_src("https://old", "2026-01-01", fetched=False)],
     )
-    assert g2_digests(scores) == []
+    assert digests(scores) == []
 
 
-def test_g2_reports_a_stale_exemption(monkeypatch):
+def test_digests_reports_a_stale_exemption(monkeypatch):
     monkeypatch.setitem(DIGEST_EXEMPT, "ghost:openness", "pre-runbook date")
-    problems = g2_digests(_score(last_verified="2026-07-30", sources=FULL))
+    problems = digests(_score(last_verified="2026-07-30", sources=FULL))
     assert any("Drop the exemption" in p for p in problems)
 
 
-def test_g2_honors_a_live_exemption(monkeypatch):
+def test_digests_honors_a_live_exemption(monkeypatch):
     monkeypatch.setitem(DIGEST_EXEMPT, "m:openness", "pre-runbook date")
     scores = _score(
         last_verified="2026-07-30",
         sources=[_src("https://a", "2026-07-30", ["weights"], fetched=False)],
     )
-    assert g2_digests(scores) == []
+    assert digests(scores) == []
 
 
 def test_the_shipped_exemption_list_is_empty():
@@ -215,55 +216,55 @@ def test_the_shipped_exemption_list_is_empty():
     assert DIGEST_EXEMPT == {}
 
 
-# --- G3 ---
+# --- the producible-pair check ---
 
-def test_producible_pairs_reads_then_and_otherwise():
+def test_rule_outcomes_reads_then_and_otherwise():
     recipe = {"openness": {"formula": [
         {"when": {"a": "b"}, "then": {"score": 2, "class": "source_available"}},
         {"otherwise": {"score": 1, "class": "closed"}},
     ]}}
-    assert producible_pairs(recipe) == {(2, "source_available"), (1, "closed")}
+    assert rule_outcomes(recipe) == {(2, "source_available"), (1, "closed")}
 
 
-def test_g3_passes_on_a_producible_pair():
-    assert g3_producible(_score(), CATEGORIES, RECIPES, {}) == []
+def test_producible_pairs_passes_on_a_producible_pair():
+    assert producible_pairs(_score(), CATEGORIES, RECIPES, {}) == []
 
 
-def test_g3_fails_on_a_class_no_rule_pairs_with_that_score():
+def test_producible_pairs_fails_on_a_class_no_rule_pairs_with_that_score():
     """`4/open_source` in software: 4 exists and `open_source` exists, never together."""
     scores = _score(score=1, **{"class": "open_source"})
-    problems = g3_producible(scores, CATEGORIES, RECIPES, {})
+    problems = producible_pairs(scores, CATEGORIES, RECIPES, {})
     assert any("1/open_source is not an outcome" in p for p in problems)
 
 
-def test_g3_fails_on_a_score_no_rule_emits():
+def test_producible_pairs_fails_on_a_score_no_rule_emits():
     """The software ladder's rungs are 1, 2, 4, 5. A software product scored 3 is impossible
     by construction, however plausible the class looks beside it."""
     scores = _score(score=3, **{"class": "open_source"})
-    assert any("3/open_source is not an outcome" in p for p in g3_producible(scores, CATEGORIES, RECIPES, {}))
+    assert any("3/open_source is not an outcome" in p for p in producible_pairs(scores, CATEGORIES, RECIPES, {}))
 
 
-def test_g3_ignores_an_unscored_product():
-    assert g3_producible(_score(score=None), CATEGORIES, RECIPES, {}) == []
+def test_producible_pairs_ignores_an_unscored_product():
+    assert producible_pairs(_score(score=None), CATEGORIES, RECIPES, {}) == []
 
 
-def test_g3_is_not_escapable_by_deferring_the_product():
-    """`check_rubric` excludes a deferred product from reproduction. G3 must not, or a
-    category could defer its way out of an impossible pair - which is how `4/open_source`
-    survived a checker that reported 33/33."""
+def test_producible_pairs_is_not_escapable_by_deferring_the_product():
+    """`check_rubric` excludes a deferred product from reproduction. Producible-pairs must
+    not, or a category could defer its way out of an impossible pair - which is how
+    `4/open_source` survived a checker that reported 33/33."""
     categories = {"models": dict(CATEGORIES["models"])}
     recipes = {"models": {"*": dict(RECIPE, deferred={"m": {"because": "needs a human, at length"}})}}
     scores = _score(score=3, **{"class": "open_source"})
-    assert g3_producible(scores, categories, recipes, {})
+    assert producible_pairs(scores, categories, recipes, {})
 
 
-def test_g3_checks_a_mixed_category_product_against_its_own_ladder_not_the_union():
-    """G1, `check_rubric` and `serialize_rubric` all select per product with `recipe_for`.
-    G3 used to test each recorded pair against the UNION of every variant in the
-    category instead, so a software product recording a pair only the model ladder can
-    emit would have passed - even though the software ladder, the one that actually
-    governs it, cannot produce that pair. That is exactly the class of failure this gate
-    exists to catch (see the module docstring's `4/open_source` story), so the union was
+def test_producible_pairs_checks_a_mixed_category_product_against_its_own_ladder_not_the_union():
+    """The invariant, `check_rubric` and `serialize_rubric` all select per product with
+    `recipe_for`. Producible-pairs used to test each recorded pair against the UNION of
+    every variant in the category instead, so a software product recording a pair only the
+    model ladder can emit would have passed - even though the software ladder, the one that
+    actually governs it, cannot produce that pair. That is exactly the class of failure this
+    gate exists to catch (see the module docstring's `4/open_source` story), so the union was
     the one place the escape hatch stayed open.
     """
     model_recipe = {"openness": {"formula": [
@@ -281,10 +282,10 @@ def test_g3_checks_a_mixed_category_product_against_its_own_ladder_not_the_union
 
     # The union of both ladders WOULD have admitted this pair (the model ladder emits
     # it), which is why the old implementation passed it.
-    union_pairs = producible_pairs(model_recipe) | producible_pairs(software_recipe)
+    union_pairs = rule_outcomes(model_recipe) | rule_outcomes(software_recipe)
     assert (3, "open_weights") in union_pairs
 
-    problems = g3_producible(scores, categories, recipes, product_types)
+    problems = producible_pairs(scores, categories, recipes, product_types)
     assert any("3/open_weights is not an outcome" in p for p in problems)
 
 
@@ -296,15 +297,15 @@ def test_the_repo_passes_all_three_gates():
 
     scores, categories, recipes = load()
     product_types = load_product_types(ROOT)
-    assert g1_invariant(scores, categories, recipes, product_types) == []
-    assert g2_digests(scores) == []
-    assert g3_producible(scores, categories, recipes, product_types) == []
+    assert invariant(scores, categories, recipes, product_types) == []
+    assert digests(scores) == []
+    assert producible_pairs(scores, categories, recipes, product_types) == []
 
 
 @pytest.mark.parametrize("axis", ["openness", "adoption", "capability"])
 def test_every_dated_axis_in_the_repo_carries_establishing_evidence(axis):
-    """Restates G1's scope as data rather than logic: whatever carries a date must be
-    covered, so a new date cannot land without the gate having an opinion about it."""
+    """Restates the invariant's scope as data rather than logic: whatever carries a date must
+    be covered, so a new date cannot land without the gate having an opinion about it."""
     from build.check_verification import ROOT
 
     for path in sorted((ROOT / "sources" / "scores").glob("*.yaml")):

--- a/tests/test_openness_buckets.py
+++ b/tests/test_openness_buckets.py
@@ -50,8 +50,9 @@ OPEN_BY_EXTERNAL_STANDARD = {"osi", "open_data"}
 # available above `gated`. So a corpus whose license defers to per-subset terms has nowhere to
 # land but `open`, and `open` is in the open bucket. `the-pile` (3/open, mixed-per-subset,
 # Books3 withdrawn) and `stack-edu` (4/open, defers to The Stack v2's gated terms) are the two
-# products, and the ladder emits these pairs only because the recorded scores do - G3 requires
-# a recorded pair be producible.
+# products, and the ladder emits these pairs only because the recorded scores do. The
+# producible-pair check requires that some rule in the recipe be able to emit every recorded
+# pair.
 #
 # The bucket count does not depend on the ladder: build/serialize.py buckets the RECORDED
 # class, so both products already counted as open before any recipe existed. All 52 dataset

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -656,8 +656,8 @@ def test_real_sources_serialize_without_errors():
                 "orchestration_agents", "telemetry_observability", "ui_api"]
     # Two DATASET categories inherit sources/rubrics/dataset.yaml, so both serialize the
     # same 22 rules. Each of the four ladders gained exactly one rung with the universal
-    # license scale, which split one tier in two - a bounded commercial licence at 3, and a
-    # licence forbidding commerce outright at 2.
+    # license scale, which split one tier in two - a bounded commercial license at 3, and a
+    # license forbidding commerce outright at 2.
     #
     # Formerly 21: 3 not-published rungs, 2 held-out-answer rungs, 6 gate rungs and 5
     # license/documentation rungs, all single-condition except the last 5.
@@ -680,11 +680,11 @@ def test_real_sources_serialize_without_errors():
     # tier the vendor sells, so 25 products left the roster and the closed frontier
     # models moved from base_pretrained to finetuned_chat.
     #
-    # Eight software categories then rose by 1-3 rows when the G3 score corrections landed:
-    # fixing an impossible score/class pair means recording the dimension that decides it, so
-    # products that had described their gating in prose gained a readable `source:` or
-    # `core-gated:` key. The two model categories are untouched, which is what the pilot
-    # counts are pinned to catch.
+    # Eight software categories then rose by 1-3 rows when the score corrections from the
+    # producible-pair check landed: fixing an impossible score/class pair means recording the
+    # dimension that decides it, so products that had described their gating in prose gained a
+    # readable `source:` or `core-gated:` key. The two model categories are untouched, which
+    # is what the pilot counts are pinned to catch.
     # `safeguards` is back at 90 rows. It had disappeared from this dict entirely when all
     # 26 of its products were deferred; 17 now reproduce, because sixteen of them were
     # recording the deciding evidence under keys the ladders do not read rather than


### PR DESCRIPTION
Supersedes #150, which GitHub closed when #149's branch was deleted on merge. Same commit, replayed onto `main`.

`G1`–`G6` work fine sitting next to their own definitions. The problem is where the number travelled away from the table and a reader has nothing to resolve it against:

- `sources/categories/benchmark_eval_data.yaml` — "G3 caught it, which is what G3 is for", in a category note an external contributor reads when tracing why a product was deferred.
- `docs/guides/product-info.md` — "gated (G1/G2)", in a prose style guide that never mentions gates otherwise.
- `--gate {g1,g2,g3}` — a flag whose values you have to go look up before you can run one check.

A numbered handle works when the number is always resolvable, which is true inside one spec document and false the moment it leaves. So: names that carry their own meaning.

| was | prose | code / CLI |
|---|---|---|
| G1 | the invariant | `invariant` |
| G2 | the digest requirement | `digests` |
| G3 | the producible-pair check | `producible_pairs`, `--gate producible-pairs` |
| G4 | the sampled re-fetch | `refetch` |
| G5 | the parity gate | `parity` |
| G6 | the release assertion | `release` |

Applied everywhere: docs, module docstrings, function names, `GATES` keys and CLI values, CI step names, test names, and that category note. The gate table in `verification.md` keeps one line recording the old numbering, because older PRs and commit messages still use it — #148's squash commit says G4 permanently and history stays as it is.

## Two things found while renaming

**A name collision that broke CI.** `check_verification` had an unrelated helper already called `producible_pairs(recipe)`. The gate took that name and the helper became `rule_outcomes` — but `build/check_recipe.py` imports it, so the surviving one-arg call bound the four-arg gate and died with a `TypeError`. Caught by the verification pass, not by review; `validate.yml` runs that command, so the branch was red until it was fixed.

**The parity row said "network, daily".** The cron is `0 6 * * 1` — Monday only — and `parity.yml`'s own comment says "this schedule is why the gate is weekly rather than daily". The wrong cell sat twelve lines above a paragraph arguing that a daily gate over a weekly chain is exactly how a gate earns its way into being ignored. `verification-pass.md` repeated it. Both corrected.

## Prose

The passages the rename touched got a pass for readability at the same time, since a lot of people read this repo: `scepticism` → `skepticism`, `catalogues` → `catalogs`, semicolons split into periods where the house style prefers them, and one plural that had lost its subject ("The gate therefore covers…" after the subject became two gates). No rule, threshold, count or date was changed — with one exception, called out below.

One meaning change was caught and reverted before commit: "the sampled re-fetch checks a sample against the recorded digests" had quietly dropped the network fetch, which is the entire point of that gate and sits in the normative paragraph that says not to relax any of the three. It now reads "goes back to the network for a sample and compares".

## Test plan

- `build.validate` → `0 error(s)`
- `build.check_verification --verbose` → all three `[OK]`, columns aligned on the longest name
- `--gate invariant` / `--gate digests` / `--gate producible-pairs` → each runs alone; `--gate g3` is now rejected
- `build.check_recipe` → `0 failure(s)`
- `pytest tests/ -q` → 337 passed
- `.github/workflows/*.yml` all parse
- Repo-wide sweep for `\bG[1-6]\b` → only the retirement note. The remaining hits are Glean's Gartner/G2 rating, Mali-G610 part numbers, and generated files.
