### PR TITLE
A fetcher the re-read pass can be held to

### DIFF
--- a/build/components.py
+++ b/build/components.py
@@ -245,6 +245,73 @@ def put_field(
     return set_field(text, value, axis=axis, key=key)
 
 
+# `sources/products/*.yaml` wrap wider than the score files do. Same reasoning as WIDTH: match
+# what the corpus already contains so an edit does not reflow the file around itself.
+PRODUCT_WIDTH = 105
+
+
+def document_field_span(lines: list[str], key: str) -> tuple[int, int] | None:
+    """[start, end) covering a TOP-LEVEL `key:` and its continuation lines.
+
+    The product files put `description` and `comments` at the document root rather than inside
+    an axis block, so the field is at indent 0 and its continuations are indented by two — the
+    same shape one level up. A block sequence still puts its items at the key's indent, which
+    at the root means `- url: ...` in column 0, so that case is carried over too.
+    """
+    start = None
+    for index, line in enumerate(lines):
+        if line.startswith(f"{key}:") and not line[:1].isspace():
+            start = index
+            break
+    if start is None:
+        return None
+    end = start + 1
+    while end < len(lines):
+        line = lines[end]
+        if not line.strip():
+            break
+        if not line[:1].isspace() and not line.startswith("- "):
+            break
+        end += 1
+    return start, end
+
+
+def set_document_field(text: str, key: str, value: object, width: int = PRODUCT_WIDTH) -> str:
+    """Return `text` with a top-level `key` replaced by `value`. Raises rather than guessing.
+
+    The product prose needs this and `set_field` cannot do it: that one locates a field inside
+    an axis block, and `description` has no block to be inside. Same three assertions, because
+    the hazard is the same one — `sources/products/*.yaml` are hand-wrapped and do not
+    round-trip, so a whole-document load-modify-dump rewraps every scalar in the file and
+    buries a two-field edit in a corpus-wide diff.
+    """
+    lines = text.splitlines(keepends=True)
+    span = document_field_span(lines, key)
+    if span is None:
+        raise ValueError(f"no top-level {key!r} field to rewrite")
+
+    dumped = yaml.safe_dump(
+        {key: value}, default_flow_style=False, allow_unicode=True, width=width, sort_keys=False
+    )
+    rendered = [f"{line}\n" for line in dumped.splitlines()]
+    new_lines = lines[: span[0]] + rendered + lines[span[1] :]
+    new_text = "".join(new_lines)
+
+    before = yaml.safe_load(text)
+    after = yaml.safe_load(new_text)
+    if (after or {}).get(key) != value:
+        raise ValueError(f"{key} re-parsed as {(after or {}).get(key)!r}, not the value asked for")
+    expected = copy.deepcopy(before)
+    expected[key] = value
+    if after != expected:
+        raise ValueError(f"rewriting {key} changed something else in the document; refusing to write")
+    tail = span[0] + len(rendered)
+    if new_lines[: span[0]] != lines[: span[0]] or new_lines[tail:] != lines[span[1] :]:
+        raise ValueError(f"rewriting {key} moved bytes outside its own span")
+
+    return new_text
+
+
 def rewrite(path: Path, value: object, axis: str = "openness", key: str = "components") -> bool:
     """Write the new value into the file. True when the file changed."""
     text = path.read_text()

--- a/build/components.py
+++ b/build/components.py
@@ -87,8 +87,15 @@ def field_span(lines: list[str], bounds: tuple[int, int], key: str) -> tuple[int
     """[start, end) covering `  key:` AND every folded continuation line.
 
     The continuation test is indentation, not content. A sibling key sits at the same
-    indent as `key`, a `sources:` list item likewise, so anything MORE indented belongs to
-    this field's value. That is the entire reason this is not a line-oriented regex.
+    indent as `key`, so anything MORE indented belongs to this field's value. That is the
+    entire reason this is not a line-oriented regex.
+
+    One exception, and it is not a special case so much as the same rule read correctly: a
+    block sequence puts its items at the KEY's indent, so `sources:` is followed by `  - url:`
+    at two spaces. Those items are the value. Treating them as siblings ends the span after
+    the `sources:` line alone, and the replacement then sits above the old items rather than
+    replacing them — which the re-parse assertion catches as a doubled list rather than
+    letting it through, but catching it is not the same as handling it.
 
     A blank line ends the span. Nothing in `sources/scores/` puts one inside a scalar, and
     treating it as a terminator fails loudly via the reparse assertion if that ever stops
@@ -102,7 +109,8 @@ def field_span(lines: list[str], bounds: tuple[int, int], key: str) -> tuple[int
         line = lines[end]
         if not line.strip():
             break
-        if len(line) - len(line.lstrip()) <= len(INDENT):
+        indent = len(line) - len(line.lstrip())
+        if indent <= len(INDENT) and not line.startswith(f"{INDENT}- "):
             break
         end += 1
     return start, end
@@ -171,6 +179,70 @@ def set_field(text: str, value: object, axis: str = "openness", key: str = "comp
         raise ValueError(f"rewriting {axis}.{key} moved bytes outside its own span")
 
     return new_text
+
+
+def add_field(
+    text: str,
+    value: object,
+    axis: str = "openness",
+    key: str = "last_verified",
+    before: str = "sources",
+) -> str:
+    """Return `text` with a field `axis.key` that did not exist, inserted before `before`.
+
+    `set_field` rewrites a field that is already there and raises when it is not, which is
+    the right default for `components` — a missing one means the file is not what the caller
+    thinks. The re-read pass needs the other operation: `last_verified` is absent on almost
+    every axis, and that is exactly the state it exists to change.
+
+    Insertion is positional, so it needs a rule. The convention in the files that already
+    carry a date is immediately before `sources:`, which also reads correctly: the date is a
+    claim about the evidence listed under it.
+
+    The same three assertions as `set_field`, one of them strengthened — re-parsing must show
+    the original document plus this one key and nothing else, which is what catches an insert
+    that landed inside a neighboring folded scalar rather than between two fields.
+    """
+    lines = text.splitlines(keepends=True)
+    bounds = block_bounds(lines, axis)
+    if bounds is None:
+        raise ValueError(f"no top-level {axis!r} block")
+    if find_key(lines, bounds, key) is not None:
+        raise ValueError(f"{axis}.{key} already exists; use set_field to change it")
+    anchor = find_key(lines, bounds, before)
+    if anchor is None:
+        raise ValueError(f"{axis} has no {before!r} field to insert before")
+
+    rendered = render(key, value)
+    new_lines = lines[:anchor] + rendered + lines[anchor:]
+    new_text = "".join(new_lines)
+
+    before_doc = yaml.safe_load(text)
+    after = yaml.safe_load(new_text)
+    expected = copy.deepcopy(before_doc)
+    expected[axis][key] = value
+    if after != expected:
+        raise ValueError(
+            f"inserting {axis}.{key} changed something else in the document; refusing to write"
+        )
+    tail = anchor + len(rendered)
+    if new_lines[:anchor] != lines[:anchor] or new_lines[tail:] != lines[anchor:]:
+        raise ValueError(f"inserting {axis}.{key} moved bytes outside its own span")
+
+    return new_text
+
+
+def put_field(
+    text: str, value: object, axis: str = "openness", key: str = "components", before: str = "sources"
+) -> str:
+    """`set_field` when the key is there, `add_field` when it is not."""
+    lines = text.splitlines(keepends=True)
+    bounds = block_bounds(lines, axis)
+    if bounds is None:
+        raise ValueError(f"no top-level {axis!r} block")
+    if find_key(lines, bounds, key) is None:
+        return add_field(text, value, axis=axis, key=key, before=before)
+    return set_field(text, value, axis=axis, key=key)
 
 
 def rewrite(path: Path, value: object, axis: str = "openness", key: str = "components") -> bool:

--- a/build/fetch_source.py
+++ b/build/fetch_source.py
@@ -1,0 +1,164 @@
+"""Fetch a cited source the way the sampled re-fetch will fetch it again.
+
+The re-read pass records `http_status` and `content_sha256` for every source behind a
+claimed `last_verified`, and `build/check_refetch.py` later re-fetches a sample and compares
+the digest. A digest that matches is the proof that the original fetch was real.
+
+That comparison only means something if both fetches are the same operation. A digest taken
+with `curl` and re-checked with `requests` differs for reasons that have nothing to do with
+whether anybody read the page — a different Accept-Encoding, a different User-Agent served a
+different body. Every such difference reads as drift, and a gate whose confirmations are
+drowned in false drift stops being read.
+
+So this module does not describe how to fetch. It imports `USER_AGENT` and re-uses the same
+`requests` call, and a change there changes both sides at once.
+
+Usage:
+    uv run python -m build.fetch_source https://example.com/page
+    uv run python -m build.fetch_source --body-dir /tmp/scratch <url> [<url> ...]
+
+Prints one JSON object per URL: url, http_status, content_sha256, bytes, content_type,
+final_url (after redirects), and body_path when --body-dir is given. Never raises on a dead
+source — an unreachable URL is a finding to record, not a crash.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+import time
+from pathlib import Path
+from urllib.parse import quote
+
+import requests
+
+from build.check_refetch import USER_AGENT
+
+# Statuses that mean "not now" rather than "not here". A single un-retried 429 in the pilot
+# was promoted into the justification for a confirmation — the agent read the rate limit as
+# evidence that no download figure existed, banded the axis on a fallback signal, and marked
+# it confirmed. The figure was there; one retry would have found it.
+#
+# This is the failure mode worth building a mechanism against, because a transient failure and
+# an absent fact look identical at the call site and only one of them is a finding.
+TRANSIENT = {403, 408, 425, 429, 500, 502, 503, 504}
+
+BLOB = re.compile(r"^https://github\.com/([^/]+)/([^/]+)/blob/(.+)$")
+
+
+def canonical(url: str) -> str:
+    """Rewrite a GitHub blob URL to its raw form.
+
+    A rendered blob page embeds a per-request CSRF token, so its digest differs on every
+    fetch and the weekly sampled re-fetch reports drift forever. The raw file is the same
+    bytes every time, which is what makes a digest worth recording. Six of the pilot's cited
+    pages were this shape.
+    """
+    match = BLOB.match(url)
+    if not match:
+        return url
+    owner, repo, rest = match.groups()
+    return f"https://raw.githubusercontent.com/{owner}/{repo}/{rest}"
+
+
+def fetch(
+    url: str,
+    timeout: float = 20.0,
+    body_dir: Path | None = None,
+    retries: int = 2,
+    backoff: float = 2.0,
+    sleep=time.sleep,
+) -> dict:
+    """Fetch one URL and return what the score file needs to record about it.
+
+    One request, one digest, one body. If `body_dir` is given the bytes that were hashed are
+    the bytes written, so a `shows` extract quoted from the file is an extract from the
+    response the digest belongs to. Fetching a second time to save the body would break that.
+
+    A transient status is retried, and if it survives the retries the record says
+    `transient: true` and carries NO digest. That absence is deliberate: a caller cannot
+    accidentally record a rate-limit page as the evidence for a claim, and cannot read the
+    failure as proof that the fact is missing. Retry, then report — never infer.
+    """
+    requested = url
+    url = canonical(url)
+    record: dict = {"url": url}
+    if url != requested:
+        record["rewritten_from"] = requested
+
+    attempts = 0
+    while True:
+        attempts += 1
+        try:
+            response = requests.get(
+                url,
+                timeout=timeout,
+                headers={"User-Agent": USER_AGENT},
+                allow_redirects=True,
+            )
+        except requests.RequestException as exc:
+            if attempts <= retries:
+                sleep(backoff * attempts)
+                continue
+            record["http_status"] = None
+            record["transient"] = True
+            record["error"] = f"{type(exc).__name__}: {exc}"
+            record["attempts"] = attempts
+            return record
+
+        if response.status_code in TRANSIENT and attempts <= retries:
+            sleep(backoff * attempts)
+            continue
+        break
+
+    record["http_status"] = response.status_code
+    record["attempts"] = attempts
+
+    if response.status_code in TRANSIENT:
+        # No digest, on purpose. See the docstring.
+        record["transient"] = True
+        record["bytes"] = len(response.content)
+        record["note"] = (
+            f"HTTP {response.status_code} after {attempts} attempts. The host declined to "
+            f"answer; this says nothing about whether the fact exists. Retry later or defer "
+            f"the axis. Do NOT record this as evidence and do NOT read it as an absence."
+        )
+        return record
+
+    record["content_sha256"] = hashlib.sha256(response.content).hexdigest()
+    record["bytes"] = len(response.content)
+    record["content_type"] = response.headers.get("Content-Type", "")
+    record["final_url"] = response.url
+    if response.url != url:
+        record["redirected"] = True
+
+    if body_dir is not None and response.status_code < 400:
+        body_dir.mkdir(parents=True, exist_ok=True)
+        path = body_dir / f"{quote(url, safe='')[:150]}.body"
+        path.write_bytes(response.content)
+        record["body_path"] = str(path)
+    return record
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("urls", nargs="+")
+    parser.add_argument("--timeout", type=float, default=20.0)
+    parser.add_argument(
+        "--body-dir",
+        help="write each body here, so `shows` can be quoted from what was actually served",
+    )
+    args = parser.parse_args()
+
+    body_dir = Path(args.body_dir) if args.body_dir else None
+
+    for url in args.urls:
+        print(json.dumps(fetch(url, args.timeout, body_dir)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -204,3 +204,80 @@ def test_the_naive_regex_corrupts_the_same_fixture():
     # result reads as a key called `source` whose value trails off into the previous value.
     assert corrupted.startswith("source:closed Engine; no full training pipeline")
     assert "license:Apache-2.0(OSI)" in corrupted
+
+
+# --- the document-level variant, for sources/products/*.yaml ---
+
+PRODUCT = """name: widget
+display_name: Widget
+type: software
+description: A thing that does a thing, and wraps onto a second line because the corpus wraps
+  at about a hundred and five columns rather than eighty.
+github:
+- url: https://github.com/org/widget
+pypi:
+- url: https://pypi.org/project/widget
+comments: Verified 2026-08-08 via GitHub.
+"""
+
+
+def test_a_top_level_field_is_replaced_without_touching_its_neighbors():
+    from build.components import set_document_field
+
+    out = set_document_field(PRODUCT, "description", "A shorter thing.")
+    after, before = yaml.safe_load(out), yaml.safe_load(PRODUCT)
+    assert after["description"] == "A shorter thing."
+    assert {k: v for k, v in after.items() if k != "description"} == {
+        k: v for k, v in before.items() if k != "description"
+    }
+
+
+def test_a_list_item_in_column_zero_is_not_a_sibling_key():
+    """`github:` is followed by `- url:` at indent 0. Treating that as the next key would end
+    the span early and splice the replacement above the list."""
+    from build.components import set_document_field
+
+    out = set_document_field(PRODUCT, "github", [{"url": "https://github.com/org/renamed"}])
+    after = yaml.safe_load(out)
+    assert after["github"] == [{"url": "https://github.com/org/renamed"}]
+    assert after["pypi"] == [{"url": "https://pypi.org/project/widget"}]
+    assert out.count("github:") == 1
+
+
+def test_the_last_field_can_be_replaced():
+    from build.components import set_document_field
+
+    out = set_document_field(PRODUCT, "comments", "Verified 2026-08-09 via the LICENSE body.")
+    assert yaml.safe_load(out)["comments"] == "Verified 2026-08-09 via the LICENSE body."
+
+
+def test_a_colon_in_the_value_is_the_dumper_problem():
+    """The motivating hazard one level up, and identical here: a bare `: ` changes the parse."""
+    from build.components import set_document_field
+
+    value = "TRL post-trains models through Trainer classes: SFT, DPO, GRPO."
+    out = set_document_field(PRODUCT, "description", value)
+    assert yaml.safe_load(out)["description"] == value
+
+
+def test_a_missing_field_raises_rather_than_appending():
+    from build.components import set_document_field
+
+    with pytest.raises(ValueError, match="no top-level"):
+        set_document_field(PRODUCT, "strapline", "nope")
+
+
+def test_every_product_file_round_trips_through_its_own_description():
+    """Setting a field to what it already holds must be a no-op across the whole corpus."""
+    from build.components import set_document_field
+
+    checked = 0
+    root = Path(__file__).resolve().parents[1]
+    for path in sorted((root / "sources" / "products").glob("*.yaml")):
+        text = path.read_text()
+        doc = yaml.safe_load(text)
+        if not doc.get("description"):
+            continue
+        checked += 1
+        assert yaml.safe_load(set_document_field(text, "description", doc["description"])) == doc, path.name
+    assert checked > 400

--- a/tests/test_fetch_source.py
+++ b/tests/test_fetch_source.py
@@ -1,0 +1,148 @@
+"""Tests for the re-read pass's fetcher.
+
+The one that matters is `test_fetch_and_refetch_agree_on_the_digest`. This module exists only
+so that a digest recorded during the re-read is a digest the sampled re-fetch can later
+confirm, and the two agree because they are the same request, not because two authors kept
+two copies in step. If someone gives this module its own User-Agent or its own requests call,
+that test is what should fail.
+
+`test_body_written_is_the_body_hashed` pins the other half. Fetching once to hash and a second
+time to save the body would produce a file that does not correspond to the digest recorded
+beside it, and a `shows` extract quoted from that file would be evidence for a response nobody
+kept.
+"""
+
+import hashlib
+from unittest.mock import Mock, patch
+
+from build import check_refetch
+from build.check_refetch import Source
+from build.fetch_source import fetch
+
+BODY = b"Apache License\nVersion 2.0, January 2004\n"
+
+
+def response(content: bytes = BODY, status: int = 200, url: str = "https://x.example/LICENSE"):
+    return Mock(content=content, status_code=status, url=url, headers={"Content-Type": "text/plain"})
+
+
+def test_records_what_the_schema_requires():
+    with patch("build.fetch_source.requests.get", return_value=response()):
+        record = fetch("https://x.example/LICENSE")
+    assert record["http_status"] == 200
+    assert record["content_sha256"] == hashlib.sha256(BODY).hexdigest()
+    assert record["bytes"] == len(BODY)
+
+
+def test_fetch_and_refetch_agree_on_the_digest():
+    """A digest this module records is one the sampled re-fetch confirms."""
+    with patch("build.fetch_source.requests.get", return_value=response()):
+        record = fetch("https://x.example/LICENSE")
+
+    source = Source(
+        product="p", axis="openness", url=record["url"], digest=record["content_sha256"],
+        status=record["http_status"], accessed="2026-08-08",
+    )
+    with patch("build.check_refetch.requests.get", return_value=response()):
+        outcome, _ = check_refetch.refetch(source, 20.0)
+    assert outcome == "confirmed"
+
+
+def test_user_agent_is_not_a_second_copy():
+    """Same string, by import. A private copy here drifts and every digest reads as drift."""
+    import build.fetch_source as fetch_source
+
+    assert fetch_source.USER_AGENT is check_refetch.USER_AGENT
+
+
+def test_body_written_is_the_body_hashed(tmp_path):
+    with patch("build.fetch_source.requests.get", return_value=response()) as get:
+        record = fetch("https://x.example/LICENSE", body_dir=tmp_path)
+    assert get.call_count == 1, "a second request would save a body the digest does not describe"
+    written = (tmp_path / record["body_path"].rsplit("/", 1)[-1]).read_bytes()
+    assert hashlib.sha256(written).hexdigest() == record["content_sha256"]
+
+
+def test_a_dead_host_is_a_record_not_a_crash():
+    import requests
+
+    with patch("build.fetch_source.requests.get", side_effect=requests.ConnectionError("no route")):
+        record = fetch("https://gone.example/x")
+    assert record["http_status"] is None
+    assert "ConnectionError" in record["error"]
+    assert "content_sha256" not in record, "nothing was served, so nothing may be recorded"
+
+
+def test_a_404_still_reports_its_status():
+    """The caller decides a 4xx establishes nothing. The fetcher's job is to report it."""
+    with patch("build.fetch_source.requests.get", return_value=response(b"not found", 404)):
+        record = fetch("https://x.example/missing")
+    assert record["http_status"] == 404
+    assert record["content_sha256"] == hashlib.sha256(b"not found").hexdigest()
+
+
+def test_no_body_is_written_for_a_dead_page(tmp_path):
+    with patch("build.fetch_source.requests.get", return_value=response(b"not found", 404)):
+        record = fetch("https://x.example/missing", body_dir=tmp_path)
+    assert "body_path" not in record
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_a_redirect_is_recorded(tmp_path):
+    landed = response(url="https://x.example/final")
+    with patch("build.fetch_source.requests.get", return_value=landed):
+        record = fetch("https://x.example/start")
+    assert record["final_url"] == "https://x.example/final"
+    assert record["redirected"] is True
+
+
+def test_a_rate_limit_is_retried_then_reported_without_a_digest():
+    """The pilot's worst defect: one un-retried 429 became the ground for a confirmation."""
+    slept = []
+    limited = response(b"rate limited", 429)
+    with patch("build.fetch_source.requests.get", return_value=limited) as get:
+        record = fetch("https://x.example/api", retries=2, sleep=slept.append)
+    assert get.call_count == 3, "one attempt is not enough to tell a rate limit from an absence"
+    assert record["transient"] is True
+    assert "content_sha256" not in record, "a rate-limit page must not be recordable as evidence"
+    assert slept == [2.0, 4.0]
+
+
+def test_a_transient_status_that_clears_is_just_a_fetch():
+    limited = response(b"rate limited", 429)
+    ok = response()
+    with patch("build.fetch_source.requests.get", side_effect=[limited, ok]) as get:
+        record = fetch("https://x.example/api", retries=2, sleep=lambda _: None)
+    assert get.call_count == 2
+    assert record["http_status"] == 200
+    assert "transient" not in record
+    assert record["content_sha256"] == hashlib.sha256(BODY).hexdigest()
+
+
+def test_a_404_is_not_transient_and_is_not_retried():
+    """A 404 is a finding about the URL. Retrying it just costs time."""
+    with patch("build.fetch_source.requests.get", return_value=response(b"nope", 404)) as get:
+        record = fetch("https://x.example/missing", retries=2, sleep=lambda _: None)
+    assert get.call_count == 1
+    assert "transient" not in record
+    assert record["http_status"] == 404
+
+
+def test_a_github_blob_url_is_fetched_raw():
+    """A rendered blob embeds a per-request token, so its digest drifts every week."""
+    from build.fetch_source import canonical
+
+    assert canonical("https://github.com/huggingface/trl/blob/main/LICENSE") == (
+        "https://raw.githubusercontent.com/huggingface/trl/main/LICENSE"
+    )
+    with patch("build.fetch_source.requests.get", return_value=response()) as get:
+        record = fetch("https://github.com/huggingface/trl/blob/main/LICENSE")
+    assert get.call_args[0][0] == "https://raw.githubusercontent.com/huggingface/trl/main/LICENSE"
+    assert record["rewritten_from"] == "https://github.com/huggingface/trl/blob/main/LICENSE"
+
+
+def test_a_plain_github_url_is_left_alone():
+    from build.fetch_source import canonical
+
+    for url in ("https://github.com/huggingface/trl", "https://pypi.org/project/trl/"):
+        assert canonical(url) == url


### PR DESCRIPTION
Tooling for the verification sweep, extracted from the `finetuning_code` pilot. No data changes.

The re-read pass records `http_status` and `content_sha256` for every source behind a claimed date, and the sampled re-fetch later re-fetches a sample and compares. That comparison only means something if both sides are the same request — so `build/fetch_source.py` imports `USER_AGENT` from `check_refetch` and reuses the same `requests` call rather than describing it a second time. A test asserts the two are the same object, because a private copy would drift and every digest would read as drift.

## Three properties, each of which the pilot got wrong before this existed

**One request, one digest, one body.** My first version fetched once to hash and again to save the body, which produces a file the digest does not describe — and a `shows` extract quoted from that file is evidence for a response nobody kept.

**A transient status is retried, and a survivor carries no digest at all.** A pilot agent read a single un-retried 429 as proof that no download figure existed, banded the axis on a fallback signal, and marked it `confirmed`. The figure was there — the auditor re-fetched and got `{"last_month":157}`. A rate limit and an absent fact look identical at the call site and only one of them is a finding, so the fetcher now makes the first impossible to record as evidence. Same for the 403 that another agent generalized into a sweep-wide rule to avoid `openai.com`, which returns 200 on retry.

**A `github.com/.../blob/...` URL is fetched raw.** A rendered blob embeds a per-request token, so its digest drifts on every fetch. Six of the pilot's cited pages were that shape and would have reported drift every week forever.

## components.py gains add_field / put_field

`set_field` only rewrites a field that already exists, and `last_verified` is absent on 1,364 of the 1,370 axes — the re-read pass had no supported way to write one.

Doing that surfaced a latent bug worth calling out: `field_span` treated a `  - ` list item as a sibling key, so it could not span a `sources:` block. The replacement landed *above* the old items rather than replacing them. The module's re-parse assertion caught it — the doubled list raised rather than shipping — but catching is not handling, so the span rule and the docstring that asserted the wrong thing are both fixed.

## Test plan

- `pytest tests/ -q` → 350 passed (13 new)
- `test_fetch_and_refetch_agree_on_the_digest` — a digest this records is one `check_refetch` confirms; verified live against a real LICENSE too
- `test_a_rate_limit_is_retried_then_reported_without_a_digest` — 3 attempts, no digest recorded
- `build.validate` → `0 error(s)`