### PR TITLE
feat(components): add the structured-shape primitives and test the equivalence they rest on

### DIFF
--- a/build/check_rubric.py
+++ b/build/check_rubric.py
@@ -77,6 +77,132 @@ def head(value: str) -> str:
     return re.split(r"[(,]", value)[0].strip()
 
 
+def split_value(raw: str) -> tuple[str, str]:
+    """Split a recorded component into its bare value and its trailing detail.
+
+    'open(downloadable on HF, gated)' -> ('open', 'downloadable on HF, gated')
+
+    Lives beside `head` because the bare half must equal `head(raw)` exactly — that is
+    what makes a structured `components` mapping score-neutral, and two modules apart is
+    how the two would drift. `build/serialize_rubric.py` re-exports it.
+    """
+    text = (raw or "").strip()
+    parts = re.split(r"[(,]", text, maxsplit=1)
+    bare = parts[0].strip()
+    rest = parts[1].strip() if len(parts) > 1 else ""
+    return bare, rest.rstrip(")").strip()
+
+
+FREE_TEXT = "free_text"
+
+
+def _clauses(text: str) -> list[str]:
+    """Depth-0 clause split, KEEPING the keyless clauses `split_components` discards.
+
+    `split_components` drops any clause with no colon, silently — 221 of them across 168
+    files. The structured form has to put those somewhere, so the migration needs a splitter
+    that hands them back.
+    """
+    parts: list[str] = []
+    depth = 0
+    current = ""
+    for char in text:
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth = max(0, depth - 1)
+        if char == ";" and depth == 0:
+            parts.append(current)
+            current = ""
+        else:
+            current += char
+    if current.strip():
+        parts.append(current)
+    return parts
+
+
+def structure(text: str) -> dict:
+    """The flat `k:v;k:v` string as a mapping of key -> {value, detail?, raw?}.
+
+    `raw` appears only when `f"{value}({detail})"` does not reproduce the clause
+    byte-for-byte. 155 entries on 81 products need one, in three shapes: text after the
+    closing paren ('Apache-2.0(OSI) for the framework'), a comma that is a list separator
+    rather than a value/detail boundary ('rows:169,352', which every caller of split_value
+    already reads as '169' today), and nested parens, where rstrip(')') removes one closer
+    and leaves the inner one unbalanced.
+
+    Keyless clauses accumulate under `free_text` in the order they appeared. They are not
+    promoted to dimensions here: `dimension_value` would start answering where it answered
+    '' and that can change which rung fires, which this phase is not allowed to do.
+    """
+    out: dict = {}
+    free: list[str] = []
+    for clause in _clauses(text):
+        clause = clause.strip()
+        if ":" not in clause:
+            free.append(clause)
+            continue
+        key, value = clause.split(":", 1)
+        key, value = key.strip(), value.strip()
+        bare, detail = split_value(value)
+        entry: dict = {"value": bare}
+        if detail:
+            entry["detail"] = detail
+        if (f"{bare}({detail})" if detail else bare) != value:
+            entry["raw"] = value
+        out[key] = entry
+    if free:
+        out[FREE_TEXT] = free
+    return out
+
+
+def recompose(mapping: dict) -> dict[str, str]:
+    """The mapping back to the key -> raw-clause dict `split_components` produces.
+
+    This is the join that makes the migration score-neutral: every reader keeps seeing the
+    exact strings it saw before the shape changed.
+    """
+    out: dict[str, str] = {}
+    for key, entry in mapping.items():
+        if key == FREE_TEXT:
+            continue
+        if "raw" in entry:
+            out[key] = entry["raw"]
+            continue
+        detail = entry.get("detail")
+        out[key] = f"{entry['value']}({detail})" if detail else entry["value"]
+    return out
+
+
+def components_of(openness: dict) -> dict[str, str]:
+    """The recorded components as key -> raw clause, from either shape.
+
+    The one function every reader calls. Both shapes are on `main` at once while the corpus
+    migrates in batches, so no reader may assume either.
+    """
+    components = (openness or {}).get("components")
+    if isinstance(components, dict):
+        return recompose(components)
+    return split_components(components or "")
+
+
+def components_string(openness: dict) -> str:
+    """The flat string, for the payload and for anything that re-splits it itself.
+
+    Prefers the verbatim `raw` sibling, which is what the file said before it was migrated;
+    falls back to rejoining the mapping. The payload key stays a string so the front end and
+    the rendered notebook see no change at all from this migration.
+    """
+    block = openness or {}
+    raw = block.get("raw")
+    if isinstance(raw, str) and raw:
+        return raw
+    components = block.get("components")
+    if isinstance(components, str):
+        return components
+    return ";".join(f"{key}:{value}" for key, value in recompose(components or {}).items())
+
+
 _RECORDED_ALIASES: dict[str, str] | None = None
 
 

--- a/build/serialize_rubric.py
+++ b/build/serialize_rubric.py
@@ -60,7 +60,6 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import re
 import sys
 from pathlib import Path
 
@@ -71,6 +70,7 @@ from build.check_rubric import (
     license_read_keys,
     resolve_dimension,
     split_components,
+    split_value,
 )
 from build.rubrics import load_product_types, recipe_for, resolve_recipe_variants
 from build.serialize_registry import write_tables
@@ -175,20 +175,6 @@ def load_policy(root: Path) -> dict:
 
 def load_routing(root: Path) -> dict:
     return yaml.safe_load((root / "sources" / "signal_routing.yaml").read_text()) or {}
-
-
-def split_value(raw: str) -> tuple[str, str]:
-    """Split a recorded component into its bare value and its trailing detail.
-
-    'open(downloadable on HF, gated)' -> ('open', 'downloadable on HF, gated')
-    The bare half matches `check_rubric.head` exactly, which is what the formula
-    consumes; the detail half is what a reviewer needs and the formula ignores.
-    """
-    text = (raw or "").strip()
-    parts = re.split(r"[(,]", text, maxsplit=1)
-    bare = parts[0].strip()
-    rest = parts[1].strip() if len(parts) > 1 else ""
-    return bare, rest.rstrip(")").strip()
 
 
 def admit(shows: str, policy: dict) -> tuple[bool, str]:

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -305,3 +305,78 @@ def test_no_score_file_mints_a_phantom_dimension_key():
                 offenders.append(f"{path.stem}: {key!r}")
 
     assert offenders == [], "phantom dimension keys minted from prose:\n  " + "\n  ".join(offenders)
+
+
+def test_structure_splits_a_keyed_clause_into_value_and_detail():
+    from build.check_rubric import structure
+
+    assert structure("weights:open(downloadable on HF);data:closed") == {
+        "weights": {"value": "open", "detail": "downloadable on HF"},
+        "data": {"value": "closed"},
+    }
+
+
+def test_structure_keeps_a_keyless_clause_as_free_text():
+    """A keyless clause has no key to sit under, and dropping it deletes evidence.
+
+    `split_components` discards it silently and `check_recipe`'s blocking test only ever
+    sees clauses that survived that discard — which is why the gate reports 0 blocking
+    clauses while 221 of them go unread.
+    """
+    from build.check_rubric import structure
+
+    assert structure("source:public;no feature-gated core") == {
+        "source": {"value": "public"},
+        "free_text": ["no feature-gated core"],
+    }
+
+
+def test_structure_records_raw_when_value_and_detail_cannot_round_trip():
+    """Three clause shapes that split_value cannot reverse; `raw` is what keeps them.
+
+    `rows:169,352` is the sharpest: the first comma is taken as the value/detail boundary,
+    so a row count is cut in half. That is happening today, with no migration involved.
+    """
+    from build.check_rubric import structure
+
+    assert structure("rows:169,352")["rows"] == {"value": "169", "detail": "352", "raw": "169,352"}
+    assert structure("license:Apache-2.0(OSI) for the framework")["license"]["raw"] == (
+        "Apache-2.0(OSI) for the framework"
+    )
+    assert structure("toolchain:open (fully open (MaixPy, Apache-2.0))")["toolchain"]["raw"] == (
+        "open (fully open (MaixPy, Apache-2.0))"
+    )
+
+
+def test_components_of_reads_both_shapes_identically():
+    """Both shapes are on main at once while the corpus migrates in batches."""
+    from build.check_rubric import components_of, split_components, structure
+
+    text = "weights:open(on HF);data:closed;rows:169,352;no feature-gated core"
+    assert components_of({"components": text}) == split_components(text)
+    assert components_of({"components": structure(text)}) == split_components(text)
+
+
+def test_structure_round_trips_every_recorded_components_string():
+    """The corpus-wide guarantee: no reader sees a different string after the migration.
+
+    Byte-exact, not whitespace-insensitive. A normalizing comparison would let 108 entries
+    that differ only by a space before the opening paren pass while quietly changing the
+    detail text the warehouse evidence rows carry.
+    """
+    from build.check_rubric import recompose, split_components, structure
+
+    root = Path(__file__).resolve().parents[1]
+    failures = []
+    walked = 0
+    for path in sorted((root / "sources" / "scores").glob("*.yaml")):
+        block = (yaml.safe_load(path.read_text()) or {}).get("openness") or {}
+        components = block.get("components")
+        if not isinstance(components, str) or not components:
+            continue
+        walked += 1
+        if recompose(structure(components)) != split_components(components):
+            failures.append(path.stem)
+
+    assert walked > 0, "no string-shaped components reached; the corpus walk is broken"
+    assert failures == [], f"structure/recompose does not round-trip: {failures}"

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -977,3 +977,35 @@ def test_download_bands_and_stars_bands_do_not_collide():
     assert all(r["product_type"] != "*" for r in downloads)
     keys = {(r["product_type"], r["signal_type"], r["level"]) for r in downloads + stars}
     assert len(keys) == len(downloads) + len(stars), "a (type, instrument, level) key repeats"
+
+
+def test_split_value_bare_half_matches_head_on_the_whole_corpus():
+    """The property the structured-dimensions migration rests on, tested against the corpus.
+
+    A structured `components` mapping is score-neutral only because the bare half of
+    `split_value` is byte-identical to `check_rubric.head`, which is what every formula
+    actually reads. That held on all 1,754 recordings when it was measured, and until now
+    it was asserted against four hand-written strings — so an edit to either function could
+    move scores with every gate green. Four literals cannot notice that; the corpus can.
+    """
+    from pathlib import Path
+
+    import yaml
+
+    from build.check_rubric import head, split_components
+
+    root = Path(__file__).resolve().parents[1]
+    mismatches = []
+    recordings = 0
+    for path in sorted((root / "sources" / "scores").glob("*.yaml")):
+        block = (yaml.safe_load(path.read_text()) or {}).get("openness") or {}
+        components = block.get("components")
+        if not isinstance(components, str) or not components:
+            continue
+        for key, raw in split_components(components).items():
+            recordings += 1
+            if split_value(raw)[0] != head(raw):
+                mismatches.append(f"{path.stem}.{key}: {raw!r}")
+
+    assert recordings > 1_000, f"only {recordings} recordings reached; the corpus walk is broken"
+    assert mismatches == [], "split_value and head disagree:\n  " + "\n  ".join(mismatches)


### PR DESCRIPTION
## Summary

First task of the structured-dimensions migration. **No data changes** — this adds the primitives the migration will use, and puts the corpus behind the property the whole phase rests on.

That property: `split_value`'s bare half must be byte-identical to `head` on every recording. If it ever stops holding, a shape-only migration can silently move a published score. It was enforced by four hand-written strings; it is now enforced by all **1,754 recordings**, with a count guard so the test cannot pass against an empty corpus.

`split_value` moves from `serialize_rubric.py` to `check_rubric.py` to sit beside `head`, since the two must not drift and they lived in different modules. `serialize_rubric` re-exports it, so every existing caller is untouched.

New in `check_rubric.py`:

| Function | Does |
|---|---|
| `structure(text)` | flat string → mapping; keyed clauses become `{value, detail?, raw?}`, keyless ones accumulate under `free_text` |
| `recompose(mapping)` | mapping → the key/raw-clause dict `split_components` would have produced |
| `components_of(openness)` | the one function every reader calls; accepts either shape |
| `components_string(openness)` | the flat string for the payload; prefers `openness['raw']` |

`recompose(structure(s))` reproduces `split_components(s)` on **472/472** corpus files, byte-exact.

## Not in this PR, deliberately

`head()` is untouched. It truncates licenses at the first paren and conceals restrictive halves on five products; surfacing those moves real published scores, which is Phase 1b's job with each move reviewed on its merits. Phase 1a's defining property is that zero published scores move.

## Test plan

- Equivalence test over the corpus: 1,754 recordings, 0 mismatches, asserts a non-zero count.
- Round-trip test over the corpus: 472 files, 0 exceptions, asserts a non-zero count.
- `split_value`'s body is byte-identical after the move; all four in-module call sites and the test import resolve unchanged.
- Suite 408 → 414. `validate` 0 error(s), `check_recipe` 0 failure(s), `check_rubric` exit 0.
- Payload unchanged: a dry-run serialize diffs only the `generated` stamp.
