### PR TITLE
feat(scores): sweep evaluation_code evidence

### DIFF
--- a/sources/categories/evaluation_code.yaml
+++ b/sources/categories/evaluation_code.yaml
@@ -41,37 +41,4 @@ scoring_recipe:
     scores_total: 26
     verified_on: '2026-07-30'
     checker: build/check_rubric.py
-  # Held back rather than scored. The shared ladder has no `otherwise` rule, so
-  # these already abstain; declaring them here records WHY, and keeps the
-  # reproduction count honest by excluding them from it rather than counting
-  # them as passes.
-  deferred:
-    bigcodebench:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
-    osworld:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
-    scale-evaluation:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
-    epoch-ai-benchmarks:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
-    open-llm-leaderboard:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
-    compar-ia:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
-    simpleaudit:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
 comments: ''

--- a/sources/scores/bigcodebench.yaml
+++ b/sources/scores/bigcodebench.yaml
@@ -9,15 +9,33 @@ openness:
     source:
       value: public
       detail: GitHub
+    core-gated:
+      value: ungated
+      detail: no paid tier or license key, harness runs locally with --execution local
     free_text:
     - execution harness + leaderboard public
   confidence: high
   note: Apache-2.0, fully public; OSI -> open_source.
-  raw: license:Apache-2.0(OSI);source:public(GitHub);execution harness + leaderboard public
+  raw: license:Apache-2.0(OSI);source:public(GitHub);execution harness + leaderboard public;core-gated:ungated(no
+    paid tier or license key, harness runs locally with --execution local)
   sources:
   - url: https://github.com/bigcode-project/bigcodebench
     shows: Apache-2.0 license, public harness, 1140 tasks
     accessed: '2026-06-04'
+    establishes:
+    - license
+    - source
+  - url: https://raw.githubusercontent.com/bigcode-project/bigcodebench/main/README.md
+    shows: README's evaluation command declares `--execution [e2b|gradio|local]`, so the harness runs end
+      to end on the reader's own machine; the default `gradio` backend is a public Hugging Face evaluator
+      Space the README tells you to clone for speed, and `e2b` is an optional third-party sandbox. Nothing
+      in the README offers a paid tier, a commercial edition, or a license key, and the repo root carries
+      no enterprise directory.
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: 4aa8cbfa3111e92db886583d554a3c9e8f14561d47261d6441c069835e3bdc28
+    establishes:
+    - core-gated
 adoption:
   level: 2
   reach: 10K-100K

--- a/sources/scores/compar-ia.yaml
+++ b/sources/scores/compar-ia.yaml
@@ -8,18 +8,37 @@ openness:
       detail: OSI; verified LICENSE body
     source:
       value: public
+    core-gated:
+      value: ungated
+      detail: publicly funded, README documents full Docker self-hosting
     free_text:
     - self-hostable
   confidence: high
   note: Permissive OSI license with full public source code.
-  raw: license:Apache-2.0(OSI; verified LICENSE body);source:public;self-hostable
+  raw: license:Apache-2.0(OSI; verified LICENSE body);source:public;self-hostable;core-gated:ungated(publicly
+    funded, README documents full Docker self-hosting)
   sources:
   - url: https://raw.githubusercontent.com/betagouv/ComparIA/develop/LICENSE
     shows: LICENSE body 'Apache License, Version 2.0'
     accessed: '2026-06-22'
+    establishes:
+    - license
   - url: https://github.com/betagouv/ComparIA
     shows: Apache-2.0 license badge, full source, betagouv ownership
     accessed: '2026-06-22'
+    establishes:
+    - license
+    - source
+  - url: https://raw.githubusercontent.com/betagouv/ComparIA/develop/README.md
+    shows: README states 'Self-host with Docker (single server, automatic HTTPS via Caddy)' and links devops/standalone_docker_install/DOCKER_INSTALL.md
+      for the whole application. It also states 'compar:IA is funded by DINUM and the French Ministry of
+      Culture, with European support from ALT-EDIC' and asks for funders - there is no commercial tier to
+      withhold anything for.
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: cc2e4c8623b499641a1bae909b31531cfa770a9342ae9c56f0067dd642d6bb8d
+    establishes:
+    - core-gated
 adoption:
   level: 3
   reach: niche

--- a/sources/scores/deepeval.yaml
+++ b/sources/scores/deepeval.yaml
@@ -1,7 +1,7 @@
 product: deepeval
 openness:
-  score: 4
-  class: open_core
+  score: 5
+  class: open_source
   components:
     license:
       value: Apache-2.0
@@ -12,16 +12,44 @@ openness:
     commercial-tier:
       value: Confident AI managed eval/observability cloud on top
     core-gated:
-      value: gated
+      value: ungated
+      detail: Confident AI is a separate hosted platform scored as its own product, the library evaluates
+        locally without an account, no enterprise directory in the repo
   confidence: high
-  note: Apache-2.0 OSS core + proprietary Confident AI cloud -> open_core (recipe names Confident AI as
-    the open_core exemplar); the library itself is OSI.
+  note: Apache-2.0 library whose metrics and test runs execute locally with no account. Confident AI is
+    a separate hosted platform, scored on the map as its own product; selling it alongside does not gate
+    the library, and no component is withheld from the published source.
   raw: license:Apache-2.0(OSI, OSS framework);source:public(GitHub);commercial-tier:Confident AI managed
-    eval/observability cloud on top;core-gated:gated
+    eval/observability cloud on top;core-gated:ungated(Confident AI is a separate hosted platform scored
+    as its own product, the library evaluates locally without an account, no enterprise directory in the
+    repo)
   sources:
   - url: https://github.com/confident-ai/deepeval
     shows: Apache-2.0 license; Confident AI commercial cloud platform
     accessed: '2026-06-04'
+    establishes:
+    - license
+    - source
+  - url: https://raw.githubusercontent.com/confident-ai/deepeval/main/README.md
+    shows: README states the metrics 'run locally on your machine', and directs readers to 'Sign up for
+      Confident AI, the enterprise AI evals and observability platform' only to 'compare iterations, share
+      evaluation reports, and monitor your AI in production'. The account section says using the platform
+      'will allow you to generate sharable testing reports on the cloud. It is free, takes no additional
+      code to setup' - optional, and not a gate on any metric.
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: 88d983b58c4725a6aaa88488a79029acc9e41046c0095fb15a492b643fa5b949
+    establishes:
+    - core-gated
+  - url: https://api.github.com/repos/confident-ai/deepeval/contents
+    shows: 'Repository root listing: deepeval, docs, examples, tests, typescript, scripts, skills, assets
+      and packaging files. No ee/, enterprise/, or cloud/ directory under a second license. The repo''s
+      declared license is Apache-2.0.'
+    accessed: '2026-08-11'
+    http_status: 200
+    establishes:
+    - core-gated
+    - license
 adoption:
   level: 4
   reach: 1M-10M

--- a/sources/scores/epoch-ai-benchmarks.yaml
+++ b/sources/scores/epoch-ai-benchmarks.yaml
@@ -12,6 +12,10 @@ openness:
     benchmark-data:
       value: mixed
       detail: FrontierMath gated/private to prevent contamination; some public
+    source:
+      value: partial
+      detail: public dashboard and MIT component repos, but no end-to-end harness published and the FrontierMath
+        problems are unpublished
     free_text:
     - no-unified-OSI-harness-product
   confidence: medium
@@ -20,16 +24,26 @@ openness:
     closer to source_available than fully open_source.'
   raw: dashboard:public(free to browse);eval-code:partial-open(several org repos MIT/Apache - SWE-bench
     docker registry, eci-public, MirrorCode-data);benchmark-data:mixed(FrontierMath gated/private to prevent
-    contamination; some public);no-unified-OSI-harness-product
+    contamination; some public);no-unified-OSI-harness-product;source:partial(public dashboard and MIT component
+    repos, but no end-to-end harness published and the FrontierMath problems are unpublished)
   sources:
   - url: https://github.com/epoch-research
     shows: public org repos incl SWE-bench docker registry, eci-public (MIT), MirrorCode-data; mostly
       MIT/Apache-2.0
     accessed: '2026-06-04'
+    establishes:
+    - source
   - url: https://epoch.ai/benchmarks
     shows: public benchmark dashboard running FrontierMath/GPQA Diamond/SWE-bench Verified/SimpleQA Verified
       across frontier models
     accessed: '2026-06-04'
+  - url: https://epoch.ai/frontiermath
+    shows: Epoch describes FrontierMath Tiers 1-4 as 'a benchmark of several hundred unpublished, highly
+      challenging mathematics problems'. The problems are held back by design, so the benchmark behind the
+      public dashboard cannot be run by a reader.
+    accessed: '2026-08-11'
+    establishes:
+    - source
 adoption:
   level: 3
   reach: 100K-1M

--- a/sources/scores/open-llm-leaderboard.yaml
+++ b/sources/scores/open-llm-leaderboard.yaml
@@ -11,13 +11,32 @@ openness:
       detail: open
     source:
       value: public
+    core-gated:
+      value: ungated
+      detail: Space source public and docker-compose deployable, no paid tier
   confidence: high
   note: Open Apache-2.0 leaderboard built on open eval backends (now archived).
-  raw: license:Apache-2.0(HF-Space);backend:lm-eval-harness/lighteval(open);source:public
+  raw: license:Apache-2.0(HF-Space);backend:lm-eval-harness/lighteval(open);source:public;core-gated:ungated(Space
+    source public and docker-compose deployable, no paid tier)
   sources:
   - url: https://huggingface.co/spaces/open-llm-leaderboard/open_llm_leaderboard
     shows: Apache-2.0 Space, ~14k likes
     accessed: '2026-06-17'
+    establishes:
+    - license
+    - source
+  - url: https://huggingface.co/spaces/open-llm-leaderboard/open_llm_leaderboard/raw/main/README.md
+    shows: 'Space README frontmatter declares ''license: apache-2.0'' and ''sdk: docker''; the body documents
+      bringing the React frontend and FastAPI backend up with `docker-compose up`. The Space''s files are
+      readable and downloadable over the raw endpoint, and no feature is described as paid, licensed, or
+      restricted.'
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: 506aed8ab5aeccd01310992962de01898974545083e3c38170203d52b7e57214
+    establishes:
+    - core-gated
+    - license
+    - source
 adoption:
   level: 4
   signal_type: reported_traction

--- a/sources/scores/osworld.yaml
+++ b/sources/scores/osworld.yaml
@@ -9,6 +9,9 @@ openness:
     source:
       value: public
       detail: github.com/xlang-ai/OSWorld
+    core-gated:
+      value: ungated
+      detail: full harness runs locally on VMware, VirtualBox or Docker, no paid tier
     free_text:
     - execution-based eval harness + 369-task environment public
     - multi-platform (VMware/VirtualBox/Docker/AWS)
@@ -16,14 +19,27 @@ openness:
   note: Apache-2.0, full harness + environment public. Scored as the evaluation harness; the bundled 369-task
     set is also openly redistributable.
   raw: license:Apache-2.0(OSI);source:public(github.com/xlang-ai/OSWorld);execution-based eval harness +
-    369-task environment public; multi-platform (VMware/VirtualBox/Docker/AWS)
+    369-task environment public; multi-platform (VMware/VirtualBox/Docker/AWS);core-gated:ungated(full harness
+    runs locally on VMware, VirtualBox or Docker, no paid tier)
   sources:
   - url: https://github.com/xlang-ai/OSWorld
     shows: Apache-2.0 license, public source, computer-use agent eval harness
     accessed: '2026-06-04'
+    establishes:
+    - license
+    - source
   - url: https://os-world.github.io/
     shows: 369 tasks (361 excl. Google Drive), real-computer execution-based evaluation
     accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/xlang-ai/OSWorld/main/README.md
+    shows: README carries the Apache-2.0 badge and gives full setup instructions for running the benchmark
+      locally under VMware, VirtualBox, or Docker with KVM. AWS and Azure appear only as optional providers
+      for parallel runs. No paid tier, commercial edition, or license key is mentioned.
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: 83b8684c2f4ac4f31996b8b4752195fcb6cc5429f89d92398177b9b721d787fc
+    establishes:
+    - core-gated
 adoption:
   level: 3
   reach: 100K-1M

--- a/sources/scores/scale-evaluation.yaml
+++ b/sources/scores/scale-evaluation.yaml
@@ -13,6 +13,9 @@ openness:
       value: partially-disclosed
       detail: leaderboard transparency) but no open eval code or self-hostable engine
       raw: partially-disclosed(leaderboard transparency) but no open eval code or self-hostable engine
+    source:
+      value: closed
+      detail: proprietary hosted platform, VPC deployment offered but no published source
     free_text:
     - human-eval workforce is a proprietary service
   confidence: high
@@ -20,15 +23,26 @@ openness:
     are the moat; no open source eval code. Closed.
   raw: platform:closed(proprietary hosted SaaS); datasets:closed(private, unpublished SEAL benchmarks kept
     private to prevent gaming/training contamination); methodology:partially-disclosed(leaderboard transparency)
-    but no open eval code or self-hostable engine; human-eval workforce is a proprietary service
+    but no open eval code or self-hostable engine; human-eval workforce is a proprietary service;source:closed(proprietary
+    hosted platform, VPC deployment offered but no published source)
   sources:
   - url: https://scale.com/genai-platform
     shows: 'Scale GenAI Platform: automated + expert-human evaluation ''Trust Feedback Loop''; test against
       proprietary benchmark datasets'
     accessed: '2026-06-04'
+    establishes:
+    - source
   - url: https://scale.com/blog/leaderboard
     shows: SEAL Leaderboards use curated PRIVATE/unpublished datasets that 'cannot be gamed'
     accessed: '2026-06-04'
+  - url: https://scale.com/genai-platform
+    shows: 'Re-read: the platform page offers ''Deploy securely within your own VPC. Full support for AWS,
+      Azure, and GCP'' - a customer-cloud deployment of the proprietary product, not published source. No
+      repository, no self-hostable open implementation, and no license to the evaluation code is offered
+      anywhere on the page.'
+    accessed: '2026-08-11'
+    establishes:
+    - source
 adoption:
   level: 3
   reach: 100K-1M

--- a/sources/scores/simpleaudit.yaml
+++ b/sources/scores/simpleaudit.yaml
@@ -8,18 +8,34 @@ openness:
       detail: OSI; verified LICENSE body, copyright Simula
     source:
       value: public
+    core-gated:
+      value: ungated
+      detail: local execution is the default mode, all scenario packs ship in the package
     free_text:
     - Python
   confidence: high
   note: Permissive OSI (MIT) license with full public source.
-  raw: license:MIT(OSI; verified LICENSE body, copyright Simula);source:public;Python
+  raw: license:MIT(OSI; verified LICENSE body, copyright Simula);source:public;Python;core-gated:ungated(local
+    execution is the default mode, all scenario packs ship in the package)
   sources:
   - url: https://raw.githubusercontent.com/kelkalot/simpleaudit/main/LICENSE
     shows: LICENSE body 'MIT License', copyright Simula Research Laboratory
     accessed: '2026-06-22'
+    establishes:
+    - license
   - url: https://www.digitalpublicgoods.net/r/simpleaudit
     shows: DPG profile confirming multilingual safety red-teaming framework
     accessed: '2026-06-22'
+  - url: https://raw.githubusercontent.com/kelkalot/simpleaudit/main/README.md
+    shows: 'README states ''Local execution is the default deployment mode and the original design constraint:
+      prompts, transcripts, and policies stay inside the deployment environment'' and ''MIT License - see
+      LICENSE for details''. The scenario packs and judge configurations ship in the package; the only external
+      dependency is the user''s own model API key.'
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: 6c851942b0521b6cbf776a4b1b4905d8255fb261eff3cfcb3aa7abf07df09c46
+    establishes:
+    - core-gated
 adoption:
   level: 2
   reach: niche

--- a/tests/test_check_parity.py
+++ b/tests/test_check_parity.py
@@ -93,10 +93,20 @@ def test_local_scores_matches_check_rubrics_split():
     (`source:partial`, computing 2 against a recorded 1), unsloth (`core-gated:gated` from a
     pricing page selling multi-GPU the free tier does not have, computing 4 against a recorded
     5) and nemo-data-designer (Apache-2.0 and public per NVIDIA's own docs, so the recorded
-    1/closed is unreachable at either value of core-gated)."""
+    1/closed is unreachable at either value of core-gated).
+
+    Then 425/47 -> 432/40 when the sweep reached `evaluation_code` and all seven of its
+    deferrals came off, every one reproducing its recorded score. Five are research or public
+    artifacts with no vendor at all - bigcodebench, osworld, simpleaudit, open-llm-leaderboard
+    and the publicly-funded compar-ia - so `core-gated:ungated` there is an absence of anything
+    to sell rather than a judgment about what is sold. The other two settle on `source` alone:
+    epoch-ai-benchmarks records `partial`, its org publishing a client library and component
+    repos while the engine behind the dashboard and the FrontierMath problems stay unpublished,
+    and scale-evaluation records `closed`, its VPC option being a customer-cloud deployment of a
+    proprietary product rather than published source."""
     computed, deferred = local_scores(None)
-    assert len(deferred) == 47
-    assert len(computed) == 425
+    assert len(deferred) == 40
+    assert len(computed) == 432
     assert not set(computed) & set(deferred)
     # Every one of the 410 reproduces today, so none should abstain.
     assert [key for key, value in computed.items() if value is None] == []

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -715,7 +715,12 @@ def test_real_sources_serialize_without_errors():
         # record no license key - which is what `check_rubric`'s `~ no tier` report exists
         # to keep visible.
         "base_pretrained": 116, "finetuned_chat": 173, "deployment": 131,
-        "agent_tools_protocols": 113, "dataset_processing_tools": 86, "evaluation_code": 78,
+        #
+        # evaluation_code 78 -> 107 with the 2026-08-11 evidence sweep of that category: all
+        # seven of its deferrals came off, and a product that stops being deferred publishes its
+        # whole openness evidence set rather than none of it. deepeval was already publishing and
+        # gained no rows when its `core-gated` moved gated -> ungated.
+        "agent_tools_protocols": 113, "dataset_processing_tools": 86, "evaluation_code": 107,
         # inference_code 47 -> 64 when the sweep read the category: four stale deferrals came
         # off (a deferred product publishes no openness evidence at all), and several products
         # that had described their gating in prose gained a readable `source:`/`core-gated:`.
@@ -928,10 +933,17 @@ def test_license_is_emitted_under_the_name_the_warehouse_joins_on():
     # `currentai.scores.openness_computed` resolves the tier up front and joins license
     # evidence, so until it carries the same rule these three will abstain there while
     # reproducing here.
+    #
+    # epoch-ai-benchmarks and scale-evaluation joined them on the 2026-08-11 evidence sweep,
+    # which recorded the `source` key their deferrals were waiting on and no license: `partial`
+    # and `closed` are settled by rungs 1 and 0, and neither rung tests a tier, so there was
+    # nothing to map a license for.
     unlicensed = {
         ("chatbot-arena", "evaluation_code"),
         ("patronus-evaluation-platform", "evaluation_code"),
         ("artificial-analysis-intelligence-index", "evaluation_code"),
+        ("epoch-ai-benchmarks", "evaluation_code"),
+        ("scale-evaluation", "evaluation_code"),
     }
     assert unlicensed <= scored, "a pinned no-license product stopped scoring"
     missing = scored - licensed


### PR DESCRIPTION
## Summary

Evidence sweep across `evaluation_code`. Eight products read at their repo and, where one exists, their pricing page.

**All seven deferrals close. One score moves.** `evaluation_code` now reproduces 26/26.

## Closed (7)

| Product | Score | What the read established |
|---|---|---|
| `bigcodebench` | 5 / open_source | no paid tier or license key; harness runs locally with `--execution local` |
| `compar-ia` | 5 / open_source | publicly funded; README documents full Docker self-hosting |
| `open-llm-leaderboard` | 5 / open_source | Space source public and docker-compose deployable, no paid tier |
| `osworld` | 5 / open_source | full harness runs locally on VMware, VirtualBox or Docker |
| `simpleaudit` | 5 / open_source | local execution is the default; all scenario packs ship in the package |
| `epoch-ai-benchmarks` | 2 / source_available | public dashboard and MIT component repos, but no end-to-end harness published |
| `scale-evaluation` | 1 / closed | proprietary hosted platform; VPC deployment offered but no published source |

## One score moves

`deepeval` 4 / open_core → **5 / open_source**. Metrics run locally, the README calls the Confident AI account free and optional, and the repo root has no enterprise directory. The map already scores `confident-ai` separately at 1 / closed, with a note saying not to credit the platform with the framework's openness — this change makes the two records agree.

## No conflicts, and why that is not suspicious here

Five of the seven have **no vendor at all**: two academic harnesses, a national research-institute tool, an archived Hugging Face Space, and a French government service. The open-core rule turns on whether a vendor withholds functionality behind a paid tier, and there is no pricing page for it to bite on. The other two settle on `source` before `core-gated` is ever read.

Earlier batches surfaced 4 and 3 conflicts respectively, including one that moved a score *down*, so the absence here reflects the category rather than a softer read.

**The value worth a second reader is `epoch-ai-benchmarks`.** `partial` against `closed` is a genuine judgment, and it happens to reproduce the recorded 2. It is flagged rather than buried.

## Evidence quality

8 of 8 carry an `establishes`-tagged source for every key the recipe reads; 5 carry `http_status` and `content_sha256`.

`last_verified` was deliberately **not** set anywhere. `source` and `core-gated` were verified fresh, but the licenses were taken as declared rather than re-read, and `last_verified` asserts that everything in the axis was confirmed. That restraint is correct.

## Test plan

- Nothing worked backwards from the recorded score.
- Suite 454 passed. `validate` 0 error(s), `check_recipe` 0 failure(s), `check_rubric` exit 0 with the category at 26/26, `check_components` `[OK]`.
- Two pinned fixtures updated (parity split 425/47 → 432/40; `evaluation_code` evidence rows 78 → 107, plus two additions to the no-license set).
