### PR TITLE
Give permissive_non_osi a rung, and fix MCP's docs license

### DIFF
--- a/sources/categories/agent_tools_protocols.yaml
+++ b/sources/categories/agent_tools_protocols.yaml
@@ -43,31 +43,16 @@ scoring_recipe:
   extends: software
   derived_from:
     method: shared software ladder, verified against the hand-authored scores
-    scores_reproduced: 27
+    scores_reproduced: 32
     scores_total: 32
-    verified_on: '2026-07-30'
+    verified_on: '2026-08-12'
     checker: build/check_rubric.py
-  # Held back rather than scored. The shared ladder has no `otherwise` rule, so
-  # these already abstain; declaring them here records WHY, and keeps the
-  # reproduction count honest by excluding them from it rather than counting
-  # them as passes.
-  deferred:
-    model-context-protocol:
-      because: >-
-        source and core-gated were read and recorded on 2026-08-12, and the license question
-        has moved on one step since. The LICENSE really does split three ways - Apache-2.0 for
-        new code and specifications, CC-BY-4.0 for documentation other than the specifications,
-        MIT retained for pre-transition contributions whose authors did not consent to
-        relicensing - and CC-BY-4.0 used to sit in no tier at all, so the compound resolved to
-        nothing and the walk hit a rung it could not evaluate. On the owner's ruling of
-        2026-08-12 that a protocol may license its documentation under Creative Commons,
-        CC-BY-4.0 is now declared in permissive_non_osi in sources/rubrics/software.yaml, with
-        the reasoning recorded there. The compound resolves on every part and the most
-        restrictive wins, so this product now resolves to permissive_non_osi rather than to
-        nothing. That tier has no rung, deliberately: a non-OSI license cannot reach the open
-        bucket under either the Model Openness Framework or OSAID, so a rung here cannot emit
-        open_source and nobody has ruled on what it should emit instead. The deferral therefore
-        stands on a rubric gap with a known shape rather than on an unrecognized license, and
-        the decision it waits on is what class a permissive non-OSI software license earns
-        - which is a rubric question for a human, not a per-product fix
+  # Nothing is deferred here any more. `model-context-protocol` was the last one, and it
+  # closed on a recording fix rather than on the rubric change it appeared to be waiting
+  # for: its CC-BY-4.0 documentation license was recorded inside the `license` compound,
+  # where most-restrictive-wins applied a license covering the project's PROSE to the
+  # artifact you run, and demoted it to 3/source_available. `autogen` had the identical
+  # facts recorded the other way - MIT under `license`, CC-BY-4.0 under a separate `docs:`
+  # key the ladder does not read - and kept its 5. MCP now matches autogen and reproduces
+  # at 5/open_source.
 comments: ''

--- a/sources/rubrics/software.yaml
+++ b/sources/rubrics/software.yaml
@@ -149,14 +149,27 @@ openness:
         # inside them either. Checked before adding, per the note on the tier below: a
         # name added for one product tiers every product that happens to record it.
         #
-        # This tier still has NO rung, and MCP therefore still abstains rather than
-        # scoring. That is deliberate and is explained at the foot of the formula: a
-        # non-OSI license cannot reach the `open` bucket under either MOF or OSAID, so a
-        # rung here would have to emit something other than open_source, and nobody has
-        # ruled on what. Declaring the tier is still the right half of the fix, because
-        # it converts "the map has never heard of this license" into "the map has placed
-        # this license and has no rung for where it landed" - a rubric gap with an owner
-        # rather than an unknown.
+        # This tier gained a rung on 2026-08-12 - 3/source_available on a public,
+        # ungated source - and NO product currently reaches it. Both halves are
+        # deliberate, and the second one is the surprise.
+        #
+        # MCP was the product the rung was ruled for, and it turned out not to need it.
+        # Its CC-BY-4.0 covers documentation other than the specifications, and it had
+        # been recorded inside the `license` compound, where most-restrictive-wins made
+        # a license over the project's PROSE decide the score of the artifact you run.
+        # `autogen` records the identical facts the other way - MIT under `license`,
+        # CC-BY-4.0 under a `docs:` key this ladder does not read - and scores 5. The
+        # convention already existed; MCP was the record that departed from it. Moving
+        # the docs license out returned MCP to 5/open_source and left this tier empty of
+        # products again.
+        #
+        # So the rung is currently unexercised, which this file elsewhere calls a place
+        # for a later edit to hide. It is kept rather than reverted for two reasons: the
+        # ruling it encodes is about the license class and not about MCP, so it stands
+        # whoever arrives next; and unlike the two rungs deleted before it, this one
+        # emits an open-ISH class, so `test_openness_buckets` bounds the damage a bad
+        # edit could do. `test_permissive_non_osi_rung_is_pinned` pins its outcome so a
+        # silent change is a test failure rather than a score move.
         examples: [CC-BY-4.0]
       competition_restricted:
         definition: >-
@@ -233,8 +246,28 @@ openness:
     because: >-
       The published source is the whole product. A managed offering alongside it does not
       change that.
-  # `permissive_non_osi` deliberately has NO rung, so a product landing there abstains and
-  # is deferred for a human. Two rungs used to sit here, emitting 4/open_core and
+  - when: {license_tier: permissive_non_osi, source: public, core_gated: ungated}
+    then: {score: 3, class: source_available}
+    because: >-
+      Attribution is all the license asks, so the published source is the whole product and
+      is freely runnable - but it is not OSI-approved, and no non-OSI license reaches the
+      open bucket under either the Model Openness Framework or OSAID. Above
+      competition_restricted because nothing here caps who may use the software or at what
+      scale, which is the line between those two tiers stated directly.
+  # The rung above is `permissive_non_osi`'s only one, added 2026-08-12 on the owner's
+  # ruling. It emits 3/source_available: above `competition_restricted`'s 2 because
+  # attribution asks less than a no-compete clause or a paid production threshold, and
+  # below the OSI rungs because no non-OSI license reaches the `open` bucket under MOF or
+  # OSAID. `source_available` is not a compromise word chosen for the bucket - it is the
+  # only class between `open_core` and `closed` that the software vocabulary in
+  # build/validate.py declares, so the alternative was inventing one.
+  #
+  # There is no gated counterpart. A second rung emitting 2/source_available for a gated
+  # permissive-non-OSI core would be dead on arrival, and dead rules are the hazard this
+  # comment block exists to record.
+  #
+  # Until 2026-08-12 the tier had no rung at all, so a product landing there abstained
+  # and was deferred for a human. Two rungs used to sit here, emitting 4/open_core and
   # 5/open_source. Both were unreachable, because this tier's `examples` list is empty and
   # no software product resolves into it - and both were wrong in the same way: they handed
   # a non-OSI license an open_source or open_core class, and openness-class-map.json puts

--- a/sources/scores/model-context-protocol.yaml
+++ b/sources/scores/model-context-protocol.yaml
@@ -11,8 +11,10 @@ openness:
       detail: OSI, new code/spec
     - name: MIT
       detail: OSI, legacy contributions
-    - name: CC-BY-4.0
-      detail: docs
+    docs:
+      value: CC-BY-4.0
+      detail: documentation other than the specifications; not read by the openness ladder, which scores
+        the artifact the product ships
     governance:
       value: Linux-Foundation/AAIF
       detail: open, co-founded Anthropic/Block/OpenAI
@@ -22,22 +24,23 @@ openness:
         modelcontextprotocol repo - there is no vendor tier to withhold anything for
   confidence: high
   note: 'Open protocol with OSI-licensed reference implementations and open foundation governance; no feature-gated
-    core. Two keys were re-read on 2026-08-12 and the record STILL does not score - see the category''s
-    deferral, which has been rewritten to say why. (1) `source` was recorded under the key `spec+reference-SDKs`,
-    which no dimension''s `reads:` list names, so the right answer sat under a key the ladder never looks
-    at and the dimension read as unanswered. Renamed to `source`. (2) `core-gated: ungated` added: the spec,
-    the JSON/TypeScript schema and the docs are in the one repo, every reference SDK is a separate public
-    modelcontextprotocol repo (mcp-python-sdk and mcp-typescript-sdk are already on the map at 5), and the
-    project is governed by the Linux Foundation''s AAIF with no vendor tier to withhold anything for. (3)
-    The actual blocker is the LICENSE, and it is not a recording error - the file really does split three
-    ways, Apache-2.0 for new code and specifications, CC-BY-4.0 for documentation other than the specifications,
-    and MIT retained for pre-transition contributions whose authors did not consent to relicensing. `license_tier`
-    resolves a compound on every part and abstains if any part is unmapped, and CC-BY-4.0 appears in no
-    tier''s examples in sources/rubrics/software.yaml, so the value resolves to nothing and the walk cannot
-    pass the rung that tests it. Whether a documentation license belongs in a software ladder at all is
-    a shared-rubric question across eleven categories and was left for a human.'
+    core. The record reproduces at 5/open_source as of 2026-08-12, after three fixes. (1) `source` was recorded
+    under the key `spec+reference-SDKs`, which no dimension''s `reads:` list names, so the right answer
+    sat under a key the ladder never looks at and the dimension read as unanswered. Renamed to `source`.
+    (2) `core-gated: ungated` added: the spec, the JSON/TypeScript schema and the docs are in the one repo,
+    every reference SDK is a separate public modelcontextprotocol repo (mcp-python-sdk and mcp-typescript-sdk
+    are already on the map at 5), and the project is governed by the Linux Foundation''s AAIF with no vendor
+    tier to withhold anything for. (3) The LICENSE really does split three ways - Apache-2.0 for new code
+    and specifications, CC-BY-4.0 for documentation other than the specifications, and MIT retained for
+    pre-transition contributions whose authors did not consent to relicensing. Recording all three under
+    `license` was the defect: `license_tier` resolves a compound on every part and takes the most restrictive,
+    so a license covering the project''s PROSE governed the artifact you run and pulled the product down
+    to 3/source_available. The documentation license now sits under a `docs:` key, which the openness ladder
+    does not read, matching how `autogen` records the identical situation - MIT code, CC-BY-4.0 docs, 5/open_source.
+    The license dimension answers a question about the shipped artifact.'
   raw: source:public(spec schema and docs in one repo plus reference SDKs in separate public repos);license:Apache-2.0(OSI,
-    new code/spec)+MIT(OSI, legacy contributions)+CC-BY-4.0(docs);governance:Linux-Foundation/AAIF(open,
+    new code/spec)+MIT(OSI, legacy contributions);docs:CC-BY-4.0(documentation other than the specifications;
+    not read by the openness ladder, which scores the artifact the product ships);governance:Linux-Foundation/AAIF(open,
     co-founded Anthropic/Block/OpenAI);core-gated:ungated(spec schema and docs ship in the one LF/AAIF-governed
     repo and every reference SDK is a public modelcontextprotocol repo - there is no vendor tier to withhold
     anything for)

--- a/tests/test_check_parity.py
+++ b/tests/test_check_parity.py
@@ -208,10 +208,23 @@ def test_local_scores_matches_check_rubrics_split():
     board in the category runs on it, so the cap would flatten all 20 to 3 and leave the 4 and 5
     rungs unreachable. Of the six that remain, model-context-protocol and txt360-pipeline both had
     their licenses recorded properly and both still abstain, which is now the finding rather than
-    a defect."""
+    a defect.
+
+    Then 466/6 -> 467/5 on 2026-08-12, when model-context-protocol closed. It did NOT close on
+    the rubric ruling it looked like it was waiting for. `permissive_non_osi` did gain a rung
+    that day - 3/source_available, on the reasoning that attribution asks less than a
+    no-compete clause but a non-OSI license still cannot enter the open bucket under MOF or
+    OSAID - and MCP does not reach it. Its CC-BY-4.0 covers documentation other than the
+    specifications and had been recorded inside the `license` compound, where
+    most-restrictive-wins let a license over the project's PROSE decide the score of the
+    artifact you run, pulling a 5 down to a 3. `autogen` records the identical facts under a
+    separate `docs:` key the ladder does not read and has always scored 5. MCP now matches it
+    and reproduces at 5/open_source, so the published score did not move. The rung stays,
+    unexercised and pinned by tests/test_openness_buckets.py, because the ruling it encodes is
+    about a license class rather than about one product."""
     computed, deferred = local_scores(None)
-    assert len(deferred) == 6
-    assert len(computed) == 466
+    assert len(deferred) == 5
+    assert len(computed) == 467
     assert not set(computed) & set(deferred)
     # Every one of the 410 reproduces today, so none should abstain.
     assert [key for key, value in computed.items() if value is None] == []

--- a/tests/test_openness_buckets.py
+++ b/tests/test_openness_buckets.py
@@ -146,6 +146,40 @@ def test_no_rung_reaches_the_open_bucket_from_a_restricted_license():
     assert not stale, f"KNOWN_VIOLATIONS entries no longer violate anything: {sorted(stale)}"
 
 
+def test_permissive_non_osi_rung_is_pinned():
+    """The software ladder's `permissive_non_osi` rung, pinned because nothing exercises it.
+
+    Added 2026-08-12 on a ruling about the license class. No product reaches it: MCP was
+    the product it was ruled for, and MCP turned out to have recorded a DOCUMENTATION
+    license inside its `license` compound, where most-restrictive-wins let a license over
+    the project's prose decide the score of the artifact you run. `autogen` records the
+    same facts under a `docs:` key the ladder does not read and scores 5. MCP now matches
+    it, and this tier is empty of products again.
+
+    A rung no product exercises is a dead rule, and this file's sibling comment in
+    software.yaml is about how the last two dead rules here went unnoticed until one of
+    them would have silently emitted 5/open_source for a non-OSI license. So the outcome
+    is pinned rather than left to `check_rubric`, which can only test rungs that fire.
+    Change the numbers here deliberately or not at all.
+    """
+    recipe = yaml.safe_load((ROOT / "sources" / "rubrics" / "software.yaml").read_text())
+    rungs = [
+        rule
+        for rule in recipe["openness"]["formula"]
+        if (rule.get("when") or {}).get("license_tier") == "permissive_non_osi"
+    ]
+    assert len(rungs) == 1, f"expected exactly one permissive_non_osi rung, found {len(rungs)}"
+
+    when, then = rungs[0]["when"], rungs[0]["then"]
+    assert when == {"license_tier": "permissive_non_osi", "source": "public", "core_gated": "ungated"}
+    assert then == {"score": 3, "class": "source_available"}
+
+    # The bucket invariant is tested generally above; asserted here too because THIS is the
+    # rung that would break it, and a general test passing tells you nothing about which
+    # specific rung it examined.
+    assert then["class"] not in set(_bucket_map()["buckets"]["open"]["classes"])
+
+
 def test_an_otherwise_rule_never_lands_in_the_open_bucket():
     """`otherwise` tests no license tier, so it cannot establish one.
 

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -680,10 +680,17 @@ def test_real_sources_serialize_without_errors():
     # accessory tracks the platform it completes. It decides a different KIND of product
     # rather than a better one - `raspberry-pi-ai-hat-plus` is a HAT, and the four rungs
     # below it all assume the thing being scored is a board.
+    # Software is 13 since 2026-08-12, and `safeguards` 23, because `permissive_non_osi`
+    # got a rung back. Three rows, not one: it tests `license_tier`, `source` and
+    # `core_gated`, and a three-condition rung serializes as three. Note the shape of the
+    # history here - the tier lost 6 rows when its two rungs came out for emitting an
+    # open-bucket class from a non-OSI license, and regained 3 for one rung emitting
+    # 3/source_available, which is open-ISH. The rows came back; the boundary violation
+    # did not.
     assert per_category("category_scoring_rules") == {
-        "base_pretrained": 12, "finetuned_chat": 10, "safeguards": 20,
+        "base_pretrained": 12, "finetuned_chat": 10, "safeguards": 23,
         "benchmark_eval_data": 24, "training_synthetic_datasets": 24, "edge_hardware": 7,
-        **{c: 10 for c in SOFTWARE},
+        **{c: 13 for c in SOFTWARE},
     }
     # Both fell with the slug migration: release-level products collapsed into the
     # tier the vendor sells, so 25 products left the roster and the closed frontier
@@ -754,7 +761,14 @@ def test_real_sources_serialize_without_errors():
         # model-context-protocol still publishes nothing: CC-BY-4.0 now has a tier, so it
         # resolves to permissive_non_osi instead of nothing, and that tier deliberately has no
         # rung.
-        "agent_tools_protocols": 127, "dataset_processing_tools": 90, "evaluation_code": 107,
+        # agent_tools_protocols rose 127 -> 134 on 2026-08-12 when the category's last
+        # deferral came off. All seven rows are `model-context-protocol`, and they are
+        # what a deferral was suppressing: `source`, `core_gated`, two `license` parts,
+        # `docs`, `governance` and the raw `core-gated` key. `docs` publishes as an
+        # undeclared-key row, exactly as `autogen`'s CC-BY-4.0 documentation license
+        # already did - which is the evidence that MCP was made to match an existing
+        # convention rather than given a new one.
+        "agent_tools_protocols": 134, "dataset_processing_tools": 90, "evaluation_code": 107,
         # inference_code 47 -> 64 when the sweep read the category: four stale deferrals came
         # off (a deferred product publishes no openness evidence at all), and several products
         # that had described their gating in prose gained a readable `source:`/`core-gated:`.


### PR DESCRIPTION
Two changes that arrived together and turned out to be independent.

## The rung

`permissive_non_osi` has had no rung since the two that emitted `open_core` and
`open_source` came out for handing a non-OSI license an open-bucket class. It now emits
**3/source_available** on a public, ungated source:

- above `competition_restricted`'s 2, because attribution asks less than a no-compete
  clause or a paid production threshold
- below the OSI rungs, because no non-OSI license reaches the open bucket under either
  the Model Openness Framework or OSAID

`source_available` is not a compromise chosen to satisfy the bucket — it is the only
class between `open_core` and `closed` that the software vocabulary in `build/validate.py`
declares.

## MCP was the product it was ruled for, and it does not reach it

Wiring the rung up first computed `3/source_available` against a recorded
`5/open_source` — a two-point demotion. That turned out not to be the license tier doing
its job.

MCP's CC-BY-4.0 covers documentation other than the specifications, and it was recorded
**inside the `license` compound**, where most-restrictive-wins let a license over the
project's *prose* decide the score of the artifact you run.

`autogen` has the identical facts recorded the other way and has always scored 5:

| | `license` compound | docs CC-BY recorded as | Result |
|---|---|---|---|
| `autogen` | `MIT (code, via LICENSE-CODE)` | separate `docs:` key, which the ladder does not read | 5/open_source |
| `model-context-protocol` (before) | `Apache-2.0 + MIT + CC-BY-4.0 (docs)` | inside the compound | 3/source_available |
| `model-context-protocol` (after) | `Apache-2.0 + MIT` | separate `docs:` key | 5/open_source |

The convention already existed; MCP was the record that departed from it. Moving the docs
license out returns MCP to its recorded score, so **the deferral closes and no published
number moves.**

`autogen` already publishes `docs | CC-BY-4.0` as an undeclared-key row in
`product_openness_evidence`. MCP's new shape is identical there too — checked, not assumed.

## The rung is now unexercised, deliberately

No product reaches it. This ladder elsewhere calls a dead rule a place for a later edit to
hide, and that is precisely how the two previous `permissive_non_osi` rungs came to be
silently emitting `open_source` for a non-OSI license.

It is kept rather than reverted because the ruling it encodes is about a license class and
not about one product. `test_permissive_non_osi_rung_is_pinned` pins its `when`/`then`, so
a silent change fails a test rather than moving a score. Unlike its predecessors this one
emits an open-*ish* class, so `test_openness_buckets` bounds the damage a bad edit could do.

## Counts that moved, and why

- **Deferrals 6 → 5.** `agent_tools_protocols` reproduces **32/32** with none deferred.
- `category_scoring_rules` +3 per software category (10 → 13), `safeguards` 20 → 23. One
  rung testing three conditions serializes as three rows.
- `product_openness_evidence` for `agent_tools_protocols` 127 → 134. All seven rows are
  MCP's, previously suppressed by the deferral.

## Test plan

- `pytest` — **461 passed**
- `validate`, `check_recipe`, `check_rubric`, `check_components`, `check_routing`,
  `check_capability`, `check_verification`, `check_retirement` — all green
- `check_payload` — 472 products, 257 organizations, ok. Run **after** `git commit`, since
  before it the check passes trivially.
- Generated files (`build/notebook_data.json`, `notebooks/ai-stack-map.py`) deliberately
  not committed — the bot owns them.

## Note on warehouse parity

`check_parity` currently reports `453 agree, 5 abstain both sides, 14 diverge`, all of one
shape: *"the warehouse thinks it is deferred."* That is 7 from #218, 6 from #220 and 1 from
this PR — the weekly compute cron has not run since before #218. The `evidence` → `scores`
refresh is being run separately; MCP's row closes when this merges and the registry
republishes.