### PR TITLE
fix(scores): resolve a license tier only when a rung tests one

### DIFF
--- a/build/check_parity.py
+++ b/build/check_parity.py
@@ -62,13 +62,7 @@ from pathlib import Path
 
 import yaml
 
-from build.check_rubric import (
-    apply_formula,
-    components_of,
-    dimension_value,
-    license_read_keys,
-    license_tier,
-)
+from build.check_rubric import components_of, score_openness
 from build.rubrics import load_product_types, load_shared, recipe_for, resolve_recipe_variants
 from build.warehouse import query
 
@@ -113,26 +107,18 @@ def local_scores(category_filter: str | None) -> tuple[dict, dict]:
                 computed[key] = None
                 continue
             openness = (yaml.safe_load(score_path.read_text()) or {}).get("openness") or {}
-            components = components_of(openness)
 
-            # Same order as check_rubric: the tier first, and only where the ladder declares
-            # one. A tier-free ladder - hardware scores design and toolchain - must not be
-            # asked for a license it never turns on.
-            facts: dict[str, str] = {}
-            has_tiers = bool(((recipe.get("openness") or {}).get("license_tier") or {}).get("values"))
-            if has_tiers:
-                raw = next(
-                    (components[k] for k in license_read_keys(recipe) if components.get(k)), ""
-                )
-                tier = license_tier(raw, recipe)
-                if tier is None:
-                    computed[key] = None
-                    continue
-                facts["license_tier"] = tier
-            declared = ((recipe.get("openness") or {}).get("dimensions")) or {}
-            for name in declared:
-                facts[name] = dimension_value(components, name, recipe)
-            computed[key] = apply_formula(recipe, facts)
+            # check_rubric's resolution exactly, via the one function all three modules
+            # share. It resolves a license tier only for a rung that tests one, so a
+            # product the ladder settles on `source` alone is computed here even when its
+            # license maps to no tier - and a product whose deciding rung DOES turn on the
+            # license still comes back None.
+            #
+            # This is a live source of parity noise until the warehouse mirror in
+            # `currentai.scores.openness_computed` carries the same rule: the SQL still
+            # resolves the tier up front, so the five products that score without one will
+            # read as local-scored / warehouse-abstained until it is updated.
+            computed[key] = score_openness(recipe, components_of(openness)).result
     return computed, deferred
 
 

--- a/build/check_recipe.py
+++ b/build/check_recipe.py
@@ -43,7 +43,6 @@ import yaml
 
 from build.check_rubric import (
     ROOT,
-    apply_formula,
     check_category,
     components_of,
     components_string,
@@ -51,11 +50,11 @@ from build.check_rubric import (
     dimension_value,
     head,
     license_read_keys,
-    license_tier,
     load_product_types,
     load_shared,
     recipe_for,
     resolve_recipe_variants,
+    score_openness,
     split_components,
 )
 from build.check_verification import rule_outcomes
@@ -337,6 +336,12 @@ def stale_deferrals(
     to the `competition_restricted` tier, so it produced its recorded 2/source_available
     exactly. That one went stale in about a week; at forty categories, on prose nobody
     re-reads, they would accumulate silently.
+
+    This used to skip any product whose license mapped to no tier, which made it blind to
+    exactly the deferrals the eager tier gate had created: five products deferred on the
+    claim that no tier resolved, every one of them recording a `source` state the ladder
+    settles without a license. `score_openness` decides for itself whether the tier is
+    needed, so nothing is skipped merely for carrying a license the lookup cannot read.
     """
     problems = []
     for product in sorted(deferred):
@@ -347,15 +352,7 @@ def stale_deferrals(
         if recipe is None:
             continue
         openness = (yaml.safe_load(path.read_text()) or {}).get("openness") or {}
-        components = components_of(openness)
-        raw = next((components[k] for k in license_read_keys(recipe) if components.get(k)), "")
-        tier = license_tier(raw, recipe)
-        if tier is None:
-            continue
-        declared = _dimensions(recipe)
-        facts = {name: dimension_value(components, name, recipe) for name in declared}
-        facts["license_tier"] = tier
-        got = apply_formula(recipe, facts)
+        got = score_openness(recipe, components_of(openness)).result
         if got is not None and got == (openness.get("score"), openness.get("class")):
             problems.append(
                 f"category '{slug}' defers '{product}', but the ladder now reproduces its "
@@ -435,7 +432,7 @@ def check_one(slug: str, verbose: bool) -> tuple[list[str], list[str]]:
     # abstention, which is the exact convention violation the safeguards review found -- 11
     # auto-abstaining products, invisible in the category YAML, while all 41 of their
     # counterparts elsewhere were declared. Nothing caught it.
-    reproduced, total, problems, deferrals = check_category(slug, verbose=False)
+    reproduced, total, problems, deferrals, tierless = check_category(slug, verbose=False)
     silent = [entry for entry in deferrals if "recipe does not decide it" in entry]
     for entry in silent:
         failures.append(
@@ -464,7 +461,20 @@ def check_one(slug: str, verbose: bool) -> tuple[list[str], list[str]]:
         f"{len([f for f in failures if 'has no key so the parser' in f])} blocking",
         f"  undeclared keys .......... {undeclared_total} "
         f"(context, reported by serialize_rubric)",
+        f"  scored with no tier ...... {len(tierless):<4}"
+        f"(context, itemized by check_rubric)",
     ]
+    # Reported, never gated, and for the same reason the reproduction mismatches below are:
+    # every one of these is a score the ladder produced correctly. The finding is that it
+    # rests on a license the tier lookup could not read, so if that license is later mapped
+    # the product may move. Gating would fail on the day it landed - five products score
+    # this way right now - and this repo's convention is that a gate failing on day one gets
+    # switched off rather than acted on.
+    #
+    # The names print unconditionally from `check_rubric` as `~ no tier` lines; the count
+    # here is so the set is visible in the gate's own summary rather than only in the other
+    # tool's output.
+    lines += [f"  ~ scored with no tier: {line}" for line in tierless]
     if verbose:
         lines += [f"  ~ {line}" for line in reported]
     # `problems` is check_rubric's reproduction mismatch list. Reported, never gated: a

--- a/build/check_rubric.py
+++ b/build/check_rubric.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import argparse
 import re
 from pathlib import Path
+from typing import NamedTuple
 
 import yaml
 
@@ -457,19 +458,136 @@ def matches(rule_when: dict, facts: dict) -> bool:
 
 
 def apply_formula(recipe: dict, facts: dict) -> tuple[int, str] | None:
-    """Walk the ordered rules, first match wins."""
+    """Walk the ordered rules, first match wins.
+
+    `facts` is a COMPLETE fact set, `license_tier` included where the ladder has one.
+    Callers that may not be able to resolve a tier want `walk_formula`, which decides
+    whether the tier is needed at all before insisting on it.
+    """
+    result, _ = walk_formula(recipe, facts, tier=facts.get("license_tier"))
+    return result
+
+
+def walk_formula(
+    recipe: dict, facts: dict, tier: str | None
+) -> tuple[tuple[int, str] | None, bool]:
+    """First match wins, consulting `tier` only where a rung actually tests it.
+
+    Returns `(result, blocked)`. `blocked` is True when a rung whose other conditions all
+    match tests `license_tier` and no tier resolved — the walk cannot continue past a rung
+    it cannot evaluate, because first-match-wins means a later rung only fires if this one
+    did not.
+
+    Why the tier is not simply resolved up front: it used to be, and a product whose
+    recorded license names nothing the tier lookup recognizes abstained before the formula
+    ran, even when the rung that decides it never asks about a license. `apify` records
+    `mixed(platform closed, SDK open)` and `source:partial`; the software ladder settles
+    `source:partial` at 2/source_available on the source dimension alone, and the license
+    it could not map was never going to be consulted. Four more products across three
+    categories were deferred for the same non-reason.
+
+    The narrower rule — resolve a tier only when a rung needs one — keeps the property
+    that made the eager version defensible. An unmapped license still blocks any rung that
+    turns on it, so nothing is scored by ignoring a license the ladder could not read.
+    That distinction is the whole fix: `dify` records `source:public`, which reaches the
+    `competition_restricted` rung, so its unmapped vendor license still blocks it and it
+    stays deferred.
+
+    Skipping an unevaluable rung and carrying on would be the other failure this repo
+    already names: partial coverage overstating openness. A product whose license may sit
+    on the restrictive rung would fall through to a more permissive one below it.
+    """
     for rule in (recipe.get("openness") or {}).get("formula") or []:
         if "otherwise" in rule:
             result = rule["otherwise"]
-            return result["score"], result["class"]
-        if matches(rule.get("when") or {}, facts):
+            return (result["score"], result["class"]), False
+        when = rule.get("when") or {}
+        wanted = when.get("license_tier")
+        if not matches({k: v for k, v in when.items() if k != "license_tier"}, facts):
+            continue
+        if wanted is None:
             result = rule["then"]
-            return result["score"], result["class"]
-    return None
+            return (result["score"], result["class"]), False
+        if tier is None:
+            return None, True
+        if tier == wanted:
+            result = rule["then"]
+            return (result["score"], result["class"]), False
+    return None, False
 
 
-def check_category(slug: str, verbose: bool) -> tuple[int, int, list[str], list[str]]:
-    """Return (reproduced, total, problems, deferred)."""
+class Outcome(NamedTuple):
+    """What a ladder makes of one product's recorded evidence.
+
+    One resolution path for the three modules that replay a ladder — `check_rubric`,
+    `check_recipe`'s stale-deferral test and `check_parity`. They each had their own copy
+    of "resolve the tier, build the facts, walk the formula", and the copies are exactly
+    what let the tier gate live in one of them and not the others.
+    """
+
+    result: tuple[int, str] | None
+    facts: dict[str, str]
+    has_tiers: bool
+    raw_license: str
+    tier: str | None
+    blocked_on_tier: bool
+
+
+def score_openness(recipe: dict, components: dict[str, str]) -> Outcome:
+    """Replay one ladder against one product's recorded components.
+
+    The tier is resolved eagerly for REPORTING — `tier is None` on a product that still
+    scores is what `check_recipe` counts and names — but it is only ever REQUIRED by
+    `walk_formula`, and only for a rung that tests it.
+
+    A ladder need not turn on a source license at all. Hardware openness is scored on
+    design, toolchain and availability: `sources/rubrics/hardware.yaml` declares no
+    `license_tier` and none of the 20 edge products records a license, so `has_tiers` is
+    False and no tier is looked for. `check_recipe`'s unreachable-rule assertion rejects a
+    `license_tier` condition with no declared tiers, so such a ladder cannot have a rung
+    that needs one.
+    """
+    has_tiers = bool(((recipe.get("openness") or {}).get("license_tier") or {}).get("values"))
+    raw_license = ""
+    tier = None
+    if has_tiers:
+        raw_license = next(
+            (components[key] for key in license_read_keys(recipe) if components.get(key)), ""
+        )
+        tier = license_tier(raw_license, recipe)
+
+    # Facts come from the dimensions the recipe DECLARES, not a fixed list. The model
+    # categories ask about weights/data/code; software categories ask whether the source is
+    # public, whether the real thing self-hosts, and whether the core is feature-gated.
+    # Hardcoding the model's four here is what would have forced a checker change per
+    # product type.
+    declared = ((recipe.get("openness") or {}).get("dimensions")) or {}
+    facts = {name: dimension_value(components, name, recipe) for name in declared}
+    result, blocked = walk_formula(recipe, facts, tier)
+    return Outcome(result, facts, has_tiers, raw_license, tier, blocked)
+
+
+class CategoryReport(NamedTuple):
+    """What one category's replay produced.
+
+    `tierless` is the set the tier-gate fix made possible: products that SCORE while their
+    recorded license maps to no tier, because no rung the walk reached asked for one. They
+    are correct scores and they must stay countable — four of them are held up by vendor
+    licenses (`Modular-Community-License`, `Dify-Open-Source-License`, `Open-WebUI-License`,
+    `LobeHub-Community-License`) that a category note calls competition-restricted in
+    substance, and the moment such a license IS mapped, the product may move. A score whose
+    license nobody could read is a score standing on less evidence than its neighbours.
+    """
+
+    reproduced: int
+    total: int
+    problems: list[str]
+    deferred: list[str]
+    tierless: list[str]
+
+
+def check_category(slug: str, verbose: bool) -> CategoryReport:
+    """Return (reproduced, total, problems, deferred, tierless)."""
     category = yaml.safe_load((ROOT / "sources" / "categories" / f"{slug}.yaml").read_text())
     # `extends: software` pulls in one shared ladder for every product; `extends: {model:
     # ..., software: ...}` pulls in one per product type, as `safeguards` does. Resolution
@@ -477,9 +595,9 @@ def check_category(slug: str, verbose: bool) -> tuple[int, int, list[str], list[
     # stop the others being checked - and cannot pass silently either.
     variants, recipe_errors = resolve_recipe_variants(category, load_shared(ROOT))
     if recipe_errors:
-        return 0, 0, [f"{slug}: {e}" for e in recipe_errors], []
+        return CategoryReport(0, 0, [f"{slug}: {e}" for e in recipe_errors], [], [])
     if not variants:
-        return 0, 0, [], []
+        return CategoryReport(0, 0, [], [], [])
     product_types = load_product_types(ROOT)
     # Deferrals are a property of the category's declaration, not of any one ladder:
     # products the category has declared the rubric does not yet decide, each with a
@@ -493,6 +611,7 @@ def check_category(slug: str, verbose: bool) -> tuple[int, int, list[str], list[
     total = 0
     problems: list[str] = []
     deferred: list[str] = []
+    tierless: list[str] = []
 
     for product in category.get("products") or []:
         path = ROOT / "sources" / "scores" / f"{product}.yaml"
@@ -511,44 +630,31 @@ def check_category(slug: str, verbose: bool) -> tuple[int, int, list[str], list[
         components = components_of(openness)
         total += 1
 
+        # One resolution path, shared with check_recipe and check_parity. The tier is
+        # consulted only by a rung that tests it, so a license the lookup cannot read stops
+        # only the products a license was going to decide. `blocked_on_tier` is that stop,
+        # and it stays a hard failure: the ladder reached a rung it could not evaluate.
+        #
         # A ladder need not turn on a source license at all. Hardware openness is scored on
         # design, toolchain and availability - `sources/rubrics/hardware.yaml` declares no
-        # `license_tier`, and none of the 20 edge products records a license. Resolving a
-        # tier against a recipe that declares none returns None for every product and would
-        # report all 20 as hard failures, so the tier step only runs where there is a tier
-        # vocabulary to resolve against. `license_tier` is then simply absent from `facts`,
-        # and a rung testing it could not have been declared: check_recipe's unreachable-rule
-        # assertion rejects a `license_tier` condition with no declared tiers.
+        # `license_tier`, and none of the 20 edge products records a license, so `has_tiers`
+        # is False and no tier is looked for at all.
         #
         # `serialize_rubric` already tolerated a tier-free ladder - `license_tiers()` emits
-        # zero rows and only requires `ordered_by` above one tier. This is check_rubric
-        # catching up, and it changes shared resolution semantics, so the warehouse mirror
-        # in `currentai.scores.openness_computed` needs the same allowance.
-        has_tiers = bool(((recipe.get("openness") or {}).get("license_tier") or {}).get("values"))
-        tier = None
-        if has_tiers:
-            raw_license = next(
-                (components[key] for key in license_read_keys(recipe) if components.get(key)), ""
+        # zero rows and only requires `ordered_by` above one tier. Both allowances change
+        # shared resolution semantics, so the warehouse mirror in
+        # `currentai.scores.openness_computed` needs them too.
+        outcome = score_openness(recipe, components)
+        facts, tier, has_tiers = outcome.facts, outcome.tier, outcome.has_tiers
+        if outcome.blocked_on_tier:
+            problems.append(
+                f"{product}: license {outcome.raw_license!r} maps to no tier, and a rung "
+                f"the ladder reached tests one "
+                f"(recorded {openness.get('score')} {openness.get('class')})"
             )
-            tier = license_tier(raw_license, recipe)
-            if tier is None:
-                problems.append(
-                    f"{product}: license {raw_license!r} maps to no tier "
-                    f"(recorded {openness.get('score')} {openness.get('class')})"
-                )
-                continue
+            continue
 
-        # Facts come from the dimensions the recipe DECLARES, not a fixed list. The
-        # model categories ask about weights/data/code; software categories ask whether
-        # the source is public, whether the real thing self-hosts, and whether the core
-        # is feature-gated. Hardcoding the model's four here is what would have forced a
-        # checker change per product type.
-        declared = ((recipe.get("openness") or {}).get("dimensions")) or {}
-        facts = {name: dimension_value(components, name, recipe) for name in declared}
-        if has_tiers:
-            facts["license_tier"] = tier
-
-        got = apply_formula(recipe, facts)
+        got = outcome.result
         expected = (openness.get("score"), openness.get("class"))
 
         # No rule matched and the recipe declares no `otherwise`, so it is telling us it
@@ -565,7 +671,7 @@ def check_category(slug: str, verbose: bool) -> tuple[int, int, list[str], list[
         # ladder itself has a gap. Abstentions print every run and are excluded from the
         # reproduced count, so neither can go quiet.
         if got is None:
-            shown = " ".join(f"{name}={facts[name]!r}" for name in declared)
+            shown = " ".join(f"{name}={value!r}" for name, value in facts.items())
             if has_tiers:
                 shown = f"{shown} tier={tier}"
             deferred.append(
@@ -575,12 +681,21 @@ def check_category(slug: str, verbose: bool) -> tuple[int, int, list[str], list[
             total -= 1
             continue
 
+        # Scored, but on a license nobody could place. Correct - no rung the walk reached
+        # asked for one - and worth naming every run rather than letting it read as an
+        # ordinary score.
+        if has_tiers and tier is None:
+            tierless.append(
+                f"{product}: {got[0]}/{got[1]} on license {outcome.raw_license!r}, "
+                f"which maps to no tier"
+            )
+
         if got == expected:
             reproduced += 1
             if verbose:
                 print(f"  ok    {product:<24} {expected[0]} {expected[1]}")
         else:
-            shown = " ".join(f"{name}={facts[name]!r}" for name in declared)
+            shown = " ".join(f"{name}={value!r}" for name, value in facts.items())
             if has_tiers:
                 shown = f"{shown} tier={tier}"
             problems.append(
@@ -591,7 +706,7 @@ def check_category(slug: str, verbose: bool) -> tuple[int, int, list[str], list[
     for product in unknown:
         problems.append(f"{product}: deferred by the recipe but not a product of this category")
 
-    return reproduced, total, problems, deferred
+    return CategoryReport(reproduced, total, problems, deferred, tierless)
 
 
 def main() -> int:
@@ -609,17 +724,25 @@ def main() -> int:
     failed = False
     checked_any = False
     for slug in slugs:
-        reproduced, total, problems, deferred = check_category(slug, args.verbose)
+        reproduced, total, problems, deferred, tierless = check_category(slug, args.verbose)
         if total == 0 and not deferred and not problems:
             continue
         checked_any = True
         status = "OK" if not problems else "FAIL"
         suffix = f", {len(deferred)} deferred" if deferred else ""
+        suffix += f", {len(tierless)} scored with no tier" if tierless else ""
         print(f"{slug}: {reproduced}/{total} reproduced{suffix}  [{status}]")
         for problem in problems:
             print(f"  ! {problem}")
         for entry in deferred:
             print(f"  ~ deferred  {entry}")
+        # Reported, never gating. A gate that fails on the day it lands gets switched off,
+        # and every one of these is a correct score - the finding is that the score rests on
+        # a license the ladder could not read, which is a curation prompt rather than a
+        # defect in the ladder. It prints unconditionally for the reason the deferrals do:
+        # an exclusion nobody sees is an exclusion nobody acts on.
+        for entry in tierless:
+            print(f"  ~ no tier   {entry}")
         if problems:
             failed = True
 

--- a/docs/guides/verification.md
+++ b/docs/guides/verification.md
@@ -389,6 +389,16 @@ What it took, beyond the generic resolution:
 - **The tier-free allowance.** The unmapped-license guard now fires only for ladders that ask
   about a license. `sources/rubrics/hardware.yaml` declares no `license_tier` and none of the
   20 edge products records one, so applied unconditionally the guard nulls all 20.
+- **The per-rung tier rule, still outstanding in the warehouse.** The repo narrowed the same
+  guard a second time: `check_rubric` resolves a license tier only for a rung that actually
+  tests one, so a product the software ladder settles on `source` alone is scored whether or
+  not its license maps. Five products score that way today — `apify`, `chatbot-arena`,
+  `patronus-evaluation-platform`, `artificial-analysis-intelligence-index` and `confer`, all
+  at 2/source_available — and the SQL in `currentai.scores.openness_computed` still resolves
+  the tier up front. Until it carries the same rule, those five reproduce in the repo and
+  abstain in the warehouse, and `check_parity` will report them as a repo/warehouse
+  disagreement. That is the safe direction and a loud one, which is the reason to leave it
+  reported rather than suppress it.
 - **`dims_recorded` and `all_recorded_dims_from_dataset`.** `dims_relied_on` counts only what
   the winning rule reads, which is the wrong denominator — this guide requires every dimension
   the score *records*. The new columns are the precondition for step 3, and for openness the

--- a/sources/categories/agent_tools_protocols.yaml
+++ b/sources/categories/agent_tools_protocols.yaml
@@ -64,12 +64,6 @@ scoring_recipe:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of
         the repo and pricing page
-    apify:
-      because: >-
-        the license is recorded as `mixed(platform closed, SDK open)`, which names no license and
-        so maps to no tier. The deciding rule reads `source` alone, but check_rubric resolves a
-        license tier before applying the formula, so it abstains. Adding the license to a tier is
-        a rubric change, held for Phase 1.
     yomo:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of

--- a/sources/categories/evaluation_code.yaml
+++ b/sources/categories/evaluation_code.yaml
@@ -54,28 +54,10 @@ scoring_recipe:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of
         the repo and pricing page
-    chatbot-arena:
-      because: >-
-        no `license` key is recorded at all; the components describe the platform and its OSS
-        heritage without naming the license the product ships under. The deciding rule reads
-        `source` alone, but check_rubric resolves a license tier before applying the formula, so
-        it abstains. Adding the license to a tier is a rubric change, held for Phase 1.
-    patronus-evaluation-platform:
-      because: >-
-        no `license` key is recorded at all - the SDK repo page does not display one, which the
-        note already flags. The deciding rule reads `source` alone, but check_rubric resolves a
-        license tier before applying the formula, so it abstains. Adding the license to a tier is
-        a rubric change, held for Phase 1.
     scale-evaluation:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of
         the repo and pricing page
-    artificial-analysis-intelligence-index:
-      because: >-
-        no `license` key is recorded at all; only Stirrup's MIT is named, and Stirrup is one eval
-        harness rather than the Index. The deciding rule reads `source` alone, but check_rubric
-        resolves a license tier before applying the formula, so it abstains. Adding the license to
-        a tier is a rubric change, held for Phase 1.
     epoch-ai-benchmarks:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of

--- a/sources/categories/ui_api.yaml
+++ b/sources/categories/ui_api.yaml
@@ -94,10 +94,6 @@ scoring_recipe:
       because: >-
         ladder computes 1/closed from the recorded evidence but the score says
         2/source_available; one of the two is wrong and it needs a human
-    confer:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
     deepseek-chat:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of

--- a/tests/test_check_parity.py
+++ b/tests/test_check_parity.py
@@ -59,12 +59,16 @@ def test_local_scores_matches_check_rubrics_split():
     synth, tulu-3-sft-mixture and wildchat-1m all recorded `dataset card present`, and four of
     them `ungated`, as clauses with no colon, which the parser discards. Their five deferral
     texts named that defect and prescribed the fix. No score moved - all five already recorded
-    the 5/open the ladder now computes."""
+    the 5/open the ladder now computes. Then 400/72 -> 405/67 when a license tier stopped
+    being resolved ahead of the formula: apify, chatbot-arena, patronus-evaluation-platform,
+    artificial-analysis-intelligence-index and confer all record a `source` value the
+    software ladder settles on its own, and were abstained on a license no rung deciding
+    them was going to read. All five reproduce their recorded 2/source_available."""
     computed, deferred = local_scores(None)
-    assert len(deferred) == 72
-    assert len(computed) == 400
+    assert len(deferred) == 67
+    assert len(computed) == 405
     assert not set(computed) & set(deferred)
-    # Every one of the 392 reproduces today, so none should abstain.
+    # Every one of the 405 reproduces today, so none should abstain.
     assert [key for key, value in computed.items() if value is None] == []
 
 

--- a/tests/test_check_rubric.py
+++ b/tests/test_check_rubric.py
@@ -258,12 +258,12 @@ class TestRealCategories:
         finetuned_chat (44 -> 26); adding the fully-open Luciole family took it to 27. The
         point of pinning this is that the count only ever moves for a reason recorded in a
         commit."""
-        reproduced, total, problems, deferred = check_category("base_pretrained", verbose=False)
+        reproduced, total, problems, deferred, _ = check_category("base_pretrained", verbose=False)
         assert problems == []
         assert (reproduced, total, deferred) == (27, 27, [])
 
     def test_finetuned_chat_reproduces_every_undeferred_score(self):
-        reproduced, total, problems, _ = check_category("finetuned_chat", verbose=False)
+        reproduced, total, problems, *_ = check_category("finetuned_chat", verbose=False)
         assert problems == []
         assert reproduced == total == 39
 
@@ -281,7 +281,7 @@ class TestRealCategories:
             category = yaml.safe_load(path.read_text())
             if not category.get("scoring_recipe"):
                 continue
-            _, _, problems, deferred = check_category(category["name"], verbose=False)
+            _, _, problems, deferred, _ = check_category(category["name"], verbose=False)
             assert problems == [], f"{category['name']}: {problems}"
             for entry in deferred:
                 reason = entry.split(":", 1)[1].strip()
@@ -289,14 +289,14 @@ class TestRealCategories:
 
     def test_finetuned_chat_currently_defers_nothing(self):
         """The count itself, pinned separately so a new deferral is visible in a diff."""
-        _, _, _, deferred = check_category("finetuned_chat", verbose=False)
+        _, _, _, deferred, _ = check_category("finetuned_chat", verbose=False)
         assert deferred == []
 
     def test_deferred_products_are_excluded_not_counted_as_reproduced(self):
         """39 scored and 0 deferred. Counting a deferral as a pass is how a rubric
         claims to describe products it cannot score, so the identity is worth keeping
         even while the deferral count is zero."""
-        _, total, _, deferred = check_category("finetuned_chat", verbose=False)
+        _, total, _, deferred, _ = check_category("finetuned_chat", verbose=False)
         assert total + len(deferred) == 39
 
 
@@ -344,7 +344,7 @@ def test_mixed_type_category_scores_each_product_on_its_own_ladder(tmp_path, mon
     # which does not exist, and the test's pass/fail depends on suite ordering.
     monkeypatch.setattr("build.check_rubric._RECORDED_ALIASES", {})
 
-    reproduced, total, problems, deferred = check_category("mixed", verbose=False)
+    reproduced, total, problems, deferred, _ = check_category("mixed", verbose=False)
 
     assert problems == []
     assert (reproduced, total) == (2, 2)
@@ -389,24 +389,19 @@ def test_a_ladder_with_no_license_tier_scores_rather_than_failing(tmp_path, monk
     monkeypatch.setattr("build.check_rubric.ROOT", tmp_path)
     monkeypatch.setattr("build.check_rubric._RECORDED_ALIASES", {})
 
-    reproduced, total, problems, deferred = check_category("boards", verbose=False)
+    reproduced, total, problems, deferred, _ = check_category("boards", verbose=False)
 
     assert problems == []
     assert (reproduced, total) == (2, 2)
 
 
-def test_a_ladder_WITH_tiers_still_fails_an_unmappable_license(tmp_path, monkeypatch):
-    """The allowance is scoped to recipes declaring no tiers, not to a missing license.
-
-    A category that HAS a tier vocabulary and meets a license outside it must still report
-    that, or the tier-free path would quietly become an escape hatch for every unmapped
-    license on the map.
-    """
+def _tier_gate_fixture(tmp_path, monkeypatch, formula, components):
+    """A one-product software category, so the tier gate can be exercised per formula."""
     write_yaml(tmp_path / "sources/rubrics/software.yaml", {
         "openness": {
             "license_tier": {"reads": ["license"], "values": {"osi": {"examples": ["MIT"]}}},
-            "dimensions": {"source": {"values": ["public"]}},
-            "formula": [{"when": {"source": "public"}, "then": {"score": 5, "class": "open_source"}}],
+            "dimensions": {"source": {"values": ["public", "partial"]}},
+            "formula": formula,
         }
     })
     write_yaml(tmp_path / "sources/categories/tools.yaml", {
@@ -415,15 +410,94 @@ def test_a_ladder_WITH_tiers_still_fails_an_unmappable_license(tmp_path, monkeyp
     })
     write_yaml(tmp_path / "sources/products/a-tool.yaml", {"name": "a-tool", "type": "software"})
     write_yaml(tmp_path / "sources/scores/a-tool.yaml", {
-        "openness": {"score": 5, "class": "open_source",
-                     "components": "source:public;license:Some-Unmapped-License"}
+        "openness": {"score": 5, "class": "open_source", "components": components}
     })
     monkeypatch.setattr("build.check_rubric.ROOT", tmp_path)
     monkeypatch.setattr("build.check_rubric._RECORDED_ALIASES", {})
+    return check_category("tools", verbose=False)
 
-    reproduced, total, problems, deferred = check_category("tools", verbose=False)
 
-    assert len(problems) == 1 and "maps to no tier" in problems[0]
+def test_a_rung_that_TESTS_the_tier_still_fails_an_unmappable_license(tmp_path, monkeypatch):
+    """The allowance is scoped to a rung that does not ask, not to a missing license.
+
+    A ladder whose deciding rung turns on `license_tier` and meets a license outside its
+    vocabulary must still report that, or "resolve the tier only when a rung needs one"
+    would quietly become an escape hatch for every unmapped license on the map. `dify`,
+    `max`, `open-webui`, `lobe-chat` and `autogpt` are the real cases: all record
+    `source:public`, which reaches a rung that tests the tier, so their vendor licenses
+    still block them.
+    """
+    report = _tier_gate_fixture(
+        tmp_path, monkeypatch,
+        formula=[{
+            "when": {"license_tier": "osi", "source": "public"},
+            "then": {"score": 5, "class": "open_source"},
+        }],
+        components="source:public;license:Some-Unmapped-License",
+    )
+
+    assert len(report.problems) == 1 and "maps to no tier" in report.problems[0]
+    assert report.tierless == []
+
+
+def test_a_rung_reading_source_alone_scores_without_resolving_a_tier(tmp_path, monkeypatch):
+    """The fix. A product settled on `source` alone must not wait on a license nobody reads.
+
+    `apify` is the case the owner ruled on: it records `mixed(platform closed, SDK open)`,
+    which names no license, and `source:partial`, which the software ladder settles at
+    2/source_available on the source dimension alone. Resolving the tier first abstained it
+    before the formula ran.
+    """
+    report = _tier_gate_fixture(
+        tmp_path, monkeypatch,
+        formula=[
+            {"when": {"source": "public"}, "then": {"score": 5, "class": "open_source"}},
+            {
+                "when": {"license_tier": "osi", "source": "partial"},
+                "then": {"score": 2, "class": "source_available"},
+            },
+        ],
+        components="source:public;license:Some-Unmapped-License",
+    )
+
+    assert report.problems == []
+    assert (report.reproduced, report.total) == (1, 1)
+
+
+def test_a_product_scoring_without_a_resolved_tier_is_reported(tmp_path, monkeypatch):
+    """Scoring without a tier is correct and must stay visible.
+
+    The guard on the fix. A score standing on a license the ladder could not read rests on
+    less evidence than its neighbours, and if that license is later mapped the product may
+    move. Reported rather than gated: every entry is a correct score, so gating would fail
+    on the day it landed.
+    """
+    report = _tier_gate_fixture(
+        tmp_path, monkeypatch,
+        formula=[{"when": {"source": "public"}, "then": {"score": 5, "class": "open_source"}}],
+        components="source:public;license:Some-Unmapped-License",
+    )
+
+    assert report.problems == []
+    assert len(report.tierless) == 1
+    assert "a-tool" in report.tierless[0]
+    assert "Some-Unmapped-License" in report.tierless[0]
+
+
+def test_a_product_whose_tier_resolves_is_not_reported_as_tierless(tmp_path, monkeypatch):
+    """The counterpart, so the report cannot silently widen to every software product.
+
+    Most products never consult a tier — a `source:closed` product is settled on the first
+    rung — and reporting those would drown the five entries that mean something.
+    """
+    report = _tier_gate_fixture(
+        tmp_path, monkeypatch,
+        formula=[{"when": {"source": "public"}, "then": {"score": 5, "class": "open_source"}}],
+        components="source:public;license:MIT",
+    )
+
+    assert report.problems == []
+    assert report.tierless == []
 
 
 def test_every_recorded_self_host_value_is_mapped():

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -704,8 +704,18 @@ def test_real_sources_serialize_without_errors():
         # unrecorded and published no evidence row. check_recipe found it.
         # base_pretrained rose by 5 (111 -> 116) when the fully-open Luciole family was
         # added: five openness dimensions recorded (weights, data, code, checkpoints, license).
+        #
+        # Five categories rose again when the license tier stopped being resolved ahead of
+        # the formula, and every row is a deferral coming off rather than a new key:
+        # agent_tools_protocols +4 (apify), evaluation_code +12 (chatbot-arena,
+        # patronus-evaluation-platform and artificial-analysis-intelligence-index, four rows
+        # each) and ui_api +5 (confer). All five record a `source` value the software ladder
+        # settles on its own and were abstained on a license no rung deciding them reads.
+        # Note the three evaluation_code products publish no `license` row at all - they
+        # record no license key - which is what `check_rubric`'s `~ no tier` report exists
+        # to keep visible.
         "base_pretrained": 116, "finetuned_chat": 173, "deployment": 131,
-        "agent_tools_protocols": 109, "dataset_processing_tools": 86, "evaluation_code": 66,
+        "agent_tools_protocols": 113, "dataset_processing_tools": 86, "evaluation_code": 78,
         # inference_code 47 -> 64 when the sweep read the category: four stale deferrals came
         # off (a deferred product publishes no openness evidence at all), and several products
         # that had described their gating in prose gained a readable `source:`/`core-gated:`.
@@ -727,7 +737,7 @@ def test_real_sources_serialize_without_errors():
         # coming off at 5 rows each, less nothing: syfthub in orchestration_agents,
         # thunderbolt and otari in ui_api. A deferred product publishes no openness evidence
         # at all, so a removed deferral is always the larger of the two effects.
-        "orchestration_agents": 159, "telemetry_observability": 94, "ui_api": 149,
+        "orchestration_agents": 159, "telemetry_observability": 94, "ui_api": 154,
         # training_synthetic_datasets is unchanged at 158 across the ladder widening, which
         # is the check that mattered: benchmark_eval_data's new dimensions and rungs did not
         # disturb the category the ladder was derived from.
@@ -874,7 +884,32 @@ def test_license_is_emitted_under_the_name_the_warehouse_joins_on():
         if r["category_slug"] not in tier_free
     } - deferred
     licensed = {(r["product_slug"], r["category_slug"]) for r in rows if r["dimension"] == "license"}
-    assert scored - licensed == set(), f"no license row emitted for: {sorted(scored - licensed)}"
+
+    # The third exclusion, and the newest. A product can now score in a tier-carrying
+    # category without a license at all: `check_rubric` resolves a tier only for a rung that
+    # tests one, so a product the software ladder settles on `source` alone is scored whether
+    # or not anyone recorded a license. Three do, all in `evaluation_code`, and none of them
+    # records a license clause of any kind — so there is genuinely no row to emit, and
+    # asserting one would again be asserting evidence we have said does not exist.
+    #
+    # Pinned by name rather than computed away, because the set is exactly what
+    # `check_rubric`'s `~ no tier` report exists to keep countable, and a silently growing
+    # exclusion here would be the way the report stops meaning anything. A fourth product
+    # appearing means someone scored something on less evidence than its neighbours, and it
+    # should have to be written down here.
+    #
+    # This carries the same warehouse asymmetry the two notes above describe:
+    # `currentai.scores.openness_computed` resolves the tier up front and joins license
+    # evidence, so until it carries the same rule these three will abstain there while
+    # reproducing here.
+    unlicensed = {
+        ("chatbot-arena", "evaluation_code"),
+        ("patronus-evaluation-platform", "evaluation_code"),
+        ("artificial-analysis-intelligence-index", "evaluation_code"),
+    }
+    assert unlicensed <= scored, "a pinned no-license product stopped scoring"
+    missing = scored - licensed
+    assert missing == unlicensed, f"no license row emitted for: {sorted(missing - unlicensed)}"
 
     deepseek = [r for r in rows if r["product_slug"] == "deepseek-coder" and r["dimension"] == "license"]
     assert len(deepseek) == 1 and deepseek[0]["value"] == "DeepSeek-Model-License"


### PR DESCRIPTION
## Summary

`check_rubric` resolved a product's `license_tier` **before** applying the category's formula. If the recorded license named nothing the tier lookup recognized, the product abstained — even when the rung that would have decided it never reads `license_tier`.

`apify` is the clearest case: its deciding rung reads `source` alone, its license is recorded as `mixed(platform closed, SDK open)` which names no license, and it abstained before the formula ran.

A tier is now resolved only when a rung actually tests one.

## Five deferrals close, none moves a score

| Product | Category | Recorded | Computed |
|---|---|---|---|
| `apify` | agent_tools_protocols | 2 / source_available | 2 / source_available |
| `chatbot-arena` | evaluation_code | 2 / source_available | 2 / source_available |
| `patronus-evaluation-platform` | evaluation_code | 2 / source_available | 2 / source_available |
| `artificial-analysis-intelligence-index` | evaluation_code | 2 / source_available | 2 / source_available |
| `confer` | safeguards | 2 / source_available | 2 / source_available |

Every one reproduces the score already recorded.

## Five deferral reasons are wrong, and this proves it

The queue suggested nine products would close. Only five do, and the discrepancy is the useful part.

The split is by `source`, not by category. A product recording **`source: partial`** is settled by a rung reading `source` alone, so the tier gate was the only thing stopping it. A product recording **`source: public`** reaches rungs 2, 3 and 4 of the software ladder, and **all three test `license_tier`**:

```
rule 2: {license_tier: competition_restricted, source: public} -> 2 / source_available
rule 3: {license_tier: osi, source: public, core_gated: gated}   -> 4 / open_core
rule 4: {license_tier: osi, source: public, core_gated: ungated} -> 5 / open_source
```

So `max`, `dify`, `open-webui`, `lobe-chat`, `autogpt` and `txt360-pipeline` all carry a deferral reason claiming *"the deciding rule reads `source` alone"*, and for every one of them that is false. They stay deferred, and what they actually need is their license mapped to a tier — which is separate work.

`confer` closes and was not on the list at all.

## The new check

A product can now score without a resolved license tier. That is correct when no rung needs one, but the set must stay visible rather than becoming invisible.

`check_rubric` now itemizes those products as `~ no tier` on every run, and `check_recipe` counts and names them per category. It **reports rather than blocks**: every current entry is a correct score, and a gate that fails on day one gets switched off.

It names 5 products today — the five above. Note the four vendor licenses (`Modular-Community-License`, `Dify-Open-Source-License`, `Open-WebUI-License`, `LobeHub-Community-License`) cannot appear here, because they block their products rather than being bypassed.

## Test plan

- Delta table computed before any change and re-measured after; the closures are exactly the predicted five, with `confer` found and the five false reasons identified.
- Nine pre-existing computed-vs-recorded disagreements are untouched and listed in the report. Nothing was adjusted on either side.
- Suite 451 → 454. `validate` 0 error(s), `check_recipe` 0 failure(s), `check_rubric` exit 0, `check_components` `[OK]`, plus `check_verification`, `check_capability` and `check_payload` green.

## Follow-up

`currentai.scores.openness_computed` still resolves the tier up front, so `check_parity` will report these five as repo/warehouse disagreements until the UDM is updated. Recorded in `docs/guides/verification.md`.
