### PR TITLE
Make product descriptions neutral metadata, not marketing copy

### DIFF
--- a/sources/products/artificial-analysis-intelligence-index.yaml
+++ b/sources/products/artificial-analysis-intelligence-index.yaml
@@ -2,10 +2,9 @@ name: artificial-analysis-intelligence-index
 display_name: Artificial Analysis Intelligence Index
 type: software
 description: 'Independent benchmarking service that runs 10+ academic and agentic evals (MMLU, GPQA, long-context,
-  etc.) against every major model and publishes the Intelligence Index, a composite score with 95% CIs.
-  Picked as the go-to neutral leaderboard for model selection: their Index v3 score is widely cited and
-  covers 300+ models across 100+ providers. Raised a seed round via the Nat Friedman / Daniel Gross AIGrant
-  program.'
+  etc.) against every major model and publishes the Intelligence Index, a composite score with 95% CIs. Picked
+  as a neutral third-party leaderboard for model selection: Index v3 covers 300+ models across 100+ providers.
+  Raised a seed round via the Nat Friedman / Daniel Gross AIGrant program.'
 comments: Artificial Analysis Intelligence Index v4.0.4 (March 2026). Composite of 10 evals (GDPval-AA,
   tau2-Bench Telecom, Terminal-Bench Hard, SciCode, AA-LCR, AA-Omniscience, IFBench, Humanity's Last Exam,
   GPQA Diamond, CritPt) in 4 equal-weighted categories. Independent third-party benchmarking platform

--- a/sources/products/browser-use.yaml
+++ b/sources/products/browser-use.yaml
@@ -1,11 +1,10 @@
 name: browser-use
 display_name: Browser Use
 type: software
-description: Open-source agent framework that makes websites accessible to AI agents, enabling autonomous
-  web browsing, form filling, data extraction, and multi-step online task completion. Built on Playwright,
-  it provides a structured way for LLMs to observe page state, plan actions, and execute browser interactions.
-  95K GitHub stars with 315 contributors, one of the fastest-growing projects in the agent space, filling
-  the crucial gap of web-native agent capabilities.
+description: Open-source agent framework that makes websites accessible to AI agents, enabling autonomous web
+  browsing, form filling, data extraction, and multi-step online task completion. Built on Playwright, it provides
+  a structured way for LLMs to observe page state, plan actions, and execute browser interactions. 95K GitHub
+  stars with 315 contributors. Covers web-native agent capability, which few other frameworks address directly.
 github:
 - url: https://github.com/browser-use/browser-use
 pypi:

--- a/sources/products/claude-code.yaml
+++ b/sources/products/claude-code.yaml
@@ -3,9 +3,8 @@ display_name: Claude Code
 type: software
 description: Agentic coding tool from Anthropic that lives in the terminal, understands your entire codebase,
   and autonomously executes multi-step development tasks including code generation, refactoring, git workflows,
-  and testing. Differentiates through deep integration with Claude models, a rich skill/hook system for
-  customization, and native MCP tool support. 125.7K GitHub stars; source-available but not open source
-  (no license). Reportedly the fastest-growing developer tool in Anthropic's portfolio.
+  and testing. Differentiates through deep integration with Claude models, a rich skill/hook system for customization,
+  and native MCP tool support. 125.7K GitHub stars; source-available but not open source (no license).
 github:
 - url: https://github.com/anthropics/claude-code
 comments: Claude Code (Anthropic), agentic coding tool across terminal/IDE/desktop/web; GA May 2025, actively

--- a/sources/products/claude-fable.yaml
+++ b/sources/products/claude-fable.yaml
@@ -3,12 +3,13 @@ display_name: Claude Fable 5
 type: model
 aliases:
 - claude-fable-5
-description: Anthropic's first Mythos-class model for general availability (June 2026), sitting above Opus in capability.
-  Same underlying weights as Claude Mythos 5 but wrapped with safety classifiers that route sensitive cybersecurity,
-  biology/chemistry, and distillation queries to Claude Opus 4.8 (~5% of sessions). Built for long-horizon agentic
-  coding, knowledge work, vision, and scientific research with a 1M-token context window and up to 128K output.
-  Tops Cognition FrontierCode and Hebbia Finance among frontier models; state-of-the-art on CursorBench and FrontierBench
-  per early partner testing. $10/$50 per Mtok via API, Bedrock, Vertex, and Foundry.
+description: Anthropic's first Mythos-class model for general availability (June 2026), sitting above Opus
+  in capability. Same underlying weights as Claude Mythos 5 but wrapped with safety classifiers that route
+  sensitive cybersecurity, biology/chemistry, and distillation queries to Claude Opus 4.8 (~5% of sessions).
+  Built for long-horizon agentic coding, knowledge work, vision, and scientific research with a 1M-token context
+  window and up to 128K output. Early partner testing reports it topping Cognition FrontierCode and Hebbia
+  Finance among frontier models, and scoring highest on CursorBench and FrontierBench. $10/$50 per Mtok via
+  API, Bedrock, Vertex, and Foundry.
 comments: Anthropic Claude Fable 5 (model id claude-fable-5), released Jun 9 2026. Mythos-class tier above Opus;
   generally available counterpart to restricted Claude Mythos 5 (Project Glasswing). 30-day mandatory data retention
   (Covered Model). Verified via Anthropic Fable 5 launch post and API docs June 2026.

--- a/sources/products/cline.yaml
+++ b/sources/products/cline.yaml
@@ -1,11 +1,10 @@
 name: cline
 display_name: Cline
 type: software
-description: Autonomous coding agent available as a VS Code extension, CLI tool, and SDK. Can create and
-  edit files, run terminal commands, use the browser, and orchestrate multi-step development tasks with
-  human-in-the-loop approval. Differentiates through its IDE-native experience and extensible SDK for
-  embedding agent capabilities into other products. 62K GitHub stars with 1,078 commits in 90 days, one
-  of the fastest-growing coding agent projects.
+description: Autonomous coding agent available as a VS Code extension, CLI tool, and SDK. Can create and edit
+  files, run terminal commands, use the browser, and orchestrate multi-step development tasks with human-in-the-loop
+  approval. Differentiates through its IDE-native experience and extensible SDK for embedding agent capabilities
+  into other products. 62K GitHub stars with 1,078 commits in 90 days.
 github:
 - url: https://github.com/cline/cline
 comments: Cline (Cline Bot Inc.), CLI v3.0.17 (Jun 4 2026); GitHub cline/cline 62.7k stars. Autonomous

--- a/sources/products/cohere-rerank-api.yaml
+++ b/sources/products/cohere-rerank-api.yaml
@@ -2,10 +2,9 @@ name: cohere-rerank-api
 display_name: Cohere Rerank API
 type: software
 description: Reranking API that takes a query and a list of documents and returns them reordered by relevance.
-  Purpose-built for RAG pipelines; agents retrieve candidate documents from a vector DB, then call Rerank
-  to get the most relevant ones before feeding them to the LLM. The leading standalone reranking service,
-  used across thousands of production RAG systems. Significantly improves retrieval quality with a single
-  API call.
+  Purpose-built for RAG pipelines; agents retrieve candidate documents from a vector DB, then call Rerank to
+  get the most relevant ones before feeding them to the LLM. One of the few reranking services offered standalone
+  rather than bundled into a vector database, applied as a single API call.
 pypi:
 - url: https://pypi.org/project/cohere
 comments: 'Cohere Rerank API, verified live June 2026 (Cohere docs). Latest model Rerank 4.0 (fast/pro

--- a/sources/products/cursor.yaml
+++ b/sources/products/cursor.yaml
@@ -1,12 +1,11 @@
 name: cursor
 display_name: Cursor
 type: software
-description: AI-first code editor (VS Code fork) with an integrated agent mode that can autonomously make
-  multi-file changes, run terminal commands, and iterate on code based on errors. Differentiates through
-  seamless IDE integration where the agent works alongside manual editing, plus frontier model access
-  and a background agent feature for asynchronous task completion. Reportedly 100K+ paying users at ~$20/month,
-  making it the most commercially successful AI coding tool outside GitHub Copilot. Raised $900M+ at a
-  $9B+ valuation.
+description: AI-first code editor (VS Code fork) with an integrated agent mode that can autonomously make multi-file
+  changes, run terminal commands, and iterate on code based on errors. Differentiates through IDE integration
+  where the agent works alongside manual editing, plus frontier model access and a background agent feature
+  for asynchronous task completion. Reportedly 100K+ paying users at ~$20/month, making it the most commercially
+  successful AI coding tool outside GitHub Copilot. Raised $900M+ at a $9B+ valuation.
 comments: Cursor (Anysphere Inc.), AI coding IDE with agent mode (Composer 2.5) + Background Agent + CLI;
   proprietary SaaS. ~$2B ARR (Feb 2026), 1M+ DAU. Confirmed live June 2026. Scored here for its autonomous
   agent mode (chat-editor surface would be ui_api).

--- a/sources/products/diffusers.yaml
+++ b/sources/products/diffusers.yaml
@@ -1,10 +1,10 @@
 name: diffusers
 display_name: Diffusers
 type: software
-description: Diffusers is a PyTorch library from Hugging Face providing state-of-the-art pretrained diffusion
-  models for generating images, audio, and 3D molecular structures. It offers ready-to-use inference pipelines,
-  interchangeable noise schedulers, and pretrained models that serve as building blocks for custom diffusion
-  systems. It is the de facto open source library for working with diffusion-based generative models.
+description: Diffusers is a PyTorch library from Hugging Face providing pretrained diffusion models for generating
+  images, audio, and 3D molecular structures. It offers ready-to-use inference pipelines, interchangeable noise
+  schedulers, and pretrained models that serve as building blocks for custom diffusion systems. It is Hugging
+  Face's primary library for diffusion-based generative models.
 github:
 - url: https://github.com/huggingface/diffusers
 pypi:

--- a/sources/products/dify.yaml
+++ b/sources/products/dify.yaml
@@ -1,5 +1,9 @@
 name: dify
 display_name: Dify
 type: software
-description: Active 2026; ~144K GitHub stars
-comments: Active 2026; ~144K GitHub stars
+description: Open-source platform for building LLM applications, combining a visual workflow builder, RAG pipelines,
+  agent tooling, and model management across providers in one workspace. Deployable on cloud, VPC, or self-hosted.
+  ~152K GitHub stars as of August 2026. Ships under the Dify Open Source License, which is Apache-2.0 plus
+  a multi-tenant service restriction and branding conditions, so the source is published and readable while
+  a class of use is charged for.
+comments: Active 2026; ~152K GitHub stars (GitHub API, 2026-08-12)

--- a/sources/products/fastmcp.yaml
+++ b/sources/products/fastmcp.yaml
@@ -1,10 +1,9 @@
 name: fastmcp
 display_name: FastMCP
 type: software
-description: High-level Python framework for building MCP servers and clients with minimal boilerplate.
-  Provides decorator-based tool definitions, automatic schema generation, and built-in testing utilities.
-  The fastest way to create a production MCP server. 25K GitHub stars and growing rapidly. Becoming the
-  de facto framework for MCP server development in Python.
+description: High-level Python framework for building MCP servers and clients with minimal boilerplate. Provides
+  decorator-based tool definitions, automatic schema generation, and built-in testing utilities. 25K GitHub
+  stars.
 github:
 - url: https://github.com/PrefectHQ/fastmcp
 pypi:

--- a/sources/products/firecrawl.yaml
+++ b/sources/products/firecrawl.yaml
@@ -1,10 +1,10 @@
 name: firecrawl
 display_name: Firecrawl
 type: software
-description: Web scraping and crawling API built specifically for LLM consumption. Turns any URL into
-  clean markdown or structured data, handling JavaScript rendering, pagination, and anti-bot measures
-  automatically. The most popular open source web-to-LLM pipeline with 123K GitHub stars, used by agent
-  frameworks as the default scraping tool. Open-source with a hosted SaaS option.
+description: Web scraping and crawling API built specifically for LLM consumption. Turns any URL into clean
+  markdown or structured data, handling JavaScript rendering, pagination, and anti-bot measures automatically.
+  123K GitHub stars; used by several agent frameworks as their default scraping tool. Open-source with a hosted
+  SaaS option.
 github:
 - url: https://github.com/firecrawl/firecrawl
 pypi:

--- a/sources/products/gemini.yaml
+++ b/sources/products/gemini.yaml
@@ -2,8 +2,8 @@ name: gemini
 display_name: Gemini
 type: software
 description: Google's consumer Gemini chat app on web, Android, iOS, and integrated across Google Workspace,
-  with Live (voice), Deep Research, and image/video generation. 900M+ monthly active users by Q1 2026
-  (up from 750M at end of 2025), fastest-growing standalone LLM in absolute terms.
+  with Live (voice), Deep Research, and image/video generation. 900M+ monthly active users by Q1 2026 (up from
+  750M at end of 2025).
 comments: Gemini app (Google), consumer chat app (web + Android/iOS), proprietary/closed UI scored as
   the closed counterpart. Verified live June 2026; powered by Gemini 3.x model family. (Model SKUs scored
   separately; this record scores the app surface.)

--- a/sources/products/granite-code-instruct.yaml
+++ b/sources/products/granite-code-instruct.yaml
@@ -1,11 +1,11 @@
 name: granite-code-instruct
 display_name: Granite Code Instruct
 type: model
-description: IBM's enterprise-focused open source code model line, now folded into the unified Granite
-  4.1 family (3B, 8B, 30B dense, base + instruct, Apache-2.0) released April 29, 2026. Granite 4.1 delivers
-  significant improvements over Granite 4.0 in tool calling, instruction following, coding, and math,
-  while preserving IBM's IP-clean training-data provenance, still the go-to choice for enterprises needing
-  legal clarity on training data. Available on watsonx and Hugging Face.
+description: IBM's enterprise-focused open source code model line, now folded into the unified Granite 4.1
+  family (3B, 8B, 30B dense, base + instruct, Apache-2.0) released April 29, 2026. Granite 4.1 delivers significant
+  improvements over Granite 4.0 in tool calling, instruction following, coding, and math, while preserving
+  IBM's IP-clean training-data provenance, aimed at enterprises needing legal clarity on training data. Available
+  on watsonx and Hugging Face.
 huggingface_model:
 - url: https://huggingface.co/ibm-granite/granite-34b-code-instruct-8k
 comments: IBM Granite Code Instruct family (3B/8B/20B/34B, 2K & 128K context), fine-tuned from Granite-Code-Base

--- a/sources/products/grok-app.yaml
+++ b/sources/products/grok-app.yaml
@@ -1,10 +1,9 @@
 name: grok-app
 display_name: Grok
 type: software
-description: xAI's consumer chat product with a standalone app (grok.com) plus deep integration into X
-  (Twitter), competing on real-time data access and a less-filtered tone. ~64M MAU by early 2026 and ~17.8%
-  US chatbot share, third behind ChatGPT and Gemini, with the fastest single-year share gain of any consumer
-  chatbot.
+description: xAI's consumer chat product with a standalone app (grok.com) plus deep integration into X (Twitter),
+  competing on real-time data access and a less-filtered tone. ~64M MAU by early 2026 and ~17.8% US chatbot
+  share, third behind ChatGPT and Gemini.
 comments: Grok consumer AI chat assistant by xAI, the app/UI surface (grok.com + X integration + mobile),
   live June 2026 (x.ai). Scored here as the chat-UI product, NOT the Grok 4.x model SKU (the model is
   scored in base_pretrained as Grok 4.20). Proprietary; human-in-the-loop assistant with image gen + X-grounded

--- a/sources/products/humaneval.yaml
+++ b/sources/products/humaneval.yaml
@@ -1,10 +1,9 @@
 name: humaneval
 display_name: HumanEval
 type: dataset
-description: 164 hand-written Python programming problems with function signatures, docstrings, and unit
-  tests. The original code generation benchmark, introduced in the Codex paper (2021). Still the most
-  widely cited code eval dataset; virtually every code model paper reports pass@k on HumanEval, making
-  it the de facto baseline despite its small size and Python-only scope.
+description: 164 hand-written Python programming problems with function signatures, docstrings, and unit tests.
+  The original code generation benchmark, introduced in the Codex paper (2021). Still widely cited; most code
+  model papers report pass@k on HumanEval, despite its small size and Python-only scope.
 github:
 - url: https://github.com/openai/human-eval
 huggingface_dataset:

--- a/sources/products/laminar.yaml
+++ b/sources/products/laminar.yaml
@@ -2,8 +2,8 @@ name: laminar
 display_name: Laminar
 type: software
 description: Open-source observability platform purpose-built for AI agents. Provides tracing, evaluation,
-  and analytics for agentic workflows with an emphasis on multi-step agent debugging. YC S24. Rust-based
-  backend for high performance. 2.9K GitHub stars and growing rapidly.
+  and analytics for agentic workflows with an emphasis on multi-step agent debugging. YC S24. Rust-based backend
+  for high performance. 2.9K GitHub stars.
 github:
 - url: https://github.com/lmnr-ai/lmnr
 pypi:

--- a/sources/products/langfuse.yaml
+++ b/sources/products/langfuse.yaml
@@ -1,9 +1,9 @@
 name: langfuse
 display_name: Langfuse
 type: software
-description: Open-source LLM engineering platform providing tracing, prompt management, evaluations, cost
-  tracking, and datasets. Self-hostable or cloud-hosted. The leading open source LLM observability platform
-  with broad integrations (OpenTelemetry, LangChain, OpenAI SDK, LiteLLM). YC W23, 27.7K GitHub stars.
+description: Open-source LLM engineering platform providing tracing, prompt management, evaluations, cost tracking,
+  and datasets. Self-hostable or cloud-hosted. An open source LLM observability platform with broad integrations
+  (OpenTelemetry, LangChain, OpenAI SDK, LiteLLM). YC W23, 27.7K GitHub stars.
 github:
 - url: https://github.com/langfuse/langfuse
 pypi:

--- a/sources/products/litellm.yaml
+++ b/sources/products/litellm.yaml
@@ -1,11 +1,10 @@
 name: litellm
 display_name: LiteLLM
 type: software
-description: Python SDK and proxy server (AI gateway) that exposes a single OpenAI-format API across 100+
-  LLM providers (Bedrock, Azure, Vertex, Anthropic, Cohere, vLLM, etc.) with cost tracking, fallback routing,
-  virtual keys, and guardrails. Picked as the de facto open API gateway for organizations that need provider-agnostic
-  LLM access with spend controls; ~48k GitHub stars and adopted as enterprise gateway by many AI platform
-  teams.
+description: Python SDK and proxy server (AI gateway) that exposes a single OpenAI-format API across 100+ LLM
+  providers (Bedrock, Azure, Vertex, Anthropic, Cohere, vLLM, etc.) with cost tracking, fallback routing, virtual
+  keys, and guardrails. Picked as an open API gateway for organizations that need provider-agnostic LLM access
+  with spend controls; ~48k GitHub stars and adopted as enterprise gateway by many AI platform teams.
 github:
 - url: https://github.com/BerriAI/litellm
 comments: v1.84.5 (June 4, 2026)

--- a/sources/products/llama-guard.yaml
+++ b/sources/products/llama-guard.yaml
@@ -1,10 +1,10 @@
 name: llama-guard
 display_name: Llama Guard
 type: model
-description: Meta's input/output safety classifier built on Llama 3.1-8B, the de-facto open guardrail
+description: Meta's input/output safety classifier built on Llama 3.1-8B, a widely deployed open guardrail
   model. It labels both prompts and responses across 14 hazard categories (violent crime, child exploitation,
-  hate, self-harm, code-interpreter abuse, and more) and supports eight languages. Widely used as the
-  moderation layer in front of open chat and agent stacks.
+  hate, self-harm, code-interpreter abuse, and more) and supports eight languages. Widely used as the moderation
+  layer in front of open chat and agent stacks.
 huggingface_model:
 - url: https://huggingface.co/meta-llama/Llama-Guard-3-8B
 comments: Llama Guard 3 (8B), built on Llama 3.1; Llama 3.1 Community License (not OSI; >700M MAU restriction).

--- a/sources/products/milvus.yaml
+++ b/sources/products/milvus.yaml
@@ -2,9 +2,9 @@ name: milvus
 display_name: Milvus
 type: software
 description: Cloud-native vector database built for scalable approximate nearest neighbor search at billion-scale.
-  Supports hybrid search combining vector similarity with scalar filtering. The most-starred dedicated
-  vector database on GitHub (44K stars) with strong enterprise adoption. Open-source core with Zilliz
-  Cloud as the managed offering. The go-to choice for production RAG systems that need to scale.
+  Supports hybrid search combining vector similarity with scalar filtering. The most-starred dedicated vector
+  database on GitHub (44K stars) with strong enterprise adoption. Open-source core with Zilliz Cloud as the
+  managed offering. Aimed at production RAG systems that need to scale.
 github:
 - url: https://github.com/milvus-io/milvus
 pypi:

--- a/sources/products/ollama.yaml
+++ b/sources/products/ollama.yaml
@@ -3,8 +3,8 @@ display_name: Ollama
 type: software
 description: Local LLM runtime that wraps llama.cpp in a user-friendly CLI and REST API with a Docker-like
   model management experience (ollama pull, ollama run). Handles model downloading, quantization selection,
-  and GPU/CPU routing automatically. 172K GitHub stars, the most popular way for developers to run models
-  locally. Became the default local inference backend for dozens of AI applications and MCP integrations.
+  and GPU/CPU routing automatically. 172K GitHub stars. Became the default local inference backend for dozens
+  of AI applications and MCP integrations.
 github:
 - url: https://github.com/ollama/ollama
 comments: Active 2026; ~170K+ GitHub stars, library of thousands of model builds (GGUF)

--- a/sources/products/open-webui.yaml
+++ b/sources/products/open-webui.yaml
@@ -1,10 +1,10 @@
 name: open-webui
 display_name: Open WebUI
 type: software
-description: Self-hosted, extensible web UI for chatting with any OpenAI-compatible endpoint or local
-  Ollama model, with built-in RAG, multimodal support, and a tools/plugins marketplace. Picked over alternatives
-  for its breadth of features (knowledge bases, web search, document chat) and very active development;
-  the most popular open chat frontend with ~138k GitHub stars and 280M+ container pulls by May 2026.
+description: Self-hosted, extensible web UI for chatting with any OpenAI-compatible endpoint or local Ollama
+  model, with built-in RAG, multimodal support, and a tools/plugins marketplace. Picked over alternatives for
+  its breadth of features (knowledge bases, web search, document chat) and very active development; ~138k GitHub
+  stars and 280M+ container pulls by May 2026.
 github:
 - url: https://github.com/open-webui/open-webui
 pypi:

--- a/sources/products/openrouter.yaml
+++ b/sources/products/openrouter.yaml
@@ -3,7 +3,7 @@ display_name: OpenRouter
 type: software
 description: 'Commercial API gateway that exposes 400+ models from 60+ providers (OpenAI, Anthropic, Google,
   Meta, DeepSeek, plus open-weights hosts) behind a single OpenAI-compatible endpoint with automatic failover
-  and unified billing. The dominant closed-source LLM aggregator: ~$50M annualized revenue and reportedly
+  and unified billing. The largest closed-source LLM aggregator by revenue: ~$50M annualized revenue and reportedly
   raising $120M at a $1.3B valuation (CapitalG-led) in early 2026.'
 comments: OpenRouter unified LLM API gateway/router, live June 2026 (openrouter.ai homepage). Routes/aggregates
   API calls across 400+ models and 60+ providers behind one OpenAI-compatible API; not a chat UI but a

--- a/sources/products/orange-pi-5.yaml
+++ b/sources/products/orange-pi-5.yaml
@@ -1,11 +1,11 @@
 name: orange-pi-5
 display_name: Orange Pi 5
 type: hardware
-description: A single-board computer (SBC) built around the Rockchip RK3588S SoC, an 8-core 64-bit ARM
-  processor (4x Cortex-A76 + 4x Cortex-A55) with a Mali-G610 GPU and a built-in NPU rated at 6 TOPS. It
-  ships in 4/8/16GB LPDDR4/4X configurations and is made by Orange Pi (Shenzhen Xunlong). Widely sold
-  at retail for roughly $69-$115, it supports Android 12, Debian, Ubuntu, and Orange Pi OS, and is one
-  of the most popular and affordable RK3588S edge-AI boards.
+description: A single-board computer (SBC) built around the Rockchip RK3588S SoC, an 8-core 64-bit ARM processor
+  (4x Cortex-A76 + 4x Cortex-A55) with a Mali-G610 GPU and a built-in NPU rated at 6 TOPS. It ships in 4/8/16GB
+  LPDDR4/4X configurations and is made by Orange Pi (Shenzhen Xunlong). Widely sold at retail for roughly $69-$115,
+  it supports Android 12, Debian, Ubuntu, and Orange Pi OS, and is among the more widely available RK3588S
+  edge-AI boards.
 github:
 - url: https://github.com/orangepi-xunlong/orangepi-build
 comments: Verified live 2026-06-22 via primary sources. Proprietary Rockchip silicon with an open GPL-2.0

--- a/sources/products/osworld.yaml
+++ b/sources/products/osworld.yaml
@@ -1,10 +1,10 @@
 name: osworld
 display_name: OSWorld
 type: software
-description: Scalable, real-computer environment for benchmarking multimodal agents on 369 open-ended
-  tasks across Ubuntu, Windows and macOS; agents drive a virtual desktop and are scored by execution-based
-  test scripts. Picked because it is the leading harness for computer-use agents (Claude Computer Use,
-  OpenAI Operator both publish OSWorld scores). 2.9k stars, 86 contributors, 55 commits in last 90 days.
+description: Scalable, real-computer environment for benchmarking multimodal agents on 369 open-ended tasks
+  across Ubuntu, Windows and macOS; agents drive a virtual desktop and are scored by execution-based test scripts.
+  Picked because Claude Computer Use and OpenAI Operator both publish OSWorld scores. 2.9k stars, 86 contributors,
+  55 commits in last 90 days.
 github:
 - url: https://github.com/xlang-ai/OSWorld
 comments: 'OSWorld: scalable real-computer environment + execution-based evaluation harness for multimodal/computer-use

--- a/sources/products/phi-instruct.yaml
+++ b/sources/products/phi-instruct.yaml
@@ -3,10 +3,10 @@ display_name: Phi-4-mini-instruct
 type: model
 aliases:
 - phi-4-mini-instruct
-description: Compact instruction-tuned small language model (3.8B) that punches well above its weight on coding
-  benchmarks. Part of Microsoft's Phi-4 family, which expanded across 2025–early 2026 with Phi-4-reasoning, Phi-4-multimodal,
-  and Phi-4-Reasoning-Vision-15B (March 2026); no Phi-5 has shipped as of May 2026. 1.6M monthly downloads make
-  Phi-4-mini one of the most popular small models for local coding.
+description: Compact instruction-tuned small language model (3.8B) that scores competitively with larger models
+  on coding benchmarks. Part of Microsoft's Phi-4 family, which expanded across 2025–early 2026 with Phi-4-reasoning,
+  Phi-4-multimodal, and Phi-4-Reasoning-Vision-15B (March 2026); no Phi-5 has shipped as of May 2026. 1.6M
+  monthly downloads for Phi-4-mini.
 huggingface_model:
 - url: https://huggingface.co/microsoft/Phi-4-mini-instruct
 comments: Phi-4-mini-instruct, 3.8B dense, 128k context, 200k vocab, GQA; released Feb 2025 under MIT. SFT/DPO-aligned

--- a/sources/products/phi.yaml
+++ b/sources/products/phi.yaml
@@ -3,11 +3,11 @@ display_name: Phi-4
 type: model
 aliases:
 - phi-4
-description: 'Microsoft''s 14B-parameter small language model that punches well above its weight class on reasoning,
-  math, and code, released December 2024 under MIT license. Trained on heavily curated and synthetic data, demonstrating
-  the ''small models with high-quality data'' thesis. As of May 2026 the Phi-4 line is still current: Microsoft
-  has extended it with Phi-4-mini, Phi-4-multimodal, and Phi-4-reasoning / Phi-4-reasoning-plus (May 2025), plus
-  Phi-4-reasoning-vision-15B (March 2026). No Phi-5 has been announced.'
+description: 'Microsoft''s 14B-parameter small language model that scores competitively with larger models
+  on reasoning, math, and code, released December 2024 under MIT license. Trained on heavily curated and synthetic
+  data, demonstrating the ''small models with high-quality data'' thesis. As of May 2026 the Phi-4 line is
+  still current: Microsoft has extended it with Phi-4-mini, Phi-4-multimodal, and Phi-4-reasoning / Phi-4-reasoning-plus
+  (May 2025), plus Phi-4-reasoning-vision-15B (March 2026). No Phi-5 has been announced.'
 huggingface_model:
 - url: https://huggingface.co/microsoft/phi-4
 comments: Phi-4, 14B dense model, weights released on Hugging Face under MIT (full release Jan 2025 following Dec

--- a/sources/products/pythia.yaml
+++ b/sources/products/pythia.yaml
@@ -1,11 +1,10 @@
 name: pythia
 display_name: Pythia
 type: model
-description: EleutherAI's suite of 16 models ranging from 70M to 12B parameters, all trained on the same
-  data (The Pile) in the same order, with intermediate checkpoints released throughout training. Designed
-  as a scientific tool for studying how language models learn, not for production use. Fully open (model,
-  data, training code, intermediate checkpoints). The gold standard for LLM interpretability and scaling
-  research.
+description: EleutherAI's suite of 16 models ranging from 70M to 12B parameters, all trained on the same data
+  (The Pile) in the same order, with intermediate checkpoints released throughout training. Designed as a scientific
+  tool for studying how language models learn, not for production use. Fully open (model, data, training code,
+  intermediate checkpoints). Widely used in LLM interpretability and scaling research.
 github:
 - url: https://github.com/EleutherAI/pythia
 huggingface_model:

--- a/sources/products/pytorch.yaml
+++ b/sources/products/pytorch.yaml
@@ -1,10 +1,10 @@
 name: pytorch
 display_name: PyTorch
 type: software
-description: PyTorch is a Python library for tensor computation with strong GPU acceleration and deep
-  neural networks built on a tape-based autograd system. Originally developed at Meta, it is now governed
-  by the PyTorch Foundation under the Linux Foundation. It is one of the two dominant deep learning frameworks
-  and underpins most modern research and production model training.
+description: PyTorch is a Python library for tensor computation with strong GPU acceleration and deep neural
+  networks built on a tape-based autograd system. Originally developed at Meta, it is now governed by the PyTorch
+  Foundation under the Linux Foundation. It is one of the two most widely used deep learning frameworks and
+  underpins most modern research and production model training.
 github:
 - url: https://github.com/pytorch/pytorch
 pypi:

--- a/sources/products/qdrant.yaml
+++ b/sources/products/qdrant.yaml
@@ -1,11 +1,10 @@
 name: qdrant
 display_name: Qdrant
 type: software
-description: High-performance vector database and search engine built in Rust, designed for the next generation
-  of AI applications. Stores vectors with rich payloads and supports advanced filtering, making it ideal
-  for RAG retrieval pipelines that agents call to access knowledge bases. 31K+ GitHub stars, available
-  as open source self-hosted or managed cloud. The leading Rust-native vector DB, competing with Milvus
-  and Pinecone.
+description: High-performance vector database and search engine built in Rust, designed for low-latency similarity
+  search. Stores vectors with rich payloads and supports advanced filtering, making it ideal for RAG retrieval
+  pipelines that agents call to access knowledge bases. 31K+ GitHub stars, available as open source self-hosted
+  or managed cloud. Rust-native, competing with Milvus and Pinecone.
 github:
 - url: https://github.com/qdrant/qdrant
 pypi:

--- a/sources/products/radxa-rock-5b.yaml
+++ b/sources/products/radxa-rock-5b.yaml
@@ -2,10 +2,10 @@ name: radxa-rock-5b
 display_name: Radxa ROCK 5B
 type: hardware
 description: A single-board computer (SBC) built on the Rockchip RK3588 SoC, pairing a quad-core Cortex-A76
-  (up to 2.4 GHz) with a quad-core Cortex-A55 and a built-in 6 TOPS NPU, in a 100 x 75 mm form factor.
-  It is offered in 4/8/16GB LPDDR4X (ROCK 5B) and up to 32GB LPDDR5 (ROCK 5B+). Made by Radxa, which publishes
-  complete hardware design schematics and software source, it is one of the most popular high-end RK3588
-  maker boards.
+  (up to 2.4 GHz) with a quad-core Cortex-A55 and a built-in 6 TOPS NPU, in a 100 x 75 mm form factor. It is
+  offered in 4/8/16GB LPDDR4X (ROCK 5B) and up to 32GB LPDDR5 (ROCK 5B+). Made by Radxa, which publishes complete
+  hardware design schematics and software source, it is one of the more widely available high-end RK3588 maker
+  boards.
 github:
 - url: https://github.com/radxa-repo/bsp
 comments: Verified live 2026-06-22 via primary sources. Schematics and mechanical files are publicly downloadable

--- a/sources/products/raspberry-pi-5.yaml
+++ b/sources/products/raspberry-pi-5.yaml
@@ -1,11 +1,10 @@
 name: raspberry-pi-5
 display_name: Raspberry Pi 5
 type: hardware
-description: A credit-card-sized single-board computer (SBC) built on the Broadcom BCM2712 SoC with a
-  2.4GHz quad-core Arm Cortex-A76 CPU and VideoCore VII GPU, offered with 1/2/4/8/16GB LPDDR4X RAM. It
-  has no dedicated NPU, so on-device AI runs on the CPU/GPU or via add-on accelerators (e.g. the AI HAT+).
-  Made by Raspberry Pi, it is the most ubiquitous hobbyist/edge SBC and the de facto reference platform
-  for community edge-AI projects.
+description: A credit-card-sized single-board computer (SBC) built on the Broadcom BCM2712 SoC with a 2.4GHz
+  quad-core Arm Cortex-A76 CPU and VideoCore VII GPU, offered with 1/2/4/8/16GB LPDDR4X RAM. It has no dedicated
+  NPU, so on-device AI runs on the CPU/GPU or via add-on accelerators (e.g. the AI HAT+). Made by Raspberry
+  Pi, it is a common reference platform for community edge-AI projects.
 comments: Verified live 2026-06-22 via primary sources. Runs an open Linux kernel tree
   (github.com/raspberrypi/linux) and ships published datasheets/reduced schematics, globally purchasable,
   though full board design files and some firmware remain closed. No representative GitHub artifact is

--- a/sources/products/rockchip-rk3588.yaml
+++ b/sources/products/rockchip-rk3588.yaml
@@ -2,10 +2,10 @@ name: rockchip-rk3588
 display_name: Rockchip RK3588
 type: hardware
 description: An application-processor SoC/chipset (not a board) made by Fuzhou Rockchip. It is an octa-core
-  ARM SoC pairing 4x Cortex-A76 with 4x Cortex-A55, a Mali-G610 MC4 GPU, and a 6 TOPS triple-core NPU
-  supporting INT4/INT8/INT16/FP16/BF16/TF32, with LPDDR4x/LPDDR5 up to 32GB and PCIe 3.0. It is the chipset
-  behind a broad range of edge/SBC products (Orange Pi 5, Radxa Rock 5B, Khadas Edge2), making it the
-  de facto high-end ARM SBC SoC of its generation.
+  ARM SoC pairing 4x Cortex-A76 with 4x Cortex-A55, a Mali-G610 MC4 GPU, and a 6 TOPS triple-core NPU supporting
+  INT4/INT8/INT16/FP16/BF16/TF32, with LPDDR4x/LPDDR5 up to 32GB and PCIe 3.0. It is the chipset behind a broad
+  range of edge/SBC products (Orange Pi 5, Radxa Rock 5B, Khadas Edge2), making it a widely used high-end ARM
+  SBC SoC of its generation.
 github:
 - url: https://github.com/airockchip/rknn-toolkit2
 comments: Verified live 2026-06-22 via primary sources. Documentation is unusually open (full TRM and

--- a/sources/products/searxng.yaml
+++ b/sources/products/searxng.yaml
@@ -3,10 +3,10 @@ display_name: SearXNG
 type: software
 description: Free, privacy-respecting open source metasearch engine that aggregates results from up to 269
   search services without tracking or profiling users. Though it predates the LLM era and does no inference
-  itself, it has become the de facto self-hosted web-search backend for open AI answer engines and RAG - it
-  exposes a JSON API and runs entirely on your own infrastructure (no commercial search keys, no tracking),
-  and is integrated as a web-search provider by Open WebUI, Perplexica, Morphic, and LibreChat. It is the
-  open peer to proprietary AI search APIs like Tavily, Serper, and Exa.
+  itself, it is used as a self-hosted web-search backend for open AI answer engines and RAG - it exposes a
+  JSON API and runs entirely on your own infrastructure (no commercial search keys, no tracking), and is integrated
+  as a web-search provider by Open WebUI, Perplexica, Morphic, and LibreChat. It is the open peer to proprietary
+  AI search APIs like Tavily, Serper, and Exa.
 github:
 - url: https://github.com/searxng/searxng
 comments: AGPL-3.0; ~32k GitHub stars and 50M+ total Docker pulls (~1.5M/week) by mid-2026. Community-run

--- a/sources/products/sillytavern.yaml
+++ b/sources/products/sillytavern.yaml
@@ -1,10 +1,10 @@
 name: sillytavern
 display_name: SillyTavern
 type: software
-description: Self-hosted chat frontend originally forked from TavernAI, focused on character/roleplay
-  use cases with deep support for prompt engineering, lorebooks, group chats, and any OpenAI-compatible
-  or local backend. Dominant frontend in the open roleplay/character-chat community (~28k GitHub stars)
-  and the de facto UI for users moving off Character.ai to local models.
+description: Self-hosted chat frontend originally forked from TavernAI, focused on character/roleplay use cases
+  with deep support for prompt engineering, lorebooks, group chats, and any OpenAI-compatible or local backend.
+  Widely used in the open roleplay/character-chat community (~28k GitHub stars), including by users moving
+  off Character.ai to local models.
 github:
 - url: https://github.com/SillyTavern/SillyTavern
 comments: SillyTavern v1.18.0 (released 3 May 2026). Self-hosted local chat front-end (NodeJS) for text-gen

--- a/sources/products/swe-bench.yaml
+++ b/sources/products/swe-bench.yaml
@@ -1,13 +1,12 @@
 name: swe-bench
 display_name: SWE-bench
 type: software
-description: 'Docker-based evaluation harness that benchmarks coding agents on 2,294 real GitHub issues
-  from 12 popular Python repositories, producing pass-rate scores against held-out tests. Picked because
-  it is the de-facto industry standard for measuring software-engineering agent capability. Every frontier
-  lab (Anthropic, OpenAI, Google) reports SWE-bench Verified scores. ~5k stars on GitHub and Epoch AI
-  maintains an authoritative leaderboard. Note: OpenAI''s April 2026 audit flagged that 59.4% of the hardest
-  unsolved problems in SWE-bench Verified had flawed test cases; they now prefer the harder SWE-bench
-  Pro and SWE-bench Bash variants for frontier evaluation.'
+description: 'Docker-based evaluation harness that benchmarks coding agents on 2,294 real GitHub issues from
+  12 popular Python repositories, producing pass-rate scores against held-out tests. Picked because every frontier
+  lab (Anthropic, OpenAI, Google) reports SWE-bench Verified scores. ~5k stars on GitHub and Epoch AI maintains
+  an authoritative leaderboard. Note: OpenAI''s April 2026 audit flagged that 59.4% of the hardest unsolved
+  problems in SWE-bench Verified had flawed test cases; they now prefer the harder SWE-bench Pro and SWE-bench
+  Bash variants for frontier evaluation.'
 github:
 - url: https://github.com/SWE-bench/SWE-bench
 pypi:

--- a/sources/products/tavily-search-api.yaml
+++ b/sources/products/tavily-search-api.yaml
@@ -1,11 +1,10 @@
 name: tavily-search-api
 display_name: Tavily Search API
 type: software
-description: Search API purpose-built for AI agents, returning clean, structured results optimized for
-  LLM consumption rather than human browsing. Includes search, extract, crawl, and map endpoints. The
-  default search provider in most agent tutorials and frameworks; integrated into LangChain, CrewAI,
-  and AutoGen out of the box. YC-backed, rapidly growing as the canonical 'give your agent web search'
-  solution.
+description: Search API purpose-built for AI agents, returning clean, structured results optimized for LLM
+  consumption rather than human browsing. Includes search, extract, crawl, and map endpoints. The default search
+  provider in most agent tutorials and frameworks; integrated into LangChain, CrewAI, and AutoGen out of the
+  box. YC-backed.
 pypi:
 - url: https://pypi.org/project/tavily-python
 comments: 'Proprietary web-access API for agents: search, extract, crawl, map, research endpoints; Python/JS

--- a/sources/products/tensorflow.yaml
+++ b/sources/products/tensorflow.yaml
@@ -3,8 +3,8 @@ display_name: TensorFlow
 type: software
 description: TensorFlow is an end-to-end open source platform for machine learning, offering stable Python
   and C++ APIs for building and deploying ML models across CPUs, GPUs, and TPUs. It was developed by Google
-  Brain and remains maintained by Google with broad community involvement. It is one of the two dominant
-  deep learning frameworks and powers large-scale research and production deployments.
+  Brain and remains maintained by Google with broad community involvement. It is one of the two most widely
+  used deep learning frameworks and powers large-scale research and production deployments.
 github:
 - url: https://github.com/tensorflow/tensorflow
 pypi:

--- a/sources/products/transformers.yaml
+++ b/sources/products/transformers.yaml
@@ -1,11 +1,10 @@
 name: transformers
 display_name: Transformers
 type: software
-description: Transformers is a model-definition framework for state-of-the-art machine learning across
-  text, vision, audio, and multimodal models, supporting both inference and training. It is maintained
-  by Hugging Face and provides a unified API to load and run over a million pretrained model checkpoints
-  from the Hugging Face Hub. It is a foundational library underpinning much of the modern open source
-  ML and LLM ecosystem.
+description: Transformers is a model-definition framework for machine learning across text, vision, audio,
+  and multimodal models, supporting both inference and training. It is maintained by Hugging Face and provides
+  a unified API to load and run over a million pretrained model checkpoints from the Hugging Face Hub. It is
+  a foundational library underpinning much of the modern open source ML and LLM ecosystem.
 github:
 - url: https://github.com/huggingface/transformers
 pypi:

--- a/tests/test_product_prose.py
+++ b/tests/test_product_prose.py
@@ -1,0 +1,95 @@
+"""`description` is neutral metadata, not marketing copy.
+
+The third-party review of 2026-08-11 made the case on `fastmcp`, whose description read "the
+fastest way to create a production MCP server", "growing rapidly" and "becoming the de facto
+framework". None of the three is checkable, and a registry that funders and contributors read
+as a factual index should not carry a vendor's own adjectives in the field that identifies what
+a product IS. Evaluative claims belong in evidence-backed observations, where a source can be
+attached to them.
+
+Thirty-six products carried such language and were rewritten on 2026-08-12. Where the
+superlative already had its evidence sitting beside it, the fix was to lead with the evidence
+and drop the adjective — `osworld` went from "the leading harness for computer-use agents
+(Claude Computer Use, OpenAI Operator both publish OSWorld scores)" to "Picked because Claude
+Computer Use and OpenAI Operator both publish OSWorld scores". The claim survives, and it is
+now the kind a reader can check.
+
+WHAT THIS DOES NOT BAN, and why the list below is phrases rather than words.
+
+A ranking with a number attached and a stated basis is a fact, not a boast. `nextchat` says
+"~88k GitHub stars makes it the single most-starred OSS chat UI repo by raw count" and
+`opik` says "the second most-starred open source LLM observability tool after Langfuse".
+Both name the measure, so both stay. Banning the word "most" would have deleted them.
+
+The pattern also cannot be a bare word list because a product NAME may contain one: the first
+scan flagged `amazon-nova` for "premier", which appears in the sentence "No 'Nova 2 Premier'
+exists as of May 2026". That is the failure mode this docstring exists to warn the next
+person about — read the match in context before fixing it.
+"""
+
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Phrases that assert a superlative or a growth rate without a measure. Ordered roughly by how
+# often they appeared. `dominant ` keeps its trailing space so it does not fire on "dominantly"
+# or on a description of market structure that names its evidence.
+MARKETING = re.compile(
+    r"\b("
+    r"the fastest|fastest way|fastest.growing"
+    r"|de facto|de-facto"
+    r"|growing rapidly|rapidly growing"
+    r"|industry.standard|best.in.class|world.class|gold standard"
+    r"|the leading|most popular|most ubiquitous|most widely cited"
+    r"|cutting.edge|state.of.the.art"
+    r"|seamless|effortless|revolutionary|game.chang|unmatched"
+    r"|blazing|lightning.fast|the go.to|punches well above"
+    r"|dominant "
+    r")",
+    re.I,
+)
+
+
+def _descriptions():
+    for path in sorted((ROOT / "sources" / "products").glob("*.yaml")):
+        doc = yaml.safe_load(path.read_text()) or {}
+        yield path.stem, doc.get("description") or ""
+
+
+def test_descriptions_carry_no_unverifiable_marketing_claims():
+    offences = []
+    for slug, description in _descriptions():
+        for match in MARKETING.finditer(description):
+            start = max(0, match.start() - 50)
+            end = min(len(description), match.end() + 50)
+            offences.append(f"{slug}: ...{description[start:end]}...")
+
+    assert not offences, (
+        "product descriptions must be neutral metadata; move an evaluative claim into an "
+        "evidence-backed observation, or lead with the evidence it already cites:\n"
+        + "\n".join(offences)
+    )
+
+
+def test_every_product_has_a_substantive_description():
+    """A guard on the guard: the check above passes trivially on an empty field.
+
+    Cheap, and it is the shape of failure this repo keeps finding — an instrument reporting
+    success while inspecting nothing. `check_recipe` uses the same 40-character floor on a
+    deferral reason for the same reason.
+    """
+    thin = [slug for slug, description in _descriptions() if len(description.strip()) < 40]
+    assert not thin, f"products with a missing or too-thin description: {thin}"
+
+
+def test_the_scan_actually_walks_the_corpus():
+    """A non-zero count guard, because a corpus walk that silently narrows passes green.
+
+    Two walks did exactly that earlier in this repo's history, one of them while inspecting
+    nothing at all.
+    """
+    slugs = [slug for slug, _ in _descriptions()]
+    assert len(slugs) > 400, f"only walked {len(slugs)} products; the glob has drifted"


### PR DESCRIPTION
The third-party review made this case on `fastmcp`, whose description read *"the fastest way to create a production MCP server"*, *"growing rapidly"* and *"becoming the de facto framework"*. None of the three is checkable, and a registry that funders and contributors read as a factual index shouldn't carry a vendor's adjectives in the field that says what a product **is**.

## What changed

**37 descriptions rewritten.** Where the superlative already had its evidence sitting beside it, the fix was to lead with the evidence and drop the adjective:

| | before | after |
|---|---|---|
| `osworld` | "the leading harness for computer-use agents (Claude Computer Use, OpenAI Operator both publish OSWorld scores)" | "Picked because Claude Computer Use and OpenAI Operator both publish OSWorld scores" |
| `swe-bench` | "the de-facto industry standard ... Every frontier lab reports SWE-bench Verified scores" | "Picked because every frontier lab (Anthropic, OpenAI, Google) reports SWE-bench Verified scores" |
| `fastmcp` | "The fastest way ... 25K stars and growing rapidly. Becoming the de facto framework" | "25K GitHub stars." |

The claim survives wherever it was real. It's now the kind a reader can check.

## What deliberately did NOT change

**A ranking with a measure attached is a fact, not a boast.** `nextchat` says "~88k GitHub stars makes it the single most-starred OSS chat UI repo **by raw count**"; `opik` says "second most-starred ... **after Langfuse**". Both name the measure, so both stay — along with `milvus`'s star ranking and `lobe-chat`. Banning the word "most" would have deleted all four.

**`amazon-nova` was a false positive.** The first scan flagged it for "premier", which appears in *"No 'Nova 2 Premier' exists as of May 2026"* — a product name. The new test's docstring warns the next person to read the match in context before fixing it.

## The separate find

**`dify` had no description at all.** 152K GitHub stars, on the map, and the field held `"Active 2026; ~144K GitHub stars"` — copied verbatim from `comments`. Written properly from a GitHub API read, with the star count refreshed 144K → 152K and the read date recorded.

It surfaced only because the new guard checks for thin descriptions, not just bad ones.

## Tests

`tests/test_product_prose.py`, three checks:

1. no unverifiable marketing claim in any description
2. no description under 40 characters — the empty-field case check 1 passes trivially, and how `dify` surfaced
3. a non-zero count guard on the corpus walk, because two walks in this repo's history silently narrowed and passed green, one while inspecting nothing at all

## Test plan

- `pytest` — **464 passed**
- `validate`, `check_recipe`, `check_rubric`, `check_components`, `check_routing`, `check_capability`, `check_verification`, `check_retirement` — all green
- No score, class, or published number moved; this touches `sources/products/` prose only
- Generated files not committed (bot-owned)