### PR TITLE
fix(freshness): date a score file from its last claim change, not its last touch

### DIFF
--- a/build/check_freshness.py
+++ b/build/check_freshness.py
@@ -17,7 +17,9 @@ when the two disagree the guide wins.
     the field landed, and watching that fill in is how we measure the automation.
   * **The score file's last commit date** — the fallback. Somebody committed this
     file on that date and left the score standing, which git records and nobody can
-    inflate. Weaker than a re-check and *not* presented as one.
+    inflate. Weaker than a re-check and *not* presented as one. Read `commit_dates` for
+    why "committed this file" has to mean a commit that changed what the file claims,
+    and not simply one that touched it.
 
 `last_verified` is deliberately NOT backfilled from `sources[].accessed`. Someone
 opening a URL is a weaker claim than the conclusion being re-confirmed, and copying
@@ -46,6 +48,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import copy
 import subprocess
 from collections import defaultdict
 from datetime import date, datetime
@@ -53,8 +56,18 @@ from pathlib import Path
 
 import yaml
 
+from build.check_rubric import FREE_TEXT, _clauses, components_of
+
 ROOT = Path(__file__).resolve().parents[1]
 AXES = ("openness", "adoption", "capability")
+
+# `git log --raw` writes this in the old- or new-blob column for an add or a delete.
+NULL_SHA = "0" * 40
+
+# The walk parses roughly a thousand historical blobs, which is the whole cost of dating
+# by content rather than by touch. libyaml does it in roughly a quarter of the time and is
+# already present; falling back keeps the module importable where it is not.
+_LOADER = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
 
 
 def parse_date(value: object) -> date | None:
@@ -68,8 +81,157 @@ def parse_date(value: object) -> date | None:
     return None
 
 
+def score_projection(text: str) -> object | None:
+    """The claim-bearing content of a score file, invariant to how it is stored.
+
+    Two revisions with equal projections say the same thing about the product, however
+    differently they spell it. That is the test for whether a commit reviewed anything.
+
+    Only one storage choice is normalized away, because only one exists: `openness.
+    components` is either the flat `k:v;k:v` string or the Phase 1a mapping plus its
+    verbatim `openness.raw` sibling. `components_of` is the single reader for both
+    (#186), so this reduces each shape to the same key -> clause dict and drops `raw`,
+    which is the migration's own bookkeeping rather than a claim. `free_text` rides
+    along because the keyless clauses `split_components` discards are still published in
+    the flat string, so losing one is not score-neutral.
+
+    Everything else in the document is compared as it stands. The normalization is narrow
+    on purpose: any field this ignored could then be changed without moving the date, and
+    nothing would report it.
+
+    **The blind spot, and the maintenance rule it implies.** A component ENTRY is compared
+    only through `recompose`, which reads `entry["raw"]` when there is one and otherwise
+    `f"{value}({detail})"`. Nothing else inside an entry reaches this comparison. So adding
+    `license_tier: 3` to an entry does not move the date, and neither does changing
+    `entry["value"]` on an entry that carries a `raw` — `recompose` returns the `raw` and
+    never looks. That is inert today because no reader reads any other per-entry key, but
+    Phase 1a exists to make entries structured, so the first real field added under one
+    would land silently unversioned. **When a per-entry field lands, add it here in the
+    same change.** This is a different case from the paragraph above, which is about
+    top-level fields; neither note covers the other.
+
+    Returns None for a revision that will not parse. A blob nothing can read cannot be
+    shown score-neutral, and the caller treats that as a change rather than a match.
+    """
+    try:
+        doc = yaml.load(text, Loader=_LOADER)
+    except yaml.YAMLError:
+        return None
+    if not isinstance(doc, dict):
+        return None
+    doc = copy.deepcopy(doc)
+    openness = doc.get("openness")
+    if isinstance(openness, dict) and "components" in openness:
+        components = openness.get("components")
+        if isinstance(components, dict):
+            free = list(components.get(FREE_TEXT) or [])
+        else:
+            free = [c.strip() for c in _clauses(str(components or "")) if ":" not in c.strip()]
+        openness["components"] = {"clauses": components_of(openness), FREE_TEXT: free}
+        openness.pop("raw", None)
+    return doc
+
+
+class _Blobs:
+    """Blob text by sha, from one long-lived `git cat-file --batch`.
+
+    One process for the whole walk. The alternative — `git show` per revision — is a
+    process spawn per blob, and `commit_dates` runs inside `serialize`, which runs in CI.
+    """
+
+    def __init__(self, root: Path) -> None:
+        self._proc = subprocess.Popen(
+            ["git", "cat-file", "--batch"],
+            cwd=root,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+        )
+        self._cache: dict[str, str | None] = {}
+
+    def text(self, sha: str) -> str | None:
+        if sha not in self._cache:
+            self._proc.stdin.write(f"{sha}\n".encode())
+            self._proc.stdin.flush()
+            header = self._proc.stdout.readline().split()
+            if len(header) < 3:
+                # "<sha> missing". Nothing to read back, and the caller must not treat
+                # an unreadable revision as equal to anything.
+                self._cache[sha] = None
+            else:
+                data = self._proc.stdout.read(int(header[2]))
+                self._proc.stdout.read(1)  # the batch record's trailing newline
+                self._cache[sha] = data.decode("utf-8", "replace")
+        return self._cache[sha]
+
+    def close(self) -> None:
+        self._proc.stdin.close()
+        self._proc.stdout.close()
+        self._proc.wait()
+
+
+def _score_history(root: Path) -> dict[str, list[tuple[date, str, str]]]:
+    """slug -> [(commit date, old blob, new blob)], newest first.
+
+    One `git log` for the whole directory rather than 472 invocations, and `--raw` rather
+    than `--name-only` so each entry carries the blob shas the walk needs — no second
+    round trip to find out what a commit did to a file.
+
+    `--no-renames` on purpose: a rename then reads as a delete plus an add, and an add is
+    where a slug's history honestly starts. With detection on, a pure rename would be
+    score-neutral for the new slug and the walk would run off the end of its history.
+    """
+    result = subprocess.run(
+        ["git", "log", "--format=%x01%cs", "--raw", "--no-abbrev", "--no-renames",
+         "--", "sources/scores"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+    )
+    history: dict[str, list[tuple[date, str, str]]] = defaultdict(list)
+    current: date | None = None
+    for line in result.stdout.splitlines():
+        if line.startswith("\x01"):
+            current = parse_date(line[1:].strip())
+            continue
+        if current is None or not line.startswith(":"):
+            continue
+        meta, _, path = line.partition("\t")
+        path = path.split("\t")[-1].strip()
+        if not (path.startswith("sources/scores/") and path.endswith(".yaml")):
+            continue
+        fields = meta.split()
+        if len(fields) < 4:
+            continue
+        history[path[len("sources/scores/") : -len(".yaml")]].append(
+            (current, fields[2], fields[3])
+        )
+    return history
+
+
+def _last_substantive(entries: list[tuple[date, str, str]], blobs: _Blobs) -> date | None:
+    """The newest commit in `entries` that changed what the file claims.
+
+    Walks newest-first and skips a commit whose two revisions of this file project to the
+    same thing. An add or a delete is never skipped: there is no other revision to compare
+    against, and both are real events in the file's life.
+
+    If every commit in reach is structural the oldest one is returned rather than nothing,
+    which only happens when history has been truncated beneath the file's add.
+    """
+    for when, old_sha, new_sha in entries:
+        if old_sha == NULL_SHA or new_sha == NULL_SHA:
+            return when
+        old_text, new_text = blobs.text(old_sha), blobs.text(new_sha)
+        if old_text is None or new_text is None:
+            return when
+        before, after = score_projection(old_text), score_projection(new_text)
+        if before is None or after is None or before != after:
+            return when
+    return entries[-1][0] if entries else None
+
+
 def commit_dates(root: Path | None = None) -> dict[str, date]:
-    """Most recent commit date per score file, from one pass over git history.
+    """Date of the last commit that changed what each score file CLAIMS.
 
     This is the fallback when an axis carries no `last_verified`, and it is a better
     one than `max(sources[].accessed)`. Committing a score file is somebody asserting
@@ -84,34 +246,36 @@ def commit_dates(root: Path | None = None) -> dict[str, date]:
     nobody has revisited this - which is why the label says `commit` and not
     `verified`.
 
-    One `git log` for the whole directory rather than 495 invocations. Walking
-    newest-first, the first time a path appears is its latest commit.
+    ## Why it is not simply the last commit that touched the file
+
+    Because some commits touch a file without reviewing it. The Phase 1a migration
+    reshapes `openness.components` from a string into a mapping in all 472 files while
+    carrying a byte-identical `raw:` copy of the string, so nothing a reader would call
+    a claim moves — and the naive fallback would republish every one of them as freshly
+    reviewed on the migration day. A commit date is only defensible here because it
+    dates a review; a commit that reviewed nothing must not supply one, or the fallback
+    starts making the same category error `sources[].accessed` made.
+
+    So the walk goes newest-first per file and skips any commit whose two revisions of
+    that file have the same `score_projection`. This needs no convention and no trailer:
+    a commit cannot claim to have reviewed something the content says it did not touch,
+    and it works on history already written.
+
+    One `git log` for the whole directory and one `git cat-file --batch` for the blobs,
+    rather than a process per file.
 
     `root` defaults to this module's own repository root, which is what every existing
     caller in this file wants. `build.freshness_payload` passes its own `root` through
     explicitly so it can be pointed at a different checkout (a test fixture, a shallow-
     clone probe) without silently reading this repository's history instead.
     """
-    result = subprocess.run(
-        ["git", "log", "--format=%cs", "--name-only", "--", "sources/scores"],
-        cwd=root or ROOT,
-        capture_output=True,
-        text=True,
-    )
-    latest: dict[str, date] = {}
-    current: date | None = None
-    for line in result.stdout.splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        # A `%cs` line parses as a date; a path line does not. That is the whole
-        # discriminator, so no state machine is needed.
-        parsed = parse_date(line)
-        if parsed is not None:
-            current = parsed
-        elif current is not None and line.startswith("sources/scores/") and line.endswith(".yaml"):
-            latest.setdefault(line[len("sources/scores/") : -len(".yaml")], current)
-    return latest
+    history = _score_history(root or ROOT)
+    blobs = _Blobs(root or ROOT)
+    try:
+        dates = {slug: _last_substantive(entries, blobs) for slug, entries in history.items()}
+    finally:
+        blobs.close()
+    return {slug: when for slug, when in dates.items() if when is not None}
 
 
 def collect() -> tuple[dict[str, list[tuple[str, str, date, bool]]], list[str]]:

--- a/build/freshness_payload.py
+++ b/build/freshness_payload.py
@@ -4,9 +4,15 @@ docs/guides/freshness.md is normative. Two tiers, and the payload says which one
 so the page can label the weaker claim rather than passing it off as the stronger one:
 
   verified  the score file carries last_verified. 6 of 470 today.
-  commit    the git commit date of sources/scores/<slug>.yaml.
+  commit    the date of the last commit that changed what sources/scores/<slug>.yaml
+            claims. Commits that only changed how a score is stored are skipped, so a
+            shape migration cannot republish a product as freshly reviewed.
 
 A date is NEVER derived from sources[].accessed (freshness.md:30).
+
+There is nothing to fix in this module for that last point: it takes the commit tier
+from `check_freshness.commit_dates`, which is where the skip lives, so the report and
+the payload cannot disagree about what a commit date means.
 """
 import subprocess
 from pathlib import Path

--- a/docs/guides/freshness.md
+++ b/docs/guides/freshness.md
@@ -46,12 +46,44 @@ staleness of 55 days when the files had in fact been revised a median of 35 days
 
 ## The fallback: the score file's last commit date
 
-Most axes carry no `last_verified` yet. For those, freshness falls back to **the last
-commit date of `sources/scores/<slug>.yaml`**.
+Most axes carry no `last_verified` yet. For those, freshness falls back to **the date of
+the last commit that changed what `sources/scores/<slug>.yaml` claims**.
 
 Somebody committed that file on that date and left the score standing, which is a
 review rather than a reading. Git records it, and nobody can inflate it. As #102 put
 it, the git history of a score file *is* its verification record.
+
+**Changed what it claims, not merely touched.** Some commits move a file without
+reviewing it. The Phase 1a migration reshapes `openness.components` from a string into a
+mapping in all 472 files, carrying a byte-identical `raw:` copy of the string it
+replaced, so no published value moves — and dating by touch would have republished 78 of
+the first batch's 84 products as reviewed on the migration day. A commit date is only
+defensible here because it dates a review, so a commit that reviewed nothing must not
+supply one. Otherwise the fallback makes the same category error as `sources[].accessed`:
+a weak signal promoted into a confirmation claim.
+
+`build/check_freshness.py` decides this by content rather than by convention. It walks a
+file's history newest-first and skips any commit whose two revisions of that file have
+the same `score_projection` — the whole document, with only the two storage shapes of
+`openness.components` reduced to one. Nothing has to be labeled or trailered, a commit
+cannot assert a review the content contradicts, and it works retroactively.
+
+Two exceptions worth knowing before you go looking for them.
+
+**Reordering the clauses of a `components` string does not advance the date**, because the
+projection compares clauses as a key -> clause mapping and a mapping has no order. This is
+the one case where something visible on the page moves — the published string is emitted in
+file order — while the date stands still. It is the right call on the rule as written,
+since clause order is storage rather than claim, but it is a real gap between what a reader
+sees change and what the date says changed.
+
+**A `git mv` of a score file resets its date to the rename commit.** Attribution runs with
+`--no-renames`, so a rename reads as a delete plus an add, and an add is where a slug's
+history starts. A rename is exactly the kind of structural touch this fix exists to skip,
+so the exception is deliberate rather than an oversight: with rename detection on, a pure
+rename is score-neutral for the new path and the walk runs off the end of its history with
+nothing to date it from. The cost is bounded because slugs are tier-level and immutable, so
+a score file should not be renamed in the normal course of things.
 
 **What the fallback does not claim.** For a file untouched since it was added, the
 commit date dates the import, not a review. That is still the answer to the question
@@ -64,7 +96,7 @@ can never be conflated.
 | field | where | what it answers |
 |---|---|---|
 | `last_verified` | `sources/scores/<slug>.yaml`, per axis | Is this score still right? Authoritative. |
-| score file commit date | git | Same question, weaker. Used when `last_verified` is absent. |
+| score file commit date | git | Same question, weaker. Used when `last_verified` is absent. Dates the last commit that changed a claim, skipping ones that only changed storage. |
 | `sources[].accessed` | `sources/scores/<slug>.yaml`, per source | When was this specific URL read? Evidence provenance. **Not freshness.** |
 | `last_checked` | `currentai.scores.openness_computed` | When did the pipeline last read *any* admitted evidence. Diagnostic. **Not freshness.** |
 | `fact_accessed` | `currentai.scores.openness_facts`, per dimension | When the evidence behind one dimension was read or fetched. Provenance, per fact. **Not freshness.** |

--- a/tests/test_commit_dates_skip_structural.py
+++ b/tests/test_commit_dates_skip_structural.py
@@ -1,0 +1,207 @@
+"""The commit-date fallback must date a claim, not a reshape.
+
+`docs/guides/freshness.md` says the fallback dates the last commit that left the score
+standing — a review. A commit that only changes how a score is *stored* reviewed nothing,
+so it must not move the date.
+
+Phase 1a is the case that forced this: `openness.components` becomes a mapping carrying a
+byte-identical `raw:` copy of the string it replaced. No claim moves, but the file is
+committed, and the naive fallback would republish every touched product as freshly
+reviewed on the migration date.
+
+Every test here builds a real git repository and makes real commits. Mocking `git log`
+would restate the implementation rather than test it, and the thing under test is exactly
+what git reports.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import date
+from pathlib import Path
+
+import yaml
+
+from build.check_freshness import commit_dates
+from build.check_rubric import structure
+
+STRING_FORM = """product: widget
+openness:
+  score: 5
+  class: open_source
+  components: license:Apache-2.0(OSI);source:public;core-gated:ungated;governance:vLLM-project(community,PyTorch-ecosystem
+    adjacent)
+  confidence: high
+adoption:
+  level: 4
+  reach: 1M-10M
+"""
+
+
+def _run(repo: Path, *args: str, when: str | None = None) -> None:
+    env = None
+    if when is not None:
+        stamp = f"{when}T12:00:00+00:00"
+        env = {"GIT_AUTHOR_DATE": stamp, "GIT_COMMITTER_DATE": stamp}
+    subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        env={**_base_env(), **(env or {})},
+    )
+
+
+def _base_env() -> dict[str, str]:
+    import os
+
+    return {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "T",
+        "GIT_AUTHOR_EMAIL": "t@example.com",
+        "GIT_COMMITTER_NAME": "T",
+        "GIT_COMMITTER_EMAIL": "t@example.com",
+    }
+
+
+def _repo(tmp_path: Path) -> Path:
+    _run(tmp_path, "init", "-q", "-b", "main", str(tmp_path))
+    (tmp_path / "sources" / "scores").mkdir(parents=True)
+    return tmp_path
+
+
+def _commit(repo: Path, slug: str, text: str, when: str, message: str = "change") -> None:
+    (repo / "sources" / "scores" / f"{slug}.yaml").write_text(text)
+    _run(repo, "add", "-A")
+    _run(repo, "commit", "-q", "-m", message, when=when)
+
+
+def _migrated(text: str) -> str:
+    """The Phase 1a reshape: components becomes a mapping, the string moves to `raw`."""
+    doc = yaml.safe_load(text)
+    raw = doc["openness"]["components"]
+    doc["openness"]["components"] = structure(raw)
+    doc["openness"]["raw"] = raw
+    return yaml.safe_dump(doc, sort_keys=False, width=100)
+
+
+def test_a_structural_reshape_does_not_advance_the_date(tmp_path):
+    """The defect. Migrating the components shape re-verified nothing."""
+    repo = _repo(tmp_path)
+    _commit(repo, "widget", STRING_FORM, "2026-06-01", "score widget")
+    _commit(repo, "widget", _migrated(STRING_FORM), "2026-08-11", "migrate components shape")
+
+    assert commit_dates(repo)["widget"] == date(2026, 6, 1)
+
+
+def test_a_changed_claim_still_advances_the_date(tmp_path):
+    """The converse. A fix that froze every date would be worse than the bug."""
+    repo = _repo(tmp_path)
+    _commit(repo, "widget", STRING_FORM, "2026-06-01", "score widget")
+    _commit(repo, "widget", STRING_FORM.replace("score: 5", "score: 4"), "2026-08-11", "correct score")
+
+    assert commit_dates(repo)["widget"] == date(2026, 8, 11)
+
+
+def test_a_reshape_that_also_changes_a_component_advances_the_date(tmp_path):
+    """A migration that mangled one value is a claim change, and must be dated as one."""
+    repo = _repo(tmp_path)
+    _commit(repo, "widget", STRING_FORM, "2026-06-01", "score widget")
+    mangled = _migrated(STRING_FORM).replace("value: ungated", "value: gated")
+    assert "value: gated" in mangled
+    _commit(repo, "widget", mangled, "2026-08-11", "migrate components shape")
+
+    assert commit_dates(repo)["widget"] == date(2026, 8, 11)
+
+
+def test_a_reshape_that_drops_a_keyless_clause_advances_the_date(tmp_path):
+    """`free_text` is published in the flat string, so losing one is not score-neutral."""
+    repo = _repo(tmp_path)
+    with_keyless = STRING_FORM.replace(
+        "components: license:Apache-2.0(OSI)", "components: no-model-card;license:Apache-2.0(OSI)"
+    )
+    _commit(repo, "widget", with_keyless, "2026-06-01", "score widget")
+    doc = yaml.safe_load(_migrated(with_keyless))
+    doc["openness"]["components"].pop("free_text")
+    doc["openness"]["raw"] = doc["openness"]["raw"].replace("no-model-card;", "")
+    _commit(repo, "widget", yaml.safe_dump(doc, sort_keys=False, width=100), "2026-08-11", "migrate")
+
+    assert commit_dates(repo)["widget"] == date(2026, 8, 11)
+
+
+def test_consecutive_structural_commits_are_all_skipped(tmp_path):
+    """Six migration batches, and a reformat on top, must not stack into a fresh date."""
+    repo = _repo(tmp_path)
+    _commit(repo, "widget", STRING_FORM, "2026-06-01", "score widget")
+    _commit(repo, "widget", _migrated(STRING_FORM), "2026-08-11", "migrate components shape")
+    reflowed = _migrated(STRING_FORM).replace("\nadoption:", "\n\nadoption:")
+    _commit(repo, "widget", reflowed, "2026-08-12", "reflow")
+
+    assert commit_dates(repo)["widget"] == date(2026, 6, 1)
+
+
+def test_a_file_never_touched_since_it_was_added_keeps_its_add_date(tmp_path):
+    repo = _repo(tmp_path)
+    _commit(repo, "widget", STRING_FORM, "2026-06-01", "score widget")
+
+    assert commit_dates(repo)["widget"] == date(2026, 6, 1)
+
+
+def test_the_walk_survives_an_unparseable_revision_in_history(tmp_path):
+    """Nothing crashes, and the date is the commit that made the file readable.
+
+    Note this passes on either rule: the two revisions also differ, so `before != after`
+    would carry it. The rule that an unparseable blob COUNTS AS a change is pinned by the
+    test below, where that comparison cannot fire.
+    """
+    repo = _repo(tmp_path)
+    _commit(repo, "widget", "product: widget\nopenness: [unclosed\n", "2026-06-01", "wip")
+    _commit(repo, "widget", STRING_FORM, "2026-08-11", "score widget")
+
+    assert commit_dates(repo)["widget"] == date(2026, 8, 11)
+
+
+def test_two_unparseable_revisions_are_not_treated_as_score_identical(tmp_path):
+    """Both revisions project to None, so only the None-as-change rule can date this.
+
+    Equality alone would call the commit structural — None == None — skip it, and hand
+    back the older date. A revision nothing can read has not been SHOWN score-neutral, and
+    the walk must not infer that it was.
+    """
+    repo = _repo(tmp_path)
+    _commit(repo, "widget", STRING_FORM, "2026-06-01", "score widget")
+    _commit(repo, "widget", "product: widget\nopenness: [unclosed\n", "2026-07-01", "wip")
+    _commit(repo, "widget", "product: widget\nopenness: [still unclosed\n", "2026-08-11", "wip")
+
+    assert commit_dates(repo)["widget"] == date(2026, 8, 11)
+
+
+def test_other_files_in_a_structural_commit_are_unaffected(tmp_path):
+    """One commit can be structural for one file and substantive for another."""
+    repo = _repo(tmp_path)
+    _commit(repo, "widget", STRING_FORM, "2026-06-01", "score widget")
+    (repo / "sources" / "scores" / "gadget.yaml").write_text(STRING_FORM.replace("widget", "gadget"))
+    _run(repo, "add", "-A")
+    _run(repo, "commit", "-q", "-m", "add gadget", when="2026-07-01")
+
+    (repo / "sources" / "scores" / "widget.yaml").write_text(_migrated(STRING_FORM))
+    (repo / "sources" / "scores" / "gadget.yaml").write_text(
+        STRING_FORM.replace("widget", "gadget").replace("score: 5", "score: 3")
+    )
+    _run(repo, "add", "-A")
+    _run(repo, "commit", "-q", "-m", "migrate widget, correct gadget", when="2026-08-11")
+
+    dates = commit_dates(repo)
+    assert dates["widget"] == date(2026, 6, 1)
+    assert dates["gadget"] == date(2026, 8, 11)
+
+
+def test_a_deleted_file_keeps_the_date_of_its_last_real_change(tmp_path):
+    """Deletion is not a reshape; it must not crash the walk either."""
+    repo = _repo(tmp_path)
+    _commit(repo, "widget", STRING_FORM, "2026-06-01", "score widget")
+    (repo / "sources" / "scores" / "widget.yaml").unlink()
+    _run(repo, "add", "-A")
+    _run(repo, "commit", "-q", "-m", "retire widget", when="2026-08-11")
+
+    assert commit_dates(repo)["widget"] == date(2026, 8, 11)


### PR DESCRIPTION
## Summary

A product's freshness date falls back to the last commit that touched its score file when an axis carries no `last_verified`. That fallback dates a file from its last *touch*, not its last *claim change*, so any mechanical edit republishes the product as freshly verified.

This matters now because the structured-components migration is about to reshape all 472 score files without changing a single claim. Measured on that migration's first batch: a dry-run serialize moved **78 of 84** products from `2026-08-08` to the migration date. `git diff --numstat build/notebook_data.json` printed `79 79` where the migration promises `1 1`.

Attribution now walks a file's history newest-first and skips any commit whose two revisions have the same score projection — the whole document, with the two `components` shapes normalized through `components_of` and `openness.raw` dropped. The date keeps meaning what `docs/guides/freshness.md` says it means.

No `last_verified` is invented. Writing an old commit date into that field was considered and rejected: it asserts everything in the score was confirmed on that date, which a commit date never established.

## Verified end to end

Against the real migration branch, in a throwaway worktree:

```
unfixed                     -> 79  79  build/notebook_data.json
same tree + this fix        ->  1   1  build/notebook_data.json
```

The fix is inert on existing history: `check_freshness`'s report is byte-identical before and after, and the payload on this branch diffs only the `generated` stamp.

## Two exceptions, now documented

`freshness.md` records both rather than leaving them to be discovered:

- Reordering clauses within `components` changes the published string without moving the date. Ordering is storage, not a claim, but it is the one visible value that can move without the date.
- A `git mv` resets a file's date to the rename commit, because attribution runs `--no-renames`. Slugs are immutable here, so a rename genuinely starts a new record.

## Test plan

- New tests run against real temporary git repositories with real commits and pinned committer dates. No mocking of `git log` — mocking the thing under test would restate the implementation.
- Three of them fail on `main` for the right reason (`assert date(2026, 8, 11) == date(2026, 6, 1)`).
- The converse is covered: a commit that genuinely changes a claim still advances the date, including a reshape that drops a keyless clause, where `free_text` is the only discriminator.
- The None-as-change guard is pinned by mutation: reducing it to a bare inequality fails that test and only that test.
- Suite 421 -> 431. `validate` 0 error(s), `check_recipe` 0 failure(s), `check_rubric` exit 0, `check_components` `[OK]`.
- `serialize` goes from about 2.5s to about 3.0s. Cost tracks commits walked per file until a real change, not corpus size.
