### PR TITLE
refactor(scores): migrate the 24 records whose value/detail split needs a verbatim raw

### DIFF
--- a/sources/scores/aegis-guard.yaml
+++ b/sources/scores/aegis-guard.yaml
@@ -2,11 +2,21 @@ product: aegis-guard
 openness:
   score: 3
   class: open_weights
-  components: weights:adapter-open(HF) but base LlamaGuard gated via Meta access;data:Aegis safety dataset
-    documented;license:Llama-2-Community(NOT OSI)
+  components:
+    weights:
+      value: adapter-open
+      detail: HF) but base LlamaGuard gated via Meta access
+      raw: adapter-open(HF) but base LlamaGuard gated via Meta access
+    data:
+      value: Aegis safety dataset documented
+    license:
+      value: Llama-2-Community
+      detail: NOT OSI
   confidence: medium
   note: Open-weights at the adapter level but the LlamaGuard base is access-gated through Meta and the
     license is the non-OSI Llama 2 Community License, so it lands at open_weights (3) with a gating caveat.
+  raw: weights:adapter-open(HF) but base LlamaGuard gated via Meta access;data:Aegis safety dataset documented;license:Llama-2-Community(NOT
+    OSI)
   sources:
   - url: https://huggingface.co/nvidia/Aegis-AI-Content-Safety-LlamaGuard-Defensive-1.0
     shows: Llama 2 Community License; adapter weights public, base gated via Meta; 13 risk categories;

--- a/sources/scores/arduino-uno-q.yaml
+++ b/sources/scores/arduino-uno-q.yaml
@@ -2,11 +2,30 @@ product: arduino-uno-q
 openness:
   class: documented
   score: 3
-  components: schematics:open (gerbers + schematics CC-BY-SA 4.0);toolchain:open (open App Lab);datasheets:public;blobs:required
-    (proprietary Qualcomm SoC firmware);retail:open_market (global)
+  components:
+    schematics:
+      value: open
+      detail: gerbers + schematics CC-BY-SA 4.0
+      raw: open (gerbers + schematics CC-BY-SA 4.0)
+    toolchain:
+      value: open
+      detail: open App Lab
+      raw: open (open App Lab)
+    datasheets:
+      value: public
+    blobs:
+      value: required
+      detail: proprietary Qualcomm SoC firmware
+      raw: required (proprietary Qualcomm SoC firmware)
+    retail:
+      value: open_market
+      detail: global
+      raw: open_market (global)
   confidence: high
   note: Board schematics and gerbers are CC-BY-SA 4.0 and tooling is open, but the QRB2210 SoC remains
     proprietary silicon needing firmware blobs.
+  raw: schematics:open (gerbers + schematics CC-BY-SA 4.0);toolchain:open (open App Lab);datasheets:public;blobs:required
+    (proprietary Qualcomm SoC firmware);retail:open_market (global)
   sources:
   - url: https://www.arduino.cc/product-uno-q
     shows: QRB2210 + STM32U585, schematics/gerbers under CC-BY-SA 4.0, App Lab open source

--- a/sources/scores/autogpt.yaml
+++ b/sources/scores/autogpt.yaml
@@ -3,13 +3,22 @@ openness:
   score: 2
   class: source_available
   confidence: high
-  components: license:DUAL, autogpt_platform/ under PolyForm Shield (non-OSI, source-available, anti-compete);
-    everything else (Classic, Forge, agbenchmark) MIT(OSI);source:public
+  components:
+    license:
+      value: DUAL
+      detail: autogpt_platform/ under PolyForm Shield (non-OSI, source-available, anti-compete
+      raw: DUAL, autogpt_platform/ under PolyForm Shield (non-OSI, source-available, anti-compete)
+    source:
+      value: public
+    free_text:
+    - everything else (Classic, Forge, agbenchmark) MIT(OSI)
   note: 'Verified dual license: the current flagship, the AutoGPT Platform, is PolyForm Shield (source-available,
     non-OSI, anti-compete), while legacy components (Classic, Forge, agbenchmark) stay MIT. Scored on the
     active product. Score corrected from 3 to 2 on 2026-07-30. The software ladder has rungs at 1, 2, 4
     and 5 and none at 3, so 3/source_available was not a pair any rule could produce; the ladder scores
     "you can read it and not run it freely" at 2.'
+  raw: license:DUAL, autogpt_platform/ under PolyForm Shield (non-OSI, source-available, anti-compete);
+    everything else (Classic, Forge, agbenchmark) MIT(OSI);source:public
   sources:
   - url: https://github.com/Significant-Gravitas/AutoGPT
     shows: 'dual license: PolyForm Shield for autogpt_platform, MIT for the rest (verified); 185k stars;

--- a/sources/scores/axelera-metis-aipu.yaml
+++ b/sources/scores/axelera-metis-aipu.yaml
@@ -2,11 +2,30 @@ product: axelera-metis-aipu
 openness:
   class: documented
   score: 3
-  components: schematics:none;toolchain:open (Voyager SDK on public GitHub);datasheets:brief (product pages/briefs
-    public);blobs:required (proprietary AIPU silicon + firmware);retail:open_market (webstore + partners)
+  components:
+    schematics:
+      value: none
+    toolchain:
+      value: open
+      detail: Voyager SDK on public GitHub
+      raw: open (Voyager SDK on public GitHub)
+    datasheets:
+      value: brief
+      detail: product pages/briefs public
+      raw: brief (product pages/briefs public)
+    blobs:
+      value: required
+      detail: proprietary AIPU silicon + firmware
+      raw: required (proprietary AIPU silicon + firmware)
+    retail:
+      value: open_market
+      detail: webstore + partners
+      raw: open_market (webstore + partners)
   confidence: medium
   note: Proprietary in-memory-compute silicon with a publicly available Voyager SDK on GitHub and retail
     purchasing, but board design files are not open.
+  raw: schematics:none;toolchain:open (Voyager SDK on public GitHub);datasheets:brief (product pages/briefs
+    public);blobs:required (proprietary AIPU silicon + firmware);retail:open_market (webstore + partners)
   sources:
   - url: https://www.axelera.ai/
     shows: Metis AIPU form factors, ~214 TOPS, Voyager SDK, webstore availability

--- a/sources/scores/beagley-ai.yaml
+++ b/sources/scores/beagley-ai.yaml
@@ -2,12 +2,29 @@ product: beagley-ai
 openness:
   class: open_hardware
   score: 5
-  components: schematics:open (schematics + 3D/mechanical files, CC-BY/CC-BY-SA-4.0, OSHWA-certified US002616);toolchain:open
-    (open Linux/U-Boot BSP);datasheets:public (public TI AM67A datasheet);blobs:required (TI DSP/WiFi firmware
-    blobs a caveat)
+  components:
+    schematics:
+      value: open
+      detail: schematics + 3D/mechanical files, CC-BY/CC-BY-SA-4.0, OSHWA-certified US002616
+      raw: open (schematics + 3D/mechanical files, CC-BY/CC-BY-SA-4.0, OSHWA-certified US002616)
+    toolchain:
+      value: open
+      detail: open Linux/U-Boot BSP
+      raw: open (open Linux/U-Boot BSP)
+    datasheets:
+      value: public
+      detail: public TI AM67A datasheet
+      raw: public (public TI AM67A datasheet)
+    blobs:
+      value: required
+      detail: TI DSP/WiFi firmware blobs a caveat
+      raw: required (TI DSP/WiFi firmware blobs a caveat)
   confidence: high
   note: Full board design files published under Creative Commons and OSHWA-certified with an open toolchain
     and public datasheet, though proprietary AM67A silicon and firmware blobs are a caveat.
+  raw: schematics:open (schematics + 3D/mechanical files, CC-BY/CC-BY-SA-4.0, OSHWA-certified US002616);toolchain:open
+    (open Linux/U-Boot BSP);datasheets:public (public TI AM67A datasheet);blobs:required (TI DSP/WiFi firmware
+    blobs a caveat)
   sources:
   - url: https://github.com/beagleboard/beagley-ai
     shows: repo with design files, 3D models, OSHWA cert, schematic PDF, CC-BY-4.0 license

--- a/sources/scores/google-coral-dev-board.yaml
+++ b/sources/scores/google-coral-dev-board.yaml
@@ -2,12 +2,31 @@ product: google-coral-dev-board
 openness:
   class: documented
   score: 3
-  components: schematics:none (no full board files);toolchain:partial (open runtime (libedgetpu) + TFLite,
-    closed Edge TPU compiler);datasheets:public;blobs:required (proprietary Edge TPU ASIC + closed compiler);retail:open_market
-    (broadly purchasable)
+  components:
+    schematics:
+      value: none
+      detail: no full board files
+      raw: none (no full board files)
+    toolchain:
+      value: partial
+      detail: open runtime (libedgetpu) + TFLite, closed Edge TPU compiler
+      raw: partial (open runtime (libedgetpu) + TFLite, closed Edge TPU compiler)
+    datasheets:
+      value: public
+    blobs:
+      value: required
+      detail: proprietary Edge TPU ASIC + closed compiler
+      raw: required (proprietary Edge TPU ASIC + closed compiler)
+    retail:
+      value: open_market
+      detail: broadly purchasable
+      raw: open_market (broadly purchasable)
   confidence: high
   note: Public datasheet and open runtime/TFLite path, but the Edge TPU silicon and the model compiler
     are proprietary closed binaries.
+  raw: schematics:none (no full board files);toolchain:partial (open runtime (libedgetpu) + TFLite, closed
+    Edge TPU compiler);datasheets:public;blobs:required (proprietary Edge TPU ASIC + closed compiler);retail:open_market
+    (broadly purchasable)
   sources:
   - url: https://coral.ai/docs/dev-board/datasheet/
     shows: 'datasheet: 4 TOPS, 2 TOPS/W, SoM form factor, TFLite, Google-designed Edge TPU'

--- a/sources/scores/hailo-10h.yaml
+++ b/sources/scores/hailo-10h.yaml
@@ -2,11 +2,30 @@ product: hailo-10h
 openness:
   class: documented
   score: 3
-  components: schematics:none;toolchain:partial (open runtime + MIT GenAI model zoo);datasheets:public (June
-    2025);blobs:required (proprietary silicon/firmware);retail:open_market (M.2 modules purchasable)
+  components:
+    schematics:
+      value: none
+    toolchain:
+      value: partial
+      detail: open runtime + MIT GenAI model zoo
+      raw: partial (open runtime + MIT GenAI model zoo)
+    datasheets:
+      value: public
+      detail: June 2025
+      raw: public (June 2025)
+    blobs:
+      value: required
+      detail: proprietary silicon/firmware
+      raw: required (proprietary silicon/firmware)
+    retail:
+      value: open_market
+      detail: M.2 modules purchasable
+      raw: open_market (M.2 modules purchasable)
   confidence: high
   note: Proprietary silicon with published datasheets and an open GenAI model zoo, but the silicon and
     full toolchain are closed.
+  raw: schematics:none;toolchain:partial (open runtime + MIT GenAI model zoo);datasheets:public (June 2025);blobs:required
+    (proprietary silicon/firmware);retail:open_market (M.2 modules purchasable)
   sources:
   - url: https://hailo.ai/products/ai-accelerators/hailo-10h-m-2-ai-acceleration-module/
     shows: official module product page for Hailo-10H

--- a/sources/scores/hailo-8.yaml
+++ b/sources/scores/hailo-8.yaml
@@ -2,11 +2,30 @@ product: hailo-8
 openness:
   class: documented
   score: 3
-  components: schematics:none;toolchain:partial (open runtime (HailoRT) + closed/registration Dataflow Compiler);datasheets:brief
-    (public briefs);blobs:required (proprietary silicon + firmware);retail:open_market (global modules)
+  components:
+    schematics:
+      value: none
+    toolchain:
+      value: partial
+      detail: open runtime (HailoRT) + closed/registration Dataflow Compiler
+      raw: partial (open runtime (HailoRT) + closed/registration Dataflow Compiler)
+    datasheets:
+      value: brief
+      detail: public briefs
+      raw: brief (public briefs)
+    blobs:
+      value: required
+      detail: proprietary silicon + firmware
+      raw: required (proprietary silicon + firmware)
+    retail:
+      value: open_market
+      detail: global modules
+      raw: open_market (global modules)
   confidence: high
   note: Proprietary silicon with an open source runtime and public product briefs, but the model-compiler
     toolchain requires registration and silicon is closed.
+  raw: schematics:none;toolchain:partial (open runtime (HailoRT) + closed/registration Dataflow Compiler);datasheets:brief
+    (public briefs);blobs:required (proprietary silicon + firmware);retail:open_market (global modules)
   sources:
   - url: https://hailo.ai/products/ai-accelerators/hailo-8-ai-accelerator/
     shows: 'official product page: form factors, frameworks, software suite'

--- a/sources/scores/hexabot.yaml
+++ b/sources/scores/hexabot.yaml
@@ -2,11 +2,18 @@ product: hexabot
 openness:
   score: 2
   class: source_available
-  components: license:FCL-1.0-ALv2 (Fair Core License, NOT OSI; converts to Apache-2.0 two years after
-    each release; competing/hosted commercial use restricted until conversion). Earlier v1/v2 were AGPL-3.0.
+  components:
+    license:
+      value: FCL-1.0-ALv2
+      detail: Fair Core License, NOT OSI; converts to Apache-2.0 two years after each release; competing/hosted
+        commercial use restricted until conversion). Earlier v1/v2 were AGPL-3.0.
+      raw: FCL-1.0-ALv2 (Fair Core License, NOT OSI; converts to Apache-2.0 two years after each release;
+        competing/hosted commercial use restricted until conversion). Earlier v1/v2 were AGPL-3.0.
   confidence: high
   note: Fair Core License is a delayed-open / fair-code model, so the current core is source-available
     rather than open source.
+  raw: license:FCL-1.0-ALv2 (Fair Core License, NOT OSI; converts to Apache-2.0 two years after each release;
+    competing/hosted commercial use restricted until conversion). Earlier v1/v2 were AGPL-3.0.
   sources:
   - url: https://github.com/Hexastack/Hexabot
     shows: Licensed under FCL-1.0-ALv2; GitHub reports license as 'Other'

--- a/sources/scores/khadas-edge2.yaml
+++ b/sources/scores/khadas-edge2.yaml
@@ -2,12 +2,32 @@ product: khadas-edge2
 openness:
   class: open_toolchain
   score: 4
-  components: schematics:published (versioned PDFs published);toolchain:open (open GPL-2.0 Fenix + mainline
-    Armbian);datasheets:public (public SoC TRM);blobs:required (Rockchip NPU/boot blobs required);retail:open_market
-    (global)
+  components:
+    schematics:
+      value: published
+      detail: versioned PDFs published
+      raw: published (versioned PDFs published)
+    toolchain:
+      value: open
+      detail: open GPL-2.0 Fenix + mainline Armbian
+      raw: open (open GPL-2.0 Fenix + mainline Armbian)
+    datasheets:
+      value: public
+      detail: public SoC TRM
+      raw: public (public SoC TRM)
+    blobs:
+      value: required
+      detail: Rockchip NPU/boot blobs required
+      raw: required (Rockchip NPU/boot blobs required)
+    retail:
+      value: open_market
+      detail: global
+      raw: open_market (global)
   confidence: high
   note: Khadas publishes versioned board schematics and an open toolchain with mainline Armbian, but proprietary
     Rockchip silicon and required blobs keep it at open_toolchain.
+  raw: schematics:published (versioned PDFs published);toolchain:open (open GPL-2.0 Fenix + mainline Armbian);datasheets:public
+    (public SoC TRM);blobs:required (Rockchip NPU/boot blobs required);retail:open_market (global)
   sources:
   - url: https://dl.khadas.com/products/edge2/schematics/
     shows: versioned schematic PDFs (edge2-sch-v11/12/13)

--- a/sources/scores/memryx-mx3.yaml
+++ b/sources/scores/memryx-mx3.yaml
@@ -2,11 +2,28 @@ product: memryx-mx3
 openness:
   class: documented
   score: 3
-  components: schematics:none;toolchain:partial (open runtime (MxAccl) + utils + driver mirror, closed NeuralCompiler);datasheets:public;blobs:required
-    (proprietary silicon);retail:open_market (Amazon/Mouser ~$149)
+  components:
+    schematics:
+      value: none
+    toolchain:
+      value: partial
+      detail: open runtime (MxAccl) + utils + driver mirror, closed NeuralCompiler
+      raw: partial (open runtime (MxAccl) + utils + driver mirror, closed NeuralCompiler)
+    datasheets:
+      value: public
+    blobs:
+      value: required
+      detail: proprietary silicon
+      raw: required (proprietary silicon)
+    retail:
+      value: open_market
+      detail: Amazon/Mouser ~$149
+      raw: open_market (Amazon/Mouser ~$149)
   confidence: high
   note: Proprietary dataflow silicon with public datasheets, retail availability, and several open source
     runtime/driver repos, though the compiler core is closed.
+  raw: schematics:none;toolchain:partial (open runtime (MxAccl) + utils + driver mirror, closed NeuralCompiler);datasheets:public;blobs:required
+    (proprietary silicon);retail:open_market (Amazon/Mouser ~$149)
   sources:
   - url: https://developer.memryx.com/specs/M.2_datasheet.html
     shows: 'MX3 M.2 datasheet: chip count, TOPS, data formats, power'

--- a/sources/scores/nvidia-jetson-agx-orin.yaml
+++ b/sources/scores/nvidia-jetson-agx-orin.yaml
@@ -2,12 +2,31 @@ product: nvidia-jetson-agx-orin
 openness:
   class: documented
   score: 3
-  components: schematics:partial (module datasheet + carrier design guide public);toolchain:closed (JetPack/Jetson
-    Linux proprietary (NVIDIA SLA));datasheets:public;blobs:required (proprietary drivers/bootloader);retail:distributor
-    (via distributors)
+  components:
+    schematics:
+      value: partial
+      detail: module datasheet + carrier design guide public
+      raw: partial (module datasheet + carrier design guide public)
+    toolchain:
+      value: closed
+      detail: JetPack/Jetson Linux proprietary (NVIDIA SLA
+      raw: closed (JetPack/Jetson Linux proprietary (NVIDIA SLA))
+    datasheets:
+      value: public
+    blobs:
+      value: required
+      detail: proprietary drivers/bootloader
+      raw: required (proprietary drivers/bootloader)
+    retail:
+      value: distributor
+      detail: via distributors
+      raw: distributor (via distributors)
   confidence: high
   note: Public datasheets and commercially purchasable, but SDK relies on proprietary NVIDIA blobs under
     license, placing it in the documented tier.
+  raw: schematics:partial (module datasheet + carrier design guide public);toolchain:closed (JetPack/Jetson
+    Linux proprietary (NVIDIA SLA));datasheets:public;blobs:required (proprietary drivers/bootloader);retail:distributor
+    (via distributors)
   sources:
   - url: https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin
     shows: 'Official spec: up to 275 TOPS, 2048-core Ampere GPU, 32/64GB LPDDR5, 699-pin module'

--- a/sources/scores/nvidia-jetson-orin-nano-super-developer-kit.yaml
+++ b/sources/scores/nvidia-jetson-orin-nano-super-developer-kit.yaml
@@ -2,12 +2,31 @@ product: nvidia-jetson-orin-nano-super-developer-kit
 openness:
   class: documented
   score: 3
-  components: schematics:partial (carrier design guide public);toolchain:closed (JetPack/Jetson Linux free
-    but NVIDIA-SLA proprietary);datasheets:public;blobs:required (proprietary GPU drivers/bootloader required);retail:open_market
-    (mass-market)
+  components:
+    schematics:
+      value: partial
+      detail: carrier design guide public
+      raw: partial (carrier design guide public)
+    toolchain:
+      value: closed
+      detail: JetPack/Jetson Linux free but NVIDIA-SLA proprietary
+      raw: closed (JetPack/Jetson Linux free but NVIDIA-SLA proprietary)
+    datasheets:
+      value: public
+    blobs:
+      value: required
+      detail: proprietary GPU drivers/bootloader required
+      raw: required (proprietary GPU drivers/bootloader required)
+    retail:
+      value: open_market
+      detail: mass-market
+      raw: open_market (mass-market)
   confidence: high
   note: Public datasheets and globally purchasable, but the SDK requires proprietary NVIDIA drivers/blobs
     under license, so it sits in the documented tier despite the community OE4T BSP.
+  raw: schematics:partial (carrier design guide public);toolchain:closed (JetPack/Jetson Linux free but
+    NVIDIA-SLA proprietary);datasheets:public;blobs:required (proprietary GPU drivers/bootloader required);retail:open_market
+    (mass-market)
   sources:
   - url: https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin/nano-super-developer-kit/
     shows: 'Official spec: 67 INT8 TOPS, 1024-core Ampere GPU, 6-core A78AE, 8GB LPDDR5, $249'

--- a/sources/scores/nvidia-jetson-orin-nx.yaml
+++ b/sources/scores/nvidia-jetson-orin-nx.yaml
@@ -2,12 +2,31 @@ product: nvidia-jetson-orin-nx
 openness:
   class: documented
   score: 3
-  components: schematics:partial (module datasheet + carrier design guide public);toolchain:closed (JetPack/Jetson
-    Linux proprietary (NVIDIA SLA));datasheets:public;blobs:required (proprietary drivers/bootloader);retail:distributor
-    (via distributors)
+  components:
+    schematics:
+      value: partial
+      detail: module datasheet + carrier design guide public
+      raw: partial (module datasheet + carrier design guide public)
+    toolchain:
+      value: closed
+      detail: JetPack/Jetson Linux proprietary (NVIDIA SLA
+      raw: closed (JetPack/Jetson Linux proprietary (NVIDIA SLA))
+    datasheets:
+      value: public
+    blobs:
+      value: required
+      detail: proprietary drivers/bootloader
+      raw: required (proprietary drivers/bootloader)
+    retail:
+      value: distributor
+      detail: via distributors
+      raw: distributor (via distributors)
   confidence: high
   note: Public datasheets and purchasable through distributors, but the SDK depends on proprietary NVIDIA
     blobs under license.
+  raw: schematics:partial (module datasheet + carrier design guide public);toolchain:closed (JetPack/Jetson
+    Linux proprietary (NVIDIA SLA));datasheets:public;blobs:required (proprietary drivers/bootloader);retail:distributor
+    (via distributors)
   sources:
   - url: https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin
     shows: 'Official spec: up to 157 TOPS, 1792-core Ampere GPU, 8/16GB LPDDR5, 260-pin SO-DIMM'

--- a/sources/scores/nxp-imx-8m-plus.yaml
+++ b/sources/scores/nxp-imx-8m-plus.yaml
@@ -2,12 +2,32 @@ product: nxp-imx-8m-plus
 openness:
   class: documented
   score: 3
-  components: schematics:none (EVK reference designs only);toolchain:open (Linux/Yocto BSP);datasheets:public
-    (IMX8MPCEC);blobs:required (proprietary silicon + NPU firmware);retail:distributor (commercial via NXP
-    and SoM partners)
+  components:
+    schematics:
+      value: none
+      detail: EVK reference designs only
+      raw: none (EVK reference designs only)
+    toolchain:
+      value: open
+      detail: Linux/Yocto BSP
+      raw: open (Linux/Yocto BSP)
+    datasheets:
+      value: public
+      detail: IMX8MPCEC
+      raw: public (IMX8MPCEC)
+    blobs:
+      value: required
+      detail: proprietary silicon + NPU firmware
+      raw: required (proprietary silicon + NPU firmware)
+    retail:
+      value: distributor
+      detail: commercial via NXP and SoM partners
+      raw: distributor (commercial via NXP and SoM partners)
   confidence: high
   note: Public datasheets and a Linux BSP with broad commercial availability, but proprietary silicon
     with no open board files.
+  raw: schematics:none (EVK reference designs only);toolchain:open (Linux/Yocto BSP);datasheets:public (IMX8MPCEC);blobs:required
+    (proprietary silicon + NPU firmware);retail:distributor (commercial via NXP and SoM partners)
   sources:
   - url: https://www.nxp.com/products/i.MX8MPLUS
     shows: 'official page: Cortex-A53/M7, up to 2.3 TOPS NPU, ML/vision focus'

--- a/sources/scores/orange-pi-5.yaml
+++ b/sources/scores/orange-pi-5.yaml
@@ -2,11 +2,32 @@ product: orange-pi-5
 openness:
   class: open_toolchain
   score: 4
-  components: schematics:published (published PDF);toolchain:open (open GPL-2.0 BSP/build system);datasheets:public
-    (public RK3588S);blobs:required (Rockchip firmware required);retail:open_market (global)
+  components:
+    schematics:
+      value: published
+      detail: published PDF
+      raw: published (published PDF)
+    toolchain:
+      value: open
+      detail: open GPL-2.0 BSP/build system
+      raw: open (open GPL-2.0 BSP/build system)
+    datasheets:
+      value: public
+      detail: public RK3588S
+      raw: public (public RK3588S)
+    blobs:
+      value: required
+      detail: Rockchip firmware required
+      raw: required (Rockchip firmware required)
+    retail:
+      value: open_market
+      detail: global
+      raw: open_market (global)
   confidence: high
   note: Proprietary Rockchip silicon with an open GPL-2.0 BSP, public datasheet and schematics, and global
     retail availability, but bootable images depend on Rockchip firmware blobs.
+  raw: schematics:published (published PDF);toolchain:open (open GPL-2.0 BSP/build system);datasheets:public
+    (public RK3588S);blobs:required (Rockchip firmware required);retail:open_market (global)
   sources:
   - url: https://github.com/orangepi-xunlong/orangepi-build
     shows: official GPL-2.0 build system supporting Orange Pi 5 / RK3588S

--- a/sources/scores/qualcomm-dragonwing-rb3-gen-2.yaml
+++ b/sources/scores/qualcomm-dragonwing-rb3-gen-2.yaml
@@ -2,12 +2,32 @@ product: qualcomm-dragonwing-rb3-gen-2
 openness:
   class: documented
   score: 3
-  components: schematics:partial (96Boards mezzanine standard);toolchain:open (open Qualcomm Linux + AI
-    Hub);datasheets:brief (public brief);blobs:required (proprietary silicon + firmware);retail:distributor
-    (via Thundercomm/distributors)
+  components:
+    schematics:
+      value: partial
+      detail: 96Boards mezzanine standard
+      raw: partial (96Boards mezzanine standard)
+    toolchain:
+      value: open
+      detail: open Qualcomm Linux + AI Hub
+      raw: open (open Qualcomm Linux + AI Hub)
+    datasheets:
+      value: brief
+      detail: public brief
+      raw: brief (public brief)
+    blobs:
+      value: required
+      detail: proprietary silicon + firmware
+      raw: required (proprietary silicon + firmware)
+    retail:
+      value: distributor
+      detail: via Thundercomm/distributors
+      raw: distributor (via Thundercomm/distributors)
   confidence: high
   note: Proprietary Qualcomm silicon with public docs and a Linux SDK, sold through distributors, but
     the board itself is not fully open hardware.
+  raw: schematics:partial (96Boards mezzanine standard);toolchain:open (open Qualcomm Linux + AI Hub);datasheets:brief
+    (public brief);blobs:required (proprietary silicon + firmware);retail:distributor (via Thundercomm/distributors)
   sources:
   - url: https://www.qualcomm.com/developer/hardware/rb3-gen-2-development-kit
     shows: 'official page: QCS6490, up to 12 TOPS, 96Boards design, Qualcomm Linux stack'

--- a/sources/scores/radxa-rock-5b.yaml
+++ b/sources/scores/radxa-rock-5b.yaml
@@ -2,11 +2,28 @@ product: radxa-rock-5b
 openness:
   class: open_toolchain
   score: 4
-  components: schematics:published (PDF + SMD maps + DXF + 3D STP + CE/FCC public);toolchain:open (open
-    BSP/kernel/U-Boot);blobs:required (Rockchip rkbin/DDR/TF-A required);retail:open_market (global)
+  components:
+    schematics:
+      value: published
+      detail: PDF + SMD maps + DXF + 3D STP + CE/FCC public
+      raw: published (PDF + SMD maps + DXF + 3D STP + CE/FCC public)
+    toolchain:
+      value: open
+      detail: open BSP/kernel/U-Boot
+      raw: open (open BSP/kernel/U-Boot)
+    blobs:
+      value: required
+      detail: Rockchip rkbin/DDR/TF-A required
+      raw: required (Rockchip rkbin/DDR/TF-A required)
+    retail:
+      value: open_market
+      detail: global
+      raw: open_market (global)
   confidence: high
   note: Schematics and mechanical files are publicly downloadable and the BSP is open, but the RK3588
     needs proprietary Rockchip blobs and editable PCB source is not released.
+  raw: schematics:published (PDF + SMD maps + DXF + 3D STP + CE/FCC public);toolchain:open (open BSP/kernel/U-Boot);blobs:required
+    (Rockchip rkbin/DDR/TF-A required);retail:open_market (global)
   sources:
   - url: https://docs.radxa.com/en/rock5/rock5b/download
     shows: downloadable schematic PDFs, SMD maps, DXF, 3D STP, CE/FCC reports

--- a/sources/scores/raspberry-pi-5.yaml
+++ b/sources/scores/raspberry-pi-5.yaml
@@ -2,11 +2,28 @@ product: raspberry-pi-5
 openness:
   class: open_toolchain
   score: 4
-  components: schematics:published (reduced published);toolchain:open (open kernel tree + Raspberry Pi OS);datasheets:public;blobs:minimal;retail:open_market
-    (mass-market)
+  components:
+    schematics:
+      value: published
+      detail: reduced published
+      raw: published (reduced published)
+    toolchain:
+      value: open
+      detail: open kernel tree + Raspberry Pi OS
+      raw: open (open kernel tree + Raspberry Pi OS)
+    datasheets:
+      value: public
+    blobs:
+      value: minimal
+    retail:
+      value: open_market
+      detail: mass-market
+      raw: open_market (mass-market)
   confidence: high
   note: Open Linux kernel tree and published datasheets/reduced schematics, globally purchasable, though
     full board design files and some firmware remain closed.
+  raw: schematics:published (reduced published);toolchain:open (open kernel tree + Raspberry Pi OS);datasheets:public;blobs:minimal;retail:open_market
+    (mass-market)
   sources:
   - url: https://www.raspberrypi.com/products/raspberry-pi-5/
     shows: 'Official product page: BCM2712, Cortex-A76, RAM options, production until 2036'

--- a/sources/scores/raspberry-pi-ai-hat-plus.yaml
+++ b/sources/scores/raspberry-pi-ai-hat-plus.yaml
@@ -2,12 +2,33 @@ product: raspberry-pi-ai-hat-plus
 openness:
   class: open_toolchain
   score: 4
-  components: schematics:partial (HAT+ mechanical spec public);toolchain:partial (open Pi driver integration,
-    Hailo compiler gated);datasheets:brief (public brief);blobs:required (Hailo firmware required);retail:open_market
-    (mass-market)
+  components:
+    schematics:
+      value: partial
+      detail: HAT+ mechanical spec public
+      raw: partial (HAT+ mechanical spec public)
+    toolchain:
+      value: partial
+      detail: open Pi driver integration, Hailo compiler gated
+      raw: partial (open Pi driver integration, Hailo compiler gated)
+    datasheets:
+      value: brief
+      detail: public brief
+      raw: brief (public brief)
+    blobs:
+      value: required
+      detail: Hailo firmware required
+      raw: required (Hailo firmware required)
+    retail:
+      value: open_market
+      detail: mass-market
+      raw: open_market (mass-market)
   confidence: medium
   note: Officially supported open Pi software stack and public product page, globally purchasable, but
     the underlying Hailo model-compiler toolchain is registration-gated.
+  raw: schematics:partial (HAT+ mechanical spec public);toolchain:partial (open Pi driver integration, Hailo
+    compiler gated);datasheets:brief (public brief);blobs:required (Hailo firmware required);retail:open_market
+    (mass-market)
   sources:
   - url: https://www.raspberrypi.com/products/ai-hat/
     shows: 'Official product page: Hailo-8 (26 TOPS) / Hailo-8L (13 TOPS), HAT+ form factor, from $70'

--- a/sources/scores/rockchip-rk3588.yaml
+++ b/sources/scores/rockchip-rk3588.yaml
@@ -2,12 +2,26 @@ product: rockchip-rk3588
 openness:
   class: documented
   score: 3
-  components: toolchain:partial (NPU SDK on GitHub but proprietary RKNN license + prebuilt blobs, rknpu
-    kernel driver open);datasheets:public (full TRM + datasheet public, no NDA);blobs:required (proprietary
-    GPU/NPU firmware)
+  components:
+    toolchain:
+      value: partial
+      detail: NPU SDK on GitHub but proprietary RKNN license + prebuilt blobs, rknpu kernel driver open
+      raw: partial (NPU SDK on GitHub but proprietary RKNN license + prebuilt blobs, rknpu kernel driver
+        open)
+    datasheets:
+      value: public
+      detail: full TRM + datasheet public, no NDA
+      raw: public (full TRM + datasheet public, no NDA)
+    blobs:
+      value: required
+      detail: proprietary GPU/NPU firmware
+      raw: required (proprietary GPU/NPU firmware)
   confidence: high
   note: Documentation is unusually open (full TRM and datasheet public) and the RKNN toolkit is openly
     distributed, but the SDK ships as prebuilt binaries under a proprietary license with closed firmware.
+  raw: toolchain:partial (NPU SDK on GitHub but proprietary RKNN license + prebuilt blobs, rknpu kernel
+    driver open);datasheets:public (full TRM + datasheet public, no NDA);blobs:required (proprietary GPU/NPU
+    firmware)
   sources:
   - url: https://www.rock-chips.com/a/en/products/RK35_Series/2022/0926/1660.html
     shows: 'official RK3588 page: 8-core A76+A55, 6 TOPS triple-core NPU, Mali-G610 MC4'

--- a/sources/scores/sipeed-maixcam.yaml
+++ b/sources/scores/sipeed-maixcam.yaml
@@ -2,12 +2,32 @@ product: sipeed-maixcam
 openness:
   class: open_toolchain
   score: 4
-  components: schematics:published (available via wiki/GitHub);toolchain:open (fully open (MaixPy/MaixCDK,
-    Apache-2.0));datasheets:public (public on wiki);blobs:required (SG2002 silicon proprietary);retail:open_market
-    (global via AliExpress/Taobao)
+  components:
+    schematics:
+      value: published
+      detail: available via wiki/GitHub
+      raw: published (available via wiki/GitHub)
+    toolchain:
+      value: open
+      detail: fully open (MaixPy/MaixCDK, Apache-2.0
+      raw: open (fully open (MaixPy/MaixCDK, Apache-2.0))
+    datasheets:
+      value: public
+      detail: public on wiki
+      raw: public (public on wiki)
+    blobs:
+      value: required
+      detail: SG2002 silicon proprietary
+      raw: required (SG2002 silicon proprietary)
+    retail:
+      value: open_market
+      detail: global via AliExpress/Taobao
+      raw: open_market (global via AliExpress/Taobao)
   confidence: high
   note: Open Apache-2.0 SDKs, public schematics/datasheets, and global retail availability, though the
     SG2002 silicon itself is proprietary.
+  raw: schematics:published (available via wiki/GitHub);toolchain:open (fully open (MaixPy/MaixCDK, Apache-2.0));datasheets:public
+    (public on wiki);blobs:required (SG2002 silicon proprietary);retail:open_market (global via AliExpress/Taobao)
   sources:
   - url: https://wiki.sipeed.com/hardware/en/maixcam/maixcam.html
     shows: 'spec page: SG2002 RISC-V, 1 TOPS NPU, 256MB DDR3, open schematics/datasheets, MaixPy/MaixCDK'

--- a/sources/scores/ti-am67a.yaml
+++ b/sources/scores/ti-am67a.yaml
@@ -2,12 +2,33 @@ product: ti-am67a
 openness:
   class: documented
   score: 3
-  components: schematics:partial (reference designs (BeagleY-AI board files open));toolchain:open (open
-    SDK + TIDL tools + Edge AI Studio);datasheets:public (Rev B);blobs:required (proprietary silicon + TIDL
-    firmware);retail:distributor (active via TI and partners)
+  components:
+    schematics:
+      value: partial
+      detail: reference designs (BeagleY-AI board files open
+      raw: partial (reference designs (BeagleY-AI board files open))
+    toolchain:
+      value: open
+      detail: open SDK + TIDL tools + Edge AI Studio
+      raw: open (open SDK + TIDL tools + Edge AI Studio)
+    datasheets:
+      value: public
+      detail: Rev B
+      raw: public (Rev B)
+    blobs:
+      value: required
+      detail: proprietary silicon + TIDL firmware
+      raw: required (proprietary silicon + TIDL firmware)
+    retail:
+      value: distributor
+      detail: active via TI and partners
+      raw: distributor (active via TI and partners)
   confidence: high
   note: Public datasheet and open SDK/TIDL tools on GitHub, commercially active, but proprietary silicon
     and firmware keep it short of fully open hardware.
+  raw: schematics:partial (reference designs (BeagleY-AI board files open));toolchain:open (open SDK + TIDL
+    tools + Edge AI Studio);datasheets:public (Rev B);blobs:required (proprietary silicon + TIDL firmware);retail:distributor
+    (active via TI and partners)
   sources:
   - url: https://www.ti.com/product/AM67A
     shows: 'official page: 4 TOPS C7x+MMA, quad A53, public datasheet, ACTIVE status, SDKs'

--- a/sources/scores/txt360-pipeline.yaml
+++ b/sources/scores/txt360-pipeline.yaml
@@ -2,8 +2,14 @@ product: txt360-pipeline
 openness:
   score: 2
   class: source_available
-  components: license:Apache-2.0 asserted in README only, no LICENSE file in repo (GitHub reports null);
-    source:public(LLM360/TxT360)
+  components:
+    license:
+      value: Apache-2.0 asserted in README only
+      detail: no LICENSE file in repo (GitHub reports null
+      raw: Apache-2.0 asserted in README only, no LICENSE file in repo (GitHub reports null)
+    source:
+      value: public
+      detail: LLM360/TxT360
   confidence: low
   note: 'The README badge asserts Apache-2.0 but the repo ships no LICENSE file, so there is no actual redistribution
     grant. Re-checked 2026-07-30: still no LICENSE file, and the GitHub license endpoint returns 404 while
@@ -11,6 +17,7 @@ openness:
     to 2 on 2026-07-30. The software ladder has rungs at 1, 2, 4 and 5 and none at 3, so 3/source_available
     was not a pair any rule could produce; the ladder scores "you can read it and not run it freely" at
     2.'
+  raw: license:Apache-2.0 asserted in README only, no LICENSE file in repo (GitHub reports null); source:public(LLM360/TxT360)
   sources:
   - url: https://github.com/LLM360/TxT360
     shows: README asserts Apache-2.0; no LICENSE file in repo (GitHub reports null license)


### PR DESCRIPTION
## Summary

Second batch of the structured-components migration: the 24 records holding at least one clause whose `{value, detail}` split cannot be reversed byte-for-byte. Those clauses get a **per-entry `raw`** beside them, 88 in total, so nothing is lost.

Four mechanisms produce an unreversible split:

| Mechanism | Example |
|---|---|
| a space before the opening paren | `open (detail)` recomposes as `open(detail)` |
| text after the closing paren | `MIT(OSI) plus a note` |
| a prose comma before the paren | `DUAL, Apache-2.0 asserted in README only(...)` |
| nested parens | a trailing `)` is lost to `rstrip` |

The derived `value` and `detail` are the driver's mechanical output and were deliberately **not** hand-improved. Several are uglier than a person would write — `aegis-guard`'s weights detail carries a stray `)` mid-string, and the hardware boards lose a trailing paren — but each is faithful to its `raw`, and a better reading would be a claim change. This phase changes no claims.

## Zero published numbers move, checked at a committed head

```
git diff --numstat build/notebook_data.json
1  1  build/notebook_data.json
```

The sole diff is the `generated` stamp. That check only means anything after `git commit` — run before, it passes trivially. #190 is what makes it hold.

## Batch precedence

`autogpt` carries both a raw-needing clause and a keyless one, and lands here rather than in the keyless batch because the classifier tests raw-needed before keyless. That ordering is what guarantees the keyless batch contains no record that also needs a per-entry `raw`. The clause itself is carried verbatim in `free_text` and validated by `check_components` on a path independent of `recompose`.

## Test plan

- Population re-derived from the corpus: 24, with the full six-batch split summing to 472.
- All 88 per-entry `raw` triples verified against the deterministic output of `structure()` run at the base commit. No hand-editing.
- Every edit through `build/components.py`, never a text substitution — 278 of 472 score files fold `components` across lines.
- Suite 431 passed. `validate` 0 error(s), `check_recipe` 0 failure(s), `check_rubric` exit 0, `check_components` `[OK]`.
