### PR TITLE
refactor(scores): migrate the 100 records whose only complication is a keyless clause

### DIFF
--- a/sources/scores/accelerate.yaml
+++ b/sources/scores/accelerate.yaml
@@ -2,9 +2,19 @@ product: accelerate
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: LICENSE file is the standard, unmodified Apache 2.0 text.
+  raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/huggingface/accelerate/blob/main/LICENSE
     shows: Standard Apache License 2.0 full text

--- a/sources/scores/aider.yaml
+++ b/sources/scores/aider.yaml
@@ -2,11 +2,22 @@ product: aider
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(GitHub);no feature-gated core; model-agnostic
-    (Claude/DeepSeek/OpenAI/local);core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: GitHub
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
+    - model-agnostic (Claude/DeepSeek/OpenAI/local)
   confidence: high
   note: Verified Apache-2.0 OSI, full source public, no managed/enterprise tier gating the core. Repo
     owner Aider-AI/aider, 45.8k stars confirmed via primary GitHub source.
+  raw: license:Apache-2.0(OSI);source:public(GitHub);no feature-gated core; model-agnostic (Claude/DeepSeek/OpenAI/local);core-gated:ungated
   sources:
   - url: https://github.com/Aider-AI/aider
     shows: Apache-2.0 license, public source, 45.8k stars (verified)

--- a/sources/scores/alpacaeval.yaml
+++ b/sources/scores/alpacaeval.yaml
@@ -2,9 +2,19 @@ product: alpacaeval
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;no-feature-gated-core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   confidence: high
   note: Fully Apache-2.0.
+  raw: license:Apache-2.0(OSI);source:public;no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://github.com/tatsu-lab/alpaca_eval
     shows: Apache-2.0, ~2.0k stars

--- a/sources/scores/anythingllm.yaml
+++ b/sources/scores/anythingllm.yaml
@@ -2,11 +2,22 @@ product: anythingllm
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public;no-feature-gated-core;optional hosted instance tier (managed convenience,
-    not a gated core);core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
+    - optional hosted instance tier (managed convenience, not a gated core)
   confidence: high
   note: Fully OSI (MIT), full source public; a hosted instance is offered but the self-hosted Desktop/Docker
     app is the complete product.
+  raw: license:MIT(OSI);source:public;no-feature-gated-core;optional hosted instance tier (managed convenience,
+    not a gated core);core-gated:ungated
   sources:
   - url: https://github.com/Mintplex-Labs/anything-llm
     shows: MIT license; all-in-one local-first RAG/agent app, v1.13.0

--- a/sources/scores/beeai.yaml
+++ b/sources/scores/beeai.yaml
@@ -2,9 +2,20 @@ product: beeai
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(Python+TS);no-feature-gated-core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: Python+TS
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   confidence: high
   note: Apache-2.0 across Python + TypeScript with no commercial gating.
+  raw: license:Apache-2.0(OSI);source:public(Python+TS);no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://github.com/i-am-bee/beeai-framework
     shows: Apache-2.0, ~3.3k stars, dual-language agent framework

--- a/sources/scores/bigcodebench.yaml
+++ b/sources/scores/bigcodebench.yaml
@@ -2,9 +2,18 @@ product: bigcodebench
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(GitHub);execution harness + leaderboard public
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: GitHub
+    free_text:
+    - execution harness + leaderboard public
   confidence: high
   note: Apache-2.0, fully public; OSI -> open_source.
+  raw: license:Apache-2.0(OSI);source:public(GitHub);execution harness + leaderboard public
   sources:
   - url: https://github.com/bigcode-project/bigcodebench
     shows: Apache-2.0 license, public harness, 1140 tasks

--- a/sources/scores/ccnet.yaml
+++ b/sources/scores/ccnet.yaml
@@ -2,9 +2,19 @@ product: ccnet
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public;no feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: Fully OSI-licensed (MIT), full source public.
+  raw: license:MIT(OSI);source:public;no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/facebookresearch/cc_net/blob/main/LICENSE
     shows: MIT License text

--- a/sources/scores/cline.yaml
+++ b/sources/scores/cline.yaml
@@ -3,10 +3,21 @@ openness:
   score: 5
   class: open_source
   confidence: high
-  components: license:Apache-2.0(OSI, (c)2026 Cline Bot Inc.);source:public;no feature-gated core; model-agnostic (30+
-    providers + MCP);core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI, (c)2026 Cline Bot Inc.
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
+    - model-agnostic (30+ providers + MCP)
   note: Verified Apache-2.0 OSI, full source public; free extension with no proprietary core gating. License/version/stars
     confirmed via primary GitHub source.
+  raw: license:Apache-2.0(OSI, (c)2026 Cline Bot Inc.);source:public;no feature-gated core; model-agnostic
+    (30+ providers + MCP);core-gated:ungated
   sources:
   - url: https://github.com/cline/cline
     shows: Apache 2.0 license, public source, CLI v3.0.17 Jun 4 2026, 62.7k stars (verified)

--- a/sources/scores/compar-ia-datasets.yaml
+++ b/sources/scores/compar-ia-datasets.yaml
@@ -2,10 +2,18 @@ product: compar-ia-datasets
 openness:
   score: 3
   class: gated
-  components: license:Etalab-2.0(permissive French-gov open license);gated:HF contact-info agreement required;dataset
-    card present
+  components:
+    license:
+      value: Etalab-2.0
+      detail: permissive French-gov open license
+    gated:
+      value: HF contact-info agreement required
+    free_text:
+    - dataset card present
   confidence: high
   note: Open license and documented, but gated access requiring agreement caps it at gated.
+  raw: license:Etalab-2.0(permissive French-gov open license);gated:HF contact-info agreement required;dataset
+    card present
   sources:
   - url: https://huggingface.co/datasets/ministere-culture/comparia-votes
     shows: License Etalab 2.0; gated access requiring contact-info agreement; dataset card present

--- a/sources/scores/compar-ia.yaml
+++ b/sources/scores/compar-ia.yaml
@@ -2,9 +2,17 @@ product: compar-ia
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI; verified LICENSE body);source:public;self-hostable
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI; verified LICENSE body
+    source:
+      value: public
+    free_text:
+    - self-hostable
   confidence: high
   note: Permissive OSI license with full public source code.
+  raw: license:Apache-2.0(OSI; verified LICENSE body);source:public;self-hostable
   sources:
   - url: https://raw.githubusercontent.com/betagouv/ComparIA/develop/LICENSE
     shows: LICENSE body 'Apache License, Version 2.0'

--- a/sources/scores/cosmopedia.yaml
+++ b/sources/scores/cosmopedia.yaml
@@ -2,9 +2,16 @@ product: cosmopedia
 openness:
   score: 5
   class: open
-  components: license:apache-2.0;ungated;dataset card present;parquet downloadable
+  components:
+    license:
+      value: apache-2.0
+    free_text:
+    - ungated
+    - dataset card present
+    - parquet downloadable
   confidence: high
   note: Permissive Apache-2.0 license, ungated, full dataset card and downloadable parquet files.
+  raw: license:apache-2.0;ungated;dataset card present;parquet downloadable
   sources:
   - url: https://huggingface.co/datasets/HuggingFaceTB/cosmopedia
     shows: Apache-2.0 license, 31M rows, full dataset card

--- a/sources/scores/crewai.yaml
+++ b/sources/scores/crewai.yaml
@@ -2,9 +2,19 @@ product: crewai
 openness:
   score: 4
   class: open_core
-  components: license:MIT(framework);source:public;CrewAI-Enterprise/AMP-managed-platform-tier;core-gated:gated
+  components:
+    license:
+      value: MIT
+      detail: framework
+    source:
+      value: public
+    core-gated:
+      value: gated
+    free_text:
+    - CrewAI-Enterprise/AMP-managed-platform-tier
   confidence: high
   note: license:MIT(framework);source:public;CrewAI-Enterprise/AMP-managed-platform-tier
+  raw: license:MIT(framework);source:public;CrewAI-Enterprise/AMP-managed-platform-tier;core-gated:gated
   sources:
   - url: https://github.com/crewAIInc/crewAI/blob/main/LICENSE
     shows: flagship phase-C verification source

--- a/sources/scores/data-juicer.yaml
+++ b/sources/scores/data-juicer.yaml
@@ -2,9 +2,19 @@ product: data-juicer
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: Fully OSI-licensed (Apache-2.0), full source public.
+  raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/datajuicer/data-juicer/blob/main/LICENSE
     shows: Apache License Version 2.0 text

--- a/sources/scores/datasette-agent.yaml
+++ b/sources/scores/datasette-agent.yaml
@@ -2,9 +2,21 @@ product: datasette-agent
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(GitHub);PyPI;no feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: GitHub
+    core-gated:
+      value: ungated
+    free_text:
+    - PyPI
+    - no feature-gated core
   confidence: high
   note: Apache-2.0 verified against LICENSE body; full source public on the datasette org; no gated tier.
+  raw: license:Apache-2.0(OSI);source:public(GitHub);PyPI;no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/datasette/datasette-agent/blob/main/LICENSE
     shows: Apache License 2.0 full text

--- a/sources/scores/datology-ai.yaml
+++ b/sources/scores/datology-ai.yaml
@@ -2,11 +2,20 @@ product: datology-ai
 openness:
   score: 1
   class: closed
-  components: license:Proprietary;source:closed;proprietary curation platform (VPC-deployed); no source available; no
-    OSS core
+  components:
+    license:
+      value: Proprietary
+    source:
+      value: closed
+    free_text:
+    - proprietary curation platform (VPC-deployed)
+    - no source available
+    - no OSS core
   confidence: high
   note: Fully proprietary automated-curation engine; the closed analogue to datatrove/NeMo Curator, science-of-data-curation
     niche.
+  raw: license:Proprietary;source:closed;proprietary curation platform (VPC-deployed); no source available;
+    no OSS core
   sources:
   - url: https://www.datologyai.com
     shows: Proprietary automated data-curation platform, no source available

--- a/sources/scores/dclm.yaml
+++ b/sources/scores/dclm.yaml
@@ -2,9 +2,19 @@ product: dclm
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public;no feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: Fully OSI-licensed (MIT), full source public.
+  raw: license:MIT(OSI);source:public;no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/mlfoundations/dclm/blob/main/LICENSE
     shows: MIT License text

--- a/sources/scores/deepspeed.yaml
+++ b/sources/scores/deepspeed.yaml
@@ -2,9 +2,19 @@ product: deepspeed
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: Apache-2.0 license body confirmed; full source public.
+  raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/deepspeedai/DeepSpeed/blob/master/LICENSE
     shows: Apache License Version 2.0 full text

--- a/sources/scores/diffusers.yaml
+++ b/sources/scores/diffusers.yaml
@@ -2,9 +2,19 @@ product: diffusers
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: LICENSE file is the standard, unmodified Apache 2.0 text.
+  raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/huggingface/diffusers/blob/main/LICENSE
     shows: Standard Apache License 2.0 full text

--- a/sources/scores/dify.yaml
+++ b/sources/scores/dify.yaml
@@ -2,7 +2,14 @@ product: dify
 openness:
   score: 2
   class: source_available
-  components: license:Dify-Open-Source-License(Apache-2.0-based,non-OSI,added-conditions:multi-tenant/branding-restrictions);source:public;cloud+enterprise-tiers
+  components:
+    license:
+      value: Dify-Open-Source-License
+      detail: Apache-2.0-based,non-OSI,added-conditions:multi-tenant/branding-restrictions
+    source:
+      value: public
+    free_text:
+    - cloud+enterprise-tiers
   confidence: high
   note: 'The Dify Open Source License is Apache-2.0 with added conditions: a multi-tenant service restriction
     and branding requirements. That puts it outside OSI approval and charges for a class of use, so the
@@ -10,6 +17,7 @@ openness:
     Score corrected from 3 to 2 on 2026-07-30. The software ladder has rungs at 1, 2, 4 and 5 and none at
     3, so 3/source_available was not a pair any rule could produce; the ladder scores "you can read it and
     not run it freely" at 2.'
+  raw: license:Dify-Open-Source-License(Apache-2.0-based,non-OSI,added-conditions:multi-tenant/branding-restrictions);source:public;cloud+enterprise-tiers
   sources:
   - url: https://github.com/langgenius/dify
     shows: flagship phase-C verification source

--- a/sources/scores/ds4.yaml
+++ b/sources/scores/ds4.yaml
@@ -2,10 +2,21 @@ product: ds4
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public;no feature-gated core;built on ggml/llama.cpp;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
+    - built on ggml/llama.cpp
   confidence: high
   note: MIT-licensed native inference engine; full C/CUDA/Obj-C source public, no proprietary tier.
   last_verified: '2026-08-09'
+  raw: license:MIT(OSI);source:public;no feature-gated core;built on ggml/llama.cpp;core-gated:ungated
   sources:
   - url: https://github.com/antirez/ds4/blob/main/LICENSE
     shows: MIT License, Copyright (c) 2026 The ds4.c authors, Copyright (c) 2023-2026 The ggml authors

--- a/sources/scores/dspy.yaml
+++ b/sources/scores/dspy.yaml
@@ -2,9 +2,20 @@ product: dspy
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public;no-feature-gated-core;no-commercial-saas;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
+    - no-commercial-saas
   confidence: high
   note: Fully MIT with no commercial tier.
+  raw: license:MIT(OSI);source:public;no-feature-gated-core;no-commercial-saas;core-gated:ungated
   sources:
   - url: https://github.com/stanfordnlp/dspy
     shows: MIT, ~35.1k stars

--- a/sources/scores/ernie.yaml
+++ b/sources/scores/ernie.yaml
@@ -2,10 +2,22 @@ product: ernie
 openness:
   score: 1
   class: closed
-  components: weights:closed;data:closed;code:closed;license:proprietary(Baidu Qianfan API);API-only(ERNIE 4.5 was
-    open, 5.x flagship closed)
+  components:
+    weights:
+      value: closed
+    data:
+      value: closed
+    code:
+      value: closed
+    license:
+      value: proprietary
+      detail: Baidu Qianfan API
+    free_text:
+    - API-only(ERNIE 4.5 was open, 5.x flagship closed)
   confidence: high
   note: No weights distributed for the 5.x flagship; closed API model.
+  raw: weights:closed;data:closed;code:closed;license:proprietary(Baidu Qianfan API);API-only(ERNIE 4.5
+    was open, 5.x flagship closed)
   sources:
   - url: https://huggingface.co/baidu
     shows: Baidu HF org lists only ERNIE 4.5 + Image open, no 5.x weights

--- a/sources/scores/fastmcp.yaml
+++ b/sources/scores/fastmcp.yaml
@@ -2,9 +2,20 @@ product: fastmcp
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;no-feature-gated-core;maintained-by-Prefect;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
+    - maintained-by-Prefect
   confidence: high
   note: Fully OSI-licensed, no open-core split observed on the repo.
+  raw: license:Apache-2.0(OSI);source:public;no-feature-gated-core;maintained-by-Prefect;core-gated:ungated
   sources:
   - url: https://github.com/jlowin/fastmcp
     shows: Apache-2.0 license, v3.4.0 (3 Jun 2026), maintained by Prefect

--- a/sources/scores/filesystem-mcp.yaml
+++ b/sources/scores/filesystem-mcp.yaml
@@ -2,9 +2,19 @@ product: filesystem-mcp
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   confidence: high
   note: Fully MIT reference server.
+  raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem
     shows: MIT, reference filesystem server

--- a/sources/scores/flax.yaml
+++ b/sources/scores/flax.yaml
@@ -2,9 +2,19 @@ product: flax
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: Apache-2.0 licensed with full public source.
+  raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/google/flax
     shows: Repo displays Apache-2.0 license and full source

--- a/sources/scores/gemini-cli.yaml
+++ b/sources/scores/gemini-cli.yaml
@@ -2,9 +2,19 @@ product: gemini-cli
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;no-feature-gated-core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   confidence: high
   note: Fully Apache-2.0; commercial relationship is on model quotas, not the tool.
+  raw: license:Apache-2.0(OSI);source:public;no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://github.com/google-gemini/gemini-cli
     shows: Apache-2.0, ~105k stars, open AI agent CLI

--- a/sources/scores/ggml.yaml
+++ b/sources/scores/ggml.yaml
@@ -2,9 +2,19 @@ product: ggml
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public;no feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: MIT license body confirmed (Copyright 2023-2026 The ggml authors); full source public.
+  raw: license:MIT(OSI);source:public;no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/ggml-org/ggml/blob/master/LICENSE
     shows: MIT License text, Copyright (c) 2023-2026 The ggml authors

--- a/sources/scores/github-mcp.yaml
+++ b/sources/scores/github-mcp.yaml
@@ -2,9 +2,19 @@ product: github-mcp
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   confidence: high
   note: Fully MIT, first-party GitHub server.
+  raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://github.com/github/github-mcp-server
     shows: MIT, ~30.8k stars, official GitHub server

--- a/sources/scores/gpt-researcher.yaml
+++ b/sources/scores/gpt-researcher.yaml
@@ -3,10 +3,21 @@ openness:
   score: 5
   class: open_source
   confidence: high
-  components: license:Apache-2.0(OSI);source:public;no feature-gated core; model-agnostic; Docker + frontend
-    included;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
+    - model-agnostic
+    - Docker + frontend included
   note: Verified Apache-2.0 OSI, full source public, no proprietary tier. License/version/stars confirmed
     via primary GitHub source.
+  raw: license:Apache-2.0(OSI);source:public;no feature-gated core; model-agnostic; Docker + frontend included;core-gated:ungated
   sources:
   - url: https://github.com/assafelovic/gpt-researcher
     shows: Apache-2.0, public source, v3.5.0 May 28 2026, 27.5k stars (verified)

--- a/sources/scores/gpt4all.yaml
+++ b/sources/scores/gpt4all.yaml
@@ -2,9 +2,19 @@ product: gpt4all
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   confidence: high
   note: Fully MIT.
+  raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://github.com/nomic-ai/gpt4all
     shows: MIT, ~77.4k stars, LocalDocs RAG + local API server

--- a/sources/scores/gradio.yaml
+++ b/sources/scores/gradio.yaml
@@ -2,9 +2,19 @@ product: gradio
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: LICENSE file is the standard, unmodified Apache 2.0 text.
+  raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/gradio-app/gradio/blob/main/LICENSE
     shows: Standard Apache License 2.0 full text

--- a/sources/scores/graphrag.yaml
+++ b/sources/scores/graphrag.yaml
@@ -2,9 +2,19 @@ product: graphrag
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   confidence: high
   note: Fully MIT.
+  raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://github.com/microsoft/graphrag
     shows: MIT, ~33.8k stars

--- a/sources/scores/helicone.yaml
+++ b/sources/scores/helicone.yaml
@@ -2,11 +2,22 @@ product: helicone
 openness:
   score: 4
   class: open_core
-  components: license:Apache-2.0(OSI);source:public;self-host supported;hosted Helicone Cloud with paid tiers(free=10k
-    req/mo) = commercial SaaS layer atop OSS core;core-gated:gated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: gated
+    free_text:
+    - self-host supported
+    - hosted Helicone Cloud with paid tiers(free=10k req/mo) = commercial SaaS layer atop OSS core
   confidence: high
   note: Apache-2.0 OSS core with a hosted commercial cloud (tiered pricing), classic open-core, same
     shelf as Langfuse/LangWatch (O4).
+  raw: license:Apache-2.0(OSI);source:public;self-host supported;hosted Helicone Cloud with paid tiers(free=10k
+    req/mo) = commercial SaaS layer atop OSS core;core-gated:gated
   sources:
   - url: https://github.com/Helicone/helicone
     shows: Apache-2.0 license; full source; hosted cloud paid tiers + self-host

--- a/sources/scores/hermes-agent.yaml
+++ b/sources/scores/hermes-agent.yaml
@@ -2,10 +2,23 @@ product: hermes-agent
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public(github.com/NousResearch/hermes-agent);no-feature-gated-core;model-agnostic(multi-provider);self-host-by-design;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+      detail: github.com/NousResearch/hermes-agent
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
+    - model-agnostic(multi-provider)
+    - self-host-by-design
   confidence: high
   note: Fully MIT-licensed, complete public source, self-hosted by design, no proprietary core; top openness,
     above open-core framework anchors.
+  raw: license:MIT(OSI);source:public(github.com/NousResearch/hermes-agent);no-feature-gated-core;model-agnostic(multi-provider);self-host-by-design;core-gated:ungated
   sources:
   - url: https://github.com/NousResearch/hermes-agent
     shows: MIT LICENSE, full public source, self-improving multi-channel agent (Python)

--- a/sources/scores/hf-datasets.yaml
+++ b/sources/scores/hf-datasets.yaml
@@ -2,9 +2,19 @@ product: hf-datasets
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: LICENSE file is the standard, unmodified Apache 2.0 text.
+  raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/huggingface/datasets/blob/main/LICENSE
     shows: Standard Apache License 2.0 full text

--- a/sources/scores/huggingchat-chat-ui.yaml
+++ b/sources/scores/huggingchat-chat-ui.yaml
@@ -2,11 +2,21 @@ product: huggingchat-chat-ui
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;no-feature-gated-core(self-hostable SvelteKit app, MongoDB
-    backend);core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core(self-hostable SvelteKit app, MongoDB backend)
   confidence: high
   note: Fully OSI (Apache-2.0); the public codebase is exactly what powers the hosted HuggingChat, self-hostable
     end to end.
+  raw: license:Apache-2.0(OSI);source:public;no-feature-gated-core(self-hostable SvelteKit app, MongoDB
+    backend);core-gated:ungated
   sources:
   - url: https://github.com/huggingface/chat-ui
     shows: Apache-2.0; 'open source codebase powering HuggingChat'; v0.10.0

--- a/sources/scores/huggingface-hub.yaml
+++ b/sources/scores/huggingface-hub.yaml
@@ -2,9 +2,19 @@ product: huggingface-hub
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: LICENSE body is verbatim Apache License 2.0; full source public.
+  raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/huggingface/huggingface_hub/blob/main/LICENSE
     shows: LICENSE file is the verbatim Apache License Version 2.0

--- a/sources/scores/jax.yaml
+++ b/sources/scores/jax.yaml
@@ -2,9 +2,19 @@ product: jax
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: Apache-2.0 licensed with full public source.
+  raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/jax-ml/jax
     shows: Repo shows Apache-2.0 license and full source

--- a/sources/scores/keras.yaml
+++ b/sources/scores/keras.yaml
@@ -2,9 +2,19 @@ product: keras
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: Apache-2.0 licensed with full public source.
+  raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/keras-team/keras
     shows: Repo shows Apache-2.0 license and full source

--- a/sources/scores/langtrace.yaml
+++ b/sources/scores/langtrace.yaml
@@ -2,12 +2,22 @@ product: langtrace
 openness:
   score: 4
   class: open_core
-  components: license:app=AGPL-3.0(OSI, copyleft);SDKs=Apache-2.0(OSI);source:public;OTel-built;hosted
-    Langtrace Cloud tier exists
+  components:
+    license:
+      value: app=AGPL-3.0
+      detail: OSI, copyleft
+    source:
+      value: public
+    free_text:
+    - SDKs=Apache-2.0(OSI)
+    - OTel-built
+    - hosted Langtrace Cloud tier exists
   confidence: high
   note: App is AGPL-3.0 (OSI-approved but strong copyleft, which deters proprietary embedding) and SDKs
     Apache-2.0; a managed cloud tier exists. Scored open_core/4 rather than 5 given the AGPL copyleft
     + hosted commercial offering.
+  raw: license:app=AGPL-3.0(OSI, copyleft);SDKs=Apache-2.0(OSI);source:public;OTel-built;hosted Langtrace
+    Cloud tier exists
   sources:
   - url: https://github.com/Scale3-Labs/langtrace
     shows: AGPL-3.0 app license, Apache-2.0 SDKs, OTel-based observability

--- a/sources/scores/librechat.yaml
+++ b/sources/scores/librechat.yaml
@@ -2,11 +2,20 @@ product: librechat
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public;no-feature-gated-core(RAG API is a separate companion OSS
-    repo);core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core(RAG API is a separate companion OSS repo)
   confidence: high
   note: Fully OSI (MIT), full source public, no paid feature-gated core. Enterprise backing via ClickHouse
     acquisition has not introduced a closed core.
+  raw: license:MIT(OSI);source:public;no-feature-gated-core(RAG API is a separate companion OSS repo);core-gated:ungated
   sources:
   - url: https://github.com/danny-avila/LibreChat
     shows: MIT license; full-featured self-hosted chat UI

--- a/sources/scores/lighteval.yaml
+++ b/sources/scores/lighteval.yaml
@@ -2,10 +2,23 @@ product: lighteval
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public(github.com/huggingface/lighteval);no feature-gated core; multi-backend
-    (Accelerate/vLLM/SGLang/TGI/LiteLLM/inspect-ai); 1000+ tasks;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+      detail: github.com/huggingface/lighteval
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
+    - multi-backend (Accelerate/vLLM/SGLang/TGI/LiteLLM/inspect-ai)
+    - 1000+ tasks
   confidence: high
   note: Fully OSI-licensed (MIT), full source public, no managed/commercial tier gating the eval engine.
+  raw: license:MIT(OSI);source:public(github.com/huggingface/lighteval);no feature-gated core; multi-backend
+    (Accelerate/vLLM/SGLang/TGI/LiteLLM/inspect-ai); 1000+ tasks;core-gated:ungated
   sources:
   - url: https://github.com/huggingface/lighteval
     shows: MIT license, public source, v0.13.0 (Nov 2025), 1000+ tasks, multi-backend support

--- a/sources/scores/lightrag.yaml
+++ b/sources/scores/lightrag.yaml
@@ -2,9 +2,19 @@ product: lightrag
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   confidence: high
   note: Fully MIT.
+  raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://github.com/HKUDS/LightRAG
     shows: MIT, ~36.7k stars, EMNLP 2025

--- a/sources/scores/llama-factory.yaml
+++ b/sources/scores/llama-factory.yaml
@@ -2,11 +2,22 @@ product: llama-factory
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(hiyouga/LLaMA-Factory);CLI+WebUI;no proprietary managed
-    tier;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: hiyouga/LLaMA-Factory
+    core-gated:
+      value: ungated
+    free_text:
+    - CLI+WebUI
+    - no proprietary managed tier
   confidence: high
   note: Fully OSI-licensed (Apache-2.0), full source public including the web UI; no feature-gated core.
   last_verified: '2026-08-09'
+  raw: license:Apache-2.0(OSI);source:public(hiyouga/LLaMA-Factory);CLI+WebUI;no proprietary managed tier;core-gated:ungated
   sources:
   - url: https://github.com/hiyouga/LLaMA-Factory
     shows: Redirects (301) to the renamed repository https://github.com/hiyouga/LlamaFactory (same owner,

--- a/sources/scores/llm.yaml
+++ b/sources/scores/llm.yaml
@@ -2,11 +2,23 @@ product: llm
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(GitHub);PyPI;plugin-extensible;no feature-gated
-    core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: GitHub
+    core-gated:
+      value: ungated
+    free_text:
+    - PyPI
+    - plugin-extensible
+    - no feature-gated core
   confidence: high
   note: Apache-2.0 verified against LICENSE body; full source public; CLI/library with no gated tier (model providers
     need their own API keys, external to the tool).
+  raw: license:Apache-2.0(OSI);source:public(GitHub);PyPI;plugin-extensible;no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/simonw/llm/blob/main/LICENSE
     shows: Apache License 2.0 full text

--- a/sources/scores/lm-evaluation-harness.yaml
+++ b/sources/scores/lm-evaluation-harness.yaml
@@ -2,9 +2,20 @@ product: lm-evaluation-harness
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public(GitHub);no feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+      detail: GitHub
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: MIT-licensed, fully public; OSI -> open_source.
+  raw: license:MIT(OSI);source:public(GitHub);no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/EleutherAI/lm-evaluation-harness
     shows: MIT license, public source, v0.4.12 (May 2026)

--- a/sources/scores/localai.yaml
+++ b/sources/scores/localai.yaml
@@ -2,10 +2,20 @@ product: localai
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   confidence: high
   note: Fully MIT; single repo, no gated tier or enterprise SKU found on the repo page.
   last_verified: '2026-08-09'
+  raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://raw.githubusercontent.com/mudler/LocalAI/master/LICENSE
     shows: 'MIT License

--- a/sources/scores/markitdown.yaml
+++ b/sources/scores/markitdown.yaml
@@ -2,10 +2,19 @@ product: markitdown
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI; repo LICENSE + pyproject, PyPI field
-    null);source:public;no-feature-gated-core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI; repo LICENSE + pyproject, PyPI field null
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   confidence: high
   note: Fully MIT; optional Azure/LLM features are pluggable, not gating.
+  raw: license:MIT(OSI; repo LICENSE + pyproject, PyPI field null);source:public;no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://raw.githubusercontent.com/microsoft/markitdown/main/LICENSE
     shows: MIT, Copyright Microsoft Corporation

--- a/sources/scores/mastra.yaml
+++ b/sources/scores/mastra.yaml
@@ -2,14 +2,24 @@ product: mastra
 openness:
   score: 4
   class: open_core
-  components: license:Apache-2.0(OSI, everything outside
-    `ee/`);source:public;ee/-auth-directories-under-Mastra-Enterprise-License;Mastra-Platform-hosted-tier-commercial;core-gated:gated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI, everything outside `ee/`
+    source:
+      value: public
+    core-gated:
+      value: gated
+    free_text:
+    - ee/-auth-directories-under-Mastra-Enterprise-License
+    - Mastra-Platform-hosted-tier-commercial
   confidence: high
   note: Open-core in the LangGraph/LlamaIndex shape rather than the n8n one - the framework itself is a real
     OSI license, not fair-code. LICENSE.md scopes the commercial carve-out narrowly to `ee/` auth directories,
     so the agent, workflow, memory and eval surfaces a user actually builds on are Apache-2.0. Not 5 because
     the enterprise auth code is source-available and the managed platform is closed.
   last_verified: '2026-07-30'
+  raw: license:Apache-2.0(OSI, everything outside `ee/`);source:public;ee/-auth-directories-under-Mastra-Enterprise-License;Mastra-Platform-hosted-tier-commercial;core-gated:gated
   sources:
   - url: https://github.com/mastra-ai/mastra/blob/main/LICENSE.md
     shows: 'LICENSE.md: "All content that resides under any directory named ''ee/'' within this repository"

--- a/sources/scores/mcp-inspector.yaml
+++ b/sources/scores/mcp-inspector.yaml
@@ -2,9 +2,19 @@ product: mcp-inspector
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   confidence: high
   note: Fully MIT.
+  raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://github.com/modelcontextprotocol/inspector
     shows: MIT license file

--- a/sources/scores/mcp-python-sdk.yaml
+++ b/sources/scores/mcp-python-sdk.yaml
@@ -2,9 +2,19 @@ product: mcp-python-sdk
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   confidence: high
   note: Fully MIT reference SDK.
+  raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://pypi.org/project/mcp/
     shows: MIT, package 'mcp', author Anthropic PBC

--- a/sources/scores/mcp-typescript-sdk.yaml
+++ b/sources/scores/mcp-typescript-sdk.yaml
@@ -2,9 +2,19 @@ product: mcp-typescript-sdk
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   confidence: high
   note: Fully MIT reference SDK.
+  raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://www.npmjs.com/package/@modelcontextprotocol/sdk
     shows: MIT, ~154M downloads/30d

--- a/sources/scores/milvus.yaml
+++ b/sources/scores/milvus.yaml
@@ -2,11 +2,19 @@ product: milvus
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0;source:public;LF-AI&Data-governed(Zilliz-Cloud is managed hosting, not gated
-    core);core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - LF-AI&Data-governed(Zilliz-Cloud is managed hosting, not gated core)
   confidence: high
   note: license:Apache-2.0;source:public;LF-AI&Data-governed(Zilliz-Cloud is managed hosting, not gated
     core)
+  raw: license:Apache-2.0;source:public;LF-AI&Data-governed(Zilliz-Cloud is managed hosting, not gated core);core-gated:ungated
   sources:
   - url: https://github.com/milvus-io/milvus/blob/master/LICENSE
     shows: flagship phase-C verification source

--- a/sources/scores/mlflow.yaml
+++ b/sources/scores/mlflow.yaml
@@ -2,11 +2,20 @@ product: mlflow
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0;source:public;core-fully-OSS(Databricks-Managed-MLflow is third-party hosting, not
-    gated core);core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - core-fully-OSS(Databricks-Managed-MLflow is third-party hosting, not gated core)
   confidence: high
   note: license:Apache-2.0;source:public;core-fully-OSS(Databricks-Managed-MLflow is third-party hosting,
     not gated core)
+  raw: license:Apache-2.0;source:public;core-fully-OSS(Databricks-Managed-MLflow is third-party hosting,
+    not gated core);core-gated:ungated
   sources:
   - url: https://github.com/mlflow/mlflow/blob/master/LICENSE.txt
     shows: flagship phase-C verification source

--- a/sources/scores/nano-graphrag.yaml
+++ b/sources/scores/nano-graphrag.yaml
@@ -2,9 +2,19 @@ product: nano-graphrag
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   confidence: high
   note: Fully MIT.
+  raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://github.com/gusye1234/nano-graphrag
     shows: MIT, ~3.9k stars

--- a/sources/scores/nemo-data-designer.yaml
+++ b/sources/scores/nemo-data-designer.yaml
@@ -2,11 +2,15 @@ product: nemo-data-designer
 openness:
   score: 1
   class: closed
-  components: proprietary NVIDIA NeMo microservice; archived gretel-synthetics OSS (Apache-2.0) is a separate
-    legacy artifact, not this product
+  components:
+    free_text:
+    - proprietary NVIDIA NeMo microservice
+    - archived gretel-synthetics OSS (Apache-2.0) is a separate legacy artifact, not this product
   confidence: medium
   note: Proprietary closed synthetic-data service; the open gretel-synthetics library is archived and
     not the shipped product.
+  raw: proprietary NVIDIA NeMo microservice; archived gretel-synthetics OSS (Apache-2.0) is a separate legacy
+    artifact, not this product
   sources:
   - url: https://techcrunch.com/2025/03/19/nvidia-reportedly-acquires-synthetic-data-startup-gretel/
     shows: NVIDIA acquired Gretel (Mar 2025); tech now shipped as NeMo Data Designer / NeMo microservices

--- a/sources/scores/notion-mcp.yaml
+++ b/sources/scores/notion-mcp.yaml
@@ -2,9 +2,19 @@ product: notion-mcp
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   confidence: high
   note: Fully MIT, first-party Notion server.
+  raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://github.com/makenotion/notion-mcp-server
     shows: MIT, ~4.4k stars, official Notion server

--- a/sources/scores/ogx.yaml
+++ b/sources/scores/ogx.yaml
@@ -2,11 +2,23 @@ product: ogx
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public;no-feature-gated-core;implements OpenAI + Anthropic API surfaces; 23
-    pluggable inference providers;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
+    - implements OpenAI + Anthropic API surfaces
+    - 23 pluggable inference providers
   confidence: high
   note: Fully open (MIT, full source). Openness scored straightforwardly; the issue is category fit, not
     openness.
+  raw: license:MIT(OSI);source:public;no-feature-gated-core;implements OpenAI + Anthropic API surfaces;
+    23 pluggable inference providers;core-gated:ungated
   sources:
   - url: https://github.com/ogx-ai/ogx
     shows: MIT license; v1.0.2 (May 13 2026); ~8.4k stars; agentic API server composing inference providers

--- a/sources/scores/ollama.yaml
+++ b/sources/scores/ollama.yaml
@@ -2,9 +2,18 @@ product: ollama
 openness:
   score: 5
   class: open_source
-  components: license:MIT;source:public;no-feature-gated-core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   confidence: high
   note: license:MIT;source:public;no-feature-gated-core
+  raw: license:MIT;source:public;no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://github.com/ollama/ollama/blob/main/LICENSE
     shows: flagship phase-C verification source

--- a/sources/scores/onnx-runtime.yaml
+++ b/sources/scores/onnx-runtime.yaml
@@ -2,11 +2,23 @@ product: onnx-runtime
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public(Microsoft);no proprietary core; plugin execution providers
-    (CUDA/WebGPU/etc.) in-repo;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+      detail: Microsoft
+    core-gated:
+      value: ungated
+    free_text:
+    - no proprietary core
+    - plugin execution providers (CUDA/WebGPU/etc.) in-repo
   confidence: high
   note: Fully MIT-licensed open source from Microsoft; no feature-gated tier. Re-confirmed unchanged.
   last_verified: '2026-08-09'
+  raw: license:MIT(OSI);source:public(Microsoft);no proprietary core; plugin execution providers (CUDA/WebGPU/etc.)
+    in-repo;core-gated:ungated
   sources:
   - url: https://github.com/microsoft/onnxruntime/blob/main/LICENSE
     shows: MIT License, Copyright (c) Microsoft Corporation, with standard MIT permission and warranty-disclaimer

--- a/sources/scores/onnx.yaml
+++ b/sources/scores/onnx.yaml
@@ -2,9 +2,19 @@ product: onnx
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: Apache-2.0 license body confirmed; full source public on GitHub.
+  raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/onnx/onnx/blob/main/LICENSE
     shows: Apache License Version 2.0 full text

--- a/sources/scores/openai-evals-api-dashboard.yaml
+++ b/sources/scores/openai-evals-api-dashboard.yaml
@@ -2,11 +2,20 @@ product: openai-evals-api-dashboard
 openness:
   score: 1
   class: closed
-  components: license:Proprietary(SaaS, OpenAI-platform-only);source:closed;managed-only(no self-host);
-    being deprecated Nov 2026
+  components:
+    license:
+      value: Proprietary
+      detail: SaaS, OpenAI-platform-only
+    source:
+      value: closed
+    free_text:
+    - managed-only(no self-host)
+    - being deprecated Nov 2026
   confidence: high
   note: Closed hosted SaaS bound to the OpenAI platform; not the MIT-licensed openai/evals repo (that
     is scored separately).
+  raw: license:Proprietary(SaaS, OpenAI-platform-only);source:closed;managed-only(no self-host); being deprecated
+    Nov 2026
   sources:
   - url: https://developers.openai.com/api/docs/guides/evals
     shows: hosted proprietary Evals API + dashboard on OpenAI platform; sunset dates (read-only Oct 31

--- a/sources/scores/opencode.yaml
+++ b/sources/scores/opencode.yaml
@@ -2,9 +2,19 @@ product: opencode
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   confidence: high
   note: Fully MIT.
+  raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://github.com/sst/opencode
     shows: MIT, ~176k stars, open coding agent

--- a/sources/scores/opencompass.yaml
+++ b/sources/scores/opencompass.yaml
@@ -2,9 +2,20 @@ product: opencompass
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(GitHub);no feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: GitHub
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: Apache-2.0, fully public; OSI -> open_source.
+  raw: license:Apache-2.0(OSI);source:public(GitHub);no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/open-compass/opencompass
     shows: Apache-2.0 license, public source, v0.5.2 (Feb 2026)

--- a/sources/scores/openfn.yaml
+++ b/sources/scores/openfn.yaml
@@ -2,10 +2,19 @@ product: openfn
 openness:
   score: 5
   class: open_source
-  components: license:LGPL-3.0/GPL-3.0(OSI copyleft);source:public;no feature-gated core per
-    maintainers;core-gated:ungated
+  components:
+    license:
+      value: LGPL-3.0/GPL-3.0
+      detail: OSI copyleft
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core per maintainers
   confidence: high
   note: Fully open source DPG with copyleft licensing and no feature-gated core.
+  raw: license:LGPL-3.0/GPL-3.0(OSI copyleft);source:public;no feature-gated core per maintainers;core-gated:ungated
   sources:
   - url: https://github.com/OpenFn/lightning
     shows: OpenFn/lightning, dual-licensed LGPL-3.0/GPL-3.0, fully open source, verified DPG

--- a/sources/scores/openlit.yaml
+++ b/sources/scores/openlit.yaml
@@ -2,11 +2,21 @@ product: openlit
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;OTel-native SDKs(Python/TS/Go);no enterprise-gated core
-    observed;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - OTel-native SDKs(Python/TS/Go)
+    - no enterprise-gated core observed
   confidence: high
   note: Fully Apache-2.0, OpenTelemetry-native, no feature-gated core; vendor-neutral by design (exports
     to any OTel backend).
+  raw: license:Apache-2.0(OSI);source:public;OTel-native SDKs(Python/TS/Go);no enterprise-gated core observed;core-gated:ungated
   sources:
   - url: https://github.com/openlit/openlit
     shows: Apache-2.0 license; OTel-native SDKs; full feature source

--- a/sources/scores/openllmetry.yaml
+++ b/sources/scores/openllmetry.yaml
@@ -2,11 +2,22 @@ product: openllmetry
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;no-feature-gated-core(SDK is fully OSS; Traceloop dashboard is an
-    optional external export target, not gated core);core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core(SDK is fully OSS; Traceloop dashboard is an optional external export target,
+      not gated core)
   confidence: high
   note: Apache-2.0 instrumentation library; exports to any OTel backend (Datadog, Honeycomb, etc.), so
     the OSS is genuinely standalone.
+  raw: license:Apache-2.0(OSI);source:public;no-feature-gated-core(SDK is fully OSS; Traceloop dashboard
+    is an optional external export target, not gated core);core-gated:ungated
   sources:
   - url: https://pypi.org/project/traceloop-sdk/
     shows: 'License: Apache-2.0; v0.61.0 (31 May 2026)'

--- a/sources/scores/openpcc.yaml
+++ b/sources/scores/openpcc.yaml
@@ -2,12 +2,23 @@ product: openpcc
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(github.com/openpcc/openpcc +
-    spec/whitepaper);reference-impl(Go)+client-SDKs;commercial-managed-service(CONFSEC)separate;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: github.com/openpcc/openpcc + spec/whitepaper
+    core-gated:
+      value: ungated
+    free_text:
+    - reference-impl(Go)+client-SDKs
+    - commercial-managed-service(CONFSEC)separate
   confidence: high
   note: Fully OSI-licensed (Apache-2.0) across the reference implementation and related repos, with the spec
     and whitepaper public. Confident Security runs a commercial managed service (CONFSEC) on top, but that
     is an open-core *business* around a fully open standard, not open-core licensing.
+  raw: license:Apache-2.0(OSI);source:public(github.com/openpcc/openpcc + spec/whitepaper);reference-impl(Go)+client-SDKs;commercial-managed-service(CONFSEC)separate;core-gated:ungated
   sources:
   - url: https://github.com/openpcc/openpcc
     shows: Apache-2.0; "open source framework for verifiably private AI inference"; OHTTP gateway, attestation,

--- a/sources/scores/openrlhf.yaml
+++ b/sources/scores/openrlhf.yaml
@@ -2,12 +2,23 @@ product: openrlhf
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(OpenRLHF/OpenRLHF);no managed tier;built on
-    Ray+vLLM+DeepSpeed;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: OpenRLHF/OpenRLHF
+    core-gated:
+      value: ungated
+    free_text:
+    - no managed tier
+    - built on Ray+vLLM+DeepSpeed
   confidence: high
   note: 'unchanged: Fully OSI-licensed (Apache-2.0), full source public, no proprietary tier -- re-confirmed
     2026-08-09 against the LICENSE body, the README, and the repo page; no gating found.'
   last_verified: '2026-08-09'
+  raw: license:Apache-2.0(OSI);source:public(OpenRLHF/OpenRLHF);no managed tier;built on Ray+vLLM+DeepSpeed;core-gated:ungated
   sources:
   - url: https://raw.githubusercontent.com/OpenRLHF/OpenRLHF/main/LICENSE
     shows: The unmodified Apache License, Version 2.0 template -- opens "Apache License" / "Version 2.0,

--- a/sources/scores/openthoughts-114k.yaml
+++ b/sources/scores/openthoughts-114k.yaml
@@ -2,9 +2,16 @@ product: openthoughts-114k
 openness:
   score: 5
   class: open
-  components: license:apache-2.0;ungated;dataset card present;GitHub repo + paper
+  components:
+    license:
+      value: apache-2.0
+    free_text:
+    - ungated
+    - dataset card present
+    - GitHub repo + paper
   confidence: high
   note: Apache-2.0 licensed, ungated, with dataset card, code repo, and paper.
+  raw: license:apache-2.0;ungated;dataset card present;GitHub repo + paper
   sources:
   - url: https://huggingface.co/datasets/open-thoughts/OpenThoughts-114k
     shows: Apache-2.0 license, dataset card, GitHub and arXiv links

--- a/sources/scores/openvino.yaml
+++ b/sources/scores/openvino.yaml
@@ -2,9 +2,19 @@ product: openvino
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: Apache-2.0 license body confirmed; full source public.
+  raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/openvinotoolkit/openvino/blob/master/LICENSE
     shows: Apache License Version 2.0 full text

--- a/sources/scores/optimum.yaml
+++ b/sources/scores/optimum.yaml
@@ -2,9 +2,19 @@ product: optimum
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: LICENSE body is verbatim Apache License 2.0; full source public.
+  raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/huggingface/optimum/blob/main/LICENSE
     shows: LICENSE file is the verbatim Apache License Version 2.0

--- a/sources/scores/oscar-2301.yaml
+++ b/sources/scores/oscar-2301.yaml
@@ -2,10 +2,18 @@ product: oscar-2301
 openness:
   score: 3
   class: gated
-  components: license:cc0-1.0(metadata);gated:manual(login + terms acceptance);card notes access temporarily
-    suspended
+  components:
+    license:
+      value: cc0-1.0
+      detail: metadata
+    gated:
+      value: manual
+      detail: login + terms acceptance
+    free_text:
+    - card notes access temporarily suspended
   confidence: high
   note: Manually gated and the card states access is temporarily suspended pending clarification.
+  raw: license:cc0-1.0(metadata);gated:manual(login + terms acceptance);card notes access temporarily suspended
   sources:
   - url: https://huggingface.co/datasets/oscar-corpus/OSCAR-2301
     shows: Card describing 151 languages/~3.57TB, CC0 metadata, gated access with a notice suspending

--- a/sources/scores/osworld.yaml
+++ b/sources/scores/osworld.yaml
@@ -2,11 +2,21 @@ product: osworld
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(github.com/xlang-ai/OSWorld);execution-based eval
-    harness + 369-task environment public; multi-platform (VMware/VirtualBox/Docker/AWS)
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: github.com/xlang-ai/OSWorld
+    free_text:
+    - execution-based eval harness + 369-task environment public
+    - multi-platform (VMware/VirtualBox/Docker/AWS)
   confidence: high
   note: Apache-2.0, full harness + environment public. Scored as the evaluation harness; the bundled 369-task
     set is also openly redistributable.
+  raw: license:Apache-2.0(OSI);source:public(github.com/xlang-ai/OSWorld);execution-based eval harness +
+    369-task environment public; multi-platform (VMware/VirtualBox/Docker/AWS)
   sources:
   - url: https://github.com/xlang-ai/OSWorld
     shows: Apache-2.0 license, public source, computer-use agent eval harness

--- a/sources/scores/playwright-mcp.yaml
+++ b/sources/scores/playwright-mcp.yaml
@@ -2,10 +2,21 @@ product: playwright-mcp
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(Microsoft
-    repo);no-feature-gated-core;no-managed-tier;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: Microsoft repo
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
+    - no-managed-tier
   confidence: high
   note: Fully OSI-licensed Microsoft repo, no open-core split.
+  raw: license:Apache-2.0(OSI);source:public(Microsoft repo);no-feature-gated-core;no-managed-tier;core-gated:ungated
   sources:
   - url: https://github.com/microsoft/playwright-mcp
     shows: Apache-2.0 license, v0.0.75 (7 May 2026)

--- a/sources/scores/postgres-mcp.yaml
+++ b/sources/scores/postgres-mcp.yaml
@@ -2,9 +2,19 @@ product: postgres-mcp
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   confidence: high
   note: Fully MIT.
+  raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://github.com/crystaldba/postgres-mcp
     shows: MIT, ~2.9k stars, Postgres MCP Pro

--- a/sources/scores/promptfoo.yaml
+++ b/sources/scores/promptfoo.yaml
@@ -2,11 +2,22 @@ product: promptfoo
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public(GitHub);no feature-gated core observed (acquired by OpenAI, stated to
-    remain MIT/open source);core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+      detail: GitHub
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core observed (acquired by OpenAI, stated to remain MIT/open source)
   confidence: high
   note: MIT-licensed, fully public; OSI -> open_source. OpenAI ownership noted but does not change the
     OSS license at scoring time.
+  raw: license:MIT(OSI);source:public(GitHub);no feature-gated core observed (acquired by OpenAI, stated
+    to remain MIT/open source);core-gated:ungated
   sources:
   - url: https://github.com/promptfoo/promptfoo
     shows: MIT license; 'remains open source and MIT licensed' under OpenAI; v0.121.14

--- a/sources/scores/pytorch.yaml
+++ b/sources/scores/pytorch.yaml
@@ -2,9 +2,19 @@ product: pytorch
 openness:
   score: 5
   class: open_source
-  components: license:BSD-3-Clause(OSI);source:public;no feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: BSD-3-Clause
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: BSD 3-Clause license with multiple contributor copyright lines; full source public.
+  raw: license:BSD-3-Clause(OSI);source:public;no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/pytorch/pytorch/blob/main/LICENSE
     shows: BSD 3-Clause license body with Facebook/contributor copyright lines

--- a/sources/scores/ragas.yaml
+++ b/sources/scores/ragas.yaml
@@ -2,11 +2,22 @@ product: ragas
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(full metrics + test-gen library); core un-gated. (Vendor also
-    offers a hosted app.ragas.io tier; not required for the library.);core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: full metrics + test-gen library
+    core-gated:
+      value: ungated
+    free_text:
+    - core un-gated. (Vendor also offers a hosted app.ragas.io tier; not required for the library.)
   confidence: high
   note: Core library is fully OSI (Apache-2.0) with no feature-gated functionality; could be argued open_core
     given the hosted cloud product, but the eval library itself is complete and open, so scored open_source.
+  raw: license:Apache-2.0(OSI);source:public(full metrics + test-gen library); core un-gated. (Vendor also
+    offers a hosted app.ragas.io tier; not required for the library.);core-gated:ungated
   sources:
   - url: https://github.com/explodinggradients/ragas
     shows: Apache-2.0 license; LLM-app eval metrics + test-set generation; v0.4.3 (Jan 2026); 14.2k stars

--- a/sources/scores/redpajama-data.yaml
+++ b/sources/scores/redpajama-data.yaml
@@ -2,9 +2,19 @@ product: redpajama-data
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: Fully OSI-licensed (Apache-2.0), full source public.
+  raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/togethercomputer/RedPajama-Data/blob/main/LICENSE
     shows: Apache License Version 2.0 text

--- a/sources/scores/safetensors.yaml
+++ b/sources/scores/safetensors.yaml
@@ -2,9 +2,19 @@ product: safetensors
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: LICENSE body is verbatim Apache License 2.0; full Rust/Python source public.
+  raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/huggingface/safetensors/blob/main/LICENSE
     shows: LICENSE file is the verbatim Apache License Version 2.0

--- a/sources/scores/semantic-kernel.yaml
+++ b/sources/scores/semantic-kernel.yaml
@@ -2,9 +2,21 @@ product: semantic-kernel
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public(C#/Python/Java);model-agnostic;no-feature-gated-core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+      detail: C#/Python/Java
+    core-gated:
+      value: ungated
+    free_text:
+    - model-agnostic
+    - no-feature-gated-core
   confidence: high
   note: MIT multi-language SDK; first-class Azure connectors but model-agnostic and self-hostable.
+  raw: license:MIT(OSI);source:public(C#/Python/Java);model-agnostic;no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://github.com/microsoft/semantic-kernel
     shows: MIT, ~28.2k stars, multi-language agent SDK

--- a/sources/scores/sentencepiece.yaml
+++ b/sources/scores/sentencepiece.yaml
@@ -2,9 +2,19 @@ product: sentencepiece
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: LICENSE body is verbatim Apache License 2.0; full C++/Python source public.
+  raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/google/sentencepiece/blob/master/LICENSE
     shows: LICENSE file is the verbatim Apache License Version 2.0

--- a/sources/scores/simple-evals.yaml
+++ b/sources/scores/simple-evals.yaml
@@ -2,9 +2,20 @@ product: simple-evals
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public(reference eval implementations); no managed tier;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+      detail: reference eval implementations
+    core-gated:
+      value: ungated
+    free_text:
+    - no managed tier
   confidence: high
   note: Fully OSI (MIT); purely a reference-implementation library, no gated core.
+  raw: license:MIT(OSI);source:public(reference eval implementations); no managed tier;core-gated:ungated
   sources:
   - url: https://github.com/openai/simple-evals
     shows: MIT license; lightweight eval library; deprecation notice (July 2025); ~4.5k stars

--- a/sources/scores/simpleaudit.yaml
+++ b/sources/scores/simpleaudit.yaml
@@ -2,9 +2,17 @@ product: simpleaudit
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI; verified LICENSE body, copyright Simula);source:public;Python
+  components:
+    license:
+      value: MIT
+      detail: OSI; verified LICENSE body, copyright Simula
+    source:
+      value: public
+    free_text:
+    - Python
   confidence: high
   note: Permissive OSI (MIT) license with full public source.
+  raw: license:MIT(OSI; verified LICENSE body, copyright Simula);source:public;Python
   sources:
   - url: https://raw.githubusercontent.com/kelkalot/simpleaudit/main/LICENSE
     shows: LICENSE body 'MIT License', copyright Simula Research Laboratory

--- a/sources/scores/slack-mcp.yaml
+++ b/sources/scores/slack-mcp.yaml
@@ -2,9 +2,19 @@ product: slack-mcp
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   confidence: high
   note: Fully MIT.
+  raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://github.com/korotovsky/slack-mcp-server
     shows: MIT, ~1.7k stars, v1.3.0

--- a/sources/scores/smolagents.yaml
+++ b/sources/scores/smolagents.yaml
@@ -2,10 +2,22 @@ product: smolagents
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(github.com/huggingface/smolagents);no-feature-gated-core;model-agnostic;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: github.com/huggingface/smolagents
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
+    - model-agnostic
   confidence: high
   note: Fully OSI-licensed (Apache-2.0), entire library public, no proprietary/managed core, top openness,
     above open-core framework anchors (CrewAI/LangChain).
+  raw: license:Apache-2.0(OSI);source:public(github.com/huggingface/smolagents);no-feature-gated-core;model-agnostic;core-gated:ungated
   sources:
   - url: https://github.com/huggingface/smolagents
     shows: Apache-2.0 license, full public source, ~1k-LOC code-agent framework

--- a/sources/scores/snorkel-flow.yaml
+++ b/sources/scores/snorkel-flow.yaml
@@ -2,11 +2,20 @@ product: snorkel-flow
 openness:
   score: 1
   class: closed
-  components: license:Proprietary;source:closed;proprietary enterprise SaaS; the original 'snorkel' weak-supervision
-    library is a separate Apache-2.0 OSS repo (stale), not the shipped product
+  components:
+    license:
+      value: Proprietary
+    source:
+      value: closed
+    free_text:
+    - proprietary enterprise SaaS
+    - the original 'snorkel' weak-supervision library is a separate Apache-2.0 OSS repo (stale), not the
+      shipped product
   confidence: high
   note: The commercial Snorkel Flow product is closed; the open snorkel library is separate and effectively
     in maintenance/wind-down.
+  raw: license:Proprietary;source:closed;proprietary enterprise SaaS; the original 'snorkel' weak-supervision
+    library is a separate Apache-2.0 OSS repo (stale), not the shipped product
   sources:
   - url: https://snorkel.ai
     shows: Commercial enterprise data-development platform; separate OSS snorkel library is stale

--- a/sources/scores/spec-kit.yaml
+++ b/sources/scores/spec-kit.yaml
@@ -2,9 +2,20 @@ product: spec-kit
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public;no-feature-gated-core;no-commercial-tier;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
+    - no-commercial-tier
   confidence: high
   note: Fully MIT, free.
+  raw: license:MIT(OSI);source:public;no-feature-gated-core;no-commercial-tier;core-gated:ungated
   sources:
   - url: https://github.com/github/spec-kit
     shows: MIT, ~113k stars, Spec-Driven Development toolkit

--- a/sources/scores/suna.yaml
+++ b/sources/scores/suna.yaml
@@ -3,13 +3,21 @@ openness:
   score: 2
   class: source_available
   confidence: high
-  components: license:Elastic License 2.0(non-OSI, source-available, restricts hosting as a managed service);source:public;managed
-    cloud + self-host tiers
+  components:
+    license:
+      value: Elastic License 2.0
+      detail: non-OSI, source-available, restricts hosting as a managed service
+    source:
+      value: public
+    free_text:
+    - managed cloud + self-host tiers
   note: 'Verified Elastic License 2.0 in the LICENSE file: source-available, not OSI approved, and restricts
     providing the software as a hosted or managed service. Marketed as "open source" while carrying managed-service
     restrictions; flagged open_washed. Score corrected from 3 to 2 on 2026-07-30. The software ladder has
     rungs at 1, 2, 4 and 5 and none at 3, so 3/source_available was not a pair any rule could produce; the
     ladder scores "you can read it and not run it freely" at 2.'
+  raw: license:Elastic License 2.0(non-OSI, source-available, restricts hosting as a managed service);source:public;managed
+    cloud + self-host tiers
   sources:
   - url: https://github.com/kortix-ai/suna/blob/main/LICENSE
     shows: Elastic License 2.0 text (verified, non-OSI)

--- a/sources/scores/swe-agent.yaml
+++ b/sources/scores/swe-agent.yaml
@@ -3,9 +3,20 @@ openness:
   score: 5
   class: open_source
   confidence: high
-  components: license:MIT(OSI);source:public;no managed tier; model-agnostic;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no managed tier
+    - model-agnostic
   note: Verified MIT OSI, full source public; academic project with no proprietary tier. License/stars/release
     date confirmed via primary GitHub source.
+  raw: license:MIT(OSI);source:public;no managed tier; model-agnostic;core-gated:ungated
   sources:
   - url: https://github.com/SWE-agent/SWE-agent/blob/main/LICENSE
     shows: MIT License text

--- a/sources/scores/swe-bench.yaml
+++ b/sources/scores/swe-bench.yaml
@@ -2,10 +2,21 @@ product: swe-bench
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public(GitHub);harness+inference+eval code public;no feature-gated
-    core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+      detail: GitHub
+    core-gated:
+      value: ungated
+    free_text:
+    - harness+inference+eval code public
+    - no feature-gated core
   confidence: high
   note: MIT-licensed harness, full source public; OSI -> open_source.
+  raw: license:MIT(OSI);source:public(GitHub);harness+inference+eval code public;no feature-gated core;core-gated:ungated
   sources:
   - url: https://pypi.org/project/swebench/
     shows: official SWE-bench package, MIT license, v4.1.0

--- a/sources/scores/synth.yaml
+++ b/sources/scores/synth.yaml
@@ -2,9 +2,16 @@ product: synth
 openness:
   score: 5
   class: open
-  components: license:CC-BY-4.0(permissive);ungated;dataset card present
+  components:
+    license:
+      value: CC-BY-4.0
+      detail: permissive
+    free_text:
+    - ungated
+    - dataset card present
   confidence: high
   note: Permissively licensed, ungated dataset with a documented card.
+  raw: license:CC-BY-4.0(permissive);ungated;dataset card present
   sources:
   - url: https://huggingface.co/datasets/PleIAs/SYNTH
     shows: License CC-BY-4.0, not gated, dataset card present

--- a/sources/scores/tensorflow.yaml
+++ b/sources/scores/tensorflow.yaml
@@ -2,9 +2,19 @@ product: tensorflow
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: Apache-2.0 licensed with full public source.
+  raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/tensorflow/tensorflow
     shows: Repo shows Apache License 2.0 and full source

--- a/sources/scores/tokenizers.yaml
+++ b/sources/scores/tokenizers.yaml
@@ -2,9 +2,19 @@ product: tokenizers
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: LICENSE body is verbatim Apache License 2.0; full Rust/Python source public.
+  raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/huggingface/tokenizers/blob/main/LICENSE
     shows: LICENSE file is the verbatim Apache License Version 2.0

--- a/sources/scores/transformers.yaml
+++ b/sources/scores/transformers.yaml
@@ -2,9 +2,19 @@ product: transformers
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: LICENSE file is the standard, unmodified Apache 2.0 text.
+  raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/huggingface/transformers/blob/main/LICENSE
     shows: Standard Apache License 2.0 full text

--- a/sources/scores/triton.yaml
+++ b/sources/scores/triton.yaml
@@ -2,9 +2,19 @@ product: triton
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public;no feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: MIT license body confirmed (Tillet/OpenAI copyright); full source public.
+  raw: license:MIT(OSI);source:public;no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/triton-lang/triton/blob/main/LICENSE
     shows: MIT License text, Copyright 2018-2020 Philippe Tillet / 2020-2022 OpenAI

--- a/sources/scores/tulu-3-sft-mixture.yaml
+++ b/sources/scores/tulu-3-sft-mixture.yaml
@@ -2,10 +2,17 @@ product: tulu-3-sft-mixture
 openness:
   score: 5
   class: open
-  components: license:odc-by(mixed subset licenses incl CC-BY-NC);ungated;dataset card present
+  components:
+    license:
+      value: odc-by
+      detail: mixed subset licenses incl CC-BY-NC
+    free_text:
+    - ungated
+    - dataset card present
   confidence: high
   note: ODC-BY licensed and ungated with a full dataset card, though some subsets carry non-commercial
     licenses.
+  raw: license:odc-by(mixed subset licenses incl CC-BY-NC);ungated;dataset card present
   sources:
   - url: https://huggingface.co/datasets/allenai/tulu-3-sft-mixture
     shows: ODC-BY-1.0 license, ~939k rows, dataset card

--- a/sources/scores/wildchat-1m.yaml
+++ b/sources/scores/wildchat-1m.yaml
@@ -2,10 +2,18 @@ product: wildchat-1m
 openness:
   score: 5
   class: open
-  components: license:odc-by;gated:false per HF API;dataset card present;parquet downloadable
+  components:
+    license:
+      value: odc-by
+    gated:
+      value: false per HF API
+    free_text:
+    - dataset card present
+    - parquet downloadable
   confidence: medium
   note: ODC-BY licensed and reported ungated by the HF API, though Ai2 datasets sometimes show an access
     notice.
+  raw: license:odc-by;gated:false per HF API;dataset card present;parquet downloadable
   sources:
   - url: https://huggingface.co/api/datasets/allenai/WildChat-1M
     shows: gated=false, license=odc-by

--- a/sources/scores/yomo.yaml
+++ b/sources/scores/yomo.yaml
@@ -2,14 +2,23 @@ product: yomo
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(declared in Cargo.toml+README);source:public;full-runtime-in-repo(Rust
-    core+QUIC+multi-language SDKs);managed-hosting-by-Vivgrid-optional
+  components:
+    license:
+      value: Apache-2.0
+      detail: declared in Cargo.toml+README
+    source:
+      value: public
+    free_text:
+    - full-runtime-in-repo(Rust core+QUIC+multi-language SDKs)
+    - managed-hosting-by-Vivgrid-optional
   confidence: medium
   note: Cargo.toml declares license = "Apache-2.0" and the README states Apache License 2.0, but no LICENSE
     file is committed at the repo root, so GitHub's detector reports no license. The full runtime (Rust
     core, QUIC transport, serverless SDKs) is in the open repo; Vivgrid's managed platform is optional
     hosting of the same open framework rather than a gated core. Scored open_source with medium confidence
     pending a committed LICENSE file.
+  raw: license:Apache-2.0(declared in Cargo.toml+README);source:public;full-runtime-in-repo(Rust core+QUIC+multi-language
+    SDKs);managed-hosting-by-Vivgrid-optional
   sources:
   - url: https://github.com/yomorun/yomo/blob/main/Cargo.toml
     shows: license = "Apache-2.0", name = "yomo", version = "2.0.4"


### PR DESCRIPTION
## Summary

Third batch of the structured-components migration: the 100 records whose only complication is a keyless clause. **146 keyless clauses** move into a `free_text` list, verbatim.

Nothing is promoted. That holds even where a clause plainly looks like it answers a dimension — `no feature-gated core` and `dataset card present` both stay free text. Whether any of them is really a dimension's only record is a methodology question, asked in #187, and answering it here would move published scores rather than reshape storage.

Two of the four non-deferred products where a promotion would actually move a score, `datology-ai` and `openai-evals-api-dashboard`, are in this batch. Their clauses stayed in `free_text`.

## The check that matters here

`recompose` drops `free_text`, so the record-level `raw` round-trip cannot prove keyless clauses survived. `check_components` validates them on a separate path, and the counts were reconciled directly against the originals:

```
files                          100
keyless clauses in originals   146
free_text entries written      146
per-file mismatches            none
```

## Zero published numbers move

```
git diff --numstat build/notebook_data.json
1  1  build/notebook_data.json
```

At a committed head. The check is meaningless before `git commit` — see #190.

## Test plan

- Population re-derived from the corpus: 100.
- Key sets compared before and after: identical on every file checked, so no clause changed shape.
- Every edit through `build/components.py`, never a text substitution — 278 of 472 score files fold `components` across lines, and `set_field` reparses and asserts byte-identity outside the touched span.
- Suite 431 passed. `validate` 0 error(s), `check_recipe` 0 failure(s) with the dropped/blocking counts unchanged, `check_rubric` exit 0, `check_components` `[OK]`, `check_verification` all `[OK]`.
