### PR TITLE
ci: gate on check_rubric, the only check that a published score reproduces

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -42,11 +42,22 @@ jobs:
 
       # Structure of every scoring recipe: a rationale on each rung, a machine_signal on
       # each dimension, no rule that cannot fire, no product abstained on without a
-      # declared reason, and no evidence the components parser silently discards. Note
-      # check_rubric is not in CI at all; this is what puts the class of check on every PR.
-      # See skills/build-rubric/SKILL.md.
+      # declared reason, and no evidence the components parser silently discards.
+      # check_rubric runs in the step below; this one gates recipe structure rather than
+      # per-product reproduction. See skills/build-rubric/SKILL.md.
       - name: Recipe gate (structure, deferral completeness, discarded evidence)
         run: uv run python -m build.check_recipe --verbose
+
+      # Does the recorded score match what the category's own rubric produces? This is the
+      # only gate that compares a published number against the rule meant to generate it,
+      # and it ran in no workflow until now. Safe to gate on: products a category has
+      # explicitly deferred are excluded from the comparison, so the escape hatch is the
+      # `deferred` block with a written reason rather than editing a score to make CI pass.
+      # check_recipe above gates the STRUCTURE of a recipe and deliberately refuses to gate
+      # on a reproduction rate; this gates per-product mismatches, which is a different
+      # claim. See build/check_rubric.py's module docstring.
+      - name: Rubric gate (recorded scores reproduce)
+        run: uv run python -m build.check_rubric
       - name: Serialize dry-run
         run: uv run python -m build.serialize --date ci-dry-run
 


### PR DESCRIPTION
## Summary

- `check_rubric` compares each published openness score against the rubric meant to produce it, and ran in no workflow. Its module docstring already said "Exit status is 1 on any mismatch, so CI can gate on it", and `validate.yml` carried a comment acknowledging the gap.
- Safe to turn on now: it exits 0 on `main`, and products a category has explicitly deferred are excluded from the comparison, so the escape hatch stays the `deferred` block with a written reason rather than editing a score to make CI pass.
- Ordered immediately after the recipe gate, which gates recipe *structure* and deliberately refuses to gate on a reproduction rate. Different claims, both worth making.

## Test plan

- `check_rubric` exits 0 on `main`.
- Verified it bites rather than assuming it: setting `vllm`'s recorded `openness.score` to 4 made it exit **1**, naming `vllm` and reporting rubric `(5, open_source)` against scores `(4, open_source)`. Reverted; working tree clean before commit.
- Workflow parses, and the new step sits directly after the recipe gate and before the serialize dry-run.
- The comment's claims were checked against the two modules rather than asserted: `check_recipe`'s docstring says it asserts no threshold on the reproduction rate in either direction, and `check_rubric` returns deferred products in a separate bucket from failures.
- Full suite, `validate`, `check_recipe` and `check_rubric` unchanged.

This PR's own CI run is the real test of the new gate.
