### PR TITLE
refactor(scores): migrate the last 18 records, the compound and multiplicity licenses

### DIFF
--- a/sources/scores/apify.yaml
+++ b/sources/scores/apify.yaml
@@ -2,9 +2,19 @@ product: apify
 openness:
   score: 2
   class: source_available
-  components: platform:proprietary(Apify-Cloud,Actor-store,managed);source:partial(Crawlee SDK published,
-    the platform that runs Actors is not);oss-sdk:Crawlee(Apache-2.0,OSI, JS+Python);license:mixed(platform
-    closed, SDK open)
+  components:
+    platform:
+      value: proprietary
+      detail: Apify-Cloud,Actor-store,managed
+    source:
+      value: partial
+      detail: Crawlee SDK published, the platform that runs Actors is not
+    oss-sdk:
+      value: Crawlee
+      detail: Apache-2.0,OSI, JS+Python
+    license:
+      value: mixed
+      detail: platform closed, SDK open
   confidence: high
   note: The product proper (Apify platform/Actor store) is proprietary SaaS; Apify also maintains the OSS
     Crawlee scraping library (Apache-2.0). Crawlee is an adjacent SDK rather than the platform core, so
@@ -12,6 +22,9 @@ openness:
     open_core means an OSI core with functionality withheld for a paid tier, and there is no open core here,
     only an open periphery. A repo that exists while the runtime does not ship is source:partial, which
     the ladder scores 2/source_available. The score itself was already 2.
+  raw: platform:proprietary(Apify-Cloud,Actor-store,managed);source:partial(Crawlee SDK published, the platform
+    that runs Actors is not);oss-sdk:Crawlee(Apache-2.0,OSI, JS+Python);license:mixed(platform closed, SDK
+    open)
   sources:
   - url: https://apify.com
     shows: proprietary full-stack scraping platform with 35,000+ Actors; Crawlee called out as their OSS

--- a/sources/scores/aws-neuron.yaml
+++ b/sources/scores/aws-neuron.yaml
@@ -2,8 +2,17 @@ product: aws-neuron
 openness:
   score: 1
   class: closed
-  components: license:mixed/proprietary-core;runtime:proprietary(Neuron Runtime+Compiler not open sourced);open-glue:Linux
-    kernel driver(GPL-2.0),vLLM-Neuron integration(Apache-2.0,vllm-project org),NKI library,samples(MIT-0);hardware-lock:AWS-Inferentia/Trainium-only
+  components:
+    license:
+      value: mixed/proprietary-core
+    runtime:
+      value: proprietary
+      detail: Neuron Runtime+Compiler not open sourced
+    open-glue:
+      value: Linux kernel driver
+      detail: GPL-2.0),vLLM-Neuron integration(Apache-2.0,vllm-project org),NKI library,samples(MIT-0
+    hardware-lock:
+      value: AWS-Inferentia/Trainium-only
   confidence: high
   note: Headline inference path (Neuron Compiler + Neuron Runtime) has no open-source release anywhere in
     AWS's own OSS repository catalog; surrounding glue (driver, vLLM integration, NKI, samples) is open
@@ -11,6 +20,8 @@ openness:
     the previously recorded Apache-2.0 to GPL-2.0, confirmed against the repo today; this does not change
     the score since the driver was already 'open-glue', not the license-bearing headline component.
   last_verified: '2026-08-09'
+  raw: license:mixed/proprietary-core;runtime:proprietary(Neuron Runtime+Compiler not open sourced);open-glue:Linux
+    kernel driver(GPL-2.0),vLLM-Neuron integration(Apache-2.0,vllm-project org),NKI library,samples(MIT-0);hardware-lock:AWS-Inferentia/Trainium-only
   sources:
   - url: https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/oss/index.html
     shows: AWS Neuron provides open source code and samples for some of its components, libraries, and tools

--- a/sources/scores/command-r.yaml
+++ b/sources/scores/command-r.yaml
@@ -3,10 +3,22 @@ openness:
   score: 2
   class: restricted
   confidence: high
-  components: weights:open(gated, contact-info required);data:closed;code:closed;license:CC-BY-NC(non-commercial,
-    non-OSI)+Cohere-Acceptable-Use-Policy
+  components:
+    weights:
+      value: open
+      detail: gated, contact-info required
+    data:
+      value: closed
+    code:
+      value: closed
+    license:
+      value: CC-BY-NC
+      detail: non-commercial, non-OSI)+Cohere-Acceptable-Use-Policy
+      raw: CC-BY-NC(non-commercial, non-OSI)+Cohere-Acceptable-Use-Policy
   note: Weights downloadable but under CC-BY-NC, a non-commercial, non-OSI license with field-of-use
     restrictions => restricted. Marketed as 'open weights' despite the non-commercial cap.
+  raw: weights:open(gated, contact-info required);data:closed;code:closed;license:CC-BY-NC(non-commercial,
+    non-OSI)+Cohere-Acceptable-Use-Policy
   sources:
   - url: https://huggingface.co/CohereLabs/c4ai-command-r-plus
     shows: License CC-BY-NC + Acceptable Use Policy, gated access, 104B instruct model

--- a/sources/scores/culturax.yaml
+++ b/sources/scores/culturax.yaml
@@ -2,9 +2,17 @@ product: culturax
 openness:
   score: 3
   class: gated
-  components: license:follows mC4 + OSCAR-2301 terms;gated:auto(contact-info agreement);card:present
+  components:
+    license:
+      value: follows mC4 + OSCAR-2301 terms
+    gated:
+      value: auto
+      detail: contact-info agreement
+    card:
+      value: present
   confidence: high
   note: Dataset card is rich but downloads require agreeing to share contact information (auto gate).
+  raw: license:follows mC4 + OSCAR-2301 terms;gated:auto(contact-info agreement);card:present
   sources:
   - url: https://huggingface.co/datasets/uonlp/CulturaX
     shows: Card with 6.3T tokens/167 languages, mC4+OSCAR license inheritance, gated access requiring

--- a/sources/scores/flan-collection.yaml
+++ b/sources/scores/flan-collection.yaml
@@ -2,10 +2,20 @@ product: flan-collection
 openness:
   score: 4
   class: open
-  components: access:ungated(conversion);license:Apache-2.0(recipe)+per-task;dataset_card:partial
+  components:
+    access:
+      value: ungated
+      detail: conversion
+    license:
+      value: Apache-2.0
+      detail: recipe)+per-task
+      raw: Apache-2.0(recipe)+per-task
+    dataset_card:
+      value: partial
   confidence: medium
   note: Released as an Apache-2.0 recipe/repo; the widely used HF conversion (ai2-adapt-dev) is ungated.
     Underlying task datasets keep their own licenses.
+  raw: access:ungated(conversion);license:Apache-2.0(recipe)+per-task;dataset_card:partial
   sources:
   - url: https://github.com/google-research/FLAN
     shows: Apache-2.0 FLAN v2 recipe

--- a/sources/scores/internlm.yaml
+++ b/sources/scores/internlm.yaml
@@ -2,13 +2,27 @@ product: internlm
 openness:
   score: 3
   class: open_weights
-  components: weights:open(custom 'Free Commercial License', academic free, commercial use free but requires an
-    application form);data:closed(pretraining corpus not released);code:open(Apache-2.0 training/inference code
-    on GitHub);license:Apache-2.0(code, OSI) + custom weights license(non-OSI, application step)
+  components:
+    weights:
+      value: open
+      detail: custom 'Free Commercial License', academic free, commercial use free but requires an application
+        form
+    data:
+      value: closed
+      detail: pretraining corpus not released
+    code:
+      value: open
+      detail: Apache-2.0 training/inference code on GitHub
+    license:
+      value: Apache-2.0
+      detail: code, OSI) + custom weights license(non-OSI, application step
   confidence: medium
   note: Code is OSI (Apache-2.0) but the weights license is a custom non-OSI 'Free Commercial License' requiring
     a commercial-license application form (HF card confirms form link, 2026-06-04), so open_weights not open_source;
     flagged for the non-OSI weights term.
+  raw: weights:open(custom 'Free Commercial License', academic free, commercial use free but requires an
+    application form);data:closed(pretraining corpus not released);code:open(Apache-2.0 training/inference
+    code on GitHub);license:Apache-2.0(code, OSI) + custom weights license(non-OSI, application step)
   sources:
   - url: https://huggingface.co/internlm/internlm2_5-7b
     shows: 'model card: code Apache-2.0; weights fully open for academic research and free commercial usage via

--- a/sources/scores/langwatch.yaml
+++ b/sources/scores/langwatch.yaml
@@ -2,11 +2,22 @@ product: langwatch
 openness:
   score: 4
   class: open_core
-  components: license:Apache-2.0(core)+MIT(SDKs);enterprise modules(SCIM,audit-logs,license/billing) under
-    langwatch/ee/ require commercial license for production;source:public;core-gated:gated
+  components:
+    license:
+      value: Apache-2.0
+      detail: core)+MIT(SDKs
+    source:
+      value: public
+    core-gated:
+      value: gated
+    free_text:
+    - enterprise modules(SCIM,audit-logs,license/billing) under langwatch/ee/ require commercial license
+      for production
   confidence: high
   note: 'Explicit open-core: Apache-2.0 core + MIT SDKs, with an /ee enterprise directory (SCIM, audit
     logs, billing) commercially licensed, same pattern as the Langfuse O4 anchor.'
+  raw: license:Apache-2.0(core)+MIT(SDKs);enterprise modules(SCIM,audit-logs,license/billing) under langwatch/ee/
+    require commercial license for production;source:public;core-gated:gated
   sources:
   - url: https://github.com/langwatch/langwatch
     shows: Apache-2.0 core, MIT SDKs, langwatch/ee/ enterprise modules requiring commercial license

--- a/sources/scores/llamafile.yaml
+++ b/sources/scores/llamafile.yaml
@@ -2,13 +2,24 @@ product: llamafile
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI)+MIT(OSI, for llama.cpp/whisper.cpp deltas);source:public(mozilla-ai/llamafile);no-feature-gated-core;core-gated:ungated
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI)+MIT(OSI, for llama.cpp/whisper.cpp deltas
+    source:
+      value: public
+      detail: mozilla-ai/llamafile
+    core-gated:
+      value: ungated
+    free_text:
+    - no-feature-gated-core
   confidence: high
   note: Fully OSI-licensed, source public, single-file llama.cpp+Cosmopolitan distribution; no proprietary
     tier. GitHub org renamed from Mozilla-Ocho to mozilla-ai; same repo, license and openness posture unchanged.
     GitHub's own classifier still reports NOASSERTION/"Other" for this repo, which the LICENSE body and
     README's licensing section both contradict with a plain Apache-2.0 (+ MIT deltas) statement.
   last_verified: '2026-08-09'
+  raw: license:Apache-2.0(OSI)+MIT(OSI, for llama.cpp/whisper.cpp deltas);source:public(mozilla-ai/llamafile);no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://github.com/mozilla-ai/llamafile
     shows: 'repo metadata: "isPrivate":false,"isArchived":false,"visibilityLabel":"Public"; License badge

--- a/sources/scores/maple-ai.yaml
+++ b/sources/scores/maple-ai.yaml
@@ -2,13 +2,26 @@ product: maple-ai
 openness:
   score: 5
   class: open_source
-  components: license:MIT(Maple-client)+AGPL-3.0(OpenSecret-platform),both-OSI;source:public(github.com/OpenSecretCloud);models:open-weight;hosted-tier:paid(managed-enclaves)
+  components:
+    license:
+      value: MIT
+      detail: Maple-client)+AGPL-3.0(OpenSecret-platform),both-OSI
+      raw: MIT(Maple-client)+AGPL-3.0(OpenSecret-platform),both-OSI
+    source:
+      value: public
+      detail: github.com/OpenSecretCloud
+    models:
+      value: open-weight
+    hosted-tier:
+      value: paid
+      detail: managed-enclaves
   confidence: medium
   note: Both halves of the stack are open under standard OSI licenses (Maple client MIT, OpenSecret platform
     AGPL-3.0) and the served models are open-weight - unusually clean for a "private AI" product. Scored
     open_source because the privacy guarantee is only credible because the code is open and attestable. A
     defensible alternative is open_core, since the delivered offering is a paid hosted service over managed
     enclaves.
+  raw: license:MIT(Maple-client)+AGPL-3.0(OpenSecret-platform),both-OSI;source:public(github.com/OpenSecretCloud);models:open-weight;hosted-tier:paid(managed-enclaves)
   sources:
   - url: https://github.com/OpenSecretCloud/Maple
     shows: MIT-licensed Maple client (Tauri/Rust/TS), active; multi-platform

--- a/sources/scores/megatron-lm.yaml
+++ b/sources/scores/megatron-lm.yaml
@@ -2,12 +2,22 @@ product: megatron-lm
 openness:
   score: 5
   class: open_source
-  components: license:BSD-3-Clause(OSI, NVIDIA core)+Apache-2.0/MIT(OSI, vendored components);source:public;core-gated:ungated;restriction:attribution/change-notice
-    only
+  components:
+    license:
+      value: BSD-3-Clause
+      detail: OSI, NVIDIA core)+Apache-2.0/MIT(OSI, vendored components
+    source:
+      value: public
+    core-gated:
+      value: ungated
+    restriction:
+      value: attribution/change-notice only
   confidence: high
   note: license:BSD-3-Clause(OSI, NVIDIA core)+Apache-2.0/MIT(OSI, vendored components);source:public;restriction:attribution/change-notice
     only
   last_verified: '2026-08-08'
+  raw: license:BSD-3-Clause(OSI, NVIDIA core)+Apache-2.0/MIT(OSI, vendored components);source:public;core-gated:ungated;restriction:attribution/change-notice
+    only
   sources:
   - url: https://raw.githubusercontent.com/NVIDIA/Megatron-LM/main/LICENSE
     shows: 'Opens "The following applies to all files unless otherwise noted:" followed by a 2019-2025 NVIDIA

--- a/sources/scores/model-context-protocol.yaml
+++ b/sources/scores/model-context-protocol.yaml
@@ -2,11 +2,20 @@ product: model-context-protocol
 openness:
   score: 5
   class: open_source
-  components: spec+reference-SDKs:public;license:Apache-2.0(OSI, new code/spec)+MIT(OSI, legacy contributions)+CC-BY-4.0(docs);governance:Linux-Foundation/AAIF(open,
-    co-founded Anthropic/Block/OpenAI)
+  components:
+    spec+reference-SDKs:
+      value: public
+    license:
+      value: Apache-2.0
+      detail: OSI, new code/spec)+MIT(OSI, legacy contributions)+CC-BY-4.0(docs
+    governance:
+      value: Linux-Foundation/AAIF
+      detail: open, co-founded Anthropic/Block/OpenAI
   confidence: high
   note: Open protocol with OSI-licensed reference implementations and open foundation governance; no feature-gated
     core.
+  raw: spec+reference-SDKs:public;license:Apache-2.0(OSI, new code/spec)+MIT(OSI, legacy contributions)+CC-BY-4.0(docs);governance:Linux-Foundation/AAIF(open,
+    co-founded Anthropic/Block/OpenAI)
   sources:
   - url: https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/LICENSE
     shows: Apache-2.0 (new code/spec) + MIT (legacy) + CC-BY-4.0 (docs) license text

--- a/sources/scores/n8n.yaml
+++ b/sources/scores/n8n.yaml
@@ -2,9 +2,18 @@ product: n8n
 openness:
   score: 2
   class: source_available
-  components: 'license:Sustainable-Use-License(fair-code,non-OSI: internal-use-only,no-resale/SaaS)+n8n-Enterprise-License;source:public;commercial:n8n-Cloud/Enterprise'
+  components:
+    license:
+      value: Sustainable-Use-License
+      detail: 'fair-code,non-OSI: internal-use-only,no-resale/SaaS)+n8n-Enterprise-License'
+      raw: 'Sustainable-Use-License(fair-code,non-OSI: internal-use-only,no-resale/SaaS)+n8n-Enterprise-License'
+    source:
+      value: public
+    commercial:
+      value: n8n-Cloud/Enterprise
   confidence: high
   note: 'Source-available fair-code, not OSI open source: the license restricts commercial/hosted use.'
+  raw: 'license:Sustainable-Use-License(fair-code,non-OSI: internal-use-only,no-resale/SaaS)+n8n-Enterprise-License;source:public;commercial:n8n-Cloud/Enterprise'
   sources:
   - url: https://docs.n8n.io/sustainable-use-license/
     shows: 'Sustainable Use License: fair-code, non-OSI, use restrictions'

--- a/sources/scores/privatemode.yaml
+++ b/sources/scores/privatemode.yaml
@@ -2,11 +2,22 @@ product: privatemode
 openness:
   score: 2
   class: source_available
-  components: license:custom-source-available(audit-only)+MIT-subdirs(proxy/web/internal-oss);source:TCB-public(github.com/edgelesssys/privatemode-public);service:proprietary-hosted;models:third-party-open-weight
+  components:
+    license:
+      value: custom-source-available
+      detail: audit-only)+MIT-subdirs(proxy/web/internal-oss
+    source:
+      value: TCB-public
+      detail: github.com/edgelesssys/privatemode-public
+    service:
+      value: proprietary-hosted
+    models:
+      value: third-party-open-weight
   confidence: high
   note: 'Not open source: the security-critical Trusted Computing Base is publicly readable (and the client
     proxy + web app are MIT), but the main license permits only viewing/compiling for audit, and the operational
     service is a proprietary hosted offering. More open than a black-box API, less than open-core.'
+  raw: license:custom-source-available(audit-only)+MIT-subdirs(proxy/web/internal-oss);source:TCB-public(github.com/edgelesssys/privatemode-public);service:proprietary-hosted;models:third-party-open-weight
   sources:
   - url: https://github.com/edgelesssys/privatemode-public
     shows: TCB source (attestation agent, proxy, web app, SDK) under a custom audit-only license with MIT-licensed

--- a/sources/scores/redpajama-data-v2.yaml
+++ b/sources/scores/redpajama-data-v2.yaml
@@ -2,10 +2,18 @@ product: redpajama-data-v2
 openness:
   score: 5
   class: open
-  components: license:CommonCrawl-ToU+Apache-2.0(code);ungated:yes;dataset_card:yes
+  components:
+    license:
+      value: CommonCrawl-ToU+Apache-2.0
+      detail: code
+    ungated:
+      value: 'yes'
+    dataset_card:
+      value: 'yes'
   confidence: high
   note: Ungated with a full dataset card; redistributable per Common Crawl ToU with Apache-2.0 processing
     code.
+  raw: license:CommonCrawl-ToU+Apache-2.0(code);ungated:yes;dataset_card:yes
   sources:
   - url: https://huggingface.co/datasets/togethercomputer/RedPajama-Data-V2
     shows: Common Crawl ToU + Apache-2.0 code license, ungated access, dataset card

--- a/sources/scores/smoltalk.yaml
+++ b/sources/scores/smoltalk.yaml
@@ -2,9 +2,18 @@ product: smoltalk
 openness:
   score: 4
   class: open
-  components: access:ungated;license:apache-2.0(new-subsets)+per-component;dataset_card:present
+  components:
+    access:
+      value: ungated
+    license:
+      value: apache-2.0
+      detail: new-subsets)+per-component
+      raw: apache-2.0(new-subsets)+per-component
+    dataset_card:
+      value: present
   confidence: high
   note: Ungated; newly created subsets are Apache-2.0, incorporated public datasets keep their own licenses.
+  raw: access:ungated;license:apache-2.0(new-subsets)+per-component;dataset_card:present
   sources:
   - url: https://huggingface.co/datasets/HuggingFaceTB/smoltalk
     shows: ungated, mixed licensing documented on card

--- a/sources/scores/the-pile.yaml
+++ b/sources/scores/the-pile.yaml
@@ -2,11 +2,18 @@ product: the-pile
 openness:
   score: 3
   class: open
-  components: access:ungated;license:mixed-per-subset;dataset_card:legacy-repo-only
+  components:
+    access:
+      value: ungated
+    license:
+      value: mixed-per-subset
+    dataset_card:
+      value: legacy-repo-only
   confidence: medium
   note: Ungated download via the deduplicated HF repo; the original EleutherAI/pile repo is a loading
     script whose mirrors are dead. The card defers licensing to per-subset terms and Books3 has been withdrawn
     from circulation.
+  raw: access:ungated;license:mixed-per-subset;dataset_card:legacy-repo-only
   sources:
   - url: https://huggingface.co/datasets/EleutherAI/the_pile_deduplicated
     shows: hosts the working parquet data (451 GB), ungated

--- a/sources/scores/unsloth.yaml
+++ b/sources/scores/unsloth.yaml
@@ -2,12 +2,21 @@ product: unsloth
 openness:
   score: 5
   class: open_source
-  components: license:Apache-2.0(OSI, core unsloth pkg)+AGPL-3.0(OSI, optional Unsloth Studio UI);source:public(unslothai/unsloth);no
-    proprietary managed-training SaaS gate
+  components:
+    license:
+      value: Apache-2.0
+      detail: OSI, core unsloth pkg)+AGPL-3.0(OSI, optional Unsloth Studio UI
+    source:
+      value: public
+      detail: unslothai/unsloth
+    free_text:
+    - no proprietary managed-training SaaS gate
   confidence: high
   note: OSI-licensed throughout (Apache-2.0 core, AGPL-3.0 for the optional Studio UI); both are OSI licenses
     so class is open_source, not open_core.
   last_verified: '2026-08-09'
+  raw: license:Apache-2.0(OSI, core unsloth pkg)+AGPL-3.0(OSI, optional Unsloth Studio UI);source:public(unslothai/unsloth);no
+    proprietary managed-training SaaS gate
   sources:
   - url: https://github.com/unslothai/unsloth
     shows: Live public repository (HTTP 200); GitHub's own page describes it as "The local UI to run and

--- a/sources/scores/zed.yaml
+++ b/sources/scores/zed.yaml
@@ -2,10 +2,19 @@ product: zed
 openness:
   score: 4
   class: open_core
-  components: license:GPL-3.0-or-later(editor)+AGPL-3.0(collab-server)+Apache-2.0(GPUI);source:public;commercial:Zed-Pro/Business(hosted
-    AI)
+  components:
+    license:
+      value: GPL-3.0-or-later
+      detail: editor)+AGPL-3.0(collab-server)+Apache-2.0(GPUI
+    source:
+      value: public
+    commercial:
+      value: Zed-Pro/Business
+      detail: hosted AI
   confidence: high
   note: Fully open editor core under GPL/AGPL; paid hosted-AI and governance tiers make the overall offering open-core.
+  raw: license:GPL-3.0-or-later(editor)+AGPL-3.0(collab-server)+Apache-2.0(GPUI);source:public;commercial:Zed-Pro/Business(hosted
+    AI)
   sources:
   - url: https://github.com/zed-industries/zed
     shows: Rust, ~85k stars, GPL/AGPL/Apache licensing

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -386,6 +386,8 @@ def test_structure_round_trips_every_recorded_components_string():
     for path in sorted((root / "sources" / "scores").glob("*.yaml")):
         block = (yaml.safe_load(path.read_text()) or {}).get("openness") or {}
         components = block.get("components")
+        if isinstance(components, dict):
+            components = block.get("raw")
         if not isinstance(components, str) or not components:
             continue
         walked += 1


### PR DESCRIPTION
## Summary

The last 18 records, and the migration is complete: **472 of 472**.

Each of these records a license whose depth-zero text carries a `+` or a multiplicity token:

| Product | Recorded license |
|---|---|
| `apify` | `mixed(platform closed, SDK open)` |
| `aws-neuron` | `mixed/proprietary-core` |
| `command-r` | `CC-BY-NC(non-commercial, non-OSI)+Cohere-Acceptable-Use-Policy` |
| `culturax` | `follows mC4 + OSCAR-2301 terms` |
| `flan-collection` | `Apache-2.0(recipe)+per-task` |
| `internlm` | `Apache-2.0(code, OSI) + custom weights license(non-OSI, application step)` |
| `langwatch` | `Apache-2.0(core)+MIT(SDKs)` |
| `llamafile` | `Apache-2.0(OSI)+MIT(OSI, for llama.cpp/whisper.cpp deltas)` |
| `maple-ai` | `MIT(Maple-client)+AGPL-3.0(OpenSecret-platform),both-OSI` |
| `megatron-lm` | `BSD-3-Clause(OSI, NVIDIA core)+Apache-2.0/MIT(OSI, vendored components)` |
| `model-context-protocol` | `Apache-2.0(OSI, new code/spec)+MIT(OSI, legacy contributions)+CC-BY-4.0(docs)` |
| `n8n` | `Sustainable-Use-License(fair-code,non-OSI: internal-use-only,no-resale/SaaS)+n8n-Enterprise-License` |
| `privatemode` | `custom-source-available(audit-only)+MIT-subdirs(proxy/web/internal-oss)` |
| `redpajama-data-v2` | `CommonCrawl-ToU+Apache-2.0(code)` |
| `smoltalk` | `apache-2.0(new-subsets)+per-component` |
| `the-pile` | `mixed-per-subset` |
| `unsloth` | `Apache-2.0(OSI, core unsloth pkg)+AGPL-3.0(OSI, optional Unsloth Studio UI)` |
| `zed` | `GPL-3.0-or-later(editor)+AGPL-3.0(collab-server)+Apache-2.0(GPUI)` |

They migrate exactly like the other 454: one `license` entry, `head()` untouched, license resolution untouched. `structure` splits at the first `(` or `,`, which is where `head()` already cuts, so `license_tier` sees the same string it saw before. **All 18 tiers are unchanged.**

## What this makes visible

The structured form makes the truncation legible without acting on it. `internlm` is the worked example:

```yaml
license:
  value: Apache-2.0
  detail: code, OSI) + custom weights license(non-OSI, application step
```

The unbalanced paren is not a migration bug. It is `split_value` reproducing exactly what `head()` does today: license resolution sees `Apache-2.0` and never sees the custom weights license that is the restrictive half. That is the clearest available statement of why the next phase exists, and it is now visible in the data rather than buried in a string.

Nothing here acts on it. Surfacing those halves moves published scores, which is separate work with each move judged on its merits.

## One expected alarm

`test_structure_round_trips_every_recorded_components_string` walks only string-shaped records and guards with `assert walked > 0`. This batch migrates the last of them, so the guard fired — as intended. It was left in place specifically to speak up at this moment. It now reads `openness.raw`, as planned.

## Test plan

- Population re-derived from the corpus: 18.
- `license_tier` resolved for all 18 before and after: identical.
- Key sets identical on every file; no `score:` or `class:` line changes anywhere in the diff.
- Payload at a committed head diffs only the `generated` stamp.
- Suite 431 passed. `validate` 0 error(s), `check_recipe` 0 failure(s), `check_rubric` exit 0, `check_components` `[OK]`.
