### PR TITLE
Declare adoption bands per product type, instead of hardcoding them in SQL

### DIFF
--- a/build/serialize_rubric.py
+++ b/build/serialize_rubric.py
@@ -128,6 +128,17 @@ TABLES: dict[str, tuple[str, ...]] = {
     # because `deferred` is declared on `scoring_recipe` itself and applies whichever ladder
     # a product resolves to.
     "category_deferrals": ("category_slug", "product_slug", "because"),
+    # Adoption bands, per product TYPE rather than per category, because the scale is a
+    # property of what the thing IS. They were hardcoded in the scoring SQL and nowhere
+    # else until 2026-08-09 — the repo/warehouse split check_parity exists to catch, one
+    # axis over. `above` is the exclusive lower bound, so the highest level whose `above`
+    # a figure exceeds wins, which is how the CASE expression already read.
+    #
+    # Hardware emits no rows on purpose. It declares `qualitative: true` and an empty
+    # `bands`, and the absence is the declaration: a consumer finding no band for a type
+    # must abstain rather than borrow another type's scale, which is exactly the
+    # "abstain rather than substitute" rule signal_routing.yaml states for sources.
+    "adoption_bands": ("product_type", "level", "above", "reach", "unit"),
     "license_aliases": ("source", "license_slug", "license_name"),
     "evidence_abstentions": ("source", "column_name", "abstain_value"),
     "product_openness_evidence": (
@@ -309,6 +320,32 @@ def license_tiers(slug: str, recipe: dict) -> tuple[list[dict], list[str]]:
     return rows, errors
 
 
+def adoption_bands(shared_rubrics: dict) -> tuple[list[dict], list[str]]:
+    """One row per (product type, level), from the shared ladders' `adoption.bands`.
+
+    Keyed on the rubric's filename stem, which IS the product type — `recipe_for` already
+    resolves a product to its ladder by `type`, so no second mapping is invented here.
+    """
+    rows, warnings = [], []
+    for product_type, rubric in sorted(shared_rubrics.items()):
+        adoption = (rubric or {}).get("adoption")
+        if adoption is None:
+            warnings.append(f"rubric {product_type!r} declares no adoption bands")
+            continue
+        bands = adoption.get("bands") or []
+        if not bands and not adoption.get("qualitative"):
+            warnings.append(f"rubric {product_type!r} declares empty bands but is not qualitative")
+        for band in bands:
+            rows.append({
+                "product_type": product_type,
+                "level": band["level"],
+                "above": band["above"],
+                "reach": str(band.get("reach") or ""),
+                "unit": str(adoption.get("unit") or ""),
+            })
+    return rows, warnings
+
+
 def category_dimensions(slug: str, recipe: dict) -> list[dict]:
     """The ladder's declared dimensions, with the keys each may be recorded under.
 
@@ -394,6 +431,8 @@ def build_rubric(sources: dict, policy: dict, routing: dict) -> tuple[dict[str, 
     errors: list[str] = []
     warnings: list[str] = []
 
+    tables["adoption_bands"], band_warnings = adoption_bands(shared_rubrics)
+    warnings.extend(band_warnings)
     tables["license_aliases"] = license_aliases(routing)
     tables["evidence_abstentions"] = evidence_abstentions(routing)
     if not tables["evidence_abstentions"]:

--- a/sources/rubrics/dataset.yaml
+++ b/sources/rubrics/dataset.yaml
@@ -277,3 +277,42 @@ openness:
       The rung above, for the five products that record the card as `yes` rather than
       `present`. Two spellings of one value, so two rungs; a components normalization on
       this category would collapse them back into one.
+
+# Adoption bands: which monthly figure maps to which level, for this product type.
+#
+# Declared here rather than in the warehouse because they were hardcoded in
+# currentai.signal_pypi.package_downloads and nowhere else - the same repo/warehouse
+# split that check_parity exists to catch, one axis over. The scoring SQL now reads
+# registry.adoption_bands, which build/serialize_registry.py emits from this block.
+#
+# The scale is a property of the product TYPE, which is what the rubrics are already
+# keyed on, so this is four declarations rather than sixteen.
+#
+# `above` is the exclusive lower bound, so the bands read the way the SQL does: the
+# highest level whose `above` the figure exceeds wins. `reach` is the label a score
+# records, and it carries the UNIT the band was read in - stars and downloads are not
+# the same reach at the same magnitude.
+#
+# ONE order of magnitude below software and model, and the reason is measured rather
+# than assumed. Across the 66 Hugging Face dataset artifacts with a download figure on
+# 2026-08-09: median 27,648, exactly one above 1M, and NONE above 10M. On the software
+# scale level 5 would be unreachable and 76% of datasets would pile into levels 2-3,
+# which is a scale that cannot discriminate.
+#
+# Shifting down one order reproduces the corpus's own bottom three levels exactly
+# (<1K->1, 1K-10K->2, 10K-100K->3) and yields a spread comparable to model's.
+#
+# Known disagreement, deliberately not resolved by this change: 14 dataset products
+# record level 4 against a reach of 1M-10M, which is level 5 on this scale. Some were
+# read in a different unit - citations for a benchmark, GitHub for a corpus shipped as
+# code - and `reach` carries the unit precisely so those are not silently comparable.
+# They are a work list, not a migration.
+adoption:
+  reach_is_monthly: true
+  unit: Hugging Face dataset downloads in the trailing 30 days
+  bands:
+  - {level: 5, above: 1000000, reach: '>1M'}
+  - {level: 4, above: 100000, reach: 100K-1M}
+  - {level: 3, above: 10000, reach: 10K-100K}
+  - {level: 2, above: 1000, reach: 1K-10K}
+  - {level: 1, above: 0, reach: <1K}

--- a/sources/rubrics/hardware.yaml
+++ b/sources/rubrics/hardware.yaml
@@ -121,3 +121,35 @@ openness:
       is named `documented` because that is precisely what it is - and it is the same 3 as
       the rung above, because from a builder's position a partial design and no design differ
       less than either differs from a design you may reuse.
+
+# Adoption bands: which monthly figure maps to which level, for this product type.
+#
+# Declared here rather than in the warehouse because they were hardcoded in
+# currentai.signal_pypi.package_downloads and nowhere else - the same repo/warehouse
+# split that check_parity exists to catch, one axis over. The scoring SQL now reads
+# registry.adoption_bands, which build/serialize_registry.py emits from this block.
+#
+# The scale is a property of the product TYPE, which is what the rubrics are already
+# keyed on, so this is four declarations rather than sixteen.
+#
+# `above` is the exclusive lower bound, so the bands read the way the SQL does: the
+# highest level whose `above` the figure exceeds wins. `reach` is the label a score
+# records, and it carries the UNIT the band was read in - stars and downloads are not
+# the same reach at the same magnitude.
+#
+# Hardware has no download to count, and the corpus has never pretended otherwise: all
+# 20 products record a qualitative reach (niche, broad, mass-market) and none records a
+# figure. So this type declares NO numeric bands, and that absence is the declaration -
+# a consumer that finds no band here must not fall back to another type's scale.
+#
+# The recorded levels span 3 to 5 only, which is honest for a category whose members are
+# all shipping products rather than an unfiltered long tail.
+adoption:
+  reach_is_monthly: false
+  qualitative: true
+  unit: qualitative reach; a board has no download count
+  reach_vocabulary: [niche, broad, mass-market]
+  bands: []
+  note: >-
+    No numeric bands by design. An adoption level here is a judgment against the
+    vocabulary above, and no machine signal routes to it.

--- a/sources/rubrics/model.yaml
+++ b/sources/rubrics/model.yaml
@@ -190,3 +190,36 @@ openness:
       The category's center of gravity - open weights, closed recipe. A fallthrough rather
       than a rule because it is what remains once the cases above are spent, and it lands in
       the open-ish bucket so unrecorded evidence never counts as open.
+
+# Adoption bands: which monthly figure maps to which level, for this product type.
+#
+# Declared here rather than in the warehouse because they were hardcoded in
+# currentai.signal_pypi.package_downloads and nowhere else - the same repo/warehouse
+# split that check_parity exists to catch, one axis over. The scoring SQL now reads
+# registry.adoption_bands, which build/serialize_registry.py emits from this block.
+#
+# The scale is a property of the product TYPE, which is what the rubrics are already
+# keyed on, so this is four declarations rather than sixteen.
+#
+# `above` is the exclusive lower bound, so the bands read the way the SQL does: the
+# highest level whose `above` the figure exceeds wins. `reach` is the label a score
+# records, and it carries the UNIT the band was read in - stars and downloads are not
+# the same reach at the same magnitude.
+#
+# Derived 2026-08-09 from the 75 model products recording both a level and a reach, and
+# identical to software's. That is the finding rather than an assumption: Hugging Face
+# model downloads and PyPI package downloads sit at the same order of magnitude across
+# this corpus (model median 41,344 over 101 artifacts), so one scale serves both.
+#
+# base_pretrained declared exactly these bands inline before this file existed. Its
+# category-level block is the only other place they appeared, and it is now the
+# exception rather than the convention.
+adoption:
+  reach_is_monthly: true
+  unit: Hugging Face downloads in the trailing 30 days, summed across the family's SKUs
+  bands:
+  - {level: 5, above: 10000000, reach: '>10M'}
+  - {level: 4, above: 1000000, reach: 1M-10M}
+  - {level: 3, above: 100000, reach: 100K-1M}
+  - {level: 2, above: 10000, reach: 10K-100K}
+  - {level: 1, above: 0, reach: <10K}

--- a/sources/rubrics/software.yaml
+++ b/sources/rubrics/software.yaml
@@ -136,3 +136,31 @@ openness:
   #
   # Restoring a rung here needs evidence from a real product, not a guess about a
   # hypothetical one. tests/test_openness_buckets.py enforces the boundary either way.
+
+# Adoption bands: which monthly figure maps to which level, for this product type.
+#
+# Declared here rather than in the warehouse because they were hardcoded in
+# currentai.signal_pypi.package_downloads and nowhere else - the same repo/warehouse
+# split that check_parity exists to catch, one axis over. The scoring SQL now reads
+# registry.adoption_bands, which build/serialize_registry.py emits from this block.
+#
+# The scale is a property of the product TYPE, which is what the rubrics are already
+# keyed on, so this is four declarations rather than sixteen.
+#
+# `above` is the exclusive lower bound, so the bands read the way the SQL does: the
+# highest level whose `above` the figure exceeds wins. `reach` is the label a score
+# records, and it carries the UNIT the band was read in - stars and downloads are not
+# the same reach at the same magnitude.
+#
+# Derived 2026-08-09 from the 279 software products recording both a level and a reach.
+# The mapping is unambiguous at every level: <10K->1 (11 of 12), 10K-100K->2 (26 of 44),
+# 100K-1M->3 (56 of 72), 1M-10M->4 (63 of 67), >10M->5 (32 of 35).
+adoption:
+  reach_is_monthly: true
+  unit: package downloads in the trailing 30 days, summed across declared artifacts
+  bands:
+  - {level: 5, above: 10000000, reach: '>10M'}
+  - {level: 4, above: 1000000, reach: 1M-10M}
+  - {level: 3, above: 100000, reach: 100K-1M}
+  - {level: 2, above: 10000, reach: 10K-100K}
+  - {level: 1, above: 0, reach: <10K}

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -862,3 +862,44 @@ def test_real_license_aliases_cover_every_slug_the_hub_actually_returns():
         if r["source"] == "huggingface"
     }
     assert observed_models <= aliased, f"unaliased Hub license slugs: {observed_models - aliased}"
+
+
+def test_adoption_bands_are_declared_per_type_and_hardware_declares_none():
+    """The bands were hardcoded in the scoring SQL until 2026-08-09.
+
+    Four types, five levels each, minus hardware — which declares `qualitative: true` and
+    an empty `bands`, so it emits no rows. That absence is load-bearing: a consumer that
+    finds no band for a type must abstain rather than borrow another type's scale.
+    """
+    from build.serialize_rubric import adoption_bands
+    from build.validate import load_sources
+    from pathlib import Path
+
+    rows, _warnings = adoption_bands(load_sources(Path(".")).get("rubrics") or {})
+    by_type = {}
+    for row in rows:
+        by_type.setdefault(row["product_type"], []).append(row)
+
+    assert set(by_type) == {"software", "model", "dataset"}
+    assert all(len(v) == 5 for v in by_type.values())
+
+    # `above` is an exclusive lower bound, so it must be strictly decreasing with level
+    # or the highest-matching-level rule silently picks the wrong band.
+    for product_type, bands in by_type.items():
+        ordered = sorted(bands, key=lambda b: -b["level"])
+        thresholds = [b["above"] for b in ordered]
+        assert thresholds == sorted(thresholds, reverse=True), product_type
+        assert ordered[-1]["above"] == 0, f"{product_type} has no floor band"
+
+
+def test_dataset_bands_sit_one_order_below_software():
+    """Measured, not assumed: no dataset artifact in the corpus exceeds 10M monthly
+    downloads and exactly one exceeds 1M, so the software scale cannot discriminate."""
+    from build.serialize_rubric import adoption_bands
+    from build.validate import load_sources
+    from pathlib import Path
+
+    rows, _ = adoption_bands(load_sources(Path(".")).get("rubrics") or {})
+    top = {r["product_type"]: r["above"] for r in rows if r["level"] == 5}
+    assert top["software"] == top["model"] == 10_000_000
+    assert top["dataset"] == 1_000_000


### PR DESCRIPTION
Prerequisite for #169. The reconciliation gate can't mean anything until the computed band comes from a declaration rather than a hardcoded CASE.

## The problem

`currentai.signal_pypi.package_downloads` derived `adoption_level` in SQL, and that was the only place the thresholds existed:

```sql
WHEN w.downloads_30d > 10000000 THEN 5
WHEN w.downloads_30d > 1000000  THEN 4
...
```

Two problems, and they're the two the openness scoring SQL already had before it was generalized. The thresholds live in the warehouse and nowhere else — the repo/warehouse split `check_parity` exists to catch, one axis over. And it applies **one scale to every product type**, when the scale is a property of the type.

## Four declarations, not sixteen

In `sources/rubrics/<type>.yaml`, keyed on the same product type `recipe_for` already resolves a product to. `serialize_rubric` emits `registry.adoption_bands`; `publish_registry` picks it up from `TABLES` with no change.

| type | level 5 floor | scale |
|---|---|---|
| `software` | >10M | <10K / 10K-100K / 100K-1M / 1M-10M / >10M |
| `model` | >10M | identical to software |
| `dataset` | >1M | <1K / 1K-10K / 10K-100K / 100K-1M / >1M |
| `hardware` | — | qualitative, no numeric bands |

**software and model sharing a scale is the finding, not the assumption.** HF model downloads and PyPI package downloads sit at the same order of magnitude across this corpus (model median 41,344 across 101 artifacts), and both reproduce the corpus's own level↔reach mapping at every level.

**dataset sits one order lower, measured rather than asserted.** Across the 66 HF dataset artifacts carrying a figure: median 27,648, exactly one above 1M, and **none above 10M**. On the software scale, level 5 is unreachable for the entire type and 76% of datasets pile into levels 2–3 — a scale that cannot discriminate. Shifted down one order it reproduces the corpus's own bottom three levels exactly (`<1K`→1, `1K-10K`→2, `10K-100K`→3) and spreads like model's.

Earlier notes in this project said datasets ran *two* orders lower. The data says one, so the declaration says one.

**hardware declares `qualitative: true` and empty bands**, so it emits no rows. That absence is the declaration: a consumer finding no band for a type must abstain rather than borrow another type's scale — the same "abstain rather than substitute" rule `signal_routing.yaml` already states for sources. All 20 hardware products record a qualitative reach (`niche`, `broad`, `mass-market`) and none records a figure, so nothing is lost.

## Known disagreement, left as a work list

14 dataset products record level 4 against a reach of `1M-10M`, which is level 5 on this scale. Some were read in a **different unit** — citations for a benchmark, GitHub for a corpus shipped as code — and `reach` carries the unit precisely so those aren't silently comparable. Moving them needs a reading, not a script. Recorded in `dataset.yaml`'s header so the next person doesn't rediscover it.

## The UDM comes second

It still hardcodes its CASE. The revision can't reference `registry.adoption_bands` before that table exists, so it changes in a second step once this lands and the registry materializes. The replacement SQL is written and reviewed; it joins the band table and takes the highest level whose exclusive lower bound the figure clears, leaving the level NULL for a type with no bands.

## Gates

```
serialize_rubric --check   ok, 15 adoption_bands rows (hardware correctly absent)
validate                   0 error(s)
pytest                     405 passed (2 new)
```