### PR TITLE
Drop two stub pypi declarations added in #165

### DIFF
--- a/sources/products/nemo-rl.yaml
+++ b/sources/products/nemo-rl.yaml
@@ -8,7 +8,5 @@ description: NeMo-RL is NVIDIA's open source library for reinforcement-learning 
   separate managed fine-tuning microservice, alongside the open library.
 github:
 - url: https://github.com/NVIDIA-NeMo/RL
-pypi:
-- url: https://pypi.org/project/nemo-rl
 comments: The nemo-rl package on PyPI is a placeholder that points back to GitHub; the library ships from source
   or NVIDIA's NGC container. Verified 2026-08-09 via GitHub, the LICENSE body, and PyPI.

--- a/sources/products/openmanus.yaml
+++ b/sources/products/openmanus.yaml
@@ -6,7 +6,5 @@ description: Open-source reimplementation of the Manus autonomous agent, built b
   Framed as a run-from-source product rather than a reusable library.
 github:
 - url: https://github.com/FoundationAgents/OpenManus
-pypi:
-- url: https://pypi.org/project/openmanus
 comments: MIT, no paid/feature-gated core. ~57k stars but a vestigial PyPI package (~186 downloads/month) - run
   via git clone, not pip.


### PR DESCRIPTION
Fixing my own error from #165. Two of the 34 declarations attach a package that is not the product's distribution channel.

| product | package | why it's wrong |
|---|---|---|
| `openmanus` | `pypi:openmanus` | Version 0.1.0, summary *"Add your description here"*, homepage `mannaandpoem/OpenManus` — **622 stars**. The product on the map is `FoundationAgents/OpenManus` — **57,911 stars**. A stub from a small predecessor repo. |
| `nemo-rl` | `pypi:nemo-rl` | Version **0.0.0** — a name reservation, not a release. 147 downloads/month for a project used from source. |

## How it got through, and how it surfaced

The cross-check in #165 *did* flag `openmanus` as a repo mismatch, and I explained it away as an org rename. It wasn't — they're two different repositories, and the prominent one is not the package's home. Comparing star counts, or simply looking at the package version, would have caught it. Neither was done.

What surfaced it was comparing the recorded adoption bands against the newly computed ones: these two were the largest disagreements in the set, at 175 and 147 monthly downloads against projects with tens of thousands of stars. The signal caught the bad declaration on its first run, which is a decent argument for the signal.

Screening all 34 for a placeholder version or summary finds **exactly these two**. The other 32 stand.

## Follow-up, not bolted on here

A version and star-count sanity check belongs in `propose_artifacts` rather than in a reviewer's head — `0.0.0`/`0.1.0`, a placeholder summary, or downloads wildly out of line with repo prominence are all mechanical tells. Its own change, so this one stays a pure data fix.

```
validate   0 error(s)
pytest     394 passed
```