### PR TITLE
feat(scores): sweep ui_api evidence

### DIFF
--- a/sources/categories/ui_api.yaml
+++ b/sources/categories/ui_api.yaml
@@ -64,14 +64,6 @@ scoring_recipe:
   # reproduction count honest by excluding them from it rather than counting
   # them as passes.
   deferred:
-    nextchat:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
-    continue:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
     maple-ai:
       because: >-
         ladder computes 4/open_core from the recorded evidence but the score says
@@ -80,16 +72,4 @@ scoring_recipe:
       because: >-
         ladder computes 1/closed from the recorded evidence but the score says
         2/source_available; one of the two is wrong and it needs a human
-    deepseek-chat:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
-    meta-ai:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
-    doubao:
-      because: >-
-        source or core-gated is not recorded in a form the ladder can read; needs a read of
-        the repo and pricing page
 comments: ''

--- a/sources/scores/continue.yaml
+++ b/sources/scores/continue.yaml
@@ -15,17 +15,58 @@ openness:
     hub:
       value: continue.dev
       detail: hosted config/model hub adjacent, core OSS
+    core-gated:
+      value: ungated
+      detail: Apache-2.0 across the whole monorepo, no ee/ or enterprise directory; the enterprise license
+        key is itself published Apache-2.0 code carrying only customerId/expiresAt/apiUrl and unlocks no
+        client feature
   note: Apache-2.0, full source public for the IDE extensions and CLI; no feature-gated core in the editor
     itself (a hosted Hub exists alongside but the assistant is OSS).
   raw: license:Apache-2.0(OSI);source:public(github.com/continuedev/continue);clients:VSCode+JetBrains+CLI;hub:continue.dev(hosted
-    config/model hub adjacent, core OSS)
+    config/model hub adjacent, core OSS);core-gated:ungated(Apache-2.0 across the whole monorepo, no ee/
+    or enterprise directory; the enterprise license key is itself published Apache-2.0 code carrying only
+    customerId/expiresAt/apiUrl and unlocks no client feature)
   sources:
   - url: https://github.com/continuedev/continue
     shows: Apache-2.0; public source; AI code assistant (chat/edit/autocomplete + agent)
     accessed: '2026-06-04'
+    establishes:
+    - license
+    - source
   - url: https://marketplace.visualstudio.com/items?itemName=Continue.continue
     shows: open source AI code agent extension listing
     accessed: '2026-06-04'
+  - url: https://api.github.com/repos/continuedev/continue/contents/
+    shows: Repository root listing read for this dimension. The tree is actions, binary, core, docs,
+      eval, extensions, gui, manual-testing-sandbox, media, packages, scripts, skills, sync - there is
+      no `ee/`, no `enterprise/`, and no second license. `extensions/` holds cli, intellij and vscode;
+      `packages/` holds config-types, config-yaml, continue-sdk, fetch, llm-info, openai-adapters and
+      terminal-security. The repo license endpoint returns Apache-2.0.
+    accessed: '2026-08-11'
+    establishes:
+    - core-gated
+  - url: https://github.com/continuedev/continue/blob/main/core/control-plane/mdm/mdm.ts
+    shows: The one thing in this repo that looks like a gate, read directly rather than assumed. Continue
+      does ship an "Enterprise License Key" - `continue.enterEnterpriseLicenseKey` in
+      extensions/vscode/src/commands.ts and an AddLicenseKey action in the IntelliJ extension. But the
+      whole validator is published Apache-2.0 code in this file, and the signed payload it verifies
+      carries only `customerId`, `createdAt`, `expiresAt` and an `apiUrl`. The key is read from
+      MDM-managed OS configuration (a macOS plist, a Windows registry path, a Linux json file), and its
+      effect is to point the client at an enterprise control-plane URL. No client feature is switched on
+      by it - nothing in the extension is compiled out, withheld, or refused without one. That is the
+      langchain shape, a paid platform beside a complete open core, not the langgraph shape of a closed
+      package behind a key.
+    accessed: '2026-08-11'
+    establishes:
+    - core-gated
+  - url: https://www.continue.dev/
+    shows: The vendor's own site now leads with Continue having been acquired by Cursor and states "our
+      open-source codebase remains freely available as a foundation for others". No pricing page is
+      linked from it any more, and https://www.continue.dev/pricing returns HTTP 404 - so there is no
+      live paid tier left to withhold anything for.
+    accessed: '2026-08-11'
+    establishes:
+    - core-gated
 adoption:
   level: 4
   reach: 1M-10M

--- a/sources/scores/deepseek-chat.yaml
+++ b/sources/scores/deepseek-chat.yaml
@@ -13,15 +13,30 @@ openness:
       value: underlying models open
       detail: MIT) but the chat application/service is closed
       raw: underlying models open(MIT) but the chat application/service is closed
+    source:
+      value: closed
+      detail: hosted chat service at chat.deepseek.com; DeepSeek's public repos are model and inference
+        releases, not the chat application
   note: The DeepSeek chat surface is a proprietary hosted service; openness of the V3/V4 weights it serves
     is a separate (model-layer) score. Scored as closed counterpart per ui_api recipe.
   raw: client:proprietary(no public source for chat.deepseek.com app);backend:hosted-SaaS;note:underlying
-    models open(MIT) but the chat application/service is closed
+    models open(MIT) but the chat application/service is closed;source:closed(hosted chat service at chat.deepseek.com;
+    DeepSeek's public repos are model and inference releases, not the chat application)
   sources:
   - url: https://www.deepseek.com/en/
     shows: Free hosted chat at chat.deepseek.com serving DeepSeek-V4 Preview; no source release for the
       chat app itself
     accessed: '2026-06-04'
+  - url: https://www.deepseek.com/en
+    shows: Re-read for this dimension. The site offers exactly two ways to use DeepSeek - 'Free access
+      to DeepSeek' pointing at chat.deepseek.com, and 'Build with the latest DeepSeek models' pointing
+      at the hosted API platform with its own pricing. The Research section links GitHub repositories
+      (DeepSeek R1, V3, Coder V2 and others), and every one of them is a model-weights or research/inference
+      release; none is the chat application. So there is no self-hostable implementation of the chat
+      surface being scored here, which is what the ladder calls a closed source.
+    accessed: '2026-08-11'
+    establishes:
+    - source
 adoption:
   level: 5
   reach: '>10M'

--- a/sources/scores/doubao.yaml
+++ b/sources/scores/doubao.yaml
@@ -14,14 +14,28 @@ openness:
       detail: closed
     license:
       value: Proprietary
+    source:
+      value: closed
+      detail: hosted consumer service plus a compiled client download; no published source for the assistant
   note: Doubao is a closed proprietary consumer assistant; no public source for the app and the Doubao
     models are not open-weight. Closed counterpart per ui_api recipe.
   raw: client:proprietary(closed consumer app);backend:hosted-SaaS on Volcano Engine;models:proprietary
-    Doubao(closed);license:Proprietary
+    Doubao(closed);license:Proprietary;source:closed(hosted consumer service plus a compiled client download;
+    no published source for the assistant)
   sources:
   - url: https://en.wikipedia.org/wiki/Doubao
     shows: Doubao is a proprietary ByteDance AI chatbot app (iOS/Android/web) on Volcano Engine
     accessed: '2026-06-04'
+  - url: https://www.doubao.com/download/desktop
+    shows: ByteDance's own distribution page for Doubao. What it offers is a compiled client - '下载豆包客户端',
+      download the Doubao client - for desktop and mobile. Nothing on the page offers source, a repository,
+      or a self-hosted deployment. WEAK EVIDENCE, and deliberately marked so - doubao.com is rendered
+      entirely client-side, so a fetch returns the page header and little else, and this reads as an
+      absence of any source offer rather than a statement that none exists. It corroborates the closed
+      reading; it does not on its own prove it.
+    accessed: '2026-08-11'
+    establishes:
+    - source
 adoption:
   level: 5
   reach: '>10M'

--- a/sources/scores/litellm.yaml
+++ b/sources/scores/litellm.yaml
@@ -12,18 +12,88 @@ openness:
       value: public
     core-gated:
       value: gated
+      detail: the enterprise/ directory ships under the proprietary BerriAI Enterprise License requiring
+        a paid subscription for production use, and the proxy gates premium features on a LITELLM_LICENSE
+        key verified against license.litellm.ai
   confidence: high
-  note: license:MIT(core);enterprise-dir:LiteLLM-Commercial-License;source:public
-  raw: license:MIT(core);enterprise-dir:LiteLLM-Commercial-License;source:public;core-gated:gated
+  note: 'MIT core with a proprietary enterprise directory in the same repository. `core-gated: gated` verified
+    2026-08-11 by a direct read, and it does NOT rest on BerriAI selling a hosted gateway. The root LICENSE
+    is explicitly split - "All content that resides under the ''enterprise/'' directory of this repository,
+    if that directory exists, is licensed under the license defined in ''enterprise/LICENSE''" - and everything
+    outside it is MIT. That enterprise license says the software "may only be used in production, if you
+    (and any entity that you represent) have agreed to, and are in compliance with, the BerriAI Subscription
+    Terms of Service ... and otherwise have a valid BerriAI Enterprise license for the correct number of
+    user seats", with copying, distribution and sale forbidden. The directory is not a stub: it ships litellm_enterprise,
+    enterprise_hooks, enterprise_ui and a cloudformation_stack. The proxy then enforces it in code - litellm/proxy/auth/litellm_license.py
+    reads a LITELLM_LICENSE environment variable and verifies it against license.litellm.ai to set premium_user.
+    A license key you must hold for the paid features to run is the dimension''s question answered directly,
+    so the 4 holds. This is the other side of the line from langchain, llama-index, pydantic-ai, zed and
+    otari, which sell a platform beside a complete open core and moved to 5.'
+  raw: license:MIT(core);enterprise-dir:LiteLLM-Commercial-License;source:public;core-gated:gated(the enterprise/
+    directory ships under the proprietary BerriAI Enterprise License requiring a paid subscription for production
+    use, and the proxy gates premium features on a LITELLM_LICENSE key verified against license.litellm.ai)
+  last_verified: '2026-08-11'
   sources:
-  - url: https://github.com/BerriAI/litellm/blob/main/LICENSE
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
-  - url: https://github.com/BerriAI/litellm
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/BerriAI/litellm/main/LICENSE
+    shows: 'Root LICENSE body, read rather than assumed. It opens "Portions of this software are licensed
+      as follows:" and then splits the repository in two - "All content that resides under the ''enterprise/''
+      directory of this repository, if that directory exists, is licensed under the license defined in
+      ''enterprise/LICENSE''" and "Content outside of the above mentioned directories or restrictions above
+      is available under the MIT license as defined below", followed by the full MIT text. So the tier-setting
+      license is MIT and the gate is a carve-out named in the license itself.'
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: b170d6bf8e8835dd357e011681db028f4d51e2fb0ea892058f56e01fb39b8273
+    establishes:
+    - license
+    - core-gated
+  - url: https://api.github.com/repos/BerriAI/litellm/contents/enterprise
+    shows: The carved-out directory exists and is not a stub. It contains LICENSE.md, README.md, __init__.py,
+      cloudformation_stack, dist, enterprise_hooks, enterprise_ui, litellm_enterprise and its own pyproject.toml
+      - hooks, a UI and a deployment stack, i.e. shipped functionality. The repository license endpoint
+      returns NOASSERTION rather than MIT, which is GitHub declining to classify the split root LICENSE.
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: 37244ca54271ed92f2f615aca46af53c0f9e8094d1619d1838c3741e07599d48
+    establishes:
+    - core-gated
+  - url: https://raw.githubusercontent.com/BerriAI/litellm/main/enterprise/LICENSE.md
+    shows: The enterprise license body. It states the software "may only be used in production, if you (and
+      any entity that you represent) have agreed to, and are in compliance with, the BerriAI Subscription
+      Terms of Service ... or other agreement governing the use of the Software, as agreed by you and BerriAI,
+      and otherwise have a valid BerriAI Enterprise license for the correct number of user seats". Copying
+      for development and testing is allowed; "it is forbidden to copy, merge, publish, distribute, sublicense,
+      and/or sell the Software". Production use behind a seat-counted paid license is functionality withheld
+      from the MIT source.
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: a3160d1176cb556447255ca8652855486d681f8025550291828796a439e1b2f9
+    establishes:
+    - core-gated
+  - url: https://raw.githubusercontent.com/BerriAI/litellm/main/litellm/proxy/auth/litellm_license.py
+    shows: The enforcement, in code. The module's own header comment is "If litellm license in env, checks
+      if it's valid". LicenseCheck reads a LITELLM_LICENSE environment variable, carries a bundled public_key.pem
+      for air-gapped verification, and otherwise checks the key against base_url https://license.litellm.ai,
+      setting the premium_user flag the proxy tests before serving paid features. A key you must hold for
+      functionality to run, which is the rubric's own wording for a gate.
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: 5e23bc01f166b884f01a4c891be8b0e0e9cf7348684963b77c0c1ebe322cdcda
+    establishes:
+    - core-gated
+  - url: https://api.github.com/repos/BerriAI/litellm
+    shows: Repository root. The published tree is the whole gateway and proxy - litellm, gateway, ui, backend,
+      helm, terraform, docker, migrations, tests - and self-hosting it needs nothing that is not in the repo,
+      so the source dimension is public. Retained from the phase-C pass with a real reading in place of the
+      placeholder.
+    accessed: '2026-08-11'
+    http_status: 200
+    content_sha256: 2caffe731172f8176152bf5f7e71585d13729d88d69799e7602a0c61db793071
+    establishes:
+    - source
   - url: https://www.litellm.ai/
-    shows: flagship phase-C verification source
+    shows: Vendor site, kept for context only. It establishes that BerriAI sells a hosted product, which
+      under the settled rule is NOT evidence for or against core-gated and is not what the 4 rests on.
     accessed: '2026-06-04'
 adoption:
   level: 3

--- a/sources/scores/meta-ai.yaml
+++ b/sources/scores/meta-ai.yaml
@@ -15,14 +15,29 @@ openness:
       raw: underlying Llama weights are restricted (non-OSI) and model-layer scored elsewhere
     free_text:
     - the assistant product is closed
+    source:
+      value: closed
+      detail: assistant Meta hosts and operates; the Meta AI Terms grant rights of access and use only
   note: Meta AI the assistant/UI is a closed proprietary consumer product; scored as closed counterpart.
     (Llama-the-model openness is a separate restricted-class score.)
   raw: client:proprietary(closed consumer app/embedded surface);backend:hosted-SaaS;note:underlying Llama
-    weights are restricted (non-OSI) and model-layer scored elsewhere; the assistant product is closed
+    weights are restricted (non-OSI) and model-layer scored elsewhere;the assistant product is closed;source:closed(assistant
+    Meta hosts and operates; the Meta AI Terms grant rights of access and use only)
   sources:
   - url: https://www.demandsage.com/meta-ai-users/
     shows: Meta AI described as proprietary consumer assistant embedded across Meta apps + meta.ai
     accessed: '2026-06-04'
+  - url: https://www.facebook.com/legal/ai-terms
+    shows: Meta's own AI Terms of Service, replacing the third-party summary above for this dimension.
+      They describe Meta AI as a service Meta provides - 'AIs and Outputs are provided on an ''as is''
+      and ''as available'' basis' - and reserve the software itself, 'We retain all our respective rights,
+      title, and interest, including intellectual property rights, in and to AIs.' The grant to the user
+      is access only, 'Other than the rights of access and use expressly granted in these Terms, these
+      Terms do not grant you any right, title, or interest in or to the AIs.' A right of access to a
+      service Meta runs, with no published implementation, is the ladder's closed rung.
+    accessed: '2026-08-11'
+    establishes:
+    - source
 adoption:
   level: 5
   reach: '>10M'

--- a/sources/scores/nextchat.yaml
+++ b/sources/scores/nextchat.yaml
@@ -10,16 +10,52 @@ openness:
       value: NextChat Enterprise
       detail: permission controls, team resource mgmt, internal knowledge base/RAG
       raw: NextChat Enterprise (permission controls, team resource mgmt, internal knowledge base/RAG)
+    source:
+      value: public
+      detail: the app IS the repo; README ships one-click Vercel/Zeabur/Gitpod deploy, a Dockerfile and
+        docker-compose, and desktop builds via src-tauri
+    core-gated:
+      value: gated
+      detail: Enterprise Edition withholds the admin panel, member/resource/knowledge-base permission control,
+        internal knowledge-base integration and security auditing from the MIT repo
   confidence: high
   note: OSI MIT core with a separate proprietary Enterprise Edition for multi-user permissions and internal-KB
     RAG -> open_core (calibrated to the LiteLLM open_core anchor).
   raw: license:MIT(core, public source);enterprise-tier:NextChat Enterprise (permission controls, team resource
-    mgmt, internal knowledge base/RAG)
+    mgmt, internal knowledge base/RAG);source:public(the app IS the repo; README ships one-click Vercel/Zeabur/Gitpod
+    deploy, a Dockerfile and docker-compose, and desktop builds via src-tauri);core-gated:gated(Enterprise
+    Edition withholds the admin panel, member/resource/knowledge-base permission control, internal knowledge-base
+    integration and security auditing from the MIT repo)
   sources:
   - url: https://github.com/ChatGPTNextWeb/NextChat
     shows: MIT license; cross-platform chat client; Enterprise Edition (permissions, team mgmt, internal
       knowledge base)
     accessed: '2026-06-04'
+    establishes:
+    - license
+  - url: https://api.github.com/repos/ChatGPTNextWeb/NextChat/contents/
+    shows: Repository root read for the source dimension. The repo license endpoint returns MIT, and the
+      tree is the whole application - app, src-tauri, public, docs, plus Dockerfile, docker-compose.yml,
+      vercel.json and .env.template. There is no `ee/` or `enterprise/` directory, so the Enterprise
+      Edition is not in this repository at all. The README's deploy buttons for Vercel, Zeabur and Gitpod
+      run this source, which is what the ladder means by a public source.
+    accessed: '2026-08-11'
+    establishes:
+    - source
+  - url: https://github.com/ChatGPTNextWeb/NextChat/blob/main/README.md
+    shows: 'The README''s own Enterprise Edition section, quoted rather than paraphrased, lists what the
+      paid edition adds - Brand Customization, Resource Integration described as "unified configuration
+      and management of dozens of AI resources by company administrators", Permission Control described
+      as "clearly defined member permissions, resource permissions, and knowledge base permissions, all
+      controlled via a corporate-grade Admin Panel", Knowledge Integration "combining your internal
+      knowledge base with AI capabilities", Security Auditing, Private Deployment, and Continuous
+      Updates. Contact is business@nextchat.club. None of that admin panel, permission model or
+      knowledge base exists in the MIT repository, whose own Features list describes the opposite design:
+      "Privacy first, all data is stored locally in the browser". So this is functionality withheld from
+      the published source rather than a hosted service beside it, which is the gated reading.'
+    accessed: '2026-08-11'
+    establishes:
+    - core-gated
 adoption:
   level: 3
   reach: 100K-1M

--- a/tests/test_check_parity.py
+++ b/tests/test_check_parity.py
@@ -103,10 +103,21 @@ def test_local_scores_matches_check_rubrics_split():
     epoch-ai-benchmarks records `partial`, its org publishing a client library and component
     repos while the engine behind the dashboard and the FrontierMath problems stay unpublished,
     and scale-evaluation records `closed`, its VPC option being a customer-cloud deployment of a
-    proprietary product rather than published source."""
+    proprietary product rather than published source.
+
+    Then 432/40 -> 437/35 when the sweep reached `ui_api` and all five of its deferrals came
+    off, every one reproducing its recorded score. deepseek-chat, doubao and meta-ai record
+    `source:closed` and settle on rung 0 alone - Meta's own AI Terms grant "rights of access
+    and use" to a service Meta runs and nothing more. nextchat records `source:public` and
+    `core-gated:gated`: its Enterprise Edition sells a private deployment with an admin panel,
+    permission control and an internal knowledge base, none of which is in the MIT repo, whose
+    own features list says all data stays local in the browser. continue records
+    `core-gated:ungated` - the whole monorepo is Apache-2.0 with no ee/ directory, and its
+    "Enterprise License Key" turns out to be published Apache-2.0 code carrying only a
+    customerId, an expiry and a control-plane apiUrl, unlocking no client feature."""
     computed, deferred = local_scores(None)
-    assert len(deferred) == 40
-    assert len(computed) == 432
+    assert len(deferred) == 35
+    assert len(computed) == 437
     assert not set(computed) & set(deferred)
     # Every one of the 410 reproduces today, so none should abstain.
     assert [key for key, value in computed.items() if value is None] == []

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -768,7 +768,13 @@ def test_real_sources_serialize_without_errors():
         # their evidence, they were simply publishing none of it. Five rows each, four
         # products, +20 exactly - and the count is the check that no FIFTH product moved with
         # them, langgraph included.
-        "orchestration_agents": 207, "telemetry_observability": 94, "ui_api": 160,
+        #
+        # ui_api 160 -> 184 on the 2026-08-11 evidence sweep of that category. All five of its
+        # deferrals came off and a newly-computed product publishes its whole openness evidence
+        # set rather than none of it: continue and nextchat contribute five rows each, doubao
+        # five, and deepseek-chat and meta-ai four apiece, those two recording no license.
+        # litellm was already computed and gained nothing when its bare `gated` was evidenced.
+        "orchestration_agents": 207, "telemetry_observability": 94, "ui_api": 184,
         # training_synthetic_datasets is unchanged at 158 across the ladder widening, which
         # is the check that mattered: benchmark_eval_data's new dimensions and rungs did not
         # disturb the category the ladder was derived from.
@@ -944,6 +950,11 @@ def test_license_is_emitted_under_the_name_the_warehouse_joins_on():
         ("artificial-analysis-intelligence-index", "evaluation_code"),
         ("epoch-ai-benchmarks", "evaluation_code"),
         ("scale-evaluation", "evaluation_code"),
+        # deepseek-chat and meta-ai joined on the ui_api sweep for the same reason: both are
+        # hosted assistants recording `source: closed`, decided by rung 0, which tests no tier.
+        # doubao is not here because it happens to record `license: Proprietary` as well.
+        ("deepseek-chat", "ui_api"),
+        ("meta-ai", "ui_api"),
     }
     assert unlicensed <= scored, "a pinned no-license product stopped scoring"
     missing = scored - licensed


### PR DESCRIPTION
## Summary

Evidence sweep across `ui_api`. Six products read at their repo, license and pricing page.

**All five deferrals close. No score moves** — every one computes exactly what was recorded. `ui_api` goes from 39/39 reproduced with 7 deferred to **41/41 with 2**.

## Closed (5)

| Product | Score | What the read established |
|---|---|---|
| `deepseek-chat` | 1 / closed | hosted chat service; the public repos are model and inference releases, not this product |
| `doubao` | 1 / closed | hosted service, no published source |
| `meta-ai` | 1 / closed | same |
| `nextchat` | 4 / open_core | Enterprise Edition withholds the admin panel and member, resource and knowledge-base permission controls |
| `continue` | 5 / open_source | Apache-2.0 across the monorepo, no `ee/` or enterprise directory |

The three closed products needed no pricing-page read — rung 0 decides on `source` alone.

## `litellm` stays at 4, and this is the useful result

`litellm` was checked during #206 and confirmed byte-identical, which meant its recorded `gated` survived that pass **without ever being examined**. It has now been examined, and the gate is real:

- the root LICENSE carves out `enterprise/` under the proprietary BerriAI Enterprise License, requiring "a valid BerriAI Enterprise license for the correct number of user seats" for production use
- that directory ships `enterprise_hooks`, `enterprise_ui` and `cloudformation_stack`
- `litellm/proxy/auth/litellm_license.py` verifies `LITELLM_LICENSE` against `license.litellm.ai` to set `premium_user`

Functionality is withheld from the published source. It stays 4 / open_core.

Its `note` was a verbatim copy of its own components string, and four `shows` fields were placeholders; both are replaced with what the sources actually say.

## One judgment worth a second reader

`continue` ships a feature literally named **"Enterprise License Key"** — the rubric's own phrase for a gate. But the payload carries only `customerId`, `expiresAt` and `apiUrl`, and unlocks no client feature. It was read as the `langchain` shape: a key that identifies a customer rather than withholding functionality.

Stopping at the file name would have produced a spurious 5-vs-4 conflict. **If the map decides that any enterprise key gates a core, `continue` goes to 4 and the rubric wording needs tightening.** Flagged rather than buried.

## A second instance of vocabulary drift

`nextchat` records `enterprise-tier`, which is a declared `core_gated` *value* alias but **not a key** in `reads: [core-gated, self-host]`. So it was silently dropped before the formula ran — the same shape as `anyscale-fine-tuning`'s `source: not-public` in #207. Two batches, two instances: a value can be legal and still be invisible because it sits under an unread key.

## Evidence quality

6 of 6 carry an `establishes`-tagged source for every key the recipe reads; 5 of 6 are independently re-derivable. `doubao` is the exception and says so in its own record — `doubao.com` renders entirely client-side and no fetch returned usable text.

## Test plan

- Nothing worked backwards from the recorded score.
- Suite 454 passed. `validate` 0 error(s), `check_recipe` 0 failure(s), `check_rubric` exit 0, `check_components` `[OK]`.
- Two pinned fixtures updated (parity 432/40 → 437/35; `ui_api` evidence rows 160 → 184).
