### PR TITLE
Band a figure of zero at level 1, not at nothing

### DIFF
--- a/sources/rubrics/dataset.yaml
+++ b/sources/rubrics/dataset.yaml
@@ -293,6 +293,11 @@ openness:
 # records, and it carries the UNIT the band was read in - stars and downloads are not
 # the same reach at the same magnitude.
 #
+# The floor band is -1 rather than 0 so that a figure of exactly ZERO still bands at 1.
+# With 0 it did not: `0 > 0` is false, the product matched no band, and it came back
+# unbanded - which asserts "no scale exists for this type" when the truth is "nobody
+# downloaded it". zentropi-cope surfaced it on the first real run.
+#
 # ONE order of magnitude below software and model, and the reason is measured rather
 # than assumed. Across the 66 Hugging Face dataset artifacts with a download figure on
 # 2026-08-09: median 27,648, exactly one above 1M, and NONE above 10M. On the software
@@ -315,4 +320,4 @@ adoption:
   - {level: 4, above: 100000, reach: 100K-1M}
   - {level: 3, above: 10000, reach: 10K-100K}
   - {level: 2, above: 1000, reach: 1K-10K}
-  - {level: 1, above: 0, reach: <1K}
+  - {level: 1, above: -1, reach: <1K}

--- a/sources/rubrics/model.yaml
+++ b/sources/rubrics/model.yaml
@@ -206,6 +206,11 @@ openness:
 # records, and it carries the UNIT the band was read in - stars and downloads are not
 # the same reach at the same magnitude.
 #
+# The floor band is -1 rather than 0 so that a figure of exactly ZERO still bands at 1.
+# With 0 it did not: `0 > 0` is false, the product matched no band, and it came back
+# unbanded - which asserts "no scale exists for this type" when the truth is "nobody
+# downloaded it". zentropi-cope surfaced it on the first real run.
+#
 # Derived 2026-08-09 from the 75 model products recording both a level and a reach, and
 # identical to software's. That is the finding rather than an assumption: Hugging Face
 # model downloads and PyPI package downloads sit at the same order of magnitude across
@@ -222,4 +227,4 @@ adoption:
   - {level: 4, above: 1000000, reach: 1M-10M}
   - {level: 3, above: 100000, reach: 100K-1M}
   - {level: 2, above: 10000, reach: 10K-100K}
-  - {level: 1, above: 0, reach: <10K}
+  - {level: 1, above: -1, reach: <10K}

--- a/sources/rubrics/software.yaml
+++ b/sources/rubrics/software.yaml
@@ -152,6 +152,11 @@ openness:
 # records, and it carries the UNIT the band was read in - stars and downloads are not
 # the same reach at the same magnitude.
 #
+# The floor band is -1 rather than 0 so that a figure of exactly ZERO still bands at 1.
+# With 0 it did not: `0 > 0` is false, the product matched no band, and it came back
+# unbanded - which asserts "no scale exists for this type" when the truth is "nobody
+# downloaded it". zentropi-cope surfaced it on the first real run.
+#
 # Derived 2026-08-09 from the 279 software products recording both a level and a reach.
 # The mapping is unambiguous at every level: <10K->1 (11 of 12), 10K-100K->2 (26 of 44),
 # 100K-1M->3 (56 of 72), 1M-10M->4 (63 of 67), >10M->5 (32 of 35).
@@ -163,4 +168,4 @@ adoption:
   - {level: 4, above: 1000000, reach: 1M-10M}
   - {level: 3, above: 100000, reach: 100K-1M}
   - {level: 2, above: 10000, reach: 10K-100K}
-  - {level: 1, above: 0, reach: <10K}
+  - {level: 1, above: -1, reach: <10K}

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -889,7 +889,11 @@ def test_adoption_bands_are_declared_per_type_and_hardware_declares_none():
         ordered = sorted(bands, key=lambda b: -b["level"])
         thresholds = [b["above"] for b in ordered]
         assert thresholds == sorted(thresholds, reverse=True), product_type
-        assert ordered[-1]["above"] == 0, f"{product_type} has no floor band"
+        # The floor is -1, not 0, so a figure of exactly ZERO still bands at 1. With 0 it
+        # did not — `0 > 0` is false, so the product matched no band and came back
+        # unbanded, which asserts "no scale exists for this type" rather than "nobody
+        # downloaded it". zentropi-cope surfaced it on the first real run.
+        assert ordered[-1]["above"] == -1, f"{product_type} floor must admit zero"
 
 
 def test_dataset_bands_sit_one_order_below_software():


### PR DESCRIPTION
Found on the first real run of the Hugging Face banding, before it shipped.

The floor band was `above: 0`, and `0 > 0` is false — so a product with exactly zero downloads matched no band at all and came back with a NULL level.

Those are two different claims, and conflating them loses the one that matters:

- **unbanded** means *no scale exists for this product type*. That's what `hardware` deliberately reports, and what a consumer must abstain on.
- **zero downloads** means *nobody downloaded it*, which belongs at level 1 with the rest of `<10K`.

`zentropi-cope` surfaced it: one model artifact, zero downloads, no level. The same hole is latent in `signal_pypi` — its lowest figure today is 147, so nothing has fallen through there yet.

Floor is now `-1` in all three numeric ladders. `hardware` still declares no bands, so its abstention is unchanged and still means what it says.

The test that pinned the floor at `0` now pins it at `-1` and carries the reason, so the next person doesn't "tidy" it back.

```
serialize_rubric --check   ok
validate                   0 error(s)
pytest                     405 passed
```