### PR TITLE
Declare 34 missing pypi artifacts, and let the proposer target one kind

### DIFF
--- a/build/propose_artifacts.py
+++ b/build/propose_artifacts.py
@@ -32,6 +32,14 @@ Usage:
     uv run python -m build.propose_artifacts --include-closed
     uv run python -m build.propose_artifacts --category base_pretrained
     uv run python -m build.propose_artifacts --format yaml      # paste-ready blocks
+    uv run python -m build.propose_artifacts --kind pypi        # missing THIS kind specifically
+
+`--kind` exists because "has an artifact" and "routes a signal" are different questions.
+`signal_routing.yaml` sends adoption to HF, then PyPI, then stars — and stars is
+`stars_fallback`, which the rubric caps at level 3. So a library with a GitHub repo and no
+declared `pypi` is fully verifiable and still pinned to a capped band. Measured 2026-08-09:
+66 of 472 products declared a `pypi` artifact, while 87 more cited a PyPI page in their
+adoption evidence, meaning a human had read the number the signal could not.
 """
 
 from __future__ import annotations
@@ -67,6 +75,13 @@ PATTERNS = [
     ("huggingface_model", re.compile(r"huggingface\.co/([\w\-.]+/[\w\-.]+)", re.I)),
     ("github", re.compile(r"github\.com/([\w\-.]+/[\w\-.]+)", re.I)),
     ("pypi", re.compile(r"pypi\.org/project/([\w\-.]+)", re.I)),
+    # pypistats, in all three shapes the corpus uses: /packages/<name>,
+    # /api/packages/<name>/recent, /api/packages/<name>/overall. It is where a human goes
+    # to READ a download count, so it is the form the evidence usually carries — 69 score
+    # files cite pypistats against 23 citing pypi.org, and mining only the latter finds a
+    # fraction of what is there. The captured name is still verified against the PyPI JSON
+    # API below before anything is proposed, so a stale or misspelled one cannot slip in.
+    ("pypi", re.compile(r"pypistats\.org/(?:api/)?packages/([\w\-.]+)", re.I)),
     ("npm", re.compile(r"npmjs\.com/package/((?:@[\w\-.]+/)?[\w\-.]+)", re.I)),
     ("crates", re.compile(r"crates\.io/crates/([\w\-.]+)", re.I)),
 ]
@@ -197,6 +212,9 @@ def main() -> int:
     parser.add_argument("--include-closed", action="store_true",
                         help="also propose for products scored `closed`")
     parser.add_argument("--format", choices=("table", "yaml"), default="table")
+    parser.add_argument("--kind", choices=VERIFIABLE_KINDS,
+                        help="propose only this artifact kind, and select products missing THIS "
+                             "kind rather than products missing every kind")
     parser.add_argument("--no-verify", action="store_true",
                         help="skip live checks (offline; verdicts become 'unchecked')")
     args = parser.parse_args()
@@ -215,7 +233,12 @@ def main() -> int:
         if args.category and category_of.get(slug) != args.category:
             continue
         product = yaml.safe_load(path.read_text()) or {}
-        if any(product.get(kind) for kind in VERIFIABLE_KINDS):
+        # Without --kind, "verifiable at all" is the bar: a product with a GitHub repo is
+        # checkable and needs nothing. With --kind, the bar is that ONE kind, because a
+        # product can be perfectly verifiable and still route no adoption signal — a
+        # library with a repo and no declared `pypi` falls through to stars_fallback,
+        # which the rubric caps.
+        if any(product.get(kind) for kind in ((args.kind,) if args.kind else VERIFIABLE_KINDS)):
             continue  # already verifiable
 
         score_path = ROOT / "sources" / "scores" / f"{slug}.yaml"
@@ -225,6 +248,8 @@ def main() -> int:
             continue
 
         found = candidates_for(product, scores or {})
+        if args.kind:
+            found = {k: v for k, v in found.items() if k == args.kind}
         verified: list[tuple[str, str, int]] = []
         for kind, idents in found.items():
             for ident in idents:

--- a/sources/products/agenta.yaml
+++ b/sources/products/agenta.yaml
@@ -6,5 +6,7 @@ description: Open-source LLMOps platform combining prompt playground, prompt man
   monitoring. Self-hostable with a cloud option. 4.1K GitHub stars.
 github:
 - url: https://github.com/Agenta-AI/agenta
+pypi:
+- url: https://pypi.org/project/agenta
 comments: agenta v0.101.1 (released 4 Jun 2026, GitHub); confirmed live June 2026. LLMOps platform; self-hostable
   OSS + Agenta Cloud managed tier.

--- a/sources/products/aider.yaml
+++ b/sources/products/aider.yaml
@@ -8,6 +8,8 @@ description: Terminal-based AI pair programming tool that edits code directly in
   'agentic coding in terminal' pattern.
 github:
 - url: https://github.com/Aider-AI/aider
+pypi:
+- url: https://pypi.org/project/aider-chat
 comments: Aider v0.86.2 (PyPI aider-chat, Feb 12 2026); GitHub repo Aider-AI/aider active, 45.8k stars.
   Terminal AI pair-programming agent that plans edits across a repo and applies git commits. Confirmed
   live June 2026.

--- a/sources/products/atropos.yaml
+++ b/sources/products/atropos.yaml
@@ -8,6 +8,8 @@ description: 'Atropos is an environment microservice framework for asynchronous 
   read-only on 2026-07-04, leaving 0.4.0 as the last release.'
 github:
 - url: https://github.com/NousResearch/atropos
+pypi:
+- url: https://pypi.org/project/atroposlib
 comments: Scored as the RL-environment and orchestration layer that feeds a fine-tuning trainer rather than
   as a trainer itself, which is the judgment behind its place in this category. Verified 2026-08-08 via the
   GitHub repository and the PyPI record for atroposlib.

--- a/sources/products/axolotl.yaml
+++ b/sources/products/axolotl.yaml
@@ -8,4 +8,6 @@ description: Axolotl is a YAML-config-driven fine-tuning framework built on Hugg
   maintains it.
 github:
 - url: https://github.com/axolotl-ai-cloud/axolotl
+pypi:
+- url: https://pypi.org/project/axolotl
 comments: Verified 2026-08-09 via GitHub, the README, the LICENSE body, and axolotl.ai.

--- a/sources/products/browser-use.yaml
+++ b/sources/products/browser-use.yaml
@@ -8,6 +8,8 @@ description: Open-source agent framework that makes websites accessible to AI ag
   the crucial gap of web-native agent capabilities.
 github:
 - url: https://github.com/browser-use/browser-use
+pypi:
+- url: https://pypi.org/project/browser-use
 comments: Browser Use, verified live June 2026 (GitHub + PyPI). OSS Python library making websites accessible
   to AI agents (navigate/click/fill/extract). MIT license. Recategorized into agent_tools_protocols (browser/scrape
   sub-segment) per assignment. Managed Browser Use Cloud tier also exists.

--- a/sources/products/daytona-sandbox.yaml
+++ b/sources/products/daytona-sandbox.yaml
@@ -7,6 +7,8 @@ description: Open-source agent-native compute platform that provisions sub-200ms
   and Figma Ventures, ~72k stars on GitHub.
 github:
 - url: https://github.com/daytonaio/daytona
+pypi:
+- url: https://pypi.org/project/daytona
 comments: 'Daytona secure/elastic runtime for AI-generated code execution; v0.184.0 (Jun 3 2026) live
   on GitHub June 2026. Repo now AGPL-3.0 (note: Daytona pivoted from dev-environments to agent code-execution
   sandboxes). Sub-90ms sandbox spin-up; managed cloud at app.daytona.io.'

--- a/sources/products/deepeval.yaml
+++ b/sources/products/deepeval.yaml
@@ -7,5 +7,7 @@ description: Pytest-style evaluation framework for LLM apps with 40+ built-in me
   90 days, the most active open source eval framework on GitHub.
 github:
 - url: https://github.com/confident-ai/deepeval
+pypi:
+- url: https://pypi.org/project/deepeval
 comments: DeepEval v4.0.5 ('Opus 4.8 Day-0 Support', May 28 2026). OSS eval framework (Apache-2.0) with
   commercial Confident AI cloud platform. Confirmed live June 2026.

--- a/sources/products/e2b-sandbox.yaml
+++ b/sources/products/e2b-sandbox.yaml
@@ -9,5 +9,7 @@ description: Open-source secure cloud runtime that gives AI agents an ephemeral 
 github:
 - url: https://github.com/e2b-dev/E2B
 - url: https://github.com/e2b-dev/infra
+pypi:
+- url: https://pypi.org/project/e2b
 comments: E2B open source sandbox infra for running AI-generated code; CLI @e2b/cli@2.10.3 (Jun 3 2026)
   confirmed live on GitHub June 2026. Isolation via Firecracker microVMs. OSS core + managed cloud (e2b.dev).

--- a/sources/products/gpt-researcher.yaml
+++ b/sources/products/gpt-researcher.yaml
@@ -8,6 +8,8 @@ description: Autonomous research agent that conducts deep web research on any to
   agent pattern that inspired similar features in ChatGPT and Gemini.
 github:
 - url: https://github.com/assafelovic/gpt-researcher
+pypi:
+- url: https://pypi.org/project/gpt-researcher
 comments: GPT Researcher (assafelovic/gpt-researcher), v3.5.0 (May 28 2026); 27.5k stars, Apache-2.0.
   Autonomous deep-research agent that plans sub-queries, searches web/local sources, and writes cited
   reports. Confirmed live June 2026.

--- a/sources/products/helm.yaml
+++ b/sources/products/helm.yaml
@@ -8,6 +8,8 @@ description: Holistic Evaluation of Language Models, Python framework for reprod
   enter maintenance mode June 2026.
 github:
 - url: https://github.com/stanford-crfm/helm
+pypi:
+- url: https://pypi.org/project/crfm-helm
 comments: 'stanford-crfm/helm, v0.5.16 (released 30 Apr 2026), Apache-2.0, ~2.8k stars. Standardized holistic
   evaluation framework + public leaderboards: HELM Capabilities, HELM Safety, VHELM (vision-language),
   HEIM (text-to-image), MedHELM, audio-LM, enterprise benchmarks; supports MMLU-Pro, GPQA, IFEval, WildBench.

--- a/sources/products/laminar.yaml
+++ b/sources/products/laminar.yaml
@@ -6,5 +6,7 @@ description: Open-source observability platform purpose-built for AI agents. Pro
   backend for high performance. 2.9K GitHub stars and growing rapidly.
 github:
 - url: https://github.com/lmnr-ai/lmnr
+pypi:
+- url: https://pypi.org/project/lmnr
 comments: lmnr Python SDK v0.7.52 (27 May 2026); platform/repo lmnr-ai/lmnr at v0.1.46 (31 May 2026).
   Confirmed live on GitHub + PyPI June 2026.

--- a/sources/products/langtrace.yaml
+++ b/sources/products/langtrace.yaml
@@ -7,5 +7,7 @@ description: Open-source, OpenTelemetry-based end-to-end observability tool for 
   1.2K GitHub stars.
 github:
 - url: https://github.com/Scale3-Labs/langtrace
+pypi:
+- url: https://pypi.org/project/langtrace-python-sdk
 comments: Langtrace app v4.0.11 (17 Apr 2026); langtrace-python-sdk v3.8.12 (8 Apr 2026). Active and maintained
   as of June 2026 (initial fetch misread release year; corrected via release pages).

--- a/sources/products/lighteval.yaml
+++ b/sources/products/lighteval.yaml
@@ -7,6 +7,8 @@ description: Lightweight successor to the eval harness HF used internally; suppo
   2.4k stars, 120 contributors, 17 commits in last 90 days; powers parts of the Open LLM Leaderboard v2.
 github:
 - url: https://github.com/huggingface/lighteval
+pypi:
+- url: https://pypi.org/project/lighteval
 comments: lighteval v0.13.0 (24 Nov 2025), latest GitHub release; confirmed live on GitHub June 2026.
   All-in-one LLM eval toolkit from HF's Leaderboard & Evals team; powers the HF Open LLM Leaderboard.
   Columbia extension (model.code.evaluation) caveat applies.

--- a/sources/products/litgpt.yaml
+++ b/sources/products/litgpt.yaml
@@ -8,5 +8,7 @@ description: LitGPT is a library of 20+ from-scratch implementations of open LLM
   quantization.
 github:
 - url: https://github.com/Lightning-AI/litgpt
+pypi:
+- url: https://pypi.org/project/litgpt
 comments: Lightning AI's hosted Studios platform is separate compute and does not gate any LitGPT functionality.
   Verified 2026-08-09 via GitHub and the LICENSE body.

--- a/sources/products/llama-factory.yaml
+++ b/sources/products/llama-factory.yaml
@@ -8,4 +8,6 @@ description: LLaMA-Factory is a toolkit for fine-tuning 100+ open LLM and vision
   as an ACL 2024 paper.
 github:
 - url: https://github.com/hiyouga/LLaMA-Factory
+pypi:
+- url: https://pypi.org/project/llamafactory
 comments: Verified 2026-08-09 via GitHub and the LICENSE body.

--- a/sources/products/lm-evaluation-harness.yaml
+++ b/sources/products/lm-evaluation-harness.yaml
@@ -7,5 +7,7 @@ description: Unified framework for evaluating language models on 200+ academic N
   benchmark numbers in papers. 12.6k GitHub stars, 392 contributors, 58 commits in last 90 days.
 github:
 - url: https://github.com/EleutherAI/lm-evaluation-harness
+pypi:
+- url: https://pypi.org/project/lm-eval
 comments: lm-eval v0.4.12 (May 11 2026); confirmed live June 2026. Backend for HuggingFace Open LLM Leaderboard.
   The de-facto-standard model-eval harness.

--- a/sources/products/lmdeploy.yaml
+++ b/sources/products/lmdeploy.yaml
@@ -8,4 +8,6 @@ description: 'LMDeploy is a toolkit for compressing, deploying, and serving larg
   models such as InternVL.'
 github:
 - url: https://github.com/InternLM/lmdeploy
+pypi:
+- url: https://pypi.org/project/lmdeploy
 comments: Verified 2026-08-09 via GitHub, the LICENSE body, and PyPI download statistics.

--- a/sources/products/megatron-lm.yaml
+++ b/sources/products/megatron-lm.yaml
@@ -6,6 +6,8 @@ description: Megatron-LM trains transformer models across large GPU clusters, pa
   tensor, pipeline, data, expert, and context parallelism, mixed-precision training, and distributed checkpointing
   for teams building their own training frameworks. NVIDIA develops both in the open, alongside a Megatron
   Bridge converter for Hugging Face checkpoints.
+pypi:
+- url: https://pypi.org/project/megatron-core
 comments: This entry covers both components shipped from the NVIDIA/Megatron-LM repository, and the scores
   are read against that repository rather than the Megatron Core package alone. Verified 2026-08-08 via the
   NVIDIA/Megatron-LM README and the Megatron Core developer documentation.

--- a/sources/products/mlflow.yaml
+++ b/sources/products/mlflow.yaml
@@ -2,4 +2,6 @@ name: mlflow
 display_name: MLflow
 type: software
 description: Active 2026; Apache 2.0; observability/tracing for agents+LLMs+ML
+pypi:
+- url: https://pypi.org/project/mlflow
 comments: Active 2026; Apache 2.0; observability/tracing for agents+LLMs+ML

--- a/sources/products/nemo-rl.yaml
+++ b/sources/products/nemo-rl.yaml
@@ -8,5 +8,7 @@ description: NeMo-RL is NVIDIA's open source library for reinforcement-learning 
   separate managed fine-tuning microservice, alongside the open library.
 github:
 - url: https://github.com/NVIDIA-NeMo/RL
+pypi:
+- url: https://pypi.org/project/nemo-rl
 comments: The nemo-rl package on PyPI is a placeholder that points back to GitHub; the library ships from source
   or NVIDIA's NGC container. Verified 2026-08-09 via GitHub, the LICENSE body, and PyPI.

--- a/sources/products/onnx-runtime.yaml
+++ b/sources/products/onnx-runtime.yaml
@@ -8,4 +8,6 @@ description: ONNX Runtime is a cross-platform accelerator for machine learning i
   Windows, Office, and Azure.
 github:
 - url: https://github.com/microsoft/onnxruntime
+pypi:
+- url: https://pypi.org/project/onnxruntime
 comments: Verified 2026-08-09 via GitHub, the LICENSE body, and PyPI download statistics.

--- a/sources/products/open-webui.yaml
+++ b/sources/products/open-webui.yaml
@@ -7,5 +7,7 @@ description: Self-hosted, extensible web UI for chatting with any OpenAI-compati
   the most popular open chat frontend with ~138k GitHub stars and 280M+ container pulls by May 2026.
 github:
 - url: https://github.com/open-webui/open-webui
+pypi:
+- url: https://pypi.org/project/open-webui
 comments: v0.9.6 (June 1, 2026), confirmed live on GitHub June 2026. Self-hosted chat UI (Ollama + OpenAI-compatible
   APIs).

--- a/sources/products/openmanus.yaml
+++ b/sources/products/openmanus.yaml
@@ -6,5 +6,7 @@ description: Open-source reimplementation of the Manus autonomous agent, built b
   Framed as a run-from-source product rather than a reusable library.
 github:
 - url: https://github.com/FoundationAgents/OpenManus
+pypi:
+- url: https://pypi.org/project/openmanus
 comments: MIT, no paid/feature-gated core. ~57k stars but a vestigial PyPI package (~186 downloads/month) - run
   via git clone, not pip.

--- a/sources/products/openpipe.yaml
+++ b/sources/products/openpipe.yaml
@@ -5,6 +5,8 @@ description: OpenPipe ships the Agent Reinforcement Trainer (ART), a library for
   with reinforcement learning (GRPO) and supervised fine-tuning. ART's client-server split lets training run
   on a self-hosted GPU or through a hosted backend, and OpenPipe sells a managed training and serving platform
   layered on the library. CoreWeave, which also owns Weights & Biases, acquired OpenPipe in September 2025.
+pypi:
+- url: https://pypi.org/project/openpipe-art
 comments: Scored on ART, the library, not OpenPipe's wider platform surface. Whether the hosted backend gates
   any ART functionality is the open question behind the openness read, and today's sources do not settle it.
   Verified 2026-08-09 via GitHub and the ART documentation.

--- a/sources/products/opik.yaml
+++ b/sources/products/opik.yaml
@@ -7,5 +7,7 @@ description: Open-source platform for debugging, evaluating, and monitoring LLM 
   the second most-starred open source LLM observability tool after Langfuse.
 github:
 - url: https://github.com/comet-ml/opik
+pypi:
+- url: https://pypi.org/project/opik
 comments: opik v2.0.57 (released 4 Jun 2026, PyPI/GitHub); confirmed live June 2026. Self-hostable OSS
   platform; Comet.com cloud is optional hosting.

--- a/sources/products/ragas.yaml
+++ b/sources/products/ragas.yaml
@@ -7,6 +7,8 @@ description: Evaluation framework purpose-built for Retrieval-Augmented Generati
   buckets in a way general harnesses do not. 14k stars, 240 contributors.
 github:
 - url: https://github.com/explodinggradients/ragas
+pypi:
+- url: https://pypi.org/project/ragas
 comments: 'explodinggradients/ragas, v0.4.3 (released 13 Jan 2026), Apache-2.0, ~14.2k stars. Toolkit
   for evaluating LLM/RAG applications: LLM-based + traditional metrics, synthetic test-set generation,
   LangChain/observability integrations. Confirmed live on GitHub + PyPI June 2026. Note: maintainer Exploding

--- a/sources/products/smolagents.yaml
+++ b/sources/products/smolagents.yaml
@@ -10,5 +10,7 @@ description: Minimal code-first agent framework from Hugging Face (~1,000 lines 
   and Cohere agent-building guides.
 github:
 - url: https://github.com/huggingface/smolagents
+pypi:
+- url: https://pypi.org/project/smolagents
 comments: smolagents by Hugging Face, minimal (~1k-LOC core) code-writing agent framework ('agents that
   think in code'). Apache-2.0. Verified live June 2026 on GitHub.

--- a/sources/products/swe-bench.yaml
+++ b/sources/products/swe-bench.yaml
@@ -10,6 +10,8 @@ description: 'Docker-based evaluation harness that benchmarks coding agents on 2
   Pro and SWE-bench Bash variants for frontier evaluation.'
 github:
 - url: https://github.com/princeton-nlp/SWE-bench
+pypi:
+- url: https://pypi.org/project/swebench
 comments: SWE-bench evaluation harness. PyPI `swebench` v4.1.0 (Sep 11 2025); repo migrated to github.com/SWE-bench/SWE-bench,
   last headline feature SWE-bench Multimodal (Jan 2025). Confirmed live June 2026. Scoring the HARNESS
   (the software that runs models against GitHub-issue tasks); the underlying dataset belongs in benchmark_eval_data.

--- a/sources/products/swift.yaml
+++ b/sources/products/swift.yaml
@@ -6,6 +6,8 @@ description: 'SWIFT, packaged as ms-swift, covers the full lifecycle of 600+ tex
   LoRA/QLoRA/DoRA, the GRPO family of RL algorithms, and preference methods such as DPO and KTO, reached through
   a CLI, a Python API, or a web UI. Alibaba''s DAMO ModelScope team maintains it, and an AAAI 2025 paper describes
   the design.'
+pypi:
+- url: https://pypi.org/project/ms-swift
 comments: The repository's About blurb still says 300+ multimodal models while the README says 400+, and the
   maintainer is named as the ModelScope community on GitHub and the DAMO ModelScope team on PyPI. Verified
   2026-08-08 via the ms-swift README, the PyPI project page, and the LICENSE body.

--- a/sources/products/torchtune.yaml
+++ b/sources/products/torchtune.yaml
@@ -8,5 +8,7 @@ description: 'torchtune is a PyTorch-native library of training recipes for post
   in 2025 and it is no longer maintained.'
 github:
 - url: https://github.com/pytorch/torchtune
+pypi:
+- url: https://pypi.org/project/torchtune
 comments: The recorded repository path pytorch/torchtune now redirects to meta-pytorch/torchtune; the content
   is unchanged. Verified 2026-08-09 via GitHub and the LICENSE body.

--- a/sources/products/unsloth.yaml
+++ b/sources/products/unsloth.yaml
@@ -7,4 +7,6 @@ description: Unsloth is a fine-tuning library that rewrites training kernels in 
   pretraining, and quantization, and its kernels slot under Hugging Face's TRL trainers.
 github:
 - url: https://github.com/unslothai/unsloth
+pypi:
+- url: https://pypi.org/project/unsloth
 comments: Verified 2026-08-09 via GitHub and the LICENSE body.

--- a/sources/products/verl.yaml
+++ b/sources/products/verl.yaml
@@ -8,6 +8,8 @@ description: verl (Volcano Engine Reinforcement Learning) is a post-training lib
   maintains it.
 github:
 - url: https://github.com/volcengine/verl
+pypi:
+- url: https://pypi.org/project/verl
 comments: The recorded GitHub URL (volcengine/verl) 301-redirects to verl-project/verl following a January
   2026 org migration noted in the README; repository content is unchanged. Verified 2026-08-09 via GitHub,
   the LICENSE body, the README, and PyPI.

--- a/sources/products/vllm.yaml
+++ b/sources/products/vllm.yaml
@@ -8,4 +8,6 @@ description: vLLM is a serving engine for large language models built on PagedAt
   under vllm-project.
 github:
 - url: https://github.com/vllm-project/vllm
+pypi:
+- url: https://pypi.org/project/vllm
 comments: Verified 2026-08-09 via GitHub and the LICENSE body.

--- a/sources/products/weave.yaml
+++ b/sources/products/weave.yaml
@@ -7,5 +7,7 @@ description: Toolkit for developing and monitoring AI-powered applications, buil
   consumed via the W&B cloud platform. 1.1K GitHub stars.
 github:
 - url: https://github.com/wandb/weave
+pypi:
+- url: https://pypi.org/project/weave
 comments: W&B Weave; OSS SDK v0.52.42 (Jun 2, 2026) confirmed live on GitHub (wandb/weave). LLM tracing
   + evaluation + monitoring layered onto the commercial W&B platform.


### PR DESCRIPTION
Prerequisite for #163. The PyPI signal wasn't stale — it was starved.

## The diagnosis

`currentai.signal_pypi.package_downloads`, queried 2026-08-09:

```
rows               66
products           66
window_start       2026-07-06   (identical on every row)
last_day_seen      2026-08-05   (identical on every row)
missing_from_pypi  0
```

Healthy. Every declared artifact has a row, no orphans, nothing flagged missing, window ends four days ago. The chain works exactly as designed — the UDM fetches what the registry lists, the registry serializes what the repo declares, and **the repo declared 66 of 472 products**.

So `vllm` had no row while a human read 5,293,683 downloads/month off pypistats by hand. Same for `onnx-runtime` (~74.7M), `lmdeploy`, `sglang`, `llama-factory` — every figure I quoted at you this week came from a manual read the signal should have supplied.

## Two changes to the proposer

`build/propose_artifacts.py` already did the hard parts: mine candidates from URLs the repo already records, verify each against the live API, write nothing.

- **`--kind`** selects products missing *one* artifact kind rather than missing every kind. The old bar was "verifiable at all", so a library with a GitHub repo and no declared package was skipped — precisely the population that matters here.
- **pypistats URLs are now mined** alongside `pypi.org` ones. 69 score files cite pypistats against 23 citing pypi.org, because pypistats is where a human goes to *read* a download count. Mining only pypi.org found 12 candidates where there were 34.

The captured name is still verified against the PyPI JSON API before anything is proposed, so a misspelled or dead package cannot slip through on the strength of appearing in a URL.

## Verification

All 34 returned 200 from the PyPI JSON API. None contested, none 404, none unverified.

Because the tool's own docstring warns that a wrong package silently attaches another project's downloads, I ran a second, independent check: compare each package's own metadata against the GitHub repo we declare. **17 point straight back at it, and none points at a different project.** The remainder either declare no repo in their PyPI metadata (10) or differ only by an org rename (7, below).

Each declaration was inserted with a reparse assertion — the document must equal itself plus exactly one `pypi` key, and no bytes outside the inserted span may move.

Registry goes **66 → 100** pypi artifacts.

## A correction to the argument that motivated this

I claimed earlier that undeclared packages were pinning products to a capped `stars_fallback` band. That is mostly **not** what was happening. Only 2 of the 34 sit on `stars_fallback` today; the other 30 already record `usage_volume`, because someone read the figure by hand and typed it in.

The real harm was manual labor and a number that ages with nothing watching it — not a suppressed score. Worth stating plainly since it was half my case for doing this.

## Surfaced, deliberately not fixed here

7 of these products declare a GitHub URL whose org has since moved:

| declared | actual |
|---|---|
| `explodinggradients/ragas` | `vibrantlabsai/ragas` |
| `princeton-nlp/swe-bench` | `swe-bench/swe-bench` |
| `volcengine/verl` | `verl-project/verl` |
| `mannaandpoem/openmanus` | `foundationagents/openmanus` |
| `nvidia-nemo/rl` | `nvidia/nemo-rl` |
| `scale3-labs/langtrace` | `scale3-labs/langtrace-python-sdk` (SDK repo) |
| `axolotl-ai-cloud/axolotl` | same, `.git` suffix only |

GitHub redirects, so nothing is broken and `repo_state` records `resolved_via_redirect`. But the recorded `artifact_id` is stale. Unrelated to this change, so it wants its own.

## Gates

```
validate         0 error(s)
check_routing    adoption 341 routed, 0 blocked
pytest           394 passed
serialize_registry   100 pypi artifacts, 0 with a missing artifact_id
```

The 2 `build_registry` errors (`arduino-uno-q`, `lm-studio` — org-level GitHub URLs naming no repo) are pre-existing on `main`; confirmed by running the same check there.