### PR TITLE
feat(scores): close six orchestration_agents deferrals on a repo and pricing read

### DIFF
--- a/sources/categories/orchestration_agents.yaml
+++ b/sources/categories/orchestration_agents.yaml
@@ -62,58 +62,67 @@ scoring_recipe:
   extends: software
   derived_from:
     method: shared software ladder, verified against the hand-authored scores
-    scores_reproduced: 36
-    scores_total: 50
-    scores_deferred: 14
-    verified_on: '2026-08-01'
+    scores_reproduced: 46
+    scores_total: 46
+    scores_deferred: 5
+    verified_on: '2026-08-11'
     checker: build/check_rubric.py
   # Held back rather than scored. The shared ladder has no `otherwise` rule, so
   # these already abstain; declaring them here records WHY, and keeps the
   # reproduction count honest by excluding them from it rather than counting
   # them as passes.
+  #
+  # Six of the eleven deferrals here were closed on 2026-08-11 by an evidence sweep that
+  # read each repo and pricing page and transcribed `source` and `core-gated` into keys the
+  # ladder reads: codex-cli, claude-code, cursor, haystack, langgraph, hexabot. What the
+  # sweep left is one shape of disagreement, and it is the same shape four times over.
+  #
+  # langchain, llama-index, pydantic-ai and zed each record 4/open_core on the strength of
+  # a `commercial:` clause naming a paid product the vendor also sells - LangSmith,
+  # LlamaCloud, Logfire, Zed Pro. A read of all four repos found no enterprise directory and
+  # no package the published source cannot build, and a read of all four pricing pages found
+  # the paid tier selling a SEPARATE service rather than a withheld feature. That is what
+  # `otari` was corrected for on 2026-08-11: a hosted offering beside an ungated core is not
+  # gating, and LiteLLM's open_core rests on an `enterprise-dir` these four do not have. So
+  # the ladder now computes 5/open_source for each, against a recorded 4.
+  #
+  # They are held rather than restated because the question is no longer evidential. Either
+  # these four scores were authored on "the vendor sells something" and should follow otari
+  # to 5, or the ladder's `gated` is meant to cover an adjacent commercial product and its
+  # definition needs to say so. One reading settles all four, and it is a call for a human.
+  # langgraph is the useful control: it looks identical from outside and is genuinely gated,
+  # because its Agent Server ships as a closed Elastic-2.0 wheel behind a license key.
   deferred:
-    codex-cli:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
-    claude-code:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
-    cursor:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
     openhands:
       because: >-
         ladder computes 5/open_source from the recorded evidence but the score says
         4/open_core; one of the two is wrong and it needs a human
     langchain:
       because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
-    langgraph:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
+        ladder computes 5/open_source from the evidence read on 2026-08-11 but the score says
+        4/open_core. The langchain repo is MIT throughout with no enterprise directory and
+        langchain.com/pricing sells only LangSmith, so nothing is withheld from the published
+        source. A human also needs to settle SCOPE: this product's own description reads 'MIT
+        core (langchain-core, langgraph, integrations)', which pulls in langgraph - a separate
+        product on this map, and one that IS gated.
     pydantic-ai:
       because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
-    haystack:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
+        ladder computes 5/open_source from the evidence read on 2026-08-11 but the score says
+        4/open_core. pydantic/pydantic-ai is MIT throughout with no enterprise directory, and
+        pydantic.dev/pricing sells Logfire observability under the strapline 'Every feature.
+        Any tier.' Same shape as llama-index, langchain and zed; one reading settles all four.
     llama-index:
       because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
+        ladder computes 5/open_source from the evidence read on 2026-08-11 but the score says
+        4/open_core. run-llama/llama_index is MIT throughout with no enterprise directory, and
+        llamaindex.ai/pricing sells LlamaParse credits, a separate document-processing service.
+        Same shape as langchain, pydantic-ai and zed; one reading settles all four.
     zed:
       because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
-    hexabot:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
+        ladder computes 5/open_source from the evidence read on 2026-08-11 but the score says
+        4/open_core. Every crate in zed-industries/zed carries LICENSE-GPL or LICENSE-APACHE,
+        the collab server included, and zed.dev/pricing sells Zed-hosted inference and an admin
+        dashboard which Zed's own FAQ says 'govern Zed's hosted services specifically'. The same
+        read also found the recorded license names AGPL-3.0 for a collab server that now carries
+        GPL; that does not move the tier, but it is why the axis carries no last_verified.
 comments: ''

--- a/sources/scores/claude-code.yaml
+++ b/sources/scores/claude-code.yaml
@@ -12,14 +12,43 @@ openness:
       detail: proprietary, API-only
     note:
       value: Agent SDK published but the product is closed SaaS
-  note: Closed/proprietary product gated behind an Anthropic subscription; the coding agent itself is
-    not open source.
+    source:
+      value: closed
+      detail: anthropics/claude-code ships plugins, examples and scripts; no runtime source and LICENSE.md
+        is all-rights-reserved
+  note: 'Closed/proprietary product gated behind an Anthropic subscription; the coding agent itself is not
+    open source. `source: closed` transcribed 2026-08-11 from a read of the repo: the GitHub contents API
+    lists only `.claude-plugin`, `.claude`, `.devcontainer`, `Script`, `examples`, `plugins`, `scripts`
+    and docs at the root, and LICENSE.md is a bare all-rights-reserved notice pointing at Anthropic''s Commercial
+    Terms. The published Agent SDK is a client that spawns the closed CLI, which the corpus already treats
+    as `closed` rather than `partial` (braintrust, promptlayer, openrouter, tavily-search-api all record
+    client SDKs under `source: closed`). `core-gated` is left unrecorded because the rubric says it is meaningful
+    only where source is public.'
+  last_verified: '2026-08-11'
   raw: license:Proprietary(closed-source CLI/app, requires Claude subscription or Console account);model:Claude(proprietary,
-    API-only);note:Agent SDK published but the product is closed SaaS
+    API-only);note:Agent SDK published but the product is closed SaaS;source:closed(anthropics/claude-code
+    ships plugins, examples and scripts; no runtime source and LICENSE.md is all-rights-reserved)
   sources:
   - url: https://code.claude.com/docs/en/overview
     shows: requires Claude subscription or Anthropic Console account; proprietary surfaces
     accessed: '2026-06-04'
+  - url: https://api.github.com/repos/anthropics/claude-code/contents/
+    shows: 'Root listing of anthropics/claude-code: .claude-plugin, .claude, .devcontainer, .gitattributes,
+      .github, .gitignore, .vscode, CHANGELOG.md, LICENSE.md, README.md, SECURITY.md, Script, demo.gif,
+      examples, feed.xml, plugins, scripts. No source tree for the CLI agent.'
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: 10b1c0faab05f24403d0fb3a36ba019adeb35572a1e312612c78b0aecddd8c48
+    establishes:
+    - source
+  - url: https://raw.githubusercontent.com/anthropics/claude-code/main/LICENSE.md
+    shows: 'Entire file: "(c) Anthropic PBC. All rights reserved. Use is subject to Anthropic''s Commercial
+      Terms of Service." No grant to the source.'
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: 728158fd1037143fad6907e8fa34804177e598b7326519503fe83cafdef849e6
+    establishes:
+    - license
 adoption:
   level: 4
   reach: 1M-10M

--- a/sources/scores/codex-cli.yaml
+++ b/sources/scores/codex-cli.yaml
@@ -14,11 +14,23 @@ openness:
       value: agent is OSS but optimized for/defaults to OpenAI models
       detail: provider-leaning, not license-restricted
       raw: agent is OSS but optimized for/defaults to OpenAI models (provider-leaning, not license-restricted)
-  note: Verified Apache-2.0 OSI with public Rust source (96.1% Rust); OpenAI's own docs call it open source.
+    core-gated:
+      value: ungated
+      detail: one Apache-2.0 LICENSE at the root governs the whole tree; a full recursive listing finds
+        no enterprise or commercial directory
+  note: 'Verified Apache-2.0 OSI with public Rust source (96.1% Rust); OpenAI''s own docs call it open source.
     Backing models are proprietary, but the orchestration agent scored here is fully open. License/version/stars
-    confirmed via primary GitHub source.
+    confirmed via primary GitHub source. `core-gated: ungated` transcribed 2026-08-11: a full recursive
+    tree of openai/codex@main (untruncated) carries exactly one governing LICENSE, the root Apache-2.0,
+    with the only other license files being vendored third-party deps (third_party/wezterm, codex-rs/vendor/bubblewrap)
+    and sample skill assets. There is no enterprise or commercial directory, which is the test LiteLLM''s
+    open_core rests on. What you pay for is model access - the README directs you to sign in with a ChatGPT
+    Plus/Pro/Business/Edu/Enterprise plan or an API key - and that is a hosted service alongside the published
+    agent, which the software ladder calls ungated on the otari precedent.'
+  last_verified: '2026-08-11'
   raw: license:Apache-2.0(OSI, the CLI agent);source:public(GitHub);note:agent is OSS but optimized for/defaults
-    to OpenAI models (provider-leaning, not license-restricted)
+    to OpenAI models (provider-leaning, not license-restricted);core-gated:ungated(one Apache-2.0 LICENSE
+    at the root governs the whole tree; a full recursive listing finds no enterprise or commercial directory)
   sources:
   - url: https://github.com/openai/codex
     shows: Apache-2.0 license, public Rust source, v0.137.0 Jun 4 2026, 88.6k stars (verified)
@@ -26,6 +38,34 @@ openness:
   - url: https://developers.openai.com/codex/cli
     shows: OpenAI describes Codex CLI as open source
     accessed: '2026-06-04'
+  - url: https://api.github.com/repos/openai/codex/git/trees/main?recursive=1
+    shows: Full untruncated recursive tree. The only LICENSE paths are the root `LICENSE`, `third_party/wezterm/LICENSE`,
+      `codex-rs/vendor/bubblewrap/LICENSE`, `docs/license.md` and four sample-skill asset licenses. No enterprise/,
+      ee/ or commercial/ directory anywhere in the tree.
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: 94eb1fbf3cc5b741307d843c65a8c09285cac078944818e34506f29bc7ad5fef
+    establishes:
+    - core-gated
+    - source
+  - url: https://api.github.com/repos/openai/codex
+    shows: 'Repo metadata: language Rust, license spdx_id Apache-2.0, size 549,758 KB, 105,340 stars, ''Lightweight
+      coding agent that runs in your terminal''.'
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: 495555fd8af1dd00aed142a7d96c6a89493977828d243dac5a1cf45497b4c7bd
+    establishes:
+    - license
+    - source
+  - url: https://raw.githubusercontent.com/openai/codex/main/README.md
+    shows: '''Using Codex with your ChatGPT plan - Run `codex` and select Sign in with ChatGPT ... to use
+      Codex as part of your Plus, Pro, Business, Edu, or Enterprise plan.'' and ''You can also use Codex
+      with an API key''. The paid relationship is model access, not a withheld CLI feature.'
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: ba4e1f69ff48386e72a9c5e1edaf76aad64a475c2d51af79ccba6d1128261ba7
+    establishes:
+    - core-gated
 adoption:
   level: 4
   reach: 1M-10M

--- a/sources/scores/cursor.yaml
+++ b/sources/scores/cursor.yaml
@@ -11,13 +11,50 @@ openness:
       value: multi-provider
       detail: OpenAI/Anthropic/Gemini/xAI) but the product is proprietary
       raw: multi-provider (OpenAI/Anthropic/Gemini/xAI) but the product is proprietary
-  note: Fully proprietary commercial product; no open source license or public source.
+    source:
+      value: closed
+      detail: cursor/cursor holds only .github, README.md and SECURITY.md; no license, no language, no editor
+        source
+  note: 'Fully proprietary commercial product; no open source license or public source. `source: closed`
+    transcribed 2026-08-11 from a read of the repo and the terms: the GitHub contents API shows `cursor/cursor`
+    holds exactly three entries (`.github`, `README.md`, `SECURITY.md`), the repo API reports `license:
+    null` and `language: null`, and the Terms of Service state that Anysphere and its licensors retain all
+    right, title and interest in the Service and reserve all rights not granted. Nothing of the editor runtime
+    is published, so the ladder settles on `source` alone and `core-gated` stays unrecorded.'
+  last_verified: '2026-08-11'
   raw: license:Proprietary(closed SaaS IDE, no public source);model:multi-provider (OpenAI/Anthropic/Gemini/xAI)
-    but the product is proprietary
+    but the product is proprietary;source:closed(cursor/cursor holds only .github, README.md and SECURITY.md;
+    no license, no language, no editor source)
   sources:
   - url: https://www.cursor.com/
     shows: proprietary commercial IDE, no OSS licensing, enterprise/Fortune-500 positioning
     accessed: '2026-06-04'
+  - url: https://api.github.com/repos/cursor/cursor/contents/
+    shows: 'Root listing of cursor/cursor is exactly three entries: .github, README.md, SECURITY.md. No
+      editor source.'
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: f8b18d2b7749499dd22755b60a8560622c926de09ed0aa1e063fc5ac258c99ea
+    establishes:
+    - source
+  - url: https://api.github.com/repos/cursor/cursor
+    shows: 'Repo metadata: license null, language null, description null, 33,098 stars. The public repo
+      declares no license and contains no code in any language.'
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: 66876c0b12d304b1db412a8fb626c34111df6b62886530b0b00d70bb78e747b0
+    establishes:
+    - source
+    - license
+  - url: https://cursor.com/terms-of-service
+    shows: 'Section 5.1 Service: ''Anysphere and its licensors shall own and retain all right, title and
+      interest in and to the Service'' and ''Anysphere reserves all rights to the Service not granted in
+      these Terms.'''
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: 25b6aa5e095ce3d4f43fc80ab07db35cad64b7f4444e6659107cf8fcd27a1163
+    establishes:
+    - license
 adoption:
   level: 4
   reach: 1M-10M

--- a/sources/scores/haystack.yaml
+++ b/sources/scores/haystack.yaml
@@ -10,13 +10,70 @@ openness:
       value: Haystack-Enterprise
     source:
       value: public
+    core-gated:
+      value: gated
+      detail: deepset names the free tier a Community Edition and sells Haystack Enterprise Starter with
+        a private template/Helm repo plus early access to security features not yet in OSS
   confidence: high
-  note: Apache-2.0 self-hostable core with a commercial enterprise tier.
-  raw: license:Apache-2.0(core);commercial:Haystack-Enterprise;source:public
+  note: 'Apache-2.0 self-hostable core with a commercial enterprise tier. `core-gated: gated` transcribed
+    2026-08-11 from a read of the repo and deepset''s own product pages. The repo itself is clean - a full
+    untruncated recursive tree of deepset-ai/haystack@main carries one governing Apache-2.0 LICENSE and
+    no enterprise/ or ee/ directory - so this is not the LiteLLM shape. What makes it gated is that the
+    withheld directory is a separate private REPOSITORY rather than a subdirectory: Haystack Enterprise
+    Starter ships ''curated pipeline templates'', a ''Helm chart and guides'', and ''early access to enterprise-grade
+    features ... like prompt injection countermeasures and other security-oriented features ahead of broader
+    release''. deepset''s own tiering calls the free product ''Haystack OSS (Community Edition)'', and a
+    commercial edition is one of the three things the rubric''s gated definition names. Distinguished from
+    the otari precedent deliberately: otari''s paid offering was a hosted platform running the same published
+    code, whereas this is code and features that the published source does not contain at the time they
+    are sold.'
+  last_verified: '2026-08-11'
+  raw: license:Apache-2.0(core);commercial:Haystack-Enterprise;source:public;core-gated:gated(deepset names
+    the free tier a Community Edition and sells Haystack Enterprise Starter with a private template/Helm
+    repo plus early access to security features not yet in OSS)
   sources:
   - url: https://github.com/deepset-ai/haystack
     shows: Apache-2.0, ~25.6k stars, Haystack Enterprise tiers
     accessed: '2026-06-17'
+  - url: https://api.github.com/repos/deepset-ai/haystack/git/trees/main?recursive=1
+    shows: Full untruncated recursive tree, 11,007 entries. Only license-related paths are the root `LICENSE`,
+      `license-header.txt`, `licenserc.toml` and a `.github/workflows/license_compliance.yml`. No enterprise/,
+      ee/, commercial/ or proprietary/ path anywhere.
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: ad9a6efe3493eeb42097d8bbe70ac151122907c6ce96fcbd78ac9f597f5a8520
+    establishes:
+    - source
+    - core-gated
+  - url: https://api.github.com/repos/deepset-ai/haystack
+    shows: 'Repo metadata: language Python, license spdx_id Apache-2.0, size 249,631 KB, 26,179 stars, default
+      branch main.'
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: c815a780271925a4918a94bdd1ba14ae62bc0fe6548f457c3debfa23ba3bfdbd
+    establishes:
+    - license
+    - source
+  - url: https://haystack.deepset.ai/blog/announcing-haystack-enterprise
+    shows: 'Lists what Haystack Enterprise Starter adds over OSS: ''Curated pipeline templates'', ''Helm
+      chart and guides for secure deployments'', and ''Early access to enterprise-grade features - Take
+      advantage of capabilities like prompt injection countermeasures and other security-oriented features
+      ahead of broader release.'' Also states ''Haystack ... will always remain an open source framework''.'
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: be96166cb05c45d80d99c690fc3e4c5bbfae29e2a009462c474ace54eb54f525
+    establishes:
+    - core-gated
+  - url: https://www.deepset.ai/blog/introducing-haystack-enterprise
+    shows: 'deepset''s own three-tier framing: ''Haystack OSS (Community Edition): 100% open source, self-supported.''
+      / ''Haystack Enterprise Starter: The power of Haystack with added enterprise pipeline and deployment
+      templates, direct and private support'' / ''Haystack Enterprise Platform (Cloud or on-prem)''. Pricing
+      ''based on the size of your organization''.'
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: 638c53b52207610717ca1fcc882b336557d79cec6cb6806b9968ccc125b5c58f
+    establishes:
+    - core-gated
 adoption:
   level: 4
   signal_type: usage_volume

--- a/sources/scores/hexabot.yaml
+++ b/sources/scores/hexabot.yaml
@@ -9,11 +9,25 @@ openness:
         commercial use restricted until conversion). Earlier v1/v2 were AGPL-3.0.
       raw: FCL-1.0-ALv2 (Fair Core License, NOT OSI; converts to Apache-2.0 two years after each release;
         competing/hosted commercial use restricted until conversion). Earlier v1/v2 were AGPL-3.0.
+    source:
+      value: public
+      detail: full TypeScript monorepo, packages/api + frontend + widget + agentic + graph + cli, docker/
+        compose
   confidence: high
-  note: Fair Core License is a delayed-open / fair-code model, so the current core is source-available
-    rather than open source.
+  note: 'Fair Core License is a delayed-open / fair-code model, so the current core is source-available
+    rather than open source. `source: public` transcribed 2026-08-11 from a read of the repo: Hexastack/Hexabot
+    publishes the whole runtime as a pnpm/turbo TypeScript monorepo (packages/api, frontend, widget, agentic,
+    graph, cli) with docker/ compose files, 55MB, GitHub reporting language TypeScript. The ladder settles
+    this on rung 2 (competition_restricted + public), so core-gated is never consulted. Worth recording
+    that a read of the pricing page found a license-key mechanism that the ladder does not see here: Community
+    is free and self-hosted with no key, and the $19/$59/$149 plans raise user, workflow and activation
+    quotas via license-key activations, while LICENSE.md forbids circumventing that key functionality. That
+    is a capacity cap rather than a withheld feature, and since no rung reads it on this product it is left
+    unrecorded rather than guessed at.'
+  last_verified: '2026-08-11'
   raw: license:FCL-1.0-ALv2 (Fair Core License, NOT OSI; converts to Apache-2.0 two years after each release;
-    competing/hosted commercial use restricted until conversion). Earlier v1/v2 were AGPL-3.0.
+    competing/hosted commercial use restricted until conversion). Earlier v1/v2 were AGPL-3.0.;source:public(full
+    TypeScript monorepo, packages/api + frontend + widget + agentic + graph + cli, docker/ compose)
   sources:
   - url: https://github.com/Hexastack/Hexabot
     shows: Licensed under FCL-1.0-ALv2; GitHub reports license as 'Other'
@@ -21,6 +35,42 @@ openness:
   - url: https://hexabot.ai/
     shows: 'Fair Core License: converts to Apache-2.0 after 2 years; competing commercial use restricted'
     accessed: '2026-06-22'
+  - url: https://api.github.com/repos/Hexastack/Hexabot/contents/packages
+    shows: packages/ holds agentic, api, cli, frontend, graph, types, widget - the whole runtime, not a
+      client.
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: 47fd391e7e1afb498c84396c05caa6c2aaaf8469af0e91a7db0fb2ec23de2fc1
+    establishes:
+    - source
+  - url: https://api.github.com/repos/Hexastack/Hexabot
+    shows: 'Repo metadata: language TypeScript, size 55,744 KB, license spdx_id NOASSERTION (GitHub cannot
+      place FCL), 1,161 stars.'
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: 14185b7b191004b625920bde6409bfe409437fdd40d2fba34b07e9ea28119d0e
+    establishes:
+    - source
+  - url: https://raw.githubusercontent.com/Hexastack/Hexabot/main/LICENSE.md
+    shows: Full text of 'Fair Core License, Version 1.0, ALv2 Future License', abbreviation FCL-1.0-ALv2,
+      Copyright 2025 Hexastack. Grants use for any 'Permitted Purpose', defined as any purpose other than
+      a 'Competing Use' - making the Software available in a commercial product or service that substitutes
+      for it or offers substantially similar functionality. Also forbids circumventing the license key functionality.
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: dbd8bc28359eec017002639f110da21a179c0287aa58af236d47bc6b7f018378
+    establishes:
+    - license
+  - url: https://hexabot.ai/pricing
+    shows: '''Community is self-hosted and free with no license key. Paid plans start at $19/month and use
+      license-key activations''. Starter $19 (3 activations / 3 users / 25 workflows), Pro $59 (10/10/150),
+      Unlimited $149 (25 activations / 25 users / unlimited workflows). ''Hexabot remains source-available
+      under FCL-1.0-ALv2''. All tiers self-hosted.'
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: 82eda9991d37564968ec2d7e56d7f19cc3cac98b494d84f2b89e7e017e8919f8
+    establishes:
+    - license
 adoption:
   level: 3
   reach: niche

--- a/sources/scores/langchain.yaml
+++ b/sources/scores/langchain.yaml
@@ -10,9 +10,30 @@ openness:
       value: LangSmith-platform/cloud
     source:
       value: public
+    core-gated:
+      value: ungated
+      detail: every package in langchain-ai/langchain is MIT with no enterprise directory; LangSmith is
+        a separately sold observability and deployment platform
   confidence: high
-  note: license:MIT(langchain-core,langgraph,integrations);commercial:LangSmith-platform/cloud;source:public
-  raw: license:MIT(langchain-core,langgraph,integrations);commercial:LangSmith-platform/cloud;source:public
+  note: 'MIT core with LangSmith sold separately. `core-gated: ungated` transcribed 2026-08-11 from a read
+    of the repo and the pricing page, and it does not reproduce the recorded 4/open_core - the ladder computes
+    5/open_source from it, so the product stays deferred for a human. What the read found: a full untruncated
+    recursive tree of langchain-ai/langchain@master is 3,587 entries whose only license files are the root
+    MIT and per-package copies under libs/ (core, langchain, langchain_v1, model-profiles, seventeen partners,
+    standard-tests, text-splitters), with no enterprise/, ee/ or commercial/ path anywhere; and langchain.com/pricing
+    sells LangSmith - observability, evaluation, deployment, sandboxes, gateway - by seat and by metered
+    compute, listing langchain, langgraph and deepagents separately under ''Open Source Frameworks''. A
+    paid platform sold alongside an unwithheld core is what the otari precedent calls ungated. The open
+    question a human should settle is SCOPE, not evidence: this product''s own description reads ''MIT core
+    (langchain-core, langgraph, integrations)'', which pulls langgraph inside langchain even though langgraph
+    is a separate product on this map with its own score - and langgraph IS gated, by the Elastic-2.0 langgraph-api
+    server. On the narrow scope (the langchain repo) this is 5; on the description''s wider scope it inherits
+    langgraph''s 4. Recorded on the narrow scope because that is what the repo evidence supports, and deferred
+    because the wider scope is a curation decision rather than something a page read can answer.'
+  last_verified: '2026-08-11'
+  raw: license:MIT(langchain-core,langgraph,integrations);commercial:LangSmith-platform/cloud;source:public;core-gated:ungated(every
+    package in langchain-ai/langchain is MIT with no enterprise directory; LangSmith is a separately sold
+    observability and deployment platform)
   sources:
   - url: https://github.com/langchain-ai/langchain
     shows: flagship phase-C verification source
@@ -23,6 +44,37 @@ openness:
   - url: https://rvernica.github.io/2026/03/langchain-license
     shows: flagship phase-C verification source
     accessed: '2026-06-04'
+  - url: https://api.github.com/repos/langchain-ai/langchain/git/trees/master?recursive=1
+    shows: 'Full untruncated recursive tree, 3,587 entries. Only license files are the root LICENSE and
+      per-package copies under libs/: core, langchain, langchain_v1, model-profiles, seventeen partners/*,
+      standard-tests, text-splitters. No enterprise/, ee/, commercial/ or proprietary/ path. Top-level directories
+      are .devcontainer, .github, .vscode, libs.'
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: e7134bbd4a5c72cadbf4fe408abcb6e831722dedef5047dc77b40df1f7b64acf
+    establishes:
+    - source
+    - core-gated
+  - url: https://api.github.com/repos/langchain-ai/langchain
+    shows: 'Repo metadata: default_branch master, language Python, license spdx_id MIT, size 588,758 KB,
+      143,996 stars.'
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: 5f39a6a46f09552389609f7e4efe5d2516881c7dbacba6fc4a77f830841c5d14
+    establishes:
+    - license
+    - source
+  - url: https://www.langchain.com/pricing
+    shows: 'Page is titled ''LangSmith Plans and Pricing'' and prices only LangSmith: Developer $0/seat,
+      Plus $39/seat, Enterprise custom, plus metered LangChain Compute Units ($1.50/LCU) and Storage Units
+      ($1.00/LSU) for Deployment, Fleet, Engine, Sandboxes and LLM Gateway. The nav lists langchain, langgraph
+      and deepagents separately under ''Open Source Frameworks''. No paid tier of the langchain library
+      itself.'
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: 55f457245dd637cd290edc1ea6be35168b134d6cd1d401ca0a72e7c3867861e2
+    establishes:
+    - core-gated
 adoption:
   level: 5
   reach: '>10M'

--- a/sources/scores/langgraph.yaml
+++ b/sources/scores/langgraph.yaml
@@ -10,13 +10,66 @@ openness:
       value: LangGraph-Platform/LangSmith
     source:
       value: public
+    core-gated:
+      value: gated
+      detail: the Agent Server runtime ships as the closed Elastic-2.0 langgraph-api package and self-hosting
+        it needs LANGGRAPH_CLOUD_LICENSE_KEY
   confidence: high
-  note: MIT-licensed self-hostable core with a commercial managed deployment platform.
-  raw: license:MIT(core);commercial:LangGraph-Platform/LangSmith;source:public
+  note: 'MIT-licensed self-hostable core with a commercial managed deployment platform. `core-gated: gated`
+    transcribed 2026-08-11 from a read of the repo, PyPI and the deployment docs, and it does NOT rest on
+    the managed platform existing. A full untruncated recursive tree of langchain-ai/langgraph@main is 830
+    entries with nine LICENSE files, all of them per-package copies of the MIT root, and no enterprise/
+    or ee/ directory - so the gate is not inside the repo. It is that a piece of the runtime is not in the
+    repo at all: PyPI reports langgraph-api, the Agent Server, under Elastic-2.0 while langgraph itself
+    is MIT, no langgraph-api source repo exists under the langchain-ai org, and LangChain''s own self-host
+    doc requires LANGGRAPH_CLOUD_LICENSE_KEY plus egress to beacon.langchain.com for license verification.
+    A license key you must hold to run the server is functionality withheld from the published source for
+    a paid tier, which is the dimension''s question stated directly. This is the axis on which langgraph
+    and langchain differ despite recording the same 4/open_core - see the langchain note.'
+  last_verified: '2026-08-11'
+  raw: license:MIT(core);commercial:LangGraph-Platform/LangSmith;source:public;core-gated:gated(the Agent
+    Server runtime ships as the closed Elastic-2.0 langgraph-api package and self-hosting it needs LANGGRAPH_CLOUD_LICENSE_KEY)
   sources:
   - url: https://github.com/langchain-ai/langgraph
     shows: MIT, ~35k stars, low-level agent orchestration
     accessed: '2026-06-17'
+  - url: https://api.github.com/repos/langchain-ai/langgraph/git/trees/main?recursive=1
+    shows: Full untruncated recursive tree, 830 entries. Nine LICENSE files, all per-package copies under
+      libs/ (checkpoint, checkpoint-postgres, checkpoint-sqlite, cli, langgraph, prebuilt, sdk-py). No enterprise/,
+      ee/, commercial/ or proprietary/ path. No langgraph-api package in the repo.
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: a29fd5a048f53cd110621fed9104115a05a53794ed22efd2e9c8b3cd87feb58a
+    establishes:
+    - source
+    - core-gated
+  - url: https://api.github.com/repos/langchain-ai/langgraph
+    shows: 'Repo metadata: language Python, license spdx_id MIT, size 525,434 KB, 39,468 stars, default
+      branch main.'
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: 3797d83a83dcae7eb9a908437b557a3e92f41f35ee27468bac41b26b0932b486
+    establishes:
+    - license
+    - source
+  - url: https://pypi.org/pypi/langgraph-api/json
+    shows: info.license is 'Elastic-2.0' for langgraph-api 0.12.3, the Agent Server runtime. For comparison
+      https://pypi.org/pypi/langgraph/json reports license_expression 'MIT' for langgraph 1.2.11.
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: 9b0cf909b75e5ac85e25166ec0d2fea489a06793fd1d85105a36117fc7675db7
+    establishes:
+    - core-gated
+  - url: https://docs.langchain.com/langsmith/deploy-standalone-server
+    shows: 'Self-hosted standalone Agent Server environment variables include ''LANGGRAPH_CLOUD_LICENSE_KEY:
+      LangSmith license key. This will be used to authenticate ONCE at server start up'' and ''Egress to
+      https://beacon.langchain.com from your network. This is required for license verification and usage
+      reporting if not running in air-gapped mode.'''
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: d3b1665df2fa581b34a27961ce638a89da8df6eeb1783d01c7ebb928eb25a9c0
+    establishes:
+    - core-gated
 adoption:
   level: 5
   signal_type: usage_volume

--- a/sources/scores/llama-index.yaml
+++ b/sources/scores/llama-index.yaml
@@ -10,13 +10,59 @@ openness:
       value: LlamaCloud/LlamaParse
     source:
       value: public
+    core-gated:
+      value: ungated
+      detail: every package in run-llama/llama_index is MIT with no enterprise directory; LlamaParse/LlamaCloud
+        is a separately sold document-processing service
   confidence: high
-  note: MIT self-hostable core with a commercial managed cloud.
-  raw: license:MIT(core);commercial:LlamaCloud/LlamaParse;source:public
+  note: 'MIT self-hostable core with a commercial managed cloud. `core-gated: ungated` transcribed 2026-08-11
+    from a read of the repo and the pricing page, and it does not reproduce the recorded 4/open_core - the
+    ladder computes 5/open_source from it, so the product stays deferred for a human. What the read found:
+    a full untruncated recursive tree of run-llama/llama_index@main is 13,820 entries whose license files
+    are the root MIT plus a per-package copy in every llama-index-integrations/* and llama-index-core package,
+    with no enterprise/, ee/, commercial/ or proprietary/ path anywhere; and llamaindex.ai/pricing prices
+    LlamaParse alone, in document-processing credits (Free 10K, Starter $50/40K, Pro $500/400K, Enterprise
+    custom), listing LlamaIndex, Workflows and LiteParse separately under ''Open Source''. Nothing is withheld
+    from the published library - LlamaParse is a different product sold beside it, which is what the otari
+    precedent calls ungated rather than gated. The recorded 4 rests on `commercial:LlamaCloud/LlamaParse`,
+    that is, on the vendor having a paid product at all, and that is the test otari was corrected for using.'
+  last_verified: '2026-08-11'
+  raw: license:MIT(core);commercial:LlamaCloud/LlamaParse;source:public;core-gated:ungated(every package
+    in run-llama/llama_index is MIT with no enterprise directory; LlamaParse/LlamaCloud is a separately
+    sold document-processing service)
   sources:
   - url: https://github.com/run-llama/llama_index
     shows: MIT, ~50.2k stars, LlamaCloud commercial tier
     accessed: '2026-06-17'
+  - url: https://api.github.com/repos/run-llama/llama_index/git/trees/main?recursive=1
+    shows: Full untruncated recursive tree, 13,820 entries. License files are the root LICENSE, llama-dev/LICENSE,
+      llama-index-core/LICENSE and a per-package LICENSE in each llama-index-integrations/* package. No
+      enterprise/, ee/, commercial/ or proprietary/ path anywhere.
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: d070385f9d480134a184cbe674316c995c97adb211f34937b05787147543666f
+    establishes:
+    - source
+    - core-gated
+  - url: https://api.github.com/repos/run-llama/llama_index
+    shows: 'Repo metadata: language Python, license spdx_id MIT, size 482,901 KB, 51,564 stars, default
+      branch main.'
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: 9b86dd5f69bcc414a32348cc167dfddc028822e08a3d14528b748d4862d38c0b
+    establishes:
+    - license
+    - source
+  - url: https://www.llamaindex.ai/pricing
+    shows: 'Titled ''LlamaParse Pricing: Compare Plans & Credits''. Prices only LlamaParse document-processing
+      credits: Free $0 / 10K credits, Starter $50 / 40K, Pro $500 / 400K, Enterprise custom with SSO and
+      hybrid deployment. The nav lists LlamaIndex, Workflows and LiteParse separately under ''Open Source
+      - OSS repos trusted by millions of developers''. No paid tier of the llama_index library.'
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: 3c4527059c30cff4944b879e0e7986db182b2fd6ec20b2443da200ef6d6eba6a
+    establishes:
+    - core-gated
 adoption:
   level: 5
   signal_type: usage_volume

--- a/sources/scores/pydantic-ai.yaml
+++ b/sources/scores/pydantic-ai.yaml
@@ -10,13 +10,58 @@ openness:
       value: Pydantic-Logfire
     source:
       value: public
+    core-gated:
+      value: ungated
+      detail: every package in pydantic/pydantic-ai is MIT with no enterprise directory; Logfire and the
+        AI Gateway are separately sold services
   confidence: high
-  note: MIT type-first agent library with a commercial Logfire observability platform.
-  raw: license:MIT(library);commercial:Pydantic-Logfire;source:public
+  note: 'MIT type-first agent library with a commercial Logfire observability platform. `core-gated: ungated`
+    transcribed 2026-08-11 from a read of the repo and the pricing page, and it does not reproduce the recorded
+    4/open_core - the ladder computes 5/open_source from it, so the product stays deferred for a human.
+    What the read found: a full untruncated recursive tree of pydantic/pydantic-ai@main is 2,664 entries
+    with six LICENSE files, the root MIT and per-package copies for clai, examples, pydantic_ai_slim, pydantic_evals
+    and pydantic_graph, and no enterprise/, ee/, commercial/ or proprietary/ path; and pydantic.dev/pricing
+    is headed ''Pydantic Logfire Pricing'' with the strapline ''10M logs/spans/metrics free. Every feature.
+    Any tier.'' - the tiers sell observability seats, retention and gateway markup, not agent-library features.
+    Nothing is withheld from the published library. The recorded 4 rests on `commercial:Pydantic-Logfire`,
+    that is, on the vendor having a paid product at all, which is the test the otari precedent was corrected
+    for using.'
+  last_verified: '2026-08-11'
+  raw: license:MIT(library);commercial:Pydantic-Logfire;source:public;core-gated:ungated(every package in
+    pydantic/pydantic-ai is MIT with no enterprise directory; Logfire and the AI Gateway are separately
+    sold services)
   sources:
   - url: https://github.com/pydantic/pydantic-ai
     shows: MIT, ~17.8k stars, Logfire integration
     accessed: '2026-06-17'
+  - url: https://api.github.com/repos/pydantic/pydantic-ai/git/trees/main?recursive=1
+    shows: 'Full untruncated recursive tree, 2,664 entries. Six LICENSE files: root, clai/, examples/, pydantic_ai_slim/,
+      pydantic_evals/, pydantic_graph/. No enterprise/, ee/, commercial/ or proprietary/ path anywhere.'
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: a9f41b34161da1d2d1e61fef24108f0dced1466989bf91a6c8770ba4619edf35
+    establishes:
+    - source
+    - core-gated
+  - url: https://api.github.com/repos/pydantic/pydantic-ai
+    shows: 'Repo metadata: language Python, license spdx_id MIT, size 226,885 KB, 19,231 stars, default
+      branch main.'
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: cbcef7945209b5d388a82b4e47f8701f4b290056d54cf07b03c4371a549cfa63
+    establishes:
+    - license
+    - source
+  - url: https://pydantic.dev/pricing
+    shows: Titled 'Pydantic Logfire Pricing', strapline '10M logs/spans/metrics free. Every feature. Any
+      tier.' Tiers are Personal $0, Team $49/mo, Growth $249/mo, Enterprise custom, and they sell observability
+      seats, projects, record volume, data retention and AI Gateway markup. Pydantic AI is listed as a separate
+      product in the nav. No paid tier of the agent library.
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: 6e8c4ca400d450e2778aa9118d97bbb16339e7132fbc5358ac424fc0b2de615f
+    establishes:
+    - core-gated
 adoption:
   level: 5
   signal_type: usage_volume

--- a/sources/scores/zed.yaml
+++ b/sources/scores/zed.yaml
@@ -11,14 +11,63 @@ openness:
     commercial:
       value: Zed-Pro/Business
       detail: hosted AI
+    core-gated:
+      value: ungated
+      detail: the whole editor and the collab server are in the repo under GPL/Apache; Pro and Business
+        sell Zed-hosted model inference and a hosted admin dashboard
   confidence: high
-  note: Fully open editor core under GPL/AGPL; paid hosted-AI and governance tiers make the overall offering open-core.
+  note: 'Fully open editor core under GPL/Apache; the paid tiers sell Zed-hosted AI and an org admin layer
+    over it. `core-gated: ungated` transcribed 2026-08-11 from a read of the repo and the pricing page,
+    and it does not reproduce the recorded 4/open_core - the ladder computes 5/open_source from it, so the
+    product stays deferred for a human. What the read found: a full untruncated recursive tree of zed-industries/zed@main
+    is 5,130 entries in which every crate carries LICENSE-GPL or LICENSE-APACHE, including crates/collab,
+    the collaboration server - so the server is published too - and there is no enterprise/, ee/, commercial/
+    or proprietary/ path. zed.dev/pricing sells Personal $0 (2,000 accepted edit predictions, unlimited
+    use with your own API keys or external agents), Pro $10 (unlimited edit predictions, Zed-hosted models,
+    $5 of tokens), Business $30/seat (org-wide AI model policies, data governance, RBAC). Zed states of
+    the Business controls that ''Since Zed is open source, these controls govern Zed''s hosted services
+    specifically'', the admin surface lives at dashboard.zed.dev, and the FAQ confirms you can bring your
+    own keys or disable AI entirely. Hosted inference quota and a hosted admin dashboard are the otari shape,
+    not a withheld editor feature. TWO THINGS A HUMAN SHOULD LOOK AT. First, the conflict above. Second,
+    the recorded license string names AGPL-3.0 for the collab server, and the tree read finds no AGPL file
+    at all - crates/collab now carries LICENSE-GPL. That does not move the tier, both being osi, so it is
+    left uncorrected here rather than edited in a sweep, and it is why this axis carries no last_verified.'
   raw: license:GPL-3.0-or-later(editor)+AGPL-3.0(collab-server)+Apache-2.0(GPUI);source:public;commercial:Zed-Pro/Business(hosted
-    AI)
+    AI);core-gated:ungated(the whole editor and the collab server are in the repo under GPL/Apache; Pro
+    and Business sell Zed-hosted model inference and a hosted admin dashboard)
   sources:
   - url: https://github.com/zed-industries/zed
     shows: Rust, ~85k stars, GPL/AGPL/Apache licensing
     accessed: '2026-06-18'
+  - url: https://api.github.com/repos/zed-industries/zed/git/trees/main?recursive=1
+    shows: Full untruncated recursive tree, 5,130 entries. Root LICENSE-GPL and LICENSE-APACHE; every crate
+      under crates/ carries one or the other, including crates/collab/LICENSE-GPL (the collaboration server)
+      and crates/gpui/LICENSE-APACHE. Zero paths containing AGPL. No enterprise/, ee/, commercial/ or proprietary/
+      path.
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: c922b1adbd496d23073226c9d906bce1aeb459d2ee135a02808d03951cfafea5
+    establishes:
+    - source
+    - core-gated
+  - url: https://raw.githubusercontent.com/zed-industries/zed/main/LICENSE-GPL
+    shows: GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007 - the full GPL-3.0 text, 34,357 bytes.
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: 0aa0322ea494da441088e4d9144c6720bf99d9e2e1eefcd29d1f58b19b5c4246
+    establishes:
+    - license
+  - url: https://zed.dev/pricing
+    shows: 'Personal $0 forever: ''2,000 accepted edit predictions'', ''Unlimited use with your API keys
+      or external agents like Claude Agent, Codex CLI''. Pro $10/mo: unlimited edit predictions, $5 of tokens,
+      Zed-hosted models. Business $30/seat: org-wide AI model policies, data governance controls, RBAC.
+      FAQ: ''Since Zed is open source, these controls govern Zed''s hosted services specifically'', admin
+      surface at dashboard.zed.dev, and ''Can I use Zed without the AI features? Yes!'''
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: 796fbd20feb7c00a566b339283d030bd20a732b9ff87cf014388901240808e47
+    establishes:
+    - core-gated
 adoption:
   level: 4
   signal_type: reported_traction

--- a/tests/test_check_parity.py
+++ b/tests/test_check_parity.py
@@ -69,10 +69,16 @@ def test_local_scores_matches_check_rubrics_split():
     the rung that tests the tier, so mapping the license was the only thing left. autogpt
     needed its license recorded by name first - it said `DUAL`, which names no license. That
     rung produces 2/source_available, which is what all five already recorded, so again no
-    score moved."""
+    score moved. Then 410/62 -> 416/56 when the orchestration_agents evidence sweep read the
+    repo and pricing page behind ten deferrals: codex-cli, claude-code, cursor, haystack,
+    langgraph and hexabot gained the `source` or `core-gated` key their deferral was waiting
+    on and every one reproduced its recorded score, so six deferrals came off. The other four
+    - langchain, llama-index, pydantic-ai and zed - recorded their evidence too but compute
+    5/open_source against a recorded 4/open_core, so they stay deferred with the conflict
+    written into the reason instead."""
     computed, deferred = local_scores(None)
-    assert len(deferred) == 62
-    assert len(computed) == 410
+    assert len(deferred) == 56
+    assert len(computed) == 416
     assert not set(computed) & set(deferred)
     # Every one of the 410 reproduces today, so none should abstain.
     assert [key for key, value in computed.items() if value is None] == []

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -745,7 +745,14 @@ def test_real_sources_serialize_without_errors():
         # coming off at 5 rows each, less nothing: syfthub in orchestration_agents,
         # thunderbolt and otari in ui_api. A deferred product publishes no openness evidence
         # at all, so a removed deferral is always the larger of the two effects.
-        "orchestration_agents": 163, "telemetry_observability": 94, "ui_api": 160,
+        #
+        # orchestration_agents 163 -> 187 on the 2026-08-11 evidence sweep, which is both
+        # effects at once. Six deferrals came off - codex-cli, claude-code, cursor, haystack,
+        # langgraph, hexabot - and each newly-computed product starts publishing its rows.
+        # The four that stayed deferred (langchain, llama-index, pydantic-ai, zed) recorded a
+        # `core-gated` key too, but a deferred product publishes nothing, so they contribute
+        # zero rows and the whole rise is the six.
+        "orchestration_agents": 187, "telemetry_observability": 94, "ui_api": 160,
         # training_synthetic_datasets is unchanged at 158 across the ladder widening, which
         # is the check that mattered: benchmark_eval_data's new dimensions and rungs did not
         # disturb the category the ladder was derived from.


### PR DESCRIPTION
## Summary

The first evidence sweep: ten `orchestration_agents` products deferred because the recorded evidence did not answer a question the ladder asks. Each was read at its repo and pricing page, the missing keys recorded with sources, and the ladder left to score.

**Six close. No score moves** — each computes exactly the number already recorded.

| Product | Score | What the read established |
|---|---|---|
| `claude-code` | 1 / closed | no public source; rung 0 fires on `source` alone |
| `cursor` | 1 / closed | same |
| `hexabot` | 2 / source_available | partial source |
| `codex-cli` | 5 / open_source | no gated core |
| `haystack` | 4 / open_core | genuinely gated |
| `langgraph` | 4 / open_core | the Agent Server runtime ships closed under Elastic-2.0 behind `LANGGRAPH_CLOUD_LICENSE_KEY` |

`orchestration_agents` goes from 40/40 reproduced with 11 deferred to **46/46 with 5**. Corpus-wide, deferrals go 62 → 56.

## Four conflicts, left deferred, and they are all one question

`langchain`, `llama-index`, `pydantic-ai` and `zed` each record **4 / open_core** while the ladder now computes **5**. The evidence is consistent across all four:

- every package in the repo is MIT (or GPL/Apache for `zed`), with no enterprise directory
- the paid offering is a **separate product**: LangSmith, LlamaParse credits, Logfire, Zed's hosted AI
- `pydantic.dev/pricing` states "Every feature. Any tier."; Zed's FAQ says the Business terms "govern Zed's hosted services specifically"

All four rest their 4 on a `commercial:` clause — that is, on *the vendor sells something*. That is precisely the reading corrected on `otari` in #201, where a hosted platform running the same open core was ruled ungated.

`langgraph` is the control. It looks identical from outside and is genuinely gated, because the core runtime itself is withheld. That distinction is the one that matters, and the evidence separates them cleanly.

These four are **not** resolved here. One human decision settles all four, and it belongs in its own change.

## Evidence quality

Nine of ten carry a digested, `establishes`-tagged source for every key the recipe reads, with `last_verified: 2026-08-11`. `zed` is the exception and has no date, because the same read found its recorded `AGPL-3.0` collab-server license is now GPL — tier-neutral, so left uncorrected rather than quietly changed.

## Test plan

- Nothing was worked backwards from the recorded score. Where computed and recorded disagreed, the product was left deferred and its reason rewritten with what the read actually found.
- Suite 454 passed. `validate` 0 error(s), `check_recipe` 0 failure(s), `check_rubric` exit 0, `check_components` `[OK]`, plus `check_verification` and `check_capability`.
- Two pinned regression counts re-pinned with reasons (parity 410/62 → 416/56; orchestration evidence rows 163 → 187).
