### PR TITLE
fix(scores): a commercial service beside an open core is not a gated core

### DIFF
--- a/docs/guides/openness-spectrum.md
+++ b/docs/guides/openness-spectrum.md
@@ -244,6 +244,48 @@ it under `self-host` all along. Two of them, `syfthub` and `thunderbolt`, reprod
 recorded 5/open_source exactly. One published score moved: `otari` from 4/open_core to
 5/open_source.
 
+### Selling something is not gating a core
+
+This is the distinction between 4/`open_core` and 5/`open_source`, and it is the one that gets
+scored wrongly most often.
+
+`core_gated` asks whether functionality is withheld **from the published source**. It does not
+ask whether the vendor makes money. A separate hosted product, a managed service, or a different
+SaaS built around an otherwise complete open core does not gate that core, however much it
+costs. A `commercial:` or `service:` clause is therefore not evidence either way, and the ladder
+reads neither key — where that is all a product records, the dimension is unanswered and the
+formula abstains.
+
+What gates a core is a piece of the product *itself* being withheld: a closed package the open
+one depends on, an enterprise or `ee/` directory under a different license, a license key that
+unlocks functionality.
+
+`langgraph` and `langchain` are the pair to hold onto, because from outside they are the same
+picture — one vendor, one paid platform — and they score differently:
+
+| Product | Reading | Why |
+|---|---|---|
+| `langgraph` | `gated`, 4/open_core | The Agent Server ships as a closed Elastic-2.0 `langgraph-api` package that exists in no public repo, and self-hosting it needs `LANGGRAPH_CLOUD_LICENSE_KEY`. |
+| `langchain` | `ungated`, 5/open_source | Every package in the repo is MIT with no enterprise directory; LangSmith is a separate observability and deployment platform sold beside it. |
+
+`llama-index` (LlamaParse), `pydantic-ai` (Logfire), `zed` (Zed-hosted inference) and `otari`
+(the hosted Otari.ai platform) are all the `langchain` shape and all sit at 5. `litellm` is on
+the other side with `langgraph`: its 4 rests on an `enterprise-dir` inside its own repo, not on
+the hosted product beside it.
+
+All five of the ungated cases had recorded 4/open_core on a `commercial:` clause — on the vendor
+selling something at all. `otari` was corrected on 2026-08-11 and the other four followed the
+same day. They were found only because a sweep happened to read `otari`'s record and infer the
+precedent, which is why the rule is now stated here and in `sources/rubrics/software.yaml`
+rather than left to be rediscovered.
+
+One caveat for anyone applying it: not every `core-gated: gated` in the corpus was recorded
+against this test. Twenty-two products reach the gated rung, and a number of them record their
+gate as a managed cloud "on top" of a complete OSI core — the shape this section says is
+*ungated* — with no withheld component named. Those predate the rule and have not been re-read.
+A `gated` value is not evidence that somebody applied this rule; check what the record says is
+actually withheld.
+
 ## How the buckets relate to MOF and OSAID
 
 The Model Openness Framework and the OSI's Open Source AI Definition are both **binary**.

--- a/sources/categories/orchestration_agents.yaml
+++ b/sources/categories/orchestration_agents.yaml
@@ -62,9 +62,9 @@ scoring_recipe:
   extends: software
   derived_from:
     method: shared software ladder, verified against the hand-authored scores
-    scores_reproduced: 46
-    scores_total: 46
-    scores_deferred: 5
+    scores_reproduced: 50
+    scores_total: 50
+    scores_deferred: 1
     verified_on: '2026-08-11'
     checker: build/check_rubric.py
   # Held back rather than scored. The shared ladder has no `otherwise` rule, so
@@ -74,55 +74,30 @@ scoring_recipe:
   #
   # Six of the eleven deferrals here were closed on 2026-08-11 by an evidence sweep that
   # read each repo and pricing page and transcribed `source` and `core-gated` into keys the
-  # ladder reads: codex-cli, claude-code, cursor, haystack, langgraph, hexabot. What the
-  # sweep left is one shape of disagreement, and it is the same shape four times over.
+  # ladder reads: codex-cli, claude-code, cursor, haystack, langgraph, hexabot. Four more
+  # closed the same day on a ruling rather than on new evidence.
   #
-  # langchain, llama-index, pydantic-ai and zed each record 4/open_core on the strength of
+  # langchain, llama-index, pydantic-ai and zed each recorded 4/open_core on the strength of
   # a `commercial:` clause naming a paid product the vendor also sells - LangSmith,
   # LlamaCloud, Logfire, Zed Pro. A read of all four repos found no enterprise directory and
   # no package the published source cannot build, and a read of all four pricing pages found
-  # the paid tier selling a SEPARATE service rather than a withheld feature. That is what
-  # `otari` was corrected for on 2026-08-11: a hosted offering beside an ungated core is not
-  # gating, and LiteLLM's open_core rests on an `enterprise-dir` these four do not have. So
-  # the ladder now computes 5/open_source for each, against a recorded 4.
+  # the paid tier selling a SEPARATE service rather than a withheld feature. The owner ruled
+  # that selling something alongside an ungated core is not gating, following the `otari`
+  # correction, and all four moved to 5/open_source. The rule is now written down in
+  # sources/rubrics/software.yaml under `core_gated` and in docs/guides/openness-spectrum.md,
+  # so the next sweep reads it instead of having to infer it from otari's record - which is
+  # how these four were found, and is not a method that scales to a parallel sweep.
   #
-  # They are held rather than restated because the question is no longer evidential. Either
-  # these four scores were authored on "the vendor sells something" and should follow otari
-  # to 5, or the ladder's `gated` is meant to cover an adjacent commercial product and its
-  # definition needs to say so. One reading settles all four, and it is a call for a human.
-  # langgraph is the useful control: it looks identical from outside and is genuinely gated,
-  # because its Agent Server ships as a closed Elastic-2.0 wheel behind a license key.
+  # langgraph is the control and did not move: it looks identical from outside and is
+  # genuinely gated, because its Agent Server ships as a closed Elastic-2.0 wheel behind a
+  # LANGGRAPH_CLOUD_LICENSE_KEY. LiteLLM is the other side of the same line, its open_core
+  # resting on an `enterprise-dir` these four do not have.
   deferred:
     openhands:
       because: >-
-        ladder computes 5/open_source from the recorded evidence but the score says
-        4/open_core; one of the two is wrong and it needs a human
-    langchain:
-      because: >-
-        ladder computes 5/open_source from the evidence read on 2026-08-11 but the score says
-        4/open_core. The langchain repo is MIT throughout with no enterprise directory and
-        langchain.com/pricing sells only LangSmith, so nothing is withheld from the published
-        source. A human also needs to settle SCOPE: this product's own description reads 'MIT
-        core (langchain-core, langgraph, integrations)', which pulls in langgraph - a separate
-        product on this map, and one that IS gated.
-    pydantic-ai:
-      because: >-
-        ladder computes 5/open_source from the evidence read on 2026-08-11 but the score says
-        4/open_core. pydantic/pydantic-ai is MIT throughout with no enterprise directory, and
-        pydantic.dev/pricing sells Logfire observability under the strapline 'Every feature.
-        Any tier.' Same shape as llama-index, langchain and zed; one reading settles all four.
-    llama-index:
-      because: >-
-        ladder computes 5/open_source from the evidence read on 2026-08-11 but the score says
-        4/open_core. run-llama/llama_index is MIT throughout with no enterprise directory, and
-        llamaindex.ai/pricing sells LlamaParse credits, a separate document-processing service.
-        Same shape as langchain, pydantic-ai and zed; one reading settles all four.
-    zed:
-      because: >-
-        ladder computes 5/open_source from the evidence read on 2026-08-11 but the score says
-        4/open_core. Every crate in zed-industries/zed carries LICENSE-GPL or LICENSE-APACHE,
-        the collab server included, and zed.dev/pricing sells Zed-hosted inference and an admin
-        dashboard which Zed's own FAQ says 'govern Zed's hosted services specifically'. The same
-        read also found the recorded license names AGPL-3.0 for a collab server that now carries
-        GPL; that does not move the tier, but it is why the axis carries no last_verified.
+        The score says 4/open_core and the ladder abstains, because neither `core-gated` nor
+        `self-host` is recorded: the gate is under `enterprise-dir: separate-license`, a key
+        the software ladder does not read. Under the `core_gated` rule a separately licensed
+        enterprise directory IS a gated core, so the 4 looks right and what is missing is the
+        transcription - but that is a repo read, not a restatement, so it stays held.
 comments: ''

--- a/sources/rubrics/software.yaml
+++ b/sources/rubrics/software.yaml
@@ -33,6 +33,28 @@ openness:
       question: Is functionality withheld from the published source for a paid tier?
       values: [gated, ungated]
       reads: [core-gated, self-host]
+      # WHAT COUNTS AS GATING. The question is whether functionality is withheld FROM THE
+      # PUBLISHED SOURCE, not whether the vendor sells anything. A separate hosted product, a
+      # managed service, or a different SaaS built around an otherwise complete open core does
+      # not gate that core, however much it costs. What gates a core is a piece of the product
+      # ITSELF being withheld: a closed package the open one depends on, an enterprise or `ee/`
+      # directory under a different license, a license key that unlocks functionality.
+      #
+      # `langgraph` against `langchain` is the pair worth remembering, because from outside the
+      # two look identical - same vendor, same paid platform. langgraph is `gated`: its Agent
+      # Server ships as a closed Elastic-2.0 `langgraph-api` package that exists in no public
+      # repo and needs LANGGRAPH_CLOUD_LICENSE_KEY to run. langchain is `ungated`: every package
+      # in the repo is MIT and LangSmith is a separate platform sold beside it. `llama-index`
+      # (LlamaParse), `pydantic-ai` (Logfire), `zed` (Zed-hosted inference) and `otari` (the
+      # hosted Otari.ai platform) are all the langchain shape. Each of those five recorded
+      # 4/open_core on a `commercial:` clause - on the vendor selling something at all - and each
+      # was corrected to 5/open_source on 2026-08-11. `litellm` is the other side of the line and
+      # kept its 4, its gate being an `enterprise-dir` in the repo rather than a product beside it.
+      #
+      # So a `commercial:` or `service:` clause is NOT evidence for this dimension, and the
+      # ladder reads neither key. Where that is all a product records, `core-gated` is unanswered
+      # and the formula abstains - the right outcome, because somebody still has to read the repo.
+      #
       # `self-host` is the same question in the vocabulary the corpus actually used.
       # Whether the vendor lets you run the published thing yourself IS whether the core is
       # withheld, and 54 records say so under that name while 164 say it under
@@ -64,11 +86,15 @@ openness:
         enterprise-tier: gated
         none for core AX features: gated
       evidence:
-      - '`gated`: features live behind an enterprise license directory, a Premium tier, or
-        a commercial edition the published source cannot build'
-      - '`ungated`: a managed or hosted offering may exist ALONGSIDE an ungated core; hosting
-        convenience is not gating. `openpcc` is the case - its commercial CONFSEC service
-        is explicitly separate from the Apache-2.0 reference implementation'
+      - '`gated`: part of the product is withheld from the published source - an enterprise
+        license directory (`litellm`, `openhands`), a Premium tier or commercial edition the
+        published source cannot build, or a closed package behind a license key (`langgraph`,
+        whose Agent Server is an Elastic-2.0 wheel needing LANGGRAPH_CLOUD_LICENSE_KEY)'
+      - '`ungated`: a managed or hosted offering may exist ALONGSIDE an ungated core; selling
+        a separate product is not gating. `openpcc` is the case - its commercial CONFSEC
+        service is explicitly separate from the Apache-2.0 reference implementation - as are
+        `langchain` (LangSmith), `llama-index` (LlamaParse), `pydantic-ai` (Logfire), `zed`
+        (Zed-hosted inference) and `otari` (the hosted Otari.ai platform)'
       note: >-
         Values are `gated`/`ungated` rather than yes/no on purpose: YAML 1.1 parses bare
         yes and no as booleans, so a `values: [yes, no]` list becomes [True, False] and

--- a/sources/scores/langchain.yaml
+++ b/sources/scores/langchain.yaml
@@ -1,7 +1,7 @@
 product: langchain
 openness:
-  score: 4
-  class: open_core
+  score: 5
+  class: open_source
   components:
     license:
       value: MIT
@@ -15,21 +15,15 @@ openness:
       detail: every package in langchain-ai/langchain is MIT with no enterprise directory; LangSmith is
         a separately sold observability and deployment platform
   confidence: high
-  note: 'MIT core with LangSmith sold separately. `core-gated: ungated` transcribed 2026-08-11 from a read
-    of the repo and the pricing page, and it does not reproduce the recorded 4/open_core - the ladder computes
-    5/open_source from it, so the product stays deferred for a human. What the read found: a full untruncated
-    recursive tree of langchain-ai/langchain@master is 3,587 entries whose only license files are the root
-    MIT and per-package copies under libs/ (core, langchain, langchain_v1, model-profiles, seventeen partners,
-    standard-tests, text-splitters), with no enterprise/, ee/ or commercial/ path anywhere; and langchain.com/pricing
-    sells LangSmith - observability, evaluation, deployment, sandboxes, gateway - by seat and by metered
-    compute, listing langchain, langgraph and deepagents separately under ''Open Source Frameworks''. A
-    paid platform sold alongside an unwithheld core is what the otari precedent calls ungated. The open
-    question a human should settle is SCOPE, not evidence: this product''s own description reads ''MIT core
-    (langchain-core, langgraph, integrations)'', which pulls langgraph inside langchain even though langgraph
-    is a separate product on this map with its own score - and langgraph IS gated, by the Elastic-2.0 langgraph-api
-    server. On the narrow scope (the langchain repo) this is 5; on the description''s wider scope it inherits
-    langgraph''s 4. Recorded on the narrow scope because that is what the repo evidence supports, and deferred
-    because the wider scope is a curation decision rather than something a page read can answer.'
+  note: 'MIT core with LangSmith sold separately. Moved from 4/open_core to 5/open_source on 2026-08-11:
+    a full untruncated recursive tree of langchain-ai/langchain@master is 3,587 entries whose only license
+    files are the root MIT and per-package copies under libs/, with no enterprise/, ee/ or commercial/ path
+    anywhere, and langchain.com/pricing sells only LangSmith - observability, evaluation, deployment - listing
+    langchain, langgraph and deepagents separately under ''Open Source Frameworks''. The old 4 rested on
+    `commercial:LangSmith-platform/cloud`, that is, on the vendor selling a paid product at all, and a separate
+    paid product beside an unwithheld core is not a gated core. Scored on the langchain repo alone: this
+    product''s description reads ''MIT core (langchain-core, langgraph, integrations)'', but langgraph is
+    a separate product on this map and stays at 4, gated by the Elastic-2.0 langgraph-api server.'
   last_verified: '2026-08-11'
   raw: license:MIT(langchain-core,langgraph,integrations);commercial:LangSmith-platform/cloud;source:public;core-gated:ungated(every
     package in langchain-ai/langchain is MIT with no enterprise directory; LangSmith is a separately sold

--- a/sources/scores/llama-index.yaml
+++ b/sources/scores/llama-index.yaml
@@ -1,7 +1,7 @@
 product: llama-index
 openness:
-  score: 4
-  class: open_core
+  score: 5
+  class: open_source
   components:
     license:
       value: MIT
@@ -15,17 +15,14 @@ openness:
       detail: every package in run-llama/llama_index is MIT with no enterprise directory; LlamaParse/LlamaCloud
         is a separately sold document-processing service
   confidence: high
-  note: 'MIT self-hostable core with a commercial managed cloud. `core-gated: ungated` transcribed 2026-08-11
-    from a read of the repo and the pricing page, and it does not reproduce the recorded 4/open_core - the
-    ladder computes 5/open_source from it, so the product stays deferred for a human. What the read found:
-    a full untruncated recursive tree of run-llama/llama_index@main is 13,820 entries whose license files
-    are the root MIT plus a per-package copy in every llama-index-integrations/* and llama-index-core package,
-    with no enterprise/, ee/, commercial/ or proprietary/ path anywhere; and llamaindex.ai/pricing prices
-    LlamaParse alone, in document-processing credits (Free 10K, Starter $50/40K, Pro $500/400K, Enterprise
-    custom), listing LlamaIndex, Workflows and LiteParse separately under ''Open Source''. Nothing is withheld
-    from the published library - LlamaParse is a different product sold beside it, which is what the otari
-    precedent calls ungated rather than gated. The recorded 4 rests on `commercial:LlamaCloud/LlamaParse`,
-    that is, on the vendor having a paid product at all, and that is the test otari was corrected for using.'
+  note: 'MIT self-hostable core with a commercial managed cloud. Moved from 4/open_core to 5/open_source
+    on 2026-08-11: a full untruncated recursive tree of run-llama/llama_index@main is 13,820 entries whose
+    license files are the root MIT plus a per-package copy in every llama-index-integrations/* and llama-index-core
+    package, with no enterprise/, ee/, commercial/ or proprietary/ path anywhere, and llamaindex.ai/pricing
+    prices LlamaParse alone in document-processing credits, listing LlamaIndex, Workflows and LiteParse separately
+    under ''Open Source''. Nothing is withheld from the published library. The old 4 rested on `commercial:LlamaCloud/LlamaParse`,
+    that is, on the vendor having a paid product at all, and LlamaParse is a different product sold beside
+    the core rather than a piece cut out of it.'
   last_verified: '2026-08-11'
   raw: license:MIT(core);commercial:LlamaCloud/LlamaParse;source:public;core-gated:ungated(every package
     in run-llama/llama_index is MIT with no enterprise directory; LlamaParse/LlamaCloud is a separately

--- a/sources/scores/pydantic-ai.yaml
+++ b/sources/scores/pydantic-ai.yaml
@@ -1,7 +1,7 @@
 product: pydantic-ai
 openness:
-  score: 4
-  class: open_core
+  score: 5
+  class: open_source
   components:
     license:
       value: MIT
@@ -15,17 +15,15 @@ openness:
       detail: every package in pydantic/pydantic-ai is MIT with no enterprise directory; Logfire and the
         AI Gateway are separately sold services
   confidence: high
-  note: 'MIT type-first agent library with a commercial Logfire observability platform. `core-gated: ungated`
-    transcribed 2026-08-11 from a read of the repo and the pricing page, and it does not reproduce the recorded
-    4/open_core - the ladder computes 5/open_source from it, so the product stays deferred for a human.
-    What the read found: a full untruncated recursive tree of pydantic/pydantic-ai@main is 2,664 entries
-    with six LICENSE files, the root MIT and per-package copies for clai, examples, pydantic_ai_slim, pydantic_evals
-    and pydantic_graph, and no enterprise/, ee/, commercial/ or proprietary/ path; and pydantic.dev/pricing
+  note: 'MIT type-first agent library with a commercial Logfire observability platform. Moved from 4/open_core
+    to 5/open_source on 2026-08-11: a full untruncated recursive tree of pydantic/pydantic-ai@main is 2,664
+    entries with six LICENSE files, the root MIT and per-package copies for clai, examples, pydantic_ai_slim,
+    pydantic_evals and pydantic_graph, and no enterprise/, ee/, commercial/ or proprietary/ path, and pydantic.dev/pricing
     is headed ''Pydantic Logfire Pricing'' with the strapline ''10M logs/spans/metrics free. Every feature.
     Any tier.'' - the tiers sell observability seats, retention and gateway markup, not agent-library features.
-    Nothing is withheld from the published library. The recorded 4 rests on `commercial:Pydantic-Logfire`,
-    that is, on the vendor having a paid product at all, which is the test the otari precedent was corrected
-    for using.'
+    Nothing is withheld from the published library. The old 4 rested on `commercial:Pydantic-Logfire`, that
+    is, on the vendor having a paid product at all, and Logfire is a separate service sold beside the core
+    rather than a piece cut out of it.'
   last_verified: '2026-08-11'
   raw: license:MIT(library);commercial:Pydantic-Logfire;source:public;core-gated:ungated(every package in
     pydantic/pydantic-ai is MIT with no enterprise directory; Logfire and the AI Gateway are separately

--- a/sources/scores/zed.yaml
+++ b/sources/scores/zed.yaml
@@ -1,7 +1,7 @@
 product: zed
 openness:
-  score: 4
-  class: open_core
+  score: 5
+  class: open_source
   components:
     license:
       value: GPL-3.0-or-later
@@ -17,21 +17,18 @@ openness:
         sell Zed-hosted model inference and a hosted admin dashboard
   confidence: high
   note: 'Fully open editor core under GPL/Apache; the paid tiers sell Zed-hosted AI and an org admin layer
-    over it. `core-gated: ungated` transcribed 2026-08-11 from a read of the repo and the pricing page,
-    and it does not reproduce the recorded 4/open_core - the ladder computes 5/open_source from it, so the
-    product stays deferred for a human. What the read found: a full untruncated recursive tree of zed-industries/zed@main
-    is 5,130 entries in which every crate carries LICENSE-GPL or LICENSE-APACHE, including crates/collab,
-    the collaboration server - so the server is published too - and there is no enterprise/, ee/, commercial/
-    or proprietary/ path. zed.dev/pricing sells Personal $0 (2,000 accepted edit predictions, unlimited
-    use with your own API keys or external agents), Pro $10 (unlimited edit predictions, Zed-hosted models,
-    $5 of tokens), Business $30/seat (org-wide AI model policies, data governance, RBAC). Zed states of
-    the Business controls that ''Since Zed is open source, these controls govern Zed''s hosted services
-    specifically'', the admin surface lives at dashboard.zed.dev, and the FAQ confirms you can bring your
-    own keys or disable AI entirely. Hosted inference quota and a hosted admin dashboard are the otari shape,
-    not a withheld editor feature. TWO THINGS A HUMAN SHOULD LOOK AT. First, the conflict above. Second,
-    the recorded license string names AGPL-3.0 for the collab server, and the tree read finds no AGPL file
-    at all - crates/collab now carries LICENSE-GPL. That does not move the tier, both being osi, so it is
-    left uncorrected here rather than edited in a sweep, and it is why this axis carries no last_verified.'
+    over it. Moved from 4/open_core to 5/open_source on 2026-08-11: a full untruncated recursive tree of
+    zed-industries/zed@main is 5,130 entries in which every crate carries LICENSE-GPL or LICENSE-APACHE,
+    including crates/collab, the collaboration server - so the server is published too - and there is no
+    enterprise/, ee/, commercial/ or proprietary/ path. Pro and Business sell Zed-hosted model inference
+    and a hosted admin dashboard at dashboard.zed.dev; Zed states of the Business controls that ''Since
+    Zed is open source, these controls govern Zed''s hosted services specifically'', and the FAQ confirms
+    you can bring your own keys or disable AI entirely. The old 4 rested on `commercial:Zed-Pro/Business`,
+    and a hosted inference quota is not an editor feature withheld from the published source. STILL OPEN
+    FOR A HUMAN: the recorded license string names AGPL-3.0 for the collab server, and the tree read finds
+    no AGPL file at all - crates/collab now carries LICENSE-GPL. That does not move the tier, both being
+    osi, so it is left uncorrected here rather than edited in a sweep, and it is why this axis carries no
+    last_verified.'
   raw: license:GPL-3.0-or-later(editor)+AGPL-3.0(collab-server)+Apache-2.0(GPUI);source:public;commercial:Zed-Pro/Business(hosted
     AI);core-gated:ungated(the whole editor and the collab server are in the repo under GPL/Apache; Pro
     and Business sell Zed-hosted model inference and a hosted admin dashboard)

--- a/tests/test_check_parity.py
+++ b/tests/test_check_parity.py
@@ -72,13 +72,16 @@ def test_local_scores_matches_check_rubrics_split():
     score moved. Then 410/62 -> 416/56 when the orchestration_agents evidence sweep read the
     repo and pricing page behind ten deferrals: codex-cli, claude-code, cursor, haystack,
     langgraph and hexabot gained the `source` or `core-gated` key their deferral was waiting
-    on and every one reproduced its recorded score, so six deferrals came off. The other four
-    - langchain, llama-index, pydantic-ai and zed - recorded their evidence too but compute
-    5/open_source against a recorded 4/open_core, so they stay deferred with the conflict
-    written into the reason instead."""
+    on and every one reproduced its recorded score, so six deferrals came off. Then 416/56 ->
+    420/52 when the other four of those ten were ruled on rather than re-read: langchain,
+    llama-index, pydantic-ai and zed each rested a 4/open_core on a `commercial:` clause naming
+    a paid product sold beside an unwithheld core, which `core_gated` does not ask about, and
+    all four moved to the 5/open_source the ladder computes. This is the one recent step where
+    published scores MOVED rather than deferrals merely coming off. langgraph did not move: its
+    gate is a closed Elastic-2.0 package behind a license key, not a product beside the core."""
     computed, deferred = local_scores(None)
-    assert len(deferred) == 56
-    assert len(computed) == 416
+    assert len(deferred) == 52
+    assert len(computed) == 420
     assert not set(computed) & set(deferred)
     # Every one of the 410 reproduces today, so none should abstain.
     assert [key for key, value in computed.items() if value is None] == []

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -752,7 +752,13 @@ def test_real_sources_serialize_without_errors():
         # The four that stayed deferred (langchain, llama-index, pydantic-ai, zed) recorded a
         # `core-gated` key too, but a deferred product publishes nothing, so they contribute
         # zero rows and the whole rise is the six.
-        "orchestration_agents": 187, "telemetry_observability": 94, "ui_api": 160,
+        #
+        # 187 -> 207 later the same day, when those same four were ruled ungated and moved to
+        # 5/open_source. This rise is purely deferrals coming off: all four already recorded
+        # their evidence, they were simply publishing none of it. Five rows each, four
+        # products, +20 exactly - and the count is the check that no FIFTH product moved with
+        # them, langgraph included.
+        "orchestration_agents": 207, "telemetry_observability": 94, "ui_api": 160,
         # training_synthetic_datasets is unchanged at 158 across the ladder widening, which
         # is the check that mattered: benchmark_eval_data's new dimensions and rungs did not
         # disturb the category the ladder was derived from.


### PR DESCRIPTION
## Summary

Four products recorded 4 / open_core while the ladder computed 5. The evidence sweep in #205 read each repo and pricing page and established that every package is MIT — GPL and Apache for `zed` — with no enterprise directory, and that the paid offering is a **separate product**.

Their 4 rested on a `commercial:` clause: the vendor sells something. That is the reading corrected on `otari` in #201.

| Product | Before | After | The commercial offering the 4 rested on |
|---|---|---|---|
| `langchain` | 4 / open_core | **5 / open_source** | LangSmith platform |
| `llama-index` | 4 / open_core | **5 / open_source** | LlamaCloud / LlamaParse |
| `pydantic-ai` | 4 / open_core | **5 / open_source** | Logfire — "Every feature. Any tier." |
| `zed` | 4 / open_core | **5 / open_source** | Zed Pro hosted AI; Business terms govern hosted services |

`langgraph` stays at 4 and is byte-identical in a before/after payload build. It looks identical from outside and is genuinely gated: the Agent Server runtime ships as a closed Elastic-2.0 package behind `LANGGRAPH_CLOUD_LICENSE_KEY`. `litellm`, `otari` and `openhands` are also byte-identical.

## The rule is now written down

This is the more important half. #205 found these four conflicts only because the agent read `otari`'s record and inferred the precedent — and its own assessment was that an agent skipping that step would have marked all four `gated` and reported a clean pass.

An unwritten rule that has to be rediscovered from a prior example is the actual defect. So it now lives in two places:

- `sources/rubrics/software.yaml`, at the head of the `core_gated` comment block, with both `evidence:` bullets rewritten
- `docs/guides/openness-spectrum.md`, as a normative section

> `core_gated` asks whether functionality is withheld from the published source, not whether the vendor sells anything. A separate hosted product beside a complete open core does not gate it; a closed package, an `ee/` directory, or a license key does.

## What this surfaced, and deliberately did not change

Of the 22 products where the gated rung decides the score, **20 record a bare `gated` with no evidence at all** — only `haystack` and `langgraph` say why, and those are the two that survive scrutiny. Reading their notes, around 13 describe a managed cloud sold on top of a complete OSI core, which is the shape this rule now calls ungated. `browser-use` and `openpipe` state in their own notes that nothing is withheld, and record `gated` anyway.

**None of them is changed here.** They have not had the repo-and-pricing read the four got, and re-scoring on a one-line summary is the same mistake in the opposite direction. A caveat in the guide says so, so the rule is not read down on first contact. They want their own sweep.

## Test plan

- Each of the four verified by replaying the ladder before editing; each already carried `core-gated: ungated` with evidence recorded by #205.
- Exactly 4 score and 4 class lines change across all of `sources/`. Only `score`, `class` and `note` touched — no `components`.
- Suite 454 passed. `validate` 0 error(s), `check_recipe` 0 failure(s), `check_rubric` exit 0, `check_components` `[OK]`, plus `check_verification` and `check_capability`.
- Two count fixtures updated for the same reason #205 updated them (parity 416/56 → 420/52; evidence rows 187 → 207, which is 4 products × 5 rows).
