### PR TITLE
refactor(scores): record the license as structured parts

### DIFF
--- a/build/check_components.py
+++ b/build/check_components.py
@@ -21,6 +21,12 @@ narrowed past, which meant a new or reverted string-shaped record passed every g
 including this one, and silently returned the corpus to mixed shape. The mapping is now the
 only shape this field may take.
 
+A FOURTH thing is a failure since the license was structured into parts: a license key
+recorded as a `{value, detail}` mapping rather than a list of `{name, detail?, raw?}`.
+`license_tier` resolves the parts a curator recorded and never splits a value itself, so a
+license left in the dimension shape is a compound nobody decomposed — which is the failure
+this repo has now had twice, once per reader.
+
 Exit status is 1 on any failure, so CI can gate on it.
 """
 
@@ -31,7 +37,7 @@ from pathlib import Path
 
 import yaml
 
-from build.check_rubric import FREE_TEXT, _clauses, recompose, split_components
+from build.check_rubric import FREE_TEXT, _clauses, is_license_key, recompose, split_components
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -69,6 +75,20 @@ def check(root: Path = ROOT) -> list[str]:
                         f"{slug}.{key}: mapping recomposes to {actual.get(key)!r}, "
                         f"raw says {expected.get(key)!r}"
                     )
+
+        for key, entry in components.items():
+            if key == FREE_TEXT or not is_license_key(key):
+                continue
+            if not isinstance(entry, list):
+                failures.append(
+                    f"{slug}.{key}: a license is recorded as a LIST of "
+                    f"{{name, detail?, raw?}} parts, one per license the product makes you "
+                    f"accept, not as {type(entry).__name__}. `license_tier` resolves the "
+                    f"parts as recorded and never splits a value itself; a mapping here "
+                    f"would abstain or resolve on the wrong half. Structure it with "
+                    f"build.check_rubric.license_entry and write it through "
+                    f"build/components.py."
+                )
 
         keyless = [c.strip() for c in _clauses(raw) if ":" not in c.strip()]
         recorded = components.get(FREE_TEXT, [])

--- a/build/check_parity.py
+++ b/build/check_parity.py
@@ -118,7 +118,7 @@ def local_scores(category_filter: str | None) -> tuple[dict, dict]:
             # `currentai.scores.openness_computed` carries the same rule: the SQL still
             # resolves the tier up front, so the five products that score without one will
             # read as local-scored / warehouse-abstained until it is updated.
-            computed[key] = score_openness(recipe, components_of(openness)).result
+            computed[key] = score_openness(recipe, openness).result
     return computed, deferred
 
 

--- a/build/check_recipe.py
+++ b/build/check_recipe.py
@@ -352,7 +352,7 @@ def stale_deferrals(
         if recipe is None:
             continue
         openness = (yaml.safe_load(path.read_text()) or {}).get("openness") or {}
-        got = score_openness(recipe, components_of(openness)).result
+        got = score_openness(recipe, openness).result
         if got is not None and got == (openness.get("score"), openness.get("class")):
             problems.append(
                 f"category '{slug}' defers '{product}', but the ladder now reproduces its "

--- a/build/check_rubric.py
+++ b/build/check_rubric.py
@@ -79,17 +79,21 @@ def head(value: str) -> str:
     Reads a DIMENSION value — `open(downloadable on HF, gated)` -> `open`. Dimension
     vocabularies are single tokens, so cutting at the first `(` or `,` is the whole job.
 
-    It is deliberately NOT the first statement of license resolution any more. A license
-    value is not a single token: `Apache-2.0(code, OSI) + custom weights license(non-OSI)`
-    is two licenses, and cutting it here resolved the product on its first half and never
-    saw the restrictive one. `license_parts` splits first and this runs per part, on a
-    fragment that IS a single token followed by its annotation.
+    It has no part in license resolution. A license value is not a single token, and
+    cutting one here resolved the product on its first half and never saw the restrictive
+    one. Licenses are now recorded as parts (see `license_segments`), so the reader is
+    handed a bare name and has nothing left to cut.
     """
     return re.split(r"[(,]", value)[0].strip()
 
 
-def license_parts(raw: str) -> list[str]:
-    """The `+`-joined halves of a compound license, split at paren depth zero.
+def license_segments(raw: str) -> list[str]:
+    """A recorded license clause cut into its `+`-joined segments, at paren depth zero.
+
+    RECORDING-time only. This is the one place the mechanical split lives, and it runs
+    when a clause is first structured into parts — never when a score is read. Reading
+    resolves the parts the curator recorded, so a compound the curator meant as one
+    declared name stays one part and nothing has to infer that from punctuation.
 
     Depth zero because annotations carry their own punctuation —
     `Sustainable-Use-License(fair-code,non-OSI: internal-use-only,no-resale/SaaS)+n8n-Enterprise-License`
@@ -98,10 +102,15 @@ def license_parts(raw: str) -> list[str]:
 
     Only `+` separates licenses. A depth-zero comma does not: every one in the corpus is
     prose trailing a single license (`Proprietary, proprietary service`,
-    `MIT(Maple-client)+AGPL-3.0(OpenSecret-platform),both-OSI`), which is why the comma
-    stays `head`'s business, inside a part, rather than becoming a separator here.
+    `MIT(Maple-client)+AGPL-3.0(OpenSecret-platform),both-OSI`), which is why the comma is
+    left inside a segment, to be split off as that part's `detail`.
+
+    Segments come back VERBATIM, padding included, and empties are kept. `+`.join of them
+    is the clause byte-for-byte, which is what lets a part carry its own `raw` and
+    `recompose` still reproduce what the file said — `internlm` is the one record whose
+    join is written ` + ` rather than `+`.
     """
-    parts: list[str] = []
+    segments: list[str] = []
     depth = 0
     current = ""
     for char in raw:
@@ -110,12 +119,12 @@ def license_parts(raw: str) -> list[str]:
         elif char == ")":
             depth = max(0, depth - 1)
         if char == "+" and depth == 0:
-            parts.append(current)
+            segments.append(current)
             current = ""
         else:
             current += char
-    parts.append(current)
-    return [part.strip() for part in parts if part.strip()]
+    segments.append(current)
+    return segments
 
 
 def split_value(raw: str) -> tuple[str, str]:
@@ -135,6 +144,96 @@ def split_value(raw: str) -> tuple[str, str]:
 
 
 FREE_TEXT = "free_text"
+
+
+def is_license_key(key: str) -> bool:
+    """Whether a recorded `components` key carries a license.
+
+    Five keys in the corpus do — `license`, `model-license`, `repo-license`,
+    `license-terms`, `per-dataset-licenses` — and three of them are named in some ladder's
+    `license_tier.reads`. The substring test covers all five and any future spelling,
+    which matters because the alternative is a hardcoded list that a new key silently
+    falls off, landing a license back in the unstructured shape.
+
+    All five take the structured part list, not just the three a ladder reads. One shape
+    for a recorded license wherever it appears; a reader should never have to know which
+    keys a recipe happens to consult to know what shape the value is in.
+    """
+    return "license" in key.lower()
+
+
+def render_license_part(part: dict) -> str:
+    """One recorded license part back as the text it was cut from.
+
+    `raw` wins where it is present, for the same reason it does on a dimension entry: the
+    `{name, detail}` split cannot reproduce a clause whose prose runs past the closing
+    paren (`Apache-2.0(OSI) for the framework`) or whose comma is a separator rather than
+    a value boundary (`Proprietary, proprietary service`).
+    """
+    if "raw" in part:
+        return part["raw"]
+    detail = part.get("detail")
+    return f"{part['name']}({detail})" if detail else part["name"]
+
+
+def license_part(segment: str) -> dict:
+    """One verbatim segment as `{name, detail?, raw?}`.
+
+    `name` is the bare license as recorded — `code `/`model ` prefixes and `assumed-`
+    included. Those are reading rules (`normalize_license` applies them), not recording
+    rules, and stripping them here would turn re-derivable evidence into a conclusion.
+
+    `raw` is the segment VERBATIM, padding included, for the segments `{name, detail}`
+    cannot reproduce. Padding is part of that: `internlm` writes its join as ` + `, and
+    since `recompose` joins on a bare `+` the spaces have to be carried by the segments
+    either side or the record recomposes one byte off what its file says.
+    """
+    bare, detail = split_value(segment.strip())
+    part: dict = {"name": bare}
+    if detail:
+        part["detail"] = detail
+    if render_license_part(part) != segment:
+        part["raw"] = segment
+    return part
+
+
+def license_entry(value: str) -> list[dict]:
+    """A recorded license clause as the list of parts a ladder resolves.
+
+    The mechanical split, applied once when the clause is structured. A curator who
+    recorded a compound-looking string that is genuinely ONE declared name overrides this
+    by hand, to a single-element list — which is the whole point of structuring: the
+    intent lives in the data rather than being re-inferred from a `+` on every read.
+    """
+    return [license_part(segment) for segment in license_segments(value)]
+
+
+def render_entry(entry: dict | list) -> str:
+    """One structured `components` entry back as its raw clause.
+
+    Both shapes: a license is a list of parts joined on `+`, anything else is the
+    `{value, detail?, raw?}` mapping.
+    """
+    if isinstance(entry, list):
+        return "+".join(render_license_part(part) for part in entry)
+    if "raw" in entry:
+        return entry["raw"]
+    detail = entry.get("detail")
+    return f"{entry['value']}({detail})" if detail else entry["value"]
+
+
+def license_parts_of(entry: object) -> list[dict]:
+    """The parts a ladder resolves, from whatever shape the entry is in.
+
+    A list is already parts. A mapping is an unmigrated license — the gate in
+    `check_components` rejects one, so this is for tools and tests rather than the corpus,
+    and it structures the recomposed clause rather than growing a second splitter.
+    """
+    if isinstance(entry, list):
+        return entry
+    if isinstance(entry, dict):
+        return license_entry(render_entry(entry))
+    return []
 
 
 def _clauses(text: str) -> list[str]:
@@ -165,6 +264,9 @@ def _clauses(text: str) -> list[str]:
 def structure(text: str) -> dict:
     """The flat `k:v;k:v` string as a mapping of key -> {value, detail?, raw?}.
 
+    A license key takes the other shape — a LIST of `{name, detail?, raw?}` parts, one per
+    `+`-joined segment. This is the only place that split runs.
+
     `raw` appears only when `f"{value}({detail})"` does not reproduce the clause
     byte-for-byte. 155 entries on 81 products need one, in three shapes: text after the
     closing paren ('Apache-2.0(OSI) for the framework'), a comma that is a list separator
@@ -185,6 +287,9 @@ def structure(text: str) -> dict:
             continue
         key, value = clause.split(":", 1)
         key, value = key.strip(), value.strip()
+        if is_license_key(key):
+            out[key] = license_entry(value)
+            continue
         bare, detail = split_value(value)
         entry: dict = {"value": bare}
         if detail:
@@ -203,16 +308,7 @@ def recompose(mapping: dict) -> dict[str, str]:
     This is the join that makes the migration score-neutral: every reader keeps seeing the
     exact strings it saw before the shape changed.
     """
-    out: dict[str, str] = {}
-    for key, entry in mapping.items():
-        if key == FREE_TEXT:
-            continue
-        if "raw" in entry:
-            out[key] = entry["raw"]
-            continue
-        detail = entry.get("detail")
-        out[key] = f"{entry['value']}({detail})" if detail else entry["value"]
-    return out
+    return {key: render_entry(entry) for key, entry in mapping.items() if key != FREE_TEXT}
 
 
 def components_of(openness: dict) -> dict[str, str]:
@@ -225,6 +321,19 @@ def components_of(openness: dict) -> dict[str, str]:
     if isinstance(components, dict):
         return recompose(components)
     return split_components(components or "")
+
+
+def structured_components_of(openness: dict) -> dict:
+    """The components as the structured mapping, from either shape.
+
+    The counterpart to `components_of` for the one reader that needs structure rather than
+    a clause: license resolution, which consumes recorded parts. A string-shaped record is
+    structured on the way past, so there is still exactly one splitter.
+    """
+    components = (openness or {}).get("components")
+    if isinstance(components, dict):
+        return components
+    return structure(components or "")
 
 
 def components_string(openness: dict) -> str:
@@ -270,11 +379,11 @@ def recorded_license_aliases() -> dict[str, str]:
 
 
 def normalize_license(raw: str) -> str:
-    """Reduce ONE recorded license to the name the tier examples are written in.
+    """Reduce ONE recorded license NAME to the spelling the tier examples use.
 
-    Runs on a single part, after `license_parts` has split a compound. Three
-    mechanical steps, all spelled out in the recipe's `normalization` list:
-      * the annotation is dropped — `Apache-2.0(code, OSI)` is Apache-2.0;
+    Runs on a part's `name`, which the record already carries bare — the annotation is
+    `detail` and no reader has to cut it off. Two mechanical steps, both spelled out in
+    the recipe's `normalization` list:
       * a `code ` or `model ` scope prefix is dropped, because the scope is which
         artifact the license covers, not a different license;
       * `assumed-Modified-MIT` — the `assumed-` prefix marks confidence, not a
@@ -284,16 +393,19 @@ def normalize_license(raw: str) -> str:
     name. Applied last, so it sees the value after the mechanical steps rather
     than having to enumerate every prefixed variant.
 
+    It does NOT truncate. It used to open with `head`, which cut at the first `(` or `,`;
+    on a structured name there is nothing to cut, and a name that still contains one is a
+    recording error that should abstain rather than resolve on its first token.
+
     The `code X + model Y` rule that used to live here — the MODEL license governs —
-    is now a consequence rather than a special case: both halves resolve and the most
+    is now a consequence rather than a special case: both parts resolve and the most
     restrictive wins, and a weights license is the restrictive half in every recorded
     instance. Where it would not be, the old rule was wrong anyway: a permissive
     weights license does not buy back a restrictive code license.
 
     Purely mechanical. Anything needing judgment is left alone to be flagged.
     """
-    value = head(raw)
-    value = re.sub(r"(?i)^\s*(code|model)\s+", "", value.strip()).strip()
+    value = re.sub(r"(?i)^\s*(code|model)\s+", "", raw.strip()).strip()
     value = re.sub(r"(?i)^assumed-", "", value).strip()
     return recorded_license_aliases().get(value.lower(), value)
 
@@ -321,30 +433,27 @@ def _tier_of(needle: str, tiers: dict) -> str | None:
     return None
 
 
-def license_tier(raw: str, recipe: dict) -> str | None:
-    """Map a license string onto a tier from the recipe's own examples.
+def license_tier(parts: list[dict], recipe: dict) -> str | None:
+    """Map the recorded license parts onto a tier from the recipe's own examples.
 
-    A compound license resolves on ALL its parts, most restrictive governing. That is
-    what `docs/guides/identity.md` already says openness does across a release's SKUs —
-    "a product is as open as the most restrictive license you must accept to use it" —
-    and a `+` in a recorded value is that same fact written on one line. Before this,
-    resolution truncated at the first `(` or `,` and so read only the first half:
-    `internlm` records Apache-2.0 code plus a custom application-gated weights license
-    and resolved as `osi`, never seeing the license that actually governs the weights.
+    Every part is resolved and the most restrictive governs. That is what
+    `docs/guides/identity.md` already says openness does across a release's SKUs — "a
+    product is as open as the most restrictive license you must accept to use it" — and a
+    product recording two licenses is that same fact written on one axis.
 
-    Two things this deliberately does not do:
+    It takes PARTS, not a string, and that is the whole design. There is no split here and
+    no whole-value pre-check: the curator recorded how many licenses there are, so a
+    compound-looking phrase that is really one declared name — `follows mC4 + OSCAR-2301
+    terms`, where neither operand is a license — arrives as a single part and resolves as
+    the one thing it is. Inferring that from punctuation is what needed the pre-check, and
+    what made this rubric expensive to state twice: `build/serialize_rubric.py` published
+    the same values through a splitter that cut at the first `(` and scored two products
+    differently from the repo.
 
-      * It does not skip a part it cannot map. Every part must resolve or the whole
-        value abstains, because an unmapped part can only ever be MORE restrictive than
-        the tier the mapped parts reached — ignoring it is exactly how partial coverage
-        overstates openness.
-      * It does not decompose a compound the recipe declared as a single name. The
-        whole, untruncated value is looked up first, so a phrase whose `+` is English
-        rather than a join — `follows mC4 + OSCAR-2301 terms`, where neither operand is
-        a license — resolves as the one thing the curator recorded. A compound whose
-        operands ARE license names does not belong in a tier's examples: it is a
-        per-product override, and decomposition handles it once each operand is
-        declared on its own.
+    One thing this deliberately does not do: skip a part it cannot map. Every part must
+    resolve or the whole value abstains, because an unmapped part can only ever be MORE
+    restrictive than the tier the mapped parts reached — ignoring it is exactly how
+    partial coverage overstates openness.
 
     Returns None when the license is unmapped, which is a finding rather than an
     error — an unmapped license means the rubric has not yet been told how to
@@ -354,13 +463,9 @@ def license_tier(raw: str, recipe: dict) -> str | None:
     if not tiers:
         return None
 
-    declared = _tier_of(
-        recorded_license_aliases().get(raw.strip().lower(), raw.strip()).lower(), tiers
-    )
-    if declared is not None:
-        return declared
-
-    resolved = [_tier_of(normalize_license(part).lower(), tiers) for part in license_parts(raw)]
+    resolved = [
+        _tier_of(normalize_license(part.get("name", "")).lower(), tiers) for part in parts
+    ]
     if not resolved or any(tier is None for tier in resolved):
         return None
     rank = tier_rank(tiers)
@@ -533,8 +638,12 @@ class Outcome(NamedTuple):
     blocked_on_tier: bool
 
 
-def score_openness(recipe: dict, components: dict[str, str]) -> Outcome:
-    """Replay one ladder against one product's recorded components.
+def score_openness(recipe: dict, openness: dict) -> Outcome:
+    """Replay one ladder against one product's recorded openness axis.
+
+    Takes the axis BLOCK rather than the recomposed clause dict it used to take, because
+    the license is resolved from its recorded parts and a clause dict has thrown that
+    structure away. Every caller had the block in hand already.
 
     The tier is resolved eagerly for REPORTING — `tier is None` on a product that still
     scores is what `check_recipe` counts and names — but it is only ever REQUIRED by
@@ -547,14 +656,17 @@ def score_openness(recipe: dict, components: dict[str, str]) -> Outcome:
     `license_tier` condition with no declared tiers, so such a ladder cannot have a rung
     that needs one.
     """
+    components = components_of(openness)
     has_tiers = bool(((recipe.get("openness") or {}).get("license_tier") or {}).get("values"))
     raw_license = ""
     tier = None
     if has_tiers:
-        raw_license = next(
-            (components[key] for key in license_read_keys(recipe) if components.get(key)), ""
-        )
-        tier = license_tier(raw_license, recipe)
+        # The key is chosen once and both the clause and the parts come from it. Choosing
+        # twice is how the reported license and the resolved one could name different keys.
+        key = next((key for key in license_read_keys(recipe) if components.get(key)), None)
+        if key is not None:
+            raw_license = components[key]
+            tier = license_tier(license_parts_of(structured_components_of(openness).get(key)), recipe)
 
     # Facts come from the dimensions the recipe DECLARES, not a fixed list. The model
     # categories ask about weights/data/code; software categories ask whether the source is
@@ -652,7 +764,7 @@ def check_category(slug: str, verbose: bool) -> CategoryReport:
         # zero rows and only requires `ordered_by` above one tier. Both allowances change
         # shared resolution semantics, so the warehouse mirror in
         # `currentai.scores.openness_computed` needs them too.
-        outcome = score_openness(recipe, components)
+        outcome = score_openness(recipe, openness)
         facts, tier, has_tiers = outcome.facts, outcome.tier, outcome.has_tiers
         if outcome.blocked_on_tier:
             problems.append(

--- a/docs/guides/verification.md
+++ b/docs/guides/verification.md
@@ -55,6 +55,24 @@ is migrating to, one dimension at a time; every reader in this repo goes through
 `build.check_rubric.components_of`, which returns the same key -> clause dict whichever
 shape a given file carries, so the audit chain above holds unchanged either way.
 
+A license is recorded differently from a dimension: as a LIST of parts, one per license the
+product makes you accept.
+
+```yaml
+license:
+- name: Apache-2.0
+  detail: OSI
+- name: per-task
+```
+
+`license_tier` resolves every part and the most restrictive governs, and it never splits a
+value itself — so how many licenses there are is something the curator states rather than
+something a reader infers from a `+`. Record one part when the product is governed by one
+thing, even where the name contains a `+`: `culturax` records `follows mC4 + OSCAR-2301
+terms` as a single part because that phrase is one declared name and neither operand is a
+license. Every part must map to a tier or the whole value abstains, since an unmapped part
+can only be more restrictive than the ones that mapped.
+
 Three of those four links hold today. **The third does not.** `sources` is a flat list per
 axis, so nothing records WHICH source establishes WHICH dimension. Measured on 2026-07-30:
 324 of 470 openness axes cite exactly one source, asserted to establish `weights`, `data`,

--- a/docs/schemas/score.schema.json
+++ b/docs/schemas/score.schema.json
@@ -60,16 +60,34 @@
             }
           },
           "additionalProperties": {
-            "type": "object",
-            "required": ["value"],
-            "properties": {
-              "value": { "type": "string" },
-              "detail": { "type": "string" },
-              "raw": { "type": "string" }
-            },
-            "additionalProperties": false
+            "oneOf": [
+              {
+                "type": "object",
+                "required": ["value"],
+                "properties": {
+                  "value": { "type": "string" },
+                  "detail": { "type": "string" },
+                  "raw": { "type": "string" }
+                },
+                "additionalProperties": false
+              },
+              {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "object",
+                  "required": ["name"],
+                  "properties": {
+                    "name": { "type": "string" },
+                    "detail": { "type": "string" },
+                    "raw": { "type": "string" }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            ]
           },
-          "description": "The evidence the openness score was read off, as an entry per dimension the category's ladder asks about: a structured mapping, `key -> {value, detail?, raw?}`, plus a reserved `free_text` list for keyless clauses. `value` is the bare token a rule reads, `detail` is the parenthetical or trailing prose a human reads but no formula sees, and `raw` carries the original clause verbatim for the entries whose `{value, detail}` split cannot reproduce it byte-for-byte. This is the most load-bearing field in the corpus, because a category is ladderable only if its VALUES are controlled tokens some dimension's declared enum contains - `edge_hardware` is 71% prose by check_rubric's measure and cannot be laddered whatever its recipe says. Written by whoever scores the product, and edited in place ONLY through build/components.py, which locates the field by indent and re-emits it through the YAML dumper rather than by regex, because a folded scalar spliced by a line-oriented substitution corrupts silently. Read by build/check_rubric.py (replays the formula against it), check_verification (the dimensions recorded here are the invariant's scope), check_parity.py (the repo/warehouse differential), and serialize_rubric.py, which emits one warehouse evidence row per component and warns on a key no dimension declares or `reads` - such a key is dropped from the score silently, which is this corpus's recurring bug. Every reader goes through build.check_rubric.components_of, which returns the same key -> clause dict; nothing in the repo should call split_components directly on this field. build/check_components.py asserts the mapping is the only shape this field may take - a string here fails the gate rather than being skipped, which is what closed the migration. Measured 2026-08-11: on all 472 files, 137 distinct keys, of which each ladder declares a handful (`license` on 439, `source` on 298, `core-gated` on 164)."
+          "description": "The evidence the openness score was read off, as an entry per dimension the category's ladder asks about: a structured mapping, `key -> {value, detail?, raw?}`, plus a reserved `free_text` list for keyless clauses. `value` is the bare token a rule reads, `detail` is the parenthetical or trailing prose a human reads but no formula sees, and `raw` carries the original clause verbatim for the entries whose `{value, detail}` split cannot reproduce it byte-for-byte. A LICENSE key takes the second shape instead - a LIST of `{name, detail?, raw?}` parts, one per license the product makes you accept - because a product can be governed by more than one and `license_tier` resolves every part with the most restrictive governing. The list is what the curator recorded, so nothing infers the part count from a `+` at read time: `culturax`'s `follows mC4 + OSCAR-2301 terms` is ONE part because it is one declared name, and the pre-structured reader needed a whole-string pre-check ahead of its splitter to get that right. Any key whose name contains `license` takes the list (five in the corpus; three are named in some ladder's `license_tier.reads`). This is the most load-bearing field in the corpus, because a category is ladderable only if its VALUES are controlled tokens some dimension's declared enum contains - `edge_hardware` is 71% prose by check_rubric's measure and cannot be laddered whatever its recipe says. Written by whoever scores the product, and edited in place ONLY through build/components.py, which locates the field by indent and re-emits it through the YAML dumper rather than by regex, because a folded scalar spliced by a line-oriented substitution corrupts silently. Read by build/check_rubric.py (replays the formula against it), check_verification (the dimensions recorded here are the invariant's scope), check_parity.py (the repo/warehouse differential), and serialize_rubric.py, which emits one warehouse evidence row per component and warns on a key no dimension declares or `reads` - such a key is dropped from the score silently, which is this corpus's recurring bug. Every reader goes through build.check_rubric.components_of, which returns the same key -> clause dict; nothing in the repo should call split_components directly on this field. build/check_components.py asserts the mapping is the only shape this field may take - a string here fails the gate rather than being skipped, which is what closed the migration. Measured 2026-08-11: on all 472 files, 137 distinct keys, of which each ladder declares a handful (`license` on 439, `source` on 298, `core-gated` on 164)."
         },
         "governing_release": {
           "type": "string",

--- a/sources/scores/accelerate.yaml
+++ b/sources/scores/accelerate.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/aegis-guard.yaml
+++ b/sources/scores/aegis-guard.yaml
@@ -10,7 +10,7 @@ openness:
     data:
       value: Aegis safety dataset documented
     license:
-      value: Llama-2-Community
+    - name: Llama-2-Community
       detail: NOT OSI
   confidence: medium
   note: Open-weights at the adapter level but the LlamaGuard base is access-gated through Meta and the

--- a/sources/scores/agent-infra-sandbox.yaml
+++ b/sources/scores/agent-infra-sandbox.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/agent2agent-protocol.yaml
+++ b/sources/scores/agent2agent-protocol.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/agenta.yaml
+++ b/sources/scores/agenta.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_core
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI, core
     source:
       value: public

--- a/sources/scores/agentops.yaml
+++ b/sources/scores/agentops.yaml
@@ -4,10 +4,10 @@ openness:
   class: source_available
   components:
     license:
-      value: Elastic-License-2.0
+    - name: Elastic-License-2.0
       detail: app/LICENSE, the AgentOps application
-      raw: Elastic-License-2.0(app/LICENSE, the AgentOps application)+MIT(OSI, root LICENSE, the agentops
-        SDK)
+    - name: MIT
+      detail: OSI, root LICENSE, the agentops SDK
     source:
       value: public
       detail: SDK + self-hostable app dir

--- a/sources/scores/ai2-arc.yaml
+++ b/sources/scores/ai2-arc.yaml
@@ -7,7 +7,7 @@ openness:
       value: open
       detail: 7,787 questions, downloadable on HF
     license:
-      value: CC-BY-SA-4.0
+    - name: CC-BY-SA-4.0
       detail: open data license, redistributable
     datasheet:
       value: 'yes'

--- a/sources/scores/aider.yaml
+++ b/sources/scores/aider.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/algolia-ai-search.yaml
+++ b/sources/scores/algolia-ai-search.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: proprietary
+    - name: proprietary
       detail: SaaS, API-first
     source:
       value: closed

--- a/sources/scores/alia-40b.yaml
+++ b/sources/scores/alia-40b.yaml
@@ -16,7 +16,7 @@ openness:
     checkpoints:
       value: not-released
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
   confidence: high
   note: 'Strong open-weights release that stops one notch short of full openness: permissive Apache-2.0

--- a/sources/scores/alpacaeval.yaml
+++ b/sources/scores/alpacaeval.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/amazon-bedrock-custom-models-fine-tuning.yaml
+++ b/sources/scores/amazon-bedrock-custom-models-fine-tuning.yaml
@@ -10,7 +10,7 @@ openness:
     runs-on:
       value: AWS-Bedrock-only
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: managed AWS service, token+storage billed
   confidence: high
   note: Proprietary managed customization service inside AWS Bedrock, no source, runs only on AWS against

--- a/sources/scores/amazon-bedrock-evaluations.yaml
+++ b/sources/scores/amazon-bedrock-evaluations.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: proprietary
+    - name: proprietary
       detail: AWS managed service
     source:
       value: closed

--- a/sources/scores/amazon-nova.yaml
+++ b/sources/scores/amazon-nova.yaml
@@ -10,7 +10,7 @@ openness:
     code:
       value: closed
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: API-only via Amazon Bedrock
   governing_release: amazon-nova-pro
   confidence: high

--- a/sources/scores/amazon-q-developer.yaml
+++ b/sources/scores/amazon-q-developer.yaml
@@ -6,7 +6,7 @@ openness:
     source:
       value: closed
     license:
-      value: proprietary
+    - name: proprietary
       detail: AWS managed service
     self-host:
       value: 'no'

--- a/sources/scores/anthropic-internal-coding-evals.yaml
+++ b/sources/scores/anthropic-internal-coding-evals.yaml
@@ -9,7 +9,7 @@ openness:
     datasheet:
       value: 'no'
     license:
-      value: none
+    - name: none
     access:
       value: internal-only
       detail: referenced in announcements/system cards, not distributed

--- a/sources/scores/antigravity.yaml
+++ b/sources/scores/antigravity.yaml
@@ -6,7 +6,7 @@ openness:
     source:
       value: closed
     license:
-      value: proprietary
+    - name: proprietary
       detail: Google product, free public preview
     self-host:
       value: 'no'

--- a/sources/scores/anyscale-fine-tuning.yaml
+++ b/sources/scores/anyscale-fine-tuning.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: proprietary
+    - name: proprietary
       detail: Anyscale-platform-only
     source:
       value: closed

--- a/sources/scores/anythingllm.yaml
+++ b/sources/scores/anythingllm.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/apertus.yaml
+++ b/sources/scores/apertus.yaml
@@ -16,7 +16,7 @@ openness:
       value: open
       detail: intermediate checkpoints on HF branches
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
   confidence: high
   note: 'Among the most transparent large-model releases to date: open weights, open data (reconstruction

--- a/sources/scores/apify.yaml
+++ b/sources/scores/apify.yaml
@@ -13,7 +13,7 @@ openness:
       value: Crawlee
       detail: Apache-2.0,OSI, JS+Python
     license:
-      value: mixed
+    - name: mixed
       detail: platform closed, SDK open
   confidence: high
   note: The product proper (Apify platform/Actor store) is proprietary SaaS; Apify also maintains the OSS

--- a/sources/scores/apple-core-ml-runtime.yaml
+++ b/sources/scores/apple-core-ml-runtime.yaml
@@ -6,7 +6,7 @@ openness:
     source:
       value: closed
     license:
-      value: proprietary
+    - name: proprietary
       detail: Apple system framework, ships compiled with the OS/SDK, no published source
     self-host:
       value: 'no'

--- a/sources/scores/apps.yaml
+++ b/sources/scores/apps.yaml
@@ -7,7 +7,7 @@ openness:
       value: downloadable
       detail: HF parquet, codeparrot/apps
     license:
-      value: MIT
+    - name: MIT
       detail: OSI/open
     datasheet:
       value: present

--- a/sources/scores/arize.yaml
+++ b/sources/scores/arize.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: Proprietary
+    - name: Proprietary
     weights:
       value: n/a
     source:

--- a/sources/scores/atropos.yaml
+++ b/sources/scores/atropos.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/autogen.yaml
+++ b/sources/scores/autogen.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: code,via LICENSE-CODE
     docs:
       value: CC-BY-4.0

--- a/sources/scores/autogpt.yaml
+++ b/sources/scores/autogpt.yaml
@@ -5,7 +5,7 @@ openness:
   confidence: high
   components:
     license:
-      value: PolyForm-Shield
+    - name: PolyForm-Shield
       detail: non-OSI, source-available, anti-compete; governs autogpt_platform/, the active product
     source:
       value: public

--- a/sources/scores/aws-lambda.yaml
+++ b/sources/scores/aws-lambda.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: Proprietary
+    - name: Proprietary
     service:
       value: proprietary AWS-only SaaS
       detail: no self-host

--- a/sources/scores/aws-neuron.yaml
+++ b/sources/scores/aws-neuron.yaml
@@ -4,7 +4,7 @@ openness:
   class: source_available
   components:
     license:
-      value: mixed/proprietary-core
+    - name: mixed/proprietary-core
     source:
       value: partial
       detail: aws-neuron-sdk is a documentation and issue-tracker repo carrying no Runtime or Compiler source,

--- a/sources/scores/axolotl.yaml
+++ b/sources/scores/axolotl.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/aya-collection.yaml
+++ b/sources/scores/aya-collection.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: apache-2.0
+    - name: apache-2.0
     gated:
       value: 'false'
     card:

--- a/sources/scores/azure-ai-foundry-observability.yaml
+++ b/sources/scores/azure-ai-foundry-observability.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: proprietary
+    - name: proprietary
       detail: Azure managed service
     source:
       value: closed

--- a/sources/scores/azure-ai-model-inference.yaml
+++ b/sources/scores/azure-ai-model-inference.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: proprietary
+    - name: proprietary
       detail: Azure managed service
     source:
       value: closed

--- a/sources/scores/azure-content-safety.yaml
+++ b/sources/scores/azure-content-safety.yaml
@@ -13,7 +13,7 @@ openness:
     source:
       value: closed
     license:
-      value: proprietary
+    - name: proprietary
   confidence: high
   note: Closed managed cloud service; no weights or source.
   raw: service:proprietary managed Azure service(no self-host);features:text/image moderation, prompt shields,

--- a/sources/scores/azure-openai-fine-tuning.yaml
+++ b/sources/scores/azure-openai-fine-tuning.yaml
@@ -10,7 +10,7 @@ openness:
     runs-on:
       value: Azure-AI-Foundry-only
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: managed Azure service
   confidence: high
   note: Proprietary managed FT service inside Microsoft Foundry; no source, runs only on Azure, tuning both

--- a/sources/scores/bedrock-guardrails.yaml
+++ b/sources/scores/bedrock-guardrails.yaml
@@ -13,7 +13,7 @@ openness:
     source:
       value: closed
     license:
-      value: proprietary
+    - name: proprietary
   confidence: high
   note: Closed managed cloud service; no weights or source.
   raw: service:proprietary managed AWS service(no self-host);features:denied topics, content filters, PII

--- a/sources/scores/beeai.yaml
+++ b/sources/scores/beeai.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/beta9.yaml
+++ b/sources/scores/beta9.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: AGPL-3.0
+    - name: AGPL-3.0
       detail: OSI, copyleft
     source:
       value: public

--- a/sources/scores/bigcode-dataset.yaml
+++ b/sources/scores/bigcode-dataset.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/bigcodebench.yaml
+++ b/sources/scores/bigcodebench.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/blaxel-sandbox.yaml
+++ b/sources/scores/blaxel-sandbox.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_core
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/braintrust.yaml
+++ b/sources/scores/braintrust.yaml
@@ -6,7 +6,7 @@ openness:
     source:
       value: closed
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI, client SDKs only, Python/TS/Go/Ruby/C#
     platform:
       value: proprietary

--- a/sources/scores/browser-use.yaml
+++ b/sources/scores/browser-use.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI, library core fully open
     source:
       value: public

--- a/sources/scores/browserbase.yaml
+++ b/sources/scores/browserbase.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: API-only managed browser infra
     source:
       value: closed

--- a/sources/scores/c4.yaml
+++ b/sources/scores/c4.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: ODC-BY
+    - name: ODC-BY
     ungated:
       value: 'yes'
     dataset_card:

--- a/sources/scores/ccnet.yaml
+++ b/sources/scores/ccnet.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/cerebras-inference.yaml
+++ b/sources/scores/cerebras-inference.yaml
@@ -11,7 +11,7 @@ openness:
     access:
       value: managed-cloud-API-only
     license:
-      value: Proprietary
+    - name: Proprietary
   confidence: high
   note: 'Proprietary cloud inference on custom wafer-scale hardware, API-only; closed per recipe (cloud
     inference engines). Re-confirmed today: the inference page shows API-only managed access with no source

--- a/sources/scores/character-ai.yaml
+++ b/sources/scores/character-ai.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: proprietary
+    - name: proprietary
       detail: SaaS
     source:
       value: closed

--- a/sources/scores/chatgpt.yaml
+++ b/sources/scores/chatgpt.yaml
@@ -9,7 +9,7 @@ openness:
     self-host:
       value: none
     license:
-      value: proprietary
+    - name: proprietary
       detail: SaaS app + API
   note: Proprietary, SaaS-only consumer app; no source, no self-host. Closed counterpart in the ui_api
     shelf.

--- a/sources/scores/claude-ai.yaml
+++ b/sources/scores/claude-ai.yaml
@@ -9,7 +9,7 @@ openness:
     self-host:
       value: none
     license:
-      value: proprietary
+    - name: proprietary
       detail: SaaS app + API
   note: Proprietary, SaaS-only consumer app; no source, no self-host. Closed counterpart in the ui_api
     shelf.

--- a/sources/scores/claude-code.yaml
+++ b/sources/scores/claude-code.yaml
@@ -5,7 +5,7 @@ openness:
   confidence: high
   components:
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: closed-source CLI/app, requires Claude subscription or Console account
     model:
       value: Claude

--- a/sources/scores/claude-fable.yaml
+++ b/sources/scores/claude-fable.yaml
@@ -10,7 +10,7 @@ openness:
     code:
       value: closed
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: API-only
   confidence: high
   note: 'No weights, data or code released. Served through the Anthropic API only, so 1/closed on every dimension.

--- a/sources/scores/claude-haiku.yaml
+++ b/sources/scores/claude-haiku.yaml
@@ -10,7 +10,7 @@ openness:
     code:
       value: closed
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: API-only
   confidence: high
   note: Closed by construction and stable across generations. Measured against Claude Haiku 4.5, the

--- a/sources/scores/claude-opus.yaml
+++ b/sources/scores/claude-opus.yaml
@@ -10,7 +10,7 @@ openness:
     code:
       value: closed
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: API/Bedrock/Vertex/claude.ai
   governing_release: claude-opus-4-x
   confidence: high

--- a/sources/scores/claude-sonnet.yaml
+++ b/sources/scores/claude-sonnet.yaml
@@ -10,7 +10,7 @@ openness:
     code:
       value: closed
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: API-only
   confidence: high
   note: Closed by construction and stable across generations - no Sonnet release has ever shipped weights,

--- a/sources/scores/cline.yaml
+++ b/sources/scores/cline.yaml
@@ -5,7 +5,7 @@ openness:
   confidence: high
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI, (c)2026 Cline Bot Inc.
     source:
       value: public

--- a/sources/scores/cloudflare-sandboxes.yaml
+++ b/sources/scores/cloudflare-sandboxes.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: Proprietary
+    - name: Proprietary
     source:
       value: closed
     service:

--- a/sources/scores/codecontests.yaml
+++ b/sources/scores/codecontests.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: CC-BY-4.0
+    - name: CC-BY-4.0
       detail: open data license, attribution-only
     redistributability:
       value: full

--- a/sources/scores/codegemma.yaml
+++ b/sources/scores/codegemma.yaml
@@ -10,7 +10,7 @@ openness:
     code:
       value: closed
     license:
-      value: Gemma-Terms-of-Use
+    - name: Gemma-Terms-of-Use
       detail: custom,use-restricted,non-OSI
   confidence: high
   note: >-

--- a/sources/scores/codellama.yaml
+++ b/sources/scores/codellama.yaml
@@ -12,7 +12,7 @@ openness:
       value: partial
       detail: inference utils, no training pipeline
     license:
-      value: Llama-2-Community
+    - name: Llama-2-Community
       detail: custom Meta license, non-OSI; AUP + commercial conditions
   confidence: high
   note: >-

--- a/sources/scores/coder-oss.yaml
+++ b/sources/scores/coder-oss.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_core
   components:
     license:
-      value: AGPL-3.0
+    - name: AGPL-3.0
       detail: OSI, Community Edition
     source:
       value: public

--- a/sources/scores/codestral.yaml
+++ b/sources/scores/codestral.yaml
@@ -12,7 +12,7 @@ openness:
       value: closed
       detail: no training pipeline
     license:
-      value: Mistral-AI-Non-Production-License
+    - name: Mistral-AI-Non-Production-License
       detail: MNPL, non-OSI, research/testing only; commercial license on demand
   confidence: high
   note: Weights downloadable but under MNPL (non-OSI, non-production); open-weights gated by a use-restricted

--- a/sources/scores/codex-cli.yaml
+++ b/sources/scores/codex-cli.yaml
@@ -5,7 +5,7 @@ openness:
   confidence: high
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI, the CLI agent
     source:
       value: public

--- a/sources/scores/cohere-rerank-api.yaml
+++ b/sources/scores/cohere-rerank-api.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: proprietary
+    - name: proprietary
       detail: hosted-API; also cloud-marketplace deploy
     source:
       value: closed

--- a/sources/scores/command-r.yaml
+++ b/sources/scores/command-r.yaml
@@ -12,9 +12,9 @@ openness:
     code:
       value: closed
     license:
-      value: CC-BY-NC
-      detail: non-commercial, non-OSI)+Cohere-Acceptable-Use-Policy
-      raw: CC-BY-NC(non-commercial, non-OSI)+Cohere-Acceptable-Use-Policy
+    - name: CC-BY-NC
+      detail: non-commercial, non-OSI
+    - name: Cohere-Acceptable-Use-Policy
   note: Weights downloadable but under CC-BY-NC, a non-commercial, non-OSI license with field-of-use
     restrictions => restricted. Marketed as 'open weights' despite the non-commercial cap.
   raw: weights:open(gated, contact-info required);data:closed;code:closed;license:CC-BY-NC(non-commercial,

--- a/sources/scores/common-corpus.yaml
+++ b/sources/scores/common-corpus.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: open
+    - name: open
       detail: uncopyrighted/freely-licensed only
     ungated:
       value: 'yes'

--- a/sources/scores/compar-ia-datasets.yaml
+++ b/sources/scores/compar-ia-datasets.yaml
@@ -4,7 +4,7 @@ openness:
   class: gated
   components:
     license:
-      value: Etalab-2.0
+    - name: Etalab-2.0
       detail: permissive French-gov open license
     gated:
       value: HF contact-info agreement required

--- a/sources/scores/compar-ia.yaml
+++ b/sources/scores/compar-ia.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI; verified LICENSE body
     source:
       value: public

--- a/sources/scores/composio.yaml
+++ b/sources/scores/composio.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_core
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI, SDK/core public on GitHub
     source:
       value: public

--- a/sources/scores/confer.yaml
+++ b/sources/scores/confer.yaml
@@ -4,7 +4,7 @@ openness:
   class: source_available
   components:
     license:
-      value: none-declared
+    - name: none-declared
       detail: no LICENSE file in either public repo
     source:
       value: partial

--- a/sources/scores/confident-ai.yaml
+++ b/sources/scores/confident-ai.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: proprietary
+    - name: proprietary
       detail: platform
     source:
       value: closed

--- a/sources/scores/continue.yaml
+++ b/sources/scores/continue.yaml
@@ -5,7 +5,7 @@ openness:
   confidence: high
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/coop.yaml
+++ b/sources/scores/coop.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/cosmopedia.yaml
+++ b/sources/scores/cosmopedia.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: apache-2.0
+    - name: apache-2.0
     access:
       value: ungated
     dataset_card:

--- a/sources/scores/crewai.yaml
+++ b/sources/scores/crewai.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: framework
     source:
       value: public

--- a/sources/scores/cruxeval.yaml
+++ b/sources/scores/cruxeval.yaml
@@ -7,7 +7,7 @@ openness:
       value: open
       detail: 800 samples public on GitHub + HF
     license:
-      value: MIT
+    - name: MIT
       detail: permissive, redistributable
     datasheet:
       value: 'yes'

--- a/sources/scores/culturax.yaml
+++ b/sources/scores/culturax.yaml
@@ -4,7 +4,7 @@ openness:
   class: gated
   components:
     license:
-      value: follows mC4 + OSCAR-2301 terms
+    - name: follows mC4 + OSCAR-2301 terms
     gated:
       value: auto
       detail: contact-info agreement

--- a/sources/scores/cursor.yaml
+++ b/sources/scores/cursor.yaml
@@ -5,7 +5,7 @@ openness:
   confidence: high
   components:
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: closed SaaS IDE, no public source
     model:
       value: multi-provider

--- a/sources/scores/data-juicer.yaml
+++ b/sources/scores/data-juicer.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/datadog-llm-observability.yaml
+++ b/sources/scores/datadog-llm-observability.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: Proprietary
+    - name: Proprietary
     source:
       value: closed
     platform:

--- a/sources/scores/datamap-rs.yaml
+++ b/sources/scores/datamap-rs.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/datasette-agent.yaml
+++ b/sources/scores/datasette-agent.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/datatrove.yaml
+++ b/sources/scores/datatrove.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/datology-ai.yaml
+++ b/sources/scores/datology-ai.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: Proprietary
+    - name: Proprietary
     source:
       value: closed
     free_text:

--- a/sources/scores/daytona-sandbox.yaml
+++ b/sources/scores/daytona-sandbox.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_core
   components:
     license:
-      value: AGPL-3.0
+    - name: AGPL-3.0
       detail: OSI, copyleft
     source:
       value: public

--- a/sources/scores/dclm-baseline.yaml
+++ b/sources/scores/dclm-baseline.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: CC-BY-4.0
+    - name: CC-BY-4.0
     gated:
       value: 'false'
     dataset_card:

--- a/sources/scores/dclm.yaml
+++ b/sources/scores/dclm.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/decon.yaml
+++ b/sources/scores/decon.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/deepeval.yaml
+++ b/sources/scores/deepeval.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI, OSS framework
     source:
       value: public

--- a/sources/scores/deepseek-coder.yaml
+++ b/sources/scores/deepseek-coder.yaml
@@ -12,7 +12,7 @@ openness:
       value: open
       detail: MIT, repo code
     model-license:
-      value: DeepSeek-Model-License
+    - name: DeepSeek-Model-License
       detail: non-OSI; Attachment A acceptable-use restrictions - military/illegal/discrimination/etc.;
         commercial allowed but use-based restrictions must propagate to derivatives
   confidence: high

--- a/sources/scores/deepseek-instruct.yaml
+++ b/sources/scores/deepseek-instruct.yaml
@@ -12,7 +12,7 @@ openness:
       value: partial
       detail: inference/serving; no training pipeline or data
     license:
-      value: MIT
+    - name: MIT
       detail: OSI-style permissive, no use restrictions
   confidence: high
   note: V4-Flash weights are MIT open (matching the V4-Pro anchor's open_weights class); training data/code closed

--- a/sources/scores/deepseek-r1.yaml
+++ b/sources/scores/deepseek-r1.yaml
@@ -13,7 +13,7 @@ openness:
       value: partial
       detail: inference; no full RL training pipeline
     license:
-      value: MIT
+    - name: MIT
       detail: OSI-style permissive, no use restrictions
   confidence: high
   note: MIT-licensed open weights with distillation rights, but RL/SFT post-training data and full training

--- a/sources/scores/deepseek.yaml
+++ b/sources/scores/deepseek.yaml
@@ -12,7 +12,7 @@ openness:
       value: partial
       detail: inference/serving; no training pipeline or data
     license:
-      value: MIT
+    - name: MIT
       detail: permissive, no use restrictions
   governing_release: deepseek-v4-pro
   confidence: high

--- a/sources/scores/deepspeed.yaml
+++ b/sources/scores/deepspeed.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/deepteam.yaml
+++ b/sources/scores/deepteam.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/devin.yaml
+++ b/sources/scores/devin.yaml
@@ -6,7 +6,7 @@ openness:
     source:
       value: closed
     license:
-      value: proprietary
+    - name: proprietary
       detail: SaaS-only
     self-host:
       value: 'no'

--- a/sources/scores/devstral.yaml
+++ b/sources/scores/devstral.yaml
@@ -12,7 +12,7 @@ openness:
       value: partial
       detail: inference/serving; no training or post-training data
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI permissive, no use restrictions
   confidence: high
   note: Apache-2.0 open weights, but training/post-training data and pipeline undisclosed -> open_weights,

--- a/sources/scores/diffusers.yaml
+++ b/sources/scores/diffusers.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/dify.yaml
+++ b/sources/scores/dify.yaml
@@ -4,7 +4,7 @@ openness:
   class: source_available
   components:
     license:
-      value: Dify-Open-Source-License
+    - name: Dify-Open-Source-License
       detail: Apache-2.0-based,non-OSI,added-conditions:multi-tenant/branding-restrictions
     source:
       value: public

--- a/sources/scores/distilabel.yaml
+++ b/sources/scores/distilabel.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/docling.yaml
+++ b/sources/scores/docling.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/dolci.yaml
+++ b/sources/scores/dolci.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: ODC-BY
+    - name: ODC-BY
     gated:
       value: 'false'
     dataset_card:

--- a/sources/scores/dolma-3.yaml
+++ b/sources/scores/dolma-3.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: ODC-BY
+    - name: ODC-BY
     gated:
       value: 'false'
     dataset_card:

--- a/sources/scores/dolma-toolkit.yaml
+++ b/sources/scores/dolma-toolkit.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/dolma.yaml
+++ b/sources/scores/dolma.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: ODC-BY
+    - name: ODC-BY
     ungated:
       value: 'yes'
     dataset_card:

--- a/sources/scores/doubao-seed.yaml
+++ b/sources/scores/doubao-seed.yaml
@@ -10,7 +10,7 @@ openness:
     code:
       value: closed
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: Doubao app + Volcano Engine API only; no downloadable weights
   confidence: high
   note: No weights released, served only through the Doubao app and Volcano Engine API. Fully closed.

--- a/sources/scores/doubao.yaml
+++ b/sources/scores/doubao.yaml
@@ -13,7 +13,7 @@ openness:
       value: proprietary Doubao
       detail: closed
     license:
-      value: Proprietary
+    - name: Proprietary
     source:
       value: closed
       detail: hosted consumer service plus a compiled client download; no published source for the assistant

--- a/sources/scores/ds4.yaml
+++ b/sources/scores/ds4.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/dspy.yaml
+++ b/sources/scores/dspy.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/duck-ai.yaml
+++ b/sources/scores/duck-ai.yaml
@@ -9,7 +9,7 @@ openness:
     self-host:
       value: none
     license:
-      value: proprietary
+    - name: proprietary
       detail: SaaS app + browser integration
   note: Proprietary anonymizing proxy in front of closed model APIs; no source, no self-host. Closed privacy-chat
     surface in the ui_api shelf.

--- a/sources/scores/duplodocus.yaml
+++ b/sources/scores/duplodocus.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/dynatrace-ai-observability.yaml
+++ b/sources/scores/dynatrace-ai-observability.yaml
@@ -7,7 +7,7 @@ openness:
       value: proprietary-SaaS
       detail: Grail-powered, Davis AI
     license:
-      value: commercial
+    - name: commercial
     ingestion:
       value: OpenTelemetry+OpenLLMetry
       detail: via Traceloop)+GenAI-semconv(open standards, not open product

--- a/sources/scores/e2b-sandbox.yaml
+++ b/sources/scores/e2b-sandbox.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/ernie.yaml
+++ b/sources/scores/ernie.yaml
@@ -10,7 +10,7 @@ openness:
     code:
       value: closed
     license:
-      value: proprietary
+    - name: proprietary
       detail: Baidu Qianfan API
     free_text:
     - API-only(ERNIE 4.5 was open, 5.x flagship closed)

--- a/sources/scores/evalplus.yaml
+++ b/sources/scores/evalplus.yaml
@@ -7,7 +7,7 @@ openness:
       value: downloadable
       detail: HF parquet, evalplus/humanevalplus + mbppplus
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI/open, on both framework and datasets
     datasheet:
       value: present

--- a/sources/scores/exa-search-api.yaml
+++ b/sources/scores/exa-search-api.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: API-only
     source:
       value: closed

--- a/sources/scores/falcon.yaml
+++ b/sources/scores/falcon.yaml
@@ -10,7 +10,7 @@ openness:
     code:
       value: closed
     license:
-      value: TII-Falcon-License-2.0
+    - name: TII-Falcon-License-2.0
       detail: Apache-based+AUP,non-OSI
   confidence: high
   note: 'Weights downloadable and freely usable commercially at any scale, corpus not released, no training code,

--- a/sources/scores/fastmcp.yaml
+++ b/sources/scores/fastmcp.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/feluda.yaml
+++ b/sources/scores/feluda.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: GPL-3.0
+    - name: GPL-3.0
       detail: OSI copyleft
     source:
       value: public

--- a/sources/scores/filesystem-mcp.yaml
+++ b/sources/scores/filesystem-mcp.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/finemath.yaml
+++ b/sources/scores/finemath.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: ODC-BY
+    - name: ODC-BY
     gated:
       value: 'false'
     dataset_card:

--- a/sources/scores/fineweb-2.yaml
+++ b/sources/scores/fineweb-2.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: ODC-BY
+    - name: ODC-BY
     gated:
       value: 'false'
     dataset_card:

--- a/sources/scores/fineweb-edu.yaml
+++ b/sources/scores/fineweb-edu.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: ODC-BY
+    - name: ODC-BY
     gated:
       value: 'false'
     dataset_card:

--- a/sources/scores/fineweb.yaml
+++ b/sources/scores/fineweb.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: ODC-BY
+    - name: ODC-BY
     gated:
       value: 'false'
     dataset_card:

--- a/sources/scores/firecracker.yaml
+++ b/sources/scores/firecracker.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/firecrawl.yaml
+++ b/sources/scores/firecrawl.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_core
   components:
     license:
-      value: AGPL-3.0
+    - name: AGPL-3.0
       detail: OSI, self-host core
     source:
       value: public

--- a/sources/scores/fireworks-fine-tuning.yaml
+++ b/sources/scores/fireworks-fine-tuning.yaml
@@ -10,7 +10,7 @@ openness:
     runs-on:
       value: Fireworks-cloud-only
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: managed service
     base-weights:
       value: open-models

--- a/sources/scores/fireworks-inference.yaml
+++ b/sources/scores/fireworks-inference.yaml
@@ -11,7 +11,7 @@ openness:
     access:
       value: managed-cloud-API-only
     license:
-      value: Proprietary
+    - name: Proprietary
   confidence: high
   note: 'Proprietary FireAttention inference engine offered only as a managed cloud service; closed per
     recipe. Re-checked 2026-08-09: fireworks.ai homepage carries no self-host, on-prem, VPC/BYOC, or repository

--- a/sources/scores/flan-collection.yaml
+++ b/sources/scores/flan-collection.yaml
@@ -7,9 +7,9 @@ openness:
       value: ungated
       detail: conversion
     license:
-      value: Apache-2.0
-      detail: recipe)+per-task
-      raw: Apache-2.0(recipe)+per-task
+    - name: Apache-2.0
+      detail: recipe
+    - name: per-task
     dataset_card:
       value: partial
   confidence: medium

--- a/sources/scores/flax.yaml
+++ b/sources/scores/flax.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/fly-sprites.yaml
+++ b/sources/scores/fly-sprites.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: Proprietary
+    - name: Proprietary
     service:
       value: proprietary
       detail: Fly.io managed

--- a/sources/scores/galileo.yaml
+++ b/sources/scores/galileo.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: proprietary
+    - name: proprietary
     source:
       value: closed
     deploy:

--- a/sources/scores/garak.yaml
+++ b/sources/scores/garak.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/gemini-cli.yaml
+++ b/sources/scores/gemini-cli.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/gemini-flash.yaml
+++ b/sources/scores/gemini-flash.yaml
@@ -10,7 +10,7 @@ openness:
     code:
       value: closed
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: Gemini app/Search/API/enterprise, no downloadable weights
   governing_release: gemini-3-5-flash
   confidence: high

--- a/sources/scores/gemini-pro.yaml
+++ b/sources/scores/gemini-pro.yaml
@@ -10,7 +10,7 @@ openness:
     code:
       value: closed
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: API-only
   confidence: high
   note: Closed by construction and stable across generations. Google's own model index files Gemini under

--- a/sources/scores/gemini.yaml
+++ b/sources/scores/gemini.yaml
@@ -9,7 +9,7 @@ openness:
     self-host:
       value: none
     license:
-      value: proprietary
+    - name: proprietary
       detail: SaaS app
   note: Proprietary, SaaS-only consumer app; no source, no self-host. Closed counterpart in the ui_api
     shelf.

--- a/sources/scores/gemma.yaml
+++ b/sources/scores/gemma.yaml
@@ -11,7 +11,7 @@ openness:
     code:
       value: closed
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI,but no open data/code
   governing_release: gemma-4
   confidence: medium

--- a/sources/scores/ggml.yaml
+++ b/sources/scores/ggml.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/giskard.yaml
+++ b/sources/scores/giskard.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/github-copilot-ide.yaml
+++ b/sources/scores/github-copilot-ide.yaml
@@ -9,7 +9,7 @@ openness:
     self-host:
       value: none
     license:
-      value: proprietary
+    - name: proprietary
       detail: subscription SaaS
   note: Proprietary, closed-source subscription product; no self-host. Closed counterpart in the ui_api
     shelf.

--- a/sources/scores/github-copilot.yaml
+++ b/sources/scores/github-copilot.yaml
@@ -6,7 +6,7 @@ openness:
     source:
       value: closed
     license:
-      value: proprietary
+    - name: proprietary
       detail: GitHub/Microsoft SaaS
     self-host:
       value: 'no'

--- a/sources/scores/github-mcp.yaml
+++ b/sources/scores/github-mcp.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/glean-assistant.yaml
+++ b/sources/scores/glean-assistant.yaml
@@ -11,7 +11,7 @@ openness:
     source:
       value: closed
     license:
-      value: Proprietary
+    - name: Proprietary
   note: Glean Assistant is a proprietary enterprise SaaS, no public source, no open-core/self-host OSS
     tier. Closed.
   raw: client:proprietary;deployment:single-tenant SaaS;source:closed;license:Proprietary

--- a/sources/scores/glean-workplace-search-ai.yaml
+++ b/sources/scores/glean-workplace-search-ai.yaml
@@ -11,7 +11,7 @@ openness:
     source:
       value: closed
     license:
-      value: Proprietary
+    - name: Proprietary
   note: Glean Search is proprietary enterprise SaaS; no public source, no OSS/self-host tier. Closed.
   raw: client:proprietary;deployment:single-tenant SaaS;source:closed;license:Proprietary
   sources:

--- a/sources/scores/glm.yaml
+++ b/sources/scores/glm.yaml
@@ -12,7 +12,7 @@ openness:
       value: open
       detail: inference
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
   governing_release: glm-5-2
   confidence: high

--- a/sources/scores/google-cloud-run.yaml
+++ b/sources/scores/google-cloud-run.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: Proprietary
+    - name: Proprietary
     service:
       value: proprietary
       detail: Google SaaS

--- a/sources/scores/google-cloud-tpu-inference.yaml
+++ b/sources/scores/google-cloud-tpu-inference.yaml
@@ -6,7 +6,7 @@ openness:
     source:
       value: closed
     license:
-      value: proprietary
+    - name: proprietary
     runtime:
       value: Pathways
       detail: Google-internal distributed runtime, not open sourced

--- a/sources/scores/google-grounding-api.yaml
+++ b/sources/scores/google-grounding-api.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: proprietary
+    - name: proprietary
       detail: GCP-managed API
     source:
       value: closed

--- a/sources/scores/goose.yaml
+++ b/sources/scores/goose.yaml
@@ -5,7 +5,7 @@ openness:
   confidence: high
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/gpqa.yaml
+++ b/sources/scores/gpqa.yaml
@@ -4,7 +4,7 @@ openness:
   class: gated
   components:
     license:
-      value: CC-BY-4.0
+    - name: CC-BY-4.0
       detail: open,redistributable+attribution
     access:
       value: gated

--- a/sources/scores/gpt-4-1.yaml
+++ b/sources/scores/gpt-4-1.yaml
@@ -10,7 +10,7 @@ openness:
     code:
       value: closed
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: API-only
   confidence: high
   note: Proprietary OpenAI API model; no weights/data/code released. Absorbed the duplicate

--- a/sources/scores/gpt-4o.yaml
+++ b/sources/scores/gpt-4o.yaml
@@ -10,7 +10,7 @@ openness:
     code:
       value: closed
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: API-only
   confidence: high
   note: No downloadable weights; API/ChatGPT-only, like the GPT-5 anchor (O1 closed). Confirmed API-only

--- a/sources/scores/gpt-5.yaml
+++ b/sources/scores/gpt-5.yaml
@@ -10,7 +10,7 @@ openness:
     code:
       value: closed
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: API + ChatGPT only
   governing_release: gpt-5-line
   confidence: high

--- a/sources/scores/gpt-oss-safeguard.yaml
+++ b/sources/scores/gpt-oss-safeguard.yaml
@@ -9,7 +9,7 @@ openness:
     data:
       value: not-released
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
   confidence: medium
   note: Open weights under Apache-2.0 (OSI) with no released training data and no published fine-tuning

--- a/sources/scores/gpt-researcher.yaml
+++ b/sources/scores/gpt-researcher.yaml
@@ -5,7 +5,7 @@ openness:
   confidence: high
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/gpt4all.yaml
+++ b/sources/scores/gpt4all.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/gradio.yaml
+++ b/sources/scores/gradio.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/granite-code-instruct.yaml
+++ b/sources/scores/granite-code-instruct.yaml
@@ -22,7 +22,7 @@ openness:
     model_card:
       value: open
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
   confidence: high
   note: OSI Apache-2.0 + downloadable weights + paper + model card, but training/post-training data only

--- a/sources/scores/granite-guardian.yaml
+++ b/sources/scores/granite-guardian.yaml
@@ -9,7 +9,7 @@ openness:
     data:
       value: not-released
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
   confidence: medium
   note: Open weights under Apache-2.0 (permissive, OSI), but neither the post-training data nor the fine-tuning

--- a/sources/scores/graphrag.yaml
+++ b/sources/scores/graphrag.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/grok-app.yaml
+++ b/sources/scores/grok-app.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: proprietary
+    - name: proprietary
       detail: SaaS/embedded in X
     source:
       value: closed

--- a/sources/scores/grok.yaml
+++ b/sources/scores/grok.yaml
@@ -10,7 +10,7 @@ openness:
     code:
       value: closed
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: API-only
   governing_release: grok-4-20
   confidence: high

--- a/sources/scores/groq-inference.yaml
+++ b/sources/scores/groq-inference.yaml
@@ -11,7 +11,7 @@ openness:
     access:
       value: managed-cloud-API-only
     license:
-      value: Proprietary
+    - name: Proprietary
   confidence: high
   note: 'Re-confirmed 2026-08-09: GroqCloud remains a managed API-only service (groq.com, GroqDocs overview);
     the groq GitHub org (29 public repos: groq-python, groq-typescript, openbench, harbor, demo apps, infra

--- a/sources/scores/gsm8k.yaml
+++ b/sources/scores/gsm8k.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI-style permissive, fully redistributable
     redistributability:
       value: full

--- a/sources/scores/guardrails-ai.yaml
+++ b/sources/scores/guardrails-ai.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_core
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI) for the framework
       raw: Apache-2.0(OSI) for the framework
     source:

--- a/sources/scores/gvisor.yaml
+++ b/sources/scores/gvisor.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/harmbench.yaml
+++ b/sources/scores/harmbench.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/haystack.yaml
+++ b/sources/scores/haystack.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_core
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: core
     commercial:
       value: Haystack-Enterprise

--- a/sources/scores/helicone.yaml
+++ b/sources/scores/helicone.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/hellaswag.yaml
+++ b/sources/scores/hellaswag.yaml
@@ -7,7 +7,7 @@ openness:
       value: open
       detail: 59,950 examples, downloadable on HF
     license:
-      value: MIT
+    - name: MIT
       detail: permissive, redistributable
     datasheet:
       value: 'yes'

--- a/sources/scores/helm.yaml
+++ b/sources/scores/helm.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/hermes-3-dataset.yaml
+++ b/sources/scores/hermes-3-dataset.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
     gated:
       value: 'false'
     dataset_card:

--- a/sources/scores/hermes-agent.yaml
+++ b/sources/scores/hermes-agent.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/hermes.yaml
+++ b/sources/scores/hermes.yaml
@@ -17,7 +17,7 @@ openness:
       value: partial
       detail: inference only
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
   note: 'Nous ships one Hermes 4 post-training recipe on four independent base models, and the base determines the
     license the weights carry: Seed-OSS-36B and Qwen3-14B are Apache-2.0, while the Llama-3.1 405B and 70B builds

--- a/sources/scores/hexabot.yaml
+++ b/sources/scores/hexabot.yaml
@@ -4,7 +4,7 @@ openness:
   class: source_available
   components:
     license:
-      value: FCL-1.0-ALv2
+    - name: FCL-1.0-ALv2
       detail: Fair Core License, NOT OSI; converts to Apache-2.0 two years after each release; competing/hosted
         commercial use restricted until conversion). Earlier v1/v2 were AGPL-3.0.
       raw: FCL-1.0-ALv2 (Fair Core License, NOT OSI; converts to Apache-2.0 two years after each release;

--- a/sources/scores/hf-datasets.yaml
+++ b/sources/scores/hf-datasets.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/hh-rlhf.yaml
+++ b/sources/scores/hh-rlhf.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: mit
+    - name: mit
     card:
       value: present
     ungated:

--- a/sources/scores/huggingchat-chat-ui.yaml
+++ b/sources/scores/huggingchat-chat-ui.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/huggingface-hub.yaml
+++ b/sources/scores/huggingface-hub.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/humaneval.yaml
+++ b/sources/scores/humaneval.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI-style permissive, fully redistributable
     redistributability:
       value: full

--- a/sources/scores/ifeval.yaml
+++ b/sources/scores/ifeval.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI/open,redistributable
     access:
       value: public

--- a/sources/scores/inflection.yaml
+++ b/sources/scores/inflection.yaml
@@ -10,7 +10,7 @@ openness:
     code:
       value: closed
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: API/enterprise-licensed, no weights
   confidence: high
   note: Closed proprietary models via API + enterprise licensing; no downloadable weights; fine-tuned models are

--- a/sources/scores/inkling.yaml
+++ b/sources/scores/inkling.yaml
@@ -13,7 +13,7 @@ openness:
       value: partial
       detail: day-0 transformers/SGLang/vLLM/llama.cpp; no training pipeline
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI for weights only
   confidence: high
   note: Apache-2.0 weights are OSI-licensed, but training data and full training code are withheld —

--- a/sources/scores/inspect-ai.yaml
+++ b/sources/scores/inspect-ai.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/internlm.yaml
+++ b/sources/scores/internlm.yaml
@@ -14,8 +14,12 @@ openness:
       value: open
       detail: Apache-2.0 training/inference code on GitHub
     license:
-      value: Apache-2.0
-      detail: code, OSI) + custom weights license(non-OSI, application step
+    - name: Apache-2.0
+      detail: code, OSI
+      raw: 'Apache-2.0(code, OSI) '
+    - name: custom weights license
+      detail: non-OSI, application step
+      raw: ' custom weights license(non-OSI, application step)'
   confidence: medium
   note: Code is OSI (Apache-2.0) but the weights license is a custom non-OSI 'Free Commercial License' requiring
     a commercial-license application form (HF card confirms form link, 2026-06-04), so open_weights not open_source;

--- a/sources/scores/jamba-large.yaml
+++ b/sources/scores/jamba-large.yaml
@@ -12,7 +12,7 @@ openness:
       value: partial
       detail: inference/usage only, no training pipeline
     license:
-      value: Jamba-Open-Model-License
+    - name: Jamba-Open-Model-License
       detail: 'non-OSI: $50M annual-revenue commercial cap + AUP + naming/attribution requirements'
   confidence: high
   note: >-

--- a/sources/scores/jan.yaml
+++ b/sources/scores/jan.yaml
@@ -5,7 +5,7 @@ openness:
   confidence: high
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/jax.yaml
+++ b/sources/scores/jax.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/jina-reader.yaml
+++ b/sources/scores/jina-reader.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/k2.yaml
+++ b/sources/scores/k2.yaml
@@ -15,7 +15,7 @@ openness:
     checkpoints:
       value: open
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
   confidence: high
   note: '360-open / fully reproducible: Apache-2.0 weights + complete TxT360 data + training code + checkpoints.

--- a/sources/scores/kata-containers.yaml
+++ b/sources/scores/kata-containers.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/keras.yaml
+++ b/sources/scores/keras.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/khoj.yaml
+++ b/sources/scores/khoj.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: AGPL-3.0
+    - name: AGPL-3.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/kimi.yaml
+++ b/sources/scores/kimi.yaml
@@ -12,7 +12,7 @@ openness:
       value: partial
       detail: inference/deploy expected; no training data or full pipeline
     license:
-      value: assumed-Modified-MIT
+    - name: assumed-Modified-MIT
       detail: continuity with Kimi K2.x; confirm on weight release
   governing_release: kimi-k3
   confidence: medium

--- a/sources/scores/lakera-guard.yaml
+++ b/sources/scores/lakera-guard.yaml
@@ -11,7 +11,7 @@ openness:
     source:
       value: closed
     license:
-      value: proprietary
+    - name: proprietary
   confidence: high
   note: Closed SaaS security product; no weights or source. (Lakera also runs the public Gandalf prompt-injection
     game, but Guard itself is proprietary.)

--- a/sources/scores/laminar.yaml
+++ b/sources/scores/laminar.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/lamini.yaml
+++ b/sources/scores/lamini.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: Proprietary
+    - name: Proprietary
     source:
       value: closed
     engine:

--- a/sources/scores/langchain.yaml
+++ b/sources/scores/langchain.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: langchain-core,langgraph,integrations
     commercial:
       value: LangSmith-platform/cloud

--- a/sources/scores/langflow.yaml
+++ b/sources/scores/langflow.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/langfuse.yaml
+++ b/sources/scores/langfuse.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_core
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: core:tracing/integrations/API/data-model/exports/evals/playground/SSO
     commercial:
       value: enterprise-security

--- a/sources/scores/langgraph.yaml
+++ b/sources/scores/langgraph.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_core
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: core
     commercial:
       value: LangGraph-Platform/LangSmith

--- a/sources/scores/langsmith.yaml
+++ b/sources/scores/langsmith.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: Proprietary
+    - name: Proprietary
     source:
       value: closed
     platform:

--- a/sources/scores/langtrace.yaml
+++ b/sources/scores/langtrace.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: AGPL-3.0
+    - name: AGPL-3.0
       detail: OSI, copyleft, the application
     source:
       value: public

--- a/sources/scores/langwatch.yaml
+++ b/sources/scores/langwatch.yaml
@@ -4,8 +4,10 @@ openness:
   class: open_core
   components:
     license:
-      value: Apache-2.0
-      detail: core)+MIT(SDKs
+    - name: Apache-2.0
+      detail: core
+    - name: MIT
+      detail: SDKs
     source:
       value: public
     core-gated:

--- a/sources/scores/le-chat.yaml
+++ b/sources/scores/le-chat.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: proprietary
+    - name: proprietary
       detail: SaaS app
     source:
       value: closed

--- a/sources/scores/librechat.yaml
+++ b/sources/scores/librechat.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/lighteval.yaml
+++ b/sources/scores/lighteval.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/lightrag.yaml
+++ b/sources/scores/lightrag.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/litellm.yaml
+++ b/sources/scores/litellm.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_core
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: core
     enterprise-dir:
       value: LiteLLM-Commercial-License

--- a/sources/scores/litgpt.yaml
+++ b/sources/scores/litgpt.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/livebench.yaml
+++ b/sources/scores/livebench.yaml
@@ -9,7 +9,7 @@ openness:
       value: public
       detail: ground_truth released
     license:
-      value: Apache-2.0/MIT
+    - name: Apache-2.0/MIT
       detail: repo LICENSE is Apache-2.0, carried over from FastChat; DATASHEET.md states the benchmark
         suite is distributed under the Apache License 2.0
     datasheet:

--- a/sources/scores/livecodebench.yaml
+++ b/sources/scores/livecodebench.yaml
@@ -7,7 +7,7 @@ openness:
       value: downloadable
       detail: HF parquet
     license:
-      value: cc
+    - name: cc
       detail: the card YAML names the Creative Commons family and no variant; no variant is stated on the
         card, the GitHub repository, the project site or the paper
     datasheet:

--- a/sources/scores/llama-cpp.yaml
+++ b/sources/scores/llama-cpp.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/llama-factory.yaml
+++ b/sources/scores/llama-factory.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/llama-guard.yaml
+++ b/sources/scores/llama-guard.yaml
@@ -11,7 +11,7 @@ openness:
     code:
       value: inference recipe public
     license:
-      value: Llama-3.1-Community
+    - name: Llama-3.1-Community
       detail: NOT OSI, >700M-MAU restriction
   confidence: medium
   note: Open-weights safety classifier under Meta's Llama Community License, which carries use restrictions

--- a/sources/scores/llama-index.yaml
+++ b/sources/scores/llama-index.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: core
     commercial:
       value: LlamaCloud/LlamaParse

--- a/sources/scores/llama-instruct.yaml
+++ b/sources/scores/llama-instruct.yaml
@@ -12,7 +12,7 @@ openness:
       value: partial
       detail: no training pipeline
     license:
-      value: Llama-3.1-Community
+    - name: Llama-3.1-Community
       detail: non-OSI; 700M-MAU commercial cap + use policy
   confidence: high
   note: >-

--- a/sources/scores/llama-prompt-guard.yaml
+++ b/sources/scores/llama-prompt-guard.yaml
@@ -9,7 +9,7 @@ openness:
     data:
       value: not-released
     license:
-      value: Llama-4-Community
+    - name: Llama-4-Community
       detail: NOT OSI
   confidence: medium
   note: Open weights under Meta's Llama 4 Community License, which is use-restricted and not OSI-approved,

--- a/sources/scores/llama.yaml
+++ b/sources/scores/llama.yaml
@@ -12,7 +12,7 @@ openness:
       value: partial
       detail: inference/utils via llama-models, no training code
     license:
-      value: Llama-4-Community
+    - name: Llama-4-Community
       detail: 'non-OSI: 700M MAU commercial cap as of Apr 2025 + no-compete/no-train-competing-LLM clause'
   governing_release: llama-4-scout-maverick
   confidence: high

--- a/sources/scores/llamafile.yaml
+++ b/sources/scores/llamafile.yaml
@@ -4,8 +4,10 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
-      detail: OSI)+MIT(OSI, for llama.cpp/whisper.cpp deltas
+    - name: Apache-2.0
+      detail: OSI
+    - name: MIT
+      detail: OSI, for llama.cpp/whisper.cpp deltas
     source:
       value: public
       detail: mozilla-ai/llamafile

--- a/sources/scores/llm-guard.yaml
+++ b/sources/scores/llm-guard.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/llm.yaml
+++ b/sources/scores/llm.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/lm-evaluation-harness.yaml
+++ b/sources/scores/lm-evaluation-harness.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/lm-studio.yaml
+++ b/sources/scores/lm-studio.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: Proprietary
+    - name: Proprietary
     source:
       value: closed
     app:

--- a/sources/scores/lmdeploy.yaml
+++ b/sources/scores/lmdeploy.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/lobe-chat.yaml
+++ b/sources/scores/lobe-chat.yaml
@@ -4,7 +4,7 @@ openness:
   class: source_available
   components:
     license:
-      value: LobeHub-Community-License
+    - name: LobeHub-Community-License
       detail: 'Apache-2.0-based, non-OSI: commercial license required to develop+distribute a derivative
         work; CLA lets LobeHub relicense contributions for cloud editions'
     source:

--- a/sources/scores/localai.yaml
+++ b/sources/scores/localai.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/lovable.yaml
+++ b/sources/scores/lovable.yaml
@@ -6,7 +6,7 @@ openness:
     source:
       value: closed
     license:
-      value: proprietary
+    - name: proprietary
       detail: SaaS
     self-host:
       value: 'no'

--- a/sources/scores/lucie-7b.yaml
+++ b/sources/scores/lucie-7b.yaml
@@ -16,7 +16,7 @@ openness:
       value: open
       detail: intermediate HF revisions
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
   confidence: high
   note: 'Full open-source tier alongside OLMo / Apertus: open weights, open training data, open training

--- a/sources/scores/luciole.yaml
+++ b/sources/scores/luciole.yaml
@@ -16,7 +16,7 @@ openness:
       value: open
       detail: intermediate + final pretraining checkpoints released
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
   confidence: high
   note: 'Full open-source tier alongside Lucie / OLMo / Apertus: open weights, open training data, open

--- a/sources/scores/lumo.yaml
+++ b/sources/scores/lumo.yaml
@@ -13,7 +13,7 @@ openness:
       value: closed
       detail: backend, routing, model-serving not public
     license:
-      value: GPLv3
+    - name: GPLv3
       detail: clients
   confidence: high
   note: 'Open clients (GPLv3) over a proprietary hosted service: the backend, routing and model-serving

--- a/sources/scores/madlad-400.yaml
+++ b/sources/scores/madlad-400.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: odc-by
+    - name: odc-by
       detail: API tag; card cites CC-BY-4.0
     gated:
       value: 'false'

--- a/sources/scores/maple-ai.yaml
+++ b/sources/scores/maple-ai.yaml
@@ -4,9 +4,11 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
-      detail: Maple-client)+AGPL-3.0(OpenSecret-platform),both-OSI
-      raw: MIT(Maple-client)+AGPL-3.0(OpenSecret-platform),both-OSI
+    - name: MIT
+      detail: Maple-client
+    - name: AGPL-3.0
+      detail: OpenSecret-platform),both-OSI
+      raw: AGPL-3.0(OpenSecret-platform),both-OSI
     source:
       value: public
       detail: github.com/OpenSecretCloud

--- a/sources/scores/marin-framework.yaml
+++ b/sources/scores/marin-framework.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/marin.yaml
+++ b/sources/scores/marin.yaml
@@ -17,7 +17,7 @@ openness:
     reproducibility:
       value: bit-for-bit
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
   confidence: high
   note: 'Stanford CRFM ''open lab'': Apache-2.0 weights plus documented code, data, experiments, hyperparameters

--- a/sources/scores/markitdown.yaml
+++ b/sources/scores/markitdown.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI; repo LICENSE + pyproject, PyPI field null
     source:
       value: public

--- a/sources/scores/mastra.yaml
+++ b/sources/scores/mastra.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_core
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI, everything outside `ee/`
     source:
       value: public

--- a/sources/scores/math.yaml
+++ b/sources/scores/math.yaml
@@ -8,7 +8,7 @@ openness:
       detail: access disabled, DMCA takedown
       raw: NOT downloadable from canonical HF repo (access disabled, DMCA takedown)
     license:
-      value: MIT
+    - name: MIT
       detail: declared
     datasheet:
       value: present

--- a/sources/scores/max.yaml
+++ b/sources/scores/max.yaml
@@ -4,10 +4,10 @@ openness:
   class: source_available
   components:
     license:
-      value: Modular-Community-License
+    - name: Modular-Community-License
       detail: non-OSI, per-device licensing and a limited redistribution grant, governs MAX/Mojo usage+distribution
     repo-license:
-      value: Apache-2.0-WITH-LLVM-exception
+    - name: Apache-2.0-WITH-LLVM-exception
       detail: the source in modular/modular
     source:
       value: public

--- a/sources/scores/mbpp.yaml
+++ b/sources/scores/mbpp.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: CC-BY-4.0
+    - name: CC-BY-4.0
       detail: open data license
     redistributability:
       value: full

--- a/sources/scores/mcp-inspector.yaml
+++ b/sources/scores/mcp-inspector.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/mcp-python-sdk.yaml
+++ b/sources/scores/mcp-python-sdk.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/mcp-typescript-sdk.yaml
+++ b/sources/scores/mcp-typescript-sdk.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/megatron-lm.yaml
+++ b/sources/scores/megatron-lm.yaml
@@ -4,8 +4,10 @@ openness:
   class: open_source
   components:
     license:
-      value: BSD-3-Clause
-      detail: OSI, NVIDIA core)+Apache-2.0/MIT(OSI, vendored components
+    - name: BSD-3-Clause
+      detail: OSI, NVIDIA core
+    - name: Apache-2.0/MIT
+      detail: OSI, vendored components
     source:
       value: public
     core-gated:

--- a/sources/scores/microsoft-copilot.yaml
+++ b/sources/scores/microsoft-copilot.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: proprietary
+    - name: proprietary
       detail: SaaS/embedded
     source:
       value: closed

--- a/sources/scores/milvus.yaml
+++ b/sources/scores/milvus.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
     source:
       value: public
     core-gated:

--- a/sources/scores/mimo-pro.yaml
+++ b/sources/scores/mimo-pro.yaml
@@ -11,7 +11,7 @@ openness:
     code:
       value: open
     license:
-      value: MIT
+    - name: MIT
       detail: HF card; older GitHub repo shows Apache-2.0
   confidence: medium
   note: Open weights under a permissive license (MIT per the model card); no open training data -> open_weights.

--- a/sources/scores/minimax.yaml
+++ b/sources/scores/minimax.yaml
@@ -12,7 +12,7 @@ openness:
       value: partial
       detail: inference only; no training pipeline/data
     license:
-      value: minimax-community
+    - name: minimax-community
       detail: custom, see HF LICENSE
   governing_release: minimax-m3
   confidence: high

--- a/sources/scores/mistral-7b-instruct.yaml
+++ b/sources/scores/mistral-7b-instruct.yaml
@@ -12,7 +12,7 @@ openness:
       value: closed
       detail: no training/post-training pipeline
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI permissive
   confidence: high
   note: Apache-2.0 open weights; instruction-tuning data and recipe undisclosed -> open_weights.

--- a/sources/scores/mistral-fine-tuning-api.yaml
+++ b/sources/scores/mistral-fine-tuning-api.yaml
@@ -10,7 +10,7 @@ openness:
     runs-on:
       value: La-Plateforme-only
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: managed service, per-token + storage pricing
     base-weights:
       value: Mistral-models

--- a/sources/scores/mistral-large.yaml
+++ b/sources/scores/mistral-large.yaml
@@ -11,7 +11,7 @@ openness:
     code:
       value: closed
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
   governing_release: mistral-large-3
   confidence: high

--- a/sources/scores/mlflow.yaml
+++ b/sources/scores/mlflow.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
     source:
       value: public
     core-gated:

--- a/sources/scores/mmlu-pro.yaml
+++ b/sources/scores/mmlu-pro.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI/open,redistributable
     access:
       value: public

--- a/sources/scores/mmlu.yaml
+++ b/sources/scores/mmlu.yaml
@@ -7,7 +7,7 @@ openness:
       value: downloadable
       detail: HF parquet, cais/mmlu
     license:
-      value: MIT
+    - name: MIT
       detail: OSI/open
     datasheet:
       value: present

--- a/sources/scores/mmmu.yaml
+++ b/sources/scores/mmmu.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI/open,redistributable
     access:
       value: public

--- a/sources/scores/modal-sandboxes.yaml
+++ b/sources/scores/modal-sandboxes.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: Proprietary
+    - name: Proprietary
     source:
       value: closed
     service:

--- a/sources/scores/model-context-protocol.yaml
+++ b/sources/scores/model-context-protocol.yaml
@@ -7,8 +7,12 @@ openness:
       value: public
       detail: spec schema and docs in one repo plus reference SDKs in separate public repos
     license:
-      value: Apache-2.0
-      detail: OSI, new code/spec)+MIT(OSI, legacy contributions)+CC-BY-4.0(docs
+    - name: Apache-2.0
+      detail: OSI, new code/spec
+    - name: MIT
+      detail: OSI, legacy contributions
+    - name: CC-BY-4.0
+      detail: docs
     governance:
       value: Linux-Foundation/AAIF
       detail: open, co-founded Anthropic/Block/OpenAI

--- a/sources/scores/morphic.yaml
+++ b/sources/scores/morphic.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/mosaic-ai-model-training.yaml
+++ b/sources/scores/mosaic-ai-model-training.yaml
@@ -11,7 +11,7 @@ openness:
       value: Databricks-workspace-only
       detail: AWS regions
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: managed service
     base-weights:
       value: Llama-Community-License

--- a/sources/scores/mt-bench.yaml
+++ b/sources/scores/mt-bench.yaml
@@ -10,7 +10,7 @@ openness:
       value: public
       detail: GPT-4 references in FastChat
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: FastChat repository LICENSE
     datasheet:
       value: present

--- a/sources/scores/multipl-e.yaml
+++ b/sources/scores/multipl-e.yaml
@@ -7,7 +7,7 @@ openness:
       value: downloadable
       detail: HF parquet, 47 subsets
     license:
-      value: MIT
+    - name: MIT
       detail: on HF dataset card
     datasheet:
       value: present

--- a/sources/scores/muse-spark.yaml
+++ b/sources/scores/muse-spark.yaml
@@ -10,7 +10,7 @@ openness:
     code:
       value: closed
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: meta.ai/Meta AI app + private API preview; no downloadable weights
   confidence: high
   note: No weights released, a closed assistant-surface model; only a private API preview. Fully closed.

--- a/sources/scores/n8n.yaml
+++ b/sources/scores/n8n.yaml
@@ -4,9 +4,9 @@ openness:
   class: source_available
   components:
     license:
-      value: Sustainable-Use-License
-      detail: 'fair-code,non-OSI: internal-use-only,no-resale/SaaS)+n8n-Enterprise-License'
-      raw: 'Sustainable-Use-License(fair-code,non-OSI: internal-use-only,no-resale/SaaS)+n8n-Enterprise-License'
+    - name: Sustainable-Use-License
+      detail: 'fair-code,non-OSI: internal-use-only,no-resale/SaaS'
+    - name: n8n-Enterprise-License
     source:
       value: public
     commercial:

--- a/sources/scores/nano-graphrag.yaml
+++ b/sources/scores/nano-graphrag.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/nemo-curator.yaml
+++ b/sources/scores/nemo-curator.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/nemo-data-designer.yaml
+++ b/sources/scores/nemo-data-designer.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI, NVIDIA-NeMo/DataDesigner LICENSE
     source:
       value: public

--- a/sources/scores/nemo-guardrails.yaml
+++ b/sources/scores/nemo-guardrails.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/nemo-rl.yaml
+++ b/sources/scores/nemo-rl.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/nemotron-cc.yaml
+++ b/sources/scores/nemotron-cc.yaml
@@ -4,7 +4,7 @@ openness:
   class: gated
   components:
     license:
-      value: NVIDIA-Open-Data
+    - name: NVIDIA-Open-Data
     gated:
       value: manual
       detail: model-training-use

--- a/sources/scores/nemotron.yaml
+++ b/sources/scores/nemotron.yaml
@@ -14,7 +14,7 @@ openness:
       value: open
       detail: training recipes + RL env configs
     license:
-      value: NVIDIA-Nemotron-Open-Model-License
+    - name: NVIDIA-Nemotron-Open-Model-License
       detail: permissive,commercial,non-OSI
   note: 'Unusually open for post-trained models: NVIDIA releases weights, the post-training data and the recipes,
     but under the non-OSI NVIDIA Open Model License, so open_weights not open_source. This category scores the post-training

--- a/sources/scores/new-relic-ai-monitoring.yaml
+++ b/sources/scores/new-relic-ai-monitoring.yaml
@@ -7,7 +7,7 @@ openness:
       value: proprietary-SaaS
       detail: closed
     license:
-      value: commercial
+    - name: commercial
       detail: Standard/Pro/Enterprise tiers
     ingestion:
       value: OpenTelemetry-compatible

--- a/sources/scores/nextchat.yaml
+++ b/sources/scores/nextchat.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_core
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: core, public source
     enterprise-tier:
       value: NextChat Enterprise

--- a/sources/scores/nono.yaml
+++ b/sources/scores/nono.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/northflank-sandboxes.yaml
+++ b/sources/scores/northflank-sandboxes.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: Proprietary
+    - name: Proprietary
     service:
       value: proprietary
       detail: Northflank managed SaaS

--- a/sources/scores/notion-mcp.yaml
+++ b/sources/scores/notion-mcp.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/o-series.yaml
+++ b/sources/scores/o-series.yaml
@@ -10,7 +10,7 @@ openness:
     code:
       value: closed
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: API+ChatGPT only
   confidence: high
   note: Proprietary OpenAI reasoning models; no weights, data, or code released.

--- a/sources/scores/oasst1.yaml
+++ b/sources/scores/oasst1.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
     gated:
       value: 'false'
     dataset_card:

--- a/sources/scores/ogx.yaml
+++ b/sources/scores/ogx.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/ollama.yaml
+++ b/sources/scores/ollama.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
     source:
       value: public
     core-gated:

--- a/sources/scores/olmo-instruct.yaml
+++ b/sources/scores/olmo-instruct.yaml
@@ -15,7 +15,7 @@ openness:
     checkpoints:
       value: open
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
   confidence: high
   note: 'Fully-open instruct line: Apache-2.0 weights + open pretraining and post-training data + open training

--- a/sources/scores/olmo.yaml
+++ b/sources/scores/olmo.yaml
@@ -16,7 +16,7 @@ openness:
       value: open
       detail: intermediate
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
   confidence: high
   note: 'Fully open: Apache-2.0 weights + the complete Dolma 3 corpus + training code + intermediate checkpoints.

--- a/sources/scores/olmocr.yaml
+++ b/sources/scores/olmocr.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/olmoe-instruct.yaml
+++ b/sources/scores/olmoe-instruct.yaml
@@ -16,7 +16,7 @@ openness:
       value: open
       detail: 244 intermediate
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
   confidence: high
   note: 'Fully-open MoE: Apache-2.0 weights + open pretraining data (OLMoE-mix-0924, on

--- a/sources/scores/onnx-runtime.yaml
+++ b/sources/scores/onnx-runtime.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/onnx.yaml
+++ b/sources/scores/onnx.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/open-llm-leaderboard.yaml
+++ b/sources/scores/open-llm-leaderboard.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: HF-Space
     backend:
       value: lm-eval-harness/lighteval

--- a/sources/scores/open-webui.yaml
+++ b/sources/scores/open-webui.yaml
@@ -4,7 +4,7 @@ openness:
   class: source_available
   components:
     license:
-      value: Open-WebUI-License
+    - name: Open-WebUI-License
       detail: 'BSD-3-Clause-based + non-OSI branding clause: branding may not be removed above 50 end-users/30d
         without enterprise license or written permission'
     source:

--- a/sources/scores/openai-code-interpreter.yaml
+++ b/sources/scores/openai-code-interpreter.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: Proprietary
+    - name: Proprietary
     service:
       value: proprietary
       detail: OpenAI-managed sandbox

--- a/sources/scores/openai-evals-api-dashboard.yaml
+++ b/sources/scores/openai-evals-api-dashboard.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: SaaS, OpenAI-platform-only
     source:
       value: closed

--- a/sources/scores/openai-evals.yaml
+++ b/sources/scores/openai-evals.yaml
@@ -4,13 +4,13 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public
       detail: full framework + registry
     per-dataset-licenses:
-      value: mixed
+    - name: mixed
       detail: CC/CC0/Apache for bundled data
     core-gated:
       value: ungated

--- a/sources/scores/openai-fine-tuning-api.yaml
+++ b/sources/scores/openai-fine-tuning-api.yaml
@@ -10,7 +10,7 @@ openness:
     runs-on:
       value: OpenAI-platform-only
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: paid API service
   confidence: high
   note: Proprietary managed fine-tuning service, no source, runs only on OpenAI's platform against OpenAI's

--- a/sources/scores/openai-internal-evals.yaml
+++ b/sources/scores/openai-internal-evals.yaml
@@ -9,7 +9,7 @@ openness:
     datasheet:
       value: 'no'
     license:
-      value: none
+    - name: none
     access:
       value: internal-only
       detail: only summarized/redacted results released alongside major deployments

--- a/sources/scores/openai-moderation.yaml
+++ b/sources/scores/openai-moderation.yaml
@@ -11,7 +11,7 @@ openness:
     source:
       value: closed
     license:
-      value: proprietary
+    - name: proprietary
   confidence: high
   note: Closed, API-only hosted classifier; no weights or source.
   raw: service:proprietary hosted API(no weights, no self-host);access:free moderation endpoint;source:closed;license:proprietary

--- a/sources/scores/openclaw.yaml
+++ b/sources/scores/openclaw.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI; body is MIT, GitHub NOASSERTION from custom copyright line
     source:
       value: public

--- a/sources/scores/opencode.yaml
+++ b/sources/scores/opencode.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/opencompass.yaml
+++ b/sources/scores/opencompass.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/openfn.yaml
+++ b/sources/scores/openfn.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: LGPL-3.0/GPL-3.0
+    - name: LGPL-3.0/GPL-3.0
       detail: OSI copyleft
     source:
       value: public

--- a/sources/scores/openguardrails.yaml
+++ b/sources/scores/openguardrails.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI) for both platform and model
       raw: Apache-2.0(OSI) for both platform and model
     source:

--- a/sources/scores/openhands.yaml
+++ b/sources/scores/openhands.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_core
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: core
     enterprise-dir:
       value: separate-license

--- a/sources/scores/openhermes-2-5.yaml
+++ b/sources/scores/openhermes-2-5.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: not-clearly-stated-on-card
+    - name: not-clearly-stated-on-card
       detail: no license field in the card YAML, no license section in the card body, no LICENSE file in
         the repository and no license tag on the Hub API
     card:

--- a/sources/scores/openlit.yaml
+++ b/sources/scores/openlit.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/openllmetry.yaml
+++ b/sources/scores/openllmetry.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/openmanus.yaml
+++ b/sources/scores/openmanus.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/openpcc.yaml
+++ b/sources/scores/openpcc.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/openpipe.yaml
+++ b/sources/scores/openpipe.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI, OpenPipe Inc.; some vendored code LGPL-3.0
     source:
       value: public

--- a/sources/scores/openrag.yaml
+++ b/sources/scores/openrag.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: AGPL-3.0
+    - name: AGPL-3.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/openrlhf.yaml
+++ b/sources/scores/openrlhf.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/openrouter.yaml
+++ b/sources/scores/openrouter.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: proprietary
+    - name: proprietary
       detail: hosted gateway
     source:
       value: closed

--- a/sources/scores/opensandbox.yaml
+++ b/sources/scores/opensandbox.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/openthoughts-114k.yaml
+++ b/sources/scores/openthoughts-114k.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: apache-2.0
+    - name: apache-2.0
     access:
       value: ungated
     dataset_card:

--- a/sources/scores/openvino.yaml
+++ b/sources/scores/openvino.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/openwebmath.yaml
+++ b/sources/scores/openwebmath.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: ODC-BY
+    - name: ODC-BY
     gated:
       value: 'false'
     dataset_card:

--- a/sources/scores/opik.yaml
+++ b/sources/scores/opik.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/optimum.yaml
+++ b/sources/scores/optimum.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/ornith.yaml
+++ b/sources/scores/ornith.yaml
@@ -13,7 +13,7 @@ openness:
     recipe:
       value: closed
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
   confidence: high
   note: MIT-licensed open weights on a Qwen 3.5 base, but no open training data or recipe -> open_weights.

--- a/sources/scores/oscar-2301.yaml
+++ b/sources/scores/oscar-2301.yaml
@@ -4,7 +4,7 @@ openness:
   class: gated
   components:
     license:
-      value: cc0-1.0
+    - name: cc0-1.0
       detail: metadata
     gated:
       value: manual

--- a/sources/scores/osprey.yaml
+++ b/sources/scores/osprey.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/osworld.yaml
+++ b/sources/scores/osworld.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/otari.yaml
+++ b/sources/scores/otari.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI, core
     source:
       value: public

--- a/sources/scores/pathway.yaml
+++ b/sources/scores/pathway.yaml
@@ -4,7 +4,7 @@ openness:
   class: source_available
   components:
     license:
-      value: BSL-1.1
+    - name: BSL-1.1
       detail: non-OSI:single-machine + no-compete, Change-Date 2027-07-20 -> Apache-2.0
     commercial:
       value: Scale/Enterprise

--- a/sources/scores/peft.yaml
+++ b/sources/scores/peft.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/perplexica.yaml
+++ b/sources/scores/perplexica.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/perplexity-sonar-api.yaml
+++ b/sources/scores/perplexity-sonar-api.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: API-only
     source:
       value: closed

--- a/sources/scores/perplexity.yaml
+++ b/sources/scores/perplexity.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: proprietary
+    - name: proprietary
       detail: SaaS
     source:
       value: closed

--- a/sources/scores/personahub.yaml
+++ b/sources/scores/personahub.yaml
@@ -4,7 +4,7 @@ openness:
   class: restricted
   components:
     license:
-      value: cc-by-nc-sa-4.0
+    - name: cc-by-nc-sa-4.0
       detail: non-commercial
     card:
       value: present

--- a/sources/scores/perspective-api.yaml
+++ b/sources/scores/perspective-api.yaml
@@ -13,7 +13,7 @@ openness:
     source:
       value: closed
     license:
-      value: proprietary
+    - name: proprietary
   confidence: high
   note: Closed, API-only hosted classifier; no weights or source. Long-standing and influential, but proprietary.
   raw: service:proprietary hosted API by Jigsaw/Google(no weights, no self-host);access:free with quota;scores:toxicity

--- a/sources/scores/pes2o.yaml
+++ b/sources/scores/pes2o.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: ODC-BY
+    - name: ODC-BY
     gated:
       value: 'false'
     dataset_card:

--- a/sources/scores/phi-instruct.yaml
+++ b/sources/scores/phi-instruct.yaml
@@ -13,7 +13,7 @@ openness:
       value: closed
       detail: no training pipeline
     license:
-      value: MIT
+    - name: MIT
       detail: OSI permissive
   confidence: high
   note: MIT-licensed open weights; training/post-training data and code not released -> open_weights.

--- a/sources/scores/phi.yaml
+++ b/sources/scores/phi.yaml
@@ -11,7 +11,7 @@ openness:
     code:
       value: closed
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
   confidence: high
   note: 'MIT weights, which is genuinely permissive with no use restrictions, but neither the training corpus nor

--- a/sources/scores/phoenix.yaml
+++ b/sources/scores/phoenix.yaml
@@ -4,7 +4,7 @@ openness:
   class: source_available
   components:
     license:
-      value: Elastic-License-2.0
+    - name: Elastic-License-2.0
       detail: 'ELv2, non-OSI: prohibits offering as a managed/hosted service to third parties'
     source:
       value: public

--- a/sources/scores/pinecone.yaml
+++ b/sources/scores/pinecone.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: proprietary
+    - name: proprietary
       detail: SaaS
     source:
       value: closed

--- a/sources/scores/playwright-mcp.yaml
+++ b/sources/scores/playwright-mcp.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/poe.yaml
+++ b/sources/scores/poe.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: proprietary
+    - name: proprietary
       detail: SaaS
     source:
       value: closed

--- a/sources/scores/postgres-mcp.yaml
+++ b/sources/scores/postgres-mcp.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/predibase.yaml
+++ b/sources/scores/predibase.yaml
@@ -15,7 +15,7 @@ openness:
     runs-on:
       value: Predibase-SaaS-or-customer-VPC
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: managed) with Apache-licensed LoRAX/Ludwig adjuncts
       raw: Proprietary(managed) with Apache-licensed LoRAX/Ludwig adjuncts
   confidence: high

--- a/sources/scores/privatemode.yaml
+++ b/sources/scores/privatemode.yaml
@@ -4,8 +4,10 @@ openness:
   class: source_available
   components:
     license:
-      value: custom-source-available
-      detail: audit-only)+MIT-subdirs(proxy/web/internal-oss
+    - name: custom-source-available
+      detail: audit-only
+    - name: MIT-subdirs
+      detail: proxy/web/internal-oss
     source:
       value: TCB-public
       detail: github.com/edgelesssys/privatemode-public

--- a/sources/scores/promptfoo.yaml
+++ b/sources/scores/promptfoo.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/promptlayer.yaml
+++ b/sources/scores/promptlayer.yaml
@@ -6,7 +6,7 @@ openness:
     source:
       value: closed
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI, client library MagnivOrg/prompt-layer-library only
     platform:
       value: proprietary-SaaS

--- a/sources/scores/pydantic-ai.yaml
+++ b/sources/scores/pydantic-ai.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: library
     commercial:
       value: Pydantic-Logfire

--- a/sources/scores/pyrit.yaml
+++ b/sources/scores/pyrit.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/pysyft.yaml
+++ b/sources/scores/pysyft.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI permissive
     source:
       value: public

--- a/sources/scores/pythia.yaml
+++ b/sources/scores/pythia.yaml
@@ -16,7 +16,7 @@ openness:
       value: open
       detail: 154 per model
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
   confidence: high
   note: 'The reference case for 5/open_source in this category. Apache-2.0 weights, the Pile released as the training

--- a/sources/scores/pytorch.yaml
+++ b/sources/scores/pytorch.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: BSD-3-Clause
+    - name: BSD-3-Clause
       detail: OSI
     source:
       value: public

--- a/sources/scores/qdrant.yaml
+++ b/sources/scores/qdrant.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI, engine core
     source:
       value: public

--- a/sources/scores/qualcomm-ai-engine-direct.yaml
+++ b/sources/scores/qualcomm-ai-engine-direct.yaml
@@ -8,7 +8,7 @@ openness:
       detail: no published source for the QNN/Qualcomm AI Runtime SDK core engine; distributed as a proprietary
         binary via the Qualcomm Software Center under an EULA
     license:
-      value: proprietary
+    - name: proprietary
       detail: no license to the source since it is not published
     open-wrapper:
       value: BSD-3-Clause

--- a/sources/scores/qwen-coder.yaml
+++ b/sources/scores/qwen-coder.yaml
@@ -13,7 +13,7 @@ openness:
       value: partial
       detail: inference/usage + chat template; no training pipeline or post-training/SFT data
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI permissive, no use restrictions
   governing_release: qwen3-coder
   confidence: high

--- a/sources/scores/qwen-instruct.yaml
+++ b/sources/scores/qwen-instruct.yaml
@@ -12,7 +12,7 @@ openness:
       value: partial
       detail: inference/chat template; no training pipeline or SFT/RLHF data
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI permissive
   confidence: high
   note: OSI Apache-2.0 open weights; post-training data and training code closed -> open_weights.

--- a/sources/scores/qwen.yaml
+++ b/sources/scores/qwen.yaml
@@ -12,7 +12,7 @@ openness:
       value: partial
       detail: inference/usage code on GitHub; no training pipeline/data
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: most restrictive distributed SKU; the proprietary Plus/Max tiers are API-only and never distributed,
         so they fall outside this axis
   governing_release: qwen-3-6

--- a/sources/scores/qwen3guard.yaml
+++ b/sources/scores/qwen3guard.yaml
@@ -9,7 +9,7 @@ openness:
     data:
       value: not-released
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
   confidence: medium
   note: Open weights under Apache-2.0 (OSI). Scored 3 because the 4-rung requires both the post-training

--- a/sources/scores/ragas.yaml
+++ b/sources/scores/ragas.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/ragflow.yaml
+++ b/sources/scores/ragflow.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/ray.yaml
+++ b/sources/scores/ray.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/redpajama-data-v2.yaml
+++ b/sources/scores/redpajama-data-v2.yaml
@@ -4,7 +4,8 @@ openness:
   class: open
   components:
     license:
-      value: CommonCrawl-ToU+Apache-2.0
+    - name: CommonCrawl-ToU
+    - name: Apache-2.0
       detail: code
     ungated:
       value: 'yes'

--- a/sources/scores/redpajama-data.yaml
+++ b/sources/scores/redpajama-data.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/refinedweb.yaml
+++ b/sources/scores/refinedweb.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: ODC-BY-1.0
+    - name: ODC-BY-1.0
     gated:
       value: 'false'
     dataset_card:

--- a/sources/scores/reka-core.yaml
+++ b/sources/scores/reka-core.yaml
@@ -11,7 +11,7 @@ openness:
     code:
       value: closed
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: API/on-prem, no weights
   confidence: high
   note: Proprietary multimodal model; API/on-prem/on-device deployment but no downloadable weights. Confirmed

--- a/sources/scores/replit-agent-code-execution-api.yaml
+++ b/sources/scores/replit-agent-code-execution-api.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: Proprietary
+    - name: Proprietary
     source:
       value: closed
     service:

--- a/sources/scores/replit-agent.yaml
+++ b/sources/scores/replit-agent.yaml
@@ -6,7 +6,7 @@ openness:
     source:
       value: closed
     license:
-      value: proprietary
+    - name: proprietary
       detail: Replit cloud SaaS
     self-host:
       value: 'no'

--- a/sources/scores/rwkv.yaml
+++ b/sources/scores/rwkv.yaml
@@ -14,7 +14,7 @@ openness:
       value: open
       detail: github.com/BlinkDL/RWKV-LM
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
   confidence: high
   last_verified: '2026-07-30'

--- a/sources/scores/safetensors.yaml
+++ b/sources/scores/safetensors.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/sambanova-cloud.yaml
+++ b/sources/scores/sambanova-cloud.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: proprietary
+    - name: proprietary
     source:
       value: closed
       detail: managed cloud API, the EULA states Customer has no right to obtain a copy of the underlying

--- a/sources/scores/sandbox-runtime.yaml
+++ b/sources/scores/sandbox-runtime.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/scale-seal-leaderboard.yaml
+++ b/sources/scores/scale-seal-leaderboard.yaml
@@ -11,7 +11,7 @@ openness:
       value: 'no'
       detail: methodology described but examples not redistributable
     license:
-      value: none
+    - name: none
       detail: not distributed
     access:
       value: held-out

--- a/sources/scores/searxng.yaml
+++ b/sources/scores/searxng.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: AGPL-3.0
+    - name: AGPL-3.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/semantic-kernel.yaml
+++ b/sources/scores/semantic-kernel.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/sentencepiece.yaml
+++ b/sources/scores/sentencepiece.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/serper.yaml
+++ b/sources/scores/serper.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: proprietary
+    - name: proprietary
       detail: API-only
     source:
       value: closed

--- a/sources/scores/sglang.yaml
+++ b/sources/scores/sglang.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/shieldgemma.yaml
+++ b/sources/scores/shieldgemma.yaml
@@ -9,7 +9,7 @@ openness:
     data:
       value: not-released
     license:
-      value: Gemma
+    - name: Gemma
       detail: NOT OSI, use-restricted
   confidence: medium
   note: Open weights under the Gemma license, which is use-restricted and not OSI-approved (per the openness

--- a/sources/scores/sillytavern.yaml
+++ b/sources/scores/sillytavern.yaml
@@ -5,7 +5,7 @@ openness:
   confidence: high
   components:
     license:
-      value: AGPL-3.0
+    - name: AGPL-3.0
       detail: OSI, copyleft
     source:
       value: public

--- a/sources/scores/simple-evals.yaml
+++ b/sources/scores/simple-evals.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/simpleaudit.yaml
+++ b/sources/scores/simpleaudit.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI; verified LICENSE body, copyright Simula
     source:
       value: public

--- a/sources/scores/slack-mcp.yaml
+++ b/sources/scores/slack-mcp.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/smallpond.yaml
+++ b/sources/scores/smallpond.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/smolagents.yaml
+++ b/sources/scores/smolagents.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/smollm.yaml
+++ b/sources/scores/smollm.yaml
@@ -13,7 +13,7 @@ openness:
       value: open
       detail: training+post-training recipe published
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
   confidence: high
   note: 'Fully-open small-model line: Apache-2.0 weights with the complete engineering blueprint (architecture,

--- a/sources/scores/smoltalk.yaml
+++ b/sources/scores/smoltalk.yaml
@@ -6,9 +6,9 @@ openness:
     access:
       value: ungated
     license:
-      value: apache-2.0
-      detail: new-subsets)+per-component
-      raw: apache-2.0(new-subsets)+per-component
+    - name: apache-2.0
+      detail: new-subsets
+    - name: per-component
     dataset_card:
       value: present
   confidence: high

--- a/sources/scores/snorkel-flow.yaml
+++ b/sources/scores/snorkel-flow.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: Proprietary
+    - name: Proprietary
     source:
       value: closed
     free_text:

--- a/sources/scores/snowflake-cortex-fine-tuning.yaml
+++ b/sources/scores/snowflake-cortex-fine-tuning.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: Proprietary
+    - name: Proprietary
     service:
       value: fully-managed-proprietary
       detail: in-Snowflake

--- a/sources/scores/spaces.yaml
+++ b/sources/scores/spaces.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: Proprietary
+    - name: Proprietary
     source:
       value: closed
     platform:

--- a/sources/scores/spec-kit.yaml
+++ b/sources/scores/spec-kit.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/stack-edu.yaml
+++ b/sources/scores/stack-edu.yaml
@@ -6,7 +6,7 @@ openness:
     access:
       value: ungated
     license:
-      value: inherits-the-stack-v2
+    - name: inherits-the-stack-v2
     dataset_card:
       value: present
   confidence: medium

--- a/sources/scores/starcoder2.yaml
+++ b/sources/scores/starcoder2.yaml
@@ -15,7 +15,7 @@ openness:
       value: open
       detail: The Stack v2
     license:
-      value: BigCode-OpenRAIL-M
+    - name: BigCode-OpenRAIL-M
       detail: open but RAIL behavioral-use restrictions, not OSI
   confidence: high
   note: 'The most open artifact in this category by evidence: weights, the full training corpus (The Stack v2) and

--- a/sources/scores/starcoderdata.yaml
+++ b/sources/scores/starcoderdata.yaml
@@ -4,7 +4,7 @@ openness:
   class: gated
   components:
     license:
-      value: permissive
+    - name: permissive
       detail: SPDX per file
     gated:
       value: terms-acceptance

--- a/sources/scores/suna.yaml
+++ b/sources/scores/suna.yaml
@@ -5,7 +5,7 @@ openness:
   confidence: high
   components:
     license:
-      value: Elastic License 2.0
+    - name: Elastic License 2.0
       detail: non-OSI, source-available, restricts hosting as a managed service
     source:
       value: public

--- a/sources/scores/surfsense.yaml
+++ b/sources/scores/surfsense.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/swe-agent.yaml
+++ b/sources/scores/swe-agent.yaml
@@ -5,7 +5,7 @@ openness:
   confidence: high
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/swe-bench-verified.yaml
+++ b/sources/scores/swe-bench-verified.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: SWE-bench repository states MIT over its code and data; the HF card for Verified still declares
         no license field
     redistributability:

--- a/sources/scores/swe-bench.yaml
+++ b/sources/scores/swe-bench.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/swift.yaml
+++ b/sources/scores/swift.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/syfthub.yaml
+++ b/sources/scores/syfthub.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/synth.yaml
+++ b/sources/scores/synth.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: CC-BY-4.0
+    - name: CC-BY-4.0
       detail: permissive
     access:
       value: ungated

--- a/sources/scores/tavily-search-api.yaml
+++ b/sources/scores/tavily-search-api.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: API-only
     source:
       value: closed

--- a/sources/scores/tensorflow.yaml
+++ b/sources/scores/tensorflow.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/tensorlake-sandbox.yaml
+++ b/sources/scores/tensorlake-sandbox.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_core
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/tensorrt-llm.yaml
+++ b/sources/scores/tensorrt-llm.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI, stated in LICENSE; GitHub reports NOASSERTION because of the bundled-dependency appendix
     source:
       value: public

--- a/sources/scores/text-generation-inference.yaml
+++ b/sources/scores/text-generation-inference.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/the-pile-pipeline.yaml
+++ b/sources/scores/the-pile-pipeline.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/the-pile.yaml
+++ b/sources/scores/the-pile.yaml
@@ -6,7 +6,7 @@ openness:
     access:
       value: ungated
     license:
-      value: mixed-per-subset
+    - name: mixed-per-subset
     dataset_card:
       value: legacy-repo-only
   confidence: medium

--- a/sources/scores/the-stack-v2.yaml
+++ b/sources/scores/the-stack-v2.yaml
@@ -4,7 +4,7 @@ openness:
   class: gated
   components:
     license:
-      value: permissive
+    - name: permissive
       detail: SPDX
     gated:
       value: terms-acceptance+contact-info

--- a/sources/scores/thunderbolt.yaml
+++ b/sources/scores/thunderbolt.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MPL-2.0
+    - name: MPL-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/tinker.yaml
+++ b/sources/scores/tinker.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: Proprietary
+    - name: Proprietary
     source:
       value: closed
     engine:

--- a/sources/scores/tinyllama-chat.yaml
+++ b/sources/scores/tinyllama-chat.yaml
@@ -17,7 +17,7 @@ openness:
       value: open
       detail: pretraining project public
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
   note: 'Unusually transparent for a chat model: open base, and named public alignment datasets (UltraChat SFT +
     UltraFeedback DPO). Corrected from 4 to 5 on 2026-07-29, and the post-training evidence moved out of a free-text

--- a/sources/scores/together-fine-tuning.yaml
+++ b/sources/scores/together-fine-tuning.yaml
@@ -10,7 +10,7 @@ openness:
     runs-on:
       value: Together-cloud-only
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: managed service, per-token training pricing
     base-weights:
       value: open-models

--- a/sources/scores/together-inference-engine.yaml
+++ b/sources/scores/together-inference-engine.yaml
@@ -12,7 +12,7 @@ openness:
     access:
       value: managed-cloud-API-only
     license:
-      value: Proprietary
+    - name: Proprietary
   confidence: high
   note: 'Re-confirmed today: no self-hostable implementation of the inference engine exists (serverless/dedicated
     pages describe a managed cloud API and ''Reserved, isolated GPU endpoints running Together''s proprietary

--- a/sources/scores/tokenizers.yaml
+++ b/sources/scores/tokenizers.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/torchtune.yaml
+++ b/sources/scores/torchtune.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: BSD-3-Clause
+    - name: BSD-3-Clause
       detail: OSI
     source:
       value: public

--- a/sources/scores/transformers.yaml
+++ b/sources/scores/transformers.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/triton.yaml
+++ b/sources/scores/triton.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/trl.yaml
+++ b/sources/scores/trl.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/trulens.yaml
+++ b/sources/scores/trulens.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
     source:
       value: public

--- a/sources/scores/truthfulqa.yaml
+++ b/sources/scores/truthfulqa.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI/open,redistributable
     access:
       value: public

--- a/sources/scores/tulu-3-sft-mixture.yaml
+++ b/sources/scores/tulu-3-sft-mixture.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: odc-by
+    - name: odc-by
       detail: mixed subset licenses incl CC-BY-NC
     access:
       value: ungated

--- a/sources/scores/tulu.yaml
+++ b/sources/scores/tulu.yaml
@@ -7,7 +7,7 @@ openness:
       value: open
       detail: downloadable
     license:
-      value: Llama-3.1-Community
+    - name: Llama-3.1-Community
       detail: non-OSI;700M-MAU cap + use policy
     post-training-data:
       value: open

--- a/sources/scores/txt360-pipeline.yaml
+++ b/sources/scores/txt360-pipeline.yaml
@@ -4,7 +4,7 @@ openness:
   class: source_available
   components:
     license:
-      value: Apache-2.0 asserted in README only
+    - name: Apache-2.0 asserted in README only
       detail: no LICENSE file in repo (GitHub reports null
       raw: Apache-2.0 asserted in README only, no LICENSE file in repo (GitHub reports null)
     source:

--- a/sources/scores/txt360.yaml
+++ b/sources/scores/txt360.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: ODC-BY
+    - name: ODC-BY
     gated:
       value: 'false'
     dataset_card:

--- a/sources/scores/ultrachat-200k.yaml
+++ b/sources/scores/ultrachat-200k.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: MIT
+    - name: MIT
     gated:
       value: 'false'
     dataset_card:

--- a/sources/scores/ultrafeedback.yaml
+++ b/sources/scores/ultrafeedback.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: mit
+    - name: mit
     card:
       value: present
     ungated:

--- a/sources/scores/ungoliant.yaml
+++ b/sources/scores/ungoliant.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/unsloth.yaml
+++ b/sources/scores/unsloth.yaml
@@ -4,8 +4,10 @@ openness:
   class: open_core
   components:
     license:
-      value: Apache-2.0
-      detail: OSI, core unsloth pkg)+AGPL-3.0(OSI, optional Unsloth Studio UI
+    - name: Apache-2.0
+      detail: OSI, core unsloth pkg
+    - name: AGPL-3.0
+      detail: OSI, optional Unsloth Studio UI
     source:
       value: public
       detail: unslothai/unsloth

--- a/sources/scores/v0.yaml
+++ b/sources/scores/v0.yaml
@@ -6,7 +6,7 @@ openness:
     source:
       value: closed
     license:
-      value: proprietary
+    - name: proprietary
       detail: Vercel SaaS
     self-host:
       value: 'no'

--- a/sources/scores/vals-ai.yaml
+++ b/sources/scores/vals-ai.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: proprietary
+    - name: proprietary
     source:
       value: closed
       detail: SaaS-only,no public repo

--- a/sources/scores/vellum.yaml
+++ b/sources/scores/vellum.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: MIT
+    - name: MIT
       detail: OSI, Copyright 2025 Vellum AI
     source:
       value: public

--- a/sources/scores/vercel-sandbox.yaml
+++ b/sources/scores/vercel-sandbox.yaml
@@ -14,7 +14,7 @@ openness:
       detail: '@vercel/sandbox JS + Python, vercel/sandbox on GitHub'
       raw: client SDK/CLI only (@vercel/sandbox JS + Python, vercel/sandbox on GitHub)
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: proprietary service
       raw: Proprietary, proprietary service
   confidence: high

--- a/sources/scores/verl.yaml
+++ b/sources/scores/verl.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/vertex-ai-gen-ai-evaluation-service.yaml
+++ b/sources/scores/vertex-ai-gen-ai-evaluation-service.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: proprietary
+    - name: proprietary
       detail: GCP managed service
     source:
       value: closed

--- a/sources/scores/vertex-ai-model-observability.yaml
+++ b/sources/scores/vertex-ai-model-observability.yaml
@@ -4,7 +4,7 @@ openness:
   class: closed
   components:
     license:
-      value: proprietary
+    - name: proprietary
       detail: Google Cloud managed service
     source:
       value: closed

--- a/sources/scores/vertex-ai-tuning.yaml
+++ b/sources/scores/vertex-ai-tuning.yaml
@@ -10,7 +10,7 @@ openness:
     runs-on:
       value: Google-Cloud-Vertex-AI-only
     license:
-      value: Proprietary
+    - name: Proprietary
       detail: managed GCP service
   confidence: high
   note: Proprietary managed tuning service inside Google Cloud's Vertex AI generative-AI docs (now also

--- a/sources/scores/vibethinker.yaml
+++ b/sources/scores/vibethinker.yaml
@@ -13,7 +13,7 @@ openness:
       value: partial
       detail: RL/SFT data not fully released
     license:
-      value: MIT
+    - name: MIT
   confidence: medium
   note: MIT-licensed weights, but a fine-tune of the open-weight Qwen2.5 line without a fully open/reproducible
     data+training pipeline -> open_weights tier, not open_source.

--- a/sources/scores/vllm.yaml
+++ b/sources/scores/vllm.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
     source:
       value: public

--- a/sources/scores/weave.yaml
+++ b/sources/scores/weave.yaml
@@ -4,7 +4,7 @@ openness:
   class: source_available
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI, SDK/client repo wandb/weave
     source:
       value: partial

--- a/sources/scores/webcontainers.yaml
+++ b/sources/scores/webcontainers.yaml
@@ -13,7 +13,7 @@ openness:
       value: proprietary
       detail: StackBlitz
     license-terms:
-      value: Proprietary
+    - name: Proprietary
       detail: free for OSS/prototypes, commercial license required for for-profit production(charge beyond
         10k API req/mo
       raw: Proprietary, free for OSS/prototypes, commercial license required for for-profit production(charge

--- a/sources/scores/whylabs.yaml
+++ b/sources/scores/whylabs.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI, whylogs + LangKit + open sourced platform
     source:
       value: public

--- a/sources/scores/wildchat-1m.yaml
+++ b/sources/scores/wildchat-1m.yaml
@@ -4,7 +4,7 @@ openness:
   class: open
   components:
     license:
-      value: odc-by
+    - name: odc-by
     gated:
       value: false per HF API
     dataset_card:

--- a/sources/scores/wildguard.yaml
+++ b/sources/scores/wildguard.yaml
@@ -15,7 +15,7 @@ openness:
     base:
       value: Mistral-7B
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI
   confidence: medium
   note: Open weights under Apache-2.0 with the WildGuardMix training corpus published, which is more than

--- a/sources/scores/windsurf.yaml
+++ b/sources/scores/windsurf.yaml
@@ -6,7 +6,7 @@ openness:
     source:
       value: closed
     license:
-      value: proprietary
+    - name: proprietary
       detail: SaaS, Cognition
     self-host:
       value: 'no'

--- a/sources/scores/yi.yaml
+++ b/sources/scores/yi.yaml
@@ -13,7 +13,7 @@ openness:
       value: partial
       detail: inference/usage examples; no training pipeline
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: OSI, permissive, no use restrictions
   confidence: high
   note: Permissive Apache-2.0 weights but training data and full training code are not released, so open_weights

--- a/sources/scores/yomo.yaml
+++ b/sources/scores/yomo.yaml
@@ -4,7 +4,7 @@ openness:
   class: open_source
   components:
     license:
-      value: Apache-2.0
+    - name: Apache-2.0
       detail: declared in Cargo.toml+README
     source:
       value: public

--- a/sources/scores/zed.yaml
+++ b/sources/scores/zed.yaml
@@ -4,8 +4,12 @@ openness:
   class: open_source
   components:
     license:
-      value: GPL-3.0-or-later
-      detail: editor)+AGPL-3.0(collab-server)+Apache-2.0(GPUI
+    - name: GPL-3.0-or-later
+      detail: editor
+    - name: AGPL-3.0
+      detail: collab-server
+    - name: Apache-2.0
+      detail: GPUI
     source:
       value: public
     commercial:

--- a/sources/scores/zentropi-cope.yaml
+++ b/sources/scores/zentropi-cope.yaml
@@ -10,7 +10,7 @@ openness:
       value: Gemma-2-9B
       detail: LoRA
     license:
-      value: zentropi-openrail-m
+    - name: zentropi-openrail-m
       detail: OpenRAIL-M, use-restricted, NOT OSI
   confidence: medium
   note: Open weights and self-hostable, but under an OpenRAIL-M license with use restrictions (e.g. surveillance),

--- a/sources/scores/zephyr.yaml
+++ b/sources/scores/zephyr.yaml
@@ -13,7 +13,7 @@ openness:
       value: open
       detail: alignment-handbook DPO recipe, Apache-2.0
     license:
-      value: MIT
+    - name: MIT
       detail: OSI
   confidence: high
   note: 'Genuinely fully-open: MIT weights, the two DPO training datasets are public and

--- a/tests/test_check_rubric.py
+++ b/tests/test_check_rubric.py
@@ -21,6 +21,7 @@ from build.check_rubric import (
     ROOT,
     check_category,
     dimension_value,
+    license_entry,
     license_tier,
     normalize_license,
     recorded_license_aliases,
@@ -169,22 +170,30 @@ class TestRecordedLicenseAliases:
         assert normalize_license("model glm-4") == "GLM-4-License"
 
     def test_alias_applies_across_a_compound_split(self):
-        """The compound itself is `license_tier`'s job. What used to be a special case -
-        `code X + model Y`, the model license governs - is now a consequence of resolving
-        both halves and keeping the more restrictive."""
-        assert license_tier("code MIT + model glm-4", RECIPE) == "use_restricted"
+        """What used to be a special case - `code X + model Y`, the model license governs -
+        is now a consequence of resolving both parts and keeping the more restrictive."""
+        assert license_tier(license_entry("code MIT + model glm-4"), RECIPE) == "use_restricted"
+
+    def test_a_name_is_never_truncated(self):
+        """`normalize_license` used to open with `head`, which cut at the first `(` or `,`.
+        A structured `name` is already bare, so the cut had nothing left to do and every
+        remaining case for it was a recording error resolving on its first token."""
+        assert normalize_license("MIT(code)") == "MIT(code)"
+        assert normalize_license("Apache-2.0, and others") == "Apache-2.0, and others"
 
     def test_canonical_names_pass_through_untouched(self):
         assert normalize_license("Apache-2.0") == "Apache-2.0"
 
     def test_an_aliased_name_reaches_a_tier(self):
         """The whole point: the spelling must not cost the product its tier."""
-        assert license_tier("Gemma-Terms-of-Use(custom,non-OSI)", RECIPE) == "use_restricted"
+        assert license_tier(license_entry("Gemma-Terms-of-Use(custom,non-OSI)"), RECIPE) == (
+            "use_restricted"
+        )
 
     def test_an_unaliased_unknown_license_still_abstains(self):
         """Aliases resolve names, never tiers. An unknown license must keep
         abstaining so it shows up as a finding rather than a guess."""
-        assert license_tier("Some-New-Vendor-License", RECIPE) is None
+        assert license_tier(license_entry("Some-New-Vendor-License"), RECIPE) is None
 
     def test_no_alias_maps_onto_a_different_canonical_name(self):
         """An alias whose target is itself an alias key would make resolution
@@ -204,32 +213,43 @@ class TestCompoundLicense:
     """
 
     def test_the_restrictive_half_governs_whichever_side_it_is_on(self):
-        assert license_tier("MIT(code)+Gemma-License(weights)", RECIPE) == "use_restricted"
-        assert license_tier("Gemma-License(weights)+MIT(code)", RECIPE) == "use_restricted"
+        assert license_tier(license_entry("MIT(code)+Gemma-License(weights)"), RECIPE) == (
+            "use_restricted"
+        )
+        assert license_tier(license_entry("Gemma-License(weights)+MIT(code)"), RECIPE) == (
+            "use_restricted"
+        )
 
     def test_all_permissive_parts_stay_permissive(self):
-        assert license_tier("Apache-2.0(core)+MIT(SDKs)", RECIPE) == "osi"
+        assert license_tier(license_entry("Apache-2.0(core)+MIT(SDKs)"), RECIPE) == "osi"
 
     def test_a_part_is_split_on_plus_only_never_on_a_comma(self):
         """Every depth-zero comma in the corpus trails prose after a single license -
         `Proprietary, proprietary service`. Treating one as a separator would invent a
         second license out of the annotation."""
-        assert license_tier("MIT(client)+Gemma-License(weights),both-published", RECIPE) == (
-            "use_restricted"
-        )
+        assert license_tier(
+            license_entry("MIT(client)+Gemma-License(weights),both-published"), RECIPE
+        ) == "use_restricted"
 
     def test_a_plus_inside_an_annotation_is_not_a_separator(self):
-        assert license_tier("MIT(bundles A + B)", RECIPE) == "osi"
+        assert license_tier(license_entry("MIT(bundles A + B)"), RECIPE) == "osi"
 
     def test_an_unmapped_part_abstains_rather_than_being_skipped(self):
         """The whole point. An unmapped part can only be MORE restrictive than the tier
         the mapped parts reached, so ignoring it publishes an overstatement."""
-        assert license_tier("Apache-2.0(code)+Some-New-Vendor-License(weights)", RECIPE) is None
+        assert license_tier(
+            license_entry("Apache-2.0(code)+Some-New-Vendor-License(weights)"), RECIPE
+        ) is None
 
-    def test_a_declared_compound_is_not_decomposed(self):
+    def test_a_declared_compound_is_recorded_as_one_part(self):
         """A recipe may declare a compound as one name - `follows mC4 + OSCAR-2301 terms`,
-        where the `+` is English joining two CORPUS names and neither operand is a
-        license. The whole, untruncated value is looked up before any split."""
+        where the `+` is English joining two CORPUS names and neither operand is a license.
+
+        `license_tier` has no whole-value pre-check to catch that any more, and does not
+        need one: the curator records ONE part, and one part is what resolves. The intent
+        is in the data instead of being re-inferred from punctuation on every read, which
+        is what let the repo and the warehouse disagree about the same value.
+        """
         recipe = {
             "openness": {
                 "license_tier": {
@@ -240,13 +260,29 @@ class TestCompoundLicense:
                 }
             }
         }
-        assert license_tier("follows mC4 + OSCAR-2301 terms", recipe) == "deferred"
+        assert license_tier([{"name": "follows mC4 + OSCAR-2301 terms"}], recipe) == "deferred"
+
+    def test_the_same_phrase_split_into_parts_abstains(self):
+        """The other half of the contract, and the reason `culturax` is recorded by hand.
+        Mechanically structured, the phrase becomes two parts that name no license, and
+        every part must resolve or the value abstains."""
+        recipe = {
+            "openness": {
+                "license_tier": {
+                    "values": {
+                        "osi": {"examples": ["MIT"]},
+                        "deferred": {"examples": ["follows mC4 + OSCAR-2301 terms"]},
+                    }
+                }
+            }
+        }
+        assert license_tier(license_entry("follows mC4 + OSCAR-2301 terms"), recipe) is None
 
     def test_a_single_license_is_unaffected(self):
-        assert license_tier("Apache-2.0(OSI, see LICENSE)", RECIPE) == "osi"
+        assert license_tier(license_entry("Apache-2.0(OSI, see LICENSE)"), RECIPE) == "osi"
 
     def test_a_ladder_with_no_tiers_still_abstains(self):
-        assert license_tier("Apache-2.0", {"openness": {}}) is None
+        assert license_tier(license_entry("Apache-2.0"), {"openness": {}}) is None
 
 
 class TestRealCategories:

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -354,12 +354,51 @@ def test_structure_records_raw_when_value_and_detail_cannot_round_trip():
     from build.check_rubric import structure
 
     assert structure("rows:169,352")["rows"] == {"value": "169", "detail": "352", "raw": "169,352"}
-    assert structure("license:Apache-2.0(OSI) for the framework")["license"]["raw"] == (
-        "Apache-2.0(OSI) for the framework"
-    )
     assert structure("toolchain:open (fully open (MaixPy, Apache-2.0))")["toolchain"]["raw"] == (
         "open (fully open (MaixPy, Apache-2.0))"
     )
+    # A license takes the part list, and `raw` sits on the part rather than on the entry.
+    assert structure("license:Apache-2.0(OSI) for the framework")["license"] == [
+        {
+            "name": "Apache-2.0",
+            "detail": "OSI) for the framework",
+            "raw": "Apache-2.0(OSI) for the framework",
+        }
+    ]
+
+
+def test_structure_cuts_a_license_into_parts():
+    """The one place the `+` split runs. Every reader is handed the parts as recorded.
+
+    A part keeps its own annotation as `detail`, and `name` keeps the recorded spelling —
+    `normalize_license` drops a `code `/`model ` scope prefix when it resolves a tier, but
+    the record carries what the LICENSE file said.
+    """
+    from build.check_rubric import structure
+
+    assert structure("license:Apache-2.0(OSI)+per-task")["license"] == [
+        {"name": "Apache-2.0", "detail": "OSI"},
+        {"name": "per-task"},
+    ]
+    assert structure("license:none")["license"] == [{"name": "none"}]
+    # A `+` inside an annotation is not a separator.
+    assert structure("license:MIT(bundles A + B)")["license"] == [
+        {"name": "MIT", "detail": "bundles A + B"}
+    ]
+
+
+def test_a_spaced_join_round_trips_through_the_parts_raw():
+    """`internlm` is the one record whose `+` is written with spaces around it.
+
+    `recompose` joins parts on a bare `+`, so the padding has to live somewhere: each part
+    carries the verbatim segment it was cut from, padding included. Without this the
+    record recomposes to a string one byte off what the file says, and `check_components`
+    fails the whole migration on a space.
+    """
+    from build.check_rubric import recompose, split_components, structure
+
+    text = "license:Apache-2.0(code, OSI) + custom weights license(non-OSI, application step)"
+    assert recompose(structure(text)) == split_components(text)
 
 
 def test_components_of_reads_both_shapes_identically():
@@ -430,6 +469,28 @@ def test_check_components_flags_a_mapping_that_disagrees_with_its_raw(tmp_path):
     failures = check(tmp_path)
     assert len(failures) == 1
     assert "mangled.weights" in failures[0]
+
+
+def test_check_components_flags_a_license_left_in_the_dimension_shape(tmp_path):
+    """A `{value, detail}` license recomposes to the right string and still scores wrong.
+
+    `license_tier` resolves the parts a curator recorded and never splits a value itself,
+    so a compound left in the dimension shape arrives as one part whose `name` is a whole
+    compound and abstains. The raw comparison cannot see it — the recomposed clause is
+    correct — so the shape has to be asserted on its own.
+    """
+    from build.check_components import check
+
+    scores = tmp_path / "sources" / "scores"
+    scores.mkdir(parents=True)
+    (scores / "unstructured.yaml").write_text(yaml.safe_dump({"openness": {
+        "components": {"license": {"value": "Apache-2.0", "detail": "OSI"}},
+        "raw": "license:Apache-2.0(OSI)",
+    }}, sort_keys=False))
+
+    failures = check(tmp_path)
+    assert len(failures) == 1
+    assert "unstructured.license" in failures[0]
 
 
 def test_check_components_requires_raw_on_a_migrated_record_and_forbids_it_otherwise(tmp_path):


### PR DESCRIPTION
## Summary

A compound license was resolving differently in the repo and the warehouse, because `serialize_rubric` published it through `split_value()`, which severs the compound at the first `(`. Rather than teach the warehouse to decompose too, the license is now **recorded as parts**, so nothing decomposes anywhere.

```yaml
license:
- name: GPL-3.0-or-later
  detail: editor
- name: AGPL-3.0
  detail: collab-server
- name: Apache-2.0
  detail: GPUI
```

The reasoning and the two rejected alternatives are on #189. In short: teaching the warehouse to decompose leaves one rubric with two implementations of the same fragile rules, which is how the bug happened; and resolving a tier at fetch time cannot work because tier assignment is per-category — `Apache-2.0` is `osi` in some ladders and `open_data` in others across 15 categories.

`detail` rather than `scope`, because the parenthetical is overloaded: sometimes a scope (`GPL-3.0-or-later(editor)`), sometimes an annotation about the license itself (`Apache-2.0(OSI)`). It mirrors the `{value, detail}` convention `components` already uses.

## The whole-string pre-check is gone

`license_tier` used to try the whole string against the tier examples first, decomposing only on a miss. That existed because a curator might record a compound-looking string that is genuinely one declared name.

Structuring at the source makes that rule unnecessary: `culturax` records `follows mC4 + OSCAR-2301 terms`, whose `+` is English, and it is now a **single part**. The curator's intent is in the data instead of being inferred by trying a lookup first.

That was derived rather than assumed — across every product/recipe pair, `culturax` is the **only** record the pre-check ever decided. `license_tier` now takes parts, and neither splits nor pre-checks. `head()` is also dropped from `normalize_license`. The mechanical split survives as `license_segments`, called from exactly one place at recording time.

## Nothing moved

All 472 scores replayed before and after — result, facts, tier and blocked flag — **0 differing rows**, and `check_rubric`'s output is byte-identical to `main`. This changes how a license is recorded and read, not what it means.

## Counts

444 license values across 442 files, under five keys:

| shape | count |
|---|---|
| simple with annotation | 360 |
| bare name | 68 |
| compound, 2 parts | 14 |
| compound, 3 parts | 2 |

`vercel-sandbox` sits on the classification boundary — `Proprietary, proprietary service` is annotated but has no parenthesis. It is counted as a bare name here; nothing about its migration depends on which bucket it lands in.

## Test plan

- Full replay of all 472 products, diffed. 0 rows differ.
- Suite 454 → 459. `validate` 0 error(s), `check_recipe` 0 failure(s), `check_rubric` exit 0, `check_components` `[OK]`.
- `check_parity` still shows the same 3 divergences, untouched — the serializer and the warehouse are stage 2.

## Not in this PR

`serialize_rubric` still publishes through `split_value`, so the warehouse continues to receive a truncated compound. Closing that is stage 2: publish one evidence row per part, and let `openness_facts` resolve each and take most-restrictive. That turns the two fragile rules — every-part-or-abstain, whole-string-first — into a `COUNT` check and a `MIN`.

One note for that work: `internlm` is the only clause whose join is written ` + ` with spaces, so its parts carry padded `raw` values to keep recomposition byte-exact. Correct and tested, but it reads oddly.
