### PR TITLE
fix(scores): resolve a compound license on all its parts, not the first

### DIFF
--- a/build/check_rubric.py
+++ b/build/check_rubric.py
@@ -73,8 +73,48 @@ def split_components(text: str) -> dict[str, str]:
 
 
 def head(value: str) -> str:
-    """The bare value, before any parenthetical or comma-separated detail."""
+    """The bare value, before any parenthetical or comma-separated detail.
+
+    Reads a DIMENSION value — `open(downloadable on HF, gated)` -> `open`. Dimension
+    vocabularies are single tokens, so cutting at the first `(` or `,` is the whole job.
+
+    It is deliberately NOT the first statement of license resolution any more. A license
+    value is not a single token: `Apache-2.0(code, OSI) + custom weights license(non-OSI)`
+    is two licenses, and cutting it here resolved the product on its first half and never
+    saw the restrictive one. `license_parts` splits first and this runs per part, on a
+    fragment that IS a single token followed by its annotation.
+    """
     return re.split(r"[(,]", value)[0].strip()
+
+
+def license_parts(raw: str) -> list[str]:
+    """The `+`-joined halves of a compound license, split at paren depth zero.
+
+    Depth zero because annotations carry their own punctuation —
+    `Sustainable-Use-License(fair-code,non-OSI: internal-use-only,no-resale/SaaS)+n8n-Enterprise-License`
+    is two licenses, and a naive split on `+` or on `,` invents fragments out of the
+    parenthetical.
+
+    Only `+` separates licenses. A depth-zero comma does not: every one in the corpus is
+    prose trailing a single license (`Proprietary, proprietary service`,
+    `MIT(Maple-client)+AGPL-3.0(OpenSecret-platform),both-OSI`), which is why the comma
+    stays `head`'s business, inside a part, rather than becoming a separator here.
+    """
+    parts: list[str] = []
+    depth = 0
+    current = ""
+    for char in raw:
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth = max(0, depth - 1)
+        if char == "+" and depth == 0:
+            parts.append(current)
+            current = ""
+        else:
+            current += char
+    parts.append(current)
+    return [part.strip() for part in parts if part.strip()]
 
 
 def split_value(raw: str) -> tuple[str, str]:
@@ -229,12 +269,13 @@ def recorded_license_aliases() -> dict[str, str]:
 
 
 def normalize_license(raw: str) -> str:
-    """Reduce a recorded license string to the license that governs the weights.
+    """Reduce ONE recorded license to the name the tier examples are written in.
 
-    Two forms in the data need flattening, both spelled out in the recipe's
-    `normalization` list:
-      * `code MIT + model DeepSeek-Model-License` — the model license governs,
-        because it is the one attached to the artifact being scored.
+    Runs on a single part, after `license_parts` has split a compound. Three
+    mechanical steps, all spelled out in the recipe's `normalization` list:
+      * the annotation is dropped — `Apache-2.0(code, OSI)` is Apache-2.0;
+      * a `code ` or `model ` scope prefix is dropped, because the scope is which
+        artifact the license covers, not a different license;
       * `assumed-Modified-MIT` — the `assumed-` prefix marks confidence, not a
         different license.
 
@@ -242,25 +283,33 @@ def normalize_license(raw: str) -> str:
     name. Applied last, so it sees the value after the mechanical steps rather
     than having to enumerate every prefixed variant.
 
+    The `code X + model Y` rule that used to live here — the MODEL license governs —
+    is now a consequence rather than a special case: both halves resolve and the most
+    restrictive wins, and a weights license is the restrictive half in every recorded
+    instance. Where it would not be, the old rule was wrong anyway: a permissive
+    weights license does not buy back a restrictive code license.
+
     Purely mechanical. Anything needing judgment is left alone to be flagged.
     """
     value = head(raw)
-    if "+" in value and "model" in value.lower():
-        value = value.split("+")[-1]
-        value = re.sub(r"(?i)^\s*model\s+", "", value)
-    value = re.sub(r"(?i)^assumed-", "", value.strip()).strip()
+    value = re.sub(r"(?i)^\s*(code|model)\s+", "", value.strip()).strip()
+    value = re.sub(r"(?i)^assumed-", "", value).strip()
     return recorded_license_aliases().get(value.lower(), value)
 
 
-def license_tier(raw: str, recipe: dict) -> str | None:
-    """Map a license string onto a tier from the recipe's own examples.
+def tier_rank(tiers: dict) -> dict[str, int]:
+    """Tier name -> position in the recipe's declaration order.
 
-    Returns None when the license is unmapped, which is a finding rather than an
-    error — an unmapped license means the rubric has not yet been told how to
-    treat it, and `mixed` means the evidence never recorded the outcome.
+    Declaration order IS restrictiveness order, ascending — every ladder declares
+    `ordered_by: restrictiveness_ascending` and `check_recipe` requires it. A name the
+    recipe does not declare ranks last, so an unrecognized tier can never be treated as
+    the more permissive of a pair.
     """
-    tiers = ((recipe.get("openness") or {}).get("license_tier") or {}).get("values") or {}
-    needle = normalize_license(raw).lower()
+    return {name: rank for rank, name in enumerate(tiers)}
+
+
+def _tier_of(needle: str, tiers: dict) -> str | None:
+    """The tier whose examples contain `needle`, already normalized and lowercased."""
     for name, spec in tiers.items():
         for example in (spec or {}).get("examples") or []:
             if example.lower() == needle:
@@ -269,6 +318,52 @@ def license_tier(raw: str, recipe: dict) -> str | None:
     if needle in ("proprietary", "closed", "none"):
         return "proprietary"
     return None
+
+
+def license_tier(raw: str, recipe: dict) -> str | None:
+    """Map a license string onto a tier from the recipe's own examples.
+
+    A compound license resolves on ALL its parts, most restrictive governing. That is
+    what `docs/guides/identity.md` already says openness does across a release's SKUs —
+    "a product is as open as the most restrictive license you must accept to use it" —
+    and a `+` in a recorded value is that same fact written on one line. Before this,
+    resolution truncated at the first `(` or `,` and so read only the first half:
+    `internlm` records Apache-2.0 code plus a custom application-gated weights license
+    and resolved as `osi`, never seeing the license that actually governs the weights.
+
+    Two things this deliberately does not do:
+
+      * It does not skip a part it cannot map. Every part must resolve or the whole
+        value abstains, because an unmapped part can only ever be MORE restrictive than
+        the tier the mapped parts reached — ignoring it is exactly how partial coverage
+        overstates openness.
+      * It does not decompose a compound the recipe declared as a single name. The
+        whole, untruncated value is looked up first, so a phrase whose `+` is English
+        rather than a join — `follows mC4 + OSCAR-2301 terms`, where neither operand is
+        a license — resolves as the one thing the curator recorded. A compound whose
+        operands ARE license names does not belong in a tier's examples: it is a
+        per-product override, and decomposition handles it once each operand is
+        declared on its own.
+
+    Returns None when the license is unmapped, which is a finding rather than an
+    error — an unmapped license means the rubric has not yet been told how to
+    treat it, and `mixed` means the evidence never recorded the outcome.
+    """
+    tiers = ((recipe.get("openness") or {}).get("license_tier") or {}).get("values") or {}
+    if not tiers:
+        return None
+
+    declared = _tier_of(
+        recorded_license_aliases().get(raw.strip().lower(), raw.strip()).lower(), tiers
+    )
+    if declared is not None:
+        return declared
+
+    resolved = [_tier_of(normalize_license(part).lower(), tiers) for part in license_parts(raw)]
+    if not resolved or any(tier is None for tier in resolved):
+        return None
+    rank = tier_rank(tiers)
+    return max(resolved, key=lambda name: rank.get(name, len(tiers)))
 
 
 def resolve_dimension(components: dict[str, str], dimension: str, recipe: dict) -> str | None:

--- a/build/notebook_data.json
+++ b/build/notebook_data.json
@@ -15166,11 +15166,11 @@
           "type": "dataset",
           "description": "The FLAN Collection (v2) is Google Research's instruction-tuning compilation of 1,800+ tasks (P3, Super-NaturalInstructions, chain-of-thought data) that trained Flan-T5 and Flan-PaLM. It remains a canonical instruction-data building block, folded into Tulu 3, OLMo 3's Dolci, and Marin's Dolmino mixes.",
           "openness": {
-            "score": 4,
+            "score": 3,
             "class": "open",
             "components": "access:ungated(conversion);license:Apache-2.0(recipe)+per-task;dataset_card:partial",
             "confidence": "medium",
-            "note": "Released as an Apache-2.0 recipe/repo; the widely used HF conversion (ai2-adapt-dev) is ungated. Underlying task datasets keep their own licenses.",
+            "note": "Released as an Apache-2.0 recipe/repo; the widely used HF conversion (ai2-adapt-dev) is ungated. Underlying task datasets keep their own licenses, so the Apache-2.0 covers the recipe and not the corpus - the license defers to its components, as `the-pile` and `stack-edu` do. Scored 4 until 2026-08-11 on a resolver that truncated the license at the first parenthesis and so read a clean Apache-2.0; reading the whole value puts it on the deferred-license rung, and a partial card takes it to 3.",
             "sources": [
               {
                 "url": "https://github.com/google-research/FLAN",

--- a/docs/guides/openness-spectrum.md
+++ b/docs/guides/openness-spectrum.md
@@ -163,6 +163,44 @@ Two things worth knowing about the shape of it:
   type with no word between `open` and `gated`, which is exactly how a non-commercial corpus
   came to sit in the `open` bucket.
 
+### A compound license resolves on all of its parts
+
+Plenty of products ship under more than one license at once — Apache-2.0 code beside a
+custom weights license, an OSI core beside a paid enterprise tier, an Apache-2.0 recipe
+assembling tasks that keep their own terms. Those are recorded on one line, joined by `+`:
+
+```
+license:Apache-2.0(code, OSI) + custom weights license(non-OSI, application step)
+```
+
+**Every part resolves, and the most restrictive one governs the cap.** This is the same rule
+`docs/guides/identity.md` states for a tier that ships several SKUs, applied within a single
+recorded value: a product is as open as the most restrictive license you have to accept.
+
+Two properties of it are load-bearing:
+
+- **A part that maps to no tier makes the whole value abstain.** It is not skipped. An
+  unmapped part can only turn out to be more restrictive than the tier the mapped parts
+  reached, so skipping it publishes an overstatement, and abstaining is the signal to
+  extend the rubric — the same thing an unmapped single license already does.
+- **A `+` inside a parenthetical is not a separator**, and neither is a comma. Every
+  depth-zero comma in the corpus trails prose after one license (`Proprietary, proprietary
+  service`), so only `+` at paren depth zero joins two licenses.
+
+A recipe may still declare a compound as a single tier example, but only where the `+` is
+not joining licenses: `follows mC4 + OSCAR-2301 terms` names two corpora in a sentence, and
+there is nothing in it to decompose. A compound whose operands *are* license names does not
+belong in an `examples` list — that is a per-product override, and the operands belong there
+individually instead.
+
+Until 2026-08-11 resolution truncated the recorded value at its first `(` or `,` and so read
+only the first license. `internlm` resolved as `osi` on its Apache-2.0 code while the
+application-gated weights license that actually governs the download was never read;
+`smoltalk` and `flan-collection` both resolved as clean Apache-2.0 while the half saying the
+assembled components keep their own terms went unseen. Reading the whole value moved one
+published score — `flan-collection` from 4 to 3 — and left the other two where the analysts
+had already put them by hand.
+
 ## How the buckets relate to MOF and OSAID
 
 The Model Openness Framework and the OSI's Open Source AI Definition are both **binary**.

--- a/sources/categories/base_pretrained.yaml
+++ b/sources/categories/base_pretrained.yaml
@@ -92,7 +92,12 @@ scoring_recipe:
             the bound and may use the model commercially without asking. Was `use_restricted`
             and capped at 2 before the universal license scale; see sources/rubrics/model.yaml
             for why the cap moved and why the tier was renamed alongside it.
-          examples: [Llama-3.1-Community-License, Llama-4-Community, Gemma-License, GLM-4-License, Qwen-License-Agreement]
+          # `InternLM-Free-Commercial-License` is the bound written as a process rather than
+          # a number: commercial use costs nothing and is granted on an application form.
+          # It reaches the ladder as the second half of `internlm`'s compound license, which
+          # was invisible until compounds resolved on both halves.
+          examples: [Llama-3.1-Community-License, Llama-4-Community, Gemma-License, GLM-4-License, Qwen-License-Agreement,
+            InternLM-Free-Commercial-License]
         commercial_forbidden:
           definition: >
             Weights are published and commercial use is prohibited, or reserved to the vendor.

--- a/sources/categories/training_synthetic_datasets.yaml
+++ b/sources/categories/training_synthetic_datasets.yaml
@@ -13,10 +13,10 @@ scoring_recipe:
   version: 1
   derived_from:
     method: reverse-engineered from hand-authored scores, then verified
-    scores_reproduced: 31
+    scores_reproduced: 32
     scores_total: 38
-    scores_deferred: 7
-    verified_on: '2026-07-31'
+    scores_deferred: 6
+    verified_on: '2026-08-11'
     checker: build/check_rubric.py
   note: >-
     First DATASET category, and the source the shared ladder was derived from. Chosen over
@@ -31,14 +31,6 @@ scoring_recipe:
 
   extends: dataset
   deferred:
-    smoltalk:
-      because: >-
-        The ladder computes 5/open and the score says 4/open. The 4 rests on
-        `license:apache-2.0(new-subsets)+per-component` - newly created subsets are
-        Apache-2.0 while incorporated datasets keep their own terms - but `head()` splits the
-        license value at the first parenthesis, so the ladder reads a clean `apache-2.0` and
-        the qualifier that justifies the 4 never reaches it. Either the per-component scope
-        belongs in a key of its own or the score is a level high; it needs a human.
     openhermes-2-5:
       because: >-
         License `not-clearly-stated-on-card` resolves to the `unstated` tier, which carries no

--- a/sources/rubrics/dataset.yaml
+++ b/sources/rubrics/dataset.yaml
@@ -139,9 +139,16 @@ openness:
         # curation fix, not a rubric one.
         # `Apache-2.0/MIT` is `livebench` dual-licensing under two open licenses, so either
         # branch lands on this rung. `Etalab-2.0` is the French government's open license.
+        #
+        # `CommonCrawl-ToU` replaces the compound `CommonCrawl-ToU+Apache-2.0`, which was
+        # `redpajama-data-v2`'s license string copied verbatim into the ladder - a
+        # per-product override, and one that only worked because resolution truncated at
+        # the first `(`. Compounds now resolve on both halves, so the operand is what
+        # belongs here. The tier is unchanged and deliberate: Common Crawl's terms permit
+        # redistribution and reuse, commercial use included, which is this tier's test.
         examples: [ODC-BY, odc-by, ODC-BY-1.0, CC-BY-4.0, CC-BY-SA-4.0, cc0-1.0, Apache-2.0,
           apache-2.0, MIT, mit, Apache-2.0/MIT, Etalab-2.0, permissive, open,
-          NVIDIA-Open-Data, CommonCrawl-ToU+Apache-2.0]
+          NVIDIA-Open-Data, CommonCrawl-ToU]
       noncommercial:
         definition: >-
           Permits redistribution but forbids commercial use. Capped at 2 by the universal
@@ -163,7 +170,18 @@ openness:
           restriction you can read is a smaller problem than an unbounded one you have to
           audit per subset, and above `unstated` because at least the obligation is
           locatable.
-        examples: [mixed-per-subset, inherits-the-stack-v2, follows mC4 + OSCAR-2301 terms]
+        # `per-task` and `per-component` are the same conclusion as `mixed-per-subset`, in
+        # the words the curator happened to use, and they appear as the SECOND half of a
+        # compound - `Apache-2.0(recipe)+per-task` on `flan-collection`. The recipe is
+        # Apache-2.0; the tasks it assembles are not, and until compounds resolved on both
+        # halves that half was invisible.
+        #
+        # `follows mC4 + OSCAR-2301 terms` stays a whole-value example, and the `+` in it is
+        # why: it is English, joining two CORPUS names rather than two licenses, so there is
+        # nothing there to decompose. That is the line between a legitimate compound example
+        # and a per-product override - whether its operands are licenses.
+        examples: [mixed-per-subset, inherits-the-stack-v2, follows mC4 + OSCAR-2301 terms,
+          per-task, per-component]
       unstated:
         definition: >-
           No license recorded on the card at all. The most restrictive tier, because absent
@@ -262,12 +280,23 @@ openness:
       A documented, ungated release whose license points somewhere else. Not 5, because
       establishing what you may do with it means reading another corpus's terms - and for
       `stack-edu` those terms are The Stack v2's, which is itself gated.
+  - when: {license_tier: deferred_to_components, documentation: partial}
+    then: {score: 3, class: open}
+    because: >-
+      Both discounts at once: the license points at somebody else's terms AND the card does
+      not describe the artifact people actually use. `flan-collection` is the case - the
+      Apache-2.0 covers the recipe while the tasks it assembles keep their own terms, and
+      the widely used HF conversion is documented by whoever converted it. Scored beside
+      `the-pile` rather than beside `stack-edu`, because a deferred license with a card you
+      cannot rely on is the-pile's situation whether the card is stale or merely partial.
   - when: {license_tier: open_data, documentation: partial}
     then: {score: 4, class: open}
     because: >-
       A clean license and an ungated download, but the card does not describe the artifact
-      people actually use. `flan-collection` documents the Apache-2.0 recipe while the
-      widely used conversion is documented by whoever converted it.
+      people actually use. One step below the rung under it for the card alone. No product
+      sits here today - `flan-collection` did, on a license the resolver truncated to a
+      clean `Apache-2.0`, and moved to the deferred-license rung above once the whole value
+      was read.
   - when: {license_tier: open_data, documentation: present}
     then: {score: 5, class: open}
     because: One license covering the release, an open download, and a card. Nothing withheld.

--- a/sources/rubrics/model.yaml
+++ b/sources/rubrics/model.yaml
@@ -85,8 +85,14 @@ openness:
         # it "use-restricted", which is looser language than the tier names use: an
         # acceptable-use policy is not a use CAP, and #117 was opened precisely because that
         # conflation had scored one OpenRAIL family two different ways.
+        # `Cohere-Acceptable-Use-Policy` is an acceptable-use policy and nothing else, which
+        # is the case #117 settled: it forbids classes of conduct without capping who may
+        # use the weights or at what scale. It rides alongside CC-BY-NC on `command-r`, and
+        # the compound resolves on the more restrictive half regardless, so its tier decides
+        # nothing there - it is declared so the compound resolves at all.
         examples: [Modified-MIT, minimax-community, NVIDIA-Open-Model-License, BigCode-OpenRAIL-M,
-          zentropi-openrail-m, DeepSeek-Model-License, TII-Falcon-License-2.0]
+          zentropi-openrail-m, DeepSeek-Model-License, TII-Falcon-License-2.0,
+          Cohere-Acceptable-Use-Policy]
       use_bounded:
         definition: >
           Commercial use is permitted, but bounded - a monthly-active-user ceiling, an annual
@@ -100,9 +106,13 @@ openness:
           the distinction the map exists to draw. Renamed with the cap change so that a stale
           reference to `use_restricted` fails loudly rather than resolving to a tier whose
           meaning moved underneath it.
+        # `InternLM-Free-Commercial-License` is the bound written as a process rather than a
+        # number: commercial use costs nothing and is granted on an application form. Still
+        # a bound, because permission is asked for rather than given, and still well inside
+        # this tier's test - commerce is available, to practically everyone who asks.
         examples: [Llama-2-Community-License, Llama-3-Community-License, Llama-3.1-Community-License,
           Llama-3.2-Community-License, Llama-4-Community, Gemma-License, GLM-4-License,
-          Qwen-License-Agreement, Jamba-Open-Model-License]
+          Qwen-License-Agreement, Jamba-Open-Model-License, InternLM-Free-Commercial-License]
       commercial_forbidden:
         definition: >
           Weights are published and commercial use is prohibited, or reserved to the vendor.

--- a/sources/rubrics/software.yaml
+++ b/sources/rubrics/software.yaml
@@ -67,9 +67,11 @@ openness:
         # Spelling variants and dual forms are listed literally rather than normalized:
         # whether `GPLv3` is OSI is a fact, and a fact is cheaper to look up than a regex
         # is to get right. `LGPL-3.0/GPL-3.0` is openfn dual-licensing under two OSI
-        # licenses, so either branch lands on this rung.
+        # licenses, so either branch lands on this rung. `Apache-2.0/MIT` is the same shape
+        # on `megatron-lm`'s vendored components, and is already declared verbatim in
+        # `dataset.yaml` for `livebench` - one spelling, one tier, in both ladders.
         examples: [Apache-2.0, MIT, BSD-3-Clause, GPL-3.0, AGPL-3.0, LGPL-3.0, MPL-2.0,
-          GPL-3.0-or-later, GPLv3, LGPL-3.0/GPL-3.0]
+          GPL-3.0-or-later, GPLv3, LGPL-3.0/GPL-3.0, Apache-2.0/MIT]
       permissive_non_osi:
         definition: >-
           Not OSI-approved, but imposes no restriction on WHO may use the software or AT
@@ -82,8 +84,13 @@ openness:
           use before a delayed conversion date. The reader can audit the code and still
           not be free to run it, which is why this sits below the OSI tiers rather than
           beside them. Delayed-conversion licenses are scored on their terms TODAY.
+        # `n8n-Enterprise-License` covers the `ee/` directories n8n ships in the same public
+        # repo as its Sustainable-Use-License core: the source is published and readable,
+        # and running it needs a paid license key. That is this tier's definition almost
+        # word for word, and it is why the tier is NOT `proprietary` - proprietary here
+        # means the source is not published, and n8n's is.
         examples: [BSL-1.1, SSPL-1.0, FCL-1.0-ALv2, Elastic-License-2.0,
-          Elastic License 2.0, Sustainable-Use-License]
+          Elastic License 2.0, Sustainable-Use-License, n8n-Enterprise-License]
       proprietary:
         definition: No license to the source, because the source is not published.
         # `commercial` is how the closed observability vendors record it.

--- a/sources/scores/flan-collection.yaml
+++ b/sources/scores/flan-collection.yaml
@@ -1,6 +1,6 @@
 product: flan-collection
 openness:
-  score: 4
+  score: 3
   class: open
   components:
     access:
@@ -14,7 +14,11 @@ openness:
       value: partial
   confidence: medium
   note: Released as an Apache-2.0 recipe/repo; the widely used HF conversion (ai2-adapt-dev) is ungated.
-    Underlying task datasets keep their own licenses.
+    Underlying task datasets keep their own licenses, so the Apache-2.0 covers the recipe and not the
+    corpus - the license defers to its components, as `the-pile` and `stack-edu` do. Scored 4 until
+    2026-08-11 on a resolver that truncated the license at the first parenthesis and so read a clean
+    Apache-2.0; reading the whole value puts it on the deferred-license rung, and a partial card takes
+    it to 3.
   raw: access:ungated(conversion);license:Apache-2.0(recipe)+per-task;dataset_card:partial
   sources:
   - url: https://github.com/google-research/FLAN

--- a/sources/signal_routing.yaml
+++ b/sources/signal_routing.yaml
@@ -210,6 +210,14 @@ dimensions:
         llama-3.1-community: Llama-3.1-Community-License
         llama-3.2-community: Llama-3.2-Community-License
         nvidia-nemotron-open-model-license: NVIDIA-Open-Model-License
+        # `internlm` records the second half of its compound license descriptively rather
+        # than by name. The license it describes has one: InternLM's "Free Commercial
+        # License", academic use free and commercial use free after an application form.
+        # Aliased rather than left to a tier example, because a phrase this generic sitting
+        # in a rubric's `examples` list is a per-product override wearing a license's
+        # clothes. If a second product ever records the same words for a different license,
+        # the fix is to make both of them name theirs.
+        custom weights license: InternLM-Free-Commercial-License
 
   weights:
     question: Are the trained weights downloadable and runnable locally?

--- a/tests/test_check_parity.py
+++ b/tests/test_check_parity.py
@@ -40,7 +40,7 @@ def run(monkeypatch, published, category=None, verbose=False):
 
 
 def test_local_scores_matches_check_rubrics_split():
-    """391 products the ladders decide, 81 the categories defer. The same 472 the warehouse
+    """392 products the ladders decide, 80 the categories defer. The same 472 the warehouse
     publishes, so a change to either number should show up as a failure here first. Was 384
     before Luciole (base_pretrained) and OpenRAG (orchestration_agents) were added, both
     computed rather than deferred, and 386/86 until the verification sweep read megatron-lm
@@ -48,12 +48,15 @@ def test_local_scores_matches_check_rubrics_split():
     when the sweep reached `inference_code`: reading vllm, apple-core-ml-runtime,
     google-cloud-tpu-inference and qualcomm-ai-engine-direct recorded the `source` and
     `core-gated` values their deferrals had been waiting on, and check_recipe failed until
-    the four stale deferrals were removed."""
+    the four stale deferrals were removed. Then 391/81 -> 392/80 when compound licenses
+    started resolving on all their parts: `smoltalk`'s deferral existed because the ladder
+    could not see the `+per-component` half of its license and computed a 5 against a
+    recorded 4, and reading the whole value makes it reproduce."""
     computed, deferred = local_scores(None)
-    assert len(deferred) == 81
-    assert len(computed) == 391
+    assert len(deferred) == 80
+    assert len(computed) == 392
     assert not set(computed) & set(deferred)
-    # Every one of the 391 reproduces today, so none should abstain.
+    # Every one of the 392 reproduces today, so none should abstain.
     assert [key for key, value in computed.items() if value is None] == []
 
 

--- a/tests/test_check_rubric.py
+++ b/tests/test_check_rubric.py
@@ -101,8 +101,17 @@ class TestRecordedLicenseAliases:
         enumerate a prefixed variant of every license."""
         assert normalize_license("assumed-Gemma-Terms-of-Use") == "Gemma-License"
 
-    def test_alias_applies_after_the_compound_split(self):
-        assert normalize_license("code MIT + model glm-4") == "GLM-4-License"
+    def test_alias_applies_after_the_scope_prefix_is_dropped(self):
+        """`normalize_license` reads ONE part now, and a part may carry the scope it
+        covers. Dropping `code `/`model ` before the lookup keeps the alias table from
+        having to enumerate a scoped variant of every license."""
+        assert normalize_license("model glm-4") == "GLM-4-License"
+
+    def test_alias_applies_across_a_compound_split(self):
+        """The compound itself is `license_tier`'s job. What used to be a special case -
+        `code X + model Y`, the model license governs - is now a consequence of resolving
+        both halves and keeping the more restrictive."""
+        assert license_tier("code MIT + model glm-4", RECIPE) == "use_restricted"
 
     def test_canonical_names_pass_through_untouched(self):
         assert normalize_license("Apache-2.0") == "Apache-2.0"
@@ -122,6 +131,61 @@ class TestRecordedLicenseAliases:
         aliases = recorded_license_aliases()
         targets = {name.lower() for name in aliases.values()}
         assert not (targets & set(aliases)), "alias target is itself an alias key"
+
+
+class TestCompoundLicense:
+    """A compound resolves on ALL its parts, most restrictive governing.
+
+    The bug this replaces was quiet and one-directional: resolution truncated at the
+    first `(` or `,`, so a value naming two licenses was decided by whichever was typed
+    first, and the half that actually restricted the artifact was never read. Every one
+    of these tests fails against that behavior.
+    """
+
+    def test_the_restrictive_half_governs_whichever_side_it_is_on(self):
+        assert license_tier("MIT(code)+Gemma-License(weights)", RECIPE) == "use_restricted"
+        assert license_tier("Gemma-License(weights)+MIT(code)", RECIPE) == "use_restricted"
+
+    def test_all_permissive_parts_stay_permissive(self):
+        assert license_tier("Apache-2.0(core)+MIT(SDKs)", RECIPE) == "osi"
+
+    def test_a_part_is_split_on_plus_only_never_on_a_comma(self):
+        """Every depth-zero comma in the corpus trails prose after a single license -
+        `Proprietary, proprietary service`. Treating one as a separator would invent a
+        second license out of the annotation."""
+        assert license_tier("MIT(client)+Gemma-License(weights),both-published", RECIPE) == (
+            "use_restricted"
+        )
+
+    def test_a_plus_inside_an_annotation_is_not_a_separator(self):
+        assert license_tier("MIT(bundles A + B)", RECIPE) == "osi"
+
+    def test_an_unmapped_part_abstains_rather_than_being_skipped(self):
+        """The whole point. An unmapped part can only be MORE restrictive than the tier
+        the mapped parts reached, so ignoring it publishes an overstatement."""
+        assert license_tier("Apache-2.0(code)+Some-New-Vendor-License(weights)", RECIPE) is None
+
+    def test_a_declared_compound_is_not_decomposed(self):
+        """A recipe may declare a compound as one name - `follows mC4 + OSCAR-2301 terms`,
+        where the `+` is English joining two CORPUS names and neither operand is a
+        license. The whole, untruncated value is looked up before any split."""
+        recipe = {
+            "openness": {
+                "license_tier": {
+                    "values": {
+                        "osi": {"examples": ["MIT"]},
+                        "deferred": {"examples": ["follows mC4 + OSCAR-2301 terms"]},
+                    }
+                }
+            }
+        }
+        assert license_tier("follows mC4 + OSCAR-2301 terms", recipe) == "deferred"
+
+    def test_a_single_license_is_unaffected(self):
+        assert license_tier("Apache-2.0(OSI, see LICENSE)", RECIPE) == "osi"
+
+    def test_a_ladder_with_no_tiers_still_abstains(self):
+        assert license_tier("Apache-2.0", {"openness": {}}) is None
 
 
 class TestRealCategories:

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -655,7 +655,12 @@ def test_real_sources_serialize_without_errors():
                 "evaluation_code", "finetuning_code", "inference_code", "ml_frameworks",
                 "orchestration_agents", "telemetry_observability", "ui_api"]
     # Two DATASET categories inherit sources/rubrics/dataset.yaml, so both serialize the
-    # same 22 rules. Each of the four ladders gained exactly one rung with the universal
+    # same 24 rules. Was 22 until compound licenses resolved on all their parts, which put
+    # `flan-collection` on a deferred-license tier it had never reached while the resolver
+    # truncated at the first parenthesis, and needed a rung for a deferred license paired
+    # with a partial card. Two rows because a two-condition rung serializes as two.
+    #
+    # Each of the four ladders gained exactly one rung with the universal
     # license scale, which split one tier in two - a bounded commercial license at 3, and a
     # license forbidding commerce outright at 2.
     #
@@ -673,7 +678,7 @@ def test_real_sources_serialize_without_errors():
     # also test `toolchain`, so 6 rows.
     assert per_category("category_scoring_rules") == {
         "base_pretrained": 12, "finetuned_chat": 10, "safeguards": 20,
-        "benchmark_eval_data": 22, "training_synthetic_datasets": 22, "edge_hardware": 6,
+        "benchmark_eval_data": 24, "training_synthetic_datasets": 24, "edge_hardware": 6,
         **{c: 10 for c in SOFTWARE},
     }
     # Both fell with the slug migration: release-level products collapsed into the
@@ -715,7 +720,10 @@ def test_real_sources_serialize_without_errors():
         # training_synthetic_datasets is unchanged at 158 across the ladder widening, which
         # is the check that mattered: benchmark_eval_data's new dimensions and rungs did not
         # disturb the category the ladder was derived from.
-        "training_synthetic_datasets": 164, "benchmark_eval_data": 111,
+        # 164 -> 169: `smoltalk`'s deferral was the ladder reading only the first half of
+        # `apache-2.0(new-subsets)+per-component`. Reading both halves reproduces its
+        # recorded 4/open, the deferral went, and its five component keys publish.
+        "training_synthetic_datasets": 169, "benchmark_eval_data": 111,
         # safeguards 90 -> 103 and training_synthetic_datasets 158 -> 164: the universal
         # license scale retired five deferrals, and a deferred product publishes no
         # openness evidence at all.


### PR DESCRIPTION
## Summary

`head()` truncated a component value at the first `(` or `,`, and it was the **first** statement of license resolution — so `normalize_license`, the compound branch, the `assumed-` strip and the alias lookup all saw text already cut. A compound license resolved on its first half and the restrictive half was never read.

`internlm` is the clearest case. It records:

```
license: Apache-2.0(code, OSI) + custom weights license(non-OSI, application step)
```

Resolution saw `Apache-2.0`. The custom, non-OSI, application-gated license that actually governs the weights was invisible.

A compound license now resolves on all its parts.

## What moves

One published score.

| Product | Before | After | Why |
|---|---|---|---|
| `flan-collection` | 4 / open | **3 / open** | `Apache-2.0(recipe)+per-task` covers the recipe while the assembled tasks keep their own terms, so it resolves `deferred_to_components`. A deferred license with its recorded `dataset_card: partial` is the same pair as `the-pile`, which the ladder scores 3. |

Two products had their *reasoning* corrected while the score stayed right, which is the more reassuring outcome:

| Product | Tier | Score |
|---|---|---|
| `internlm` | `osi` → `use_bounded` — free commercial use behind an application form | 3, unchanged; both paths gave 3, so the score was right and the reason was wrong |
| `smoltalk` | `open_data` → `deferred_to_components` | 4, unchanged — and it reproduces now, so its deferral is removed |

`smoltalk`'s deferral named `head()` as the cause, so retiring it resolves the deferral rather than papering over it. Computed products go 391 → 392.

## `redpajama-data-v2` and the compound tier example

`sources/rubrics/dataset.yaml` carried `CommonCrawl-ToU+Apache-2.0` as a literal tier example, and `redpajama-data-v2`'s license is exactly that string — so removing the example without handling the product would have dropped it a rung. The example is replaced by its operand, `CommonCrawl-ToU`. Decomposition resolves both halves to `open_data`, `redpajama` stays 5 / open, and the tier judgment the compound encoded now generalizes to any Common Crawl-derived corpus instead of matching one product by name.

The other compound tier examples go for the same reason: they were per-product overrides wearing a license name.

## One thing surfaced, not decided

`model-context-protocol` now abstains on its third part, `CC-BY-4.0(docs)`, which is undeclared for software. It is deferred, so nothing published depends on it, and declaring `permissive_non_osi`'s first example is a call worth making on its own rather than inside this change.

## Test plan

- Delta table computed **before** any code change, then re-measured after: the moves are exactly the three predicted products, no surprises.
- Every `head()` caller handled deliberately, so no axis keeps truncating while another stops.
- Suite 433 → 442. `validate` 0 error(s), `check_recipe` 0 failure(s), `check_rubric` exit 0, `check_components` `[OK]`, plus `check_verification`, `check_capability` and `check_payload` green.
- Exactly one `score:` line changes across the whole diff.

## Follow-up required

`currentai.scores.openness_computed` mirrors this logic in hand-written SQL and **still truncates**. `check_parity` runs weekly and cannot distinguish staleness from drift, so it will report divergence until the UDM is updated. That is warehouse-side work and needs doing before the next Monday run.
