### PR TITLE
Point 16 github declarations at the repos they now resolve to

### DIFF
--- a/sources/products/firecrawl.yaml
+++ b/sources/products/firecrawl.yaml
@@ -6,7 +6,7 @@ description: Web scraping and crawling API built specifically for LLM consumptio
   automatically. The most popular open source web-to-LLM pipeline with 123K GitHub stars, used by agent
   frameworks as the default scraping tool. Open-source with a hosted SaaS option.
 github:
-- url: https://github.com/mendableai/firecrawl
+- url: https://github.com/firecrawl/firecrawl
 pypi:
 - url: https://pypi.org/project/firecrawl-py
 comments: Web scrape/crawl/search API that returns LLM-ready data (markdown/JSON/structured). Self-hostable

--- a/sources/products/giskard.yaml
+++ b/sources/products/giskard.yaml
@@ -5,6 +5,6 @@ description: An open-source Python library for testing and red-teaming LLM and a
   Scan automatically probes applications for vulnerabilities (prompt injection, harmful output, hallucination),
   and Giskard Checks runs scenario-based evaluations, including multi-turn agent validation.
 github:
-- url: https://github.com/Giskard-AI/giskard
+- url: https://github.com/Giskard-AI/giskard-oss
 comments: Giskard, Apache-2.0, Python; ~5.5K GitHub stars (June 2026). Scan (automated red-teaming) +
   Checks (scenario evals). Verified live June 2026.

--- a/sources/products/goose.yaml
+++ b/sources/products/goose.yaml
@@ -7,7 +7,7 @@ description: Open-source extensible AI agent from Block (fka Square) that goes b
   stars with 452 contributors and 918 commits in 90 days, one of the most actively developed open source
   agents, backed by a major tech company.
 github:
-- url: https://github.com/block/goose
+- url: https://github.com/aaif-goose/goose
 comments: 'Goose, v1.37.0 (Jun 3 2026). VERIFIED: repo has moved from block/goose to aaif-goose/goose
   under the Agentic AI Foundation (AAIF) at the Linux Foundation; 46.4k stars. General-purpose on-machine
   AI agent (Rust) with 70+ MCP extensions, 15+ LLM providers. Confirmed live June 2026.'

--- a/sources/products/hexabot.yaml
+++ b/sources/products/hexabot.yaml
@@ -7,7 +7,7 @@ description: Hexabot is an AI chatbot / agent builder by the company Hexastack f
   channels like WhatsApp, Telegram, Slack, and Facebook. v3 combines workflows, actions, agents, and conversational
   channels in one runtime.
 github:
-- url: https://github.com/Hexastack/Hexabot
+- url: https://github.com/hexabot-ai/Hexabot
 npm:
 - url: https://www.npmjs.com/package/@hexabot-ai/widget
 comments: Verified live 2026-06-22 via primary sources. Fair Core License is a delayed-open / fair-code

--- a/sources/products/llama-factory.yaml
+++ b/sources/products/llama-factory.yaml
@@ -7,7 +7,7 @@ description: LLaMA-Factory is a toolkit for fine-tuning 100+ open LLM and vision
   and the Gradio-based LLaMA Board web UI run the same pipeline without custom code, and the project appeared
   as an ACL 2024 paper.
 github:
-- url: https://github.com/hiyouga/LLaMA-Factory
+- url: https://github.com/hiyouga/LlamaFactory
 pypi:
 - url: https://pypi.org/project/llamafactory
 comments: Verified 2026-08-09 via GitHub and the LICENSE body.

--- a/sources/products/nemo-curator.yaml
+++ b/sources/products/nemo-curator.yaml
@@ -5,7 +5,7 @@ description: 'GPU-accelerated, scalable data-curation toolkit for LLM training c
   video, and audio: extraction, language ID, exact/fuzzy/substring dedup, quality classification, and
   synthetic generation.'
 github:
-- url: https://github.com/NVIDIA/NeMo-Curator
+- url: https://github.com/NVIDIA-NeMo/Curator
 pypi:
 - url: https://pypi.org/project/nemo-curator
 comments: NVIDIA NeMo Curator; repo actively maintained (v1.2.0, 2026-05-14), Apache-2.0 confirmed live

--- a/sources/products/nemo-guardrails.yaml
+++ b/sources/products/nemo-guardrails.yaml
@@ -6,6 +6,6 @@ description: NVIDIA's open-source toolkit for adding programmable guardrails aro
   a small policy language (Colang), and works across multiple LLM providers. Deployable as a Python library,
   CLI, Docker, or standalone server.
 github:
-- url: https://github.com/NVIDIA/NeMo-Guardrails
+- url: https://github.com/NVIDIA-NeMo/Guardrails
 comments: NeMo Guardrails, Apache-2.0, Python; ~6.6K GitHub stars (June 2026). Fully open source and self-hostable.
   Verified live June 2026.

--- a/sources/products/opencode.yaml
+++ b/sources/products/opencode.yaml
@@ -5,7 +5,7 @@ description: Open-source terminal (TUI) AI coding agent from the SST team (now A
   with 75+ LLM providers (Claude, GPT, Gemini, Bedrock, local models). A polished native TUI with multi-session
   agents, shareable sessions, built-in LSP, and a client/server architecture.
 github:
-- url: https://github.com/sst/opencode
+- url: https://github.com/anomalyco/opencode
 npm:
 - url: https://www.npmjs.com/package/opencode-ai
 comments: MIT. ~176k stars; repo recently renamed sst/opencode -> anomalyco/opencode (old URL redirects). Distributed

--- a/sources/products/openhands.yaml
+++ b/sources/products/openhands.yaml
@@ -7,5 +7,5 @@ description: Open-source autonomous coding agent (formerly OpenDevin) that can w
   the top open source agents. 74.5K GitHub stars with 460+ contributors and extremely active development
   (710+ commits in 90 days).
 github:
-- url: https://github.com/All-Hands-AI/OpenHands
+- url: https://github.com/OpenHands/OpenHands
 comments: Active 2026 (All-Hands AI); ~75.8k GitHub stars; SWE-bench Verified ~77.6

--- a/sources/products/opensandbox.yaml
+++ b/sources/products/opensandbox.yaml
@@ -6,7 +6,7 @@ description: Apache-2.0 sandbox runtime from Alibaba aimed squarely at AI agents
   plus Docker and Kubernetes runtimes. Picked by teams wanting an open protocol-driven alternative to
   E2B at K8s scale; ~10.8k stars and 910 commits in the last 90d signal serious investment.
 github:
-- url: https://github.com/alibaba/OpenSandbox
+- url: https://github.com/opensandbox-group/OpenSandbox
 comments: Alibaba OpenSandbox, general-purpose sandbox platform for AI agents (coding agents, GUI agents,
   agent eval, RL training); open sourced Mar 2026; components/execd 1.0.18 (May 25 2026) confirmed live
   on GitHub. Go execd daemon; Docker/Kubernetes runtimes; multi-language SDKs (Python/TS/Go/Java); MCP

--- a/sources/products/ragas.yaml
+++ b/sources/products/ragas.yaml
@@ -6,7 +6,7 @@ description: Evaluation framework purpose-built for Retrieval-Augmented Generati
   Picked when the system under test is RAG; Ragas decomposes pipeline failure into retrieval vs. generation
   buckets in a way general harnesses do not. 14k stars, 240 contributors.
 github:
-- url: https://github.com/explodinggradients/ragas
+- url: https://github.com/vibrantlabsai/ragas
 pypi:
 - url: https://pypi.org/project/ragas
 comments: 'explodinggradients/ragas, v0.4.3 (released 13 Jan 2026), Apache-2.0, ~14.2k stars. Toolkit

--- a/sources/products/safetensors.yaml
+++ b/sources/products/safetensors.yaml
@@ -7,7 +7,7 @@ description: Safetensors is a file format and library for safely storing and loa
   frameworks. Maintained by Hugging Face, it has become the default weight format for models on the Hugging
   Face Hub.
 github:
-- url: https://github.com/huggingface/safetensors
+- url: https://github.com/safetensors/safetensors
 pypi:
 - url: https://pypi.org/project/safetensors/
 comments: Verified live 2026-06-22 via primary sources. LICENSE body is verbatim Apache License 2.0; full

--- a/sources/products/swe-bench-verified.yaml
+++ b/sources/products/swe-bench-verified.yaml
@@ -9,7 +9,7 @@ description: 500 human-verified instances drawn from the broader SWE-bench datas
   had flawed test cases and that frontier models can reproduce gold patches verbatim. OpenAI now prefers
   SWE-bench Pro for headline coding evaluations.
 github:
-- url: https://github.com/princeton-nlp/SWE-bench
+- url: https://github.com/SWE-bench/SWE-bench
 huggingface_dataset:
 - url: https://huggingface.co/datasets/princeton-nlp/SWE-bench_Verified
 comments: SWE-bench Verified (princeton-nlp/SWE-bench_Verified), 500 human-validated GitHub issue-resolution

--- a/sources/products/swe-bench.yaml
+++ b/sources/products/swe-bench.yaml
@@ -9,7 +9,7 @@ description: 'Docker-based evaluation harness that benchmarks coding agents on 2
   unsolved problems in SWE-bench Verified had flawed test cases; they now prefer the harder SWE-bench
   Pro and SWE-bench Bash variants for frontier evaluation.'
 github:
-- url: https://github.com/princeton-nlp/SWE-bench
+- url: https://github.com/SWE-bench/SWE-bench
 pypi:
 - url: https://pypi.org/project/swebench
 comments: SWE-bench evaluation harness. PyPI `swebench` v4.1.0 (Sep 11 2025); repo migrated to github.com/SWE-bench/SWE-bench,

--- a/sources/products/torchtune.yaml
+++ b/sources/products/torchtune.yaml
@@ -7,7 +7,7 @@ description: 'torchtune is a PyTorch-native library of training recipes for post
   via FSDP2, and integrates with Hugging Face Hub and Weights & Biases. Meta built it; development wound down
   in 2025 and it is no longer maintained.'
 github:
-- url: https://github.com/pytorch/torchtune
+- url: https://github.com/meta-pytorch/torchtune
 pypi:
 - url: https://pypi.org/project/torchtune
 comments: The recorded repository path pytorch/torchtune now redirects to meta-pytorch/torchtune; the content

--- a/sources/products/verl.yaml
+++ b/sources/products/verl.yaml
@@ -7,7 +7,7 @@ description: verl (Volcano Engine Reinforcement Learning) is a post-training lib
   runs on FSDP or Megatron-LM with vLLM and SGLang rollout. ByteDance Seed started the project; the verl community
   maintains it.
 github:
-- url: https://github.com/volcengine/verl
+- url: https://github.com/verl-project/verl
 pypi:
 - url: https://pypi.org/project/verl
 comments: The recorded GitHub URL (volcengine/verl) 301-redirects to verl-project/verl following a January


### PR DESCRIPTION
Follow-on from #165, which tripped over a few of these. Rather than fix the handful I happened to see, I asked the signal: `signal_github` already records `resolved_via_redirect` and `resolved_repo`, so the complete list is a query rather than a sample. It found **16**, not the 7 I'd noticed.

Each was then re-confirmed against the GitHub API, which returns the canonical `full_name` after a rename. All 16 agree with the signal; none is archived.

| product | declared | resolves to |
|---|---|---|
| `firecrawl` | `mendableai/firecrawl` | `firecrawl/firecrawl` |
| `giskard` | `Giskard-AI/giskard` | `Giskard-AI/giskard-oss` |
| `goose` | `block/goose` | `aaif-goose/goose` |
| `hexabot` | `Hexastack/Hexabot` | `hexabot-ai/Hexabot` |
| `llama-factory` | `hiyouga/LLaMA-Factory` | `hiyouga/LlamaFactory` |
| `nemo-curator` | `NVIDIA/NeMo-Curator` | `NVIDIA-NeMo/Curator` |
| `nemo-guardrails` | `NVIDIA/NeMo-Guardrails` | `NVIDIA-NeMo/Guardrails` |
| `opencode` | `sst/opencode` | `anomalyco/opencode` |
| `openhands` | `All-Hands-AI/OpenHands` | `OpenHands/OpenHands` |
| `opensandbox` | `alibaba/OpenSandbox` | `opensandbox-group/OpenSandbox` |
| `ragas` | `explodinggradients/ragas` | `vibrantlabsai/ragas` |
| `safetensors` | `huggingface/safetensors` | `safetensors/safetensors` |
| `swe-bench` | `princeton-nlp/SWE-bench` | `SWE-bench/SWE-bench` |
| `swe-bench-verified` | `princeton-nlp/SWE-bench` | `SWE-bench/SWE-bench` |
| `torchtune` | `pytorch/torchtune` | `meta-pytorch/torchtune` |
| `verl` | `volcengine/verl` | `verl-project/verl` |

## Why fix it rather than lean on the redirect

A redirect is not a permanent guarantee. GitHub frees the old path for reuse, and `identity.md` already records this exact hazard one level up: `grok` was renamed and the slug was **later reused by an unrelated product**, which is why that rename deliberately carries no alias. A re-created `princeton-nlp/SWE-bench` would silently attach another repo's stars, license and liveness to this one — and it would look like a working signal, not a broken one.

Two products had already spotted their move and written it into prose, because prose was the only field that pass was allowed to touch: `torchtune`'s comments say *"The recorded repository path pytorch/torchtune now redirects to meta-pytorch/torchtune"*, and `swe-bench`'s say *"repo migrated to github.com/SWE-bench/SWE-bench"*. The observation was made; it just had nowhere to go.

## Score-file source URLs are deliberately left alone

`sources[].url` carries an `accessed` date and a digest, and together they record *what was fetched that day*. The old paths did resolve when they were read. Rewriting them would assert a fetch nobody performed — the same category of error as deriving a `last_verified`. They still resolve, and each will pick up the canonical path the next time its category is re-read.

## Flagged, not acted on: four moves that may bear on a score

An org move is sometimes a governance fact, and one of these looks like more than a rename. These sit outside any category being swept right now, and each needs evidence rather than an inference, so they go to the relevant category's pass:

- **`giskard` → `Giskard-AI/giskard-oss`.** A repo renamed to `-oss` commonly accompanies an open-core split, which is directly the `core_gated` question. Currently 5 / `open_source` with no `last_verified`. Worth a real look during `safeguards`.
- **`goose` → `aaif-goose/goose`.** Out of Block's org into what appears to be a foundation. Governance dimension. (`orchestration_agents`)
- **`safetensors` → `safetensors/safetensors`.** Out of the Hugging Face org into its own. (`ml_frameworks`)
- **`opencode` → `anomalyco/opencode`.** Out of `sst` into a company org. (`orchestration_agents`)

By category, the 16 fall as: `orchestration_agents` 4, `finetuning_code` 3, `safeguards` 2, `evaluation_code` 2, and one each in `agent_tools_protocols`, `dataset_processing_tools`, `deployment`, `ml_frameworks`, `benchmark_eval_data`.

## Gates

```
validate        0 error(s)
check_recipe    0 failure(s)
pytest          394 passed
```