### PR TITLE
fix(scores): read the cards behind five license deferrals

### DIFF
--- a/sources/categories/benchmark_eval_data.yaml
+++ b/sources/categories/benchmark_eval_data.yaml
@@ -11,10 +11,10 @@ scoring_recipe:
   derived_from:
     method: shared dataset ladder, widened by this category, then verified against the
       hand-authored scores
-    scores_reproduced: 18
+    scores_reproduced: 20
     scores_total: 27
-    scores_deferred: 9
-    verified_on: '2026-08-01'
+    scores_deferred: 7
+    verified_on: '2026-08-12'
     checker: build/check_rubric.py
   note: >-
     Second DATASET category. The shared ladder as first written could not read this category
@@ -24,10 +24,22 @@ scoring_recipe:
     adding the `answers` dimension fixed both, and training_synthetic_datasets reproduces
     identically before and after.
 
-    Nine products are deferred and eight of the nine are recording defects rather than open
-    questions - a license inside a compound key, a gate written as a sentence, a bare `cc`
-    naming no terms. The one that is not is `math`, scored on a DMCA takedown the ladder has
-    no way to see.
+    Nine products were deferred at the outset and most were recording defects rather than
+    open questions - a license inside a compound key, a gate written as a sentence, a bare
+    `cc` naming no terms. Two have since resolved on a card read: `mt-bench` and `livebench`
+    each recorded a license and an answer state and nothing about their documentation or
+    access, and the top rung asks for a card deliberately. Both document themselves in the
+    repository rather than on a Hub card - FastChat's llm_judge README for one, a full
+    datasheets-for-datasets questionnaire for the other - and recording that reproduces the
+    5/open both already carried.
+
+    Seven are left and they now split three ways. Four are still recording defects
+    (`gaia`, `humanitys-last-exam`, `compar-ia-datasets`, `multipl-e`). `math` is scored on
+    a DMCA takedown the ladder has no way to see. And two are the license question answered
+    rather than avoided: `livecodebench`'s bare `cc` was researched to the point of
+    exhaustion and the variant genuinely is not published anywhere, while
+    `swe-bench-verified` turned out to have a stated MIT after all, which turns its deferral
+    from an unreadable value into a live 4-versus-5 disagreement.
 
     A tenth, `gpqa`, was corrected rather than deferred: it recorded 4/gated, a pair no rung
     produces, and the ladder's answer of 3 is what the other nine gated corpora on the map
@@ -47,18 +59,29 @@ scoring_recipe:
         repo over AMC/AIME problem rights. Recording `access:closed` would settle it.
     swe-bench-verified:
       because: >-
-        License `undeclared on HF dataset card` resolves to the `unstated` tier, which carries
-        no rung: absent a grant there is no permission to rely on, however freely the files
-        download. Recorded 4/open, and its note explicitly scores 4 rather than 5 on that
-        ambiguity - which is the same reasoning the `unstated` tier encodes, so the disagreement
-        is only about whether an inferred license can support a 4 at all. Note
-        `openhermes-2-5` in training_synthetic_datasets is deferred for the same tier and
-        recorded 5, so the two disagree with each other; one answer should cover both.
+        Now a live disagreement rather than an unreadable value. The card read on 2026-08-12
+        confirmed the HF card for Verified still declares no license, but found the license
+        stated where the deferral had assumed it was only inferred: the canonical SWE-bench
+        repository describes itself as "Code and data for the following works", lists SWE-bench
+        among them, and its "Citation & license" section says "MIT license", with the citation
+        directly beneath headed "For SWE-bench (Verified)". Recording `license:MIT` resolves
+        the `open_data` tier and, with `datasheet:yes`, the ladder computes 5/open against a
+        recorded 4. Neither side has been adjusted. The 4 rests on the reading that a license
+        stated by the project but absent from the distribution point is weaker than one stated
+        on the card; the ladder does not draw that distinction. Someone has to pick.
     livecodebench:
       because: >-
-        License recorded as a bare `cc`, which names no terms - CC-BY and CC-BY-NC are both
-        `cc`, and they sit two tiers apart. Resolves to `unstated`, which carries no rung.
-        Recorded 4/open on exactly that ambiguity. Reading the card for the variant settles it.
+        Researched and genuinely unstated. The bare `cc` names no terms - CC-BY and CC-BY-NC
+        are both `cc` and sit two tiers apart - and a read on 2026-08-12 could not find the
+        variant anywhere the project publishes it: the card front matter, the Hub API
+        cardData and tags, the sibling `code_generation` and `test_generation` corpora, the
+        repository LICENSE (MIT, and it covers the lcb_runner harness rather than the
+        problems), the 217-line repository README, ERRATA.md, the project site and
+        leaderboard, and the paper. The repo discussions never raise it. The problems are
+        collected from LeetCode, AtCoder and Codeforces, which is a plausible reason no
+        variant has been committed to. An artifact whose publisher has not named its terms
+        is a real state of the world; the abstention is the right answer and not a gap in
+        the research.
     multipl-e:
       because: >-
         Recorded 4/open; the ladder computes 5/open. The 4 rests on a `caveat:` key recording
@@ -84,16 +107,6 @@ scoring_recipe:
         The gate is recorded as `gated:HF contact-info agreement required`, a sentence rather
         than a token, so `head()` returns the whole phrase and it matches no rung. The recorded
         3/gated is what `terms-acceptance+contact-info` produces. A vocabulary fix, not research.
-    mt-bench:
-      because: >-
-        Records neither a card nor an availability key - only `license:Apache-2.0` and
-        `answers:public`. The top rung requires documentation deliberately, so that a product
-        recording nothing cannot reach 5 by default. Recorded 5/open; needs its card and
-        access state recorded.
-    livebench:
-      because: >-
-        As `mt-bench`: `license:Apache-2.0/MIT` and `answers:public` and nothing else. Recorded
-        5/open, and the ladder declines to award it on an unrecorded card.
 products:
 - humaneval
 - gsm8k

--- a/sources/categories/training_synthetic_datasets.yaml
+++ b/sources/categories/training_synthetic_datasets.yaml
@@ -34,16 +34,27 @@ scoring_recipe:
     `dataset_card:present` and `ungated` became `access:ungated`, which is the same evidence
     under a name the ladder reads. No score moved.
 
-    One is left, `openhermes-2-5`, and it is the one that does need an answer rather than a key.
+    One is left, `openhermes-2-5`, and it is the one that needed an answer rather than a key.
+    The answer came back on 2026-08-12 and it is that there is no license: not in the card
+    front matter, not in the card body, not as a file in the repository, not on the Hub API.
+    The deferral stands, and what it now records is a finding rather than a question. Whether
+    a corpus nobody has licensed can carry 5/open is a curation call.
 
   extends: dataset
   deferred:
     openhermes-2-5:
       because: >-
-        License `not-clearly-stated-on-card` resolves to the `unstated` tier, which carries no
-        rung: absent a grant there is no permission to rely on, however freely the files
-        download. Recorded 5/open with the note conceding no explicit license string exists.
-        Either the license is findable, in which case record it, or a 5 is not supportable.
+        Researched and genuinely unstated, so the deferral stands on a finding rather than on
+        an open question. A read on 2026-08-12 checked everywhere the publisher could state
+        terms: the card front matter carries language, pretty_name and tags and no `license:`
+        key; the 126-line body runs from the constituent source list through the sharegpt
+        format description to the citation with no terms section and no occurrence of the word
+        "license"; the repository holds only .gitattributes, README.md and openhermes2_5.json,
+        so no LICENSE file ships with the data; and the Hub API returns no license and no
+        `license:` tag. The `commonly cited as permissive` detail was a third-party reading and
+        has been dropped. Nobody has granted anything, so the `unstated` tier is correct and
+        the recorded 5/open is not supportable on the license. Moving it is a curation call,
+        not a research one.
 products:
 - fineweb
 - fineweb-edu

--- a/sources/scores/livebench.yaml
+++ b/sources/scores/livebench.yaml
@@ -10,13 +10,53 @@ openness:
       detail: ground_truth released
     license:
       value: Apache-2.0/MIT
+      detail: repo LICENSE is Apache-2.0, carried over from FastChat; DATASHEET.md states the benchmark
+        suite is distributed under the Apache License 2.0
+    datasheet:
+      value: present
+      detail: docs/DATASHEET.md, a full datasheets-for-datasets questionnaire covering motivation, composition,
+        collection and distribution
+    access:
+      value: ungated
+      detail: HF datasets download without a gate
   confidence: high
   note: All questions, answers, and code are released openly; rotation is for freshness, not access control.
-  raw: questions:public;answers:public(ground_truth released);license:Apache-2.0/MIT
+    The documentation is a full datasheets-for-datasets questionnaire in the repository rather than a
+    Hugging Face card, and it states the distribution license outright.
+  raw: questions:public;answers:public(ground_truth released);license:Apache-2.0/MIT(repo LICENSE is Apache-2.0,
+    carried over from FastChat; DATASHEET.md states the benchmark suite is distributed under the Apache
+    License 2.0);datasheet:present(docs/DATASHEET.md, a full datasheets-for-datasets questionnaire covering
+    motivation, composition, collection and distribution);access:ungated(HF datasets download without a
+    gate)
+  last_verified: '2026-08-12'
   sources:
   - url: https://huggingface.co/datasets/livebench/reasoning
     shows: public ground_truth column, release/removal dates
     accessed: '2026-06-17'
+  - url: https://huggingface.co/datasets/livebench/reasoning/raw/main/README.md
+    shows: card describing the benchmark and linking the paper, leaderboard and datasheet; the declared
+      features include a `ground_truth` string column alongside `turns`, so the answers ship with the
+      questions; no gate and no license field in the card metadata
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 88c6f322d82d166840b4f622ea07b06a77d50ffb1f6b7c2eec08f91dee786440
+    establishes: [access, answers]
+  - url: https://raw.githubusercontent.com/LiveBench/LiveBench/main/docs/DATASHEET.md
+    shows: 'the datasheets-for-datasets questionnaire, covering motivation, composition, collection,
+      preprocessing, uses, distribution and maintenance; under "When will the dataset be released/first
+      distributed? What license (if any) is it distributed under?": "The benchmark suite is public as
+      of June 12, 2024, distributed under the Apache License 2.0."'
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 8f5036b7330c01de1a9cd5a9f02a0e6f5d359bd08b210d7dde0635731fbce1f4
+    establishes: [datasheet, license]
+  - url: https://raw.githubusercontent.com/LiveBench/LiveBench/main/LICENSE
+    shows: Apache License 2.0, prefaced "The original LICENSE from https://github.com/lm-sys/FastChat
+      is copied below"
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 8fb1d09632b9c03b426c87654d62c5d8fb953643e51e6866f3446401903005c3
+    establishes: [license]
 adoption:
   level: 4
   signal_type: usage_volume

--- a/sources/scores/livecodebench.yaml
+++ b/sources/scores/livecodebench.yaml
@@ -8,7 +8,8 @@ openness:
       detail: HF parquet
     license:
       value: cc
-      detail: generic CC tag, specific variant unspecified on dataset card
+      detail: the card YAML names the Creative Commons family and no variant; no variant is stated on the
+        card, the GitHub repository, the project site or the paper
     datasheet:
       value: present
       detail: README documents versions/sources/structure
@@ -19,10 +20,17 @@ openness:
   confidence: medium
   note: Open and downloadable with a datasheet, but the HF card declares only a generic 'cc' license (no
     specific CC variant), so the exact reuse terms are ambiguous. Scored open but not a clean CC-BY;
-    capped at 4.
-  raw: data:downloadable(HF parquet);license:cc(generic CC tag, specific variant unspecified on dataset
-    card);datasheet:present(README documents versions/sources/structure);redistributable:yes;splits:public
-    problems with hidden test cases bundled
+    capped at 4. A card read on 2026-08-12 went looking for the variant and did not find one. The bare
+    'cc' is the only license statement the project makes about the corpus, and it is repeated identically
+    on code_generation and test_generation. The MIT LICENSE in the GitHub repository covers the lcb_runner
+    harness code, not the problems; the CC-BY-4.0 on the arXiv posting covers the paper. The problems
+    themselves are collected from LeetCode, AtCoder and Codeforces, which is a plausible reason the
+    project has not committed to a variant. Recording CC-BY here would be a guess, and CC-BY and CC-BY-NC
+    sit two tiers apart, so the abstention stands.
+  raw: data:downloadable(HF parquet);license:cc(the card YAML names the Creative Commons family and no variant;
+    no variant is stated on the card, the GitHub repository, the project site or the paper);datasheet:present(README
+    documents versions/sources/structure);redistributable:yes;splits:public problems with hidden test cases
+    bundled
   sources:
   - url: https://huggingface.co/datasets/livecodebench/code_generation_lite
     shows: license:cc, 880 problems (release_v5), 71,393 monthly downloads, datasheet/README
@@ -30,6 +38,37 @@ openness:
   - url: https://huggingface.co/datasets/livecodebench/code_generation_lite/blob/main/README.md
     shows: 'YAML metadata license: cc'
     accessed: '2026-06-04'
+  - url: https://huggingface.co/datasets/livecodebench/code_generation_lite/raw/main/README.md
+    shows: 'card front matter is `license: cc` with tags, pretty_name and size_categories, and nothing
+      naming a Creative Commons variant; the body is a change log of release_v1..v5, a dataset description
+      and usage instructions. Re-read 2026-08-12'
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: fbf0df23c9fb430778f037691bd191ece41d49373c0695151d87549b6f45d809
+    establishes: [license]
+  - url: https://huggingface.co/api/datasets/livecodebench/code_generation_lite
+    shows: 'cardData.license is the string "cc" and the repository tags carry `license:cc`; the sibling
+      corpora code_generation and test_generation carry the same bare `cc`, and execution carries no
+      license at all. The open discussions on the repo are about loading, parquet conversion and version
+      sizes - none asks or answers what the CC variant is'
+    accessed: '2026-08-12'
+    http_status: 200
+    establishes: [license]
+  - url: https://raw.githubusercontent.com/LiveCodeBench/LiveCodeBench/main/LICENSE
+    shows: MIT License, copyright 2024 LiveCodeBench. This is the repository holding lcb_runner, the
+      evaluation harness; the problems are distributed from the Hugging Face repos and this file makes
+      no statement about them
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 104099948b78ebc36f2e951b3a7973b956adfa7d39aaec0d1512f97a2686d15d
+    establishes: [license]
+  - url: https://raw.githubusercontent.com/LiveCodeBench/LiveCodeBench/main/README.md
+    shows: 217 lines covering install, running the harness, scenarios and submissions, with no licensing
+      or terms section at all
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: ee0029cddc1d9051f35818f3348a4327819a3e35a9e597732519245605195cf6
+    establishes: [license]
 adoption:
   level: 4
   reach: 1M-10M

--- a/sources/scores/mt-bench.yaml
+++ b/sources/scores/mt-bench.yaml
@@ -5,18 +5,52 @@ openness:
   components:
     questions:
       value: public
+      detail: question.jsonl in the public FastChat git tree
     answers:
       value: public
       detail: GPT-4 references in FastChat
     license:
       value: Apache-2.0
+      detail: FastChat repository LICENSE
+    datasheet:
+      value: present
+      detail: fastchat/llm_judge/README.md documents the data, the judging protocol and the released judgment
+        sets; arXiv:2306.05685 documents composition
+    access:
+      value: ungated
+      detail: questions and reference answers sit in the public git tree, no download barrier
   confidence: high
-  note: Both questions and reference answers are public and openly licensed.
-  raw: questions:public;answers:public(GPT-4 references in FastChat);license:Apache-2.0
+  note: Both questions and reference answers are public and openly licensed. MT-Bench ships inside FastChat
+    rather than as a standalone dataset repo, so its documentation is the llm_judge package README and
+    the LLM-as-a-Judge paper rather than a Hugging Face card, and its access state is a public git tree
+    rather than a Hub download.
+  raw: questions:public(question.jsonl in the public FastChat git tree);answers:public(GPT-4 references
+    in FastChat);license:Apache-2.0(FastChat repository LICENSE);datasheet:present(fastchat/llm_judge/README.md
+    documents the data, the judging protocol and the released judgment sets; arXiv:2306.05685 documents
+    composition);access:ungated(questions and reference answers sit in the public git tree, no download
+    barrier)
+  last_verified: '2026-08-12'
   sources:
   - url: https://github.com/lm-sys/FastChat/tree/main/fastchat/llm_judge/data/mt_bench
     shows: public questions + GPT-4 references
     accessed: '2026-06-17'
+    establishes: [access, answers]
+  - url: https://raw.githubusercontent.com/lm-sys/FastChat/main/LICENSE
+    shows: the FastChat repository, which contains the MT-Bench questions and reference answers, is
+      licensed Apache License 2.0
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
+    establishes: [license]
+  - url: https://raw.githubusercontent.com/lm-sys/FastChat/main/fastchat/llm_judge/README.md
+    shows: '"MT-bench is a set of challenging multi-turn open-ended questions for evaluating chat assistants";
+      documents the data files, the GPT-4 judging protocol, the pre-generated model answers and judgments,
+      and the agreement computation. The reference answers and judgments are downloaded from the public
+      repo by `download_mt_bench_pregenerated.py` with no credential or approval step'
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 4104f9e877fe04a4a87a5b6618114adc8604f09ceca09be198f96189c4c2238e
+    establishes: [datasheet, answers, access]
 adoption:
   level: 3
   signal_type: stars_fallback

--- a/sources/scores/openhermes-2-5.yaml
+++ b/sources/scores/openhermes-2-5.yaml
@@ -5,7 +5,8 @@ openness:
   components:
     license:
       value: not-clearly-stated-on-card
-      detail: commonly cited as permissive
+      detail: no license field in the card YAML, no license section in the card body, no LICENSE file in
+        the repository and no license tag on the Hub API
     card:
       value: present
     ungated:
@@ -16,12 +17,32 @@ openness:
       value: ~1M
   confidence: medium
   note: Publicly downloadable and ungated with a full card, though an explicit license string is not stated
-    on the card.
-  raw: license:not-clearly-stated-on-card(commonly cited as permissive);card:present;ungated:yes;format:JSON/Parquet;rows:~1M
+    on the card. A card read on 2026-08-12 confirms there is no license anywhere the publisher controls
+    - the card front matter carries language, pretty_name and tags and no license key, the 126-line body
+    runs from the source list through the format description to the citation without a terms section,
+    the repository holds only .gitattributes, README.md and openhermes2_5.json so there is no LICENSE
+    file, and the Hub API returns no license for it. The 'commonly cited as permissive' detail this record
+    used to carry was a third-party reading and has been dropped.
+  raw: license:not-clearly-stated-on-card(no license field in the card YAML, no license section in the card
+    body, no LICENSE file in the repository and no license tag on the Hub API);card:present;ungated:yes;format:JSON/Parquet;rows:~1M
   sources:
   - url: https://huggingface.co/datasets/teknium/OpenHermes-2.5
     shows: Public ungated dataset card, ~1M rows, synthetic/GPT-4 tags
     accessed: '2026-06-22'
+  - url: https://huggingface.co/datasets/teknium/OpenHermes-2.5/raw/main/README.md
+    shows: 'card front matter is language, pretty_name and tags only, with no `license:` key; the 126-line
+      body covers the dataset description, the Lilac integration, the full list of constituent source
+      datasets, the sharegpt format and a citation, and contains no occurrence of "license" or "terms"'
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 92fd711b9f0f6f8c7312d18d93ad412af415cd25a207584554c8e72c0cfe9f64
+    establishes: [license]
+  - url: https://huggingface.co/api/datasets/teknium/OpenHermes-2.5
+    shows: cardData carries no license and the repository has no `license:` tag; siblings are .gitattributes,
+      README.md and openhermes2_5.json, so no LICENSE file ships with the data
+    accessed: '2026-08-12'
+    http_status: 200
+    establishes: [license]
 adoption:
   level: 3
   reach: 10k-100k

--- a/sources/scores/swe-bench-verified.yaml
+++ b/sources/scores/swe-bench-verified.yaml
@@ -4,9 +4,9 @@ openness:
   class: open
   components:
     license:
-      value: undeclared on HF dataset card
-      detail: underlying SWE-bench harness repo is MIT
-      raw: undeclared on HF dataset card (underlying SWE-bench harness repo is MIT)
+      value: MIT
+      detail: SWE-bench repository states MIT over its code and data; the HF card for Verified still declares
+        no license field
     redistributability:
       value: full
       detail: downloadable parquet, ungated
@@ -16,19 +16,23 @@ openness:
     held-out:
       value: no hidden split in Verified itself
       detail: the public 500-instance set is fully released; gold patches + tests included
-      raw: no hidden split in Verified itself (the public 500-instance set is fully released; gold patches
-        + tests included)
     data-source:
       value: real GitHub PR/issue pairs
   confidence: medium
-  note: Effectively open (ungated, downloadable, full gold patches and tests, datasheet present) but
-    the HF dataset card declares NO explicit license field, so the data-license class is inferred from
-    the MIT harness repo and public redistribution rather than a stated data license. Scored 4 not 5 on
-    that ambiguity. (Distinct from SWE-bench's broader/hidden variants which can carry held-out splits.)
-  raw: license:undeclared on HF dataset card (underlying SWE-bench harness repo is MIT);redistributability:full(downloadable
-    parquet, ungated);datasheet:yes(dataset card + arXiv:2310.06770);held-out:no hidden split in Verified
-    itself (the public 500-instance set is fully released; gold patches + tests included);data-source:real
-    GitHub PR/issue pairs
+  note: Effectively open - ungated, downloadable, full gold patches and tests, datasheet present. The
+    HF card for Verified declares no license field, which is what the recorded 4 rests on, but a card
+    read on 2026-08-12 found the canonical SWE-bench repository stating MIT over the artifact rather
+    than only over the harness. Its README calls the repository "Code and data for the following works",
+    lists SWE-bench among them, and its "Citation & license" section says "MIT license", with the
+    citation block directly beneath headed "For SWE-bench (Verified)". Verified is a 500-instance human-validated
+    subset of that same test set, released with OpenAI Preparedness. On that reading the license is
+    stated rather than inferred and the ladder computes 5; the recorded 4 has been left alone and the
+    disagreement is carried as a deferral. (Distinct from SWE-bench's broader/hidden variants which
+    can carry held-out splits.)
+  raw: license:MIT(SWE-bench repository states MIT over its code and data; the HF card for Verified still
+    declares no license field);redistributability:full(downloadable parquet, ungated);datasheet:yes(dataset
+    card + arXiv:2310.06770);held-out:no hidden split in Verified itself(the public 500-instance set is
+    fully released; gold patches + tests included);data-source:real GitHub PR/issue pairs
   sources:
   - url: https://huggingface.co/datasets/princeton-nlp/SWE-bench_Verified
     shows: 500 instances, ~2.1 MB, not gated, dataset card present, gold patch + FAIL_TO_PASS/PASS_TO_PASS
@@ -40,6 +44,31 @@ openness:
   - url: https://huggingface.co/datasets/princeton-nlp/SWE-bench_Verified/blob/main/README.md
     shows: dataset card metadata has no license field declared
     accessed: '2026-06-04'
+  - url: https://huggingface.co/datasets/princeton-nlp/SWE-bench_Verified/raw/main/README.md
+    shows: card front matter carries dataset_info, splits and configs and no `license:` key; body describes
+      the 500 human-validated instances and the swebench.com leaderboard. Re-read on 2026-08-12 and
+      still unlicensed at source. The repository holds only .gitattributes, README.md and one parquet
+      file, so there is no LICENSE file alongside the data either
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 6edb58b1b2c44ce858426c4ebc90077827713b75cebc243661e4433c81fd57f5
+    establishes: [license]
+  - url: https://raw.githubusercontent.com/SWE-bench/SWE-bench/main/README.md
+    shows: '"Code and data for the following works:" listing SWE-bench and SWE-bench Multimodal; the
+      "Citation & license" section reads "MIT license. Check `LICENSE.md`." and the citation immediately
+      under it is headed "For SWE-bench (Verified)"; the news entry for Aug. 13, 2024 introduces Verified
+      as a 500-problem subset produced with OpenAI Preparedness'
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 56438c6b147990c0fd93d81fefcecaa94c909d379037487a49d48ac4990a4573
+    establishes: [license]
+  - url: https://raw.githubusercontent.com/SWE-bench/SWE-bench/main/LICENSE
+    shows: 'MIT License, copyright 2023 the SWE-bench authors. Note the README points at `LICENSE.md`,
+      which 404s; the file is `LICENSE`'
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 2bd2e08df7147f67a69b42c10efae09bd4bf119df397371036187d5dd1b02f57
+    establishes: [license]
 adoption:
   level: 4
   reach: 1M-10M

--- a/tests/test_check_parity.py
+++ b/tests/test_check_parity.py
@@ -142,7 +142,15 @@ def test_local_scores_matches_check_rubrics_split():
     the CC-BY-4.0 documentation branch maps to no tier, so the ladder abstains on the license
     rather than on the missing keys the old reason blamed.
 
-    Then 442/30 -> 446/26 when the four guardrail-model deferrals in `safeguards` came off.
+    Then 446/26 -> 448/24 when a card read closed mt-bench and livebench in
+    `benchmark_eval_data`. Neither needed a license: both already recorded one the ladder
+    reads, and what the top rung was missing was a documentation key, which it asks for
+    deliberately so a product recording nothing cannot reach 5 by default. Both document
+    themselves in the repository rather than on a Hub card - FastChat's llm_judge README for
+    mt-bench, a datasheets-for-datasets questionnaire for livebench - and recording that
+    reproduces the 5/open each already carried.
+
+    Before that, 442/30 -> 446/26 when the four guardrail-model deferrals in `safeguards` came off.
     All four were recorded 4/open_weights against a ladder computing 3, and all four dropped
     to 3 rather than the ladder bending. qwen3guard, granite-guardian and gpt-oss-safeguard
     were one case argued once - Apache-2.0 weights, `data:not-released`, no recipe published -
@@ -154,8 +162,8 @@ def test_local_scores_matches_check_rubrics_split():
     and the card sends readers to the paper appendix for training details. That is
     `code:partial`, the 4-rung still fails, and open data on its own does not carry it."""
     computed, deferred = local_scores(None)
-    assert len(deferred) == 26
-    assert len(computed) == 446
+    assert len(deferred) == 24
+    assert len(computed) == 448
     assert not set(computed) & set(deferred)
     # Every one of the 410 reproduces today, so none should abstain.
     assert [key for key, value in computed.items() if value is None] == []

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -804,9 +804,13 @@ def test_real_sources_serialize_without_errors():
         # `availability` and `documentation` dimensions those two normalize onto - and a
         # deferred product publishes none at all, so 5 x 5 is the whole of the move. The
         # promotion added no key to a product that was already computed, which is why
-        # benchmark_eval_data holds at 111: compar-ia-datasets got the same `dataset_card`
+        # benchmark_eval_data held at 111: compar-ia-datasets got the same `dataset_card`
         # key and stays deferred on its unrelated gate-vocabulary defect.
-        "training_synthetic_datasets": 194, "benchmark_eval_data": 111,
+        # 111 -> 125 when the card read closed mt-bench and livebench. Each recorded a
+        # license and an answer state and nothing else, and each gained a `datasheet` and an
+        # `access` key plus the `availability` and `documentation` dimensions they normalize
+        # onto - so both go from publishing nothing to publishing seven rows.
+        "training_synthetic_datasets": 194, "benchmark_eval_data": 125,
         # safeguards 90 -> 103 and training_synthetic_datasets 158 -> 164: the universal
         # license scale retired five deferrals, and a deferred product publishes no
         # openness evidence at all.


### PR DESCRIPTION
## Summary

Five deferrals all turned on the same question: what a product's license actually is, when the record does not say clearly. Rather than applying a blanket cap to an unstated license, each card was read.

**Two close. One is a conflict. Two are genuinely unstated — which is itself the finding.**

## Closed (2)

| Product | License established | Score |
|---|---|---|
| `mt-bench` | Apache-2.0, from the FastChat repo LICENSE; plus `datasheet: present` from the `llm_judge` README and `access: ungated` | 5 / open, matching the record |
| `livebench` | Apache-2.0, stated outright in `docs/DATASHEET.md` — "distributed under the Apache License 2.0"; plus `datasheet: present` and `access: ungated` | 5 / open, matching the record |

These two were never really license problems. Their licenses were recorded; what was missing was the **documentation** key the dataset ladder's top rung requires deliberately, so a product recording nothing cannot reach 5 by default.

One caveat left for a curator: `livebench` records `Apache-2.0/MIT` and only the Apache half is confirmed. Same tier either way, and not the deferral's cause, so it was left alone.

## One conflict

`swe-bench-verified` — recorded **4**, computes **5**. The Hugging Face card still declares nothing, but the canonical SWE-bench repo README calls itself "Code and data for the following works", and its "Citation & license" section says MIT with the citation beneath headed "For SWE-bench (Verified)".

`license: MIT` is now recorded with three cited sources. The score was not touched and it stays deferred, because the open question is a real one: **does a license stated by the project but absent from the distribution point govern the artifact?** That is a policy call, not a research result.

## Two are genuinely unstated

This is the outcome worth having, and it took the most work to establish.

**`livecodebench`** was recorded as a bare `cc` — and CC-BY versus CC-BY-NC sit two tiers apart, so this looked like the single highest-value card read in the set. It turns out no variant is published **anywhere the project controls**: not the card front matter, the HF API `cardData` or tags, the sibling `code_generation` and `test_generation` datasets, the repo LICENSE (MIT, and it covers `lcb_runner` only), the README, ERRATA.md, the project site, the leaderboard, the paper, or any of the 14 repo discussions. The arXiv CC-BY-4.0 covers the paper, not the corpus.

Recording CC-BY would have been a two-tier guess dressed as evidence.

**`openhermes-2-5`** — card front matter, the 126-line card body, the repo file list (no LICENSE ships) and the Hub API tag all checked. An unsupported "commonly cited as permissive" detail was dropped from the record.

Both stay deferred, with reasons naming where the search went. An artifact whose license nobody has declared is a real state of the world, not a gap in our research.

## Test plan

- Nothing worked backwards from the recorded score; the conflict and the two unstated products all stayed deferred.
- Suite 454 passed. `validate` 0 error(s), `check_recipe` 0 failure(s), `check_rubric` exit 0, `check_components` `[OK]`.
- Two count fixtures updated with reasoning.
