### PR TITLE
Show the benchmark name again in the capability panel

### DIFF
--- a/build/render.py
+++ b/build/render.py
@@ -812,7 +812,7 @@ def details_payload(DATA, ORDER, mo):
           row('Reach',ad.reach)+row('Signal',ad.signal_type)+row('Detail',ad.note)+row('Confidence',ad.confidence)+
           '<div class="v3-row"><span class="v3-lbl">Sources</span><span class="v3-val">'+srcs(ad.sources)+'</span></div>'+
           '<div class="v3-sect">Capability '+(cap.score==null?'n/a':cap.score+'/5')+'</div>'+
-          row('Basis',cap.basis)+row('Value',cap.value)+row('Detail',cap.note)+row('Confidence',cap.confidence)+
+          row('Basis',cap.basis_detail?cap.basis+': '+cap.basis_detail:cap.basis)+row('Value',cap.value)+row('Detail',cap.note)+row('Confidence',cap.confidence)+
           '<div class="v3-row"><span class="v3-lbl">Sources</span><span class="v3-val">'+srcs(cap.sources)+'</span></div>'+
           (p.lineage?('<div class="v3-sect">Lineage</div>'+
             (p.lineage.derived_from&&p.lineage.derived_from.length?row('Derived from',p.lineage.derived_from.join(', ')):'')+


### PR DESCRIPTION
A display regression from #153, found by checking what the schema change actually renders.

Splitting `capability.basis` into an enum plus `basis_detail` moved the benchmark's name out of a field the notebook renders and into one it doesn't. The product detail panel went from

```
Basis: benchmark:SWE-bench Verified
```

to

```
Basis: benchmark
```

for the **145 products** carrying a `basis_detail`, and the name appeared nowhere else on the page. `build/render.py` now shows `basis: basis_detail` when the detail exists, and the bare enum when it doesn't.

## Blast radius, for the record

I traced both consumers rather than assuming:

- **The front end (`aipotluck.org`) is unaffected.** It declares `capability.basis` in `web/src/lib/types/scores.ts` but renders nothing from it — the only `basis` matches in the Svelte components are a Tailwind `basis-[360px]` class. `relative_to`, `relation` and `basis_detail` reach the payload and are ignored.
- **The notebook was the only surface**, via `build/render.py`.

The prose half of the sweep is the part that *is* visible: `description` and `version_note` both render in `product-detail.svelte`, so the ~447 products still needing a verification line will change what readers see.

## Test plan

- `build.serialize` + `build.render` → the generated notebook carries the new expression
- `build.validate` → `0 error(s)`
- `pytest tests/ -q` → 381 passed
- Generated files reverted before commit; the bot owns them