### PR TITLE
test(components): keep the equivalence walk covering the whole corpus as records migrate

### DIFF
--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -291,19 +291,33 @@ def test_no_score_file_mints_a_phantom_dimension_key():
     corrupts every corpus-wide key inventory and would carry into the structured form.
     A phantom key is recognizable: real dimension keys are short, lowercase, and contain
     no spaces or parentheses.
+
+    Reads keys via `components_of`, not `split_components` directly on the raw field:
+    `components_of` reads either shape, while a migrated record's `components` is a dict
+    and handing that straight to `split_components` (which iterates its argument
+    character by character) silently yields no keys at all rather than erroring. Left
+    that way, this test's coverage would have shrunk to nothing as the migration
+    proceeded, without ever failing loudly.
     """
-    from build.check_rubric import split_components
+    from build.check_rubric import components_of
 
     root = Path(__file__).resolve().parents[1]
     offenders = []
+    inspected = 0
     for path in sorted((root / "sources" / "scores").glob("*.yaml")):
-        components = (yaml.safe_load(path.read_text()).get("openness") or {}).get("components")
-        if not components:
-            continue
-        for key in split_components(components):
+        openness = (yaml.safe_load(path.read_text()) or {}).get("openness") or {}
+        for key in components_of(openness):
+            inspected += 1
             if " " in key or "(" in key or ")" in key:
                 offenders.append(f"{path.stem}: {key!r}")
 
+    # A floor, not an exact count, for the same reason as the sibling equivalence test in
+    # test_serialize_rubric.py: the corpus only grows as products are scored, so more keys
+    # inspected than this is ordinary curation. This guard is here because `offenders == []`
+    # alone cannot tell "nothing to flag" from "nothing was inspected" — which is exactly
+    # how this test passed green while checking zero keys from every migrated record before
+    # the `components_of` fix above.
+    assert inspected >= 1_754, f"only {inspected} keys inspected; the corpus walk is broken"
     assert offenders == [], "phantom dimension keys minted from prose:\n  " + "\n  ".join(offenders)
 
 

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -987,25 +987,38 @@ def test_split_value_bare_half_matches_head_on_the_whole_corpus():
     actually reads. That held on all 1,754 recordings when it was measured, and until now
     it was asserted against four hand-written strings — so an edit to either function could
     move scores with every gate green. Four literals cannot notice that; the corpus can.
+
+    Reads each record's flat string via `components_string`, which is the one function
+    every reader uses to look past the migration's shape change: it prefers the verbatim
+    `raw` a migrated record keeps, and falls back to the literal `components` string for a
+    record not yet migrated. That keeps this walk at the full original population — 1,754
+    recordings — regardless of how many records have been reshaped, instead of shrinking
+    as `components` stops being a plain string.
     """
     from pathlib import Path
 
     import yaml
 
-    from build.check_rubric import head, split_components
+    from build.check_rubric import components_string, head, split_components
 
     root = Path(__file__).resolve().parents[1]
     mismatches = []
     recordings = 0
     for path in sorted((root / "sources" / "scores").glob("*.yaml")):
         block = (yaml.safe_load(path.read_text()) or {}).get("openness") or {}
-        components = block.get("components")
-        if not isinstance(components, str) or not components:
+        components = components_string(block)
+        if not components:
             continue
         for key, raw in split_components(components).items():
             recordings += 1
             if split_value(raw)[0] != head(raw):
                 mismatches.append(f"{path.stem}.{key}: {raw!r}")
 
-    assert recordings > 1_000, f"only {recordings} recordings reached; the corpus walk is broken"
+    # A floor, not an exact count: this is the full pre-migration recording count, and the
+    # corpus only grows from here as products are scored and edited (37 commits to
+    # sources/scores/ in the last 30 days alone), so recordings > 1,754 is ordinary
+    # curation, not a bug. A DROP below it means the walk stopped following the migrated
+    # shape — the failure this test exists to catch, which moved the count in hundreds at
+    # a time (1,754 -> 1,060 -> 510), never by ones. Growth needs no alarm; a shrink does.
+    assert recordings >= 1_754, f"only {recordings} recordings reached; the corpus walk is broken"
     assert mismatches == [], "split_value and head disagree:\n  " + "\n  ".join(mismatches)


### PR DESCRIPTION
## Summary

Two corpus-walking tests were silently narrowing as records migrate to the structured `components` shape, because both fed `components` to code that only understands the string form.

**`test_split_value_bare_half_matches_head_on_the_whole_corpus`** guards the property the migration rests on: `split_value`'s bare half must equal `head` on every recording, or a shape-only reshape can move a published score. Its walk had gone 1,754 recordings -> 1,060, and the next batch would have taken it to 510. Its count guard tripped, which is how all of this surfaced.

**`test_no_score_file_mints_a_phantom_dimension_key`** had the same defect and **no guard**. It fed a migrated record's mapping straight into `split_components`, which iterates a string character by character, so it yielded nothing: **0 of 352** migrated records contributed a single key. It was passing green while inspecting nothing, and would have reached fully vacuous by the end of the migration.

Both now read through `components_of` / `components_string`, which already implement the raw-vs-components preference every other reader uses. No second copy of that rule.

## Guards

Both tests now assert a floor of 1,754 — the full pre-migration recording count — with a comment on each explaining the number.

A floor rather than an exact count deliberately. The corpus only grows as products are scored, and `sources/scores/` took 37 commits in the last 30 days; an exact count would fail on ordinary curation with a message reading "the corpus walk is broken", which is how a gate stops being trusted. A shrink is never subtle here — the bug dropped the count by hundreds at a time.

## Test plan

- Walk reaches 1,754 on today's corpus, up from 1,060.
- Verified against the next batch: applying the 144-record batch D in a throwaway worktree keeps both tests at 1,754 and green. Worktree torn down.
- Repo-wide sweep for other populations that shrink as records migrate. One further hit is a payload output-contract check that does not skip by shape, and one is a round-trip test correctly scoped to the pre-migration form, already self-guarding with `walked > 0` so it will speak up on the batch that migrates the last string record. Neither touched.
- No `sources/` change. Suite 431 passed; `validate` 0 error(s), `check_recipe` 0 failure(s), `check_rubric` exit 0, `check_components` `[OK]`.
