### PR TITLE
fix(scores): promote the keyless clauses that are a dimension's only record

### DIFF
--- a/sources/categories/training_synthetic_datasets.yaml
+++ b/sources/categories/training_synthetic_datasets.yaml
@@ -13,21 +13,28 @@ scoring_recipe:
   version: 1
   derived_from:
     method: reverse-engineered from hand-authored scores, then verified
-    scores_reproduced: 32
+    scores_reproduced: 37
     scores_total: 38
-    scores_deferred: 6
+    scores_deferred: 1
     verified_on: '2026-08-11'
     checker: build/check_rubric.py
   note: >-
     First DATASET category, and the source the shared ladder was derived from. Chosen over
     benchmark_eval_data because its recorded evidence is the cleanest in the map: 38 of 38
-    name a license and almost every value is a controlled token rather than a sentence. Eight
-    products are deferred below and none of the eight is deferred for being awkward - five
-    record their evidence in clauses the components parser discards, one is the only
-    non-commercial license on the ladder, one records no license at all, and one hides the
-    fact that decides it inside a parenthetical. The non-commercial one, `personahub`, resolved
-    on 2026-08-01 when the universal license scale gave that tier a rung at 2 - it had been the
-    one place this ladder declined to decide.
+    name a license and almost every value is a controlled token rather than a sentence. Not one
+    of its deferrals was ever a case of the ladder finding the product hard. Eight were declared
+    at the outset: five recorded their evidence in clauses the components parser discards, one
+    was the only non-commercial license on the ladder, one records no license at all, and one
+    hid the fact that decides it inside a parenthetical.
+
+    Seven have since resolved and none of the seven needed research. `personahub` resolved on
+    2026-08-01, when the universal license scale gave the non-commercial tier a rung at 2 - it
+    had been the one place this ladder declined to decide. The five parser cases resolved on
+    2026-08-11 by promoting the discarded clauses to keys: `dataset card present` became
+    `dataset_card:present` and `ungated` became `access:ungated`, which is the same evidence
+    under a name the ladder reads. No score moved.
+
+    One is left, `openhermes-2-5`, and it is the one that does need an answer rather than a key.
 
   extends: dataset
   deferred:
@@ -37,39 +44,6 @@ scoring_recipe:
         rung: absent a grant there is no permission to rely on, however freely the files
         download. Recorded 5/open with the note conceding no explicit license string exists.
         Either the license is findable, in which case record it, or a 5 is not supportable.
-    cosmopedia:
-      because: >-
-        Records `ungated` and `dataset card present` as clauses with no key, which
-        split_components discards, so neither the availability nor the documentation dimension has a
-        value and no rung can fire. The evidence is present and correct; only the keys are
-        missing. Fixed by recording `gated:false;dataset_card:present`.
-    openthoughts-114k:
-      because: >-
-        Records `ungated` and `dataset card present` as clauses with no key, which
-        split_components discards, so neither the availability nor the documentation dimension has a
-        value and no rung can fire. The evidence is present and correct; only the keys are
-        missing. Fixed by recording `gated:false;dataset_card:present`.
-    synth:
-      because: >-
-        Records `ungated` and `dataset card present` as clauses with no key, which
-        split_components discards, so neither the availability nor the documentation dimension has a
-        value and no rung can fire. The evidence is present and correct; only the keys are
-        missing. Fixed by recording `gated:false;dataset_card:present`.
-    tulu-3-sft-mixture:
-      because: >-
-        Records `ungated` and `dataset card present` as clauses with no key, which
-        split_components discards, so neither the availability nor the documentation dimension has a
-        value and no rung can fire. The evidence is present and correct; only the keys are
-        missing. Fixed by recording `gated:false;dataset_card:present`. Note the recorded
-        license carries `(mixed subset licenses incl CC-BY-NC)`, so once the keys are fixed
-        this product raises the same question `personahub` is deferred for.
-    wildchat-1m:
-      because: >-
-        Records `dataset card present` as a clause with no key, so the documentation dimension
-        has no value. Separately its availability reads `false per HF API`, whose `head()` is the whole
-        phrase rather than `false`, so the value sits outside the declared enum too. Both are
-        recording defects rather than missing research: `gated:false;dataset_card:present`
-        settles it.
 products:
 - fineweb
 - fineweb-edu

--- a/sources/scores/compar-ia-datasets.yaml
+++ b/sources/scores/compar-ia-datasets.yaml
@@ -8,12 +8,11 @@ openness:
       detail: permissive French-gov open license
     gated:
       value: HF contact-info agreement required
-    free_text:
-    - dataset card present
+    dataset_card:
+      value: present
   confidence: high
   note: Open license and documented, but gated access requiring agreement caps it at gated.
-  raw: license:Etalab-2.0(permissive French-gov open license);gated:HF contact-info agreement required;dataset
-    card present
+  raw: license:Etalab-2.0(permissive French-gov open license);gated:HF contact-info agreement required;dataset_card:present
   sources:
   - url: https://huggingface.co/datasets/ministere-culture/comparia-votes
     shows: License Etalab 2.0; gated access requiring contact-info agreement; dataset card present

--- a/sources/scores/cosmopedia.yaml
+++ b/sources/scores/cosmopedia.yaml
@@ -5,13 +5,15 @@ openness:
   components:
     license:
       value: apache-2.0
+    access:
+      value: ungated
+    dataset_card:
+      value: present
     free_text:
-    - ungated
-    - dataset card present
     - parquet downloadable
   confidence: high
   note: Permissive Apache-2.0 license, ungated, full dataset card and downloadable parquet files.
-  raw: license:apache-2.0;ungated;dataset card present;parquet downloadable
+  raw: license:apache-2.0;access:ungated;dataset_card:present;parquet downloadable
   sources:
   - url: https://huggingface.co/datasets/HuggingFaceTB/cosmopedia
     shows: Apache-2.0 license, 31M rows, full dataset card

--- a/sources/scores/openthoughts-114k.yaml
+++ b/sources/scores/openthoughts-114k.yaml
@@ -5,13 +5,15 @@ openness:
   components:
     license:
       value: apache-2.0
+    access:
+      value: ungated
+    dataset_card:
+      value: present
     free_text:
-    - ungated
-    - dataset card present
     - GitHub repo + paper
   confidence: high
   note: Apache-2.0 licensed, ungated, with dataset card, code repo, and paper.
-  raw: license:apache-2.0;ungated;dataset card present;GitHub repo + paper
+  raw: license:apache-2.0;access:ungated;dataset_card:present;GitHub repo + paper
   sources:
   - url: https://huggingface.co/datasets/open-thoughts/OpenThoughts-114k
     shows: Apache-2.0 license, dataset card, GitHub and arXiv links

--- a/sources/scores/synth.yaml
+++ b/sources/scores/synth.yaml
@@ -6,12 +6,13 @@ openness:
     license:
       value: CC-BY-4.0
       detail: permissive
-    free_text:
-    - ungated
-    - dataset card present
+    access:
+      value: ungated
+    dataset_card:
+      value: present
   confidence: high
   note: Permissively licensed, ungated dataset with a documented card.
-  raw: license:CC-BY-4.0(permissive);ungated;dataset card present
+  raw: license:CC-BY-4.0(permissive);access:ungated;dataset_card:present
   sources:
   - url: https://huggingface.co/datasets/PleIAs/SYNTH
     shows: License CC-BY-4.0, not gated, dataset card present

--- a/sources/scores/tulu-3-sft-mixture.yaml
+++ b/sources/scores/tulu-3-sft-mixture.yaml
@@ -6,13 +6,14 @@ openness:
     license:
       value: odc-by
       detail: mixed subset licenses incl CC-BY-NC
-    free_text:
-    - ungated
-    - dataset card present
+    access:
+      value: ungated
+    dataset_card:
+      value: present
   confidence: high
   note: ODC-BY licensed and ungated with a full dataset card, though some subsets carry non-commercial
     licenses.
-  raw: license:odc-by(mixed subset licenses incl CC-BY-NC);ungated;dataset card present
+  raw: license:odc-by(mixed subset licenses incl CC-BY-NC);access:ungated;dataset_card:present
   sources:
   - url: https://huggingface.co/datasets/allenai/tulu-3-sft-mixture
     shows: ODC-BY-1.0 license, ~939k rows, dataset card

--- a/sources/scores/wildchat-1m.yaml
+++ b/sources/scores/wildchat-1m.yaml
@@ -7,13 +7,14 @@ openness:
       value: odc-by
     gated:
       value: false per HF API
+    dataset_card:
+      value: present
     free_text:
-    - dataset card present
     - parquet downloadable
   confidence: medium
   note: ODC-BY licensed and reported ungated by the HF API, though Ai2 datasets sometimes show an access
     notice.
-  raw: license:odc-by;gated:false per HF API;dataset card present;parquet downloadable
+  raw: license:odc-by;gated:false per HF API;dataset_card:present;parquet downloadable
   sources:
   - url: https://huggingface.co/api/datasets/allenai/WildChat-1M
     shows: gated=false, license=odc-by

--- a/tests/test_check_parity.py
+++ b/tests/test_check_parity.py
@@ -54,10 +54,15 @@ def test_local_scores_matches_check_rubrics_split():
     recorded 4, and reading the whole value makes it reproduce. Then 392/80 -> 395/77 when
     `core_gated` started reading `self-host`: syfthub, thunderbolt and otari were all deferred
     with the same text, that core-gated is not recorded in a form the ladder can read, and all
-    three had recorded it under `self-host`."""
+    three had recorded it under `self-host`. Then 395/77 -> 400/72 when the keyless clauses
+    that were a dimension's only record were promoted to keys: cosmopedia, openthoughts-114k,
+    synth, tulu-3-sft-mixture and wildchat-1m all recorded `dataset card present`, and four of
+    them `ungated`, as clauses with no colon, which the parser discards. Their five deferral
+    texts named that defect and prescribed the fix. No score moved - all five already recorded
+    the 5/open the ladder now computes."""
     computed, deferred = local_scores(None)
-    assert len(deferred) == 77
-    assert len(computed) == 395
+    assert len(deferred) == 72
+    assert len(computed) == 400
     assert not set(computed) & set(deferred)
     # Every one of the 392 reproduces today, so none should abstain.
     assert [key for key, value in computed.items() if value is None] == []

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -734,7 +734,15 @@ def test_real_sources_serialize_without_errors():
         # 164 -> 169: `smoltalk`'s deferral was the ladder reading only the first half of
         # `apache-2.0(new-subsets)+per-component`. Reading both halves reproduces its
         # recorded 4/open, the deferral went, and its five component keys publish.
-        "training_synthetic_datasets": 169, "benchmark_eval_data": 111,
+        # 169 -> 194: the five remaining parser deferrals came off together. Each of
+        # cosmopedia, openthoughts-114k, synth, tulu-3-sft-mixture and wildchat-1m now
+        # publishes five rows - license, the gate key and the card key, plus the
+        # `availability` and `documentation` dimensions those two normalize onto - and a
+        # deferred product publishes none at all, so 5 x 5 is the whole of the move. The
+        # promotion added no key to a product that was already computed, which is why
+        # benchmark_eval_data holds at 111: compar-ia-datasets got the same `dataset_card`
+        # key and stays deferred on its unrelated gate-vocabulary defect.
+        "training_synthetic_datasets": 194, "benchmark_eval_data": 111,
         # safeguards 90 -> 103 and training_synthetic_datasets 158 -> 164: the universal
         # license scale retired five deferrals, and a deferred product publishes no
         # openness evidence at all.


### PR DESCRIPTION
## Summary

A component clause with no key is discarded silently by the parser — 221 of them across 168 products. Most restate a fact already recorded under a key. A few are the **only record of a dimension the product's ladder tests**, so the product was scoring without an input it had evidence for.

**No score moves.** Five products go from abstaining to computed, and in every case the ladder computes the value already recorded by hand.

## Deferrals resolved

| Product | The deferral this removes |
|---|---|
| `cosmopedia` | named the missing `documentation` record and prescribed this fix |
| `openthoughts-114k` | same |
| `synth` | same |
| `tulu-3-sft-mixture` | same |
| `wildchat-1m` | same |

`training_synthetic_datasets` goes from 32/32 reproduced with 6 deferred to **37/37 with 1**. Map-wide, computed products go 395 → 400 and deferrals 77 → 72.

Each of these deferral texts named this exact defect and told us what to do about it. Removing them is the deferral working as intended rather than being written off.

## Ten pairs promoted, not six

Promoting the `dataset card present` clauses alone fails `check_recipe` with 5 blocking errors: once a product is un-deferred, its leftover `ungated` clause becomes the only record of another tested dimension. Both scenarios were simulated before anything was written.

The four extra promotions are `access: ungated`, which passes the **strict** test — the clause text is verbatim a declared `availability` value, so it is not a phrase-map judgment at all.

## Nine candidates declined

The fifteen candidates in #187 rest on a hand-written phrase map, and the issue is explicit that the map is a judgment rather than a measurement. Nine are declined, including **all four non-deferred products** that would have moved a live score.

The decisive one: **`agenta` records the free text `self-hostable` and a keyed `core-gated: gated` on the same product.** On the one record carrying both, the curator meant them to coexist — which kills the `self-hostable → ungated` reading. The rest are inert on measurement: `phoenix` resolves on its license before `core_gated` is read, and the other three record `source: closed`, which `software.yaml` settles on `source` alone.

## Relationship to #201

Disjoint. Not one of the eleven products records a `self-host` key, so #201 made none of these candidates redundant. #201 moved products recording the fact under a *different* key; these recorded it under *no* key.

## Test plan

- Both groups re-derived at this commit before any change; delta table computed first, re-measured after, no surprises.
- Every promotion made through `build/components.py`, never a text substitution. `check_components` compares each mapping against its `raw` and stays green.
- Suite 451 passed. `validate` 0 error(s), `check_recipe` 0 failure(s), `check_rubric` exit 0, `check_components` `[OK]`.
- Two pinned-count guards updated with written reasons: the parity split, and evidence rows 169 → 194, which is 5 products x 5 rows and was verified per product.

## Flagged, not fixed

- `tulu-3-sft-mixture` now computes 5/open on a license recorded as `odc-by(mixed subset licenses incl CC-BY-NC)`. Its removed deferral raised this. The score is unchanged, but the most-restrictive-subset question needs its own change, alongside `multipl-e`.
- `compar-ia-datasets` stays deferred and now computes 5/open against a recorded 3/gated.
