### PR TITLE
fix(openness): retire documented_only, a class the schema forbids and nothing carries

### DIFF
--- a/build/render.py
+++ b/build/render.py
@@ -183,7 +183,6 @@ def style():
         "source_available": ("Source available", 2, "signal"),
         "restricted": ("Restricted", 2, "signal"),
         "gated": ("Gated", 2, "warm"),
-        "documented_only": ("Documented only", 1, "ink_3"),
         "closed": ("Closed", 1, "ink_3"),
         "open_hardware": ("Open hardware", 5, "healthy"),
         "open_toolchain": ("Open toolchain", 3, "warm"),
@@ -255,7 +254,7 @@ def verdict_logic(DATA, LAYER_WEIGHTS):
     # at-a-glance overview, and each section. Strict OSI/MOF cut:
     #   open    = open_source / open / open_core
     #   openish = open_weights / source_available / gated
-    #   closed  = restricted / documented_only / closed
+    #   closed  = restricted / documented / closed
     _OPEN = {"open_source", "open", "open_core", "open_hardware"}
     _OPENISH = {"open_weights", "source_available", "gated", "open_toolchain"}
 
@@ -388,7 +387,7 @@ def openness_distribution(C, DATA, F, mo):
         if _cls in ("restricted", "source_available", "gated", "documented"):
             return C["signal"]
         return C["closed"]
-    _CLS_ORDER = ["open_source", "open", "open_hardware", "open_core", "open_weights", "open_toolchain", "source_available", "gated", "documented", "restricted", "documented_only", "closed"]
+    _CLS_ORDER = ["open_source", "open", "open_hardware", "open_core", "open_weights", "open_toolchain", "source_available", "gated", "documented", "restricted", "closed"]
     _bars = []
     for _tk, _tl in [("model", "Models"), ("dataset", "Datasets"), ("software", "Software"), ("hardware", "Hardware")]:
         _cnt = _collections.Counter()

--- a/build/validate.py
+++ b/build/validate.py
@@ -36,7 +36,7 @@ OPENNESS_CLASSES = {
     # had nowhere to land but `open` - which is how `personahub` came to be 5/open under a
     # licence that caps a model at 2. The word already exists for models and hardware, and
     # already carries gradient 2 and the closed bucket in openness-class-map.json.
-    "dataset": {"open", "gated", "restricted", "documented_only", "closed"},
+    "dataset": {"open", "gated", "restricted", "closed"},
     "hardware": {"open_hardware", "open_toolchain", "documented", "restricted"},
 }
 SIGNAL_TYPES = {"active_users", "usage_volume", "reported_traction", "stars_fallback", "unknown"}

--- a/docs/guides/openness-spectrum.md
+++ b/docs/guides/openness-spectrum.md
@@ -23,7 +23,7 @@ Each `sources/scores/<slug>.yaml` carries two separate, analyst-assigned opennes
 
 | Field | Type | What it is |
 |-------|------|------------|
-| `openness.class` | categorical | An OSI / Model Openness Framework (MOF) label. In use today, by frequency: `open_source`, `closed`, `open`, `open_weights`, `open_core`, `source_available`, `documented`, `gated`, `restricted`, `open_toolchain`, `open_hardware`. `documented_only` is also defined in the vocabulary but no product currently carries it. [`openness-class-map.json`](../openness-class-map.json) is the authoritative list. |
+| `openness.class` | categorical | An OSI / Model Openness Framework (MOF) label. In use today, by frequency: `open_source`, `closed`, `open`, `open_weights`, `open_core`, `source_available`, `documented`, `gated`, `restricted`, `open_toolchain`, `open_hardware`. [`openness-class-map.json`](../openness-class-map.json) is the authoritative list. |
 | `openness.score` | integer 0–5 | A graded openness score with a `components` breakdown (models: `weights / data / code / checkpoints / license`; software: OSI-class license tests; datasets: access / license / documentation). |
 
 Every non-null value needs a primary `sources:` entry. Both fields were originally assigned
@@ -99,7 +99,6 @@ spectrum coordinate:
 | `source_available` | Source available | 2 |
 | `restricted` | Restricted | 2 |
 | `gated` | Gated | 2 |
-| `documented_only` | Documented only | 1 |
 | `closed` | Closed | 1 |
 | `open_hardware` | Open hardware | 5 |
 | `open_toolchain` | Open toolchain | 3 |
@@ -114,7 +113,7 @@ retail-available = `open_toolchain`; datasheets public but proprietary design / 
 
 - **open** = `open_source` / `open` / `open_core` / `open_hardware`
 - **open-ish** = `open_weights` / `source_available` / `gated` / `open_toolchain`
-- **closed** = `restricted` / `documented_only` / `closed` / `documented`
+- **closed** = `restricted` / `closed` / `documented`
 
 ## The license scale
 
@@ -214,7 +213,7 @@ Both are choices, not oversights, and neither moves the binary line.
 
 ### Where the boundary is currently weakest
 
-The **dataset** vocabulary has no middle. Its classes are `open`, `gated`, `documented_only`
+The **dataset** vocabulary has no middle. Its classes are `open`, `gated`, `restricted`
 and `closed`, and `open` is the only word above `gated`, so every corpus scored 3 or higher
 lands in the `open` bucket — 52 products today, including one at 3 and six at 4. A model at 4
 is `open_weights` and open-ish; a corpus at 4 is `open`. `the-pile` (license deferring to
@@ -238,9 +237,9 @@ lean on it:
   and `gated` all share gradient = 2, but bucket differently: `source_available` and `gated`
   are *open-ish* while `restricted` is *closed*. If your visualization shows both a fine
   gradient and a coarse bucket, expect them to disagree at the 2-fill band.
-- **Some distinctions collapse.** `open_source` and `open` both map to 5; `documented_only`
-  and `closed` both map to 1. That's intentional for the map but may be too coarse depending
-  on what you're showing.
+- **Some distinctions collapse.** `open_source` and `open` both map to 5; `documented`
+  and `closed` both sit in the closed bucket. That's intentional for the map but may be too
+  coarse depending on what you're showing.
 
 If you want a different lens than the published map, you're free to define one — just do it
 deliberately and note where it diverges from this table.

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -61,7 +61,7 @@ Every value also records what the source showed and when we accessed it. Across 
 
 #### Axis 1: Openness
 
-Openness has two fields. The first, the class, is a categorical label drawn from the [Model Openness Framework](https://isitopen.ai/) and OSI license taxonomy (for example `open_source`, `open_weights`, `open_core`, `source_available`, `restricted`, `gated`, `documented_only`, `closed`). The class serves as the cross-category normalizer: it is the field to use when positioning a product on an openness spectrum. The second, the score, is a 0–5 grade with a component-level breakdown: weights, data, code, checkpoints, and license for models; license tests for software; access, license, and documentation for datasets.
+Openness has two fields. The first, the class, is a categorical label drawn from the [Model Openness Framework](https://isitopen.ai/) and OSI license taxonomy (for example `open_source`, `open_weights`, `open_core`, `source_available`, `restricted`, `gated`, `closed`). The class serves as the cross-category normalizer: it is the field to use when positioning a product on an openness spectrum. The second, the score, is a 0–5 grade with a component-level breakdown: weights, data, code, checkpoints, and license for models; license tests for software; access, license, and documentation for datasets.
 
 The score is graded relative to what is achievable within a product type, so the same number does not carry the same meaning across categories. A pretrained model at 2 is genuinely restricted, because the openness range for models is compressed: open weights typically land near 3, and a 5 requires a fully open pipeline of the Pythia or OLMo kind. A deployment tool at 2 sits elsewhere entirely. The raw 0–5 score should therefore be read as a within-type detail, not as a cross-category coordinate.
 
@@ -69,7 +69,7 @@ For analysis across the whole stack, we collapse the class vocabulary into three
 
 - Open: `open_source`, `open`, `open_core`, `open_hardware`
 - Open-ish: `open_weights`, `source_available`, `gated`, `open_toolchain`
-- Closed: `restricted`, `documented_only`, `closed`, `documented`
+- Closed: `restricted`, `closed`, `documented`
 
 Hardware uses its own openness vocabulary, parallel to the software and model classes: open schematics with an open toolchain (`open_hardware`); proprietary silicon but an open SDK with public datasheets and retail availability (`open_toolchain`); public datasheets but proprietary design or firmware (`documented`); and private or NDA-gated availability (`restricted`).
 

--- a/docs/openness-class-map.json
+++ b/docs/openness-class-map.json
@@ -9,7 +9,6 @@
     "gated":       { "label": "Gated",             "gradient": 2, "bucket": "openish", "color": "#d97c2a" },
     "source_available": { "label": "Source available", "gradient": 2, "bucket": "openish", "color": "#c8341d" },
     "restricted":  { "label": "Restricted",        "gradient": 2, "bucket": "closed",  "color": "#c8341d" },
-    "documented_only": { "label": "Documented only", "gradient": 1, "bucket": "closed", "color": "#6b6253" },
     "closed":      { "label": "Closed",            "gradient": 1, "bucket": "closed",  "color": "#6b6253" },
     "open_hardware":  { "label": "Open hardware",  "gradient": 5, "bucket": "open",    "color": "#1b6b5e" },
     "open_toolchain": { "label": "Open toolchain", "gradient": 3, "bucket": "openish", "color": "#d97c2a" },
@@ -18,6 +17,6 @@
   "buckets": {
     "open":    { "label": "Open",     "color": "#1b6b5e", "classes": ["open_source", "open", "open_core", "open_hardware"] },
     "openish": { "label": "Open-ish", "color": "#d97c2a", "classes": ["open_weights", "source_available", "gated", "open_toolchain"] },
-    "closed":  { "label": "Closed",   "color": "#c8341d", "classes": ["restricted", "documented_only", "closed", "documented"] }
+    "closed":  { "label": "Closed",   "color": "#c8341d", "classes": ["restricted", "closed", "documented"] }
   }
 }

--- a/sources/categories/training_synthetic_datasets.yaml
+++ b/sources/categories/training_synthetic_datasets.yaml
@@ -119,4 +119,4 @@ products:
 - hermes-3-dataset
 comments: 'Pre-training corpora + post-training/synthetic/preference data: everything
   consumed to BUILD a model, as opposed to benchmark_eval_data which scores one. Dataset
-  openness vocabulary (open / gated / documented_only / closed). Proposed in issue #10.'
+  openness vocabulary (open / gated / restricted / closed). Proposed in issue #10.'

--- a/tests/test_openness_buckets.py
+++ b/tests/test_openness_buckets.py
@@ -46,7 +46,7 @@ OPEN_BY_EXTERNAL_STANDARD = {"osi", "open_data"}
 # formula does not silently move an exemption onto a different rung.
 #
 # Both entries are the same defect and it is NOT license laxity: the dataset class vocabulary
-# in build/validate.py is {open, gated, documented_only, closed}, and `open` is the only word
+# in build/validate.py is {open, gated, restricted, closed}, and `open` is the only word
 # available above `gated`. So a corpus whose license defers to per-subset terms has nowhere to
 # land but `open`, and `open` is in the open bucket. `the-pile` (3/open, mixed-per-subset,
 # Books3 withdrawn) and `stack-edu` (4/open, defers to The Stack v2's gated terms) are the two
@@ -162,3 +162,19 @@ def test_an_otherwise_rule_never_lands_in_the_open_bucket():
             assert got not in open_classes, (
                 f"{name} falls through to {got!r}, which is in the open bucket"
             )
+
+
+def test_validate_vocabulary_is_a_subset_of_the_schema_enum():
+    """Every class build/validate.py permits must be one the schema allows.
+
+    These drifted: validate.py permitted `documented_only` for datasets while the schema
+    enum omitted it, so a dataset scored that way passed one check and failed the other
+    depending on order. No product ever carried it.
+    """
+    schema = json.loads((ROOT / "docs" / "schemas" / "score.schema.json").read_text())
+    allowed = set(schema["properties"]["openness"]["properties"]["class"]["enum"])
+
+    from build.validate import OPENNESS_CLASSES
+
+    permitted = {cls for classes in OPENNESS_CLASSES.values() for cls in classes}
+    assert permitted <= allowed, f"validate.py permits classes the schema forbids: {sorted(permitted - allowed)}"


### PR DESCRIPTION
## Summary

- `documented_only` was permitted by `build/validate.py` for datasets and absent from `score.schema.json`'s enum, so the two disagreed in shipped code and a dataset scored that way passed one check and failed the other depending on order.
- No product has ever carried it, and `docs/methodology.md` advertised it to readers of the published map.
- `documented` already covers the case. Removed from the code, the class map, the methodology, the openness guide and one category comment.

Also corrected two sentences in `openness-spectrum.md` that had drifted:

- One still omitted `restricted` from the dataset vocabulary it joined with the universal license scale.
- One claimed "`documented_only` and `closed` both map to 1". `documented`'s gradient is 2, not 1, so the claim is restated on the bucket rather than the gradient, which is true for both.

## Test plan

- New test asserts `validate.py`'s permitted vocabulary is a subset of the schema enum. Fails on `main` naming `documented_only`.
- `grep -rn documented_only build/ docs/ sources/ tests/ .github/` returns only the new test's own docstring, where the class is named as the historical bug it describes.
- Score-neutral: no product carried the class, so nothing serializes differently.
- `validate`, `check_recipe`, `check_rubric` and the full suite unchanged (409 -> 410, the new test).

`notebooks/ai-stack-map.py` and `notebooks/__marimo__/` still contain the string until the bot regenerates them. That is expected and deliberately not hand-edited.
