### PR TITLE
refactor(scores): migrate the 84 unambiguous components records to the structured mapping

### DIFF
--- a/sources/scores/ai2-arc.yaml
+++ b/sources/scores/ai2-arc.yaml
@@ -2,10 +2,23 @@ product: ai2-arc
 openness:
   score: 5
   class: open
-  components: data:open(7,787 questions, downloadable on HF);license:CC-BY-SA-4.0(open data license, redistributable);datasheet:yes(HF
-    dataset card + arXiv paper);access:public(train/val/test splits all released, not held-out)
+  components:
+    data:
+      value: open
+      detail: 7,787 questions, downloadable on HF
+    license:
+      value: CC-BY-SA-4.0
+      detail: open data license, redistributable
+    datasheet:
+      value: 'yes'
+      detail: HF dataset card + arXiv paper
+    access:
+      value: public
+      detail: train/val/test splits all released, not held-out
   confidence: high
   note: Fully open under CC-BY-SA-4.0 with dataset card; the canonical open-data benchmark profile.
+  raw: data:open(7,787 questions, downloadable on HF);license:CC-BY-SA-4.0(open data license, redistributable);datasheet:yes(HF
+    dataset card + arXiv paper);access:public(train/val/test splits all released, not held-out)
   sources:
   - url: https://huggingface.co/datasets/allenai/ai2_arc
     shows: CC-BY-SA-4.0, 7,787 questions, public splits, dataset card, ~479K downloads last month

--- a/sources/scores/alia-40b.yaml
+++ b/sources/scores/alia-40b.yaml
@@ -2,15 +2,31 @@ product: alia-40b
 openness:
   score: 4
   class: open_weights
-  components: weights:open(Apache-2.0, safetensors on HF BSC-LT/ALIA-40b);data:documented-not-released(60+
-    named sources described in the model card, but the pretraining corpus "will not be released or distributed
-    to third parties");code:open(all training scripts + configuration files at github.com/langtech-bsc/alia);checkpoints:not-released;license:Apache-2.0(OSI)
+  components:
+    weights:
+      value: open
+      detail: Apache-2.0, safetensors on HF BSC-LT/ALIA-40b
+    data:
+      value: documented-not-released
+      detail: 60+ named sources described in the model card, but the pretraining corpus "will not be released
+        or distributed to third parties"
+    code:
+      value: open
+      detail: all training scripts + configuration files at github.com/langtech-bsc/alia
+    checkpoints:
+      value: not-released
+    license:
+      value: Apache-2.0
+      detail: OSI
   confidence: high
   note: 'Strong open-weights release that stops one notch short of full openness: permissive Apache-2.0
     weights plus the complete training code/recipe published on GitHub, but the pretraining corpus is only
     documented (60+ named sources) rather than released or reconstructable. That missing open-data component
     is the bright line that keeps it at open_weights (4) rather than the OLMo/Pythia/Apertus open_source
     (5) tier, where Apertus reaches 5 by shipping data-reconstruction scripts. No intermediate checkpoints.'
+  raw: weights:open(Apache-2.0, safetensors on HF BSC-LT/ALIA-40b);data:documented-not-released(60+ named
+    sources described in the model card, but the pretraining corpus "will not be released or distributed
+    to third parties");code:open(all training scripts + configuration files at github.com/langtech-bsc/alia);checkpoints:not-released;license:Apache-2.0(OSI)
   sources:
   - url: https://huggingface.co/BSC-LT/ALIA-40b
     shows: Apache-2.0 license; downloadable safetensors weights; 40.4B params; 9.37T training tokens; corpus

--- a/sources/scores/amazon-nova.yaml
+++ b/sources/scores/amazon-nova.yaml
@@ -2,12 +2,22 @@ product: amazon-nova
 openness:
   score: 1
   class: closed
-  components: weights:closed;data:closed;code:closed;license:Proprietary(API-only via Amazon Bedrock)
+  components:
+    weights:
+      value: closed
+    data:
+      value: closed
+    code:
+      value: closed
+    license:
+      value: Proprietary
+      detail: API-only via Amazon Bedrock
   governing_release: amazon-nova-pro
   confidence: high
   note: Served only through Amazon Bedrock with no weights released, so 1/closed. Nova Pro governs and carries adoption
     4; the broader Nova record scored 3. Consolidated because Amazon markets Nova as one family with Micro, Lite
     and Pro as tiers within it.
+  raw: weights:closed;data:closed;code:closed;license:Proprietary(API-only via Amazon Bedrock)
   sources:
   - url: https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html
     shows: Nova Pro accessed only through API via Amazon Bedrock; multimodal understanding model

--- a/sources/scores/anthropic-internal-coding-evals.yaml
+++ b/sources/scores/anthropic-internal-coding-evals.yaml
@@ -2,10 +2,21 @@ product: anthropic-internal-coding-evals
 openness:
   score: 0
   class: closed
-  components: data:closed(internal coding eval/take-home exam sets, never published);datasheet:no;license:none;access:internal-only(referenced
-    in announcements/system cards, not distributed)
+  components:
+    data:
+      value: closed
+      detail: internal coding eval/take-home exam sets, never published
+    datasheet:
+      value: 'no'
+    license:
+      value: none
+    access:
+      value: internal-only
+      detail: referenced in announcements/system cards, not distributed
   confidence: high
   note: Internal proprietary coding eval sets; only narrative results are mentioned, the data is not redistributable.
+  raw: data:closed(internal coding eval/take-home exam sets, never published);datasheet:no;license:none;access:internal-only(referenced
+    in announcements/system cards, not distributed)
   sources:
   - url: https://www.anthropic.com/news/claude-opus-4-5
     shows: references to internal coding benchmarks and an internal performance-engineering take-home

--- a/sources/scores/apertus.yaml
+++ b/sources/scores/apertus.yaml
@@ -2,9 +2,22 @@ product: apertus
 openness:
   score: 5
   class: open_source
-  components: weights:open(Apache-2.0, BF16 safetensors);data:open(full pretraining-data reconstruction
-    scripts, github.com/swiss-ai/pretrain-data);code:open(Megatron-LM training recipe + reconstruction
-    scripts);checkpoints:open(intermediate checkpoints on HF branches);license:Apache-2.0(OSI)
+  components:
+    weights:
+      value: open
+      detail: Apache-2.0, BF16 safetensors
+    data:
+      value: open
+      detail: full pretraining-data reconstruction scripts, github.com/swiss-ai/pretrain-data
+    code:
+      value: open
+      detail: Megatron-LM training recipe + reconstruction scripts
+    checkpoints:
+      value: open
+      detail: intermediate checkpoints on HF branches
+    license:
+      value: Apache-2.0
+      detail: OSI
   confidence: high
   note: 'Among the most transparent large-model releases to date: open weights, open data (reconstruction
     scripts rather than a raw dump, to respect opt-out/robots.txt and strip personal data), open training
@@ -12,6 +25,9 @@ openness:
     data-protection/copyright compliance docs. All Apache-2.0. Sits in the OLMo/Pythia full-openness
     tier.'
   last_verified: '2026-07-30'
+  raw: weights:open(Apache-2.0, BF16 safetensors);data:open(full pretraining-data reconstruction scripts,
+    github.com/swiss-ai/pretrain-data);code:open(Megatron-LM training recipe + reconstruction scripts);checkpoints:open(intermediate
+    checkpoints on HF branches);license:Apache-2.0(OSI)
   sources:
   - url: https://api.github.com/repos/swiss-ai/pretrain-data
     shows: '`private: false`, `archived: false`, license `Apache-2.0`, description "Pretraining data

--- a/sources/scores/axolotl.yaml
+++ b/sources/scores/axolotl.yaml
@@ -2,11 +2,18 @@ product: axolotl
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(axolotl-ai-cloud/axolotl)
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: axolotl-ai-cloud/axolotl
   confidence: high
   note: Fully OSI-licensed (Apache-2.0); no proprietary managed training service, only deployment templates
     for third-party clouds.
   last_verified: '2026-08-09'
+  raw: license:Apache-2.0(OSI);source:public(axolotl-ai-cloud/axolotl)
   sources:
   - url: https://raw.githubusercontent.com/axolotl-ai-cloud/axolotl/main/LICENSE
     shows: The body is the standard, unmodified Apache License, Version 2.0 text, with no custom copyright

--- a/sources/scores/aya-collection.yaml
+++ b/sources/scores/aya-collection.yaml
@@ -2,9 +2,16 @@ product: aya-collection
 openness:
   score: 5
   class: open
-  components: license:apache-2.0;gated:false;card:present
+  components:
+    license:
+      value: apache-2.0
+    gated:
+      value: 'false'
+    card:
+      value: present
   confidence: high
   note: Ungated, Apache-2.0 licensed, with a complete dataset card.
+  raw: license:apache-2.0;gated:false;card:present
   sources:
   - url: https://huggingface.co/datasets/CohereLabs/aya_collection
     shows: Card describing 114+ languages, templated/translated subsets, Apache-2.0, ungated

--- a/sources/scores/c4.yaml
+++ b/sources/scores/c4.yaml
@@ -2,9 +2,16 @@ product: c4
 openness:
   score: 5
   class: open
-  components: license:ODC-BY;ungated:yes;dataset_card:yes
+  components:
+    license:
+      value: ODC-BY
+    ungated:
+      value: 'yes'
+    dataset_card:
+      value: 'yes'
   confidence: high
   note: Permissively licensed (ODC-BY) and ungated with a full dataset card.
+  raw: license:ODC-BY;ungated:yes;dataset_card:yes
   sources:
   - url: https://huggingface.co/datasets/allenai/c4
     shows: ODC-BY license, ungated access, dataset card, size variants

--- a/sources/scores/claude-fable.yaml
+++ b/sources/scores/claude-fable.yaml
@@ -2,11 +2,21 @@ product: claude-fable
 openness:
   score: 1
   class: closed
-  components: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
+  components:
+    weights:
+      value: closed
+    data:
+      value: closed
+    code:
+      value: closed
+    license:
+      value: Proprietary
+      detail: API-only
   confidence: high
   note: 'No weights, data or code released. Served through the Anthropic API only, so 1/closed on every dimension.
     Recorded here rather than in base_pretrained because a closed model has no observable base checkpoint to score,
     which is the convention #114 settled.'
+  raw: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
   sources:
   - url: https://www.anthropic.com/news/claude-fable-5-mythos-5
     shows: Mythos-class flagship, proprietary, claude-fable-5 via API and cloud marketplaces only

--- a/sources/scores/claude-haiku.yaml
+++ b/sources/scores/claude-haiku.yaml
@@ -2,10 +2,20 @@ product: claude-haiku
 openness:
   score: 1
   class: closed
-  components: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
+  components:
+    weights:
+      value: closed
+    data:
+      value: closed
+    code:
+      value: closed
+    license:
+      value: Proprietary
+      detail: API-only
   confidence: high
   note: Closed by construction and stable across generations. Measured against Claude Haiku 4.5, the
     generation shipping at the time of scoring.
+  raw: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
   sources:
   - url: https://www.anthropic.com/claude/haiku
     shows: Haiku is offered as an API and product tier only, with no weight download

--- a/sources/scores/claude-opus.yaml
+++ b/sources/scores/claude-opus.yaml
@@ -2,13 +2,23 @@ product: claude-opus
 openness:
   score: 1
   class: closed
-  components: weights:closed;data:closed;code:closed;license:Proprietary(API/Bedrock/Vertex/claude.ai)
+  components:
+    weights:
+      value: closed
+    data:
+      value: closed
+    code:
+      value: closed
+    license:
+      value: Proprietary
+      detail: API/Bedrock/Vertex/claude.ai
   governing_release: claude-opus-4-x
   confidence: high
   note: No weights distributed in any form. Served only through the Anthropic API, Bedrock, Vertex and claude.ai,
     so 1/closed on every dimension. Opus 4.x governs as the current release; 4.7 scored identically, and nothing
     about the tier's openness turns on which release is read. Consolidated because Anthropic markets Claude Opus
     as the product and 4.7 and 4.8 are versions of it.
+  raw: weights:closed;data:closed;code:closed;license:Proprietary(API/Bedrock/Vertex/claude.ai)
   sources:
   - url: https://www.anthropic.com/news/claude-opus-4-8
     shows: Opus 4.8 (May 28 2026) proprietary, claude-opus-4-8 via API at $5/$25 per Mtok

--- a/sources/scores/claude-sonnet.yaml
+++ b/sources/scores/claude-sonnet.yaml
@@ -2,11 +2,21 @@ product: claude-sonnet
 openness:
   score: 1
   class: closed
-  components: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
+  components:
+    weights:
+      value: closed
+    data:
+      value: closed
+    code:
+      value: closed
+    license:
+      value: Proprietary
+      detail: API-only
   confidence: high
   note: Closed by construction and stable across generations - no Sonnet release has ever shipped weights,
     so this axis does not move when the tier advances. Measured against Claude Sonnet 4.6 (released
     2026-02-17), Anthropic's production default coding tier at the time of scoring.
+  raw: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
   sources:
   - url: https://www.anthropic.com/news/claude-sonnet-4-6
     shows: launch post presents Sonnet 4.6 as available through the Anthropic API and the Claude apps, with

--- a/sources/scores/codegemma.yaml
+++ b/sources/scores/codegemma.yaml
@@ -2,7 +2,16 @@ product: codegemma
 openness:
   score: 3
   class: open_weights
-  components: weights:open;data:closed;code:closed;license:Gemma-Terms-of-Use(custom,use-restricted,non-OSI)
+  components:
+    weights:
+      value: open
+    data:
+      value: closed
+    code:
+      value: closed
+    license:
+      value: Gemma-Terms-of-Use
+      detail: custom,use-restricted,non-OSI
   confidence: high
   note: >-
     Open weights under Google's custom Gemma terms, with no open training data or code. Was 3,
@@ -14,6 +23,7 @@ openness:
     surviving `gemma` records an Apache-2.0 license rather than Gemma terms, so that comparison no
     longer holds - and whether `gemma`'s recorded license is right is a separate question worth a
     look.
+  raw: weights:open;data:closed;code:closed;license:Gemma-Terms-of-Use(custom,use-restricted,non-OSI)
   sources:
   - url: https://huggingface.co/google/codegemma-7b-it
     shows: 'model card: Gemma license, sizes, intended use'

--- a/sources/scores/codellama.yaml
+++ b/sources/scores/codellama.yaml
@@ -2,8 +2,18 @@ product: codellama
 openness:
   score: 3
   class: open_weights
-  components: weights:open(downloadable on HF);data:closed;code:partial(inference utils, no training pipeline);license:Llama-2-Community(custom
-    Meta license, non-OSI; AUP + commercial conditions)
+  components:
+    weights:
+      value: open
+      detail: downloadable on HF
+    data:
+      value: closed
+    code:
+      value: partial
+      detail: inference utils, no training pipeline
+    license:
+      value: Llama-2-Community
+      detail: custom Meta license, non-OSI; AUP + commercial conditions
   confidence: high
   note: >-
     Weights downloadable under Meta's non-OSI Llama-2 Community license. Marketed as open, which
@@ -13,6 +23,8 @@ openness:
     one does, for everyone inside the bound. A license that forbids commerce outright - CC-BY-NC,
     Mistral Non-Production - stays at 2. Nine other products carry a bounded license and all now
     score 3; four of them were already recorded there, which is the inconsistency this resolves.
+  raw: weights:open(downloadable on HF);data:closed;code:partial(inference utils, no training pipeline);license:Llama-2-Community(custom
+    Meta license, non-OSI; AUP + commercial conditions)
   sources:
   - url: https://huggingface.co/codellama/CodeLlama-13b-Instruct-hf
     shows: live model card; license=Llama 2 / custom Meta commercial license; 13B instruct

--- a/sources/scores/codestral.yaml
+++ b/sources/scores/codestral.yaml
@@ -2,11 +2,23 @@ product: codestral
 openness:
   score: 2
   class: restricted
-  components: weights:open(downloadable on HF);data:closed;code:closed(no training pipeline);license:Mistral-AI-Non-Production-License(MNPL,
-    non-OSI, research/testing only; commercial license on demand)
+  components:
+    weights:
+      value: open
+      detail: downloadable on HF
+    data:
+      value: closed
+    code:
+      value: closed
+      detail: no training pipeline
+    license:
+      value: Mistral-AI-Non-Production-License
+      detail: MNPL, non-OSI, research/testing only; commercial license on demand
   confidence: high
   note: Weights downloadable but under MNPL (non-OSI, non-production); open-weights gated by a use-restricted
     license, so restricted not open_weights.
+  raw: weights:open(downloadable on HF);data:closed;code:closed(no training pipeline);license:Mistral-AI-Non-Production-License(MNPL,
+    non-OSI, research/testing only; commercial license on demand)
   sources:
   - url: https://mistral.ai/news/codestral/
     shows: Codestral open-weight on HF under Mistral AI Non-Production License (research/testing; commercial

--- a/sources/scores/common-corpus.yaml
+++ b/sources/scores/common-corpus.yaml
@@ -2,9 +2,17 @@ product: common-corpus
 openness:
   score: 5
   class: open
-  components: license:open(uncopyrighted/freely-licensed only);ungated:yes;dataset_card:yes
+  components:
+    license:
+      value: open
+      detail: uncopyrighted/freely-licensed only
+    ungated:
+      value: 'yes'
+    dataset_card:
+      value: 'yes'
   confidence: high
   note: Ungated with a full dataset card and built exclusively from uncopyrighted or openly licensed sources.
+  raw: license:open(uncopyrighted/freely-licensed only);ungated:yes;dataset_card:yes
   sources:
   - url: https://huggingface.co/datasets/PleIAs/common_corpus
     shows: open-license-only content, ungated access, dataset card, 2.27T tokens

--- a/sources/scores/cruxeval.yaml
+++ b/sources/scores/cruxeval.yaml
@@ -2,10 +2,23 @@ product: cruxeval
 openness:
   score: 5
   class: open
-  components: data:open(800 samples public on GitHub + HF);license:MIT(permissive, redistributable);datasheet:yes(README
-    + arXiv paper documenting construction);access:public(downloadable, fully released, not held-out)
+  components:
+    data:
+      value: open
+      detail: 800 samples public on GitHub + HF
+    license:
+      value: MIT
+      detail: permissive, redistributable
+    datasheet:
+      value: 'yes'
+      detail: README + arXiv paper documenting construction
+    access:
+      value: public
+      detail: downloadable, fully released, not held-out
   confidence: high
   note: Fully open public benchmark dataset under MIT with documented construction methodology.
+  raw: data:open(800 samples public on GitHub + HF);license:MIT(permissive, redistributable);datasheet:yes(README
+    + arXiv paper documenting construction);access:public(downloadable, fully released, not held-out)
   sources:
   - url: https://github.com/facebookresearch/cruxeval
     shows: MIT-licensed 800-sample Python code-reasoning benchmark, publicly downloadable with CRUXEval-I/-O

--- a/sources/scores/deepseek-coder.yaml
+++ b/sources/scores/deepseek-coder.yaml
@@ -2,9 +2,19 @@ product: deepseek-coder
 openness:
   score: 3
   class: open_weights
-  components: weights:open(downloadable on HF);data:closed;code:open(MIT, repo code);model-license:DeepSeek-Model-License(non-OSI;
-    Attachment A acceptable-use restrictions - military/illegal/discrimination/etc.; commercial allowed but use-based
-    restrictions must propagate to derivatives)
+  components:
+    weights:
+      value: open
+      detail: downloadable on HF
+    data:
+      value: closed
+    code:
+      value: open
+      detail: MIT, repo code
+    model-license:
+      value: DeepSeek-Model-License
+      detail: non-OSI; Attachment A acceptable-use restrictions - military/illegal/discrimination/etc.;
+        commercial allowed but use-based restrictions must propagate to derivatives
   confidence: high
   note: 'MIT-licensed inference code with downloadable weights under the DeepSeek Model License, corpus not released,
     so 3/open_weights. Corrected from 2/restricted on 2026-07-29 under issue #117. The license''s Attachment A forbids
@@ -12,6 +22,9 @@ openness:
     use at any scale - a conduct restriction, not a commercial one. This also removes the contradiction that opened
     #117: base_pretrained already tiered the same license permissive_non_osi, so the same terms were producing a
     3 in one category and a 2 in another. Now consistent with the `deepseek` tier, which reaches 3 under plain MIT.'
+  raw: weights:open(downloadable on HF);data:closed;code:open(MIT, repo code);model-license:DeepSeek-Model-License(non-OSI;
+    Attachment A acceptable-use restrictions - military/illegal/discrimination/etc.; commercial allowed
+    but use-based restrictions must propagate to derivatives)
   sources:
   - url: https://huggingface.co/deepseek-ai/DeepSeek-Coder-V2-Instruct
     shows: model license = 'DeepSeek Model Agreement', code license = MIT, 236B-A21B MoE instruct coder

--- a/sources/scores/deepseek-instruct.yaml
+++ b/sources/scores/deepseek-instruct.yaml
@@ -2,11 +2,23 @@ product: deepseek-instruct
 openness:
   score: 3
   class: open_weights
-  components: weights:open(MIT, on HF);data:closed;code:partial(inference/serving; no training pipeline or data);license:MIT(OSI-style
-    permissive, no use restrictions)
+  components:
+    weights:
+      value: open
+      detail: MIT, on HF
+    data:
+      value: closed
+    code:
+      value: partial
+      detail: inference/serving; no training pipeline or data
+    license:
+      value: MIT
+      detail: OSI-style permissive, no use restrictions
   confidence: high
   note: V4-Flash weights are MIT open (matching the V4-Pro anchor's open_weights class); training data/code closed
     -> open_weights. Consistent with the frozen V4-Pro anchor's openness ladder.
+  raw: weights:open(MIT, on HF);data:closed;code:partial(inference/serving; no training pipeline or data);license:MIT(OSI-style
+    permissive, no use restrictions)
   sources:
   - url: https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash
     shows: MIT license, 284B-A13B MoE, 1M context, downloadable FP4/FP8 weights

--- a/sources/scores/deepseek-r1.yaml
+++ b/sources/scores/deepseek-r1.yaml
@@ -2,12 +2,25 @@ product: deepseek-r1
 openness:
   score: 3
   class: open_weights
-  components: weights:open(MIT, on HF; distillation explicitly permitted);data:closed(RL/SFT training
-    data not released);code:partial(inference; no full RL training pipeline);license:MIT(OSI-style permissive,
-    no use restrictions)
+  components:
+    weights:
+      value: open
+      detail: MIT, on HF; distillation explicitly permitted
+    data:
+      value: closed
+      detail: RL/SFT training data not released
+    code:
+      value: partial
+      detail: inference; no full RL training pipeline
+    license:
+      value: MIT
+      detail: OSI-style permissive, no use restrictions
   confidence: high
   note: MIT-licensed open weights with distillation rights, but RL/SFT post-training data and full training
     code are not released -> open_weights.
+  raw: weights:open(MIT, on HF; distillation explicitly permitted);data:closed(RL/SFT training data not
+    released);code:partial(inference; no full RL training pipeline);license:MIT(OSI-style permissive, no
+    use restrictions)
   sources:
   - url: https://huggingface.co/deepseek-ai/DeepSeek-R1
     shows: MIT license (commercial use + distillation permitted), 671B-A37B MoE reasoning model card

--- a/sources/scores/deepseek.yaml
+++ b/sources/scores/deepseek.yaml
@@ -2,8 +2,18 @@ product: deepseek
 openness:
   score: 3
   class: open_weights
-  components: weights:open(MIT, on HF, both Pro and Flash);data:closed;code:partial(inference/serving; no training
-    pipeline or data);license:MIT(permissive, no use restrictions)
+  components:
+    weights:
+      value: open
+      detail: MIT, on HF, both Pro and Flash
+    data:
+      value: closed
+    code:
+      value: partial
+      detail: inference/serving; no training pipeline or data
+    license:
+      value: MIT
+      detail: permissive, no use restrictions
   governing_release: deepseek-v4-pro
   confidence: high
   note: 'MIT weights across the V4 line, training corpus not released, inference and serving code only, so 3. V4-Pro
@@ -11,6 +21,8 @@ openness:
     retired deepseek-v3-base record carried a compound `code MIT + model DeepSeek-Model-License`, and whether that
     license''s acceptable-use restrictions count as use-restricting is open in issue #117. The tier does not depend
     on that ruling. Adoption 5 is carried from V3.2, the most downloaded release.'
+  raw: weights:open(MIT, on HF, both Pro and Flash);data:closed;code:partial(inference/serving; no training
+    pipeline or data);license:MIT(permissive, no use restrictions)
   sources:
   - url: https://huggingface.co/api/models/deepseek-ai/DeepSeek-V4-Pro
     shows: license mit, ungated, 864.8GB of weight files, 1,635,092 downloads last month

--- a/sources/scores/devstral.yaml
+++ b/sources/scores/devstral.yaml
@@ -2,11 +2,23 @@ product: devstral
 openness:
   score: 3
   class: open_weights
-  components: weights:open(Apache-2.0, on HF);data:closed;code:partial(inference/serving; no training
-    or post-training data);license:Apache-2.0(OSI permissive, no use restrictions)
+  components:
+    weights:
+      value: open
+      detail: Apache-2.0, on HF
+    data:
+      value: closed
+    code:
+      value: partial
+      detail: inference/serving; no training or post-training data
+    license:
+      value: Apache-2.0
+      detail: OSI permissive, no use restrictions
   confidence: high
   note: Apache-2.0 open weights, but training/post-training data and pipeline undisclosed -> open_weights,
     not open_source.
+  raw: weights:open(Apache-2.0, on HF);data:closed;code:partial(inference/serving; no training or post-training
+    data);license:Apache-2.0(OSI permissive, no use restrictions)
   sources:
   - url: https://huggingface.co/mistralai/Devstral-Small-2507
     shows: live card; license=apache-2.0; 24B agentic coding model; SWE-bench Verified 53.6%

--- a/sources/scores/dolci.yaml
+++ b/sources/scores/dolci.yaml
@@ -2,9 +2,16 @@ product: dolci
 openness:
   score: 5
   class: open
-  components: license:ODC-BY;gated:false;dataset_card:present
+  components:
+    license:
+      value: ODC-BY
+    gated:
+      value: 'false'
+    dataset_card:
+      value: present
   confidence: high
   note: ODC-BY, ungated, per-stage dataset cards.
+  raw: license:ODC-BY;gated:false;dataset_card:present
   sources:
   - url: https://huggingface.co/datasets/allenai/Dolci-Instruct-SFT
     shows: ODC-BY license, ungated, dataset card

--- a/sources/scores/dolma-3.yaml
+++ b/sources/scores/dolma-3.yaml
@@ -2,9 +2,16 @@ product: dolma-3
 openness:
   score: 5
   class: open
-  components: license:ODC-BY;gated:false;dataset_card:present
+  components:
+    license:
+      value: ODC-BY
+    gated:
+      value: 'false'
+    dataset_card:
+      value: present
   confidence: high
   note: ODC-BY, ungated, fully documented pool and training mixes.
+  raw: license:ODC-BY;gated:false;dataset_card:present
   sources:
   - url: https://huggingface.co/datasets/allenai/dolma3_pool
     shows: ODC-BY license, ungated, dataset card

--- a/sources/scores/doubao-seed.yaml
+++ b/sources/scores/doubao-seed.yaml
@@ -2,10 +2,20 @@ product: doubao-seed
 openness:
   score: 1
   class: closed
-  components: weights:closed;data:closed;code:closed;license:Proprietary(Doubao app + Volcano Engine API only; no
-    downloadable weights)
+  components:
+    weights:
+      value: closed
+    data:
+      value: closed
+    code:
+      value: closed
+    license:
+      value: Proprietary
+      detail: Doubao app + Volcano Engine API only; no downloadable weights
   confidence: high
   note: No weights released, served only through the Doubao app and Volcano Engine API. Fully closed.
+  raw: weights:closed;data:closed;code:closed;license:Proprietary(Doubao app + Volcano Engine API only;
+    no downloadable weights)
   sources:
   - url: https://technode.com/2026/02/14/bytedance-releases-doubao-seed-2-0-positions-pro-model-against-gpt-5-2-and-gemini-3-pro/
     shows: Doubao Seed 2.0 available on Doubao app and Volcano Engine API (no open weights)

--- a/sources/scores/falcon.yaml
+++ b/sources/scores/falcon.yaml
@@ -2,7 +2,16 @@ product: falcon
 openness:
   score: 3
   class: open_weights
-  components: weights:open;data:closed;code:closed;license:TII-Falcon-License-2.0(Apache-based+AUP,non-OSI)
+  components:
+    weights:
+      value: open
+    data:
+      value: closed
+    code:
+      value: closed
+    license:
+      value: TII-Falcon-License-2.0
+      detail: Apache-based+AUP,non-OSI
   confidence: high
   note: 'Weights downloadable and freely usable commercially at any scale, corpus not released, no training code,
     so 3/open_weights. Corrected from 2/restricted on 2026-07-29 under issue #117: TII-Falcon-License-2.0 is Apache-based
@@ -11,6 +20,7 @@ openness:
     Llama''s 700M-MAU ceiling. Not 4 or 5: the corpus and the pipeline are both closed, and the license is non-OSI
     regardless, since the OSD forbids discriminating against a field of endeavor. The Hub reports this license as
     `other`, an abstention rather than an answer, so the tier rests on TII''s published text.'
+  raw: weights:open;data:closed;code:closed;license:TII-Falcon-License-2.0(Apache-based+AUP,non-OSI)
   sources:
   - url: https://huggingface.co/api/models/tiiuae/Falcon3-10B-Base
     shows: ungated, 41.2GB of weight files, 7,688 downloads last month; cardData.license is `other`, so the Hub

--- a/sources/scores/feluda.yaml
+++ b/sources/scores/feluda.yaml
@@ -2,9 +2,15 @@ product: feluda
 openness:
   score: 5
   class: open_source
-  components: license:GPL-3.0(OSI copyleft);source:public
+  components:
+    license:
+      value: GPL-3.0
+      detail: OSI copyleft
+    source:
+      value: public
   confidence: high
   note: GPL-3.0 licensed open source project with public source.
+  raw: license:GPL-3.0(OSI copyleft);source:public
   sources:
   - url: https://github.com/tattle-made/feluda
     shows: GPL-3.0 license, public source under tattle-made org

--- a/sources/scores/finemath.yaml
+++ b/sources/scores/finemath.yaml
@@ -2,9 +2,16 @@ product: finemath
 openness:
   score: 5
   class: open
-  components: license:ODC-BY;gated:false;dataset_card:present
+  components:
+    license:
+      value: ODC-BY
+    gated:
+      value: 'false'
+    dataset_card:
+      value: present
   confidence: high
   note: ODC-BY, ungated, full dataset card.
+  raw: license:ODC-BY;gated:false;dataset_card:present
   sources:
   - url: https://huggingface.co/datasets/HuggingFaceTB/finemath
     shows: ODC-BY license, ungated, dataset card

--- a/sources/scores/gemini-flash.yaml
+++ b/sources/scores/gemini-flash.yaml
@@ -2,14 +2,24 @@ product: gemini-flash
 openness:
   score: 1
   class: closed
-  components: weights:closed;data:closed;code:closed;license:Proprietary(Gemini app/Search/API/enterprise, no downloadable
-    weights)
+  components:
+    weights:
+      value: closed
+    data:
+      value: closed
+    code:
+      value: closed
+    license:
+      value: Proprietary
+      detail: Gemini app/Search/API/enterprise, no downloadable weights
   governing_release: gemini-3-5-flash
   confidence: high
   note: Proprietary and API-only across the Flash line, no downloadable weights, so 1/closed. Gemini 3.5 Flash governs
     as the current release and is a genuine capability jump - it scores 5 where 2.5 Flash scored 3 - which is why
     the versions were worth combining rather than keeping the older figure. Held apart from Gemini Pro, which Google
     prices and positions as a separate tier.
+  raw: weights:closed;data:closed;code:closed;license:Proprietary(Gemini app/Search/API/enterprise, no downloadable
+    weights)
   sources:
   - url: https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/
     shows: proprietary launch across Gemini app/Search/API/enterprise, no open weights

--- a/sources/scores/gemini-pro.yaml
+++ b/sources/scores/gemini-pro.yaml
@@ -2,11 +2,21 @@ product: gemini-pro
 openness:
   score: 1
   class: closed
-  components: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
+  components:
+    weights:
+      value: closed
+    data:
+      value: closed
+    code:
+      value: closed
+    license:
+      value: Proprietary
+      detail: API-only
   confidence: high
   note: Closed by construction and stable across generations. Google's own model index files Gemini under
     API and app access while placing Gemma separately under "Open models", so the line is drawn by the vendor
     rather than inferred. Measured against Gemini 3 Pro, the GA Pro release at the time of scoring.
+  raw: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
   sources:
   - url: https://deepmind.google/models/gemini/
     shows: Google's model index lists Gemini under API and app access and files Gemma separately under a

--- a/sources/scores/gemma.yaml
+++ b/sources/scores/gemma.yaml
@@ -2,7 +2,17 @@ product: gemma
 openness:
   score: 3
   class: open_weights
-  components: weights:open(Apache-2.0);data:closed;code:closed;license:Apache-2.0(OSI,but no open data/code)
+  components:
+    weights:
+      value: open
+      detail: Apache-2.0
+    data:
+      value: closed
+    code:
+      value: closed
+    license:
+      value: Apache-2.0
+      detail: OSI,but no open data/code
   governing_release: gemma-4
   confidence: medium
   note: 'Apache-2.0 weights, no open training data and no training code, so open_weights rather than a fully-open
@@ -11,6 +21,7 @@ openness:
     the Hub on 2026-07-29. The current release governs, so a family that becomes more open is recorded as such rather
     than pinned to its worst historical release. Adoption 5 is carried from Gemma 2, which still out-downloads Gemma
     4.'
+  raw: weights:open(Apache-2.0);data:closed;code:closed;license:Apache-2.0(OSI,but no open data/code)
   sources:
   - url: https://ai.google.dev/gemma/docs/releases
     shows: Gemma 4 sizes, release dates, Apache-2.0 license

--- a/sources/scores/glm.yaml
+++ b/sources/scores/glm.yaml
@@ -2,13 +2,25 @@ product: glm
 openness:
   score: 3
   class: open_weights
-  components: weights:open(MIT);data:closed;code:open(inference);license:MIT(OSI)
+  components:
+    weights:
+      value: open
+      detail: MIT
+    data:
+      value: closed
+    code:
+      value: open
+      detail: inference
+    license:
+      value: MIT
+      detail: OSI
   governing_release: glm-5-2
   confidence: high
   note: 'MIT weights on the current release, data closed, no training pipeline, so 3. Z.ai moved to MIT partway
     through the family: GLM-4 and GLM-4-9B carried the GLM-4 License, which requires commercial-use registration
     and a ''Built with GLM'' attribution and scored 2, while GLM-4.6, GLM-5.1 and GLM-5.2 are plain MIT. GLM-5.2
     governs as the current release. Capability 5 comes from the GLM-5 line; the GLM-4 line scored 2.'
+  raw: weights:open(MIT);data:closed;code:open(inference);license:MIT(OSI)
   sources:
   - url: https://huggingface.co/zai-org/GLM-5.2/blob/main/LICENSE
     shows: MIT, (c) Zhipu AI 2026

--- a/sources/scores/gpt-4-1.yaml
+++ b/sources/scores/gpt-4-1.yaml
@@ -2,11 +2,21 @@ product: gpt-4-1
 openness:
   score: 1
   class: closed
-  components: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
+  components:
+    weights:
+      value: closed
+    data:
+      value: closed
+    code:
+      value: closed
+    license:
+      value: Proprietary
+      detail: API-only
   confidence: high
   note: Proprietary OpenAI API model; no weights/data/code released. Absorbed the duplicate
     base_pretrained record on 2026-07-29, which contributed OpenAI's own model docs as a primary source
     alongside the press coverage, and the exact context window (1,047,576 tokens).
+  raw: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
   sources:
   - url: https://developers.openai.com/api/docs/models/gpt-4.1
     shows: 'OpenAI''s own model page: API-only, no downloadable weights, 1,047,576-token context, knowledge

--- a/sources/scores/gpt-4o.yaml
+++ b/sources/scores/gpt-4o.yaml
@@ -2,10 +2,20 @@ product: gpt-4o
 openness:
   score: 1
   class: closed
-  components: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
+  components:
+    weights:
+      value: closed
+    data:
+      value: closed
+    code:
+      value: closed
+    license:
+      value: Proprietary
+      detail: API-only
   confidence: high
   note: No downloadable weights; API/ChatGPT-only, like the GPT-5 anchor (O1 closed). Confirmed API-only
     with 128K context and Oct 2023 cutoff on OpenAI docs 2026-06-04.
+  raw: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
   sources:
   - url: https://developers.openai.com/api/docs/models/gpt-4o
     shows: GPT-4o API-only model, 128K context, text+image input, no open weights, Oct 2023 cutoff

--- a/sources/scores/gpt-5.yaml
+++ b/sources/scores/gpt-5.yaml
@@ -2,13 +2,23 @@ product: gpt-5
 openness:
   score: 1
   class: closed
-  components: weights:closed;data:closed;code:closed;license:Proprietary(API + ChatGPT only)
+  components:
+    weights:
+      value: closed
+    data:
+      value: closed
+    code:
+      value: closed
+    license:
+      value: Proprietary
+      detail: API + ChatGPT only
   governing_release: gpt-5-line
   confidence: high
   note: No downloadable weights, no published training data or code. Served through the OpenAI API and ChatGPT only,
     so 1/closed. Kept apart from GPT-4o and GPT-4.1 because OpenAI markets those as distinct products rather than
     versions of a single line, which is the same reason their slugs keep their version tokens. Adoption 5 reflects
     ChatGPT-scale reach.
+  raw: weights:closed;data:closed;code:closed;license:Proprietary(API + ChatGPT only)
   sources:
   - url: https://en.wikipedia.org/wiki/GPT-5
     shows: GPT-5 (Aug 7 2025) is OpenAI's proprietary unified model, free-tier + paid via ChatGPT, API access

--- a/sources/scores/gpt-oss-safeguard.yaml
+++ b/sources/scores/gpt-oss-safeguard.yaml
@@ -2,10 +2,19 @@ product: gpt-oss-safeguard
 openness:
   score: 4
   class: open_weights
-  components: weights:open(gpt-oss-safeguard-20b/120b on HF);data:not-released;license:Apache-2.0(OSI)
+  components:
+    weights:
+      value: open
+      detail: gpt-oss-safeguard-20b/120b on HF
+    data:
+      value: not-released
+    license:
+      value: Apache-2.0
+      detail: OSI
   confidence: medium
   note: Open weights under Apache-2.0 (OSI), training data not released, so open_weights (4) rather than
     open_source. Notable as a policy-conditioned safety reasoning model rather than a fixed classifier.
+  raw: weights:open(gpt-oss-safeguard-20b/120b on HF);data:not-released;license:Apache-2.0(OSI)
   sources:
   - url: https://huggingface.co/openai/gpt-oss-safeguard-20b
     shows: Apache-2.0; open weights; policy-conditioned safety reasoning; 20b/120b; ~131K downloads/month,

--- a/sources/scores/granite-guardian.yaml
+++ b/sources/scores/granite-guardian.yaml
@@ -2,10 +2,19 @@ product: granite-guardian
 openness:
   score: 4
   class: open_weights
-  components: weights:open(granite-guardian-3.2-5b on HF);data:not-released;license:Apache-2.0(OSI)
+  components:
+    weights:
+      value: open
+      detail: granite-guardian-3.2-5b on HF
+    data:
+      value: not-released
+    license:
+      value: Apache-2.0
+      detail: OSI
   confidence: medium
   note: Open weights under Apache-2.0 (permissive, OSI), but the training data is not released, so it
     stops short of the open_source (5) tier; a strong open_weights release at 4.
+  raw: weights:open(granite-guardian-3.2-5b on HF);data:not-released;license:Apache-2.0(OSI)
   sources:
   - url: https://huggingface.co/ibm-granite/granite-guardian-3.2-5b
     shows: Apache-2.0; open weights; harm/bias/jailbreak + RAG groundedness checks; ~1,377 downloads/month,

--- a/sources/scores/grok.yaml
+++ b/sources/scores/grok.yaml
@@ -2,12 +2,22 @@ product: grok
 openness:
   score: 1
   class: closed
-  components: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
+  components:
+    weights:
+      value: closed
+    data:
+      value: closed
+    code:
+      value: closed
+    license:
+      value: Proprietary
+      detail: API-only
   governing_release: grok-4-20
   confidence: high
   note: Proprietary, served through the xAI API, grok.com and X, with no downloadable weights, so 1/closed. Grok
     4.20 governs and contributes capability 4; adoption 3 is carried from Grok 3, which had wider reach. The bare
     `grok` slug names this model line - the consumer chat app is a separate product recorded as grok-app.
+  raw: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
   sources:
   - url: https://docs.x.ai/developers/release-notes
     shows: xAI release notes record "Grok 4.20 and Grok 4.20 Multi-agent are live" and point at the API docs; no

--- a/sources/scores/hellaswag.yaml
+++ b/sources/scores/hellaswag.yaml
@@ -2,10 +2,23 @@ product: hellaswag
 openness:
   score: 5
   class: open
-  components: data:open(59,950 examples, downloadable on HF);license:MIT(permissive, redistributable);datasheet:yes(HF
-    dataset card + ACL 2019 paper);access:public(train/val/test all released, not held-out)
+  components:
+    data:
+      value: open
+      detail: 59,950 examples, downloadable on HF
+    license:
+      value: MIT
+      detail: permissive, redistributable
+    datasheet:
+      value: 'yes'
+      detail: HF dataset card + ACL 2019 paper
+    access:
+      value: public
+      detail: train/val/test all released, not held-out
   confidence: high
   note: Fully open under MIT with dataset card; canonical open-data benchmark profile.
+  raw: data:open(59,950 examples, downloadable on HF);license:MIT(permissive, redistributable);datasheet:yes(HF
+    dataset card + ACL 2019 paper);access:public(train/val/test all released, not held-out)
   sources:
   - url: https://huggingface.co/datasets/Rowan/hellaswag
     shows: MIT license, 59,950 examples, public splits, dataset card, ~270K downloads last month

--- a/sources/scores/hermes-3-dataset.yaml
+++ b/sources/scores/hermes-3-dataset.yaml
@@ -2,9 +2,16 @@ product: hermes-3-dataset
 openness:
   score: 5
   class: open
-  components: license:Apache-2.0;gated:false;dataset_card:present
+  components:
+    license:
+      value: Apache-2.0
+    gated:
+      value: 'false'
+    dataset_card:
+      value: present
   confidence: high
   note: Apache-2.0, ungated, dataset card.
+  raw: license:Apache-2.0;gated:false;dataset_card:present
   sources:
   - url: https://huggingface.co/datasets/NousResearch/Hermes-3-Dataset
     shows: Apache-2.0 license, ungated, dataset card

--- a/sources/scores/inflection.yaml
+++ b/sources/scores/inflection.yaml
@@ -2,10 +2,20 @@ product: inflection
 openness:
   score: 1
   class: closed
-  components: weights:closed;data:closed;code:closed;license:Proprietary(API/enterprise-licensed, no weights)
+  components:
+    weights:
+      value: closed
+    data:
+      value: closed
+    code:
+      value: closed
+    license:
+      value: Proprietary
+      detail: API/enterprise-licensed, no weights
   confidence: high
   note: Closed proprietary models via API + enterprise licensing; no downloadable weights; fine-tuned models are
     the customer's alone. Confirmed via primary Intel Newsroom press release (2026-06-04).
+  raw: weights:closed;data:closed;code:closed;license:Proprietary(API/enterprise-licensed, no weights)
   sources:
   - url: https://www.maginative.com/article/inflection-ai-unveils-enterprise-offering-with-new-inflection-3-0-models-2/
     shows: Inflection 3.0 (Pi + Productivity), enterprise/API, proprietary (aggregator source)

--- a/sources/scores/inkling.yaml
+++ b/sources/scores/inkling.yaml
@@ -2,13 +2,25 @@ product: inkling
 openness:
   score: 3
   class: open_weights
-  components: weights:open(Apache-2.0 on HF, BF16 + NVFP4);data:closed(public+third-party+synthetic, not
-    redistributed);code:partial(day-0 transformers/SGLang/vLLM/llama.cpp; no training pipeline);license:Apache-2.0(OSI
-    for weights only)
+  components:
+    weights:
+      value: open
+      detail: Apache-2.0 on HF, BF16 + NVFP4
+    data:
+      value: closed
+      detail: public+third-party+synthetic, not redistributed
+    code:
+      value: partial
+      detail: day-0 transformers/SGLang/vLLM/llama.cpp; no training pipeline
+    license:
+      value: Apache-2.0
+      detail: OSI for weights only
   confidence: high
   note: Apache-2.0 weights are OSI-licensed, but training data and full training code are withheld —
     open_weights / 3, not open_source / 5. Press often calls this 'open source' because of the license
     tag; our spectrum requires open data + code for class open_source.
+  raw: weights:open(Apache-2.0 on HF, BF16 + NVFP4);data:closed(public+third-party+synthetic, not redistributed);code:partial(day-0
+    transformers/SGLang/vLLM/llama.cpp; no training pipeline);license:Apache-2.0(OSI for weights only)
   sources:
   - url: https://huggingface.co/thinkingmachines/Inkling
     shows: Apache-2.0 license tag; 975B/41B MoE; weights downloadable; model card states data from public,

--- a/sources/scores/jamba-large.yaml
+++ b/sources/scores/jamba-large.yaml
@@ -2,9 +2,18 @@ product: jamba-large
 openness:
   score: 3
   class: open_weights
-  components: 'weights:open(downloadable on HF, contact-info gate);data:closed;code:partial(inference/usage only,
-    no training pipeline);license:Jamba-Open-Model-License(non-OSI: $50M annual-revenue commercial cap + AUP + naming/attribution
-    requirements)'
+  components:
+    weights:
+      value: open
+      detail: downloadable on HF, contact-info gate
+    data:
+      value: closed
+    code:
+      value: partial
+      detail: inference/usage only, no training pipeline
+    license:
+      value: Jamba-Open-Model-License
+      detail: 'non-OSI: $50M annual-revenue commercial cap + AUP + naming/attribution requirements'
   confidence: high
   note: >-
     Weights downloadable under the Jamba Open Model License: non-OSI, with a $50M annual-revenue
@@ -15,6 +24,9 @@ openness:
     commerce outright - CC-BY-NC, Mistral Non-Production - stays at 2. Nine other products carry a
     bounded license and all now score 3; four of them were already recorded there, which is the
     inconsistency this resolves.
+  raw: 'weights:open(downloadable on HF, contact-info gate);data:closed;code:partial(inference/usage only,
+    no training pipeline);license:Jamba-Open-Model-License(non-OSI: $50M annual-revenue commercial cap +
+    AUP + naming/attribution requirements)'
   sources:
   - url: https://huggingface.co/ai21labs/AI21-Jamba-1.5-Large
     shows: Jamba Open Model License + downloadable Safetensors weights, instruction-following model card

--- a/sources/scores/kimi.yaml
+++ b/sources/scores/kimi.yaml
@@ -2,9 +2,18 @@ product: kimi
 openness:
   score: 3
   class: open_weights
-  components: weights:pending(scheduled 2026-07-27; API live today);data:closed;code:partial(inference/deploy expected;
-    no training data or full pipeline);license:assumed-Modified-MIT(continuity with Kimi K2.x; confirm on weight
-    release)
+  components:
+    weights:
+      value: pending
+      detail: scheduled 2026-07-27; API live today
+    data:
+      value: closed
+    code:
+      value: partial
+      detail: inference/deploy expected; no training data or full pipeline
+    license:
+      value: assumed-Modified-MIT
+      detail: continuity with Kimi K2.x; confirm on weight release
   governing_release: kimi-k3
   confidence: medium
   note: 'Modified-MIT weights - standard MIT below a 100M-MAU and $20M-monthly-revenue threshold - with a closed
@@ -12,6 +21,9 @@ openness:
     is recorded as `assumed-Modified-MIT` by continuity with K2.x rather than confirmed against a published file.
     K2.6''s Modified-MIT is confirmed, so the tier''s openness firms up as soon as K3''s terms are read directly.
     Adoption 4 is carried from K2.6.'
+  raw: weights:pending(scheduled 2026-07-27; API live today);data:closed;code:partial(inference/deploy expected;
+    no training data or full pipeline);license:assumed-Modified-MIT(continuity with Kimi K2.x; confirm on
+    weight release)
   sources:
   - url: https://www.kimi.com/blog/kimi-k3
     shows: primary announcement — 2.8T MoE, 1M context, native vision; API live; full weights by 2026-07-27

--- a/sources/scores/llama-guard.yaml
+++ b/sources/scores/llama-guard.yaml
@@ -2,12 +2,23 @@ product: llama-guard
 openness:
   score: 3
   class: open_weights
-  components: weights:open(Llama-Guard-3-8B safetensors on HF);data:not-released;code:inference recipe
-    public;license:Llama-3.1-Community(NOT OSI, >700M-MAU restriction)
+  components:
+    weights:
+      value: open
+      detail: Llama-Guard-3-8B safetensors on HF
+    data:
+      value: not-released
+    code:
+      value: inference recipe public
+    license:
+      value: Llama-3.1-Community
+      detail: NOT OSI, >700M-MAU restriction
   confidence: medium
   note: Open-weights safety classifier under Meta's Llama Community License, which carries use restrictions
     and is not OSI-approved, so it lands at the open_weights tier (3) like the rest of the Llama family
     rather than open_source.
+  raw: weights:open(Llama-Guard-3-8B safetensors on HF);data:not-released;code:inference recipe public;license:Llama-3.1-Community(NOT
+    OSI, >700M-MAU restriction)
   sources:
   - url: https://huggingface.co/meta-llama/Llama-Guard-3-8B
     shows: Llama 3.1 Community License; open weights; 14 hazard categories; I/O classifier; ~237K downloads/month,

--- a/sources/scores/llama-instruct.yaml
+++ b/sources/scores/llama-instruct.yaml
@@ -2,8 +2,18 @@ product: llama-instruct
 openness:
   score: 3
   class: open_weights
-  components: weights:open(downloadable);data:closed;code:partial(no training pipeline);license:Llama-3.1-Community(non-OSI;
-    700M-MAU commercial cap + use policy)
+  components:
+    weights:
+      value: open
+      detail: downloadable
+    data:
+      value: closed
+    code:
+      value: partial
+      detail: no training pipeline
+    license:
+      value: Llama-3.1-Community
+      detail: non-OSI; 700M-MAU commercial cap + use policy
   confidence: high
   note: >-
     Weights open under Meta's non-OSI Llama 3.1 Community License, with its 700M-MAU commercial
@@ -13,6 +23,8 @@ openness:
     bound. A license that forbids commerce outright - CC-BY-NC, Mistral Non-Production - stays at
     2. Nine other products carry a bounded license and all now score 3; four of them were already
     recorded there, which is the inconsistency this resolves.
+  raw: weights:open(downloadable);data:closed;code:partial(no training pipeline);license:Llama-3.1-Community(non-OSI;
+    700M-MAU commercial cap + use policy)
   sources:
   - url: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
     shows: live card; license=Llama 3.1 Community License w/ 700M MAU cap; 11,077,966 downloads last month

--- a/sources/scores/llama-prompt-guard.yaml
+++ b/sources/scores/llama-prompt-guard.yaml
@@ -2,11 +2,20 @@ product: llama-prompt-guard
 openness:
   score: 3
   class: open_weights
-  components: weights:open(Llama-Prompt-Guard-2-86M/22M on HF);data:not-released;license:Llama-4-Community(NOT
-    OSI)
+  components:
+    weights:
+      value: open
+      detail: Llama-Prompt-Guard-2-86M/22M on HF
+    data:
+      value: not-released
+    license:
+      value: Llama-4-Community
+      detail: NOT OSI
   confidence: medium
   note: Open weights under Meta's Llama 4 Community License, which is use-restricted and not OSI-approved,
     so open_weights (3) like the rest of the Llama family.
+  raw: weights:open(Llama-Prompt-Guard-2-86M/22M on HF);data:not-released;license:Llama-4-Community(NOT
+    OSI)
   sources:
   - url: https://huggingface.co/meta-llama/Llama-Prompt-Guard-2-86M
     shows: Llama 4 Community License; open weights; 86M/22M; prompt-injection/jailbreak classifier; ~90,441

--- a/sources/scores/llama.yaml
+++ b/sources/scores/llama.yaml
@@ -2,9 +2,18 @@ product: llama
 openness:
   score: 3
   class: open_weights
-  components: 'weights:open(downloadable on HF);data:closed;code:partial(inference/utils via llama-models, no training
-    code);license:Llama-4-Community(non-OSI: 700M MAU commercial cap as of Apr 2025 + no-compete/no-train-competing-LLM
-    clause)'
+  components:
+    weights:
+      value: open
+      detail: downloadable on HF
+    data:
+      value: closed
+    code:
+      value: partial
+      detail: inference/utils via llama-models, no training code
+    license:
+      value: Llama-4-Community
+      detail: 'non-OSI: 700M MAU commercial cap as of Apr 2025 + no-compete/no-train-competing-LLM clause'
   governing_release: llama-4-scout-maverick
   confidence: high
   note: >-
@@ -17,6 +26,9 @@ openness:
     commerce outright - CC-BY-NC, Mistral Non-Production - stays at 2. Nine other products carry a
     bounded license and all now score 3; four of them were already recorded there, which is the
     inconsistency this resolves.
+  raw: 'weights:open(downloadable on HF);data:closed;code:partial(inference/utils via llama-models, no training
+    code);license:Llama-4-Community(non-OSI: 700M MAU commercial cap as of Apr 2025 + no-compete/no-train-competing-LLM
+    clause)'
   sources:
   - url: https://huggingface.co/api/models/meta-llama/Llama-4-Scout-17B-16E
     shows: gated (manual approval), 217.3GB of weight files, 32,527 downloads last month; cardData.license is `other`,

--- a/sources/scores/lucie-7b.yaml
+++ b/sources/scores/lucie-7b.yaml
@@ -2,8 +2,22 @@ product: lucie-7b
 openness:
   score: 5
   class: open_source
-  components: weights:open(Apache-2.0);data:open(Lucie-Training-Dataset on HF, redistributed in training
-    form);code:open(Lucie-Training Megatron-DeepSpeed fork);checkpoints:open(intermediate HF revisions);license:Apache-2.0(OSI)
+  components:
+    weights:
+      value: open
+      detail: Apache-2.0
+    data:
+      value: open
+      detail: Lucie-Training-Dataset on HF, redistributed in training form
+    code:
+      value: open
+      detail: Lucie-Training Megatron-DeepSpeed fork
+    checkpoints:
+      value: open
+      detail: intermediate HF revisions
+    license:
+      value: Apache-2.0
+      detail: OSI
   confidence: high
   note: 'Full open-source tier alongside OLMo / Apertus: open weights, open training data, open training
     code, intermediate checkpoints. Authors position Lucie as OSI-definition-compliant for open-source AI.
@@ -14,6 +28,8 @@ openness:
     survive a strict reading, and Lucie is a weaker full-openness exemplar than OLMo, whose Dolma is
     `odc-by`.'
   last_verified: '2026-07-30'
+  raw: weights:open(Apache-2.0);data:open(Lucie-Training-Dataset on HF, redistributed in training form);code:open(Lucie-Training
+    Megatron-DeepSpeed fork);checkpoints:open(intermediate HF revisions);license:Apache-2.0(OSI)
   sources:
   - url: https://huggingface.co/api/datasets/OpenLLM-France/Lucie-Training-Dataset
     shows: '`gated: false`, `private: false`, 2,823 downloads, 38 likes. Card license is `cc-by-nc-sa-4.0`

--- a/sources/scores/luciole.yaml
+++ b/sources/scores/luciole.yaml
@@ -2,16 +2,31 @@ product: luciole
 openness:
   score: 5
   class: open_source
-  components: weights:open(Apache-2.0, safetensors on HF for 1B/8B/23B base + Instruct-1.1);data:open(Luciole-Training-Dataset
-    on HF, ~4.65T tokens, "only corpora under open licenses");code:open(Luciole-Training pretraining +
-    data-processing pipeline on GitHub, GPL-3.0);checkpoints:open(intermediate + final pretraining checkpoints
-    released);license:Apache-2.0(OSI)
+  components:
+    weights:
+      value: open
+      detail: Apache-2.0, safetensors on HF for 1B/8B/23B base + Instruct-1.1
+    data:
+      value: open
+      detail: Luciole-Training-Dataset on HF, ~4.65T tokens, "only corpora under open licenses"
+    code:
+      value: open
+      detail: Luciole-Training pretraining + data-processing pipeline on GitHub, GPL-3.0
+    checkpoints:
+      value: open
+      detail: intermediate + final pretraining checkpoints released
+    license:
+      value: Apache-2.0
+      detail: OSI
   confidence: high
   note: 'Full open-source tier alongside Lucie / OLMo / Apertus: open weights, open training data, open
     training code, and intermediate checkpoints. Notably a cleaner full-openness exemplar than its Lucie
     predecessor — the Luciole-Training-Dataset is described as containing only openly licensed corpora,
     where Lucie-Training-Dataset carried a non-commercial cc-by-nc-sa license. The weights are Apache-2.0
     (OSI) across every distributed size, so the data + code + OSI-license rule lands at 5.'
+  raw: weights:open(Apache-2.0, safetensors on HF for 1B/8B/23B base + Instruct-1.1);data:open(Luciole-Training-Dataset
+    on HF, ~4.65T tokens, "only corpora under open licenses");code:open(Luciole-Training pretraining + data-processing
+    pipeline on GitHub, GPL-3.0);checkpoints:open(intermediate + final pretraining checkpoints released);license:Apache-2.0(OSI)
   sources:
   - url: https://huggingface.co/OpenLLM-France/Luciole-23B-Instruct-1.1
     shows: Apache-2.0 license; downloadable safetensors weights; fine-tuned + DPO-aligned version of

--- a/sources/scores/madlad-400.yaml
+++ b/sources/scores/madlad-400.yaml
@@ -2,9 +2,17 @@ product: madlad-400
 openness:
   score: 5
   class: open
-  components: license:odc-by(API tag; card cites CC-BY-4.0);gated:false;card:present
+  components:
+    license:
+      value: odc-by
+      detail: API tag; card cites CC-BY-4.0
+    gated:
+      value: 'false'
+    card:
+      value: present
   confidence: high
   note: Ungated with a permissive open-data license and a complete dataset card.
+  raw: license:odc-by(API tag; card cites CC-BY-4.0);gated:false;card:present
   sources:
   - url: https://huggingface.co/api/datasets/allenai/MADLAD-400
     shows: gated = false, license = odc-by

--- a/sources/scores/mimo-pro.yaml
+++ b/sources/scores/mimo-pro.yaml
@@ -2,9 +2,21 @@ product: mimo-pro
 openness:
   score: 3
   class: open_weights
-  components: weights:open(MIT per HF card);data:closed;code:open;license:MIT(HF card; older GitHub repo shows Apache-2.0)
+  components:
+    weights:
+      value: open
+      detail: MIT per HF card
+    data:
+      value: closed
+    code:
+      value: open
+    license:
+      value: MIT
+      detail: HF card; older GitHub repo shows Apache-2.0
   confidence: medium
   note: Open weights under a permissive license (MIT per the model card); no open training data -> open_weights.
+  raw: weights:open(MIT per HF card);data:closed;code:open;license:MIT(HF card; older GitHub repo shows
+    Apache-2.0)
   sources:
   - url: https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro
     shows: MIT, 1.02T/42B MoE, 1M context, benchmarks

--- a/sources/scores/minimax.yaml
+++ b/sources/scores/minimax.yaml
@@ -2,14 +2,26 @@ product: minimax
 openness:
   score: 3
   class: open_weights
-  components: weights:open(on HF; ungated; safetensors/BF16; MoE);data:closed;code:partial(inference only; no training
-    pipeline/data);license:minimax-community(custom, see HF LICENSE)
+  components:
+    weights:
+      value: open
+      detail: on HF; ungated; safetensors/BF16; MoE
+    data:
+      value: closed
+    code:
+      value: partial
+      detail: inference only; no training pipeline/data
+    license:
+      value: minimax-community
+      detail: custom, see HF LICENSE
   governing_release: minimax-m3
   confidence: high
   note: Weights distributed under the custom minimax-community license with a closed corpus, so 3. M3 governs as
     the current release. Capability 5 is carried from M2.5 because M3 records no capability score at all, so the
     tier's capability describes the older release and should be re-read when M3 is benchmarked - it is the one axis
     here not sourced to the governing release.
+  raw: weights:open(on HF; ungated; safetensors/BF16; MoE);data:closed;code:partial(inference only; no training
+    pipeline/data);license:minimax-community(custom, see HF LICENSE)
   sources:
   - url: https://huggingface.co/api/models/MiniMaxAI/MiniMax-M3
     shows: Public ungated weights repo (safetensors/MoE), license=minimax-community, created 2026-06-02

--- a/sources/scores/mistral-7b-instruct.yaml
+++ b/sources/scores/mistral-7b-instruct.yaml
@@ -2,10 +2,22 @@ product: mistral-7b-instruct
 openness:
   score: 3
   class: open_weights
-  components: weights:open(Apache-2.0, on HF);data:closed;code:closed(no training/post-training pipeline);license:Apache-2.0(OSI
-    permissive)
+  components:
+    weights:
+      value: open
+      detail: Apache-2.0, on HF
+    data:
+      value: closed
+    code:
+      value: closed
+      detail: no training/post-training pipeline
+    license:
+      value: Apache-2.0
+      detail: OSI permissive
   confidence: high
   note: Apache-2.0 open weights; instruction-tuning data and recipe undisclosed -> open_weights.
+  raw: weights:open(Apache-2.0, on HF);data:closed;code:closed(no training/post-training pipeline);license:Apache-2.0(OSI
+    permissive)
   sources:
   - url: https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2
     shows: live card; license=apache-2.0; 7B instruct; 32k context; 2,504,301 downloads last month

--- a/sources/scores/mistral-large.yaml
+++ b/sources/scores/mistral-large.yaml
@@ -2,13 +2,24 @@ product: mistral-large
 openness:
   score: 3
   class: open_weights
-  components: weights:open(Apache-2.0);data:closed;code:closed;license:Apache-2.0(OSI)
+  components:
+    weights:
+      value: open
+      detail: Apache-2.0
+    data:
+      value: closed
+    code:
+      value: closed
+    license:
+      value: Apache-2.0
+      detail: OSI
   governing_release: mistral-large-3
   confidence: high
   note: 'Apache-2.0 weights with closed data and no training code, so 3. Mistral relicensed between releases: Large
     2 shipped under the Mistral Research License, which permits research and non-commercial use only and scored
     2, and Large 3 is Apache-2.0. Large 3 governs, so the tier records the relicensing rather than the family''s
     worst historical terms.'
+  raw: weights:open(Apache-2.0);data:closed;code:closed;license:Apache-2.0(OSI)
   sources:
   - url: https://huggingface.co/api/models/mistralai/Mistral-Large-3-675B-Base-2512
     shows: license apache-2.0, ungated, 1,352.0GB of weight files; the base checkpoint, distinct from the -Instruct-2512

--- a/sources/scores/muse-spark.yaml
+++ b/sources/scores/muse-spark.yaml
@@ -2,10 +2,20 @@ product: muse-spark
 openness:
   score: 1
   class: closed
-  components: weights:closed;data:closed;code:closed;license:Proprietary(meta.ai/Meta AI app + private
-    API preview; no downloadable weights)
+  components:
+    weights:
+      value: closed
+    data:
+      value: closed
+    code:
+      value: closed
+    license:
+      value: Proprietary
+      detail: meta.ai/Meta AI app + private API preview; no downloadable weights
   confidence: high
   note: No weights released, a closed assistant-surface model; only a private API preview. Fully closed.
+  raw: weights:closed;data:closed;code:closed;license:Proprietary(meta.ai/Meta AI app + private API preview;
+    no downloadable weights)
   sources:
   - url: https://ai.meta.com/blog/introducing-muse-spark-msl/
     shows: Muse Spark available at meta.ai and Meta AI app + private API preview; no open weights

--- a/sources/scores/nemotron-cc.yaml
+++ b/sources/scores/nemotron-cc.yaml
@@ -2,10 +2,18 @@ product: nemotron-cc
 openness:
   score: 3
   class: gated
-  components: license:NVIDIA-Open-Data;gated:manual(model-training-use);dataset_card:present
+  components:
+    license:
+      value: NVIDIA-Open-Data
+    gated:
+      value: manual
+      detail: model-training-use
+    dataset_card:
+      value: present
   confidence: high
   note: Manually gated behind the NVIDIA Data Agreement for Model Training; synthetic portions may inherit
     generator-model license terms.
+  raw: license:NVIDIA-Open-Data;gated:manual(model-training-use);dataset_card:present
   sources:
   - url: https://huggingface.co/datasets/nvidia/Nemotron-CC-v2
     shows: gated (manual), NVIDIA Open Data License, dataset card

--- a/sources/scores/nemotron.yaml
+++ b/sources/scores/nemotron.yaml
@@ -3,8 +3,19 @@ openness:
   score: 4
   class: open_weights
   confidence: high
-  components: weights:open;data:open(~40M post-training/SFT+RL samples released as Nemotron-SFT-Data/Nemotron-RL-Data;
-    pretraining sets only partly released);code:open(training recipes + RL env configs);license:NVIDIA-Nemotron-Open-Model-License(permissive,commercial,non-OSI)
+  components:
+    weights:
+      value: open
+    data:
+      value: open
+      detail: ~40M post-training/SFT+RL samples released as Nemotron-SFT-Data/Nemotron-RL-Data; pretraining
+        sets only partly released
+    code:
+      value: open
+      detail: training recipes + RL env configs
+    license:
+      value: NVIDIA-Nemotron-Open-Model-License
+      detail: permissive,commercial,non-OSI
   note: 'Unusually open for post-trained models: NVIDIA releases weights, the post-training data and the recipes,
     but under the non-OSI NVIDIA Open Model License, so open_weights not open_source. This category scores the post-training
     data, which is genuinely released. The pretraining side is thinner than NVIDIA''s "fully open" framing suggests
@@ -12,6 +23,8 @@ openness:
     metadata parquet describing the code corpus rather than the corpus, so the earlier "~10T-token pretraining released"
     wording overstated it and has been narrowed. Score is unaffected: the post-training answer is what this category
     asks for.'
+  raw: weights:open;data:open(~40M post-training/SFT+RL samples released as Nemotron-SFT-Data/Nemotron-RL-Data;
+    pretraining sets only partly released);code:open(training recipes + RL env configs);license:NVIDIA-Nemotron-Open-Model-License(permissive,commercial,non-OSI)
   sources:
   - url: https://research.nvidia.com/labs/nemotron/Nemotron-3/
     shows: Nemotron 3 Nano/Super/Ultra family; post-trained models; Nemotron-SFT-Data + Nemotron-RL-Data + training

--- a/sources/scores/o-series.yaml
+++ b/sources/scores/o-series.yaml
@@ -2,9 +2,19 @@ product: o-series
 openness:
   score: 1
   class: closed
-  components: weights:closed;data:closed;code:closed;license:Proprietary(API+ChatGPT only)
+  components:
+    weights:
+      value: closed
+    data:
+      value: closed
+    code:
+      value: closed
+    license:
+      value: Proprietary
+      detail: API+ChatGPT only
   confidence: high
   note: Proprietary OpenAI reasoning models; no weights, data, or code released.
+  raw: weights:closed;data:closed;code:closed;license:Proprietary(API+ChatGPT only)
   sources:
   - url: https://en.wikipedia.org/wiki/OpenAI_o3
     shows: o3/o4-mini are proprietary reasoning models served via ChatGPT/API, released Apr 16 2025

--- a/sources/scores/oasst1.yaml
+++ b/sources/scores/oasst1.yaml
@@ -2,9 +2,16 @@ product: oasst1
 openness:
   score: 5
   class: open
-  components: license:Apache-2.0;gated:false;dataset_card:present
+  components:
+    license:
+      value: Apache-2.0
+    gated:
+      value: 'false'
+    dataset_card:
+      value: present
   confidence: high
   note: Apache-2.0, ungated, full dataset card.
+  raw: license:Apache-2.0;gated:false;dataset_card:present
   sources:
   - url: https://huggingface.co/datasets/OpenAssistant/oasst1
     shows: Apache-2.0 license, ungated, dataset card

--- a/sources/scores/olmo.yaml
+++ b/sources/scores/olmo.yaml
@@ -2,11 +2,27 @@ product: olmo
 openness:
   score: 5
   class: open_source
-  components: weights:open(Apache-2.0);data:open(Dolma 3, 9.3T tokens, all stages);code:open(training code+recipes+logs);checkpoints:open(intermediate);license:Apache-2.0(OSI)
+  components:
+    weights:
+      value: open
+      detail: Apache-2.0
+    data:
+      value: open
+      detail: Dolma 3, 9.3T tokens, all stages
+    code:
+      value: open
+      detail: training code+recipes+logs
+    checkpoints:
+      value: open
+      detail: intermediate
+    license:
+      value: Apache-2.0
+      detail: OSI
   confidence: high
   note: 'Fully open: Apache-2.0 weights + the complete Dolma 3 corpus + training code + intermediate checkpoints.
     The reference fully-open model line.'
   last_verified: '2026-07-30'
+  raw: weights:open(Apache-2.0);data:open(Dolma 3, 9.3T tokens, all stages);code:open(training code+recipes+logs);checkpoints:open(intermediate);license:Apache-2.0(OSI)
   sources:
   - url: https://huggingface.co/api/datasets/allenai/dolma
     shows: '`gated: false`, `private: false`, 2,767 downloads, 1,064 likes, card license `odc-by`.

--- a/sources/scores/openai-internal-evals.yaml
+++ b/sources/scores/openai-internal-evals.yaml
@@ -2,11 +2,22 @@ product: openai-internal-evals
 openness:
   score: 0
   class: closed
-  components: data:closed(internal eval sets for frontier-risk Tracked Categories, never published);datasheet:no;license:none;access:internal-only(only
-    summarized/redacted results released alongside major deployments)
+  components:
+    data:
+      value: closed
+      detail: internal eval sets for frontier-risk Tracked Categories, never published
+    datasheet:
+      value: 'no'
+    license:
+      value: none
+    access:
+      value: internal-only
+      detail: only summarized/redacted results released alongside major deployments
   confidence: high
   note: Fully internal/private eval datasets; only redacted result summaries are published, the underlying
     example sets are not redistributable.
+  raw: data:closed(internal eval sets for frontier-risk Tracked Categories, never published);datasheet:no;license:none;access:internal-only(only
+    summarized/redacted results released alongside major deployments)
   sources:
   - url: https://cdn.openai.com/pdf/18a02b5d-6b67-4cec-ab64-68cdfbddebcd/preparedness-framework-v2.pdf
     shows: Preparedness Framework v2 describes internal capability evaluations per Tracked Category with

--- a/sources/scores/openwebmath.yaml
+++ b/sources/scores/openwebmath.yaml
@@ -2,9 +2,16 @@ product: openwebmath
 openness:
   score: 5
   class: open
-  components: license:ODC-BY;gated:false;dataset_card:present
+  components:
+    license:
+      value: ODC-BY
+    gated:
+      value: 'false'
+    dataset_card:
+      value: present
   confidence: high
   note: ODC-BY 1.0, ungated, full dataset card.
+  raw: license:ODC-BY;gated:false;dataset_card:present
   sources:
   - url: https://huggingface.co/datasets/open-web-math/open-web-math
     shows: ODC-BY 1.0 license, ungated, dataset card

--- a/sources/scores/pes2o.yaml
+++ b/sources/scores/pes2o.yaml
@@ -2,9 +2,16 @@ product: pes2o
 openness:
   score: 5
   class: open
-  components: license:ODC-BY;gated:false;dataset_card:present
+  components:
+    license:
+      value: ODC-BY
+    gated:
+      value: 'false'
+    dataset_card:
+      value: present
   confidence: high
   note: ODC-BY, ungated, full dataset card.
+  raw: license:ODC-BY;gated:false;dataset_card:present
   sources:
   - url: https://huggingface.co/datasets/allenai/peS2o
     shows: ODC-BY license, ungated, dataset card

--- a/sources/scores/phi-instruct.yaml
+++ b/sources/scores/phi-instruct.yaml
@@ -2,10 +2,23 @@ product: phi-instruct
 openness:
   score: 3
   class: open_weights
-  components: weights:open(MIT, on HF);data:closed(synthetic-heavy training data undisclosed);code:closed(no training
-    pipeline);license:MIT(OSI permissive)
+  components:
+    weights:
+      value: open
+      detail: MIT, on HF
+    data:
+      value: closed
+      detail: synthetic-heavy training data undisclosed
+    code:
+      value: closed
+      detail: no training pipeline
+    license:
+      value: MIT
+      detail: OSI permissive
   confidence: high
   note: MIT-licensed open weights; training/post-training data and code not released -> open_weights.
+  raw: weights:open(MIT, on HF);data:closed(synthetic-heavy training data undisclosed);code:closed(no training
+    pipeline);license:MIT(OSI permissive)
   sources:
   - url: https://huggingface.co/microsoft/Phi-4-mini-instruct
     shows: live card; license=MIT; 3.8B instruct; 1,537,561 downloads last month

--- a/sources/scores/phi.yaml
+++ b/sources/scores/phi.yaml
@@ -2,12 +2,23 @@ product: phi
 openness:
   score: 3
   class: open_weights
-  components: weights:open(MIT);data:closed;code:closed;license:MIT(OSI)
+  components:
+    weights:
+      value: open
+      detail: MIT
+    data:
+      value: closed
+    code:
+      value: closed
+    license:
+      value: MIT
+      detail: OSI
   confidence: high
   note: 'MIT weights, which is genuinely permissive with no use restrictions, but neither the training corpus nor
     the training pipeline is published - Microsoft describes the synthetic data mix without releasing it. So 3/open_weights:
     the artifact is free to use and the recipe is not reproducible. Reaching 4 or 5 would need the data or the pipeline,
     not a more permissive license.'
+  raw: weights:open(MIT);data:closed;code:closed;license:MIT(OSI)
   sources:
   - url: https://huggingface.co/api/models/microsoft/phi-4
     shows: license mit, ungated, 29.3GB of weight files, 712,912 downloads last month

--- a/sources/scores/pysyft.yaml
+++ b/sources/scores/pysyft.yaml
@@ -2,9 +2,15 @@ product: pysyft
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI permissive);source:public
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI permissive
+    source:
+      value: public
   confidence: high
   note: Apache-2.0 licensed with full public source code.
+  raw: license:Apache-2.0(OSI permissive);source:public
   sources:
   - url: https://github.com/OpenMined/PySyft
     shows: Apache-2.0 license, public source, 9.9k stars

--- a/sources/scores/pythia.yaml
+++ b/sources/scores/pythia.yaml
@@ -2,8 +2,22 @@ product: pythia
 openness:
   score: 5
   class: open_source
-  components: weights:open(Apache-2.0);data:open(the Pile, with dataloader reconstruction tools);code:open(training+analysis
-    code, GitHub);checkpoints:open(154 per model);license:Apache-2.0(OSI)
+  components:
+    weights:
+      value: open
+      detail: Apache-2.0
+    data:
+      value: open
+      detail: the Pile, with dataloader reconstruction tools
+    code:
+      value: open
+      detail: training+analysis code, GitHub
+    checkpoints:
+      value: open
+      detail: 154 per model
+    license:
+      value: Apache-2.0
+      detail: OSI
   confidence: high
   note: 'The reference case for 5/open_source in this category. Apache-2.0 weights, the Pile released as the training
     corpus together with dataloader tools that reconstruct the exact token order, training and analysis code on
@@ -11,6 +25,8 @@ openness:
     something downloadable, which is what separates 5 from the open-weights tier: the run is reproducible, not merely
     the model usable.'
   last_verified: '2026-07-30'
+  raw: weights:open(Apache-2.0);data:open(the Pile, with dataloader reconstruction tools);code:open(training+analysis
+    code, GitHub);checkpoints:open(154 per model);license:Apache-2.0(OSI)
   sources:
   - url: https://huggingface.co/api/datasets/EleutherAI/pile
     shows: '`gated: false`, `private: false`, 2,308 downloads, 502 likes. The Pile is published and

--- a/sources/scores/qwen-coder.yaml
+++ b/sources/scores/qwen-coder.yaml
@@ -2,14 +2,28 @@ product: qwen-coder
 openness:
   score: 3
   class: open_weights
-  components: weights:open(Apache-2.0, on HF);data:closed(no training corpus released);code:partial(inference/usage
-    + chat template; no training pipeline or post-training/SFT data);license:Apache-2.0(OSI permissive, no use restrictions)
+  components:
+    weights:
+      value: open
+      detail: Apache-2.0, on HF
+    data:
+      value: closed
+      detail: no training corpus released
+    code:
+      value: partial
+      detail: inference/usage + chat template; no training pipeline or post-training/SFT data
+    license:
+      value: Apache-2.0
+      detail: OSI permissive, no use restrictions
   governing_release: qwen3-coder
   confidence: high
   note: Apache-2.0 weights with a closed corpus and inference code only, so 3, consistent across both generations
     - Qwen2.5-Coder and Qwen3-Coder are both plain Apache with no use restrictions. Qwen3-Coder governs and contributes
     capability 4; adoption 4 is carried from Qwen2.5-Coder, which has had longer to accumulate downloads. Kept apart
     from the base Qwen tier because Alibaba ships and markets the Coder line separately.
+  raw: weights:open(Apache-2.0, on HF);data:closed(no training corpus released);code:partial(inference/usage
+    + chat template; no training pipeline or post-training/SFT data);license:Apache-2.0(OSI permissive,
+    no use restrictions)
   sources:
   - url: https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct
     shows: Apache-2.0 license, 480B-A35B MoE instruct model card, downloadable BF16 weights

--- a/sources/scores/qwen-instruct.yaml
+++ b/sources/scores/qwen-instruct.yaml
@@ -2,10 +2,22 @@ product: qwen-instruct
 openness:
   score: 3
   class: open_weights
-  components: weights:open(Apache-2.0, on HF);data:closed;code:partial(inference/chat template; no training pipeline
-    or SFT/RLHF data);license:Apache-2.0(OSI permissive)
+  components:
+    weights:
+      value: open
+      detail: Apache-2.0, on HF
+    data:
+      value: closed
+    code:
+      value: partial
+      detail: inference/chat template; no training pipeline or SFT/RLHF data
+    license:
+      value: Apache-2.0
+      detail: OSI permissive
   confidence: high
   note: OSI Apache-2.0 open weights; post-training data and training code closed -> open_weights.
+  raw: weights:open(Apache-2.0, on HF);data:closed;code:partial(inference/chat template; no training pipeline
+    or SFT/RLHF data);license:Apache-2.0(OSI permissive)
   sources:
   - url: https://huggingface.co/Qwen/Qwen2.5-14B-Instruct
     shows: Apache-2.0 license, 14.7B instruct model card, downloadable BF16 weights

--- a/sources/scores/qwen.yaml
+++ b/sources/scores/qwen.yaml
@@ -2,9 +2,19 @@ product: qwen
 openness:
   score: 3
   class: open_weights
-  components: weights:open(Apache-2.0 for open variants e.g. 27B/35B-A3B);data:closed;code:partial(inference/usage
-    code on GitHub; no training pipeline/data);license:Apache-2.0(most restrictive distributed SKU; the proprietary
-    Plus/Max tiers are API-only and never distributed, so they fall outside this axis)
+  components:
+    weights:
+      value: open
+      detail: Apache-2.0 for open variants e.g. 27B/35B-A3B
+    data:
+      value: closed
+    code:
+      value: partial
+      detail: inference/usage code on GitHub; no training pipeline/data
+    license:
+      value: Apache-2.0
+      detail: most restrictive distributed SKU; the proprietary Plus/Max tiers are API-only and never distributed,
+        so they fall outside this axis
   governing_release: qwen-3-6
   confidence: high
   note: 'Apache-2.0 across the distributed base variants, data closed and only inference code published, so 3. The
@@ -15,6 +25,9 @@ openness:
     Agreement; from Qwen3 onward the distributed set is Apache. Replaces an earlier note that was a copy of the
     components string and recorded the license as `mixed`, a value the rubric forbids because it states that SKUs
     differ without recording the outcome.'
+  raw: weights:open(Apache-2.0 for open variants e.g. 27B/35B-A3B);data:closed;code:partial(inference/usage
+    code on GitHub; no training pipeline/data);license:Apache-2.0(most restrictive distributed SKU; the
+    proprietary Plus/Max tiers are API-only and never distributed, so they fall outside this axis)
   sources:
   - url: https://huggingface.co/api/models/Qwen/Qwen3.6-27B
     shows: license apache-2.0, ungated, 55.6GB of weight files, 6,232,995 downloads last month

--- a/sources/scores/qwen3guard.yaml
+++ b/sources/scores/qwen3guard.yaml
@@ -2,10 +2,19 @@ product: qwen3guard
 openness:
   score: 4
   class: open_weights
-  components: weights:open(Qwen3Guard 0.6B/4B/8B on HF);data:not-released;license:Apache-2.0(OSI)
+  components:
+    weights:
+      value: open
+      detail: Qwen3Guard 0.6B/4B/8B on HF
+    data:
+      value: not-released
+    license:
+      value: Apache-2.0
+      detail: OSI
   confidence: medium
   note: Open weights under Apache-2.0 (OSI); training data not released, so open_weights (4) rather than
     open_source. Unusually broad multilingual coverage (119 languages) plus a streaming variant.
+  raw: weights:open(Qwen3Guard 0.6B/4B/8B on HF);data:not-released;license:Apache-2.0(OSI)
   sources:
   - url: https://huggingface.co/Qwen/Qwen3Guard-Gen-8B
     shows: Apache-2.0; open weights; 0.6B/4B/8B; 119 languages; safe/controversial/unsafe; ~74,669 downloads/month,

--- a/sources/scores/reka-core.yaml
+++ b/sources/scores/reka-core.yaml
@@ -2,11 +2,22 @@ product: reka-core
 openness:
   score: 1
   class: closed
-  components: weights:closed;data:closed(mix of public+licensed proprietary);code:closed;license:Proprietary(API/on-prem,
-    no weights)
+  components:
+    weights:
+      value: closed
+    data:
+      value: closed
+      detail: mix of public+licensed proprietary
+    code:
+      value: closed
+    license:
+      value: Proprietary
+      detail: API/on-prem, no weights
   confidence: high
   note: Proprietary multimodal model; API/on-prem/on-device deployment but no downloadable weights. Confirmed
     on launch page.
+  raw: weights:closed;data:closed(mix of public+licensed proprietary);code:closed;license:Proprietary(API/on-prem,
+    no weights)
   sources:
   - url: https://reka.ai/news/reka-core-our-frontier-class-multimodal-language-model
     shows: Reka Core via API/on-prem/on-device, proprietary, no open weights

--- a/sources/scores/rwkv.yaml
+++ b/sources/scores/rwkv.yaml
@@ -2,9 +2,20 @@ product: rwkv
 openness:
   score: 4
   class: open_weights
-  components: weights:open(Apache-2.0);data:documented-not-released(itemized machine-readable component
-    index with resolvable links to public datasets, but no released corpus and no reconstruction
-    pipeline);code:open(github.com/BlinkDL/RWKV-LM);license:Apache-2.0(OSI)
+  components:
+    weights:
+      value: open
+      detail: Apache-2.0
+    data:
+      value: documented-not-released
+      detail: itemized machine-readable component index with resolvable links to public datasets, but no
+        released corpus and no reconstruction pipeline
+    code:
+      value: open
+      detail: github.com/BlinkDL/RWKV-LM
+    license:
+      value: Apache-2.0
+      detail: OSI
   confidence: high
   last_verified: '2026-07-30'
   note: 'Corrected from 5/open_source on 2026-07-28, then re-examined the same day after challenge.
@@ -25,6 +36,8 @@ openness:
     reproducible" is meaningfully more open than prose documentation and less than a released corpus,
     and the data enum has no value for it. Nemotron 3''s partial release hits the same gap, so two of
     the nine products checked fall between the available values.'
+  raw: weights:open(Apache-2.0);data:documented-not-released(itemized machine-readable component index with
+    resolvable links to public datasets, but no released corpus and no reconstruction pipeline);code:open(github.com/BlinkDL/RWKV-LM);license:Apache-2.0(OSI)
   sources:
   - url: https://huggingface.co/datasets/RWKV/RWKV-World-Listing/raw/main/train.csv
     shows: 'Header `Dataset;Category;Categories;Citation;Version;URL;Notes`; every source named with a

--- a/sources/scores/scale-seal-leaderboard.yaml
+++ b/sources/scores/scale-seal-leaderboard.yaml
@@ -2,13 +2,26 @@ product: scale-seal-leaderboard
 openness:
   score: 1
   class: closed
-  components: data:closed(proprietary held-out prompt sets, ~1,000 examples/domain, deliberately unpublished
-    to prevent contamination/training-set leakage);datasheet:no(methodology described but examples not
-    redistributable);license:none(not distributed);access:held-out(results visible on leaderboard, dataset
-    not downloadable)
+  components:
+    data:
+      value: closed
+      detail: proprietary held-out prompt sets, ~1,000 examples/domain, deliberately unpublished to prevent
+        contamination/training-set leakage
+    datasheet:
+      value: 'no'
+      detail: methodology described but examples not redistributable
+    license:
+      value: none
+      detail: not distributed
+    access:
+      value: held-out
+      detail: results visible on leaderboard, dataset not downloadable
   confidence: high
   note: Intentionally private/held-out eval sets per the data-openness rubric (closed = proprietary held-out
     test suite); only the leaderboard results are public, the data itself is not.
+  raw: data:closed(proprietary held-out prompt sets, ~1,000 examples/domain, deliberately unpublished to
+    prevent contamination/training-set leakage);datasheet:no(methodology described but examples not redistributable);license:none(not
+    distributed);access:held-out(results visible on leaderboard, dataset not downloadable)
   sources:
   - url: https://scale.com/blog/leaderboard
     shows: Scale states SEAL datasets remain private/unpublished, combining proprietary held-out sets

--- a/sources/scores/shieldgemma.yaml
+++ b/sources/scores/shieldgemma.yaml
@@ -2,10 +2,19 @@ product: shieldgemma
 openness:
   score: 3
   class: open_weights
-  components: weights:open(shieldgemma 2B/9B/27B on HF);data:not-released;license:Gemma(NOT OSI, use-restricted)
+  components:
+    weights:
+      value: open
+      detail: shieldgemma 2B/9B/27B on HF
+    data:
+      value: not-released
+    license:
+      value: Gemma
+      detail: NOT OSI, use-restricted
   confidence: medium
   note: Open weights under the Gemma license, which is use-restricted and not OSI-approved (per the openness
     rubric, Gemma = open_weights, not open_source), so it sits at 3.
+  raw: weights:open(shieldgemma 2B/9B/27B on HF);data:not-released;license:Gemma(NOT OSI, use-restricted)
   sources:
   - url: https://huggingface.co/google/shieldgemma-2b
     shows: Gemma license (not OSI); open weights; four harm categories; ~8,555 downloads/month, 124 likes

--- a/sources/scores/smollm.yaml
+++ b/sources/scores/smollm.yaml
@@ -2,11 +2,24 @@ product: smollm
 openness:
   score: 5
   class: open_source
-  components: weights:open(Apache-2.0);data:open(public data mixtures, ~11T tokens);code:open(training+post-training
-    recipe published);license:Apache-2.0(OSI)
+  components:
+    weights:
+      value: open
+      detail: Apache-2.0
+    data:
+      value: open
+      detail: public data mixtures, ~11T tokens
+    code:
+      value: open
+      detail: training+post-training recipe published
+    license:
+      value: Apache-2.0
+      detail: OSI
   confidence: high
   note: 'Fully-open small-model line: Apache-2.0 weights with the complete engineering blueprint (architecture,
     data mixtures, training and post-training recipe) published.'
+  raw: weights:open(Apache-2.0);data:open(public data mixtures, ~11T tokens);code:open(training+post-training
+    recipe published);license:Apache-2.0(OSI)
   sources:
   - url: https://huggingface.co/blog/smollm3
     shows: 'fully-open 3B: 11T tokens, 128K context, multilingual, full recipe published'

--- a/sources/scores/stack-edu.yaml
+++ b/sources/scores/stack-edu.yaml
@@ -2,9 +2,16 @@ product: stack-edu
 openness:
   score: 4
   class: open
-  components: access:ungated;license:inherits-the-stack-v2;dataset_card:present
+  components:
+    access:
+      value: ungated
+    license:
+      value: inherits-the-stack-v2
+    dataset_card:
+      value: present
   confidence: medium
   note: Ungated download with a card; the card defers the data license to The Stack v2's terms.
+  raw: access:ungated;license:inherits-the-stack-v2;dataset_card:present
   sources:
   - url: https://huggingface.co/datasets/HuggingFaceTB/stack-edu
     shows: ungated access, card defers license to the-stack-v2

--- a/sources/scores/starcoderdata.yaml
+++ b/sources/scores/starcoderdata.yaml
@@ -2,9 +2,17 @@ product: starcoderdata
 openness:
   score: 3
   class: gated
-  components: license:permissive(SPDX per file);gated:terms-acceptance;dataset_card:present
+  components:
+    license:
+      value: permissive
+      detail: SPDX per file
+    gated:
+      value: terms-acceptance
+    dataset_card:
+      value: present
   confidence: high
   note: Terms-gated like its parent The Stack v1; permissively licensed source files.
+  raw: license:permissive(SPDX per file);gated:terms-acceptance;dataset_card:present
   sources:
   - url: https://huggingface.co/datasets/bigcode/starcoderdata
     shows: gated (auto) access with terms, dataset card

--- a/sources/scores/the-stack-v2.yaml
+++ b/sources/scores/the-stack-v2.yaml
@@ -2,9 +2,17 @@ product: the-stack-v2
 openness:
   score: 3
   class: gated
-  components: license:permissive(SPDX);gated:terms-acceptance+contact-info;dataset_card:yes
+  components:
+    license:
+      value: permissive
+      detail: SPDX
+    gated:
+      value: terms-acceptance+contact-info
+    dataset_card:
+      value: 'yes'
   confidence: high
   note: Requires acceptance of terms and sharing contact info before download, so access is gated.
+  raw: license:permissive(SPDX);gated:terms-acceptance+contact-info;dataset_card:yes
   sources:
   - url: https://huggingface.co/datasets/bigcode/the-stack-v2
     shows: gated access requiring terms acceptance and contact-info sharing, permissive licenses, dataset

--- a/sources/scores/txt360.yaml
+++ b/sources/scores/txt360.yaml
@@ -2,9 +2,16 @@ product: txt360
 openness:
   score: 5
   class: open
-  components: license:ODC-BY;gated:false;dataset_card:present
+  components:
+    license:
+      value: ODC-BY
+    gated:
+      value: 'false'
+    dataset_card:
+      value: present
   confidence: high
   note: ODC-BY, ungated, documented pipeline on GitHub.
+  raw: license:ODC-BY;gated:false;dataset_card:present
   sources:
   - url: https://huggingface.co/datasets/LLM360/TxT360
     shows: ODC-BY license, ungated, dataset card

--- a/sources/scores/ultrachat-200k.yaml
+++ b/sources/scores/ultrachat-200k.yaml
@@ -2,9 +2,16 @@ product: ultrachat-200k
 openness:
   score: 5
   class: open
-  components: license:MIT;gated:false;dataset_card:present
+  components:
+    license:
+      value: MIT
+    gated:
+      value: 'false'
+    dataset_card:
+      value: present
   confidence: high
   note: MIT-licensed, ungated, full dataset card.
+  raw: license:MIT;gated:false;dataset_card:present
   sources:
   - url: https://huggingface.co/datasets/HuggingFaceH4/ultrachat_200k
     shows: MIT license, ungated access, dataset card

--- a/sources/scores/yi.yaml
+++ b/sources/scores/yi.yaml
@@ -2,11 +2,24 @@ product: yi
 openness:
   score: 3
   class: open_weights
-  components: weights:open(Apache-2.0, on HF);data:closed(pretraining corpus not released);code:partial(inference/usage
-    examples; no training pipeline);license:Apache-2.0(OSI, permissive, no use restrictions)
+  components:
+    weights:
+      value: open
+      detail: Apache-2.0, on HF
+    data:
+      value: closed
+      detail: pretraining corpus not released
+    code:
+      value: partial
+      detail: inference/usage examples; no training pipeline
+    license:
+      value: Apache-2.0
+      detail: OSI, permissive, no use restrictions
   confidence: high
   note: Permissive Apache-2.0 weights but training data and full training code are not released, so open_weights
     not open_source. Apache-2.0 confirmed on HF base cards 2026-06-04.
+  raw: weights:open(Apache-2.0, on HF);data:closed(pretraining corpus not released);code:partial(inference/usage
+    examples; no training pipeline);license:Apache-2.0(OSI, permissive, no use restrictions)
   sources:
   - url: https://huggingface.co/01-ai/Yi-1.5-34B
     shows: Apache-2.0 license, 34B base model (base vs chat variants listed), downloadable weights

--- a/sources/scores/zephyr.yaml
+++ b/sources/scores/zephyr.yaml
@@ -2,15 +2,27 @@ product: zephyr
 openness:
   score: 5
   class: open_source
-  components: weights:open(MIT;base Mistral-7B Apache-2.0);data:open(UltraChat_200k +
-    UltraFeedback_binarized, both MIT, ungated);code:open(alignment-handbook DPO recipe,
-    Apache-2.0);license:MIT(OSI)
+  components:
+    weights:
+      value: open
+      detail: MIT;base Mistral-7B Apache-2.0
+    data:
+      value: open
+      detail: UltraChat_200k + UltraFeedback_binarized, both MIT, ungated
+    code:
+      value: open
+      detail: alignment-handbook DPO recipe, Apache-2.0
+    license:
+      value: MIT
+      detail: OSI
   confidence: high
   note: 'Genuinely fully-open: MIT weights, the two DPO training datasets are public and
     MIT, and the end-to-end training code (alignment-handbook) is Apache-2.0 and replicates
     zephyr-7b-beta. Open_source tier 5. Caveat (does not change the class): upstream
     UltraChat/UltraFeedback were partly generated with OpenAI model outputs, but the
     released HF artifacts are open and MIT.'
+  raw: weights:open(MIT;base Mistral-7B Apache-2.0);data:open(UltraChat_200k + UltraFeedback_binarized,
+    both MIT, ungated);code:open(alignment-handbook DPO recipe, Apache-2.0);license:MIT(OSI)
   sources:
   - url: https://huggingface.co/HuggingFaceH4/zephyr-7b-beta
     shows: License MIT; DPO fine-tune of Mistral-7B on UltraChat/UltraFeedback


### PR DESCRIPTION
## Summary

First batch of the structured-components migration: the 84 records with nothing to decide. Every clause is keyed, every key is declared vocabulary for the product's governing recipe, every value round-trips byte-for-byte, and none has a keyless clause.

Each record keeps a `raw:` sibling holding the original string verbatim. `components_string` prefers it, so the published payload receives a byte-identical string and nothing downstream changes.

```yaml
components:
  data:
    value: open
    detail: 7,787 questions, downloadable on HF
  license:
    value: CC-BY-SA-4.0
    detail: open data license, redistributable
raw: data:open(7,787 questions, downloadable on HF);license:CC-BY-SA-4.0(open data license, redistributable)
```

## Zero published numbers move, checked where it counts

At this commit, a dry-run serialize gives:

```
git diff --numstat build/notebook_data.json
1  1  build/notebook_data.json
```

The sole diff is the `generated` stamp.

That check is only meaningful **after** committing. Run before `git commit`, it passes trivially, because the freshness fallback still points at the previous commit. Run on the original version of this branch it printed `79 79` — 78 products republished as freshly verified by a reshape that verified nothing. #190 fixed the attribution; this branch is rebased on it.

## Review this by reading the gate, not the diff

84 near-identical mechanical records cannot be usefully reviewed by eye. `build/check_components.py` is what makes them safe, and it computes both sides independently: `split_components(raw)` against `recompose(components)`, diffed over the union of keys. A dropped clause, a renamed key, an altered value or detail, or a stale `raw` all fail it. Keyless clauses are checked separately, not through `recompose`, which drops them.

The population was re-derived from the corpus rather than taken from the plan: 84 for this batch, and the full split across the six batches sums to 472.

## Test plan

- Suite 431 passed. `validate` 0 error(s), `check_recipe` 0 failure(s), `check_rubric` exit 0, `check_components` `[OK]`.
- Payload diffs only the `generated` stamp, at a committed head.
- Every edit made through `build/components.py`, never a text substitution — 278 of 472 score files fold `components` across lines.
- 7 of the 84 wrap `raw:` onto a different number of physical lines than the original field. Whitespace only; PyYAML folds newlines to spaces in plain scalars, so the parsed string is identical.
