### PR TITLE
docs(freshness): the refresh window is 30 days

### DIFF
--- a/docs/guides/verification.md
+++ b/docs/guides/verification.md
@@ -458,10 +458,23 @@ score for this reason.
 
 ### 5. Turn on the age gate
 
-`build/check_freshness.py --max-age-days` becomes a CI gate. This is the entire point of
+`build/check_freshness.py --max-age-days 30` becomes a CI gate. This is the entire point of
 having the field: a category whose oldest axis is 50 days old is a category to go and look
 at. Gating earlier would only fail on the pre-automation backlog rather than on genuine
 staleness.
+
+**The window is 30 days, decided 2026-08-09.** It is a judgment about how much re-reading the
+map is worth rather than anything derivable, so it is recorded here with its date and its owner
+and not re-argued per category. Earlier drafts suggested 90; that was a placeholder for an
+unmade decision, and this replaces it.
+
+At 30 days the re-read is continuous rather than occasional: sixteen categories inside a
+month is roughly four a week. Two things follow. A whole category shares one confirmation
+date, because a category is re-read in a single run, so categories expire in cliffs rather
+than drifting past the line one product at a time — that is the shape of the work, not a
+backlog. And the sampled re-fetch will keep reporting drift on pages that change daily;
+at this window that drift is noise, and a digest that *matches* remains the only thing it
+positively proves.
 
 ## Related
 

--- a/skills/refresh-all-categories/SKILL.md
+++ b/skills/refresh-all-categories/SKILL.md
@@ -55,10 +55,20 @@ The first is the current job. The second is what this becomes afterwards, and th
 does both — pass the window straight through to `refresh-category`, which refreshes only the
 products it returns.
 
-A sensible default once the first pass is done is 90 days, matching the age gate
-`docs/guides/verification.md` step 5 turns on. Do not invent a tighter one silently: a window is
-a decision about how much re-reading the map is worth, and it belongs to whoever is paying for
-it.
+**The window is 30 days**, decided 2026-08-09 by the person paying for the re-reading. So
+`--max-age-days 30` is the maintenance-mode invocation, and `docs/guides/verification.md` step 5
+turns the age gate on at the same number. It had been an unmade decision carrying a suggested 90;
+this replaces it rather than adding an option.
+
+Two consequences worth stating, because both were weighed:
+
+- **A month is not a promise about any individual page.** Live pages change daily, and the weekly
+  sampled re-fetch will keep reporting drift on the volatile ones. That drift is noise at this
+  window, not a signal to chase. What 30 days buys is that no score sits unexamined for a quarter.
+- **Categories will come back round in cliffs.** A category is re-read in one run, so all of its
+  axes carry one date and all of them age out together. Sixteen categories against a 30-day window
+  means roughly four categories a week, and the queue from each lands at the same time. Do not
+  read a cliff as a backlog.
 
 ### 2. Pick
 


### PR DESCRIPTION
Records a decision rather than changing behavior. Docs and one skill; no data, no code.

The refresh window had been an unmade decision carrying a suggested 90 days, with an explicit note that the number belongs to whoever is paying for the re-reading. It's now decided: **30 days**, 2026-08-09. `--max-age-days 30` becomes the maintenance-mode invocation, and `check_freshness` step 5 turns the age gate on at the same number.

Two consequences are written down because both were weighed, and both look like problems if you meet them cold:

- **Categories expire in cliffs.** A category is re-read in one run, so all of its axes carry one date and age out together. Sixteen categories inside a month is roughly four a week, each arriving whole. That's the shape of the work, not a backlog.
- **Drift on volatile pages is noise at this window.** The weekly sampled re-fetch will keep reporting it — GitHub star counters, rotating leaderboards. A digest that *matches* remains the only thing that gate positively proves, which is unchanged; the point is that a non-match at 30 days isn't worth chasing.

The gate stays **off** for now, unchanged: turning it on today fails on the pre-automation backlog rather than on genuine staleness. Two of sixteen categories carry real dates so far.

Separate from #161 deliberately — that one is `inference_code` data, this is policy.