### PR TITLE
Check a deferral's stated reason against the blocker the ladder actually hits

### DIFF
--- a/build/check_recipe.py
+++ b/build/check_recipe.py
@@ -361,6 +361,77 @@ def stale_deferrals(
     return problems
 
 
+def deferral_reasons_name_the_real_blocker(
+    slug: str, variants: dict, product_types: dict[str, str], deferrals: dict
+) -> list[str]:
+    """Does a deferral's stated cause match the one the ladder actually abstains on?
+
+    A deferral reason is hand-written prose and nothing verified it, so the queue that drives
+    the work could lie about why the work exists. Roughly six of twenty reasons examined
+    closely across two sessions misdescribed their own cause, and one nearly produced a wrong
+    ruling: `arduino-uno-q`'s reason claimed it was held at 3 for a proprietary SoC, which is
+    a reason the hardware ladder never applies — every board in that category runs on
+    proprietary silicon, so a cap on it would flatten all twenty. The reason was invented
+    after the fact to explain a number.
+
+    `model-context-protocol` was the same shape one session later. Its reason said the product
+    was blocked on a rubric ruling about non-OSI licenses. It was actually blocked on having
+    recorded a DOCUMENTATION license inside the `license` compound, which `autogen` records
+    under a `docs:` key the ladder does not read. Nobody had compared the two, and the reason
+    read plausibly enough that it survived several reviews.
+
+    So this replays the ladder and requires the prose to mention what actually stopped it.
+    There are exactly three ways a walk fails to produce a score, and each has a token the
+    reason has to contain:
+
+      * blocked ON a tier — a rung tests `license_tier` and nothing resolved;
+      * a tier resolved but no rung consumes it, which is the `unstated` case;
+      * a declared dimension is unanswered, so no rung's conditions are met.
+
+    Matching is deliberately loose — a substring, case-folded. The goal is to catch a reason
+    describing a DIFFERENT mechanism, not to dictate phrasing. A reason that names the real
+    blocker and then argues at length about what should happen next still passes, which is
+    what the good ones already do.
+    """
+    problems = []
+    for product, block in sorted(deferrals.items()):
+        path = ROOT / "sources" / "scores" / f"{product}.yaml"
+        if not path.exists():
+            continue
+        recipe, _ = recipe_for(variants, product_types.get(product, ""))
+        if recipe is None:
+            continue
+        because = str((block or {}).get("because") or "").strip().lower()
+        if not because:
+            continue  # the empty-reason check owns this one
+
+        outcome = score_openness(recipe, (yaml.safe_load(path.read_text()) or {}).get("openness") or {})
+        if outcome.result is not None:
+            continue  # stale_deferrals owns this one
+
+        if outcome.blocked_on_tier:
+            expected, described = "license tier", ("tier" in because or "license" in because)
+        elif outcome.tier is not None:
+            expected = f"tier {outcome.tier!r}, which no rung consumes"
+            described = outcome.tier.lower() in because or "rung" in because or "tier" in because
+        else:
+            unanswered = [name for name, value in outcome.facts.items() if not value]
+            expected = f"unanswered dimension(s) {unanswered}"
+            described = any(
+                name.lower() in because or name.replace("_", "-").lower() in because
+                for name in unanswered
+            )
+
+        if not described:
+            problems.append(
+                f"category '{slug}' defers '{product}' with a reason that does not name what "
+                f"the ladder actually abstains on: {expected}. A deferral queue drives the "
+                f"work, so a reason that describes the wrong mechanism sends somebody at the "
+                f"wrong fix."
+            )
+    return problems
+
+
 def check_one(slug: str, verbose: bool) -> tuple[list[str], list[str]]:
     """Check one category. Returns (failures, report_lines)."""
     category = yaml.safe_load(
@@ -446,6 +517,9 @@ def check_one(slug: str, verbose: bool) -> tuple[list[str], list[str]]:
                 f"honest state; silence is not."
             )
     failures += stale_deferrals(slug, variants, product_types, deferred)
+    failures += deferral_reasons_name_the_real_blocker(
+        slug, variants, product_types, (category.get("scoring_recipe") or {}).get("deferred") or {}
+    )
 
     lines = [
         f"  dimensions declared ...... {dimension_count:<4}"

--- a/tests/test_deferral_reasons.py
+++ b/tests/test_deferral_reasons.py
@@ -1,0 +1,105 @@
+"""The deferral-reason gate, and proof that it fires.
+
+A deferral reason is hand-written prose that nothing verified, and the deferral list IS the
+work queue — `check_recipe` already enforces that a reason exists and runs past 40 characters,
+which makes it substantive without making it TRUE.
+
+Across two sessions, roughly six of twenty reasons examined closely misdescribed their own
+cause. Two nearly produced wrong work:
+
+  * `arduino-uno-q` claimed it was held at 3 for a proprietary SoC. The hardware ladder never
+    applies that reason — every board in the category runs on proprietary silicon, so the cap
+    would flatten all twenty and leave the 4 and 5 rungs unreachable. The reason had been
+    invented after the fact to explain a number.
+  * `model-context-protocol` claimed it was blocked on a rubric ruling about non-OSI licenses.
+    It was actually blocked on recording a DOCUMENTATION license inside the `license` compound,
+    where most-restrictive-wins applied it to the artifact you run. `autogen` records the
+    identical facts under a `docs:` key the ladder does not read. The reason read plausibly
+    and survived several reviews.
+
+The gate replays the ladder and requires the prose to name the mechanism that actually stopped
+it. These tests exist because a gate that has only ever returned zero has not been shown to
+work — that is the shape of instrument failure this repo has found four times.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from build.check_recipe import deferral_reasons_name_the_real_blocker
+from build.rubrics import load_product_types, load_shared, resolve_recipe_variants
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def fixture():
+    """A real deferred product, its category's ladder variants, and the product-type map."""
+    product_types = load_product_types(ROOT)
+    shared = load_shared(ROOT)
+    for path in sorted((ROOT / "sources" / "categories").glob("*.yaml")):
+        category = yaml.safe_load(path.read_text()) or {}
+        deferrals = (category.get("scoring_recipe") or {}).get("deferred") or {}
+        if deferrals:
+            variants, _ = resolve_recipe_variants(category, shared)
+            slug = sorted(deferrals)[0]
+            return path.stem, variants, product_types, slug, deferrals[slug]
+    pytest.skip("no deferrals in the corpus to exercise the gate against")
+
+
+def test_the_corpus_passes_its_own_gate(fixture):
+    """Every deferral on record names the blocker the ladder actually hits."""
+    product_types = load_product_types(ROOT)
+    shared = load_shared(ROOT)
+    problems = []
+    for path in sorted((ROOT / "sources" / "categories").glob("*.yaml")):
+        category = yaml.safe_load(path.read_text()) or {}
+        deferrals = (category.get("scoring_recipe") or {}).get("deferred") or {}
+        if not deferrals:
+            continue
+        variants, _ = resolve_recipe_variants(category, shared)
+        problems += deferral_reasons_name_the_real_blocker(
+            path.stem, variants, product_types, deferrals
+        )
+    assert not problems, "\n".join(problems)
+
+
+def test_the_gate_rejects_a_reason_describing_the_wrong_mechanism(fixture):
+    """The one that matters. A plausible reason naming nothing real must FAIL.
+
+    Phrased the way the bad ones actually read — confident, specific, and about a mechanism
+    this product's walk never reaches.
+    """
+    slug, variants, product_types, product, _block = fixture
+    doctored = {
+        product: {
+            "because": (
+                "Held back because the vendor ships a proprietary accelerator and the "
+                "hardware ladder caps anything with closed silicon at 3, which is a "
+                "policy question rather than a recording defect and needs a human ruling "
+                "before this product can be scored against its peers."
+            )
+        }
+    }
+    problems = deferral_reasons_name_the_real_blocker(slug, variants, product_types, doctored)
+    assert problems, f"the gate accepted a reason that names nothing the ladder does for {product}"
+    assert product in problems[0]
+
+
+def test_the_gate_accepts_the_real_reason(fixture):
+    """The other half: the recorded reason passes, so the gate is not simply always-fail."""
+    slug, variants, product_types, product, block = fixture
+    problems = deferral_reasons_name_the_real_blocker(
+        slug, variants, product_types, {product: block}
+    )
+    assert not problems, problems
+
+
+def test_an_empty_reason_is_left_to_the_check_that_owns_it(fixture):
+    """No double-reporting: the empty-reason failure has its own message elsewhere."""
+    slug, variants, product_types, product, _ = fixture
+    problems = deferral_reasons_name_the_real_blocker(
+        slug, variants, product_types, {product: {"because": "   "}}
+    )
+    assert not problems


### PR DESCRIPTION
A deferral reason is hand-written prose that nothing verified — and the deferral list **is** the work queue. `check_recipe` already enforced that a reason exists and runs past 40 characters, which makes it substantive without making it *true*.

## Why this keeps mattering

Across two sessions, roughly **six of twenty** reasons examined closely misdescribed their own cause. Two nearly produced wrong work:

- **`arduino-uno-q`** claimed it was held at 3 for a proprietary SoC. The hardware ladder never applies that reason — every board in the category runs on proprietary silicon, so the cap would flatten all twenty and leave the 4 and 5 rungs unreachable. The reason had been invented after the fact to explain a number.
- **`model-context-protocol`** claimed a rubric ruling on non-OSI licenses was blocking it. It was actually blocked on recording a *documentation* license inside the `license` compound, where most-restrictive-wins applied it to the artifact you run — while `autogen` records the identical facts under a `docs:` key the ladder doesn't read. Nobody had compared the two, and the reason survived several reviews.

Both read plausibly. That's the problem: a confident, specific, wrong reason sends the next person at the wrong fix.

## The check

Replays the ladder and requires the prose to name the mechanism that actually stopped the walk. There are exactly three ways it fails to produce a score, and each has a token the reason must contain:

| failure | what the reason must mention |
|---|---|
| blocked **on** a tier — a rung tests `license_tier`, nothing resolved | tier / license |
| a tier resolved but no rung consumes it (the `unstated` case) | the tier name, or rung/tier |
| a declared dimension left unanswered | that dimension's name |

Matching is a case-folded substring **on purpose**. The goal is to catch a reason describing a *different mechanism*, not to dictate phrasing. A reason that names the real blocker and then argues at length about what should happen next still passes — which is what all five current ones do.

## Why now

**All five current deferrals pass.** The bad ones were fixed in earlier batches, so this locks in the accuracy rather than papering over a backlog. Adding it while the corpus is clean means the next wrong reason fails on the PR that introduces it.

## The test that matters

`tests/test_deferral_reasons.py` proves the gate **fires**, not just that it returns zero. It feeds a deliberately wrong reason — plausible, confident, specific, and about a mechanism the product's walk never reaches — and asserts a failure. It also asserts the real reason passes, so the gate isn't simply always-fail, and that an empty reason is left to the check that owns it rather than double-reported.

Four checks in this repo's history reported success while looking in the wrong place. A gate that has only ever returned zero has not been shown to work.

## Also swept, and deliberately unchanged

Score `note` fields were scanned for text contradicting a scored axis. Seven matched the heuristic and **all seven were false positives** — `flan-collection`'s "the license defers to its components" is a tier name, `axolotl`'s "Closes the deferral without moving the score" is accurate history. No change made. The notes are in better shape than the reasons were.

## Test plan

- `pytest` — **465 passed** (4 new)
- `validate`, `check_recipe`, `check_rubric`, `check_components`, `check_capability`, `check_verification` — all green
- No score, class, or published number moved