### PR TITLE
refactor(scores): migrate the 144 records whose undeclared keys are all recurring ones

### DIFF
--- a/sources/scores/agent2agent-protocol.yaml
+++ b/sources/scores/agent2agent-protocol.yaml
@@ -2,11 +2,22 @@ product: agent2agent-protocol
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(spec + reference SDKs in 6 languages);governance:Linux
-    Foundation (vendor-neutral, Google-contributed)
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: spec + reference SDKs in 6 languages
+    governance:
+      value: Linux Foundation
+      detail: vendor-neutral, Google-contributed
+      raw: Linux Foundation (vendor-neutral, Google-contributed)
   confidence: high
   note: Reference spec and SDKs are Apache-2.0 under neutral LF governance; for a protocol this is the
     openness ceiling.
+  raw: license:Apache-2.0(OSI);source:public(spec + reference SDKs in 6 languages);governance:Linux Foundation
+    (vendor-neutral, Google-contributed)
   sources:
   - url: https://github.com/a2aproject/A2A
     shows: Apache-2.0 license, LF-hosted open protocol, spec v1.0.1 + 6-language SDKs, ~24k stars

--- a/sources/scores/agenta.yaml
+++ b/sources/scores/agenta.yaml
@@ -2,11 +2,24 @@ product: agenta
 openness:
   score: 4
   class: open_core
-  components: license:MIT(OSI, core);source:public;self-hostable;commercial:Agenta-Cloud-managed-tier(free tier
-    available);core-gated:gated
+  components:
+    license:
+      value: MIT
+      detail: OSI, core
+    source:
+      value: public
+    commercial:
+      value: Agenta-Cloud-managed-tier
+      detail: free tier available
+    core-gated:
+      value: gated
+    free_text:
+    - self-hostable
   confidence: high
   note: MIT/OSI core, self-hostable via GitHub, with a managed cloud tier, open_core. (Borderline open_source;
     scored open_core for the hosted commercial tier.)
+  raw: license:MIT(OSI, core);source:public;self-hostable;commercial:Agenta-Cloud-managed-tier(free tier
+    available);core-gated:gated
   sources:
   - url: https://github.com/Agenta-AI/agenta
     shows: MIT license; self-host + Agenta Cloud managed tier

--- a/sources/scores/agentops.yaml
+++ b/sources/scores/agentops.yaml
@@ -2,10 +2,19 @@ product: agentops
 openness:
   score: 4
   class: open_core
-  components: license:MIT(OSI, SDK);source:public(SDK + self-hostable app dir);commercial:app.agentops.ai-SaaS-dashboard-is-the-primary-product
+  components:
+    license:
+      value: MIT
+      detail: OSI, SDK
+    source:
+      value: public
+      detail: SDK + self-hostable app dir
+    commercial:
+      value: app.agentops.ai-SaaS-dashboard-is-the-primary-product
   confidence: medium
   note: SDK is MIT/OSI and self-host is possible, but the hosted dashboard is the product surface, closer
     to open_core than pure open_source. Scored 4.
+  raw: license:MIT(OSI, SDK);source:public(SDK + self-hostable app dir);commercial:app.agentops.ai-SaaS-dashboard-is-the-primary-product
   sources:
   - url: https://github.com/AgentOps-AI/agentops
     shows: MIT-licensed SDK; complementary SaaS dashboard at app.agentops.ai; self-host option

--- a/sources/scores/amazon-bedrock-custom-models-fine-tuning.yaml
+++ b/sources/scores/amazon-bedrock-custom-models-fine-tuning.yaml
@@ -2,12 +2,22 @@ product: amazon-bedrock-custom-models-fine-tuning
 openness:
   score: 1
   class: closed
-  components: source:closed;training-code:closed;runs-on:AWS-Bedrock-only;license:Proprietary(managed
-    AWS service, token+storage billed)
+  components:
+    source:
+      value: closed
+    training-code:
+      value: closed
+    runs-on:
+      value: AWS-Bedrock-only
+    license:
+      value: Proprietary
+      detail: managed AWS service, token+storage billed
   confidence: high
   note: Proprietary managed customization service inside AWS Bedrock, no source, runs only on AWS against
     Bedrock-hosted foundation models.
   last_verified: '2026-08-09'
+  raw: source:closed;training-code:closed;runs-on:AWS-Bedrock-only;license:Proprietary(managed AWS service,
+    token+storage billed)
   sources:
   - url: https://docs.aws.amazon.com/bedrock/latest/userguide/custom-models.html
     shows: Lists supervised fine-tuning, reinforcement fine-tuning, and distillation as the three customization

--- a/sources/scores/amazon-q-developer.yaml
+++ b/sources/scores/amazon-q-developer.yaml
@@ -2,9 +2,17 @@ product: amazon-q-developer
 openness:
   score: 1
   class: closed
-  components: source:closed;license:proprietary(AWS managed service);self-host:no
+  components:
+    source:
+      value: closed
+    license:
+      value: proprietary
+      detail: AWS managed service
+    self-host:
+      value: 'no'
   confidence: high
   note: Proprietary AWS managed service; free and Pro tiers but no source or self-hosting.
+  raw: source:closed;license:proprietary(AWS managed service);self-host:no
   sources:
   - url: https://aws.amazon.com/q/developer/
     shows: AWS proprietary agentic coding assistant, Free/Pro tiers, enterprise security controls

--- a/sources/scores/antigravity.yaml
+++ b/sources/scores/antigravity.yaml
@@ -2,10 +2,18 @@ product: antigravity
 openness:
   score: 1
   class: closed
-  components: source:closed;license:proprietary(Google product, free public preview);self-host:no
+  components:
+    source:
+      value: closed
+    license:
+      value: proprietary
+      detail: Google product, free public preview
+    self-host:
+      value: 'no'
   confidence: high
   note: Proprietary Google agentic dev platform; free in preview but not open source and locked to Google's
     stack.
+  raw: source:closed;license:proprietary(Google product, free public preview);self-host:no
   sources:
   - url: https://antigravity.google
     shows: Google Antigravity product page (agentic development platform)

--- a/sources/scores/apple-core-ml-runtime.yaml
+++ b/sources/scores/apple-core-ml-runtime.yaml
@@ -2,14 +2,22 @@ product: apple-core-ml-runtime
 openness:
   score: 1
   class: closed
-  components: source:closed;license:proprietary(Apple system framework, ships compiled with the OS/SDK,
-    no published source);self-host:no
+  components:
+    source:
+      value: closed
+    license:
+      value: proprietary
+      detail: Apple system framework, ships compiled with the OS/SDK, no published source
+    self-host:
+      value: 'no'
   confidence: high
   note: 'Core ML has no repository - Apple''s own documentation describes it purely as an API surface (`MLModel`
     etc.) that a person''s app calls into; there is no source tree to self-host or fork. The ladder''s `source:
     closed` rule fires regardless of license tier, so core-gated is not applicable here (the note in software.yaml:
     that dimension only matters where source is public).'
   last_verified: '2026-08-09'
+  raw: source:closed;license:proprietary(Apple system framework, ships compiled with the OS/SDK, no published
+    source);self-host:no
   sources:
   - url: https://developer.apple.com/tutorials/data/documentation/coreml.md
     shows: Use Core ML to integrate machine learning models into your app... Copyright &copy; 2026 Apple

--- a/sources/scores/azure-ai-foundry-observability.yaml
+++ b/sources/scores/azure-ai-foundry-observability.yaml
@@ -2,11 +2,22 @@ product: azure-ai-foundry-observability
 openness:
   score: 1
   class: closed
-  components: license:proprietary(Azure managed service);source:closed;note:tracing built on open OTel
-    standard + Azure Monitor App Insights, but the observability product is proprietary and Azure-locked
+  components:
+    license:
+      value: proprietary
+      detail: Azure managed service
+    source:
+      value: closed
+    note:
+      value: tracing built on open OTel standard + Azure Monitor App Insights
+      detail: but the observability product is proprietary and Azure-locked
+      raw: tracing built on open OTel standard + Azure Monitor App Insights, but the observability product
+        is proprietary and Azure-locked
   confidence: high
   note: Proprietary Microsoft Azure managed offering. OTel is the wire standard (trace data is portable)
     but the service itself is closed.
+  raw: license:proprietary(Azure managed service);source:closed;note:tracing built on open OTel standard
+    + Azure Monitor App Insights, but the observability product is proprietary and Azure-locked
   sources:
   - url: https://learn.microsoft.com/en-us/azure/foundry/concepts/observability
     shows: Microsoft Foundry observability (eval/monitoring/tracing) as a managed Azure service built

--- a/sources/scores/azure-openai-fine-tuning.yaml
+++ b/sources/scores/azure-openai-fine-tuning.yaml
@@ -2,12 +2,22 @@ product: azure-openai-fine-tuning
 openness:
   score: 1
   class: closed
-  components: source:closed;training-code:closed;runs-on:Azure-AI-Foundry-only;license:Proprietary(managed
-    Azure service)
+  components:
+    source:
+      value: closed
+    training-code:
+      value: closed
+    runs-on:
+      value: Azure-AI-Foundry-only
+    license:
+      value: Proprietary
+      detail: managed Azure service
   confidence: high
   note: Proprietary managed FT service inside Microsoft Foundry; no source, runs only on Azure, tuning both
     closed OpenAI models (GA) and preview open-weight models (Ministral, Qwen, Llama, gpt-oss).
   last_verified: '2026-08-09'
+  raw: source:closed;training-code:closed;runs-on:Azure-AI-Foundry-only;license:Proprietary(managed Azure
+    service)
   sources:
   - url: https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/fine-tuning
     shows: Supported-models table lists gpt-4o-mini as SFT-only; gpt-4o and the gpt-4.1/mini/nano trio as

--- a/sources/scores/beta9.yaml
+++ b/sources/scores/beta9.yaml
@@ -2,13 +2,25 @@ product: beta9
 openness:
   score: 4
   class: open_core
-  components: license:AGPL-3.0(OSI, copyleft);source:public;managed-tier:Beam (beam.cloud) fully-managed GPU cloud
-    (proprietary);core-gated:gated
+  components:
+    license:
+      value: AGPL-3.0
+      detail: OSI, copyleft
+    source:
+      value: public
+    managed-tier:
+      value: Beam
+      detail: beam.cloud) fully-managed GPU cloud (proprietary
+      raw: Beam (beam.cloud) fully-managed GPU cloud (proprietary)
+    core-gated:
+      value: gated
   confidence: high
   note: >-
     AGPL-3.0 (OSI copyleft) engine plus the proprietary managed Beam cloud => open_core. Scored
     4 on the same footing as the Apache-licensed open-core peers. Corrected from 3, which had
     followed Daytona in penalizing copyleft; both are corrected together.
+  raw: license:AGPL-3.0(OSI, copyleft);source:public;managed-tier:Beam (beam.cloud) fully-managed GPU cloud
+    (proprietary);core-gated:gated
   sources:
   - url: https://github.com/beam-cloud/beta9
     shows: AGPL-3.0 license; open source serverless AI runtime; engine powering managed Beam cloud (beam.cloud)

--- a/sources/scores/bigcode-dataset.yaml
+++ b/sources/scores/bigcode-dataset.yaml
@@ -2,10 +2,23 @@ product: bigcode-dataset
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(bigcode-project/bigcode-dataset);governance:BigCode;no
-    feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: bigcode-project/bigcode-dataset
+    governance:
+      value: BigCode
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: Fully OSI-licensed (Apache-2.0), full source public.
+  raw: license:Apache-2.0(OSI);source:public(bigcode-project/bigcode-dataset);governance:BigCode;no feature-gated
+    core;core-gated:ungated
   sources:
   - url: https://github.com/bigcode-project/bigcode-dataset/blob/main/LICENSE
     shows: Apache License Version 2.0 text

--- a/sources/scores/blaxel-sandbox.yaml
+++ b/sources/scores/blaxel-sandbox.yaml
@@ -2,12 +2,23 @@ product: blaxel-sandbox
 openness:
   score: 4
   class: open_core
-  components: license:MIT(OSI);source:public(sandbox API, self-hostable via Docker Compose);managed-tier:Blaxel
-    proprietary perpetual-standby platform;core-gated:gated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+      detail: sandbox API, self-hostable via Docker Compose
+    managed-tier:
+      value: Blaxel proprietary perpetual-standby platform
+    core-gated:
+      value: gated
   confidence: medium
   note: MIT sandbox API that is self-hostable via Docker Compose, with a proprietary managed perpetual-standby
     platform, so open-core. The open component carries a maximally permissive MIT license; the standby/scale
     platform is the closed value-add. Open surface is narrower than E2B's full self-hostable infra.
+  raw: license:MIT(OSI);source:public(sandbox API, self-hostable via Docker Compose);managed-tier:Blaxel
+    proprietary perpetual-standby platform;core-gated:gated
   sources:
   - url: https://github.com/blaxel-ai/sandbox
     shows: MIT license; sandbox API self-hostable via Docker Compose (port 8080)

--- a/sources/scores/braintrust.yaml
+++ b/sources/scores/braintrust.yaml
@@ -2,13 +2,24 @@ product: braintrust
 openness:
   score: 1
   class: closed
-  components: source:closed;license:Apache-2.0(OSI, client SDKs only,
-    Python/TS/Go/Ruby/C#);platform:proprietary(Brainstore custom DB, evals/tracing/automation all
-    SaaS);self-host:enterprise-only(hybrid)
+  components:
+    source:
+      value: closed
+    license:
+      value: Apache-2.0
+      detail: OSI, client SDKs only, Python/TS/Go/Ruby/C#
+    platform:
+      value: proprietary
+      detail: Brainstore custom DB, evals/tracing/automation all SaaS
+    self-host:
+      value: enterprise-only
+      detail: hybrid
   confidence: high
   note: Open SDKs but a closed SaaS core (Brainstore backend, dashboards, automation are proprietary);
     no OSS core, so 'closed' (not open_core) like LangSmith/Galileo per recipe's closed examples. The
     Apache-2.0 client SDK is instrumentation only and does not open the product.
+  raw: source:closed;license:Apache-2.0(OSI, client SDKs only, Python/TS/Go/Ruby/C#);platform:proprietary(Brainstore
+    custom DB, evals/tracing/automation all SaaS);self-host:enterprise-only(hybrid)
   sources:
   - url: https://github.com/braintrustdata/braintrust-sdk
     shows: Apache-2.0 license on client SDK; platform itself at braintrust.dev

--- a/sources/scores/browser-use.yaml
+++ b/sources/scores/browser-use.yaml
@@ -2,13 +2,23 @@ product: browser-use
 openness:
   score: 4
   class: open_core
-  components: license:MIT(OSI, library core fully
-    open);source:public;managed-tier:Browser-Use-Cloud(proxies/stealth/captcha/hosted browsers,
-    proprietary);core-gated:gated
+  components:
+    license:
+      value: MIT
+      detail: OSI, library core fully open
+    source:
+      value: public
+    managed-tier:
+      value: Browser-Use-Cloud
+      detail: proxies/stealth/captcha/hosted browsers, proprietary
+    core-gated:
+      value: gated
   confidence: high
   note: Core library is fully MIT/OSI open (no feature-gated core); a separate proprietary Browser Use
     Cloud adds managed infra. Scored open_core at 4 because the OSS core is complete and the cloud is
     optional hosting, not a gated core.
+  raw: license:MIT(OSI, library core fully open);source:public;managed-tier:Browser-Use-Cloud(proxies/stealth/captcha/hosted
+    browsers, proprietary);core-gated:gated
   sources:
   - url: https://github.com/browser-use/browser-use
     shows: MIT (OSI) license, full public source; Browser Use Cloud as optional managed tier

--- a/sources/scores/browserbase.yaml
+++ b/sources/scores/browserbase.yaml
@@ -2,12 +2,24 @@ product: browserbase
 openness:
   score: 1
   class: closed
-  components: license:Proprietary(API-only managed browser infra);source:closed(cloud browser fleet/session
-    infra);note:companion Stagehand SDK IS open source (Apache/MIT) but the Browserbase service being
-    scored is the closed managed platform
+  components:
+    license:
+      value: Proprietary
+      detail: API-only managed browser infra
+    source:
+      value: closed
+      detail: cloud browser fleet/session infra
+    note:
+      value: companion Stagehand SDK IS open source
+      detail: Apache/MIT) but the Browserbase service being scored is the closed managed platform
+      raw: companion Stagehand SDK IS open source (Apache/MIT) but the Browserbase service being scored
+        is the closed managed platform
   confidence: high
   note: The scored product is the managed browser-infrastructure service, which is closed/proprietary;
     only the separate Stagehand client SDK is open; do not let the open SDK reclassify the closed service.
+  raw: license:Proprietary(API-only managed browser infra);source:closed(cloud browser fleet/session infra);note:companion
+    Stagehand SDK IS open source (Apache/MIT) but the Browserbase service being scored is the closed managed
+    platform
   sources:
   - url: https://docs.browserbase.com/
     shows: one API key for cloud browsers/search/fetch/runtime, managed proprietary platform; Stagehand

--- a/sources/scores/cerebras-inference.yaml
+++ b/sources/scores/cerebras-inference.yaml
@@ -2,13 +2,23 @@ product: cerebras-inference
 openness:
   score: 1
   class: closed
-  components: engine:proprietary(WSE wafer-scale stack);source:closed;access:managed-cloud-API-only;license:Proprietary
+  components:
+    engine:
+      value: proprietary
+      detail: WSE wafer-scale stack
+    source:
+      value: closed
+    access:
+      value: managed-cloud-API-only
+    license:
+      value: Proprietary
   confidence: high
   note: 'Proprietary cloud inference on custom wafer-scale hardware, API-only; closed per recipe (cloud
     inference engines). Re-confirmed today: the inference page shows API-only managed access with no source
     or weights release, and the Inference Terms and Conditions grant only a non-exclusive, limited, non-transferable,
     non-sublicensable right to access the hosted Services.'
   last_verified: '2026-08-09'
+  raw: engine:proprietary(WSE wafer-scale stack);source:closed;access:managed-cloud-API-only;license:Proprietary
   sources:
   - url: https://www.cerebras.ai/inference
     shows: 'Cerebras Inference is a hosted cloud service (tiers: Free Trial with "Get API Key", Developer

--- a/sources/scores/character-ai.yaml
+++ b/sources/scores/character-ai.yaml
@@ -2,9 +2,20 @@ product: character-ai
 openness:
   score: 1
   class: closed
-  components: license:proprietary(SaaS);source:closed;self-host:none;models:own+licensed(closed)
+  components:
+    license:
+      value: proprietary
+      detail: SaaS
+    source:
+      value: closed
+    self-host:
+      value: none
+    models:
+      value: own+licensed
+      detail: closed
   confidence: high
   note: Proprietary consumer chat app; closed counterpart on the shelf.
+  raw: license:proprietary(SaaS);source:closed;self-host:none;models:own+licensed(closed)
   sources:
   - url: https://www.businessofapps.com/data/character-ai-statistics/
     shows: Character.AI is a proprietary consumer companion-chat app (product/company profile)

--- a/sources/scores/chatgpt.yaml
+++ b/sources/scores/chatgpt.yaml
@@ -3,9 +3,17 @@ openness:
   score: 1
   class: closed
   confidence: high
-  components: source:closed;self-host:none;license:proprietary(SaaS app + API)
+  components:
+    source:
+      value: closed
+    self-host:
+      value: none
+    license:
+      value: proprietary
+      detail: SaaS app + API
   note: Proprietary, SaaS-only consumer app; no source, no self-host. Closed counterpart in the ui_api
     shelf.
+  raw: source:closed;self-host:none;license:proprietary(SaaS app + API)
   sources:
   - url: https://openai.com/index/how-people-are-using-chatgpt/
     shows: OpenAI's proprietary ChatGPT product page/usage report

--- a/sources/scores/claude-ai.yaml
+++ b/sources/scores/claude-ai.yaml
@@ -3,9 +3,17 @@ openness:
   score: 1
   class: closed
   confidence: high
-  components: source:closed;self-host:none;license:proprietary(SaaS app + API)
+  components:
+    source:
+      value: closed
+    self-host:
+      value: none
+    license:
+      value: proprietary
+      detail: SaaS app + API
   note: Proprietary, SaaS-only consumer app; no source, no self-host. Closed counterpart in the ui_api
     shelf.
+  raw: source:closed;self-host:none;license:proprietary(SaaS app + API)
   sources:
   - url: https://claude.com/product/overview
     shows: Anthropic's proprietary Claude consumer product page (artifacts, projects, web search, code

--- a/sources/scores/claude-code.yaml
+++ b/sources/scores/claude-code.yaml
@@ -3,10 +3,19 @@ openness:
   score: 1
   class: closed
   confidence: high
-  components: license:Proprietary(closed-source CLI/app, requires Claude subscription or Console account);model:Claude(proprietary,
-    API-only);note:Agent SDK published but the product is closed SaaS
+  components:
+    license:
+      value: Proprietary
+      detail: closed-source CLI/app, requires Claude subscription or Console account
+    model:
+      value: Claude
+      detail: proprietary, API-only
+    note:
+      value: Agent SDK published but the product is closed SaaS
   note: Closed/proprietary product gated behind an Anthropic subscription; the coding agent itself is
     not open source.
+  raw: license:Proprietary(closed-source CLI/app, requires Claude subscription or Console account);model:Claude(proprietary,
+    API-only);note:Agent SDK published but the product is closed SaaS
   sources:
   - url: https://code.claude.com/docs/en/overview
     shows: requires Claude subscription or Anthropic Console account; proprietary surfaces

--- a/sources/scores/codex-cli.yaml
+++ b/sources/scores/codex-cli.yaml
@@ -3,11 +3,22 @@ openness:
   score: 5
   class: open_source
   confidence: high
-  components: license:Apache-2.0(OSI, the CLI agent);source:public(GitHub);note:agent is OSS but optimized
-    for/defaults to OpenAI models (provider-leaning, not license-restricted)
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI, the CLI agent
+    source:
+      value: public
+      detail: GitHub
+    note:
+      value: agent is OSS but optimized for/defaults to OpenAI models
+      detail: provider-leaning, not license-restricted
+      raw: agent is OSS but optimized for/defaults to OpenAI models (provider-leaning, not license-restricted)
   note: Verified Apache-2.0 OSI with public Rust source (96.1% Rust); OpenAI's own docs call it open source.
     Backing models are proprietary, but the orchestration agent scored here is fully open. License/version/stars
     confirmed via primary GitHub source.
+  raw: license:Apache-2.0(OSI, the CLI agent);source:public(GitHub);note:agent is OSS but optimized for/defaults
+    to OpenAI models (provider-leaning, not license-restricted)
   sources:
   - url: https://github.com/openai/codex
     shows: Apache-2.0 license, public Rust source, v0.137.0 Jun 4 2026, 88.6k stars (verified)

--- a/sources/scores/composio.yaml
+++ b/sources/scores/composio.yaml
@@ -2,12 +2,24 @@ product: composio
 openness:
   score: 4
   class: open_core
-  components: license:MIT(OSI, SDK/core public on GitHub);source:public(Python + TypeScript
-    SDKs);managed-tier:Composio hosted platform + Rube MCP server (auth, hosted tool execution) is the
-    commercial layer;core-gated:gated
+  components:
+    license:
+      value: MIT
+      detail: OSI, SDK/core public on GitHub
+    source:
+      value: public
+      detail: Python + TypeScript SDKs
+    managed-tier:
+      value: Composio hosted platform + Rube MCP server
+      detail: auth, hosted tool execution) is the commercial layer
+      raw: Composio hosted platform + Rube MCP server (auth, hosted tool execution) is the commercial layer
+    core-gated:
+      value: gated
   confidence: high
   note: SDK/core is MIT and public; the hosted multi-app integration/auth platform is the proprietary
     tier, classic open-core.
+  raw: license:MIT(OSI, SDK/core public on GitHub);source:public(Python + TypeScript SDKs);managed-tier:Composio
+    hosted platform + Rube MCP server (auth, hosted tool execution) is the commercial layer;core-gated:gated
   sources:
   - url: https://github.com/ComposioHQ/composio
     shows: MIT LICENSE, public SDK source, 1000+ toolkits, ~28.6k stars

--- a/sources/scores/confer.yaml
+++ b/sources/scores/confer.yaml
@@ -2,12 +2,25 @@ product: confer
 openness:
   score: 2
   class: source_available
-  components: license:none-declared(no LICENSE file in either public repo);source:partial(confer-proxy +
-    confer-image public,client-app private);self-host:no(depends on vendor attestation infra);models:open source(undisclosed)
+  components:
+    license:
+      value: none-declared
+      detail: no LICENSE file in either public repo
+    source:
+      value: partial
+      detail: confer-proxy + confer-image public,client-app private
+    self-host:
+      value: 'no'
+      detail: depends on vendor attestation infra
+    models:
+      value: open source
+      detail: undisclosed
   confidence: high
   note: 'Marketed as open source, but neither public repo declares any license (GitHub reports license:null),
     so re-use rights are undefined, and the end-user client is not public. Source is published for verifiability/reproducible
     builds, not for self-deployment. Accurate classification is source-available, not open_source.'
+  raw: license:none-declared(no LICENSE file in either public repo);source:partial(confer-proxy + confer-image
+    public,client-app private);self-host:no(depends on vendor attestation infra);models:open source(undisclosed)
   sources:
   - url: https://confer.to/blog/2026/01/private-inference/
     shows: architecture (TEE, Noise pipes, dm-verity, reproducible nix/mkosi builds, transparency log); names

--- a/sources/scores/confident-ai.yaml
+++ b/sources/scores/confident-ai.yaml
@@ -2,12 +2,23 @@ product: confident-ai
 openness:
   score: 1
   class: closed
-  components: license:proprietary(platform);source:closed(platform);note:companion OSS framework DeepEval
-    is Apache-2.0 but is a separate registry-scope product;self-host:enterprise-tier
+  components:
+    license:
+      value: proprietary
+      detail: platform
+    source:
+      value: closed
+      detail: platform
+    note:
+      value: companion OSS framework DeepEval is Apache-2.0 but is a separate registry-scope product
+    self-host:
+      value: enterprise-tier
   confidence: high
   note: The scored entity is the Confident AI platform itself, which is proprietary SaaS. DeepEval (the
     open Apache-2.0 framework, ~15.9k stars) is a distinct product; do not credit the platform with the
     framework's openness.
+  raw: license:proprietary(platform);source:closed(platform);note:companion OSS framework DeepEval is Apache-2.0
+    but is a separate registry-scope product;self-host:enterprise-tier
   sources:
   - url: https://www.confident-ai.com/
     shows: proprietary cloud platform distinct from open source DeepEval; self-hosted enterprise option

--- a/sources/scores/coop.yaml
+++ b/sources/scores/coop.yaml
@@ -2,9 +2,22 @@ product: coop
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(github.com/roostorg/coop);self-host:yes;service:none;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: github.com/roostorg/coop
+    self-host:
+      value: 'yes'
+    service:
+      value: none
+    core-gated:
+      value: ungated
   confidence: high
   note: 'Fully open source: Apache-2.0 self-hosted moderation review console from ROOST.'
+  raw: license:Apache-2.0(OSI);source:public(github.com/roostorg/coop);self-host:yes;service:none;core-gated:ungated
   sources:
   - url: https://github.com/roostorg/coop
     shows: Apache-2.0; review queues, routing, enforcement rules, REST/GraphQL APIs

--- a/sources/scores/cursor.yaml
+++ b/sources/scores/cursor.yaml
@@ -3,9 +3,17 @@ openness:
   score: 1
   class: closed
   confidence: high
-  components: license:Proprietary(closed SaaS IDE, no public source);model:multi-provider (OpenAI/Anthropic/Gemini/xAI)
-    but the product is proprietary
+  components:
+    license:
+      value: Proprietary
+      detail: closed SaaS IDE, no public source
+    model:
+      value: multi-provider
+      detail: OpenAI/Anthropic/Gemini/xAI) but the product is proprietary
+      raw: multi-provider (OpenAI/Anthropic/Gemini/xAI) but the product is proprietary
   note: Fully proprietary commercial product; no open source license or public source.
+  raw: license:Proprietary(closed SaaS IDE, no public source);model:multi-provider (OpenAI/Anthropic/Gemini/xAI)
+    but the product is proprietary
   sources:
   - url: https://www.cursor.com/
     shows: proprietary commercial IDE, no OSS licensing, enterprise/Fortune-500 positioning

--- a/sources/scores/datadog-llm-observability.yaml
+++ b/sources/scores/datadog-llm-observability.yaml
@@ -2,11 +2,22 @@ product: datadog-llm-observability
 openness:
   score: 1
   class: closed
-  components: license:Proprietary;source:closed;platform:proprietary SaaS(no source);only the ddtrace instrumentation
-    SDK is open;product itself closed
+  components:
+    license:
+      value: Proprietary
+    source:
+      value: closed
+    platform:
+      value: proprietary SaaS
+      detail: no source
+    free_text:
+    - only the ddtrace instrumentation SDK is open
+    - product itself closed
   confidence: high
   note: Closed proprietary SaaS; only Datadog's tracing client libraries are open, the LLM Observability
     product and backend are closed.
+  raw: license:Proprietary;source:closed;platform:proprietary SaaS(no source);only the ddtrace instrumentation
+    SDK is open;product itself closed
   sources:
   - url: https://docs.datadoghq.com/llm_observability/
     shows: Datadog LLM Observability described as a proprietary cloud SaaS platform for monitoring LLM

--- a/sources/scores/datamap-rs.yaml
+++ b/sources/scores/datamap-rs.yaml
@@ -2,10 +2,23 @@ product: datamap-rs
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(allenai/datamap-rs);governance:Allen Institute for AI;no
-    feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: allenai/datamap-rs
+    governance:
+      value: Allen Institute for AI
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: Fully OSI-licensed (Apache-2.0), full source public.
+  raw: license:Apache-2.0(OSI);source:public(allenai/datamap-rs);governance:Allen Institute for AI;no feature-gated
+    core;core-gated:ungated
   sources:
   - url: https://github.com/allenai/datamap-rs/blob/main/LICENSE
     shows: Apache License Version 2.0 text

--- a/sources/scores/datatrove.yaml
+++ b/sources/scores/datatrove.yaml
@@ -2,10 +2,25 @@ product: datatrove
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(huggingface/datatrove);governance:Hugging Face;no feature-gated
-    core;managed-tier:none;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: huggingface/datatrove
+    governance:
+      value: Hugging Face
+    managed-tier:
+      value: none
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: Fully OSI-licensed (Apache-2.0), full source public, no proprietary core or managed gate.
+  raw: license:Apache-2.0(OSI);source:public(huggingface/datatrove);governance:Hugging Face;no feature-gated
+    core;managed-tier:none;core-gated:ungated
   sources:
   - url: https://github.com/huggingface/datatrove/blob/main/LICENSE
     shows: Apache License Version 2.0 text

--- a/sources/scores/daytona-sandbox.yaml
+++ b/sources/scores/daytona-sandbox.yaml
@@ -2,8 +2,18 @@ product: daytona-sandbox
 openness:
   score: 4
   class: open_core
-  components: license:AGPL-3.0(OSI, copyleft);source:public;managed-tier:app.daytona.io hosted cloud + hybrid
-    (proprietary);core-gated:gated
+  components:
+    license:
+      value: AGPL-3.0
+      detail: OSI, copyleft
+    source:
+      value: public
+    managed-tier:
+      value: app.daytona.io hosted cloud + hybrid
+      detail: proprietary
+      raw: app.daytona.io hosted cloud + hybrid (proprietary)
+    core-gated:
+      value: gated
   confidence: high
   note: >-
     AGPL-3.0 (OSI-approved copyleft) core plus a proprietary managed cloud => open_core. Scored
@@ -12,6 +22,7 @@ openness:
     than capping who may use the software or at what scale. Corrected from 3, which had
     penalized copyleft for 'constraining commercial reuse' - a rationale the other 22 copyleft
     software products do not apply.
+  raw: license:AGPL-3.0(OSI, copyleft);source:public;managed-tier:app.daytona.io hosted cloud + hybrid (proprietary);core-gated:gated
   sources:
   - url: https://github.com/daytonaio/daytona
     shows: AGPL-3.0 license; secure runtime for AI-generated code; managed cloud at app.daytona.io

--- a/sources/scores/decon.yaml
+++ b/sources/scores/decon.yaml
@@ -2,10 +2,23 @@ product: decon
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(allenai/decon);governance:Allen Institute for AI;no feature-gated
-    core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: allenai/decon
+    governance:
+      value: Allen Institute for AI
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: Fully OSI-licensed (Apache-2.0), full source public.
+  raw: license:Apache-2.0(OSI);source:public(allenai/decon);governance:Allen Institute for AI;no feature-gated
+    core;core-gated:ungated
   sources:
   - url: https://github.com/allenai/decon/blob/main/LICENSE
     shows: Apache License Version 2.0 text

--- a/sources/scores/deepseek-chat.yaml
+++ b/sources/scores/deepseek-chat.yaml
@@ -3,10 +3,20 @@ openness:
   score: 1
   class: closed
   confidence: high
-  components: client:proprietary(no public source for chat.deepseek.com app);backend:hosted-SaaS;note:underlying
-    models open(MIT) but the chat application/service is closed
+  components:
+    client:
+      value: proprietary
+      detail: no public source for chat.deepseek.com app
+    backend:
+      value: hosted-SaaS
+    note:
+      value: underlying models open
+      detail: MIT) but the chat application/service is closed
+      raw: underlying models open(MIT) but the chat application/service is closed
   note: The DeepSeek chat surface is a proprietary hosted service; openness of the V3/V4 weights it serves
     is a separate (model-layer) score. Scored as closed counterpart per ui_api recipe.
+  raw: client:proprietary(no public source for chat.deepseek.com app);backend:hosted-SaaS;note:underlying
+    models open(MIT) but the chat application/service is closed
   sources:
   - url: https://www.deepseek.com/en/
     shows: Free hosted chat at chat.deepseek.com serving DeepSeek-V4 Preview; no source release for the

--- a/sources/scores/deepteam.yaml
+++ b/sources/scores/deepteam.yaml
@@ -2,9 +2,21 @@ product: deepteam
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;self-host:yes;service:none;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    self-host:
+      value: 'yes'
+    service:
+      value: none
+    core-gated:
+      value: ungated
   confidence: high
   note: 'Fully open source: Apache-2.0 red-teaming framework, self-hostable.'
+  raw: license:Apache-2.0(OSI);source:public;self-host:yes;service:none;core-gated:ungated
   sources:
   - url: https://github.com/confident-ai/deepteam
     shows: Apache-2.0; ~1.9k stars; 50+ vuln checks, 20+ attacks; OWASP/NIST/MITRE aligned

--- a/sources/scores/devin.yaml
+++ b/sources/scores/devin.yaml
@@ -2,10 +2,18 @@ product: devin
 openness:
   score: 1
   class: closed
-  components: source:closed;license:proprietary(SaaS-only);self-host:no
+  components:
+    source:
+      value: closed
+    license:
+      value: proprietary
+      detail: SaaS-only
+    self-host:
+      value: 'no'
   confidence: high
   note: Proprietary subscription SaaS; no source or self-hosting, matching the recipe's 'closed' example
     (Devin).
+  raw: source:closed;license:proprietary(SaaS-only);self-host:no
   sources:
   - url: https://docs.devin.ai
     shows: proprietary SaaS coding agent, app.devin.ai signup, Individual/Teams plans

--- a/sources/scores/distilabel.yaml
+++ b/sources/scores/distilabel.yaml
@@ -2,10 +2,23 @@ product: distilabel
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(argilla-io/distilabel);governance:Argilla/Hugging Face;no
-    feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: argilla-io/distilabel
+    governance:
+      value: Argilla/Hugging Face
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: Fully OSI-licensed (Apache-2.0), full source public, no proprietary core.
+  raw: license:Apache-2.0(OSI);source:public(argilla-io/distilabel);governance:Argilla/Hugging Face;no feature-gated
+    core;core-gated:ungated
   sources:
   - url: https://github.com/argilla-io/distilabel/blob/main/LICENSE
     shows: Apache License Version 2.0 text

--- a/sources/scores/docling.yaml
+++ b/sources/scores/docling.yaml
@@ -2,9 +2,22 @@ product: docling
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public(github.com/docling-project/docling);self-host:primary;no-feature-gated-core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+      detail: github.com/docling-project/docling
+    self-host:
+      value: primary
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   confidence: high
   note: MIT, local-first document parsing, fully self-hostable with integrated open-weight models.
+  raw: license:MIT(OSI);source:public(github.com/docling-project/docling);self-host:primary;no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://github.com/docling-project/docling
     shows: MIT, ~61.8k stars, multi-format document parser

--- a/sources/scores/dolma-toolkit.yaml
+++ b/sources/scores/dolma-toolkit.yaml
@@ -2,10 +2,23 @@ product: dolma-toolkit
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(allenai/dolma);governance:Allen Institute for AI;no feature-gated
-    core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: allenai/dolma
+    governance:
+      value: Allen Institute for AI
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: Fully OSI-licensed (Apache-2.0), full source public.
+  raw: license:Apache-2.0(OSI);source:public(allenai/dolma);governance:Allen Institute for AI;no feature-gated
+    core;core-gated:ungated
   sources:
   - url: https://github.com/allenai/dolma/blob/main/LICENSE
     shows: Apache License Version 2.0 text

--- a/sources/scores/doubao.yaml
+++ b/sources/scores/doubao.yaml
@@ -3,10 +3,21 @@ openness:
   score: 1
   class: closed
   confidence: high
-  components: client:proprietary(closed consumer app);backend:hosted-SaaS on Volcano Engine;models:proprietary
-    Doubao(closed);license:Proprietary
+  components:
+    client:
+      value: proprietary
+      detail: closed consumer app
+    backend:
+      value: hosted-SaaS on Volcano Engine
+    models:
+      value: proprietary Doubao
+      detail: closed
+    license:
+      value: Proprietary
   note: Doubao is a closed proprietary consumer assistant; no public source for the app and the Doubao
     models are not open-weight. Closed counterpart per ui_api recipe.
+  raw: client:proprietary(closed consumer app);backend:hosted-SaaS on Volcano Engine;models:proprietary
+    Doubao(closed);license:Proprietary
   sources:
   - url: https://en.wikipedia.org/wiki/Doubao
     shows: Doubao is a proprietary ByteDance AI chatbot app (iOS/Android/web) on Volcano Engine

--- a/sources/scores/duck-ai.yaml
+++ b/sources/scores/duck-ai.yaml
@@ -3,9 +3,17 @@ openness:
   score: 1
   class: closed
   confidence: high
-  components: source:closed;self-host:none;license:proprietary(SaaS app + browser integration)
+  components:
+    source:
+      value: closed
+    self-host:
+      value: none
+    license:
+      value: proprietary
+      detail: SaaS app + browser integration
   note: Proprietary anonymizing proxy in front of closed model APIs; no source, no self-host. Closed privacy-chat
     surface in the ui_api shelf.
+  raw: source:closed;self-host:none;license:proprietary(SaaS app + browser integration)
   sources:
   - url: https://duckduckgo.com/duckduckgo-help-pages/duckai/ai-chat-privacy
     shows: DuckDuckGo's proprietary Duck.ai privacy/help documentation

--- a/sources/scores/duplodocus.yaml
+++ b/sources/scores/duplodocus.yaml
@@ -2,10 +2,23 @@ product: duplodocus
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(allenai/duplodocus);governance:Allen Institute for AI;no
-    feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: allenai/duplodocus
+    governance:
+      value: Allen Institute for AI
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: Fully OSI-licensed (Apache-2.0), full source public.
+  raw: license:Apache-2.0(OSI);source:public(allenai/duplodocus);governance:Allen Institute for AI;no feature-gated
+    core;core-gated:ungated
   sources:
   - url: https://github.com/allenai/duplodocus/blob/main/LICENSE
     shows: Apache License Version 2.0 text

--- a/sources/scores/e2b-sandbox.yaml
+++ b/sources/scores/e2b-sandbox.yaml
@@ -2,11 +2,24 @@ product: e2b-sandbox
 openness:
   score: 4
   class: open_core
-  components: license:Apache-2.0(OSI);source:public(SDKs+infra, Terraform self-host);managed-tier:e2b.dev hosted
-    sandbox cloud (proprietary);core-gated:gated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: SDKs+infra, Terraform self-host
+    managed-tier:
+      value: e2b.dev hosted sandbox cloud
+      detail: proprietary
+      raw: e2b.dev hosted sandbox cloud (proprietary)
+    core-gated:
+      value: gated
   confidence: high
   note: Apache-2.0 OSS core (SDKs + self-hostable infra) with a proprietary managed cloud; classic open-core
     per recipe (E2B named as open-core example).
+  raw: license:Apache-2.0(OSI);source:public(SDKs+infra, Terraform self-host);managed-tier:e2b.dev hosted
+    sandbox cloud (proprietary);core-gated:gated
   sources:
   - url: https://github.com/e2b-dev/E2B
     shows: Apache-2.0 license; open source sandbox infra + Terraform self-host; managed cloud at e2b.dev

--- a/sources/scores/exa-search-api.yaml
+++ b/sources/scores/exa-search-api.yaml
@@ -2,10 +2,21 @@ product: exa-search-api
 openness:
   score: 1
   class: closed
-  components: license:Proprietary(API-only);source:closed(neural search models + index proprietary; only
-    client SDKs public);managed:cloud SaaS with API keys, usage-based pricing
+  components:
+    license:
+      value: Proprietary
+      detail: API-only
+    source:
+      value: closed
+      detail: neural search models + index proprietary; only client SDKs public
+    managed:
+      value: cloud SaaS with API keys
+      detail: usage-based pricing
+      raw: cloud SaaS with API keys, usage-based pricing
   confidence: high
   note: Closed neural-search API; no self-hostable core, the index and ranking models are proprietary.
+  raw: license:Proprietary(API-only);source:closed(neural search models + index proprietary; only client
+    SDKs public);managed:cloud SaaS with API keys, usage-based pricing
   sources:
   - url: https://exa.ai/about
     shows: search-as-a-service, API dashboard, no self-host/open source option

--- a/sources/scores/firecracker.yaml
+++ b/sources/scores/firecracker.yaml
@@ -2,11 +2,23 @@ product: firecracker
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(Rust 78.7%);governance:AWS-led open
-    project;no-feature-gated-core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: Rust 78.7%
+    governance:
+      value: AWS-led open project
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   confidence: high
   note: Fully Apache-2.0, source public, no gated core; AWS-developed but openly governed (recipe lists
     Firecracker as an open_source exemplar).
+  raw: license:Apache-2.0(OSI);source:public(Rust 78.7%);governance:AWS-led open project;no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://github.com/firecracker-microvm/firecracker
     shows: Apache-2.0 license; v1.16.0 (Jun 4 2026); powers AWS Lambda and Fargate

--- a/sources/scores/fireworks-inference.yaml
+++ b/sources/scores/fireworks-inference.yaml
@@ -2,7 +2,16 @@ product: fireworks-inference
 openness:
   score: 1
   class: closed
-  components: engine:proprietary(FireAttention kernels);source:closed;access:managed-cloud-API-only;license:Proprietary
+  components:
+    engine:
+      value: proprietary
+      detail: FireAttention kernels
+    source:
+      value: closed
+    access:
+      value: managed-cloud-API-only
+    license:
+      value: Proprietary
   confidence: high
   note: 'Proprietary FireAttention inference engine offered only as a managed cloud service; closed per
     recipe. Re-checked 2026-08-09: fireworks.ai homepage carries no self-host, on-prem, VPC/BYOC, or repository
@@ -11,6 +20,7 @@ openness:
     itself, consistent with license:Proprietary under this ladder''s own definition (''no license to the
     source, because the source is not published'').'
   last_verified: '2026-08-09'
+  raw: engine:proprietary(FireAttention kernels);source:closed;access:managed-cloud-API-only;license:Proprietary
   sources:
   - url: https://fireworks.ai/
     shows: the site markets Fireworks purely as a hosted API/pricing product (serverless and on-demand tiers,

--- a/sources/scores/garak.yaml
+++ b/sources/scores/garak.yaml
@@ -2,9 +2,21 @@ product: garak
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;self-host:yes;service:none;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    self-host:
+      value: 'yes'
+    service:
+      value: none
+    core-gated:
+      value: ungated
   confidence: high
   note: 'Fully open source: Apache-2.0 scanner, self-hostable, no proprietary tier.'
+  raw: license:Apache-2.0(OSI);source:public;self-host:yes;service:none;core-gated:ungated
   sources:
   - url: https://github.com/NVIDIA/garak
     shows: Apache-2.0; ~8.3k stars; probes for injection, leakage, jailbreaks, toxicity across providers

--- a/sources/scores/gemini.yaml
+++ b/sources/scores/gemini.yaml
@@ -3,9 +3,17 @@ openness:
   score: 1
   class: closed
   confidence: high
-  components: source:closed;self-host:none;license:proprietary(SaaS app)
+  components:
+    source:
+      value: closed
+    self-host:
+      value: none
+    license:
+      value: proprietary
+      detail: SaaS app
   note: Proprietary, SaaS-only consumer app; no source, no self-host. Closed counterpart in the ui_api
     shelf.
+  raw: source:closed;self-host:none;license:proprietary(SaaS app)
   sources:
   - url: https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/
     shows: Google's proprietary Gemini app/model product page

--- a/sources/scores/giskard.yaml
+++ b/sources/scores/giskard.yaml
@@ -2,10 +2,23 @@ product: giskard
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;self-host:yes;service:none(per the repo);core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    self-host:
+      value: 'yes'
+    service:
+      value: none
+      detail: per the repo
+    core-gated:
+      value: ungated
   confidence: high
   note: 'Fully open source: Apache-2.0 Python library, self-hostable; no commercial tier mentioned on
     the repo.'
+  raw: license:Apache-2.0(OSI);source:public;self-host:yes;service:none(per the repo);core-gated:ungated
   sources:
   - url: https://github.com/Giskard-AI/giskard
     shows: Apache-2.0; ~5.5k stars; automated scan + scenario checks; adversarial/injection testing

--- a/sources/scores/github-copilot-ide.yaml
+++ b/sources/scores/github-copilot-ide.yaml
@@ -3,9 +3,17 @@ openness:
   score: 1
   class: closed
   confidence: high
-  components: source:closed;self-host:none;license:proprietary(subscription SaaS)
+  components:
+    source:
+      value: closed
+    self-host:
+      value: none
+    license:
+      value: proprietary
+      detail: subscription SaaS
   note: Proprietary, closed-source subscription product; no self-host. Closed counterpart in the ui_api
     shelf.
+  raw: source:closed;self-host:none;license:proprietary(subscription SaaS)
   sources:
   - url: https://github.com/features/copilot
     shows: proprietary GitHub Copilot product page; closed source

--- a/sources/scores/github-copilot.yaml
+++ b/sources/scores/github-copilot.yaml
@@ -2,10 +2,18 @@ product: github-copilot
 openness:
   score: 1
   class: closed
-  components: source:closed;license:proprietary(GitHub/Microsoft SaaS);self-host:no
+  components:
+    source:
+      value: closed
+    license:
+      value: proprietary
+      detail: GitHub/Microsoft SaaS
+    self-host:
+      value: 'no'
   confidence: high
   note: Proprietary GitHub/Microsoft product; agent mode is a closed SaaS feature, model-agnostic on the
     backend but not open source.
+  raw: source:closed;license:proprietary(GitHub/Microsoft SaaS);self-host:no
   sources:
   - url: https://github.com/features/copilot
     shows: GitHub Copilot proprietary product, agent mode autonomous task execution, third-party model

--- a/sources/scores/google-grounding-api.yaml
+++ b/sources/scores/google-grounding-api.yaml
@@ -2,10 +2,18 @@ product: google-grounding-api
 openness:
   score: 1
   class: closed
-  components: license:proprietary(GCP-managed API);source:closed;managed:Vertex-AI/Gemini-Agent-Platform
+  components:
+    license:
+      value: proprietary
+      detail: GCP-managed API
+    source:
+      value: closed
+    managed:
+      value: Vertex-AI/Gemini-Agent-Platform
   confidence: high
   note: Fully proprietary Google Cloud managed grounding service; no open source component or self-host.
     Tied to Gemini + Google Search index.
+  raw: license:proprietary(GCP-managed API);source:closed;managed:Vertex-AI/Gemini-Agent-Platform
   sources:
   - url: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/grounding/overview
     shows: Grounding with Google Search listed as a managed grounding option in the Gemini Enterprise

--- a/sources/scores/goose.yaml
+++ b/sources/scores/goose.yaml
@@ -3,10 +3,26 @@ openness:
   score: 5
   class: open_source
   confidence: high
-  components: license:Apache-2.0(OSI);source:public;governance:Agentic AI Foundation/Linux Foundation (neutral
-    foundation); model-agnostic; MCP-native; no feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    governance:
+      value: Agentic AI Foundation/Linux Foundation
+      detail: neutral foundation
+      raw: Agentic AI Foundation/Linux Foundation (neutral foundation)
+    core-gated:
+      value: ungated
+    free_text:
+    - model-agnostic
+    - MCP-native
+    - no feature-gated core
   note: Verified Apache-2.0 OSI, now under Linux Foundation (AAIF) governance; full source public, no
     proprietary tier. Repo confirmed relocated to aaif-goose/goose (block/goose redirects).
+  raw: license:Apache-2.0(OSI);source:public;governance:Agentic AI Foundation/Linux Foundation (neutral
+    foundation); model-agnostic; MCP-native; no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/aaif-goose/goose
     shows: Apache-2.0, v1.37.0 Jun 3 2026, repo moved from block/goose to AAIF/Linux Foundation, 46.4k

--- a/sources/scores/gpqa.yaml
+++ b/sources/scores/gpqa.yaml
@@ -2,9 +2,20 @@ product: gpqa
 openness:
   score: 3
   class: gated
-  components: license:CC-BY-4.0(open,redistributable+attribution);access:gated(HF login + click-through
-    agreement NOT to publish examples in plaintext, to limit training-corpus contamination);datasheet:present(paper+card);splits:public(no
-    hidden held-out test)
+  components:
+    license:
+      value: CC-BY-4.0
+      detail: open,redistributable+attribution
+    access:
+      value: gated
+      detail: HF login + click-through agreement NOT to publish examples in plaintext, to limit training-corpus
+        contamination
+    datasheet:
+      value: present
+      detail: paper+card
+    splits:
+      value: public
+      detail: no hidden held-out test
   confidence: high
   note: Open CC-BY-4.0 license and fully redistributable, but access is login-walled with an anti-contamination
     click-through agreement, so the headline class is gated rather than open. Scored 3 with every
@@ -14,6 +25,9 @@ openness:
     restrictive one, but only this product records why its gate exists, and a rung for that would
     turn on evidence one product carries. Corrected 2026-08-01 from 4 when the dataset ladder made
     the pair checkable; no source was re-read.
+  raw: license:CC-BY-4.0(open,redistributable+attribution);access:gated(HF login + click-through agreement
+    NOT to publish examples in plaintext, to limit training-corpus contamination);datasheet:present(paper+card);splits:public(no
+    hidden held-out test)
   sources:
   - url: https://huggingface.co/datasets/Idavidrein/gpqa
     shows: CC-BY-4.0 license, gated access with anti-leakage agreement, 448 questions, dataset card present

--- a/sources/scores/grok-app.yaml
+++ b/sources/scores/grok-app.yaml
@@ -2,10 +2,20 @@ product: grok-app
 openness:
   score: 1
   class: closed
-  components: license:proprietary(SaaS/embedded in X);source:closed;self-host:none;model:xAI Grok(closed
-    weights)
+  components:
+    license:
+      value: proprietary
+      detail: SaaS/embedded in X
+    source:
+      value: closed
+    self-host:
+      value: none
+    model:
+      value: xAI Grok
+      detail: closed weights
   confidence: high
   note: Proprietary chat UI (and its underlying model is closed); closed counterpart on the shelf.
+  raw: license:proprietary(SaaS/embedded in X);source:closed;self-host:none;model:xAI Grok(closed weights)
   sources:
   - url: https://x.ai/news/grok-4-1
     shows: xAI Grok is a proprietary assistant/product (official xAI release notes)

--- a/sources/scores/groq-inference.yaml
+++ b/sources/scores/groq-inference.yaml
@@ -2,7 +2,16 @@ product: groq-inference
 openness:
   score: 1
   class: closed
-  components: engine:proprietary(LPU stack);source:closed;access:managed-cloud-API-only;license:Proprietary
+  components:
+    engine:
+      value: proprietary
+      detail: LPU stack
+    source:
+      value: closed
+    access:
+      value: managed-cloud-API-only
+    license:
+      value: Proprietary
   confidence: high
   note: 'Re-confirmed 2026-08-09: GroqCloud remains a managed API-only service (groq.com, GroqDocs overview);
     the groq GitHub org (29 public repos: groq-python, groq-typescript, openbench, harbor, demo apps, infra
@@ -10,6 +19,7 @@ openness:
     No license is granted to the underlying product -- groq.com/terms-of-use''s limited license covers only
     the marketing website, not GroqCloud or the LPU stack. source:closed and license:Proprietary both hold.'
   last_verified: '2026-08-09'
+  raw: engine:proprietary(LPU stack);source:closed;access:managed-cloud-API-only;license:Proprietary
   sources:
   - url: https://console.groq.com/docs/overview
     shows: Fast LLM inference, OpenAI-compatible. Simple to integrate, easy to scale. Start building in

--- a/sources/scores/gsm8k.yaml
+++ b/sources/scores/gsm8k.yaml
@@ -2,10 +2,24 @@ product: gsm8k
 openness:
   score: 5
   class: open
-  components: license:MIT(OSI-style permissive, fully redistributable);redistributability:full(downloadable
-    parquet, ungated);datasheet:yes(dataset card);size:8.5K problems;splits:train/test public
+  components:
+    license:
+      value: MIT
+      detail: OSI-style permissive, fully redistributable
+    redistributability:
+      value: full
+      detail: downloadable parquet, ungated
+    datasheet:
+      value: 'yes'
+      detail: dataset card
+    size:
+      value: 8.5K problems
+    splits:
+      value: train/test public
   confidence: high
   note: 'Fully open: MIT, ungated, downloadable, with a dataset card. Clean open-data case.'
+  raw: license:MIT(OSI-style permissive, fully redistributable);redistributability:full(downloadable parquet,
+    ungated);datasheet:yes(dataset card);size:8.5K problems;splits:train/test public
   sources:
   - url: https://huggingface.co/datasets/openai/gsm8k
     shows: MIT license; not gated; 8.5K problems (7473 train/1319 test); dataset card; ~948k downloads

--- a/sources/scores/gvisor.yaml
+++ b/sources/scores/gvisor.yaml
@@ -2,11 +2,23 @@ product: gvisor
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(Go);governance:Google-led open
-    project;no-feature-gated-core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: Go
+    governance:
+      value: Google-led open project
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   confidence: high
   note: Fully Apache-2.0 application kernel, source public, no gated core (recipe lists gVisor as an open_source
     exemplar).
+  raw: license:Apache-2.0(OSI);source:public(Go);governance:Google-led open project;no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://github.com/google/gvisor
     shows: Apache-2.0 license; application kernel implementing Linux-like interface in userspace (Go)

--- a/sources/scores/harmbench.yaml
+++ b/sources/scores/harmbench.yaml
@@ -2,9 +2,21 @@ product: harmbench
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public;self-host:yes;service:none;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+    self-host:
+      value: 'yes'
+    service:
+      value: none
+    core-gated:
+      value: ungated
   confidence: high
   note: 'Fully open source: MIT-licensed standardized red-teaming evaluation framework, self-hostable.'
+  raw: license:MIT(OSI);source:public;self-host:yes;service:none;core-gated:ungated
   sources:
   - url: https://github.com/centerforaisafety/HarmBench
     shows: MIT; standardized automated red-teaming eval; 18 attacks x 33 target models; ~993 stars

--- a/sources/scores/haystack.yaml
+++ b/sources/scores/haystack.yaml
@@ -2,9 +2,17 @@ product: haystack
 openness:
   score: 4
   class: open_core
-  components: license:Apache-2.0(core);commercial:Haystack-Enterprise;source:public
+  components:
+    license:
+      value: Apache-2.0
+      detail: core
+    commercial:
+      value: Haystack-Enterprise
+    source:
+      value: public
   confidence: high
   note: Apache-2.0 self-hostable core with a commercial enterprise tier.
+  raw: license:Apache-2.0(core);commercial:Haystack-Enterprise;source:public
   sources:
   - url: https://github.com/deepset-ai/haystack
     shows: Apache-2.0, ~25.6k stars, Haystack Enterprise tiers

--- a/sources/scores/helm.yaml
+++ b/sources/scores/helm.yaml
@@ -2,10 +2,24 @@ product: helm
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(framework + standardized datasets + web UI + leaderboard
-    code);governance:Stanford CRFM(academic); no gated core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: framework + standardized datasets + web UI + leaderboard code
+    governance:
+      value: Stanford CRFM
+      detail: academic
+    core-gated:
+      value: ungated
+    free_text:
+    - no gated core
   confidence: high
   note: Fully OSI (Apache-2.0); framework, standardized data formats, web UI, and leaderboards all public.
+  raw: license:Apache-2.0(OSI);source:public(framework + standardized datasets + web UI + leaderboard code);governance:Stanford
+    CRFM(academic); no gated core;core-gated:ungated
   sources:
   - url: https://github.com/stanford-crfm/helm
     shows: Apache-2.0 license; holistic eval framework with standardized datasets, web UI, leaderboards;

--- a/sources/scores/hermes.yaml
+++ b/sources/scores/hermes.yaml
@@ -4,8 +4,21 @@ openness:
   class: open_weights
   governing_release: hermes-4-3-36b
   confidence: high
-  components: weights:open(Apache-2.0);base:Seed-OSS-36B-Base;post-training-data:closed(proprietary ~5M-sample corpus);code:partial(inference
-    only);license:Apache-2.0(OSI)
+  components:
+    weights:
+      value: open
+      detail: Apache-2.0
+    base:
+      value: Seed-OSS-36B-Base
+    post-training-data:
+      value: closed
+      detail: proprietary ~5M-sample corpus
+    code:
+      value: partial
+      detail: inference only
+    license:
+      value: Apache-2.0
+      detail: OSI
   note: 'Nous ships one Hermes 4 post-training recipe on four independent base models, and the base determines the
     license the weights carry: Seed-OSS-36B and Qwen3-14B are Apache-2.0, while the Llama-3.1 405B and 70B builds
     inherit Meta''s Llama-3.1-Community terms (700M-MAU commercial cap, acceptable-use policy, naming requirements).
@@ -15,6 +28,8 @@ openness:
     takes the 36B or 14B build and gets it, so the family genuinely offers open weights. Not 4 or 5: the post-training
     corpus is proprietary and only inference code ships, so the recipe is not reproducible. Corrected from 2/restricted
     on 2026-07-29 after the tier consolidation initially applied most-restrictive across all four bases.'
+  raw: weights:open(Apache-2.0);base:Seed-OSS-36B-Base;post-training-data:closed(proprietary ~5M-sample
+    corpus);code:partial(inference only);license:Apache-2.0(OSI)
   sources:
   - url: https://huggingface.co/NousResearch/Hermes-4-405B-FP8
     shows: 'License: Llama3, base Meta-Llama/Llama-3.1-405B'

--- a/sources/scores/ifeval.yaml
+++ b/sources/scores/ifeval.yaml
@@ -2,10 +2,23 @@ product: ifeval
 openness:
   score: 5
   class: open
-  components: license:Apache-2.0(OSI/open,redistributable);access:public(not gated);datasheet:present(card+structure+citation);splits:public(single
-    train split, no held-out)
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI/open,redistributable
+    access:
+      value: public
+      detail: not gated
+    datasheet:
+      value: present
+      detail: card+structure+citation
+    splits:
+      value: public
+      detail: single train split, no held-out
   confidence: high
   note: 'Fully open: Apache-2.0, ungated, redistributable, with a complete dataset card.'
+  raw: license:Apache-2.0(OSI/open,redistributable);access:public(not gated);datasheet:present(card+structure+citation);splits:public(single
+    train split, no held-out)
   sources:
   - url: https://huggingface.co/datasets/google/IFEval
     shows: Apache-2.0 license, not gated, 541 examples, dataset card present

--- a/sources/scores/inspect-ai.yaml
+++ b/sources/scores/inspect-ai.yaml
@@ -2,10 +2,25 @@ product: inspect-ai
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public(full framework, 200+ evals);governance:public-sector(UK AISI)+Meridian
-    Labs; no managed/gated tier;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+      detail: full framework, 200+ evals
+    governance:
+      value: public-sector
+      detail: UK AISI)+Meridian Labs
+      raw: public-sector(UK AISI)+Meridian Labs
+    core-gated:
+      value: ungated
+    free_text:
+    - no managed/gated tier
   confidence: high
   note: Fully OSI (MIT), government-backed, no proprietary core, full pipeline open.
+  raw: license:MIT(OSI);source:public(full framework, 200+ evals);governance:public-sector(UK AISI)+Meridian
+    Labs; no managed/gated tier;core-gated:ungated
   sources:
   - url: https://github.com/UKGovernmentBEIS/inspect_ai
     shows: MIT license; framework for LLM evals with 200+ pre-built evals; UK AISI maintainer; 2.2k stars,

--- a/sources/scores/jan.yaml
+++ b/sources/scores/jan.yaml
@@ -3,10 +3,24 @@ openness:
   score: 5
   class: open_source
   confidence: high
-  components: license:Apache-2.0(OSI);source:public(github.com/janhq/jan);no-feature-gated-core;self-host:primary(desktop
-    app, 100% offline-capable);core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: github.com/janhq/jan
+    self-host:
+      value: primary
+      detail: desktop app, 100% offline-capable
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   note: Fully OSI-licensed (Apache-2.0), full source public, no proprietary feature-gated core, a true
     open chat UI.
+  raw: license:Apache-2.0(OSI);source:public(github.com/janhq/jan);no-feature-gated-core;self-host:primary(desktop
+    app, 100% offline-capable);core-gated:ungated
   sources:
   - url: https://github.com/janhq/jan/blob/dev/LICENSE
     shows: Apache-2.0 license text

--- a/sources/scores/jina-reader.yaml
+++ b/sources/scores/jina-reader.yaml
@@ -2,11 +2,22 @@ product: jina-reader
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(TypeScript, stateless mode self-hostable via Docker);managed-tier:r.jina.ai/s.jina.ai
-    hosted SaaS (free tier + paid API key) on top of the same OSS core
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: TypeScript, stateless mode self-hostable via Docker
+    managed-tier:
+      value: r.jina.ai/s.jina.ai hosted SaaS
+      detail: free tier + paid API key) on top of the same OSS core
+      raw: r.jina.ai/s.jina.ai hosted SaaS (free tier + paid API key) on top of the same OSS core
   confidence: high
   note: Repo is Apache-2.0 with the full reader pipeline public and self-hostable; hosted Jina API is
     convenience hosting, not a gated core.
+  raw: license:Apache-2.0(OSI);source:public(TypeScript, stateless mode self-hostable via Docker);managed-tier:r.jina.ai/s.jina.ai
+    hosted SaaS (free tier + paid API key) on top of the same OSS core
   sources:
   - url: https://github.com/jina-ai/reader
     shows: Apache-2.0 license, public source, self-host Docker instructions, ~11k stars

--- a/sources/scores/kata-containers.yaml
+++ b/sources/scores/kata-containers.yaml
@@ -2,11 +2,24 @@ product: kata-containers
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;governance:open community (OpenInfra
-    Foundation);no-feature-gated-core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    governance:
+      value: open community
+      detail: OpenInfra Foundation
+      raw: open community (OpenInfra Foundation)
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   confidence: high
   note: Fully Apache-2.0, source public, vendor-neutral open-foundation governance, no managed-tier gating
     from the project itself.
+  raw: license:Apache-2.0(OSI);source:public;governance:open community (OpenInfra Foundation);no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://github.com/kata-containers/kata-containers
     shows: Apache-2.0 license; lightweight VMs with container UX + VM isolation; v3.31.0 (May 19 2026)

--- a/sources/scores/khoj.yaml
+++ b/sources/scores/khoj.yaml
@@ -2,12 +2,26 @@ product: khoj
 openness:
   score: 5
   class: open_source
-  components: license:AGPL-3.0(OSI);source:public(github.com/khoj-ai/khoj);self-host:primary(Docker+pip);cloud-tier-sunset-2026-04(no
-    remaining feature-gating);core-gated:ungated
+  components:
+    license:
+      value: AGPL-3.0
+      detail: OSI
+    source:
+      value: public
+      detail: github.com/khoj-ai/khoj
+    self-host:
+      value: primary
+      detail: Docker+pip
+    core-gated:
+      value: ungated
+    free_text:
+    - cloud-tier-sunset-2026-04(no remaining feature-gating)
   confidence: high
   note: OSI-licensed (AGPL-3.0), full source public, self-hostable via Docker or pip. The paid Khoj Cloud
     tier was discontinued 2026-04-15 and the team frames self-hosting as the complete replacement, so the
     earlier open-core characteristics no longer apply to the shipping product.
+  raw: license:AGPL-3.0(OSI);source:public(github.com/khoj-ai/khoj);self-host:primary(Docker+pip);cloud-tier-sunset-2026-04(no
+    remaining feature-gating);core-gated:ungated
   sources:
   - url: https://github.com/khoj-ai/khoj
     shows: AGPL-3.0 license; ~35k stars; self-hostable AI personal assistant

--- a/sources/scores/lakera-guard.yaml
+++ b/sources/scores/lakera-guard.yaml
@@ -2,11 +2,20 @@ product: lakera-guard
 openness:
   score: 1
   class: closed
-  components: service:proprietary SaaS API(no self-host);note:vendor Lakera acquired by Check Point Nov
-    2025;source:closed;license:proprietary
+  components:
+    service:
+      value: proprietary SaaS API
+      detail: no self-host
+    note:
+      value: vendor Lakera acquired by Check Point Nov 2025
+    source:
+      value: closed
+    license:
+      value: proprietary
   confidence: high
   note: Closed SaaS security product; no weights or source. (Lakera also runs the public Gandalf prompt-injection
     game, but Guard itself is proprietary.)
+  raw: service:proprietary SaaS API(no self-host);note:vendor Lakera acquired by Check Point Nov 2025;source:closed;license:proprietary
   sources:
   - url: https://www.lakera.ai/
     shows: proprietary AI security / prompt-injection defense SaaS; Lakera acquired by Check Point (2025)

--- a/sources/scores/langchain.yaml
+++ b/sources/scores/langchain.yaml
@@ -2,9 +2,17 @@ product: langchain
 openness:
   score: 4
   class: open_core
-  components: license:MIT(langchain-core,langgraph,integrations);commercial:LangSmith-platform/cloud;source:public
+  components:
+    license:
+      value: MIT
+      detail: langchain-core,langgraph,integrations
+    commercial:
+      value: LangSmith-platform/cloud
+    source:
+      value: public
   confidence: high
   note: license:MIT(langchain-core,langgraph,integrations);commercial:LangSmith-platform/cloud;source:public
+  raw: license:MIT(langchain-core,langgraph,integrations);commercial:LangSmith-platform/cloud;source:public
   sources:
   - url: https://github.com/langchain-ai/langchain
     shows: flagship phase-C verification source

--- a/sources/scores/langflow.yaml
+++ b/sources/scores/langflow.yaml
@@ -2,9 +2,22 @@ product: langflow
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public;no-feature-gated-core;commercial:DataStax-hosted(separate);core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+    commercial:
+      value: DataStax-hosted
+      detail: separate
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   confidence: high
   note: MIT core, fully open; managed cloud does not gate the OSS core.
+  raw: license:MIT(OSI);source:public;no-feature-gated-core;commercial:DataStax-hosted(separate);core-gated:ungated
   sources:
   - url: https://github.com/langflow-ai/langflow
     shows: MIT, ~149.8k stars, visual agent builder

--- a/sources/scores/langfuse.yaml
+++ b/sources/scores/langfuse.yaml
@@ -2,9 +2,18 @@ product: langfuse
 openness:
   score: 4
   class: open_core
-  components: license:MIT(core:tracing/integrations/API/data-model/exports/evals/playground/SSO);commercial:enterprise-security(SCIM,audit-logs,data-retention);source:public
+  components:
+    license:
+      value: MIT
+      detail: core:tracing/integrations/API/data-model/exports/evals/playground/SSO
+    commercial:
+      value: enterprise-security
+      detail: SCIM,audit-logs,data-retention
+    source:
+      value: public
   confidence: high
   note: license:MIT(core:tracing/integrations/API/data-model/exports/evals/playground/SSO);commercial:enterprise-security(SCIM,audit-logs,data-retention);source:public
+  raw: license:MIT(core:tracing/integrations/API/data-model/exports/evals/playground/SSO);commercial:enterprise-security(SCIM,audit-logs,data-retention);source:public
   sources:
   - url: https://github.com/langfuse/langfuse
     shows: flagship phase-C verification source

--- a/sources/scores/langgraph.yaml
+++ b/sources/scores/langgraph.yaml
@@ -2,9 +2,17 @@ product: langgraph
 openness:
   score: 4
   class: open_core
-  components: license:MIT(core);commercial:LangGraph-Platform/LangSmith;source:public
+  components:
+    license:
+      value: MIT
+      detail: core
+    commercial:
+      value: LangGraph-Platform/LangSmith
+    source:
+      value: public
   confidence: high
   note: MIT-licensed self-hostable core with a commercial managed deployment platform.
+  raw: license:MIT(core);commercial:LangGraph-Platform/LangSmith;source:public
   sources:
   - url: https://github.com/langchain-ai/langgraph
     shows: MIT, ~35k stars, low-level agent orchestration

--- a/sources/scores/langsmith.yaml
+++ b/sources/scores/langsmith.yaml
@@ -2,13 +2,24 @@ product: langsmith
 openness:
   score: 1
   class: closed
-  components: license:Proprietary;source:closed;platform:proprietary(no public source for LangSmith
-    itself);self-hosting=licensed enterprise deployment of closed software, not OSS;OSS
-    siblings(LangChain/LangGraph) are separate products not scored here
+  components:
+    license:
+      value: Proprietary
+    source:
+      value: closed
+    platform:
+      value: proprietary
+      detail: no public source for LangSmith itself
+    free_text:
+    - self-hosting=licensed enterprise deployment of closed software, not OSS
+    - OSS siblings(LangChain/LangGraph) are separate products not scored here
   confidence: high
   note: LangSmith the observability/eval platform is closed/proprietary; only the LangChain/LangGraph
     frameworks (separate registry entries) are open. Self-host/BYOC are licensed deployments of closed
     software, not source-available.
+  raw: license:Proprietary;source:closed;platform:proprietary(no public source for LangSmith itself);self-hosting=licensed
+    enterprise deployment of closed software, not OSS;OSS siblings(LangChain/LangGraph) are separate products
+    not scored here
   sources:
   - url: https://www.langchain.com/langsmith
     shows: LangSmith described as managed SaaS with BYOC/self-host enterprise options; open source items

--- a/sources/scores/le-chat.yaml
+++ b/sources/scores/le-chat.yaml
@@ -2,11 +2,21 @@ product: le-chat
 openness:
   score: 1
   class: closed
-  components: license:proprietary(SaaS app);source:closed(the Le Chat product; underlying Mistral models
-    are open-weights but the chat UI/service is not);self-host:none
+  components:
+    license:
+      value: proprietary
+      detail: SaaS app
+    source:
+      value: closed
+      detail: the Le Chat product; underlying Mistral models are open-weights but the chat UI/service is
+        not
+    self-host:
+      value: none
   confidence: high
   note: The Le Chat product/service is proprietary SaaS (closed), distinct from Mistral's open-weight
     models scored elsewhere; closed counterpart on the shelf.
+  raw: license:proprietary(SaaS app);source:closed(the Le Chat product; underlying Mistral models are open-weights
+    but the chat UI/service is not);self-host:none
   sources:
   - url: https://techcrunch.com/2025/02/19/mistrals-le-chat-tops-1m-downloads-in-just-14-days/
     shows: Le Chat is Mistral's proprietary consumer chat app (product profile)

--- a/sources/scores/livecodebench.yaml
+++ b/sources/scores/livecodebench.yaml
@@ -2,13 +2,27 @@ product: livecodebench
 openness:
   score: 4
   class: open
-  components: data:downloadable(HF parquet);license:cc(generic CC tag, specific variant unspecified on
-    dataset card);datasheet:present(README documents versions/sources/structure);redistributable:yes;splits:public
-    problems with hidden test cases bundled
+  components:
+    data:
+      value: downloadable
+      detail: HF parquet
+    license:
+      value: cc
+      detail: generic CC tag, specific variant unspecified on dataset card
+    datasheet:
+      value: present
+      detail: README documents versions/sources/structure
+    redistributable:
+      value: 'yes'
+    splits:
+      value: public problems with hidden test cases bundled
   confidence: medium
   note: Open and downloadable with a datasheet, but the HF card declares only a generic 'cc' license (no
     specific CC variant), so the exact reuse terms are ambiguous. Scored open but not a clean CC-BY;
     capped at 4.
+  raw: data:downloadable(HF parquet);license:cc(generic CC tag, specific variant unspecified on dataset
+    card);datasheet:present(README documents versions/sources/structure);redistributable:yes;splits:public
+    problems with hidden test cases bundled
   sources:
   - url: https://huggingface.co/datasets/livecodebench/code_generation_lite
     shows: license:cc, 880 problems (release_v5), 71,393 monthly downloads, datasheet/README

--- a/sources/scores/llama-cpp.yaml
+++ b/sources/scores/llama-cpp.yaml
@@ -2,13 +2,25 @@ product: llama-cpp
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public;governance:ggml-org/Hugging Face(community);no feature-gated
-    core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+    governance:
+      value: ggml-org/Hugging Face
+      detail: community
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: 'Fully MIT-licensed C/C++ inference engine; entire source public, no proprietary tier. Checked the
     repo page and the ggml-org GitHub org profile for a hosted or paid SKU and found none: the only distribution
     is the one MIT-licensed codebase.'
   last_verified: '2026-08-09'
+  raw: license:MIT(OSI);source:public;governance:ggml-org/Hugging Face(community);no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/ggml-org/llama.cpp/blob/master/LICENSE
     shows: MIT License text, "Copyright (c) 2023-2026 The ggml authors"

--- a/sources/scores/llama-index.yaml
+++ b/sources/scores/llama-index.yaml
@@ -2,9 +2,17 @@ product: llama-index
 openness:
   score: 4
   class: open_core
-  components: license:MIT(core);commercial:LlamaCloud/LlamaParse;source:public
+  components:
+    license:
+      value: MIT
+      detail: core
+    commercial:
+      value: LlamaCloud/LlamaParse
+    source:
+      value: public
   confidence: high
   note: MIT self-hostable core with a commercial managed cloud.
+  raw: license:MIT(core);commercial:LlamaCloud/LlamaParse;source:public
   sources:
   - url: https://github.com/run-llama/llama_index
     shows: MIT, ~50.2k stars, LlamaCloud commercial tier

--- a/sources/scores/llm-guard.yaml
+++ b/sources/scores/llm-guard.yaml
@@ -2,11 +2,25 @@ product: llm-guard
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public(full Python implementation);self-host:yes;service:none(the
-    OSS toolkit; Protect AI's platform is separate);core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+      detail: full Python implementation
+    self-host:
+      value: 'yes'
+    service:
+      value: none
+      detail: the OSS toolkit; Protect AI's platform is separate
+    core-gated:
+      value: ungated
   confidence: high
   note: 'Fully open source: MIT-licensed, complete source, self-hostable. (Protect AI''s commercial platform
     is a separate product; this is the standalone OSS toolkit.)'
+  raw: license:MIT(OSI);source:public(full Python implementation);self-host:yes;service:none(the OSS toolkit;
+    Protect AI's platform is separate);core-gated:ungated
   sources:
   - url: https://github.com/protectai/llm-guard
     shows: MIT; full Python source; input/output scanners; ~3.1k stars

--- a/sources/scores/lovable.yaml
+++ b/sources/scores/lovable.yaml
@@ -2,10 +2,18 @@ product: lovable
 openness:
   score: 1
   class: closed
-  components: source:closed;license:proprietary(SaaS);self-host:no
+  components:
+    source:
+      value: closed
+    license:
+      value: proprietary
+      detail: SaaS
+    self-host:
+      value: 'no'
   confidence: high
   note: Proprietary SaaS app builder; closed source. (GPT Engineer, its open source predecessor, is a
     separate legacy repo; the scored product is the proprietary Lovable platform.)
+  raw: source:closed;license:proprietary(SaaS);self-host:no
   sources:
   - url: https://lovable.dev
     shows: proprietary SaaS AI app builder, chat-to-build, one-click deploy

--- a/sources/scores/marin-framework.yaml
+++ b/sources/scores/marin-framework.yaml
@@ -2,11 +2,24 @@ product: marin-framework
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(marin-community/marin);governance:Marin community/Stanford CRFM;no
-    feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: marin-community/marin
+    governance:
+      value: Marin community/Stanford CRFM
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: Fully OSI-licensed (Apache-2.0), full source public. Repo is the framework; the Marin model is
     a separate artifact.
+  raw: license:Apache-2.0(OSI);source:public(marin-community/marin);governance:Marin community/Stanford
+    CRFM;no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/marin-community/marin/blob/main/LICENSE
     shows: Apache License Version 2.0 text

--- a/sources/scores/math.yaml
+++ b/sources/scores/math.yaml
@@ -2,13 +2,28 @@ product: math
 openness:
   score: 2
   class: gated
-  components: data:NOT downloadable from canonical HF repo (access disabled, DMCA takedown);license:MIT(declared);datasheet:present(card
-    still documents schema);redistributability:BLOCKED on the primary registry; problems sourced from
-    AMC/AIME competitions, takedown reflects unresolved rights
+  components:
+    data:
+      value: NOT downloadable from canonical HF repo
+      detail: access disabled, DMCA takedown
+      raw: NOT downloadable from canonical HF repo (access disabled, DMCA takedown)
+    license:
+      value: MIT
+      detail: declared
+    datasheet:
+      value: present
+      detail: card still documents schema
+    redistributability:
+      value: BLOCKED on the primary registry
+    free_text:
+    - problems sourced from AMC/AIME competitions, takedown reflects unresolved rights
   confidence: medium
   note: Declared MIT, but the canonical HF dataset is access-disabled under a DMCA takedown, so it is
     not currently redistributable from the primary registry; scored gated/blocked rather than open. Mirrors
     and eval harnesses still embed it, but the primary source is walled; revisit if the takedown is resolved.
+  raw: data:NOT downloadable from canonical HF repo (access disabled, DMCA takedown);license:MIT(declared);datasheet:present(card
+    still documents schema);redistributability:BLOCKED on the primary registry; problems sourced from AMC/AIME
+    competitions, takedown reflects unresolved rights
   sources:
   - url: https://huggingface.co/datasets/hendrycks/competition_math
     shows: MIT tag, 12,500 problems, but 'Access Disabled' DMCA takedown notice (discussions/5)

--- a/sources/scores/mbpp.yaml
+++ b/sources/scores/mbpp.yaml
@@ -2,12 +2,26 @@ product: mbpp
 openness:
   score: 5
   class: open
-  components: license:CC-BY-4.0(open data license);redistributability:full(downloadable, ungated);datasheet:yes(extensive
-    dataset card);size:~974 full / 427 sanitized problems w/ test_list;splits:train/test/validation/prompt
-    public
+  components:
+    license:
+      value: CC-BY-4.0
+      detail: open data license
+    redistributability:
+      value: full
+      detail: downloadable, ungated
+    datasheet:
+      value: 'yes'
+      detail: extensive dataset card
+    size:
+      value: ~974 full / 427 sanitized problems w/ test_list
+    splits:
+      value: train/test/validation/prompt public
   confidence: high
   note: 'Fully open: CC-BY-4.0, ungated, downloadable, with an extensive dataset card. Clean open-data
     case; the standard companion to HumanEval for basic Python code-gen eval.'
+  raw: license:CC-BY-4.0(open data license);redistributability:full(downloadable, ungated);datasheet:yes(extensive
+    dataset card);size:~974 full / 427 sanitized problems w/ test_list;splits:train/test/validation/prompt
+    public
   sources:
   - url: https://huggingface.co/datasets/google-research-datasets/mbpp
     shows: CC-BY-4.0 license; not gated; ~974 full/427 sanitized problems; dataset card present; ~198k

--- a/sources/scores/meta-ai.yaml
+++ b/sources/scores/meta-ai.yaml
@@ -3,11 +3,22 @@ openness:
   score: 1
   class: closed
   confidence: high
-  components: client:proprietary(closed consumer app/embedded surface);backend:hosted-SaaS;note:underlying
-    Llama weights are restricted (non-OSI) and model-layer scored elsewhere; the assistant product is
-    closed
+  components:
+    client:
+      value: proprietary
+      detail: closed consumer app/embedded surface
+    backend:
+      value: hosted-SaaS
+    note:
+      value: underlying Llama weights are restricted
+      detail: non-OSI) and model-layer scored elsewhere
+      raw: underlying Llama weights are restricted (non-OSI) and model-layer scored elsewhere
+    free_text:
+    - the assistant product is closed
   note: Meta AI the assistant/UI is a closed proprietary consumer product; scored as closed counterpart.
     (Llama-the-model openness is a separate restricted-class score.)
+  raw: client:proprietary(closed consumer app/embedded surface);backend:hosted-SaaS;note:underlying Llama
+    weights are restricted (non-OSI) and model-layer scored elsewhere; the assistant product is closed
   sources:
   - url: https://www.demandsage.com/meta-ai-users/
     shows: Meta AI described as proprietary consumer assistant embedded across Meta apps + meta.ai

--- a/sources/scores/microsoft-copilot.yaml
+++ b/sources/scores/microsoft-copilot.yaml
@@ -2,9 +2,20 @@ product: microsoft-copilot
 openness:
   score: 1
   class: closed
-  components: license:proprietary(SaaS/embedded);source:closed;self-host:none;model:OpenAI+Microsoft(closed)
+  components:
+    license:
+      value: proprietary
+      detail: SaaS/embedded
+    source:
+      value: closed
+    self-host:
+      value: none
+    model:
+      value: OpenAI+Microsoft
+      detail: closed
   confidence: high
   note: Fully proprietary, SaaS/embedded, the closed counterpart on the UI/API shelf.
+  raw: license:proprietary(SaaS/embedded);source:closed;self-host:none;model:OpenAI+Microsoft(closed)
   sources:
   - url: https://learn.microsoft.com/en-us/microsoft-365/admin/activity-reports/microsoft-copilot-usage?view=o365-worldwide
     shows: Microsoft 365 Copilot Chat is a Microsoft-operated proprietary product (admin usage reporting

--- a/sources/scores/mmlu-pro.yaml
+++ b/sources/scores/mmlu-pro.yaml
@@ -2,10 +2,23 @@ product: mmlu-pro
 openness:
   score: 5
   class: open
-  components: license:MIT(OSI/open,redistributable);access:public(not gated);datasheet:present(comprehensive
-    card+leaderboard);splits:public(test+validation, no hidden held-out)
+  components:
+    license:
+      value: MIT
+      detail: OSI/open,redistributable
+    access:
+      value: public
+      detail: not gated
+    datasheet:
+      value: present
+      detail: comprehensive card+leaderboard
+    splits:
+      value: public
+      detail: test+validation, no hidden held-out
   confidence: high
   note: 'Fully open: MIT, ungated, redistributable, comprehensive card.'
+  raw: license:MIT(OSI/open,redistributable);access:public(not gated);datasheet:present(comprehensive card+leaderboard);splits:public(test+validation,
+    no hidden held-out)
   sources:
   - url: https://huggingface.co/datasets/TIGER-Lab/MMLU-Pro
     shows: MIT license, not gated, 12,032 questions, dataset card + leaderboard present

--- a/sources/scores/mmmu.yaml
+++ b/sources/scores/mmmu.yaml
@@ -2,12 +2,26 @@ product: mmmu
 openness:
   score: 5
   class: open
-  components: license:Apache-2.0(OSI/open,redistributable);access:public(not gated);datasheet:present(comprehensive
-    card);splits:dev+validation+test all public (test answers released 2026-02-12; previously EvalAI-gated)
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI/open,redistributable
+    access:
+      value: public
+      detail: not gated
+    datasheet:
+      value: present
+      detail: comprehensive card
+    splits:
+      value: dev+validation+test all public
+      detail: test answers released 2026-02-12; previously EvalAI-gated
+      raw: dev+validation+test all public (test answers released 2026-02-12; previously EvalAI-gated)
   confidence: high
   note: 'Fully open: Apache-2.0, ungated, redistributable, comprehensive card. Test-set answers were released
     2026-02-12 (previously held out via EvalAI), so there is no longer a held-out element; scored 5 as
     a fully-public benchmark.'
+  raw: license:Apache-2.0(OSI/open,redistributable);access:public(not gated);datasheet:present(comprehensive
+    card);splits:dev+validation+test all public (test answers released 2026-02-12; previously EvalAI-gated)
   sources:
   - url: https://huggingface.co/datasets/MMMU/MMMU
     shows: Apache-2.0, not gated, 11,550 questions (dev 150/val 900/test 10,500); test answers released

--- a/sources/scores/morphic.yaml
+++ b/sources/scores/morphic.yaml
@@ -2,10 +2,24 @@ product: morphic
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(github.com/miurla/morphic);self-host:primary(Docker);no-feature-gated-core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: github.com/miurla/morphic
+    self-host:
+      value: primary
+      detail: Docker
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   confidence: high
   note: Fully OSI-licensed (Apache-2.0), full source public, Docker-deployable for self-hosting - a true
     open generative-search UI.
+  raw: license:Apache-2.0(OSI);source:public(github.com/miurla/morphic);self-host:primary(Docker);no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://github.com/miurla/morphic
     shows: Apache-2.0 license; ~8.9k stars; open generative-UI answer engine

--- a/sources/scores/nemo-curator.yaml
+++ b/sources/scores/nemo-curator.yaml
@@ -2,10 +2,22 @@ product: nemo-curator
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(NVIDIA/NeMo-Curator);governance:NVIDIA;no feature-gated
-    core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: NVIDIA/NeMo-Curator
+    governance:
+      value: NVIDIA
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: Fully OSI-licensed (Apache-2.0), full source public. Vendor-backed but not gated.
+  raw: license:Apache-2.0(OSI);source:public(NVIDIA/NeMo-Curator);governance:NVIDIA;no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/NVIDIA/NeMo-Curator/blob/main/LICENSE
     shows: Apache License Version 2.0 text

--- a/sources/scores/nemo-guardrails.yaml
+++ b/sources/scores/nemo-guardrails.yaml
@@ -2,9 +2,23 @@ product: nemo-guardrails
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(full Python implementation);self-host:yes(library/CLI/Docker/server);service:none;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: full Python implementation
+    self-host:
+      value: 'yes'
+      detail: library/CLI/Docker/server
+    service:
+      value: none
+    core-gated:
+      value: ungated
   confidence: high
   note: 'Fully open source: Apache-2.0, complete source, self-hostable with no proprietary tier.'
+  raw: license:Apache-2.0(OSI);source:public(full Python implementation);self-host:yes(library/CLI/Docker/server);service:none;core-gated:ungated
   sources:
   - url: https://github.com/NVIDIA/NeMo-Guardrails
     shows: Apache-2.0; full Python source; self-hostable as library/CLI/Docker/server; ~6.6k stars

--- a/sources/scores/olmocr.yaml
+++ b/sources/scores/olmocr.yaml
@@ -2,10 +2,23 @@ product: olmocr
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(allenai/olmocr);governance:Allen Institute for AI;no feature-gated
-    core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: allenai/olmocr
+    governance:
+      value: Allen Institute for AI
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: Fully OSI-licensed (Apache-2.0), full source public.
+  raw: license:Apache-2.0(OSI);source:public(allenai/olmocr);governance:Allen Institute for AI;no feature-gated
+    core;core-gated:ungated
   sources:
   - url: https://github.com/allenai/olmocr/blob/main/LICENSE
     shows: Apache License Version 2.0 text

--- a/sources/scores/open-llm-leaderboard.yaml
+++ b/sources/scores/open-llm-leaderboard.yaml
@@ -2,9 +2,18 @@ product: open-llm-leaderboard
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(HF-Space);backend:lm-eval-harness/lighteval(open);source:public
+  components:
+    license:
+      value: Apache-2.0
+      detail: HF-Space
+    backend:
+      value: lm-eval-harness/lighteval
+      detail: open
+    source:
+      value: public
   confidence: high
   note: Open Apache-2.0 leaderboard built on open eval backends (now archived).
+  raw: license:Apache-2.0(HF-Space);backend:lm-eval-harness/lighteval(open);source:public
   sources:
   - url: https://huggingface.co/spaces/open-llm-leaderboard/open_llm_leaderboard
     shows: Apache-2.0 Space, ~14k likes

--- a/sources/scores/openai-fine-tuning-api.yaml
+++ b/sources/scores/openai-fine-tuning-api.yaml
@@ -2,12 +2,21 @@ product: openai-fine-tuning-api
 openness:
   score: 1
   class: closed
-  components: source:closed;training-code:closed;runs-on:OpenAI-platform-only;license:Proprietary(paid
-    API service)
+  components:
+    source:
+      value: closed
+    training-code:
+      value: closed
+    runs-on:
+      value: OpenAI-platform-only
+    license:
+      value: Proprietary
+      detail: paid API service
   confidence: high
   note: Proprietary managed fine-tuning service, no source, runs only on OpenAI's platform against OpenAI's
     closed models.
   last_verified: '2026-08-08'
+  raw: source:closed;training-code:closed;runs-on:OpenAI-platform-only;license:Proprietary(paid API service)
   sources:
   - url: https://openai.com/policies/services-agreement/
     shows: 'Section 9.1 Reservation of Rights: "Customer obtains only a limited right to use the Services,

--- a/sources/scores/openai-moderation.yaml
+++ b/sources/scores/openai-moderation.yaml
@@ -2,9 +2,19 @@ product: openai-moderation
 openness:
   score: 1
   class: closed
-  components: service:proprietary hosted API(no weights, no self-host);access:free moderation endpoint;source:closed;license:proprietary
+  components:
+    service:
+      value: proprietary hosted API
+      detail: no weights, no self-host
+    access:
+      value: free moderation endpoint
+    source:
+      value: closed
+    license:
+      value: proprietary
   confidence: high
   note: Closed, API-only hosted classifier; no weights or source.
+  raw: service:proprietary hosted API(no weights, no self-host);access:free moderation endpoint;source:closed;license:proprietary
   sources:
   - url: https://platform.openai.com/docs/guides/moderation
     shows: free hosted moderation API; OpenAI content-policy categories; no weights

--- a/sources/scores/openclaw.yaml
+++ b/sources/scores/openclaw.yaml
@@ -2,10 +2,22 @@ product: openclaw
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI; body is MIT, GitHub NOASSERTION from custom copyright
-    line);source:public;self-host:primary(local-first);no-feature-gated-core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI; body is MIT, GitHub NOASSERTION from custom copyright line
+    source:
+      value: public
+    self-host:
+      value: primary
+      detail: local-first
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   confidence: high
   note: Genuinely MIT open source; the NOASSERTION flag is a classifier artifact, not a restriction.
+  raw: license:MIT(OSI; body is MIT, GitHub NOASSERTION from custom copyright line);source:public;self-host:primary(local-first);no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://github.com/openclaw/openclaw/blob/main/LICENSE
     shows: MIT text, Copyright OpenClaw Foundation

--- a/sources/scores/openguardrails.yaml
+++ b/sources/scores/openguardrails.yaml
@@ -2,11 +2,25 @@ product: openguardrails
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI) for both platform and model;source:public;self-host:yes(on-prem/private);model:OpenGuardrails-Text-2510
-    open weights Apache-2.0;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI) for both platform and model
+      raw: Apache-2.0(OSI) for both platform and model
+    source:
+      value: public
+    self-host:
+      value: 'yes'
+      detail: on-prem/private
+    model:
+      value: OpenGuardrails-Text-2510 open weights Apache-2.0
+    core-gated:
+      value: ungated
   confidence: high
   note: 'Fully open source: both the guardrails platform and the safety model are Apache-2.0 and self-hostable,
     including on-prem deployment.'
+  raw: license:Apache-2.0(OSI) for both platform and model;source:public;self-host:yes(on-prem/private);model:OpenGuardrails-Text-2510
+    open weights Apache-2.0;core-gated:ungated
   sources:
   - url: https://github.com/openguardrails/openguardrails
     shows: Apache-2.0 platform; ~80 stars; on-prem deployment

--- a/sources/scores/openmanus.yaml
+++ b/sources/scores/openmanus.yaml
@@ -2,9 +2,21 @@ product: openmanus
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public;self-host:primary;no-feature-gated-core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+    self-host:
+      value: primary
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   confidence: high
   note: Fully MIT, run from source, no commercial layer.
+  raw: license:MIT(OSI);source:public;self-host:primary;no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://github.com/FoundationAgents/OpenManus
     shows: MIT, ~56.6k stars, MetaGPT-team maintainers

--- a/sources/scores/openrag.yaml
+++ b/sources/scores/openrag.yaml
@@ -2,11 +2,24 @@ product: openrag
 openness:
   score: 5
   class: open_source
-  components: license:AGPL-3.0(OSI);source:public;self-host:primary(Docker Compose);core-gated:ungated;commercial:none
+  components:
+    license:
+      value: AGPL-3.0
+      detail: OSI
+    source:
+      value: public
+    self-host:
+      value: primary
+      detail: Docker Compose
+    core-gated:
+      value: ungated
+    commercial:
+      value: none
   confidence: high
   note: Fully open AGPL-3.0 RAG application stack — the published source is the whole product, self-hosted
     via Docker Compose, with no feature-gated enterprise tier and no vendor lock-in. AGPL is OSI-approved and
     sits beside Apache on the software ladder, so osi + public + ungated lands at 5.
+  raw: license:AGPL-3.0(OSI);source:public;self-host:primary(Docker Compose);core-gated:ungated;commercial:none
   sources:
   - url: https://github.com/linagora/openrag
     shows: AGPL-3.0 license; full source for backend (Python) + frontend (TS/JS); self-hostable via Docker

--- a/sources/scores/openrouter.yaml
+++ b/sources/scores/openrouter.yaml
@@ -2,10 +2,19 @@ product: openrouter
 openness:
   score: 1
   class: closed
-  components: license:proprietary(hosted gateway);source:closed(SDK present, core service closed);self-host:none
+  components:
+    license:
+      value: proprietary
+      detail: hosted gateway
+    source:
+      value: closed
+      detail: SDK present, core service closed
+    self-host:
+      value: none
   confidence: high
   note: Proprietary hosted routing gateway, the closed counterpart to open gateways (LiteLLM); listed
     as closed in the recipe.
+  raw: license:proprietary(hosted gateway);source:closed(SDK present, core service closed);self-host:none
   sources:
   - url: https://openrouter.ai/
     shows: hosted unified API gateway across 400+ models/60+ providers; proprietary service (no self-host)

--- a/sources/scores/opik.yaml
+++ b/sources/scores/opik.yaml
@@ -2,11 +2,24 @@ product: opik
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;self-hostable-full-stack;commercial:Comet-cloud-hosting(not a
-    gated core);core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    commercial:
+      value: Comet-cloud-hosting
+      detail: not a gated core
+    core-gated:
+      value: ungated
+    free_text:
+    - self-hostable-full-stack
   confidence: high
   note: Apache-2.0, full platform self-hostable; cloud is managed hosting rather than a feature-gated
     proprietary core.
+  raw: license:Apache-2.0(OSI);source:public;self-hostable-full-stack;commercial:Comet-cloud-hosting(not
+    a gated core);core-gated:ungated
   sources:
   - url: https://pypi.org/project/opik/
     shows: 'License: Apache 2.0; v2.0.57 (4 Jun 2026)'

--- a/sources/scores/ornith.yaml
+++ b/sources/scores/ornith.yaml
@@ -2,9 +2,22 @@ product: ornith
 openness:
   score: 3
   class: open_weights
-  components: weights:open(MIT);base:Qwen3.5;data:closed;recipe:closed;license:MIT(OSI)
+  components:
+    weights:
+      value: open
+      detail: MIT
+    base:
+      value: Qwen3.5
+    data:
+      value: closed
+    recipe:
+      value: closed
+    license:
+      value: MIT
+      detail: OSI
   confidence: high
   note: MIT-licensed open weights on a Qwen 3.5 base, but no open training data or recipe -> open_weights.
+  raw: weights:open(MIT);base:Qwen3.5;data:closed;recipe:closed;license:MIT(OSI)
   sources:
   - url: https://huggingface.co/deepreinforce-ai/Ornith-1.0-9B
     shows: license:mit tag; qwen3_5 architecture; safetensors weights

--- a/sources/scores/osprey.yaml
+++ b/sources/scores/osprey.yaml
@@ -2,10 +2,22 @@ product: osprey
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;self-host:yes;service:none;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    self-host:
+      value: 'yes'
+    service:
+      value: none
+    core-gated:
+      value: ungated
   confidence: high
   note: 'Fully open source: Apache-2.0 real-time safety rules engine, self-hostable, no proprietary tier.
     Donated by Discord to ROOST.'
+  raw: license:Apache-2.0(OSI);source:public;self-host:yes;service:none;core-gated:ungated
   sources:
   - url: https://github.com/roostorg/osprey
     shows: Apache-2.0; Rust coordinator + stateless Python workers; SML rules DSL

--- a/sources/scores/otari.yaml
+++ b/sources/scores/otari.yaml
@@ -2,12 +2,23 @@ product: otari
 openness:
   score: 4
   class: open_core
-  components: license:Apache-2.0(OSI, core);source:public;self-host:yes(Docker Compose);service:hosted
-    Otari.ai platform on the same core
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI, core
+    source:
+      value: public
+    self-host:
+      value: 'yes'
+      detail: Docker Compose
+    service:
+      value: hosted Otari.ai platform on the same core
   confidence: high
   note: Apache-2.0 self-hostable gateway (github.com/mozilla-ai/otari) with a hosted Otari.ai platform on
     the same core; classed open_core alongside peer gateways such as LiteLLM. Would be open_source (5) if
     the hosted platform is not a commercial tier.
+  raw: license:Apache-2.0(OSI, core);source:public;self-host:yes(Docker Compose);service:hosted Otari.ai
+    platform on the same core
   sources:
   - url: https://github.com/mozilla-ai/otari
     shows: Apache-2.0; OpenAI-compatible gateway; self-host via Docker Compose

--- a/sources/scores/pathway.yaml
+++ b/sources/scores/pathway.yaml
@@ -2,10 +2,18 @@ product: pathway
 openness:
   score: 2
   class: source_available
-  components: license:BSL-1.1(non-OSI:single-machine + no-compete, Change-Date 2027-07-20 -> Apache-2.0);commercial:Scale/Enterprise;source:public
+  components:
+    license:
+      value: BSL-1.1
+      detail: non-OSI:single-machine + no-compete, Change-Date 2027-07-20 -> Apache-2.0
+    commercial:
+      value: Scale/Enterprise
+    source:
+      value: public
   confidence: high
   note: Source-available under BSL 1.1, not open source; production use is license-restricted with paid enterprise
     tiers.
+  raw: license:BSL-1.1(non-OSI:single-machine + no-compete, Change-Date 2027-07-20 -> Apache-2.0);commercial:Scale/Enterprise;source:public
   sources:
   - url: https://github.com/pathwaycom/pathway
     shows: BSL 1.1, ~62.9k stars

--- a/sources/scores/peft.yaml
+++ b/sources/scores/peft.yaml
@@ -2,11 +2,26 @@ product: peft
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(huggingface/peft);governance:Hugging Face;no feature-gated
-    core;managed-tier:none;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: huggingface/peft
+    governance:
+      value: Hugging Face
+    managed-tier:
+      value: none
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: Fully OSI-licensed (Apache-2.0), full source public, no proprietary tier.
   last_verified: '2026-08-09'
+  raw: license:Apache-2.0(OSI);source:public(huggingface/peft);governance:Hugging Face;no feature-gated
+    core;managed-tier:none;core-gated:ungated
   sources:
   - url: https://raw.githubusercontent.com/huggingface/peft/main/LICENSE
     shows: Full unmodified Apache License, Version 2.0 text, opening "Apache License / Version 2.0, January

--- a/sources/scores/perplexica.yaml
+++ b/sources/scores/perplexica.yaml
@@ -2,11 +2,25 @@ product: perplexica
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public(github.com/ItzCrazyKns/Vane);self-host:primary(single bundled Docker
-    image);no-feature-gated-core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+      detail: github.com/ItzCrazyKns/Vane
+    self-host:
+      value: primary
+      detail: single bundled Docker image
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   confidence: high
   note: Fully OSI-licensed (MIT), complete source public, self-hosting is the primary distribution via a
     bundled Docker image - a true open answer engine. No premium tier or gated functionality identified.
+  raw: license:MIT(OSI);source:public(github.com/ItzCrazyKns/Vane);self-host:primary(single bundled Docker
+    image);no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://github.com/ItzCrazyKns/Vane
     shows: MIT license; ~35k stars; open Perplexity-alternative answer engine (formerly Perplexica)

--- a/sources/scores/perplexity-sonar-api.yaml
+++ b/sources/scores/perplexity-sonar-api.yaml
@@ -2,10 +2,21 @@ product: perplexity-sonar-api
 openness:
   score: 1
   class: closed
-  components: license:Proprietary(API-only);source:closed(Sonar models, search index, ranking all proprietary);managed:cloud
-    SaaS, token + per-request pricing
+  components:
+    license:
+      value: Proprietary
+      detail: API-only
+    source:
+      value: closed
+      detail: Sonar models, search index, ranking all proprietary
+    managed:
+      value: cloud SaaS
+      detail: token + per-request pricing
+      raw: cloud SaaS, token + per-request pricing
   confidence: high
   note: Fully closed search-grounded API; no weights, source, or self-host path.
+  raw: license:Proprietary(API-only);source:closed(Sonar models, search index, ranking all proprietary);managed:cloud
+    SaaS, token + per-request pricing
   sources:
   - url: https://docs.perplexity.ai/
     shows: Sonar/Search/Embeddings APIs, token + per-request pricing, proprietary hosted service

--- a/sources/scores/perplexity.yaml
+++ b/sources/scores/perplexity.yaml
@@ -2,9 +2,20 @@ product: perplexity
 openness:
   score: 1
   class: closed
-  components: license:proprietary(SaaS);source:closed;self-host:none;models:multi-provider(closed orchestration)
+  components:
+    license:
+      value: proprietary
+      detail: SaaS
+    source:
+      value: closed
+    self-host:
+      value: none
+    models:
+      value: multi-provider
+      detail: closed orchestration
   confidence: high
   note: Proprietary SaaS chat/answer engine; closed counterpart on the shelf.
+  raw: license:proprietary(SaaS);source:closed;self-host:none;models:multi-provider(closed orchestration)
   sources:
   - url: https://www.perplexity.ai/
     shows: consumer AI answer/search chat product, proprietary SaaS (no source/self-host)

--- a/sources/scores/phoenix.yaml
+++ b/sources/scores/phoenix.yaml
@@ -2,14 +2,24 @@ product: phoenix
 openness:
   score: 2
   class: source_available
-  components: 'license:Elastic-License-2.0(ELv2, non-OSI: prohibits offering as a managed/hosted service
-    to third parties);source:public;self-hostable;commercial:Arize-AX-SaaS-is-separate-closed-product'
+  components:
+    license:
+      value: Elastic-License-2.0
+      detail: 'ELv2, non-OSI: prohibits offering as a managed/hosted service to third parties'
+    source:
+      value: public
+    commercial:
+      value: Arize-AX-SaaS-is-separate-closed-product
+    free_text:
+    - self-hostable
   confidence: high
   note: The LICENSE file is ELv2 verbatim, which is not an OSI license, while Arize markets Phoenix as "the
     open source platform" (open_washed). Source-available and self-hostable, with Arize AX as a separate
     closed SaaS product. Score corrected from 3 to 2 on 2026-07-30. The software ladder has rungs at 1,
     2, 4 and 5 and none at 3, so 3/source_available was not a pair any rule could produce; the ladder scores
     "you can read it and not run it freely" at 2.
+  raw: 'license:Elastic-License-2.0(ELv2, non-OSI: prohibits offering as a managed/hosted service to third
+    parties);source:public;self-hostable;commercial:Arize-AX-SaaS-is-separate-closed-product'
   sources:
   - url: https://github.com/Arize-ai/phoenix/blob/main/LICENSE
     shows: Elastic License 2.0 (ELv2) full text

--- a/sources/scores/pinecone.yaml
+++ b/sources/scores/pinecone.yaml
@@ -2,11 +2,22 @@ product: pinecone
 openness:
   score: 1
   class: closed
-  components: license:proprietary(SaaS);source:closed;self-host:none(BYOC runs Pinecone-managed in customer
-    VPC, not OSS);managed:Pinecone-Cloud
+  components:
+    license:
+      value: proprietary
+      detail: SaaS
+    source:
+      value: closed
+    self-host:
+      value: none
+      detail: BYOC runs Pinecone-managed in customer VPC, not OSS
+    managed:
+      value: Pinecone-Cloud
   confidence: high
   note: Fully proprietary managed vector DB; no open source core (contrast Milvus/Qdrant which are OSI-licensed).
     BYOC is still closed-source software run in customer cloud.
+  raw: license:proprietary(SaaS);source:closed;self-host:none(BYOC runs Pinecone-managed in customer VPC,
+    not OSS);managed:Pinecone-Cloud
   sources:
   - url: https://www.pinecone.io/pricing/
     shows: proprietary tiered SaaS pricing (Starter/Builder/Standard/Enterprise/BYOC); no OSS/self-host

--- a/sources/scores/poe.yaml
+++ b/sources/scores/poe.yaml
@@ -2,9 +2,20 @@ product: poe
 openness:
   score: 1
   class: closed
-  components: license:proprietary(SaaS);source:closed;self-host:none;models:multi-provider aggregation(closed)
+  components:
+    license:
+      value: proprietary
+      detail: SaaS
+    source:
+      value: closed
+    self-host:
+      value: none
+    models:
+      value: multi-provider aggregation
+      detail: closed
   confidence: high
   note: Proprietary multi-model chat aggregator; closed counterpart on the shelf.
+  raw: license:proprietary(SaaS);source:closed;self-host:none;models:multi-provider aggregation(closed)
   sources:
   - url: https://poe.com/about
     shows: proprietary multi-model chat aggregator (no source/self-host), Quora-affiliated

--- a/sources/scores/promptlayer.yaml
+++ b/sources/scores/promptlayer.yaml
@@ -2,12 +2,23 @@ product: promptlayer
 openness:
   score: 1
   class: closed
-  components: source:closed;license:Apache-2.0(OSI, client library MagnivOrg/prompt-layer-library
-    only);platform:proprietary-SaaS(API-key gated, hosted prompt
-    registry/logging/evals);self-host:no(managed only)
+  components:
+    source:
+      value: closed
+    license:
+      value: Apache-2.0
+      detail: OSI, client library MagnivOrg/prompt-layer-library only
+    platform:
+      value: proprietary-SaaS
+      detail: API-key gated, hosted prompt registry/logging/evals
+    self-host:
+      value: 'no'
+      detail: managed only
   confidence: high
   note: Open client SDK over a closed hosted backend (prompt CMS, logging, evals are SaaS), no OSS core,
     so 'closed' alongside the Braintrust/LangSmith pattern; the open library is instrumentation only.
+  raw: source:closed;license:Apache-2.0(OSI, client library MagnivOrg/prompt-layer-library only);platform:proprietary-SaaS(API-key
+    gated, hosted prompt registry/logging/evals);self-host:no(managed only)
   sources:
   - url: https://github.com/MagnivOrg/prompt-layer-library
     shows: Apache-2.0 official PromptLayer Python library; platform at promptlayer.com requiring API key

--- a/sources/scores/pydantic-ai.yaml
+++ b/sources/scores/pydantic-ai.yaml
@@ -2,9 +2,17 @@ product: pydantic-ai
 openness:
   score: 4
   class: open_core
-  components: license:MIT(library);commercial:Pydantic-Logfire;source:public
+  components:
+    license:
+      value: MIT
+      detail: library
+    commercial:
+      value: Pydantic-Logfire
+    source:
+      value: public
   confidence: high
   note: MIT type-first agent library with a commercial Logfire observability platform.
+  raw: license:MIT(library);commercial:Pydantic-Logfire;source:public
   sources:
   - url: https://github.com/pydantic/pydantic-ai
     shows: MIT, ~17.8k stars, Logfire integration

--- a/sources/scores/pyrit.yaml
+++ b/sources/scores/pyrit.yaml
@@ -2,9 +2,22 @@ product: pyrit
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public(full Python framework);self-host:yes;service:none;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+      detail: full Python framework
+    self-host:
+      value: 'yes'
+    service:
+      value: none
+    core-gated:
+      value: ungated
   confidence: high
   note: 'Fully open source: MIT-licensed automation framework, self-hostable, no proprietary tier.'
+  raw: license:MIT(OSI);source:public(full Python framework);self-host:yes;service:none;core-gated:ungated
   sources:
   - url: https://github.com/microsoft/PyRIT
     shows: MIT; open red-teaming framework from the Microsoft AI Red Team

--- a/sources/scores/qdrant.yaml
+++ b/sources/scores/qdrant.yaml
@@ -2,11 +2,24 @@ product: qdrant
 openness:
   score: 4
   class: open_core
-  components: license:Apache-2.0(OSI, engine core);source:public(Rust);managed-tier:Qdrant Cloud (hosted, paid + free
-    tier);core-gated:gated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI, engine core
+    source:
+      value: public
+      detail: Rust
+    managed-tier:
+      value: Qdrant Cloud
+      detail: hosted, paid + free tier
+      raw: Qdrant Cloud (hosted, paid + free tier)
+    core-gated:
+      value: gated
   confidence: high
   note: Engine core is Apache-2.0 OSI, but a managed Qdrant Cloud tier sits on top; recipe explicitly
     classes Qdrant Cloud as open_core, so scored 4 rather than the pure-OSS 5 the Milvus anchor carries.
+  raw: license:Apache-2.0(OSI, engine core);source:public(Rust);managed-tier:Qdrant Cloud (hosted, paid
+    + free tier);core-gated:gated
   sources:
   - url: https://github.com/qdrant/qdrant/blob/master/LICENSE
     shows: Apache-2.0 license text

--- a/sources/scores/ragflow.yaml
+++ b/sources/scores/ragflow.yaml
@@ -2,9 +2,23 @@ product: ragflow
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;self-host:primary(Docker);commercial:cloud/enterprise(separate);core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    self-host:
+      value: primary
+      detail: Docker
+    commercial:
+      value: cloud/enterprise
+      detail: separate
+    core-gated:
+      value: ungated
   confidence: high
   note: Apache-2.0 self-hostable engine; cloud is the commercial tier.
+  raw: license:Apache-2.0(OSI);source:public;self-host:primary(Docker);commercial:cloud/enterprise(separate);core-gated:ungated
   sources:
   - url: https://github.com/infiniflow/ragflow
     shows: Apache-2.0, ~83k stars, RAG engine

--- a/sources/scores/refinedweb.yaml
+++ b/sources/scores/refinedweb.yaml
@@ -2,10 +2,19 @@ product: refinedweb
 openness:
   score: 5
   class: open
-  components: license:ODC-BY-1.0;gated:false;dataset_card:present;note:public_extract
+  components:
+    license:
+      value: ODC-BY-1.0
+    gated:
+      value: 'false'
+    dataset_card:
+      value: present
+    note:
+      value: public_extract
   confidence: high
   note: Permissive ODC-BY 1.0 license, ungated download, with a dataset card (a public extract of the
     full corpus).
+  raw: license:ODC-BY-1.0;gated:false;dataset_card:present;note:public_extract
   sources:
   - url: https://huggingface.co/datasets/tiiuae/falcon-refinedweb
     shows: Dataset card, ODC-By 1.0 license, ungated public download

--- a/sources/scores/replit-agent-code-execution-api.yaml
+++ b/sources/scores/replit-agent-code-execution-api.yaml
@@ -2,15 +2,28 @@ product: replit-agent-code-execution-api
 openness:
   score: 1
   class: closed
-  components: license:Proprietary;source:closed;service:proprietary(Replit managed Autoscale Deployments, no
-    self-host);open-part:third-party isolation primitive omegajail(github.com/omegaup/omegajail) + an
-    ARCHIVED thin client (replit-code-exec, ISC, read-only since 2025-02-11);no self-hostable execution
-    service
+  components:
+    license:
+      value: Proprietary
+    source:
+      value: closed
+    service:
+      value: proprietary
+      detail: Replit managed Autoscale Deployments, no self-host
+    open-part:
+      value: third-party isolation primitive omegajail
+      detail: github.com/omegaup/omegajail) + an ARCHIVED thin client (replit-code-exec, ISC, read-only
+        since 2025-02-11
+    free_text:
+    - no self-hostable execution service
   confidence: medium
   note: 'Closed managed service. The sandbox primitive (omegajail) is open source but it is a third-party
     dependency, not Replit''s own open core, and the thin client is archived; there is no self-hostable
     open product, so an open dependency under a closed service is not open_core. Reclassified from open_core
     (borderline).'
+  raw: license:Proprietary;source:closed;service:proprietary(Replit managed Autoscale Deployments, no self-host);open-part:third-party
+    isolation primitive omegajail(github.com/omegaup/omegajail) + an ARCHIVED thin client (replit-code-exec,
+    ISC, read-only since 2025-02-11);no self-hostable execution service
   sources:
   - url: https://replit.com/blog/ai-agents-code-execution
     shows: Code Execution API uses omegajail (open source unprivileged container sandbox) on Replit's

--- a/sources/scores/replit-agent.yaml
+++ b/sources/scores/replit-agent.yaml
@@ -2,9 +2,17 @@ product: replit-agent
 openness:
   score: 1
   class: closed
-  components: source:closed;license:proprietary(Replit cloud SaaS);self-host:no
+  components:
+    source:
+      value: closed
+    license:
+      value: proprietary
+      detail: Replit cloud SaaS
+    self-host:
+      value: 'no'
   confidence: high
   note: Proprietary cloud agent embedded in Replit's hosted IDE; no source or self-hosting.
+  raw: source:closed;license:proprietary(Replit cloud SaaS);self-host:no
   sources:
   - url: https://replit.com/agent
     shows: Replit Agent 4 proprietary AI app-building product within Replit's cloud platform

--- a/sources/scores/searxng.yaml
+++ b/sources/scores/searxng.yaml
@@ -2,12 +2,26 @@ product: searxng
 openness:
   score: 5
   class: open_source
-  components: license:AGPL-3.0(OSI);source:public(github.com/searxng/searxng);self-host:only(no official
-    SaaS);reproducible-Docker-build;no-proprietary-backend;core-gated:ungated
+  components:
+    license:
+      value: AGPL-3.0
+      detail: OSI
+    source:
+      value: public
+      detail: github.com/searxng/searxng
+    self-host:
+      value: only
+      detail: no official SaaS
+    core-gated:
+      value: ungated
+    free_text:
+    - reproducible-Docker-build
+    - no-proprietary-backend
   confidence: high
   note: Fully open source under copyleft AGPL-3.0, complete source public, reproducible official Docker image,
     no proprietary backend or gated hosted tier - self-hosting (or community public instances) is the only
     distribution.
+  raw: license:AGPL-3.0(OSI);source:public(github.com/searxng/searxng);self-host:only(no official SaaS);reproducible-Docker-build;no-proprietary-backend;core-gated:ungated
   sources:
   - url: https://github.com/searxng/searxng
     shows: AGPL-3.0 license; ~32k stars; privacy metasearch engine, no tracking

--- a/sources/scores/serper.yaml
+++ b/sources/scores/serper.yaml
@@ -2,10 +2,19 @@ product: serper
 openness:
   score: 1
   class: closed
-  components: license:proprietary(API-only);source:closed;managed:Serper-Cloud(key-gated)
+  components:
+    license:
+      value: proprietary
+      detail: API-only
+    source:
+      value: closed
+    managed:
+      value: Serper-Cloud
+      detail: key-gated
   confidence: high
   note: Proprietary commercial SERP API; no source or self-host. Closed counterpart to OSS-adjacent search
     tools, like Tavily/Exa per the recipe.
+  raw: license:proprietary(API-only);source:closed;managed:Serper-Cloud(key-gated)
   sources:
   - url: https://serper.dev
     shows: commercial key-gated Google Search API, JSON output, 2,500 free queries then paid; no OSS license

--- a/sources/scores/sglang.yaml
+++ b/sources/scores/sglang.yaml
@@ -2,10 +2,19 @@ product: sglang
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;governance:LMSYS/PyTorch-ecosystem(community)
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    governance:
+      value: LMSYS/PyTorch-ecosystem
+      detail: community
   confidence: high
   note: license:Apache-2.0(OSI);source:public;governance:LMSYS/PyTorch-ecosystem(community)
   last_verified: '2026-08-09'
+  raw: license:Apache-2.0(OSI);source:public;governance:LMSYS/PyTorch-ecosystem(community)
   sources:
   - url: https://github.com/sgl-project/sglang
     shows: 'GitHub - sgl-project/sglang: SGLang is a high-performance serving framework for large language

--- a/sources/scores/smallpond.yaml
+++ b/sources/scores/smallpond.yaml
@@ -2,10 +2,22 @@ product: smallpond
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public(deepseek-ai/smallpond);governance:DeepSeek;no feature-gated
-    core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+      detail: deepseek-ai/smallpond
+    governance:
+      value: DeepSeek
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: Fully OSI-licensed (MIT), full source public.
+  raw: license:MIT(OSI);source:public(deepseek-ai/smallpond);governance:DeepSeek;no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/deepseek-ai/smallpond/blob/main/LICENSE
     shows: MIT License text (Copyright 2025 DeepSeek)

--- a/sources/scores/surfsense.yaml
+++ b/sources/scores/surfsense.yaml
@@ -2,11 +2,25 @@ product: surfsense
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(github.com/MODSetter/SurfSense);self-host:primary(Docker/Compose);no-feature-gated-core-found;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: github.com/MODSetter/SurfSense
+    self-host:
+      value: primary
+      detail: Docker/Compose
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core-found
   confidence: high
   note: Permissive OSI license (Apache-2.0), complete source public, self-host-first via Docker/Compose.
     No paid tier or gated features found on the repo or site (mild uncertainty - treated as fully open until
     a commercial tier appears).
+  raw: license:Apache-2.0(OSI);source:public(github.com/MODSetter/SurfSense);self-host:primary(Docker/Compose);no-feature-gated-core-found;core-gated:ungated
   sources:
   - url: https://github.com/MODSetter/SurfSense/blob/main/LICENSE
     shows: Apache License 2.0

--- a/sources/scores/syfthub.yaml
+++ b/sources/scores/syfthub.yaml
@@ -2,10 +2,21 @@ product: syfthub
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(github.com/OpenMined/syft-hub-sdk);self-host:yes;service:none
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: github.com/OpenMined/syft-hub-sdk
+    self-host:
+      value: 'yes'
+    service:
+      value: none
   confidence: high
   note: 'Fully open source: Apache-2.0 SDK, self-hostable, no proprietary tier. Built on OpenMined''s
     open Syft privacy stack.'
+  raw: license:Apache-2.0(OSI);source:public(github.com/OpenMined/syft-hub-sdk);self-host:yes;service:none
   sources:
   - url: https://github.com/OpenMined/syft-hub-sdk
     shows: Apache-2.0; federated RAG client SDK

--- a/sources/scores/tavily-search-api.yaml
+++ b/sources/scores/tavily-search-api.yaml
@@ -2,11 +2,22 @@ product: tavily-search-api
 openness:
   score: 1
   class: closed
-  components: license:Proprietary(API-only);source:closed(no self-hostable core; only thin client SDKs
-    are public);managed:cloud SaaS with API keys, credits, rate limits
+  components:
+    license:
+      value: Proprietary
+      detail: API-only
+    source:
+      value: closed
+      detail: no self-hostable core; only thin client SDKs are public
+    managed:
+      value: cloud SaaS with API keys
+      detail: credits, rate limits
+      raw: cloud SaaS with API keys, credits, rate limits
   confidence: high
   note: Closed search/scrape API (the recipe's closed counterpart to Milvus/Qdrant); only client SDKs
     are open, the search service itself is proprietary.
+  raw: license:Proprietary(API-only);source:closed(no self-hostable core; only thin client SDKs are public);managed:cloud
+    SaaS with API keys, credits, rate limits
   sources:
   - url: https://docs.tavily.com/
     shows: API keys, credits, rate limits, hosted endpoints, no self-hostable open core

--- a/sources/scores/tensorlake-sandbox.yaml
+++ b/sources/scores/tensorlake-sandbox.yaml
@@ -2,12 +2,23 @@ product: tensorlake-sandbox
 openness:
   score: 4
   class: open_core
-  components: license:Apache-2.0(OSI);source:public(runtime+SDK, BYOC self-host in your own
-    AWS/GCP/Azure);managed-tier:Tensorlake hosted cloud + proprietary Lattice scheduler;core-gated:gated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: runtime+SDK, BYOC self-host in your own AWS/GCP/Azure
+    managed-tier:
+      value: Tensorlake hosted cloud + proprietary Lattice scheduler
+    core-gated:
+      value: gated
   confidence: medium
   note: Apache-2.0 runtime and SDK with a genuine bring-your-own-cloud self-host path, plus a proprietary
     managed scheduler, so open-core on par with the permissive-Apache peers (E2B). The open part is permissive
     and self-hostable; the managed scheduler is the closed value-add.
+  raw: license:Apache-2.0(OSI);source:public(runtime+SDK, BYOC self-host in your own AWS/GCP/Azure);managed-tier:Tensorlake
+    hosted cloud + proprietary Lattice scheduler;core-gated:gated
   sources:
   - url: https://github.com/tensorlakeai/tensorlake
     shows: Apache-2.0 license; sandbox runtime + SDK (Python + Rust); BYOC self-host

--- a/sources/scores/text-generation-inference.yaml
+++ b/sources/scores/text-generation-inference.yaml
@@ -2,12 +2,24 @@ product: text-generation-inference
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;note:was briefly under restrictive HFOIL license in
-    2023, reverted to Apache-2.0; current LICENSE confirmed Apache-2.0
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    note:
+      value: was briefly under restrictive HFOIL license in 2023
+      detail: reverted to Apache-2.0
+      raw: was briefly under restrictive HFOIL license in 2023, reverted to Apache-2.0
+    free_text:
+    - current LICENSE confirmed Apache-2.0
   confidence: high
   note: Current LICENSE body re-read verbatim, still standard Apache-2.0 (not HFOIL). Repository page confirms
     'Public archive' visibility, so source remains public despite the archive.
   last_verified: '2026-08-09'
+  raw: license:Apache-2.0(OSI);source:public;note:was briefly under restrictive HFOIL license in 2023, reverted
+    to Apache-2.0; current LICENSE confirmed Apache-2.0
   sources:
   - url: https://github.com/huggingface/text-generation-inference/blob/main/LICENSE
     shows: Apache License Version 2.0, January 2004; Copyright 2022 Hugging Face

--- a/sources/scores/the-pile-pipeline.yaml
+++ b/sources/scores/the-pile-pipeline.yaml
@@ -2,10 +2,22 @@ product: the-pile-pipeline
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public(EleutherAI/the-pile);governance:EleutherAI;no feature-gated
-    core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+      detail: EleutherAI/the-pile
+    governance:
+      value: EleutherAI
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: Fully OSI-licensed (MIT), full source public.
+  raw: license:MIT(OSI);source:public(EleutherAI/the-pile);governance:EleutherAI;no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/EleutherAI/the-pile/blob/master/LICENSE
     shows: MIT License text

--- a/sources/scores/thunderbolt.yaml
+++ b/sources/scores/thunderbolt.yaml
@@ -2,11 +2,24 @@ product: thunderbolt
 openness:
   score: 5
   class: open_source
-  components: license:MPL-2.0(OSI);source:public(github.com/thunderbird/thunderbolt);self-host:primary(enterprise
-    self-hosting);governance:MZLA-Technologies(Mozilla-Foundation-subsidiary)
+  components:
+    license:
+      value: MPL-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: github.com/thunderbird/thunderbolt
+    self-host:
+      value: primary
+      detail: enterprise self-hosting
+    governance:
+      value: MZLA-Technologies
+      detail: Mozilla-Foundation-subsidiary
   confidence: high
   note: OSI-licensed (MPL-2.0), full source public from launch, designed primarily for self-hosting - a
     true open AI client.
+  raw: license:MPL-2.0(OSI);source:public(github.com/thunderbird/thunderbolt);self-host:primary(enterprise
+    self-hosting);governance:MZLA-Technologies(Mozilla-Foundation-subsidiary)
   sources:
   - url: https://github.com/thunderbird/thunderbolt
     shows: public source repo under MPL-2.0; "AI You Control" self-hosted client

--- a/sources/scores/tinyllama-chat.yaml
+++ b/sources/scores/tinyllama-chat.yaml
@@ -3,8 +3,22 @@ openness:
   score: 5
   class: open_source
   confidence: high
-  components: weights:open(Apache-2.0);base:TinyLlama-1.1B(open, 3T-token pretrain documented);post-training-data:open(SFT
-    on UltraChat + DPO on UltraFeedback, both public datasets);code:open(pretraining project public);license:Apache-2.0(OSI)
+  components:
+    weights:
+      value: open
+      detail: Apache-2.0
+    base:
+      value: TinyLlama-1.1B
+      detail: open, 3T-token pretrain documented
+    post-training-data:
+      value: open
+      detail: SFT on UltraChat + DPO on UltraFeedback, both public datasets
+    code:
+      value: open
+      detail: pretraining project public
+    license:
+      value: Apache-2.0
+      detail: OSI
   note: 'Unusually transparent for a chat model: open base, and named public alignment datasets (UltraChat SFT +
     UltraFeedback DPO). Corrected from 4 to 5 on 2026-07-29, and the post-training evidence moved out of a free-text
     `post-training` key into `post-training-data` so it carries a value the rubric can read. The old 4 rested on
@@ -12,6 +26,8 @@ openness:
     data -- what the tuner released -- and zephyr scores 5/open_source on these same two datasets while sitting
     on Mistral-7B, whose corpus is closed outright. Judging TinyLlama by its base while judging zephyr by its post-training
     set penalized the more open of the two bases. Strongest openness in this batch alongside Nemotron.'
+  raw: weights:open(Apache-2.0);base:TinyLlama-1.1B(open, 3T-token pretrain documented);post-training-data:open(SFT
+    on UltraChat + DPO on UltraFeedback, both public datasets);code:open(pretraining project public);license:Apache-2.0(OSI)
   sources:
   - url: https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0
     shows: Apache-2.0; base TinyLlama-1.1B; SFT on UltraChat + DPO on UltraFeedback

--- a/sources/scores/together-inference-engine.yaml
+++ b/sources/scores/together-inference-engine.yaml
@@ -2,8 +2,17 @@ product: together-inference-engine
 openness:
   score: 1
   class: closed
-  components: engine:proprietary(Together Inference Engine);source:closed(though Together publishes OSS
-    research e.g. FlashAttention/ThunderKittens separately);access:managed-cloud-API-only;license:Proprietary
+  components:
+    engine:
+      value: proprietary
+      detail: Together Inference Engine
+    source:
+      value: closed
+      detail: though Together publishes OSS research e.g. FlashAttention/ThunderKittens separately
+    access:
+      value: managed-cloud-API-only
+    license:
+      value: Proprietary
   confidence: high
   note: 'Re-confirmed today: no self-hostable implementation of the inference engine exists (serverless/dedicated
     pages describe a managed cloud API and ''Reserved, isolated GPU endpoints running Together''s proprietary
@@ -11,6 +20,8 @@ openness:
     access the service while Together reserves all IP. Both recorded dimensions (source, license) unchanged
     from the prior read.'
   last_verified: '2026-08-09'
+  raw: engine:proprietary(Together Inference Engine);source:closed(though Together publishes OSS research
+    e.g. FlashAttention/ThunderKittens separately);access:managed-cloud-API-only;license:Proprietary
   sources:
   - url: https://www.together.ai/inference
     shows: '"Pay-per-use access to 200+ open-source models across chat, image, video, code, and voice modalities.

--- a/sources/scores/torchtune.yaml
+++ b/sources/scores/torchtune.yaml
@@ -2,8 +2,19 @@ product: torchtune
 openness:
   score: 5
   class: open_source
-  components: license:BSD-3-Clause(OSI);source:public(pytorch/torchtune);governance:PyTorch Foundation/Meta;no managed
-    tier;core-gated:ungated
+  components:
+    license:
+      value: BSD-3-Clause
+      detail: OSI
+    source:
+      value: public
+      detail: pytorch/torchtune
+    governance:
+      value: PyTorch Foundation/Meta
+    core-gated:
+      value: ungated
+    free_text:
+    - no managed tier
   confidence: high
   note: Fully OSI-licensed (BSD-3-Clause), re-read from the raw LICENSE body rather than the GitHub classifier
     since this license is off the category's Apache-2.0 norm; text is clean, unmodified three-clause BSD
@@ -11,6 +22,8 @@ openness:
     pytorch/torchtune 301-redirects there). No enterprise/pricing directory found; openness unaffected by
     the project being wound down.
   last_verified: '2026-08-09'
+  raw: license:BSD-3-Clause(OSI);source:public(pytorch/torchtune);governance:PyTorch Foundation/Meta;no
+    managed tier;core-gated:ungated
   sources:
   - url: https://github.com/pytorch/torchtune
     shows: 'Redirects (final_url https://github.com/meta-pytorch/torchtune) to the repo now hosted under

--- a/sources/scores/trl.yaml
+++ b/sources/scores/trl.yaml
@@ -2,12 +2,26 @@ product: trl
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(huggingface/trl);governance:Hugging Face;no feature-gated
-    core;managed-tier:none;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: huggingface/trl
+    governance:
+      value: Hugging Face
+    managed-tier:
+      value: none
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: Fully OSI-licensed (Apache-2.0), full source public, no proprietary core or managed training SaaS
     gate.
   last_verified: '2026-08-08'
+  raw: license:Apache-2.0(OSI);source:public(huggingface/trl);governance:Hugging Face;no feature-gated core;managed-tier:none;core-gated:ungated
   sources:
   - url: https://github.com/huggingface/trl/blob/main/LICENSE
     shows: 'Rendered blob of the repository LICENSE. Body carries the full Apache License text: the heading

--- a/sources/scores/truthfulqa.yaml
+++ b/sources/scores/truthfulqa.yaml
@@ -2,10 +2,23 @@ product: truthfulqa
 openness:
   score: 5
   class: open
-  components: license:Apache-2.0(OSI/open,redistributable);access:public(not gated);datasheet:present(card+creation
-    methodology+citation);splits:public(817 Qs, two configs, no hidden held-out)
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI/open,redistributable
+    access:
+      value: public
+      detail: not gated
+    datasheet:
+      value: present
+      detail: card+creation methodology+citation
+    splits:
+      value: public
+      detail: 817 Qs, two configs, no hidden held-out
   confidence: high
   note: 'Fully open: Apache-2.0, ungated, redistributable, complete card with creation methodology.'
+  raw: license:Apache-2.0(OSI/open,redistributable);access:public(not gated);datasheet:present(card+creation
+    methodology+citation);splits:public(817 Qs, two configs, no hidden held-out)
   sources:
   - url: https://huggingface.co/datasets/truthfulqa/truthful_qa
     shows: Apache-2.0 license, not gated, 817 questions, dataset card present

--- a/sources/scores/ungoliant.yaml
+++ b/sources/scores/ungoliant.yaml
@@ -2,10 +2,23 @@ product: ungoliant
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(oscar-project/ungoliant);governance:OSCAR project;no feature-gated
-    core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: oscar-project/ungoliant
+    governance:
+      value: OSCAR project
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: Fully OSI-licensed (Apache-2.0), full source public.
+  raw: license:Apache-2.0(OSI);source:public(oscar-project/ungoliant);governance:OSCAR project;no feature-gated
+    core;core-gated:ungated
   sources:
   - url: https://github.com/oscar-project/ungoliant/blob/main/LICENSE
     shows: Apache License Version 2.0 text

--- a/sources/scores/v0.yaml
+++ b/sources/scores/v0.yaml
@@ -2,9 +2,17 @@ product: v0
 openness:
   score: 1
   class: closed
-  components: source:closed;license:proprietary(Vercel SaaS);self-host:no
+  components:
+    source:
+      value: closed
+    license:
+      value: proprietary
+      detail: Vercel SaaS
+    self-host:
+      value: 'no'
   confidence: high
   note: Proprietary Vercel product; closed source, subscription SaaS tied to Vercel deploy infra.
+  raw: source:closed;license:proprietary(Vercel SaaS);self-host:no
   sources:
   - url: https://v0.app/
     shows: proprietary Vercel agentic app builder, 'agentic by default', Opus 4.8 backbone

--- a/sources/scores/vercel-sandbox.yaml
+++ b/sources/scores/vercel-sandbox.yaml
@@ -2,14 +2,29 @@ product: vercel-sandbox
 openness:
   score: 1
   class: closed
-  components: source:closed;service:proprietary Vercel Fluid-compute managed cloud (no self-host of the Firecracker
-    microVM plane);open-part:client SDK/CLI only (@vercel/sandbox JS + Python, vercel/sandbox on
-    GitHub);license:Proprietary, proprietary service
+  components:
+    source:
+      value: closed
+    service:
+      value: proprietary Vercel Fluid-compute managed cloud
+      detail: no self-host of the Firecracker microVM plane
+      raw: proprietary Vercel Fluid-compute managed cloud (no self-host of the Firecracker microVM plane)
+    open-part:
+      value: client SDK/CLI only
+      detail: '@vercel/sandbox JS + Python, vercel/sandbox on GitHub'
+      raw: client SDK/CLI only (@vercel/sandbox JS + Python, vercel/sandbox on GitHub)
+    license:
+      value: Proprietary
+      detail: proprietary service
+      raw: Proprietary, proprietary service
   confidence: high
   note: 'Closed managed service. The SDK/CLI are open, but they are only a client for Vercel''s proprietary
     microVM cloud, which cannot be self-hosted; an open client over a closed runtime is not open_core (the
     core is proprietary). Reclassified from open_core; sits with the other proprietary sandbox clouds (Google
     Cloud Run, Fly Sprites, Northflank).'
+  raw: source:closed;service:proprietary Vercel Fluid-compute managed cloud (no self-host of the Firecracker
+    microVM plane);open-part:client SDK/CLI only (@vercel/sandbox JS + Python, vercel/sandbox on GitHub);license:Proprietary,
+    proprietary service
   sources:
   - url: https://vercel.com/docs/sandbox
     shows: Firecracker microVM isolation; SDK/CLI on GitHub vercel/sandbox; managed Vercel cloud, pay-for-active-CPU

--- a/sources/scores/verl.yaml
+++ b/sources/scores/verl.yaml
@@ -2,13 +2,26 @@ product: verl
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;governance:community(ByteDance-Seed origin);no feature-gated
-    core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    governance:
+      value: community
+      detail: ByteDance-Seed origin
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: 'Re-confirmed 2026-08-09: Apache-2.0 is the unmodified boilerplate license text; the full training/rollout
     source ships in the public repo (recipe/ is a public verl-project/verl-recipe submodule); no paid or
     enterprise tier withholds any method from the published source.'
   last_verified: '2026-08-09'
+  raw: license:Apache-2.0(OSI);source:public;governance:community(ByteDance-Seed origin);no feature-gated
+    core;core-gated:ungated
   sources:
   - url: https://raw.githubusercontent.com/volcengine/verl/main/LICENSE
     shows: 202-line, 11,358-byte plain-text Apache License, Version 2.0 (January 2004), unmodified through

--- a/sources/scores/vertex-ai-model-observability.yaml
+++ b/sources/scores/vertex-ai-model-observability.yaml
@@ -2,11 +2,20 @@ product: vertex-ai-model-observability
 openness:
   score: 1
   class: closed
-  components: license:proprietary(Google Cloud managed service);source:closed;note:tracing is built on
-    the open OTel standard but the observability product/service itself is proprietary and cloud-locked
+  components:
+    license:
+      value: proprietary
+      detail: Google Cloud managed service
+    source:
+      value: closed
+    note:
+      value: tracing is built on the open OTel standard but the observability product/service itself is
+        proprietary and cloud-locked
   confidence: high
   note: Proprietary GCP managed offering (Agent Engine + Cloud Trace/Monitoring/Logging). OTel is the
     wire standard but the service is closed and tied to Google Cloud.
+  raw: license:proprietary(Google Cloud managed service);source:closed;note:tracing is built on the open
+    OTel standard but the observability product/service itself is proprietary and cloud-locked
   sources:
   - url: https://docs.cloud.google.com/agent-builder/agent-engine/manage/tracing
     shows: Cloud Trace tracing for Agent Engine as a managed Google Cloud service

--- a/sources/scores/vertex-ai-tuning.yaml
+++ b/sources/scores/vertex-ai-tuning.yaml
@@ -2,13 +2,23 @@ product: vertex-ai-tuning
 openness:
   score: 1
   class: closed
-  components: source:closed;training-code:closed;runs-on:Google-Cloud-Vertex-AI-only;license:Proprietary(managed
-    GCP service)
+  components:
+    source:
+      value: closed
+    training-code:
+      value: closed
+    runs-on:
+      value: Google-Cloud-Vertex-AI-only
+    license:
+      value: Proprietary
+      detail: managed GCP service
   confidence: high
   note: Proprietary managed tuning service inside Google Cloud's Vertex AI generative-AI docs (now also
     mirrored under 'Gemini Enterprise Agent Platform' branding); no source, runs only on Google Cloud against
     closed Gemini models.
   last_verified: '2026-08-09'
+  raw: source:closed;training-code:closed;runs-on:Google-Cloud-Vertex-AI-only;license:Proprietary(managed
+    GCP service)
   sources:
   - url: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/tune-models
     shows: 'The tuning introduction page (redirected today to the canonical docs.cloud.google.com/gemini-enterprise-agent-platform/models/tuning)

--- a/sources/scores/vibethinker.yaml
+++ b/sources/scores/vibethinker.yaml
@@ -2,10 +2,22 @@ product: vibethinker
 openness:
   score: 3
   class: open_weights
-  components: weights:open(MIT);base:open_weights(Qwen2.5);data:partial(RL/SFT data not fully released);license:MIT
+  components:
+    weights:
+      value: open
+      detail: MIT
+    base:
+      value: open_weights
+      detail: Qwen2.5
+    data:
+      value: partial
+      detail: RL/SFT data not fully released
+    license:
+      value: MIT
   confidence: medium
   note: MIT-licensed weights, but a fine-tune of the open-weight Qwen2.5 line without a fully open/reproducible
     data+training pipeline -> open_weights tier, not open_source.
+  raw: weights:open(MIT);base:open_weights(Qwen2.5);data:partial(RL/SFT data not fully released);license:MIT
   sources:
   - url: https://huggingface.co/WeiboAI/VibeThinker-3B
     shows: VibeThinker-3B; MIT license; fine-tuned from Qwen2.5-3B / Qwen2.5-Coder-3B

--- a/sources/scores/vllm.yaml
+++ b/sources/scores/vllm.yaml
@@ -2,13 +2,24 @@ product: vllm
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;core-gated:ungated;governance:vLLM-project(community,PyTorch-ecosystem
-    adjacent)
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    governance:
+      value: vLLM-project
+      detail: community,PyTorch-ecosystem adjacent
   confidence: high
   note: Apache-2.0 across the repo, re-confirmed today against the LICENSE body. The published tree is the
     full engine with no commercial edition or enterprise-licensed directory, so nothing is gated out of
     the source. Governance sits with the vLLM project community, adjacent to the PyTorch ecosystem.
   last_verified: '2026-08-09'
+  raw: license:Apache-2.0(OSI);source:public;core-gated:ungated;governance:vLLM-project(community,PyTorch-ecosystem
+    adjacent)
   sources:
   - url: https://github.com/vllm-project/vllm
     shows: Public repository vllm-project/vllm, described as "A high-throughput and memory-efficient inference

--- a/sources/scores/wildguard.yaml
+++ b/sources/scores/wildguard.yaml
@@ -2,11 +2,23 @@ product: wildguard
 openness:
   score: 4
   class: open_weights
-  components: weights:open(allenai/wildguard on HF);data:open(WildGuardMix corpus public);base:Mistral-7B;license:Apache-2.0(OSI)
+  components:
+    weights:
+      value: open
+      detail: allenai/wildguard on HF
+    data:
+      value: open
+      detail: WildGuardMix corpus public
+    base:
+      value: Mistral-7B
+    license:
+      value: Apache-2.0
+      detail: OSI
   confidence: medium
   note: Open weights under Apache-2.0 with the WildGuardMix training corpus published; from Ai2, which
     sits at the open end of the spectrum. Scored open_weights (4); a strong open release, just short of
     the full open_source pipeline tier.
+  raw: weights:open(allenai/wildguard on HF);data:open(WildGuardMix corpus public);base:Mistral-7B;license:Apache-2.0(OSI)
   sources:
   - url: https://huggingface.co/allenai/wildguard
     shows: Apache-2.0; 7B Mistral fine-tune; prompt/response/refusal detection; open WildGuardMix corpus;

--- a/sources/scores/windsurf.yaml
+++ b/sources/scores/windsurf.yaml
@@ -2,9 +2,17 @@ product: windsurf
 openness:
   score: 1
   class: closed
-  components: source:closed;license:proprietary(SaaS, Cognition);self-host:no
+  components:
+    source:
+      value: closed
+    license:
+      value: proprietary
+      detail: SaaS, Cognition
+    self-host:
+      value: 'no'
   confidence: high
   note: Proprietary agentic IDE; now part of Cognition's Devin Desktop. Closed source, subscription SaaS.
+  raw: source:closed;license:proprietary(SaaS, Cognition);self-host:no
   sources:
   - url: https://devin.ai/desktop
     shows: Windsurf rebranded as Devin Desktop, proprietary agentic IDE (Cognition)

--- a/sources/scores/zentropi-cope.yaml
+++ b/sources/scores/zentropi-cope.yaml
@@ -2,11 +2,21 @@ product: zentropi-cope
 openness:
   score: 3
   class: open_weights
-  components: weights:open(zentropi-ai/cope-a-9b on HF);base:Gemma-2-9B(LoRA);license:zentropi-openrail-m(OpenRAIL-M,
-    use-restricted, NOT OSI)
+  components:
+    weights:
+      value: open
+      detail: zentropi-ai/cope-a-9b on HF
+    base:
+      value: Gemma-2-9B
+      detail: LoRA
+    license:
+      value: zentropi-openrail-m
+      detail: OpenRAIL-M, use-restricted, NOT OSI
   confidence: medium
   note: Open weights and self-hostable, but under an OpenRAIL-M license with use restrictions (e.g. surveillance),
     which is not OSI-approved, so open_weights (3).
+  raw: weights:open(zentropi-ai/cope-a-9b on HF);base:Gemma-2-9B(LoRA);license:zentropi-openrail-m(OpenRAIL-M,
+    use-restricted, NOT OSI)
   sources:
   - url: https://huggingface.co/zentropi-ai/cope-a-9b
     shows: zentropi-openrail-m (OpenRAIL-M, use-restricted); open weights; Gemma-2-9B LoRA; policy-adaptive


### PR DESCRIPTION
## Summary

Fourth batch of the structured-components migration: the 144 records that record at least one key no ladder declares, where every such key is one of the 22 that recur five or more times across the corpus.

Corpus-wide there are 413 such clauses under 118 keys across 254 files; the 22 recurring keys cover 267 of the 413.

**Every undeclared key carries through under its own name, unchanged.** Nothing promoted, demoted or renamed — each of those changes what a ladder reads, and this phase changes no claims. A key no dimension declares or `reads` is dropped from the score silently today, so carrying them through unchanged keeps them exactly as inert as they were. What to do with each one is asked in #188.

`self-host` is the one worth naming: 54 clauses, and almost certainly the same fact as `core-gated` recorded under a second name. That is a disposition for #188 to settle, not something to act on inside a reshape.

## Zero published numbers move

```
git diff --numstat build/notebook_data.json
1  1  build/notebook_data.json
```

At a committed head, which is the only state where this check means anything.

## Test plan

- Population re-derived from the corpus: 144, with 254 / 118 / 413 / 267 all reproducing.
- Key sets compared before and after on all 144: identical on every file. Also re-checked across all 352 records migrated to date: 352/352 identical.
- `check_recipe`'s undeclared-key context lines are byte-identical before and after, which is what confirms nothing was promoted or renamed.
- Every edit through `build/components.py`, never a text substitution — 278 of 472 score files fold `components` across lines.
- Suite 431 passed. `validate` 0 error(s), `check_recipe` 0 failure(s), `check_rubric` exit 0, `check_components` `[OK]`.
