### PR TITLE
fix(scores): resolve six deferrals from the batch-2 rulings

### DIFF
--- a/docs/guides/openness-spectrum.md
+++ b/docs/guides/openness-spectrum.md
@@ -286,6 +286,48 @@ gate as a managed cloud "on top" of a complete OSI core — the shape this secti
 A `gated` value is not evidence that somebody applied this rule; check what the record says is
 actually withheld.
 
+### A product is scored on the artifact it ships, not on what it can load
+
+A harness that runs against a model you supply is scored on the harness. The model it happens to
+be shipped alongside is a different product with its own score, and scoring the harness down for
+it would count the same license twice.
+
+`llamafirewall` is the case the rule was settled on (2026-08-12). It is an MIT firewall that
+inspects prompts and code and calls out to whatever guard model you point it at; the PurpleLlama
+monorepo ships it next to Prompt Guard 2 and Llama Guard, which carry the use-restricted Llama
+Community License. The repository makes the split explicit — the root `LICENSE` is the Llama 3.2
+Community License and `LlamaFirewall/LICENSE` is plain MIT — and both guard models are separately
+scored on this map at 3/open_weights. So the restrictive terms are not being overlooked; they are
+recorded against the artifact they actually govern. `llamafirewall` is 5/open_source.
+
+`openai-evals` was already resolved this way before the rule was written: it records
+`license: MIT`, `source: public(full framework + registry)` and
+`per-dataset-licenses: mixed(CC/CC0/Apache for bundled data)`, and scores 5 on the framework.
+Those two are the only bundles of this shape in the corpus today.
+
+The rule does have an edge, and it is worth stating so nobody stretches it. It applies where the
+bundled artifact is *substitutable* — you can point LlamaFirewall at a different model and it
+still works. Where the published thing genuinely cannot run without the restricted component, the
+component is not a bundle but a dependency, and `core_gated` is the dimension that asks about it.
+
+### An accessory tracks the platform it completes
+
+An add-on is not a board, and asking board questions of one answers about the wrong artifact.
+What a builder gets from a HAT or a carrier is the openness of the system it completes.
+
+`raspberry-pi-ai-hat-plus` is the case (2026-08-12). It publishes a HAT+ mechanical specification
+rather than board design files, and its toolchain is half open — the Pi driver integration is
+open, Hailo's Dataflow Compiler is registration-gated. Both of its own answers are `partial` and
+neither describes the system anyone runs. It plugs into a `raspberry-pi-5`, which scores
+4/open_toolchain, and so does it.
+
+This is recorded as an `accessory_host` dimension in `sources/rubrics/hardware.yaml` rather than
+as an extra rung. The rung version — `{schematics: partial, toolchain: partial}` → 4 — would have
+reproduced the same number and been non-monotonic: `ti-am67a` and
+`qualcomm-dragonwing-rb3-gen-2` both record `{partial, open}` and score 3, so it would have ranked
+strictly weaker evidence strictly higher. One product records `accessory-host` today; the next
+accessory records its host rather than needing another rung.
+
 ## How the buckets relate to MOF and OSAID
 
 The Model Openness Framework and the OSI's Open Source AI Definition are both **binary**.

--- a/sources/categories/agent_tools_protocols.yaml
+++ b/sources/categories/agent_tools_protocols.yaml
@@ -54,18 +54,20 @@ scoring_recipe:
   deferred:
     model-context-protocol:
       because: >-
-        source and core-gated were read and recorded on 2026-08-12, and the record still does
-        not score. The blocker is the license, and it is not a recording error: the LICENSE
-        really does split three ways - Apache-2.0 for new code and specifications, CC-BY-4.0
-        for documentation other than the specifications, MIT retained for pre-transition
-        contributions whose authors did not consent to relicensing. license_tier resolves a
-        compound on every part and abstains if any part is unmapped, and CC-BY-4.0 is in no
-        tier's examples in sources/rubrics/software.yaml, so the whole value resolves to
-        nothing and the walk cannot pass the rung that tests it. Whether a documentation
-        license belongs in a ladder shared by eleven software categories is a rubric question
-        for a human, not a per-product fix
-    jina-reader:
-      because: >-
-        ladder computes 4/open_core from the recorded evidence but the score says
-        5/open_source; one of the two is wrong and it needs a human
+        source and core-gated were read and recorded on 2026-08-12, and the license question
+        has moved on one step since. The LICENSE really does split three ways - Apache-2.0 for
+        new code and specifications, CC-BY-4.0 for documentation other than the specifications,
+        MIT retained for pre-transition contributions whose authors did not consent to
+        relicensing - and CC-BY-4.0 used to sit in no tier at all, so the compound resolved to
+        nothing and the walk hit a rung it could not evaluate. On the owner's ruling of
+        2026-08-12 that a protocol may license its documentation under Creative Commons,
+        CC-BY-4.0 is now declared in permissive_non_osi in sources/rubrics/software.yaml, with
+        the reasoning recorded there. The compound resolves on every part and the most
+        restrictive wins, so this product now resolves to permissive_non_osi rather than to
+        nothing. That tier has no rung, deliberately: a non-OSI license cannot reach the open
+        bucket under either the Model Openness Framework or OSAID, so a rung here cannot emit
+        open_source and nobody has ruled on what it should emit instead. The deferral therefore
+        stands on a rubric gap with a known shape rather than on an unrecognized license, and
+        the decision it waits on is what class a permissive non-OSI software license earns
+        - which is a rubric question for a human, not a per-product fix
 comments: ''

--- a/sources/categories/dataset_processing_tools.yaml
+++ b/sources/categories/dataset_processing_tools.yaml
@@ -47,12 +47,18 @@ scoring_recipe:
   deferred:
     txt360-pipeline:
       because: >-
-        the license is recorded as prose - `Apache-2.0 asserted in README only, no LICENSE file in
-        repo` - so the tier lookup reads a sentence rather than a license name. Confirmed
-        2026-07-30: the repo still ships no LICENSE file and the GitHub license endpoint 404s. The
-        deciding rule reads `source` alone, but check_rubric resolves a license tier before
-        applying the formula, so it abstains. Adding the license to a tier is a rubric change,
-        held for Phase 1.
+        the license is genuinely unstated and the ladder has no tier for that. The record used to
+        carry it as prose - `Apache-2.0 asserted in README only, no LICENSE file in repo` - which
+        made the abstention look like a recording defect. On the owner's ruling of 2026-08-12 it
+        now reads `none-declared`, the same form gaia and openhermes-2-5 use, so the tier lookup
+        reads a license name rather than a sentence. The finding behind it stands: confirmed
+        2026-07-30 that the repo ships no LICENSE file and the GitHub license endpoint 404s, so
+        the README badge is an assertion with no grant behind it. The outcome is unchanged and is
+        now the answer rather than an artifact - `source: public` carries the walk past the two
+        rungs that read source alone and into the rung that tests a license tier, `none-declared`
+        is in no tier, and the walk stops there. A tier for unstated licenses is a rubric change
+        across eleven software categories, and it is the same open question `livecodebench` and
+        `openhermes-2-5` are waiting on one ladder over.
 comments: 'The software that produces the training_synthetic_datasets row (Columbia model-components layer;
   MOF ''Data Preprocessing Code''). Scoped to data-processing software; human-data / RLHF labor marketplaces (Scale, Surge, Mercor) are
   out of scope -- per the Columbia framework their output is data (the datasets category) and their labor

--- a/sources/categories/edge_hardware.yaml
+++ b/sources/categories/edge_hardware.yaml
@@ -11,10 +11,10 @@ scoring_recipe:
   version: 1
   derived_from:
     method: reverse-engineered from hand-authored scores, then verified
-    scores_reproduced: 17
+    scores_reproduced: 19
     scores_total: 20
-    scores_deferred: 3
-    verified_on: '2026-08-01'
+    scores_deferred: 1
+    verified_on: '2026-08-12'
     checker: build/check_rubric.py
   note: >-
     First HARDWARE category, and the only ladder in the map with no `license_tier` - none of
@@ -29,8 +29,17 @@ scoring_recipe:
     inferred `schematics` value, which is the honest way to surface that the ladder asks a
     board question of a bare chipset.
 
-    The other two deferrals are real disagreements between the ladder and a recorded score,
-    and both survived the normalization unchanged.
+    The other two deferrals were real disagreements between the ladder and a recorded score,
+    and the owner ruled on both on 2026-08-12. `arduino-uno-q` moved 3 to 5, matching
+    `beagley-ai` on openly licensed design files: this ladder scores design-file openness
+    rather than silicon, and the proprietary QRB2210 the old note cited is a reason no rung
+    applies. A cap on proprietary silicon was considered and rejected - every board here runs
+    on it, so the cap would flatten all 20 products to 3 and make the 4 and 5 rungs
+    unreachable, which check_recipe's no_unreachable_rule gate treats as a defect.
+    `raspberry-pi-ai-hat-plus` kept its 4 and the ladder was extended to say why: an accessory
+    tracks the platform it completes, which is now the `accessory_host` dimension in
+    sources/rubrics/hardware.yaml rather than a rung on a pair of partials that would have
+    ranked weaker evidence higher.
 
   extends: hardware
   deferred:
@@ -41,29 +50,12 @@ scoring_recipe:
         rather than a negative one. Recording `none` would conflate "not applicable" with
         "withheld", and would be inferring evidence from the product description rather than
         transcribing what the openness axis records. The other four chip-class products all
-        record a schematics clause of their own and so are scored normally; this one does not.
-        A `form_factor` key distinguishing board / module / chipset would let the ladder ask
-        the right question of each, and is a curation proposal rather than something to infer.
-    arduino-uno-q:
-      because: >-
-        Recorded 3/documented; the ladder computes 5/open_hardware. Its board schematics and
-        gerbers are CC-BY-SA-4.0 and its toolchain is open, which is the same combination that
-        earns `beagley-ai` a 5. The recorded note gives the reason for the 3 as the proprietary
-        QRB2210 SoC needing firmware blobs - but that is equally true of `beagley-ai` (TI
-        AM67A, DSP and WiFi blobs), `orange-pi-5`, `khadas-edge2` and `sipeed-maixcam`, all of
-        which score above 3. Either this is scored low, or `beagley-ai`'s 5 rests on OSHWA
-        certification specifically, in which case that is a rung condition nobody has written
-        down. Needs a human.
-    raspberry-pi-ai-hat-plus:
-      because: >-
-        Recorded 4/open_toolchain; the ladder computes 3/documented. It records a HAT+
-        mechanical spec rather than board design files, and a partial toolchain - the Pi
-        driver integration is open while the Hailo model compiler is registration-gated.
-        Nothing about the accessory itself is open at the level the other 4s are; what it
-        inherits is the Pi ecosystem around it. A rung for `{schematics: partial, toolchain:
-        partial}` would reproduce it and would exist solely because one product needs it,
-        which this ladder does not do. Whether an accessory's score should track its host
-        platform is a curation question.
+        record a schematics clause of their own and so are scored normally; this one does not,
+        which means the line between scored and deferred for a chipset currently falls wherever
+        a curator happened to write something in that field. The owner ruled on 2026-08-12 not
+        to score it and to raise the taxonomy change instead: a `form_factor` key distinguishing
+        board / module / chipset would let the ladder ask the right question of each. That is
+        issue #219, and this deferral stands until it lands.
 products:
 - raspberry-pi-5
 - raspberry-pi-ai-hat-plus

--- a/sources/categories/safeguards.yaml
+++ b/sources/categories/safeguards.yaml
@@ -16,9 +16,9 @@ scoring_recipe:
   derived_from:
     method: per-type extends over the shared ladders; evidence transcribed into the keys the
       ladders read, then verified
-    scores_reproduced: 25
+    scores_reproduced: 26
     scores_total: 26
-    scores_deferred: 1
+    scores_deferred: 0
     verified_on: '2026-08-12'
     checker: build/check_rubric.py
   note: >-
@@ -45,19 +45,13 @@ scoring_recipe:
     readers to the paper appendix for training details, so `code` is `partial` and the 4-rung
     still fails. Open data on its own does not carry the rung.
 
-    One remains. It needs a decision about which artifact a bundled product is scored on.
-  deferred:
-    llamafirewall:
-      because: >-
-        Recorded 5/open_source; the ladders abstain, because neither `source` nor `license` is
-        recorded under a key the software ladder reads - the MIT framework facts sit under
-        `framework` and `self-host`. Deliberately left untranscribed, unlike the other sixteen:
-        the same components string records that the bundled guard models (Prompt Guard 2, Llama
-        Guard) carry the use-restricted Llama Community License, so transcribing only the
-        favourable half would manufacture a 5 while ignoring the question. Which artifact a
-        bundled product is scored on is the multi-SKU rule applied to a case where "SKU" is
-        arguable - the harness is MIT and runs against whatever model you point it at.
-        Needs a human.
+    The last one, `llamafirewall`, needed a decision about which artifact a bundled product is
+    scored on, and the owner gave it on 2026-08-12: a product is scored on the artifact it
+    ships, not on what it can load. The harness is MIT in its own LICENSE file and the bundled
+    Prompt Guard 2 and Llama Guard are separate products here with their own scores, so
+    transcribing `source` and `license` off the `framework` and `self-host` keys reproduces the
+    recorded 5 without leaving the Llama Community License unscored. The rule is written down in
+    docs/guides/openness-spectrum.md.
 
 products:
 - aegis-guard

--- a/sources/categories/ui_api.yaml
+++ b/sources/categories/ui_api.yaml
@@ -59,17 +59,4 @@ scoring_recipe:
     scores_total: 43
     verified_on: '2026-07-30'
     checker: build/check_rubric.py
-  # Held back rather than scored. The shared ladder has no `otherwise` rule, so
-  # these already abstain; declaring them here records WHY, and keeps the
-  # reproduction count honest by excluding them from it rather than counting
-  # them as passes.
-  deferred:
-    maple-ai:
-      because: >-
-        ladder computes 4/open_core from the recorded evidence but the score says
-        5/open_source; one of the two is wrong and it needs a human
-    privatemode:
-      because: >-
-        ladder computes 1/closed from the recorded evidence but the score says
-        2/source_available; one of the two is wrong and it needs a human
 comments: ''

--- a/sources/rubrics/hardware.yaml
+++ b/sources/rubrics/hardware.yaml
@@ -73,6 +73,44 @@ openness:
       # therefore a discriminator between none of them.
       values: [none, minimal, required]
       machine_signal: none - requires reading the BSP
+    accessory_host:
+      question: >-
+        Is this an add-on rather than a board, and if so, what does the host platform it
+        plugs into score?
+      reads: [accessory-host]
+      values: [open_hardware, open_toolchain, documented]
+      # WHY THIS DIMENSION EXISTS, and why it is not the obvious alternative.
+      #
+      # The owner ruled on 2026-08-12 that an accessory's openness should track its host
+      # platform: what a HAT or a carrier board offers a builder is the openness of the
+      # system it completes, and asking the board questions of a thing that is not a board
+      # answers about the wrong artifact. `raspberry-pi-ai-hat-plus` is the case and, today,
+      # the only one - it publishes the HAT+ mechanical specification rather than board
+      # design files, and its toolchain is half open, the Pi driver integration being open
+      # while Hailo's Dataflow Compiler is registration-gated.
+      #
+      # The obvious way to reproduce its 4 was a rung on `{schematics: partial, toolchain:
+      # partial}`, and that was rejected after checking what it would say. Across the 20
+      # products in the category that pair is unique to this one product, so it would fire
+      # for exactly one thing either way - but it would ALSO be non-monotonic: `ti-am67a`
+      # and `qualcomm-dragonwing-rb3-gen-2` both record `{partial, open}` and score 3, so a
+      # rung handing `{partial, partial}` a 4 would rank strictly weaker evidence strictly
+      # higher. A rule that is false as a general statement is the thing this repo has
+      # already been bitten by twice (issues #132 and #133), and a curator reading the
+      # ladder later has no way to know it was meant narrowly.
+      #
+      # So the principle is recorded as its own axis instead. It says what it means, it is
+      # orthogonal to the design and toolchain questions rather than contradicting them,
+      # and the next accessory records its host rather than needing another rung. The
+      # narrowness is real and is not hidden: one product records this key today.
+      evidence:
+      - '`open_toolchain`: the accessory completes a platform scoring 4/open_toolchain.
+        `raspberry-pi-ai-hat-plus` plugs into `raspberry-pi-5`, whose schematics are
+        published and whose stack builds from open source'
+      - '`open_hardware` and `documented` are declared for symmetry with the classes a host
+        can hold, and no product records either yet. Neither has a rung, so an accessory
+        landing there abstains and is deferred rather than being scored by analogy'
+      machine_signal: none - needs a human to identify the host and read its score
     retail:
       question: Can anyone buy one?
       # Declared, tested by no rung. Two products record nothing here and the rest split
@@ -94,6 +132,14 @@ openness:
   # #133 is what that looks like when it goes wrong. The tier is described in the category's
   # comments so the vocabulary is not lost; it becomes a rung when a part needs it.
   formula:
+  - when: {accessory_host: open_toolchain}
+    then: {score: 4, class: open_toolchain}
+    because: >-
+      An accessory tracks the platform it completes. A HAT is not a board and the design
+      questions below answer about the wrong artifact when asked of one: what a builder gets
+      from `raspberry-pi-ai-hat-plus` is the openness of the Raspberry Pi 5 it plugs into,
+      which is 4/open_toolchain. Placed first because it decides a different KIND of product,
+      not a better one - the rungs below assume the thing being scored is the board.
   - when: {schematics: open, toolchain: open}
     then: {score: 5, class: open_hardware}
     because: >-

--- a/sources/rubrics/software.yaml
+++ b/sources/rubrics/software.yaml
@@ -132,7 +132,32 @@ openness:
         definition: >-
           Not OSI-approved, but imposes no restriction on WHO may use the software or AT
           WHAT SCALE. Attribution and naming requirements belong here.
-        examples: []
+        # CC-BY-4.0 is the first entry, added 2026-08-12 on the owner's ruling that a
+        # protocol may license its documentation under Creative Commons. It is here and
+        # not in `osi` because OSI approves software licenses and has never approved a
+        # Creative Commons content license; CC-BY-4.0's own deed warns it is "not
+        # recommended for software". It is here and not lower because attribution is all
+        # it asks: it caps neither who may use the work nor at what scale, which is this
+        # tier's definition stated directly, and it is the same reading that put
+        # TII-Falcon-License-2.0 and the DeepSeek Model License in the model ladder's
+        # copy of this tier under issue #117.
+        #
+        # `model-context-protocol` is the only software product it reaches. The other
+        # five CC-BY-4.0 records on the map - codecontests, dclm-baseline, gpqa, mbpp,
+        # synth - are corpora scored by `dataset.yaml`, which keeps its own tier list, so
+        # this addition moves no score outside the eleven software categories and none
+        # inside them either. Checked before adding, per the note on the tier below: a
+        # name added for one product tiers every product that happens to record it.
+        #
+        # This tier still has NO rung, and MCP therefore still abstains rather than
+        # scoring. That is deliberate and is explained at the foot of the formula: a
+        # non-OSI license cannot reach the `open` bucket under either MOF or OSAID, so a
+        # rung here would have to emit something other than open_source, and nobody has
+        # ruled on what. Declaring the tier is still the right half of the fix, because
+        # it converts "the map has never heard of this license" into "the map has placed
+        # this license and has no rung for where it landed" - a rubric gap with an owner
+        # rather than an unknown.
+        examples: [CC-BY-4.0]
       competition_restricted:
         definition: >-
           Source is published and readable, but the license forbids or charges for a class

--- a/sources/scores/arduino-uno-q.yaml
+++ b/sources/scores/arduino-uno-q.yaml
@@ -1,7 +1,7 @@
 product: arduino-uno-q
 openness:
-  class: documented
-  score: 3
+  class: open_hardware
+  score: 5
   components:
     schematics:
       value: open
@@ -22,8 +22,11 @@ openness:
       detail: global
       raw: open_market (global)
   confidence: high
-  note: Board schematics and gerbers are CC-BY-SA 4.0 and tooling is open, but the QRB2210 SoC remains
-    proprietary silicon needing firmware blobs.
+  note: 'Board schematics and gerbers are openly licensed under CC-BY-SA 4.0 and the App Lab toolchain
+    is open, which is the same open-and-open pair that puts beagley-ai at 5. Corrected from 3/documented
+    on 2026-08-12. This ladder scores design-file openness rather than silicon: the level-5 rung says
+    so in its own text, and every board in the category runs on proprietary silicon, so the QRB2210
+    firmware blobs the old note cited are a reason no rung applies.'
   raw: schematics:open (gerbers + schematics CC-BY-SA 4.0);toolchain:open (open App Lab);datasheets:public;blobs:required
     (proprietary Qualcomm SoC firmware);retail:open_market (global)
   sources:

--- a/sources/scores/jina-reader.yaml
+++ b/sources/scores/jina-reader.yaml
@@ -9,19 +9,59 @@ openness:
     source:
       value: public
       detail: TypeScript, stateless mode self-hostable via Docker
+    core-gated:
+      value: ungated
+      detail: no enterprise directory or license key; the paid tiers buy rate limit on the hosted endpoint
     managed-tier:
       value: r.jina.ai/s.jina.ai hosted SaaS
       detail: free tier + paid API key) on top of the same OSS core
       raw: r.jina.ai/s.jina.ai hosted SaaS (free tier + paid API key) on top of the same OSS core
   confidence: high
-  note: Repo is Apache-2.0 with the full reader pipeline public and self-hostable; hosted Jina API is
-    convenience hosting, not a gated core.
-  raw: license:Apache-2.0(OSI);source:public(TypeScript, stateless mode self-hostable via Docker);managed-tier:r.jina.ai/s.jina.ai
+  note: 'Apache-2.0 throughout with no enterprise directory and no license key, and a read on 2026-08-12
+    found the paid tiers buying throughput on the hosted endpoint rather than functionality: jina.ai/reader
+    lists Reader at 20 RPM without a key, 500 RPM with a free key and 5,000 RPM on Premium, with PDF,
+    MS-Office, image captioning and search available at every tier. The published branch does have the
+    MongoDB-backed SaaS storage layer stripped out, which the README states plainly, but it is accounting
+    and persistence for the hosted service rather than a piece of the reader the open build needs - the
+    README says the branch "runs in stateless mode out of the box, with optional MinIO/S3-compatible bucket
+    caching". Nothing is withheld from the published source, so core-gated is ungated.'
+  raw: license:Apache-2.0(OSI);source:public(TypeScript, stateless mode self-hostable via Docker);core-gated:ungated(no
+    enterprise directory or license key; the paid tiers buy rate limit on the hosted endpoint);managed-tier:r.jina.ai/s.jina.ai
     hosted SaaS (free tier + paid API key) on top of the same OSS core
+  last_verified: '2026-08-12'
   sources:
   - url: https://github.com/jina-ai/reader
     shows: Apache-2.0 license, public source, self-host Docker instructions, ~11k stars
     accessed: '2026-06-04'
+  - url: https://github.com/jina-ai/reader/blob/main/LICENSE
+    shows: the repository LICENSE is the Apache License, Version 2.0, headed "Copyright 2020-2024 Jina
+      AI Limited"; the GitHub repo API reports the SPDX id Apache-2.0
+    accessed: '2026-08-12'
+    establishes:
+    - license
+    http_status: 200
+    content_sha256: ee3aeb6c37d4222522d759df6c7014542880b6af1b55cdc5b3bfb11f160e9210
+  - url: https://github.com/jina-ai/reader/blob/main/README.md
+    shows: 'the repo is "the open source branch of the codebase behind https://r.jina.ai and https://s.jina.ai";
+      it "runs in stateless or bucket-cached mode; the MongoDB-backed SaaS storage layer is not included
+      here"; the 2026-04 entry adds that the oss branch "runs in stateless mode out of the box, with optional
+      MinIO/S3-compatible bucket caching via docker compose"'
+    accessed: '2026-08-12'
+    establishes:
+    - source
+    - core-gated
+    http_status: 200
+    content_sha256: 583b250f78916c63a244eeb2903077548bcc39e9245f471947857fe84c70536c
+  - url: https://jina.ai/reader
+    shows: 'the pricing and rate-limit table: Reader 20 RPM with no key, 500 RPM with a free API key, 5,000
+      RPM on Premium, and Search 100/1,000 RPM; the feature list (PDF reading, image captioning, web search)
+      is the same at every tier, so the tiers differ on throughput rather than on features. No enterprise
+      or commercial edition is offered.'
+    accessed: '2026-08-12'
+    establishes:
+    - core-gated
+    http_status: 200
+    content_sha256: 90bd4a738a01b7cfba9b2005d7d281aeee056650aced9eab573172dce4f9d188
 adoption:
   level: 3
   reach: 100K-1M

--- a/sources/scores/llamafirewall.yaml
+++ b/sources/scores/llamafirewall.yaml
@@ -3,6 +3,12 @@ openness:
   score: 5
   class: open_source
   components:
+    license:
+    - name: MIT
+      detail: LlamaFirewall/LICENSE, covering the LlamaFirewall and CodeShield code
+    source:
+      value: public
+      detail: github.com/meta-llama/PurpleLlama, LlamaFirewall/
     framework:
       value: open
       detail: LlamaFirewall + CodeShield code, MIT-licensed in PurpleLlama
@@ -14,14 +20,54 @@ openness:
       raw: bundled guard models (Prompt Guard 2, Llama Guard) carry the Llama Community License
   confidence: high
   note: The firewall framework and CodeShield are open-source (MIT) and self-hostable; it orchestrates
-    Meta's Llama-licensed guard models. Scored on the framework, which is genuinely open source (5).
-  raw: framework:open(LlamaFirewall + CodeShield code, MIT-licensed in PurpleLlama);self-host:yes;note:bundled
+    Meta's Llama-licensed guard models. Scored on the artifact it ships, which is the rule the owner
+    settled on 2026-08-12 - a product is scored on what it distributes, not on what it can load. A repo
+    read the same day confirmed the split is a real one in the tree rather than a reading of it. PurpleLlama's
+    root LICENSE is the Llama 3.2 Community License and governs the guard-model directories; LlamaFirewall/LICENSE
+    is plain MIT and governs the harness. The bundled Prompt Guard 2 and Llama Guard are separate products
+    on this map carrying their own scores, both 3/open_weights, so nothing about their terms goes unscored
+    by scoring the harness on its own.
+  raw: license:MIT(LlamaFirewall/LICENSE, covering the LlamaFirewall and CodeShield code);source:public(github.com/meta-llama/PurpleLlama,
+    LlamaFirewall/);framework:open(LlamaFirewall + CodeShield code, MIT-licensed in PurpleLlama);self-host:yes;note:bundled
     guard models (Prompt Guard 2, Llama Guard) carry the Llama Community License
+  last_verified: '2026-08-12'
   sources:
   - url: https://github.com/meta-llama/PurpleLlama
     shows: 'PurpleLlama: MIT evals + Llama-licensed safeguard models; ~4.2k stars; LlamaFirewall, Prompt
       Guard, CodeShield components'
     accessed: '2026-06-29'
+  - url: https://github.com/meta-llama/PurpleLlama/blob/main/LlamaFirewall/README.md
+    shows: 'the whole product installs and runs locally - prerequisites are Python 3.10, pip and a HuggingFace
+      account for the Llama models, installation is `pip install llamafirewall`, and the basic usage example
+      instantiates LlamaFirewall in-process. No paid tier, no hosted service and no license key appears
+      anywhere in the document; the scanners it lists (PromptGuard 2, AlignmentCheck, regex/custom, CodeShield)
+      are all in the published package'
+    accessed: '2026-08-12'
+    establishes:
+    - self-host
+    - source
+    http_status: 200
+    content_sha256: 9bf4c794eae9870c6d9403490949eec85568c275229775f9477a72e48b679d12
+  - url: https://github.com/meta-llama/PurpleLlama/blob/main/LlamaFirewall/LICENSE
+    shows: the LlamaFirewall directory carries a plain MIT License, "Copyright (c) Meta Platforms, Inc.
+      and affiliates", granting use, copy, modify, merge, publish, distribute, sublicense and sell without
+      restriction
+    accessed: '2026-08-12'
+    establishes:
+    - license
+    - source
+    http_status: 200
+    content_sha256: da6d3703ed11cbe42bd212c725957c98da23cbff1998c05fa4b3d976d1a58e93
+  - url: https://github.com/meta-llama/PurpleLlama/blob/main/LICENSE
+    shows: 'the monorepo root LICENSE is the LLAMA 3.2 COMMUNITY LICENSE AGREEMENT, which is what covers
+      the guard-model directories alongside the harness: the repo tree holds Llama-Guard, Llama-Guard2,
+      Llama-Guard3, Llama-Guard4, Llama-Prompt-Guard-2 and Prompt-Guard beside LlamaFirewall and CodeShield,
+      and GitHub reports the repo license as NOASSERTION'
+    accessed: '2026-08-12'
+    establishes:
+    - license
+    http_status: 200
+    content_sha256: 8cc15535a8a34b41888f644b339a1a9eb428af793a4f5e24df58a3e5b1487d74
 adoption:
   level: 3
   reach: 10K-100K

--- a/sources/scores/maple-ai.yaml
+++ b/sources/scores/maple-ai.yaml
@@ -12,18 +12,31 @@ openness:
     source:
       value: public
       detail: github.com/OpenSecretCloud
+    core-gated:
+      value: ungated
+      detail: billing and feature-flag APIs are optional and external; no enterprise directory, no license
+        key
     models:
       value: open-weight
     hosted-tier:
       value: paid
       detail: managed-enclaves
   confidence: medium
-  note: Both halves of the stack are open under standard OSI licenses (Maple client MIT, OpenSecret platform
+  note: 'Both halves of the stack are open under standard OSI licenses (Maple client MIT, OpenSecret platform
     AGPL-3.0) and the served models are open-weight - unusually clean for a "private AI" product. Scored
-    open_source because the privacy guarantee is only credible because the code is open and attestable. A
-    defensible alternative is open_core, since the delivered offering is a paid hosted service over managed
-    enclaves.
-  raw: license:MIT(Maple-client)+AGPL-3.0(OpenSecret-platform),both-OSI;source:public(github.com/OpenSecretCloud);models:open-weight;hosted-tier:paid(managed-enclaves)
+    open_source because the privacy guarantee is only credible because the code is open and attestable.
+    A repo read on 2026-08-12 settled the open_core alternative against itself. The Maple README makes
+    the billing and feature-flag services optional external clients, VITE_MAPLE_BILLING_API_URL and
+    VITE_OS_FLAGS_BASE_URL, and the OpenSecret README says their "server implementations are not part
+    of this repository setup"; a self-hosted backend runs without either, so what the subscription buys
+    is usage on the hosted enclaves rather than functionality withheld from the source. Neither repo has
+    an enterprise directory or a license key. The one closed-looking artifact is the 15MB
+    continuum-proxy-x86_64 binary vendored into opensecret, and it is the third-party TEE proxy from
+    Edgeless Systems, carried alongside a git submodule of edgelesssys/privatemode-public rather than
+    being anything OpenSecret withholds from a self-hoster.'
+  raw: license:MIT(Maple-client)+AGPL-3.0(OpenSecret-platform),both-OSI;source:public(github.com/OpenSecretCloud);core-gated:ungated(billing
+    and feature-flag APIs are optional and external; no enterprise directory, no license key);models:open-weight;hosted-tier:paid(managed-enclaves)
+  last_verified: '2026-08-12'
   sources:
   - url: https://github.com/OpenSecretCloud/Maple
     shows: MIT-licensed Maple client (Tauri/Rust/TS), active; multi-platform
@@ -31,6 +44,42 @@ openness:
   - url: https://github.com/OpenSecretCloud/opensecret
     shows: AGPL-3.0 OpenSecret platform; AWS Nitro enclave / TEE confidential-computing architecture
     accessed: '2026-06-17'
+  - url: https://github.com/OpenSecretCloud/Maple/blob/master/LICENSE
+    shows: the Maple client repository LICENSE is a plain MIT License; the GitHub repo API reports the
+      SPDX id MIT
+    accessed: '2026-08-12'
+    establishes:
+    - license
+    http_status: 200
+    content_sha256: 076f3390f6342f51a64feadb9cd84d4ca41f56ebc6c2f9f1fe98fa255d853ad8
+  - url: https://github.com/OpenSecretCloud/opensecret/blob/master/LICENSE
+    shows: the OpenSecret platform repository LICENSE is the GNU Affero General Public License Version
+      3; the GitHub repo API reports the SPDX id AGPL-3.0
+    accessed: '2026-08-12'
+    establishes:
+    - license
+    http_status: 200
+    content_sha256: 8486a10c4393cee1c25392769ddd3b2d6c242d6ec7928e1414efff7dfb2f07ef
+  - url: https://github.com/OpenSecretCloud/Maple/blob/master/README.md
+    shows: 'the configuration surface lists VITE_OS_FLAGS_BASE_URL as "an optional feature-flags API" and
+      VITE_MAPLE_BILLING_API_URL as "an optional billing API", and states "Flags and billing are independent
+      clients"; the quick start runs the client against a local OpenSecret backend at 127.0.0.1:3000 with
+      no paid component'
+    accessed: '2026-08-12'
+    establishes:
+    - core-gated
+    http_status: 200
+    content_sha256: 278de0205fecb4841f4c6ce7ec2df9e2e16eb9f0306dd03f671b32e5767be1b4
+  - url: https://github.com/OpenSecretCloud/opensecret/blob/master/README.md
+    shows: 'the backend is "the open-source Rust backend for confidential AI applications such as Maple"
+      and builds from the Nix flake; "Billing and feature flags are optional external HTTP APIs whose administrative
+      credentials remain in the backend; their server implementations are not part of this repository setup"'
+    accessed: '2026-08-12'
+    establishes:
+    - source
+    - core-gated
+    http_status: 200
+    content_sha256: 41dbc79949c8be048aa6d719ee168312648bcbfe59cf75ecbf04f9f50c14901b
 adoption:
   level: 3
   signal_type: reported_traction

--- a/sources/scores/privatemode.yaml
+++ b/sources/scores/privatemode.yaml
@@ -9,8 +9,9 @@ openness:
     - name: MIT-subdirs
       detail: proxy/web/internal-oss
     source:
-      value: TCB-public
-      detail: github.com/edgelesssys/privatemode-public
+      value: partial
+      detail: the TCB components are published and reproducibly buildable at github.com/edgelesssys/privatemode-public;
+        the service around them is not, and the license permits building only to audit
     service:
       value: proprietary-hosted
     models:
@@ -18,13 +19,44 @@ openness:
   confidence: high
   note: 'Not open source: the security-critical Trusted Computing Base is publicly readable (and the client
     proxy + web app are MIT), but the main license permits only viewing/compiling for audit, and the operational
-    service is a proprietary hosted offering. More open than a black-box API, less than open-core.'
-  raw: license:custom-source-available(audit-only)+MIT-subdirs(proxy/web/internal-oss);source:TCB-public(github.com/edgelesssys/privatemode-public);service:proprietary-hosted;models:third-party-open-weight
+    service is a proprietary hosted offering. More open than a black-box API, less than open-core. A read
+    on 2026-08-12 recorded source as partial rather than public or closed, which is what the ladder was
+    missing. The repo README scopes itself to "all components of Privatemode that are part of the TCB",
+    so the operating service around them - accounts, billing, orchestration - is not published, and the
+    LICENSE grants permission "to view, analyze, and compile this source code solely for the purpose of
+    auditing and for verifying its reproducibility and cryptographic hashes", with redistribution,
+    modification and use for any other purpose prohibited. There is no self-hostable implementation, so
+    source is not public; a real component set does ship, so it is not closed either. That is the same
+    shape as lumo, apify and confer, which the ladder already places at 2.'
+  raw: license:custom-source-available(audit-only)+MIT-subdirs(proxy/web/internal-oss);source:partial(the
+    TCB components are published and reproducibly buildable at github.com/edgelesssys/privatemode-public;
+    the service around them is not, and the license permits building only to audit);service:proprietary-hosted;models:third-party-open-weight
+  last_verified: '2026-08-12'
   sources:
   - url: https://github.com/edgelesssys/privatemode-public
     shows: TCB source (attestation agent, proxy, web app, SDK) under a custom audit-only license with MIT-licensed
       subdirectories
     accessed: '2026-06-17'
+  - url: https://github.com/edgelesssys/privatemode-public/blob/main/README.md
+    shows: 'the repo "contains the source code of all components of Privatemode that are part of the TCB",
+      that "the build is reproducible", and that this "allows users to fully verify the Privatemode service"
+      - verification, not deployment'
+    accessed: '2026-08-12'
+    establishes:
+    - source
+    http_status: 200
+    content_sha256: e4c9a73f76e9969ccaec1d9fd459d542108f32f1a15502cd25a7872a8cb0483b
+  - url: https://github.com/edgelesssys/privatemode-public/blob/main/LICENSE
+    shows: 'permission is granted "to view, analyze, and compile this source code solely for the purpose
+      of auditing and for verifying its reproducibility and cryptographic hashes", and "Redistribution,
+      modification, and use of the software for any other purpose are prohibited unless explicitly permitted
+      by the copyright holder"; privatemode-proxy/, app/web/ and internal/oss/ are additionally MIT'
+    accessed: '2026-08-12'
+    establishes:
+    - license
+    - source
+    http_status: 200
+    content_sha256: e8fab96ce879946cf49f66f752947da7f0a4dca4dc180dd70bf5a4dd41451bef
 adoption:
   level: 2
   signal_type: reported_traction

--- a/sources/scores/raspberry-pi-ai-hat-plus.yaml
+++ b/sources/scores/raspberry-pi-ai-hat-plus.yaml
@@ -7,6 +7,9 @@ openness:
       value: partial
       detail: HAT+ mechanical spec public
       raw: partial (HAT+ mechanical spec public)
+    accessory-host:
+      value: open_toolchain
+      detail: Raspberry Pi 5, which scores 4/open_toolchain
     toolchain:
       value: partial
       detail: open Pi driver integration, Hailo compiler gated
@@ -25,10 +28,15 @@ openness:
       raw: open_market (mass-market)
   confidence: medium
   note: Officially supported open Pi software stack and public product page, globally purchasable, but
-    the underlying Hailo model-compiler toolchain is registration-gated.
-  raw: schematics:partial (HAT+ mechanical spec public);toolchain:partial (open Pi driver integration, Hailo
-    compiler gated);datasheets:brief (public brief);blobs:required (Hailo firmware required);retail:open_market
-    (mass-market)
+    the underlying Hailo model-compiler toolchain is registration-gated. Scored as an accessory on the
+    owner's ruling of 2026-08-12 - an add-on tracks the platform it completes, and what a builder gets
+    from this HAT is the openness of the Raspberry Pi 5 it plugs into, which is 4/open_toolchain. Its
+    own design and toolchain answers are both partial and neither describes the system anyone actually
+    uses, so accessory-host is what the ladder now reads. See the dimension of that name in
+    sources/rubrics/hardware.yaml for why the principle is an axis rather than an extra rung.
+  raw: schematics:partial (HAT+ mechanical spec public);accessory-host:open_toolchain(Raspberry Pi 5, which
+    scores 4/open_toolchain);toolchain:partial (open Pi driver integration, Hailo compiler gated);datasheets:brief
+    (public brief);blobs:required (Hailo firmware required);retail:open_market (mass-market)
   sources:
   - url: https://www.raspberrypi.com/products/ai-hat/
     shows: 'Official product page: Hailo-8 (26 TOPS) / Hailo-8L (13 TOPS), HAT+ form factor, from $70'

--- a/sources/scores/txt360-pipeline.yaml
+++ b/sources/scores/txt360-pipeline.yaml
@@ -4,9 +4,9 @@ openness:
   class: source_available
   components:
     license:
-    - name: Apache-2.0 asserted in README only
-      detail: no LICENSE file in repo (GitHub reports null
-      raw: Apache-2.0 asserted in README only, no LICENSE file in repo (GitHub reports null)
+    - name: none-declared
+      detail: the README badge asserts Apache-2.0 but the repo ships no LICENSE file and the GitHub license
+        endpoint 404s
     source:
       value: public
       detail: LLM360/TxT360
@@ -16,8 +16,12 @@ openness:
     the repo API reports a null license. Scored on that rather than on the badge. Score corrected from 3
     to 2 on 2026-07-30. The software ladder has rungs at 1, 2, 4 and 5 and none at 3, so 3/source_available
     was not a pair any rule could produce; the ladder scores "you can read it and not run it freely" at
-    2.'
-  raw: license:Apache-2.0 asserted in README only, no LICENSE file in repo (GitHub reports null); source:public(LLM360/TxT360)
+    2. On 2026-08-12 the license was moved from prose to the unstated form the corpus already uses for
+    gaia and openhermes-2-5, so the tier lookup reads a license name rather than a sentence. The value
+    of the fix is that the abstention is now about the map rather than about the record: none-declared
+    is in no tier, and no software category declares a tier for a license nobody granted.'
+  raw: license:none-declared(the README badge asserts Apache-2.0 but the repo ships no LICENSE file and
+    the GitHub license endpoint 404s);source:public(LLM360/TxT360)
   sources:
   - url: https://github.com/LLM360/TxT360
     shows: README asserts Apache-2.0; no LICENSE file in repo (GitHub reports null license)

--- a/tests/test_check_parity.py
+++ b/tests/test_check_parity.py
@@ -187,10 +187,31 @@ def test_local_scores_matches_check_rubrics_split():
     library. Three stayed deferred and each on a rubric gap rather than a missing fact:
     livecodebench and openhermes-2-5 record 3 on unstated licenses the ladder gives no rung,
     and multipl-e records the repository's BSD-3-with-ML-restriction, which this ladder has
-    no tier for."""
+    no tier for.
+
+    Then 460/12 -> 465/7 when the second resolution batch ran, on 2026-08-12. Five closed and
+    none of them moved a published score. Three were evidence reads whose deferral texts had
+    gone stale: jina-reader, maple-ai and privatemode were all recorded as computing a score
+    that disagreed with the record, and none of them computed anything by the time they were
+    read - #201 and #203 had turned all three into ordinary unanswered dimensions. jina-reader
+    and maple-ai gained `core-gated:ungated` on repo and pricing reads, and privatemode gained
+    `source:partial`, its recorded `TCB-public` being outside the dimension's enum. The other
+    two were rulings. llamafirewall transcribed `source` and `license` off its `framework` and
+    `self-host` keys, on the rule that a product is scored on the artifact it ships rather than
+    on what it can load - the bundled guard models are separate products here with their own
+    scores. raspberry-pi-ai-hat-plus kept its 4 through a new `accessory_host` dimension in the
+    hardware ladder, because an accessory tracks the platform it completes. arduino-uno-q is the
+    sixth and the only published score that moved, 3/documented -> the 5/open_hardware the ladder
+    computes: its design files are openly licensed under CC-BY-SA 4.0, which is the same
+    `schematics: open` that puts beagley-ai at 5, and the proprietary SoC the old note cited is a
+    reason no rung applies. A cap on proprietary silicon was considered and rejected because every
+    board in the category runs on it, so the cap would flatten all 20 to 3 and leave the 4 and 5
+    rungs unreachable. Of the six that remain, model-context-protocol and txt360-pipeline both had
+    their licenses recorded properly and both still abstain, which is now the finding rather than
+    a defect."""
     computed, deferred = local_scores(None)
-    assert len(deferred) == 12
-    assert len(computed) == 460
+    assert len(deferred) == 6
+    assert len(computed) == 466
     assert not set(computed) & set(deferred)
     # Every one of the 410 reproduces today, so none should abstain.
     assert [key for key, value in computed.items() if value is None] == []
@@ -229,24 +250,34 @@ def test_a_missing_row_fails(monkeypatch, capsys):
     assert "no row in the warehouse at all" in capsys.readouterr().out
 
 
+# Both tests below need a category that actually defers something, and the category they
+# named is chosen by the corpus rather than by them. They ran against `safeguards` and
+# `ui_api` until 2026-08-12, when the second resolution batch took both to zero deferrals -
+# at which point one raised IndexError and the other passed while asserting "0 abstain on
+# both sides", which is the silent-narrowing failure this repo has already been bitten by
+# three times. `edge_hardware` holds the two deferrals least likely to close soon: one waits
+# on the form_factor taxonomy proposal (#219) and one on a direction for the whole hardware
+# ladder. Re-point them rather than loosening them if that stops being true.
 def test_scoring_a_deferred_product_fails(monkeypatch, capsys):
     """The safeguards bug: a ladder ending in `otherwise` scoring what the repo declined."""
-    computed, deferred = local_scores("safeguards")
+    computed, deferred = local_scores("edge_hardware")
+    assert deferred, "pick a category that still defers something"
     published = {
         key: row(key[0], key[1], value[0], value[1], rule=0) for key, value in computed.items()
     }
     published.update({key: row(key[0], key[1], deferred=True) for key in deferred})
     victim = sorted(deferred)[0]
     published[victim] = row(victim[0], victim[1], 3, "open_weights", deferred=False, rule=6)
-    assert run(monkeypatch, published, "safeguards") == 1
+    assert run(monkeypatch, published, "edge_hardware") == 1
     assert "repo defers it, the warehouse does not know" in capsys.readouterr().out
 
 
 def test_a_shared_abstention_is_not_a_divergence(monkeypatch, capsys):
     """Both sides declining is a curation work list, not a parity failure."""
-    _, deferred = local_scores("ui_api")
+    _, deferred = local_scores("edge_hardware")
+    assert deferred, "pick a category that still defers something"
     published = {key: row(key[0], key[1], deferred=True) for key in deferred}
-    assert run(monkeypatch, published, "ui_api") == 1  # the scored products are missing
+    assert run(monkeypatch, published, "edge_hardware") == 1  # the scored products are missing
     out = capsys.readouterr().out
     assert f"{len(deferred)} abstain on both sides" in out
 

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -674,11 +674,15 @@ def test_real_sources_serialize_without_errors():
     # a different number means it stopped inheriting.
     #
     # `edge_hardware` is the first HARDWARE category and the only ladder with no
-    # `license_tier`: 4 rungs, each a single condition on `schematics` except the two that
-    # also test `toolchain`, so 6 rows.
+    # `license_tier`. It was 6: 4 rungs, each a single condition on `schematics` except the
+    # two that also test `toolchain`. It is 7 since 2026-08-12, when a single-condition
+    # `accessory_host` rung was added at the top of the formula on the ruling that an
+    # accessory tracks the platform it completes. It decides a different KIND of product
+    # rather than a better one - `raspberry-pi-ai-hat-plus` is a HAT, and the four rungs
+    # below it all assume the thing being scored is a board.
     assert per_category("category_scoring_rules") == {
         "base_pretrained": 12, "finetuned_chat": 10, "safeguards": 20,
-        "benchmark_eval_data": 24, "training_synthetic_datasets": 24, "edge_hardware": 6,
+        "benchmark_eval_data": 24, "training_synthetic_datasets": 24, "edge_hardware": 7,
         **{c: 10 for c in SOFTWARE},
     }
     # Both fell with the slug migration: release-level products collapsed into the
@@ -742,7 +746,15 @@ def test_real_sources_serialize_without_errors():
         # the repository ships the generation engine itself and the NeMo Platform adds
         # infrastructure around it rather than withholding anything from it - and the record
         # moved from an unreproducible 1/closed to the 5/open_source the ladder computes.
-        "agent_tools_protocols": 122, "dataset_processing_tools": 90, "evaluation_code": 107,
+        #
+        # agent_tools_protocols 122 -> 127 when jina-reader's deferral closed on 2026-08-12. A
+        # repo and pricing read recorded `core-gated: ungated` - Apache-2.0 throughout with no
+        # enterprise directory and paid tiers that buy rate limit on the hosted endpoint - and
+        # its recorded 5/open_source reproduces. Five rows, from none while deferred.
+        # model-context-protocol still publishes nothing: CC-BY-4.0 now has a tier, so it
+        # resolves to permissive_non_osi instead of nothing, and that tier deliberately has no
+        # rung.
+        "agent_tools_protocols": 127, "dataset_processing_tools": 90, "evaluation_code": 107,
         # inference_code 47 -> 64 when the sweep read the category: four stale deferrals came
         # off (a deferred product publishes no openness evidence at all), and several products
         # that had described their gating in prose gained a readable `source:`/`core-gated:`.
@@ -823,7 +835,16 @@ def test_real_sources_serialize_without_errors():
         # not read; a repo read confirmed the enterprise directory is carved out to PolyForm
         # Free Trial 1.0.0 while the core stays MIT, `core-gated: gated` was transcribed, and
         # the recorded 4/open_core reproduces. Five rows, and the category now defers nothing.
-        "orchestration_agents": 215, "telemetry_observability": 114, "ui_api": 184,
+        #
+        # ui_api 184 -> 196 when both of its remaining deferrals closed on 2026-08-12, six rows
+        # each. Neither was the conflict its reason claimed: maple-ai and privatemode had both
+        # been abstaining on an unanswered dimension since #201 and #203, not disagreeing with
+        # a computed score. maple-ai gained `core-gated: ungated` on a read of the Maple and
+        # OpenSecret repos, whose billing and feature-flag services are optional external
+        # clients; privatemode gained `source: partial`, its recorded `TCB-public` having been
+        # outside the dimension's enum. Both reproduce the score they carried. The category now
+        # defers nothing.
+        "orchestration_agents": 215, "telemetry_observability": 114, "ui_api": 196,
         # training_synthetic_datasets is unchanged at 158 across the ladder widening, which
         # is the check that mattered: benchmark_eval_data's new dimensions and rungs did not
         # disturb the category the ladder was derived from.
@@ -856,11 +877,28 @@ def test_real_sources_serialize_without_errors():
         # recorded 4 to the 3 the ladder computes, and a product that no longer defers
         # publishes its component keys. wildguard carries four of the fourteen rows because
         # the read that settled it added `code:partial` to the three keys it already had.
-        "safeguards": 117,
+        # safeguards 117 -> 123 when llamafirewall, its last deferral, closed on 2026-08-12 on
+        # the ruling that a product is scored on the artifact it ships rather than on what it
+        # can load. Its MIT facts had been sitting under `framework` and `self-host`;
+        # transcribing `source` and `license` reproduces the recorded 5/open_source, and the
+        # six rows it now publishes include the `framework` and `note` keys it already carried.
+        # The category now defers nothing.
+        "safeguards": 123,
         # 17 scored hardware products across the five recorded dimensions, less the keys
         # individual products do not record. No license row among them, by design -
         # `edge_hardware` is the only category whose ladder declares no `license_tier`.
-        "edge_hardware": 83,
+        #
+        # 83 -> 90 when raspberry-pi-ai-hat-plus's deferral closed on 2026-08-12. It had been
+        # publishing nothing while deferred and now publishes its six recorded keys plus the
+        # new `accessory-host`, which is the dimension that reproduces its 4: an accessory
+        # tracks the platform it completes.
+        #
+        # 90 -> 95 the same day when arduino-uno-q moved 3/documented to the 5/open_hardware
+        # the ladder computes, on openly licensed CC-BY-SA 4.0 design files - the same
+        # `schematics: open` as beagley-ai. Five rows, from none while deferred.
+        # rockchip-rk3588 stays deferred pending the form_factor proposal (#219) and so still
+        # publishes nothing, which is what holds the rise to the one product.
+        "edge_hardware": 95,
     }
     assert {r["grade"] for r in tables["product_openness_evidence"]} == {"document"}
 


### PR DESCRIPTION
## Summary

Six deferrals close. Deferrals go **12 → 6**. One score moves.

## The three "live disagreements" were not disagreements

`jina-reader`, `maple-ai` and `privatemode` each carried a deferral claiming the ladder computed one score while the record said another. **None of them computed anything at `main`.** PRs #201 and #203 had already turned all three into ordinary unanswered dimensions, and the deferral text was never updated. There was nothing to rule on — only evidence to record.

| Product | What the read established | Result |
|---|---|---|
| `jina-reader` | Apache-2.0, no `ee/` directory, no license key; tiers buy RPM (20 → 500 → 5,000) with every feature at every tier, and the stripped MongoDB SaaS layer "runs in stateless mode out of the box" | `core-gated: ungated`, **5** reproduces |
| `maple-ai` | billing and feature-flag APIs are optional external clients whose servers are in neither repo; the 15MB `continuum-proxy` binary is Edgeless's third-party TEE proxy, not a withheld own-product piece | `core-gated: ungated`, **5** reproduces |
| `privatemode` | recorded `TCB-public`, a value outside the enum; the README scopes the repo to TCB components and the LICENSE permits compiling "solely for auditing" | `source: partial`, **2** reproduces |

`privatemode` is the same shape as `lumo`, `apify` and `confer` — a value that is legal English and invisible to the ladder.

## `arduino-uno-q` 3 → 5

Moves to what the ladder computes, matching `beagley-ai` on openly licensed design files.

**OSHWA is not a hidden rung.** `hardware.yaml`'s `schematics` evidence already writes the condition as an `or` and names `arduino-uno-q` as a worked example. The rubric *header* describes `beagley-ai` as "CC-BY/CC-BY-SA **and** OSHWA-certified", and that is what the original deferral misread as a certification requirement.

A proprietary-silicon cap was considered and rejected: every board in the category runs proprietary silicon, so it would flatten all 20 products to 3 and leave the 4 and 5 rungs unreachable — which `check_recipe`'s `no_unreachable_rule` gate treats as a defect.

## `raspberry-pi-ai-hat-plus` — an accessory tracks its host

Implemented as a new `accessory_host` dimension with one rung, **not** the `{schematics: partial, toolchain: partial}` rung the deferral suggested.

That rung would have been unique to one product either way, but it is also **non-monotonic**: `ti-am67a` and `qualcomm-dragonwing-rb3-gen-2` record `{partial, open}` and score 3, so a `{partial, partial}` rung at 4 would rank weaker evidence higher. The new axis says what was actually ruled instead of encoding it as a coincidence of two partials.

## `llamafirewall` — scored on the artifact it ships

**A product is scored on what it ships, not on what it can load.** LlamaFirewall is an MIT harness that runs against whatever model you point it at; the bundled Prompt Guard 2 and Llama Guard carry the use-restricted Llama Community License and are separate products with their own scores. Written into `docs/guides/openness-spectrum.md`.

`openai-evals` is the only other bundle of this shape, and it was already resolved this way before the rule existed.

## `CC-BY-4.0` declared, and a question it surfaces

Mapped to `permissive_non_osi` in `software.yaml`, with the reasoning stated in the tier — it is a content licence, not OSI-approved. No other product is affected; the five other `CC-BY-4.0` records are dataset-ladder corpora.

**`model-context-protocol` still abstains.** Most-restrictive-wins resolves its three-way compound to `permissive_non_osi`, which **has no rung by design** — the bucket invariant in `test_openness_buckets` keeps anything below an externally-open licence out of the open bucket. So the remaining question is narrower and cleaner than the one we started with: *what class does a permissive non-OSI software licence earn?* That is a one-line ruling, and it is not made here.

## `txt360-pipeline` and `rockchip-rk3588`

`txt360-pipeline` records its licence as unstated rather than as prose, and abstains — which is the honest answer for a repo that ships no LICENSE file and whose GitHub licence endpoint 404s.

`rockchip-rk3588` is not scored. It is an application-processor SoC, not a board, so `schematics` is *not applicable* rather than absent, and recording `none` would conflate the two. Proposed as a `form_factor` key (board / module / chipset) in **#219**.

## Test plan

- Suite 460 passed. `validate` 0 error(s), `check_recipe` 0 failure(s), `check_rubric` exit 0, `check_components` `[OK]`, plus `check_verification` and `check_payload`.
- Exactly one `score:` line changes.
- Two count fixtures updated with reasoning.
