### PR TITLE
fix(scores): map five vendor licenses to competition_restricted

### DIFF
--- a/build/check_rubric.py
+++ b/build/check_rubric.py
@@ -572,11 +572,19 @@ class CategoryReport(NamedTuple):
 
     `tierless` is the set the tier-gate fix made possible: products that SCORE while their
     recorded license maps to no tier, because no rung the walk reached asked for one. They
-    are correct scores and they must stay countable — four of them are held up by vendor
-    licenses (`Modular-Community-License`, `Dify-Open-Source-License`, `Open-WebUI-License`,
-    `LobeHub-Community-License`) that a category note calls competition-restricted in
-    substance, and the moment such a license IS mapped, the product may move. A score whose
-    license nobody could read is a score standing on less evidence than its neighbours.
+    are correct scores and they must stay countable, because a score whose license nobody
+    could read is a score standing on less evidence than its neighbours. What remains here
+    is licenses nobody has NAMED — `apify`'s `mixed(platform closed, SDK open)`, `confer`'s
+    `none-declared`, three products recording no license key at all. That is a curation
+    prompt, not a rubric gap: there is nothing to map until someone reads the card.
+
+    It is deliberately not the same set as the products blocked ON a tier. Those reach a
+    rung that asks, and they stay deferred until their license joins a tier — which is what
+    happened to the five vendor licenses (`Modular-Community-License`,
+    `Dify-Open-Source-License`, `Open-WebUI-License`, `LobeHub-Community-License`,
+    `PolyForm-Shield`) that were held for exactly that reason. All five landed on
+    `competition_restricted` and none of the five products moved a score, because the rung
+    they reach produces the 2/source_available they already recorded.
     """
 
     reproduced: int

--- a/sources/categories/inference_code.yaml
+++ b/sources/categories/inference_code.yaml
@@ -44,14 +44,6 @@ scoring_recipe:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of
         the repo and pricing page
-    max:
-      because: >-
-        `Modular-Community-License` appears in no tier's examples. Read 2026-07-30: it licenses
-        per discrete device and grants a limited redistribution right over certain components
-        only, which is competition_restricted in substance - but recording that means adding it to
-        the tier list. The deciding rule reads `source` alone, but check_rubric resolves a license
-        tier before applying the formula, so it abstains. Adding the license to a tier is a rubric
-        change, held for Phase 1.
     aws-neuron:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of

--- a/sources/categories/orchestration_agents.yaml
+++ b/sources/categories/orchestration_agents.yaml
@@ -76,13 +76,6 @@ scoring_recipe:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of
         the repo and pricing page
-    autogpt:
-      because: >-
-        the license is recorded as `DUAL, autogpt_platform/ under PolyForm Shield ...`, so the
-        tier lookup reads `DUAL`. PolyForm Shield is an anti-compete license and governs the
-        active product, which is why the score is 2. The deciding rule reads `source` alone, but
-        check_rubric resolves a license tier before applying the formula, so it abstains. Adding
-        the license to a tier is a rubric change, held for Phase 1.
     claude-code:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of
@@ -91,13 +84,6 @@ scoring_recipe:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of
         the repo and pricing page
-    dify:
-      because: >-
-        `Dify-Open-Source-License` appears in no tier's examples. Its multi-tenant and branding
-        conditions on top of Apache-2.0 make it competition_restricted in substance. The deciding
-        rule reads `source` alone, but check_rubric resolves a license tier before applying the
-        formula, so it abstains. Adding the license to a tier is a rubric change, held for Phase
-        1.
     openhands:
       because: >-
         ladder computes 5/open_source from the recorded evidence but the score says

--- a/sources/categories/ui_api.yaml
+++ b/sources/categories/ui_api.yaml
@@ -64,20 +64,6 @@ scoring_recipe:
   # reproduction count honest by excluding them from it rather than counting
   # them as passes.
   deferred:
-    open-webui:
-      because: >-
-        `Open-WebUI-License` appears in no tier's examples. Its branding-retention clause above 50
-        end-users/30d charges for a class of use, which is competition_restricted in substance.
-        The deciding rule reads `source` alone, but check_rubric resolves a license tier before
-        applying the formula, so it abstains. Adding the license to a tier is a rubric change,
-        held for Phase 1.
-    lobe-chat:
-      because: >-
-        `LobeHub-Community-License` appears in no tier's examples. Requiring a commercial license
-        to distribute a derivative work is a restriction Apache-2.0 does not carry. The deciding
-        rule reads `source` alone, but check_rubric resolves a license tier before applying the
-        formula, so it abstains. Adding the license to a tier is a rubric change, held for Phase
-        1.
     nextchat:
       because: >-
         source or core-gated is not recorded in a form the ladder can read; needs a read of

--- a/sources/rubrics/software.yaml
+++ b/sources/rubrics/software.yaml
@@ -119,8 +119,34 @@ openness:
         # and running it needs a paid license key. That is this tier's definition almost
         # word for word, and it is why the tier is NOT `proprietary` - proprietary here
         # means the source is not published, and n8n's is.
+        #
+        # The five vendor licenses below join on the same reading, each confirmed against the
+        # terms its product's score records rather than against the marketing:
+        #   * `Modular-Community-License` caps capacity by device architecture - eight devices
+        #     on any accelerator other than X86/ARM/NVIDIA-PTX - and grants only "a limited
+        #     right to redistribute certain components of the SDK". Scale, not attribution.
+        #   * `Dify-Open-Source-License` is Apache-2.0 plus a multi-tenant service restriction
+        #     and branding conditions. The multi-tenant clause is the anti-compete clause.
+        #   * `Open-WebUI-License` is BSD-3-Clause plus a branding-retention clause that binds
+        #     above 50 end-users per 30 days unless an enterprise license is bought. A
+        #     threshold above which production use is charged for.
+        #   * `LobeHub-Community-License` is Apache-2.0 plus a requirement to buy a commercial
+        #     license before distributing a derivative work. This one restricts DISTRIBUTION
+        #     rather than running, so it is the loosest fit of the five - but a paid gate on
+        #     derivatives is still a class of use charged for, and it is plainly neither OSI
+        #     nor `permissive_non_osi`, which admits attribution and naming and nothing more.
+        #   * `PolyForm-Shield` forbids use in anything competing with the licensor's product,
+        #     which is this tier's first clause stated directly. It governs `autogpt_platform/`,
+        #     AutoGPT's active product; the legacy MIT components do not lift it.
+        #
+        # Every one of the five is recorded by exactly one product, so adding them here moved
+        # no other score. That is worth checking before extending this list rather than after:
+        # the list is shared across eleven categories, and a name added for one product tiers
+        # every product that happens to record it.
         examples: [BSL-1.1, SSPL-1.0, FCL-1.0-ALv2, Elastic-License-2.0,
-          Elastic License 2.0, Sustainable-Use-License, n8n-Enterprise-License]
+          Elastic License 2.0, Sustainable-Use-License, n8n-Enterprise-License,
+          Modular-Community-License, Dify-Open-Source-License, Open-WebUI-License,
+          LobeHub-Community-License, PolyForm-Shield]
       proprietary:
         definition: No license to the source, because the source is not published.
         # `commercial` is how the closed observability vendors record it.

--- a/sources/scores/autogpt.yaml
+++ b/sources/scores/autogpt.yaml
@@ -5,20 +5,21 @@ openness:
   confidence: high
   components:
     license:
-      value: DUAL
-      detail: autogpt_platform/ under PolyForm Shield (non-OSI, source-available, anti-compete
-      raw: DUAL, autogpt_platform/ under PolyForm Shield (non-OSI, source-available, anti-compete)
+      value: PolyForm-Shield
+      detail: non-OSI, source-available, anti-compete; governs autogpt_platform/, the active product
     source:
       value: public
     free_text:
     - everything else (Classic, Forge, agbenchmark) MIT(OSI)
   note: 'Verified dual license: the current flagship, the AutoGPT Platform, is PolyForm Shield (source-available,
     non-OSI, anti-compete), while legacy components (Classic, Forge, agbenchmark) stay MIT. Scored on the
-    active product. Score corrected from 3 to 2 on 2026-07-30. The software ladder has rungs at 1, 2, 4
-    and 5 and none at 3, so 3/source_available was not a pair any rule could produce; the ladder scores
-    "you can read it and not run it freely" at 2.'
-  raw: license:DUAL, autogpt_platform/ under PolyForm Shield (non-OSI, source-available, anti-compete);
-    everything else (Classic, Forge, agbenchmark) MIT(OSI);source:public
+    active product. The license was recorded as `DUAL` until 2026-08-11, which named no license and left
+    the tier lookup reading the word itself; `DUAL` describes the arrangement, not the terms, so the governing
+    license is now recorded by name and the MIT half stays beside it. Score corrected from 3 to 2 on 2026-07-30.
+    The software ladder has rungs at 1, 2, 4 and 5 and none at 3, so 3/source_available was not a pair any
+    rule could produce; the ladder scores "you can read it and not run it freely" at 2.'
+  raw: license:PolyForm-Shield(non-OSI, source-available, anti-compete; governs autogpt_platform/, the active
+    product); everything else (Classic, Forge, agbenchmark) MIT(OSI);source:public
   sources:
   - url: https://github.com/Significant-Gravitas/AutoGPT
     shows: 'dual license: PolyForm Shield for autogpt_platform, MIT for the rest (verified); 185k stars;

--- a/tests/test_check_parity.py
+++ b/tests/test_check_parity.py
@@ -63,12 +63,18 @@ def test_local_scores_matches_check_rubrics_split():
     being resolved ahead of the formula: apify, chatbot-arena, patronus-evaluation-platform,
     artificial-analysis-intelligence-index and confer all record a `source` value the
     software ladder settles on its own, and were abstained on a license no rung deciding
-    them was going to read. All five reproduce their recorded 2/source_available."""
+    them was going to read. All five reproduce their recorded 2/source_available. Then
+    405/67 -> 410/62 when five vendor licenses joined the `competition_restricted` tier:
+    max, dify, open-webui, lobe-chat and autogpt all record `source:public`, which reaches
+    the rung that tests the tier, so mapping the license was the only thing left. autogpt
+    needed its license recorded by name first - it said `DUAL`, which names no license. That
+    rung produces 2/source_available, which is what all five already recorded, so again no
+    score moved."""
     computed, deferred = local_scores(None)
-    assert len(deferred) == 67
-    assert len(computed) == 405
+    assert len(deferred) == 62
+    assert len(computed) == 410
     assert not set(computed) & set(deferred)
-    # Every one of the 405 reproduces today, so none should abstain.
+    # Every one of the 410 reproduces today, so none should abstain.
     assert [key for key, value in computed.items() if value is None] == []
 
 

--- a/tests/test_check_rubric.py
+++ b/tests/test_check_rubric.py
@@ -423,9 +423,11 @@ def test_a_rung_that_TESTS_the_tier_still_fails_an_unmappable_license(tmp_path, 
     A ladder whose deciding rung turns on `license_tier` and meets a license outside its
     vocabulary must still report that, or "resolve the tier only when a rung needs one"
     would quietly become an escape hatch for every unmapped license on the map. `dify`,
-    `max`, `open-webui`, `lobe-chat` and `autogpt` are the real cases: all record
+    `max`, `open-webui`, `lobe-chat` and `autogpt` were the real cases: all record
     `source:public`, which reaches a rung that tests the tier, so their vendor licenses
-    still block them.
+    blocked them until those licenses were mapped to `competition_restricted`. Mapping the
+    license is the fix this gate is meant to force; the gate itself is unchanged, which is
+    why the assertion below stands on a fixture rather than on any of the five.
     """
     report = _tier_gate_fixture(
         tmp_path, monkeypatch,

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -719,7 +719,15 @@ def test_real_sources_serialize_without_errors():
         # inference_code 47 -> 64 when the sweep read the category: four stale deferrals came
         # off (a deferred product publishes no openness evidence at all), and several products
         # that had described their gating in prose gained a readable `source:`/`core-gated:`.
-        "finetuning_code": 124, "inference_code": 65, "ml_frameworks": 80,
+        #
+        # Three categories then rose by 14 rows in total when five vendor licenses joined the
+        # `competition_restricted` tier and the deferrals waiting on them came off:
+        # inference_code +4 (max, which records repo-license and commercial-tier beside the two
+        # dimensions), orchestration_agents +4 (autogpt and dify, two rows each) and ui_api +6
+        # (open-webui and lobe-chat, each with a tier key beside the two). Every row is a
+        # deferral coming off; no product that was already computed gained a key, which is why
+        # the other twelve categories hold.
+        "finetuning_code": 124, "inference_code": 69, "ml_frameworks": 80,
         # orchestration_agents rose by 3 when n8n's stale deferral was removed: a deferred
         # product publishes no openness evidence, and n8n had been deferred as "not recorded"
         # while recording everything the ladder needed. Then by 6 more (140 -> 146) when
@@ -737,7 +745,7 @@ def test_real_sources_serialize_without_errors():
         # coming off at 5 rows each, less nothing: syfthub in orchestration_agents,
         # thunderbolt and otari in ui_api. A deferred product publishes no openness evidence
         # at all, so a removed deferral is always the larger of the two effects.
-        "orchestration_agents": 159, "telemetry_observability": 94, "ui_api": 154,
+        "orchestration_agents": 163, "telemetry_observability": 94, "ui_api": 160,
         # training_synthetic_datasets is unchanged at 158 across the ladder widening, which
         # is the check that mattered: benchmark_eval_data's new dimensions and rungs did not
         # disturb the category the ladder was derived from.


### PR DESCRIPTION
## Summary

PR #203 proved that six products' deferral reasons were wrong: they claim the deciding rule reads `source` alone, but every one records `source: public`, and every rung reaching such a product tests `license_tier`. What they actually need is their license mapped.

`software.yaml` already declares a **`competition_restricted`** tier with examples `BSL-1.1`, `SSPL-1.0`, `FCL-1.0-ALv2`, `Elastic-License-2.0`, `Sustainable-Use-License`, `n8n-Enterprise-License`. These five are the same family, so this applies an established precedent rather than inventing a category.

## Five deferrals close, no score moves

| Product | License | What restricts it |
|---|---|---|
| `max` | `Modular-Community-License` | licenses per discrete device; limited redistribution over certain components only |
| `dify` | `Dify-Open-Source-License` | multi-tenant and branding conditions on top of Apache-2.0 |
| `open-webui` | `Open-WebUI-License` | branding retention above 50 end-users per 30 days |
| `lobe-chat` | `LobeHub-Community-License` | a commercial license required to distribute a derivative |
| `autogpt` | `PolyForm-Shield` | anti-compete, and it governs the active product |

All five already recorded 2 / source_available, and rule 2 produces exactly that, so each closes on the score it already carried. A corpus-wide replay of all 472 products shows exactly five state changes, every one abstain → its recorded score.

## `autogpt`: the record was fixed, not the lookup

Its license read `DUAL, autogpt_platform/ under PolyForm Shield ...`, so the lookup saw the literal token `DUAL`. Mapping `DUAL` would have poisoned the tier for every future dual-licensed product regardless of what its two licenses actually are. Instead `license` now reads `PolyForm-Shield` with the dual arrangement in the detail and the MIT half kept in `free_text`. Versionless, matching the evidence and the existing `Sustainable-Use-License` precedent.

## Two things recorded rather than fixed

- **`LobeHub-Community-License` is the loosest fit of the five.** It restricts *distribution* of derivatives rather than running the software. Mapped anyway, because `permissive_non_osi` admits only attribution and naming conditions, and the tier's own definition leads with "forbids or charges for a class of use". The caveat is written into the YAML rather than left to be rediscovered.
- **`dify`'s sources are placeholders** — no digests, no `last_verified`. The characterization sits on the record at `confidence: high` and the score is 2 either way, but that card needs reading.

`txt360-pipeline` carries the same untrue deferral reason and deliberately did **not** close: its license is `Apache-2.0 asserted in README only, no LICENSE file in repo`, which is unstated rather than restricted, and the unstated-license products are having their cards read before any ruling.

## Test plan

- Each of the five characterizations checked against the product's own recorded note and sources before mapping. None rejected.
- Every added name is recorded by exactly one product, no `signal_routing` alias resolves to any of them, and each product sits in one category — so extending the shared `examples` list touches nothing else. Confirmed by the corpus-wide replay, not by inspection alone.
- Suite 454 passed. `validate` 0 error(s), `check_recipe` 0 failure(s), `check_rubric` exit 0, `check_components` `[OK]`, plus `check_verification`, `check_capability`, `check_payload`, both serializer `--check` runs and the notebook render.
- Three pinned regression counts updated, each verified as exactly the 14 evidence rows these five products publish.
