### PR TITLE
fix(scores): drop four safeguards guardrail models to 3/open_weights

### DIFF
--- a/sources/categories/safeguards.yaml
+++ b/sources/categories/safeguards.yaml
@@ -16,10 +16,10 @@ scoring_recipe:
   derived_from:
     method: per-type extends over the shared ladders; evidence transcribed into the keys the
       ladders read, then verified
-    scores_reproduced: 21
+    scores_reproduced: 25
     scores_total: 26
-    scores_deferred: 5
-    verified_on: '2026-08-01'
+    scores_deferred: 1
+    verified_on: '2026-08-12'
     checker: build/check_rubric.py
   note: >-
     Was 0/26. Sixteen products were not disagreeing with the ladders at all - they recorded the
@@ -35,33 +35,18 @@ scoring_recipe:
     bounded commercial licence at 2, and the scale sets that tier to 3. Four hand-authored
     scores already agreeing with the scale was part of the evidence for it.
 
-    Five remain. Four are scored 4 where the recorded evidence supports 3 - three of them the
-    same `data:not-released` case, so one reading settles all three. One needs a decision about
-    which artifact a bundled product is scored on.
+    Four more were scored 4 where the evidence supported 3, and all four dropped to 3.
+    `qwen3guard`, `granite-guardian` and `gpt-oss-safeguard` were the same `data:not-released`
+    case, and the ruling was that the rung is right as written - Apache-2.0 weights with no
+    released training recipe is a 3, which is how every comparable model here is scored.
+    `wildguard` had a different cause and was settled by reading the project rather than by
+    judgment. Its `data:open` is correct, the WildGuardMix corpus really is public, but the
+    `allenai/wildguard` repo ships an inference package with no trainer and the card sends
+    readers to the paper appendix for training details, so `code` is `partial` and the 4-rung
+    still fails. Open data on its own does not carry the rung.
+
+    One remains. It needs a decision about which artifact a bundled product is scored on.
   deferred:
-    qwen3guard:
-      because: >-
-        Recorded 4/open_weights; the ladders compute 3/open_weights. Apache-2.0, so the license
-        is not the constraint: model.yaml's 4-rung needs BOTH post-training data and the
-        fine-tuning pipeline released, and this records `data:not-released` with no `code` at
-        all. Either the 4 is crediting a recipe the product's own record says is not published,
-        or the 4-rung is the wrong test for a guardrail model. Same shape as `granite-guardian`
-        and `gpt-oss-safeguard`; one reading should settle all three.
-    granite-guardian:
-      because: >-
-        Recorded 4/open_weights; the ladders compute 3/open_weights. As `qwen3guard`: an
-        OSI license, `data:not-released`, no `code` recorded, and the 4-rung needs both.
-    gpt-oss-safeguard:
-      because: >-
-        Recorded 4/open_weights; the ladders compute 3/open_weights. As `qwen3guard`: an
-        OSI license, `data:not-released`, no `code` recorded, and the 4-rung needs both.
-    wildguard:
-      because: >-
-        Recorded 4/open_weights; the ladders compute 3/open_weights. Different cause from the
-        three above: `data:open` is genuinely correct, since the WildGuardMix corpus is public,
-        but `code` was never recorded and the 4-rung needs both. This is the one of the four
-        that a repo read could settle rather than a judgment call - if the fine-tuning pipeline
-        is published, recording it makes the 4 reproduce.
     llamafirewall:
       because: >-
         Recorded 5/open_source; the ladders abstain, because neither `source` nor `license` is

--- a/sources/scores/gpt-oss-safeguard.yaml
+++ b/sources/scores/gpt-oss-safeguard.yaml
@@ -1,6 +1,6 @@
 product: gpt-oss-safeguard
 openness:
-  score: 4
+  score: 3
   class: open_weights
   components:
     weights:
@@ -12,8 +12,10 @@ openness:
       value: Apache-2.0
       detail: OSI
   confidence: medium
-  note: Open weights under Apache-2.0 (OSI), training data not released, so open_weights (4) rather than
-    open_source. Notable as a policy-conditioned safety reasoning model rather than a fixed classifier.
+  note: Open weights under Apache-2.0 (OSI) with no released training data and no published fine-tuning
+    pipeline. The 4-rung requires both, so this scores 3, the same rung as every other model that ships
+    permissive weights without a recipe. Notable as a policy-conditioned safety reasoning model rather
+    than a fixed classifier, but that shapes capability, not openness.
   raw: weights:open(gpt-oss-safeguard-20b/120b on HF);data:not-released;license:Apache-2.0(OSI)
   sources:
   - url: https://huggingface.co/openai/gpt-oss-safeguard-20b

--- a/sources/scores/granite-guardian.yaml
+++ b/sources/scores/granite-guardian.yaml
@@ -1,6 +1,6 @@
 product: granite-guardian
 openness:
-  score: 4
+  score: 3
   class: open_weights
   components:
     weights:
@@ -12,8 +12,10 @@ openness:
       value: Apache-2.0
       detail: OSI
   confidence: medium
-  note: Open weights under Apache-2.0 (permissive, OSI), but the training data is not released, so it
-    stops short of the open_source (5) tier; a strong open_weights release at 4.
+  note: Open weights under Apache-2.0 (permissive, OSI), but neither the post-training data nor the fine-tuning
+    pipeline is released. The 4-rung requires both, so this scores 3, the rung every comparable Apache-2.0
+    guardrail model sits on. A strong open-weights release even so, and the license is not what holds
+    it back.
   raw: weights:open(granite-guardian-3.2-5b on HF);data:not-released;license:Apache-2.0(OSI)
   sources:
   - url: https://huggingface.co/ibm-granite/granite-guardian-3.2-5b

--- a/sources/scores/qwen3guard.yaml
+++ b/sources/scores/qwen3guard.yaml
@@ -1,6 +1,6 @@
 product: qwen3guard
 openness:
-  score: 4
+  score: 3
   class: open_weights
   components:
     weights:
@@ -12,8 +12,10 @@ openness:
       value: Apache-2.0
       detail: OSI
   confidence: medium
-  note: Open weights under Apache-2.0 (OSI); training data not released, so open_weights (4) rather than
-    open_source. Unusually broad multilingual coverage (119 languages) plus a streaming variant.
+  note: Open weights under Apache-2.0 (OSI). Scored 3 because the 4-rung requires both the post-training
+    data and the fine-tuning pipeline to be released, and neither is. The card records the training data
+    as not released and publishes no recipe. Apache-2.0 weights over a closed recipe scores 3 everywhere
+    else on the map. Unusually broad multilingual coverage (119 languages) plus a streaming variant.
   raw: weights:open(Qwen3Guard 0.6B/4B/8B on HF);data:not-released;license:Apache-2.0(OSI)
   sources:
   - url: https://huggingface.co/Qwen/Qwen3Guard-Gen-8B

--- a/sources/scores/wildguard.yaml
+++ b/sources/scores/wildguard.yaml
@@ -1,6 +1,6 @@
 product: wildguard
 openness:
-  score: 4
+  score: 3
   class: open_weights
   components:
     weights:
@@ -9,21 +9,49 @@ openness:
     data:
       value: open
       detail: WildGuardMix corpus public
+    code:
+      value: partial
+      detail: inference/serving package only; no training pipeline
     base:
       value: Mistral-7B
     license:
       value: Apache-2.0
       detail: OSI
   confidence: medium
-  note: Open weights under Apache-2.0 with the WildGuardMix training corpus published; from Ai2, which
-    sits at the open end of the spectrum. Scored open_weights (4); a strong open release, just short of
-    the full open_source pipeline tier.
-  raw: weights:open(allenai/wildguard on HF);data:open(WildGuardMix corpus public);base:Mistral-7B;license:Apache-2.0(OSI)
+  note: Open weights under Apache-2.0 with the WildGuardMix training corpus published, which is more than
+    most guardrail models release. The fine-tuning pipeline is not published, though. The allenai/wildguard
+    repo ships an inference package only (nine files, no trainer or training config), the companion Safety-Eval
+    repo is an evaluation suite, and the model card refers readers to the paper appendix for training
+    details rather than to code. The 4-rung requires released data and released code, so this scores 3.
+    Recorded 4 until the components were completed; open data alone does not lift the rung.
+  raw: weights:open(allenai/wildguard on HF);data:open(WildGuardMix corpus public);code:partial(inference/serving
+    package only; no training pipeline);base:Mistral-7B;license:Apache-2.0(OSI)
   sources:
   - url: https://huggingface.co/allenai/wildguard
     shows: Apache-2.0; 7B Mistral fine-tune; prompt/response/refusal detection; open WildGuardMix corpus;
       ~265K downloads/month
     accessed: '2026-06-29'
+  - url: https://api.github.com/repos/allenai/wildguard/contents
+    shows: Root listing of the project's own repo, which is the whole of what it ships as code. Nine entries
+      (.gitignore, LICENSE.md, README.md, docs, examples, pyproject.toml, requirements.txt, tests, wildguard).
+      No training directory, no trainer entrypoint, no SFT or DPO config. The `wildguard` package is the
+      classifier wrapper and `examples/wildguard_filter` is a serving demo, so the published code is inference
+      and serving only.
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: c4fb6dc1020ec916c47d6d6a90161fa20226b7bac3f147f26da9521c542a26e6
+    establishes:
+    - code
+  - url: https://github.com/allenai/wildguard/blob/main/README.md
+    shows: The project's own README installs with `pip install wildguard` and documents `load_wildguard()`
+      plus `classify()`. Its only outbound links are the paper, the WildGuardMix dataset, the model, and
+      the Safety-Eval companion repo, which it describes as holding "the details of evaluations run in
+      the WildGuard paper". No training pipeline is offered or linked.
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: e9b46a0e3e74792e8cebe692f444607e21767d1888a2ade3785d3657fd33c699
+    establishes:
+    - code
 adoption:
   level: 4
   reach: 100K-1M

--- a/tests/test_check_parity.py
+++ b/tests/test_check_parity.py
@@ -140,10 +140,22 @@ def test_local_scores_matches_check_rubrics_split():
     on cloud storage the user already owns. model-context-protocol stayed, and its reason was
     rewritten: source and core-gated are now recorded, but its LICENSE splits three ways and
     the CC-BY-4.0 documentation branch maps to no tier, so the ladder abstains on the license
-    rather than on the missing keys the old reason blamed."""
+    rather than on the missing keys the old reason blamed.
+
+    Then 442/30 -> 446/26 when the four guardrail-model deferrals in `safeguards` came off.
+    All four were recorded 4/open_weights against a ladder computing 3, and all four dropped
+    to 3 rather than the ladder bending. qwen3guard, granite-guardian and gpt-oss-safeguard
+    were one case argued once - Apache-2.0 weights, `data:not-released`, no recipe published -
+    and the 4-rung needs the post-training data AND the fine-tuning pipeline, so the recorded
+    4 was crediting a recipe the products' own cards say does not exist. wildguard looked
+    different and was settled by reading the project rather than by judgment: its `data:open`
+    is real, the WildGuardMix corpus is public, but `allenai/wildguard` ships nine files with
+    no trainer and no training config, its companion Safety-Eval repo is an evaluation suite,
+    and the card sends readers to the paper appendix for training details. That is
+    `code:partial`, the 4-rung still fails, and open data on its own does not carry it."""
     computed, deferred = local_scores(None)
-    assert len(deferred) == 30
-    assert len(computed) == 442
+    assert len(deferred) == 26
+    assert len(computed) == 446
     assert not set(computed) & set(deferred)
     # Every one of the 410 reproduces today, so none should abstain.
     assert [key for key, value in computed.items() if value is None] == []

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -810,7 +810,12 @@ def test_real_sources_serialize_without_errors():
         # safeguards 90 -> 103 and training_synthetic_datasets 158 -> 164: the universal
         # license scale retired five deferrals, and a deferred product publishes no
         # openness evidence at all.
-        "safeguards": 103,
+        # safeguards 103 -> 117 when the four guardrail-model deferrals came off. Each of
+        # qwen3guard, granite-guardian, gpt-oss-safeguard and wildguard dropped from a
+        # recorded 4 to the 3 the ladder computes, and a product that no longer defers
+        # publishes its component keys. wildguard carries four of the fourteen rows because
+        # the read that settled it added `code:partial` to the three keys it already had.
+        "safeguards": 117,
         # 17 scored hardware products across the five recorded dimensions, less the keys
         # individual products do not record. No license row among them, by design -
         # `edge_hardware` is the only category whose ladder declares no `license_tier`.


### PR DESCRIPTION
## Summary

Four guardrail models recorded 4 / open_weights while the ladder computed 3. `model.yaml`'s 4-rung requires **both** the post-training data and the fine-tuning pipeline:

```
rule 5: {data: open, code: open} -> 4 / open_weights
```

All four drop to **3 / open_weights**. The rung is deliberate and consistent with how every other model on the map is scored: an OSI license over weights with no released training recipe is a 3.

| Product | Before | After | Why |
|---|---|---|---|
| `qwen3guard` | 4 | **3** | Apache-2.0, `data: not-released`, no pipeline recorded |
| `granite-guardian` | 4 | **3** | same |
| `gpt-oss-safeguard` | 4 | **3** | same |
| `wildguard` | 4 | **3** | `data: open` is correct — WildGuardMix is public — but no pipeline exists |

## `wildguard` was read rather than assumed

It was held back from the ruling because its cause is genuinely different: its corpus **is** public, so the missing piece was only `code`, which might have been a recording gap.

It is not. `allenai/wildguard` is nine root entries across 19 paths with no trainer, no SFT or DPO config, and no training directory — `wildguard/` is the classifier wrapper and `examples/` a serving demo. The README installs via `pip install wildguard` and documents `classify()`; it links the paper, dataset, model and Safety-Eval, which is self-described as an evaluation suite. The model card sends readers to the paper appendix for training details.

Recorded `code: partial`, matching the ladder's own definition and the corpus convention, with two `establishes: [code]` sources carrying re-derivable digests.

## A correction to the premise this task started from

The task assumed that finding a pipeline would reproduce `wildguard`'s recorded 4. It would not. `wildguard` is Apache-2.0, so `data: open` plus `code: open` matches the **OSI** rule and computes **5 / open_source**.

The recorded 4 was unreachable at either value of `code`. That is worth recording: the number on file did not correspond to any state of the evidence.

## Scope

No other product hits this rung. All nine model products in `safeguards` now sit at 3; the other five reach it through the `use_bounded` license rung instead.

Category `stage` (3, Viable Alternatives) and `gaps` are unchanged, as are all four `maturity` values — none of the four crossed a threshold, because all were already below it.

## Test plan

- Each of the four verified against the pre-change tree before editing.
- Suite 454 passed. `validate` 0 error(s), `check_recipe` 0 failure(s), `check_rubric` exit 0, `check_components` `[OK]`.
- Exactly four `score:` lines change.
- Two pinned fixtures updated (deferrals 30 → 26; `safeguards` evidence rows 103 → 117), each matching the measured delta.
