### PR TITLE
refactor(scores): migrate the 102 records with long-tail undeclared keys

### DIFF
--- a/sources/scores/agent-infra-sandbox.yaml
+++ b/sources/scores/agent-infra-sandbox.yaml
@@ -2,11 +2,24 @@ product: agent-infra-sandbox
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(GitHub);packaging:self-hostable Docker image + K8s deploy
-    examples;no feature-gated core observed;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: GitHub
+    packaging:
+      value: self-hostable Docker image + K8s deploy examples
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core observed
   confidence: high
   note: Apache-2.0, fully self-hostable single-container runtime; no separate proprietary/managed tier
     gating the core.
+  raw: license:Apache-2.0(OSI);source:public(GitHub);packaging:self-hostable Docker image + K8s deploy examples;no
+    feature-gated core observed;core-gated:ungated
   sources:
   - url: https://github.com/agent-infra/sandbox
     shows: Apache-2.0 license, single-Docker-container all-in-one agent sandbox, self-hostable

--- a/sources/scores/algolia-ai-search.yaml
+++ b/sources/scores/algolia-ai-search.yaml
@@ -2,10 +2,22 @@ product: algolia-ai-search
 openness:
   score: 1
   class: closed
-  components: license:proprietary(SaaS, API-first);source:closed(search engine core);oss:client/UI-libraries-only(InstantSearch);managed:Algolia-Cloud
+  components:
+    license:
+      value: proprietary
+      detail: SaaS, API-first
+    source:
+      value: closed
+      detail: search engine core
+    oss:
+      value: client/UI-libraries-only
+      detail: InstantSearch
+    managed:
+      value: Algolia-Cloud
   confidence: high
   note: Closed proprietary hosted search engine; only client/UI integration libraries are open. Core ranking/index
     engine is not OSS or self-hostable.
+  raw: license:proprietary(SaaS, API-first);source:closed(search engine core);oss:client/UI-libraries-only(InstantSearch);managed:Algolia-Cloud
   sources:
   - url: https://www.algolia.com/products/ai-search/
     shows: proprietary API-first cloud search platform; OSS limited to client/integration libraries

--- a/sources/scores/amazon-bedrock-evaluations.yaml
+++ b/sources/scores/amazon-bedrock-evaluations.yaml
@@ -2,10 +2,22 @@ product: amazon-bedrock-evaluations
 openness:
   score: 1
   class: closed
-  components: license:proprietary(AWS managed service);source:closed;deployment:cloud-only(AWS-hosted
-    eval jobs, S3 I/O);billing:pay-as-you-go(judge-model inference + AWS-managed human workforce)
+  components:
+    license:
+      value: proprietary
+      detail: AWS managed service
+    source:
+      value: closed
+    deployment:
+      value: cloud-only
+      detail: AWS-hosted eval jobs, S3 I/O
+    billing:
+      value: pay-as-you-go
+      detail: judge-model inference + AWS-managed human workforce
   confidence: high
   note: Proprietary AWS managed service; no source, no self-host, runs as billed Bedrock evaluation jobs.
+  raw: license:proprietary(AWS managed service);source:closed;deployment:cloud-only(AWS-hosted eval jobs,
+    S3 I/O);billing:pay-as-you-go(judge-model inference + AWS-managed human workforce)
   sources:
   - url: https://docs.aws.amazon.com/bedrock/latest/userguide/evaluation.html
     shows: managed Bedrock service running automatic/judge/human eval jobs on AWS, CORS S3 I/O, CloudTrail

--- a/sources/scores/anyscale-fine-tuning.yaml
+++ b/sources/scores/anyscale-fine-tuning.yaml
@@ -2,8 +2,20 @@ product: anyscale-fine-tuning
 openness:
   score: 1
   class: closed
-  components: license:proprietary(Anyscale-platform-only);source:not-public;built-on:Ray+DeepSpeed+HF-Accelerate(OSS
-    deps) but LLMForge itself not redistributable;methods:LoRA+full-FT;status:deprecated
+  components:
+    license:
+      value: proprietary
+      detail: Anyscale-platform-only
+    source:
+      value: not-public
+    built-on:
+      value: Ray+DeepSpeed+HF-Accelerate
+      detail: OSS deps) but LLMForge itself not redistributable
+      raw: Ray+DeepSpeed+HF-Accelerate(OSS deps) but LLMForge itself not redistributable
+    methods:
+      value: LoRA+full-FT
+    status:
+      value: deprecated
   confidence: high
   note: 'LLMForge, Anyscale''s own fine-tuning library, has been fully retired and is absent from current
     docs; Anyscale''s fine-tuning capability continues live, now orchestrating open frameworks (LLaMA-Factory,
@@ -11,6 +23,8 @@ openness:
     of Service define it as a proprietary SaaS delivered in object code only, so openness follows the platform,
     not the open frameworks running underneath it.'
   last_verified: '2026-08-09'
+  raw: license:proprietary(Anyscale-platform-only);source:not-public;built-on:Ray+DeepSpeed+HF-Accelerate(OSS
+    deps) but LLMForge itself not redistributable;methods:LoRA+full-FT;status:deprecated
   sources:
   - url: https://www.anyscale.com/terms
     shows: Terms of Service defines the delivered product, "Platform Services", as Anyscale's own proprietary

--- a/sources/scores/apps.yaml
+++ b/sources/scores/apps.yaml
@@ -2,11 +2,25 @@ product: apps
 openness:
   score: 5
   class: open
-  components: data:downloadable(HF parquet, codeparrot/apps);license:MIT(OSI/open);datasheet:present(card
-    documents 10k problems, 131,777 tests, difficulty levels, schema);redistributable:yes;paper:public(NeurIPS
-    2021)
+  components:
+    data:
+      value: downloadable
+      detail: HF parquet, codeparrot/apps
+    license:
+      value: MIT
+      detail: OSI/open
+    datasheet:
+      value: present
+      detail: card documents 10k problems, 131,777 tests, difficulty levels, schema
+    redistributable:
+      value: 'yes'
+    paper:
+      value: public
+      detail: NeurIPS 2021
   confidence: high
   note: 'Clean open data: MIT, downloadable, documented datasheet, public paper: full open class.'
+  raw: data:downloadable(HF parquet, codeparrot/apps);license:MIT(OSI/open);datasheet:present(card documents
+    10k problems, 131,777 tests, difficulty levels, schema);redistributable:yes;paper:public(NeurIPS 2021)
   sources:
   - url: https://huggingface.co/datasets/codeparrot/apps
     shows: MIT license, 10,000 problems, 131,777 test cases, 13,834 monthly downloads

--- a/sources/scores/arize.yaml
+++ b/sources/scores/arize.yaml
@@ -2,11 +2,25 @@ product: arize
 openness:
   score: 1
   class: closed
-  components: license:Proprietary;weights:n/a;source:closed(proprietary SaaS);self-host:none for core AX
-    features;note:open source Phoenix is a separate companion product, not the AX platform
+  components:
+    license:
+      value: Proprietary
+    weights:
+      value: n/a
+    source:
+      value: closed
+      detail: proprietary SaaS
+    self-host:
+      value: none for core AX features
+    note:
+      value: open source Phoenix is a separate companion product
+      detail: not the AX platform
+      raw: open source Phoenix is a separate companion product, not the AX platform
   confidence: high
   note: Arize AX is closed/proprietary SaaS with no self-hostable core; only the separate Phoenix project
     is source-available.
+  raw: license:Proprietary;weights:n/a;source:closed(proprietary SaaS);self-host:none for core AX features;note:open
+    source Phoenix is a separate companion product, not the AX platform
   sources:
   - url: https://arize.com/
     shows: '''enterprise AI engineering platform''; closed AX with proprietary Alyx agent + adb datastore;

--- a/sources/scores/artificial-analysis-intelligence-index.yaml
+++ b/sources/scores/artificial-analysis-intelligence-index.yaml
@@ -2,11 +2,24 @@ product: artificial-analysis-intelligence-index
 openness:
   score: 2
   class: source_available
-  components: platform:closed(proprietary benchmarking site + methodology); source:partial(Stirrup covers
-    one of ten evals; the Index pipeline does not ship); methodology:documented(public methodology page,
-    per-eval breakdown, temp/token params); datasets:closed(maintains internal copies of all eval datasets);
-    harness:partial-open(Stirrup MIT, used for the agentic GDPval-AA eval only, 413 stars); the full Intelligence
-    Index harness is not open
+  components:
+    platform:
+      value: closed
+      detail: proprietary benchmarking site + methodology
+    source:
+      value: partial
+      detail: Stirrup covers one of ten evals; the Index pipeline does not ship
+    methodology:
+      value: documented
+      detail: public methodology page, per-eval breakdown, temp/token params
+    datasets:
+      value: closed
+      detail: maintains internal copies of all eval datasets
+    harness:
+      value: partial-open
+      detail: Stirrup MIT, used for the agentic GDPval-AA eval only, 413 stars
+    free_text:
+    - the full Intelligence Index harness is not open
   confidence: high
   note: 'Methodology is well documented and one component harness (Stirrup) is MIT, but the Index itself
     (pipeline, internal dataset copies, grader config) is proprietary. The earlier note reasoned "not source_available
@@ -16,6 +29,11 @@ openness:
     with functionality withheld for a paid tier, and there is no open core here, only an open periphery.
     A repo that exists while the runtime does not ship is source:partial, which the ladder scores 2/source_available.
     The score itself was already 2.'
+  raw: platform:closed(proprietary benchmarking site + methodology); source:partial(Stirrup covers one of
+    ten evals; the Index pipeline does not ship); methodology:documented(public methodology page, per-eval
+    breakdown, temp/token params); datasets:closed(maintains internal copies of all eval datasets); harness:partial-open(Stirrup
+    MIT, used for the agentic GDPval-AA eval only, 413 stars); the full Intelligence Index harness is not
+    open
   sources:
   - url: https://artificialanalysis.ai/methodology/intelligence-benchmarking
     shows: v4.0.4 (Mar 2026), 10-eval composite, internal copies of all datasets, standardized params

--- a/sources/scores/atropos.yaml
+++ b/sources/scores/atropos.yaml
@@ -2,12 +2,26 @@ product: atropos
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public;scope:async RL-environments framework + trajectory API; trainer-integrations:Axolotl/Tinker;
-    no feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+    scope:
+      value: async RL-environments framework + trajectory API
+    trainer-integrations:
+      value: Axolotl/Tinker
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: Fully OSI-licensed (MIT) and public, no managed/closed core. Fits finetuning_code as the RL-training-environment
     layer (RLHF/RLAIF/GRPO).
   last_verified: '2026-08-08'
+  raw: license:MIT(OSI);source:public;scope:async RL-environments framework + trajectory API; trainer-integrations:Axolotl/Tinker;
+    no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/NousResearch/atropos
     shows: 'Repo page carries the label "Public archive" and the banner "This repository was archived by

--- a/sources/scores/autogen.yaml
+++ b/sources/scores/autogen.yaml
@@ -2,9 +2,21 @@ product: autogen
 openness:
   score: 5
   class: open_source
-  components: license:MIT(code,via LICENSE-CODE);docs:CC-BY-4.0;source:public;no-feature-gated-core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: code,via LICENSE-CODE
+    docs:
+      value: CC-BY-4.0
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   confidence: high
   note: Code is MIT and fully open; the GitHub-surfaced CC-BY-4.0 is only the docs license.
+  raw: license:MIT(code,via LICENSE-CODE);docs:CC-BY-4.0;source:public;no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://github.com/microsoft/autogen/blob/main/LICENSE-CODE
     shows: MIT code license

--- a/sources/scores/aws-lambda.yaml
+++ b/sources/scores/aws-lambda.yaml
@@ -2,12 +2,25 @@ product: aws-lambda
 openness:
   score: 1
   class: closed
-  components: license:Proprietary;service:proprietary AWS-only SaaS (no self-host);underlying-microVM:Firecracker is
-    Apache-2.0 OSS but the Lambda control/data plane is closed;weights:n/a;source:closed
+  components:
+    license:
+      value: Proprietary
+    service:
+      value: proprietary AWS-only SaaS
+      detail: no self-host
+      raw: proprietary AWS-only SaaS (no self-host)
+    underlying-microVM:
+      value: Firecracker is Apache-2.0 OSS but the Lambda control/data plane is closed
+    weights:
+      value: n/a
+    source:
+      value: closed
   confidence: high
   note: Lambda is a proprietary managed serverless service (closed), per recipe's explicit 'Lambda as
     closed counterpart'. Firecracker (the microVM substrate) is separately open source but is a different
     artifact; Lambda itself is not self-hostable.
+  raw: license:Proprietary;service:proprietary AWS-only SaaS (no self-host);underlying-microVM:Firecracker
+    is Apache-2.0 OSS but the Lambda control/data plane is closed;weights:n/a;source:closed
   sources:
   - url: https://aws.amazon.com/blogs/aws/firecracker-lightweight-virtualization-for-serverless-computing/
     shows: Firecracker microVM powers Lambda; Lambda is AWS-managed proprietary service

--- a/sources/scores/azure-ai-model-inference.yaml
+++ b/sources/scores/azure-ai-model-inference.yaml
@@ -2,10 +2,20 @@ product: azure-ai-model-inference
 openness:
   score: 1
   class: closed
-  components: license:proprietary(Azure managed service);source:closed;interface:OpenAI-compatible REST
-    endpoint over Foundry model deployments;hardware:Azure-managed
+  components:
+    license:
+      value: proprietary
+      detail: Azure managed service
+    source:
+      value: closed
+    interface:
+      value: OpenAI-compatible REST endpoint over Foundry model deployments
+    hardware:
+      value: Azure-managed
   confidence: high
   note: Fully proprietary managed Azure service; no source released. Scored closed.
+  raw: license:proprietary(Azure managed service);source:closed;interface:OpenAI-compatible REST endpoint
+    over Foundry model deployments;hardware:Azure-managed
   sources:
   - url: https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/endpoints
     shows: single managed Azure inference endpoint over model deployments; proprietary Azure resource,

--- a/sources/scores/azure-content-safety.yaml
+++ b/sources/scores/azure-content-safety.yaml
@@ -2,10 +2,22 @@ product: azure-content-safety
 openness:
   score: 1
   class: closed
-  components: service:proprietary managed Azure service(no self-host);features:text/image moderation, prompt
-    shields, groundedness;source:closed;license:proprietary
+  components:
+    service:
+      value: proprietary managed Azure service
+      detail: no self-host
+    features:
+      value: text/image moderation
+      detail: prompt shields, groundedness
+      raw: text/image moderation, prompt shields, groundedness
+    source:
+      value: closed
+    license:
+      value: proprietary
   confidence: high
   note: Closed managed cloud service; no weights or source.
+  raw: service:proprietary managed Azure service(no self-host);features:text/image moderation, prompt shields,
+    groundedness;source:closed;license:proprietary
   sources:
   - url: https://azure.microsoft.com/en-us/products/ai-services/ai-content-safety
     shows: 'managed content-safety APIs: moderation, prompt shields, groundedness; proprietary'

--- a/sources/scores/bedrock-guardrails.yaml
+++ b/sources/scores/bedrock-guardrails.yaml
@@ -2,10 +2,22 @@ product: bedrock-guardrails
 openness:
   score: 1
   class: closed
-  components: service:proprietary managed AWS service(no self-host);features:denied topics, content filters,
-    PII redaction, contextual grounding;source:closed;license:proprietary
+  components:
+    service:
+      value: proprietary managed AWS service
+      detail: no self-host
+    features:
+      value: denied topics
+      detail: content filters, PII redaction, contextual grounding
+      raw: denied topics, content filters, PII redaction, contextual grounding
+    source:
+      value: closed
+    license:
+      value: proprietary
   confidence: high
   note: Closed managed cloud service; no weights or source.
+  raw: service:proprietary managed AWS service(no self-host);features:denied topics, content filters, PII
+    redaction, contextual grounding;source:closed;license:proprietary
   sources:
   - url: https://aws.amazon.com/bedrock/guardrails/
     shows: 'managed guardrails: denied topics, content filters, PII redaction, grounding; proprietary'

--- a/sources/scores/chatbot-arena.yaml
+++ b/sources/scores/chatbot-arena.yaml
@@ -2,11 +2,24 @@ product: chatbot-arena
 openness:
   score: 2
   class: source_available
-  components: platform:closed(hosted arena.ai, proprietary live leaderboard + private vote data); source:partial(FastChat
-    is a real arena implementation but stale relative to the operating platform; the current ranking pipeline
-    does not ship); reference-code:FastChat Apache-2.0 (powers Chatbot Arena but stale, last release Feb
-    2024, 39.5k stars); aux-OSS:Arena-Hard-Auto Apache-2.0 (automatic LLM eval, highest correlation to LMArena);
-    ranking methodology + crowd-vote dataset not fully open
+  components:
+    platform:
+      value: closed
+      detail: hosted arena.ai, proprietary live leaderboard + private vote data
+    source:
+      value: partial
+      detail: FastChat is a real arena implementation but stale relative to the operating platform; the
+        current ranking pipeline does not ship
+    reference-code:
+      value: FastChat Apache-2.0
+      detail: powers Chatbot Arena but stale, last release Feb 2024, 39.5k stars
+      raw: FastChat Apache-2.0 (powers Chatbot Arena but stale, last release Feb 2024, 39.5k stars)
+    aux-OSS:
+      value: Arena-Hard-Auto Apache-2.0
+      detail: automatic LLM eval, highest correlation to LMArena
+      raw: Arena-Hard-Auto Apache-2.0 (automatic LLM eval, highest correlation to LMArena)
+    free_text:
+    - ranking methodology + crowd-vote dataset not fully open
   confidence: medium
   note: 'Scored as the hosted platform: the live evaluation product, its vote stream and the current ranking
     pipeline are closed, while substantial OSS heritage (FastChat) and an OSS automatic-eval companion (Arena-Hard-Auto)
@@ -16,6 +29,11 @@ openness:
     for a paid tier, and there is no open core here, only an open periphery. A repo that exists while the
     runtime does not ship is source:partial, which the ladder scores 2/source_available. The score itself
     was already 2.'
+  raw: platform:closed(hosted arena.ai, proprietary live leaderboard + private vote data); source:partial(FastChat
+    is a real arena implementation but stale relative to the operating platform; the current ranking pipeline
+    does not ship); reference-code:FastChat Apache-2.0 (powers Chatbot Arena but stale, last release Feb
+    2024, 39.5k stars); aux-OSS:Arena-Hard-Auto Apache-2.0 (automatic LLM eval, highest correlation to LMArena);
+    ranking methodology + crowd-vote dataset not fully open
   sources:
   - url: https://github.com/lm-sys/FastChat
     shows: Apache-2.0; 'FastChat powers Chatbot Arena (lmarena.ai), serving over 10M chat requests for

--- a/sources/scores/cloudflare-sandboxes.yaml
+++ b/sources/scores/cloudflare-sandboxes.yaml
@@ -2,14 +2,31 @@ product: cloudflare-sandboxes
 openness:
   score: 1
   class: closed
-  components: license:Proprietary;source:closed;service:proprietary Cloudflare edge (Workers/Durable Objects/Dynamic
-    Worker Loader - no self-host of the isolate/container plane);open-part:Sandbox SDK only
-    (@cloudflare/sandbox Apache-2.0, cloudflare/sandbox-sdk on GitHub);pricing:Workers paid plan, Dynamic
-    Workers $0.002/unique-worker/day
+  components:
+    license:
+      value: Proprietary
+    source:
+      value: closed
+    service:
+      value: proprietary Cloudflare edge
+      detail: Workers/Durable Objects/Dynamic Worker Loader - no self-host of the isolate/container plane
+      raw: proprietary Cloudflare edge (Workers/Durable Objects/Dynamic Worker Loader - no self-host of
+        the isolate/container plane)
+    open-part:
+      value: Sandbox SDK only
+      detail: '@cloudflare/sandbox Apache-2.0, cloudflare/sandbox-sdk on GitHub'
+      raw: Sandbox SDK only (@cloudflare/sandbox Apache-2.0, cloudflare/sandbox-sdk on GitHub)
+    pricing:
+      value: Workers paid plan
+      detail: Dynamic Workers $0.002/unique-worker/day
+      raw: Workers paid plan, Dynamic Workers $0.002/unique-worker/day
   confidence: high
   note: 'Closed managed service. The Sandbox SDK is Apache-2.0, but execution requires Cloudflare''s proprietary
     managed edge network (no self-host of the isolate/container plane); an open client SDK over a closed
     runtime is not open_core. Reclassified from open_core.'
+  raw: license:Proprietary;source:closed;service:proprietary Cloudflare edge (Workers/Durable Objects/Dynamic
+    Worker Loader - no self-host of the isolate/container plane);open-part:Sandbox SDK only (@cloudflare/sandbox
+    Apache-2.0, cloudflare/sandbox-sdk on GitHub);pricing:Workers paid plan, Dynamic Workers $0.002/unique-worker/day
   sources:
   - url: https://github.com/cloudflare/sandbox-sdk
     shows: Apache-2.0 SDK; runs on Cloudflare Containers/Workers/Durable Objects (managed edge)

--- a/sources/scores/codecontests.yaml
+++ b/sources/scores/codecontests.yaml
@@ -2,12 +2,27 @@ product: codecontests
 openness:
   score: 5
   class: open
-  components: license:CC-BY-4.0(open data license, attribution-only);redistributability:full(downloadable,
-    ungated);datasheet:yes(comprehensive dataset card + arXiv:2203.07814);size:~4k problems w/ rich test
-    cases;sources:Codeforces/AtCoder/CodeChef/Aizu/HackerEarth + Description2Code(MIT)+CodeNet(Apache-2.0)
+  components:
+    license:
+      value: CC-BY-4.0
+      detail: open data license, attribution-only
+    redistributability:
+      value: full
+      detail: downloadable, ungated
+    datasheet:
+      value: 'yes'
+      detail: comprehensive dataset card + arXiv:2203.07814
+    size:
+      value: ~4k problems w/ rich test cases
+    sources:
+      value: Codeforces/AtCoder/CodeChef/Aizu/HackerEarth + Description2Code
+      detail: MIT)+CodeNet(Apache-2.0
   confidence: high
   note: 'Fully open: CC-BY-4.0, ungated, downloadable, with a thorough datasheet documenting provenance.
     Clean open-data case on the dataset-openness path.'
+  raw: license:CC-BY-4.0(open data license, attribution-only);redistributability:full(downloadable, ungated);datasheet:yes(comprehensive
+    dataset card + arXiv:2203.07814);size:~4k problems w/ rich test cases;sources:Codeforces/AtCoder/CodeChef/Aizu/HackerEarth
+    + Description2Code(MIT)+CodeNet(Apache-2.0)
   sources:
   - url: https://huggingface.co/datasets/deepmind/code_contests
     shows: CC-BY-4.0 license; not gated; 3,760 train/117 val/165 test (4,044 total); dataset card present;

--- a/sources/scores/coder-oss.yaml
+++ b/sources/scores/coder-oss.yaml
@@ -2,11 +2,22 @@ product: coder-oss
 openness:
   score: 4
   class: open_core
-  components: license:AGPL-3.0(OSI, Community Edition);source:public(GitHub);commercial-tier:Premium/Enterprise paid
-    features for large teams under separate Coder enterprise license;core-gated:gated
+  components:
+    license:
+      value: AGPL-3.0
+      detail: OSI, Community Edition
+    source:
+      value: public
+      detail: GitHub
+    commercial-tier:
+      value: Premium/Enterprise paid features for large teams under separate Coder enterprise license
+    core-gated:
+      value: gated
   confidence: high
   note: AGPL-3.0 OSI core (Community Edition) with a separate proprietary Premium/Enterprise tier => open_core,
     calibrated identically to the Ray anchor (O4 open_core).
+  raw: license:AGPL-3.0(OSI, Community Edition);source:public(GitHub);commercial-tier:Premium/Enterprise
+    paid features for large teams under separate Coder enterprise license;core-gated:gated
   sources:
   - url: https://github.com/coder/coder
     shows: AGPL-3.0 Community Edition + Premium paid tier (compare-plans), self-hosted workspaces

--- a/sources/scores/cohere-rerank-api.yaml
+++ b/sources/scores/cohere-rerank-api.yaml
@@ -2,10 +2,20 @@ product: cohere-rerank-api
 openness:
   score: 1
   class: closed
-  components: license:proprietary(hosted-API; also cloud-marketplace deploy);source:closed;weights:not-released;managed:Cohere+Azure/AWS/Oracle
+  components:
+    license:
+      value: proprietary
+      detail: hosted-API; also cloud-marketplace deploy
+    source:
+      value: closed
+    weights:
+      value: not-released
+    managed:
+      value: Cohere+Azure/AWS/Oracle
   confidence: high
   note: Proprietary closed reranking models served via API and cloud marketplaces; no open weights or
     source. Marketed as 'open' in search-relevance contexts but is not OSS.
+  raw: license:proprietary(hosted-API; also cloud-marketplace deploy);source:closed;weights:not-released;managed:Cohere+Azure/AWS/Oracle
   sources:
   - url: https://docs.cohere.com/docs/rerank-overview
     shows: commercial Rerank API; models 4.0/3.5/3.0, no source or weight release

--- a/sources/scores/continue.yaml
+++ b/sources/scores/continue.yaml
@@ -3,10 +3,22 @@ openness:
   score: 5
   class: open_source
   confidence: high
-  components: license:Apache-2.0(OSI);source:public(github.com/continuedev/continue);clients:VSCode+JetBrains+CLI;hub:continue.dev(hosted
-    config/model hub adjacent, core OSS)
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: github.com/continuedev/continue
+    clients:
+      value: VSCode+JetBrains+CLI
+    hub:
+      value: continue.dev
+      detail: hosted config/model hub adjacent, core OSS
   note: Apache-2.0, full source public for the IDE extensions and CLI; no feature-gated core in the editor
     itself (a hosted Hub exists alongside but the assistant is OSS).
+  raw: license:Apache-2.0(OSI);source:public(github.com/continuedev/continue);clients:VSCode+JetBrains+CLI;hub:continue.dev(hosted
+    config/model hub adjacent, core OSS)
   sources:
   - url: https://github.com/continuedev/continue
     shows: Apache-2.0; public source; AI code assistant (chat/edit/autocomplete + agent)

--- a/sources/scores/dclm-baseline.yaml
+++ b/sources/scores/dclm-baseline.yaml
@@ -2,9 +2,18 @@ product: dclm-baseline
 openness:
   score: 5
   class: open
-  components: license:CC-BY-4.0;gated:false;dataset_card:present;github:mlfoundations/dclm
+  components:
+    license:
+      value: CC-BY-4.0
+    gated:
+      value: 'false'
+    dataset_card:
+      value: present
+    github:
+      value: mlfoundations/dclm
   confidence: high
   note: Permissive CC-BY-4.0 license, ungated download, with open code repo and dataset card.
+  raw: license:CC-BY-4.0;gated:false;dataset_card:present;github:mlfoundations/dclm
   sources:
   - url: https://huggingface.co/datasets/mlfoundations/dclm-baseline-1.0
     shows: Dataset card, CC-BY-4.0 license, ungated public download, GitHub link

--- a/sources/scores/deepeval.yaml
+++ b/sources/scores/deepeval.yaml
@@ -2,11 +2,22 @@ product: deepeval
 openness:
   score: 4
   class: open_core
-  components: license:Apache-2.0(OSI, OSS framework);source:public(GitHub);commercial-tier:Confident AI managed
-    eval/observability cloud on top;core-gated:gated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI, OSS framework
+    source:
+      value: public
+      detail: GitHub
+    commercial-tier:
+      value: Confident AI managed eval/observability cloud on top
+    core-gated:
+      value: gated
   confidence: high
   note: Apache-2.0 OSS core + proprietary Confident AI cloud -> open_core (recipe names Confident AI as
     the open_core exemplar); the library itself is OSI.
+  raw: license:Apache-2.0(OSI, OSS framework);source:public(GitHub);commercial-tier:Confident AI managed
+    eval/observability cloud on top;core-gated:gated
   sources:
   - url: https://github.com/confident-ai/deepeval
     shows: Apache-2.0 license; Confident AI commercial cloud platform

--- a/sources/scores/dolma.yaml
+++ b/sources/scores/dolma.yaml
@@ -2,9 +2,18 @@ product: dolma
 openness:
   score: 5
   class: open
-  components: license:ODC-BY;ungated:yes;dataset_card:yes;code:apache-2.0-toolkit
+  components:
+    license:
+      value: ODC-BY
+    ungated:
+      value: 'yes'
+    dataset_card:
+      value: 'yes'
+    code:
+      value: apache-2.0-toolkit
   confidence: high
   note: Permissively licensed (ODC-BY), ungated download with a full dataset card and replication toolkit.
+  raw: license:ODC-BY;ungated:yes;dataset_card:yes;code:apache-2.0-toolkit
   sources:
   - url: https://huggingface.co/datasets/allenai/dolma
     shows: ODC-BY license, ungated access, dataset card, ~3T tokens

--- a/sources/scores/dynatrace-ai-observability.yaml
+++ b/sources/scores/dynatrace-ai-observability.yaml
@@ -2,11 +2,22 @@ product: dynatrace-ai-observability
 openness:
   score: 1
   class: closed
-  components: platform:proprietary-SaaS(Grail-powered, Davis AI);license:commercial;ingestion:OpenTelemetry+OpenLLMetry(via
-    Traceloop)+GenAI-semconv(open standards, not open product);source:closed
+  components:
+    platform:
+      value: proprietary-SaaS
+      detail: Grail-powered, Davis AI
+    license:
+      value: commercial
+    ingestion:
+      value: OpenTelemetry+OpenLLMetry
+      detail: via Traceloop)+GenAI-semconv(open standards, not open product
+    source:
+      value: closed
   confidence: high
   note: Fully proprietary Dynatrace platform; AI Observability is a commercial app/module. OTel + OpenLLMetry
     ingestion are open standards consumed by a closed product. Scored closed (1).
+  raw: platform:proprietary-SaaS(Grail-powered, Davis AI);license:commercial;ingestion:OpenTelemetry+OpenLLMetry(via
+    Traceloop)+GenAI-semconv(open standards, not open product);source:closed
   sources:
   - url: https://docs.dynatrace.com/docs/observe/dynatrace-for-ai-observability
     shows: proprietary Dynatrace platform AI Observability; Grail/Davis AI; OTel + OpenLLMetry ingestion

--- a/sources/scores/epoch-ai-benchmarks.yaml
+++ b/sources/scores/epoch-ai-benchmarks.yaml
@@ -2,13 +2,25 @@ product: epoch-ai-benchmarks
 openness:
   score: 2
   class: source_available
-  components: dashboard:public(free to browse);eval-code:partial-open(several org repos MIT/Apache - SWE-bench
-    docker registry, eci-public, MirrorCode-data);benchmark-data:mixed(FrontierMath gated/private to prevent
-    contamination; some public);no-unified-OSI-harness-product
+  components:
+    dashboard:
+      value: public
+      detail: free to browse
+    eval-code:
+      value: partial-open
+      detail: several org repos MIT/Apache - SWE-bench docker registry, eci-public, MirrorCode-data
+    benchmark-data:
+      value: mixed
+      detail: FrontierMath gated/private to prevent contamination; some public
+    free_text:
+    - no-unified-OSI-harness-product
   confidence: medium
   note: 'Mixed-tier: public results dashboard plus some MIT/Apache-licensed eval components, but the headline
     benchmark (FrontierMath) is deliberately private and there is no single OSI-licensed end-to-end harness,
     closer to source_available than fully open_source.'
+  raw: dashboard:public(free to browse);eval-code:partial-open(several org repos MIT/Apache - SWE-bench
+    docker registry, eci-public, MirrorCode-data);benchmark-data:mixed(FrontierMath gated/private to prevent
+    contamination; some public);no-unified-OSI-harness-product
   sources:
   - url: https://github.com/epoch-research
     shows: public org repos incl SWE-bench docker registry, eci-public (MIT), MirrorCode-data; mostly

--- a/sources/scores/evalplus.yaml
+++ b/sources/scores/evalplus.yaml
@@ -2,11 +2,26 @@ product: evalplus
 openness:
   score: 5
   class: open
-  components: 'data:downloadable(HF parquet, evalplus/humanevalplus + mbppplus);license:Apache-2.0(OSI/open,
-    on both framework and datasets);datasheet:present(card documents structure: task_id/prompt/canonical_solution/test);redistributable:yes;framework-code:open(Apache-2.0)'
+  components:
+    data:
+      value: downloadable
+      detail: HF parquet, evalplus/humanevalplus + mbppplus
+    license:
+      value: Apache-2.0
+      detail: OSI/open, on both framework and datasets
+    datasheet:
+      value: present
+      detail: 'card documents structure: task_id/prompt/canonical_solution/test'
+    redistributable:
+      value: 'yes'
+    framework-code:
+      value: open
+      detail: Apache-2.0
   confidence: high
   note: 'Clean open data: Apache-2.0 on both datasets and the evaluation framework, downloadable with
     a documented schema, full open class.'
+  raw: 'data:downloadable(HF parquet, evalplus/humanevalplus + mbppplus);license:Apache-2.0(OSI/open, on
+    both framework and datasets);datasheet:present(card documents structure: task_id/prompt/canonical_solution/test);redistributable:yes;framework-code:open(Apache-2.0)'
   sources:
   - url: https://huggingface.co/datasets/evalplus/humanevalplus
     shows: Apache-2.0 license, 164 problems, 25,817 monthly downloads, documented schema

--- a/sources/scores/fineweb-2.yaml
+++ b/sources/scores/fineweb-2.yaml
@@ -2,9 +2,18 @@ product: fineweb-2
 openness:
   score: 5
   class: open
-  components: license:ODC-BY;gated:false;dataset_card:present;languages:1000+
+  components:
+    license:
+      value: ODC-BY
+    gated:
+      value: 'false'
+    dataset_card:
+      value: present
+    languages:
+      value: 1000+
   confidence: high
   note: Permissive ODC-BY license, ungated, with a dataset card spanning 1000+ languages.
+  raw: license:ODC-BY;gated:false;dataset_card:present;languages:1000+
   sources:
   - url: https://huggingface.co/datasets/HuggingFaceFW/fineweb-2
     shows: Dataset page exists on public hub, ODC-BY, 1000+ languages

--- a/sources/scores/fineweb-edu.yaml
+++ b/sources/scores/fineweb-edu.yaml
@@ -2,9 +2,18 @@ product: fineweb-edu
 openness:
   score: 5
   class: open
-  components: license:ODC-BY;gated:false;dataset_card:present;format:parquet
+  components:
+    license:
+      value: ODC-BY
+    gated:
+      value: 'false'
+    dataset_card:
+      value: present
+    format:
+      value: parquet
   confidence: high
   note: Permissive ODC-BY license with ungated download and full dataset card.
+  raw: license:ODC-BY;gated:false;dataset_card:present;format:parquet
   sources:
   - url: https://huggingface.co/datasets/HuggingFaceFW/fineweb-edu
     shows: Dataset card present, ODC-BY license, public ungated download

--- a/sources/scores/fineweb.yaml
+++ b/sources/scores/fineweb.yaml
@@ -2,9 +2,18 @@ product: fineweb
 openness:
   score: 5
   class: open
-  components: license:ODC-BY;gated:false;dataset_card:present;format:parquet
+  components:
+    license:
+      value: ODC-BY
+    gated:
+      value: 'false'
+    dataset_card:
+      value: present
+    format:
+      value: parquet
   confidence: high
   note: Permissive ODC-BY license with ungated download and a full dataset card.
+  raw: license:ODC-BY;gated:false;dataset_card:present;format:parquet
   sources:
   - url: https://huggingface.co/datasets/HuggingFaceFW/fineweb
     shows: Dataset card present, ODC-BY license, public ungated download

--- a/sources/scores/firecrawl.yaml
+++ b/sources/scores/firecrawl.yaml
@@ -2,11 +2,21 @@ product: firecrawl
 openness:
   score: 4
   class: open_core
-  components: license:AGPL-3.0(OSI, self-host core);source:public;managed-cloud:firecrawl.dev with 'additional
-    features' beyond OSS = open-core split;core-gated:gated
+  components:
+    license:
+      value: AGPL-3.0
+      detail: OSI, self-host core
+    source:
+      value: public
+    managed-cloud:
+      value: firecrawl.dev with 'additional features' beyond OSS = open-core split
+    core-gated:
+      value: gated
   confidence: high
   note: AGPL-3.0 OSI core is fully open, but the managed cloud carries features beyond the OSS build,
     making this open-core rather than pure open_source.
+  raw: license:AGPL-3.0(OSI, self-host core);source:public;managed-cloud:firecrawl.dev with 'additional
+    features' beyond OSS = open-core split;core-gated:gated
   sources:
   - url: https://github.com/mendableai/firecrawl/blob/main/LICENSE
     shows: AGPL-3.0 license text, Sideguide Technologies Inc.

--- a/sources/scores/fireworks-fine-tuning.yaml
+++ b/sources/scores/fireworks-fine-tuning.yaml
@@ -2,12 +2,25 @@ product: fireworks-fine-tuning
 openness:
   score: 1
   class: closed
-  components: source:closed;training-pipeline:closed;runs-on:Fireworks-cloud-only;license:Proprietary(managed
-    service); base-weights:open-models(varies)
+  components:
+    source:
+      value: closed
+    training-pipeline:
+      value: closed
+    runs-on:
+      value: Fireworks-cloud-only
+    license:
+      value: Proprietary
+      detail: managed service
+    base-weights:
+      value: open-models
+      detail: varies
   confidence: high
   note: The managed FT service/pipeline is proprietary and runs only on Fireworks' cloud; no source. (Fireworks'
     separate reward-kit RFT toolkit is OSS but was not confirmed as part of this product this run.)
   last_verified: '2026-08-09'
+  raw: source:closed;training-pipeline:closed;runs-on:Fireworks-cloud-only;license:Proprietary(managed service);
+    base-weights:open-models(varies)
   sources:
   - url: https://docs.fireworks.ai/fine-tuning/fine-tuning-models
     shows: The docs describe SFT, DPO/ORPO, and reinforcement fine-tuning jobs run via Fireworks' own dashboard,

--- a/sources/scores/fly-sprites.yaml
+++ b/sources/scores/fly-sprites.yaml
@@ -2,12 +2,27 @@ product: fly-sprites
 openness:
   score: 1
   class: closed
-  components: license:Proprietary;service:proprietary(Fly.io managed);source:closed;clients:CLI/REST/JS/Go SDKs
-    (client libs only, no open runtime);isolation:Firecracker(Firecracker itself is OSS/AWS, but the Sprites
-    product/orchestration is proprietary)
+  components:
+    license:
+      value: Proprietary
+    service:
+      value: proprietary
+      detail: Fly.io managed
+    source:
+      value: closed
+    clients:
+      value: CLI/REST/JS/Go SDKs
+      detail: client libs only, no open runtime
+      raw: CLI/REST/JS/Go SDKs (client libs only, no open runtime)
+    isolation:
+      value: Firecracker
+      detail: Firecracker itself is OSS/AWS, but the Sprites product/orchestration is proprietary
   confidence: high
   note: Proprietary managed sandbox SaaS; no open source runtime published (only client SDKs). Underlying
     Firecracker is OSS but the product is not.
+  raw: license:Proprietary;service:proprietary(Fly.io managed);source:closed;clients:CLI/REST/JS/Go SDKs
+    (client libs only, no open runtime);isolation:Firecracker(Firecracker itself is OSS/AWS, but the Sprites
+    product/orchestration is proprietary)
   sources:
   - url: https://sprites.dev/
     shows: Sprites = hardware-isolated Firecracker execution env for arbitrary code; managed service,

--- a/sources/scores/gaia.yaml
+++ b/sources/scores/gaia.yaml
@@ -2,9 +2,19 @@ product: gaia
 openness:
   score: 2
   class: gated
-  components: questions:public(val);answers:held-out(300-Q test,private);access:HF-gated(accept-terms,anti-resharing)
+  components:
+    questions:
+      value: public
+      detail: val
+    answers:
+      value: held-out
+      detail: 300-Q test,private
+    access:
+      value: HF-gated
+      detail: accept-terms,anti-resharing
   confidence: high
   note: Test answers are private and the dataset itself is access-gated.
+  raw: questions:public(val);answers:held-out(300-Q test,private);access:HF-gated(accept-terms,anti-resharing)
   sources:
   - url: https://huggingface.co/datasets/gaia-benchmark/GAIA
     shows: gated access, private test answers

--- a/sources/scores/galileo.yaml
+++ b/sources/scores/galileo.yaml
@@ -2,11 +2,21 @@ product: galileo
 openness:
   score: 1
   class: closed
-  components: license:proprietary;source:closed;deploy:SaaS/VPC/on-prem(managed);no-OSS-core(open source
-    contributions exist as separate tools/benchmarks, not the product)
+  components:
+    license:
+      value: proprietary
+    source:
+      value: closed
+    deploy:
+      value: SaaS/VPC/on-prem
+      detail: managed
+    free_text:
+    - no-OSS-core(open source contributions exist as separate tools/benchmarks, not the product)
   confidence: high
   note: Proprietary platform; recipe lists Galileo explicitly as a closed example. No OSI-licensed core
     product.
+  raw: license:proprietary;source:closed;deploy:SaaS/VPC/on-prem(managed);no-OSS-core(open source contributions
+    exist as separate tools/benchmarks, not the product)
   sources:
   - url: https://galileo.ai/
     shows: proprietary platform; SaaS/VPC/on-prem deploy, no open source core product

--- a/sources/scores/glean-assistant.yaml
+++ b/sources/scores/glean-assistant.yaml
@@ -3,9 +3,18 @@ openness:
   score: 1
   class: closed
   confidence: high
-  components: client:proprietary;deployment:single-tenant SaaS;source:closed;license:Proprietary
+  components:
+    client:
+      value: proprietary
+    deployment:
+      value: single-tenant SaaS
+    source:
+      value: closed
+    license:
+      value: Proprietary
   note: Glean Assistant is a proprietary enterprise SaaS, no public source, no open-core/self-host OSS
     tier. Closed.
+  raw: client:proprietary;deployment:single-tenant SaaS;source:closed;license:Proprietary
   sources:
   - url: https://www.glean.com/product/assistant
     shows: Proprietary SaaS enterprise assistant; RAG over Enterprise Graph; not open source

--- a/sources/scores/glean-workplace-search-ai.yaml
+++ b/sources/scores/glean-workplace-search-ai.yaml
@@ -3,8 +3,17 @@ openness:
   score: 1
   class: closed
   confidence: high
-  components: client:proprietary;deployment:single-tenant SaaS;source:closed;license:Proprietary
+  components:
+    client:
+      value: proprietary
+    deployment:
+      value: single-tenant SaaS
+    source:
+      value: closed
+    license:
+      value: Proprietary
   note: Glean Search is proprietary enterprise SaaS; no public source, no OSS/self-host tier. Closed.
+  raw: client:proprietary;deployment:single-tenant SaaS;source:closed;license:Proprietary
   sources:
   - url: https://www.glean.com/product/overview
     shows: Glean Search as proprietary single-tenant SaaS enterprise search on Enterprise Graph

--- a/sources/scores/google-cloud-run.yaml
+++ b/sources/scores/google-cloud-run.yaml
@@ -2,12 +2,26 @@ product: google-cloud-run
 openness:
   score: 1
   class: closed
-  components: license:Proprietary;service:proprietary(Google SaaS);source:closed;isolation-runtime:gVisor(open source,
-    github.com/google/gvisor) but the Cloud Run product/control-plane is proprietary;managed-only(no
-    self-host)
+  components:
+    license:
+      value: Proprietary
+    service:
+      value: proprietary
+      detail: Google SaaS
+    source:
+      value: closed
+    isolation-runtime:
+      value: gVisor
+      detail: open source, github.com/google/gvisor) but the Cloud Run product/control-plane is proprietary
+      raw: gVisor(open source, github.com/google/gvisor) but the Cloud Run product/control-plane is proprietary
+    free_text:
+    - managed-only(no self-host)
   confidence: high
   note: Proprietary managed serverless platform; only the underlying gVisor sandbox runtime is OSS, not
     Cloud Run itself.
+  raw: license:Proprietary;service:proprietary(Google SaaS);source:closed;isolation-runtime:gVisor(open
+    source, github.com/google/gvisor) but the Cloud Run product/control-plane is proprietary;managed-only(no
+    self-host)
   sources:
   - url: https://cloud.google.com/run
     shows: Cloud Run described as fully-managed Google serverless container product (proprietary SaaS)

--- a/sources/scores/google-cloud-tpu-inference.yaml
+++ b/sources/scores/google-cloud-tpu-inference.yaml
@@ -2,13 +2,31 @@ product: google-cloud-tpu-inference
 openness:
   score: 1
   class: closed
-  components: source:closed;license:proprietary;runtime:Pathways(Google-internal distributed runtime, not
-    open sourced);hardware-lock:Google TPU-only;managed:Google Cloud/GKE;note:JetStream(separate, Apache-2.0
-    OSS) is the open serving frontend but the scored product is the proprietary Pathways/TPU runtime
+  components:
+    source:
+      value: closed
+    license:
+      value: proprietary
+    runtime:
+      value: Pathways
+      detail: Google-internal distributed runtime, not open sourced
+    hardware-lock:
+      value: Google TPU-only
+    managed:
+      value: Google Cloud/GKE
+    note:
+      value: JetStream
+      detail: separate, Apache-2.0 OSS) is the open serving frontend but the scored product is the proprietary
+        Pathways/TPU runtime
+      raw: JetStream(separate, Apache-2.0 OSS) is the open serving frontend but the scored product is the
+        proprietary Pathways/TPU runtime
   confidence: high
   note: The named product (Pathways / TPU Runtime managed inference) is proprietary, TPU-locked, and cloud-delivered.
     JetStream (open) is a distinct artifact and not what this SKU is; scored closed.
   last_verified: '2026-08-09'
+  raw: source:closed;license:proprietary;runtime:Pathways(Google-internal distributed runtime, not open
+    sourced);hardware-lock:Google TPU-only;managed:Google Cloud/GKE;note:JetStream(separate, Apache-2.0
+    OSS) is the open serving frontend but the scored product is the proprietary Pathways/TPU runtime
   sources:
   - url: https://cloud.google.com/blog/products/compute/ai-hypercomputer-inference-updates-for-google-cloud-tpu-and-gpu
     shows: Available for the first time for Google Cloud customers, Google's Pathways runtime is now integrated

--- a/sources/scores/granite-code-instruct.yaml
+++ b/sources/scores/granite-code-instruct.yaml
@@ -2,14 +2,36 @@ product: granite-code-instruct
 openness:
   score: 3
   class: open_weights
-  components: weights:open(Apache-2.0,on HF);code:partial(inference + fine-tune sample scripts via Dolomite
-    Engine; no full training pipeline in repo);data:described_not_released(CommitPackFT/MathInstruct/Glaive/HelpSteer/Open-Platypus
-    named in card but processed corpus not redistributable);post-training-data:described(SFT mixture named,
-    not released);paper:open(arXiv 2405.04324);model_card:open;license:Apache-2.0(OSI)
+  components:
+    weights:
+      value: open
+      detail: Apache-2.0,on HF
+    code:
+      value: partial
+      detail: inference + fine-tune sample scripts via Dolomite Engine; no full training pipeline in repo
+    data:
+      value: described_not_released
+      detail: CommitPackFT/MathInstruct/Glaive/HelpSteer/Open-Platypus named in card but processed corpus
+        not redistributable
+    post-training-data:
+      value: described
+      detail: SFT mixture named, not released
+    paper:
+      value: open
+      detail: arXiv 2405.04324
+    model_card:
+      value: open
+    license:
+      value: Apache-2.0
+      detail: OSI
   confidence: high
   note: OSI Apache-2.0 + downloadable weights + paper + model card, but training/post-training data only
     described (not redistributable) and no full training pipeline => open_weights, not open_source. Strong
     within the open_weights class (genuinely permissive, no use caps).
+  raw: weights:open(Apache-2.0,on HF);code:partial(inference + fine-tune sample scripts via Dolomite Engine;
+    no full training pipeline in repo);data:described_not_released(CommitPackFT/MathInstruct/Glaive/HelpSteer/Open-Platypus
+    named in card but processed corpus not redistributable);post-training-data:described(SFT mixture named,
+    not released);paper:open(arXiv 2405.04324);model_card:open;license:Apache-2.0(OSI)
   sources:
   - url: https://huggingface.co/ibm-granite/granite-3b-code-instruct-2k
     shows: Apache-2.0 license, instruction-tuned model card, named training-data sources, HumanEvalSynthesis

--- a/sources/scores/guardrails-ai.yaml
+++ b/sources/scores/guardrails-ai.yaml
@@ -2,11 +2,24 @@ product: guardrails-ai
 openness:
   score: 4
   class: open_core
-  components: license:Apache-2.0(OSI) for the framework;source:public;hub:Guardrails Hub validator registry;commercial:hosted/enterprise
-    tier;core-gated:gated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI) for the framework
+      raw: Apache-2.0(OSI) for the framework
+    source:
+      value: public
+    hub:
+      value: Guardrails Hub validator registry
+    commercial:
+      value: hosted/enterprise tier
+    core-gated:
+      value: gated
   confidence: medium
   note: Apache-2.0 framework that is fully self-hostable, with a Hub of validators and a commercial tier
     on top; classed open_core alongside other OSS-core-plus-commercial tools.
+  raw: license:Apache-2.0(OSI) for the framework;source:public;hub:Guardrails Hub validator registry;commercial:hosted/enterprise
+    tier;core-gated:gated
   sources:
   - url: https://github.com/guardrails-ai/guardrails
     shows: Apache-2.0 framework; ~7.1k stars; Guardrails Hub validators; commercial offerings

--- a/sources/scores/hh-rlhf.yaml
+++ b/sources/scores/hh-rlhf.yaml
@@ -2,9 +2,22 @@ product: hh-rlhf
 openness:
   score: 5
   class: open
-  components: license:mit;card:present;ungated:yes;rows:169,352;size:94.7MB
+  components:
+    license:
+      value: mit
+    card:
+      value: present
+    ungated:
+      value: 'yes'
+    rows:
+      value: '169'
+      detail: '352'
+      raw: 169,352
+    size:
+      value: 94.7MB
   confidence: high
   note: Publicly downloadable and ungated under the permissive MIT license.
+  raw: license:mit;card:present;ungated:yes;rows:169,352;size:94.7MB
   sources:
   - url: https://huggingface.co/datasets/Anthropic/hh-rlhf
     shows: MIT license, ungated card, 169,352 rows, 94.7 MB

--- a/sources/scores/humaneval.yaml
+++ b/sources/scores/humaneval.yaml
@@ -2,12 +2,28 @@ product: humaneval
 openness:
   score: 5
   class: open
-  components: license:MIT(OSI-style permissive, fully redistributable);redistributability:full(downloadable
-    parquet, no gating);datasheet:yes(dataset card);size:164 problems/test split;contamination:hand-written
-    to avoid GitHub-dump overlap (per design)
+  components:
+    license:
+      value: MIT
+      detail: OSI-style permissive, fully redistributable
+    redistributability:
+      value: full
+      detail: downloadable parquet, no gating
+    datasheet:
+      value: 'yes'
+      detail: dataset card
+    size:
+      value: 164 problems/test split
+    contamination:
+      value: hand-written to avoid GitHub-dump overlap
+      detail: per design
+      raw: hand-written to avoid GitHub-dump overlap (per design)
   confidence: high
   note: 'Fully open: MIT license, ungated, downloadable, with a dataset card. Textbook open-data case
     for this category.'
+  raw: license:MIT(OSI-style permissive, fully redistributable);redistributability:full(downloadable parquet,
+    no gating);datasheet:yes(dataset card);size:164 problems/test split;contamination:hand-written to avoid
+    GitHub-dump overlap (per design)
   sources:
   - url: https://huggingface.co/datasets/openai/openai_humaneval
     shows: MIT license; not gated; 164 problems; dataset card present; ~287k downloads last month

--- a/sources/scores/humanitys-last-exam.yaml
+++ b/sources/scores/humanitys-last-exam.yaml
@@ -2,10 +2,19 @@ product: humanitys-last-exam
 openness:
   score: 2
   class: gated
-  components: questions+answers:public(MIT,2500-Q);access:HF-gated(accept-conditions,no-redistribution,canary);holdout:private
+  components:
+    questions+answers:
+      value: public
+      detail: MIT,2500-Q
+    access:
+      value: HF-gated
+      detail: accept-conditions,no-redistribution,canary
+    holdout:
+      value: private
   confidence: medium
   note: Public set is MIT-licensed with answers, but access is gated and a private held-out set exists - judgment
     call (could be open under a license-weighted reading).
+  raw: questions+answers:public(MIT,2500-Q);access:HF-gated(accept-conditions,no-redistribution,canary);holdout:private
   sources:
   - url: https://huggingface.co/datasets/cais/hle
     shows: MIT, gated access, no-redistribution notice

--- a/sources/scores/k2.yaml
+++ b/sources/scores/k2.yaml
@@ -2,10 +2,25 @@ product: k2
 openness:
   score: 5
   class: open_source
-  components: weights:open(Apache-2.0);data:open(TxT360 pretraining + midtraining + SFT);code:open(k2v2_train);checkpoints:open;license:Apache-2.0(OSI)
+  components:
+    weights:
+      value: open
+      detail: Apache-2.0
+    data:
+      value: open
+      detail: TxT360 pretraining + midtraining + SFT
+    code:
+      value: open
+      detail: k2v2_train
+    checkpoints:
+      value: open
+    license:
+      value: Apache-2.0
+      detail: OSI
   confidence: high
   note: '360-open / fully reproducible: Apache-2.0 weights + complete TxT360 data + training code + checkpoints.
     A clean fully-open exemplar at 70B.'
+  raw: weights:open(Apache-2.0);data:open(TxT360 pretraining + midtraining + SFT);code:open(k2v2_train);checkpoints:open;license:Apache-2.0(OSI)
   sources:
   - url: https://huggingface.co/LLM360/K2-V2
     shows: K2-V2 70B; Apache-2.0; open data/code/checkpoints

--- a/sources/scores/laminar.yaml
+++ b/sources/scores/laminar.yaml
@@ -2,11 +2,25 @@ product: laminar
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(Rust core + TS UI);SDKs:Apache-2.0;no feature-gated core observed
-    in repo;managed Laminar Cloud is hosting not a gated tier;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: Rust core + TS UI
+    SDKs:
+      value: Apache-2.0
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core observed in repo
+    - managed Laminar Cloud is hosting not a gated tier
   confidence: medium
   note: Repo and SDKs Apache-2.0 with full source; a hosted cloud exists but no enterprise-gated module
     split was visible in the repo (less explicit open-core boundary than Langfuse/LangWatch).
+  raw: license:Apache-2.0(OSI);source:public(Rust core + TS UI);SDKs:Apache-2.0;no feature-gated core observed
+    in repo;managed Laminar Cloud is hosting not a gated tier;core-gated:ungated
   sources:
   - url: https://github.com/lmnr-ai/lmnr
     shows: Apache-2.0 license; Rust+TS source public; OTel-native tracing/evals/datasets features

--- a/sources/scores/lamini.yaml
+++ b/sources/scores/lamini.yaml
@@ -2,14 +2,30 @@ product: lamini
 openness:
   score: 1
   class: closed
-  components: license:Proprietary;source:closed;engine:closed(hosted memory-tuning/fine-tuning service on Lamini/AMD
-    servers);client-sdk:open(Apache-2.0,
-    lamini-ai/lamini);data:closed;training-code:closed;access:API-key-gated
+  components:
+    license:
+      value: Proprietary
+    source:
+      value: closed
+    engine:
+      value: closed
+      detail: hosted memory-tuning/fine-tuning service on Lamini/AMD servers
+    client-sdk:
+      value: open
+      detail: Apache-2.0, lamini-ai/lamini
+    data:
+      value: closed
+    training-code:
+      value: closed
+    access:
+      value: API-key-gated
   confidence: high
   note: Proprietary managed fine-tuning platform; no source is published for the engine in any of the on-demand,
     reserved, or self-managed deployment tiers, and the only open artifact is a thin API client SDK, so
     the product itself remains closed.
   last_verified: '2026-08-09'
+  raw: license:Proprietary;source:closed;engine:closed(hosted memory-tuning/fine-tuning service on Lamini/AMD
+    servers);client-sdk:open(Apache-2.0, lamini-ai/lamini);data:closed;training-code:closed;access:API-key-gated
   sources:
   - url: https://github.com/lamini-ai/lamini
     shows: Repo title/description read "The Official Python Client for Lamini's API"; GitHub's own repo

--- a/sources/scores/litellm.yaml
+++ b/sources/scores/litellm.yaml
@@ -2,9 +2,19 @@ product: litellm
 openness:
   score: 4
   class: open_core
-  components: license:MIT(core);enterprise-dir:LiteLLM-Commercial-License;source:public;core-gated:gated
+  components:
+    license:
+      value: MIT
+      detail: core
+    enterprise-dir:
+      value: LiteLLM-Commercial-License
+    source:
+      value: public
+    core-gated:
+      value: gated
   confidence: high
   note: license:MIT(core);enterprise-dir:LiteLLM-Commercial-License;source:public
+  raw: license:MIT(core);enterprise-dir:LiteLLM-Commercial-License;source:public;core-gated:gated
   sources:
   - url: https://github.com/BerriAI/litellm/blob/main/LICENSE
     shows: flagship phase-C verification source

--- a/sources/scores/litgpt.yaml
+++ b/sources/scores/litgpt.yaml
@@ -2,11 +2,23 @@ product: litgpt
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;maintainer:Lightning-AI;no feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    maintainer:
+      value: Lightning-AI
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: Apache-2.0, full source public. The library's own README describes itself as unrestricted for enterprise
     use; Lightning AI's separate Studios platform is hosted compute, not a gated core.
   last_verified: '2026-08-09'
+  raw: license:Apache-2.0(OSI);source:public;maintainer:Lightning-AI;no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/Lightning-AI/litgpt
     shows: The repository's top-level file listing (16 items) is .devcontainer, .github, .lightning/workflows,

--- a/sources/scores/livebench.yaml
+++ b/sources/scores/livebench.yaml
@@ -2,9 +2,17 @@ product: livebench
 openness:
   score: 5
   class: open
-  components: questions:public;answers:public(ground_truth released);license:Apache-2.0/MIT
+  components:
+    questions:
+      value: public
+    answers:
+      value: public
+      detail: ground_truth released
+    license:
+      value: Apache-2.0/MIT
   confidence: high
   note: All questions, answers, and code are released openly; rotation is for freshness, not access control.
+  raw: questions:public;answers:public(ground_truth released);license:Apache-2.0/MIT
   sources:
   - url: https://huggingface.co/datasets/livebench/reasoning
     shows: public ground_truth column, release/removal dates

--- a/sources/scores/llamafirewall.yaml
+++ b/sources/scores/llamafirewall.yaml
@@ -2,11 +2,21 @@ product: llamafirewall
 openness:
   score: 5
   class: open_source
-  components: framework:open(LlamaFirewall + CodeShield code, MIT-licensed in PurpleLlama);self-host:yes;note:bundled
-    guard models (Prompt Guard 2, Llama Guard) carry the Llama Community License
+  components:
+    framework:
+      value: open
+      detail: LlamaFirewall + CodeShield code, MIT-licensed in PurpleLlama
+    self-host:
+      value: 'yes'
+    note:
+      value: bundled guard models
+      detail: Prompt Guard 2, Llama Guard) carry the Llama Community License
+      raw: bundled guard models (Prompt Guard 2, Llama Guard) carry the Llama Community License
   confidence: high
   note: The firewall framework and CodeShield are open-source (MIT) and self-hostable; it orchestrates
     Meta's Llama-licensed guard models. Scored on the framework, which is genuinely open source (5).
+  raw: framework:open(LlamaFirewall + CodeShield code, MIT-licensed in PurpleLlama);self-host:yes;note:bundled
+    guard models (Prompt Guard 2, Llama Guard) carry the Llama Community License
   sources:
   - url: https://github.com/meta-llama/PurpleLlama
     shows: 'PurpleLlama: MIT evals + Llama-licensed safeguard models; ~4.2k stars; LlamaFirewall, Prompt

--- a/sources/scores/lm-studio.yaml
+++ b/sources/scores/lm-studio.yaml
@@ -2,10 +2,22 @@ product: lm-studio
 openness:
   score: 1
   class: closed
-  components: license:Proprietary;source:closed;app:proprietary-freeware(ToS forbids
-    modify/reverse-engineer/redistribute);sdk+cli:MIT(public);core-engine:closed
+  components:
+    license:
+      value: Proprietary
+    source:
+      value: closed
+    app:
+      value: proprietary-freeware
+      detail: ToS forbids modify/reverse-engineer/redistribute
+    sdk+cli:
+      value: MIT
+      detail: public
+    core-engine:
+      value: closed
   confidence: high
   note: Core app/engine is closed proprietary freeware; only peripheral CLI/SDKs are open.
+  raw: license:Proprietary;source:closed;app:proprietary-freeware(ToS forbids modify/reverse-engineer/redistribute);sdk+cli:MIT(public);core-engine:closed
   sources:
   - url: https://lmstudio.ai/app-terms
     shows: 'ToS: no modification/reverse-engineering/redistribution'

--- a/sources/scores/lmdeploy.yaml
+++ b/sources/scores/lmdeploy.yaml
@@ -2,7 +2,20 @@ product: lmdeploy
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(InternLM/lmdeploy);no-feature-gated-core;quantization:weight-only+kv(AWQ/W4A16);core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: InternLM/lmdeploy
+    quantization:
+      value: weight-only+kv
+      detail: AWQ/W4A16
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   confidence: high
   note: 'Re-confirmed: repo public and active, LICENSE body is the unmodified Apache-2.0 text, GitHub''s
     repo metadata also reports spdxId Apache-2.0. No pricing/enterprise page or paid-tier mention exists
@@ -10,6 +23,7 @@ openness:
     own site navigation chrome, not LMDeploy content, so core-gated:ungated stands. AWQ/W4A16 weight-only
     and kv-cache quantization still documented on the repo page.'
   last_verified: '2026-08-09'
+  raw: license:Apache-2.0(OSI);source:public(InternLM/lmdeploy);no-feature-gated-core;quantization:weight-only+kv(AWQ/W4A16);core-gated:ungated
   sources:
   - url: https://github.com/InternLM/lmdeploy
     shows: repo metadata "license":{"spdxId":"Apache-2.0","name":"Apache License 2.0"}; README documents

--- a/sources/scores/lobe-chat.yaml
+++ b/sources/scores/lobe-chat.yaml
@@ -2,15 +2,24 @@ product: lobe-chat
 openness:
   score: 2
   class: source_available
-  components: 'license:LobeHub-Community-License(Apache-2.0-based, non-OSI: commercial license required
-    to develop+distribute a derivative work; CLA lets LobeHub relicense contributions for cloud editions);source:public;cloud-tier:LobeHub
-    Cloud'
+  components:
+    license:
+      value: LobeHub-Community-License
+      detail: 'Apache-2.0-based, non-OSI: commercial license required to develop+distribute a derivative
+        work; CLA lets LobeHub relicense contributions for cloud editions'
+    source:
+      value: public
+    cloud-tier:
+      value: LobeHub Cloud
   confidence: high
   note: 'Source-available, not OSI: distributing a derivative work requires a commercial license, and the
     CLA lets LobeHub relicense contributions for its cloud editions. Both exceed Apache-2.0, though it is
     still presented publicly as open source. Score corrected from 3 to 2 on 2026-07-30. The software ladder
     has rungs at 1, 2, 4 and 5 and none at 3, so 3/source_available was not a pair any rule could produce;
     the ladder scores "you can read it and not run it freely" at 2.'
+  raw: 'license:LobeHub-Community-License(Apache-2.0-based, non-OSI: commercial license required to develop+distribute
+    a derivative work; CLA lets LobeHub relicense contributions for cloud editions);source:public;cloud-tier:LobeHub
+    Cloud'
   sources:
   - url: https://github.com/lobehub/lobe-chat/blob/main/LICENSE
     shows: LobeHub Community License (Apache-2.0 based) requiring a commercial license to distribute derivative

--- a/sources/scores/lumo.yaml
+++ b/sources/scores/lumo.yaml
@@ -2,9 +2,19 @@ product: lumo
 openness:
   score: 2
   class: source_available
-  components: source:partial(GPLv3 clients only; backend, routing and model-serving are not published);clients:open(GPLv3
-    - web in ProtonMail/WebClients, iOS/Android in ProtonLumo);service:closed(backend, routing, model-serving
-    not public);license:GPLv3(clients)
+  components:
+    source:
+      value: partial
+      detail: GPLv3 clients only; backend, routing and model-serving are not published
+    clients:
+      value: open
+      detail: GPLv3 - web in ProtonMail/WebClients, iOS/Android in ProtonLumo
+    service:
+      value: closed
+      detail: backend, routing, model-serving not public
+    license:
+      value: GPLv3
+      detail: clients
   confidence: high
   note: 'Open clients (GPLv3) over a proprietary hosted service: the backend, routing and model-serving
     layer are not published. Marketed as "fully open source", but support pages and third-party reviews
@@ -12,6 +22,9 @@ openness:
     wrong: the ladder has no rung at 3, and a published client standing in for an unpublished engine is
     source:partial, which it scores 2/source_available. open_core would mean an OSI core with a paid tier
     withheld.'
+  raw: source:partial(GPLv3 clients only; backend, routing and model-serving are not published);clients:open(GPLv3
+    - web in ProtonMail/WebClients, iOS/Android in ProtonLumo);service:closed(backend, routing, model-serving
+    not public);license:GPLv3(clients)
   sources:
   - url: https://github.com/ProtonLumo/ios-lumo
     shows: iOS client source under GPLv3

--- a/sources/scores/marin.yaml
+++ b/sources/scores/marin.yaml
@@ -2,10 +2,27 @@ product: marin
 openness:
   score: 5
   class: open_source
-  components: weights:open(Apache-2.0);data:open(documented mixtures);code:open(marin + Levanter, JAX);checkpoints:open;reproducibility:bit-for-bit;license:Apache-2.0(OSI)
+  components:
+    weights:
+      value: open
+      detail: Apache-2.0
+    data:
+      value: open
+      detail: documented mixtures
+    code:
+      value: open
+      detail: marin + Levanter, JAX
+    checkpoints:
+      value: open
+    reproducibility:
+      value: bit-for-bit
+    license:
+      value: Apache-2.0
+      detail: OSI
   confidence: high
   note: 'Stanford CRFM ''open lab'': Apache-2.0 weights plus documented code, data, experiments, hyperparameters
     and training logs, with bit-for-bit reproducible training.'
+  raw: weights:open(Apache-2.0);data:open(documented mixtures);code:open(marin + Levanter, JAX);checkpoints:open;reproducibility:bit-for-bit;license:Apache-2.0(OSI)
   sources:
   - url: http://marin.community/blog/2025/05/19/announcement/
     shows: 'Marin open lab: code, data, experiments, logs all shared'

--- a/sources/scores/max.yaml
+++ b/sources/scores/max.yaml
@@ -2,10 +2,18 @@ product: max
 openness:
   score: 2
   class: source_available
-  components: license:Modular-Community-License(non-OSI, per-device licensing and a limited redistribution
-    grant, governs MAX/Mojo usage+distribution);repo-license:Apache-2.0-WITH-LLVM-exception(the source in
-    modular/modular);source:public(~450k LOC incl MAX kernels + inference server + Mojo stdlib);commercial-tier:Modular
-    enterprise/managed deployment
+  components:
+    license:
+      value: Modular-Community-License
+      detail: non-OSI, per-device licensing and a limited redistribution grant, governs MAX/Mojo usage+distribution
+    repo-license:
+      value: Apache-2.0-WITH-LLVM-exception
+      detail: the source in modular/modular
+    source:
+      value: public
+      detail: ~450k LOC incl MAX kernels + inference server + Mojo stdlib
+    commercial-tier:
+      value: Modular enterprise/managed deployment
   confidence: high
   note: 'Large public codebase; the repo''s own LICENSE is Apache-2.0 with LLVM Exceptions. GitHub''s repo
     page still states "Modular, MAX and Mojo usage and distribution are licensed under the Modular Community
@@ -17,6 +25,9 @@ openness:
     Marketed as "open"; flag open_washed. Score corrected from 3 to 2 on 2026-07-30 and unchanged on this
     re-read.'
   last_verified: '2026-08-09'
+  raw: license:Modular-Community-License(non-OSI, per-device licensing and a limited redistribution grant,
+    governs MAX/Mojo usage+distribution);repo-license:Apache-2.0-WITH-LLVM-exception(the source in modular/modular);source:public(~450k
+    LOC incl MAX kernels + inference server + Mojo stdlib);commercial-tier:Modular enterprise/managed deployment
   sources:
   - url: https://github.com/modular/modular
     shows: Modular, MAX and Mojo usage and distribution are licensed under the Modular Community License

--- a/sources/scores/mistral-fine-tuning-api.yaml
+++ b/sources/scores/mistral-fine-tuning-api.yaml
@@ -2,8 +2,19 @@ product: mistral-fine-tuning-api
 openness:
   score: 1
   class: closed
-  components: source:closed;training-pipeline:closed;runs-on:La-Plateforme-only;license:Proprietary(managed
-    service, per-token + storage pricing); base-weights:Mistral-models(open-weight variants exist)
+  components:
+    source:
+      value: closed
+    training-pipeline:
+      value: closed
+    runs-on:
+      value: La-Plateforme-only
+    license:
+      value: Proprietary
+      detail: managed service, per-token + storage pricing
+    base-weights:
+      value: Mistral-models
+      detail: open-weight variants exist
   confidence: high
   note: 'The hosted FT API on Mistral''s Studio platform (formerly branded La Plateforme) is a proprietary
     managed service (LoRA adapters under the hood); no source for the service. Mistral separately ships
@@ -14,6 +25,8 @@ openness:
     with no separate catalog entry for general text/vision SFT. Openness is unaffected either way: still
     a closed, proprietary managed offering with no self-hostable implementation.'
   last_verified: '2026-08-09'
+  raw: source:closed;training-pipeline:closed;runs-on:La-Plateforme-only;license:Proprietary(managed service,
+    per-token + storage pricing); base-weights:Mistral-models(open-weight variants exist)
   sources:
   - url: https://mistral.ai/news/customization
     shows: States it will 'leverage our proprietary fine-tuning techniques with our managed fine-tuning

--- a/sources/scores/mmlu.yaml
+++ b/sources/scores/mmlu.yaml
@@ -2,10 +2,25 @@ product: mmlu
 openness:
   score: 5
   class: open
-  components: data:downloadable(HF parquet, cais/mmlu);license:MIT(OSI/open);datasheet:present(card documents
-    57 subjects, splits dev/val/test, schema);redistributable:yes;paper:public(ICLR 2021)
+  components:
+    data:
+      value: downloadable
+      detail: HF parquet, cais/mmlu
+    license:
+      value: MIT
+      detail: OSI/open
+    datasheet:
+      value: present
+      detail: card documents 57 subjects, splits dev/val/test, schema
+    redistributable:
+      value: 'yes'
+    paper:
+      value: public
+      detail: ICLR 2021
   confidence: high
   note: 'Clean open data: MIT, downloadable, documented datasheet, public paper: full open class.'
+  raw: data:downloadable(HF parquet, cais/mmlu);license:MIT(OSI/open);datasheet:present(card documents 57
+    subjects, splits dev/val/test, schema);redistributable:yes;paper:public(ICLR 2021)
   sources:
   - url: https://huggingface.co/datasets/cais/mmlu
     shows: MIT license, 57 subjects, 231,400 rows / 14,042 test, 541,723 monthly downloads, documented

--- a/sources/scores/modal-sandboxes.yaml
+++ b/sources/scores/modal-sandboxes.yaml
@@ -2,14 +2,31 @@ product: modal-sandboxes
 openness:
   score: 1
   class: closed
-  components: license:Proprietary;source:closed;service:proprietary Modal managed cloud (no self-host of the gVisor
-    execution plane);open-part:client SDK only (modal Python/JS client libraries);pricing:pay-as-you-go
-    usage, free starter credits
+  components:
+    license:
+      value: Proprietary
+    source:
+      value: closed
+    service:
+      value: proprietary Modal managed cloud
+      detail: no self-host of the gVisor execution plane
+      raw: proprietary Modal managed cloud (no self-host of the gVisor execution plane)
+    open-part:
+      value: client SDK only
+      detail: modal Python/JS client libraries
+      raw: client SDK only (modal Python/JS client libraries)
+    pricing:
+      value: pay-as-you-go usage
+      detail: free starter credits
+      raw: pay-as-you-go usage, free starter credits
   confidence: high
   note: 'Closed managed service. The client SDK is open, but the execution substrate is a proprietary
     managed cloud with no self-host; an open client over a closed runtime is not open_core. Corrects a
     prior mis-calibration that grouped Modal with the genuinely self-hostable E2B (E2B ships self-hostable
     infra; Modal does not).'
+  raw: license:Proprietary;source:closed;service:proprietary Modal managed cloud (no self-host of the gVisor
+    execution plane);open-part:client SDK only (modal Python/JS client libraries);pricing:pay-as-you-go
+    usage, free starter credits
   sources:
   - url: https://modal.com/pricing
     shows: Modal is a managed proprietary cloud platform, pay-per-CPU-cycle, $30/mo free credits

--- a/sources/scores/mosaic-ai-model-training.yaml
+++ b/sources/scores/mosaic-ai-model-training.yaml
@@ -2,12 +2,26 @@ product: mosaic-ai-model-training
 openness:
   score: 1
   class: closed
-  components: source:closed;training-code:closed;runs-on:Databricks-workspace-only(AWS regions);license:Proprietary(managed
-    service); base-weights:Llama-Community-License(non-OSI)
+  components:
+    source:
+      value: closed
+    training-code:
+      value: closed
+    runs-on:
+      value: Databricks-workspace-only
+      detail: AWS regions
+    license:
+      value: Proprietary
+      detail: managed service
+    base-weights:
+      value: Llama-Community-License
+      detail: non-OSI
   confidence: high
   note: Proprietary managed FT service running only inside a Databricks workspace; no source. (Databricks'
     separate LLM Foundry / Composer libs are OSS but are not this product.)
   last_verified: '2026-08-09'
+  raw: source:closed;training-code:closed;runs-on:Databricks-workspace-only(AWS regions);license:Proprietary(managed
+    service); base-weights:Llama-Community-License(non-OSI)
   sources:
   - url: https://docs.databricks.com/aws/en/large-language-models/foundation-model-training/
     shows: Foundation Model Fine-tuning requires a Databricks workspace in AWS us-east-1 or us-west-2 and

--- a/sources/scores/mt-bench.yaml
+++ b/sources/scores/mt-bench.yaml
@@ -2,9 +2,17 @@ product: mt-bench
 openness:
   score: 5
   class: open
-  components: questions:public;answers:public(GPT-4 references in FastChat);license:Apache-2.0
+  components:
+    questions:
+      value: public
+    answers:
+      value: public
+      detail: GPT-4 references in FastChat
+    license:
+      value: Apache-2.0
   confidence: high
   note: Both questions and reference answers are public and openly licensed.
+  raw: questions:public;answers:public(GPT-4 references in FastChat);license:Apache-2.0
   sources:
   - url: https://github.com/lm-sys/FastChat/tree/main/fastchat/llm_judge/data/mt_bench
     shows: public questions + GPT-4 references

--- a/sources/scores/multipl-e.yaml
+++ b/sources/scores/multipl-e.yaml
@@ -2,15 +2,33 @@ product: multipl-e
 openness:
   score: 4
   class: open
-  components: data:downloadable(HF parquet, 47 subsets);license:MIT(on HF dataset card);datasheet:present(card
-    documents prompts/doctests/tests/stop-tokens);redistributable:yes(HF);caveat:GitHub repo LICENSE is
-    a non-OSI 'BSD-3-Clause + no-ML-training' modified license, conflicting with the MIT on the HF data
-    artifact
+  components:
+    data:
+      value: downloadable
+      detail: HF parquet, 47 subsets
+    license:
+      value: MIT
+      detail: on HF dataset card
+    datasheet:
+      value: present
+      detail: card documents prompts/doctests/tests/stop-tokens
+    redistributable:
+      value: 'yes'
+      detail: HF
+    caveat:
+      value: GitHub repo LICENSE is a non-OSI 'BSD-3-Clause + no-ML-training' modified license
+      detail: conflicting with the MIT on the HF data artifact
+      raw: GitHub repo LICENSE is a non-OSI 'BSD-3-Clause + no-ML-training' modified license, conflicting
+        with the MIT on the HF data artifact
   confidence: medium
   note: The scored artifact (HF dataset) is MIT and openly downloadable with a datasheet, open class.
     But the source repo carries a modified BSD-3 with an explicit 'may not be used as training data for
     ML' clause (non-OSI), a conflict worth flagging; scored on the data artifact's MIT terms, capped at
     4 for the licensing inconsistency.
+  raw: data:downloadable(HF parquet, 47 subsets);license:MIT(on HF dataset card);datasheet:present(card
+    documents prompts/doctests/tests/stop-tokens);redistributable:yes(HF);caveat:GitHub repo LICENSE is
+    a non-OSI 'BSD-3-Clause + no-ML-training' modified license, conflicting with the MIT on the HF data
+    artifact
   sources:
   - url: https://huggingface.co/datasets/nuprl/MultiPL-E
     shows: MIT license, 47 subsets across 22-23 languages, downloadable parquet, documented schema

--- a/sources/scores/nemo-rl.yaml
+++ b/sources/scores/nemo-rl.yaml
@@ -2,13 +2,25 @@ product: nemo-rl
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;maintainer:NVIDIA;no feature-gated core (NVIDIA-GPU oriented, not
-    a license restriction);core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    maintainer:
+      value: NVIDIA
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core (NVIDIA-GPU oriented, not a license restriction)
   confidence: high
   note: Apache-2.0 (OSI), full source public, no enterprise/paid directory in the repo (30-item top-level
     tree). NVIDIA's separate NeMo Customizer microservice, part of NeMo Microservices, does not withhold
     anything from the published repo. GPU orientation is a hardware practicality, not a license restriction.
   last_verified: '2026-08-09'
+  raw: license:Apache-2.0(OSI);source:public;maintainer:NVIDIA;no feature-gated core (NVIDIA-GPU oriented,
+    not a license restriction);core-gated:ungated
   sources:
   - url: https://github.com/NVIDIA-NeMo/RL
     shows: README opens "NeMo RL is an open-source post-training library under the NVIDIA NeMo Framework,

--- a/sources/scores/new-relic-ai-monitoring.yaml
+++ b/sources/scores/new-relic-ai-monitoring.yaml
@@ -2,11 +2,23 @@ product: new-relic-ai-monitoring
 openness:
   score: 1
   class: closed
-  components: platform:proprietary-SaaS(closed);license:commercial(Standard/Pro/Enterprise tiers);ingestion:OpenTelemetry-compatible(open
-    standard, not open product);source:closed
+  components:
+    platform:
+      value: proprietary-SaaS
+      detail: closed
+    license:
+      value: commercial
+      detail: Standard/Pro/Enterprise tiers
+    ingestion:
+      value: OpenTelemetry-compatible
+      detail: open standard, not open product
+    source:
+      value: closed
   confidence: high
   note: Fully proprietary SaaS observability platform; AI Monitoring is a commercial module. OTel ingestion
     support does not make the product open. Scored closed (1).
+  raw: platform:proprietary-SaaS(closed);license:commercial(Standard/Pro/Enterprise tiers);ingestion:OpenTelemetry-compatible(open
+    standard, not open product);source:closed
   sources:
   - url: https://newrelic.com/platform/ai-monitoring
     shows: proprietary SaaS AI observability with Standard/Pro/Enterprise tiers; OTel ingestion

--- a/sources/scores/nextchat.yaml
+++ b/sources/scores/nextchat.yaml
@@ -2,11 +2,19 @@ product: nextchat
 openness:
   score: 4
   class: open_core
-  components: license:MIT(core, public source);enterprise-tier:NextChat Enterprise (permission controls,
-    team resource mgmt, internal knowledge base/RAG)
+  components:
+    license:
+      value: MIT
+      detail: core, public source
+    enterprise-tier:
+      value: NextChat Enterprise
+      detail: permission controls, team resource mgmt, internal knowledge base/RAG
+      raw: NextChat Enterprise (permission controls, team resource mgmt, internal knowledge base/RAG)
   confidence: high
   note: OSI MIT core with a separate proprietary Enterprise Edition for multi-user permissions and internal-KB
     RAG -> open_core (calibrated to the LiteLLM open_core anchor).
+  raw: license:MIT(core, public source);enterprise-tier:NextChat Enterprise (permission controls, team resource
+    mgmt, internal knowledge base/RAG)
   sources:
   - url: https://github.com/ChatGPTNextWeb/NextChat
     shows: MIT license; cross-platform chat client; Enterprise Edition (permissions, team mgmt, internal

--- a/sources/scores/nono.yaml
+++ b/sources/scores/nono.yaml
@@ -2,13 +2,30 @@ product: nono
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(full Rust implementation, self-hostable);distribution:curl /
-    Homebrew / Debian-Ubuntu-Fedora-Arch-RHEL-openSUSE-Nix + FFI bindings (nono-py, nono-ts,
-    nono-go);service:none(standalone CLI/library, no proprietary backend);core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: full Rust implementation, self-hostable
+    distribution:
+      value: curl / Homebrew / Debian-Ubuntu-Fedora-Arch-RHEL-openSUSE-Nix + FFI bindings
+      detail: nono-py, nono-ts, nono-go
+      raw: curl / Homebrew / Debian-Ubuntu-Fedora-Arch-RHEL-openSUSE-Nix + FFI bindings (nono-py, nono-ts,
+        nono-go)
+    service:
+      value: none
+      detail: standalone CLI/library, no proprietary backend
+    core-gated:
+      value: ungated
   confidence: high
   note: 'Fully open source: an Apache-2.0 Rust implementation that is self-hostable as a standalone CLI
     or library with no proprietary service tier. A clean contrast with the managed sandbox clouds (Vercel,
     Cloudflare, Modal), which publish only a client SDK over a closed runtime.'
+  raw: license:Apache-2.0(OSI);source:public(full Rust implementation, self-hostable);distribution:curl
+    / Homebrew / Debian-Ubuntu-Fedora-Arch-RHEL-openSUSE-Nix + FFI bindings (nono-py, nono-ts, nono-go);service:none(standalone
+    CLI/library, no proprietary backend);core-gated:ungated
   sources:
   - url: https://github.com/nolabs-ai/nono
     shows: Apache-2.0 license; full Rust source; self-hostable; install via curl / Homebrew / Linux package

--- a/sources/scores/northflank-sandboxes.yaml
+++ b/sources/scores/northflank-sandboxes.yaml
@@ -2,10 +2,22 @@ product: northflank-sandboxes
 openness:
   score: 1
   class: closed
-  components: license:Proprietary;service:proprietary(Northflank managed SaaS);source:closed;isolation:microVM;no
-    self-hostable open runtime
+  components:
+    license:
+      value: Proprietary
+    service:
+      value: proprietary
+      detail: Northflank managed SaaS
+    source:
+      value: closed
+    isolation:
+      value: microVM
+    free_text:
+    - no self-hostable open runtime
   confidence: high
   note: Proprietary managed deployment/sandbox platform; no open source runtime published.
+  raw: license:Proprietary;service:proprietary(Northflank managed SaaS);source:closed;isolation:microVM;no
+    self-hostable open runtime
   sources:
   - url: https://northflank.com/
     shows: Northflank Sandboxes = secure microVM sandbox for untrusted/code-gen execution; proprietary

--- a/sources/scores/olmo-instruct.yaml
+++ b/sources/scores/olmo-instruct.yaml
@@ -2,11 +2,26 @@ product: olmo-instruct
 openness:
   score: 5
   class: open_source
-  components: weights:open(Apache-2.0);data:open(Dolma 3 pretraining + open post-training mixtures);code:open(OLMo
-    + open-instruct);checkpoints:open;license:Apache-2.0(OSI)
+  components:
+    weights:
+      value: open
+      detail: Apache-2.0
+    data:
+      value: open
+      detail: Dolma 3 pretraining + open post-training mixtures
+    code:
+      value: open
+      detail: OLMo + open-instruct
+    checkpoints:
+      value: open
+    license:
+      value: Apache-2.0
+      detail: OSI
   confidence: high
   note: 'Fully-open instruct line: Apache-2.0 weights + open pretraining and post-training data + open training
     code + checkpoints.'
+  raw: weights:open(Apache-2.0);data:open(Dolma 3 pretraining + open post-training mixtures);code:open(OLMo
+    + open-instruct);checkpoints:open;license:Apache-2.0(OSI)
   sources:
   - url: https://huggingface.co/allenai/Olmo-3-7B-Instruct
     shows: OLMo 3 7B Instruct on HF; Apache-2.0

--- a/sources/scores/olmoe-instruct.yaml
+++ b/sources/scores/olmoe-instruct.yaml
@@ -2,13 +2,28 @@ product: olmoe-instruct
 openness:
   score: 5
   class: open_source
-  components: weights:open(Apache-2.0);data:open(OLMoE-mix-0924 pretraining + Tulu/UltraFeedback
-    post-training);code:open(OLMoE training code, SFT/DPO/KTO recipes);checkpoints:open(244
-    intermediate);license:Apache-2.0(OSI)
+  components:
+    weights:
+      value: open
+      detail: Apache-2.0
+    data:
+      value: open
+      detail: OLMoE-mix-0924 pretraining + Tulu/UltraFeedback post-training
+    code:
+      value: open
+      detail: OLMoE training code, SFT/DPO/KTO recipes
+    checkpoints:
+      value: open
+      detail: 244 intermediate
+    license:
+      value: Apache-2.0
+      detail: OSI
   confidence: high
   note: 'Fully-open MoE: Apache-2.0 weights + open pretraining data (OLMoE-mix-0924, on
     Dolma/DataComp) + open post-training data + open code + 244 intermediate checkpoints.
     Open_source tier 5.'
+  raw: weights:open(Apache-2.0);data:open(OLMoE-mix-0924 pretraining + Tulu/UltraFeedback post-training);code:open(OLMoE
+    training code, SFT/DPO/KTO recipes);checkpoints:open(244 intermediate);license:Apache-2.0(OSI)
   sources:
   - url: https://huggingface.co/allenai/OLMoE-1B-7B-0924-Instruct
     shows: License Apache-2.0; SFT+DPO instruct; open data and code

--- a/sources/scores/open-webui.yaml
+++ b/sources/scores/open-webui.yaml
@@ -2,9 +2,15 @@ product: open-webui
 openness:
   score: 2
   class: source_available
-  components: 'license:Open-WebUI-License(BSD-3-Clause-based + non-OSI branding clause: branding may not
-    be removed above 50 end-users/30d without enterprise license or written permission);source:public;enterprise-tier:commercial
-    license to remove branding'
+  components:
+    license:
+      value: Open-WebUI-License
+      detail: 'BSD-3-Clause-based + non-OSI branding clause: branding may not be removed above 50 end-users/30d
+        without enterprise license or written permission'
+    source:
+      value: public
+    enterprise-tier:
+      value: commercial license to remove branding
   confidence: high
   note: 'Source-available, not OSI: a branding-retention clause caps free branding removal at 50 end-users
     per 30 days, above which an enterprise license or written permission is required. That charges for a
@@ -12,6 +18,9 @@ openness:
     from 3 to 2 on 2026-07-30. The software ladder has rungs at 1, 2, 4 and 5 and none at 3, so 3/source_available
     was not a pair any rule could produce; the ladder scores "you can read it and not run it freely" at
     2.'
+  raw: 'license:Open-WebUI-License(BSD-3-Clause-based + non-OSI branding clause: branding may not be removed
+    above 50 end-users/30d without enterprise license or written permission);source:public;enterprise-tier:commercial
+    license to remove branding'
   sources:
   - url: https://github.com/open-webui/open-webui/blob/main/LICENSE
     shows: BSD-3-Clause-derived license with Section 4 branding-retention clause (<=50 users/30d), non-OSI

--- a/sources/scores/openai-code-interpreter.yaml
+++ b/sources/scores/openai-code-interpreter.yaml
@@ -2,11 +2,24 @@ product: openai-code-interpreter
 openness:
   score: 1
   class: closed
-  components: license:Proprietary;service:proprietary(OpenAI-managed
-    sandbox);source:closed;isolation:undisclosed;access:API/tool only(no self-host, no open runtime)
+  components:
+    license:
+      value: Proprietary
+    service:
+      value: proprietary
+      detail: OpenAI-managed sandbox
+    source:
+      value: closed
+    isolation:
+      value: undisclosed
+    access:
+      value: API/tool only
+      detail: no self-host, no open runtime
   confidence: high
   note: Fully proprietary managed code-execution sandbox; OpenAI does not document the isolation mechanism
     or release any runtime.
+  raw: license:Proprietary;service:proprietary(OpenAI-managed sandbox);source:closed;isolation:undisclosed;access:API/tool
+    only(no self-host, no open runtime)
   sources:
   - url: https://developers.openai.com/api/docs/assistants/tools/code-interpreter
     shows: Code Interpreter runs Python in a proprietary OpenAI-managed sandbox; $0.03/session; isolation

--- a/sources/scores/openai-evals.yaml
+++ b/sources/scores/openai-evals.yaml
@@ -2,11 +2,25 @@ product: openai-evals
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public(full framework + registry);per-dataset-licenses:mixed(CC/CC0/Apache for
-    bundled data); no feature-gated core;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+      detail: full framework + registry
+    per-dataset-licenses:
+      value: mixed
+      detail: CC/CC0/Apache for bundled data
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: Framework code is fully OSI (MIT); the included eval datasets carry their own open licenses, which
     is standard for a harness.
+  raw: license:MIT(OSI);source:public(full framework + registry);per-dataset-licenses:mixed(CC/CC0/Apache
+    for bundled data); no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/openai/evals/blob/main/LICENSE.md
     shows: MIT License text (copyright 2023 OpenAI)

--- a/sources/scores/openhands.yaml
+++ b/sources/scores/openhands.yaml
@@ -2,9 +2,19 @@ product: openhands
 openness:
   score: 4
   class: open_core
-  components: license:MIT(core);enterprise-dir:separate-license;source:public;OpenHands-Cloud-managed-tier
+  components:
+    license:
+      value: MIT
+      detail: core
+    enterprise-dir:
+      value: separate-license
+    source:
+      value: public
+    free_text:
+    - OpenHands-Cloud-managed-tier
   confidence: high
   note: license:MIT(core);enterprise-dir:separate-license;source:public;OpenHands-Cloud-managed-tier
+  raw: license:MIT(core);enterprise-dir:separate-license;source:public;OpenHands-Cloud-managed-tier
   sources:
   - url: https://github.com/All-Hands-AI/OpenHands
     shows: flagship phase-C verification source

--- a/sources/scores/openhermes-2-5.yaml
+++ b/sources/scores/openhermes-2-5.yaml
@@ -2,10 +2,22 @@ product: openhermes-2-5
 openness:
   score: 5
   class: open
-  components: license:not-clearly-stated-on-card(commonly cited as permissive);card:present;ungated:yes;format:JSON/Parquet;rows:~1M
+  components:
+    license:
+      value: not-clearly-stated-on-card
+      detail: commonly cited as permissive
+    card:
+      value: present
+    ungated:
+      value: 'yes'
+    format:
+      value: JSON/Parquet
+    rows:
+      value: ~1M
   confidence: medium
   note: Publicly downloadable and ungated with a full card, though an explicit license string is not stated
     on the card.
+  raw: license:not-clearly-stated-on-card(commonly cited as permissive);card:present;ungated:yes;format:JSON/Parquet;rows:~1M
   sources:
   - url: https://huggingface.co/datasets/teknium/OpenHermes-2.5
     shows: Public ungated dataset card, ~1M rows, synthetic/GPT-4 tags

--- a/sources/scores/openpipe.yaml
+++ b/sources/scores/openpipe.yaml
@@ -2,15 +2,28 @@ product: openpipe
 openness:
   score: 4
   class: open_core
-  components: license:Apache-2.0(OSI, OpenPipe Inc.; some vendored code LGPL-3.0);source:public;methods:RL(GRPO)+SFT
-    trajectory training;managed-tier:OpenPipe hosted training/serving SaaS on top of the OSS
-    lib;core-gated:gated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI, OpenPipe Inc.; some vendored code LGPL-3.0
+    source:
+      value: public
+    methods:
+      value: RL
+      detail: GRPO)+SFT trajectory training
+      raw: RL(GRPO)+SFT trajectory training
+    managed-tier:
+      value: OpenPipe hosted training/serving SaaS on top of the OSS lib
+    core-gated:
+      value: gated
   confidence: high
   note: ART's own FAQ and backend docs (fetched 2026-08-09) describe the hosted ServerlessBackend as an
     optional convenience alongside a fully self-hostable LocalBackend, with no ART feature withheld from
     the free path. The OSI-licensed, self-hostable core is the whole product, which the software ladder's
     rule for {license_tier:osi, source:public, core_gated:ungated} scores 5/open_source rather than 4/open_core.
   last_verified: '2026-08-09'
+  raw: license:Apache-2.0(OSI, OpenPipe Inc.; some vendored code LGPL-3.0);source:public;methods:RL(GRPO)+SFT
+    trajectory training;managed-tier:OpenPipe hosted training/serving SaaS on top of the OSS lib;core-gated:gated
   sources:
   - url: https://github.com/OpenPipe/ART
     shows: Repo metadata reads `"isPrivate":false`, `"isArchived":false`, `"visibilityLabel":"Public"`,

--- a/sources/scores/opensandbox.yaml
+++ b/sources/scores/opensandbox.yaml
@@ -2,11 +2,24 @@ product: opensandbox
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(Go execd + multi-language
-    SDKs);runtimes:Docker/Kubernetes;no-managed-tier-observed;no-feature-gated-core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: Go execd + multi-language SDKs
+    runtimes:
+      value: Docker/Kubernetes
+    core-gated:
+      value: ungated
+    free_text:
+    - no-managed-tier-observed
+    - no-feature-gated-core
   confidence: high
   note: Apache-2.0, fully self-hostable, no managed/enterprise gating observed => open_source (not open_core).
     Alibaba says it open sourced the sandbox infra used internally.
+  raw: license:Apache-2.0(OSI);source:public(Go execd + multi-language SDKs);runtimes:Docker/Kubernetes;no-managed-tier-observed;no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://github.com/alibaba/OpenSandbox
     shows: Apache-2.0 license; general-purpose AI-agent sandbox; Docker/K8s runtimes; multi-language SDKs;

--- a/sources/scores/patronus-evaluation-platform.yaml
+++ b/sources/scores/patronus-evaluation-platform.yaml
@@ -2,9 +2,18 @@ product: patronus-evaluation-platform
 openness:
   score: 2
   class: source_available
-  components: platform:closed(hosted SaaS; remote Judge/Lynx/Glider evaluators run on Patronus infrastructure);source:partial(patronus-py
-    is a client wiring to the hosted API, not the engine);client-SDKs:open(patronus-py public on GitHub,
-    v0.1.25, but only 7 stars and wires to the hosted API);eval engine + proprietary evaluators not self-hostable
+  components:
+    platform:
+      value: closed
+      detail: hosted SaaS; remote Judge/Lynx/Glider evaluators run on Patronus infrastructure
+    source:
+      value: partial
+      detail: patronus-py is a client wiring to the hosted API, not the engine
+    client-SDKs:
+      value: open
+      detail: patronus-py public on GitHub, v0.1.25, but only 7 stars and wires to the hosted API
+    free_text:
+    - eval engine + proprietary evaluators not self-hostable
   confidence: medium
   note: The open-source SDK is a thin client to a closed hosted evaluation backend; the core scoring engine
     and the managed Lynx/Glider evaluators are proprietary and not self-hostable. License text is not displayed
@@ -12,6 +21,9 @@ openness:
     OSI core with functionality withheld for a paid tier, and there is no open core here, only an open periphery.
     A repo that exists while the runtime does not ship is source:partial, which the ladder scores 2/source_available.
     The score itself was already 2.
+  raw: platform:closed(hosted SaaS; remote Judge/Lynx/Glider evaluators run on Patronus infrastructure);source:partial(patronus-py
+    is a client wiring to the hosted API, not the engine);client-SDKs:open(patronus-py public on GitHub,
+    v0.1.25, but only 7 stars and wires to the hosted API);eval engine + proprietary evaluators not self-hostable
   sources:
   - url: https://github.com/patronus-ai/patronus-py
     shows: Python SDK whose remote evaluators 'run remotely on Patronus infrastructure'; v0.1.25 Jan 2026;

--- a/sources/scores/personahub.yaml
+++ b/sources/scores/personahub.yaml
@@ -2,8 +2,16 @@ product: personahub
 openness:
   score: 2
   class: restricted
-  components: license:cc-by-nc-sa-4.0(non-commercial);card:present;ungated:yes;scope:~370M personas+seed
-    samples
+  components:
+    license:
+      value: cc-by-nc-sa-4.0
+      detail: non-commercial
+    card:
+      value: present
+    ungated:
+      value: 'yes'
+    scope:
+      value: ~370M personas+seed samples
   confidence: high
   note: >-
     Publicly downloadable and ungated, and licensed CC-BY-NC-SA-4.0, which permits redistribution
@@ -14,6 +22,7 @@ openness:
     reuse. The scale settles it on the commercial-use test, and the Open Definition agrees - data
     is not open unless it may be reused commercially. `restricted` is new to the dataset class
     vocabulary for this: it was the only product type with no word between `open` and `gated`.
+  raw: license:cc-by-nc-sa-4.0(non-commercial);card:present;ungated:yes;scope:~370M personas+seed samples
   sources:
   - url: https://huggingface.co/datasets/proj-persona/PersonaHub
     shows: CC-BY-NC-SA-4.0 license, ungated card, persona counts and paper reference

--- a/sources/scores/perspective-api.yaml
+++ b/sources/scores/perspective-api.yaml
@@ -2,10 +2,22 @@ product: perspective-api
 openness:
   score: 1
   class: closed
-  components: service:proprietary hosted API by Jigsaw/Google(no weights, no self-host);access:free with
-    quota;scores:toxicity + related attributes;source:closed;license:proprietary
+  components:
+    service:
+      value: proprietary hosted API by Jigsaw/Google
+      detail: no weights, no self-host
+    access:
+      value: free with quota
+    scores:
+      value: toxicity + related attributes
+    source:
+      value: closed
+    license:
+      value: proprietary
   confidence: high
   note: Closed, API-only hosted classifier; no weights or source. Long-standing and influential, but proprietary.
+  raw: service:proprietary hosted API by Jigsaw/Google(no weights, no self-host);access:free with quota;scores:toxicity
+    + related attributes;source:closed;license:proprietary
   sources:
   - url: https://perspectiveapi.com/
     shows: Jigsaw (Google) free hosted toxicity-scoring API; no weights or self-host

--- a/sources/scores/predibase.yaml
+++ b/sources/scores/predibase.yaml
@@ -2,10 +2,22 @@ product: predibase
 openness:
   score: 2
   class: source_available
-  components: core-platform:closed(proprietary post-training stack + turbo serving);source:partial(LoRAX
-    and Ludwig are adjacent OSS; the fine-tuning platform does not ship);OSS-components:LoRAX(open source
-    multi-LoRA serving)+Ludwig(open source);runs-on:Predibase-SaaS-or-customer-VPC;license:Proprietary(managed)
-    with Apache-licensed LoRAX/Ludwig adjuncts
+  components:
+    core-platform:
+      value: closed
+      detail: proprietary post-training stack + turbo serving
+    source:
+      value: partial
+      detail: LoRAX and Ludwig are adjacent OSS; the fine-tuning platform does not ship
+    OSS-components:
+      value: LoRAX
+      detail: open source multi-LoRA serving)+Ludwig(open source
+    runs-on:
+      value: Predibase-SaaS-or-customer-VPC
+    license:
+      value: Proprietary
+      detail: managed) with Apache-licensed LoRAX/Ludwig adjuncts
+      raw: Proprietary(managed) with Apache-licensed LoRAX/Ludwig adjuncts
   confidence: high
   note: The founders created and maintain OSS LoRAX (multi-LoRA serving) and Ludwig, but the Predibase fine-tuning/RFT
     platform, which is the thing being scored, is proprietary managed SaaS running on Predibase's own cloud
@@ -14,6 +26,10 @@ openness:
     and there is no open core here, only an open periphery. A repo that exists while the runtime does not
     ship is source:partial, which the ladder scores 2/source_available. The score itself was already 2.
   last_verified: '2026-08-09'
+  raw: core-platform:closed(proprietary post-training stack + turbo serving);source:partial(LoRAX and Ludwig
+    are adjacent OSS; the fine-tuning platform does not ship);OSS-components:LoRAX(open source multi-LoRA
+    serving)+Ludwig(open source);runs-on:Predibase-SaaS-or-customer-VPC;license:Proprietary(managed) with
+    Apache-licensed LoRAX/Ludwig adjuncts
   sources:
   - url: https://pypi.org/pypi/predibase/json
     shows: 'The JSON API''s info object records license: null, classifiers: [], summary: null, and home_page:

--- a/sources/scores/qualcomm-ai-engine-direct.yaml
+++ b/sources/scores/qualcomm-ai-engine-direct.yaml
@@ -2,15 +2,27 @@ product: qualcomm-ai-engine-direct
 openness:
   score: 1
   class: closed
-  components: source:closed(no published source for the QNN/Qualcomm AI Runtime SDK core engine; distributed
-    as a proprietary binary via the Qualcomm Software Center under an EULA);license:proprietary(no license
-    to the source since it is not published);open-wrapper:BSD-3-Clause(qualcomm/qai-appbuilder, formerly
-    quic/ai-engine-direct-helper -- a convenience API layer that requires the proprietary SDK libraries)
+  components:
+    source:
+      value: closed
+      detail: no published source for the QNN/Qualcomm AI Runtime SDK core engine; distributed as a proprietary
+        binary via the Qualcomm Software Center under an EULA
+    license:
+      value: proprietary
+      detail: no license to the source since it is not published
+    open-wrapper:
+      value: BSD-3-Clause
+      detail: qualcomm/qai-appbuilder, formerly quic/ai-engine-direct-helper -- a convenience API layer
+        that requires the proprietary SDK libraries
   confidence: high
   note: 'Re-read against the ladder''s controlled vocabulary: source is closed (the core engine has no published
     repo and ships only as an EULA-gated download from the Qualcomm Software Center), so the formula settles
     on source alone and the BSD-3 wrapper does not change the class. The wrapper repo has moved from quic/ai-engine-direct-helper
     to qualcomm/qai-appbuilder; both names now redirect to the same place.'
+  raw: source:closed(no published source for the QNN/Qualcomm AI Runtime SDK core engine; distributed as
+    a proprietary binary via the Qualcomm Software Center under an EULA);license:proprietary(no license
+    to the source since it is not published);open-wrapper:BSD-3-Clause(qualcomm/qai-appbuilder, formerly
+    quic/ai-engine-direct-helper -- a convenience API layer that requires the proprietary SDK libraries)
   sources:
   - url: https://github.com/quic/ai-engine-direct-helper
     shows: QAI AppBuilder is an extension of the Qualcomm® AI Runtime SDK, which is used to simplify the

--- a/sources/scores/ray.yaml
+++ b/sources/scores/ray.yaml
@@ -2,11 +2,22 @@ product: ray
 openness:
   score: 4
   class: open_core
-  components: license:Apache-2.0(OSI);source:public(all Ray libraries OSS);commercial-tier:Anyscale managed SaaS on
-    top;core-gated:gated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: all Ray libraries OSS
+    commercial-tier:
+      value: Anyscale managed SaaS on top
+    core-gated:
+      value: gated
   confidence: high
   note: license:Apache-2.0(OSI);source:public(all Ray libraries OSS);commercial-tier:Anyscale managed
     SaaS on top
+  raw: license:Apache-2.0(OSI);source:public(all Ray libraries OSS);commercial-tier:Anyscale managed SaaS
+    on top;core-gated:gated
   sources:
   - url: https://github.com/ray-project/ray
     shows: flagship phase-C verification source

--- a/sources/scores/sambanova-cloud.yaml
+++ b/sources/scores/sambanova-cloud.yaml
@@ -2,12 +2,22 @@ product: sambanova-cloud
 openness:
   score: 1
   class: closed
-  components: license:proprietary;software-stack:closed(SambaFlow compiler/runtime not open);hardware:SN40L-RDU-only;delivery:managed-cloud-API
+  components:
+    license:
+      value: proprietary
+    software-stack:
+      value: closed
+      detail: SambaFlow compiler/runtime not open
+    hardware:
+      value: SN40L-RDU-only
+    delivery:
+      value: managed-cloud-API
   confidence: high
   note: Proprietary managed cloud inference on SambaNova's own RDU silicon; no open source software disclosed.
     The Cloud EULA confirms a non-exclusive, non-transferable, limited license to use the hosted service
     only -- not a redistribution or source grant. Scored closed.
   last_verified: '2026-08-09'
+  raw: license:proprietary;software-stack:closed(SambaFlow compiler/runtime not open);hardware:SN40L-RDU-only;delivery:managed-cloud-API
   sources:
   - url: https://sambanova.ai/cloud-end-user-license-agreement
     shows: SambaNova hereby grants to Customer a non-exclusive, non-transferable, limited license during

--- a/sources/scores/sandbox-runtime.yaml
+++ b/sources/scores/sandbox-runtime.yaml
@@ -2,11 +2,24 @@ product: sandbox-runtime
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public(GitHub);distribution:npm package;no managed/proprietary tier(it is
-    a local library, not a service);core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+      detail: GitHub
+    distribution:
+      value: npm package
+    core-gated:
+      value: ungated
+    free_text:
+    - no managed/proprietary tier(it is a local library, not a service)
   confidence: high
   note: Apache-2.0 OS-level sandboxing library, fully open and self-contained; no feature-gated core or
     paid tier.
+  raw: license:Apache-2.0(OSI);source:public(GitHub);distribution:npm package;no managed/proprietary tier(it
+    is a local library, not a service);core-gated:ungated
   sources:
   - url: https://github.com/anthropic-experimental/sandbox-runtime
     shows: Apache-2.0 license; OS-level (bubblewrap/seatbelt) sandbox library, no container required

--- a/sources/scores/scale-evaluation.yaml
+++ b/sources/scores/scale-evaluation.yaml
@@ -2,13 +2,25 @@ product: scale-evaluation
 openness:
   score: 1
   class: closed
-  components: platform:closed(proprietary hosted SaaS); datasets:closed(private, unpublished SEAL benchmarks
-    kept private to prevent gaming/training contamination); methodology:partially-disclosed(leaderboard
-    transparency) but no open eval code or self-hostable engine; human-eval workforce is a proprietary
-    service
+  components:
+    platform:
+      value: closed
+      detail: proprietary hosted SaaS
+    datasets:
+      value: closed
+      detail: private, unpublished SEAL benchmarks kept private to prevent gaming/training contamination
+    methodology:
+      value: partially-disclosed
+      detail: leaderboard transparency) but no open eval code or self-hostable engine
+      raw: partially-disclosed(leaderboard transparency) but no open eval code or self-hostable engine
+    free_text:
+    - human-eval workforce is a proprietary service
   confidence: high
   note: Proprietary by design; the deliberately-private benchmark datasets and hosted expert-eval workforce
     are the moat; no open source eval code. Closed.
+  raw: platform:closed(proprietary hosted SaaS); datasets:closed(private, unpublished SEAL benchmarks kept
+    private to prevent gaming/training contamination); methodology:partially-disclosed(leaderboard transparency)
+    but no open eval code or self-hostable engine; human-eval workforce is a proprietary service
   sources:
   - url: https://scale.com/genai-platform
     shows: 'Scale GenAI Platform: automated + expert-human evaluation ''Trust Feedback Loop''; test against

--- a/sources/scores/sillytavern.yaml
+++ b/sources/scores/sillytavern.yaml
@@ -3,10 +3,26 @@ openness:
   score: 5
   class: open_source
   confidence: high
-  components: license:AGPL-3.0(OSI, copyleft);source:public(github.com/SillyTavern/SillyTavern);self-host:only(local
-    install);no-managed-tier;extensions:third-party;core-gated:ungated
+  components:
+    license:
+      value: AGPL-3.0
+      detail: OSI, copyleft
+    source:
+      value: public
+      detail: github.com/SillyTavern/SillyTavern
+    self-host:
+      value: only
+      detail: local install
+    extensions:
+      value: third-party
+    core-gated:
+      value: ungated
+    free_text:
+    - no-managed-tier
   note: AGPL-3.0 (OSI-approved copyleft), full source public, self-host only, fully open. No proprietary/SaaS
     tier.
+  raw: license:AGPL-3.0(OSI, copyleft);source:public(github.com/SillyTavern/SillyTavern);self-host:only(local
+    install);no-managed-tier;extensions:third-party;core-gated:ungated
   sources:
   - url: https://github.com/SillyTavern/SillyTavern
     shows: AGPL-3.0; public source; v1.18.0 (3 May 2026); local UI for LLM/image/TTS backends

--- a/sources/scores/snowflake-cortex-fine-tuning.yaml
+++ b/sources/scores/snowflake-cortex-fine-tuning.yaml
@@ -2,12 +2,29 @@ product: snowflake-cortex-fine-tuning
 openness:
   score: 1
   class: closed
-  components: license:Proprietary;service:fully-managed-proprietary(in-Snowflake);source:closed;method:PEFT(LoRA-class,
-    not specified);base-models:fixed allowlist;access:Snowflake-account+credits;data:user-data stays in
-    account but engine closed
+  components:
+    license:
+      value: Proprietary
+    service:
+      value: fully-managed-proprietary
+      detail: in-Snowflake
+    source:
+      value: closed
+    method:
+      value: PEFT
+      detail: LoRA-class, not specified
+    base-models:
+      value: fixed allowlist
+    access:
+      value: Snowflake-account+credits
+    data:
+      value: user-data stays in account but engine closed
   confidence: high
   note: Proprietary fully-managed SaaS fine-tuning feature; no source, no self-host. Closed.
   last_verified: '2026-08-09'
+  raw: license:Proprietary;service:fully-managed-proprietary(in-Snowflake);source:closed;method:PEFT(LoRA-class,
+    not specified);base-models:fixed allowlist;access:Snowflake-account+credits;data:user-data stays in
+    account but engine closed
   sources:
   - url: https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-finetuning
     shows: Cortex Fine-tuning is a fully managed service that runs entirely inside Snowflake via the FINETUNE

--- a/sources/scores/spaces.yaml
+++ b/sources/scores/spaces.yaml
@@ -2,13 +2,27 @@ product: spaces
 openness:
   score: 1
   class: closed
-  components: license:Proprietary;source:closed;platform:proprietary(HF-managed hosting/orchestration, no
-    self-hostable Spaces);open-part:app SDKs only (Gradio Apache-2.0, Streamlit) which are separate,
-    portable OSS products;hardware-tiers:CPU free + paid GPU upgrades
+  components:
+    license:
+      value: Proprietary
+    source:
+      value: closed
+    platform:
+      value: proprietary
+      detail: HF-managed hosting/orchestration, no self-hostable Spaces
+    open-part:
+      value: app SDKs only
+      detail: Gradio Apache-2.0, Streamlit) which are separate, portable OSS products
+      raw: app SDKs only (Gradio Apache-2.0, Streamlit) which are separate, portable OSS products
+    hardware-tiers:
+      value: CPU free + paid GPU upgrades
   confidence: medium
   note: 'Closed managed hosting service. Apps are built with OSS SDKs (Gradio etc.) that run anywhere,
     but Spaces itself - the managed host/orchestration - is proprietary and not self-hostable; those SDKs
     are separate products, not a Spaces open core. Reclassified from open_core (borderline).'
+  raw: license:Proprietary;source:closed;platform:proprietary(HF-managed hosting/orchestration, no self-hostable
+    Spaces);open-part:app SDKs only (Gradio Apache-2.0, Streamlit) which are separate, portable OSS products;hardware-tiers:CPU
+    free + paid GPU upgrades
   sources:
   - url: https://huggingface.co/docs/hub/spaces
     shows: Spaces hosts apps via Gradio (OSS SDK), Streamlit, arbitrary Dockerfile, or static HTML on

--- a/sources/scores/starcoder2.yaml
+++ b/sources/scores/starcoder2.yaml
@@ -2,9 +2,21 @@ product: starcoder2
 openness:
   score: 4
   class: open_weights
-  components: weights:open;data:open(self-oss-instruct-sc2-exec-filter-50k + 7 documented intermediate datasets);code:open(starcoder2-self-align
-    pipeline on GitHub);base-data:open(The Stack v2);license:BigCode-OpenRAIL-M(open but RAIL behavioral-use restrictions,
-    not OSI)
+  components:
+    weights:
+      value: open
+    data:
+      value: open
+      detail: self-oss-instruct-sc2-exec-filter-50k + 7 documented intermediate datasets
+    code:
+      value: open
+      detail: starcoder2-self-align pipeline on GitHub
+    base-data:
+      value: open
+      detail: The Stack v2
+    license:
+      value: BigCode-OpenRAIL-M
+      detail: open but RAIL behavioral-use restrictions, not OSI
   confidence: high
   note: 'The most open artifact in this category by evidence: weights, the full training corpus (The Stack v2) and
     the self-align pipeline are all published. Held to 4 rather than 5 because BigCode-OpenRAIL-M is not OSI-approved
@@ -13,6 +25,9 @@ openness:
     the score was right but 4/open_source is a pair this ladder cannot emit, and the mismatch is what flagged it.
     Resolved under issue #117 by tiering RAIL as a conduct restriction, which is what keeps a fully-open pipeline
     off the 2/restricted floor it would otherwise have hit on the license alone.'
+  raw: weights:open;data:open(self-oss-instruct-sc2-exec-filter-50k + 7 documented intermediate datasets);code:open(starcoder2-self-align
+    pipeline on GitHub);base-data:open(The Stack v2);license:BigCode-OpenRAIL-M(open but RAIL behavioral-use
+    restrictions, not OSI)
   sources:
   - url: https://huggingface.co/bigcode/starcoder2-15b-instruct-v0.1
     shows: self-aligned; open dataset + open self-align code + OpenRAIL-M license

--- a/sources/scores/swe-bench-verified.yaml
+++ b/sources/scores/swe-bench-verified.yaml
@@ -2,15 +2,33 @@ product: swe-bench-verified
 openness:
   score: 4
   class: open
-  components: license:undeclared on HF dataset card (underlying SWE-bench harness repo is MIT);redistributability:full(downloadable
-    parquet, ungated);datasheet:yes(dataset card + arXiv:2310.06770);held-out:no hidden split in Verified
-    itself (the public 500-instance set is fully released; gold patches + tests included);data-source:real
-    GitHub PR/issue pairs
+  components:
+    license:
+      value: undeclared on HF dataset card
+      detail: underlying SWE-bench harness repo is MIT
+      raw: undeclared on HF dataset card (underlying SWE-bench harness repo is MIT)
+    redistributability:
+      value: full
+      detail: downloadable parquet, ungated
+    datasheet:
+      value: 'yes'
+      detail: dataset card + arXiv:2310.06770
+    held-out:
+      value: no hidden split in Verified itself
+      detail: the public 500-instance set is fully released; gold patches + tests included
+      raw: no hidden split in Verified itself (the public 500-instance set is fully released; gold patches
+        + tests included)
+    data-source:
+      value: real GitHub PR/issue pairs
   confidence: medium
   note: Effectively open (ungated, downloadable, full gold patches and tests, datasheet present) but
     the HF dataset card declares NO explicit license field, so the data-license class is inferred from
     the MIT harness repo and public redistribution rather than a stated data license. Scored 4 not 5 on
     that ambiguity. (Distinct from SWE-bench's broader/hidden variants which can carry held-out splits.)
+  raw: license:undeclared on HF dataset card (underlying SWE-bench harness repo is MIT);redistributability:full(downloadable
+    parquet, ungated);datasheet:yes(dataset card + arXiv:2310.06770);held-out:no hidden split in Verified
+    itself (the public 500-instance set is fully released; gold patches + tests included);data-source:real
+    GitHub PR/issue pairs
   sources:
   - url: https://huggingface.co/datasets/princeton-nlp/SWE-bench_Verified
     shows: 500 instances, ~2.1 MB, not gated, dataset card present, gold patch + FAIL_TO_PASS/PASS_TO_PASS

--- a/sources/scores/swift.yaml
+++ b/sources/scores/swift.yaml
@@ -2,11 +2,23 @@ product: swift
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI);source:public;maintainer:ModelScope(Alibaba);no feature-gated
-    core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI
+    source:
+      value: public
+    maintainer:
+      value: ModelScope
+      detail: Alibaba
+    core-gated:
+      value: ungated
+    free_text:
+    - no feature-gated core
   confidence: high
   note: Fully OSI-licensed open source training/deploy framework; source public.
   last_verified: '2026-08-08'
+  raw: license:Apache-2.0(OSI);source:public;maintainer:ModelScope(Alibaba);no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/modelscope/ms-swift
     shows: Repository tree lists swift/, setup.py, requirements/, tests/, docs/ and LICENSE, and the README

--- a/sources/scores/tensorrt-llm.yaml
+++ b/sources/scores/tensorrt-llm.yaml
@@ -2,9 +2,18 @@ product: tensorrt-llm
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI, stated in LICENSE; GitHub reports NOASSERTION because of the bundled-dependency
-    appendix);source:public;core-gated:ungated;caveat:runs only on NVIDIA GPUs (vendor-hardware lock, not
-    a license restriction)
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI, stated in LICENSE; GitHub reports NOASSERTION because of the bundled-dependency appendix
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    caveat:
+      value: runs only on NVIDIA GPUs
+      detail: vendor-hardware lock, not a license restriction
+      raw: runs only on NVIDIA GPUs (vendor-hardware lock, not a license restriction)
   confidence: high
   note: Apache-2.0 across the repo, re-confirmed today. The LICENSE body still opens "This project is licensed
     under the Apache 2.0 license" and appends the terms of bundled third-party code (MIT, BSD-3-Clause,
@@ -13,6 +22,9 @@ openness:
     rather than a stub, so nothing is gated out of the source; NVIDIA sells NIM and enterprise support as
     separate products. No change from the 2026-07-30 correction (4->5, open_core->open_source).
   last_verified: '2026-08-09'
+  raw: license:Apache-2.0(OSI, stated in LICENSE; GitHub reports NOASSERTION because of the bundled-dependency
+    appendix);source:public;core-gated:ungated;caveat:runs only on NVIDIA GPUs (vendor-hardware lock, not
+    a license restriction)
   sources:
   - url: https://github.com/NVIDIA/TensorRT-LLM
     shows: TensorRT LLM provides users with an easy-to-use Python API to define Large Language Models (LLMs)

--- a/sources/scores/tinker.yaml
+++ b/sources/scores/tinker.yaml
@@ -2,14 +2,32 @@ product: tinker
 openness:
   score: 1
   class: closed
-  components: license:Proprietary;source:closed;engine:closed(hosted distributed-training service on TML
-    infra);cookbook:open(Apache-2.0,
-    thinking-machines-lab/tinker-cookbook);api:public-but-proprietary(forward_backward/optim_step/sample/save_state);method:LoRA(+RL
-    via sample);access:paid+account-gated
+  components:
+    license:
+      value: Proprietary
+    source:
+      value: closed
+    engine:
+      value: closed
+      detail: hosted distributed-training service on TML infra
+    cookbook:
+      value: open
+      detail: Apache-2.0, thinking-machines-lab/tinker-cookbook
+    api:
+      value: public-but-proprietary
+      detail: forward_backward/optim_step/sample/save_state
+    method:
+      value: LoRA
+      detail: +RL via sample
+    access:
+      value: paid+account-gated
   confidence: high
   note: Core training service is a proprietary hosted API; only the example cookbook is OSI-licensed,
     so the product is closed. Not open_core since no self-hostable engine exists.
   last_verified: '2026-08-09'
+  raw: license:Proprietary;source:closed;engine:closed(hosted distributed-training service on TML infra);cookbook:open(Apache-2.0,
+    thinking-machines-lab/tinker-cookbook);api:public-but-proprietary(forward_backward/optim_step/sample/save_state);method:LoRA(+RL
+    via sample);access:paid+account-gated
   sources:
   - url: https://thinkingmachines.ai/tinker/
     shows: Describes Tinker as "a training API for researchers" where users "Control every aspect of model

--- a/sources/scores/together-fine-tuning.yaml
+++ b/sources/scores/together-fine-tuning.yaml
@@ -2,14 +2,27 @@ product: together-fine-tuning
 openness:
   score: 1
   class: closed
-  components: source:closed;training-pipeline:closed;runs-on:Together-cloud-only;license:Proprietary(managed
-    service, per-token training pricing); base-weights:open-models(varies)
+  components:
+    source:
+      value: closed
+    training-pipeline:
+      value: closed
+    runs-on:
+      value: Together-cloud-only
+    license:
+      value: Proprietary
+      detail: managed service, per-token training pricing
+    base-weights:
+      value: open-models
+      detail: varies
   confidence: high
   note: The fine-tuning service and its training pipeline are proprietary and run only on Together's cloud;
     there is no self-hostable implementation. Together's Terms of Service bar reverse-engineering the underlying
     source code and vest all IP in Together AI, granting users only a non-sublicensable right to use the
     service. (Together tunes open-weight base models, but the offering itself is closed.)
   last_verified: '2026-08-09'
+  raw: source:closed;training-pipeline:closed;runs-on:Together-cloud-only;license:Proprietary(managed service,
+    per-token training pricing); base-weights:open-models(varies)
   sources:
   - url: https://docs.together.ai/docs/fine-tuning-overview
     shows: '"Together AI handles the full lifecycle: data upload, training, hosting, and inference on a

--- a/sources/scores/trulens.yaml
+++ b/sources/scores/trulens.yaml
@@ -2,11 +2,25 @@ product: trulens
 openness:
   score: 5
   class: open_source
-  components: license:MIT(OSI);source:public(github.com/truera/trulens);commercial:Snowflake-Cortex-AI-Observability(separate
-    hosted product);library:not-feature-gated;core-gated:ungated
+  components:
+    license:
+      value: MIT
+      detail: OSI
+    source:
+      value: public
+      detail: github.com/truera/trulens
+    commercial:
+      value: Snowflake-Cortex-AI-Observability
+      detail: separate hosted product
+    library:
+      value: not-feature-gated
+    core-gated:
+      value: ungated
   confidence: high
   note: MIT library that is fully functional standalone; the Snowflake Cortex hosted product is separate, not a
     gate on the library.
+  raw: license:MIT(OSI);source:public(github.com/truera/trulens);commercial:Snowflake-Cortex-AI-Observability(separate
+    hosted product);library:not-feature-gated;core-gated:ungated
   sources:
   - url: https://github.com/truera/trulens
     shows: MIT, ~3.4k stars, LLM eval + tracing

--- a/sources/scores/tulu.yaml
+++ b/sources/scores/tulu.yaml
@@ -2,8 +2,25 @@ product: tulu
 openness:
   score: 3
   class: open_weights
-  components: weights:open(downloadable);license:Llama-3.1-Community(non-OSI;700M-MAU cap + use policy);post-training-data:open(Apache-2.0/ODC-BY);code:open(open-instruct
-    Apache-2.0);recipe:open(SFT->DPO->RLVR);evals:open(OLMES)
+  components:
+    weights:
+      value: open
+      detail: downloadable
+    license:
+      value: Llama-3.1-Community
+      detail: non-OSI;700M-MAU cap + use policy
+    post-training-data:
+      value: open
+      detail: Apache-2.0/ODC-BY
+    code:
+      value: open
+      detail: open-instruct Apache-2.0
+    recipe:
+      value: open
+      detail: SFT->DPO->RLVR
+    evals:
+      value: open
+      detail: OLMES
   confidence: high
   note: >-
     The released weights inherit Meta's Llama 3.1 Community License (non-OSI, 700M-MAU cap), so
@@ -17,6 +34,8 @@ openness:
     3/restricted, a pair no rule in the category ladder could produce. The universal license scale
     now caps a bounded commercial license at 3/open_weights, which IS producible, so the score
     returns while the objection that removed it stays answered.
+  raw: weights:open(downloadable);license:Llama-3.1-Community(non-OSI;700M-MAU cap + use policy);post-training-data:open(Apache-2.0/ODC-BY);code:open(open-instruct
+    Apache-2.0);recipe:open(SFT->DPO->RLVR);evals:open(OLMES)
   sources:
   - url: https://huggingface.co/allenai/Llama-3.1-Tulu-3-8B
     shows: 'License: Llama 3.1 Community License Agreement (non-OSI); base meta-llama/Llama-3.1-8B'

--- a/sources/scores/ultrafeedback.yaml
+++ b/sources/scores/ultrafeedback.yaml
@@ -2,9 +2,22 @@ product: ultrafeedback
 openness:
   score: 5
   class: open
-  components: license:mit;card:present;ungated:yes;rows:63,967;size:940MB
+  components:
+    license:
+      value: mit
+    card:
+      value: present
+    ungated:
+      value: 'yes'
+    rows:
+      value: '63'
+      detail: '967'
+      raw: 63,967
+    size:
+      value: 940MB
   confidence: high
   note: Publicly downloadable and ungated under the permissive MIT license.
+  raw: license:mit;card:present;ungated:yes;rows:63,967;size:940MB
   sources:
   - url: https://huggingface.co/datasets/openbmb/UltraFeedback
     shows: MIT license, ungated card, 63,967 rows / 940 MB

--- a/sources/scores/vals-ai.yaml
+++ b/sources/scores/vals-ai.yaml
@@ -2,11 +2,22 @@ product: vals-ai
 openness:
   score: 1
   class: closed
-  components: license:proprietary;source:closed(SaaS-only,no public repo);benchmarks:proprietary/private-held-out(Vals
-    Index on non-public datasets);eval-harness:closed
+  components:
+    license:
+      value: proprietary
+    source:
+      value: closed
+      detail: SaaS-only,no public repo
+    benchmarks:
+      value: proprietary/private-held-out
+      detail: Vals Index on non-public datasets
+    eval-harness:
+      value: closed
   confidence: high
   note: Closed third-party eval platform; benchmarks deliberately held private to prevent dataset leakage,
     eval infra not open sourced.
+  raw: license:proprietary;source:closed(SaaS-only,no public repo);benchmarks:proprietary/private-held-out(Vals
+    Index on non-public datasets);eval-harness:closed
   sources:
   - url: https://www.vals.ai
     shows: proprietary SaaS eval platform, 'proprietary benchmarks' require contact, no GitHub/self-host

--- a/sources/scores/vellum.yaml
+++ b/sources/scores/vellum.yaml
@@ -2,10 +2,23 @@ product: vellum
 openness:
   score: 5
   class: open_source
-  components: 'license:MIT(OSI, Copyright 2025 Vellum AI);source:public(the full agent - gateway, clients,
-    skill framework, memory - in github.com/vellum-ai/vellum-assistant);core-gated:ungated(README: managed
-    runtime on Vellum Platform or self-hosted, "Same codebase, same data model");self-host:yes(by design);managed-cloud:hosting
-    convenience, not a feature tier'
+  components:
+    license:
+      value: MIT
+      detail: OSI, Copyright 2025 Vellum AI
+    source:
+      value: public
+      detail: the full agent - gateway, clients, skill framework, memory - in github.com/vellum-ai/vellum-assistant
+    core-gated:
+      value: ungated
+      detail: 'README: managed runtime on Vellum Platform or self-hosted, "Same codebase, same data model"'
+    self-host:
+      value: 'yes'
+      detail: by design
+    managed-cloud:
+      value: hosting convenience
+      detail: not a feature tier
+      raw: hosting convenience, not a feature tier
   confidence: high
   note: 'CORRECTED from the record''s "closed/score 1". The agent''s complete source is public and MIT-licensed
     (LICENSE: "Copyright (c) 2025 Vellum AI"), covering the backend gateway, the Mac/Slack/Telegram clients,
@@ -16,6 +29,10 @@ openness:
     the managed runtime and the self-hosted one are the "Same codebase, same data model", so hosting is
     convenience rather than a feature tier. The ladder''s core_gated note is explicit that a hosted offering
     alongside an ungated core is not gating, and 4 pairs with open_core in any case.'
+  raw: 'license:MIT(OSI, Copyright 2025 Vellum AI);source:public(the full agent - gateway, clients, skill
+    framework, memory - in github.com/vellum-ai/vellum-assistant);core-gated:ungated(README: managed runtime
+    on Vellum Platform or self-hosted, "Same codebase, same data model");self-host:yes(by design);managed-cloud:hosting
+    convenience, not a feature tier'
   sources:
   - url: https://www.vellum.ai
     shows: personal AI assistant 'AI layer for your life'; comparison table labels Vellum 'Proprietary'

--- a/sources/scores/vertex-ai-gen-ai-evaluation-service.yaml
+++ b/sources/scores/vertex-ai-gen-ai-evaluation-service.yaml
@@ -2,10 +2,21 @@ product: vertex-ai-gen-ai-evaluation-service
 openness:
   score: 1
   class: closed
-  components: license:proprietary(GCP managed service);source:closed;deployment:cloud-only(Vertex AI pipelines/AutoSxS);billing:GCP
-    managed-service pricing
+  components:
+    license:
+      value: proprietary
+      detail: GCP managed service
+    source:
+      value: closed
+    deployment:
+      value: cloud-only
+      detail: Vertex AI pipelines/AutoSxS
+    billing:
+      value: GCP managed-service pricing
   confidence: high
   note: Proprietary Google Cloud managed service; no source, no self-host, runs as Vertex AI eval pipelines.
+  raw: license:proprietary(GCP managed service);source:closed;deployment:cloud-only(Vertex AI pipelines/AutoSxS);billing:GCP
+    managed-service pricing
   sources:
   - url: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/evaluation-overview
     shows: managed GCP eval service (computation-based + autorater + AutoSxS) within Gemini Enterprise

--- a/sources/scores/weave.yaml
+++ b/sources/scores/weave.yaml
@@ -2,12 +2,23 @@ product: weave
 openness:
   score: 4
   class: open_core
-  components: license:Apache-2.0(OSI, SDK/client repo wandb/weave);source:public;backend:commercial(W&B
-    SaaS platform hosts traces/evals; full platform is proprietary, self-host is enterprise);eval+tracing-client:OSS
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI, SDK/client repo wandb/weave
+    source:
+      value: public
+    backend:
+      value: commercial
+      detail: W&B SaaS platform hosts traces/evals; full platform is proprietary, self-host is enterprise
+    eval+tracing-client:
+      value: OSS
   confidence: high
   note: Apache-2.0 OSS instrumentation SDK (@weave.op tracing + eval scoring) but the trace store / dashboards
     / monitoring backend is the proprietary W&B SaaS platform, open-core, calibrated below MLflow O5
     (fully-OSS core) and at/with Langfuse O4 (OSS core + commercial backend).
+  raw: license:Apache-2.0(OSI, SDK/client repo wandb/weave);source:public;backend:commercial(W&B SaaS platform
+    hosts traces/evals; full platform is proprietary, self-host is enterprise);eval+tracing-client:OSS
   sources:
   - url: https://github.com/wandb/weave
     shows: Apache-2.0 license on the Weave SDK repo; LLM logging/tracing/eval toolkit

--- a/sources/scores/webcontainers.yaml
+++ b/sources/scores/webcontainers.yaml
@@ -2,14 +2,33 @@ product: webcontainers
 openness:
   score: 2
   class: source_available
-  components: source:partial;public-repo:webcontainer-core is MIT but issue-tracker only (no runtime
-    source);actual-runtime:proprietary(StackBlitz);license-terms:Proprietary, free for OSS/prototypes,
-    commercial license required for for-profit production(charge beyond 10k API
-    req/mo);distribution:@webcontainer/api npm (proprietary binary)
+  components:
+    source:
+      value: partial
+    public-repo:
+      value: webcontainer-core is MIT but issue-tracker only
+      detail: no runtime source
+      raw: webcontainer-core is MIT but issue-tracker only (no runtime source)
+    actual-runtime:
+      value: proprietary
+      detail: StackBlitz
+    license-terms:
+      value: Proprietary
+      detail: free for OSS/prototypes, commercial license required for for-profit production(charge beyond
+        10k API req/mo
+      raw: Proprietary, free for OSS/prototypes, commercial license required for for-profit production(charge
+        beyond 10k API req/mo)
+    distribution:
+      value: '@webcontainer/api npm'
+      detail: proprietary binary
+      raw: '@webcontainer/api npm (proprietary binary)'
   confidence: high
   note: The MIT 'open' repo holds no implementation; the runtime is closed and gated by a commercial
     license for production use. Best classed source_available leaning closed; flag open_washed for the
     MIT-issue-tracker-as-open source framing.
+  raw: source:partial;public-repo:webcontainer-core is MIT but issue-tracker only (no runtime source);actual-runtime:proprietary(StackBlitz);license-terms:Proprietary,
+    free for OSS/prototypes, commercial license required for for-profit production(charge beyond 10k API
+    req/mo);distribution:@webcontainer/api npm (proprietary binary)
   sources:
   - url: https://github.com/stackblitz/webcontainer-core
     shows: MIT repo is a central hub for issues/bug reports, not the runtime implementation

--- a/sources/scores/whylabs.yaml
+++ b/sources/scores/whylabs.yaml
@@ -2,9 +2,22 @@ product: whylabs
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI, whylogs + LangKit + open sourced platform);source:public(github.com/whylabs);core-gated:ungated(nothing
-    is withheld - the company ceased operations and open sourced the platform on closure);hosted-SaaS:discontinued;status:company-ceased-ops,
-    platform open sourced on closure
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI, whylogs + LangKit + open sourced platform
+    source:
+      value: public
+      detail: github.com/whylabs
+    core-gated:
+      value: ungated
+      detail: nothing is withheld - the company ceased operations and open sourced the platform on closure
+    hosted-SaaS:
+      value: discontinued
+    status:
+      value: company-ceased-ops
+      detail: platform open sourced on closure
+      raw: company-ceased-ops, platform open sourced on closure
   confidence: high
   note: 'Scored on what remains accessible: the OSS stack. whylogs (data logging) and LangKit (LLM monitoring)
     are Apache-2.0, and WhyLabs open sourced its platform on shutdown. Score corrected from 4 to 5 on 2026-07-30.
@@ -12,6 +25,9 @@ openness:
     rather than a turnkey observability product, which are maturity judgments and are already recorded as
     adoption 2 and capability 2. On the openness question the published source is the whole product, because
     there is no longer anything else, and 4 pairs with open_core rather than open_source.'
+  raw: license:Apache-2.0(OSI, whylogs + LangKit + open sourced platform);source:public(github.com/whylabs);core-gated:ungated(nothing
+    is withheld - the company ceased operations and open sourced the platform on closure);hosted-SaaS:discontinued;status:company-ceased-ops,
+    platform open sourced on closure
   sources:
   - url: https://whylabs.ai/langkit
     shows: '''WhyLabs, Inc. is discontinuing operations''; platform/whylogs/LangKit open sourced'


### PR DESCRIPTION
## Summary

Fifth batch of the structured-components migration: the 102 records using at least one undeclared key that is not among the 22 recurring ones. 63 of the 118 undeclared keys occur exactly once across the whole corpus — `underlying-microVM`, `open-glue`, `spec+reference-SDKs`, `eval+tracing-client`, `hardware-tiers`.

**Every key carries through under its own name, unchanged**, however odd it looks. Nothing promoted, renamed, normalized or tidied — a rename changes what a ladder could read, and this phase changes no claims. These keys are inert today, since a key no dimension declares or `reads` is dropped from the score silently, and they stay exactly that inert. What to do with each is asked in #188, where the proposed disposition is free text unless a category editor claims the key.

18 string-shaped records remain after this, which is batch F.

## Zero published numbers move

```
git diff --numstat build/notebook_data.json
1  1  build/notebook_data.json
```

At a committed head.

## Test plan

- Population re-derived from the corpus: 102.
- Key sets compared before and after on all 102: identical on every file.
- `check_recipe`'s undeclared-key context lines byte-identical before and after, which is what confirms nothing was promoted or renamed.
- Every edit through `build/components.py`, never a text substitution — 278 of 472 score files fold `components` across lines.
- Suite 431 passed. `validate` 0 error(s), `check_recipe` 0 failure(s), `check_rubric` exit 0, `check_components` `[OK]`.
