### PR TITLE
fix(scores): read self-host as core-gated, the same question under another name

### DIFF
--- a/build/check_rubric.py
+++ b/build/check_rubric.py
@@ -366,6 +366,30 @@ def license_tier(raw: str, recipe: dict) -> str | None:
     return max(resolved, key=lambda name: rank.get(name, len(tiers)))
 
 
+def dimension_spec(dimension: str, recipe: dict) -> dict:
+    return (((recipe.get("openness") or {}).get("dimensions") or {}).get(dimension)) or {}
+
+
+def normalize_dimension_value(value: str, spec: dict) -> str:
+    """A recorded spelling translated to the declared value it means.
+
+    `reads:` widens which KEY answers a dimension; this widens which VALUE does. The two
+    are separate because `reads:` selects a key and takes its value verbatim, so a synonym
+    key whose vocabulary differs - `self-host: none` for `core_gated: gated` - still reads
+    as unanswered without a translation step. `dataset.yaml`'s `availability` note is the
+    same observation from the other side: there, every spelling was declared as its own
+    value and the rules were written to test only one polarity, which works because the
+    other polarity falls through. `core_gated` has a rung on both sides, so falling through
+    is not available and the spellings have to collapse onto the two declared values.
+
+    An unmapped spelling is returned unchanged, which puts it outside the enum and leaves
+    the dimension unanswered. That is deliberate: the formula declares no `otherwise`, so
+    abstaining is what happens to evidence the ladder does not understand, and guessing a
+    polarity from an unrecognized word is exactly the failure that would not surface.
+    """
+    return (spec.get("value_aliases") or {}).get(value, value)
+
+
 def resolve_dimension(components: dict[str, str], dimension: str, recipe: dict) -> str | None:
     """Which recorded key answers a dimension, or None if nothing does.
 
@@ -388,20 +412,25 @@ def resolve_dimension(components: dict[str, str], dimension: str, recipe: dict) 
     need the parenthetical detail attached to that key too, and re-deriving the
     preference in a second place is how the two would drift.
     """
-    spec = (((recipe.get("openness") or {}).get("dimensions") or {}).get(dimension)) or {}
+    spec = dimension_spec(dimension, recipe)
     keys = spec.get("reads") or [dimension]
     allowed = set(spec.get("values") or ())
     present = [key for key in keys if key in components]
     for key in present:
-        if head(components[key]) in allowed:
+        if normalize_dimension_value(head(components[key]), spec) in allowed:
             return key
     return present[0] if present else None
 
 
 def dimension_value(components: dict[str, str], dimension: str, recipe: dict) -> str:
-    """The bare value the formula reads for a dimension, or '' if unanswered."""
+    """The bare value the formula reads for a dimension, or '' if unanswered.
+
+    Alias-translated, so the formula only ever tests the declared vocabulary.
+    """
     key = resolve_dimension(components, dimension, recipe)
-    return head(components[key]) if key is not None else ""
+    if key is None:
+        return ""
+    return normalize_dimension_value(head(components[key]), dimension_spec(dimension, recipe))
 
 
 def dimension_read_map(recipe: dict) -> dict[str, str]:

--- a/build/serialize_rubric.py
+++ b/build/serialize_rubric.py
@@ -69,6 +69,7 @@ from build.check_rubric import (
     components_of,
     dimension_read_map,
     license_read_keys,
+    normalize_dimension_value,
     resolve_dimension,
     split_value,
 )
@@ -569,6 +570,14 @@ def build_rubric(sources: dict, policy: dict, routing: dict) -> tuple[dict[str, 
                         continue
                     resolved_keys[dimension] = key
                     bare, detail = split_value(components[key])
+                    # Translated before it leaves, so the warehouse joins a rule's
+                    # `condition_value` against the declared vocabulary and never has to
+                    # learn the synonym table. `self-host:none` goes out as the `core_gated`
+                    # dimension valued `gated`; the recorded spelling is not lost, because
+                    # the traceability pass below still emits `self-host` under its own name.
+                    # Normalizing here rather than in the SQL is what keeps this change off
+                    # check_parity's list.
+                    bare = normalize_dimension_value(bare, spec or {})
                     allowed = (spec or {}).get("values")
                     in_enum = bare in allowed if allowed else ""
                     if in_enum is False:

--- a/docs/guides/openness-spectrum.md
+++ b/docs/guides/openness-spectrum.md
@@ -201,6 +201,49 @@ assembled components keep their own terms went unseen. Reading the whole value m
 published score — `flan-collection` from 4 to 3 — and left the other two where the analysts
 had already put them by hand.
 
+### `self-host` and `core-gated` are one question
+
+The software ladder asks whether functionality is withheld from the published source for a
+paid tier, and records the answer under `core-gated` with values `gated` and `ungated`. The
+corpus also answered that question 54 times under `self-host`, in a vocabulary of its own:
+`yes`, `primary`, `only` on one side and `no`, `none`, `enterprise-only`, `enterprise-tier`
+on the other. Whether a vendor lets you run the published thing yourself *is* whether the
+core is withheld, so these were never two facts.
+
+Twenty-three records carry both keys, and they never disagree — 11 `yes`/`ungated`, 10
+`primary`/`ungated`, 2 `only`/`ungated`, and no contradictions in either direction. That
+agreement is what licenses the merge. Until 2026-08-11 `self-host` was an undeclared key,
+which meant it was dropped before the formula ran, and the 31 records that used it *instead*
+of `core-gated` left the dimension unanswered.
+
+Two mechanisms carry it, and they do different jobs:
+
+- **`reads:`** widens which recorded KEY answers a dimension. `core_gated` now reads
+  `[core-gated, self-host]`, first key whose value lands in the enum winning.
+- **`value_aliases:`** widens which recorded VALUE does. `reads:` selects a key and takes its
+  value verbatim, so a synonym key with its own vocabulary still reads as unanswered without
+  a translation table. `dataset.yaml`'s `availability` handles the same problem the other way
+  round, by declaring every spelling as its own value and writing rules that test only one
+  polarity — which works there because the other polarity falls through to the license rungs.
+  `core_gated` has a rung on both sides, so nothing falls through and the spellings have to
+  collapse onto the two declared values.
+
+A spelling with no entry in `value_aliases` is not guessed at. It stays outside the enum, the
+dimension reads as unanswered, and the formula abstains, which is the same treatment an
+unmapped license part gets and for the same reason: the software ladder declares no
+`otherwise`, so abstaining is what the ladder does with evidence it does not understand.
+
+The merge is conservative by construction, and the numbers say so. Of the 31 records whose
+answer changed, 28 kept the score they had: 26 of those are hosted products recording
+`source: closed`, where the first rung fires on `source` alone and `core_gated` is never
+read, and the software ladder already says the dimension is "only meaningful where `source`
+is public". This is the case worth being careful about — a hosted service has no core to gate
+— and rule ordering already neutralizes it. The remaining three had been deferred with the
+same sentence, that core-gated is not recorded in a form the ladder can read, while recording
+it under `self-host` all along. Two of them, `syfthub` and `thunderbolt`, reproduce their
+recorded 5/open_source exactly. One published score moved: `otari` from 4/open_core to
+5/open_source.
+
 ## How the buckets relate to MOF and OSAID
 
 The Model Openness Framework and the OSI's Open Source AI Definition are both **binary**.

--- a/sources/categories/orchestration_agents.yaml
+++ b/sources/categories/orchestration_agents.yaml
@@ -122,10 +122,6 @@ scoring_recipe:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of
         the repo and pricing page
-    syfthub:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
     zed:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of

--- a/sources/categories/ui_api.yaml
+++ b/sources/categories/ui_api.yaml
@@ -86,10 +86,6 @@ scoring_recipe:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of
         the repo and pricing page
-    thunderbolt:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
     maple-ai:
       because: >-
         ladder computes 4/open_core from the recorded evidence but the score says
@@ -111,10 +107,6 @@ scoring_recipe:
         source or core-gated is not recorded in a form the ladder can read; needs a read of
         the repo and pricing page
     doubao:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
-    otari:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of
         the repo and pricing page

--- a/sources/rubrics/software.yaml
+++ b/sources/rubrics/software.yaml
@@ -32,7 +32,37 @@ openness:
     core_gated:
       question: Is functionality withheld from the published source for a paid tier?
       values: [gated, ungated]
-      reads: [core-gated]
+      reads: [core-gated, self-host]
+      # `self-host` is the same question in the vocabulary the corpus actually used.
+      # Whether the vendor lets you run the published thing yourself IS whether the core is
+      # withheld, and 54 records say so under that name while 164 say it under
+      # `core-gated`. Where both are recorded - 23 records - they never disagree: 11
+      # `yes`/`ungated`, 10 `primary`/`ungated`, 2 `only`/`ungated`, and no contradictions.
+      # Until this list read it, `self-host` was an undeclared key and was dropped before
+      # the formula ran, which is why check_recipe's docstring names it as the single most
+      # common piece of vocabulary drift on the map.
+      #
+      # `reads:` selects a key and takes its value, so a synonym key still needs its values
+      # translated - the problem dataset.yaml's `availability` notes it cannot solve by
+      # widening `reads:` alone. `value_aliases` is that translation, and it is the same
+      # idea `license_tier` already uses: a canonical rung with the literal spellings that
+      # land on it declared beside it, because whether `enterprise-only` means gated is a
+      # fact worth writing down rather than a regex worth getting wrong. A recorded
+      # spelling with no entry here is not guessed at - it falls outside the enum, the
+      # dimension reads as unanswered, and the formula abstains.
+      #
+      # `'yes'` and `'no'` are quoted for the reason the note below gives about `values`:
+      # YAML 1.1 parses both bare as booleans, and a boolean key never matches the string
+      # the parser hands it.
+      value_aliases:
+        'yes': ungated
+        primary: ungated
+        only: ungated
+        'no': gated
+        none: gated
+        enterprise-only: gated
+        enterprise-tier: gated
+        none for core AX features: gated
       evidence:
       - '`gated`: features live behind an enterprise license directory, a Premium tier, or
         a commercial edition the published source cannot build'

--- a/sources/scores/apple-core-ml-runtime.yaml
+++ b/sources/scores/apple-core-ml-runtime.yaml
@@ -26,6 +26,12 @@ openness:
     establishes:
     - source
     - license
+    # The same page settles `self-host`, which now answers `core_gated` on the software
+    # ladder. "An API surface a person's app calls into, with no source tree" is one fact
+    # stated once, and it is both why the source is closed and why there is nothing to run
+    # yourself. Attribution names the recorded key rather than the dimension, because that
+    # is what the page is evidence of.
+    - self-host
     http_status: 200
     content_sha256: a2aa644242309dfefa82b7e0c4b739e5a086622f7d5e395f31e30f48e7948f25
 adoption:

--- a/sources/scores/otari.yaml
+++ b/sources/scores/otari.yaml
@@ -1,7 +1,7 @@
 product: otari
 openness:
-  score: 4
-  class: open_core
+  score: 5
+  class: open_source
   components:
     license:
       value: Apache-2.0
@@ -15,8 +15,13 @@ openness:
       value: hosted Otari.ai platform on the same core
   confidence: high
   note: Apache-2.0 self-hostable gateway (github.com/mozilla-ai/otari) with a hosted Otari.ai platform on
-    the same core; classed open_core alongside peer gateways such as LiteLLM. Would be open_source (5) if
-    the hosted platform is not a commercial tier.
+    the same core. Scored 4/open_core until 2026-08-11 on an analogy to LiteLLM that the recorded evidence
+    does not carry. LiteLLM's open_core rests on `enterprise-dir` naming a separately licensed directory
+    in its repo, and Otari records nothing of the kind. What it does record is a published Apache-2.0
+    core, self-hosting via Docker Compose, and a hosted platform on that same core, which the software
+    ladder calls ungated because hosting convenience is not gating. The old note's own conditional, that
+    this would be open_source if the hosted platform is not a commercial tier, was a hedge rather than
+    evidence of a tier.
   raw: license:Apache-2.0(OSI, core);source:public;self-host:yes(Docker Compose);service:hosted Otari.ai
     platform on the same core
   sources:

--- a/tests/test_check_parity.py
+++ b/tests/test_check_parity.py
@@ -51,10 +51,13 @@ def test_local_scores_matches_check_rubrics_split():
     the four stale deferrals were removed. Then 391/81 -> 392/80 when compound licenses
     started resolving on all their parts: `smoltalk`'s deferral existed because the ladder
     could not see the `+per-component` half of its license and computed a 5 against a
-    recorded 4, and reading the whole value makes it reproduce."""
+    recorded 4, and reading the whole value makes it reproduce. Then 392/80 -> 395/77 when
+    `core_gated` started reading `self-host`: syfthub, thunderbolt and otari were all deferred
+    with the same text, that core-gated is not recorded in a form the ladder can read, and all
+    three had recorded it under `self-host`."""
     computed, deferred = local_scores(None)
-    assert len(deferred) == 80
-    assert len(computed) == 392
+    assert len(deferred) == 77
+    assert len(computed) == 395
     assert not set(computed) & set(deferred)
     # Every one of the 392 reproduces today, so none should abstain.
     assert [key for key, value in computed.items() if value is None] == []

--- a/tests/test_check_rubric.py
+++ b/tests/test_check_rubric.py
@@ -83,6 +83,67 @@ class TestDimensionValue:
         assert dimension_value(components, "data", RECIPE) == "open"
 
 
+ALIAS_RECIPE = {
+    "openness": {
+        "dimensions": {
+            "core_gated": {
+                "values": ["gated", "ungated"],
+                "reads": ["core-gated", "self-host"],
+                "value_aliases": {
+                    "yes": "ungated", "primary": "ungated", "only": "ungated",
+                    "no": "gated", "none": "gated", "enterprise-only": "gated",
+                },
+            },
+        },
+    }
+}
+
+
+class TestValueAliases:
+    """`reads` widens which KEY answers a dimension; `value_aliases` widens which VALUE
+    does. Both are needed for a synonym key that carries its own vocabulary, which is what
+    `self-host` is to `core-gated`.
+    """
+
+    def test_a_synonym_value_resolves_to_the_declared_one(self):
+        components = split_components("self-host:none")
+        assert dimension_value(components, "core_gated", ALIAS_RECIPE) == "gated"
+
+    def test_the_declared_value_is_returned_unchanged(self):
+        components = split_components("core-gated:ungated")
+        assert dimension_value(components, "core_gated", ALIAS_RECIPE) == "ungated"
+
+    def test_parenthetical_detail_is_stripped_before_translation(self):
+        """`enterprise-only(hybrid)` and `no(managed only)` are both real recordings, and
+        the alias table holds bare tokens rather than every phrasing around them."""
+        components = split_components("self-host:enterprise-only(hybrid)")
+        assert dimension_value(components, "core_gated", ALIAS_RECIPE) == "gated"
+
+    def test_the_preferred_key_still_wins_when_both_are_recorded(self):
+        """23 records carry both keys. `core-gated` is declared first and is the
+        dimension's own vocabulary, so it decides."""
+        components = split_components("self-host:yes;core-gated:gated")
+        assert dimension_value(components, "core_gated", ALIAS_RECIPE) == "gated"
+
+    def test_a_synonym_key_wins_when_the_preferred_one_is_out_of_enum(self):
+        """The in-enum preference has to survive translation, or a garbled `core-gated`
+        would shadow a `self-host` that answers cleanly."""
+        components = split_components("core-gated:see pricing page;self-host:none")
+        assert dimension_value(components, "core_gated", ALIAS_RECIPE) == "gated"
+
+    def test_an_unmapped_value_is_not_guessed_at(self):
+        """It comes back untranslated, lands outside the enum, and the formula abstains.
+        The software ladder declares no `otherwise`, so abstaining is the safe default and
+        inventing a polarity from an unrecognized word is the failure that would not
+        surface."""
+        components = split_components("self-host:byoc")
+        assert dimension_value(components, "core_gated", ALIAS_RECIPE) == "byoc"
+
+    def test_a_dimension_with_no_aliases_is_unaffected(self):
+        components = split_components("data:closed;post-training-data:open")
+        assert dimension_value(components, "data", RECIPE) == "open"
+
+
 class TestRecordedLicenseAliases:
     @pytest.mark.parametrize(
         ("recorded", "canonical"),
@@ -363,3 +424,37 @@ def test_a_ladder_WITH_tiers_still_fails_an_unmappable_license(tmp_path, monkeyp
     reproduced, total, problems, deferred = check_category("tools", verbose=False)
 
     assert len(problems) == 1 and "maps to no tier" in problems[0]
+
+
+def test_every_recorded_self_host_value_is_mapped():
+    """A ratchet on the real corpus, not a unit test of the mechanism.
+
+    `value_aliases` is a hand-written table over vocabulary contributors keep adding to, and
+    an unmapped spelling fails quietly by design: the dimension reads as unanswered and the
+    product abstains, which looks exactly like a product nobody has researched yet. This
+    turns the quiet case loud at the moment the spelling is introduced, which is the only
+    moment anyone knows what it was meant to mean.
+
+    All eight recorded spellings map today. Adding a ninth means adding it here too, or
+    recording `core-gated` directly.
+    """
+    import yaml as _yaml
+
+    from build.check_rubric import components_of, head
+
+    aliases = _yaml.safe_load(
+        (ROOT / "sources/rubrics/software.yaml").read_text()
+    )["openness"]["dimensions"]["core_gated"]["value_aliases"]
+
+    unmapped = {}
+    for path in sorted((ROOT / "sources/scores").glob("*.yaml")):
+        components = components_of(_yaml.safe_load(path.read_text()).get("openness") or {})
+        value = components.get("self-host")
+        if value is not None and head(value) not in aliases:
+            unmapped[path.stem] = head(value)
+
+    assert unmapped == {}, (
+        f"unmapped `self-host` spellings: {unmapped}. Map each to `gated` or `ungated` in "
+        "software.yaml's core_gated.value_aliases, or record `core-gated` on the product."
+    )
+    assert set(aliases.values()) == {"gated", "ungated"}

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -705,18 +705,29 @@ def test_real_sources_serialize_without_errors():
         # base_pretrained rose by 5 (111 -> 116) when the fully-open Luciole family was
         # added: five openness dimensions recorded (weights, data, code, checkpoints, license).
         "base_pretrained": 116, "finetuned_chat": 173, "deployment": 131,
-        "agent_tools_protocols": 108, "dataset_processing_tools": 86, "evaluation_code": 66,
+        "agent_tools_protocols": 109, "dataset_processing_tools": 86, "evaluation_code": 66,
         # inference_code 47 -> 64 when the sweep read the category: four stale deferrals came
         # off (a deferred product publishes no openness evidence at all), and several products
         # that had described their gating in prose gained a readable `source:`/`core-gated:`.
-        "finetuning_code": 124, "inference_code": 64, "ml_frameworks": 80,
+        "finetuning_code": 124, "inference_code": 65, "ml_frameworks": 80,
         # orchestration_agents rose by 3 when n8n's stale deferral was removed: a deferred
         # product publishes no openness evidence, and n8n had been deferred as "not recorded"
         # while recording everything the ladder needed. Then by 6 more (140 -> 146) when
         # OpenRAG was added: it records source, core-gated, license, self-host, commercial,
         # and the normalized core_gated the ladder reads from core-gated — the same six-row
         # shape RAGFlow already contributes.
-        "orchestration_agents": 146, "telemetry_observability": 90, "ui_api": 127,
+        #
+        # Five categories then rose by 41 rows in total when `core_gated` started reading
+        # `self-host`, and the split is worth keeping visible because the two causes are
+        # different sizes. 29 rows are one new `core_gated` row each, on products that were
+        # already computed and stay at the score they had: agent_tools_protocols +1
+        # (pinecone), inference_code +1 (apple-core-ml-runtime), telemetry_observability +4,
+        # orchestration_agents +8 and ui_api +12, every one of them a closed hosted product
+        # the `source: closed` rung decides on its own. The other 12 are three deferrals
+        # coming off at 5 rows each, less nothing: syfthub in orchestration_agents,
+        # thunderbolt and otari in ui_api. A deferred product publishes no openness evidence
+        # at all, so a removed deferral is always the larger of the two effects.
+        "orchestration_agents": 159, "telemetry_observability": 94, "ui_api": 149,
         # training_synthetic_datasets is unchanged at 158 across the ladder widening, which
         # is the check that mattered: benchmark_eval_data's new dimensions and rungs did not
         # disturb the category the ladder was derived from.
@@ -763,6 +774,31 @@ def test_every_scored_product_carries_a_row_for_each_formula_dimension():
         if category == "finetuned_chat" and "data" not in dimensions
     ]
     assert missing == [], f"no data row emitted for: {missing}"
+
+
+def test_a_value_alias_is_translated_before_it_reaches_the_warehouse():
+    """`core_gated` reads `self-host`, whose vocabulary is `yes`/`no`/`none` rather than
+    `gated`/`ungated`. The warehouse joins a rule's `condition_value` against this column,
+    so the translation has to happen on the way out or `openness_computed` would have to
+    carry a copy of the alias table — the repo/warehouse split check_parity exists to catch.
+    Normalizing here is what keeps this change off that list.
+
+    The recorded spelling is not lost: `self-host` is still emitted under its own name by
+    the traceability pass, so both rows are in the evidence store.
+    """
+    from pathlib import Path
+
+    from build.serialize_rubric import load_policy, load_routing
+
+    root = Path(__file__).resolve().parents[1]
+    tables, _, _ = build_rubric(_real_sources(root), load_policy(root), load_routing(root))
+
+    rows = {
+        (r["dimension"], r["value"], r["in_declared_enum"])
+        for r in tables["product_openness_evidence"]
+        if r["product_slug"] == "chatgpt" and r["dimension"] in ("core_gated", "self-host")
+    }
+    assert rows == {("core_gated", "gated", True), ("self-host", "none", "")}
 
 
 def test_license_is_emitted_under_the_name_the_warehouse_joins_on():


### PR DESCRIPTION
## Summary

`self-host` is an undeclared component key on **54 records**, so no ladder reads it and it is dropped from scoring silently. `core-gated` is a declared dimension asking the same question.

The evidence that they are the same fact is unusually clean: **23 records carry both, and they never disagree** — `yes/ungated` 11, `primary/ungated` 10, `only/ungated` 2, zero contradictions. `core-gated` now reads `self-host` as a fallback, using the existing `reads` idiom that prefers the first key whose value is in the enum.

All eight spellings map, including arize's phrase `none for core AX features`. A ratchet test fails the build if a ninth appears.

## What moves

One score, and it moves up.

| Product | Before | After | Why |
|---|---|---|---|
| `otari` | 4 / open_core | **5 / open_source** | Records an Apache-2.0 core, `source: public`, `self-host: yes(Docker Compose)` and `service: hosted platform on the same core`. The ladder defines a hosted offering alongside an ungated core as ungated. The 4 rested on a LiteLLM analogy that Otari's own record does not support — LiteLLM carries `enterprise-dir` and an explicit `core-gated: gated`; Otari carries neither. |

Two more went from abstaining to deciding and reproduce their recorded score unchanged: `syfthub` and `thunderbolt`, both 5 / open_source. Their deferrals are removed — `check_recipe`'s stale-deferral gate caught them without being asked.

## The concern this change was tested against

The worry was that answering `core-gated: gated` for the ~27 products recording a negative `self-host` would lower a batch of scores. **It does not.** 28 products get a decided answer where they previously had none, and 26 of them are `source: closed` hosted services where the first rung fires on `source` alone — so rule ordering already neutralizes the case where "no self-hosting" does not mean "a gated core". The remaining 2 stay abstained on an unmapped license, unrelated to this change.

That was the substantive risk, and it is measured rather than argued.

## Test plan

- Every figure re-derived from the corpus before implementing: 54 / 23 / 31 / 27 all reproduce, and all 54 records are `product_type: software`.
- Delta table computed before the change and re-measured after; the moves are exactly what was predicted, no surprises.
- Suite 442 → 451. `validate` 0 error(s), `check_recipe` 0 failure(s), `check_rubric` exit 0, `check_components` `[OK]`, plus `check_verification`, `check_capability` and `check_payload` green.
- Exactly one `score:` line changes across the whole diff.

## Follow-up

Same as #200: `currentai.scores.openness_computed` mirrors this logic in hand-written SQL and does not yet read `self-host`. `check_parity` will report divergence until the UDM is updated.
