### PR TITLE
Check declared artifacts against what they actually resolve to

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -1,0 +1,54 @@
+name: artifacts
+
+# Does each declared artifact still name the thing we think it names?
+#
+# An artifact_id is a join key, so a stale one does not fail loudly — it attaches another
+# project's stars, license and downloads to a product and keeps reporting them. That is
+# indistinguishable from a working signal, which is why this needs a scheduled check
+# rather than a reviewer's attention. Three drifts, all of which happened in one week:
+# 16 repositories had moved (#166), and two packages were reservations rather than
+# distributions (#167). The reasoning is in build/check_artifacts.py.
+#
+# Two of the checks read signals that were already being computed weekly and never read:
+# signal_github.resolved_via_redirect and signal_pypi.missing_from_pypi. The other two
+# need the PyPI JSON API, which is what --live turns on.
+#
+# Timed against the chain it depends on rather than the calendar, which is the lesson
+# parity.yml records: the signal user models recompute Monday 03:00-05:00 UTC, so this
+# runs at 07:00 and reads a warehouse that has caught up. Running it before that would
+# report last week's roster and call it drift.
+#
+# Report-only. `--strict` exists and CI does not pass it yet: the first real run surfaced
+# 4 legitimate client-package cases that needed waivers, and a gate that fails on the day
+# it lands gets switched off rather than fixed. Turn it on once the findings stay at zero
+# across a few runs.
+
+on:
+  schedule:
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+    inputs:
+      strict:
+        description: "Exit non-zero on any unwaived finding"
+        type: boolean
+        default: false
+
+jobs:
+  artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Install dependencies
+        run: uv sync --locked
+      - name: Check declared artifacts against what they resolve to
+        env:
+          OSO_API_KEY: ${{ secrets.OSO_API_KEY }}
+        run: |
+          if [ "${{ inputs.strict }}" = "true" ]; then
+            uv run python -m build.check_artifacts --live --strict
+          else
+            uv run python -m build.check_artifacts --live
+          fi

--- a/build/check_artifacts.py
+++ b/build/check_artifacts.py
@@ -1,0 +1,193 @@
+"""Catch a declared artifact that has drifted away from the thing it names.
+
+An artifact_id is a join key. `signal_github` keys on it, `signal_pypi` keys on it, and
+every adoption band downstream rests on whatever it resolves to. So a stale one does not
+fail loudly — it attaches another project's stars, license and downloads to this product
+and keeps reporting them, which is indistinguishable from a working signal.
+
+Three drifts, all of which happened in the week this was written:
+
+  * **A repository moved.** 16 declarations pointed at a path that now redirects (#166).
+    GitHub redirects today and frees the old path for reuse tomorrow; `identity.md`
+    records the same hazard one level up, where `grok` was renamed and the slug was later
+    reused by an unrelated product. A re-created `princeton-nlp/SWE-bench` would silently
+    become this product's evidence.
+  * **A package is a reservation, not a distribution.** `pypi:openmanus` was version
+    0.1.0 with the summary "Add your description here", published from a 622-star
+    predecessor repo while the product on the map has 57,911 (#167). It returned 200, so
+    existence checks passed it.
+  * **A package belongs to a different project.** The corroboration `stub_reason` cannot
+    do on its own: does the package's own metadata name the repository we declare?
+
+Two of the three need no network. `signal_github.resolved_via_redirect` and
+`signal_pypi.missing_from_pypi` are computed weekly and were simply never read.
+
+## Reports rather than fails, by default
+
+Following the parity gate, and for the reason `verification.md` gives: a gate whose
+schedule does not match its chain's fails for reasons that are not drift, and a gate that
+cries wolf gets switched off. The signals refresh weekly, so this runs after them, and
+`--strict` is what CI would use once the backlog is clear.
+
+A legitimate mismatch is waived on the product with `artifact_exceptions`, keyed by check
+name — presence is the exemption, the value is the reason.
+
+Usage:
+    uv run python -m build.check_artifacts                  # warehouse checks only, no network
+    uv run python -m build.check_artifacts --live           # add the PyPI metadata checks
+    uv run python -m build.check_artifacts --strict         # exit 1 on any unwaived finding
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import yaml
+
+from build.propose_artifacts import _get_json, declared_repo, pypi_info, stub_reason
+from build.serialize_registry import artifact_id
+from build.warehouse import query
+
+ROOT = Path(__file__).resolve().parents[1]
+
+CHECKS = ("github_moved", "pypi_missing", "pypi_stub", "pypi_repo_mismatch")
+
+
+def load_products() -> dict[str, dict]:
+    return {
+        path.stem: yaml.safe_load(path.read_text()) or {}
+        for path in sorted((ROOT / "sources" / "products").glob("*.yaml"))
+    }
+
+
+def declared(products: dict[str, dict], kind: str) -> dict[str, str]:
+    """slug -> artifact_id, for products declaring this kind. First entry wins."""
+    out: dict[str, str] = {}
+    for slug, product in products.items():
+        for entry in product.get(kind) or []:
+            ident = artifact_id(kind, entry.get("url") or "")
+            if ident:
+                out[slug] = ident
+                break
+    return out
+
+
+def waived(product: dict, check: str) -> str | None:
+    return ((product.get("artifact_exceptions") or {}).get(check)) or None
+
+
+def github_moved(products: dict[str, dict]) -> list[tuple[str, str, str]]:
+    """Declarations whose repo now resolves somewhere else, per the signal's own probe."""
+    rows = query(
+        "SELECT product_slug, repo, resolved_repo FROM currentai.signal_github.repo_state "
+        "WHERE resolved_via_redirect = true"
+    )
+    findings = []
+    for row in rows:
+        slug, resolved = row["product_slug"], row["resolved_repo"]
+        declared_id = declared(products, "github").get(slug)
+        if not declared_id or not resolved:
+            continue
+        # The signal probes what the repo declares, so compare against the declaration
+        # rather than against the signal's own `repo` column, which is the same string.
+        if declared_id.lower() != resolved.lower():
+            findings.append((slug, declared_id, resolved))
+    return findings
+
+
+def canonical_repo(repo: str) -> str:
+    """`owner/name` after GitHub's own rename resolution, lowercased.
+
+    Only called on a disagreement, so this costs one request per finding rather than one
+    per package.
+    """
+    body = _get_json(f"https://api.github.com/repos/{repo}", None)
+    full = (body or {}).get("full_name")
+    return (full or repo).lower()
+
+
+def pypi_missing(products: dict[str, dict]) -> list[tuple[str, str, str]]:
+    """Declared packages the signal could not find on PyPI at all."""
+    rows = query(
+        "SELECT product_slug, package FROM currentai.signal_pypi.package_downloads "
+        "WHERE missing_from_pypi = true"
+    )
+    return [(r["product_slug"], r["package"], "absent from PyPI") for r in rows]
+
+
+def pypi_content(products: dict[str, dict]) -> tuple[list, list]:
+    """Live checks: a package that is a stub, or that names a different repository.
+
+    One fetch per package, not two. Both questions are answered by the same JSON body,
+    and this runs over every declared package weekly — fetching twice would double the
+    rate-limit exposure to learn nothing extra.
+    """
+    stubs, mismatches = [], []
+    packages = declared(products, "pypi")
+    repos = declared(products, "github")
+    for slug, package in sorted(packages.items()):
+        info = pypi_info(package)
+        if info is None:
+            continue  # a transport failure is not evidence of anything
+        reason = stub_reason("pypi", package, info=info)
+        if reason:
+            stubs.append((slug, package, reason))
+            continue  # a stub's metadata is not worth corroborating
+        names = declared_repo("pypi", package, info=info)
+        ours = (repos.get(slug) or "").lower()
+        # No repo in the metadata is an absence of evidence, not a mismatch. Only a
+        # package naming a DIFFERENT repo than the one we declare is a finding.
+        if not (names and ours and names != ours):
+            continue
+        # A package's own metadata goes stale exactly the way our declarations did, so a
+        # raw string comparison reports a mismatch when WE are the current one. Resolve
+        # the package's repo through GitHub's rename before believing the disagreement:
+        # torchtune's metadata still names pytorch/torchtune, the path #166 corrected.
+        if canonical_repo(names) == canonical_repo(ours):
+            continue
+        mismatches.append((slug, package, f"names {names}, we declare {ours}"))
+    return stubs, mismatches
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--live", action="store_true", help="also run the PyPI metadata checks")
+    parser.add_argument("--strict", action="store_true", help="exit 1 on any unwaived finding")
+    args = parser.parse_args()
+
+    products = load_products()
+    results: dict[str, list[tuple[str, str, str]]] = {
+        "github_moved": github_moved(products),
+        "pypi_missing": pypi_missing(products),
+        "pypi_stub": [],
+        "pypi_repo_mismatch": [],
+    }
+    if args.live:
+        results["pypi_stub"], results["pypi_repo_mismatch"] = pypi_content(products)
+
+    unwaived = 0
+    for check in CHECKS:
+        findings = results[check]
+        if not args.live and check in ("pypi_stub", "pypi_repo_mismatch"):
+            print(f"{check:<22} skipped (needs --live)")
+            continue
+        live_findings = [f for f in findings if not waived(products.get(f[0]) or {}, check)]
+        waived_count = len(findings) - len(live_findings)
+        unwaived += len(live_findings)
+        suffix = f", {waived_count} waived" if waived_count else ""
+        print(f"{check:<22} {len(live_findings)} finding(s){suffix}")
+        for slug, ident, detail in live_findings:
+            print(f"    {slug:<28} {ident:<34} {detail}")
+
+    print()
+    if unwaived:
+        print(f"{unwaived} artifact(s) have drifted from what they name.")
+        print("Fix the declaration, or waive it on the product with `artifact_exceptions`.")
+    else:
+        print("Every declared artifact still resolves to the thing it names.")
+    return 1 if (args.strict and unwaived) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build/propose_artifacts.py
+++ b/build/propose_artifacts.py
@@ -45,6 +45,7 @@ adoption evidence, meaning a human had read the number the signal could not.
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import re
 import time
@@ -141,6 +142,80 @@ def _get(url: str, token: str | None) -> int:
         return exc.code
     except (urllib.error.URLError, TimeoutError):
         return 0
+
+
+def _get_json(url: str, token: str | None) -> dict | None:
+    """The body, or None on any failure. Existence is `_get`'s job; this reads content."""
+    headers = {"User-Agent": USER_AGENT}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(request, timeout=25) as response:
+            return json.load(response)
+    except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError, ValueError):
+        return None
+
+
+# A version nobody has moved off, on a package whose description was never written.
+# Both of the wrong declarations in #165 carried one of these and one carried both.
+PLACEHOLDER_VERSIONS = {"0.0.0", "0.1.0"}
+# The literal string uv and poetry scaffold into a fresh pyproject. An EMPTY summary is
+# deliberately not a tell: safetensors, tokenizers and cohere all ship one and are among
+# the most-downloaded packages in the corpus. Flagging those was this check's first
+# false-positive class.
+PLACEHOLDER_SUMMARY = re.compile(r"add your description here|^placeholder", re.I)
+
+
+def pypi_info(ident: str) -> dict | None:
+    """The `info` block of a package's PyPI JSON, or None on any failure."""
+    body = _get_json(f"https://pypi.org/pypi/{ident}/json", None)
+    return None if body is None else (body.get("info") or {})
+
+
+def stub_reason(kind: str, ident: str, info: dict | None = None) -> str | None:
+    """Why this artifact looks like a reservation rather than a distribution, or None.
+
+    A 200 answers "does this name exist", which is not the question. `pypi:openmanus`
+    existed, returned 200, and was a stub published from a 622-star predecessor repo
+    while the product on the map had 57,911 stars — so its download count measured a
+    different project. `pypi:nemo-rl` existed at version 0.0.0, a reserved name with no
+    release behind it.
+
+    Only PyPI is checked today because that is where the evidence is. The same shape
+    applies to npm and crates and can be added when one of them bites.
+    """
+    if kind != "pypi":
+        return None
+    if info is None:
+        info = pypi_info(ident)
+    if info is None:
+        return None  # a transport failure is not evidence of a stub
+    reasons = []
+    version = str(info.get("version") or "")
+    if version in PLACEHOLDER_VERSIONS:
+        reasons.append(f"version {version}")
+    if PLACEHOLDER_SUMMARY.search(str(info.get("summary") or "")):
+        reasons.append("placeholder summary")
+    return "; ".join(reasons) or None
+
+
+def declared_repo(kind: str, ident: str, info: dict | None = None) -> str | None:
+    """The repository this artifact's own metadata points at, lowercased, or None.
+
+    Corroboration rather than existence: a package whose metadata names a different
+    project than the one we declare is the failure `stub_reason` cannot see on its own.
+    """
+    if kind != "pypi":
+        return None
+    if info is None:
+        info = pypi_info(ident)
+    if info is None:
+        return None
+    blob = " ".join(str(v) for v in (info.get("project_urls") or {}).values())
+    blob += " " + str(info.get("home_page") or "")
+    found = re.findall(r"github\.com/([\w\-.]+/[\w\-.]+)", blob, re.I)
+    return found[0].lower().removesuffix(".git") if found else None
 
 
 def check_token(gh_token: str | None) -> str | None:
@@ -258,6 +333,17 @@ def main() -> int:
                 if not args.no_verify:
                     time.sleep(0.12)  # stay polite across a few hundred calls
 
+        # A 200 says the name resolves, not that it is this product's distribution.
+        # Screen the live ones before they can be reported as safe to accept.
+        stubs: list[tuple[str, str, str]] = []
+        if not args.no_verify:
+            for kind, ident, status in [v for v in verified if v[2] == 200]:
+                reason = stub_reason(kind, ident)
+                if reason:
+                    stubs.append((kind, ident, reason))
+        stub_idents = {(k, i) for k, i, _ in stubs}
+        verified = [v for v in verified if (v[0], v[1]) not in stub_idents]
+
         live = [v for v in verified if v[2] == 200]
         # Only 404 means absent. 401/403 is auth or rate limiting, 0 is a transport
         # failure, and reading either as "this repo does not exist" turns a broken
@@ -277,7 +363,10 @@ def main() -> int:
         if args.no_verify:
             verdict = "unchecked" if verified else "NONE"
         elif not verified:
-            verdict = "NONE"
+            # Every candidate was screened out. Say STUB rather than NONE: "no candidate
+            # in the repo" and "the only candidate is a reservation" are different
+            # findings, and the second is the one that nearly shipped twice.
+            verdict = "STUB" if stubs else "NONE"
         elif contested:
             verdict = "REVIEW"
         elif live_by_kind:
@@ -295,6 +384,7 @@ def main() -> int:
             "candidates": verified,
             "live": live,
             "live_by_kind": live_by_kind,
+            "stubs": stubs,
             "verdict": verdict,
         })
 
@@ -308,7 +398,7 @@ def main() -> int:
                 print(f"- url: {public_url(kind, idents[0])}")
             print()
         counts = {v: sum(1 for r in rows if r["verdict"] == v) for v in
-                  ("single", "multi-kind", "REVIEW", "ALL-404", "NONE")}
+                  ("single", "multi-kind", "REVIEW", "ALL-404", "NONE", "STUB")}
         print(f"# ready: {counts['single'] + counts['multi-kind']}  "
               f"needs a choice: {counts['REVIEW']}  no candidate: {counts['NONE']}")
         return 0
@@ -321,14 +411,21 @@ def main() -> int:
         print(f"  {row['display_name'][:24]:<26}{str(row['openness_class']):<17}"
               f"{row['verdict']:<11}{shown[:64]}")
 
+    stubbed = [(r["slug"], k, i, why) for r in rows for k, i, why in r["stubs"]]
+    if stubbed:
+        print("\nscreened out as reservations rather than distributions:")
+        for slug, kind, ident, why in stubbed:
+            print(f"  {slug:<24}{kind}:{ident} — {why}")
+
     counts = {v: sum(1 for r in rows if r["verdict"] == v) for v in
-              ("single", "multi-kind", "REVIEW", "UNVERIFIED", "ALL-404", "NONE")}
+              ("single", "multi-kind", "REVIEW", "UNVERIFIED", "ALL-404", "NONE", "STUB")}
     print(f"\nsingle verified candidate (safe to accept): {counts['single']}")
     print(f"several kinds, all verified (accept all):    {counts['multi-kind']}")
     print(f"two of the SAME kind (pick one):            {counts['REVIEW']}")
     print(f"could not verify (auth/rate limit/network): {counts['UNVERIFIED']}")
     print(f"candidates found but confirmed 404:         {counts['ALL-404']}")
     print(f"no candidate in the repo at all:            {counts['NONE']}")
+    print(f"only candidate was a stub/reservation:      {counts['STUB']}")
     print("\nNothing written. Review, then add the artifact block to the product yaml.")
     return 0
 

--- a/docs/schemas/product.schema.json
+++ b/docs/schemas/product.schema.json
@@ -135,6 +135,22 @@
         }
       },
       "description": "Display-only provenance: what this product was built from, what curated it, and what it went on to train. It feeds no score and gates nothing. build/serialize.py resolves any reference matching an on-map slug into that product's display name and passes everything else through verbatim, which is deliberate, because a corpus's ancestors are usually off-map (Common Crawl, Project Gutenberg, \"templated NLP datasets\"). Nothing validates a reference, so a mistyped slug renders as literal text rather than failing a check: 98 of 175 references resolve to a product on 2026-08-08 and the remaining 77 are intentional free text, which is why this is not gated. Also emitted to registry/product_lineage.csv as (product_slug, relation, target). 38 of 472 products carry a block, nearly all of them datasets and models."
+    },
+    "artifact_exceptions": {
+      "type": "object",
+      "description": "Why a declared artifact fails one of build/check_artifacts.py's checks legitimately, keyed by check name. The presence of the key is the exemption and the value is the reason, the same shape as `version_in_identity` and a category's `deferred` block. Kept on the record it describes rather than in a central file, because docs/guides/identity.md records what went wrong with the central one: a duplicate key silently kept the last value. Real cases: a package published from a subtree so its metadata names no repo (megatron-core), or a package deliberately named for its distribution rather than its project (crfm-helm for HELM). Never a way to silence a check that is right - a wrong artifact attaches another project's downloads and license.",
+      "additionalProperties": {
+        "type": "string",
+        "minLength": 20
+      },
+      "propertyNames": {
+        "enum": [
+          "pypi_repo_mismatch",
+          "pypi_stub",
+          "github_moved",
+          "pypi_missing"
+        ]
+      }
     }
   },
   "definitions": {

--- a/sources/products/distilabel.yaml
+++ b/sources/products/distilabel.yaml
@@ -7,6 +7,9 @@ github:
 - url: https://github.com/argilla-io/distilabel
 pypi:
 - url: https://pypi.org/project/distilabel
+artifact_exceptions:
+  pypi_repo_mismatch: The package metadata names argilla/distilabel, which no longer resolves; Argilla's org
+    is argilla-io and that is where the repo lives. Upstream metadata is stale, our declaration is current.
 comments: Argilla/Hugging Face distilabel; latest release v1.5.3 (2025-01-28), repo active into 2026,
   Apache-2.0 confirmed live 2026-07-21. Used to build the Zephyr/Notus preference data and the FinePersonas
   dataset.

--- a/sources/products/langtrace.yaml
+++ b/sources/products/langtrace.yaml
@@ -9,5 +9,9 @@ github:
 - url: https://github.com/Scale3-Labs/langtrace
 pypi:
 - url: https://pypi.org/project/langtrace-python-sdk
+artifact_exceptions:
+  pypi_repo_mismatch: langtrace-python-sdk is published from scale3-labs/langtrace-python-sdk, the SDK's own
+    repo, while the product is the platform at scale3-labs/langtrace. Two repos in one org, both correct for
+    what they name.
 comments: Langtrace app v4.0.11 (17 Apr 2026); langtrace-python-sdk v3.8.12 (8 Apr 2026). Active and maintained
   as of June 2026 (initial fetch misread release year; corrected via release pages).

--- a/sources/products/milvus.yaml
+++ b/sources/products/milvus.yaml
@@ -9,4 +9,8 @@ github:
 - url: https://github.com/milvus-io/milvus
 pypi:
 - url: https://pypi.org/project/pymilvus
+artifact_exceptions:
+  pypi_repo_mismatch: pymilvus is the Python client, published from milvus-io/pymilvus; the product is the
+    vector database at milvus-io/milvus. The client's downloads are the best available usage signal for the
+    server.
 comments: v2.6.x stable (late 2025); v3.0 RC published May 2026; LF AI & Data project

--- a/sources/products/qdrant.yaml
+++ b/sources/products/qdrant.yaml
@@ -10,6 +10,9 @@ github:
 - url: https://github.com/qdrant/qdrant
 pypi:
 - url: https://pypi.org/project/qdrant-client
+artifact_exceptions:
+  pypi_repo_mismatch: qdrant-client is the Python client, published from qdrant/qdrant-client; the product
+    is the vector database at qdrant/qdrant. Same shape as milvus.
 comments: High-performance Rust vector database / vector search engine (dense, sparse, multi-vector, hybrid
   search, quantization). Apache-2.0 core + Qdrant Cloud managed tier (free tier available). v1.18.2 released
   4 Jun 2026; verified live June 2026. Calibrated against frozen anchor Milvus (O5 open_source/A3/C4).

--- a/tests/test_check_artifacts.py
+++ b/tests/test_check_artifacts.py
@@ -1,0 +1,116 @@
+"""Tests for the artifact drift check.
+
+No network. What needs testing is the judgment, not the fetching: which disagreements
+count as drift, which are the artifact's own metadata being stale, and which are waived.
+
+Every case here is one this check was written to catch or was caught getting wrong on its
+first run against the real corpus.
+"""
+
+import build.check_artifacts as artifacts
+from build.propose_artifacts import stub_reason
+
+
+def product(github=None, pypi=None, exceptions=None):
+    out = {}
+    if github:
+        out["github"] = [{"url": f"https://github.com/{github}"}]
+    if pypi:
+        out["pypi"] = [{"url": f"https://pypi.org/project/{pypi}"}]
+    if exceptions:
+        out["artifact_exceptions"] = exceptions
+    return out
+
+
+def test_a_moved_repo_is_a_finding(monkeypatch):
+    """The #166 shape: the declaration names a path that now redirects elsewhere."""
+    monkeypatch.setattr(artifacts, "query", lambda _sql: [
+        {"product_slug": "swe-bench", "repo": "princeton-nlp/SWE-bench",
+         "resolved_repo": "SWE-bench/SWE-bench"},
+    ])
+    found = artifacts.github_moved({"swe-bench": product(github="princeton-nlp/SWE-bench")})
+    assert found == [("swe-bench", "princeton-nlp/SWE-bench", "SWE-bench/SWE-bench")]
+
+
+def test_a_repo_already_corrected_is_not_a_finding(monkeypatch):
+    """After the fix lands, the signal still carries the redirect row until it re-runs.
+
+    Comparing against `resolved_repo` rather than the signal's own `repo` column is what
+    makes the check quiet once the declaration is right, instead of nagging for a week.
+    """
+    monkeypatch.setattr(artifacts, "query", lambda _sql: [
+        {"product_slug": "swe-bench", "repo": "princeton-nlp/SWE-bench",
+         "resolved_repo": "SWE-bench/SWE-bench"},
+    ])
+    assert artifacts.github_moved({"swe-bench": product(github="SWE-bench/SWE-bench")}) == []
+
+
+def test_case_alone_is_not_drift(monkeypatch):
+    monkeypatch.setattr(artifacts, "query", lambda _sql: [
+        {"product_slug": "x", "repo": "Foo/Bar", "resolved_repo": "foo/bar"},
+    ])
+    assert artifacts.github_moved({"x": product(github="Foo/Bar")}) == []
+
+
+def test_stub_versions_are_caught_and_a_real_release_is_not():
+    """The #167 shape. `info` is passed in, so this makes no request."""
+    assert stub_reason("pypi", "openmanus",
+                       info={"version": "0.1.0", "summary": "Add your description here"})
+    assert stub_reason("pypi", "nemo-rl", info={"version": "0.0.0", "summary": "NeMo RL"})
+    assert stub_reason("pypi", "vllm", info={"version": "0.11.2", "summary": "A serving engine"}) is None
+
+
+def test_an_empty_summary_is_not_a_stub():
+    """This check's first false-positive class, on its first real run.
+
+    safetensors, tokenizers and cohere all publish an empty summary and are among the
+    most-downloaded packages in the corpus. Only the scaffolded placeholder string counts.
+    """
+    assert stub_reason("pypi", "safetensors", info={"version": "0.6.2", "summary": ""}) is None
+    assert stub_reason("pypi", "tokenizers", info={"version": "0.21.0", "summary": None}) is None
+
+
+def test_a_package_naming_a_stale_repo_is_not_drift(monkeypatch):
+    """A package's metadata goes stale exactly as our declarations did.
+
+    torchtune's PyPI metadata still names pytorch/torchtune, which is the path #166
+    corrected here. Resolving through GitHub's rename makes the two agree, so the finding
+    would be reporting that WE are current.
+    """
+    monkeypatch.setattr(artifacts, "pypi_info", lambda _p: {"version": "0.6.1", "summary": "recipes"})
+    monkeypatch.setattr(artifacts, "stub_reason", lambda *a, **k: None)
+    monkeypatch.setattr(artifacts, "declared_repo", lambda *a, **k: "pytorch/torchtune")
+    monkeypatch.setattr(artifacts, "canonical_repo", lambda repo: "meta-pytorch/torchtune")
+    products = {"torchtune": product(github="meta-pytorch/torchtune", pypi="torchtune")}
+    stubs, mismatches = artifacts.pypi_content(products)
+    assert (stubs, mismatches) == ([], [])
+
+
+def test_a_package_naming_a_genuinely_different_project_is_drift(monkeypatch):
+    monkeypatch.setattr(artifacts, "pypi_info", lambda _p: {"version": "0.1.0", "summary": "x"})
+    monkeypatch.setattr(artifacts, "stub_reason", lambda *a, **k: None)
+    monkeypatch.setattr(artifacts, "declared_repo", lambda *a, **k: "mannaandpoem/openmanus")
+    monkeypatch.setattr(artifacts, "canonical_repo", lambda repo: repo)
+    products = {"openmanus": product(github="foundationagents/openmanus", pypi="openmanus")}
+    _stubs, mismatches = artifacts.pypi_content(products)
+    assert [m[0] for m in mismatches] == ["openmanus"]
+
+
+def test_a_waiver_silences_its_own_check_only():
+    """A client package for a server product is legitimate; the waiver names why.
+
+    Scoped per check, so waiving the repo mismatch does not also waive a future stub.
+    """
+    waived = product(github="qdrant/qdrant", pypi="qdrant-client",
+                     exceptions={"pypi_repo_mismatch": "qdrant-client is the Python client."})
+    assert artifacts.waived(waived, "pypi_repo_mismatch")
+    assert artifacts.waived(waived, "pypi_stub") is None
+
+
+def test_missing_metadata_is_not_a_mismatch(monkeypatch):
+    """Absence of evidence. megatron-core names no repo at all and is still correct."""
+    monkeypatch.setattr(artifacts, "pypi_info", lambda _p: {"version": "0.15.0", "summary": "core"})
+    monkeypatch.setattr(artifacts, "stub_reason", lambda *a, **k: None)
+    monkeypatch.setattr(artifacts, "declared_repo", lambda *a, **k: None)
+    products = {"megatron-lm": product(github="NVIDIA/Megatron-LM", pypi="megatron-core")}
+    assert artifacts.pypi_content(products) == ([], [])


### PR DESCRIPTION
Closes #168.

An `artifact_id` is a join key. `signal_github` keys on it, `signal_pypi` keys on it, and every adoption band downstream rests on whatever it resolves to. So a stale one never fails loudly — it attaches another project's stars, license and downloads to a product and keeps reporting them, which is indistinguishable from a working signal. Three drifts hit in one week and all three were found by hand.

## `build/check_artifacts.py`

| check | catches | needs network? |
|---|---|---|
| `github_moved` | the declaration vs `signal_github.resolved_repo` | no |
| `pypi_missing` | `signal_pypi.missing_from_pypi` | no |
| `pypi_stub` | a `0.0.0`/`0.1.0` version or a scaffolded summary | yes |
| `pypi_repo_mismatch` | does the package's metadata name the repo we declare | yes |

The first two read signals that were **already being computed weekly and never read** — `github_moved` would have found all 16 of #166 the week they moved.

It compares against the *resolution* rather than the signal's own `repo` column, which matters: the check goes quiet as soon as a declaration is fixed, instead of nagging for a week until the signal re-runs. There's a test for exactly that.

## Two things the first real run taught

Both fixed rather than waived, because both were the check being wrong:

- **An empty summary is not a stub tell.** It flagged `safetensors`, `tokenizers`, `cohere` and `beeai-framework` — all real packages, among the most-downloaded in the corpus, that simply publish no summary. Only the scaffolded `"Add your description here"` counts now.
- **A package's metadata goes stale exactly as our declarations did.** A raw string comparison reported a mismatch when *we* were the current one: `torchtune`'s PyPI metadata still names `pytorch/torchtune`, the path #166 corrected. The package's repo is now resolved through GitHub's rename before the disagreement is believed — one request per finding rather than per package.

## The 4 remaining findings, all waived

| product | package | why it's legitimate |
|---|---|---|
| `milvus` | `pymilvus` | Python client for a server product |
| `qdrant` | `qdrant-client` | same shape |
| `langtrace` | `langtrace-python-sdk` | SDK's own repo, same org as the platform |
| `distilabel` | `distilabel` | upstream metadata names `argilla/distilabel`, which no longer resolves; ours is current |

Waived on the product with `artifact_exceptions`, keyed by check name so waiving a repo mismatch doesn't also waive a future stub. Presence is the exemption, the value is the reason — the same idiom as `version_in_identity`, and kept on the record rather than in a central file because `identity.md` records what went wrong with the central one.

## `propose_artifacts` can no longer make the #167 mistake

It screens stubs before proposing. A product whose only candidate is a stub now reports `STUB` rather than `NONE`, because "no candidate in the repo" and "the only candidate is a reservation" are different findings — and the second is the one that nearly shipped twice. Re-running it against the corpus now screens out exactly `nemo-rl` and `openmanus`.

## Schedule

Weekly, Monday 07:00 UTC — **after** the signal models recompute at 03:00–05:00, per the lesson `parity.yml` records about a gate whose schedule doesn't match its chain's. Report-only: `--strict` exists and CI doesn't pass it yet, since the first run surfaced 4 legitimate cases needing waivers and a gate that fails the day it lands gets switched off rather than fixed.

## Gates

```
check_artifacts --live --strict   0 findings, 4 waived
validate                          0 error(s)
pytest                            403 passed (9 new)
```