### PR TITLE
feat(routing): declare npm and crates as unbridged sources

### DIFF
--- a/sources/signal_routing.yaml
+++ b/sources/signal_routing.yaml
@@ -58,6 +58,25 @@ sources:
     key: product_slug
     evidence_url: https://pypistats.org/packages/{package}
     bridged: true
+  npm:
+    table: null
+    key: null
+    evidence_url: https://www.npmjs.com/package/{package}
+    bridged: false
+    bridge_note: >
+      12 products declare an npm package and no signal model reads the npm registry, so their
+      adoption falls through to the stars scale and its cap of 3 - four of them, including
+      `gemini-cli` and `openclaw`, record 5. npm download counts are a direct analogue of the
+      pypi route, so this is a missing model rather than a missing method. Declared here so
+      the gap is a backlog entry instead of a silent cap.
+  crates:
+    table: null
+    key: null
+    evidence_url: https://crates.io/crates/{package}
+    bridged: false
+    bridge_note: >
+      One product (`yomo`) declares a crates package. Same shape as npm: crates.io publishes
+      download counts and no model reads them.
   semanticscholar:
     table: currentai.signal_semanticscholar.paper_citations
     key: product_slug

--- a/tests/test_signal_routing.py
+++ b/tests/test_signal_routing.py
@@ -1,0 +1,41 @@
+"""`signal_routing.yaml` declares which machine-readable sources exist. Nothing else in the
+suite checks that declaration against what products actually claim to have, so an artifact
+kind can go undeclared indefinitely and every product carrying it silently falls through to
+the stars fallback and its cap of 3 — no test fails, no error surfaces, the score is simply
+lower than it should be.
+"""
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_every_declared_artifact_kind_has_a_route_or_is_declared_unbridged():
+    """A product may declare an artifact kind no route can reach, but the gap must be visible.
+
+    npm and crates were absent from signal_routing entirely, so 13 products with a real
+    countable distribution artifact silently fell through to the stars scale and its cap of 3.
+    Declaring the source `bridged: false` is this file's idiom for machine-readable but not
+    yet joinable, and it turns the gap into a backlog entry.
+
+    This only covers the kinds enumerated in `ARTIFACT_KINDS` below. A product key outside
+    that set - `arxiv` already is - is invisible to this check and can go undeclared with no
+    failure here, whether or not it turns out to be a distribution artifact.
+    """
+    routing = yaml.safe_load((ROOT / "sources" / "signal_routing.yaml").read_text())
+    declared = set(routing["sources"])
+
+    # Only kinds named here are checked. Adding a new artifact kind to a product record
+    # (e.g. a `go` or `docker` key) does not make it visible to this test until it is added
+    # to this set too.
+    ARTIFACT_KINDS = {"github", "npm", "pypi", "crates", "go", "huggingface_model", "huggingface_dataset"}
+    in_use = set()
+    for path in sorted((ROOT / "sources" / "products").glob("*.yaml")):
+        record = yaml.safe_load(path.read_text()) or {}
+        in_use |= {k for k in ARTIFACT_KINDS if record.get(k)}
+
+    assert in_use <= declared, (
+        "artifact kinds in use with no declared source: " + str(sorted(in_use - declared))
+    )


### PR DESCRIPTION
## Summary

13 products declare an npm or crates package, and `sources/signal_routing.yaml` declared neither source. Their adoption has nowhere to route, so it falls through to the stars scale and its cap of 3 — while eight of them record level 4 or 5.

No npm signal model exists on the warehouse, so both are declared **`bridged: false`**, this file's existing idiom for a machine-readable source with no join key yet, already used by `artificialanalysis` and `lmarena`. That turns a silent cap into a visible backlog entry. Building the npm model is separate work.

## Measured

```
13 products declare npm or crates and have no route

  gemini-cli               npm      level=5 signal=usage_volume
  mcp-typescript-sdk       npm      level=5 signal=usage_volume
  n8n                      npm      level=5 signal=usage_volume
  openclaw                 npm      level=5 signal=usage_volume
  mastra                   npm      level=4 signal=usage_volume
  mcp-inspector            npm      level=4 signal=usage_volume
  opencode                 npm      level=4 signal=reported_traction
  playwright-mcp           npm      level=4 signal=usage_volume
  beeai                    npm      level=3 signal=stars_fallback
  filesystem-mcp           npm      level=3 signal=stars_fallback
  hexabot                  npm      level=3 signal=stars_fallback
  notion-mcp               npm      level=3 signal=stars_fallback
  yomo                     crates   level=3 signal=stars_fallback

npm 12, crates 1, level >= 4: 8
```

The four already sitting at level 3 on `stars_fallback` are the cap in action.

## What this does and does not change

These flags are **documentation of the gap, not a behavior change.** `build/check_routing.py` evaluates `bridged` only for sources referenced by a `dimensions.*.routes` entry, and neither npm nor crates is referenced by any route. `check_routing`'s output is byte-identical before and after. Nothing in the repo reads these two flags today; Phase 3 is where an unbridged source must be honored when deciding whether a route can write.

## Test plan

- New `tests/test_signal_routing.py` asserts every artifact kind in use has a declared source. Fails on `main` naming exactly `npm` and `crates` — `go` is in the checked set but no product declares it.
- The test's limits are stated in its own docstring: it covers only the kinds enumerated in `ARTIFACT_KINDS`, so a kind outside that set — `arxiv` already is — is invisible to it. Tightening that needs a ruling on whether `arxiv` is a distribution artifact or metadata, which is a taxonomy question, not a cleanup one. Tracked separately.
- Every figure above recomputed from `sources/` at this commit; both `bridge_note` strings state those measurements.
- Full suite 407 -> 408. `validate`, `check_recipe` and `check_rubric` unchanged.
