### PR TITLE
feat(build): publish the license as one evidence row per part

### DIFF
--- a/build/serialize_rubric.py
+++ b/build/serialize_rubric.py
@@ -49,7 +49,8 @@ Emitted tables (CSVs into `build/registry/`, alongside the registry's own):
   category_deferrals          products a category has declared its ladder does not decide
   license_aliases             a source's license slug -> canonical license name
   evidence_abstentions        values that mean "this source has no answer"
-  product_openness_evidence   per-dimension values parsed from `components`
+  product_openness_evidence   per-dimension values read off `components`, and one row per
+                              part of a recorded license
   product_score_sources       per-axis sources, each with an admission verdict
 
 Usage:
@@ -68,10 +69,12 @@ import yaml
 from build.check_rubric import (
     components_of,
     dimension_read_map,
+    license_parts_of,
     license_read_keys,
     normalize_dimension_value,
     resolve_dimension,
     split_value,
+    structured_components_of,
 )
 from build.rubrics import load_product_types, recipe_for, resolve_recipe_variants
 from build.serialize_registry import write_tables
@@ -147,10 +150,31 @@ TABLES: dict[str, tuple[str, ...]] = {
     "adoption_bands": ("product_type", "signal_type", "level", "above", "reach", "unit"),
     "license_aliases": ("source", "license_slug", "license_name"),
     "evidence_abstentions": ("source", "column_name", "abstain_value"),
+    # Grain: one row per (product_slug, category_slug, dimension, part_index).
+    #
+    # `part_index` exists for the license and is 0 everywhere else. A license is recorded
+    # as a LIST of parts — `GPL-3.0-or-later(editor) + AGPL-3.0(collab-server)` is two
+    # licenses, and `check_rubric.license_tier` resolves each and takes the most
+    # restrictive. Publishing it as one row meant publishing one license, because the row's
+    # `value` came out of `split_value`, which severs a compound at the first `(`. The
+    # warehouse then resolved half a license and scored `flan-collection`, `smoltalk` and
+    # `redpajama-data-v2` differently from the repo.
+    #
+    # One row per part rather than a joined string, so the warehouse never splits anything:
+    # a join per part, a COUNT for the abstain rule, a MAX on tier rank. Any string
+    # manipulation on the far side would be this same rubric written twice, which is what
+    # check_parity keeps catching.
+    #
+    # The index carries ORDER, not identity — the parts of one license associate by
+    # (product_slug, category_slug, dimension) alone. It is here because two parts can be
+    # byte-identical, which would otherwise collapse the abstain COUNT, and because the
+    # warehouse reassembles the recorded license for `fact_input` and that reassembly must
+    # read the way the file does.
     "product_openness_evidence": (
         "product_slug",
         "category_slug",
         "dimension",
+        "part_index",
         "value",
         "value_detail",
         "grade",
@@ -549,6 +573,10 @@ def build_rubric(sources: dict, policy: dict, routing: dict) -> tuple[dict[str, 
 
                 openness = record.get("openness") or {}
                 components = components_of(openness)
+                # Both shapes of the same record. `components` is key -> raw clause, which
+                # every dimension reader wants; `structured` keeps the license's parts
+                # apart, and only the license block below needs it.
+                structured = structured_components_of(openness)
                 if not components:
                     warnings.append(
                         f"product '{product_slug}' in '{slug}' records no openness components"
@@ -590,6 +618,8 @@ def build_rubric(sources: dict, policy: dict, routing: dict) -> tuple[dict[str, 
                             "product_slug": product_slug,
                             "category_slug": slug,
                             "dimension": dimension,
+                            # A dimension answers once. Only the license is a list.
+                            "part_index": 0,
                             "value": bare,
                             "value_detail": detail,
                             "grade": "document",
@@ -605,21 +635,37 @@ def build_rubric(sources: dict, policy: dict, routing: dict) -> tuple[dict[str, 
                 # as `model-license`, the SQL looked only for `license`, and the product
                 # abstained in the warehouse while reproducing locally. Same drift as the
                 # dimension resolution above, one key over.
+                #
+                # One row per recorded PART, because a license can be several licenses and
+                # the tier is the most restrictive of them. The parts come from the record
+                # rather than from a splitter run here, which is the point of the structured
+                # shape: `culturax` writes `follows mC4 + OSCAR-2301 terms` as ONE part,
+                # neither operand being a license, and it goes out as one row. A serializer
+                # that split on punctuation could not tell that from a genuine compound, and
+                # the pre-check that used to paper over it is what made this rubric
+                # expensive enough to state twice.
                 license_key = next((k for k in license_keys if components.get(k)), None)
                 if license_key:
-                    bare, detail = split_value(components[license_key])
-                    tables["product_openness_evidence"].append(
-                        {
-                            "product_slug": product_slug,
-                            "category_slug": slug,
-                            "dimension": "license",
-                            "value": bare,
-                            "value_detail": detail,
-                            "grade": "document",
-                            # No enum: `license` is the raw input the tier lookup consumes.
-                            "in_declared_enum": "",
-                        }
-                    )
+                    parts = license_parts_of(structured.get(license_key))
+                    for index, part in enumerate(parts):
+                        tables["product_openness_evidence"].append(
+                            {
+                                "product_slug": product_slug,
+                                "category_slug": slug,
+                                "dimension": "license",
+                                "part_index": index,
+                                # The name as recorded, `code `/`model ` prefix and
+                                # `assumed-` included. Those are reading rules that
+                                # `normalize_license` applies, and the warehouse mirrors,
+                                # so stripping them here would publish a conclusion in
+                                # place of the evidence.
+                                "value": part.get("name", ""),
+                                "value_detail": part.get("detail", ""),
+                                "grade": "document",
+                                # No enum: `license` is the raw input the tier lookup consumes.
+                                "in_declared_enum": "",
+                            }
+                        )
 
                 # Then every recorded key that is not itself a dimension name, so nothing
                 # the repo recorded is dropped. This carries the license the tier lookup
@@ -667,6 +713,7 @@ def build_rubric(sources: dict, policy: dict, routing: dict) -> tuple[dict[str, 
                             "product_slug": product_slug,
                             "category_slug": slug,
                             "dimension": key,
+                            "part_index": 0,
                             "value": bare,
                             "value_detail": detail,
                             "grade": "document",

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -714,7 +714,17 @@ def test_real_sources_serialize_without_errors():
         # Note the three evaluation_code products publish no `license` row at all - they
         # record no license key - which is what `check_rubric`'s `~ no tier` report exists
         # to keep visible.
-        "base_pretrained": 116, "finetuned_chat": 173, "deployment": 131,
+        #
+        # Then +13 rows across seven categories when the license started publishing one row
+        # per recorded PART instead of one truncated row per product. Twelve products record a
+        # compound license: eleven in two parts and `zed` in three. No product gained a
+        # component and none lost one - the same licenses were always in the files, the
+        # serializer was publishing the first of them. The split is base_pretrained +1
+        # (internlm), finetuned_chat +1 (command-r), inference_code +1 (llamafile),
+        # finetuning_code +2 (megatron-lm, unsloth), orchestration_agents +3 (n8n, zed's two
+        # extra), telemetry_observability +2 (agentops, langwatch) and
+        # training_synthetic_datasets +3 (flan-collection, redpajama-data-v2, smoltalk).
+        "base_pretrained": 117, "finetuned_chat": 174, "deployment": 131,
         #
         # evaluation_code 78 -> 107 with the 2026-08-11 evidence sweep of that category: all
         # seven of its deferrals came off, and a product that stops being deferred publishes its
@@ -751,7 +761,7 @@ def test_real_sources_serialize_without_errors():
         # aws-neuron each already recorded the deciding dimension and were publishing nothing
         # because a deferred product publishes nothing; the score moved to what the ladder
         # computes and the rows appeared.
-        "finetuning_code": 137, "inference_code": 89, "ml_frameworks": 88,
+        "finetuning_code": 139, "inference_code": 90, "ml_frameworks": 88,
         # orchestration_agents rose by 3 when n8n's stale deferral was removed: a deferred
         # product publishes no openness evidence, and n8n had been deferred as "not recorded"
         # while recording everything the ladder needed. Then by 6 more (140 -> 146) when
@@ -801,7 +811,7 @@ def test_real_sources_serialize_without_errors():
         # publishes its rows for the first time: agentops five (license, source, commercial,
         # core-gated and the normalized core_gated), langtrace four and weave four. The
         # category now defers nothing.
-        "orchestration_agents": 207, "telemetry_observability": 112, "ui_api": 184,
+        "orchestration_agents": 210, "telemetry_observability": 114, "ui_api": 184,
         # training_synthetic_datasets is unchanged at 158 across the ladder widening, which
         # is the check that mattered: benchmark_eval_data's new dimensions and rungs did not
         # disturb the category the ladder was derived from.
@@ -820,7 +830,7 @@ def test_real_sources_serialize_without_errors():
         # license and an answer state and nothing else, and each gained a `datasheet` and an
         # `access` key plus the `availability` and `documentation` dimensions they normalize
         # onto - so both go from publishing nothing to publishing seven rows.
-        "training_synthetic_datasets": 194, "benchmark_eval_data": 125,
+        "training_synthetic_datasets": 197, "benchmark_eval_data": 125,
         # safeguards 90 -> 103 and training_synthetic_datasets 158 -> 164: the universal
         # license scale retired five deferrals, and a deferred product publishes no
         # openness evidence at all.
@@ -1000,9 +1010,57 @@ def test_license_is_emitted_under_the_name_the_warehouse_joins_on():
     assert len(deepseek) == 1 and deepseek[0]["value"] == "DeepSeek-Model-License"
 
 
+def test_a_compound_license_publishes_every_part():
+    """The three products check_parity was diverging on, and the one that must NOT split.
+
+    `serialize_rubric` used to publish the license through `split_value`, which severs a
+    clause at the first `(`. `zed` went out as `GPL-3.0-or-later` alone and the warehouse
+    resolved a tier for a third of the license; `flan-collection`, `smoltalk` and
+    `redpajama-data-v2` were the three products where that changed the published score.
+    `check_rubric.license_tier` reads all the parts and takes the most restrictive, so the
+    parts have to cross the bridge.
+
+    `culturax` is the control. `follows mC4 + OSCAR-2301 terms` is one declared name with a
+    `+` inside it — neither operand is a license — and the curator recorded it as a single
+    part. A serializer that split on punctuation cannot tell it from `zed`; one that
+    publishes what the record says does not have to.
+    """
+    from pathlib import Path
+
+    from build.serialize_rubric import load_policy, load_routing
+
+    root = Path(__file__).resolve().parents[1]
+    tables, _, _ = build_rubric(_real_sources(root), load_policy(root), load_routing(root))
+
+    def license_parts(product):
+        return [
+            r["value"]
+            for r in sorted(
+                (
+                    r
+                    for r in tables["product_openness_evidence"]
+                    if r["product_slug"] == product and r["dimension"] == "license"
+                ),
+                key=lambda r: r["part_index"],
+            )
+        ]
+
+    assert license_parts("zed") == ["GPL-3.0-or-later", "AGPL-3.0", "Apache-2.0"]
+    assert license_parts("flan-collection") == ["Apache-2.0", "per-task"]
+    assert license_parts("smoltalk") == ["apache-2.0", "per-component"]
+    assert license_parts("redpajama-data-v2") == ["CommonCrawl-ToU", "Apache-2.0"]
+    assert license_parts("culturax") == ["follows mC4 + OSCAR-2301 terms"]
+
+
 def test_evidence_never_puts_two_values_on_one_grain():
-    """One product/category/dimension must carry one value. Two would let the
+    """One product/category/dimension/part must carry one value. Two would let the
     warehouse pick between a base corpus and a post-training mixture by row order.
+
+    `part_index` is in the grain because the license is a LIST — twelve products record a
+    compound one and each part gets a row, so the warehouse can resolve every part and take
+    the most restrictive. Every other dimension answers once and pins the index at 0, which
+    this asserts separately: a dimension that started emitting a second row would otherwise
+    hide behind the license's allowance.
     """
     from collections import Counter
     from pathlib import Path
@@ -1011,12 +1069,27 @@ def test_evidence_never_puts_two_values_on_one_grain():
 
     root = Path(__file__).resolve().parents[1]
     tables, _, _ = build_rubric(_real_sources(root), load_policy(root), load_routing(root))
+    rows = tables["product_openness_evidence"]
 
     counts = Counter(
-        (r["product_slug"], r["category_slug"], r["dimension"])
-        for r in tables["product_openness_evidence"]
+        (r["product_slug"], r["category_slug"], r["dimension"], r["part_index"]) for r in rows
     )
     assert [key for key, n in counts.items() if n > 1] == []
+    assert [r for r in rows if r["dimension"] != "license" and r["part_index"] != 0] == []
+    # Contiguous from zero, because the index is the recorded order and the warehouse joins
+    # the names back together in it to report which license it could not map.
+    parts = Counter(
+        (r["product_slug"], r["category_slug"]) for r in rows if r["dimension"] == "license"
+    )
+    for (product, category), n in parts.items():
+        indexes = sorted(
+            r["part_index"]
+            for r in rows
+            if r["dimension"] == "license"
+            and r["product_slug"] == product
+            and r["category_slug"] == category
+        )
+        assert indexes == list(range(n)), f"{product}/{category} part indexes are {indexes}"
 
 
 def test_real_license_aliases_cover_every_slug_the_hub_actually_returns():


### PR DESCRIPTION
## Summary

Stage 2 of the structured-license work, and the repo half of it. #216 recorded the license as parts; this publishes those parts to the warehouse instead of severing the compound at the first `(`.

`product_openness_evidence` gains **`part_index`**, and the grain becomes `(product_slug, category_slug, dimension, part_index)`. License emits one row per recorded part — 429 rows to 442, across the 12 compound products. Every other dimension pins index 0.

The index carries **order, not identity**: parts associate by product, category and dimension. It exists for two concrete reasons. Two parts of one license can be byte-identical, which would collapse the abstain rule's `COUNT`. And the warehouse reassembles `fact_input` in the order the curator recorded.

## What this enables, and what it removes

Once the SQL follows, `openness_facts` resolves each part and combines them: a join per part, a `COUNT` for "every part must resolve or the whole value abstains", and a rank comparison for most-restrictive. **No string splitting in Trino, no depth-zero parsing, no whole-string pre-check** — the rules that made the original bug possible stop existing in a second language.

## Simulated before deploying, over all 442 published license rows

| | |
|---|---|
| products newly abstaining | **0** |
| products agreeing with `check_rubric` | 429 / 429 |
| newly resolving | 1 — `redpajama-data-v2` |
| tiers corrected | 3 — `flan-collection`, `smoltalk`, `internlm` |

Both new models were also executed against the live warehouse with `part_index` shimmed to 0, and reproduced the deployed tables exactly: 1,623 facts and 2,543 evidence rows, zero column differences.

That simulation is the point. An earlier attempt at this problem would have broken ~355 products to fix 3, and only a simulation caught it — not a deploy.

## Nothing moved locally

All 472 scores replayed: `check_rubric` output byte-identical. Of the 16 registry CSVs only `product_openness_evidence.csv` differs, and within it every non-license row and every single-part license value is unchanged.

## Deliberately not deployed

`serialize_rubric.py` sits in `registry.yml`'s push paths, so CI publishes the new column on merge. Releasing the SQL **now** would fail materialization against a table without `part_index` and take the whole evidence dataset down — strictly worse than the three divergences it fixes.

Order: merge this, confirm the column landed, then release `product_evidence` (rev 7→8) and `openness_facts` (rev 6→7), run `evidence` then `scores`, then `check_parity`. Both SQL files are written and staged.

**`check_parity` reaching 0 is therefore unverified rather than claimed.**

## One thing the counting turned up

`category_license_tiers` lists 17 example licenses two or three times per ladder, so the tier lookup is now deduped with `MIN_BY(tier, tier_rank)` — least restrictive, mirroring `check_rubric._tier_of`. A no-op against today's data, verified, but the abstain rule counts rows and duplicates would have skewed it.

## Test plan

- Suite 459 → 460, the new test asserting a compound publishes every part.
- `validate` 0 error(s), `check_recipe` 0 failure(s), `check_rubric` exit 0, `check_components` `[OK]`.
- The static-model new-column constraint was re-probed rather than assumed: adding columns now works, so no delete-and-recreate is needed.
