### PR TITLE
fix(scores): rule on five sweep conflicts, and correct two license records

### DIFF
--- a/sources/categories/dataset_processing_tools.yaml
+++ b/sources/categories/dataset_processing_tools.yaml
@@ -55,17 +55,17 @@ scoring_recipe:
         held for Phase 1.
     nemo-data-designer:
       because: >-
-        the 2026-08-11 evidence sweep recorded the missing keys and they contradict the score on
-        file. NVIDIA's own NeMo microservices docs state "The service is built on the open-source
-        NVIDIA NeMo Data Designer library" and link to github.com/NVIDIA-NeMo/DataDesigner, which
-        is Apache-2.0, installs with `pip install data-designer`, and ships the whole generation
-        framework rather than a client for a hosted service. So `source` is public and the license
-        is OSI, rung 0 no longer fires, and the recorded 1/closed cannot be reproduced at either
-        value of core-gated - the product is somewhere in {4, 5}. The prior 1/closed rested on a
-        single TechCrunch article and carried no last_verified. core-gated is deliberately still
-        unrecorded, because closing it needs a read of what, if anything, the NeMo Platform
-        withholds from the published library. Score, class and the product description left
-        untouched for a human.
+        `source` is public and the license is OSI, so the recorded 1/closed is not reproducible at
+        any value of core-gated - NVIDIA's own NeMo microservices docs state "The service is built
+        on the open-source NVIDIA NeMo Data Designer library" and link to
+        github.com/NVIDIA-NeMo/DataDesigner, which is Apache-2.0, installs with
+        `pip install data-designer`, and ships the whole generation framework rather than a client
+        for a hosted service. The prior 1 rested on a single TechCrunch article. It stays deferred
+        because both remaining rungs test core-gated and no read has established what, if
+        anything, the NeMo Platform withholds from the published library, so the product is
+        somewhere in {4, 5} and a core-gated value was deliberately not invented to close it.
+        Reviewed 2026-08-12 alongside five other sweep conflicts; the other five closed and this
+        one did not.
 comments: 'The software that produces the training_synthetic_datasets row (Columbia model-components layer;
   MOF ''Data Preprocessing Code''). Scoped to data-processing software; human-data / RLHF labor marketplaces (Scale, Surge, Mercor) are
   out of scope -- per the Columbia framework their output is data (the datasets category) and their labor

--- a/sources/categories/finetuning_code.yaml
+++ b/sources/categories/finetuning_code.yaml
@@ -43,21 +43,6 @@ scoring_recipe:
     scores_total: 27
     verified_on: '2026-07-30'
     checker: build/check_rubric.py
-  # Held back rather than scored. The shared ladder has no `otherwise` rule, so
-  # these already abstain; declaring them here records WHY, and keeps the
-  # reproduction count honest by excluding them from it rather than counting
-  # them as passes.
-  deferred:
-    unsloth:
-      because: >-
-        the 2026-08-11 evidence sweep read unsloth.ai/pricing and recorded core-gated as `gated`,
-        and the ladder then computes 4/open_core against the recorded 5/open_source, so this is a
-        conflict rather than a closure. Unsloth Pro and Enterprise are not a hosted service sold
-        beside the open package; they are builds of the same product carrying capabilities the
-        free column says it does not have. The free tier lists MultiGPU as "coming soon" while Pro
-        lists "Enhanced MultiGPU support" and "Up to 8 GPUS support", and Enterprise adds
-        multi-node, "Supports full training" and "5x faster inference". Pro is advertised as
-        "20% less memory than OSS", an explicit comparison against the published package. Neither
-        side was adjusted. Caveat: the pricing page names Llama 1/2/3 and Mistral/Gemma and looks
-        stale, so the exact feature line may have moved even though the tiering has not.
+  # No deferrals. unsloth was the last one, closed on 2026-08-12 by taking the recorded
+  # `core-gated: gated` at its word and moving the score to 4/open_core.
 comments: ''

--- a/sources/categories/inference_code.yaml
+++ b/sources/categories/inference_code.yaml
@@ -35,22 +35,6 @@ scoring_recipe:
     scores_total: 20
     verified_on: '2026-07-30'
     checker: build/check_rubric.py
-  # Held back rather than scored. The shared ladder has no `otherwise` rule, so
-  # these already abstain; declaring them here records WHY, and keeps the
-  # reproduction count honest by excluding them from it rather than counting
-  # them as passes.
-  deferred:
-    aws-neuron:
-      because: >-
-        the 2026-08-11 evidence sweep read AWS's own OSS catalog and the aws-neuron-sdk repo and
-        recorded the missing `source` key, and it reads `partial`, not `closed`. The ladder now
-        computes 2/source_available against the recorded 1/closed, so this is a conflict rather
-        than a closure. `closed` is defined as a managed service with no self-hostable
-        implementation, and Neuron is not a managed service - it installs on the customer's own
-        EC2 instance from proprietary packages. `partial` is defined as a repo existing while the
-        runtime does not ship, an SDK or issue tracker standing in for the engine, which is what
-        aws-neuron-sdk is: a docs-and-issues repo whose compiler/ and neuron-runtime/ directories
-        hold documentation, alongside four genuinely open functional components. `webcontainers`
-        is already scored 2/source_available for the same shape. Neither side was adjusted; a
-        human decides which reading the map wants.
+  # No deferrals. aws-neuron was the last one, closed on 2026-08-12 by taking the recorded
+  # `source: partial` at its word and moving the score to 2/source_available.
 comments: ''

--- a/sources/categories/telemetry_observability.yaml
+++ b/sources/categories/telemetry_observability.yaml
@@ -41,51 +41,8 @@ scoring_recipe:
     scores_total: 26
     verified_on: '2026-07-30'
     checker: build/check_rubric.py
-  # Held back rather than scored. The shared ladder has no `otherwise` rule, so
-  # these already abstain; declaring them here records WHY, and keeps the
-  # reproduction count honest by excluding them from it rather than counting
-  # them as passes.
-  #
-  # All four were read on 2026-08-12. langfuse closed and now scores; the other three
-  # each turned out to be held back by something other than the missing core-gated key,
-  # so their reasons now say what the read actually found. The evidence is recorded on
-  # each score file with `establishes` tags either way - what is deferred is the
-  # judgment, not the research.
-  deferred:
-    agentops:
-      because: >-
-        read 2026-08-12 and it does not reproduce the 4. Nothing is withheld from the
-        published source - app/ ships api, dashboard, ClickHouse, the OTel collector,
-        Supabase and a compose file, with no ee/ directory and no license key - so
-        core-gated reads `ungated`, which against the recorded MIT computes 5. But the
-        recorded MIT is the SDK's: app/LICENSE is the Elastic License 2.0, which forbids
-        offering the software as a hosted service and so tiers as competition_restricted,
-        landing on the 2/source_available rung. 5 or 2, not 4. Needs a human to settle
-        which SKU this slug is scored on; the vendor's README calls the app MIT and its
-        LICENSE file does not
-    langtrace:
-      because: >-
-        read 2026-08-12, and the recorded blocker was the wrong one - check_rubric
-        abstains on `blocked_on_tier`, because the license value `app=AGPL-3.0` is a
-        scoped spelling matching no license_tier example, so no rung testing a tier can
-        fire whatever core-gated says. On the evidence it is ungated: the whole AGPL-3.0
-        application is in the repo with no ee/ or enterprise directory, self-hosting is
-        documented, and the vendor's own FAQ says Langtrace Cloud is not charged for. That
-        computes 5/open_source against a recorded 4 whose stated grounds - AGPL copyleft
-        and a hosted tier - are both rationales the map has since rejected (#125 and the
-        core_gated rule). Needs a human to settle the 4 and fix the license spelling
-        together
-    weave:
-      because: >-
-        read 2026-08-12, and the finding lands on `source` rather than on core-gated. The
-        Apache-2.0 repo publishes the SDK and a real ClickHouse trace-server library, but
-        no UI, no deployment manifest, and not the HTTP service - the repo's own
-        trace_server README diagrams that as "(in core)", W&B's closed repository - while
-        the README's prerequisite is a W&B account and W&B's docs require a purchased
-        Server license to self-manage. That is software.yaml's `partial`, the
-        webcontainers shape, which computes 2/source_available against a recorded 4. The
-        record's own note already says the backend is proprietary while its `source` key
-        says public. Recording core-gated would make the components compute exactly 4 and
-        close this on a `source` value the read does not support, so it was not recorded.
-        Needs a human to settle `source` first
+  # No deferrals. agentops, langtrace and weave were the last three, and the 2026-08-12
+  # evidence sweep settled all three on 2026-08-12: agentops on app/LICENSE being Elastic
+  # 2.0 rather than the root MIT, langtrace on the `app=` scope prefix that had blocked its
+  # tier lookup, weave on `source` being `partial` rather than `public`.
 comments: ''

--- a/sources/scores/agentops.yaml
+++ b/sources/scores/agentops.yaml
@@ -1,36 +1,39 @@
 product: agentops
 openness:
-  score: 4
-  class: open_core
+  score: 2
+  class: source_available
   components:
     license:
-      value: MIT
-      detail: OSI, SDK
+      value: Elastic-License-2.0
+      detail: app/LICENSE, the AgentOps application
+      raw: Elastic-License-2.0(app/LICENSE, the AgentOps application)+MIT(OSI, root LICENSE, the agentops
+        SDK)
     source:
       value: public
       detail: SDK + self-hostable app dir
     commercial:
       value: app.agentops.ai-SaaS-dashboard-is-the-primary-product
+    core-gated:
+      value: ungated
+      detail: app/ ships the whole platform - api, dashboard, clickhouse, opentelemetry-collector, supabase,
+        deploy, landing and compose.yaml - with no ee/ or enterprise directory, no license-key check and
+        no premium flag
   confidence: medium
-  note: 'MIT SDK plus a self-hostable app, and the read on 2026-08-12 found the recorded license does not
-    describe the product. Left DEFERRED rather than closed, because the evidence does not reproduce the
-    4. What the read established, in order. (1) Nothing is withheld from the published source: app/ ships
-    the whole platform - api, dashboard, clickhouse, opentelemetry-collector, supabase, deploy, landing,
-    compose.yaml - and app/README.md walks through bringing it up on docker compose with a local ClickHouse.
-    There is no ee/ or enterprise directory, no license-key check and no premium flag anywhere in the tree,
-    so on the core_gated question alone this is `ungated`, which against the recorded MIT would compute
-    5/open_source, not 4. (2) But the app is not MIT. app/LICENSE is the Elastic License 2.0, added in the
-    "AgentOps OSS release" (#1190) on 2025-08-09, and it forbids providing the software "to third parties
-    as a hosted or managed service, where the service provides users with access to any substantial set
-    of the features or functionality of the software". That is this ladder''s competition_restricted tier
-    stated directly, and with source public it lands on the 2/source_available rung. The root MIT LICENSE
-    covers the agentops SDK. So the recorded `license: MIT(OSI, SDK)` is accurate about the SDK and silent
-    about the observability app, which is what the map scores under this slug. The vendor''s own README
-    makes the same slip, saying "The AgentOps app is open source under the MIT license" while app/LICENSE
-    says Elastic 2.0; the LICENSE file governs. Neither reading reaches 4 - `ungated` on the recorded MIT
-    gives 5, and the app''s actual license gives 2 - so the components are left untouched and this needs
-    a human to decide which SKU the slug is scored on.'
-  raw: license:MIT(OSI, SDK);source:public(SDK + self-hostable app dir);commercial:app.agentops.ai-SaaS-dashboard-is-the-primary-product
+  note: Scored on app/LICENSE, which is the Elastic License 2.0 and forbids providing the software to third
+    parties as a hosted or managed service. That is this ladder's competition_restricted tier stated directly,
+    and with the source published it lands on the 2/source_available rung. The root LICENSE is plain MIT
+    with no carve-out, so it governs the repository root where the agentops SDK lives and says nothing about
+    app/; both licenses are now recorded as a compound so the ladder applies its own most-restrictive rule
+    rather than reading only the first half. The record previously carried the root MIT alone, which described
+    the SDK and not the observability application this slug is scored on. Nothing is withheld for a paid
+    tier - app/ ships api, dashboard, ClickHouse, the OTel collector, Supabase, deploy and a compose file,
+    with no ee/ directory and no license key - so core-gated is now recorded as `ungated`, but the license
+    rung fires above any rung that reads it. The vendor's README calls the app MIT; app/LICENSE says Elastic
+    2.0, and the LICENSE file governs.
+  raw: license:Elastic-License-2.0(app/LICENSE, the AgentOps application)+MIT(OSI, root LICENSE, the agentops
+    SDK);source:public(SDK + self-hostable app dir);commercial:app.agentops.ai-SaaS-dashboard-is-the-primary-product;core-gated:ungated(app/
+    ships the whole platform - api, dashboard, clickhouse, opentelemetry-collector, supabase, deploy, landing
+    and compose.yaml - with no ee/ or enterprise directory, no license-key check and no premium flag)
   last_verified: '2026-08-12'
   sources:
   - url: https://github.com/AgentOps-AI/agentops

--- a/sources/scores/aws-neuron.yaml
+++ b/sources/scores/aws-neuron.yaml
@@ -1,7 +1,7 @@
 product: aws-neuron
 openness:
-  score: 1
-  class: closed
+  score: 2
+  class: source_available
   components:
     license:
       value: mixed/proprietary-core
@@ -18,18 +18,17 @@ openness:
     hardware-lock:
       value: AWS-Inferentia/Trainium-only
   confidence: high
-  note: 'Headline inference path (Neuron Compiler + Neuron Runtime) has no open-source release anywhere
-    in AWS''s own OSS repository catalog; surrounding glue (kernel driver GPL-2.0, vLLM-for-Neuron, NKI
-    kernel library, MIT-0 samples) is open under various OSI licenses but does not make the engine open_source.
-    CONFLICT, left deferred: the sweep of 2026-08-11 recorded the missing `source` key and it reads `partial`,
-    not `closed`. software.yaml defines `closed` as "a managed service with no self-hostable implementation"
-    and Neuron is not a managed service -- the SDK installs and runs on the customer''s own EC2 instance
-    from proprietary packages. It defines `partial` as "a repo exists but the runtime does not ship - a
-    client, an SDK, or an issue tracker standing in for the engine", which is aws-neuron-sdk exactly: a
-    docs-and-issues repo whose compiler/ and neuron-runtime/ directories hold documentation rather than
-    source, alongside four genuinely open functional components. On that reading the ladder computes 2/source_available
-    against the recorded 1/closed, matching how `webcontainers` is already scored for the same shape. Neither
-    side was adjusted; a human decides which reading the map wants.'
+  note: '2/source_available on `source: partial`. software.yaml defines `closed` as a managed service with
+    no self-hostable implementation, and Neuron is not one - the SDK installs and runs on the customer''s
+    own EC2 instance, from proprietary packages. It defines `partial` as a repo existing while the runtime
+    does not ship, a client, an SDK or an issue tracker standing in for the engine, and aws-neuron-sdk is
+    that exactly: a docs-and-issues repo whose compiler/ and neuron-runtime/ directories hold documentation
+    rather than source. AWS''s own OSS catalog lists six public repositories and neither the Neuron Runtime
+    nor the Neuron Compiler is among them, while the kernel driver (GPL-2.0), the NKI kernel library, vLLM-for-Neuron
+    (Apache-2.0) and the MIT-0 samples do ship as source. The headline inference path is still closed, which
+    is why this is not an open rung; `webcontainers` is already scored 2/source_available for the same shape.
+    The license value `mixed/proprietary-core` maps to no tier, and none is needed: the partial-source rung
+    fires above every rung that tests one.'
   last_verified: '2026-08-11'
   raw: license:mixed/proprietary-core;source:partial(aws-neuron-sdk is a documentation and issue-tracker
     repo carrying no Runtime or Compiler source, while the kernel driver, NKI kernel library, vLLM-for-Neuron

--- a/sources/scores/langtrace.yaml
+++ b/sources/scores/langtrace.yaml
@@ -1,38 +1,39 @@
 product: langtrace
 openness:
-  score: 4
-  class: open_core
+  score: 5
+  class: open_source
   components:
     license:
-      value: app=AGPL-3.0
-      detail: OSI, copyleft
+      value: AGPL-3.0
+      detail: OSI, copyleft, the application
     source:
       value: public
     free_text:
     - SDKs=Apache-2.0(OSI)
     - OTel-built
     - hosted Langtrace Cloud tier exists
+    core-gated:
+      value: ungated
+      detail: the whole AGPL-3.0 application is in the repository - app, components, lib, prisma, proto,
+        Dockerfile, docker-compose.yaml - with no ee/ or enterprise directory, no second license and no
+        license-key check, and the vendor's FAQ says Langtrace Cloud is not charged for
   confidence: high
-  note: 'AGPL-3.0 application, Apache-2.0 SDKs, no enterprise carve-out anywhere, and a cloud tier the vendor
-    says it does not charge for. Left DEFERRED after the 2026-08-12 read, for two reasons that compound.
-    (1) The blocker is not the one the deferral records. `check_rubric` abstains on this product with `blocked_on_tier`,
-    because the recorded license value `app=AGPL-3.0` is a scoped spelling that matches no entry in software.yaml''s
-    license_tier examples and no compound part, so no tier resolves and no rung that tests one can fire.
-    Recording core-gated changes nothing while that holds. Both licenses involved are already declared -
-    AGPL-3.0 and Apache-2.0 are both in the osi examples - so this is a transcription problem, not a missing
-    rule. (2) On the evidence, this is `ungated`. The whole application is in the repository under AGPL-3.0
-    - app, components, lib, prisma, proto, Dockerfile, docker-compose.yaml - with no ee/, no enterprise
-    directory, no second license and no license-key check. The README documents self hosting as a first-class
-    path, and its own FAQ says of the hosted tier "Currently, we are not charging anything for Langtrace
-    cloud and we are primarily looking for feedback so we can continue to improve the project." So there
-    is no paid tier for anything to be withheld for. That combination - osi tier, source public, core-gated
-    ungated - computes 5/open_source against a recorded 4, so the components are left untouched. The recorded
-    4 rests on two rationales the map has since settled against it: the note scores it down for "the AGPL
-    copyleft", which issue #125 rejected (AGPL sits beside Apache on the osi rung), and for a "hosted commercial
-    offering", which the core_gated rule rejects and which in this case is not even charged for. A human
-    should settle the 4 and fix the license spelling in one move.'
-  raw: license:app=AGPL-3.0(OSI, copyleft);source:public;SDKs=Apache-2.0(OSI);OTel-built;hosted Langtrace
-    Cloud tier exists
+  note: 'AGPL-3.0 application, Apache-2.0 SDKs, and nothing withheld from the published source, which is
+    the osi + public + ungated rung at 5/open_source. Two corrections got it there. The license was recorded
+    as `app=AGPL-3.0`, a scope prefix that matches no license_tier example, so no tier resolved and every
+    rung testing one was blocked; the scope is which artifact a license covers rather than a different license,
+    so it is dropped and the SDK''s Apache-2.0 stays recorded beside it. And core-gated reads `ungated`:
+    the whole application is in the repository with no ee/ or enterprise directory, no second license and
+    no license key, self-hosting is documented as a first-class path, and the vendor''s own FAQ says of
+    the hosted tier "Currently, we are not charging anything for Langtrace cloud". The prior 4 rested on
+    AGPL copyleft and on a hosted tier existing, and the map has settled against both - issue #125 puts
+    AGPL beside Apache on the osi rung, and a product sold beside an otherwise complete open core does not
+    gate that core.'
+  raw: license:AGPL-3.0(OSI, copyleft, the application);source:public;core-gated:ungated(the whole AGPL-3.0
+    application is in the repository - app, components, lib, prisma, proto, Dockerfile, docker-compose.yaml
+    - with no ee/ or enterprise directory, no second license and no license-key check, and the vendor's
+    FAQ says Langtrace Cloud is not charged for);SDKs=Apache-2.0(OSI);OTel-built;hosted Langtrace Cloud
+    tier exists
   last_verified: '2026-08-12'
   sources:
   - url: https://github.com/Scale3-Labs/langtrace

--- a/sources/scores/nemo-data-designer.yaml
+++ b/sources/scores/nemo-data-designer.yaml
@@ -13,15 +13,17 @@ openness:
     free_text:
     - the archived gretel-synthetics OSS repo (Apache-2.0) is a separate legacy artifact, not this product
   confidence: medium
-  note: 'CONFLICT, left deferred. The prior record described this as a proprietary closed NeMo microservice
-    on the strength of a single TechCrunch article. NVIDIA''s own documentation contradicts it: the NeMo
-    microservices Data Designer page states "The service is built on the open-source NVIDIA NeMo Data Designer
-    library" and links to github.com/NVIDIA-NeMo/DataDesigner, which is Apache-2.0, installs with `pip install
-    data-designer`, and ships the whole generation framework rather than a client for a hosted service.
-    So `source` is public and the license is OSI, and rung 0 no longer fires -- the recorded 1/closed cannot
-    be reproduced from the evidence at any value of core-gated. `core-gated` was deliberately NOT recorded:
-    closing it needs a read of what, if anything, the NeMo Platform withholds from the published library,
-    which this pass did not do. Score, class and the product description are left untouched for a human.'
+  note: 'Still deferred, and the reason has changed. The prior 1/closed described this as a proprietary
+    NeMo microservice on the strength of a single TechCrunch article, and NVIDIA''s own documentation contradicts
+    it: the NeMo microservices Data Designer page states "The service is built on the open-source NVIDIA
+    NeMo Data Designer library" and links to github.com/NVIDIA-NeMo/DataDesigner, which is Apache-2.0, installs
+    with `pip install data-designer`, and ships the whole generation framework rather than a client for
+    a hosted service. So `source` is public and the license is OSI, the closed rung cannot fire, and the
+    recorded 1 is not reproducible at any value of core-gated. What keeps it deferred is that the ladder''s
+    remaining rungs both test core-gated, and no read has yet established what, if anything, the NeMo Platform
+    withholds from the published library. The product is somewhere in {4, 5} and a value was deliberately
+    not invented to close it. Score and class are left at the unreproducible 1 rather than guessed, which
+    is what the deferral records.'
   raw: license:Apache-2.0(OSI, NVIDIA-NeMo/DataDesigner LICENSE);source:public(pip install data-designer,
     the published framework runs locally against any configured inference provider);the archived gretel-synthetics
     OSS repo (Apache-2.0) is a separate legacy artifact, not this product

--- a/sources/scores/unsloth.yaml
+++ b/sources/scores/unsloth.yaml
@@ -1,7 +1,7 @@
 product: unsloth
 openness:
-  score: 5
-  class: open_source
+  score: 4
+  class: open_core
   components:
     license:
       value: Apache-2.0
@@ -16,17 +16,16 @@ openness:
         support and up to 8 GPUs, and Enterprise adds multi-node, full training and 5x faster inference;
         Pro is advertised as 20% less memory than OSS, an explicit comparison against the published package'
   confidence: high
-  note: 'OSI-licensed throughout (Apache-2.0 core, AGPL-3.0 for the optional Studio UI). CONFLICT, left
-    deferred: the 2026-08-11 read of unsloth.ai/pricing records core-gated as gated, and the ladder then
-    computes 4/open_core against the recorded 5/open_source. Unsloth Pro and Enterprise are not a separate
-    hosted service sold beside the open package; they are builds of the same product carrying capabilities
-    the free column says it does not have. The free tier lists MultiGPU as "coming soon" while Pro lists
-    "Enhanced MultiGPU support" and "Up to 8 GPUS support", and Enterprise adds multi-node, "Supports full
-    training" and "5x faster inference". Pro is advertised as "20% less memory than OSS", an explicit comparison
-    against the published package. That is functionality withheld from the published source, which is what
-    software.yaml defines gating to be. Neither side was adjusted. Caveat for the human: the pricing page
-    names Llama 1/2/3 and Mistral/Gemma and looks stale, so the exact feature line may have moved even though
-    the tiering has not.'
+  note: '4/open_core: OSI-licensed throughout (Apache-2.0 core, AGPL-3.0 for the optional Studio UI) with
+    the source published, and unsloth.ai/pricing sells Unsloth Pro and Enterprise on capabilities the free
+    open-source tier does not have. Those are not a hosted service sold beside the open package; they are
+    builds of the same product. The free column lists MultiGPU as "coming soon" while Pro lists "Enhanced
+    MultiGPU support" and "Up to 8 GPUS support", Enterprise adds multi-node, "Supports full training" and
+    "5x faster inference", and Pro is advertised as "20% less memory than OSS", an explicit comparison against
+    the published package. That is functionality withheld from the published source, which is what software.yaml
+    defines gating to be, so the recorded 5 moves to the osi + public + gated rung. Caveat: the pricing
+    page names Llama 1/2/3 and Mistral/Gemma and looks stale, so the exact feature line may have moved even
+    though the tiering has not.'
   last_verified: '2026-08-11'
   raw: 'license:Apache-2.0(OSI, core unsloth pkg)+AGPL-3.0(OSI, optional Unsloth Studio UI);source:public(unslothai/unsloth);core-gated:gated(unsloth.ai/pricing
     sells Unsloth Pro and Enterprise on capabilities the free open-source tier does not have: the free column

--- a/sources/scores/weave.yaml
+++ b/sources/scores/weave.yaml
@@ -1,40 +1,38 @@
 product: weave
 openness:
-  score: 4
-  class: open_core
+  score: 2
+  class: source_available
   components:
     license:
       value: Apache-2.0
       detail: OSI, SDK/client repo wandb/weave
     source:
-      value: public
+      value: partial
+      detail: the Apache-2.0 repo publishes the SDK and a ClickHouse-backed trace-server library, but no
+        web UI, no deployment manifest and not the HTTP service that fronts the trace server, which its
+        own trace_server/README.md places in W&B's closed core repository
     backend:
       value: commercial
       detail: W&B SaaS platform hosts traces/evals; full platform is proprietary, self-host is enterprise
     eval+tracing-client:
       value: OSS
   confidence: high
-  note: 'Apache-2.0 SDK and trace-server library from Weights & Biases, with the runnable Weave application
-    not published. Left DEFERRED after the 2026-08-12 read, because the read undercuts `source: public`
-    rather than filling the core-gated gap, and the two cannot both stand. What is published, and it is
-    more than an SDK: wandb/weave is Apache-2.0 and weave/trace_server/ holds a real ClickHouse-backed implementation
-    - clickhouse_trace_server_batched.py, a schema, migrations, query builders, workers, kafka, file storage
-    and OpenTelemetry ingest. What is not published: any web UI, any deployment manifest (no docker-compose,
-    no chart, bin/ holds two codex setup scripts), and the HTTP service that fronts the trace server - the
-    repository''s own weave/trace_server/README.md diagrams it as "(in core) trace_server.py TraceWebServer",
-    core being W&B''s closed repository. sdks/ contains only node. The README''s stated prerequisite is
-    "A Weights & Biases account", and W&B''s deployment docs say a self-managed install needs a W&B Server
-    license obtained before installation, with "Some features and functionality require an Enterprise license."
-    So you cannot stand the product up from the published repository, which is software.yaml''s definition
-    of `partial` - the webcontainers shape, a core published and the engine withheld - and `partial` computes
-    2/source_available against a recorded 4. The record''s own prose already says as much ("the trace store
-    / dashboards / monitoring backend is the proprietary W&B SaaS platform, ... self-host is enterprise")
-    while its `source` key says `public`; the key and the note disagree. Recording `core-gated: gated` would
-    make the recorded components compute exactly 4 and close this, which is why it was not done - the 4
-    would then rest on a `source` value this read does not support. A human should settle `source` first;
-    core-gated only matters if it stays `public`.'
-  raw: license:Apache-2.0(OSI, SDK/client repo wandb/weave);source:public;backend:commercial(W&B SaaS platform
-    hosts traces/evals; full platform is proprietary, self-host is enterprise);eval+tracing-client:OSS
+  note: '`source` is `partial`, so this scores 2/source_available on the rung above any license test. wandb/weave
+    is Apache-2.0 and publishes more than an SDK - weave/trace_server/ holds a working ClickHouse implementation
+    with schema, migrations, query builders, workers, Kafka, file storage and OpenTelemetry ingest - but
+    the repository carries no web UI, no docker-compose or chart, and not the HTTP service that fronts the
+    trace server. The repository''s own weave/trace_server/README.md diagrams that service as "(in core)
+    trace_server.py TraceWebServer", core being W&B''s closed repository; the package README''s stated prerequisite
+    is a Weights & Biases account; and W&B''s deployment docs say a self-managed install needs a W&B Server
+    license obtained before installation. You cannot stand the product up from what is published, which
+    is software.yaml''s definition of `partial` and the shape `webcontainers` is already scored on. The
+    record''s own prose had said as much while its `source` key said `public`; the key now matches the read.
+    core-gated is not reached and stays unrecorded.'
+  raw: license:Apache-2.0(OSI, SDK/client repo wandb/weave);source:partial(the Apache-2.0 repo publishes
+    the SDK and a ClickHouse-backed trace-server library, but no web UI, no deployment manifest and not
+    the HTTP service that fronts the trace server, which its own trace_server/README.md places in W&B's
+    closed core repository);backend:commercial(W&B SaaS platform hosts traces/evals; full platform is proprietary,
+    self-host is enterprise);eval+tracing-client:OSS
   last_verified: '2026-08-12'
   sources:
   - url: https://github.com/wandb/weave

--- a/tests/test_check_parity.py
+++ b/tests/test_check_parity.py
@@ -160,10 +160,23 @@ def test_local_scores_matches_check_rubrics_split():
     is real, the WildGuardMix corpus is public, but `allenai/wildguard` ships nine files with
     no trainer and no training config, its companion Safety-Eval repo is an evaluation suite,
     and the card sends readers to the paper appendix for training details. That is
-    `code:partial`, the 4-rung still fails, and open data on its own does not carry it."""
+    `code:partial`, the 4-rung still fails, and open data on its own does not carry it.
+
+    Then 448/24 -> 453/19 when the five conflicts the sweep had left open were ruled on
+    rather than re-read, on 2026-08-12. Two were factual errors in the record: agentops
+    carried the root MIT that covers only its SDK while app/LICENSE is Elastic 2.0, and
+    langtrace spelled its license `app=AGPL-3.0`, a scope prefix matching no tier example
+    and so blocking every rung that tests one. One was a read recorded but not acted on:
+    weave's `source` said `public` while the read established `partial`. The other two
+    already computed a score the record disagreed with, and the record moved: unsloth
+    4/open_core on its recorded `core-gated:gated`, aws-neuron 2/source_available on its
+    recorded `source:partial`. Four of the five moved a published score, in both
+    directions. nemo-data-designer stayed deferred - both rungs it can reach test
+    core-gated, nobody has read what the NeMo Platform withholds from the published
+    library, and a value was not invented to close it."""
     computed, deferred = local_scores(None)
-    assert len(deferred) == 24
-    assert len(computed) == 448
+    assert len(deferred) == 19
+    assert len(computed) == 453
     assert not set(computed) & set(deferred)
     # Every one of the 410 reproduces today, so none should abstain.
     assert [key for key, value in computed.items() if value is None] == []

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -746,7 +746,12 @@ def test_real_sources_serialize_without_errors():
         # ml_frameworks 80 -> 88 with the same sweep: pysyft and feluda were its only two
         # deferrals and both closed on a `core-gated:ungated` read, so the category now defers
         # nothing at all.
-        "finetuning_code": 133, "inference_code": 84, "ml_frameworks": 88,
+        # finetuning_code 133 -> 137 and inference_code 84 -> 89 when the last two conflicts in
+        # those categories were ruled on rather than re-read, on 2026-08-12. unsloth and
+        # aws-neuron each already recorded the deciding dimension and were publishing nothing
+        # because a deferred product publishes nothing; the score moved to what the ladder
+        # computes and the rows appeared.
+        "finetuning_code": 137, "inference_code": 89, "ml_frameworks": 88,
         # orchestration_agents rose by 3 when n8n's stale deferral was removed: a deferred
         # product publishes no openness evidence, and n8n had been deferred as "not recorded"
         # while recording everything the ladder needed. Then by 6 more (140 -> 146) when
@@ -791,7 +796,12 @@ def test_real_sources_serialize_without_errors():
         # count is the check on that. The three bare-`gated` products in the category were
         # already computed: agenta and langwatch kept their 4 with the gate now evidenced, and
         # helicone moved 4 -> 5 on `core-gated:ungated`, none of which adds or removes a row.
-        "orchestration_agents": 207, "telemetry_observability": 99, "ui_api": 184,
+        #
+        # telemetry_observability 99 -> 112 when the last three came off on 2026-08-12. Each
+        # publishes its rows for the first time: agentops five (license, source, commercial,
+        # core-gated and the normalized core_gated), langtrace four and weave four. The
+        # category now defers nothing.
+        "orchestration_agents": 207, "telemetry_observability": 112, "ui_api": 184,
         # training_synthetic_datasets is unchanged at 158 across the ladder widening, which
         # is the check that mattered: benchmark_eval_data's new dimensions and rungs did not
         # disturb the category the ladder was derived from.


### PR DESCRIPTION
## Summary

The evidence sweep read the sources for six deferred products and recorded what it found, then deliberately left each recorded score alone rather than reconciling it. This lets the recorded evidence govern the recorded score.

**Five resolve. One is stopped on, deliberately.** Scores move in both directions.

| Product | Before | After | Why |
|---|---|---|---|
| `agentops` | 4 / open_core | **2 / source_available** | the application is under Elastic License 2.0, which forbids hosted-service use and tiers as `competition_restricted` |
| `weave` | 4 / open_core | **2 / source_available** | the repo publishes an SDK and a trace-server library but not the UI, the deploy manifest or the HTTP service, so `source` is `partial` |
| `unsloth` | 5 / open_source | **4 / open_core** | Pro and Enterprise sell multi-GPU, multi-node and full training the free column says the open package lacks |
| `langtrace` | 4 / open_core | **5 / open_source** | with the `app=` scope prefix dropped the license tiers as `osi`, and nothing is withheld from the published source |
| `aws-neuron` | 1 / closed | **2 / source_available** | Neuron is not a managed service; `aws-neuron-sdk` is a docs-and-issues repo standing in for an engine that does not ship |

Two of these were **factual errors** rather than disagreements about policy. `agentops` recorded a license its repository does not carry. `langtrace` recorded `app=AGPL-3.0`, a scope-prefixed spelling matching no tier example, which silently blocked every tier-testing rung — and its 4 rested on AGPL copyleft plus the existence of a hosted tier, both rules the map has since rejected.

## `agentops`: the ladder decided, not the author

The root LICENSE is MIT and covers only the SDK; `app/LICENSE` is Elastic 2.0 and covers the application. Rather than picking one, **both are now recorded as a compound** — `Elastic-License-2.0(app/LICENSE…)+MIT(OSI, root LICENSE, the agentops SDK)` — so the most-restrictive-part rule introduced in #200 selects it mechanically.

It is also the right SKU: the slug sits in `telemetry_observability`, and its own product record calls the SaaS dashboard the primary product, so the observability application is what is being scored.

## Stopped on: `nemo-data-designer`

`source: public` and an OSI license make the recorded 1 / closed unreproducible — NVIDIA's own docs state the service is built on the open-source library at `NVIDIA-NeMo/DataDesigner`, and the recorded 1 rested on a single TechCrunch link.

But both reachable rungs test `core-gated`, and no read has established what the NeMo Platform withholds. It stays deferred with a rewritten reason. **No `core-gated` value was invented to make it close**, which is the whole point of stopping.

## Result

Deferrals 24 → **19**. `telemetry_observability`, `finetuning_code` and `inference_code` now defer nothing — 26/26, 27/27 and 20/20 respectively.

## Test plan

- Each product's state verified before it was touched.
- Every move explainable in one sentence from evidence already on file, recorded by the sweep that read it.
- Suite 454 passed. `validate` 0 error(s), `check_recipe` 0 failure(s), `check_rubric` exit 0, `check_components` `[OK]`.
- Two pinned fixtures updated with reasons in their docstrings.
