### PR TITLE
Declare the stars scale, once, on the route that produces it

### DIFF
--- a/build/serialize_rubric.py
+++ b/build/serialize_rubric.py
@@ -138,7 +138,12 @@ TABLES: dict[str, tuple[str, ...]] = {
     # `bands`, and the absence is the declaration: a consumer finding no band for a type
     # must abstain rather than borrow another type's scale, which is exactly the
     # "abstain rather than substitute" rule signal_routing.yaml states for sources.
-    "adoption_bands": ("product_type", "level", "above", "reach", "unit"),
+    # `signal_type` distinguishes the two banded instruments. Download bands are per
+    # product type, because a dataset's downloads run an order below a package's. The
+    # stars band is per INSTRUMENT and type-independent — a star is a star whatever it
+    # was given to — so it is emitted once with product_type '*' and is declared on its
+    # route in signal_routing.yaml rather than in four rubrics that could drift.
+    "adoption_bands": ("product_type", "signal_type", "level", "above", "reach", "unit"),
     "license_aliases": ("source", "license_slug", "license_name"),
     "evidence_abstentions": ("source", "column_name", "abstain_value"),
     "product_openness_evidence": (
@@ -320,6 +325,37 @@ def license_tiers(slug: str, recipe: dict) -> tuple[list[dict], list[str]]:
     return rows, errors
 
 
+def stars_bands(routing: dict) -> tuple[list[dict], list[str]]:
+    """The stars scale, from the adoption route that produces it.
+
+    Emitted with product_type '*' because it does not vary by type, and capped: a
+    stars-derived band may never claim levels 4 or 5, since stars measure attention
+    rather than use. The cap is enforced here rather than trusted, so a later edit that
+    adds a level-4 stars band fails the serializer instead of quietly publishing one.
+    """
+    routes = ((routing.get("dimensions") or {}).get("adoption") or {}).get("routes") or []
+    rows, warnings = [], []
+    for route in routes:
+        if route.get("signal_type") != "stars_fallback":
+            continue
+        cap = route.get("cap")
+        for band in route.get("bands") or []:
+            if cap is not None and band["level"] > cap:
+                warnings.append(
+                    f"stars band level {band['level']} exceeds the declared cap {cap}; dropped"
+                )
+                continue
+            rows.append({
+                "product_type": "*",
+                "signal_type": "stars_fallback",
+                "level": band["level"],
+                "above": band["above"],
+                "reach": str(band.get("reach") or ""),
+                "unit": "GitHub stars",
+            })
+    return rows, warnings
+
+
 def adoption_bands(shared_rubrics: dict) -> tuple[list[dict], list[str]]:
     """One row per (product type, level), from the shared ladders' `adoption.bands`.
 
@@ -338,6 +374,7 @@ def adoption_bands(shared_rubrics: dict) -> tuple[list[dict], list[str]]:
         for band in bands:
             rows.append({
                 "product_type": product_type,
+                "signal_type": "usage_volume",
                 "level": band["level"],
                 "above": band["above"],
                 "reach": str(band.get("reach") or ""),
@@ -433,6 +470,9 @@ def build_rubric(sources: dict, policy: dict, routing: dict) -> tuple[dict[str, 
 
     tables["adoption_bands"], band_warnings = adoption_bands(shared_rubrics)
     warnings.extend(band_warnings)
+    star_rows, star_warnings = stars_bands(routing)
+    tables["adoption_bands"].extend(star_rows)
+    warnings.extend(star_warnings)
     tables["license_aliases"] = license_aliases(routing)
     tables["evidence_abstentions"] = evidence_abstentions(routing)
     if not tables["evidence_abstentions"]:

--- a/docs/guides/adoption.md
+++ b/docs/guides/adoption.md
@@ -86,6 +86,37 @@ rather than borrow another type's scale. That is the same "abstain rather than s
 rule `sources/signal_routing.yaml` states for sources, and it is why the scoring models LEFT
 JOIN the band table rather than defaulting.
 
+### The stars scale is per instrument, not per type
+
+Stars get their own scale, declared **once** on the adoption route that produces it in
+`sources/signal_routing.yaml` rather than in the four type rubrics:
+
+| level | stars |
+|---|---|
+| 3 | >10K |
+| 2 | 1K-10K |
+| 1 | <1K |
+
+Two reasons it lives there. A dataset's downloads run an order below a package's, which is
+why *those* bands are per type — but a star is a star whatever it was given to, so the scale
+is a property of the instrument. And declaring it once is the only way to avoid four copies
+of a number that must not drift.
+
+**Capped at 3, and the cap is enforced rather than trusted.** Stars measure attention rather
+than use, so a stars-derived band may never claim levels 4 or 5 however large the count.
+`build/serialize_rubric.py` drops a band above the cap with a warning, so a later edit adding
+a level-4 stars band fails the serializer instead of quietly publishing one. The corpus
+already respects this: no `stars_fallback` product records 4 or 5.
+
+Thresholds set 2026-08-10 from the medians the corpus already used — the 71 `stars_fallback`
+products with a live GitHub row sit at medians of ~93, ~1,733 and ~15,801 stars for levels 1,
+2 and 3. The ranges overlap badly (20,901 stars recorded at 2 against 77 recorded at 3), so
+**this scale tightens a loose convention rather than describing one**, and applying it will
+move products.
+
+Both scales share `registry.adoption_bands`, distinguished by `signal_type`. A consumer that
+joins without filtering on it will band a package's downloads against the stars scale.
+
 ### The floor admits zero
 
 Level 1's threshold is `above: -1`, not `0`. With `0` a product measuring exactly zero

--- a/sources/signal_routing.yaml
+++ b/sources/signal_routing.yaml
@@ -249,6 +249,28 @@ dimensions:
       note: >
         Last resort, and explicitly last. Stars measure attention, not use, and
         the rubric already ranks this below every real usage signal.
+      # The stars scale lives HERE rather than in sources/rubrics/<type>.yaml,
+      # because it is a property of the INSTRUMENT rather than of the product
+      # type. A dataset's downloads run an order below a package's, which is why
+      # those bands are per type; a star is a star whatever it was given to.
+      # Declaring it once on the route that produces it is also the only way to
+      # avoid four copies of a scale that must not drift.
+      #
+      # Thresholds set 2026-08-10 from the medians the corpus already used: the
+      # 71 stars_fallback products with a live GitHub row sit at medians of ~93,
+      # ~1,733 and ~15,801 stars for levels 1, 2 and 3. The ranges overlap badly
+      # - 20,901 stars recorded at 2 against 77 recorded at 3 - so this scale is
+      # a decision that tightens a loose convention rather than a description of
+      # one.
+      cap: 3
+      cap_because: >
+        Stars measure attention, not use, so a stars-derived band may never claim
+        the top two levels however large the count. The corpus already respects
+        this: no stars_fallback product records 4 or 5.
+      bands:
+      - {level: 3, above: 10000, reach: '>10K stars'}
+      - {level: 2, above: 1000, reach: 1K-10K stars}
+      - {level: 1, above: -1, reach: <1K stars}
     sum_across_artifacts: true
     sum_note: >
       A model family ships several SKUs. The map's unit is the family, so

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -907,3 +907,73 @@ def test_dataset_bands_sit_one_order_below_software():
     top = {r["product_type"]: r["above"] for r in rows if r["level"] == 5}
     assert top["software"] == top["model"] == 10_000_000
     assert top["dataset"] == 1_000_000
+
+
+def test_stars_bands_are_declared_once_and_capped():
+    """Stars are per INSTRUMENT, not per product type.
+
+    A dataset's downloads run an order below a package's, which is why those bands are
+    per type. A star is a star whatever it was given to, so the scale is declared once on
+    its route in signal_routing.yaml and emitted with product_type '*'. Four copies in
+    four rubrics is exactly the drift this whole table exists to stop.
+    """
+    import yaml
+    from pathlib import Path
+
+    from build.serialize_rubric import stars_bands
+
+    routing = yaml.safe_load(Path("sources/signal_routing.yaml").read_text())
+    rows, warnings = stars_bands(routing)
+
+    assert warnings == []
+    assert {r["product_type"] for r in rows} == {"*"}
+    assert {r["signal_type"] for r in rows} == {"stars_fallback"}
+    # Capped at 3: stars measure attention rather than use, so a stars-derived band may
+    # never claim the top two levels however large the count.
+    assert max(r["level"] for r in rows) == 3
+    assert sorted(r["above"] for r in rows) == [-1, 1000, 10000]
+
+
+def test_a_stars_band_above_the_cap_is_dropped_with_a_warning():
+    """The cap is enforced, not trusted. A later edit adding a level-4 stars band should
+    fail the serializer rather than quietly publish one."""
+    from build.serialize_rubric import stars_bands
+
+    routing = {
+        "dimensions": {
+            "adoption": {
+                "routes": [
+                    {
+                        "signal_type": "stars_fallback",
+                        "cap": 3,
+                        "bands": [
+                            {"level": 4, "above": 100000, "reach": ">100K stars"},
+                            {"level": 3, "above": 10000, "reach": ">10K stars"},
+                        ],
+                    }
+                ]
+            }
+        }
+    }
+    rows, warnings = stars_bands(routing)
+    assert [r["level"] for r in rows] == [3]
+    assert any("exceeds the declared cap" in w for w in warnings)
+
+
+def test_download_bands_and_stars_bands_do_not_collide():
+    """Both live in one table, distinguished by signal_type. A consumer joining without
+    filtering on it would band a package's downloads against the stars scale."""
+    from pathlib import Path
+
+    import yaml
+
+    from build.serialize_rubric import adoption_bands, stars_bands
+    from build.validate import load_sources
+
+    downloads, _ = adoption_bands(load_sources(Path(".")).get("rubrics") or {})
+    stars, _ = stars_bands(yaml.safe_load(Path("sources/signal_routing.yaml").read_text()))
+
+    assert {r["signal_type"] for r in downloads} == {"usage_volume"}
+    assert all(r["product_type"] != "*" for r in downloads)
+    keys = {(r["product_type"], r["signal_type"], r["level"]) for r in downloads + stars}
+    assert len(keys) == len(downloads) + len(stars), "a (type, instrument, level) key repeats"


### PR DESCRIPTION
Your approved thresholds: **<1K → 1, 1K–10K → 2, >10K → 3**, capped at 3.

## Where it lives, and why not in the rubrics

Declared in `sources/signal_routing.yaml`, on the adoption route that already produces stars — not in the four type rubrics where the download bands live.

The download scale is per **product type** because a dataset's downloads genuinely run an order below a package's. A star is a star whatever it was given to, so the stars scale is a property of the **instrument**. Declaring it once is also the only way to avoid four copies of a number that must not drift, which is the entire reason `registry.adoption_bands` exists.

`adoption_bands` gains a `signal_type` column so both scales share one table; stars rows carry `product_type: '*'`. A consumer joining without filtering on `signal_type` would band a package's downloads against the stars scale, so there's a test asserting the `(type, instrument, level)` keys cannot collide.

## The cap is enforced, not trusted

`serialize_rubric` drops any band above the declared cap with a warning, so a later edit adding a level-4 stars band fails the serializer rather than quietly publishing one. Stars measure attention, not use — the corpus already respects this, with no `stars_fallback` product at 4 or 5.

## These thresholds will move products

Worth being explicit: they come from the medians the corpus already used — the 71 `stars_fallback` products with a live GitHub row sit at medians of ~93, ~1,733 and ~15,801 stars for levels 1, 2 and 3 — but the ranges overlap badly, with 20,901 stars recorded at 2 against 77 recorded at 3.

So this **tightens a loose convention rather than describing one**, and applying it will reclassify some products. Nothing is applied here: this declares the scale and publishes it. The banding model over `repo_state` comes next, once the registry materializes, and I'll show which products move before anything touches a score.

## Guide first

`docs/guides/adoption.md` documents the scale, the cap, the reason it sits on the route, and the overlap caveat — updated before the serializer, per the convention the guides themselves state.

```
validate   0 error(s)
pytest     408 passed (3 new)
```