### PR TITLE
feat(components): admit a structured components mapping and route every reader through one function

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -48,6 +48,13 @@ jobs:
       - name: Recipe gate (structure, deferral completeness, discarded evidence)
         run: uv run python -m build.check_recipe --verbose
 
+      # Does a structured `components` mapping say what the string it replaced said? This is
+      # the only gate that compares the shape migration's output against its input, and it
+      # has to run BEFORE the rubric gate, because the rubric gate reads the mapping and
+      # would simply believe a mangled one. Vacuously green until the first batch migrates.
+      - name: Components gate (a structured mapping matches its raw string)
+        run: uv run python -m build.check_components
+
       # Does the recorded score match what the category's own rubric produces? This is the
       # only gate that compares a published number against the rule meant to generate it,
       # and it ran in no workflow until now. Safe to gate on: products a category has

--- a/build/check_components.py
+++ b/build/check_components.py
@@ -1,0 +1,78 @@
+"""Gate: a structured `components` mapping says exactly what the string said.
+
+Phase 1a changes the SHAPE of the most load-bearing field in the corpus and promises it
+moves no score. That promise is only as good as the migration, and a migration that mangled
+one value would still parse, still validate, and still pass every existing gate — because
+every existing gate reads the mapping and would simply believe it.
+
+So each migrated record keeps its original string in `openness.raw`, and this gate asserts
+the mapping and the string produce the same key -> clause dict, key for key, byte for byte.
+It is the only check that compares the migration's output against its input.
+
+It also asserts the two directions nobody would otherwise notice:
+
+  * a migrated record MUST carry `raw`, or there is nothing to check it against;
+  * an unmigrated record must NOT, or a stale `raw` will be silently believed by
+    `components_string` and shipped to the payload.
+
+Exit status is 1 on any failure, so CI can gate on it.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+from build.check_rubric import FREE_TEXT, _clauses, recompose, split_components
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def check(root: Path = ROOT) -> list[str]:
+    failures: list[str] = []
+    for path in sorted((root / "sources" / "scores").glob("*.yaml")):
+        block = (yaml.safe_load(path.read_text()) or {}).get("openness") or {}
+        components = block.get("components")
+        raw = block.get("raw")
+        slug = path.stem
+
+        if not isinstance(components, dict):
+            if raw is not None:
+                failures.append(f"{slug}: carries openness.raw but components is still a string")
+            continue
+
+        if not isinstance(raw, str) or not raw:
+            failures.append(f"{slug}: components is a mapping with no openness.raw to check it against")
+            continue
+
+        expected = split_components(raw)
+        actual = recompose(components)
+        if actual != expected:
+            for key in sorted(set(expected) | set(actual)):
+                if expected.get(key) != actual.get(key):
+                    failures.append(
+                        f"{slug}.{key}: mapping recomposes to {actual.get(key)!r}, "
+                        f"raw says {expected.get(key)!r}"
+                    )
+
+        keyless = [c.strip() for c in _clauses(raw) if ":" not in c.strip()]
+        recorded = components.get(FREE_TEXT, [])
+        if keyless != recorded:
+            failures.append(f"{slug}: free_text is {recorded!r}, raw's keyless clauses are {keyless!r}")
+
+    return failures
+
+
+def main() -> int:
+    failures = check()
+    for line in failures:
+        print(f"  x {line}")
+    print(f"\ncomponents gate  a structured mapping that disagrees with its raw string  "
+          f"{'[OK]' if not failures else f'{len(failures)} failure(s)'}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/check_parity.py
+++ b/build/check_parity.py
@@ -64,10 +64,10 @@ import yaml
 
 from build.check_rubric import (
     apply_formula,
+    components_of,
     dimension_value,
     license_read_keys,
     license_tier,
-    split_components,
 )
 from build.rubrics import load_product_types, load_shared, recipe_for, resolve_recipe_variants
 from build.warehouse import query
@@ -113,7 +113,7 @@ def local_scores(category_filter: str | None) -> tuple[dict, dict]:
                 computed[key] = None
                 continue
             openness = (yaml.safe_load(score_path.read_text()) or {}).get("openness") or {}
-            components = split_components(openness.get("components") or "")
+            components = components_of(openness)
 
             # Same order as check_rubric: the tier first, and only where the ladder declares
             # one. A tier-free ladder - hardware scores design and toolchain - must not be

--- a/build/check_recipe.py
+++ b/build/check_recipe.py
@@ -45,6 +45,8 @@ from build.check_rubric import (
     ROOT,
     apply_formula,
     check_category,
+    components_of,
+    components_string,
     dimension_read_map,
     dimension_value,
     head,
@@ -345,7 +347,7 @@ def stale_deferrals(
         if recipe is None:
             continue
         openness = (yaml.safe_load(path.read_text()) or {}).get("openness") or {}
-        components = split_components(openness.get("components") or "")
+        components = components_of(openness)
         raw = next((components[k] for k in license_read_keys(recipe) if components.get(k)), "")
         tier = license_tier(raw, recipe)
         if tier is None:
@@ -405,7 +407,7 @@ def check_one(slug: str, verbose: bool) -> tuple[list[str], list[str]]:
         recipe, _ = recipe_for(variants, product_types.get(product, ""))
         if recipe is None:
             continue
-        by_recipe.setdefault(id(recipe), {})[product] = openness.get("components") or ""
+        by_recipe.setdefault(id(recipe), {})[product] = components_string(openness)
         pair = (openness.get("score"), openness.get("class"))
         if pair[0] is not None and pair not in rule_outcomes(recipe):
             impossible += 1

--- a/build/check_rubric.py
+++ b/build/check_rubric.py
@@ -384,7 +384,7 @@ def check_category(slug: str, verbose: bool) -> tuple[int, int, list[str], list[
             continue
         scores = yaml.safe_load(path.read_text())
         openness = scores.get("openness") or {}
-        components = split_components(openness.get("components") or "")
+        components = components_of(openness)
         total += 1
 
         # A ladder need not turn on a source license at all. Hardware openness is scored on

--- a/build/check_verification.py
+++ b/build/check_verification.py
@@ -65,7 +65,7 @@ from pathlib import Path
 
 import yaml
 
-from build.check_rubric import license_read_keys, resolve_dimension, split_components
+from build.check_rubric import components_of, license_read_keys, resolve_dimension
 from build.rubrics import load_product_types, load_shared, recipe_for, resolve_recipe_variants
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -193,7 +193,7 @@ def invariant(
 
             if axis != "openness":
                 continue
-            components = split_components(block.get("components") or "")
+            components = components_of(block)
             required = recorded_dimensions(components, recipe)
             for dimension, key in sorted(required.items()):
                 names = {dimension, key}

--- a/build/serialize.py
+++ b/build/serialize.py
@@ -10,6 +10,8 @@ import json
 import re
 import yaml
 
+from build.check_rubric import components_string
+
 ROOT = Path(__file__).resolve().parents[1]
 
 PRODUCT_KEY_ORDER = ["slug", "product", "org_slug", "org", "type", "description",
@@ -183,7 +185,18 @@ def _row(slug: str, prod: dict, org_slug: str, org_name: str, score: dict,
     # Pre-compute the open / open-ish / closed bucket alongside the raw class, so
     # consumers get a stable 3-way verdict that survives changes to the openness.class
     # vocabulary. Same collapse the category gap logic uses (_gap_bucket).
-    openness = {**score["openness"], "bucket": _gap_bucket((score["openness"] or {}).get("class"))}
+    # The payload's `components` stays a flat string whatever shape the record carries, and
+    # `raw` never ships. The front end's contract with this payload is undocumented and
+    # untested, and build/render.py plus the rendered notebook both do `row('Components',
+    # o.components)` on it — so a mapping here would render as [object Object] in the product
+    # detail panel and force a regeneration of a bot-owned file. Keeping the key a string
+    # means the structured-dimensions migration is invisible downstream, which is also what
+    # makes "zero published scores moved" a byte comparison rather than a judgment.
+    block = score["openness"] or {}
+    openness = {**block, "bucket": _gap_bucket(block.get("class"))}
+    openness.pop("raw", None)
+    if block.get("components"):
+        openness["components"] = components_string(block)
     row = {
         "slug": slug,
         "product": prod["display_name"],

--- a/build/serialize_rubric.py
+++ b/build/serialize_rubric.py
@@ -66,10 +66,10 @@ from pathlib import Path
 import yaml
 
 from build.check_rubric import (
+    components_of,
     dimension_read_map,
     license_read_keys,
     resolve_dimension,
-    split_components,
     split_value,
 )
 from build.rubrics import load_product_types, recipe_for, resolve_recipe_variants
@@ -547,7 +547,7 @@ def build_rubric(sources: dict, policy: dict, routing: dict) -> tuple[dict[str, 
                 declared = ((recipe.get("openness") or {}).get("dimensions")) or {}
 
                 openness = record.get("openness") or {}
-                components = split_components(openness.get("components") or "")
+                components = components_of(openness)
                 if not components:
                     warnings.append(
                         f"product '{product_slug}' in '{slug}' records no openness components"

--- a/docs/guides/product-info.md
+++ b/docs/guides/product-info.md
@@ -221,8 +221,10 @@ search` — which is precisely what the canonical form below forbids.
 
 The license is the clearest case, and the one this guide used to get backwards. It is not
 merely descriptive: it *is* the openness score's basis, recorded in
-`sources/scores/<slug>.yaml` as `openness.components` (`license:Apache-2.0(OSI);…`) with
-`sources[].accessed` behind it and the invariant and the digest requirement in front of it.
+`sources/scores/<slug>.yaml` as `openness.components` — either the legacy flat string
+(`license:Apache-2.0(OSI);…`) or the structured mapping the corpus is migrating to, always
+read via `components_of` rather than assumed to be either shape — with `sources[].accessed`
+behind it and the invariant and the digest requirement in front of it.
 
 Restating it in `comments` creates a second copy with none of that. The two then drift in
 one direction only: a relicense flows correctly through `verification.md`, the score
@@ -230,10 +232,11 @@ updates, and the prose is quietly left wrong with nothing to catch it. That is t
 "liability with no owner" the volatile-facts rule names, made worse by the copy *looking*
 authoritative.
 
-It also buys the reader nothing. `build/serialize.py` emits the whole `openness` dict into
-the payload, and the front end already renders `openness.components` in the product detail
-panel — in larger type than the prose `version_note` directly above it. The license is on
-screen either way; only one copy carries evidence.
+It also buys the reader nothing. `build/serialize.py` emits the `openness` dict into the
+payload, flattening `components` back to a string via `components_string` whichever shape
+the score file carries, and the front end already renders `openness.components` in the
+product detail panel — in larger type than the prose `version_note` directly above it. The
+license is on screen either way; only one copy carries evidence.
 
 So: **read the LICENSE body, and do not write it into prose.** Reading it stays essential —
 the GitHub classifier lies (a custom copyright line makes a genuine MIT/Apache repo report
@@ -372,7 +375,8 @@ Use this to refresh an existing product's prose (the `verify-product` skill auto
 - [ ] No "latest/current version" clause, unless it is identity, terminal, or an absence.
 - [ ] No curator rationale — no "Picked when …" / "Chosen because …" clause in `description`.
 - [ ] No funding round, acquisition, or IPO, unless it says who ships the product now.
-- [ ] No license restatement — it is `openness.components` in the score file.
+- [ ] No license restatement — it is `openness.components` in the score file (string or
+      structured mapping, read via `components_of`, edited only via `build/components.py`).
 - [ ] `comments` says nothing `description` already says — no product facts, footnotes only.
 - [ ] Verification line in canonical form: `Verified <YYYY-MM-DD> via <source>.`
 - [ ] `<source>` names a document someone could reopen, never a method ("web search").

--- a/docs/guides/verification.md
+++ b/docs/guides/verification.md
@@ -50,6 +50,11 @@ score  <-  the rule that fired      (category scoring_recipe)
        <-  a source                 (openness.sources[].url)
 ```
 
+`openness.components` is either the legacy flat string or the structured mapping the corpus
+is migrating to, one dimension at a time; every reader in this repo goes through
+`build.check_rubric.components_of`, which returns the same key -> clause dict whichever
+shape a given file carries, so the audit chain above holds unchanged either way.
+
 Three of those four links hold today. **The third does not.** `sources` is a flat list per
 axis, so nothing records WHICH source establishes WHICH dimension. Measured on 2026-07-30:
 324 of 470 openness axes cite exactly one source, asserted to establish `weights`, `data`,

--- a/docs/schemas/score.schema.json
+++ b/docs/schemas/score.schema.json
@@ -50,8 +50,31 @@
           "description": "The openness VOCABULARY: the band a reader sees, paired with `score`. Eleven values, one per rung any ladder can emit \u2014 the software, model, dataset and hardware ladders do not share a vocabulary, which is why this is longer than the five a single ladder uses. `docs/openness-class-map.json` maps each to a display label, a gradient and the three-way open / open-ish / closed bucket the payload carries. Until 2026-08-08 this was an unconstrained string and the vocabulary lived only in that map and in build/render.py."
         },
         "components": {
-          "type": "string",
-          "description": "The evidence the openness score was read off, as one `k:v;k:v` string with an entry per dimension the category's ladder asks about: `weights:open(Apache-2.0);data:open(Dolma 3, 9.3T tokens);code:open;license:Apache-2.0(OSI)`. The bare value before the first `(` or `,` is what a rule reads; the parenthetical is detail for a human and no formula sees it. This is the most load-bearing field in the corpus, because a category is ladderable only if its VALUES are controlled tokens some dimension's declared enum contains - `edge_hardware` is 71% prose by check_rubric's measure and cannot be laddered whatever its recipe says. Written by whoever scores the product, and edited in place ONLY through build/components.py: 277 of the 472 files fold this string across lines, so the obvious regex substitution splices the old tail onto the new value and corrupts silently. Read by build/check_rubric.py (replays the formula against it), check_verification (the dimensions recorded here are the invariant's scope), check_parity.py (the repo/warehouse differential), and serialize_rubric.py, which emits one warehouse evidence row per component and warns on a key no dimension declares or `reads` - such a key is dropped from the score silently, which is this corpus's recurring bug. All readers share build.check_rubric.split_components, which splits on `;` at paren depth zero because values contain semicolons inside parentheses. Measured 2026-08-08: on all 472 files, 141 distinct keys, of which each ladder declares a handful (`license` on 437, `source` on 295, `core-gated` on 163)."
+          "oneOf": [
+            { "type": "string" },
+            {
+              "type": "object",
+              "minProperties": 1,
+              "properties": {
+                "free_text": {
+                  "type": "array",
+                  "items": { "type": "string" },
+                  "minItems": 1
+                }
+              },
+              "additionalProperties": {
+                "type": "object",
+                "required": ["value"],
+                "properties": {
+                  "value": { "type": "string" },
+                  "detail": { "type": "string" },
+                  "raw": { "type": "string" }
+                },
+                "additionalProperties": false
+              }
+            }
+          ],
+          "description": "The evidence the openness score was read off, as an entry per dimension the category's ladder asks about. Two shapes coexist while the corpus migrates: the legacy flat string, one `k:v;k:v` clause per dimension - `weights:open(Apache-2.0);data:open(Dolma 3, 9.3T tokens);code:open;license:Apache-2.0(OSI)`, where the bare value before the first `(` or `,` is what a rule reads and the parenthetical is detail for a human that no formula sees - and the structured mapping, `key -> {value, detail?, raw?}` plus a reserved `free_text` list for keyless clauses. This is the most load-bearing field in the corpus, because a category is ladderable only if its VALUES are controlled tokens some dimension's declared enum contains - `edge_hardware` is 71% prose by check_rubric's measure and cannot be laddered whatever its recipe says. Written by whoever scores the product, and edited in place ONLY through build/components.py: 277 of the 472 files fold this string across lines, so the obvious regex substitution splices the old tail onto the new value and corrupts silently. Read by build/check_rubric.py (replays the formula against it), check_verification (the dimensions recorded here are the invariant's scope), check_parity.py (the repo/warehouse differential), and serialize_rubric.py, which emits one warehouse evidence row per component and warns on a key no dimension declares or `reads` - such a key is dropped from the score silently, which is this corpus's recurring bug. Every reader goes through build.check_rubric.components_of, which returns the same key -> clause dict whichever shape the file carries; nothing in the repo should call split_components directly on this field anymore. Measured 2026-08-11: on all 472 files, 137 distinct keys, of which each ladder declares a handful (`license` on 439, `source` on 298, `core-gated` on 164)."
         },
         "governing_release": {
           "type": "string",
@@ -80,6 +103,10 @@
           "type": "string",
           "format": "date",
           "description": "The most recent date on which everything in this axis's score was confirmed still correct. Written when the axis is re-checked against its sources, whether or not the value changed. Absent means never confirmed, in which case freshness falls back to the score file's last commit date. Never backfill it from source access dates: opening a URL is a weaker claim than re-confirming a conclusion, and no aggregation of accessed dates fixes that. Normative definition in docs/guides/freshness.md."
+        },
+        "raw": {
+          "type": "string",
+          "description": "The verbatim `openness.components` string this record carried before it was migrated to the structured mapping. Present on every migrated file and on no other. It is the reversibility record for the 155 recordings on 81 products whose `{value, detail}` split cannot be reversed byte-for-byte, the input build/check_components.py compares the mapping against, and the string build/serialize.py puts in the payload so the front end and the rendered notebook see no change from the migration. It is a shadow-phase field and is removed when the mapping becomes the only shape."
         }
       },
       "additionalProperties": false

--- a/skills/refresh-category/SKILL.md
+++ b/skills/refresh-category/SKILL.md
@@ -261,8 +261,10 @@ not less.
 
 - Read-only on the warehouse. No MCP writes, no uploads.
 - Edits `sources/` only, and only for products in the named category.
-- Does not clear deferrals, split a type, restructure `openness.components`, or change a ladder.
-  Each is its own project. If the sweep surfaces evidence for one, record it and carry on.
+- Does not clear deferrals, split a type, restructure `openness.components` (string or
+  structured mapping — edit only via `build/components.py`, never by hand), or change a
+  ladder. Each is its own project. If the sweep surfaces evidence for one, record it and
+  carry on.
 
 ## Related
 

--- a/skills/verify-product/SKILL.md
+++ b/skills/verify-product/SKILL.md
@@ -77,7 +77,9 @@ comes out of the prose rather than staying in on the grounds that it was already
    nothing will notice. Keep a version only when it is the entry's identity (a named model
    release), terminal (the project is archived), or a statement of absence ("no tagged
    releases"). **Strip any license restatement** — the license is `openness.components` in
-   the score file, where it carries evidence and a gate; a second copy in prose only drifts.
+   the score file (string or structured mapping, read via `components_of`, edited only via
+   `build/components.py`), where it carries evidence and a gate; a second copy in prose only
+   drifts.
    Then set the verification line to the canonical form:
    ```
    Verified <YYYY-MM-DD> via <source>.

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -380,3 +380,125 @@ def test_structure_round_trips_every_recorded_components_string():
 
     assert walked > 0, "no string-shaped components reached; the corpus walk is broken"
     assert failures == [], f"structure/recompose does not round-trip: {failures}"
+
+
+def test_check_components_flags_a_mapping_that_disagrees_with_its_raw(tmp_path):
+    """A mangled migration parses, validates, and passes every other gate.
+
+    Every reader takes the mapping at its word, so nothing else in the repo can tell a
+    faithful migration from a lossy one. This gate can, and only because the original
+    string is kept beside it.
+    """
+    from build.check_components import check
+
+    scores = tmp_path / "sources" / "scores"
+    scores.mkdir(parents=True)
+    (scores / "good.yaml").write_text(yaml.safe_dump({"openness": {
+        "components": {"weights": {"value": "open", "detail": "on HF"}},
+        "raw": "weights:open(on HF)",
+    }}, sort_keys=False))
+    (scores / "mangled.yaml").write_text(yaml.safe_dump({"openness": {
+        "components": {"weights": {"value": "closed"}},
+        "raw": "weights:open(on HF)",
+    }}, sort_keys=False))
+
+    failures = check(tmp_path)
+    assert len(failures) == 1
+    assert "mangled.weights" in failures[0]
+
+
+def test_check_components_requires_raw_on_a_migrated_record_and_forbids_it_otherwise(tmp_path):
+    from build.check_components import check
+
+    scores = tmp_path / "sources" / "scores"
+    scores.mkdir(parents=True)
+    (scores / "no-raw.yaml").write_text(yaml.safe_dump({"openness": {
+        "components": {"weights": {"value": "open"}},
+    }}, sort_keys=False))
+    (scores / "stale-raw.yaml").write_text(yaml.safe_dump({"openness": {
+        "components": "weights:open", "raw": "weights:closed",
+    }}, sort_keys=False))
+
+    failures = sorted(check(tmp_path))
+    assert len(failures) == 2
+    assert "no openness.raw" in failures[0]
+    assert "still a string" in failures[1]
+
+
+def test_check_components_flags_a_dropped_keyless_clause(tmp_path):
+    """Dropping a keyless clause deletes evidence with every other gate green.
+
+    `check_recipe`'s blocking test only ever sees clauses that survived
+    `split_components`, which discards these before it runs — which is why it reports 0
+    blocking clauses while 221 of them go unread.
+    """
+    from build.check_components import check
+
+    scores = tmp_path / "sources" / "scores"
+    scores.mkdir(parents=True)
+    (scores / "dropped.yaml").write_text(yaml.safe_dump({"openness": {
+        "components": {"source": {"value": "public"}},
+        "raw": "source:public;no feature-gated core",
+    }}, sort_keys=False))
+
+    failures = check(tmp_path)
+    assert len(failures) == 1
+    assert "free_text" in failures[0]
+
+
+def test_components_string_returns_the_flat_string_unchanged():
+    """Branch 1: `components` is already a string, so there is nothing to recompose.
+
+    This is the only branch the corpus exercises today (all 472 files), and it is also
+    exactly what the payload emitted before this migration touched serialize.py — the
+    property this test protects is that an unmigrated file's payload output is untouched.
+    """
+    from build.check_rubric import components_string
+
+    openness = {"components": "weights:open(on HF);license:MIT"}
+    assert components_string(openness) == "weights:open(on HF);license:MIT"
+
+
+def test_components_string_prefers_the_raw_sibling_over_recomposing():
+    """Branch 2: a migrated record's `raw` wins even though `components` is also present.
+
+    `raw` is the verbatim pre-migration string, so preferring it is what makes the payload
+    byte-identical to what it was before the file moved to the structured shape. If this
+    preferred the recompose path instead, a migration could change the payload's `Components`
+    text without moving a score, which is exactly the silent drift `raw` exists to catch.
+    """
+    from build.check_rubric import components_string
+
+    openness = {
+        "components": {"weights": {"value": "closed"}},  # deliberately disagrees with raw
+        "raw": "weights:open(on HF);license:MIT",
+    }
+    assert components_string(openness) == "weights:open(on HF);license:MIT"
+
+
+def test_components_string_recomposes_a_mapping_with_no_raw_sibling():
+    """Branch 3: a structured mapping with no `raw` to fall back on.
+
+    Every file Tasks 4-9 migrate hits this exact branch until `raw` is added alongside the
+    mapping (or, per `check_components`'s invariant, never — a mapping with no `raw` is a
+    gate failure, but `components_string` itself must still degrade sensibly if called on
+    one). Exercises all three recompose cases in one mapping so a change to any of them
+    fails this test: a keyed entry with a `detail` (parenthesized back on), a keyed entry
+    with no `detail` (bare value), and a keyless `free_text` clause.
+
+    `free_text` clauses are NOT restored into the joined string: `recompose` only walks
+    keyed entries, so a keyless clause that survived structuring is dropped from this
+    fallback's output. That is current, deliberate behavior of `recompose` (it has no key to
+    rejoin the clause under) and this test pins it down rather than leaving it to be
+    discovered by a migrated file's payload going quietly shorter than its `raw`.
+    """
+    from build.check_rubric import FREE_TEXT, components_string
+
+    openness = {
+        "components": {
+            "weights": {"value": "open", "detail": "on HF"},
+            "license": {"value": "MIT"},
+            FREE_TEXT: ["no feature-gated core"],
+        },
+    }
+    assert components_string(openness) == "weights:open(on HF);license:MIT"

--- a/tests/test_openness_buckets.py
+++ b/tests/test_openness_buckets.py
@@ -178,3 +178,22 @@ def test_validate_vocabulary_is_a_subset_of_the_schema_enum():
 
     permitted = {cls for classes in OPENNESS_CLASSES.values() for cls in classes}
     assert permitted <= allowed, f"validate.py permits classes the schema forbids: {sorted(permitted - allowed)}"
+
+
+def test_payload_openness_carries_a_string_components_and_never_raw():
+    """The payload's contract with the front end does not change with the record's shape.
+
+    build/render.py and the rendered notebook both do `row('Components', o.components)`, and
+    the notebook is bot-owned — `generated-files-guard` fails any PR that edits it. So the
+    payload key stays a string whatever `sources/scores/` carries, and the shadow `raw`
+    sibling never ships.
+    """
+    payload = json.loads((ROOT / "build" / "notebook_data.json").read_text())
+    for category in payload["categories"].values():
+        for row in category["products"]:
+            openness = row.get("openness") or {}
+            assert "raw" not in openness, f"{row['slug']}: payload openness carries raw"
+            components = openness.get("components")
+            assert components is None or isinstance(components, str), (
+                f"{row['slug']}: payload components is {type(components).__name__}, not a string"
+            )


### PR DESCRIPTION
## Summary

Second task of the structured-dimensions migration. **No data changes** — `sources/` is untouched. This widens the schema to admit the structured mapping and routes every reader through one function, so the corpus can then be migrated file by file without any reader caring which shape a given file is in.

- `docs/schemas/score.schema.json` — `components` becomes `oneOf(string | mapping)`, and `raw` is admitted as a sibling. `openness` carries `additionalProperties: false`, so both had to be declared explicitly. Malformed input is still rejected: a non-object entry, an entry missing `value`, an entry with an unknown key, and an empty mapping all still fail.
- Six readers now go through `components_of` / `components_string`: `check_rubric`, `check_parity`, `check_verification`, `serialize_rubric`, and `check_recipe` in two places. A repo-wide sweep found no reader missed.
- `build/check_components.py` — a new gate, wired into CI between the recipe and rubric gates. It catches a mangled migration, a missing or stale `raw`, and a dropped keyless clause.

## The payload stays a flat string

`serialize.py` passed the openness block through wholesale, so a structured block would have flowed into the published payload and broken `render.py` and the bot-generated notebook. It now forces `components` back to a string and drops the `raw` sibling before serializing.

That is what keeps this phase's defining property mechanically checkable: **zero published scores move.** After a dry-run serialize, `git diff --numstat build/notebook_data.json` prints `1 1` — the sole diff being the `generated` date stamp.

## Not in this PR, deliberately

`head()` is untouched, including its two calls in `check_recipe`. It truncates licenses at the first paren and conceals restrictive halves on five products; surfacing those moves real published scores, which belongs in its own change where each move can be judged on its merits.

## Test plan

- Suite 414 -> 421. `validate` 0 error(s), `check_recipe` 0 failure(s), `check_rubric` exit 0, `check_components` `[OK]`.
- `components_string`'s three branches each have a dedicated test built on hand-made fixtures rather than corpus data — the dict-recompose branch is what every migrated file will hit, so it is tested before any file is migrated. Those tests also pin a behavior worth knowing: `recompose` drops `free_text`.
- The new gate's own tests construct fixture YAML and assert on failure messages, not on internal calls.
- Payload byte-identical apart from the date stamp.
- Docs and skills describe the two shapes as coexisting during the migration rather than asserting the structured shape already exists.
