### PR TITLE
fix(components): make the mapping the only accepted shape and correct four stale descriptions

### DIFF
--- a/build/check_components.py
+++ b/build/check_components.py
@@ -15,6 +15,12 @@ It also asserts the two directions nobody would otherwise notice:
   * an unmigrated record must NOT, or a stale `raw` will be silently believed by
     `components_string` and shipped to the payload.
 
+The migration finished at 472 of 472 records, so a THIRD thing is now a failure rather than
+a skip: `components` recorded as a string at all. Before this the string shape was simply
+narrowed past, which meant a new or reverted string-shaped record passed every gate,
+including this one, and silently returned the corpus to mixed shape. The mapping is now the
+only shape this field may take.
+
 Exit status is 1 on any failure, so CI can gate on it.
 """
 
@@ -38,9 +44,16 @@ def check(root: Path = ROOT) -> list[str]:
         raw = block.get("raw")
         slug = path.stem
 
+        if isinstance(components, str):
+            failures.append(
+                f"{slug}: openness.components is still a string. The mapping is now the "
+                f"only accepted shape for this field (phase 1a migrated all 472 records); "
+                f"migrate it with build/components.py rather than hand-writing a string."
+            )
+            continue
+
         if not isinstance(components, dict):
-            if raw is not None:
-                failures.append(f"{slug}: carries openness.raw but components is still a string")
+            failures.append(f"{slug}: openness.components is missing or not a mapping")
             continue
 
         if not isinstance(raw, str) or not raw:

--- a/build/components.py
+++ b/build/components.py
@@ -2,22 +2,31 @@
 
 ## Why a module rather than a `re.sub`
 
-`components` is one long `k:v;k:v` string, and 277 of the 470 score files fold it across
-lines — 57 of them across three or more. So the obvious edit,
+`components` is a structured mapping — `key -> {value, detail?, raw?}`, plus a reserved
+`free_text` list for keyless clauses — and PyYAML renders it as a nested block, so it spans
+multiple lines in every one of the 472 score files. Before phase 1a migrated the corpus, this
+field was a single `k:v;k:v` string that PyYAML folded across lines whenever it ran past the
+configured width, and folding was the hazard the obvious edit did not see:
 
     re.sub(r"^  components: (.*)$", ..., text, flags=re.M)
 
-matches the FIRST line of a folded scalar and leaves the continuation lines standing. The
-result parses cleanly and is wrong: the old tail is spliced onto the new value, usually
+matched only the FIRST line of a folded scalar and left the continuation lines standing. The
+result parsed cleanly and was wrong: the old tail was spliced onto the new value, usually
 mid-key, producing something like `...;core-gated:gatedn(OSI);source:public`. Nothing
-downstream complains, because a components string is only ever split on `;` and `:` and
-those fragments are still shaped like keys. It corrupts silently, which is the one failure
-mode worth building a mechanism against.
+downstream complained, because the string was only ever split on `;` and `:` and those
+fragments were still shaped like keys. It corrupted silently, which is the one failure mode
+worth building a mechanism against.
+
+The structured mapping does not fold the same way — every record's value is already
+multi-line by construction — but the discipline carries over unchanged, because the general
+hazard is the same: any multi-line YAML value invites a line-oriented substitution, and the
+right fix is to stop reasoning about lines at all.
 
 Rather than get the regex right, this module does not use one:
 
   * locate the field by INDENT, taking every following more-indented line as part of it;
-  * re-emit the value with PyYAML, so quoting and folding are the emitter's problem;
+  * re-emit the value with PyYAML, so quoting and block-style formatting are the emitter's
+    problem;
   * re-parse the whole file and assert the new value is what was asked for AND that every
     other field is unchanged, then assert the bytes outside the span never moved.
 
@@ -33,7 +42,10 @@ could have the same bug.
 
 Usage:
     from build.components import rewrite, set_field
-    rewrite(Path("sources/scores/mastra.yaml"), "license:Apache-2.0(OSI);source:public")
+    rewrite(
+        Path("sources/scores/mastra.yaml"),
+        {"license": {"value": "Apache-2.0", "detail": "OSI"}, "source": {"value": "public"}},
+    )
 """
 
 from __future__ import annotations

--- a/docs/schemas/score.schema.json
+++ b/docs/schemas/score.schema.json
@@ -50,31 +50,26 @@
           "description": "The openness VOCABULARY: the band a reader sees, paired with `score`. Eleven values, one per rung any ladder can emit \u2014 the software, model, dataset and hardware ladders do not share a vocabulary, which is why this is longer than the five a single ladder uses. `docs/openness-class-map.json` maps each to a display label, a gradient and the three-way open / open-ish / closed bucket the payload carries. Until 2026-08-08 this was an unconstrained string and the vocabulary lived only in that map and in build/render.py."
         },
         "components": {
-          "oneOf": [
-            { "type": "string" },
-            {
-              "type": "object",
-              "minProperties": 1,
-              "properties": {
-                "free_text": {
-                  "type": "array",
-                  "items": { "type": "string" },
-                  "minItems": 1
-                }
-              },
-              "additionalProperties": {
-                "type": "object",
-                "required": ["value"],
-                "properties": {
-                  "value": { "type": "string" },
-                  "detail": { "type": "string" },
-                  "raw": { "type": "string" }
-                },
-                "additionalProperties": false
-              }
+          "type": "object",
+          "minProperties": 1,
+          "properties": {
+            "free_text": {
+              "type": "array",
+              "items": { "type": "string" },
+              "minItems": 1
             }
-          ],
-          "description": "The evidence the openness score was read off, as an entry per dimension the category's ladder asks about. Two shapes coexist while the corpus migrates: the legacy flat string, one `k:v;k:v` clause per dimension - `weights:open(Apache-2.0);data:open(Dolma 3, 9.3T tokens);code:open;license:Apache-2.0(OSI)`, where the bare value before the first `(` or `,` is what a rule reads and the parenthetical is detail for a human that no formula sees - and the structured mapping, `key -> {value, detail?, raw?}` plus a reserved `free_text` list for keyless clauses. This is the most load-bearing field in the corpus, because a category is ladderable only if its VALUES are controlled tokens some dimension's declared enum contains - `edge_hardware` is 71% prose by check_rubric's measure and cannot be laddered whatever its recipe says. Written by whoever scores the product, and edited in place ONLY through build/components.py: 277 of the 472 files fold this string across lines, so the obvious regex substitution splices the old tail onto the new value and corrupts silently. Read by build/check_rubric.py (replays the formula against it), check_verification (the dimensions recorded here are the invariant's scope), check_parity.py (the repo/warehouse differential), and serialize_rubric.py, which emits one warehouse evidence row per component and warns on a key no dimension declares or `reads` - such a key is dropped from the score silently, which is this corpus's recurring bug. Every reader goes through build.check_rubric.components_of, which returns the same key -> clause dict whichever shape the file carries; nothing in the repo should call split_components directly on this field anymore. Measured 2026-08-11: on all 472 files, 137 distinct keys, of which each ladder declares a handful (`license` on 439, `source` on 298, `core-gated` on 164)."
+          },
+          "additionalProperties": {
+            "type": "object",
+            "required": ["value"],
+            "properties": {
+              "value": { "type": "string" },
+              "detail": { "type": "string" },
+              "raw": { "type": "string" }
+            },
+            "additionalProperties": false
+          },
+          "description": "The evidence the openness score was read off, as an entry per dimension the category's ladder asks about: a structured mapping, `key -> {value, detail?, raw?}`, plus a reserved `free_text` list for keyless clauses. `value` is the bare token a rule reads, `detail` is the parenthetical or trailing prose a human reads but no formula sees, and `raw` carries the original clause verbatim for the entries whose `{value, detail}` split cannot reproduce it byte-for-byte. This is the most load-bearing field in the corpus, because a category is ladderable only if its VALUES are controlled tokens some dimension's declared enum contains - `edge_hardware` is 71% prose by check_rubric's measure and cannot be laddered whatever its recipe says. Written by whoever scores the product, and edited in place ONLY through build/components.py, which locates the field by indent and re-emits it through the YAML dumper rather than by regex, because a folded scalar spliced by a line-oriented substitution corrupts silently. Read by build/check_rubric.py (replays the formula against it), check_verification (the dimensions recorded here are the invariant's scope), check_parity.py (the repo/warehouse differential), and serialize_rubric.py, which emits one warehouse evidence row per component and warns on a key no dimension declares or `reads` - such a key is dropped from the score silently, which is this corpus's recurring bug. Every reader goes through build.check_rubric.components_of, which returns the same key -> clause dict; nothing in the repo should call split_components directly on this field. build/check_components.py asserts the mapping is the only shape this field may take - a string here fails the gate rather than being skipped, which is what closed the migration. Measured 2026-08-11: on all 472 files, 137 distinct keys, of which each ladder declares a handful (`license` on 439, `source` on 298, `core-gated` on 164)."
         },
         "governing_release": {
           "type": "string",

--- a/skills/build-rubric/SKILL.md
+++ b/skills/build-rubric/SKILL.md
@@ -48,7 +48,8 @@ It cannot work when values are sentences. Count them:
 
 ```python
 # prose share of components values, for one category
-from build.check_rubric import split_components, head
+from build.check_rubric import components_of, head
+vals = [v for openness in category_openness for v in components_of(openness).values()]
 prose = sum(1 for v in vals if len(head(v).split()) > 1)
 ```
 
@@ -157,10 +158,10 @@ pair, no product abstained on without a declared reason, and no evidence the com
 silently discards. It runs in CI on every PR.
 
 What it reports rather than fails on is worth reading. `clauses dropped` counts `components`
-clauses with no key — `split_components` discards those silently, and 170 of 470 products have
+clauses with no key — `split_components` discards those silently, and 168 of 472 products have
 at least one. Most are harmless free-text tails or prose restating a properly keyed value, but
 a clause that is the *only* record of a dimension is lost evidence, and that cost
-`dataset.yaml` five of its eight deferrals. Same for `undeclared keys`: 113 exist across the
+`dataset.yaml` five of its eight deferrals. Same for `undeclared keys`: 118 exist across the
 map, and the gate fails only when one demonstrably holds an answer the ladder wanted.
 
 Then the human checklist, which is only what a machine cannot judge:

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -394,7 +394,16 @@ def test_structure_round_trips_every_recorded_components_string():
         if recompose(structure(components)) != split_components(components):
             failures.append(path.stem)
 
-    assert walked > 0, "no string-shaped components reached; the corpus walk is broken"
+    # A floor, not an exact count, for the same reason as the sibling equivalence tests in
+    # this file and in test_serialize_rubric.py: the corpus only grows as products are
+    # scored, so more records walked than this is ordinary curation. `walked > 0` caught
+    # total collapse but not a partial one — if a later change stripped `raw` from 400 of
+    # 472 records, `walked` would drop to 72 and this test would pass having lost most of
+    # its coverage, the same shrink-without-noticing failure the sibling tests were fixed
+    # for. 472 is every record in the corpus today: phase 1a finished at 472 of 472
+    # migrated, and check_components requires `raw` on every migrated record, so this walk
+    # is now the full corpus rather than a subset of it.
+    assert walked >= 472, f"only {walked} components strings walked; the corpus walk is broken"
     assert failures == [], f"structure/recompose does not round-trip: {failures}"
 
 
@@ -460,6 +469,45 @@ def test_check_components_flags_a_dropped_keyless_clause(tmp_path):
     failures = check(tmp_path)
     assert len(failures) == 1
     assert "free_text" in failures[0]
+
+
+def test_check_components_rejects_a_string_shaped_record(tmp_path):
+    """Phase 1a finished at 472 of 472 records migrated to the mapping shape. Before this,
+    a string-shaped `components` was silently skipped rather than flagged, so a new record
+    scored from a stale template — or a hand-written string — would pass every gate and
+    quietly return the corpus to mixed shape.
+    """
+    from build.check_components import check
+
+    scores = tmp_path / "sources" / "scores"
+    scores.mkdir(parents=True)
+    (scores / "reverted.yaml").write_text(yaml.safe_dump({"openness": {
+        "components": "license:MIT(OSI);source:public",
+    }}, sort_keys=False))
+
+    failures = check(tmp_path)
+    assert len(failures) == 1
+    assert "still a string" in failures[0]
+
+
+def test_schema_rejects_a_string_shaped_components():
+    """The schema must state the same rule check_components enforces: the mapping is the
+    only accepted shape, so a new string-shaped record fails validation rather than being
+    silently accepted by a `oneOf(string | mapping)` left over from the migration.
+    """
+    import json
+
+    import jsonschema
+
+    root = Path(__file__).resolve().parents[1]
+    schema = json.loads((root / "docs/schemas/score.schema.json").read_text())
+    doc = yaml.safe_load((root / "sources/scores/mastra.yaml").read_text())
+
+    jsonschema.validate(doc, schema)
+
+    doc["openness"]["components"] = "license:MIT(OSI);source:public"
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(doc, schema)
 
 
 def test_components_string_returns_the_flat_string_unchanged():


### PR DESCRIPTION
## Summary

Defensive follow-ups from the Phase 1a whole-branch review. All 472 records are now mapping-shaped; these close the gaps that let the corpus drift back, and correct four descriptions that outlived the migration.

**The mapping is now the only accepted shape.** `check_components` skipped any record whose `components` was not a mapping, and the schema's `oneOf` still admitted a string — so a new product scored from a stale template, or a hand-written string, would have returned the corpus to mixed shape with every gate green. The gate now fails a string-shaped record with a message that says what to do, and the schema states the same rule.

**A live skill was reading the old shape.** `skills/build-rubric/SKILL.md` imported `split_components` and called it on `components`. That function iterates its argument character by character, so handed a mapping it returns `{}` — silently, no error. This is the same defect fixed in two tests during the phase, still live in an agent-followed workflow, and in the skill whose first step is inventorying prose across a category. It now uses `components_of`. Its stale figures were re-derived: 168 of 472 products, 118 undeclared keys.

**The components editor described a shape that no longer exists.** `build/components.py` is the only supported way to edit the field, and three documents point curators at it, but its own docstring opened with "`components` is one long `k:v;k:v` string" and its usage example wrote a flat string back into a file. Mechanics were already correct — `field_span` and `render` handle a mapping fine — so this is self-description only. No function's behavior changed.

**A guard that caught total collapse but not partial.** `test_structure_round_trips_every_recorded_components_string` carried `assert walked > 0` while its two siblings carry numeric floors. It now carries a floor of 472: with `raw` mandatory on every record and the string shape forbidden, `walked` is pinned to the whole corpus rather than a shrinking subset.

**The schema description** said "two shapes coexist while the corpus migrates". That transition is finished.

## Not in this PR

`check_recipe`'s keyless-clause accounting reads the flat string, so its population survives only because `raw` does. It is inert today and its fix belongs in the change that eventually removes `raw` — which is a sequenced design step, not a cleanup, because removing `raw` also changes 173 published `components` strings and makes `check_components` unsatisfiable. Filed separately.

## Test plan

- New tests: a string-shaped record must fail the gate, and must fail schema validation. Verified by hand as well — reverting one record to a string produces `1 failure(s)` naming it.
- Whole corpus still passes with the assertion active, so no record was missed.
- Every figure re-derived from the corpus rather than copied.
- No `sources/` change. Suite 431 -> 433. `validate` 0 error(s), `check_recipe` 0 failure(s), `check_rubric` exit 0, `check_components` `[OK]`. Payload unchanged.
