### PR TITLE
fix(scores): resolve seven deferrals from the batch-1 rulings

### DIFF
--- a/sources/categories/benchmark_eval_data.yaml
+++ b/sources/categories/benchmark_eval_data.yaml
@@ -11,9 +11,9 @@ scoring_recipe:
   derived_from:
     method: shared dataset ladder, widened by this category, then verified against the
       hand-authored scores
-    scores_reproduced: 20
+    scores_reproduced: 25
     scores_total: 27
-    scores_deferred: 7
+    scores_deferred: 2
     verified_on: '2026-08-12'
     checker: build/check_rubric.py
   note: >-
@@ -33,13 +33,23 @@ scoring_recipe:
     datasheets-for-datasets questionnaire for the other - and recording that reproduces the
     5/open both already carried.
 
-    Seven are left and they now split three ways. Four are still recording defects
-    (`gaia`, `humanitys-last-exam`, `compar-ia-datasets`, `multipl-e`). `math` is scored on
-    a DMCA takedown the ladder has no way to see. And two are the license question answered
-    rather than avoided: `livecodebench`'s bare `cc` was researched to the point of
-    exhaustion and the variant genuinely is not published anywhere, while
-    `swe-bench-verified` turned out to have a stated MIT after all, which turns its deferral
-    from an unreadable value into a live 4-versus-5 disagreement.
+    Five more closed on 2026-08-12. Three were pure transcription and moved no score:
+    `gaia`'s license was recorded nowhere and is recorded as unstated now that a read has
+    established nobody has granted anything, `humanitys-last-exam`'s MIT was buried inside a
+    `questions+answers:` compound, and `compar-ia-datasets` recorded its gate as a sentence
+    where `terms-acceptance+contact-info` is the token. `swe-bench-verified` moved 4 to 5 on
+    the owner's ruling that a repository license governs over a distribution point that
+    states none. `math` moved 2 to 1: recording the DMCA takedown as `access:closed` lands it
+    on the rung for data that is not distributed, which is a step below the gated rung the
+    hand-authored score had assumed.
+
+    Two are left and neither is a recording defect. `livecodebench` has no published license
+    at all and now records 3/gated on the curation rule that a free download without a grant
+    is not open; the ladder declares no rung for the `unstated` tier, so it abstains rather
+    than agreeing. `multipl-e` records the repository's BSD-3-with-ML-restriction under the
+    same repository-governs ruling, and this ladder has no tier for a license that permits
+    redistribution while bounding what the corpus may be used FOR. Both are rubric gaps
+    rather than open questions about the products.
 
     A tenth, `gpqa`, was corrected rather than deferred: it recorded 4/gated, a pair no rung
     produces, and the ladder's answer of 3 is what the other nine gated corpora on the map
@@ -48,27 +58,6 @@ scoring_recipe:
 
   extends: dataset
   deferred:
-    math:
-      because: >-
-        Recorded 2/gated; the ladder computes 5/open, and this is the one place the ladder
-        gets a confidently wrong answer rather than abstaining. Both facts that justify the 2
-        are recorded as prose - `data:NOT downloadable from canonical HF repo` and
-        `redistributability:BLOCKED on the primary registry` - so `head()` reduces neither to
-        a token, `availability` matches no rung, and the product falls through to the license
-        rungs which do not test it. The underlying fact is a DMCA takedown on the canonical HF
-        repo over AMC/AIME problem rights. Recording `access:closed` would settle it.
-    swe-bench-verified:
-      because: >-
-        Now a live disagreement rather than an unreadable value. The card read on 2026-08-12
-        confirmed the HF card for Verified still declares no license, but found the license
-        stated where the deferral had assumed it was only inferred: the canonical SWE-bench
-        repository describes itself as "Code and data for the following works", lists SWE-bench
-        among them, and its "Citation & license" section says "MIT license", with the citation
-        directly beneath headed "For SWE-bench (Verified)". Recording `license:MIT` resolves
-        the `open_data` tier and, with `datasheet:yes`, the ladder computes 5/open against a
-        recorded 4. Neither side has been adjusted. The 4 rests on the reading that a license
-        stated by the project but absent from the distribution point is weaker than one stated
-        on the card; the ladder does not draw that distinction. Someone has to pick.
     livecodebench:
       because: >-
         Researched and genuinely unstated. The bare `cc` names no terms - CC-BY and CC-BY-NC
@@ -79,34 +68,29 @@ scoring_recipe:
         problems), the 217-line repository README, ERRATA.md, the project site and
         leaderboard, and the paper. The repo discussions never raise it. The problems are
         collected from LeetCode, AtCoder and Codeforces, which is a plausible reason no
-        variant has been committed to. An artifact whose publisher has not named its terms
-        is a real state of the world; the abstention is the right answer and not a gap in
-        the research.
+        variant has been committed to. The curation call that followed dropped the record from
+        4/open to 3/gated on the same rule applied to `openhermes-2-5`: files that download
+        freely without a grant are not open, and not closed either. The deferral stands
+        because the ladder has nothing to say either way - the only rungs that read a tier
+        test `noncommercial`, `deferred_to_components` and `open_data`, so an `unstated`
+        corpus with an open download matches nothing and the formula abstains. Giving
+        `unstated` a rung is a rubric change, not a per-product fix.
     multipl-e:
       because: >-
-        Recorded 4/open; the ladder computes 5/open. The 4 rests on a `caveat:` key recording
-        that the source repo carries a modified BSD-3 with a no-ML-training clause conflicting
-        with the MIT on the HF data artifact. `caveat` is not a key any dimension reads, so the
-        ladder sees clean MIT. This is the multi-SKU problem in dataset form: two licenses on
-        two artifacts of one product, and the ladder scores whichever one is recorded under
-        `license`.
-    gaia:
-      because: >-
-        No license key is recorded at all, so no tier resolves and the product abstains before
-        the formula runs. The evidence the ladder WOULD use is present and correct -
-        `answers:held-out` reaches the 2/gated rung, which is the recorded score - so this is
-        one missing key away from reproducing.
-    humanitys-last-exam:
-      because: >-
-        The license is recorded inside a compound key, `questions+answers:public(MIT,2500-Q)`,
-        which no dimension reads and which the license lookup cannot see. Same shape as `gaia`:
-        `holdout:private` already reaches the 2/gated rung, so recording `license:MIT` would
-        settle it.
-    compar-ia-datasets:
-      because: >-
-        The gate is recorded as `gated:HF contact-info agreement required`, a sentence rather
-        than a token, so `head()` returns the whole phrase and it matches no rung. The recorded
-        3/gated is what `terms-acceptance+contact-info` produces. A vocabulary fix, not research.
+        No longer a recording defect. The owner's ruling of 2026-08-12 is that where a
+        repository license and a distribution-point license differ, the repository license
+        governs, so the modified BSD-3 that used to sit under a `caveat:` key is now recorded
+        under `license` and the MIT on the HF artifact is carried as its detail. The
+        repository LICENSE is headed "BSD 3-Clause License with Machine Learning Restriction"
+        and its clause 4 reads "The contents of this repository may not be used as training
+        data for any machine learning model, including but not limited to neural networks."
+        That is what keeps it deferred: this ladder's tiers turn on redistribution and on
+        commercial use, and it declares none for a license that permits both while bounding
+        what you may use the corpus FOR. `model.yaml` has the word for it, `use_bounded`, and
+        the dataset ladder does not. So the tier lookup abstains, the walk blocks on the first
+        rung that tests a tier, and the recorded 4 stands rather than being replaced by a
+        number nobody derived. Extending the dataset ladder with a use-bounded tier is the fix
+        and it is a rubric change.
 products:
 - humaneval
 - gsm8k

--- a/sources/categories/dataset_processing_tools.yaml
+++ b/sources/categories/dataset_processing_tools.yaml
@@ -36,9 +36,9 @@ scoring_recipe:
   extends: software
   derived_from:
     method: shared software ladder, verified against the hand-authored scores
-    scores_reproduced: 19
+    scores_reproduced: 20
     scores_total: 21
-    verified_on: '2026-07-30'
+    verified_on: '2026-08-12'
     checker: build/check_rubric.py
   # Held back rather than scored. The shared ladder has no `otherwise` rule, so
   # these already abstain; declaring them here records WHY, and keeps the
@@ -53,19 +53,6 @@ scoring_recipe:
         deciding rule reads `source` alone, but check_rubric resolves a license tier before
         applying the formula, so it abstains. Adding the license to a tier is a rubric change,
         held for Phase 1.
-    nemo-data-designer:
-      because: >-
-        `source` is public and the license is OSI, so the recorded 1/closed is not reproducible at
-        any value of core-gated - NVIDIA's own NeMo microservices docs state "The service is built
-        on the open-source NVIDIA NeMo Data Designer library" and link to
-        github.com/NVIDIA-NeMo/DataDesigner, which is Apache-2.0, installs with
-        `pip install data-designer`, and ships the whole generation framework rather than a client
-        for a hosted service. The prior 1 rested on a single TechCrunch article. It stays deferred
-        because both remaining rungs test core-gated and no read has established what, if
-        anything, the NeMo Platform withholds from the published library, so the product is
-        somewhere in {4, 5} and a core-gated value was deliberately not invented to close it.
-        Reviewed 2026-08-12 alongside five other sweep conflicts; the other five closed and this
-        one did not.
 comments: 'The software that produces the training_synthetic_datasets row (Columbia model-components layer;
   MOF ''Data Preprocessing Code''). Scoped to data-processing software; human-data / RLHF labor marketplaces (Scale, Surge, Mercor) are
   out of scope -- per the Columbia framework their output is data (the datasets category) and their labor

--- a/sources/categories/orchestration_agents.yaml
+++ b/sources/categories/orchestration_agents.yaml
@@ -62,10 +62,10 @@ scoring_recipe:
   extends: software
   derived_from:
     method: shared software ladder, verified against the hand-authored scores
-    scores_reproduced: 50
-    scores_total: 50
-    scores_deferred: 1
-    verified_on: '2026-08-11'
+    scores_reproduced: 51
+    scores_total: 51
+    scores_deferred: 0
+    verified_on: '2026-08-12'
     checker: build/check_rubric.py
   # Held back rather than scored. The shared ladder has no `otherwise` rule, so
   # these already abstain; declaring them here records WHY, and keeps the
@@ -92,12 +92,14 @@ scoring_recipe:
   # genuinely gated, because its Agent Server ships as a closed Elastic-2.0 wheel behind a
   # LANGGRAPH_CLOUD_LICENSE_KEY. LiteLLM is the other side of the same line, its open_core
   # resting on an `enterprise-dir` these four do not have.
-  deferred:
-    openhands:
-      because: >-
-        The score says 4/open_core and the ladder abstains, because neither `core-gated` nor
-        `self-host` is recorded: the gate is under `enterprise-dir: separate-license`, a key
-        the software ladder does not read. Under the `core_gated` rule a separately licensed
-        enterprise directory IS a gated core, so the 4 looks right and what is missing is the
-        transcription - but that is a repo read, not a restatement, so it stays held.
+  #
+  # The last one, `openhands`, closed on 2026-08-12 and it is litellm's shape rather than
+  # langchain's. The gate was recorded under `enterprise-dir: separate-license`, a key the
+  # ladder does not read. A repo read confirmed it: the monorepo LICENSE opens "Portions of
+  # this software are licensed as follows" and carves everything under enterprise/ out to
+  # enterprise/LICENSE, which is PolyForm Free Trial License 1.0.0, and that directory's
+  # README says outright "This is NOT an open source license. Usage is limited to 30 days per
+  # calendar year without a commercial license." The enterprise server now lives in its own
+  # active repo under the same license while the core stays MIT. `core-gated: gated`
+  # transcribed, and the recorded 4/open_core reproduces. Nothing deferred here now.
 comments: ''

--- a/sources/categories/training_synthetic_datasets.yaml
+++ b/sources/categories/training_synthetic_datasets.yaml
@@ -37,8 +37,10 @@ scoring_recipe:
     One is left, `openhermes-2-5`, and it is the one that needed an answer rather than a key.
     The answer came back on 2026-08-12 and it is that there is no license: not in the card
     front matter, not in the card body, not as a file in the repository, not on the Hub API.
-    The deferral stands, and what it now records is a finding rather than a question. Whether
-    a corpus nobody has licensed can carry 5/open is a curation call.
+    The curation call that followed dropped it from 5/open to 3/gated - files that download
+    freely without a grant are not open, and not closed either. The deferral stands anyway,
+    because the ladder declares no rung that tests the `unstated` tier on its own, so it
+    abstains rather than agreeing or disagreeing with the 3.
 
   extends: dataset
   deferred:
@@ -53,8 +55,12 @@ scoring_recipe:
         so no LICENSE file ships with the data; and the Hub API returns no license and no
         `license:` tag. The `commonly cited as permissive` detail was a third-party reading and
         has been dropped. Nobody has granted anything, so the `unstated` tier is correct and
-        the recorded 5/open is not supportable on the license. Moving it is a curation call,
-        not a research one.
+        the 5/open was not supportable on the license. The curation call came back on
+        2026-08-12 and the record now says 3/gated. What keeps the product deferred is the
+        ladder rather than the evidence: the only rungs that read a license tier test
+        `noncommercial`, `deferred_to_components` and `open_data`, so an `unstated` corpus with
+        an open download matches nothing and the formula abstains. Giving `unstated` a rung is
+        a rubric change, not a per-product fix.
 products:
 - fineweb
 - fineweb-edu

--- a/sources/scores/compar-ia-datasets.yaml
+++ b/sources/scores/compar-ia-datasets.yaml
@@ -7,12 +7,16 @@ openness:
     - name: Etalab-2.0
       detail: permissive French-gov open license
     gated:
-      value: HF contact-info agreement required
+      value: terms-acceptance+contact-info
+      detail: HF contact-info agreement required
     dataset_card:
       value: present
   confidence: high
-  note: Open license and documented, but gated access requiring agreement caps it at gated.
-  raw: license:Etalab-2.0(permissive French-gov open license);gated:HF contact-info agreement required;dataset_card:present
+  note: Open license and documented, but gated access requiring agreement caps it at gated. The gate was
+    recorded as a sentence rather than a token; it is a click-through agreement that also collects contact
+    details, which is terms-acceptance+contact-info.
+  raw: license:Etalab-2.0(permissive French-gov open license);gated:terms-acceptance+contact-info(HF contact-info
+    agreement required);dataset_card:present
   sources:
   - url: https://huggingface.co/datasets/ministere-culture/comparia-votes
     shows: License Etalab 2.0; gated access requiring contact-info agreement; dataset card present

--- a/sources/scores/gaia.yaml
+++ b/sources/scores/gaia.yaml
@@ -3,6 +3,10 @@ openness:
   score: 2
   class: gated
   components:
+    license:
+    - name: not-clearly-stated-on-card
+      detail: the Hub API cardData carries no license key and no license tag; the card states only the no-resharing
+        condition, and the paper states no release terms
     questions:
       value: public
       detail: val
@@ -13,12 +17,26 @@ openness:
       value: HF-gated
       detail: accept-terms,anti-resharing
   confidence: high
-  note: Test answers are private and the dataset itself is access-gated.
-  raw: questions:public(val);answers:held-out(300-Q test,private);access:HF-gated(accept-terms,anti-resharing)
+  note: 'Test answers are private and the dataset itself is access-gated. A read on 2026-08-12 established
+    that no license is stated anywhere the project publishes: the Hub API returns no license field and no
+    license tag, the gated card states only the no-resharing condition, and the paper states no release
+    terms. Recorded as unstated, which is a fact rather than a guess; the held-out answers decide the score
+    either way.'
+  raw: license:not-clearly-stated-on-card(the Hub API cardData carries no license key and no license tag;
+    the card states only the no-resharing condition, and the paper states no release terms);questions:public(val);answers:held-out(300-Q
+    test,private);access:HF-gated(accept-terms,anti-resharing)
   sources:
   - url: https://huggingface.co/datasets/gaia-benchmark/GAIA
     shows: gated access, private test answers
     accessed: '2026-06-17'
+  - url: https://huggingface.co/api/datasets/gaia-benchmark/GAIA
+    shows: cardData carries no license key and the tags array carries no license tag; gating is auto with
+      a no-resharing condition
+    accessed: '2026-08-12'
+    establishes:
+    - license
+    http_status: 200
+    content_sha256: 0bcfa21e0181419fa7c6c33c382a5e50ac59e8d343ab40a9ad4557a33377c4f0
 adoption:
   level: 4
   signal_type: usage_volume

--- a/sources/scores/humanitys-last-exam.yaml
+++ b/sources/scores/humanitys-last-exam.yaml
@@ -3,18 +3,22 @@ openness:
   score: 2
   class: gated
   components:
+    license:
+    - name: MIT
+      detail: the public 2,500-question set
     questions+answers:
       value: public
-      detail: MIT,2500-Q
+      detail: 2500-Q
     access:
       value: HF-gated
       detail: accept-conditions,no-redistribution,canary
     holdout:
       value: private
   confidence: medium
-  note: Public set is MIT-licensed with answers, but access is gated and a private held-out set exists - judgment
-    call (could be open under a license-weighted reading).
-  raw: questions+answers:public(MIT,2500-Q);access:HF-gated(accept-conditions,no-redistribution,canary);holdout:private
+  note: Public set is MIT-licensed with answers, but access is gated and a private held-out set exists.
+    The MIT was recorded inside the compound questions+answers key, where no dimension could read it; it
+    is now recorded under license, and the private holdout is what decides the score.
+  raw: license:MIT(the public 2,500-question set);questions+answers:public(2500-Q);access:HF-gated(accept-conditions,no-redistribution,canary);holdout:private
   sources:
   - url: https://huggingface.co/datasets/cais/hle
     shows: MIT, gated access, no-redistribution notice

--- a/sources/scores/livecodebench.yaml
+++ b/sources/scores/livecodebench.yaml
@@ -1,7 +1,7 @@
 product: livecodebench
 openness:
-  score: 4
-  class: open
+  score: 3
+  class: gated
   components:
     data:
       value: downloadable
@@ -18,15 +18,14 @@ openness:
     splits:
       value: public problems with hidden test cases bundled
   confidence: medium
-  note: Open and downloadable with a datasheet, but the HF card declares only a generic 'cc' license (no
-    specific CC variant), so the exact reuse terms are ambiguous. Scored open but not a clean CC-BY;
-    capped at 4. A card read on 2026-08-12 went looking for the variant and did not find one. The bare
-    'cc' is the only license statement the project makes about the corpus, and it is repeated identically
-    on code_generation and test_generation. The MIT LICENSE in the GitHub repository covers the lcb_runner
-    harness code, not the problems; the CC-BY-4.0 on the arXiv posting covers the paper. The problems
-    themselves are collected from LeetCode, AtCoder and Codeforces, which is a plausible reason the
-    project has not committed to a variant. Recording CC-BY here would be a guess, and CC-BY and CC-BY-NC
-    sit two tiers apart, so the abstention stands.
+  note: 'Downloadable with a datasheet, but the only license statement the project makes about the corpus
+    is a bare cc naming no variant, and CC-BY and CC-BY-NC sit two tiers apart. A read on 2026-08-12 went
+    looking for the variant across the card front matter, the Hub API, the sibling code_generation and test_generation
+    corpora, the repository LICENSE (MIT, covering the lcb_runner harness rather than the problems), the
+    README, ERRATA.md, the project site, the leaderboard and the paper, and did not find one. Files that
+    download freely without a grant are not open, and not closed either, so the recorded 4/open drops to
+    3/gated: the barrier is the missing permission rather than a login. The problems are collected from
+    LeetCode, AtCoder and Codeforces, which is a plausible reason no variant has been committed to.'
   raw: data:downloadable(HF parquet);license:cc(the card YAML names the Creative Commons family and no variant;
     no variant is stated on the card, the GitHub repository, the project site or the paper);datasheet:present(README
     documents versions/sources/structure);redistributable:yes;splits:public problems with hidden test cases

--- a/sources/scores/math.yaml
+++ b/sources/scores/math.yaml
@@ -1,15 +1,18 @@
 product: math
 openness:
-  score: 2
-  class: gated
+  score: 1
+  class: closed
   components:
+    license:
+    - name: MIT
+      detail: declared
+    access:
+      value: closed
+      detail: canonical HF repo access-disabled under a DMCA takedown
     data:
       value: NOT downloadable from canonical HF repo
       detail: access disabled, DMCA takedown
       raw: NOT downloadable from canonical HF repo (access disabled, DMCA takedown)
-    license:
-    - name: MIT
-      detail: declared
     datasheet:
       value: present
       detail: card still documents schema
@@ -18,12 +21,15 @@ openness:
     free_text:
     - problems sourced from AMC/AIME competitions, takedown reflects unresolved rights
   confidence: medium
-  note: Declared MIT, but the canonical HF dataset is access-disabled under a DMCA takedown, so it is
-    not currently redistributable from the primary registry; scored gated/blocked rather than open. Mirrors
-    and eval harnesses still embed it, but the primary source is walled; revisit if the takedown is resolved.
-  raw: data:NOT downloadable from canonical HF repo (access disabled, DMCA takedown);license:MIT(declared);datasheet:present(card
-    still documents schema);redistributability:BLOCKED on the primary registry; problems sourced from AMC/AIME
-    competitions, takedown reflects unresolved rights
+  note: Declared MIT, but the canonical HF dataset is access-disabled under a DMCA takedown over AMC/AIME
+    problem rights, so the corpus is not distributed from its primary registry. The takedown was recorded
+    only as prose; it is now recorded as access:closed, which is the ladder rung for data that is not distributed
+    however it came to be that way, and that rung produces 1/closed rather than the 2/gated this record
+    carried. Mirrors and eval harnesses still embed the problems; revisit if the takedown is resolved.
+  raw: license:MIT(declared);access:closed(canonical HF repo access-disabled under a DMCA takedown);data:NOT
+    downloadable from canonical HF repo (access disabled, DMCA takedown);datasheet:present(card still documents
+    schema);redistributability:BLOCKED on the primary registry;problems sourced from AMC/AIME competitions,
+    takedown reflects unresolved rights
   sources:
   - url: https://huggingface.co/datasets/hendrycks/competition_math
     shows: MIT tag, 12,500 problems, but 'Access Disabled' DMCA takedown notice (discussions/5)

--- a/sources/scores/multipl-e.yaml
+++ b/sources/scores/multipl-e.yaml
@@ -7,35 +7,39 @@ openness:
       value: downloadable
       detail: HF parquet, 47 subsets
     license:
-    - name: MIT
-      detail: on HF dataset card
+    - name: BSD-3-Clause-with-ML-Restriction
+      detail: the nuprl/MultiPL-E repository LICENSE, whose clause 4 forbids using the contents as training
+        data for any machine learning model; the HF data artifact carries MIT
     datasheet:
       value: present
       detail: card documents prompts/doctests/tests/stop-tokens
     redistributable:
       value: 'yes'
       detail: HF
-    caveat:
-      value: GitHub repo LICENSE is a non-OSI 'BSD-3-Clause + no-ML-training' modified license
-      detail: conflicting with the MIT on the HF data artifact
-      raw: GitHub repo LICENSE is a non-OSI 'BSD-3-Clause + no-ML-training' modified license, conflicting
-        with the MIT on the HF data artifact
   confidence: medium
-  note: The scored artifact (HF dataset) is MIT and openly downloadable with a datasheet, open class.
-    But the source repo carries a modified BSD-3 with an explicit 'may not be used as training data for
-    ML' clause (non-OSI), a conflict worth flagging; scored on the data artifact's MIT terms, capped at
-    4 for the licensing inconsistency.
-  raw: data:downloadable(HF parquet, 47 subsets);license:MIT(on HF dataset card);datasheet:present(card
-    documents prompts/doctests/tests/stop-tokens);redistributable:yes(HF);caveat:GitHub repo LICENSE is
-    a non-OSI 'BSD-3-Clause + no-ML-training' modified license, conflicting with the MIT on the HF data
-    artifact
+  note: Where a repository license and a distribution-point license differ the repository license governs,
+    and nuprl/MultiPL-E ships a LICENSE headed "BSD 3-Clause License with Machine Learning Restriction"
+    whose clause 4 says "The contents of this repository may not be used as training data for any machine
+    learning model, including but not limited to neural networks." That is the license recorded here; the
+    MIT on the HF data artifact is the weaker statement of the two. It was previously recorded under a caveat
+    key no dimension reads, which left the ladder seeing clean MIT and computing 5/open. The dataset ladder
+    declares no tier for a license that permits redistribution while bounding what you may use the corpus
+    FOR, so the tier lookup abstains and the score stays where the curator put it rather than being invented.
+  raw: data:downloadable(HF parquet, 47 subsets);license:BSD-3-Clause-with-ML-Restriction(the nuprl/MultiPL-E
+    repository LICENSE, whose clause 4 forbids using the contents as training data for any machine learning
+    model; the HF data artifact carries MIT);datasheet:present(card documents prompts/doctests/tests/stop-tokens);redistributable:yes(HF)
   sources:
   - url: https://huggingface.co/datasets/nuprl/MultiPL-E
     shows: MIT license, 47 subsets across 22-23 languages, downloadable parquet, documented schema
     accessed: '2026-06-04'
   - url: https://github.com/nuprl/MultiPL-E/blob/main/LICENSE
-    shows: modified BSD-3-Clause with no-ML-training-data restriction (non-OSI)
-    accessed: '2026-06-04'
+    shows: LICENSE headed "BSD 3-Clause License with Machine Learning Restriction"; clause 4 forbids use
+      of the repository contents as training data for any machine learning model
+    accessed: '2026-08-12'
+    establishes:
+    - license
+    http_status: 200
+    content_sha256: 6891bf32c7df59f0665d45a22bc09224ed122394eae4404048e0e4c7e4bc2f23
 adoption:
   level: 3
   reach: 100K-1M

--- a/sources/scores/nemo-data-designer.yaml
+++ b/sources/scores/nemo-data-designer.yaml
@@ -1,7 +1,7 @@
 product: nemo-data-designer
 openness:
-  score: 1
-  class: closed
+  score: 5
+  class: open_source
   components:
     license:
     - name: Apache-2.0
@@ -10,24 +10,29 @@ openness:
       value: public
       detail: pip install data-designer, the published framework runs locally against any configured inference
         provider
+    core-gated:
+      value: ungated
+      detail: the NeMo Platform adds infrastructure around the published library rather than withholding
+        generation from it
     free_text:
     - the archived gretel-synthetics OSS repo (Apache-2.0) is a separate legacy artifact, not this product
   confidence: medium
-  note: 'Still deferred, and the reason has changed. The prior 1/closed described this as a proprietary
-    NeMo microservice on the strength of a single TechCrunch article, and NVIDIA''s own documentation contradicts
-    it: the NeMo microservices Data Designer page states "The service is built on the open-source NVIDIA
-    NeMo Data Designer library" and links to github.com/NVIDIA-NeMo/DataDesigner, which is Apache-2.0, installs
-    with `pip install data-designer`, and ships the whole generation framework rather than a client for
-    a hosted service. So `source` is public and the license is OSI, the closed rung cannot fire, and the
-    recorded 1 is not reproducible at any value of core-gated. What keeps it deferred is that the ladder''s
-    remaining rungs both test core-gated, and no read has yet established what, if anything, the NeMo Platform
-    withholds from the published library. The product is somewhere in {4, 5} and a value was deliberately
-    not invented to close it. Score and class are left at the unreproducible 1 rather than guessed, which
-    is what the deferral records.'
+  note: 'The prior 1/closed described this as a proprietary NeMo microservice on the strength of a single
+    TechCrunch article, and NVIDIA''s own documentation contradicts it: the NeMo microservices Data Designer
+    page states "The service is built on the open-source NVIDIA NeMo Data Designer library" and links to
+    github.com/NVIDIA-NeMo/DataDesigner, which is Apache-2.0 and installs with pip install data-designer.
+    A read on 2026-08-12 settled the core-gated question the deferral was held on: the repository ships
+    data-designer-config, data-designer-engine and data-designer, so the generation engine itself is published,
+    and what the NeMo Platform adds over it is infrastructure - inference routed through the NMP gateway,
+    distributed job execution with monitoring, NMP fileset seeds, NMP artifact storage and the NMP Secrets
+    service. None of that is functionality withheld from the published source, which is the test this ladder
+    applies; it is a managed service sold alongside a complete open core, the langchain and otari shape
+    rather than the langgraph one. So core-gated is ungated and the product scores 5/open_source.'
   raw: license:Apache-2.0(OSI, NVIDIA-NeMo/DataDesigner LICENSE);source:public(pip install data-designer,
-    the published framework runs locally against any configured inference provider);the archived gretel-synthetics
-    OSS repo (Apache-2.0) is a separate legacy artifact, not this product
-  last_verified: '2026-08-11'
+    the published framework runs locally against any configured inference provider);core-gated:ungated(the
+    NeMo Platform adds infrastructure around the published library rather than withholding generation from
+    it);the archived gretel-synthetics OSS repo (Apache-2.0) is a separate legacy artifact, not this product
+  last_verified: '2026-08-12'
   sources:
   - url: https://docs.nvidia.com/nemo/microservices/latest/data-designer/index.html
     shows: NVIDIA's own NeMo microservices documentation for Data Designer states that "The service is built
@@ -62,6 +67,17 @@ openness:
       Third-party summary, retained only for the acquisition history, and not relied on for any recorded
       key.
     accessed: '2026-07-21'
+  - url: https://github.com/NVIDIA-NeMo/DataDesigner
+    shows: Apache-2.0, 2.1k stars, packages/ ships data-designer-config, data-designer-engine and data-designer;
+      README documents pip install data-designer and local generation against NVIDIA Build, OpenAI or OpenRouter
+      providers
+    accessed: '2026-08-12'
+    establishes:
+    - core-gated
+    - source
+    - license
+    http_status: 200
+    content_sha256: 57e66c991213a59848bc5e27b4eff0dc8306096adc8d43b881c6b6de301a818b
 adoption:
   level: 3
   reach: enterprise

--- a/sources/scores/openhands.yaml
+++ b/sources/scores/openhands.yaml
@@ -6,15 +6,26 @@ openness:
     license:
     - name: MIT
       detail: core
-    enterprise-dir:
-      value: separate-license
     source:
       value: public
+    core-gated:
+      value: gated
+      detail: the enterprise server is PolyForm Free Trial 1.0.0, not an OSI license
+    enterprise-dir:
+      value: separate-license
     free_text:
     - OpenHands-Cloud-managed-tier
   confidence: high
-  note: license:MIT(core);enterprise-dir:separate-license;source:public;OpenHands-Cloud-managed-tier
-  raw: license:MIT(core);enterprise-dir:separate-license;source:public;OpenHands-Cloud-managed-tier
+  note: 'MIT core with a separately licensed enterprise server, which is what open_core means here. A repo
+    read on 2026-08-12 confirmed it: the monorepo LICENSE opens "Portions of this software are licensed
+    as follows" and carves out everything under enterprise/ to enterprise/LICENSE, which is PolyForm Free
+    Trial License 1.0.0, and that directory README says outright "This is NOT an open source license. Usage
+    is limited to 30 days per calendar year without a commercial license." The enterprise server now lives
+    in its own active repo, OpenHands/OpenHands-Cloud, under the same PolyForm license, while OpenHands/OpenHands
+    stays MIT. Functionality is withheld from the published source for a paid tier, so core-gated is gated.'
+  raw: license:MIT(core);source:public;core-gated:gated(the enterprise server is PolyForm Free Trial 1.0.0,
+    not an OSI license);enterprise-dir:separate-license;OpenHands-Cloud-managed-tier
+  last_verified: '2026-08-12'
   sources:
   - url: https://github.com/All-Hands-AI/OpenHands
     shows: flagship phase-C verification source
@@ -22,6 +33,24 @@ openness:
   - url: https://docs.openhands.dev/sdk
     shows: flagship phase-C verification source
     accessed: '2026-06-04'
+  - url: https://github.com/OpenHands/legacy/blob/main/LICENSE
+    shows: the monorepo LICENSE opens "Portions of this software are licensed as follows" and carves everything
+      under enterprise/ out to enterprise/LICENSE, with everything else under MIT
+    accessed: '2026-08-12'
+    establishes:
+    - license
+    - source
+    - core-gated
+    http_status: 200
+    content_sha256: 90bd960a6d24cce8f64f3f2b9be5923d5b33e2650afd6fb683ced4be83e5bb94
+  - url: https://github.com/OpenHands/OpenHands-Cloud/blob/main/LICENSE
+    shows: PolyForm Free Trial License 1.0.0 on the live enterprise/cloud server repo, while OpenHands/OpenHands
+      stays MIT
+    accessed: '2026-08-12'
+    establishes:
+    - core-gated
+    http_status: 200
+    content_sha256: 6aa0ab5bdfcb32eb7d4d60d76ac6bb665afac574aae2d1700bd91ab580f17197
 adoption:
   level: 3
   reach: 100K-1M

--- a/sources/scores/openhermes-2-5.yaml
+++ b/sources/scores/openhermes-2-5.yaml
@@ -1,7 +1,7 @@
 product: openhermes-2-5
 openness:
-  score: 5
-  class: open
+  score: 3
+  class: gated
   components:
     license:
     - name: not-clearly-stated-on-card
@@ -16,13 +16,13 @@ openness:
     rows:
       value: ~1M
   confidence: medium
-  note: Publicly downloadable and ungated with a full card, though an explicit license string is not stated
-    on the card. A card read on 2026-08-12 confirms there is no license anywhere the publisher controls
-    - the card front matter carries language, pretty_name and tags and no license key, the 126-line body
-    runs from the source list through the format description to the citation without a terms section,
-    the repository holds only .gitattributes, README.md and openhermes2_5.json so there is no LICENSE
-    file, and the Hub API returns no license for it. The 'commonly cited as permissive' detail this record
-    used to carry was a third-party reading and has been dropped.
+  note: 'Publicly downloadable and ungated with a full card, and no license anywhere the publisher controls.
+    A read on 2026-08-12 confirmed it: the card front matter carries language, pretty_name and tags and
+    no license key, the 126-line body runs from the source list through the format description to the citation
+    without a terms section, the repository holds only .gitattributes, README.md and openhermes2_5.json
+    so there is no LICENSE file, and the Hub API returns no license. Files that download freely without
+    a grant are not open, and not closed either, so the recorded 5/open drops to 3/gated. The commonly cited
+    as permissive detail this record used to carry was a third-party reading and has been dropped.'
   raw: license:not-clearly-stated-on-card(no license field in the card YAML, no license section in the card
     body, no LICENSE file in the repository and no license tag on the Hub API);card:present;ungated:yes;format:JSON/Parquet;rows:~1M
   sources:

--- a/sources/scores/swe-bench-verified.yaml
+++ b/sources/scores/swe-bench-verified.yaml
@@ -1,6 +1,6 @@
 product: swe-bench-verified
 openness:
-  score: 4
+  score: 5
   class: open
   components:
     license:
@@ -19,16 +19,13 @@ openness:
     data-source:
       value: real GitHub PR/issue pairs
   confidence: medium
-  note: Effectively open - ungated, downloadable, full gold patches and tests, datasheet present. The
-    HF card for Verified declares no license field, which is what the recorded 4 rests on, but a card
-    read on 2026-08-12 found the canonical SWE-bench repository stating MIT over the artifact rather
-    than only over the harness. Its README calls the repository "Code and data for the following works",
-    lists SWE-bench among them, and its "Citation & license" section says "MIT license", with the
-    citation block directly beneath headed "For SWE-bench (Verified)". Verified is a 500-instance human-validated
-    subset of that same test set, released with OpenAI Preparedness. On that reading the license is
-    stated rather than inferred and the ladder computes 5; the recorded 4 has been left alone and the
-    disagreement is carried as a deferral. (Distinct from SWE-bench's broader/hidden variants which
-    can carry held-out splits.)
+  note: Ungated, downloadable, full gold patches and tests, datasheet present, and the license is stated.
+    The canonical SWE-bench repository calls itself "Code and data for the following works", lists SWE-bench
+    among them, and its "Citation & license" section says "MIT license" with the citation block directly
+    beneath headed "For SWE-bench (Verified)". The HF card for Verified still declares no license field,
+    and where a repository license and a distribution-point license differ the repository license governs,
+    so the recorded 4 moves to the 5/open the ladder computes. (Distinct from SWE-bench broader/hidden variants,
+    which can carry held-out splits.)
   raw: license:MIT(SWE-bench repository states MIT over its code and data; the HF card for Verified still
     declares no license field);redistributability:full(downloadable parquet, ungated);datasheet:yes(dataset
     card + arXiv:2310.06770);held-out:no hidden split in Verified itself(the public 500-instance set is

--- a/tests/test_check_parity.py
+++ b/tests/test_check_parity.py
@@ -173,10 +173,24 @@ def test_local_scores_matches_check_rubrics_split():
     recorded `source:partial`. Four of the five moved a published score, in both
     directions. nemo-data-designer stayed deferred - both rungs it can reach test
     core-gated, nobody has read what the NeMo Platform withholds from the published
-    library, and a value was not invented to close it."""
+    library, and a value was not invented to close it.
+
+    Then 453/19 -> 460/12 when the owner ruled on the ten deferrals of the first resolution
+    batch, on 2026-08-12. Seven closed. Five were transcription and four of those moved no
+    score - gaia's unstated license, humanitys-last-exam's MIT out of a compound key,
+    compar-ia-datasets' gate as a token, openhands' enterprise directory as `core-gated:
+    gated`. math moved 2 -> 1: recording the DMCA takedown as `access:closed` lands it on the
+    rung for data that is not distributed rather than the gated rung the record assumed.
+    swe-bench-verified moved 4 -> 5 and nemo-data-designer 1 -> 5, the first on the ruling
+    that a repository license governs over a distribution point that states none, the second
+    on a read that established the NeMo Platform withholds nothing from the published
+    library. Three stayed deferred and each on a rubric gap rather than a missing fact:
+    livecodebench and openhermes-2-5 record 3 on unstated licenses the ladder gives no rung,
+    and multipl-e records the repository's BSD-3-with-ML-restriction, which this ladder has
+    no tier for."""
     computed, deferred = local_scores(None)
-    assert len(deferred) == 19
-    assert len(computed) == 453
+    assert len(deferred) == 12
+    assert len(computed) == 460
     assert not set(computed) & set(deferred)
     # Every one of the 410 reproduces today, so none should abstain.
     assert [key for key, value in computed.items() if value is None] == []

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -736,7 +736,13 @@ def test_real_sources_serialize_without_errors():
         # the last of which now records source and core-gated but abstains on a three-way
         # license), and a product that stops being deferred publishes its whole openness
         # evidence set rather than none of it.
-        "agent_tools_protocols": 122, "dataset_processing_tools": 86, "evaluation_code": 107,
+        #
+        # dataset_processing_tools 86 -> 90 when nemo-data-designer's deferral came off on
+        # 2026-08-12. A read of NVIDIA-NeMo/DataDesigner established `core-gated: ungated` -
+        # the repository ships the generation engine itself and the NeMo Platform adds
+        # infrastructure around it rather than withholding anything from it - and the record
+        # moved from an unreproducible 1/closed to the 5/open_source the ladder computes.
+        "agent_tools_protocols": 122, "dataset_processing_tools": 90, "evaluation_code": 107,
         # inference_code 47 -> 64 when the sweep read the category: four stale deferrals came
         # off (a deferred product publishes no openness evidence at all), and several products
         # that had described their gating in prose gained a readable `source:`/`core-gated:`.
@@ -811,7 +817,13 @@ def test_real_sources_serialize_without_errors():
         # publishes its rows for the first time: agentops five (license, source, commercial,
         # core-gated and the normalized core_gated), langtrace four and weave four. The
         # category now defers nothing.
-        "orchestration_agents": 210, "telemetry_observability": 114, "ui_api": 184,
+        #
+        # orchestration_agents 210 -> 215 when openhands, its last deferral, closed on
+        # 2026-08-12. Its gate had been recorded under `enterprise-dir`, a key the ladder does
+        # not read; a repo read confirmed the enterprise directory is carved out to PolyForm
+        # Free Trial 1.0.0 while the core stays MIT, `core-gated: gated` was transcribed, and
+        # the recorded 4/open_core reproduces. Five rows, and the category now defers nothing.
+        "orchestration_agents": 215, "telemetry_observability": 114, "ui_api": 184,
         # training_synthetic_datasets is unchanged at 158 across the ladder widening, which
         # is the check that mattered: benchmark_eval_data's new dimensions and rungs did not
         # disturb the category the ladder was derived from.
@@ -830,7 +842,12 @@ def test_real_sources_serialize_without_errors():
         # license and an answer state and nothing else, and each gained a `datasheet` and an
         # `access` key plus the `availability` and `documentation` dimensions they normalize
         # onto - so both go from publishing nothing to publishing seven rows.
-        "training_synthetic_datasets": 197, "benchmark_eval_data": 125,
+        # 125 -> 154 when the owner's rulings of 2026-08-12 closed five of the seven
+        # deferrals here. gaia, humanitys-last-exam, compar-ia-datasets, math and
+        # swe-bench-verified each start publishing their whole openness evidence set, having
+        # published none of it while deferred. livecodebench and multipl-e stay deferred and
+        # so still publish nothing, which is what keeps the rise to those five.
+        "training_synthetic_datasets": 197, "benchmark_eval_data": 154,
         # safeguards 90 -> 103 and training_synthetic_datasets 158 -> 164: the universal
         # license scale retired five deferrals, and a deferred product publishes no
         # openness evidence at all.


### PR DESCRIPTION
## Summary

Seven deferrals close. Deferrals go **19 → 12**.

## Transcription — a fact recorded under a key the ladder does not read (4 closed)

| Product | Score | What was recorded |
|---|---|---|
| `gaia` | 2 / gated | its license is genuinely unstated — the Hub API carries no license key or tag and the paper states no terms — so recording that resolves the tier and lets `answers: held-out` fire |
| `humanitys-last-exam` | 2 / gated | the license was inside `questions+answers:public(MIT,2500-Q)`, which no dimension reads |
| `compar-ia-datasets` | 3 / gated | the gate was a sentence rather than a token; `terms-acceptance+contact-info` is what produces the 3 |
| `openhands` | 4 / open_core | repo read confirmed the root LICENSE carves `enterprise/` out to PolyForm Free Trial 1.0.0, described there as "NOT an open source license", while the core stays MIT |

## `math` 2 / gated → 1 / closed

The deferral said recording `access: closed` would settle it at its recorded 2. It does not: `access: closed` fires the `availability: closed` rung, which sits **above** both `answers` rungs, and there is no path to 2 because MATH's solutions are public while the corpus is not.

The evidence is unchanged and is what it always was — the canonical Hugging Face repo is access-disabled under a DMCA takedown over AMC/AIME problem rights. The artifact is not obtainable from where the map points, and 1 is the honest reading of that.

Worth recording separately: **the deferral's own suggested fix was wrong about the resulting number.** That is the fourth time a deferral reason has misdescribed its own cause.

## The repo license governs where two differ

New rule, applied to three products: when a repository license and a distribution-point license differ, **the repository license governs**.

- **`swe-bench-verified` 4 → 5.** The canonical SWE-bench repo's "Citation & license" section says MIT, with the SWE-bench (Verified) citation directly beneath it. The Hugging Face card still declares nothing. That resolves `open_data` and, with `datasheet: yes`, the ladder computes 5.
- **`nemo-data-designer` 1 → 5 / open_source.** The recorded 1 rested on a single TechCrunch article. NVIDIA publishes the library at `NVIDIA-NeMo/DataDesigner` under Apache-2.0, and a read established the repo ships `data-designer-engine` itself — the NeMo Platform adds gateway, jobs, storage and secrets *around* it. That is the shape the rubric already rules is not a gated core.
- **`multipl-e` does not close, and the reason is a real gap.** Under the rule it now records the repo's "BSD 3-Clause License with Machine Learning Restriction", whose clause 4 forbids use as ML training data. **The ladder has no tier for a license that permits redistribution while bounding what the corpus may be used for.** The tier lookup abstains and the walk blocks. Recorded 4 stands and it stays deferred, with the gap named rather than papered over.

## Two unstated licenses recorded at 3

`livecodebench` 4 → 3 and `openhermes-2-5` 5 → 3. Both were researched exhaustively and no license is published anywhere the project controls; files that download freely without a grant are not open, and not closed either.

Both **stay deferred**: the dataset ladder declares no rung for the `unstated` tier, so it abstains rather than agreeing with the recorded 3. That is the ladder being honest about a tier it does not score.

## Test plan

- Every score that moved carries a one-sentence reason in its `note`.
- Suite 460 passed. `validate` 0 error(s), `check_recipe` 0 failure(s), `check_rubric` exit 0, `check_components` `[OK]`.
- Two count fixtures updated with reasoning rather than loosened.
- `check_parity` will diverge until the registry republishes on merge, then return to agreement.
