### PR TITLE
refresh-category, and refresh-all-categories to drive it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,12 +202,17 @@ All warehouse write operations are maintainer steps. See `docs/runbooks/`.
 
 ## Skills
 
-Four editor skills live in `skills/`:
+Editor skills live in `skills/`. They compose: the sweep drives a category, a category
+drives its products, and a product's prose has its own procedure.
 
 | Skill | When to use |
 |-------|------------|
 | `curate-category` | Edit category definition, weights, litmus, or product roster |
 | `add-product` | Add a new product (scaffolds product + score YAML, updates roster) |
+| `build-rubric` | Derive a category's openness ladder, or extend a shared one to it |
+| `verify-product` | Refresh one product's `description` and `comments` against its sources |
+| `refresh-category` | Re-verify a whole category: scores and prose together, to the PR |
+| `refresh-all-categories` | Drive the sweep — report progress, pick the next category |
 | `add-data-source` | Register a new external data source and add a fetcher |
 | `pyoso-analyst` | Query `currentai.*` tables via `pyoso` (read-only analysis) |
 

--- a/build/sweep_status.py
+++ b/build/sweep_status.py
@@ -30,10 +30,20 @@ sweep is cheapest to change. Coverage is measured locally as the share of a cate
 carrying a routable artifact block, which is the same thing `check_routing` counts and does not
 need the warehouse.
 
+## Refreshing rather than finishing
+
+Once a category is gate-clean it stays "done" forever, which is wrong the moment a confirmation
+ages: `last_verified` is a claim about a day, and the map keeps moving. `--max-age-days` (or
+`--since`) reads a confirmation older than the window as `stale` rather than `verified`, so the
+same tooling that drove the first pass drives the recurring one. The prose ages on the same
+clock, because the canonical verification line carries its own date.
+
 Usage:
     uv run python -m build.sweep_status
     uv run python -m build.sweep_status --verbose
-    uv run python -m build.sweep_status --next        # just the next category's slug
+    uv run python -m build.sweep_status --next            # just the next category's slug
+    uv run python -m build.sweep_status --max-age-days 30 # what has gone stale in a month
+    uv run python -m build.sweep_status --since 2026-07-01
 """
 
 from __future__ import annotations
@@ -41,6 +51,7 @@ from __future__ import annotations
 import argparse
 import re
 import sys
+from datetime import date, timedelta
 from pathlib import Path
 
 import yaml
@@ -49,7 +60,7 @@ ROOT = Path(__file__).resolve().parents[1]
 AXES = ("openness", "adoption", "capability")
 VALUE_KEY = {"openness": "score", "adoption": "level", "capability": "score"}
 ARTIFACTS = ("github", "pypi", "npm", "crates", "huggingface_model", "huggingface_dataset")
-VERIFIED_LINE = re.compile(r"Verified \d{4}-\d{2}-\d{2} via ")
+VERIFIED_LINE = re.compile(r"Verified (\d{4}-\d{2}-\d{2}) via ")
 
 
 def load() -> tuple[dict, dict, dict, dict, dict]:
@@ -67,33 +78,66 @@ def load() -> tuple[dict, dict, dict, dict, dict]:
     return _dir("categories"), _dir("products"), _dir("scores"), queue, {}
 
 
-def product_state(slug: str, product: dict, score: dict, held: dict) -> dict:
-    """Per-product: which axes are settled, whether the prose is, and whether it is held."""
+def _on_or_after(value: object, cutoff: date | None) -> bool:
+    """True when `value` is a date at or after the cutoff. No cutoff means any date passes."""
+    if cutoff is None:
+        return True
+    if isinstance(value, date):
+        return value >= cutoff
+    try:
+        return date.fromisoformat(str(value)) >= cutoff
+    except (TypeError, ValueError):
+        return False
+
+
+def product_state(
+    slug: str, product: dict, score: dict, held: dict, cutoff: date | None = None
+) -> dict:
+    """Per-product: which axes are settled, whether the prose is, and whether it is held.
+
+    With a `cutoff`, a confirmation older than it counts as `stale` rather than `verified` -
+    which is what turns the sweep from a one-time pass into a recurring refresh. An axis that
+    was never confirmed is `open` whatever the cutoff, and unlike `check_freshness` there is no
+    commit-date fallback here: the question this asks is "has anyone re-read this", and a commit
+    date answers "did anyone touch the file", which is a different question.
+    """
     axes = {}
     for axis in AXES:
         block = score.get(axis) or {}
         if block.get("last_verified"):
-            axes[axis] = "verified"
+            axes[axis] = "verified" if _on_or_after(block["last_verified"], cutoff) else "stale"
         elif block.get(VALUE_KEY[axis]) is None:
             axes[axis] = "abstained"
         else:
             axes[axis] = "open"
-    prose = bool(VERIFIED_LINE.search(str(product.get("comments") or "")))
+    # The canonical verification line carries its own date, so the prose ages on the same clock.
+    match = VERIFIED_LINE.search(str(product.get("comments") or ""))
+    if not match:
+        prose_state = "missing"
+    elif _on_or_after(match.group(1), cutoff):
+        prose_state = "verified"
+    else:
+        prose_state = "stale"
+    prose = prose_state == "verified"
     return {
         "axes": axes,
         "prose": prose,
+        "prose_state": prose_state,
         "held": slug in held,
-        "done": slug in held or (all(v != "open" for v in axes.values()) and prose),
+        "done": slug in held or (
+            all(v not in ("open", "stale") for v in axes.values()) and prose
+        ),
     }
 
 
-def survey() -> list[dict]:
+def survey(cutoff: date | None = None) -> list[dict]:
     cats, prods, scores, held, _ = load()
     rows = []
     for slug, cat in cats.items():
         roster = cat.get("products") or []
         states = {
-            p: product_state(p, prods.get(p) or {}, scores.get(p) or {}, held) for p in roster
+            p: product_state(p, prods.get(p) or {}, scores.get(p) or {}, held, cutoff)
+            for p in roster
         }
         routable = sum(
             1 for p in roster if any((prods.get(p) or {}).get(k) for k in ARTIFACTS)
@@ -115,9 +159,24 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--verbose", action="store_true", help="list what is unfinished")
     parser.add_argument("--next", action="store_true", help="print the next category and exit")
+    parser.add_argument(
+        "--max-age-days", type=int,
+        help="treat a confirmation older than this as needing a refresh",
+    )
+    parser.add_argument(
+        "--since", help="treat a confirmation before this date (YYYY-MM-DD) as needing a refresh"
+    )
     args = parser.parse_args()
 
-    rows = survey()
+    if args.max_age_days is not None and args.since:
+        parser.error("--max-age-days and --since say the same thing two ways; pass one")
+    cutoff = None
+    if args.max_age_days is not None:
+        cutoff = date.today() - timedelta(days=args.max_age_days)
+    elif args.since:
+        cutoff = date.fromisoformat(args.since)
+
+    rows = survey(cutoff)
     pending = [r for r in rows if r["done"] < r["products"]]
 
     if args.next:
@@ -126,6 +185,8 @@ def main() -> int:
 
     total = sum(r["products"] for r in rows)
     done = sum(r["done"] for r in rows)
+    if cutoff:
+        print(f"counting a confirmation before {cutoff} as needing a refresh\n")
     print(f"{'category':30}{'done':>6}{'held':>6}{'of':>5}{'artifacts':>11}")
     for row in rows:
         print(
@@ -149,14 +210,19 @@ def main() -> int:
             print(f"\n{row['category']}:")
             for slug, state in sorted(unfinished.items()):
                 open_axes = [a for a, v in state["axes"].items() if v == "open"]
+                stale = [a for a, v in state["axes"].items() if v == "stale"]
                 abstained = [a for a, v in state["axes"].items() if v == "abstained"]
                 bits = []
                 if open_axes:
                     bits.append("open: " + ",".join(open_axes))
+                if stale:
+                    bits.append("stale: " + ",".join(stale))
                 if abstained:
                     bits.append("abstained: " + ",".join(abstained))
-                if not state["prose"]:
+                if state["prose_state"] == "missing":
                     bits.append("no verification line")
+                elif state["prose_state"] == "stale":
+                    bits.append("prose line stale")
                 print(f"  {slug:38} {'; '.join(bits)}")
     return 0
 

--- a/build/sweep_status.py
+++ b/build/sweep_status.py
@@ -1,0 +1,165 @@
+"""Where the verification sweep has got to, derived from the corpus rather than stored.
+
+`/goal` runs one category per invocation and has to know which one is next. That could be a
+pointer in a file, and a pointer is a second copy of a fact the corpus already carries — it
+desyncs the first time a category is finished by hand, or half-finished, or reverted. So there
+is no pointer. This module reads `sources/` and works it out.
+
+## What "done" means for a product
+
+The bar agreed on 2026-08-08, and it is per product rather than per axis:
+
+  * every axis carries a real `last_verified`, or abstains deliberately (a null value, which
+    `verification.md` explains for the 46 axes that have one), or the product is held;
+  * `comments` ends in the canonical verification line, which is the prose half's proxy —
+    `product-info.md` has rules a checker cannot enforce, but the line is the one thing a
+    finished product always has;
+  * held products count as resolved, not as remaining. A product whose evidence cannot be
+    settled goes into `sources/verification_queue.yaml` with a reason and stops blocking its
+    category, which is what let the pilot ship five of six.
+
+Deliberately NOT counted as done: an axis whose value is null because nobody looked. The two
+are indistinguishable in the file today, which is the gap the per-axis deferral idea closes.
+Until that exists this over-counts, and `--verbose` prints the null axes so the number can be
+read with that in mind.
+
+## Order
+
+Worst artifact coverage first, so the categories where automation helps least go while the
+sweep is cheapest to change. Coverage is measured locally as the share of a category's products
+carrying a routable artifact block, which is the same thing `check_routing` counts and does not
+need the warehouse.
+
+Usage:
+    uv run python -m build.sweep_status
+    uv run python -m build.sweep_status --verbose
+    uv run python -m build.sweep_status --next        # just the next category's slug
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+AXES = ("openness", "adoption", "capability")
+VALUE_KEY = {"openness": "score", "adoption": "level", "capability": "score"}
+ARTIFACTS = ("github", "pypi", "npm", "crates", "huggingface_model", "huggingface_dataset")
+VERIFIED_LINE = re.compile(r"Verified \d{4}-\d{2}-\d{2} via ")
+
+
+def load() -> tuple[dict, dict, dict, dict, dict]:
+    def _dir(name: str) -> dict:
+        out = {}
+        for path in sorted((ROOT / "sources" / name).glob("*.yaml")):
+            doc = yaml.safe_load(path.read_text()) or {}
+            out[doc.get("name") or doc.get("product") or path.stem] = doc
+        return out
+
+    queue_path = ROOT / "sources" / "verification_queue.yaml"
+    queue = {}
+    if queue_path.exists():
+        queue = (yaml.safe_load(queue_path.read_text()) or {}).get("held") or {}
+    return _dir("categories"), _dir("products"), _dir("scores"), queue, {}
+
+
+def product_state(slug: str, product: dict, score: dict, held: dict) -> dict:
+    """Per-product: which axes are settled, whether the prose is, and whether it is held."""
+    axes = {}
+    for axis in AXES:
+        block = score.get(axis) or {}
+        if block.get("last_verified"):
+            axes[axis] = "verified"
+        elif block.get(VALUE_KEY[axis]) is None:
+            axes[axis] = "abstained"
+        else:
+            axes[axis] = "open"
+    prose = bool(VERIFIED_LINE.search(str(product.get("comments") or "")))
+    return {
+        "axes": axes,
+        "prose": prose,
+        "held": slug in held,
+        "done": slug in held or (all(v != "open" for v in axes.values()) and prose),
+    }
+
+
+def survey() -> list[dict]:
+    cats, prods, scores, held, _ = load()
+    rows = []
+    for slug, cat in cats.items():
+        roster = cat.get("products") or []
+        states = {
+            p: product_state(p, prods.get(p) or {}, scores.get(p) or {}, held) for p in roster
+        }
+        routable = sum(
+            1 for p in roster if any((prods.get(p) or {}).get(k) for k in ARTIFACTS)
+        )
+        rows.append({
+            "category": slug,
+            "products": len(roster),
+            "done": sum(1 for s in states.values() if s["done"]),
+            "held": sum(1 for s in states.values() if s["held"]),
+            "coverage": routable / len(roster) if roster else 1.0,
+            "states": states,
+        })
+    # Worst coverage first; a finished category sorts to the back whatever its coverage.
+    rows.sort(key=lambda r: (r["done"] >= r["products"], r["coverage"], r["category"]))
+    return rows
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--verbose", action="store_true", help="list what is unfinished")
+    parser.add_argument("--next", action="store_true", help="print the next category and exit")
+    args = parser.parse_args()
+
+    rows = survey()
+    pending = [r for r in rows if r["done"] < r["products"]]
+
+    if args.next:
+        print(pending[0]["category"] if pending else "")
+        return 0
+
+    total = sum(r["products"] for r in rows)
+    done = sum(r["done"] for r in rows)
+    print(f"{'category':30}{'done':>6}{'held':>6}{'of':>5}{'artifacts':>11}")
+    for row in rows:
+        print(
+            f"{row['category']:30}{row['done']:6}{row['held']:6}{row['products']:5}"
+            f"{row['coverage']:10.0%}"
+        )
+    print(f"{'TOTAL':30}{done:6}{sum(r['held'] for r in rows):6}{total:5}")
+    print()
+    if pending:
+        nxt = pending[0]
+        print(f"next: {nxt['category']} — {nxt['products'] - nxt['done']} products remaining, "
+              f"{nxt['coverage']:.0%} carry a routable artifact")
+    else:
+        print("every category is finished.")
+
+    if args.verbose:
+        for row in rows:
+            unfinished = {p: s for p, s in row["states"].items() if not s["done"]}
+            if not unfinished:
+                continue
+            print(f"\n{row['category']}:")
+            for slug, state in sorted(unfinished.items()):
+                open_axes = [a for a, v in state["axes"].items() if v == "open"]
+                abstained = [a for a, v in state["axes"].items() if v == "abstained"]
+                bits = []
+                if open_axes:
+                    bits.append("open: " + ",".join(open_axes))
+                if abstained:
+                    bits.append("abstained: " + ",".join(abstained))
+                if not state["prose"]:
+                    bits.append("no verification line")
+                print(f"  {slug:38} {'; '.join(bits)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/refresh-all-categories/SKILL.md
+++ b/skills/refresh-all-categories/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: refresh-all-categories
+description: Use when driving the verification sweep toward its goal — every product in os-ai-map gate-clean. Reports what is finished, picks the next category by worst artifact coverage, and hands it to refresh-category. One category per run, because each one is reviewed before the next starts.
+---
+
+# Refresh All Categories
+
+The objective: **every product on the map gate-clean** — each axis dated or deliberately
+abstaining, each source carrying a status and a digest, each product's prose satisfying
+`product-info.md`.
+
+This skill is the driver. It holds no verification logic of its own: it works out where the
+sweep has got to, picks what is next, and hands one category to `refresh-category`.
+
+## One category per run
+
+Each category is reviewed and merged before the next starts. That is a deliberate gate, not a
+limitation — a systemic defect in one batch costs one category rather than fifteen, and the
+pilot found three defect classes that only a human reading a PR would have caught.
+
+So this skill advances the goal by one category per invocation, then stops. Run it again for
+the next.
+
+## Steps
+
+### 1. Report
+
+```bash
+uv run python -m build.sweep_status
+```
+
+```
+category                        done  held   of  artifacts
+finetuning_code                    5     0   27       41%
+inference_code                     0     0   20       45%
+...
+TOTAL                              5     0  472
+
+next: finetuning_code — 22 products remaining, 41% carry a routable artifact
+```
+
+State is **derived from the corpus, never stored**. A pointer file recording "we are on category
+N" is a second copy of a fact `sources/` already carries, and it desyncs the first time someone
+finishes a category by hand, half-finishes one, or reverts. So this is correct after any of
+those, and after a run that crashed halfway.
+
+Give the user the table. It is the answer to "how far along are we", which is the question this
+skill exists to answer.
+
+### 2. Pick
+
+Take the category `sweep_status` names, unless the user asks for a different one. The order is
+**worst artifact coverage first**: the categories where machine signal helps least go while the
+sweep is still cheap to change, so no manual reading duplicates what an automated pass would
+later have earned for free.
+
+Two reasons to override it, and say which applies:
+
+- **A category is mid-flight.** `finetuning_code` has five products done and one held; finishing
+  a started category beats starting a new one.
+- **An anchor lives elsewhere.** If the next category's products place their capability bands
+  against a peer in another category, that peer needs a date first. `check_capability` enforces
+  it, so this surfaces as a failure rather than silently.
+
+### 3. Hand off
+
+Invoke `refresh-category` with the chosen slug and let it run to its PR. Do not reimplement any
+of it here, and do not "help" by pre-fetching or pre-deciding — its preflight exists because a
+pilot run invented product slugs from a summary.
+
+### 4. Stop
+
+Report the PR, the counts, and what the next invocation will pick up. Then stop. The human
+merges.
+
+## What finished looks like
+
+```
+TOTAL                            472     n  472
+every category is finished.
+```
+
+At which point the remaining work is the queue: `sources/verification_queue.yaml` holds the
+products whose evidence could not be settled, each with a reason and a date. That backlog is the
+honest residue of the sweep, and working it is a different job from running it.
+
+## Boundaries
+
+- Holds no verification rules. They live in the guides `refresh-category` points at.
+- Does not merge. Every category PR is reviewed by a human.
+- Does not batch two categories into one PR, however small they look.
+
+## Related
+
+- `skills/refresh-category/SKILL.md` — the unit of work this drives
+- `build/sweep_status.py` — the derived state, and its own docstring on what "done" means
+- `docs/runbooks/verification-pass.md` — the phases the sweep is executing

--- a/skills/refresh-all-categories/SKILL.md
+++ b/skills/refresh-all-categories/SKILL.md
@@ -26,7 +26,8 @@ the next.
 ### 1. Report
 
 ```bash
-uv run python -m build.sweep_status
+uv run python -m build.sweep_status                     # what has never been confirmed
+uv run python -m build.sweep_status --max-age-days 30   # what has also gone stale
 ```
 
 ```
@@ -46,6 +47,18 @@ those, and after a run that crashed halfway.
 
 Give the user the table. It is the answer to "how far along are we", which is the question this
 skill exists to answer.
+
+**Ask which question they mean**, unless they said. Without a window the sweep is finishing
+something: every product confirmed once. With `--max-age-days 30` it is maintaining something:
+every product confirmed within the month, so a category that finished in June comes back round.
+The first is the current job. The second is what this becomes afterwards, and the same tooling
+does both — pass the window straight through to `refresh-category`, which refreshes only the
+products it returns.
+
+A sensible default once the first pass is done is 90 days, matching the age gate
+`docs/guides/verification.md` step 5 turns on. Do not invent a tighter one silently: a window is
+a decision about how much re-reading the map is worth, and it belongs to whoever is paying for
+it.
 
 ### 2. Pick
 

--- a/skills/refresh-category/SKILL.md
+++ b/skills/refresh-category/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: refresh-category
+description: Use when one category's products need re-verifying against primary sources — researching each product, auditing the evidence, applying scores and prose together, gating, and opening the category PR. Takes one category slug and finishes it, in os-ai-map.
+---
+
+# Refresh a Category
+
+Takes one category from wherever it is to **gate-clean**, then opens a PR and stops. The unit is
+the category because that is the unit a rubric, a stage and a reviewer all work in.
+
+## How this composes
+
+- **Runs `verify-product`'s procedure INSIDE the score re-read**, not beside it. That skill's
+  boundary — prose only, never `last_verified` — holds when it is run alone. Here the same
+  product gets both halves from one read, because refreshing the prose means opening the
+  repository, model card and vendor docs the score re-read already fetches, and because a prose
+  pass run on its own does not open primary sources at all. See `verification-pass.md` Phase 4.
+- **Escalates to `build-rubric`** when a category's `components` values turn out to be prose
+  rather than controlled tokens. That skill's step 0 is the test, and a category that fails it
+  cannot be laddered no matter how well its products are read. Do not normalize a vocabulary
+  inline as a side effect of a sweep.
+- **Invoked by `refresh-all-categories`**, which decides which category is next. Run directly
+  when you want a specific one.
+
+## This file is orchestration only
+
+Every rule about *how to verify* lives in the guides, and this skill restates none of them. Two
+copies drift, and that is the exact failure the sweep exists to fix. The agents you dispatch
+read these, and so should you before dispatching them:
+
+- `docs/guides/verification.md` — how an axis earns `last_verified`, the invariant, the gates,
+  and what a capability confirmation attests to
+- `docs/guides/freshness.md` — what `last_verified` means
+- `docs/guides/product-info.md` — the prose spec and the claim-class table
+- `docs/guides/identity.md` — slugs, aliases, and the combine rules when releases merge
+- `docs/runbooks/verification-pass.md` Phase 4 — the per-product unit of work
+
+If a rule needs changing, change the guide. Never the prompt.
+
+## Definition of done, per product
+
+- every axis carries a real `last_verified`, or abstains deliberately, or the product is held;
+- every source behind a claimed date records `http_status` and `content_sha256`;
+- `description` and `comments` satisfy `product-info.md`, with the canonical verification line;
+- `capability.relative_to` + `relation` recorded where the note places the band against a peer.
+
+A product whose evidence cannot be settled is **held**, not forced. Held is a legitimate
+outcome; a date you cannot support is the failure this whole apparatus exists to prevent.
+
+## Steps
+
+### 1. Take the category, and order the batch
+
+```bash
+uv run python -m build.sweep_status --verbose      # what is unfinished in it
+```
+
+**Anchor first.** If any product records `capability.relative_to`, the peer it points at must be
+verified in this run or already dated — a derived band cannot be fresher than what it derives
+from, and `check_capability` fails if it is. Put anchors at the front. In `finetuning_code` that
+was `megatron-lm`, which twelve notes place themselves against.
+
+### 2. Preflight — gather once, centrally
+
+Agents must not each rediscover this, and must not guess at it. A pilot run invented three
+product slugs from a truncated terminal listing.
+
+- The roster, from `sources/categories/<slug>.yaml`. Never retype it.
+- Recorded openness dimensions per product, computed with the repo's own helpers
+  (`build.check_verification.recorded_dimensions` over `build.rubrics.recipe_for`). Do not ask
+  an agent to re-derive them, and do not paraphrase them into a brief.
+- Warehouse signal rows for the whole category in **one** query — `signal_github.repo_state`,
+  `signal_huggingface.hub_state`, `signal_pypi.package_downloads`. Read
+  `sources/signal_routing.yaml` for which source governs which dimension, and respect its
+  `never` routes: a GitHub license is a fact about the code, never about the weights.
+
+### 3. Research — one agent per product
+
+Dispatch a `Workflow`, one agent per product, roughly ten concurrent. Each agent reads the guides
+above and its own product's two files, fetches, and **edits no file** — it returns a packet.
+
+Fetch **only** through `uv run python -m build.fetch_source --body-dir <scratch> <url>`, never
+curl and never WebFetch, so the digest recorded is one the weekly sampled re-fetch can confirm.
+
+Give every agent these. Each is a defect the pilot actually produced:
+
+- **A transient status is not an absence.** `fetch_source` retries and returns
+  `"transient": true` with no digest when one survives. That means retry or defer. It never
+  means the fact is missing. One un-retried 429 was promoted into the ground for a confirmation;
+  the figure was there.
+- **An asserted negative needs a stated method.** "A grep of the sdist found nothing" was
+  claimed against a compressed `.tar.gz`. If you claim something is absent from an archive, say
+  how you walked it, and walk it.
+- **Quote verbatim or drop the quotation marks.** `shows` is the field whose whole job is
+  letting someone else check the work.
+- **Inventory the prose before rewriting it.** List every factual claim in the current
+  `description` and `comments` and mark each keep / move / drop with a reason from
+  `product-info.md`. The commonest pilot defect was a rewrite that silently dropped a true,
+  durable fact. Return the ledger.
+- **One spelling per dimension** in `establishes`, using the recorded key, and only on openness
+  unless the routing file gives the axis a vocabulary.
+
+### 4. Audit — assume a rubber stamp
+
+Two auditors over the packets. They earn their cost: on the pilot they caught a false
+confirmation, a false negative, and three products writing capability relations they could not
+support.
+
+- **Evidence.** Re-fetch every digest and compare. Grep every `shows` against the saved body.
+  Check the invariant per recorded dimension. Check no 4xx is used as evidence. Check
+  `body_path` decodes to its own source's URL.
+- **Prose.** Check the fact ledger against the *current* file — a durable fact that vanished
+  without a ledger entry is the defect. Check the claim-class table, the length band, and the
+  canonical line.
+
+A `failed` verdict means hold the product. A `suspect` verdict with specific corrections means
+apply the corrections. Do not re-run automatically: a second attempt on a systemic prompt defect
+just fails twice.
+
+### 5. Apply — deterministically, never by an agent
+
+A script, not a model. `sources/` YAML is hand-wrapped and does not round-trip: use
+`build.components` (`set_field`, `put_field`, `set_document_field`), which asserts on reparse
+that the edit did what was asked and touched nothing else.
+
+Held products go to `sources/verification_queue.yaml`, otherwise untouched:
+
+```yaml
+held:
+  predibase:
+    category: finetuning_code
+    since: '2026-08-08'
+    because: >-
+      Adoption evidence rests on an asserted negative its own saved body contradicts.
+```
+
+Data, not a PR comment nobody re-reads.
+
+### 6. Gate
+
+```bash
+uv run python -m build.validate
+uv run python -m build.check_verification --verbose
+uv run python -m build.check_capability
+uv run python -m build.check_recipe
+uv run python -m build.check_refetch --product <one you just wrote>
+uv run python -m build.check_freshness --category <slug>
+uv run python -m pytest tests/ -q
+```
+
+Expect gates to **fail first and tell you something**. On the pilot, `validate` rejected an
+`establishes` naming a components key no ladder reads, and `check_recipe` demanded a stale
+deferral be removed because the product it deferred now reproduced. Both were right. Read a
+failure before working around it.
+
+`check_refetch` confirming a digest is the positive evidence the sweep is real. Quote the count.
+
+Never commit `build/notebook_data.json` or `notebooks/` — bot-owned, and `generated-files-guard`
+fails the PR.
+
+### 7. PR, then stop
+
+One PR for the category. Itemize every moved score with its evidence, every held product with
+its reason, and the re-fetch confirmations. Then stop: a human merges.
+
+## Cost, measured
+
+`finetuning_code`, 2026-08-08: **5–10 fetches and about 15 minutes per product**, with a tail
+where the citations have rotted — `predibase` took 25 fetches because all four of its cited URLs
+were dead or blocked. Budget by the tail, not the median.
+
+## Boundaries
+
+- Read-only on the warehouse. No MCP writes, no uploads.
+- Edits `sources/` only, and only for products in the named category.
+- Does not clear deferrals, split a type, restructure `openness.components`, or change a ladder.
+  Each is its own project. If the sweep surfaces evidence for one, record it and carry on.
+
+## Related
+
+- `skills/verify-product/SKILL.md` — the prose half, run inside this
+- `skills/build-rubric/SKILL.md` — when a category's values are not ladderable
+- `skills/refresh-all-categories/SKILL.md` — the driver that picks the next category

--- a/skills/refresh-category/SKILL.md
+++ b/skills/refresh-category/SKILL.md
@@ -49,11 +49,28 @@ outcome; a date you cannot support is the failure this whole apparatus exists to
 
 ## Steps
 
-### 1. Take the category, and order the batch
+### 1. Take the category, and decide which of its products are in scope
 
 ```bash
-uv run python -m build.sweep_status --verbose      # what is unfinished in it
+uv run python -m build.sweep_status --verbose                    # never confirmed
+uv run python -m build.sweep_status --max-age-days 30 --verbose  # or confirmed too long ago
 ```
+
+**Two modes, same machinery.** The first pass over a category takes every product that has
+never been confirmed. After that the category is done until its confirmations age, and
+`--max-age-days N` (or `--since YYYY-MM-DD`) reads anything older than the window as `stale`
+rather than `verified`. Pass the same window the caller gave you, and refresh only what it
+returns — re-reading a product confirmed last week costs a full unit of work and earns a date
+it already had.
+
+`last_verified` is a claim about a day, so a refresh window is the honest way to ask "is this
+still true" without asking it of everything. The prose ages on the same clock, because the
+canonical verification line carries its own date: a product can be score-fresh and prose-stale,
+and `--verbose` distinguishes `stale` from `open` and `prose line stale` from
+`no verification line`.
+
+There is no default window. Absent one, "confirmed once" counts as confirmed, which is right
+for the first pass and wrong forever after — so the caller chooses, and says why.
 
 **Anchor first.** If any product records `capability.relative_to`, the peer it points at must be
 verified in this run or already dated — a derived band cannot be fresher than what it derives

--- a/skills/verify-product/SKILL.md
+++ b/skills/verify-product/SKILL.md
@@ -15,7 +15,7 @@ openness/adoption/capability value.
 > and the source of the rules below. This skill is the procedure; the guide is the
 > authority.
 
-**Where this runs.** In the category sweep the prose refresh happens *inside* the score
+**Where this runs.** Under `refresh-category` the prose refresh happens *inside* the score
 re-read (`docs/runbooks/verification-pass.md`, Phase 4): one agent opens a product's sources
 once and writes both halves from them, and one PR carries the category. This skill stays the
 prose half, and the boundary below still holds — the score half follows

--- a/tests/test_sweep_status.py
+++ b/tests/test_sweep_status.py
@@ -1,0 +1,80 @@
+"""Tests for the sweep's state, which is derived rather than stored.
+
+`test_state_is_derived_not_stored` is the one that matters. A pointer file recording "we are on
+category N" is a second copy of a fact the corpus already carries, and it desyncs the first time
+someone finishes a category by hand. These assert the survey reads the corpus.
+"""
+
+from build.sweep_status import product_state, survey
+
+
+def score(**axes) -> dict:
+    base = {"openness": {"score": 5}, "adoption": {"level": 3}, "capability": {"score": 4}}
+    for axis, extra in axes.items():
+        base[axis] = {**base[axis], **extra}
+    return base
+
+
+VERIFIED = "Verified 2026-08-08 via the LICENSE body."
+
+
+def test_a_product_is_done_when_every_axis_is_dated_and_the_prose_carries_the_line():
+    state = product_state(
+        "p", {"comments": VERIFIED},
+        score(openness={"last_verified": "2026-08-08"},
+              adoption={"last_verified": "2026-08-08"},
+              capability={"last_verified": "2026-08-08"}),
+        held={},
+    )
+    assert state["done"] is True
+    assert set(state["axes"].values()) == {"verified"}
+
+
+def test_a_dated_product_with_no_verification_line_is_not_done():
+    """Prose is half the job. The canonical line is the one part a checker can see."""
+    state = product_state(
+        "p", {"comments": "Some note without the line."},
+        score(openness={"last_verified": "2026-08-08"},
+              adoption={"last_verified": "2026-08-08"},
+              capability={"last_verified": "2026-08-08"}),
+        held={},
+    )
+    assert state["done"] is False
+    assert state["prose"] is False
+
+
+def test_a_null_axis_abstains_rather_than_blocking():
+    """46 axes are deliberately null - a hosted feature with no usage figure to band."""
+    state = product_state(
+        "p", {"comments": VERIFIED},
+        score(openness={"last_verified": "2026-08-08"},
+              adoption={"level": None},
+              capability={"score": None}),
+        held={},
+    )
+    assert state["axes"]["adoption"] == "abstained"
+    assert state["done"] is True
+
+
+def test_a_held_product_is_resolved_not_remaining():
+    """One product whose evidence cannot be settled must not block its category."""
+    state = product_state("p", {}, score(), held={"p": {"because": "..."}})
+    assert state["held"] is True
+    assert state["done"] is True
+
+
+def test_an_undated_axis_is_open():
+    state = product_state("p", {"comments": VERIFIED}, score(), held={})
+    assert set(state["axes"].values()) == {"open"}
+    assert state["done"] is False
+
+
+def test_the_real_corpus_surveys_and_orders_worst_coverage_first():
+    rows = survey()
+    assert len(rows) == 16
+    assert sum(r["products"] for r in rows) == 472
+    pending = [r for r in rows if r["done"] < r["products"]]
+    assert pending, "the sweep is not finished, so something must be pending"
+    # Finished categories sort last whatever their coverage; among the rest, worst first.
+    coverages = [r["coverage"] for r in rows if r["done"] < r["products"]]
+    assert coverages == sorted(coverages), "pending categories must be worst-coverage first"

--- a/tests/test_sweep_status.py
+++ b/tests/test_sweep_status.py
@@ -5,6 +5,8 @@ category N" is a second copy of a fact the corpus already carries, and it desync
 someone finishes a category by hand. These assert the survey reads the corpus.
 """
 
+from datetime import date
+
 from build.sweep_status import product_state, survey
 
 
@@ -78,3 +80,60 @@ def test_the_real_corpus_surveys_and_orders_worst_coverage_first():
     # Finished categories sort last whatever their coverage; among the rest, worst first.
     coverages = [r["coverage"] for r in rows if r["done"] < r["products"]]
     assert coverages == sorted(coverages), "pending categories must be worst-coverage first"
+
+
+# --- the refresh window ---
+
+def _dated(day: str) -> dict:
+    return score(openness={"last_verified": day},
+                 adoption={"last_verified": day},
+                 capability={"last_verified": day})
+
+
+def test_without_a_cutoff_any_confirmation_counts():
+    state = product_state("p", {"comments": "Verified 2020-01-01 via GitHub."},
+                          _dated("2020-01-01"), held={})
+    assert state["done"] is True
+
+
+def test_a_confirmation_older_than_the_window_is_stale_not_verified():
+    """This is what turns the sweep from a one-time pass into a recurring refresh."""
+    state = product_state("p", {"comments": "Verified 2026-06-01 via GitHub."},
+                          _dated("2026-06-01"), held={}, cutoff=date(2026, 7, 1))
+    assert set(state["axes"].values()) == {"stale"}
+    assert state["done"] is False
+
+
+def test_a_confirmation_on_the_cutoff_still_counts():
+    state = product_state("p", {"comments": "Verified 2026-07-01 via GitHub."},
+                          _dated("2026-07-01"), held={}, cutoff=date(2026, 7, 1))
+    assert set(state["axes"].values()) == {"verified"}
+    assert state["done"] is True
+
+
+def test_a_never_confirmed_axis_is_open_not_stale():
+    """Open and stale are different jobs: one has never been read, the other has aged."""
+    state = product_state("p", {"comments": "Verified 2026-08-08 via GitHub."},
+                          score(), held={}, cutoff=date(2026, 7, 1))
+    assert set(state["axes"].values()) == {"open"}
+
+
+def test_the_prose_ages_on_the_same_clock():
+    """The canonical line carries its own date, so it can go stale without going missing."""
+    fresh = product_state("p", {"comments": "Verified 2026-08-08 via GitHub."},
+                          _dated("2026-08-08"), held={}, cutoff=date(2026, 7, 1))
+    assert fresh["prose_state"] == "verified"
+
+    aged = product_state("p", {"comments": "Verified 2026-06-01 via GitHub."},
+                         _dated("2026-08-08"), held={}, cutoff=date(2026, 7, 1))
+    assert aged["prose_state"] == "stale", "a dated line that has aged is stale, not missing"
+    assert aged["done"] is False
+
+    none = product_state("p", {"comments": "No line at all."},
+                         _dated("2026-08-08"), held={}, cutoff=date(2026, 7, 1))
+    assert none["prose_state"] == "missing"
+
+
+def test_a_held_product_stays_resolved_under_any_window():
+    state = product_state("p", {}, _dated("2020-01-01"), held={"p": {}}, cutoff=date(2026, 7, 1))
+    assert state["done"] is True


### PR DESCRIPTION
The sweep is 467 products across 15 categories. Two skills, split along the line the repo's other skills already use — a unit of work, and the thing that drives it.

| skill | scope |
|---|---|
| `refresh-all-categories` | the objective, and which category is next |
| `refresh-category` | one category, end to end, to its PR |

Plus `build/sweep_status.py`, which is where the state comes from.

## They compose downward into what exists

```
add-product  ⇄  curate-category  →  build-rubric
     ↓                                   ↑
verify-product  ←  runs inside  ←  refresh-category
                                         ↑
                              refresh-all-categories
```

`refresh-category` runs **`verify-product`'s procedure inside the score re-read**, not beside it — the merge decision from #149. Refreshing prose means opening the repository, model card and vendor docs the score re-read already fetches, and a prose pass run alone doesn't open primary sources at all. `verify-product`'s standalone boundary still holds and now says which skill contains it.

It **escalates sideways to `build-rubric`** when a category's `components` values turn out to be prose rather than tokens. That skill's step 0 is the test for whether a category can be laddered at all, and a sweep must not normalize a vocabulary as a side effect of reading products.

Neither new skill restates a verification rule. They point at the guides, which the dispatched agents read.

## State is derived, never stored

```
category                        done  held   of  artifacts
finetuning_code                    5     0   27       41%
inference_code                     0     0   20       45%
...
next: finetuning_code — 22 products remaining
```

A pointer recording "we are on category N" is a second copy of a fact `sources/` already carries, and it desyncs the first time someone finishes a category by hand, half-finishes one, or reverts. Worst artifact coverage first, so the categories where machine signal helps least go while the sweep is still cheap to change.

## What the skills encode: how the pilot failed

Each is a defect the `finetuning_code` run actually produced, now a rule:

- **A transient HTTP status is not an absence.** One un-retried 429 became the stated ground for a `confirmed` verdict; the figure was there.
- **An asserted negative needs a stated method.** "A grep of the sdist found nothing" — against a compressed `.tar.gz`.
- **Quote verbatim or drop the quotation marks.**
- **Inventory the prose before rewriting it.** The commonest defect was a rewrite silently dropping a true, durable fact. A ledger is required output.
- **Verify the anchor first.** A derived capability band can't be fresher than what it derives from — `check_capability` fails if the peer isn't dated.

And: expect gates to fail first and *read the failure*. On the pilot, `validate` rejected an `establishes` naming a key no ladder reads, and `check_recipe` demanded a stale deferral be removed. Both were right.

## Measured cost

**5–10 fetches and about 15 minutes per product**, with a tail where citations have rotted — `predibase` took 25 because all four of its cited URLs were dead or blocked. Budget by the tail.

## Also

`AGENTS.md` said "Four editor skills live in `skills/`" and listed four of the six that existed — `build-rubric` and `verify-product` were undiscoverable from it. It now lists all eight and says how they stack.

## Test plan

- `pytest tests/ -q` → 387 passed (6 new)
- `build.sweep_status` → names `finetuning_code` as next, 5 done from the pilot
- held counts as resolved; a null axis abstains; a dated product with no verification line is not done
- `build.validate` → `0 error(s)`