### PR TITLE
Mirror signal_pypi's SQL into warehouse/models, reading the declared bands

### DIFF
--- a/warehouse/models/README.md
+++ b/warehouse/models/README.md
@@ -10,7 +10,23 @@ entities (USER_MODEL)      — resolved identities: repos, projects, packages, m
 events (USER_MODEL)        — pre-filtered event logs (GitHub Archive)
 metrics (USER_MODEL)       — normalized daily activity per repo
 scores (USER_MODEL)        — interpretive: taxonomy, dependencies, fragility, rankings
+registry (STATIC_MODEL)    — pushed by CI from sources/; see build/publish_registry.py
+signal_* (USER_MODEL)      — one dataset per external source; see below
 ```
+
+### The signal_* models are deployed and mostly NOT mirrored here
+
+`signal_github`, `signal_huggingface`, `signal_pypi`, `signal_lmarena`,
+`signal_artificialanalysis`, `signal_semanticscholar` and `signal_goodailist` all run in
+the warehouse, and until 2026-08-09 none of their SQL was in this directory — while the
+deploy runbook says this is where the source of truth lives. That gap is how
+`signal_pypi` came to carry the adoption bands as a hardcoded CASE that nothing in the
+repo could see.
+
+`signal_pypi_package_downloads.sql` is the first one mirrored back. The rest still need
+recovering from the platform, and a revision's `cron`, `kind` and `schema` are not
+readable through the GraphQL API, so recovering them is a UI job rather than a scripted
+one.
 
 ## Catalog (Static Model)
 

--- a/warehouse/models/signal_pypi_package_downloads.sql
+++ b/warehouse/models/signal_pypi_package_downloads.sql
@@ -1,0 +1,103 @@
+-- currentai.signal_pypi.package_downloads
+-- Monthly PyPI download volume for the map's declared pypi artifacts.
+--
+-- Roster from currentai.registry.product_artifacts (the CI-pushed declaration),
+-- joined to the oso.pypi_downloads marketplace dataset. SQL rather than Python:
+-- there is no fetch and no secret here, so this needs neither the Python sandbox
+-- nor the flaky UDM host.
+--
+-- Grain: one row per (product_slug, package).
+--
+-- Two honest limits, both inherited from the source and surfaced as columns
+-- rather than buried:
+--   * Counts are raw installer requests. They include CI jobs, mirrors and other
+--     automated traffic, so they are volume, not unique users. `downloads_30d` is
+--     the adoption input; it is not a user count.
+--   * History is short. `days_observed` and `window_start` make the window
+--     explicit so a partial window is visible instead of reading as a decline.
+--
+-- The adoption bands are NOT defined here. They were, until 2026-08-09, as a
+-- hardcoded CASE that applied one scale to every product type - which is the
+-- repo/warehouse split check_parity exists to catch, one axis over, and it was
+-- wrong for datasets: no dataset artifact in the corpus exceeds 10M monthly
+-- downloads, so level 5 was unreachable for the whole type. They now come from
+-- currentai.registry.adoption_bands, declared per product type in
+-- sources/rubrics/<type>.yaml and pushed by CI.
+--
+-- A type with no bands declared gets a NULL level rather than another type's
+-- scale. `hardware` is deliberately in that state - a board has no download
+-- count - and the abstention is the same rule signal_routing.yaml states for
+-- sources: abstain rather than substitute.
+WITH bounds AS (
+  SELECT MAX(day) AS last_day FROM oso.pypi_downloads.daily_downloads_by_package
+),
+roster AS (
+  SELECT DISTINCT
+    product_slug,
+    product_type,
+    artifact_id AS package
+  FROM currentai.registry.product_artifacts
+  WHERE artifact_kind = 'pypi'
+),
+windowed AS (
+  SELECT
+    d.package,
+    SUM(CASE WHEN d.day > b.last_day - INTERVAL '30' DAY THEN d.downloads ELSE 0 END) AS downloads_30d,
+    SUM(CASE WHEN d.day > b.last_day - INTERVAL '7' DAY THEN d.downloads ELSE 0 END) AS downloads_7d,
+    COUNT(DISTINCT CASE WHEN d.day > b.last_day - INTERVAL '30' DAY THEN d.day END) AS days_observed,
+    MAX(d.country_count) AS max_country_count,
+    MIN(d.day) AS first_day_seen,
+    MAX(d.day) AS last_day_seen
+  FROM oso.pypi_downloads.daily_downloads_by_package d
+  CROSS JOIN bounds b
+  GROUP BY d.package
+),
+measured AS (
+  SELECT
+    r.product_slug,
+    r.product_type,
+    r.package,
+    w.downloads_30d,
+    w.downloads_7d,
+    w.days_observed,
+    w.max_country_count AS countries_seen,
+    w.first_day_seen,
+    w.last_day_seen,
+    CAST(b.last_day - INTERVAL '30' DAY AS DATE) AS window_start,
+    w.package IS NULL AS missing_from_pypi
+  FROM roster r
+  CROSS JOIN bounds b
+  LEFT JOIN windowed w
+    ON LOWER(r.package) = LOWER(w.package)
+),
+-- The highest band whose exclusive lower bound the figure clears. A type absent
+-- from the table contributes no row, so the LEFT JOIN leaves the level NULL.
+banded AS (
+  SELECT
+    m.product_slug,
+    m.package,
+    MAX(b.level) AS adoption_level
+  FROM measured m
+  JOIN currentai.registry.adoption_bands b
+    ON b.product_type = m.product_type
+   AND m.downloads_30d > b.above
+  WHERE m.downloads_30d IS NOT NULL
+  GROUP BY m.product_slug, m.package
+)
+SELECT
+  m.product_slug,
+  m.product_type,
+  m.package,
+  m.downloads_30d,
+  m.downloads_7d,
+  m.days_observed,
+  m.countries_seen,
+  m.first_day_seen,
+  m.last_day_seen,
+  m.window_start,
+  bd.adoption_level,
+  m.missing_from_pypi
+FROM measured m
+LEFT JOIN banded bd
+  ON bd.product_slug = m.product_slug
+ AND bd.package = m.package


### PR DESCRIPTION
Second half of #171. The bands are declared and `registry.adoption_bands` is live with 15 rows; this is the SQL that consumes them instead of hardcoding.

**Not deployed — see the blocker below.** Review the SQL here and I'll apply it, or apply it yourself in the UI.

## What changes

The band CASE goes away. The model joins `currentai.registry.adoption_bands` on `product_type` and takes the highest level whose exclusive lower bound the figure clears:

```sql
JOIN currentai.registry.adoption_bands b
  ON b.product_type = m.product_type
 AND m.downloads_30d > b.above
GROUP BY ...  -- MAX(b.level)
```

A product type with no bands declared contributes no row, so the LEFT JOIN leaves `adoption_level` NULL. `hardware` abstains by construction rather than borrowing another type's scale — the same "abstain rather than substitute" rule `signal_routing.yaml` states for sources.

## Why the file exists at all

`docs/runbooks/deploy-udms.md` says UDM source of truth lives in `warehouse/models/`, and **no `signal_*` model was ever put there** — not `signal_github`, `signal_huggingface`, `signal_pypi`, or any of the other four. That gap is exactly how the adoption bands came to live in a CASE expression nothing in the repo could see, applying the software scale to datasets where level 5 is unreachable.

This is the first one mirrored back. The README now says so rather than implying the directory is complete.

## The blocker

`createDataModelRevision` requires `cron`, `kind` and `schema` alongside the code, and none of the three is readable through the GraphQL API that exposes revisions — `GetDataModel` and `GetAssetRevision` both return the code and neither returns those. Inferring them is not safe on a production model: a wrong cron silently changes the refresh cadence, and a wrong column type silently changes what everything downstream reads.

I stopped rather than guess.

## Worth knowing before choosing the cron

**`signal_pypi` has never run on a schedule.** All four of its runs are `MANUAL`:

| when | who |
|---|---|
| 2026-07-27 | manual (one failed, one succeeded) |
| 2026-08-08 | manual |
| 2026-08-09 | manual — mine, to pick up the 34 new declarations |

Its description says "Weekly". So the freshness of every adoption figure it feeds has depended on somebody remembering, and the four-day-old window I reported earlier was four days old because you refreshed it by hand on the 8th.

That's worth fixing in the same edit as the band change, since setting the cron is part of creating the revision either way.