### PR TITLE
Record the capability comparison, so it can be checked

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -31,6 +31,15 @@ jobs:
       - name: Verification gates (invariant, digests, producible-pairs)
         run: uv run python -m build.check_verification --verbose
 
+      # Capability's own gate. Most bands on this map were placed against a named peer, and
+      # until `relative_to` existed that comparison lived in a note where nothing could check
+      # it. This requires the recorded relation to agree with the two recorded scores, and a
+      # dated band's peer to be confirmed at least as recently. It ratchets the same way the
+      # verification gates do: it covers the products that record a comparison, which grows
+      # as the axis is curated. See docs/guides/verification.md.
+      - name: Capability gate (recorded comparisons hold)
+        run: uv run python -m build.check_capability
+
       # Structure of every scoring recipe: a rationale on each rung, a machine_signal on
       # each dimension, no rule that cannot fire, no product abstained on without a
       # declared reason, and no evidence the components parser silently discards. Note

--- a/build/check_capability.py
+++ b/build/check_capability.py
@@ -1,0 +1,228 @@
+"""The capability axis's gates: a recorded comparison must be consistent, and must be fresh.
+
+`docs/guides/verification.md` is normative. This module implements what that guide says about
+capability, and where the two disagree the guide wins.
+
+## Why this exists
+
+Openness earned its gates by making the thing the score rests on into data. Its win was not
+`components` in itself, it was that a judgment became a recorded structure, attributable to a
+source and walkable by a ladder.
+
+Capability's scores rest on something else, and the corpus says so plainly: measured on
+2026-08-08, 79 of 472 products sit at capability 5 and roughly a hundred place themselves
+against a named peer in the same category — "one tier below the Megatron-LM anchor", "not the
+frontier multi-node-scale anchor". That comparison IS the instrument for most of the axis. It
+lived in an English sentence, so nothing could check it, nothing refreshed it, and nothing
+noticed when the product it referred to moved.
+
+`relative_to` and `relation` record it. This module then asks the three questions that a
+recorded comparison makes answerable and a sentence never did.
+
+## The three checks
+
+**Consistency.** If a product records `relative_to: megatron-lm, relation: one_below`, then its
+score must be exactly one below Megatron-LM's. This is the direct analogue of the
+producible-pair check: the recorded relation and the recorded scores are two statements of the
+same fact, and they can disagree. Unlike the openness ladder it needs no rubric, because
+arithmetic over two integers is the whole rule.
+
+**Same category.** A band is placed against a peer, and a peer is something in the same
+category. A cross-category comparison is not obviously wrong, but it is never what the notes
+are doing, and allowing it silently would let the anchor graph sprawl into a ranking of the
+whole map.
+
+**Transitive freshness.** A confirmation of a derived band cannot be more recent than the
+confirmation of the band it derives from. If Megatron-LM's capability was last confirmed in
+June and `trl` claims today, `trl` is claiming to have re-derived a comparison against a fact
+nobody re-read. This is the structural analogue of the openness invariant, which is why it is
+worth the trouble: it is the same insight, that a date is only as good as the least recently
+confirmed thing underneath it.
+
+## What this does NOT do
+
+It does not make capability derivable, and it produces no score from evidence. The comparison
+remains a judgment with no cited source behind it. It converts an unfalsifiable claim into a
+falsifiable one and gives it a freshness dependency — the same thing `establishes` did for
+openness, which also does not verify that a source says what it claims. The sampled re-fetch
+does that.
+
+## Why it ratchets
+
+The three checks apply only to products that record `relative_to`, which is a minority today
+and grows as the axis is curated. The gate therefore covers exactly what has been done and
+never blocks progress, which is how the openness gates were landed and the only way one gets
+adopted mid-corpus. `--candidates` reports the products that look like they should carry the
+field and do not; that number is the backlog, and it is reported rather than failed so that a
+curation job cannot masquerade as a regression.
+
+Usage:
+    uv run python -m build.check_capability
+    uv run python -m build.check_capability --candidates
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# `at` is not redundant with "no relation recorded". It says the placement was made by
+# comparison and landed level, which is a different claim from never having compared.
+DELTA = {"at": 0, "one_below": -1, "two_below": -2, "one_above": 1}
+
+# Comparative language, for the candidate report only. Deliberately loose: a false positive
+# costs a reader ten seconds and a false negative hides exactly the case this exists to find.
+COMPARATIVE = re.compile(
+    r"\b(one tier|two tiers|a tier|tier below|tier above|anchor|reference point|"
+    r"on par|par with|compared to|relative to|versus|vs\.?|behind|ahead of|"
+    r"below the|above the|mid-tier|top-tier|best-in-class|not the frontier)\b",
+    re.I,
+)
+
+
+def load() -> tuple[dict, dict]:
+    """(scores by slug, category slug by product slug)."""
+    scores = {}
+    for path in sorted((ROOT / "sources" / "scores").glob("*.yaml")):
+        doc = yaml.safe_load(path.read_text()) or {}
+        if doc.get("product"):
+            scores[doc["product"]] = doc
+    owner = {}
+    for path in sorted((ROOT / "sources" / "categories").glob("*.yaml")):
+        doc = yaml.safe_load(path.read_text()) or {}
+        for product in doc.get("products") or []:
+            owner[product] = doc.get("name") or path.stem
+    return scores, owner
+
+
+def parse_date(value: object) -> date | None:
+    if isinstance(value, date):
+        return value
+    try:
+        return date.fromisoformat(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def check(scores: dict, owner: dict) -> list[str]:
+    problems: list[str] = []
+    for slug, doc in sorted(scores.items()):
+        block = doc.get("capability") or {}
+        target = block.get("relative_to")
+        relation = block.get("relation")
+        if not target and not relation:
+            continue
+        if not target or not relation:
+            # The schema's dependentRequired catches this too. Repeated here because a gate
+            # that assumes another gate ran is a gate that silently passes when it does not.
+            problems.append(f"{slug}:capability: records {'relation' if relation else 'relative_to'} without the other")
+            continue
+
+        if target == slug:
+            problems.append(f"{slug}:capability: relative_to points at itself")
+            continue
+        if target not in scores:
+            problems.append(f"{slug}:capability: relative_to {target!r} is not a product on the map")
+            continue
+        if owner.get(slug) != owner.get(target):
+            problems.append(
+                f"{slug}:capability: relative_to {target!r} is in {owner.get(target)!r}, not "
+                f"{owner.get(slug)!r}. A band is placed against a peer in its own category"
+            )
+            continue
+
+        other = scores[target].get("capability") or {}
+        mine, theirs = block.get("score"), other.get("score")
+        if mine is None or theirs is None:
+            problems.append(
+                f"{slug}:capability: {relation} {target}, but "
+                f"{'this score' if mine is None else f'{target}'} is null, so the relation "
+                f"asserts nothing"
+            )
+            continue
+        expected = theirs + DELTA[relation]
+        if not 1 <= expected <= 5:
+            # The relation cannot be satisfied by any legal band, so it is wrong regardless of
+            # what this product scores. `one_above` a 5 is the case that turns up in practice.
+            problems.append(
+                f"{slug}:capability: records {relation} {target} ({theirs}), which needs a band "
+                f"of {expected}. The scale stops at 1 and 5, so no score satisfies it"
+            )
+        elif mine != expected:
+            problems.append(
+                f"{slug}:capability: records {relation} {target} ({theirs}), which is {expected}, "
+                f"but the score is {mine}. The relation and the scores disagree"
+            )
+
+        claimed = parse_date(block.get("last_verified"))
+        if claimed is None:
+            continue
+        anchor_date = parse_date(other.get("last_verified"))
+        if anchor_date is None:
+            problems.append(
+                f"{slug}:capability: claims last_verified {claimed} while its comparison "
+                f"{target} carries no confirmation at all. A derived band cannot be fresher "
+                f"than what it derives from"
+            )
+        elif anchor_date < claimed:
+            problems.append(
+                f"{slug}:capability: claims last_verified {claimed}, but {target} was last "
+                f"confirmed {anchor_date}. The comparison was not re-derived"
+            )
+    return problems
+
+
+def candidates(scores: dict, owner: dict) -> list[str]:
+    """Products whose note compares them to a same-category peer without recording it."""
+    found: list[str] = []
+    for slug, doc in sorted(scores.items()):
+        block = doc.get("capability") or {}
+        if block.get("relative_to"):
+            continue
+        text = f"{block.get('note') or ''} {block.get('value') or ''}"
+        if not COMPARATIVE.search(text):
+            continue
+        for peer in scores:
+            if peer == slug or owner.get(peer) != owner.get(slug):
+                continue
+            if re.search(rf"\b{re.escape(peer.replace('-', '[- ]'))}\b", text, re.I):
+                found.append(f"{slug}:capability: note compares against {peer}, unrecorded")
+                break
+    return found
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--candidates", action="store_true", help="also list the unrecorded comparisons"
+    )
+    args = parser.parse_args()
+
+    scores, owner = load()
+    problems = check(scores, owner)
+    recorded = sum(1 for d in scores.values() if (d.get("capability") or {}).get("relative_to"))
+
+    status = "OK" if not problems else "FAIL"
+    print(f"capability-anchors  a recorded comparison that does not hold  [{status}]")
+    for problem in problems:
+        print(f"  ! {problem}")
+    print(f"  {recorded} of {len(scores)} products record a comparison")
+
+    if args.candidates:
+        backlog = candidates(scores, owner)
+        print(f"\n  {len(backlog)} unrecorded comparison(s), the curation backlog:")
+        for line in backlog:
+            print(f"    - {line}")
+
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/guides/verification.md
+++ b/docs/guides/verification.md
@@ -129,6 +129,7 @@ gate every PR. The ones needing the network run periodically.
 | refetch | fabricated or rotted sources | sampled re-fetch, digest and `shows` token match | network, weekly |
 | parity | repo and warehouse drifting apart | `build/check_parity.py`, a per-product differential | network, weekly |
 | release | a UDM revision that was never released | assert latest revision == latest release | network, per publish |
+| capability-anchors | a recorded peer comparison that does not hold | `relation` must agree with both scores, and a dated band's peer must be confirmed at least as recently | free |
 
 These were numbered G1-G6 until 2026-08-08. Older PRs and commit messages use the numbers.
 
@@ -204,6 +205,61 @@ pricing page read.
 
 So every openness axis needs at least one read, permanently. Adoption and capability are
 different in kind and can be automated — see the table below.
+
+## What a capability confirmation attests to
+
+Less than the other two axes, and the difference is worth stating before roughly 400 dates get
+written across adoption and capability in step 3. **Zero capability axes carry a
+`last_verified` today**, so this is a paragraph now and an audit of 400 dates later.
+
+Capability is not measured on this map. Measured on 2026-08-08, 322 of 472 products record
+`basis: feature_matrix` against 86 `benchmark`, and `value` is prose in every one of the 372
+cases where it is populated — not a single bare number. There is no capability ladder in any of
+the four rubrics, and `signal_routing.yaml` records the axis as effectively unroutable: both
+external anchors are unbridged, and both rank *models*, so neither can say anything about a
+training framework or a sandbox.
+
+What actually places most bands is a comparison to a peer. Roughly a hundred products in the
+corpus put themselves against another product in their own category — "one tier below the
+Megatron-LM anchor", "mid-tier next to langfuse" — and in `finetuning_code` every one of the
+27 notes does it. That comparison was the instrument, and it lived in an English sentence.
+
+So it is recorded instead:
+
+```yaml
+capability:
+  score: 4
+  basis: feature_matrix
+  relative_to: megatron-lm
+  relation: one_below
+```
+
+**`relation` is arithmetic over two recorded integers, and it can be wrong.** That is the
+point, and it is the producible-pair check's shape rather than the invariant's: two statements
+of the same fact — the relation and the two scores — can disagree, and now one of them is
+checkable. `build/check_capability.py` gates it, and it ratchets like the others, covering the
+products that record a comparison rather than blocking on the ones that do not.
+
+**A dated band cannot be fresher than the band it derives from.** If `trl` claims a
+confirmation today while Megatron-LM's capability was last confirmed in June, `trl` is claiming
+to have re-derived a comparison against a fact nobody re-read. This is the openness invariant's
+insight applied to a different dependency: a date is worth no more than the least recently
+confirmed thing underneath it.
+
+With that recorded, a capability `last_verified` means: **the feature matrix still reads as
+described, and the comparison the band rests on has been re-derived against a peer confirmed at
+least as recently.** It does not mean the band was measured. Where `basis: benchmark`, it also
+does not mean the benchmark was re-run — re-reading a published number is the claim, and the
+number is a property of a harness-plus-model pairing rather than of the product alone.
+
+Two things this deliberately does not do. It does not make capability derivable from evidence,
+and the comparison itself still carries no cited source — recording it converts an
+unfalsifiable claim into a falsifiable one, which is what `establishes` did for openness, and
+`establishes` does not verify that a source says what it claims either. That is the sampled
+re-fetch's job. Nor does it try to turn `capability.value` into structured components: at 61%
+prose by `check_rubric`'s own measure, against the 71% that stopped `edge_hardware`, and with
+four different instruments sharing one field name, there is no shared ladder at the end of that
+work the way openness got four.
 
 ## Current state, 2026-08-08
 

--- a/docs/runbooks/verification-pass.md
+++ b/docs/runbooks/verification-pass.md
@@ -293,6 +293,10 @@ The unit of work is therefore per product, not per axis:
    `content_sha256`, and a `shows` extract that actually appears in the body. A cited URL that
    404s is a finding, not something to paper over.
 3. Re-derive each recorded dimension and attribute it: `establishes: [...]`.
+   On capability, that means the peer comparison: if the band was placed against another
+   product, record it as `relative_to` + `relation` rather than leaving it in the note, and
+   confirm the peer at least as recently. A capability date attests to less than the other two
+   axes — `verification.md`, "What a capability confirmation attests to", says exactly what.
 4. **Rewrite the prose** per `product-info.md` — `description` load-bearing and within the
    length band, `comments` a footnote ending in the canonical verification line. Delete rather
    than research a superlative, a corporate event, or a curator rationale clause; the guide's

--- a/docs/schemas/score.schema.json
+++ b/docs/schemas/score.schema.json
@@ -2,63 +2,223 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Score",
   "type": "object",
-  "required": ["product", "openness", "adoption", "capability"],
+  "required": [
+    "product",
+    "openness",
+    "adoption",
+    "capability"
+  ],
   "additionalProperties": false,
   "properties": {
-    "product": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+    "product": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]*$"
+    },
     "openness": {
       "type": "object",
-      "required": ["score", "class"],
+      "required": [
+        "score",
+        "class"
+      ],
       "properties": {
-        "score": { "type": ["integer", "null"], "minimum": 0, "maximum": 5 },
-        "class": { "type": "string" },
-        "components": { "type": "string" },
-        "confidence": { "enum": ["high", "medium", "low"] },
-        "note": { "type": "string" },
-        "sources": { "type": "array", "items": { "$ref": "#/definitions/source" } },
-        "last_verified": { "type": "string", "format": "date", "description": "The most recent date on which everything in this axis's score was confirmed still correct. Written when the axis is re-checked against its sources, whether or not the value changed. Absent means never confirmed, in which case freshness falls back to the score file's last commit date. Never backfill it from source access dates: opening a URL is a weaker claim than re-confirming a conclusion, and no aggregation of accessed dates fixes that. Normative definition in docs/guides/freshness.md." }
+        "score": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 5
+        },
+        "class": {
+          "type": "string"
+        },
+        "components": {
+          "type": "string"
+        },
+        "confidence": {
+          "enum": [
+            "high",
+            "medium",
+            "low"
+          ]
+        },
+        "note": {
+          "type": "string"
+        },
+        "sources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/source"
+          }
+        },
+        "last_verified": {
+          "type": "string",
+          "format": "date",
+          "description": "The most recent date on which everything in this axis's score was confirmed still correct. Written when the axis is re-checked against its sources, whether or not the value changed. Absent means never confirmed, in which case freshness falls back to the score file's last commit date. Never backfill it from source access dates: opening a URL is a weaker claim than re-confirming a conclusion, and no aggregation of accessed dates fixes that. Normative definition in docs/guides/freshness.md."
+        }
       }
     },
     "adoption": {
       "type": "object",
-      "required": ["level"],
+      "required": [
+        "level"
+      ],
       "properties": {
-        "level": { "type": ["integer", "null"], "minimum": 1, "maximum": 5 },
-        "reach": { "type": ["string", "null"] },
-        "signal_type": { "enum": ["active_users", "usage_volume", "reported_traction", "stars_fallback", "unknown"] },
-        "confidence": { "enum": ["high", "medium", "low"] },
-        "note": { "type": "string" },
-        "sources": { "type": "array", "items": { "$ref": "#/definitions/source" } },
-        "last_verified": { "type": "string", "format": "date", "description": "The most recent date on which everything in this axis's score was confirmed still correct. Written when the axis is re-checked against its sources, whether or not the value changed. Absent means never confirmed, in which case freshness falls back to the score file's last commit date. Never backfill it from source access dates: opening a URL is a weaker claim than re-confirming a conclusion, and no aggregation of accessed dates fixes that. Normative definition in docs/guides/freshness.md." }
+        "level": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1,
+          "maximum": 5
+        },
+        "reach": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "signal_type": {
+          "enum": [
+            "active_users",
+            "usage_volume",
+            "reported_traction",
+            "stars_fallback",
+            "unknown"
+          ]
+        },
+        "confidence": {
+          "enum": [
+            "high",
+            "medium",
+            "low"
+          ]
+        },
+        "note": {
+          "type": "string"
+        },
+        "sources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/source"
+          }
+        },
+        "last_verified": {
+          "type": "string",
+          "format": "date",
+          "description": "The most recent date on which everything in this axis's score was confirmed still correct. Written when the axis is re-checked against its sources, whether or not the value changed. Absent means never confirmed, in which case freshness falls back to the score file's last commit date. Never backfill it from source access dates: opening a URL is a weaker claim than re-confirming a conclusion, and no aggregation of accessed dates fixes that. Normative definition in docs/guides/freshness.md."
+        }
       }
     },
     "capability": {
       "type": "object",
-      "required": ["score", "basis"],
+      "required": [
+        "score",
+        "basis"
+      ],
       "properties": {
-        "score": { "type": ["integer", "null"], "minimum": 1, "maximum": 5 },
-        "basis": { "type": "string" },
-        "value": { "type": ["string", "number", "null"] },
-        "confidence": { "enum": ["high", "medium", "low"] },
-        "note": { "type": "string" },
-        "sources": { "type": "array", "items": { "$ref": "#/definitions/source" } },
-        "last_verified": { "type": "string", "format": "date", "description": "The most recent date on which everything in this axis's score was confirmed still correct. Written when the axis is re-checked against its sources, whether or not the value changed. Absent means never confirmed, in which case freshness falls back to the score file's last commit date. Never backfill it from source access dates: opening a URL is a weaker claim than re-confirming a conclusion, and no aggregation of accessed dates fixes that. Normative definition in docs/guides/freshness.md." }
+        "score": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1,
+          "maximum": 5
+        },
+        "basis": {
+          "enum": [
+            "feature_matrix",
+            "benchmark",
+            "training_value",
+            "n/a"
+          ],
+          "description": "Which INSTRUMENT the band was read with, not what it measured. Four, because these are four genuinely different things and a checker that cannot tell them apart cannot route or gate the axis: `benchmark` is a published number, `training_value` is ablation or downstream-model evidence, `feature_matrix` is a judgment over what the product does, `n/a` is an honest abstention. This was 85 free-text strings until 2026-08-08, 65 of them used once, with the benchmark's NAME jammed into the string in 56 spellings; that detail now lives in `basis_detail`."
+        },
+        "value": {
+          "type": [
+            "string",
+            "number",
+            "null"
+          ]
+        },
+        "confidence": {
+          "enum": [
+            "high",
+            "medium",
+            "low"
+          ]
+        },
+        "note": {
+          "type": "string"
+        },
+        "sources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/source"
+          }
+        },
+        "last_verified": {
+          "type": "string",
+          "format": "date",
+          "description": "The most recent date on which everything in this axis's score was confirmed still correct. Written when the axis is re-checked against its sources, whether or not the value changed. Absent means never confirmed, in which case freshness falls back to the score file's last commit date. Never backfill it from source access dates: opening a URL is a weaker claim than re-confirming a conclusion, and no aggregation of accessed dates fixes that. Normative definition in docs/guides/freshness.md."
+        },
+        "basis_detail": {
+          "type": "string",
+          "description": "What the instrument was, in prose: the benchmark's name for `benchmark`, the kind of coverage for `feature_matrix`, `superseded` or `ablation` for `training_value`. Free text on purpose - the enum is what a checker reads, and this is what a reader needs. Not yet controlled; the benchmark names in particular are a normalization job of their own."
+        },
+        "relative_to": {
+          "type": "string",
+          "description": "The slug of the product THIS band was placed against, when it was placed by comparison rather than measured. Peer-relative placement is the map's dominant capability instrument - the note usually says something like 'one tier below the Megatron-LM anchor' - and until this field existed that comparison lived in an English sentence where nothing could check it, refresh it, or notice when it went stale. Recording it makes the claim falsifiable: build/check_capability.py requires the relation to be arithmetically consistent with both recorded scores, and requires the target's confirmation to be at least as recent as this one's. Same category as this product. Normative definition in docs/guides/verification.md."
+        },
+        "relation": {
+          "enum": [
+            "at",
+            "one_below",
+            "two_below",
+            "one_above"
+          ],
+          "description": "How this product's band sits against `relative_to`. Required with it, and meaningless without it. Deliberately tiny and domain-free, so it generalizes across categories as different as edge_hardware and benchmark_eval_data without asserting anything about what capability means in either."
+        }
+      },
+      "dependentRequired": {
+        "relative_to": [
+          "relation"
+        ],
+        "relation": [
+          "relative_to"
+        ]
       }
     }
   },
   "definitions": {
     "source": {
       "type": "object",
-      "required": ["url", "shows", "accessed"],
+      "required": [
+        "url",
+        "shows",
+        "accessed"
+      ],
       "properties": {
-        "url": { "type": "string", "pattern": "^https?://" },
-        "shows": { "type": "string", "minLength": 1 },
-        "accessed": { "type": "string", "minLength": 1 },
+        "url": {
+          "type": "string",
+          "pattern": "^https?://"
+        },
+        "shows": {
+          "type": "string",
+          "minLength": 1
+        },
+        "accessed": {
+          "type": "string",
+          "minLength": 1
+        },
         "establishes": {
           "type": "array",
           "minItems": 1,
           "uniqueItems": true,
-          "items": { "type": "string", "minLength": 1 },
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
           "description": "Which dimensions of this axis's score THIS source settles. `sources` is a flat list per axis, so without it nothing records which source establishes which dimension, and a re-check claim cannot be checked. Every name must be a dimension some category's scoring_recipe declares, or a recorded key one of those dimensions reads; build/validate.py enforces that cross-file, because a typo'd name would establish nothing while looking like attribution. Optional and forward-populated: build/check_verification.py requires it only on axes that claim a last_verified. Normative definition in docs/guides/verification.md."
         },
         "http_status": {
@@ -70,7 +230,7 @@
         "content_sha256": {
           "type": "string",
           "pattern": "^[0-9a-f]{64}$",
-          "description": "SHA-256 of the fetched response body at `accessed` time. A changed digest says the page moved under a claim that still cites it — a reason to re-check rather than a failure on its own, since pages legitimately change. A MISSING digest on a newly claimed confirmation is a hard failure, because it means the tool fetched nothing."
+          "description": "SHA-256 of the fetched response body at `accessed` time. A changed digest says the page moved under a claim that still cites it \u2014 a reason to re-check rather than a failure on its own, since pages legitimately change. A MISSING digest on a newly claimed confirmation is a hard failure, because it means the tool fetched nothing."
         }
       }
     }

--- a/docs/schemas/score.schema.json
+++ b/docs/schemas/score.schema.json
@@ -56,7 +56,8 @@
           "format": "date",
           "description": "The most recent date on which everything in this axis's score was confirmed still correct. Written when the axis is re-checked against its sources, whether or not the value changed. Absent means never confirmed, in which case freshness falls back to the score file's last commit date. Never backfill it from source access dates: opening a URL is a weaker claim than re-confirming a conclusion, and no aggregation of accessed dates fixes that. Normative definition in docs/guides/freshness.md."
         }
-      }
+      },
+      "additionalProperties": false
     },
     "adoption": {
       "type": "object",
@@ -108,7 +109,8 @@
           "format": "date",
           "description": "The most recent date on which everything in this axis's score was confirmed still correct. Written when the axis is re-checked against its sources, whether or not the value changed. Absent means never confirmed, in which case freshness falls back to the score file's last commit date. Never backfill it from source access dates: opening a URL is a weaker claim than re-confirming a conclusion, and no aggregation of accessed dates fixes that. Normative definition in docs/guides/freshness.md."
         }
-      }
+      },
+      "additionalProperties": false
     },
     "capability": {
       "type": "object",
@@ -168,7 +170,7 @@
         },
         "relative_to": {
           "type": "string",
-          "description": "The slug of the product THIS band was placed against, when it was placed by comparison rather than measured. Peer-relative placement is the map's dominant capability instrument - the note usually says something like 'one tier below the Megatron-LM anchor' - and until this field existed that comparison lived in an English sentence where nothing could check it, refresh it, or notice when it went stale. Recording it makes the claim falsifiable: build/check_capability.py requires the relation to be arithmetically consistent with both recorded scores, and requires the target's confirmation to be at least as recent as this one's. Same category as this product. Normative definition in docs/guides/verification.md."
+          "description": "The slug of the product THIS band was placed against, when it was placed by comparison rather than measured. Peer-relative placement is the map's dominant capability instrument - the note usually says something like 'one tier below the Megatron-LM anchor' - and until this field existed that comparison lived in an English sentence where nothing could check it, refresh it, or notice when it went stale. Recording it makes the claim falsifiable: build/check_capability.py requires the relation to be arithmetically consistent with both recorded scores, and requires the target's confirmation to be at least as recent as this one's. Same category as this product. Normative definition in docs/guides/verification.md. Declared on capability only, and `additionalProperties: false` on all three axes keeps it there: a `relation` written onto openness or adoption used to validate silently and be read by nothing, which a sweep run produced on four axes before this was closed."
         },
         "relation": {
           "enum": [
@@ -187,7 +189,8 @@
         "relation": [
           "relative_to"
         ]
-      }
+      },
+      "additionalProperties": false
     }
   },
   "definitions": {

--- a/sources/scores/aegis-guard.yaml
+++ b/sources/scores/aegis-guard.yaml
@@ -25,7 +25,8 @@ adoption:
     accessed: '2026-06-29'
 capability:
   score: 4
-  basis: risk coverage
+  basis: feature_matrix
+  basis_detail: risk coverage
   value: 13 critical safety risk categories across prompts and responses, with an open safety dataset
     and a defensive/permissive variant pair.
   confidence: low

--- a/sources/scores/agenta.yaml
+++ b/sources/scores/agenta.yaml
@@ -28,6 +28,8 @@ adoption:
 capability:
   score: 4
   basis: feature_matrix
+  relative_to: langfuse
+  relation: at
   value: prompt management+versioning(branching/environments, 50+ models), evals(20+ evaluators, UI+API,
     test cases from prod/CSV), observability/tracing(OTel-native, OpenLLMetry/OpenInference compatible,
     cost/latency), multi-model playground

--- a/sources/scores/aider.yaml
+++ b/sources/scores/aider.yaml
@@ -28,7 +28,10 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 3
-  basis: benchmark:SWE-bench Verified
+  basis: benchmark
+  basis_detail: SWE-bench Verified
+  relative_to: openhands
+  relation: two_below
   value: SWE-bench Verified ~31.4% (architect mode, Claude Sonnet 4.5)
   confidence: medium
   note: 'Mid-tier on SWE-bench Verified; well below OpenHands (68.4%) and Cline (59.8%). NOTE: headline

--- a/sources/scores/alia-40b.yaml
+++ b/sources/scores/alia-40b.yaml
@@ -36,7 +36,10 @@ adoption:
     accessed: '2026-06-26'
 capability:
   score: 2
-  basis: scale + multilingual pretraining (full benchmarks pending technical report)
+  basis: feature_matrix
+  basis_detail: scale + multilingual pretraining (full benchmarks pending technical report)
+  relative_to: apertus
+  relation: one_below
   value: 40.4B params, decoder-only, 9.37T pretraining tokens, 35 European languages + 92 programming languages;
     mid-tier and below the 2026 frontier. Detailed benchmarks are deferred to a forthcoming technical report;
     the model card cites the Salamandra technical report (arXiv:2502.08489) for the shared methodology.

--- a/sources/scores/amazon-nova.yaml
+++ b/sources/scores/amazon-nova.yaml
@@ -26,7 +26,7 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 3
-  basis: benchmark:n/a
+  basis: benchmark
   value: null
   confidence: low
   note: Live vendor page confirms NO standardized benchmark scores; positioning is price-performance + case studies.

--- a/sources/scores/antigravity.yaml
+++ b/sources/scores/antigravity.yaml
@@ -28,6 +28,8 @@ adoption:
 capability:
   score: 4
   basis: feature_matrix
+  relative_to: openhands
+  relation: one_below
   value: Multi-agent orchestration (plan/code/test-in-browser/deploy), Agent Manager, Gemini 3.5 Flash
     backbone, deep Google-surface integration, desktop app + CLI + SDK; no first-party SWE-bench number
     published for the platform itself

--- a/sources/scores/apertus.yaml
+++ b/sources/scores/apertus.yaml
@@ -59,7 +59,10 @@ adoption:
     accessed: '2026-06-08'
 capability:
   score: 3
-  basis: benchmark:MMLU / pretraining suite
+  basis: benchmark
+  basis_detail: MMLU / pretraining suite
+  relative_to: llama
+  relation: at
   value: Apertus-70B pretraining-eval avg 67.5% (ARC/HellaSwag/WinoGrande/XNLI/XCOPA/PIQA), ~on par with
     Llama 3.1-70B (67.3%); Apertus-70B-Instruct MMLU 69.6%, trailing Llama 3.3-70B (87.5%) and Qwen2.5-72B
     (86.6%) by ~17-20 pts.

--- a/sources/scores/apple-core-ml-runtime.yaml
+++ b/sources/scores/apple-core-ml-runtime.yaml
@@ -28,6 +28,8 @@ adoption:
 capability:
   score: 4
   basis: feature_matrix
+  relative_to: vllm
+  relation: one_below
   value: on-device inference across CPU/GPU/Neural Engine; broad model coverage via coremltools (PyTorch/TF
     conversion); quantization/compression; transformer + diffusion support
   confidence: medium

--- a/sources/scores/aya-collection.yaml
+++ b/sources/scores/aya-collection.yaml
@@ -21,7 +21,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 4
-  basis: training_value:downstream
+  basis: training_value
+  basis_detail: downstream
   value: null
   confidence: high
   note: Instruction collection behind Aya 101 (2024), Aya 23, and Aya Expanse, which beat Gemma 2 / Qwen

--- a/sources/scores/azure-content-safety.yaml
+++ b/sources/scores/azure-content-safety.yaml
@@ -22,7 +22,8 @@ adoption:
     accessed: '2026-06-29'
 capability:
   score: 4
-  basis: feature coverage
+  basis: feature_matrix
+  basis_detail: feature coverage
   value: Text and image moderation, prompt-shield jailbreak/injection detection, and groundedness detection
     in one managed service.
   confidence: low

--- a/sources/scores/bedrock-guardrails.yaml
+++ b/sources/scores/bedrock-guardrails.yaml
@@ -22,7 +22,8 @@ adoption:
     accessed: '2026-06-29'
 capability:
   score: 4
-  basis: feature coverage
+  basis: feature_matrix
+  basis_detail: feature coverage
   value: Denied topics, content filters, PII redaction, word filters, and contextual-grounding checks
     across any Bedrock model.
   confidence: low

--- a/sources/scores/braintrust.yaml
+++ b/sources/scores/braintrust.yaml
@@ -34,6 +34,8 @@ adoption:
 capability:
   score: 5
   basis: feature_matrix
+  relative_to: langfuse
+  relation: one_above
   value: tracing(real-time inspection across millions of logs, tool calls); evals(LLM/code/human scorers,
     experiments vs datasets); prompt mgmt + playground; automation(Topics pattern discovery, continuous
     scoring, quality gates blocking releases); datasets/annotation; OTel + MCP + framework-agnostic SDKs(5

--- a/sources/scores/c4.yaml
+++ b/sources/scores/c4.yaml
@@ -21,7 +21,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 3
-  basis: training_value:superseded
+  basis: training_value
+  basis_detail: superseded
   value: null
   confidence: high
   note: Powered T5 (2019) and UL2 (2022); now a baseline that FineWeb and DCLM beat, superseded by modern

--- a/sources/scores/cerebras-inference.yaml
+++ b/sources/scores/cerebras-inference.yaml
@@ -25,7 +25,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 5
-  basis: benchmark:ArtificialAnalysis(provider-speed)
+  basis: benchmark
+  basis_detail: ArtificialAnalysis(provider-speed)
   value: Fastest provider on the Artificial Analysis gpt-oss-120b provider leaderboard at ~1,726 output
     tokens/sec (next-fastest SambaNova ~692.5 t/s, ~2.5x; Fireworks ~658.8 t/s 3rd); vendor claims up
     to 15x faster than NVIDIA GPUs and >2,000 t/s on Llama 4 Scout.

--- a/sources/scores/claude-code.yaml
+++ b/sources/scores/claude-code.yaml
@@ -28,7 +28,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 5
-  basis: benchmark:SWE-bench Verified
+  basis: benchmark
+  basis_detail: SWE-bench Verified
   value: Backed by frontier Claude Opus models leading SWE-bench Verified (Claude Opus 4.8 ~88.6%, 4.7
     ~87.6%); Claude Code is the reference agent harness for these scores.
   confidence: high

--- a/sources/scores/claude-fable.yaml
+++ b/sources/scores/claude-fable.yaml
@@ -32,7 +32,8 @@ adoption:
     accessed: '2026-06-23'
 capability:
   score: 5
-  basis: benchmark:FrontierCode
+  basis: benchmark
+  basis_detail: FrontierCode
   value: null
   confidence: high
   note: 'Anthropic-reported: highest among frontier models on Cognition FrontierCode (even at medium effort); top

--- a/sources/scores/claude-haiku.yaml
+++ b/sources/scores/claude-haiku.yaml
@@ -23,7 +23,8 @@ adoption:
     accessed: '2026-07-29'
 capability:
   score: 4
-  basis: benchmark:SWE-bench Verified
+  basis: benchmark
+  basis_detail: SWE-bench Verified
   value: null
   confidence: medium
   note: Haiku 4.5 is strong for its size class and competitive with the previous Sonnet generation, but

--- a/sources/scores/claude-opus.yaml
+++ b/sources/scores/claude-opus.yaml
@@ -34,7 +34,8 @@ adoption:
     accessed: '2026-06-23'
 capability:
   score: 5
-  basis: benchmark:GDPval-AA
+  basis: benchmark
+  basis_detail: GDPval-AA
   value: null
   confidence: high
   note: 'Anthropic-reported: state-of-the-art on GDPval-AA and Finance Agent; CursorBench 70% (vs 58% for Opus 4.6);

--- a/sources/scores/claude-sonnet.yaml
+++ b/sources/scores/claude-sonnet.yaml
@@ -26,7 +26,8 @@ adoption:
     accessed: '2026-07-29'
 capability:
   score: 4
-  basis: benchmark:SWE-bench Verified
+  basis: benchmark
+  basis_detail: SWE-bench Verified
   value: null
   confidence: medium
   note: Sonnet 4.6 posts 79.6% on SWE-bench Verified, strong for a mid-tier model but below the Opus and

--- a/sources/scores/cline.yaml
+++ b/sources/scores/cline.yaml
@@ -24,7 +24,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 4
-  basis: benchmark:SWE-bench Verified
+  basis: benchmark
+  basis_detail: SWE-bench Verified
   value: SWE-bench Verified 59.8% (Autonomous Mode, Claude Sonnet 4.6)
   confidence: medium
   note: 'Second only to OpenHands (68.4%) among open coding agents on the April 2026 leaderboard; above

--- a/sources/scores/codegemma.yaml
+++ b/sources/scores/codegemma.yaml
@@ -38,7 +38,8 @@ adoption:
     accessed: '2026-06-17'
 capability:
   score: 3
-  basis: benchmark:HumanEval/MBPP
+  basis: benchmark
+  basis_detail: HumanEval/MBPP
   value: competent FIM/code completion at 2B/7B circa 2024
   confidence: medium
   note: >-

--- a/sources/scores/codellama.yaml
+++ b/sources/scores/codellama.yaml
@@ -36,7 +36,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 3
-  basis: benchmark:HumanEval
+  basis: benchmark
+  basis_detail: HumanEval
   value: Code Llama Instruct 13B ~HumanEval pass@1 ~42%; family 34B/70B-Instruct higher but all 2023-era
   confidence: medium
   note: >-

--- a/sources/scores/codestral.yaml
+++ b/sources/scores/codestral.yaml
@@ -31,7 +31,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 3
-  basis: benchmark:HumanEval/MBPP
+  basis: benchmark
+  basis_detail: HumanEval/MBPP
   value: HumanEval pass@1 ~86.6%, MBPP ~91.2%; strong on completion/FIM and RepoBench long-context, but
     ~22B specialist, weak on agentic SWE-bench (single-run resolves only a small fraction)
   confidence: medium

--- a/sources/scores/command-r.yaml
+++ b/sources/scores/command-r.yaml
@@ -25,7 +25,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 2
-  basis: benchmark:MMLU
+  basis: benchmark
+  basis_detail: MMLU
   value: Open LLM Leaderboard avg 74.6 (MMLU 75.7, ARC-C 70.99, HellaSwag 88.6, GSM8K 70.7, TruthfulQA
     56.3), strong vs 2024 peers (DBRX, Mixtral 8x7B)
   confidence: medium

--- a/sources/scores/common-corpus.yaml
+++ b/sources/scores/common-corpus.yaml
@@ -21,7 +21,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 3
-  basis: training_value:downstream
+  basis: training_value
+  basis_detail: downstream
   value: null
   confidence: high
   note: Trains the Pleias 1.0 SLM family and several European models (2024-25), but small demonstrator

--- a/sources/scores/coop.yaml
+++ b/sources/scores/coop.yaml
@@ -35,7 +35,8 @@ adoption:
     accessed: '2026-07-03'
 capability:
   score: 3
-  basis: feature coverage
+  basis: feature_matrix
+  basis_detail: feature coverage
   value: Review queues, routing, automated enforcement rules, analytics, and REST/GraphQL APIs, plus
     child-safety workflows (HMA hash matching, NCMEC reporting) and OpenAI Moderation / Google Content
     Safety integrations.

--- a/sources/scores/cosmopedia.yaml
+++ b/sources/scores/cosmopedia.yaml
@@ -21,7 +21,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 3
-  basis: training_value:superseded
+  basis: training_value
+  basis_detail: superseded
   value: null
   confidence: high
   note: Cosmo-1B beats TinyLlama on ARC/MMLU but trails Phi-1.5; explicitly superseded by Cosmopedia v2.

--- a/sources/scores/culturax.yaml
+++ b/sources/scores/culturax.yaml
@@ -22,7 +22,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 3
-  basis: training_value:superseded
+  basis: training_value
+  basis_detail: superseded
   value: null
   confidence: high
   note: A strong 2023-24 default multilingual corpus, but explicitly beaten by FineWeb-2 in controlled

--- a/sources/scores/cursor.yaml
+++ b/sources/scores/cursor.yaml
@@ -27,7 +27,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 4
-  basis: benchmark:SWE-bench Verified
+  basis: benchmark
+  basis_detail: SWE-bench Verified
   value: Cursor Background Agent SWE-bench Verified 65.7% (April 2026 coding-agent leaderboard)
   confidence: medium
   note: 'High-tier autonomous coding agent (Background Agent 65.7%), just below OpenHands (68.4%); mature

--- a/sources/scores/dclm-baseline.yaml
+++ b/sources/scores/dclm-baseline.yaml
@@ -21,7 +21,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 5
-  basis: training_value:ablation
+  basis: training_value
+  basis_detail: ablation
   value: null
   confidence: high
   note: Leads the DataComp-LM leaderboard (beats C4/RefinedWeb/RedPajama/Dolma); current 2024-26 default

--- a/sources/scores/deepseek-coder.yaml
+++ b/sources/scores/deepseek-coder.yaml
@@ -32,7 +32,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 3
-  basis: benchmark:code-tasks
+  basis: benchmark
+  basis_detail: code-tasks
   value: 'Vendor: comparable to GPT-4 Turbo on code-specific tasks, beats Claude 3 Opus / Gemini 1.5 Pro on coding+math
     at 2024 release; 338-language support'
   confidence: medium

--- a/sources/scores/deepseek-instruct.yaml
+++ b/sources/scores/deepseek-instruct.yaml
@@ -25,7 +25,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 4
-  basis: benchmark:MMLU-Pro/LiveCodeBench
+  basis: benchmark
+  basis_detail: MMLU-Pro/LiveCodeBench
   value: 'Instruct (Max mode): MMLU-Pro 86.2, LiveCodeBench 91.6, MRCR-1M 78.7; base MMLU 88.7, HumanEval 69.5,
     GSM8K 90.8 (HF card)'
   confidence: medium

--- a/sources/scores/deepseek-r1.yaml
+++ b/sources/scores/deepseek-r1.yaml
@@ -27,7 +27,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 4
-  basis: benchmark:AIME/MATH-500/GPQA/SWE-bench
+  basis: benchmark
+  basis_detail: AIME/MATH-500/GPQA/SWE-bench
   value: AIME 2024 79.8, MATH-500 97.3, GPQA Diamond 71.5, MMLU 90.8, SWE-bench Verified 49.2, LiveCodeBench
     65.9 (HF card, vs OpenAI o1)
   confidence: high

--- a/sources/scores/deepseek.yaml
+++ b/sources/scores/deepseek.yaml
@@ -44,7 +44,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 5
-  basis: benchmark:SWE-bench/MMLU-Pro/GPQA
+  basis: benchmark
+  basis_detail: SWE-bench/MMLU-Pro/GPQA
   value: null
   confidence: high
   note: SWE-bench Verified 80.6% (trails Claude Opus 4.6 by ~0.2), MMLU-Pro 87.5, GPQA Diamond 90.1, LiveCodeBench

--- a/sources/scores/deepteam.yaml
+++ b/sources/scores/deepteam.yaml
@@ -21,7 +21,8 @@ adoption:
     accessed: '2026-06-29'
 capability:
   score: 4
-  basis: vuln + standards coverage
+  basis: feature_matrix
+  basis_detail: vuln + standards coverage
   value: 50+ vulnerability checks and 20+ attack methods (jailbreak, injection, multi-turn) mapped to
     OWASP Top 10 for LLMs, NIST AI RMF, and MITRE ATLAS, plus production guardrails.
   confidence: medium

--- a/sources/scores/devin.yaml
+++ b/sources/scores/devin.yaml
@@ -27,7 +27,10 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 3
-  basis: benchmark:SWE-bench Verified
+  basis: benchmark
+  basis_detail: SWE-bench Verified
+  relative_to: openhands
+  relation: two_below
   value: 'Cognition''s own technical report: 13.86% (2024, 570-problem subset); Devin 2.0 ~45.8% SWE-bench
     Verified (unassisted single-agent, vendor-reported and corroborated)'
   confidence: medium

--- a/sources/scores/devstral.yaml
+++ b/sources/scores/devstral.yaml
@@ -24,7 +24,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 3
-  basis: benchmark:SWE-bench Verified
+  basis: benchmark
+  basis_detail: SWE-bench Verified
   value: 'Devstral Small 1.1 SWE-bench Verified 53.6% (OpenHands scaffold); #1 open source at its release'
   confidence: high
   note: Best open coding model in its release window at a small 24B size, but below 2026 frontier coders

--- a/sources/scores/distilabel.yaml
+++ b/sources/scores/distilabel.yaml
@@ -22,7 +22,8 @@ adoption:
     accessed: '2026-07-21'
 capability:
   score: 4
-  basis: downstream_proxy
+  basis: training_value
+  basis_detail: downstream proxy
   value: No benchmark of the tool itself; inferred from controlled downstream results. Notus-7B-v1 (identical
     Zephyr recipe, only the preference data recurated with distilabel) reaches 91.42 AlpacaEval vs Zephyr-7B-beta's
     90.60; a distilabel-curated Orca-DPO set (46% of the data) beats full-data DPO on the Nous suite (54.04

--- a/sources/scores/dolci.yaml
+++ b/sources/scores/dolci.yaml
@@ -21,7 +21,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 5
-  basis: training_value:downstream
+  basis: training_value
+  basis_detail: downstream
   value: null
   confidence: high
   note: The current fully-open frontier post-training suite; OLMo 3-Think 32B leads the fully-open thinking-model

--- a/sources/scores/dolma-3.yaml
+++ b/sources/scores/dolma-3.yaml
@@ -21,7 +21,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 5
-  basis: training_value:downstream
+  basis: training_value
+  basis_detail: downstream
   value: null
   confidence: high
   note: The current (2025) corpus behind OLMo 3, the strongest fully-open base and thinking models; uses

--- a/sources/scores/dolma.yaml
+++ b/sources/scores/dolma.yaml
@@ -21,7 +21,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 3
-  basis: training_value:superseded
+  basis: training_value
+  basis_detail: superseded
   value: null
   confidence: high
   note: Proven training corpus for OLMo 1/2 and OLMoE, but loses to FineWeb in the canonical FineWeb ablation

--- a/sources/scores/doubao-seed.yaml
+++ b/sources/scores/doubao-seed.yaml
@@ -25,7 +25,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 5
-  basis: benchmark:AIME/Codeforces
+  basis: benchmark
+  basis_detail: AIME/Codeforces
   value: 'Seed 2.0 Pro: AIME 2025 98.3, Codeforces rating 3020, VideoMME 89.5; positioned vs GPT-5.2 / Claude Opus
     4.5 / Gemini 3 Pro'
   confidence: low

--- a/sources/scores/e2b-sandbox.yaml
+++ b/sources/scores/e2b-sandbox.yaml
@@ -29,6 +29,8 @@ adoption:
 capability:
   score: 4
   basis: feature_matrix
+  relative_to: firecracker
+  relation: one_below
   value: isolation:VM (Firecracker microVM, strong); cold-start:fast (sub-second class); language/runtime
     breadth:Python+JS/TS code interpreter + custom templates; persistence:filesystem; scale:1B+ sandboxes
     started

--- a/sources/scores/ernie.yaml
+++ b/sources/scores/ernie.yaml
@@ -22,7 +22,8 @@ adoption:
     accessed: '2026-06-18'
 capability:
   score: 5
-  basis: benchmark:LMArena/AIME
+  basis: benchmark
+  basis_detail: LMArena/AIME
   value: 'AIME 2026 (with tools) 99.6, strong GPQA/MMLU-Pro; MoE, 128K context; LMArena frontier (Baidu claims #13
     Text)'
   confidence: medium

--- a/sources/scores/falcon.yaml
+++ b/sources/scores/falcon.yaml
@@ -41,7 +41,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 2
-  basis: benchmark:MMLU-Pro
+  basis: benchmark
+  basis_detail: MMLU-Pro
   value: null
   confidence: high
   note: 'Falcon3-10B-Base: MMLU 73.1, MMLU-Pro 42.5, GSM8K 83.0; Falcon3-7B-Base: MMLU 67.4, MMLU-Pro 39.2. Competitive

--- a/sources/scores/finemath.yaml
+++ b/sources/scores/finemath.yaml
@@ -21,7 +21,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 5
-  basis: training_value:ablation
+  basis: training_value
+  basis_detail: ablation
   value: null
   confidence: high
   note: Leads controlled math ablations (FineMath-4+ ~2x GSM8K and ~6x MATH over InfiMM-WebMath, beats

--- a/sources/scores/fineweb-2.yaml
+++ b/sources/scores/fineweb-2.yaml
@@ -21,7 +21,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 5
-  basis: training_value:downstream
+  basis: training_value
+  basis_detail: downstream
   value: null
   confidence: high
   note: Primary web corpus for Apertus 8B/70B (2025), 1811 languages; the current multilingual default,

--- a/sources/scores/fineweb-edu.yaml
+++ b/sources/scores/fineweb-edu.yaml
@@ -21,7 +21,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 5
-  basis: training_value:ablation
+  basis: training_value
+  basis_detail: ablation
   value: null
   confidence: high
   note: Dominates FineWeb and all peers on MMLU/ARC, matching full FineWeb with ~10x fewer tokens; current

--- a/sources/scores/fineweb.yaml
+++ b/sources/scores/fineweb.yaml
@@ -21,7 +21,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 4
-  basis: training_value:ablation
+  basis: training_value
+  basis_detail: ablation
   value: null
   confidence: high
   note: The FineWeb paper's 1.7B ablation beats C4, RefinedWeb, RedPajama, Dolma, The Pile, and OSCAR;

--- a/sources/scores/fireworks-inference.yaml
+++ b/sources/scores/fireworks-inference.yaml
@@ -25,7 +25,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 4
-  basis: benchmark:ArtificialAnalysis(provider-speed)
+  basis: benchmark
+  basis_detail: ArtificialAnalysis(provider-speed)
   value: '3rd-fastest provider for gpt-oss-120b on the Artificial Analysis leaderboard at 658.8 output
     tokens/sec (top GPU-based provider; behind wafer/LPU-class Cerebras 1,726.0 and SambaNova 692.5).
     Customer case studies: Notion ~2s -> 350ms latency, Quora 3x speedup. (AA is a living leaderboard;

--- a/sources/scores/flan-collection.yaml
+++ b/sources/scores/flan-collection.yaml
@@ -25,7 +25,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 3
-  basis: training_value:superseded
+  basis: training_value
+  basis_detail: superseded
   value: null
   confidence: high
   note: Strong historical comparative ablations (Flan 2022 beats P3/T0/SNI on the same T5-XL) and still

--- a/sources/scores/garak.yaml
+++ b/sources/scores/garak.yaml
@@ -21,7 +21,8 @@ adoption:
     accessed: '2026-06-29'
 capability:
   score: 4
-  basis: probe coverage
+  basis: feature_matrix
+  basis_detail: probe coverage
   value: Large library of vulnerability probes (hallucination, leakage, injection, misinformation, toxicity,
     jailbreaks) across many model providers.
   confidence: medium

--- a/sources/scores/gemini-flash.yaml
+++ b/sources/scores/gemini-flash.yaml
@@ -33,7 +33,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 5
-  basis: benchmark:Terminal-Bench 2.1
+  basis: benchmark
+  basis_detail: Terminal-Bench 2.1
   value: Terminal-Bench 2.1 76.2%, MCP Atlas 83.6%, CharXiv Reasoning 84.2%, GDPval-AA 1656 Elo; reported to lead
     Opus 4.7 and GPT-5.5 on several agentic/multimodal suites
   confidence: high

--- a/sources/scores/gemini-pro.yaml
+++ b/sources/scores/gemini-pro.yaml
@@ -26,7 +26,8 @@ adoption:
     accessed: '2026-07-29'
 capability:
   score: 5
-  basis: benchmark:LMArena/GPQA-Diamond/HLE
+  basis: benchmark
+  basis_detail: LMArena/GPQA-Diamond/HLE
   value: null
   confidence: medium
   note: Frontier tier. Gemini 3 Pro is competitive at the top of LMArena, GPQA-Diamond and HLE, and the 3.1

--- a/sources/scores/gemma.yaml
+++ b/sources/scores/gemma.yaml
@@ -31,7 +31,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 5
-  basis: benchmark:LMArena
+  basis: benchmark
+  basis_detail: LMArena
   value: high intelligence-per-parameter; multimodal (vision+audio); Google claims top-tier Arena rankings vs much
     larger models
   confidence: medium

--- a/sources/scores/giskard.yaml
+++ b/sources/scores/giskard.yaml
@@ -22,7 +22,8 @@ adoption:
     accessed: '2026-06-29'
 capability:
   score: 4
-  basis: scan + checks coverage
+  basis: feature_matrix
+  basis_detail: scan + checks coverage
   value: Automated vulnerability scanning (injection, harmful output, hallucination) plus scenario-based
     and multi-turn agent evaluations.
   confidence: medium

--- a/sources/scores/glm.yaml
+++ b/sources/scores/glm.yaml
@@ -26,7 +26,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 5
-  basis: benchmark:SWE-bench
+  basis: benchmark
+  basis_detail: SWE-bench
   value: null
   confidence: high
   note: 'SWE-Bench Pro 58.4 (reported #1 at release, edging GPT-5.4 57.7 and Claude Opus 4.6 57.3); Terminal-Bench

--- a/sources/scores/gpt-4-1.yaml
+++ b/sources/scores/gpt-4-1.yaml
@@ -33,7 +33,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 3
-  basis: benchmark:SWE-bench Verified
+  basis: benchmark
+  basis_detail: SWE-bench Verified
   value: SWE-bench Verified 54.6% (vs GPT-4o 33.2%); 1M-token context
   confidence: high
   note: Solid non-reasoning coding model at Apr 2025 (54.6 SWE-bench, +21pts over GPT-4o), but well below

--- a/sources/scores/gpt-4o.yaml
+++ b/sources/scores/gpt-4o.yaml
@@ -28,7 +28,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 3
-  basis: benchmark:MMLU/MMMU
+  basis: benchmark
+  basis_detail: MMLU/MMMU
   value: 'GPT-4o launch-era external figures: MMLU ~88.7, MMMU ~69.1 (NOT confirmed on current OpenAI
     docs, which carry no benchmark numbers); a 2024 frontier non-reasoning multimodal model.'
   confidence: medium

--- a/sources/scores/gpt-5.yaml
+++ b/sources/scores/gpt-5.yaml
@@ -32,7 +32,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 5
-  basis: benchmark:SWE-bench Verified
+  basis: benchmark
+  basis_detail: SWE-bench Verified
   value: null
   confidence: high
   note: 'OpenAI-reported at launch: SWE-bench Verified 74.9%, MMMU 84.2%, AIME 2025 94.6% (no tools), Aider Polyglot

--- a/sources/scores/gpt-oss-safeguard.yaml
+++ b/sources/scores/gpt-oss-safeguard.yaml
@@ -24,7 +24,8 @@ adoption:
     accessed: '2026-06-29'
 capability:
   score: 4
-  basis: reasoning + configurable policy
+  basis: feature_matrix
+  basis_detail: reasoning + configurable policy
   value: Policy-conditioned safety reasoning (bring-your-own-policy), reasoned decisions rather than just
     scores, configurable reasoning effort; 20b and 120b.
   confidence: medium

--- a/sources/scores/granite-code-instruct.yaml
+++ b/sources/scores/granite-code-instruct.yaml
@@ -37,7 +37,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 2
-  basis: benchmark:HumanEval
+  basis: benchmark
+  basis_detail: HumanEval
   value: 'granite-3b-code-instruct-2k HumanEvalSynthesis pass@1: Python 51.2, JS 43.9, Java 41.5, C++
     40.2, Go 31.7, Rust 29.3; 8B variant ~SOTA-among-open-code-LLMs at 2024 release on HumanEvalPack'
   confidence: high

--- a/sources/scores/granite-guardian.yaml
+++ b/sources/scores/granite-guardian.yaml
@@ -24,7 +24,8 @@ adoption:
     accessed: '2026-06-29'
 capability:
   score: 4
-  basis: risk coverage + RAG checks
+  basis: feature_matrix
+  basis_detail: risk coverage + RAG checks
   value: Harm, bias, jailbreak, violence, profanity, sexual content plus RAG hallucination checks (context
     relevance, groundedness, answer relevance); broader than pure I/O moderation.
   confidence: medium

--- a/sources/scores/grok.yaml
+++ b/sources/scores/grok.yaml
@@ -31,7 +31,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 4
-  basis: benchmark:Artificial Analysis Intelligence Index
+  basis: benchmark
+  basis_detail: Artificial Analysis Intelligence Index
   value: null
   confidence: high
   note: 'Artificial Analysis Intelligence Index v4.0 score of 49, ranked #24 of 150 (median 36); index includes

--- a/sources/scores/groq-inference.yaml
+++ b/sources/scores/groq-inference.yaml
@@ -24,7 +24,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 5
-  basis: benchmark:ArtificialAnalysis(provider-speed)
+  basis: benchmark
+  basis_detail: ArtificialAnalysis(provider-speed)
   value: Groq LPU is among the top tokens/sec providers on the Artificial Analysis provider leaderboard
     (purpose-built inference silicon); listed among the fastest-class providers for open models, though
     Cerebras leads on gpt-oss-120b. Speed/latency frontier among inference engines.

--- a/sources/scores/guardrails-ai.yaml
+++ b/sources/scores/guardrails-ai.yaml
@@ -23,7 +23,8 @@ adoption:
     accessed: '2026-06-29'
 capability:
   score: 4
-  basis: validator coverage
+  basis: feature_matrix
+  basis_detail: validator coverage
   value: Input/output guards plus a Hub of pre-built validators (PII, toxicity, injection, structure)
     and structured-output enforcement.
   confidence: medium

--- a/sources/scores/harmbench.yaml
+++ b/sources/scores/harmbench.yaml
@@ -22,7 +22,8 @@ adoption:
     accessed: '2026-06-29'
 capability:
   score: 4
-  basis: standardized eval coverage
+  basis: feature_matrix
+  basis_detail: standardized eval coverage
   value: A standardized pipeline spanning 18 automated attack methods and 33 target models, enabling rigorous
     attack/defense comparison and co-development.
   confidence: medium

--- a/sources/scores/helicone.yaml
+++ b/sources/scores/helicone.yaml
@@ -29,6 +29,8 @@ adoption:
 capability:
   score: 4
   basis: feature_matrix
+  relative_to: langfuse
+  relation: at
   value: 'Has: observability + agent tracing; prompt management (version using production data); cost/latency/quality
     analytics; LLM routing via AI Gateway (100+ models) with automatic fallbacks; datasets & fine-tuning;
     caching.'

--- a/sources/scores/hermes-3-dataset.yaml
+++ b/sources/scores/hermes-3-dataset.yaml
@@ -21,7 +21,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 4
-  basis: training_value:downstream
+  basis: training_value
+  basis_detail: downstream
   value: null
   confidence: high
   note: Proven value with documented Hermes 3 results and explicitly folded into Hermes 4 (2025), but

--- a/sources/scores/hermes.yaml
+++ b/sources/scores/hermes.yaml
@@ -31,7 +31,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 4
-  basis: benchmark:AIME/MMLU-Pro/LiveCodeBench
+  basis: benchmark
+  basis_detail: AIME/MMLU-Pro/LiveCodeBench
   value: MATH-500 96.2, AIME'24 81.9, AIME'25 78.1, GPQA Diamond 70.6, MMLU-Pro 80.6, LiveCodeBench 61.3, BBH 86.3
     (tech report / OpenRouter)
   confidence: medium

--- a/sources/scores/hh-rlhf.yaml
+++ b/sources/scores/hh-rlhf.yaml
@@ -21,7 +21,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 3
-  basis: training_value:superseded
+  basis: training_value
+  basis_detail: superseded
   value: null
   confidence: high
   note: Documented 2022 RLHF results and huge historical influence, but dropped from frontier open preference

--- a/sources/scores/huggingchat-chat-ui.yaml
+++ b/sources/scores/huggingchat-chat-ui.yaml
@@ -30,6 +30,8 @@ adoption:
 capability:
   score: 3
   basis: feature_matrix
+  relative_to: open-webui
+  relation: one_below
   value: model breadth (115-123 open models via 15 inference providers, Omni smart-router on Arch-Router-1.5B);
     multimodal input; MCP tools; OpenAI-compatible API; multi-user (hosted). Current branch removed legacy
     provider-specific integrations and GGUF discovery

--- a/sources/scores/inflection.yaml
+++ b/sources/scores/inflection.yaml
@@ -27,7 +27,7 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 2
-  basis: benchmark:n/a
+  basis: benchmark
   value: null
   confidence: low
   note: 2024 EQ/productivity-focused model, never a leaderboard frontier model; development effectively halted after

--- a/sources/scores/inkling.yaml
+++ b/sources/scores/inkling.yaml
@@ -34,7 +34,10 @@ adoption:
     accessed: '2026-07-19'
 capability:
   score: 4
-  basis: benchmark:SWE-bench/GPQA/AIME
+  basis: benchmark
+  basis_detail: SWE-bench/GPQA/AIME
+  relative_to: kimi
+  relation: one_below
   value: 'SWE-bench Verified 77.6%; SWE-bench Pro 54.3%; GPQA Diamond 87.2%; AIME 2026 97.1% (effort=0.99)'
   confidence: high
   note: Strong open-weight multimodal base — beats Nemotron 3 Ultra on SWE Verified (77.6 vs 70.7) but

--- a/sources/scores/internlm.yaml
+++ b/sources/scores/internlm.yaml
@@ -34,7 +34,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 2
-  basis: benchmark:MMLU
+  basis: benchmark
+  basis_detail: MMLU
   value: 'InternLM2.5-7B base: MMLU 71.6 (5-shot, OpenCompass); matches Yi-1.5-9B, beats Llama-3-8B (66.4).'
   confidence: medium
   note: Strong sub-8B model for 2024 with 1M-context, but below 2026 frontier; calibrates near Falcon 3 (C2) / Yi-1.5

--- a/sources/scores/jamba-large.yaml
+++ b/sources/scores/jamba-large.yaml
@@ -42,7 +42,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 3
-  basis: benchmark:Arena-Hard/MMLU
+  basis: benchmark
+  basis_detail: Arena-Hard/MMLU
   value: Arena Hard 65.4 (AI21-reported, outpacing Llama 3.1 70B and 405B at launch); MMLU (CoT) 81.2; GSM-8K 87;
     RULER 256K effective context (93.9% at full length)
   confidence: medium

--- a/sources/scores/k2.yaml
+++ b/sources/scores/k2.yaml
@@ -26,7 +26,8 @@ adoption:
     accessed: '2026-06-30'
 capability:
   score: 4
-  basis: benchmark:MMLU/GSM8K/reasoning
+  basis: benchmark
+  basis_detail: MMLU/GSM8K/reasoning
   value: Outperforms Qwen2.5-72B; approaches Qwen3-235B
   confidence: medium
   note: Strongest fully-open model by parameter scale (70B dense), with strong long-context and math/reasoning;

--- a/sources/scores/kimi.yaml
+++ b/sources/scores/kimi.yaml
@@ -36,7 +36,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 5
-  basis: benchmark:SWE-bench/Terminal-Bench
+  basis: benchmark
+  basis_detail: SWE-bench/Terminal-Bench
   value: null
   confidence: high
   note: SWE-bench Verified 80.2%, SWE-bench Pro 58.6% (up from 50.7% in K2.5), Terminal-Bench 2.0 66.7% (up from

--- a/sources/scores/lakera-guard.yaml
+++ b/sources/scores/lakera-guard.yaml
@@ -24,7 +24,8 @@ adoption:
     accessed: '2026-06-29'
 capability:
   score: 4
-  basis: defense coverage
+  basis: feature_matrix
+  basis_detail: defense coverage
   value: Real-time prompt-injection, jailbreak, data-leakage, and content-risk defense for LLM apps.
   confidence: low
   note: Category-defining prompt-injection defense; strong coverage, now part of Check Point's platform.

--- a/sources/scores/langwatch.yaml
+++ b/sources/scores/langwatch.yaml
@@ -25,6 +25,8 @@ adoption:
 capability:
   score: 4
   basis: feature_matrix
+  relative_to: langfuse
+  relation: at
   value: 'Has: OTel/OTLP-native tracing; LLM evals (offline + production monitoring); agent simulations/scenario
     testing; prompt management with GitHub integration; dataset creation + annotation; AI Gateway (cost
     control, failover); broad framework/provider integrations.'

--- a/sources/scores/llama-guard.yaml
+++ b/sources/scores/llama-guard.yaml
@@ -26,7 +26,8 @@ adoption:
     accessed: '2026-06-29'
 capability:
   score: 4
-  basis: hazard coverage + benchmarks
+  basis: feature_matrix
+  basis_detail: hazard coverage + benchmarks
   value: 14 hazard categories across input and output, 8 languages, MLCommons-aligned taxonomy; strong
     and widely-benchmarked safety classifier, the reference open baseline.
   confidence: medium

--- a/sources/scores/llama-instruct.yaml
+++ b/sources/scores/llama-instruct.yaml
@@ -36,7 +36,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 3
-  basis: benchmark:MMLU/IFEval
+  basis: benchmark
+  basis_detail: MMLU/IFEval
   value: Llama 3.1 8B-Instruct ~MMLU ~69, solid 8B chat; no reasoning/agentic frontier scores
   confidence: medium
   note: >-

--- a/sources/scores/llama-prompt-guard.yaml
+++ b/sources/scores/llama-prompt-guard.yaml
@@ -25,7 +25,8 @@ adoption:
     accessed: '2026-06-29'
 capability:
   score: 4
-  basis: injection detection + latency
+  basis: feature_matrix
+  basis_detail: injection detection + latency
   value: Dedicated prompt-injection/jailbreak detection at 99.8% AUC and 97.5% recall at 1% FPR (English),
     8 languages, sub-100ms latency; narrow but best-in-class at its job.
   confidence: medium

--- a/sources/scores/llama.yaml
+++ b/sources/scores/llama.yaml
@@ -57,7 +57,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 3
-  basis: benchmark:Artificial Analysis Intelligence Index
+  basis: benchmark
+  basis_detail: Artificial Analysis Intelligence Index
   value: 'Llama 3.1 405B: AA Intelligence Index 17, ranked #29/43, ''below average'' vs current peers (peer average
     23); mid-2024 non-reasoning model surpassed by 2026 frontier.'
   confidence: medium

--- a/sources/scores/llamafirewall.yaml
+++ b/sources/scores/llamafirewall.yaml
@@ -24,7 +24,8 @@ adoption:
     accessed: '2026-06-29'
 capability:
   score: 4
-  basis: layered agent defenses
+  basis: feature_matrix
+  basis_detail: layered agent defenses
   value: 'Layered, agent-focused defenses: jailbreak/injection detection (Prompt Guard 2), agent-alignment/goal-hijack
     checks, and insecure-code filtering (CodeShield) in one real-time firewall.'
   confidence: medium

--- a/sources/scores/llm-guard.yaml
+++ b/sources/scores/llm-guard.yaml
@@ -23,7 +23,8 @@ adoption:
     accessed: '2026-06-29'
 capability:
   score: 3
-  basis: scanner coverage
+  basis: feature_matrix
+  basis_detail: scanner coverage
   value: Input/output scanners for prompt injection, PII/data leakage, toxicity, and harmful content,
     with sanitization.
   confidence: medium

--- a/sources/scores/lmdeploy.yaml
+++ b/sources/scores/lmdeploy.yaml
@@ -29,6 +29,8 @@ adoption:
 capability:
   score: 4
   basis: feature_matrix
+  relative_to: vllm
+  relation: one_below
   value: TurboMind + PyTorch engines; persistent/continuous batching, blocked KV cache, weight-only +
     kv (AWQ/W4A16) quantization, tensor parallelism, broad LLM + VLM architecture coverage; vendor-reported
     4-bit inference ~2.4x FP16

--- a/sources/scores/lucie-7b.yaml
+++ b/sources/scores/lucie-7b.yaml
@@ -68,7 +68,8 @@ adoption:
     accessed: '2026-07-19'
 capability:
   score: 2
-  basis: benchmark:multilingual-pretrain-suite
+  basis: benchmark
+  basis_detail: multilingual-pretrain-suite
   value: null
   confidence: medium
   note: 7B multilingual base prioritizing French cultural representation and data-rights constraints —

--- a/sources/scores/luciole.yaml
+++ b/sources/scores/luciole.yaml
@@ -46,7 +46,8 @@ adoption:
     accessed: '2026-08-07'
 capability:
   score: 2
-  basis: benchmark:multilingual-pretrain-suite
+  basis: benchmark
+  basis_detail: multilingual-pretrain-suite
   value: null
   confidence: low
   note: Multilingual French–English family up to 23B, prioritizing French cultural representation and open

--- a/sources/scores/madlad-400.yaml
+++ b/sources/scores/madlad-400.yaml
@@ -21,7 +21,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 4
-  basis: training_value:downstream
+  basis: training_value
+  basis_detail: downstream
   value: null
   confidence: high
   note: Underpins Google's MADLAD-400 MT models (10.7B/8B, 2023) competitive with NLLB-54B; a strong documented

--- a/sources/scores/marin.yaml
+++ b/sources/scores/marin.yaml
@@ -26,7 +26,10 @@ adoption:
     accessed: '2026-06-30'
 capability:
   score: 3
-  basis: benchmark:MMLU/academic
+  basis: benchmark
+  basis_detail: MMLU/academic
+  relative_to: olmo
+  relation: one_below
   value: Marin 8B Base competitive among fully-open models; 32B Base released
   confidence: medium
   note: Mid-tier fully-open capability at 8B/32B; OLMo 3 outperforms it on fully-open model evaluations.

--- a/sources/scores/milvus.yaml
+++ b/sources/scores/milvus.yaml
@@ -33,7 +33,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 4
-  basis: benchmark:ANN-Benchmarks
+  basis: benchmark
+  basis_detail: ANN-Benchmarks
   value: null
   confidence: high
   note: High-performance cloud-native vector ANN search; covered by independent ANN-Benchmarks and first-party

--- a/sources/scores/mimo-pro.yaml
+++ b/sources/scores/mimo-pro.yaml
@@ -20,7 +20,8 @@ adoption:
     accessed: '2026-06-18'
 capability:
   score: 4
-  basis: benchmark:LMArena/MMLU-Pro
+  basis: benchmark
+  basis_detail: LMArena/MMLU-Pro
   value: MMLU 89.4, MMLU-Pro 68.5, GSM8K 99.6, HumanEval+ 75.6; efficiency-focused; lower end of the LMArena frontier
     band (~#29 per mirrors)
   confidence: medium

--- a/sources/scores/minimax.yaml
+++ b/sources/scores/minimax.yaml
@@ -29,7 +29,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 5
-  basis: benchmark:SWE-bench Verified
+  basis: benchmark
+  basis_detail: SWE-bench Verified
   value: SWE-bench Verified 80.2%, SWE-bench Pro 55.4%, GPQA-D 85.2%, AIME25 86.3%, BrowseComp 76.3%; VIBE-Pro on
     par with Opus 4.5
   confidence: medium

--- a/sources/scores/mistral-7b-instruct.yaml
+++ b/sources/scores/mistral-7b-instruct.yaml
@@ -23,7 +23,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 2
-  basis: benchmark:MT-Bench/MMLU
+  basis: benchmark
+  basis_detail: MT-Bench/MMLU
   value: Mistral 7B Instruct v0.2 ~MT-Bench ~7.6 / MMLU ~60 class; 2023-era 7B chat quality
   confidence: medium
   note: Excellent for a 7B in 2023-24; clearly below 2026 frontier and below modern small instruct models (Phi-4-mini,

--- a/sources/scores/mistral-large.yaml
+++ b/sources/scores/mistral-large.yaml
@@ -35,7 +35,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 4
-  basis: benchmark:LMArena
+  basis: benchmark
+  basis_detail: LMArena
   value: null
   confidence: high
   note: 'Debuts #2 in LMArena OSS non-reasoning category (#6 among all OSS models). Per-benchmark MMLU-Pro/GPQA/SWE-bench

--- a/sources/scores/modal-sandboxes.yaml
+++ b/sources/scores/modal-sandboxes.yaml
@@ -32,6 +32,8 @@ adoption:
 capability:
   score: 4
   basis: feature_matrix
+  relative_to: ray
+  relation: at
   value: isolation:gVisor user-space kernel (Sentry intercepts syscalls) - strong container isolation,
     below microVM but above plain containers; cold-start:optimized container stack, fast startup; runtime
     breadth:arbitrary images/dependencies (custom images, any deps, repo checkout); persistence:named/ID

--- a/sources/scores/muse-spark.yaml
+++ b/sources/scores/muse-spark.yaml
@@ -30,7 +30,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 5
-  basis: benchmark:LMArena/HLE
+  basis: benchmark
+  basis_detail: LMArena/HLE
   value: 'LMArena #6 overall (~1487 Elo, mid-2026); Humanity''s Last Exam 58%, FrontierScience Research
     38% (Contemplating mode); positioned vs Gemini Deep Think / GPT Pro extreme-reasoning modes'
   confidence: medium

--- a/sources/scores/nemo-curator.yaml
+++ b/sources/scores/nemo-curator.yaml
@@ -24,6 +24,8 @@ adoption:
 capability:
   score: 5
   basis: benchmark
+  relative_to: dclm
+  relation: at
   value: Nemotron-CC, built with NeMo Curator, beats DCLM by +5.6 MMLU (59.0 vs 53.4) for its HQ subset
     at 8B/1T tokens; a 15T-token long-horizon run reached 70.3 MMLU vs Llama 3.1 8B's 65.3 while retaining
     ~4x more unique tokens than DCLM/FineWeb-Edu.

--- a/sources/scores/nemo-guardrails.yaml
+++ b/sources/scores/nemo-guardrails.yaml
@@ -22,7 +22,8 @@ adoption:
     accessed: '2026-06-29'
 capability:
   score: 4
-  basis: feature coverage
+  basis: feature_matrix
+  basis_detail: feature coverage
   value: Programmable rails for I/O moderation, dialog/topic control, retrieval filtering, and tool-use
     control via Colang; multi-provider.
   confidence: medium

--- a/sources/scores/nemotron-cc.yaml
+++ b/sources/scores/nemotron-cc.yaml
@@ -22,7 +22,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 5
-  basis: training_value:ablation
+  basis: training_value
+  basis_detail: ablation
   value: null
   confidence: high
   note: Wins vs DCLM at a long token horizon (Nemotron-CC-HQ +5.6 MMLU over DCLM; a 15T-token 8B beats

--- a/sources/scores/nemotron.yaml
+++ b/sources/scores/nemotron.yaml
@@ -56,7 +56,8 @@ adoption:
     accessed: '2026-07-29'
 capability:
   score: 5
-  basis: benchmark:SWE-bench/AIME/GPQA/MMLU-Pro
+  basis: benchmark
+  basis_detail: SWE-bench/AIME/GPQA/MMLU-Pro
   value: 'Nemotron 3 Super (per NVIDIA tech report): SWE-Bench Verified 60.47, AIME 2025 90.21, GPQA (no tools)
     79.23, MMLU-Pro 83.73; ~2.2x inference throughput vs GPT-OSS-120B'
   confidence: high

--- a/sources/scores/nono.yaml
+++ b/sources/scores/nono.yaml
@@ -28,7 +28,8 @@ adoption:
     accessed: '2026-06-29'
 capability:
   score: 3
-  basis: feature coverage (cross-platform least-privilege agent sandboxing)
+  basis: feature_matrix
+  basis_detail: feature coverage (cross-platform least-privilege agent sandboxing)
   value: Least-privilege agent sandboxing across macOS / Linux / Windows with near-zero startup, FFI bindings
     for Rust / Python / TypeScript / Go, and an agent registry. Lighter-weight than the microVM-based sandboxes
     (E2B, Firecracker) but with the widest local-platform coverage and lowest setup friction.

--- a/sources/scores/o-series.yaml
+++ b/sources/scores/o-series.yaml
@@ -26,7 +26,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 4
-  basis: benchmark:SWE-bench/GPQA/Codeforces/AIME
+  basis: benchmark
+  basis_detail: SWE-bench/GPQA/Codeforces/AIME
   value: 'o3: SWE-bench Verified 71.7%, GPQA Diamond 87.7%, Codeforces Elo 2727; o4-mini: AIME 2025 99.5% pass@1
     with Python tool, GPQA ~81%'
   confidence: high

--- a/sources/scores/oasst1.yaml
+++ b/sources/scores/oasst1.yaml
@@ -21,7 +21,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 3
-  basis: training_value:downstream
+  basis: training_value
+  basis_detail: downstream
   value: null
   confidence: high
   note: Proven with ongoing downstream use (Guanaco, Tulu 3, OLMo 3 Dolci) but dated, reduced to a fractional

--- a/sources/scores/olmo-instruct.yaml
+++ b/sources/scores/olmo-instruct.yaml
@@ -27,7 +27,8 @@ adoption:
     accessed: '2026-06-30'
 capability:
   score: 4
-  basis: benchmark:IFEval/AlpacaEval/MMLU
+  basis: benchmark
+  basis_detail: IFEval/AlpacaEval/MMLU
   value: OLMo 3-Instruct 7B ties or surpasses Qwen 2.5, Gemma 3 and Llama 3.1 at its scale
   confidence: high
   note: Strongest fully-open chat line; competitive with same-scale open-weight instruct models but below the 2026

--- a/sources/scores/olmo.yaml
+++ b/sources/scores/olmo.yaml
@@ -43,7 +43,8 @@ adoption:
     accessed: '2026-06-30'
 capability:
   score: 4
-  basis: benchmark:MMLU/GPQA/reasoning
+  basis: benchmark
+  basis_detail: MMLU/GPQA/reasoning
   value: OLMo 3-Think 32B narrows the gap to Qwen3-32B on reasoning at ~6x fewer tokens
   confidence: high
   note: Strongest fully-open base/reasoning model to date; competitive with Qwen2.5/Gemma3 and approaching Qwen3-32B,

--- a/sources/scores/olmoe-instruct.yaml
+++ b/sources/scores/olmoe-instruct.yaml
@@ -30,7 +30,8 @@ adoption:
     accessed: '2026-06-25'
 capability:
   score: 2
-  basis: benchmark:MMLU/AlpacaEval
+  basis: benchmark
+  basis_detail: MMLU/AlpacaEval
   value: OLMoE-1B-7B-Instruct MMLU 51.9, GSM8k 45.5, HumanEval 54.8, AlpacaEval1 84.0,
     IFEval 48.1
   confidence: medium

--- a/sources/scores/onnx-runtime.yaml
+++ b/sources/scores/onnx-runtime.yaml
@@ -28,7 +28,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 4
-  basis: benchmark:MLPerf
+  basis: benchmark
+  basis_detail: MLPerf
   value: Appears in MLPerf Inference v5.0 submissions (ResNet50, RetinaNet, offline; multiple ORT versions
     v1.20.1-v1.23.2). Execution providers across CUDA/WebGPU/CPU/TensorRT/OpenVINO/CoreML; cross-framework
     (PyTorch/TF/scikit-learn/XGBoost). Quantization + graph optimization.

--- a/sources/scores/openai-moderation.yaml
+++ b/sources/scores/openai-moderation.yaml
@@ -22,7 +22,8 @@ adoption:
     accessed: '2026-06-29'
 capability:
   score: 3
-  basis: category coverage
+  basis: feature_matrix
+  basis_detail: category coverage
   value: Multi-category text (and image) moderation aligned to OpenAI's content policy; convenient but
     fixed taxonomy.
   confidence: low

--- a/sources/scores/openguardrails.yaml
+++ b/sources/scores/openguardrails.yaml
@@ -27,7 +27,8 @@ adoption:
     accessed: '2026-06-29'
 capability:
   score: 4
-  basis: platform + model + multilingual
+  basis: feature_matrix
+  basis_detail: platform + model + multilingual
   value: A safety/manipulation-detection model plus a deployable platform (APIs, deployment scripts, modular
     components) covering content safety, prompt injection/jailbreak, code-interpreter abuse, and data
     leakage across 119 languages.

--- a/sources/scores/openhands.yaml
+++ b/sources/scores/openhands.yaml
@@ -28,7 +28,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 5
-  basis: benchmark:SWE-bench Verified
+  basis: benchmark
+  basis_detail: SWE-bench Verified
   value: null
   confidence: high
   note: Reported 77.6% on SWE-bench Verified, at or above proprietary coding agents; model-agnostic (100+

--- a/sources/scores/openhermes-2-5.yaml
+++ b/sources/scores/openhermes-2-5.yaml
@@ -22,7 +22,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 3
-  basis: training_value:superseded
+  basis: training_value
+  basis_detail: superseded
   value: null
   confidence: high
   note: Attributed gains inside SmolTalk (MMLU/BBH/WinoGrande) but no standalone ablation; superseded

--- a/sources/scores/openthoughts-114k.yaml
+++ b/sources/scores/openthoughts-114k.yaml
@@ -21,7 +21,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 3
-  basis: training_value:superseded
+  basis: training_value
+  basis_detail: superseded
   value: null
   confidence: high
   note: Strong early-2025 reasoning results (OpenThinker-32B led open-data MATH500/GPQA-D) but superseded

--- a/sources/scores/openwebmath.yaml
+++ b/sources/scores/openwebmath.yaml
@@ -21,7 +21,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 3
-  basis: training_value:superseded
+  basis: training_value
+  basis_detail: superseded
   value: null
   confidence: high
   note: Proven math corpus (Llemma/Proof-Pile-2, OLMoE, StarCoder2 math supplement) but Oct-2023 vintage

--- a/sources/scores/opik.yaml
+++ b/sources/scores/opik.yaml
@@ -31,6 +31,8 @@ adoption:
 capability:
   score: 4
   basis: feature_matrix
+  relative_to: langfuse
+  relation: at
   value: tracing(OTel-native + 70+ integrations), evals(datasets/experiments, pytest CI/CD), LLM-as-judge
     metrics(hallucination/moderation/relevance/context-precision), prompt playground, datasets, cost tracking
   confidence: high

--- a/sources/scores/ornith.yaml
+++ b/sources/scores/ornith.yaml
@@ -25,7 +25,8 @@ adoption:
     accessed: '2026-07-03'
 capability:
   score: 4
-  basis: benchmark:SWE-Bench/Terminal-Bench
+  basis: benchmark
+  basis_detail: SWE-Bench/Terminal-Bench
   value: SWE-Bench Verified 69.4, SWE-Bench Pro 42.9, Terminal-Bench 2.1 ~43 (Terminus-2) / ~40.6 (Claude
     Code); agentic coding with reasoning and tool-calling
   confidence: medium

--- a/sources/scores/oscar-2301.yaml
+++ b/sources/scores/oscar-2301.yaml
@@ -23,7 +23,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 3
-  basis: training_value:superseded
+  basis: training_value
+  basis_detail: superseded
   value: null
   confidence: high
   note: A dated 2022-snapshot web corpus with access suspended; the derived Colossal OSCAR trains ALIA/Salamandra

--- a/sources/scores/osprey.yaml
+++ b/sources/scores/osprey.yaml
@@ -24,7 +24,8 @@ adoption:
     accessed: '2026-07-01'
 capability:
   score: 4
-  basis: throughput / rules coverage
+  basis: feature_matrix
+  basis_detail: throughput / rules coverage
   value: High-performance real-time event-decisioning engine with a Python rules DSL (SML); ~2.3M rules/sec
     and 400M daily actions at Discord.
   confidence: medium

--- a/sources/scores/personahub.yaml
+++ b/sources/scores/personahub.yaml
@@ -38,7 +38,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 2
-  basis: training_value:results
+  basis: training_value
+  basis_detail: results
   value: null
   confidence: high
   note: >-

--- a/sources/scores/perspective-api.yaml
+++ b/sources/scores/perspective-api.yaml
@@ -23,7 +23,8 @@ adoption:
     accessed: '2026-06-29'
 capability:
   score: 3
-  basis: attribute coverage
+  basis: feature_matrix
+  basis_detail: attribute coverage
   value: Scores toxicity and related attributes (insult, threat, profanity, identity attack) for text,
     multilingual; established but a fixed attribute set.
   confidence: low

--- a/sources/scores/pes2o.yaml
+++ b/sources/scores/pes2o.yaml
@@ -21,7 +21,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 4
-  basis: training_value:downstream
+  basis: training_value
+  basis_detail: downstream
   value: null
   confidence: high
   note: The standard open science corpus with documented multi-model reuse (OLMoE 57B tokens, Marin, Nemotron

--- a/sources/scores/phi-instruct.yaml
+++ b/sources/scores/phi-instruct.yaml
@@ -23,7 +23,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 2
-  basis: benchmark:MMLU-Pro/GPQA
+  basis: benchmark
+  basis_detail: MMLU-Pro/GPQA
   value: MMLU 67.3, MMLU-Pro 52.8, GPQA 25.2, GSM8K 88.6, MATH 64.0 (overall 63.5)
   confidence: high
   note: Strong-for-size 3.8B with good math (GSM8K 88.6) but low GPQA (25.2) and overall well below 2026 frontier

--- a/sources/scores/phi.yaml
+++ b/sources/scores/phi.yaml
@@ -35,7 +35,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 3
-  basis: benchmark:GPQA
+  basis: benchmark
+  basis_detail: GPQA
   value: null
   confidence: high
   note: '14B model with outsized math/reasoning: ~56.1% on graduate-level (GPQA-style) science questions, 80.4%

--- a/sources/scores/phoenix.yaml
+++ b/sources/scores/phoenix.yaml
@@ -34,6 +34,8 @@ adoption:
 capability:
   score: 4
   basis: feature_matrix
+  relative_to: langfuse
+  relation: at
   value: tracing(OTel-native), evals(LLM-as-judge response+retrieval), datasets/experiments, prompt management+playground,
     cost/latency, broad framework integrations (OpenAI/Claude/LangGraph/LlamaIndex/CrewAI)
   confidence: high

--- a/sources/scores/pinecone.yaml
+++ b/sources/scores/pinecone.yaml
@@ -33,7 +33,10 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 4
-  basis: benchmark:ANN-Benchmarks
+  basis: benchmark
+  basis_detail: ANN-Benchmarks
+  relative_to: milvus
+  relation: at
   value: P50 latency ~26-60ms at 1.4B-vector scale, 5,700 QPS; serverless auto-indexing, dedicated read
     nodes
   confidence: medium

--- a/sources/scores/promptlayer.yaml
+++ b/sources/scores/promptlayer.yaml
@@ -27,6 +27,8 @@ adoption:
 capability:
   score: 3
   basis: feature_matrix
+  relative_to: langfuse
+  relation: one_below
   value: 'prompt mgmt/versioning(registry-based CMS, visual no-code editor, A/B testing); tracing(logs
     every request/response); evals(basic, regression sets); cost/monitoring(narrower than full-stack).
     Missing: deep LLM-as-judge eval + broad OTel/framework observability vs anchors.'

--- a/sources/scores/pyrit.yaml
+++ b/sources/scores/pyrit.yaml
@@ -22,7 +22,8 @@ adoption:
     accessed: '2026-06-29'
 capability:
   score: 4
-  basis: red-team coverage
+  basis: feature_matrix
+  basis_detail: red-team coverage
   value: Automated adversarial prompting, attack-strategy orchestration, and scoring to identify harms
     across providers.
   confidence: medium

--- a/sources/scores/pythia.yaml
+++ b/sources/scores/pythia.yaml
@@ -59,7 +59,7 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 1
-  basis: benchmark:n/a
+  basis: benchmark
   value: null
   confidence: high
   note: Not built for capability. Pythia models (max 12B, 2023-era Pile training) are intentionally research instruments

--- a/sources/scores/qdrant.yaml
+++ b/sources/scores/qdrant.yaml
@@ -31,7 +31,10 @@ adoption:
     accessed: '2026-06-25'
 capability:
   score: 4
-  basis: benchmark:ANN-Benchmarks
+  basis: benchmark
+  basis_detail: ANN-Benchmarks
+  relative_to: milvus
+  relation: at
   value: 'Included in ANN-Benchmarks (37 algorithms incl. Qdrant/Milvus/faiss/scann). Vendor benchmark:
     highest RPS and lowest latency in almost all scenarios vs Milvus/Weaviate/Elasticsearch/Redis at matched
     precision; advanced filtered-search query planning.'

--- a/sources/scores/qwen-coder.yaml
+++ b/sources/scores/qwen-coder.yaml
@@ -26,7 +26,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 4
-  basis: benchmark:SWE-bench/agentic-coding
+  basis: benchmark
+  basis_detail: SWE-bench/agentic-coding
   value: Vendor positions agentic coding comparable to Claude Sonnet class; 480B-A35B MoE, repository-scale long
     context; non-thinking mode
   confidence: medium

--- a/sources/scores/qwen-instruct.yaml
+++ b/sources/scores/qwen-instruct.yaml
@@ -23,7 +23,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 3
-  basis: benchmark:MMLU/instruction-following
+  basis: benchmark
+  basis_detail: MMLU/instruction-following
   value: General-purpose 14B instruct; vendor reports gains in coding, math, instruction-following and long-text
     vs predecessor; detailed scores in Qwen2.5 blog
   confidence: medium

--- a/sources/scores/qwen.yaml
+++ b/sources/scores/qwen.yaml
@@ -44,7 +44,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 5
-  basis: benchmark:SWE-bench/Terminal-Bench
+  basis: benchmark
+  basis_detail: SWE-bench/Terminal-Bench
   value: null
   confidence: high
   note: 'Dense Qwen3.6-27B: SWE-bench Verified 77.2, Terminal-Bench 2.0 59.3 (reported matching Claude 4.5 Opus

--- a/sources/scores/qwen3guard.yaml
+++ b/sources/scores/qwen3guard.yaml
@@ -24,7 +24,8 @@ adoption:
     accessed: '2026-06-29'
 capability:
   score: 4
-  basis: coverage + multilingual + streaming
+  basis: feature_matrix
+  basis_detail: coverage + multilingual + streaming
   value: Prompt and response classification across 119 languages with a three-level verdict and a token-level
     streaming variant; size ladder from 0.6B to 8B.
   confidence: medium

--- a/sources/scores/redpajama-data-v2.yaml
+++ b/sources/scores/redpajama-data-v2.yaml
@@ -22,7 +22,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 3
-  basis: training_value:superseded
+  basis: training_value
+  basis_detail: superseded
   value: null
   confidence: high
   note: Competitive in its own filtered ablation but loses to FineWeb in FineWeb's 1.82B run; primarily

--- a/sources/scores/refinedweb.yaml
+++ b/sources/scores/refinedweb.yaml
@@ -22,7 +22,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 3
-  basis: training_value:superseded
+  basis: training_value
+  basis_detail: superseded
   value: null
   confidence: high
   note: Filtered web alone beat The Pile and was the best legacy corpus in DCLM's tests; powered Falcon

--- a/sources/scores/reka-core.yaml
+++ b/sources/scores/reka-core.yaml
@@ -25,7 +25,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 2
-  basis: benchmark:MMMU
+  basis: benchmark
+  basis_detail: MMMU
   value: Comparable to GPT-4V on MMMU; outperforms Claude-3 Opus on multimodal human eval; surpasses Gemini
     Ultra on video (Apr 2024 claims)
   confidence: low

--- a/sources/scores/rwkv.yaml
+++ b/sources/scores/rwkv.yaml
@@ -77,7 +77,8 @@ adoption:
     accessed: '2026-06-18'
 capability:
   score: 4
-  basis: benchmark:RWKV-7 Goose (arXiv:2503.14456)
+  basis: benchmark
+  basis_detail: RWKV-7 Goose (arXiv:2503.14456)
   value: 'RWKV-7 ''Goose'' 2.9B: claimed 3B SoTA multilingual and matching 3B SoTA English on far fewer training
     tokens; MMLU rose to ~43% across generations'
   confidence: medium

--- a/sources/scores/sglang.yaml
+++ b/sources/scores/sglang.yaml
@@ -28,6 +28,8 @@ adoption:
 capability:
   score: 5
   basis: feature_matrix
+  relative_to: vllm
+  relation: at
   value: null
   confidence: high
   note: RadixAttention, structured generation, multi-step pipelines; benchmarked as top-tier vs vLLM/TensorRT-LLM

--- a/sources/scores/shieldgemma.yaml
+++ b/sources/scores/shieldgemma.yaml
@@ -22,7 +22,8 @@ adoption:
     accessed: '2026-06-29'
 capability:
   score: 3
-  basis: hazard coverage
+  basis: feature_matrix
+  basis_detail: hazard coverage
   value: Four harm categories (sexual, dangerous, hate, harassment), yes/no policy classifier in 2B/9B/27B;
     narrower taxonomy than Llama Guard but multiple sizes.
   confidence: medium

--- a/sources/scores/smollm.yaml
+++ b/sources/scores/smollm.yaml
@@ -27,7 +27,8 @@ adoption:
     accessed: '2026-06-30'
 capability:
   score: 3
-  basis: benchmark:reasoning/multilingual
+  basis: benchmark
+  basis_detail: reasoning/multilingual
   value: Outperforms Llama-3.2-3B and Qwen2.5-3B; competitive with 4B Qwen3/Gemma3
   confidence: high
   note: Strong intelligence-per-parameter for a 3B model, but small absolute capability vs larger open and open-weight

--- a/sources/scores/smoltalk.yaml
+++ b/sources/scores/smoltalk.yaml
@@ -21,7 +21,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 5
-  basis: training_value:ablation
+  basis: training_value
+  basis_detail: ablation
   value: null
   confidence: high
   note: Leads head-to-head SFT-mixture ablations (beats OpenHermes-2.5, UltraChat, MagPie-Pro) and is

--- a/sources/scores/stack-edu.yaml
+++ b/sources/scores/stack-edu.yaml
@@ -21,7 +21,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 5
-  basis: training_value:ablation
+  basis: training_value
+  basis_detail: ablation
   value: null
   confidence: high
   note: Leads controlled classifier ablations, beating StarCoder2Data on MultiPL-E across all languages

--- a/sources/scores/starcoder2.yaml
+++ b/sources/scores/starcoder2.yaml
@@ -36,7 +36,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 3
-  basis: benchmark:HumanEval
+  basis: benchmark
+  basis_detail: HumanEval
   value: StarCoder2-15B-Instruct-v0.1 HumanEval pass@1 72.6% (HumanEval+ 63.4%)
   confidence: high
   note: Strong HumanEval for a fully-open 16B in 2024 (best fully-self-aligned code model at release), but HumanEval

--- a/sources/scores/starcoderdata.yaml
+++ b/sources/scores/starcoderdata.yaml
@@ -21,7 +21,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 3
-  basis: training_value:superseded
+  basis: training_value
+  basis_detail: superseded
   value: null
   confidence: high
   note: Proven pretraining component (TinyLlama, Granite Code, ALIA, OLMoE) but drawn from The Stack v1

--- a/sources/scores/swe-agent.yaml
+++ b/sources/scores/swe-agent.yaml
@@ -26,7 +26,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 3
-  basis: benchmark:SWE-bench Verified
+  basis: benchmark
+  basis_detail: SWE-bench Verified
   value: SWE-bench Verified 43.2% (SWE-agent v1, Claude Sonnet 4.5)
   confidence: medium
   note: 'Originator of the SWE-bench agent scaffold; mid-tier on the 2026 leaderboard (43.2%), above Aider

--- a/sources/scores/swift.yaml
+++ b/sources/scores/swift.yaml
@@ -28,6 +28,8 @@ adoption:
 capability:
   score: 4
   basis: feature_matrix
+  relative_to: megatron-lm
+  relation: one_below
   value: 'Methods: full FT, LoRA/QLoRA/DoRA, SFT, GRPO family (GRPO/DAPO/GSPO/SAPO/CISPO/CHORD/RLOO/Reinforce++),
     preference (DPO/KTO/RM/CPO/SimPO/ORPO), pretraining; 600+ models; integrated quantization/eval/deploy.'
   confidence: high

--- a/sources/scores/synth.yaml
+++ b/sources/scores/synth.yaml
@@ -21,7 +21,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 4
-  basis: training_value:results
+  basis: training_value
+  basis_detail: results
   value: null
   confidence: medium
   note: A novel fully-open synthetic reasoning corpus with real first-party end-to-end results (Baguettotron

--- a/sources/scores/tensorrt-llm.yaml
+++ b/sources/scores/tensorrt-llm.yaml
@@ -41,7 +41,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 5
-  basis: benchmark:MLPerf
+  basis: benchmark
+  basis_detail: MLPerf
   value: null
   confidence: high
   note: Maximum NVIDIA-hardware performance; featured in MLPerf Inference (HGX H100 ~3x GPT-J gain attributed

--- a/sources/scores/the-pile.yaml
+++ b/sources/scores/the-pile.yaml
@@ -26,7 +26,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 3
-  basis: training_value:superseded
+  basis: training_value
+  basis_detail: superseded
   value: null
   confidence: high
   note: The foundational 2020-era template, proven for a wide 2022-23 family (Pythia, GPT-NeoX-20B, GPT-J,

--- a/sources/scores/the-stack-v2.yaml
+++ b/sources/scores/the-stack-v2.yaml
@@ -22,7 +22,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 4
-  basis: training_value:downstream
+  basis: training_value
+  basis_detail: downstream
   value: null
   confidence: high
   note: Trained StarCoder2 (2024) and is the code base of SmolLM3 (2025) plus the source for Stack-Edu;

--- a/sources/scores/tinyllama-chat.yaml
+++ b/sources/scores/tinyllama-chat.yaml
@@ -29,7 +29,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 1
-  basis: benchmark:MMLU
+  basis: benchmark
+  basis_detail: MMLU
   value: 1.1B Llama-2-era model; intended for lightweight/edge use, not competitive on 2026 capability benchmarks
   confidence: high
   note: Intentionally tiny (1.1B, 2023 Llama-2 architecture). Its value is footprint and openness, not capability;

--- a/sources/scores/tulu-3-sft-mixture.yaml
+++ b/sources/scores/tulu-3-sft-mixture.yaml
@@ -22,7 +22,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 4
-  basis: training_value:downstream
+  basis: training_value
+  basis_detail: downstream
   value: null
   confidence: high
   note: Current multi-org SFT default (Marin, SmolLM3, OLMo 2) with SOTA open-recipe claims, but a reused

--- a/sources/scores/tulu.yaml
+++ b/sources/scores/tulu.yaml
@@ -54,7 +54,8 @@ adoption:
     accessed: '2026-06-25'
 capability:
   score: 3
-  basis: benchmark:MMLU/GSM8K/IFEval
+  basis: benchmark
+  basis_detail: MMLU/GSM8K/IFEval
   value: Tulu-3-405B MMLU 87.0, GSM8K 95.5, IFEval 86.0, HumanEval 95.9, MATH 67.3
   confidence: high
   note: >-

--- a/sources/scores/txt360.yaml
+++ b/sources/scores/txt360.yaml
@@ -21,7 +21,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 4
-  basis: training_value:ablation
+  basis: training_value
+  basis_detail: ablation
   value: null
   confidence: medium
   note: A self-reported controlled ablation beats FineWeb (8x8B MoE, 1.5T tokens) but without published

--- a/sources/scores/ultrachat-200k.yaml
+++ b/sources/scores/ultrachat-200k.yaml
@@ -21,7 +21,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 3
-  basis: training_value:superseded
+  basis: training_value
+  basis_detail: superseded
   value: null
   confidence: high
   note: Clean SFT before/after in the Zephyr paper (MT-Bench ~6.64), but dropped from 2024-25 default

--- a/sources/scores/ultrafeedback.yaml
+++ b/sources/scores/ultrafeedback.yaml
@@ -21,7 +21,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 4
-  basis: training_value:ablation
+  basis: training_value
+  basis_detail: ablation
   value: null
   confidence: high
   note: Clean documented DPO before/after (Zephyr MT-Bench 6.64->7.34); its pipeline is the template for

--- a/sources/scores/vercel-sandbox.yaml
+++ b/sources/scores/vercel-sandbox.yaml
@@ -32,6 +32,8 @@ adoption:
 capability:
   score: 4
   basis: feature_matrix
+  relative_to: aws-lambda
+  relation: one_below
   value: isolation:Firecracker microVM with dedicated kernel (stronger than container/gVisor); cold-start:starts
     in milliseconds; runtime breadth:moderate (Amazon Linux 2023; node22/24/26 + python3.13 runtimes,
     sudo+root, install any package, can run Docker/VPN/FUSE); persistence:persistent-by-default (auto-save

--- a/sources/scores/vibethinker.yaml
+++ b/sources/scores/vibethinker.yaml
@@ -23,7 +23,8 @@ adoption:
     accessed: '2026-06-30'
 capability:
   score: 3
-  basis: benchmark:AIME/GPQA/LeetCode
+  basis: benchmark
+  basis_detail: AIME/GPQA/LeetCode
   value: AIME 2026 94.3, GPQA Diamond 70.2, IMO-AnswerBench 76.4, LeetCode 96.1% accept
   confidence: medium
   note: Frontier-range on narrow verifiable math/code reasoning despite 3B, but explicitly not for general/agentic

--- a/sources/scores/vllm.yaml
+++ b/sources/scores/vllm.yaml
@@ -33,7 +33,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 5
-  basis: benchmark:MLPerf
+  basis: benchmark
+  basis_detail: MLPerf
   value: null
   confidence: high
   note: Reference PagedAttention implementation; used in MLPerf Inference submissions (Red Hat OpenShift

--- a/sources/scores/weave.yaml
+++ b/sources/scores/weave.yaml
@@ -27,6 +27,8 @@ adoption:
 capability:
   score: 4
   basis: feature_matrix
+  relative_to: langfuse
+  relation: at
   value: tracing(auto-logs OpenAI/Anthropic calls incl inputs/outputs/tokens/cost); evals(LLM-as-judge
     + code scorers, experiments vs datasets); datasets/annotation; cost tracking; integrations(OpenAI/Anthropic
     + framework hooks). Missing dedicated prompt-management/versioning depth vs MLflow/Langfuse.

--- a/sources/scores/whylabs.yaml
+++ b/sources/scores/whylabs.yaml
@@ -34,6 +34,8 @@ adoption:
 capability:
   score: 2
   basis: feature_matrix
+  relative_to: langfuse
+  relation: two_below
   value: 'whylogs(data logging/profiling, drift + data-quality monitoring, privacy-preserving) + LangKit(LLM
     text-quality/safety metrics: sentiment, toxicity, prompt-injection signals). No live tracing backend,
     no eval-experiment/prompt-mgmt platform (open sourced but unmaintained). Narrow vs anchor C4 tools.'

--- a/sources/scores/wildchat-1m.yaml
+++ b/sources/scores/wildchat-1m.yaml
@@ -22,7 +22,8 @@ adoption:
     accessed: '2026-07-04'
 capability:
   score: 4
-  basis: training_value:downstream
+  basis: training_value
+  basis_detail: downstream
   value: null
   confidence: medium
   note: A sustained cross-recipe SFT ingredient (Tulu 3 2024, OLMo 3 Dolci 2025), but its own ablation

--- a/sources/scores/wildguard.yaml
+++ b/sources/scores/wildguard.yaml
@@ -24,7 +24,8 @@ adoption:
     accessed: '2026-06-29'
 capability:
   score: 4
-  basis: joint detection + benchmarks
+  basis: feature_matrix
+  basis_detail: joint detection + benchmarks
   value: Joint prompt-harm, response-harm, and refusal detection across 13 subcategories; reported above
     GPT-4 and prior open baselines, with low over-blocking on benign traffic.
   confidence: medium

--- a/sources/scores/yi.yaml
+++ b/sources/scores/yi.yaml
@@ -31,7 +31,8 @@ adoption:
     accessed: '2026-06-04'
 capability:
   score: 2
-  basis: benchmark:MMLU/GSM8K
+  basis: benchmark
+  basis_detail: MMLU/GSM8K
   value: 'Yi-1.5-34B base: MMLU 76.3, C-Eval 81.4, BBH 54.3; 34B-Chat GSM8K 90.2. Competitive in 2024 mid-size class.'
   confidence: medium
   note: Strong for a 2024 sub-35B model but well below 2026 frontier open models (DeepSeek-V4, Qwen 3.6); calibrates

--- a/sources/scores/zentropi-cope.yaml
+++ b/sources/scores/zentropi-cope.yaml
@@ -25,7 +25,8 @@ adoption:
     accessed: '2026-06-29'
 capability:
   score: 4
-  basis: steerable bring-your-own-policy
+  basis: feature_matrix
+  basis_detail: steerable bring-your-own-policy
   value: 'Policy-adaptive labeling: evaluates content against arbitrary natural-language policies rather
     than a fixed taxonomy, with strong F1 across hate, sexual, violence, harassment, self-harm, and toxicity.'
   confidence: low

--- a/sources/scores/zephyr.yaml
+++ b/sources/scores/zephyr.yaml
@@ -33,7 +33,8 @@ adoption:
     accessed: '2026-06-25'
 capability:
   score: 2
-  basis: benchmark:MT-Bench/AlpacaEval
+  basis: benchmark
+  basis_detail: MT-Bench/AlpacaEval
   value: zephyr-7b-beta MT-Bench 7.34, AlpacaEval 90.6% win rate, Open LLM Leaderboard
     avg 52.15
   confidence: high

--- a/sources/signal_routing.yaml
+++ b/sources/signal_routing.yaml
@@ -273,9 +273,20 @@ dimensions:
         Citations are a reach signal, not a quality one. Usable as corroboration
         for a benchmark's standing, not as the capability score itself.
     status: >
-      Effectively unroutable today. The two real capability anchors are both
-      unbridged, and no category's scoring_recipe has calibrated 1-5 thresholds
-      against them. Capability stays hand-authored until both are fixed.
+      Effectively unroutable, and more permanently than "until the bridge lands"
+      suggests. The two external anchors are unbridged AND both rank models, so
+      neither can say anything about a training framework, a sandbox or a
+      dataset tool. No category has calibrated 1-5 thresholds either. MLPerf
+      Training was checked on 2026-08-08 as the obvious candidate for the
+      software categories and rejected: it names exactly 1 of our 27
+      finetuning_code slugs across five rounds, its `framework` field is free
+      text describing the submitter's container rather than the library under
+      test, and 117 of 119 v6.0 rows are closed division, which by rule holds
+      the software constant. It measures hardware.
+      What actually places most bands is a comparison to a peer in the same
+      category, so that is recorded rather than routed: capability.relative_to
+      and capability.relation, gated by build/check_capability.py. See
+      docs/guides/verification.md, "What a capability confirmation attests to".
 
 # Dimensions with no machine signal at all, listed so their absence is a
 # recorded decision rather than an oversight.

--- a/tests/test_check_capability.py
+++ b/tests/test_check_capability.py
@@ -1,0 +1,203 @@
+"""Tests for the capability comparison gates.
+
+The two that carry the design are `test_relation_and_scores_can_disagree` and
+`test_a_derived_band_cannot_be_fresher_than_what_it_derives_from`. The first is the whole
+reason to record a comparison rather than write it in a note: two statements of the same fact
+can drift, and only one of them was ever checkable. The second is the openness invariant's
+shape applied to a different dependency — a date is worth no more than the least recently
+confirmed thing underneath it.
+
+`test_the_gate_ratchets` pins the property that let the openness gates land mid-corpus at all.
+A product that records no comparison is not a failure; it is work not yet done, and a gate that
+cannot tell those apart gets switched off.
+"""
+
+from datetime import date
+
+import pytest
+
+from build.check_capability import candidates, check
+
+CATS = {"a": "cat", "b": "cat", "c": "cat", "far": "other"}
+
+
+def scores(**products) -> dict:
+    out = {}
+    for slug, block in products.items():
+        out[slug] = {"product": slug, "capability": block}
+    return out
+
+
+def test_a_consistent_comparison_passes():
+    data = scores(
+        a={"score": 4, "basis": "feature_matrix", "relative_to": "b", "relation": "one_below"},
+        b={"score": 5, "basis": "feature_matrix"},
+    )
+    assert check(data, CATS) == []
+
+
+def test_relation_and_scores_can_disagree():
+    """The producible-pair check's shape: a recorded relation is falsifiable arithmetic."""
+    data = scores(
+        a={"score": 3, "basis": "feature_matrix", "relative_to": "b", "relation": "one_below"},
+        b={"score": 5, "basis": "feature_matrix"},
+    )
+    problems = check(data, CATS)
+    assert len(problems) == 1
+    assert "which is 4" in problems[0] and "the score is 3" in problems[0]
+
+
+@pytest.mark.parametrize(
+    "relation,mine,ok",
+    [("at", 5, True), ("at", 4, False), ("one_below", 4, True), ("two_below", 3, True), ("two_below", 4, False)],
+)
+def test_every_relation_is_arithmetic(relation, mine, ok):
+    data = scores(
+        a={"score": mine, "basis": "feature_matrix", "relative_to": "b", "relation": relation},
+        b={"score": 5, "basis": "feature_matrix"},
+    )
+    assert (check(data, CATS) == []) is ok
+
+
+def test_one_above_works_when_the_anchor_leaves_room():
+    """Real case: telemetry's operative anchor is a 4, and two products sit above it."""
+    data = scores(
+        a={"score": 5, "basis": "feature_matrix", "relative_to": "b", "relation": "one_above"},
+        b={"score": 4, "basis": "feature_matrix"},
+    )
+    assert check(data, CATS) == []
+
+
+def test_a_relation_no_band_could_satisfy_is_its_own_finding():
+    data = scores(
+        a={"score": 5, "basis": "feature_matrix", "relative_to": "b", "relation": "one_above"},
+        b={"score": 5, "basis": "feature_matrix"},
+    )
+    assert "no score satisfies it" in check(data, CATS)[0]
+
+
+def test_a_derived_band_cannot_be_fresher_than_what_it_derives_from():
+    data = scores(
+        a={
+            "score": 4, "basis": "feature_matrix", "relative_to": "b", "relation": "one_below",
+            "last_verified": date(2026, 8, 8),
+        },
+        b={"score": 5, "basis": "feature_matrix", "last_verified": date(2026, 6, 4)},
+    )
+    problems = check(data, CATS)
+    assert len(problems) == 1
+    assert "was last confirmed 2026-06-04" in problems[0]
+
+
+def test_an_undated_anchor_cannot_support_a_dated_band():
+    data = scores(
+        a={
+            "score": 4, "basis": "feature_matrix", "relative_to": "b", "relation": "one_below",
+            "last_verified": date(2026, 8, 8),
+        },
+        b={"score": 5, "basis": "feature_matrix"},
+    )
+    assert "carries no confirmation at all" in check(data, CATS)[0]
+
+
+def test_an_anchor_confirmed_the_same_day_is_fine():
+    same = date(2026, 8, 8)
+    data = scores(
+        a={"score": 4, "basis": "feature_matrix", "relative_to": "b", "relation": "one_below", "last_verified": same},
+        b={"score": 5, "basis": "feature_matrix", "last_verified": same},
+    )
+    assert check(data, CATS) == []
+
+
+def test_an_undated_band_needs_no_anchor_date():
+    """Freshness is only a question once a confirmation is claimed."""
+    data = scores(
+        a={"score": 4, "basis": "feature_matrix", "relative_to": "b", "relation": "one_below"},
+        b={"score": 5, "basis": "feature_matrix"},
+    )
+    assert check(data, CATS) == []
+
+
+def test_a_comparison_must_stay_inside_the_category():
+    data = scores(
+        a={"score": 4, "basis": "feature_matrix", "relative_to": "far", "relation": "one_below"},
+        far={"score": 5, "basis": "feature_matrix"},
+    )
+    assert "is in 'other', not 'cat'" in check(data, CATS)[0]
+
+
+def test_a_missing_target_is_caught():
+    data = scores(a={"score": 4, "basis": "feature_matrix", "relative_to": "ghost", "relation": "at"})
+    assert "is not a product on the map" in check(data, CATS)[0]
+
+
+def test_a_self_reference_is_caught():
+    data = scores(a={"score": 4, "basis": "feature_matrix", "relative_to": "a", "relation": "at"})
+    assert "points at itself" in check(data, CATS)[0]
+
+
+def test_half_a_comparison_is_caught_here_too():
+    """The schema also catches it. A gate that assumes another gate ran passes silently."""
+    data = scores(a={"score": 4, "basis": "feature_matrix", "relative_to": "b"})
+    assert "without the other" in check(data, CATS)[0]
+
+
+def test_a_null_score_makes_the_relation_assert_nothing():
+    data = scores(
+        a={"score": None, "basis": "n/a", "relative_to": "b", "relation": "one_below"},
+        b={"score": 5, "basis": "feature_matrix"},
+    )
+    assert "asserts nothing" in check(data, CATS)[0]
+
+
+def test_the_gate_ratchets():
+    """No comparison recorded is work not yet done, not a failure."""
+    data = scores(
+        a={"score": 4, "basis": "feature_matrix", "note": "one tier below b, the anchor"},
+        b={"score": 5, "basis": "feature_matrix"},
+    )
+    assert check(data, CATS) == []
+
+
+def test_candidates_finds_the_unrecorded_comparison():
+    data = scores(
+        a={"score": 4, "basis": "feature_matrix", "note": "One tier below b, the frontier anchor."},
+        b={"score": 5, "basis": "feature_matrix"},
+    )
+    assert candidates(data, CATS) == ["a:capability: note compares against b, unrecorded"]
+
+
+def test_candidates_ignores_a_product_that_already_records_one():
+    data = scores(
+        a={
+            "score": 4, "basis": "feature_matrix", "relative_to": "b", "relation": "one_below",
+            "note": "One tier below b, the frontier anchor.",
+        },
+        b={"score": 5, "basis": "feature_matrix"},
+    )
+    assert candidates(data, CATS) == []
+
+
+def test_candidates_ignores_a_peer_named_without_comparison():
+    """Naming a product is not comparing to it. 'Built on b' is a fact about lineage."""
+    data = scores(
+        a={"score": 4, "basis": "feature_matrix", "note": "Built on b's scheduler."},
+        b={"score": 5, "basis": "feature_matrix"},
+    )
+    assert candidates(data, CATS) == []
+
+
+def test_candidates_ignores_a_cross_category_mention():
+    data = scores(
+        a={"score": 4, "basis": "feature_matrix", "note": "One tier below far, the anchor."},
+        far={"score": 5, "basis": "feature_matrix"},
+    )
+    assert candidates(data, CATS) == []
+
+
+def test_the_real_corpus_holds():
+    """Whatever is recorded today must be consistent. This is the gate, run for real."""
+    from build.check_capability import load
+
+    corpus, owner = load()
+    assert check(corpus, owner) == []

--- a/tests/test_check_capability.py
+++ b/tests/test_check_capability.py
@@ -13,6 +13,7 @@ cannot tell those apart gets switched off.
 """
 
 from datetime import date
+from pathlib import Path
 
 import pytest
 
@@ -201,3 +202,24 @@ def test_the_real_corpus_holds():
 
     corpus, owner = load()
     assert check(corpus, owner) == []
+
+
+def test_a_relation_outside_capability_is_rejected_by_the_schema():
+    """A sweep run wrote `relation` onto openness and adoption on four axes. The fields are
+    declared under capability only, but every axis had additionalProperties unset, so they
+    validated silently and were read by nothing."""
+    import json
+
+    import jsonschema
+    import yaml
+
+    root = Path(__file__).resolve().parents[1]
+    schema = json.loads((root / "docs/schemas/score.schema.json").read_text())
+    doc = yaml.safe_load((root / "sources/scores/trl.yaml").read_text())
+
+    jsonschema.validate(doc, schema)
+    for axis in ("openness", "adoption"):
+        stray = yaml.safe_load((root / "sources/scores/trl.yaml").read_text())
+        stray[axis]["relation"] = "at"
+        with pytest.raises(jsonschema.ValidationError, match="Additional properties"):
+            jsonschema.validate(stray, schema)


### PR DESCRIPTION
Answers "can we ingest the Megatron-LM anchor on a recurring basis?" — the short version is that we can, it costs almost nothing, and it would have bought almost nothing, so this does the thing underneath instead.

## Why not ingestion

Three findings killed it, each verified rather than assumed:

- **MLPerf Training measures hardware.** It names exactly **1 of our 27** `finetuning_code` slugs across five rounds and 478 system rows. Megatron appears in 0 systems in three of the last five rounds, and NVIDIA never names it. 117 of 119 v6.0 rows are closed division, which by rule holds the software constant — twelve submissions on identical B300 hardware land in a 3% band while carrying twelve different framework strings for the same container.
- **The existing capability routes are model-shaped.** Artificial Analysis and LMArena rank models, so even fully bridged neither can say anything about a training framework. `signal_routing.yaml` already said "effectively unroutable"; it now says why, permanently.
- **The anchor's own record is empty where it matters.** `megatron-lm.yaml` has `capability.value: null`. Every fact the other 26 products are placed against lives in its note. Re-fetching a page whose extracted facts are recorded nowhere re-derives nothing.

## What most capability bands actually rest on

A comparison to a peer. Roughly a hundred products say so in prose — "one tier below the Megatron-LM anchor", "on par with Langfuse C4" — and in `finetuning_code` all 27 notes do it. **That comparison is the instrument**, and it lived in a sentence where nothing could check it, refresh it, or notice when the peer moved.

```yaml
capability:
  score: 4
  basis: feature_matrix
  relative_to: megatron-lm
  relation: one_below
```

`build/check_capability.py` gates three things, wired into `validate.yml`:

1. **The relation must agree with both scores.** This is the producible-pair check's shape rather than the invariant's — the relation and the two scores are two statements of one fact, and they can disagree.
2. **The peer is in the same category.**
3. **A dated band's peer must be confirmed at least as recently.** A derived date is worth no more than what it derives from — the openness invariant's insight on a different dependency.

It ratchets: it covers the 27 products that record a comparison and grows, and `--candidates` reports the backlog rather than failing on it.

## basis becomes an enum first

You cannot gate an axis whose instrument is one of 85 free-text strings, 65 used once. Now `feature_matrix` 322, `benchmark` 86, `training_value` 39, `n/a` 25. The benchmark names that were jammed into the string in **56 spellings** move to `basis_detail`, so nothing is lost. 148 files migrated through `components.py`, so every edit carried its re-parse assertion — the diffs are two lines each.

## Four contradictions, needing your call

Surfaced immediately, and **not recorded** — writing a relation known to be false only reddens CI. Each is a score decision:

| product | the prose says | the scores say |
|---|---|---|
| `anythingllm` | "on par with LibreChat/Open WebUI" | those two are 5 and 4, so parity with both is impossible |
| `swe-agent` | above `aider` (43.2% vs 31.4% SWE-bench) | both are 3 |
| `zed` | level with `cursor` and `windsurf` | zed is 5, both peers are 4 |
| `dolma-toolkit` | "a tier below" the frontier | its scores are two tiers below |

## Scope notes

**Per-product `relative_to`, no category-level anchor.** I proposed a category anchor and dropped it: telemetry's operative reference is `langfuse` at capability 4 while `arize` and `braintrust` sit at 5, so "top of the category" and "what things are placed against" are different. Per-product sidesteps it and checks more.

**`capability.components` was considered and rejected.** At 61% prose by `check_rubric`'s own measure against the 71% that stopped `edge_hardware`, with four instruments sharing one field name, there is no shared ladder at the end of that work the way openness got four.

**The backlog is 33, not 33 units of work.** 29 are notes comparing against a *class* ("the microVM frontier", "frontier labs") or asserting direction with no tier distance, which the loose candidate regex cannot distinguish from a peer placement. The extraction agents refused to record those, correctly — "recording it would be fitting the field to the gate". The other 4 are the contradictions above.

## Test plan

- `pytest tests/ -q` → 361 passed (24 new)
- `build.check_capability` → `[OK]`, 27 of 472 record a comparison
- `build.validate` → `0 error(s)` — the schema's `dependentRequired` rejects half a comparison
- `test_the_real_corpus_holds` runs the gate against the real corpus inside the suite