### PR TITLE
llama-factory: close both queued axes on a download series

### DIFF
--- a/sources/scores/llama-factory.yaml
+++ b/sources/scores/llama-factory.yaml
@@ -40,31 +40,62 @@ openness:
     - license
     - source
 adoption:
-  level: 3
-  reach: 100K-1M
+  level: 2
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: medium
-  note: ~234.6K PyPI (llamafactory) downloads last month plus very large GitHub adoption (~71.9K stars,
-    8.8K forks) and named users (Amazon, NVIDIA, Alibaba/Aliyun). Many users run from source/WebUI rather
-    than pip, so pip undercounts; level 3 on download volume + named-deployment breadth, stars corroborate
-    only.
+  note: 'PyPI downloads of the llamafactory package spiked and returned rather than collapsing: 14,311 in
+    February, 27,761 in March, 30,043 in April, then 233,960 in May and 779,461 in June, falling to 100,640
+    in July and 21,867 over the trailing 30 days. The June read of ~234.6K was the trailing window during
+    the spike. Steady state before and after it is 20-30K/month, which bands at 2 (10K-100K). Stars and
+    forks kept growing throughout (73,939 stars today), which is why this looked like a contradiction from
+    two point reads. One known undercount, unquantified: the project is commonly run from a git clone and
+    its WebUI rather than installed from PyPI, and GitHub releases capture none of it either (5,242 asset
+    downloads across 30 releases). No signal available measures the clone channel.'
+  last_verified: '2026-08-09'
   sources:
-  - url: https://pypistats.org/packages/llamafactory
-    shows: 'Downloads last month: 234,631'
-    accessed: '2026-06-04'
+  - url: https://pypistats.org/api/packages/llamafactory/overall?mirrors=false
+    shows: daily download series; summed by month it gives 14,311 (Feb), 27,761 (Mar), 30,043 (Apr), 233,960
+      (May), 779,461 (Jun) and 100,640 (Jul) for 2026
+    accessed: '2026-08-09'
+    http_status: 200
+    content_sha256: dfc2e82ec9df7847f79eda038449a4ab10f74242fb81899e73f8ccc533aefe42
+  - url: https://pypistats.org/api/packages/llamafactory/recent
+    shows: '"last_month":21867'
+    accessed: '2026-08-09'
+    http_status: 200
+    content_sha256: 691a9ea38be0daf95cb946a25299cef27d0a0bcff977e1732a322f2c94229bba
+  - url: https://api.github.com/repos/hiyouga/LLaMA-Factory/releases
+    shows: 30 releases carrying 5,242 asset downloads in total, so no meaningful distribution channel outside
+      PyPI
+    accessed: '2026-08-09'
+    http_status: 200
+    content_sha256: 7ab70dd9505370b2453956ff20e9e0ac2223a065aa487fedb809c041fe6733f6
   - url: https://github.com/hiyouga/LLaMA-Factory
-    shows: ~71.9K stars; named users Amazon/NVIDIA/Alibaba/Aliyun
-    accessed: '2026-06-04'
+    shows: '"73939 users starred"'
+    accessed: '2026-08-09'
+    http_status: 200
+    content_sha256: 25ae5a46952062ba4d6e68fd8a06facd2acff6623c3c397000f36dd780f28a26
 capability:
   score: 4
   basis: feature_matrix
+  relative_to: megatron-lm
+  relation: one_below
   value: 'Methods: full FT, LoRA, QLoRA, plus preference/RL tuning; 100+ LLM/VLM architectures; CLI +
     web UI; multimodal (VLM) support. Broad model coverage and a no-code WebUI distinguish it; parallelism
     present but headline scale below Megatron-LM anchor.'
   confidence: medium
-  note: Strong breadth (100+ models, VLMs, no-code UI) puts it at C4; lacks the demonstrated frontier-scale
-    parallelism of the Megatron-LM C5 anchor.
+  note: 'Breadth rather than scale: the README tagline is "Unified Efficient Fine-Tuning of 100+ LLMs",
+    covering LoRA/QLoRA, full-tuning, DPO and PPO, multimodal models and the LLaMA Board no-code web UI.
+    Placed one below the megatron-lm anchor, which was re-confirmed on 2026-08-09 at capability 5: Megatron-LM
+    demonstrates frontier-scale parallelism (462B parameters across 6,144 H100 GPUs) that LLaMA-Factory
+    does not claim. The comparison was previously carried in this note as prose; it is now recorded as relative_to/relation
+    so check_capability can test it.'
+  last_verified: '2026-08-09'
   sources:
   - url: https://github.com/hiyouga/LLaMA-Factory
-    shows: 100+ LLMs/VLMs, LoRA/QLoRA/full FT, CLI+WebUI
-    accessed: '2026-06-04'
+    shows: '"Unified Efficient Fine-Tuning of 100+ LLMs"; README lists LoRA, QLoRA, full-tuning, DPO and
+      PPO, multimodal support and the "LLaMA Board" web UI'
+    accessed: '2026-08-09'
+    http_status: 200
+    content_sha256: 25ae5a46952062ba4d6e68fd8a06facd2acff6623c3c397000f36dd780f28a26

--- a/sources/scores/megatron-lm.yaml
+++ b/sources/scores/megatron-lm.yaml
@@ -143,7 +143,7 @@ capability:
     of this category places itself against. The parallelism, precision and scaling facts now sit in `value`
     with establishing sources rather than being asserted here. No MLPerf-Training submission verified for
     the library itself, so the basis is feature_matrix plus NVIDIA-reported scaling benchmarks.
-  last_verified: '2026-08-08'
+  last_verified: '2026-08-09'
   sources:
   - url: https://github.com/NVIDIA/Megatron-LM
     shows: 'The README describes Megatron Core as providing "transformer building blocks, advanced parallelism
@@ -155,9 +155,9 @@ capability:
       strong-scaling paragraph scales a GPT-3 model of slightly more than 175 billion parameters from 96
       H100 GPUs to 4,608 GPUs at a fixed batch size of 1,152 sequences, MFU falling 47% to 42%. Results
       are noted as measured without training to convergence.'
-    accessed: '2026-08-08'
+    accessed: '2026-08-09'
     http_status: 200
-    content_sha256: 87f1c5e263bfa0f32ff4decf9794c00d34ba2e514182c6624f5e26e0701d83f3
+    content_sha256: 81dc3e5166bb2ca313461fbbe4e65b98d383e89464bc0053c4e2a45947643555
   - url: https://developer.nvidia.com/megatron-core
     shows: 'NVIDIA''s own scaling documentation, and the second independent statement of the anchor figure:
       "In the weak scaling experiments below, with GPT models ranging from 2 billion to 462 billion parameters,
@@ -169,9 +169,9 @@ capability:
       distributed optimizers and distributed checkpointing, resiliency (automatic restart, fault/hang detection),
       and "features like FP8 mixed precision and advanced parallelism"; it also cites Nemotron-4 340B trained
       at up to 6K+ H100 GPU scale.'
-    accessed: '2026-08-08'
+    accessed: '2026-08-09'
     http_status: 200
-    content_sha256: f68c234747aa1592c8a3ea87a5f0643c417b792777f8cc92cf9beadf4a9fc24b
+    content_sha256: 03e35b28e69d3dc08983e285e3e7fb7f7a989af9a6c49b31cbebab3d6d9b4e68
   - url: https://docs.nvidia.com/megatron-core/developer-guide/latest/user-guide/parallelism-guide.html
     shows: 'The Parallelism Strategies Guide opens "Megatron Core supports multiple parallelism strategies
       that can be combined to efficiently train models from billions to trillions of parameters across thousands
@@ -181,6 +181,6 @@ capability:
       --pipeline-model-parallel-size, --context-parallel-size, --expert-model-parallel-size, --use-megatron-fsdp
       with ZeRO-1/2/3 sharding strategies, --sequence-parallel — and states that sequence parallelism must
       be enabled when EP is combined with TP. This is the composability claim, documented rather than asserted.'
-    accessed: '2026-08-08'
+    accessed: '2026-08-09'
     http_status: 200
     content_sha256: cc5b5cf00b32cac4b1d59e9c2482f19cafba61e4b9ce17c2b22d4497471daac0

--- a/sources/verification_queue.yaml
+++ b/sources/verification_queue.yaml
@@ -9,21 +9,6 @@
 version: 1
 
 held:
-  llama-factory:
-    adoption:
-      since: '2026-08-09'
-      because: >-
-        PyPI downloads fell from ~234.6K/month in June to 22,005, a ~90% drop, while stars,
-        forks and named enterprise adopters all kept growing. A fall that large against rising
-        breadth signals is likelier a packaging or measurement change than a collapse in use.
-        Settling it needs the download history rather than two point reads.
-    capability:
-      since: '2026-08-09'
-      because: >-
-        The band is anchored to a comparison against megatron-lm, whose own capability was
-        confirmed 2026-08-08 - a day older than this pass. A derived band cannot be fresher
-        than what it derives from, so the comparison waits for the anchor to be re-read.
-
   verl:
     capability:
       since: '2026-08-09'
@@ -36,9 +21,11 @@ held:
     capability:
       since: '2026-08-09'
       because: >-
-        Same anchor-freshness case as llama-factory: the recorded band rests on an explicit
-        comparison to Megatron-scale training stacks, and megatron-lm was confirmed a day
-        earlier than this pass.
+        The recorded band rests on an explicit comparison to Megatron-scale training stacks.
+        The anchor half is no longer the blocker - megatron-lm was re-confirmed 2026-08-09 - but
+        this axis still cites only a 2026-06-04 read of the ART repository, with no digest, so
+        the band itself has not been re-derived. Settling it needs that re-read, after which the
+        comparison can be recorded as relative_to/relation the way llama-factory's now is.
 
   amazon-bedrock-custom-models-fine-tuning:
     capability:


### PR DESCRIPTION
Works the queue rather than a category. Both of `llama-factory`'s held axes now carry a date, and the queue goes from 10 axes to 8.

## Adoption 3 → 2: a spike that ended, not a collapse

The queue entry recorded a ~90% fall against rising stars, forks and named adopters, called it "likelier a packaging or measurement change than a collapse in use", and asked for the download history. The history settles it, and the answer is neither of the two hypotheses:

| Feb | Mar | Apr | May | Jun | Jul | trailing 30d |
|---|---|---|---|---|---|---|
| 14,311 | 27,761 | 30,043 | 233,960 | **779,461** | 100,640 | 21,867 |

It spiked and returned. The prior read of ~234.6K was the trailing window taken *during* the spike, on 2026-06-04. Steady state either side is 20–30K/month, which bands at 2 (10K-100K).

That also dissolves the contradiction the entry recorded: stars and forks kept growing throughout because the underlying user base never fell — only the spike did. Two point reads could not have distinguished this from a decline, which is exactly the argument in #163.

**One undercount, named and left unquantified.** LLaMA-Factory is commonly run from a git clone and its WebUI rather than installed from PyPI, and GitHub releases capture none of it either — 5,242 asset downloads across 30 releases. No signal available to us measures the clone channel, so the note says so rather than inflating the band to compensate.

## Capability 4: the comparison is now recorded, not described

This axis was blocked on anchor freshness — the band rests on a comparison to Megatron-scale training stacks, and `megatron-lm` was confirmed 2026-08-08, a day behind any date this pass could claim.

So the anchor was re-confirmed first. All three of its cited capability sources re-fetched, and every claim still holds in today's bodies: `2B to 462B` parameters, `6,144 H100 GPUs`, `47% Model FLOP Utilization`, `Superlinear scaling`. One digest identical, two drifted on page counters. `megatron-lm` capability now carries 2026-08-09.

With the anchor current, `llama-factory` records `relative_to: megatron-lm` / `relation: one_below` rather than leaving the comparison in an English sentence — 4 against the anchor's 5, which `check_capability` now tests. 28 products record a comparison, up from 27.

## openpipe stays queued, with a corrected reason

Its entry said "same anchor-freshness case as llama-factory". That is no longer true now that the anchor is current, and leaving it would make the queue lie. The real remaining blocker is that the axis still cites only a 2026-06-04 read of the ART repo with no digest, so the band has not been re-derived. Rewritten to say that.

## Gates

```
validate              0 error(s)
check_verification    invariant / digests / producible-pairs   [OK]
check_capability      [OK]  28 of 472 products record a comparison
check_recipe          0 failure(s)
check_refetch         llama-factory: 8 digests, 5 confirmed, 0 dead
pytest                394 passed
```