### PR TITLE
fix(scores): stop six components strings minting unreadable dimension keys

### DIFF
--- a/sources/scores/atropos.yaml
+++ b/sources/scores/atropos.yaml
@@ -2,8 +2,8 @@ product: atropos
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public;scope:async RL-environments framework + trajectory API; trainer
-    integrations:Axolotl/Tinker; no feature-gated core;core-gated:ungated
+  components: license:MIT(OSI);source:public;scope:async RL-environments framework + trajectory API; trainer-integrations:Axolotl/Tinker;
+    no feature-gated core;core-gated:ungated
   confidence: high
   note: Fully OSI-licensed (MIT) and public, no managed/closed core. Fits finetuning_code as the RL-training-environment
     layer (RLHF/RLAIF/GRPO).

--- a/sources/scores/axolotl.yaml
+++ b/sources/scores/axolotl.yaml
@@ -2,8 +2,7 @@ product: axolotl
 openness:
   score: 5
   class: open_source
-  components: 'license:Apache-2.0(OSI);source:public(axolotl-ai-cloud/axolotl);no managed SaaS tier (cloud-template
-    integrations only: RunPod/Modal/etc.)'
+  components: license:Apache-2.0(OSI);source:public(axolotl-ai-cloud/axolotl)
   confidence: high
   note: Fully OSI-licensed (Apache-2.0); no proprietary managed training service, only deployment templates
     for third-party clouds.

--- a/sources/scores/fireworks-fine-tuning.yaml
+++ b/sources/scores/fireworks-fine-tuning.yaml
@@ -3,7 +3,7 @@ openness:
   score: 1
   class: closed
   components: source:closed;training-pipeline:closed;runs-on:Fireworks-cloud-only;license:Proprietary(managed
-    service); base weights:open-models(varies)
+    service); base-weights:open-models(varies)
   confidence: high
   note: The managed FT service/pipeline is proprietary and runs only on Fireworks' cloud; no source. (Fireworks'
     separate reward-kit RFT toolkit is OSS but was not confirmed as part of this product this run.)

--- a/sources/scores/mistral-fine-tuning-api.yaml
+++ b/sources/scores/mistral-fine-tuning-api.yaml
@@ -3,7 +3,7 @@ openness:
   score: 1
   class: closed
   components: source:closed;training-pipeline:closed;runs-on:La-Plateforme-only;license:Proprietary(managed
-    service, per-token + storage pricing); base weights:Mistral-models(open-weight variants exist)
+    service, per-token + storage pricing); base-weights:Mistral-models(open-weight variants exist)
   confidence: high
   note: 'The hosted FT API on Mistral''s Studio platform (formerly branded La Plateforme) is a proprietary
     managed service (LoRA adapters under the hood); no source for the service. Mistral separately ships

--- a/sources/scores/mosaic-ai-model-training.yaml
+++ b/sources/scores/mosaic-ai-model-training.yaml
@@ -3,7 +3,7 @@ openness:
   score: 1
   class: closed
   components: source:closed;training-code:closed;runs-on:Databricks-workspace-only(AWS regions);license:Proprietary(managed
-    service); base weights:Llama-Community-License(non-OSI)
+    service); base-weights:Llama-Community-License(non-OSI)
   confidence: high
   note: Proprietary managed FT service running only inside a Databricks workspace; no source. (Databricks'
     separate LLM Foundry / Composer libs are OSS but are not this product.)

--- a/sources/scores/together-fine-tuning.yaml
+++ b/sources/scores/together-fine-tuning.yaml
@@ -3,7 +3,7 @@ openness:
   score: 1
   class: closed
   components: source:closed;training-pipeline:closed;runs-on:Together-cloud-only;license:Proprietary(managed
-    service, per-token training pricing); base weights:open-models(varies)
+    service, per-token training pricing); base-weights:open-models(varies)
   confidence: high
   note: The fine-tuning service and its training pipeline are proprietary and run only on Together's cloud;
     there is no self-hostable implementation. Together's Terms of Service bar reverse-engineering the underlying

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -281,3 +281,27 @@ def test_every_product_file_round_trips_through_its_own_description():
         checked += 1
         assert yaml.safe_load(set_document_field(text, "description", doc["description"])) == doc, path.name
     assert checked > 400
+
+
+def test_no_score_file_mints_a_phantom_dimension_key():
+    """A components clause with no key must not produce a dimension.
+
+    split_components splits each clause on its first ':' with no paren-awareness, so a
+    keyless clause whose parenthetical contains a colon mints a key out of prose. That
+    corrupts every corpus-wide key inventory and would carry into the structured form.
+    A phantom key is recognizable: real dimension keys are short, lowercase, and contain
+    no spaces or parentheses.
+    """
+    from build.check_rubric import split_components
+
+    root = Path(__file__).resolve().parents[1]
+    offenders = []
+    for path in sorted((root / "sources" / "scores").glob("*.yaml")):
+        components = (yaml.safe_load(path.read_text()).get("openness") or {}).get("components")
+        if not components:
+            continue
+        for key in split_components(components):
+            if " " in key or "(" in key or ")" in key:
+                offenders.append(f"{path.stem}: {key!r}")
+
+    assert offenders == [], "phantom dimension keys minted from prose:\n  " + "\n  ".join(offenders)


### PR DESCRIPTION
## Summary

`build.check_rubric.split_components` splits each `;`-delimited clause on its first `:` with no paren-awareness, so a components string can produce a "dimension key" that is not one. Six score files did, in two different ways:

- `axolotl` ended with a **keyless** clause whose parenthetical contains a colon, so the parser minted `no managed SaaS tier (cloud-template integrations only` as a key out of prose. Dropped the clause: the fact it recorded is already carried by `source: public` and by the axis `note`.
- Five files carried an **intended** key containing a space — `base weights` on the four managed fine-tuning services, `trainer integrations` on `atropos`. Hyphenated to the repo's own idiom; every other key in the corpus is kebab-case (`core-gated`, `self-host`, `runs-on`, `training-code`, `managed-tier`).

Every corpus-wide key inventory was wrong by six as a result, and the structured-YAML migration would have carried all six in.

## Test plan

- New test asserts no score file produces a key containing a space or a parenthesis. It fails on `main` with exactly these six offenders and passes clean here — no allowlist.
- Score-neutral: no category recipe reads `base weights` or `trainer integrations`, and all six products reproduce their recorded scores. `build/notebook_data.json` untouched.
- Every edit made through `build/components.py`, never a text substitution — 278 of 472 score files fold `components` across lines.
- `validate`, `check_recipe`, `check_rubric` and the full suite unchanged (408 -> 409, the new test).

## Not in scope

`atropos` also carries `no feature-gated core`, a colon-less clause the parser discards silently. Different defect, left alone.
