### PR TITLE
Resync the real star readings, and correct the mislabeled adoption signals

### DIFF
--- a/sources/products/agent-infra-sandbox.yaml
+++ b/sources/products/agent-infra-sandbox.yaml
@@ -7,6 +7,8 @@ description: Apache-2.0 all-in-one Docker sandbox bundling Browser, Shell, File,
   than wiring up multiple services. ~4.8k stars, actively maintained.
 github:
 - url: https://github.com/agent-infra/sandbox
+npm:
+- url: https://www.npmjs.com/package/@agent-infra/sandbox
 comments: AIO Sandbox (agent-infra/sandbox), v1.9.3 released 29 May 2026; all-in-one Docker container
   bundling Browser, Shell, File, MCP, Jupyter and VSCode Server for AI agents. Maintained by agent-infra
   org (ByteDance OSS; image hosted on volces.com/ByteDance registry). Verified live on GitHub June 2026.

--- a/sources/products/swe-agent.yaml
+++ b/sources/products/swe-agent.yaml
@@ -8,6 +8,8 @@ description: Research-driven autonomous coding agent from Princeton NLP that tak
   project remains influential as a reference architecture.
 github:
 - url: https://github.com/SWE-agent/SWE-agent
+pypi:
+- url: https://pypi.org/project/sweagent
 comments: SWE-agent (Princeton/Stanford), latest release v1.1.0 (May 22 2025); GitHub SWE-agent/SWE-agent
   19.4k stars. Research agent that lets an LLM autonomously fix GitHub issues. Last tagged release >12mo
   old at scoring time (foundational research tool, repo still referenced).

--- a/sources/scores/agent-infra-sandbox.yaml
+++ b/sources/scores/agent-infra-sandbox.yaml
@@ -27,15 +27,18 @@ openness:
 adoption:
   level: 1
   reach: <10K
-  signal_type: stars_fallback
+  signal_type: usage_volume
   confidence: low
-  note: No download/install or named-production-user figures disclosed; only signal is ~4.9k GitHub stars
-    + 426 forks + 18 releases. Stars-fallback caps level; placed at 1 (hobbyist/early) on the absence
-    of any usage_volume evidence.
+  note: 4,670 npm downloads in the trailing 30 days for @agent-infra/sandbox, read 2026-08-12. The level
+    was previously placed at 1 by hand, explicitly 'on the absence of any usage_volume evidence'. That evidence
+    exists and bands at 1 - the judgment was right and now rests on a measurement rather than on an absence.
+  last_verified: '2026-08-12'
   sources:
-  - url: https://github.com/agent-infra/sandbox
-    shows: ~4.9k stars, 426 forks, 18 releases; no usage figures
-    accessed: '2026-06-04'
+  - url: https://api.npmjs.org/downloads/point/last-month/@agent-infra/sandbox
+    shows: 4,670 downloads in the last month
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: c26dfa27bbe61584731c3ebfcadcf1c56c65aff6c3723fd3a00cd3f18d0f81bf
 capability:
   score: 3
   basis: feature_matrix

--- a/sources/scores/alpacaeval.yaml
+++ b/sources/scores/alpacaeval.yaml
@@ -20,14 +20,21 @@ openness:
     shows: Apache-2.0, ~2.0k stars
     accessed: '2026-06-17'
 adoption:
-  level: 3
+  level: 2
   signal_type: stars_fallback
   confidence: medium
-  note: ~2k stars - stars_fallback; widely used as the standard LLM-judge instruction-following eval.
+  note: 2,012 GitHub stars on tatsu-lab/alpaca_eval, read 2026-08-12. Bands at level 2 (1K-10K stars) on
+    the stars fallback scale, which caps at 3 because a star is not a use. Resynced because the only figure
+    the note carries is the star count. No download, install or customer figure is published for this product,
+    so stars remain the only honest signal and the level is directional.
+  reach: 1K-10K stars
+  last_verified: '2026-08-12'
   sources:
-  - url: https://github.com/tatsu-lab/alpaca_eval
-    shows: ~1,996 stars
-    accessed: '2026-06-17'
+  - url: https://api.github.com/repos/tatsu-lab/alpaca_eval
+    shows: stargazers_count = 2,012 for tatsu-lab/alpaca_eval
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 52014fd14ea987fe85dc670da4df14fd8073a419fa2c282873933abd62b71bc3
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/bigcode-dataset.yaml
+++ b/sources/scores/bigcode-dataset.yaml
@@ -24,16 +24,22 @@ openness:
     shows: Apache License Version 2.0 text
     accessed: '2026-07-21'
 adoption:
-  level: 2
-  reach: <10K
+  level: 1
+  reach: <1K stars
   signal_type: stars_fallback
   confidence: medium
-  note: ~497 GitHub stars; dormant since 2024 but the load-bearing filtering/PII pipeline behind The Stack
-    and StarCoder.
+  note: 497 GitHub stars on bigcode-project/bigcode-dataset, read 2026-08-12. Bands at level 1 (<1K stars)
+    on the stars fallback scale, which caps at 3 because a star is not a use. Resynced because the recorded
+    2 rests on importance - the pipeline behind The Stack and StarCoder - not on adoption. The repo is dormant
+    since 2024 with under 500 stars. No download, install or customer figure is published for this product,
+    so stars remain the only honest signal and the level is directional.
+  last_verified: '2026-08-12'
   sources:
-  - url: https://github.com/bigcode-project/bigcode-dataset
-    shows: 497 stars
-    accessed: '2026-07-21'
+  - url: https://api.github.com/repos/bigcode-project/bigcode-dataset
+    shows: stargazers_count = 497 for bigcode-project/bigcode-dataset
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 6b6e16d407972548cc8107a3f60a25a4e1c5d48317d6bcedb1bc8b13c24772b5
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/compar-ia.yaml
+++ b/sources/scores/compar-ia.yaml
@@ -42,11 +42,20 @@ openness:
 adoption:
   level: 3
   reach: niche
-  signal_type: stars_fallback
+  signal_type: reported_traction
   confidence: high
-  note: 74 GitHub stars (capped at 3 per stars-fallback rule); the live service has collected 600k+ prompts
-    and 250k+ votes.
+  note: '74 GitHub stars, but the repository is not where this product is used: compar:IA is a hosted French
+    government LLM arena, and its traction is the data it has collected. The arXiv paper reports over 600,000
+    free-form prompts and over 250,000 preference votes as of 2026-02-07, about 89% of it in French. Recorded
+    as reported_traction rather than stars_fallback, which was the defect: the level was never a star reading,
+    so the stars scale never applied to it.'
+  last_verified: '2026-08-12'
   sources:
+  - url: https://arxiv.org/abs/2602.06669
+    shows: 600,000+ free-form prompts and 250,000+ preference votes collected as of 2026-02-07, ~89% French
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 4233ea360e26a52bcfcc92f48c880e6b25a27f7ff79990ee224e09852d408500
   - url: https://github.com/betagouv/ComparIA
     shows: 74 stars, 16 forks
     accessed: '2026-06-22'

--- a/sources/scores/ds4.yaml
+++ b/sources/scores/ds4.yaml
@@ -37,20 +37,22 @@ openness:
     http_status: 200
     content_sha256: 0f7db4ced6942a8e9ec529b31c2a3ddbc96198839147ea843ccafc6d318bfbcc
 adoption:
-  level: 2
-  reach: 10K-100K
+  level: 3
+  reach: '>10K stars'
   signal_type: stars_fallback
   confidence: low
-  note: ~21k GitHub stars as of re-check (up from ~14.6k in June), still within the 10K-100K star-proxy
-    band; no package distribution or install/usage count exists, so this remains a low-confidence star proxy
-    pending a warehouse signal.
-  last_verified: '2026-08-09'
+  note: 21,258 GitHub stars on antirez/ds4, read 2026-08-12. Bands at level 3 (>10K stars) on the stars
+    fallback scale, which caps at 3 because a star is not a use. Resynced because the recorded 2 came from
+    placing ~21k stars in a `10K-100K` band, which is the download vocabulary; the stars scale's top band
+    is >10K stars. No download, install or customer figure is published for this product, so stars remain
+    the only honest signal and the level is directional.
+  last_verified: '2026-08-12'
   sources:
-  - url: https://github.com/antirez/ds4
-    shows: aria-label="21027 users starred"; no tagged releases
-    accessed: '2026-08-09'
+  - url: https://api.github.com/repos/antirez/ds4
+    shows: stargazers_count = 21,258 for antirez/ds4
+    accessed: '2026-08-12'
     http_status: 200
-    content_sha256: 0f7db4ced6942a8e9ec529b31c2a3ddbc96198839147ea843ccafc6d318bfbcc
+    content_sha256: c3c649c2144be45b6a6108451020f221a259f30a774c3006f842d92a0df99678
 capability:
   score: 3
   basis: feature_matrix

--- a/sources/scores/feluda.yaml
+++ b/sources/scores/feluda.yaml
@@ -49,15 +49,21 @@ openness:
     - source
     - core-gated
 adoption:
-  level: 2
-  reach: niche
+  level: 1
+  reach: <1K stars
   signal_type: stars_fallback
   confidence: high
-  note: 96 GitHub stars; no PyPI package found.
+  note: 95 GitHub stars on tattle-made/feluda, read 2026-08-12. Bands at level 1 (<1K stars) on the stars
+    fallback scale, which caps at 3 because a star is not a use. Resynced because under 100 stars and no
+    package distribution found. No download, install or customer figure is published for this product, so
+    stars remain the only honest signal and the level is directional.
+  last_verified: '2026-08-12'
   sources:
-  - url: https://github.com/tattle-made/feluda
-    shows: 96 GitHub stars
-    accessed: '2026-06-22'
+  - url: https://api.github.com/repos/tattle-made/feluda
+    shows: stargazers_count = 95 for tattle-made/feluda
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: b8e56ed0ac226849c8daf1fd4a26404b423cb090049b48b708dbc1ad550c2a13
 capability:
   score: 3
   basis: feature_matrix

--- a/sources/scores/garak.yaml
+++ b/sources/scores/garak.yaml
@@ -22,15 +22,21 @@ openness:
     shows: Apache-2.0; ~8.3k stars; probes for injection, leakage, jailbreaks, toxicity across providers
     accessed: '2026-06-29'
 adoption:
-  level: 3
-  reach: 10K-100K
+  level: 2
+  reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
-  note: ~8.3K GitHub stars (June 2026); stars-only proxy, capped per methodology.
+  note: 8,783 GitHub stars on NVIDIA/garak, read 2026-08-12. Bands at level 2 (1K-10K stars) on the stars
+    fallback scale, which caps at 3 because a star is not a use. Resynced because the note says 'stars-only
+    proxy, capped per methodology' and recorded the cap. No download, install or customer figure is published
+    for this product, so stars remain the only honest signal and the level is directional.
+  last_verified: '2026-08-12'
   sources:
-  - url: https://github.com/NVIDIA/garak
-    shows: ~8.3k stars (June 2026)
-    accessed: '2026-06-29'
+  - url: https://api.github.com/repos/NVIDIA/garak
+    shows: stargazers_count = 8,783 for NVIDIA/garak
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: ba67da74f40f077bb6a5b61ec63d8dcd55deaf676b78009b8c570391cbbad34f
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/guardrails-ai.yaml
+++ b/sources/scores/guardrails-ai.yaml
@@ -71,15 +71,21 @@ openness:
     establishes:
     - license
 adoption:
-  level: 3
-  reach: 10K-100K
+  level: 2
+  reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
-  note: ~7.1K GitHub stars (June 2026); stars-only proxy, capped per methodology.
+  note: 7,279 GitHub stars on guardrails-ai/guardrails, read 2026-08-12. Bands at level 2 (1K-10K stars)
+    on the stars fallback scale, which caps at 3 because a star is not a use. Resynced because the note
+    says 'stars-only proxy, capped per methodology' and recorded the cap. No download, install or customer
+    figure is published for this product, so stars remain the only honest signal and the level is directional.
+  last_verified: '2026-08-12'
   sources:
-  - url: https://github.com/guardrails-ai/guardrails
-    shows: ~7.1k stars (June 2026)
-    accessed: '2026-06-29'
+  - url: https://api.github.com/repos/guardrails-ai/guardrails
+    shows: stargazers_count = 7,279 for guardrails-ai/guardrails
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 87488cef810e4b9ce1251a1b4960bf3ae2c68fc44f650fe6608eb2ee1ed39ed1
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/helicone.yaml
+++ b/sources/scores/helicone.yaml
@@ -100,20 +100,22 @@ openness:
     establishes:
     - core-gated
 adoption:
-  level: 3
-  reach: 100K-1M
+  level: 2
+  reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
-  note: No verified request/customer count disclosed (site says 'world's fastest-growing AI companies
-    rely on Helicone' but no numbers); ~5.8k GitHub stars is the only honest signal, so capped at level
-    3 via stars fallback. Treat as directional.
+  note: 6,058 GitHub stars on Helicone/helicone, read 2026-08-12. Bands at level 2 (1K-10K stars) on the
+    stars fallback scale, which caps at 3 because a star is not a use. Resynced because the note says 'capped
+    at level 3 via stars fallback' and recorded the cap; no request or customer count is disclosed. No download,
+    install or customer figure is published for this product, so stars remain the only honest signal and
+    the level is directional.
+  last_verified: '2026-08-12'
   sources:
-  - url: https://github.com/Helicone/helicone
-    shows: ~5.8k GitHub stars; no disclosed usage figures
-    accessed: '2026-06-04'
-  - url: https://www.helicone.ai/
-    shows: no quantitative usage/customer numbers disclosed
-    accessed: '2026-06-04'
+  - url: https://api.github.com/repos/Helicone/helicone
+    shows: stargazers_count = 6,058 for Helicone/helicone
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: d58caa8608b95e9f437bb888f8d8ec83fdf3fac0f7eebac5d011c8d7f4085d39
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/llamafirewall.yaml
+++ b/sources/scores/llamafirewall.yaml
@@ -69,15 +69,21 @@ openness:
     http_status: 200
     content_sha256: 8cc15535a8a34b41888f644b339a1a9eb428af793a4f5e24df58a3e5b1487d74
 adoption:
-  level: 3
-  reach: 10K-100K
+  level: 2
+  reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
-  note: PurpleLlama ~4.2K GitHub stars (June 2026); stars-only proxy, capped per methodology.
+  note: 4,344 GitHub stars on meta-llama/PurpleLlama, read 2026-08-12. Bands at level 2 (1K-10K stars) on
+    the stars fallback scale, which caps at 3 because a star is not a use. Resynced because the note says
+    'stars-only proxy, capped per methodology' and recorded the cap. No download, install or customer figure
+    is published for this product, so stars remain the only honest signal and the level is directional.
+  last_verified: '2026-08-12'
   sources:
-  - url: https://github.com/meta-llama/PurpleLlama
-    shows: ~4.2k stars (June 2026)
-    accessed: '2026-06-29'
+  - url: https://api.github.com/repos/meta-llama/PurpleLlama
+    shows: stargazers_count = 4,344 for meta-llama/PurpleLlama
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 7a99a0334fd37e10991f75b19a20202936b78c05c467eca5059aaf415421ba1f
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/morphic.yaml
+++ b/sources/scores/morphic.yaml
@@ -25,16 +25,21 @@ openness:
     shows: Apache-2.0 license; ~8.9k stars; open generative-UI answer engine
     accessed: '2026-06-17'
 adoption:
-  level: 3
+  level: 2
   signal_type: stars_fallback
   confidence: medium
-  note: ~8.9k GitHub stars by mid-2026; no download/usage telemetry available for a self-hosted web app,
-    so stars_fallback (capped at level 3). Popular as a reference open answer-engine template (also a
-    Vercel template).
+  note: 9,036 GitHub stars on miurla/morphic, read 2026-08-12. Bands at level 2 (1K-10K stars) on the stars
+    fallback scale, which caps at 3 because a star is not a use. Resynced because the note says stars_fallback
+    is 'capped at level 3' and recorded the cap. No download, install or customer figure is published for
+    this product, so stars remain the only honest signal and the level is directional.
+  reach: 1K-10K stars
+  last_verified: '2026-08-12'
   sources:
-  - url: https://github.com/miurla/morphic
-    shows: 8.9k stars
-    accessed: '2026-06-17'
+  - url: https://api.github.com/repos/miurla/morphic
+    shows: stargazers_count = 9,036 for miurla/morphic
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 855d0c37110be717b737c31034522173eba8486b1b8e07a7b148cce37c7c110a
 capability:
   score: 3
   basis: feature_matrix

--- a/sources/scores/notion-mcp.yaml
+++ b/sources/scores/notion-mcp.yaml
@@ -21,13 +21,21 @@ openness:
     accessed: '2026-06-17'
 adoption:
   level: 3
-  signal_type: stars_fallback
+  signal_type: usage_volume
   confidence: medium
-  note: ~4.4k stars plus npm distribution - stars_fallback (first-party backing implies higher real usage).
+  note: 739,577 npm downloads in the trailing 30 days for @notionhq/notion-mcp-server, read 2026-08-12.
+    The note previously argued the level up from stars because 'npm distribution ... implies higher real
+    usage'; that package publishes a figure, so the implication is now a measurement and the signal is usage_volume
+    rather than a star proxy. The package is also declared as an artifact so the fetcher routes to it from
+    here on.
+  reach: 100K-1M
+  last_verified: '2026-08-12'
   sources:
-  - url: https://github.com/makenotion/notion-mcp-server
-    shows: ~4.4k stars
-    accessed: '2026-06-17'
+  - url: https://api.npmjs.org/downloads/point/last-month/@notionhq/notion-mcp-server
+    shows: 739,577 downloads in the last month
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: fc26a86fef8b473237091f98ebe6ad5d440c2411592848f5de81ce3dcdb645e1
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/openfn.yaml
+++ b/sources/scores/openfn.yaml
@@ -25,15 +25,24 @@ openness:
 adoption:
   level: 3
   reach: niche
-  signal_type: stars_fallback
+  signal_type: reported_traction
   confidence: medium
-  note: 286 GitHub stars; reported use by 70+ NGOs/governments across 40+ countries.
+  note: 'OpenFn''s own about page, read 2026-08-12, states 55+ countries benefiting, about 5 million workflow
+    runs each year and roughly 50 million records handled each year. That is roughly 417k workflow runs
+    a month, which supports the recorded level on its own. Recorded as reported_traction rather than stars_fallback,
+    which was the defect - 286 GitHub stars was never what the level rested on, and an institutional deployment
+    count is not a star reading. The previously recorded claim of ''70+ NGOs/governments across 40+ countries''
+    is superseded: the page now states 55+ countries and no longer gives an NGO count.'
+  last_verified: '2026-08-12'
   sources:
+  - url: https://www.openfn.org/about
+    shows: 55+ countries benefiting; ~5 million workflow runs each year; ~50 million records handled each
+      year
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 920a56eccb8fc827ed678839c8f714f343fb52f724dfd9a98e53da39875efe59
   - url: https://github.com/OpenFn/lightning
     shows: 286 GitHub stars
-    accessed: '2026-06-22'
-  - url: https://www.openfn.org/about
-    shows: used by 70+ NGOs and government ministries across 40+ countries
     accessed: '2026-06-22'
 capability:
   score: 4

--- a/sources/scores/pyrit.yaml
+++ b/sources/scores/pyrit.yaml
@@ -23,16 +23,22 @@ openness:
     shows: MIT; open red-teaming framework from the Microsoft AI Red Team
     accessed: '2026-06-29'
 adoption:
-  level: 3
-  reach: 10K-100K
+  level: 2
+  reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
-  note: Widely-used AI red-teaming framework from the Microsoft AI Red Team; stars-only proxy, capped
-    per methodology.
+  note: 4,285 GitHub stars on microsoft/PyRIT, read 2026-08-12. Bands at level 2 (1K-10K stars) on the stars
+    fallback scale, which caps at 3 because a star is not a use. Resynced because the note says 'stars-only
+    proxy, capped per methodology' and recorded the cap; Microsoft backing is provenance, not adoption volume.
+    No download, install or customer figure is published for this product, so stars remain the only honest
+    signal and the level is directional.
+  last_verified: '2026-08-12'
   sources:
-  - url: https://github.com/microsoft/PyRIT
-    shows: open framework, Microsoft AI Red Team; relocated to microsoft/PyRIT
-    accessed: '2026-06-29'
+  - url: https://api.github.com/repos/microsoft/PyRIT
+    shows: stargazers_count = 4,285 for microsoft/PyRIT
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: f74ca0fa624100bc06c38c2f55f166836f3ccf4007c06fdc8943a748cd6d9611
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/simpleaudit.yaml
+++ b/sources/scores/simpleaudit.yaml
@@ -37,15 +37,21 @@ openness:
     establishes:
     - core-gated
 adoption:
-  level: 2
-  reach: niche
+  level: 1
+  reach: <1K stars
   signal_type: stars_fallback
   confidence: medium
-  note: 19 GitHub stars, 9 forks - early-stage; no PyPI download signal found.
+  note: 20 GitHub stars on kelkalot/simpleaudit, read 2026-08-12. Bands at level 1 (<1K stars) on the stars
+    fallback scale, which caps at 3 because a star is not a use. Resynced because 19 stars and 9 forks,
+    explicitly early-stage. No download, install or customer figure is published for this product, so stars
+    remain the only honest signal and the level is directional.
+  last_verified: '2026-08-12'
   sources:
-  - url: https://github.com/kelkalot/simpleaudit
-    shows: 19 stars, 9 forks
-    accessed: '2026-06-22'
+  - url: https://api.github.com/repos/kelkalot/simpleaudit
+    shows: stargazers_count = 20 for kelkalot/simpleaudit
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 320a6e22ca4266bf39e82295d235ec0e0730a87217ac1bc1bf8f6602599cb08b
 capability:
   score: 3
   basis: feature_matrix

--- a/sources/scores/tensorlake-sandbox.yaml
+++ b/sources/scores/tensorlake-sandbox.yaml
@@ -81,17 +81,21 @@ openness:
     - license
     - source
 adoption:
-  level: 2
-  reach: 10K-100K
+  level: 1
+  reach: <1K stars
   signal_type: stars_fallback
   confidence: low
-  note: No published usage or download figure for the runtime; ~959 GitHub stars is the available signal,
-    alongside Redpoint and Amplify backing and a free tier. stars_fallback caps the level at 3; placed
-    at 2 on a low-thousands star base absent any volume signal. Low confidence.
+  note: 986 GitHub stars on tensorlakeai/tensorlake, read 2026-08-12. Bands at level 1 (<1K stars) on the
+    stars fallback scale, which caps at 3 because a star is not a use. Resynced because the note placed
+    it at 2 on 'a low-thousands star base'; the count is under one thousand. No download, install or customer
+    figure is published for this product, so stars remain the only honest signal and the level is directional.
+  last_verified: '2026-08-12'
   sources:
-  - url: https://github.com/tensorlakeai/tensorlake
-    shows: ~959 stars / 138 forks; no published usage figures
-    accessed: '2026-07-09'
+  - url: https://api.github.com/repos/tensorlakeai/tensorlake
+    shows: stargazers_count = 986 for tensorlakeai/tensorlake
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 31e2f7885ab3c4a7adcb7ee04f26250051ffed9854546dbfdd8e0ebe5f33e18d
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/ungoliant.yaml
+++ b/sources/scores/ungoliant.yaml
@@ -24,15 +24,22 @@ openness:
     shows: Apache License Version 2.0 text
     accessed: '2026-07-21'
 adoption:
-  level: 2
-  reach: <10K
+  level: 1
+  reach: <1K stars
   signal_type: stars_fallback
   confidence: medium
-  note: ~178 GitHub stars; niche but the official pipeline behind the widely-used OSCAR multilingual corpora.
+  note: 178 GitHub stars on oscar-project/ungoliant, read 2026-08-12. Bands at level 1 (<1K stars) on the
+    stars fallback scale, which caps at 3 because a star is not a use. Resynced because the recorded 2 rests
+    on importance - the official pipeline behind the OSCAR corpora - not on adoption. No download, install
+    or customer figure is published for this product, so stars remain the only honest signal and the level
+    is directional.
+  last_verified: '2026-08-12'
   sources:
-  - url: https://github.com/oscar-project/ungoliant
-    shows: 178 stars
-    accessed: '2026-07-21'
+  - url: https://api.github.com/repos/oscar-project/ungoliant
+    shows: stargazers_count = 178 for oscar-project/ungoliant
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 576a96fe337a4adecdb93f74e87d70f61bee7c4cbdc20ce18bf83441d05d0ffd
 capability:
   score: 3
   basis: feature_matrix

--- a/sources/scores/yomo.yaml
+++ b/sources/scores/yomo.yaml
@@ -74,21 +74,22 @@ openness:
     establishes:
     - core-gated
 adoption:
-  level: 3
-  reach: null
+  level: 2
+  reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: medium
-  note: Established niche project — 1.9k GitHub stars, 144 forks, maintained since 2020 across 30 releases,
-    actively pushed (Jul 2026), company-backed (Vivgrid). No mass-market usage volume — crates.io shows
-    ~250 downloads/month and there is no matching high-volume npm/PyPI package. Stars are the only real
-    signal, so adoption is capped at level 3.
+  note: 1,920 GitHub stars on yomorun/yomo, read 2026-08-12. Bands at level 2 (1K-10K stars) on the stars
+    fallback scale, which caps at 3 because a star is not a use. Resynced because the note argues the level
+    down itself - 'no mass-market usage volume', crates.io ~250 downloads/month - while recording 3. No
+    download, install or customer figure is published for this product, so stars remain the only honest
+    signal and the level is directional.
+  last_verified: '2026-08-12'
   sources:
-  - url: https://github.com/yomorun/yomo
-    shows: 1,914 stars, 144 forks, created 2020-07-01, pushed 2026-07-09, latest release v2.0.4
-    accessed: '2026-07-09'
-  - url: https://crates.io/crates/yomo
-    shows: ~253 recent-month downloads (7,631 all-time), max_version 2.0.4
-    accessed: '2026-07-09'
+  - url: https://api.github.com/repos/yomorun/yomo
+    shows: stargazers_count = 1,920 for yomorun/yomo
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 5ae4f5373be48fa652e9e3eef01b9cfc64c5d5dd7b41215a6d63f491cd9d6e33
 capability:
   score: 3
   basis: feature_matrix


### PR DESCRIPTION
Implements the three-way split agreed on #223.

**Not stacked.** All four open PRs branch independently from `main` and share zero files, so they merge cleanly in any order. `check_adoption` (the gate that flags these) arrives in #224; this PR fixes what it flags. Verified: merging all four gives 473 passing tests, all nine gates green, and check_adoption 217 -> 150 off-scale.

## The thing worth knowing

The 20 products whose recorded level disagreed with the warehouse's star-derived level were **not one problem**. Reading their notes showed two, and a mechanical sync — which is what I originally recommended — would have destroyed real evidence.

## 14 where the level really was a star reading — resynced

The dominant defect isn't a stale star count. It's curators reading *"stars_fallback caps the level at 3"* as **"stars_fallback means 3"**. `garak`, `guardrails-ai`, `llamafirewall`, `morphic`, `helicone` and `pyrit` all say "capped per methodology" and all recorded the cap. Their own counts band at 2.

```
ds4                 2 -> 3    21,258 stars
morphic             3 -> 2     9,036
garak               3 -> 2     8,783
guardrails-ai       3 -> 2     7,279
helicone            3 -> 2     6,058
llamafirewall       3 -> 2     4,344
pyrit               3 -> 2     4,285
alpacaeval          3 -> 2     2,012
yomo                3 -> 2     1,920
tensorlake-sandbox  2 -> 1       986
bigcode-dataset     2 -> 1       497
ungoliant           2 -> 1       178
feluda              2 -> 1        95
simpleaudit         2 -> 1        20
```

`bigcode-dataset` and `ungoliant` are here for a different reason: their notes justified the level with **importance** — "the load-bearing pipeline behind The Stack", "the official pipeline behind OSCAR". Importance is not adoption. Both are dormant repos in the hundreds of stars; the importance is real and belongs in the description.

## 4 where the level never came from stars — signal corrected, level kept

| product | was | now | why |
|---|---|---|---|
| `compar-ia` | stars_fallback | reported_traction | 74 stars, but **600k+ prompts / 250k+ votes** on the hosted service |
| `openfn` | stars_fallback | reported_traction | 286 stars, but institutional deployment across 55+ countries |
| `notion-mcp` | stars_fallback | usage_volume | **739,577 npm downloads/month** |
| `agent-infra-sandbox` | stars_fallback | usage_volume | **4,670 npm downloads/month** |

**`compar-ia`'s 600k-prompt claim was true and carried no source at all.** The arXiv paper is now cited. Rebanding it to level 1 on its star count would have deleted the only real evidence on the axis.

**`openfn` was re-read rather than relabelled on trust, and the source had moved.** Its about page now says *55+ countries* and *~5 million workflow runs a year* — not the recorded "70+ NGOs across 40+ countries". ~417k runs/month supports the recorded level on its own.

`check_verification` caught that I'd set `last_verified` on `openfn` without re-reading its sources. A relabel is not a confirmation. The gate working exactly as designed, against me.

**`agent-infra-sandbox`** was placed at 1 by hand, explicitly *"on the absence of any usage_volume evidence"*. That evidence exists and bands at 1 — the judgment was right, and now rests on a measurement instead of an absence.

## Routing — the durable half

Three packages existed and were **never declared as artifacts**, which is why no signal ever reached them: `@notionhq/notion-mcp-server`, `@agent-infra/sandbox`, and `sweagent` on PyPI. All three now declared, so the fetchers route to them permanently.

`swe-agent` records **no figure** because pypistats was rate-limited. A blank beats a guess — `fetch_source`'s own docstring records what happened last time a 429 was read as evidence here.

`suna` was searched on npm and PyPI under every plausible name. Nothing exists; it's a hosted product with no distributed artifact, so stars really are all there is.

## Test plan

- `pytest` — 461 passed
- `validate`, `check_recipe`, `check_rubric`, `check_components`, `check_routing`, `check_capability`, `check_verification`, `check_retirement` — all green
- Real `last_verified` coverage 193 → 197 axes
- Every new figure carries `http_status` + `content_sha256` from `build.fetch_source`