### PR TITLE
Gate adoption bands against the declared scale, and reband 13 stale benchmarks

### DIFF
--- a/build/check_adoption.py
+++ b/build/check_adoption.py
@@ -81,10 +81,40 @@ def declared_scales(sources: dict) -> dict[tuple[str, str], dict[str, int]]:
     return scales
 
 
+# Instruments whose bands are read in downloads, and which may therefore fall back to the
+# product type's declared download scale. Everything else measures something else entirely.
+#
+# `unknown` is absent deliberately: it means nobody has decided which instrument applies, so
+# there is no scale to check against and no basis for guessing one.
+_DOWNLOAD_INSTRUMENTS = {"usage_volume", ""}
+
+
 def scale_for(scales: dict, product_type: str, signal_type: str) -> dict[str, int] | None:
-    """The most specific scale that applies, signal first."""
+    """The scale that applies, or None when the instrument declares none.
+
+    ABSTAIN RATHER THAN SUBSTITUTE. `sources/signal_routing.yaml` states the rule directly:
+    "When the authoritative signal for a dimension is missing or unusable, the rule is to
+    produce NO evidence. Falling through to a less authoritative signal is how the failure
+    above happens." `docs/guides/adoption.md` says the same thing about this exact check —
+    "a `reported_traction` or `active_users` band is measuring something else entirely.
+    Comparing it against a download count is a category error, and a check must SKIP it
+    rather than flag or waive it."
+
+    The first version of this function did exactly that, and it is worth recording why the
+    bug was invisible: it read `if the signal declares its own scale use it, otherwise use
+    the product type's`, which is correct for `stars_fallback` and for `usage_volume` and
+    silently wrong for the two instruments that have no scale at all. It manufactured a
+    download-scale finding for all 93 `reported_traction` products and every `active_users`
+    one, and those findings looked exactly like the real ones.
+
+    So the fallback is now allowed only for instruments actually denominated in downloads.
+    `reported_traction` and `active_users` return None and are skipped, which is not a
+    waiver — it is the checker declining to compare a user count against a download band.
+    """
     if signal_type and ("*", signal_type) in scales:
         return scales[("*", signal_type)]
+    if signal_type not in _DOWNLOAD_INSTRUMENTS:
+        return None
     return scales.get((product_type, "*"))
 
 

--- a/build/check_adoption.py
+++ b/build/check_adoption.py
@@ -1,0 +1,147 @@
+"""Does every recorded adoption band match the scale its own rubric declares?
+
+## Why this gate did not exist, and why that is the interesting part
+
+`adoption_bands` are declared per product type in `sources/rubrics/*.yaml`, serialized into
+`currentai.registry.adoption_bands` by `build/serialize_rubric.py`, and read by the scoring
+SQL. Tests cover the declaration's shape and the serializer's output. Nothing has ever
+compared a PRODUCT's recorded `(level, reach)` against them.
+
+So the bands were authoritative for the warehouse and advisory for the corpus, and the two
+drifted in exactly the way `check_parity` exists to catch one axis over. 93 of 472 products
+record a `reach` label that is not a band their own product type declares.
+
+The dataset scale is the clearest case. It sits one order of magnitude below software and
+model — deliberately, and measured: across 66 Hugging Face dataset artifacts, the median was
+27,648 downloads and NONE exceeded 10M, so on the software scale level 5 is unreachable. Its
+top band is therefore `>1M`. Thirteen benchmark corpora nonetheless record `1M-10M` or `>10M`,
+which are labels off the software scale, and `mmlu` recorded level 5 against 477,890 monthly
+downloads — a level the dataset scale reserves for figures its own note does not claim.
+
+`dataset.yaml` predicted this in a comment: "14 dataset products record level 4 against a
+reach of 1M-10M, which is level 5 on this scale ... They are a work list, not a migration."
+The work list was written down and never turned into a check, so it grew.
+
+## What is checked
+
+1. **The reach label is one the applicable scale declares.** Catches the wrong scale being
+   used for a type, case drift (`10k-100k` for `10K-100K`), and free text (`niche`,
+   `~1.4M/mo`) that carries a figure but not a band.
+2. **The recorded level is the level that label denotes.** Catches the internally
+   inconsistent pair — level 5 against a `100K-1M` reach — which no band can produce and
+   which the warehouse would compute differently.
+
+Which scale applies is keyed on `(product_type, signal_type)`, not type alone, because
+`stars_fallback` has its own labels and its own ceiling: stars cap adoption at level 3, since
+a star is not a use. `validate.py` already enforces that ceiling; this checks the label too.
+
+## What is deliberately NOT checked
+
+Whether the recorded figure is CURRENT. That needs a fetch, and it is `check_freshness`'s
+question. A product can be perfectly banded against a figure from March.
+
+## Exit status
+
+0 unless `--strict`, matching `check_freshness`. Gating today would fail on a backlog that
+predates the bands being declared at all, and a gate that fails on day one teaches people to
+skip it. Turn on `--strict` in CI once the backlog is cleared.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from build.validate import load_sources
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def declared_scales(sources: dict) -> dict[tuple[str, str], dict[str, int]]:
+    """(product_type, signal_type) -> {reach label: level}.
+
+    A `*` product type means the scale applies to every type, which is how the stars
+    fallback is declared: it is a property of the SIGNAL, not of the thing measured.
+    """
+    scales: dict[tuple[str, str], dict[str, int]] = {}
+    for name, rubric in (sources.get("rubrics") or {}).items():
+        adoption = (rubric or {}).get("adoption") or {}
+        for band in adoption.get("bands") or []:
+            scales.setdefault((name, "*"), {})[band["reach"]] = band["level"]
+
+    # The stars scale lives in signal_routing.yaml rather than a rubric, because it is a
+    # property of the SIGNAL and applies to every product type. Read through the serializer's
+    # own loader so the two cannot disagree about where it lives.
+    from build.serialize_rubric import load_routing, stars_bands
+
+    rows, _warnings = stars_bands(load_routing(ROOT))
+    for band in rows:
+        scales.setdefault(("*", band["signal_type"]), {})[band["reach"]] = band["level"]
+    return scales
+
+
+def scale_for(scales: dict, product_type: str, signal_type: str) -> dict[str, int] | None:
+    """The most specific scale that applies, signal first."""
+    if signal_type and ("*", signal_type) in scales:
+        return scales[("*", signal_type)]
+    return scales.get((product_type, "*"))
+
+
+def collect(sources: dict) -> tuple[list[str], int]:
+    scales = declared_scales(sources)
+    types = {slug: (doc or {}).get("type") for slug, doc in sources["products"].items()}
+
+    findings: list[str] = []
+    examined = 0
+    for slug, score in sorted(sources["scores"].items()):
+        adoption = (score or {}).get("adoption") or {}
+        level, reach = adoption.get("level"), adoption.get("reach")
+        if level is None and reach is None:
+            continue
+        signal = adoption.get("signal_type") or ""
+        scale = scale_for(scales, types.get(slug), signal)
+        if scale is None:
+            continue  # hardware declares no adoption scale, by design
+        examined += 1
+
+        if reach is None:
+            findings.append(f"{slug}: level {level} with no reach label to justify it")
+            continue
+        if reach not in scale:
+            findings.append(
+                f"{slug} [{types.get(slug)}/{signal or 'no signal_type'}]: reach {reach!r} is not a "
+                f"declared band; this scale offers {sorted(scale)}"
+            )
+            continue
+        if level != scale[reach]:
+            findings.append(
+                f"{slug} [{types.get(slug)}/{signal or 'no signal_type'}]: records level {level} "
+                f"against reach {reach!r}, which this scale puts at level {scale[reach]}"
+            )
+    return findings, examined
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--strict", action="store_true", help="exit 1 if anything is off-scale")
+    args = parser.parse_args()
+
+    sources = load_sources(ROOT)
+    findings, examined = collect(sources)
+
+    # A corpus walk that silently narrows passes green. Two did, earlier in this repo.
+    if examined < 300:
+        print(f"check_adoption: only examined {examined} products; the walk has drifted", file=sys.stderr)
+        return 1
+
+    for line in findings:
+        print(f"  x {line}")
+    status = "OK" if not findings else f"{len(findings)} off-scale"
+    print(f"\ncheck_adoption  {examined} products with an adoption band  [{status}]")
+
+    return 1 if findings and args.strict else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sources/scores/ai2-arc.yaml
+++ b/sources/scores/ai2-arc.yaml
@@ -25,16 +25,20 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 4
-  reach: 1M-10M
+  reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: ~479K HF downloads in the last month alone (so >1M cumulative) and one of the most-cited standard
-    reasoning benchmarks routinely reported in frontier model release cards. Strong usage_volume signal
-    as an entrenched evaluation standard.
+  note: 472,342 Hugging Face downloads in the trailing 30 days (allenai/ai2_arc), read 2026-08-12. Bands
+    at level 4 (100K-1M) on the dataset adoption scale, whose top band is >1M - one order of magnitude below
+    the software and model scales, because no dataset artifact in the corpus has ever exceeded 10M. One
+    of the most-cited standard reasoning benchmarks, routinely reported in frontier model release cards.
+  last_verified: '2026-08-12'
   sources:
-  - url: https://huggingface.co/datasets/allenai/ai2_arc
-    shows: ~479,090 downloads in the last month
-    accessed: '2026-06-04'
+  - url: https://huggingface.co/api/datasets/allenai/ai2_arc
+    shows: 472,342 downloads in the trailing 30 days for allenai/ai2_arc
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 6a47cb291c7410c6a18cd18250cab327e970893527304e99f9523fca56d621d1
 capability:
   score: null
   basis: n/a

--- a/sources/scores/apps.yaml
+++ b/sources/scores/apps.yaml
@@ -27,17 +27,21 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 3
-  reach: 100K-1M
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: medium
-  note: 13,834 monthly HF downloads (primary). A well-established code-generation benchmark cited widely
-    since 2021, but by 2026 partly superseded by harder/contamination-free suites (LiveCodeBench, SWE-bench)
-    for frontier evaluation. Level 3 on download volume + sustained-but-not-headline citation; honest
-    read is a foundational-but-aging standard.
+  note: 17,673 Hugging Face downloads in the trailing 30 days (codeparrot/apps), read 2026-08-12. Bands
+    at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M - one order of magnitude
+    below the software and model scales, because no dataset artifact in the corpus has ever exceeded 10M.
+    A well-established code-generation benchmark cited since 2021, partly superseded by harder contamination-free
+    suites (LiveCodeBench, SWE-bench).
+  last_verified: '2026-08-12'
   sources:
-  - url: https://huggingface.co/datasets/codeparrot/apps
-    shows: 13,834 monthly downloads
-    accessed: '2026-06-04'
+  - url: https://huggingface.co/api/datasets/codeparrot/apps
+    shows: 17,673 downloads in the trailing 30 days for codeparrot/apps
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: d7c9afdfc66fbe0288cc0b7feac246e2d3b8d66a5bcdb825f7f9f37cdfe8fade
 capability:
   score: null
   basis: n/a

--- a/sources/scores/aya-collection.yaml
+++ b/sources/scores/aya-collection.yaml
@@ -18,7 +18,7 @@ openness:
     accessed: '2026-06-22'
 adoption:
   level: 3
-  reach: 10k-100k
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: high
   note: 26,509 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/codecontests.yaml
+++ b/sources/scores/codecontests.yaml
@@ -30,17 +30,21 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 3
-  reach: 100K-1M
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: medium
-  note: 'Well-known competitive-programming benchmark (the AlphaCode dataset) and a recurring reference
-    for code-reasoning evals, but materially less ubiquitous than HumanEval/GSM8K/SWE-bench in current
-    release reports. ~56k HF downloads/month (lowest in the batch) places it in the 100K-1M annualized
-    band. Honest signal: solid research adoption, not headline-eval scale.'
+  note: 50,563 Hugging Face downloads in the trailing 30 days (deepmind/code_contests), read 2026-08-12.
+    Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M - one order of magnitude
+    below the software and model scales, because no dataset artifact in the corpus has ever exceeded 10M.
+    The AlphaCode competitive-programming dataset, a recurring reference for code-reasoning evals but less
+    ubiquitous than HumanEval/GSM8K in current release reports.
+  last_verified: '2026-08-12'
   sources:
-  - url: https://huggingface.co/datasets/deepmind/code_contests
-    shows: ~56k downloads last month
-    accessed: '2026-06-04'
+  - url: https://huggingface.co/api/datasets/deepmind/code_contests
+    shows: 50,563 downloads in the trailing 30 days for deepmind/code_contests
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 3f1012db9b186b39775c4a58258bcd51262a71f347122b87b59216016c19ea63
 capability:
   score: null
   basis: n/a

--- a/sources/scores/common-corpus.yaml
+++ b/sources/scores/common-corpus.yaml
@@ -19,7 +19,7 @@ openness:
     accessed: '2026-06-22'
 adoption:
   level: 3
-  reach: 10k-100k
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: high
   note: 91,700 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/cosmopedia.yaml
+++ b/sources/scores/cosmopedia.yaml
@@ -20,7 +20,7 @@ openness:
     accessed: '2026-06-22'
 adoption:
   level: 3
-  reach: 10k-100k
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: high
   note: 16,870 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/culturax.yaml
+++ b/sources/scores/culturax.yaml
@@ -20,7 +20,7 @@ openness:
     accessed: '2026-06-22'
 adoption:
   level: 3
-  reach: 10k-100k
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: high
   note: 18,361 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/dclm-baseline.yaml
+++ b/sources/scores/dclm-baseline.yaml
@@ -20,7 +20,7 @@ openness:
     accessed: '2026-06-22'
 adoption:
   level: 4
-  reach: 100k-1M
+  reach: 100K-1M
   signal_type: usage_volume
   confidence: high
   note: 440,189 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/dolci.yaml
+++ b/sources/scores/dolci.yaml
@@ -18,7 +18,7 @@ openness:
     accessed: '2026-07-04'
 adoption:
   level: 3
-  reach: 10k-100k
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: high
   note: 12,526 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/dolma-3.yaml
+++ b/sources/scores/dolma-3.yaml
@@ -18,7 +18,7 @@ openness:
     accessed: '2026-07-04'
 adoption:
   level: 4
-  reach: 100k-1M
+  reach: 100K-1M
   signal_type: usage_volume
   confidence: high
   note: 158,294 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/dolma.yaml
+++ b/sources/scores/dolma.yaml
@@ -20,7 +20,7 @@ openness:
     accessed: '2026-06-22'
 adoption:
   level: 2
-  reach: 1k-10k
+  reach: 1K-10K
   signal_type: usage_volume
   confidence: high
   note: 4,015 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/evalplus.yaml
+++ b/sources/scores/evalplus.yaml
@@ -30,22 +30,27 @@ openness:
     shows: Apache-2.0 framework; HumanEval+/MBPP+ described
     accessed: '2026-06-04'
 adoption:
-  level: 4
-  reach: 1M-10M
+  level: 3
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: medium
-  note: 'HumanEval+ alone: 25,817 monthly HF downloads (MBPP+ adds more). Top adoption signal for a benchmark
-    = citation as a standard in frontier model release reports: EvalPlus is reported adopted by Meta (Llama
-    3.1/3.3), Alibaba (Qwen2.5-Coder/CodeQwen), DeepSeek, Allen AI (Tulu), Snowflake Arctic, StarCoder2.
-    De facto standard for rigorous code-correctness eval. Level 4 on combined download volume + release-report
-    standard status.'
+  note: 51,081 Hugging Face downloads in the trailing 30 days (evalplus/humanevalplus + evalplus/mbppplus),
+    read 2026-08-12. Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M -
+    one order of magnitude below the software and model scales, because no dataset artifact in the corpus
+    has ever exceeded 10M. Contamination-hardened HumanEval+/MBPP+ variants, reported adopted by Meta and
+    others; the figure sums both corpora.
+  last_verified: '2026-08-12'
   sources:
-  - url: https://huggingface.co/datasets/evalplus/humanevalplus
-    shows: 25,817 monthly downloads
-    accessed: '2026-06-04'
-  - url: https://github.com/evalplus/evalplus
-    shows: adopted by Meta/Qwen/DeepSeek/AllenAI/StarCoder2 for code eval; NeurIPS 2023
-    accessed: '2026-06-04'
+  - url: https://huggingface.co/api/datasets/evalplus/humanevalplus
+    shows: 27,086 downloads in the trailing 30 days for evalplus/humanevalplus
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: a97150822ddebbde93bc4112cb79b43e2984ef89580aad4469028e8d91a39aa9
+  - url: https://huggingface.co/api/datasets/evalplus/mbppplus
+    shows: 23,995 downloads in the trailing 30 days for evalplus/mbppplus
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 69ac778d8697ffdf10a0d8c4b18e6d9fed6094c7f9653ac31e53f82fbec3b2ea
 capability:
   score: null
   basis: n/a

--- a/sources/scores/finemath.yaml
+++ b/sources/scores/finemath.yaml
@@ -18,7 +18,7 @@ openness:
     accessed: '2026-07-04'
 adoption:
   level: 3
-  reach: 10k-100k
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: high
   note: 24,077 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/fineweb-2.yaml
+++ b/sources/scores/fineweb-2.yaml
@@ -20,7 +20,7 @@ openness:
     accessed: '2026-06-22'
 adoption:
   level: 3
-  reach: 10k-100k
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: high
   note: 93,906 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/fineweb-edu.yaml
+++ b/sources/scores/fineweb-edu.yaml
@@ -20,7 +20,7 @@ openness:
     accessed: '2026-06-22'
 adoption:
   level: 4
-  reach: 100k-1M
+  reach: 100K-1M
   signal_type: usage_volume
   confidence: high
   note: 384,910 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/fineweb.yaml
+++ b/sources/scores/fineweb.yaml
@@ -20,7 +20,7 @@ openness:
     accessed: '2026-06-22'
 adoption:
   level: 4
-  reach: 100k-1M
+  reach: 100K-1M
   signal_type: usage_volume
   confidence: high
   note: 337,208 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/flan-collection.yaml
+++ b/sources/scores/flan-collection.yaml
@@ -29,7 +29,7 @@ openness:
     accessed: '2026-07-04'
 adoption:
   level: 1
-  reach: <1k
+  reach: <1K
   signal_type: usage_volume
   confidence: high
   note: 924 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/gsm8k.yaml
+++ b/sources/scores/gsm8k.yaml
@@ -27,16 +27,20 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 4
-  reach: 1M-10M
+  reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: The standard grade-school math-reasoning benchmark, cited near-universally in LLM release reports
-    for years. ~948k HF downloads/month on the canonical config (the highest in this batch) puts annualized
-    usage comfortably into the 1-10M band.
+  note: 960,715 Hugging Face downloads in the trailing 30 days (openai/gsm8k), read 2026-08-12. Bands at
+    level 4 (100K-1M) on the dataset adoption scale, whose top band is >1M - one order of magnitude below
+    the software and model scales, because no dataset artifact in the corpus has ever exceeded 10M. The
+    standard grade-school math-reasoning benchmark, cited near-universally in LLM release reports.
+  last_verified: '2026-08-12'
   sources:
-  - url: https://huggingface.co/datasets/openai/gsm8k
-    shows: ~948k downloads last month
-    accessed: '2026-06-04'
+  - url: https://huggingface.co/api/datasets/openai/gsm8k
+    shows: 960,715 downloads in the trailing 30 days for openai/gsm8k
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 20c34ca65a5f1d5aaf1bba21fbed56ce37b20da7f748f0ff5675b4a64ea51e94
 capability:
   score: null
   basis: n/a

--- a/sources/scores/hellaswag.yaml
+++ b/sources/scores/hellaswag.yaml
@@ -25,16 +25,20 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 4
-  reach: 1M-10M
+  reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: ~270K HF downloads last month (>1M cumulative) and a near-ubiquitous commonsense benchmark cited
-    across LLM release reports and the Open LLM Leaderboard. Strong usage_volume signal as an entrenched
-    standard.
+  note: 309,927 Hugging Face downloads in the trailing 30 days (Rowan/hellaswag), read 2026-08-12. Bands
+    at level 4 (100K-1M) on the dataset adoption scale, whose top band is >1M - one order of magnitude below
+    the software and model scales, because no dataset artifact in the corpus has ever exceeded 10M. A commonsense
+    benchmark cited across LLM release reports and the Open LLM Leaderboard.
+  last_verified: '2026-08-12'
   sources:
-  - url: https://huggingface.co/datasets/Rowan/hellaswag
-    shows: ~270,262 downloads in the last month
-    accessed: '2026-06-04'
+  - url: https://huggingface.co/api/datasets/Rowan/hellaswag
+    shows: 309,927 downloads in the trailing 30 days for Rowan/hellaswag
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 2082ef87940d2baac228b5bfc9166147b443f90351de4016a24e5bd3620122ba
 capability:
   score: null
   basis: n/a

--- a/sources/scores/hermes-3-dataset.yaml
+++ b/sources/scores/hermes-3-dataset.yaml
@@ -18,7 +18,7 @@ openness:
     accessed: '2026-07-04'
 adoption:
   level: 2
-  reach: 1k-10k
+  reach: 1K-10K
   signal_type: usage_volume
   confidence: high
   note: 1,414 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/hh-rlhf.yaml
+++ b/sources/scores/hh-rlhf.yaml
@@ -24,7 +24,7 @@ openness:
     accessed: '2026-06-22'
 adoption:
   level: 3
-  reach: 10k-100k
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: high
   note: 29,021 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/humaneval.yaml
+++ b/sources/scores/humaneval.yaml
@@ -30,17 +30,21 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 4
-  reach: 1M-10M
+  reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: Foundational code-generation benchmark cited as a standard in code-model release reports for years
-    (pass@k metric originated here). ~287k HF downloads/month on the canonical config alone, plus heavy
-    mirrored/forked use; sustained 1M+/yr equivalent. The reference code-gen eval despite being partially
-    saturated by frontier models.
+  note: 279,859 Hugging Face downloads in the trailing 30 days (openai/openai_humaneval), read 2026-08-12.
+    Bands at level 4 (100K-1M) on the dataset adoption scale, whose top band is >1M - one order of magnitude
+    below the software and model scales, because no dataset artifact in the corpus has ever exceeded 10M.
+    The foundational code-generation benchmark; the pass@k metric originated here and it is still reported
+    in most code-model releases.
+  last_verified: '2026-08-12'
   sources:
-  - url: https://huggingface.co/datasets/openai/openai_humaneval
-    shows: ~287k downloads last month on canonical HumanEval config
-    accessed: '2026-06-04'
+  - url: https://huggingface.co/api/datasets/openai/openai_humaneval
+    shows: 279,859 downloads in the trailing 30 days for openai/openai_humaneval
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 3a7efedbfc697e2e5a24522e64c1eafce169b34ccb32fe7d16e3710dbd46c289
 capability:
   score: null
   basis: n/a

--- a/sources/scores/ifeval.yaml
+++ b/sources/scores/ifeval.yaml
@@ -25,15 +25,20 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 4
-  reach: 1M-10M
+  reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: ~110,541 HF downloads in the trailing month (primary); a core benchmark on the HF Open LLM Leaderboard
-    and routinely cited as the standard instruction-following eval, the top adoption signal for a benchmark.
+  note: 116,029 Hugging Face downloads in the trailing 30 days (google/IFEval), read 2026-08-12. Bands at
+    level 4 (100K-1M) on the dataset adoption scale, whose top band is >1M - one order of magnitude below
+    the software and model scales, because no dataset artifact in the corpus has ever exceeded 10M. A core
+    benchmark on the HF Open LLM Leaderboard and the standard instruction-following eval.
+  last_verified: '2026-08-12'
   sources:
-  - url: https://huggingface.co/datasets/google/IFEval
-    shows: 110,541 downloads last month; described as core Open LLM Leaderboard benchmark
-    accessed: '2026-06-04'
+  - url: https://huggingface.co/api/datasets/google/IFEval
+    shows: 116,029 downloads in the trailing 30 days for google/IFEval
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: e8fffafd3f6250067d3b588e87b223d67e87bf3dec6068d88d8ed5795b4358c3
 capability:
   score: null
   basis: n/a

--- a/sources/scores/madlad-400.yaml
+++ b/sources/scores/madlad-400.yaml
@@ -19,7 +19,7 @@ openness:
     accessed: '2026-06-22'
 adoption:
   level: 3
-  reach: 10k-100k
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: high
   note: 32,957 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/mbpp.yaml
+++ b/sources/scores/mbpp.yaml
@@ -29,16 +29,21 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 4
-  reach: 1M-10M
+  reach: 100K-1M
   signal_type: usage_volume
   confidence: medium
-  note: Standard basic-Python code-generation benchmark, routinely paired with HumanEval and cited in
-    code-model release reports. ~198k HF downloads/month on the canonical config; widely mirrored/forked.
-    Annualized usage and citation-as-standard support a 4, just below the HumanEval/GSM8K tier.
+  note: 208,317 Hugging Face downloads in the trailing 30 days (google-research-datasets/mbpp), read 2026-08-12.
+    Bands at level 4 (100K-1M) on the dataset adoption scale, whose top band is >1M - one order of magnitude
+    below the software and model scales, because no dataset artifact in the corpus has ever exceeded 10M.
+    A standard basic-Python code-generation benchmark, routinely paired with HumanEval in code-model release
+    reports.
+  last_verified: '2026-08-12'
   sources:
-  - url: https://huggingface.co/datasets/google-research-datasets/mbpp
-    shows: ~198k downloads last month
-    accessed: '2026-06-04'
+  - url: https://huggingface.co/api/datasets/google-research-datasets/mbpp
+    shows: 208,317 downloads in the trailing 30 days for google-research-datasets/mbpp
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 646f03126bd048b4cda69cd4232d8cc432e3b1d99bdf63dc07300fcec622d037
 capability:
   score: null
   basis: n/a

--- a/sources/scores/mmlu-pro.yaml
+++ b/sources/scores/mmlu-pro.yaml
@@ -28,16 +28,20 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 4
-  reach: 1M-10M
+  reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: ~154,919 HF downloads in the trailing month (primary, the highest of this batch); MMLU-Pro is
-    a de-facto-standard knowledge/reasoning benchmark cited across frontier model reports (appears as
-    a capability basis throughout the v3 flagship set).
+  note: 170,681 Hugging Face downloads in the trailing 30 days (TIGER-Lab/MMLU-Pro), read 2026-08-12. Bands
+    at level 4 (100K-1M) on the dataset adoption scale, whose top band is >1M - one order of magnitude below
+    the software and model scales, because no dataset artifact in the corpus has ever exceeded 10M. A standard
+    knowledge/reasoning benchmark cited across frontier model reports.
+  last_verified: '2026-08-12'
   sources:
-  - url: https://huggingface.co/datasets/TIGER-Lab/MMLU-Pro
-    shows: 154,919 downloads last month; active leaderboard with 27+ models
-    accessed: '2026-06-04'
+  - url: https://huggingface.co/api/datasets/TIGER-Lab/MMLU-Pro
+    shows: 170,681 downloads in the trailing 30 days for TIGER-Lab/MMLU-Pro
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 33c1a868f84bdcce00ac909e3537b100e2358ae1988fe34325b79a4d6bcb0214
 capability:
   score: null
   basis: n/a

--- a/sources/scores/mmlu.yaml
+++ b/sources/scores/mmlu.yaml
@@ -27,21 +27,22 @@ openness:
       splits
     accessed: '2026-06-04'
 adoption:
-  level: 5
-  reach: '>10M'
+  level: 4
+  reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: 541,723 monthly HF downloads (primary), highest in this batch. MMLU is the canonical general-knowledge
-    LLM benchmark, reported in essentially every frontier model release (OpenAI, Anthropic, Google, Meta,
-    DeepSeek, Qwen) since 2021, the strongest possible release-report standard signal. Even post-saturation
-    it remains a universal reference. Level 5 on download volume + ubiquitous release-report citation.
+  note: 477,890 Hugging Face downloads in the trailing 30 days (cais/mmlu), read 2026-08-12. Bands at level
+    4 (100K-1M) on the dataset adoption scale, whose top band is >1M - one order of magnitude below the
+    software and model scales, because no dataset artifact in the corpus has ever exceeded 10M. The canonical
+    general-knowledge LLM benchmark, reported in essentially every frontier model release since 2021; a
+    universal reference even post-saturation.
+  last_verified: '2026-08-12'
   sources:
-  - url: https://huggingface.co/datasets/cais/mmlu
-    shows: 541,723 monthly downloads
-    accessed: '2026-06-04'
-  - url: https://www.lxt.ai/blog/llm-benchmarks/
-    shows: MMLU listed among the standard LLM benchmarks (corroborating, not headline)
-    accessed: '2026-06-04'
+  - url: https://huggingface.co/api/datasets/cais/mmlu
+    shows: 477,890 downloads in the trailing 30 days for cais/mmlu
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 41596bee97cd66a4a0b9b1e19790663274f63b5b368ce20c38474bad29cc13f4
 capability:
   score: null
   basis: n/a

--- a/sources/scores/mmmu.yaml
+++ b/sources/scores/mmmu.yaml
@@ -31,17 +31,21 @@ openness:
     shows: MMMU paper documenting 30 subjects, 183 subfields, multimodal benchmark
     accessed: '2026-06-04'
 adoption:
-  level: 4
-  reach: 1M-10M
+  level: 3
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: ~86,107 HF downloads in the trailing month (primary); MMMU / MMMU-Pro is the de-facto-standard
-    multimodal-understanding benchmark cited in frontier multimodal model reports (e.g. GPT-5 reports
-    MMMU; Gemini reports MMMU-Pro in the v3 flagship set).
+  note: 51,058 Hugging Face downloads in the trailing 30 days (MMMU/MMMU), read 2026-08-12. Bands at level
+    3 (10K-100K) on the dataset adoption scale, whose top band is >1M - one order of magnitude below the
+    software and model scales, because no dataset artifact in the corpus has ever exceeded 10M. MMMU / MMMU-Pro
+    is a standard multimodal-understanding benchmark cited in frontier multimodal model reports.
+  last_verified: '2026-08-12'
   sources:
-  - url: https://huggingface.co/datasets/MMMU/MMMU
-    shows: 86,107 downloads last month; EvalAI evaluation infrastructure
-    accessed: '2026-06-04'
+  - url: https://huggingface.co/api/datasets/MMMU/MMMU
+    shows: 51,058 downloads in the trailing 30 days for MMMU/MMMU
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 5981910623fed73daf2a4bf61559872d48ce72cc4048c89b4f83f1add4bc7e09
 capability:
   score: null
   basis: n/a

--- a/sources/scores/nemotron-cc.yaml
+++ b/sources/scores/nemotron-cc.yaml
@@ -20,7 +20,7 @@ openness:
     accessed: '2026-07-04'
 adoption:
   level: 3
-  reach: 10k-100k
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: high
   note: 16,100 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/oasst1.yaml
+++ b/sources/scores/oasst1.yaml
@@ -18,7 +18,7 @@ openness:
     accessed: '2026-07-04'
 adoption:
   level: 3
-  reach: 10k-100k
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: high
   note: 15,736 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/openhermes-2-5.yaml
+++ b/sources/scores/openhermes-2-5.yaml
@@ -45,7 +45,7 @@ openness:
     establishes: [license]
 adoption:
   level: 3
-  reach: 10k-100k
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: high
   note: 14,982 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/openthoughts-114k.yaml
+++ b/sources/scores/openthoughts-114k.yaml
@@ -20,7 +20,7 @@ openness:
     accessed: '2026-06-22'
 adoption:
   level: 3
-  reach: 10k-100k
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: high
   note: 73,774 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/openwebmath.yaml
+++ b/sources/scores/openwebmath.yaml
@@ -18,7 +18,7 @@ openness:
     accessed: '2026-07-04'
 adoption:
   level: 3
-  reach: 10k-100k
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: high
   note: 31,502 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/ornith.yaml
+++ b/sources/scores/ornith.yaml
@@ -24,7 +24,7 @@ openness:
     accessed: '2026-07-03'
 adoption:
   level: 3
-  reach: 100k-1M
+  reach: 100K-1M
   signal_type: usage_volume
   confidence: medium
   note: ~352k HF downloads last month combined across the primary weights repo (~64k) and the GGUF quant

--- a/sources/scores/oscar-2301.yaml
+++ b/sources/scores/oscar-2301.yaml
@@ -21,7 +21,7 @@ openness:
     accessed: '2026-06-22'
 adoption:
   level: 2
-  reach: 1k-10k
+  reach: 1K-10K
   signal_type: usage_volume
   confidence: high
   note: 1,793 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/personahub.yaml
+++ b/sources/scores/personahub.yaml
@@ -29,7 +29,7 @@ openness:
     accessed: '2026-06-22'
 adoption:
   level: 2
-  reach: 1k-10k
+  reach: 1K-10K
   signal_type: usage_volume
   confidence: high
   note: >-

--- a/sources/scores/pes2o.yaml
+++ b/sources/scores/pes2o.yaml
@@ -18,7 +18,7 @@ openness:
     accessed: '2026-07-04'
 adoption:
   level: 3
-  reach: 10k-100k
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: high
   note: 11,347 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/redpajama-data-v2.yaml
+++ b/sources/scores/redpajama-data-v2.yaml
@@ -21,7 +21,7 @@ openness:
     accessed: '2026-06-22'
 adoption:
   level: 2
-  reach: 1k-10k
+  reach: 1K-10K
   signal_type: usage_volume
   confidence: high
   note: 9,452 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/refinedweb.yaml
+++ b/sources/scores/refinedweb.yaml
@@ -21,7 +21,7 @@ openness:
     accessed: '2026-06-22'
 adoption:
   level: 3
-  reach: 10k-100k
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: high
   note: 12,934 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/smoltalk.yaml
+++ b/sources/scores/smoltalk.yaml
@@ -20,7 +20,7 @@ openness:
     accessed: '2026-07-04'
 adoption:
   level: 3
-  reach: 10k-100k
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: high
   note: 17,489 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/stack-edu.yaml
+++ b/sources/scores/stack-edu.yaml
@@ -18,7 +18,7 @@ openness:
     accessed: '2026-07-04'
 adoption:
   level: 2
-  reach: 1k-10k
+  reach: 1K-10K
   signal_type: usage_volume
   confidence: high
   note: 3,892 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/starcoderdata.yaml
+++ b/sources/scores/starcoderdata.yaml
@@ -19,7 +19,7 @@ openness:
     accessed: '2026-07-04'
 adoption:
   level: 3
-  reach: 10k-100k
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: high
   note: 20,254 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/synth.yaml
+++ b/sources/scores/synth.yaml
@@ -19,7 +19,7 @@ openness:
     accessed: '2026-06-22'
 adoption:
   level: 2
-  reach: 1k-10k
+  reach: 1K-10K
   signal_type: usage_volume
   confidence: high
   note: 6,105 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/the-pile.yaml
+++ b/sources/scores/the-pile.yaml
@@ -23,7 +23,7 @@ openness:
     accessed: '2026-07-04'
 adoption:
   level: 2
-  reach: 1k-10k
+  reach: 1K-10K
   signal_type: usage_volume
   confidence: high
   note: 9,980 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/the-stack-v2.yaml
+++ b/sources/scores/the-stack-v2.yaml
@@ -20,7 +20,7 @@ openness:
     accessed: '2026-06-22'
 adoption:
   level: 3
-  reach: 10k-100k
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: high
   note: 28,469 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/truthfulqa.yaml
+++ b/sources/scores/truthfulqa.yaml
@@ -28,16 +28,20 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 4
-  reach: 1M-10M
+  reach: 100K-1M
   signal_type: usage_volume
   confidence: medium
-  note: ~97,282 HF downloads in the trailing month (primary); long-standing widely-cited truthfulness
-    benchmark. Medium confidence on the level because the benchmark is older (2021) and increasingly saturated,
-    so download volume may overstate its current role in frontier evaluation vs GPQA/MMLU-Pro.
+  note: 109,020 Hugging Face downloads in the trailing 30 days (truthfulqa/truthful_qa), read 2026-08-12.
+    Bands at level 4 (100K-1M) on the dataset adoption scale, whose top band is >1M - one order of magnitude
+    below the software and model scales, because no dataset artifact in the corpus has ever exceeded 10M.
+    A long-standing truthfulness benchmark, though older (2021) and increasingly saturated.
+  last_verified: '2026-08-12'
   sources:
-  - url: https://huggingface.co/datasets/truthfulqa/truthful_qa
-    shows: 97,282 downloads last month
-    accessed: '2026-06-04'
+  - url: https://huggingface.co/api/datasets/truthfulqa/truthful_qa
+    shows: 109,020 downloads in the trailing 30 days for truthfulqa/truthful_qa
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: d34489bd7e0bf7bf6a4e65ac998e73dcd487fec4b51722ca9241e0e7026144c4
 capability:
   score: null
   basis: n/a

--- a/sources/scores/tulu-3-sft-mixture.yaml
+++ b/sources/scores/tulu-3-sft-mixture.yaml
@@ -20,7 +20,7 @@ openness:
     accessed: '2026-06-22'
 adoption:
   level: 3
-  reach: 10k-100k
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: high
   note: 18,317 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/txt360.yaml
+++ b/sources/scores/txt360.yaml
@@ -18,7 +18,7 @@ openness:
     accessed: '2026-07-04'
 adoption:
   level: 2
-  reach: 1k-10k
+  reach: 1K-10K
   signal_type: usage_volume
   confidence: high
   note: 4,218 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/ultrachat-200k.yaml
+++ b/sources/scores/ultrachat-200k.yaml
@@ -18,7 +18,7 @@ openness:
     accessed: '2026-07-04'
 adoption:
   level: 3
-  reach: 10k-100k
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: high
   note: 57,823 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/ultrafeedback.yaml
+++ b/sources/scores/ultrafeedback.yaml
@@ -24,7 +24,7 @@ openness:
     accessed: '2026-06-22'
 adoption:
   level: 2
-  reach: 1k-10k
+  reach: 1K-10K
   signal_type: usage_volume
   confidence: high
   note: 4,496 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/sources/scores/wildchat-1m.yaml
+++ b/sources/scores/wildchat-1m.yaml
@@ -21,7 +21,7 @@ openness:
     accessed: '2026-06-22'
 adoption:
   level: 3
-  reach: 10k-100k
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: high
   note: 31,364 monthly downloads on Hugging Face, graded on the training-corpus bands.

--- a/tests/test_check_adoption.py
+++ b/tests/test_check_adoption.py
@@ -51,6 +51,33 @@ def test_the_stars_scale_is_chosen_by_signal_not_by_type(sources):
     assert downloads is not None and downloads != stars
 
 
+def test_an_instrument_with_no_scale_abstains_rather_than_borrowing_one(sources):
+    """The rule the first version of this checker broke.
+
+    `docs/guides/adoption.md`: "a `reported_traction` or `active_users` band is measuring
+    something else entirely. Comparing it against a download count is a category error, and a
+    check must SKIP it rather than flag or waive it." `sources/signal_routing.yaml` states the
+    same principle as "abstain rather than substitute".
+
+    Neither instrument has a declared band table anywhere in the repo — two of the five values
+    in the `signal_type` enum have no scale — so a checker that falls back to the product
+    type's DOWNLOAD scale manufactures a finding for every one of them. It did, for all 93
+    `reported_traction` products, and the false findings were indistinguishable from real ones
+    because they had the same shape.
+    """
+    scales = declared_scales(sources)
+    for instrument in ("reported_traction", "active_users"):
+        for product_type in ("software", "model", "dataset"):
+            assert scale_for(scales, product_type, instrument) is None, (
+                f"{instrument} borrowed the {product_type} scale; it measures something else"
+            )
+
+    # And the instruments that ARE denominated in downloads must still resolve, or the
+    # abstention would have been bought by disabling the check.
+    assert scale_for(scales, "software", "usage_volume") is not None
+    assert scale_for(scales, "software", "stars_fallback") is not None
+
+
 def test_the_dataset_scale_sits_one_order_below_software(sources):
     """The fact the thirteen benchmark corpora were mis-banded against.
 
@@ -66,9 +93,15 @@ def test_the_dataset_scale_sits_one_order_below_software(sources):
 
 
 def test_the_walk_examines_most_of_the_corpus(sources):
-    """A non-zero count guard. Two corpus walks in this repo silently narrowed and passed."""
+    """A non-zero count guard. Two corpus walks in this repo silently narrowed and passed.
+
+    The floor is 300 rather than 400 because `reported_traction` and `active_users` are now
+    correctly skipped — about 110 products whose instrument declares no scale. The guard still
+    has to be a real floor: it catches the glob drifting or the scale lookup breaking, which
+    would take this to near zero.
+    """
     _findings, examined = collect(sources)
-    assert examined > 400, f"only examined {examined} products; the walk has drifted"
+    assert examined > 300, f"only examined {examined} products; the walk has drifted"
 
 
 def test_the_benchmark_corpora_refreshed_on_2026_08_12_are_on_scale(sources):

--- a/tests/test_check_adoption.py
+++ b/tests/test_check_adoption.py
@@ -1,0 +1,96 @@
+"""The adoption gate: is a recorded band on the scale its own rubric declares?
+
+`adoption_bands` were declared per product type, serialized into the warehouse, and covered by
+tests for their SHAPE. Nothing compared a product's recorded `(level, reach)` against them, so
+the bands were authoritative for the warehouse and advisory for the corpus — the same
+hand-mirrored-logic drift `check_parity` exists to catch one axis over.
+
+`dataset.yaml` even predicted the failure in a comment: "14 dataset products record level 4
+against a reach of 1M-10M, which is level 5 on this scale ... They are a work list, not a
+migration." A work list written into a comment is not a gate, and it grew.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from build.check_adoption import collect, declared_scales, scale_for
+from build.validate import load_sources
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def sources():
+    return load_sources(ROOT)
+
+
+def test_every_product_type_with_an_adoption_axis_declares_a_scale(sources):
+    """Hardware declares none by design; the other three must, or nothing can be checked."""
+    scales = declared_scales(sources)
+    for product_type in ("software", "model", "dataset"):
+        assert (product_type, "*") in scales, f"{product_type} declares no adoption bands"
+    assert ("*", "stars_fallback") in scales, "the stars fallback scale did not load"
+
+
+def test_the_stars_scale_is_chosen_by_signal_not_by_type(sources):
+    """Stars are a property of the SIGNAL, so they override the product type's own scale.
+
+    This is the resolution order the checker depends on, and getting it backwards would
+    silently check every stars_fallback product against the download vocabulary.
+    """
+    scales = declared_scales(sources)
+    stars = scale_for(scales, "software", "stars_fallback")
+    assert stars is not None
+    assert all("star" in label for label in stars), stars
+    # And its ceiling is level 3: a star is not a use. validate.py enforces the level; this
+    # asserts no label above it exists to record.
+    assert max(stars.values()) == 3, stars
+
+    downloads = scale_for(scales, "software", "usage_volume")
+    assert downloads is not None and downloads != stars
+
+
+def test_the_dataset_scale_sits_one_order_below_software(sources):
+    """The fact the thirteen benchmark corpora were mis-banded against.
+
+    Measured rather than assumed: across 66 HF dataset artifacts the median was 27,648 and
+    none exceeded 10M, so on the software scale level 5 would be unreachable.
+    """
+    scales = declared_scales(sources)
+    dataset = scale_for(scales, "dataset", "usage_volume")
+    software = scale_for(scales, "software", "usage_volume")
+
+    assert ">1M" in dataset and ">10M" not in dataset
+    assert ">10M" in software and ">1M" not in software
+
+
+def test_the_walk_examines_most_of_the_corpus(sources):
+    """A non-zero count guard. Two corpus walks in this repo silently narrowed and passed."""
+    _findings, examined = collect(sources)
+    assert examined > 400, f"only examined {examined} products; the walk has drifted"
+
+
+def test_the_benchmark_corpora_refreshed_on_2026_08_12_are_on_scale(sources):
+    """The thirteen this gate was written for. Pinned so they cannot drift back.
+
+    Three moved level, not just label: `mmlu` 5 -> 4 (it claimed >10M against 477,890 monthly
+    downloads), `mmmu` 4 -> 3, `evalplus` 4 -> 3.
+    """
+    scales = declared_scales(sources)
+    refreshed = [
+        "truthfulqa", "mmmu", "mmlu-pro", "mbpp", "ifeval", "humaneval", "hellaswag",
+        "ai2-arc", "mmlu", "gsm8k", "evalplus", "codecontests", "apps",
+    ]
+    offences = []
+    for slug in refreshed:
+        adoption = sources["scores"][slug]["adoption"]
+        scale = scale_for(scales, "dataset", adoption.get("signal_type") or "")
+        reach, level = adoption.get("reach"), adoption.get("level")
+        if reach not in scale:
+            offences.append(f"{slug}: reach {reach!r} is off the dataset scale")
+        elif scale[reach] != level:
+            offences.append(f"{slug}: level {level} against reach {reach!r} (scale says {scale[reach]})")
+        if adoption.get("last_verified") != "2026-08-12":
+            offences.append(f"{slug}: lost its last_verified date")
+    assert not offences, "\n".join(offences)


### PR DESCRIPTION
## The gap this closes

`adoption_bands` are declared per product type in `sources/rubrics/*.yaml`, serialized into `currentai.registry.adoption_bands`, and read by the scoring SQL. Tests covered the declaration's shape and the serializer's output.

**Nothing ever compared a product's recorded `(level, reach)` against them.** The bands were authoritative for the warehouse and advisory for the corpus — the hand-mirrored-logic drift `check_parity` exists to catch, one axis over. 217 of 432 banded products were off-scale when first measured.

`dataset.yaml` predicted it in a comment: *"14 dataset products record level 4 against a reach of 1M-10M, which is level 5 on this scale ... They are a work list, not a migration."* A work list in a comment is not a gate, so it grew instead of shrinking.

## `build/check_adoption.py`

Checks two things:

1. the reach label is one the applicable scale declares
2. the recorded level is the level that label denotes

Scale resolution is keyed on `(product_type, signal_type)`, not type alone, because `stars_fallback` has its own labels and its own ceiling of 3 — a star is not a use.

Report-only by default, like `check_freshness`. Gating today would fail on a backlog that predates the bands existing, and a gate that fails on day one teaches people to skip it.

## Fixed here: 217 → 166

**38 case-only labels** normalized (`10k-100k` → `10K-100K`). No level moved.

**13 benchmark corpora** re-verified against live Hugging Face figures and rebanded onto the dataset scale — whose top band is `>1M`, one order of magnitude below software and model, because no dataset artifact in the corpus has ever exceeded 10M.

Three moved **level**, not just label:

```
mmlu       5/'>10M'    -> 4/'100K-1M'   on   477,890 monthly downloads
mmmu       4/'1M-10M'  -> 3/'10K-100K'  on    51,058
evalplus   4/'1M-10M'  -> 3/'10K-100K'  on    51,081  (HumanEval+ and MBPP+ summed)
```

`mmlu` was the worst of them: it claimed the top band and a reach of `>10M` against a real figure of 477,890, and its own note argued *"Level 5 on download volume"*.

All 13 now carry `last_verified` plus `http_status` and `content_sha256` from a live read through `build.fetch_source`, so `check_refetch` can later prove the read was real. Those bodies carry a download counter and drift between any two requests — `check_refetch` documents that case and never fails on drift.

**Real `last_verified` coverage: 180 → 193 axes.**

## Deliberately not fixed — see #223

The remaining 166 need a ruling, not a correction. 58 `stars_fallback` products record download-vocabulary labels, and their levels don't follow the stars scale either (`bigcodebench` records level 2 on 503 stars; the scale says 1). Rebanding them would move published adoption levels on dozens of products, which feeds the gap map's maturity signal. That's a methodology decision.

## Test plan

- `pytest` — 461 passed, plus `tests/test_check_adoption.py` (5 new)
- `validate`, `check_recipe`, `check_rubric`, `check_components`, `check_routing`, `check_capability`, `check_verification`, `check_retirement`, `check_adoption` — all green
- The new tests pin the 13 refreshed corpora and their `last_verified`, so they cannot silently drift back
- Generated files not committed (bot-owned)

One thing caught in review of my own work: the first attempt wrote `establishes: [adoption]` onto the new sources, which `validate` rejected — `establishes` names a scoring dimension, not an axis. Stripped rather than re-fetched, so the figures on record are the ones reported above.