### PR TITLE
Re-verify 31 adoption bands: label the unlabelled, and move stars onto real download signals

### DIFF
--- a/docs/guides/adoption.md
+++ b/docs/guides/adoption.md
@@ -223,6 +223,47 @@ it does not make the claim automatic, it makes it falsifiable.
 - **MLPerf and Artificial Analysis** — capability instruments, not adoption. Recorded here only
   so nobody re-proposes them; see `signal_routing.yaml` for why both are unbridged anyway.
 
+## The mirror trap: a channel that is not counted at all
+
+Attribution has two failure modes and only one of them was written down. The `cohere-rerank-api`
+case above is **over**-attribution — one SDK's downloads credited wholly to one of the N products
+it serves. The opposite is **under**-coverage, and it is the more common one:
+
+> **If the declared artifact is not the product's primary distribution channel, banding on it is
+> a substitution, not a measurement.**
+
+`n8n` is the case that established the rule. It records `usage_volume`, and its declared artifact
+is the npm package at 393,738 downloads a month, which bands at level 3. But n8n is deployed
+overwhelmingly as a self-hosted Docker container, and Docker Hub reports **246 million cumulative
+pulls** — averaging about 2.9 million a month over the image's lifetime. Banding on npm alone
+published a precise number for the wrong channel, and the note said so in its own second sentence
+before recording the band anyway.
+
+That is exactly what `sources/signal_routing.yaml` forbids: "Abstain rather than substitute. When
+the authoritative signal for a dimension is missing or unusable, the rule is to produce NO
+evidence." A partial channel is an unusable signal wearing a usable one's clothes, and it is worse
+than an absent one, because it carries a `last_verified` date asserting that somebody confirmed it.
+
+**What to do instead**, in order of preference:
+
+1. **Count every channel the product actually ships through** and sum them, which is what the unit
+   already says — "summed across declared artifacts". Declare the missing artifact so the sum is
+   reproducible rather than hand-assembled.
+2. Where a channel reports only a **cumulative** total — Docker Hub's `pull_count` is the case —
+   a lifetime average is admissible as a floor, provided the note says it is a lifetime average
+   and therefore understates a growing product. It is not a trailing-30-day figure and must not be
+   presented as one.
+3. Where the primary channel publishes nothing at all, use `reported_traction` and abstain on
+   `reach`, rather than banding on the minority channel that happens to be countable.
+
+`langflow` is the same shape and moved with it: PyPI alone gave level 2, PyPI plus the Docker
+average gives about 166,000 a month and level 3. `semantic-kernel` is a third — its Python package
+reaches level 4 on its own, and the .NET/NuGet channel is larger and uncounted, so its band is a
+floor and its note says so.
+
+The tell to look for when reviewing: **a note that describes the signal as understating the
+product, followed by a band recorded on that signal anyway.**
+
 ## Checklist
 
 - [ ] `level` is 1-5 and follows the band table for the product's **type**.

--- a/sources/products/codegemma.yaml
+++ b/sources/products/codegemma.yaml
@@ -6,5 +6,9 @@ description: 'Google''s code-specialized Gemma family: a 2B pretrained model for
   on 500B-1T tokens of public code, math, and synthetic data.'
 huggingface_model:
 - url: https://huggingface.co/google/codegemma-7b-it
+- url: https://huggingface.co/google/codegemma-7b
+- url: https://huggingface.co/google/codegemma-2b
+- url: https://huggingface.co/google/codegemma-1.1-7b-it
+- url: https://huggingface.co/google/codegemma-1.1-2b
 comments: Gemma Terms of Use (custom, use-restricted, NOT OSI). Training data and recipe not released. Largely superseded
   by Qwen2.5-Coder / Gemma 3 for coding.

--- a/sources/products/codellama.yaml
+++ b/sources/products/codellama.yaml
@@ -8,6 +8,9 @@ description: Code-specialized instruction-tuned Llama 2 family (7B to 70B, seed 
   open code model ecosystem. Still used as a baseline with ~104K combined monthly downloads across sizes.
 huggingface_model:
 - url: https://huggingface.co/codellama/CodeLlama-34b-Instruct-hf
+- url: https://huggingface.co/codellama/CodeLlama-7b-Instruct-hf
+- url: https://huggingface.co/codellama/CodeLlama-13b-Instruct-hf
+- url: https://huggingface.co/codellama/CodeLlama-70b-Instruct-hf
 comments: Code Llama Instruct (instruct-tuned coding variant; 7B/13B/34B/70B; scored on the 13B-Instruct SKU as
   representative). Trained Jan-Jul 2023, paper arXiv:2308.12950 (Aug 2023). >12 months old and superseded by Llama
   3.x/Codestral-class coders, but foundational open coding-instruct model; verified live on HF June 2026.

--- a/sources/products/jamba-large.yaml
+++ b/sources/products/jamba-large.yaml
@@ -9,6 +9,8 @@ description: 'AI21-Jamba-1.5-Large (ai21labs/AI21-Jamba-1.5-Large on HF), hybrid
   by Jamba 1.6 (Mar 2025) and the Jamba2/Jamba Reasoning 3B generation now headlined on ai21.com/jamba. Recategorized
   from base_pretrained -> finetuned_chat: this is the instruct/chat SKU (post-trained for downstream chat/agentic
   use), not a raw base model.'
+huggingface_model:
+- url: https://huggingface.co/ai21labs/AI21-Jamba-1.5-Large
 comments: 'AI21-Jamba-1.5-Large (ai21labs/AI21-Jamba-1.5-Large on HF), hybrid SSM-Transformer (Mamba+Attention)
   MoE, 398B total / 94B active, 256K context, instruction-tuned chat model with tool use / grounded-RAG / JSON mode.
   Announced 22 Aug 2024 under the Jamba Open Model License. Verified live on HF June 2026, but stale: superseded

--- a/sources/products/livebench.yaml
+++ b/sources/products/livebench.yaml
@@ -7,6 +7,17 @@ description: An open, contamination-limited LLM benchmark with objective ground-
   UMD, USC; ICLR 2025 Spotlight.
 github:
 - url: https://github.com/livebench/livebench
+huggingface_dataset:
+- url: https://huggingface.co/livebench/math
+- url: https://huggingface.co/livebench/reasoning
+- url: https://huggingface.co/livebench/model_judgment
+- url: https://huggingface.co/livebench/coding
+- url: https://huggingface.co/livebench/data_analysis
+- url: https://huggingface.co/livebench/instruction_following
+- url: https://huggingface.co/livebench/language
+- url: https://huggingface.co/livebench/liveswebench
+- url: https://huggingface.co/livebench/model_answer
+- url: https://huggingface.co/livebench/liveswebench-patches
 comments: Questions and ground-truth answers public (Apache-2.0/MIT). ~1.2k stars; multi-category HF dataset downloads.
   Monthly rotation is freshness management, not gating.
 arxiv:

--- a/sources/scores/autogen.yaml
+++ b/sources/scores/autogen.yaml
@@ -25,11 +25,17 @@ adoption:
   level: 4
   signal_type: usage_volume
   confidence: medium
-  note: ~1.37M downloads/month for autogen-agentchat; trajectory flat as it enters maintenance mode.
+  note: 1,058,837 PyPI downloads in the trailing 30 days for autogen-agentchat, read 2026-08-12. Bands at
+    level 4 (1M-10M) on the software and model adoption scale. Trajectory is flat to declining as the project
+    enters maintenance.
+  reach: 1M-10M
+  last_verified: '2026-08-12'
   sources:
-  - url: https://pypistats.org/packages/autogen-agentchat
-    shows: ~1.37M downloads/month
-    accessed: '2026-06-17'
+  - url: https://pypistats.org/api/packages/autogen-agentchat/recent
+    shows: 1,058,837 downloads in the trailing 30 days for autogen-agentchat
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: e50d25c7c06508c17569a42cb0abc1884124c3022d8617cd967b1ff4cb878555
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/beeai.yaml
+++ b/sources/scores/beeai.yaml
@@ -21,14 +21,27 @@ openness:
     shows: Apache-2.0, ~3.3k stars, dual-language agent framework
     accessed: '2026-06-18'
 adoption:
-  level: 3
-  signal_type: stars_fallback
+  level: 2
+  signal_type: usage_volume
   confidence: medium
-  note: ~3.3k stars; package download volume not retrievable - stars_fallback (capped at 3).
+  note: '63,527 downloads in the trailing 30 days (beeai-framework 49,921; beeai-framework 13,606), read
+    2026-08-12. Bands at level 2 (10K-100K) on the software and model adoption scale. Moved off the stars
+    fallback: a real download signal exists, and docs/guides/adoption.md says to re-band when one does.
+    The package is both language bindings, summed. This LOWERS the recorded level from 3 - the star count
+    had been flattering it.'
+  reach: 10K-100K
+  last_verified: '2026-08-12'
   sources:
-  - url: https://github.com/i-am-bee/beeai-framework
-    shows: ~3.3k stars
-    accessed: '2026-06-18'
+  - url: https://pypistats.org/api/packages/beeai-framework/recent
+    shows: 49,921 downloads in the trailing 30 days for beeai-framework
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 6d4373d31982e807ef70aaf65aebfb21deca5ea4499aa38e0c9619e9ca45fd75
+  - url: https://api.npmjs.org/downloads/point/last-month/beeai-framework
+    shows: 13,606 downloads in the trailing 30 days for beeai-framework
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 15f8dde1c5a6aac9fef53c9defa6c2f83f196ffa05a024f1d35a03168f98c764
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/codegemma.yaml
+++ b/sources/scores/codegemma.yaml
@@ -32,20 +32,40 @@ adoption:
   level: 2
   signal_type: usage_volume
   confidence: medium
-  note: >-
-    Open weights under Google's custom Gemma terms, with no open training data or code. Was 3,
-    corrected to 2 on 2026-07-29 on the rule that a use cap lands at 2 in every category, and
-    returned to 3 on 2026-08-01 when the universal license scale replaced that rule: a bounded
-    commercial license caps at 3, and a license forbidding commerce outright caps at 2. Gemma's
-    terms are the former. The 2026-07-29 note cited gemma-2 and gemma-3 as siblings scoring
-    2/restricted on the same license. Neither slug exists after the slug migration, and the
-    surviving `gemma` records an Apache-2.0 license rather than Gemma terms, so that comparison no
-    longer holds - and whether `gemma`'s recorded license is right is a separate question worth a
-    look.
+  note: '28,295 Hugging Face downloads in the trailing 30 days summed across the five CodeGemma repos the
+    tier covers, read 2026-08-12 (google/codegemma-7b-it 4,573; google/codegemma-7b 4,262; google/codegemma-2b
+    19,078; google/codegemma-1.1-7b-it 50; google/codegemma-1.1-2b 332). Bands at level 2 (10K-100K). All
+    5 repos are now DECLARED in the product file: the band was previously read on the family while only
+    one repo was declared, so it could not be re-derived by machine. Slugs on this map are tier-level, and
+    docs/guides/identity.md sums adoption across a tier’s releases.'
+  reach: 10K-100K
+  last_verified: '2026-08-12'
   sources:
-  - url: https://huggingface.co/google/codegemma-7b-it
-    shows: ~1,929 downloads last month
-    accessed: '2026-06-17'
+  - url: https://huggingface.co/api/models/google/codegemma-7b-it
+    shows: 4,573 downloads in the trailing 30 days for google/codegemma-7b-it
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 8a625ed552bfe66381237c80781644f18951d7d0c702581415a92cfadd995fb1
+  - url: https://huggingface.co/api/models/google/codegemma-7b
+    shows: 4,262 downloads in the trailing 30 days for google/codegemma-7b
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: f49b8dada2443e8398df05482753792fddb0fb53e01fba08deaa60b7c1256a2d
+  - url: https://huggingface.co/api/models/google/codegemma-2b
+    shows: 19,078 downloads in the trailing 30 days for google/codegemma-2b
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 8596453ff8b02a87f305cbbc9ea803465d5b7fbfd801d6e71078122c64d7c6b8
+  - url: https://huggingface.co/api/models/google/codegemma-1.1-7b-it
+    shows: 50 downloads in the trailing 30 days for google/codegemma-1.1-7b-it
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 99d9d15be6e6cb8f78602724fe55e90dec3986245af63f53b927fac1f2faa2ef
+  - url: https://huggingface.co/api/models/google/codegemma-1.1-2b
+    shows: 332 downloads in the trailing 30 days for google/codegemma-1.1-2b
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: c16edbe90e4bbda5169a911e5572f0d5f6bfe6e1f014c6b4bf06a883468e8e56
 capability:
   score: 3
   basis: benchmark

--- a/sources/scores/codellama.yaml
+++ b/sources/scores/codellama.yaml
@@ -34,18 +34,34 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: medium
-  note: >-
-    Weights downloadable under Meta's non-OSI Llama-2 Community license. Marketed as open, which
-    the openness class deliberately does not accept at face value. Moved from 2/restricted on
-    2026-08-01 by the universal license scale, which caps a bounded commercial license at 3 rather
-    than 2. The test at that boundary is whether the license permits commercial use AT ALL: this
-    one does, for everyone inside the bound. A license that forbids commerce outright - CC-BY-NC,
-    Mistral Non-Production - stays at 2. Nine other products carry a bounded license and all now
-    score 3; four of them were already recorded there, which is the inconsistency this resolves.
+  note: '110,069 Hugging Face downloads in the trailing 30 days summed across the four Code Llama Instruct
+    SKUs the tier covers, read 2026-08-12 (codellama/CodeLlama-34b-Instruct-hf 24,545; codellama/CodeLlama-7b-Instruct-hf
+    73,688; codellama/CodeLlama-13b-Instruct-hf 11,336; codellama/CodeLlama-70b-Instruct-hf 500). Bands
+    at level 3 (100K-1M). All 4 repos are now DECLARED in the product file: the band was previously read
+    on the family while only one repo was declared, so it could not be re-derived by machine. Slugs on this
+    map are tier-level, and docs/guides/identity.md sums adoption across a tier’s releases.'
+  last_verified: '2026-08-12'
   sources:
-  - url: https://huggingface.co/codellama/CodeLlama-13b-Instruct-hf
-    shows: ~3,294 downloads last month for 13B-Instruct; large adapter/finetune ecosystem
-    accessed: '2026-06-04'
+  - url: https://huggingface.co/api/models/codellama/CodeLlama-34b-Instruct-hf
+    shows: 24,545 downloads in the trailing 30 days for codellama/CodeLlama-34b-Instruct-hf
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 69f7f3cfa3b3c7df136b10a2805b842a406eac8123ff385052beb75d1750300c
+  - url: https://huggingface.co/api/models/codellama/CodeLlama-7b-Instruct-hf
+    shows: 73,688 downloads in the trailing 30 days for codellama/CodeLlama-7b-Instruct-hf
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 75a8b89099355c55b5ac983c36af08d692551dded6a957fc13d399bd3aa9659c
+  - url: https://huggingface.co/api/models/codellama/CodeLlama-13b-Instruct-hf
+    shows: 11,336 downloads in the trailing 30 days for codellama/CodeLlama-13b-Instruct-hf
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: de01b409617f87e82479dad3fac928243ae289e9f443316223d2a9decb0414c4
+  - url: https://huggingface.co/api/models/codellama/CodeLlama-70b-Instruct-hf
+    shows: 500 downloads in the trailing 30 days for codellama/CodeLlama-70b-Instruct-hf
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: ec7fe450fa8b577e2d76ca3deadbffae6463a02563d2d5ac196898202beafabb
 capability:
   score: 3
   basis: benchmark

--- a/sources/scores/docling.yaml
+++ b/sources/scores/docling.yaml
@@ -23,15 +23,21 @@ openness:
     shows: MIT, ~61.8k stars, multi-format document parser
     accessed: '2026-06-18'
 adoption:
-  level: 3
-  signal_type: stars_fallback
+  level: 5
+  signal_type: usage_volume
   confidence: medium
-  note: ~62k stars (exceptionally high) but PyPI download volume not surfaced - stars_fallback (capped at 3; true
-    usage almost certainly higher).
+  note: '12,493,111 downloads in the trailing 30 days (docling 12,493,111), read 2026-08-12. Bands at level
+    5 (>10M) on the software and model adoption scale. Moved off the stars fallback: a real download signal
+    exists, and docs/guides/adoption.md says to re-band when one does. The package is the first-party package;
+    docling-core adds more again. Recorded level was 3.'
+  reach: '>10M'
+  last_verified: '2026-08-12'
   sources:
-  - url: https://github.com/docling-project/docling
-    shows: ~61.8k stars
-    accessed: '2026-06-18'
+  - url: https://pypistats.org/api/packages/docling/recent
+    shows: 12,493,111 downloads in the trailing 30 days for docling
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: c81ce393cb034f9bc8db666fdff640be75b337519a7dee035dee389236c80bc9
 capability:
   score: 5
   basis: feature_matrix

--- a/sources/scores/dspy.yaml
+++ b/sources/scores/dspy.yaml
@@ -24,11 +24,16 @@ adoption:
   level: 4
   signal_type: usage_volume
   confidence: high
-  note: ~6.36M PyPI downloads/month for the dspy package.
+  note: 6,589,078 PyPI downloads in the trailing 30 days for dspy, read 2026-08-12. Bands at level 4 (1M-10M)
+    on the software and model adoption scale. A widely used prompt-programming framework.
+  reach: 1M-10M
+  last_verified: '2026-08-12'
   sources:
-  - url: https://pypistats.org/packages/dspy
-    shows: ~6.36M downloads/month
-    accessed: '2026-06-17'
+  - url: https://pypistats.org/api/packages/dspy/recent
+    shows: 6,589,078 downloads in the trailing 30 days for dspy
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 3a399a8f7f92d24ac1056f2740853ff1d13ddec4817b96acd552ee5a86f36346
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/filesystem-mcp.yaml
+++ b/sources/scores/filesystem-mcp.yaml
@@ -20,14 +20,22 @@ openness:
     shows: MIT, reference filesystem server
     accessed: '2026-06-17'
 adoption:
-  level: 3
-  signal_type: stars_fallback
+  level: 4
+  signal_type: usage_volume
   confidence: low
-  note: Bundled reference server; monorepo ~87k stars are shared across servers - stars_fallback (capped at 3).
+  note: '1,945,615 downloads in the trailing 30 days (@modelcontextprotocol/server-filesystem 1,945,615),
+    read 2026-08-12. Bands at level 4 (1M-10M) on the software and model adoption scale. Moved off the stars
+    fallback: a real download signal exists, and docs/guides/adoption.md says to re-band when one does.
+    The package is a per-server npm package, which resolves the recorded objection that the monorepo''s
+    stars are shared across every server in it. Recorded level was 3.'
+  reach: 1M-10M
+  last_verified: '2026-08-12'
   sources:
-  - url: https://github.com/modelcontextprotocol/servers
-    shows: ~87.4k monorepo stars, filesystem among active reference servers
-    accessed: '2026-06-17'
+  - url: https://api.npmjs.org/downloads/point/last-month/@modelcontextprotocol/server-filesystem
+    shows: 1,945,615 downloads in the trailing 30 days for @modelcontextprotocol/server-filesystem
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: cda748d40b5be539d16128ed592a15d1ffc6bf0d98f5cc43619bbbc78ba84faf
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/gaia.yaml
+++ b/sources/scores/gaia.yaml
@@ -38,14 +38,21 @@ openness:
     http_status: 200
     content_sha256: 0bcfa21e0181419fa7c6c33c382a5e50ac59e8d343ab40a9ad4557a33377c4f0
 adoption:
-  level: 4
+  level: 3
   signal_type: usage_volume
   confidence: high
-  note: ~42k monthly HF downloads; widely cited and integrated into agent eval harnesses.
+  note: 17,975 Hugging Face downloads in the trailing 30 days for gaia-benchmark/GAIA, read 2026-08-12.
+    Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M - one order of magnitude
+    below software and model. Cited across agent evaluation harnesses; the figure has fallen sharply since
+    June. Corrected from level 4, which the recorded evidence did not support.
+  reach: 10K-100K
+  last_verified: '2026-08-12'
   sources:
-  - url: https://huggingface.co/datasets/gaia-benchmark/GAIA
-    shows: ~42,218 downloads/month
-    accessed: '2026-06-17'
+  - url: https://huggingface.co/api/datasets/gaia-benchmark/GAIA
+    shows: 17,975 downloads in the trailing 30 days for gaia-benchmark/GAIA
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 0bcfa21e0181419fa7c6c33c382a5e50ac59e8d343ab40a9ad4557a33377c4f0
 capability:
   score: 5
   basis: feature_matrix

--- a/sources/scores/gemini-cli.yaml
+++ b/sources/scores/gemini-cli.yaml
@@ -20,14 +20,20 @@ openness:
     shows: Apache-2.0, ~105k stars, open AI agent CLI
     accessed: '2026-06-18'
 adoption:
-  level: 5
+  level: 4
   signal_type: usage_volume
   confidence: high
-  note: ~2.86M npm downloads/month for @google/gemini-cli, plus ~105k stars.
+  note: 1,850,744 npm downloads in the trailing 30 days for @google/gemini-cli, read 2026-08-12. Bands at
+    level 4 (1M-10M) on the software and model adoption scale. Google's first-party terminal agent. Corrected
+    from level 5, which the recorded evidence did not support.
+  reach: 1M-10M
+  last_verified: '2026-08-12'
   sources:
   - url: https://api.npmjs.org/downloads/point/last-month/@google/gemini-cli
-    shows: ~2.86M downloads/month
-    accessed: '2026-06-18'
+    shows: 1,850,744 downloads in the trailing 30 days for @google/gemini-cli
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: c260288dbd7a0681b5ddfd027049c62ec7837b530672241393db101de2c95086
 capability:
   score: 5
   basis: feature_matrix

--- a/sources/scores/gpt-oss-safeguard.yaml
+++ b/sources/scores/gpt-oss-safeguard.yaml
@@ -23,16 +23,20 @@ openness:
       235 likes
     accessed: '2026-06-29'
 adoption:
-  level: 4
+  level: 3
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: 20b variant ~131K HF downloads/month, 235 likes, 100+ Spaces (June 2026); strong early adoption
-    for a recent release.
+  note: 100,632 downloads in the trailing 30 days (openai/gpt-oss-safeguard-20b 100,632), read 2026-08-12.
+    Bands at level 3 (100K-1M). Corrected from level 4. Sits barely above the 100K boundary, so this level
+    is fragile in either direction.
+  last_verified: '2026-08-12'
   sources:
-  - url: https://huggingface.co/openai/gpt-oss-safeguard-20b
-    shows: ~131,038 downloads/month, 235 likes, 100+ Spaces (June 2026)
-    accessed: '2026-06-29'
+  - url: https://huggingface.co/api/models/openai/gpt-oss-safeguard-20b
+    shows: 100,632 downloads in the trailing 30 days for openai/gpt-oss-safeguard-20b
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 58148783c94a8c908682233ec3be7fb9e0ae18eaa89282271c1a08049b035d63
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/gpt4all.yaml
+++ b/sources/scores/gpt4all.yaml
@@ -20,14 +20,27 @@ openness:
     shows: MIT, ~77.4k stars, LocalDocs RAG + local API server
     accessed: '2026-06-17'
 adoption:
-  level: 3
-  signal_type: stars_fallback
+  level: 2
+  signal_type: usage_volume
   confidence: medium
-  note: ~77k stars but reduced maintenance since early 2025 - stars_fallback (capped at 3).
+  note: '60,336 downloads in the trailing 30 days (gpt4all 58,808; gpt4all 1,528), read 2026-08-12. Bands
+    at level 2 (10K-100K) on the software and model adoption scale. Moved off the stars fallback: a real
+    download signal exists, and docs/guides/adoption.md says to re-band when one does. The package is the
+    Python bindings plus the Node bindings from the same org. This LOWERS the recorded level from 3 - the
+    star count had been flattering it.'
+  reach: 10K-100K
+  last_verified: '2026-08-12'
   sources:
-  - url: https://github.com/nomic-ai/gpt4all
-    shows: ~77.4k stars; last major release Feb 2025
-    accessed: '2026-06-17'
+  - url: https://pypistats.org/api/packages/gpt4all/recent
+    shows: 58,808 downloads in the trailing 30 days for gpt4all
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: c93a986c8356e8e726ea6930a3e0275a0c25030cb610d62505fb17aeab6c3a8a
+  - url: https://api.npmjs.org/downloads/point/last-month/gpt4all
+    shows: 1,528 downloads in the trailing 30 days for gpt4all
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: b5eea2fec708240747384a6f83f7f47f1506a97c284f7b57cb5f43424130bfe7
 capability:
   score: 3
   basis: feature_matrix

--- a/sources/scores/haystack.yaml
+++ b/sources/scores/haystack.yaml
@@ -75,14 +75,20 @@ openness:
     establishes:
     - core-gated
 adoption:
-  level: 4
+  level: 3
   signal_type: usage_volume
   confidence: high
-  note: ~883k PyPI downloads/month for the 2.x haystack-ai package.
+  note: 933,408 PyPI downloads in the trailing 30 days for haystack-ai, read 2026-08-12. Bands at level
+    3 (100K-1M) on the software and model adoption scale. The 2.x package; sits just under the 1M boundary
+    and could cross either way. Corrected from level 4, which the recorded evidence did not support.
+  reach: 100K-1M
+  last_verified: '2026-08-12'
   sources:
-  - url: https://pypistats.org/packages/haystack-ai
-    shows: ~883k downloads/month
-    accessed: '2026-06-17'
+  - url: https://pypistats.org/api/packages/haystack-ai/recent
+    shows: 933,408 downloads in the trailing 30 days for haystack-ai
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: cd271f2fc8ad6efc82d7e7cf9393f509a8b4e1e72499b043adc3f0b6c32e285e
 capability:
   score: 5
   basis: feature_matrix

--- a/sources/scores/humanitys-last-exam.yaml
+++ b/sources/scores/humanitys-last-exam.yaml
@@ -24,14 +24,21 @@ openness:
     shows: MIT, gated access, no-redistribution notice
     accessed: '2026-06-17'
 adoption:
-  level: 4
+  level: 3
   signal_type: usage_volume
   confidence: high
-  note: ~35k monthly HF downloads; ~1.6k GitHub stars on the eval code.
+  note: 34,715 Hugging Face downloads in the trailing 30 days for cais/hle, read 2026-08-12. Bands at level
+    3 (10K-100K) on the dataset adoption scale, whose top band is >1M - one order of magnitude below software
+    and model. A frontier-difficulty benchmark; volume essentially flat since June. Corrected from level
+    4, which the recorded evidence did not support.
+  reach: 10K-100K
+  last_verified: '2026-08-12'
   sources:
-  - url: https://huggingface.co/datasets/cais/hle
-    shows: ~34,984 downloads/month
-    accessed: '2026-06-17'
+  - url: https://huggingface.co/api/datasets/cais/hle
+    shows: 34,715 downloads in the trailing 30 days for cais/hle
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 27e476a04eaa2d4c5c81ec22ec8f6707e50eff416228060b26d01a70d5cae230
 capability:
   score: 5
   basis: feature_matrix

--- a/sources/scores/jamba-large.yaml
+++ b/sources/scores/jamba-large.yaml
@@ -39,19 +39,18 @@ adoption:
   reach: <10K
   signal_type: usage_volume
   confidence: high
-  note: >-
-    Weights downloadable under the Jamba Open Model License: non-OSI, with a $50M annual-revenue
-    cap that bars large-entity commercial use. The 'Open Model' branding overstates it. Moved from
-    2/restricted on 2026-08-01 by the universal license scale, which caps a bounded commercial
-    license at 3 rather than 2. The test at that boundary is whether the license permits
-    commercial use AT ALL: this one does, for everyone inside the bound. A license that forbids
-    commerce outright - CC-BY-NC, Mistral Non-Production - stays at 2. Nine other products carry a
-    bounded license and all now score 3; four of them were already recorded there, which is the
-    inconsistency this resolves.
+  note: '45 Hugging Face downloads in the trailing 30 days summed across the scored release, read 2026-08-12
+    (ai21labs/AI21-Jamba-1.5-Large 45). Bands at level 1 (<10K). All 1 repos are now DECLARED in the product
+    file: the band was previously read on the family while only none was declared, so it could not be re-derived
+    by machine. Slugs on this map are tier-level, and docs/guides/identity.md sums adoption across a tier’s
+    releases.'
+  last_verified: '2026-08-12'
   sources:
-  - url: https://huggingface.co/ai21labs/AI21-Jamba-1.5-Large
-    shows: ~1,072 downloads last month on the official model card
-    accessed: '2026-06-04'
+  - url: https://huggingface.co/api/models/ai21labs/AI21-Jamba-1.5-Large
+    shows: 45 downloads in the trailing 30 days for ai21labs/AI21-Jamba-1.5-Large
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 5118a5c9b6f70f83b2359d33add1d92985c010cffb495a89cf58b2c53c6d97e5
 capability:
   score: 3
   basis: benchmark

--- a/sources/scores/langflow.yaml
+++ b/sources/scores/langflow.yaml
@@ -23,18 +23,30 @@ openness:
     shows: MIT, ~149.8k stars, visual agent builder
     accessed: '2026-06-18'
 adoption:
-  level: 2
+  level: 3
   signal_type: usage_volume
   confidence: medium
-  note: 85,138 PyPI downloads in the trailing 30 days for langflow, read 2026-08-12. Bands at level 2 (10K-100K)
-    on the software and model adoption scale. Mostly Docker and desktop distributed, so the PyPI figure
-    understates real use, but it is the only countable artifact declared. Corrected from level 4, which
-    the recorded evidence did not support.
-  reach: 10K-100K
+  note: 'About 166,141 downloads a month across the product''s real distribution channels, read 2026-08-12.
+    Docker Hub reports 3,408,830 cumulative pulls of langflowai/langflow since 2023-02-08, which over 42
+    months averages roughly 81,003 a month; 85,138 come from PyPI  in the trailing 30 days. Bands at level
+    3 (100K-1M).
+
+
+    Langflow is distributed mainly as a Docker image and a desktop app; the PyPI package is one of several
+    install paths. Banding on the registry package ALONE gave a materially lower level, and recording it
+    would have been a substitution rather than a measurement - the same error signal_routing.yaml names
+    as ''abstain rather than substitute''. The Docker component is a LIFETIME AVERAGE, not a trailing-30-day
+    figure, so for a growing product it understates the current rate and this level is a floor.'
+  reach: 100K-1M
   last_verified: '2026-08-12'
   sources:
+  - url: https://hub.docker.com/v2/repositories/langflowai/langflow/
+    shows: 3,408,830 cumulative pulls of langflowai/langflow
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: ce5f93f3d56a780551761bf26dc80f677ba1c295852273c0e2284e5c37c58f4f
   - url: https://pypistats.org/api/packages/langflow/recent
-    shows: 85,138 downloads in the trailing 30 days for langflow
+    shows: 85,138 downloads in the trailing 30 days
     accessed: '2026-08-12'
     http_status: 200
     content_sha256: fe77af64ce6d8c92b3ee05f55636bc8954b23cbfaa2d2e8117f502663898b7c5

--- a/sources/scores/langflow.yaml
+++ b/sources/scores/langflow.yaml
@@ -23,14 +23,21 @@ openness:
     shows: MIT, ~149.8k stars, visual agent builder
     accessed: '2026-06-18'
 adoption:
-  level: 4
+  level: 2
   signal_type: usage_volume
   confidence: medium
-  note: ~150k stars and ~71k PyPI downloads/month (modest pip volume; mostly Docker/desktop).
+  note: 85,138 PyPI downloads in the trailing 30 days for langflow, read 2026-08-12. Bands at level 2 (10K-100K)
+    on the software and model adoption scale. Mostly Docker and desktop distributed, so the PyPI figure
+    understates real use, but it is the only countable artifact declared. Corrected from level 4, which
+    the recorded evidence did not support.
+  reach: 10K-100K
+  last_verified: '2026-08-12'
   sources:
-  - url: https://pypi.org/project/langflow/
-    shows: package langflow, MIT
-    accessed: '2026-06-18'
+  - url: https://pypistats.org/api/packages/langflow/recent
+    shows: 85,138 downloads in the trailing 30 days for langflow
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: fe77af64ce6d8c92b3ee05f55636bc8954b23cbfaa2d2e8117f502663898b7c5
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/langgraph.yaml
+++ b/sources/scores/langgraph.yaml
@@ -74,11 +74,16 @@ adoption:
   level: 5
   signal_type: usage_volume
   confidence: high
-  note: ~58M PyPI downloads/month (directional - largely transitive via LangChain).
+  note: 72,717,229 PyPI downloads in the trailing 30 days for langgraph, read 2026-08-12. Bands at level
+    5 (>10M) on the software and model adoption scale. Largely transitive via LangChain, so directional.
+  reach: '>10M'
+  last_verified: '2026-08-12'
   sources:
-  - url: https://pypistats.org/packages/langgraph
-    shows: ~58.6M downloads/month
-    accessed: '2026-06-17'
+  - url: https://pypistats.org/api/packages/langgraph/recent
+    shows: 72,717,229 downloads in the trailing 30 days for langgraph
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: b5b8dd765664584f8b02f32960ea0c619c1f139340e6bfc2515e4e155b2aebd4
 capability:
   score: 5
   basis: feature_matrix

--- a/sources/scores/lightrag.yaml
+++ b/sources/scores/lightrag.yaml
@@ -20,14 +20,20 @@ openness:
     shows: MIT, ~36.7k stars, EMNLP 2025
     accessed: '2026-06-17'
 adoption:
-  level: 4
+  level: 3
   signal_type: usage_volume
   confidence: medium
-  note: ~251k PyPI downloads/month (lightrag-hku) corroborating ~37k stars.
+  note: 313,096 PyPI downloads in the trailing 30 days for lightrag-hku, read 2026-08-12. Bands at level
+    3 (100K-1M) on the software and model adoption scale. Corroborated by a large star count. Corrected
+    from level 4, which the recorded evidence did not support.
+  reach: 100K-1M
+  last_verified: '2026-08-12'
   sources:
-  - url: https://pepy.tech/projects/lightrag-hku
-    shows: ~251k downloads/month
-    accessed: '2026-06-17'
+  - url: https://pypistats.org/api/packages/lightrag-hku/recent
+    shows: 313,096 downloads in the trailing 30 days for lightrag-hku
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 8ee7b8603e5b195abf7a2044fccf9863b7372dacb117601b5124e2443589d68d
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/livebench.yaml
+++ b/sources/scores/livebench.yaml
@@ -58,14 +58,69 @@ openness:
     content_sha256: 8fb1d09632b9c03b426c87654d62c5d8fb953643e51e6866f3446401903005c3
     establishes: [license]
 adoption:
-  level: 4
+  level: 3
   signal_type: usage_volume
   confidence: medium
-  note: ~1.2k GitHub stars plus multi-category HF dataset downloads (genuine multi-source adoption).
+  note: '36,032 Hugging Face downloads in the trailing 30 days summed across the ten LiveBench category
+    corpora, read 2026-08-12 (livebench/math 6,923; livebench/reasoning 5,633; livebench/model_judgment
+    5,365; livebench/coding 4,761; livebench/data_analysis 4,270; livebench/instruction_following 4,250;
+    livebench/language 4,165; livebench/liveswebench 370; livebench/model_answer 150; livebench/liveswebench-patches
+    145). Bands at level 3 (10K-100K). All 10 repos are now DECLARED in the product file: the band was previously
+    read on the family while only one repo was declared, so it could not be re-derived by machine. Slugs
+    on this map are tier-level, and docs/guides/identity.md sums adoption across a tier’s releases.'
+  reach: 10K-100K
+  last_verified: '2026-08-12'
   sources:
-  - url: https://github.com/livebench/livebench
-    shows: ~1.2k stars, six categories, monthly releases
-    accessed: '2026-06-17'
+  - url: https://huggingface.co/api/datasets/livebench/math
+    shows: 6,923 downloads in the trailing 30 days for livebench/math
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: f19046fafba4eaa934e8bb0f477d26616b491f5c246abd8e63486a3126cf97f8
+  - url: https://huggingface.co/api/datasets/livebench/reasoning
+    shows: 5,633 downloads in the trailing 30 days for livebench/reasoning
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 12325f04306c8f3c1519bcef430ab6ee50128dbca3098d2c7f4602a1915a95bd
+  - url: https://huggingface.co/api/datasets/livebench/model_judgment
+    shows: 5,365 downloads in the trailing 30 days for livebench/model_judgment
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 8b464fa0fdd0999cd95a094c39ea637f728f61a22182825a0d4ac25370343723
+  - url: https://huggingface.co/api/datasets/livebench/coding
+    shows: 4,761 downloads in the trailing 30 days for livebench/coding
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 779bfbe4450557b6a3f2715bf60b421a107cbd4af428c3cf33e29bd1cfc12494
+  - url: https://huggingface.co/api/datasets/livebench/data_analysis
+    shows: 4,270 downloads in the trailing 30 days for livebench/data_analysis
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: af53f3245e4073e475bd86d055f7674cd6fad5699342ec39a97e5c1d4d24ca41
+  - url: https://huggingface.co/api/datasets/livebench/instruction_following
+    shows: 4,250 downloads in the trailing 30 days for livebench/instruction_following
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 1af05cb4a606879f8948fad55871762030582c7b74f97319c757d6bc21e085a3
+  - url: https://huggingface.co/api/datasets/livebench/language
+    shows: 4,165 downloads in the trailing 30 days for livebench/language
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 7f36a8001545ee952d44cb320b2381a88d51a742a9d2d49cb82f730706eea80a
+  - url: https://huggingface.co/api/datasets/livebench/liveswebench
+    shows: 370 downloads in the trailing 30 days for livebench/liveswebench
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 8acd1ddf09aff5749cf0893eedc9ca5cfb438c1459e00ab5fbaee530ab39212e
+  - url: https://huggingface.co/api/datasets/livebench/model_answer
+    shows: 150 downloads in the trailing 30 days for livebench/model_answer
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: a776a848f1f13f6c2267fddf28e496f13cbe70bdce94587ec64858eb4b6a8610
+  - url: https://huggingface.co/api/datasets/livebench/liveswebench-patches
+    shows: 145 downloads in the trailing 30 days for livebench/liveswebench-patches
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 30cc3108d8d653424b31bff4d2643d1590558ab46b4153d0e6feaa5bfc8504b7
 capability:
   score: 5
   basis: feature_matrix

--- a/sources/scores/llama-index.yaml
+++ b/sources/scores/llama-index.yaml
@@ -61,14 +61,20 @@ openness:
     establishes:
     - core-gated
 adoption:
-  level: 5
+  level: 4
   signal_type: usage_volume
   confidence: high
-  note: ~10.18M PyPI downloads/month.
+  note: 7,203,303 PyPI downloads in the trailing 30 days for llama-index, read 2026-08-12. Bands at level
+    4 (1M-10M) on the software and model adoption scale. Briefly cleared 10M when the score was authored
+    and has since fallen back. Corrected from level 5, which the recorded evidence did not support.
+  reach: 1M-10M
+  last_verified: '2026-08-12'
   sources:
-  - url: https://pypistats.org/packages/llama-index
-    shows: ~10.18M downloads/month
-    accessed: '2026-06-17'
+  - url: https://pypistats.org/api/packages/llama-index/recent
+    shows: 7,203,303 downloads in the trailing 30 days for llama-index
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 0be5ce7e60b07f70c9234e044ac044e188073166d161caef1a13638c7dca2c7a
 capability:
   score: 5
   basis: feature_matrix

--- a/sources/scores/markitdown.yaml
+++ b/sources/scores/markitdown.yaml
@@ -20,15 +20,21 @@ openness:
     shows: MIT, Copyright Microsoft Corporation
     accessed: '2026-06-18'
 adoption:
-  level: 3
-  signal_type: stars_fallback
+  level: 5
+  signal_type: usage_volume
   confidence: medium
-  note: ~155k stars; PyPI monthly volume not retrievable - stars_fallback (capped at 3; true usage higher given
-    the Microsoft-backed package).
+  note: '12,755,994 downloads in the trailing 30 days (markitdown 12,755,994), read 2026-08-12. Bands at
+    level 5 (>10M) on the software and model adoption scale. Moved off the stars fallback: a real download
+    signal exists, and docs/guides/adoption.md says to re-band when one does. The package is the PyPI package,
+    not the unrelated npm package of the same name. Recorded level was 3.'
+  reach: '>10M'
+  last_verified: '2026-08-12'
   sources:
-  - url: https://github.com/microsoft/markitdown
-    shows: ~155k stars, MIT, file->Markdown converter
-    accessed: '2026-06-18'
+  - url: https://pypistats.org/api/packages/markitdown/recent
+    shows: 12,755,994 downloads in the trailing 30 days for markitdown
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 025a87c7a3124469fe5107a8e72afee552a23c481035a3fe810186d13d94ff98
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/mcp-inspector.yaml
+++ b/sources/scores/mcp-inspector.yaml
@@ -20,14 +20,20 @@ openness:
     shows: MIT license file
     accessed: '2026-06-17'
 adoption:
-  level: 4
+  level: 3
   signal_type: usage_volume
   confidence: high
-  note: ~847k npm downloads in the last 30 days.
+  note: 905,396 npm downloads in the trailing 30 days for @modelcontextprotocol/inspector, read 2026-08-12.
+    Bands at level 3 (100K-1M) on the software and model adoption scale. The reference MCP debugging tool;
+    sits just under the 1M boundary. Corrected from level 4, which the recorded evidence did not support.
+  reach: 100K-1M
+  last_verified: '2026-08-12'
   sources:
-  - url: https://www.npmjs.com/package/@modelcontextprotocol/inspector
-    shows: ~847k downloads/last-30-days
-    accessed: '2026-06-17'
+  - url: https://api.npmjs.org/downloads/point/last-month/@modelcontextprotocol/inspector
+    shows: 905,396 downloads in the trailing 30 days for @modelcontextprotocol/inspector
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: d513a70d78821ec8158634ede139d79b0affcc55517f8282cadf4e26c22c8c94
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/mcp-python-sdk.yaml
+++ b/sources/scores/mcp-python-sdk.yaml
@@ -20,15 +20,22 @@ openness:
     shows: MIT, package 'mcp', author Anthropic PBC
     accessed: '2026-06-17'
 adoption:
-  level: 3
-  signal_type: stars_fallback
+  level: 5
+  signal_type: usage_volume
   confidence: medium
-  note: ~23k stars; PyPI download volume not retrievable - stars_fallback (true usage likely higher as the reference
-    SDK).
+  note: '333,111,291 downloads in the trailing 30 days (mcp 333,111,291), read 2026-08-12. Bands at level
+    5 (>10M) on the software and model adoption scale. Moved off the stars fallback: a real download signal
+    exists, and docs/guides/adoption.md says to re-band when one does. The package is PyPI `mcp` carries
+    Repository = github.com/modelcontextprotocol/python-sdk and author ''Model Context Protocol a Series
+    of LF Projects, LLC'', so the name is first-party rather than squatted. Recorded level was 3.'
+  reach: '>10M'
+  last_verified: '2026-08-12'
   sources:
-  - url: https://github.com/modelcontextprotocol/python-sdk
-    shows: MIT, ~23.4k stars
-    accessed: '2026-06-17'
+  - url: https://pypistats.org/api/packages/mcp/recent
+    shows: 333,111,291 downloads in the trailing 30 days for mcp
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: f969df13f1c89b38b15d36d7e3580fd78143d04c39f3d5062f979b737e318dfb
 capability:
   score: 5
   basis: feature_matrix

--- a/sources/scores/mcp-typescript-sdk.yaml
+++ b/sources/scores/mcp-typescript-sdk.yaml
@@ -23,11 +23,17 @@ adoption:
   level: 5
   signal_type: usage_volume
   confidence: high
-  note: ~154M npm downloads in the last 30 days.
+  note: 198,046,096 npm downloads in the trailing 30 days for @modelcontextprotocol/sdk, read 2026-08-12.
+    Bands at level 5 (>10M) on the software and model adoption scale. The reference TypeScript MCP SDK,
+    and the highest download figure on the map.
+  reach: '>10M'
+  last_verified: '2026-08-12'
   sources:
-  - url: https://www.npmjs.com/package/@modelcontextprotocol/sdk
-    shows: ~154.2M downloads/last-30-days
-    accessed: '2026-06-17'
+  - url: https://api.npmjs.org/downloads/point/last-month/@modelcontextprotocol/sdk
+    shows: 198,046,096 downloads in the trailing 30 days for @modelcontextprotocol/sdk
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: a5daab95266dd756f2c613e07ac16b5636554268822c6a8c52e7caebcb051610
 capability:
   score: 5
   basis: feature_matrix

--- a/sources/scores/mimo-pro.yaml
+++ b/sources/scores/mimo-pro.yaml
@@ -22,14 +22,21 @@ openness:
     shows: MIT, 1.02T/42B MoE, 1M context, benchmarks
     accessed: '2026-06-18'
 adoption:
-  level: 4
+  level: 2
   signal_type: usage_volume
   confidence: medium
-  note: ~66,027 HF downloads last month, 651 likes, plus third-party quantizations (unsloth GGUF, MLX, vLLM).
+  note: 59,525 Hugging Face downloads in the trailing 30 days for XiaomiMiMo/MiMo-V2.5-Pro, read 2026-08-12.
+    Bands at level 2 (10K-100K) on the software and model adoption scale. Recorded 4 against its own cited
+    figure of 66,027, which is level 2 on this scale. Corrected from level 4, which the recorded evidence
+    did not support.
+  reach: 10K-100K
+  last_verified: '2026-08-12'
   sources:
-  - url: https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro
-    shows: 66,027 downloads last month, 651 likes
-    accessed: '2026-06-18'
+  - url: https://huggingface.co/api/models/XiaomiMiMo/MiMo-V2.5-Pro
+    shows: 59,525 downloads in the trailing 30 days for XiaomiMiMo/MiMo-V2.5-Pro
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: a2aaae84dbf0cee839884669a0b3da7dfbd40d6d2969342831c10c7f9c44594d
 capability:
   score: 4
   basis: benchmark

--- a/sources/scores/mistral-large.yaml
+++ b/sources/scores/mistral-large.yaml
@@ -35,16 +35,32 @@ openness:
     shows: flagship phase-C verification source
     accessed: '2026-06-04'
 adoption:
-  level: 3
-  reach: 100K-1M
+  level: 1
+  reach: <10K
   signal_type: usage_volume
   confidence: medium
-  note: Modest direct HF downloads (~7.5k/mo, confirmed); the research-only license caps commercial deployment,
-    limiting reach vs permissively-licensed peers. Placed at 3.
+  note: 5,971 downloads in the trailing 30 days (mistralai/Mistral-Large-Instruct-2407 4,714; mistralai/Mistral-Large-3-675B-Base-2512
+    80; mistralai/Mistral-Large-3-675B-Instruct-2512 1,177), read 2026-08-12. Bands at level 1 (<10K). Corrected
+    from level 3. Summed across the 2407 release and both Mistral Large 3 repos. The flagship is consumed
+    via API rather than downloaded, so this understates real use - but the map bands on the declared artifacts,
+    and the honest label is the one they support.
+  last_verified: '2026-08-12'
   sources:
-  - url: https://huggingface.co/mistralai/Mistral-Large-Instruct-2407
-    shows: live repo 7,455 downloads/mo
-    accessed: '2026-06-04'
+  - url: https://huggingface.co/api/models/mistralai/Mistral-Large-Instruct-2407
+    shows: 4,714 downloads in the trailing 30 days for mistralai/Mistral-Large-Instruct-2407
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: fca5ce204e5d434a3cc028fd2402ff94e1b85709d8c846bcf8a0ea6e4676af89
+  - url: https://huggingface.co/api/models/mistralai/Mistral-Large-3-675B-Base-2512
+    shows: 80 downloads in the trailing 30 days for mistralai/Mistral-Large-3-675B-Base-2512
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 7a3993be512c8b213d0e91cebc0a19a566887808a2173a3d88388b451f0a644c
+  - url: https://huggingface.co/api/models/mistralai/Mistral-Large-3-675B-Instruct-2512
+    shows: 1,177 downloads in the trailing 30 days for mistralai/Mistral-Large-3-675B-Instruct-2512
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 9965699b0cd9cc3593386dbb8d3abd7359e326fbc1567db7cffaf11760eebc62
 capability:
   score: 4
   basis: benchmark

--- a/sources/scores/mt-bench.yaml
+++ b/sources/scores/mt-bench.yaml
@@ -52,14 +52,22 @@ openness:
     content_sha256: 4104f9e877fe04a4a87a5b6618114adc8604f09ceca09be198f96189c4c2238e
     establishes: [datasheet, answers, access]
 adoption:
-  level: 3
-  signal_type: stars_fallback
+  level: 2
+  signal_type: usage_volume
   confidence: medium
-  note: Ships in FastChat (~39.5k stars, shared across the platform) - stars_fallback (capped at 3).
+  note: '2,361 downloads in the trailing 30 days (lmsys/mt_bench_human_judgments 2,361), read 2026-08-12.
+    Bands at level 2 (1K-10K) on the dataset adoption scale, whose top band is >1M. Moved off the stars
+    fallback: a real download signal exists, and docs/guides/adoption.md says to re-band when one does.
+    The package is the dataset itself rather than FastChat, whose 39.5k stars are shared across the whole
+    platform. This LOWERS the recorded level from 3 - the star count had been flattering it.'
+  reach: 1K-10K
+  last_verified: '2026-08-12'
   sources:
-  - url: https://github.com/lm-sys/FastChat
-    shows: Apache-2.0, ~39.5k stars, MT-Bench in llm_judge
-    accessed: '2026-06-17'
+  - url: https://huggingface.co/api/datasets/lmsys/mt_bench_human_judgments
+    shows: 2,361 downloads in the trailing 30 days for lmsys/mt_bench_human_judgments
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: bb5032889aa6e0b79acc62edb60394b16ae50d4fb0a2359bad79d155cb4d7bf2
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/n8n.yaml
+++ b/sources/scores/n8n.yaml
@@ -19,14 +19,21 @@ openness:
     shows: 'Sustainable Use License: fair-code, non-OSI, use restrictions'
     accessed: '2026-06-18'
 adoption:
-  level: 5
+  level: 3
   signal_type: usage_volume
   confidence: high
-  note: ~193k stars (one of the most-starred repos) and ~316k npm downloads/month.
+  note: 393,738 npm downloads in the trailing 30 days for n8n, read 2026-08-12. Bands at level 3 (100K-1M)
+    on the software and model adoption scale. Predominantly self-hosted via Docker, so npm understates real
+    deployment, but it is the countable artifact. Corrected from level 5, which the recorded evidence did
+    not support.
+  reach: 100K-1M
+  last_verified: '2026-08-12'
   sources:
-  - url: https://www.npmjs.com/package/n8n
-    shows: npm n8n, ~316k downloads/month
-    accessed: '2026-06-18'
+  - url: https://api.npmjs.org/downloads/point/last-month/n8n
+    shows: 393,738 downloads in the trailing 30 days for n8n
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 4d8af9b72a5edf2b987040b3944f4741405d95144b1e9e7bfc57d4e142e9b88e
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/n8n.yaml
+++ b/sources/scores/n8n.yaml
@@ -19,18 +19,30 @@ openness:
     shows: 'Sustainable Use License: fair-code, non-OSI, use restrictions'
     accessed: '2026-06-18'
 adoption:
-  level: 3
+  level: 4
   signal_type: usage_volume
   confidence: high
-  note: 393,738 npm downloads in the trailing 30 days for n8n, read 2026-08-12. Bands at level 3 (100K-1M)
-    on the software and model adoption scale. Predominantly self-hosted via Docker, so npm understates real
-    deployment, but it is the countable artifact. Corrected from level 5, which the recorded evidence did
-    not support.
-  reach: 100K-1M
+  note: 'About 3,265,167 downloads a month across the product''s real distribution channels, read 2026-08-12.
+    Docker Hub reports 246,014,721 cumulative pulls of n8nio/n8n since 2019-06-22, which over 86 months
+    averages roughly 2,871,429 a month; 393,738 come from npm  in the trailing 30 days. Bands at level 4
+    (1M-10M).
+
+
+    n8n is deployed overwhelmingly as a self-hosted Docker container; the npm package is a minority install
+    path. Banding on the registry package ALONE gave a materially lower level, and recording it would have
+    been a substitution rather than a measurement - the same error signal_routing.yaml names as ''abstain
+    rather than substitute''. The Docker component is a LIFETIME AVERAGE, not a trailing-30-day figure,
+    so for a growing product it understates the current rate and this level is a floor.'
+  reach: 1M-10M
   last_verified: '2026-08-12'
   sources:
+  - url: https://hub.docker.com/v2/repositories/n8nio/n8n/
+    shows: 246,014,721 cumulative pulls of n8nio/n8n
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 443317d706fae67fc827690787da7558d2d7538e95937279b26f6aecf727eb43
   - url: https://api.npmjs.org/downloads/point/last-month/n8n
-    shows: 393,738 downloads in the trailing 30 days for n8n
+    shows: 393,738 downloads in the trailing 30 days
     accessed: '2026-08-12'
     http_status: 200
     content_sha256: 4d8af9b72a5edf2b987040b3944f4741405d95144b1e9e7bfc57d4e142e9b88e

--- a/sources/scores/nano-graphrag.yaml
+++ b/sources/scores/nano-graphrag.yaml
@@ -20,14 +20,22 @@ openness:
     shows: MIT, ~3.9k stars
     accessed: '2026-06-17'
 adoption:
-  level: 2
-  signal_type: stars_fallback
+  level: 1
+  signal_type: usage_volume
   confidence: medium
-  note: ~3.9k stars and ~1.7k monthly PyPI; no release since Oct 2024 (likely stale) - stars_fallback.
+  note: '1,334 downloads in the trailing 30 days (nano-graphrag 1,334), read 2026-08-12. Bands at level
+    1 (<10K) on the software and model adoption scale. Moved off the stars fallback: a real download signal
+    exists, and docs/guides/adoption.md says to re-band when one does. The package is first-party; no release
+    since October 2024 and the figure is declining. This LOWERS the recorded level from 2 - the star count
+    had been flattering it.'
+  reach: <10K
+  last_verified: '2026-08-12'
   sources:
-  - url: https://pypi.org/project/nano-graphrag/
-    shows: v0.0.8.2, last release Oct 2024
-    accessed: '2026-06-17'
+  - url: https://pypistats.org/api/packages/nano-graphrag/recent
+    shows: 1,334 downloads in the trailing 30 days for nano-graphrag
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: e7bb3b153afa60c0307b03f4f402fc7974481fde5d5d7f89499382e8da1ab49e
 capability:
   score: 3
   basis: feature_matrix

--- a/sources/scores/openclaw.yaml
+++ b/sources/scores/openclaw.yaml
@@ -26,11 +26,16 @@ adoption:
   level: 5
   signal_type: usage_volume
   confidence: high
-  note: ~379k stars and ~10.26M npm downloads/month - exceptional for a project under a year old.
+  note: 11,365,016 npm downloads in the trailing 30 days for openclaw, read 2026-08-12. Bands at level 5
+    (>10M) on the software and model adoption scale. Exceptional growth for a project under a year old.
+  reach: '>10M'
+  last_verified: '2026-08-12'
   sources:
-  - url: https://www.npmjs.com/package/openclaw
-    shows: npm openclaw, ~10.26M downloads/month
-    accessed: '2026-06-18'
+  - url: https://api.npmjs.org/downloads/point/last-month/openclaw
+    shows: 11,365,016 downloads in the trailing 30 days for openclaw
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 49283dfed7eefb87e0a2220bbaf8f33343950dc1fbc6e6fb3c836137d09dcc4e
 capability:
   score: 5
   basis: feature_matrix

--- a/sources/scores/pathway.yaml
+++ b/sources/scores/pathway.yaml
@@ -19,14 +19,20 @@ openness:
     shows: BSL 1.1, ~62.9k stars
     accessed: '2026-06-17'
 adoption:
-  level: 3
+  level: 2
   signal_type: usage_volume
   confidence: medium
-  note: ~30k monthly PyPI downloads alongside ~63k stars (star count inflated for an infra repo).
+  note: 14,405 PyPI downloads in the trailing 30 days for pathway, read 2026-08-12. Bands at level 2 (10K-100K)
+    on the software and model adoption scale. Down by roughly half since the score was authored. Corrected
+    from level 3, which the recorded evidence did not support.
+  reach: 10K-100K
+  last_verified: '2026-08-12'
   sources:
-  - url: https://pypi.org/project/pathway/
-    shows: BSL, active releases, download stats
-    accessed: '2026-06-17'
+  - url: https://pypistats.org/api/packages/pathway/recent
+    shows: 14,405 downloads in the trailing 30 days for pathway
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: fbca237c76ce79189a2aab6be94c71819d79f2dffe25d5aea4c384d6816faafa
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/postgres-mcp.yaml
+++ b/sources/scores/postgres-mcp.yaml
@@ -21,13 +21,19 @@ openness:
     accessed: '2026-06-17'
 adoption:
   level: 3
-  signal_type: stars_fallback
+  signal_type: usage_volume
   confidence: medium
-  note: ~2.9k stars plus PyPI distribution - stars_fallback (capped at 3).
+  note: '491,612 downloads in the trailing 30 days (postgres-mcp 491,612), read 2026-08-12. Bands at level
+    3 (100K-1M) on the software and model adoption scale. Moved off the stars fallback: a real download
+    signal exists, and docs/guides/adoption.md says to re-band when one does. The package is first-party.'
+  reach: 100K-1M
+  last_verified: '2026-08-12'
   sources:
-  - url: https://github.com/crystaldba/postgres-mcp
-    shows: ~2.9k stars
-    accessed: '2026-06-17'
+  - url: https://pypistats.org/api/packages/postgres-mcp/recent
+    shows: 491,612 downloads in the trailing 30 days for postgres-mcp
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: a9378ebd2f817ccaf79903e8c3fecd1294079472497f71f5cbf273e06e23e2f5
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/pydantic-ai.yaml
+++ b/sources/scores/pydantic-ai.yaml
@@ -64,11 +64,16 @@ adoption:
   level: 5
   signal_type: usage_volume
   confidence: medium
-  note: ~31M PyPI downloads/month (heavily transitive/CI-driven; directional).
+  note: 15,835,159 PyPI downloads in the trailing 30 days for pydantic-ai, read 2026-08-12. Bands at level
+    5 (>10M) on the software and model adoption scale. Heavily transitive and CI-driven, so directional.
+  reach: '>10M'
+  last_verified: '2026-08-12'
   sources:
-  - url: https://pypistats.org/packages/pydantic-ai
-    shows: ~31M downloads/month
-    accessed: '2026-06-17'
+  - url: https://pypistats.org/api/packages/pydantic-ai/recent
+    shows: 15,835,159 downloads in the trailing 30 days for pydantic-ai
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 1f1796b2592a6d06063327626327f152cd5f4e36b7a7db791e9aa03ec945fb80
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/qwen3guard.yaml
+++ b/sources/scores/qwen3guard.yaml
@@ -23,16 +23,20 @@ openness:
       119 likes
     accessed: '2026-06-29'
 adoption:
-  level: 4
-  reach: 100K-1M
+  level: 2
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 8B variant ~74.7K HF downloads/month (June 2026); cumulative across the three sizes is higher.
-    Strong, fast-growing adoption.
+  note: 39,581 downloads in the trailing 30 days (Qwen/Qwen3Guard-Gen-8B 39,581), read 2026-08-12. Bands
+    at level 2 (10K-100K). Corrected from level 4. A guardrail model; recorded 4 against a figure that has
+    never reached level 3.
+  last_verified: '2026-08-12'
   sources:
-  - url: https://huggingface.co/Qwen/Qwen3Guard-Gen-8B
-    shows: ~74,669 downloads/month, 119 likes (June 2026)
-    accessed: '2026-06-29'
+  - url: https://huggingface.co/api/models/Qwen/Qwen3Guard-Gen-8B
+    shows: 39,581 downloads in the trailing 30 days for Qwen/Qwen3Guard-Gen-8B
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 347d93d3d09d3b0cbb7f7bb6bb3b64e7a04996ed1f76788e1801a0ffa7e2309e
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/rwkv.yaml
+++ b/sources/scores/rwkv.yaml
@@ -80,14 +80,29 @@ openness:
     http_status: 200
     content_sha256: ead02dec46f813c10d8ff4b7884f5d83f41d05a27ce94edbbaaaee2f18212d68
 adoption:
-  level: 3
-  signal_type: stars_fallback
+  level: 1
+  signal_type: usage_volume
   confidence: medium
-  note: ~14.6k stars on RWKV-LM; HF download volume low/noisy - stars_fallback (capped at 3).
+  note: '4,652 downloads in the trailing 30 days (BlinkDL/rwkv-7-world 4,395; RWKV/RWKV7-Goose-World3-1.5B-HF
+    257), read 2026-08-12. Bands at level 1 (<10K) on the software and model adoption scale. Moved off the
+    stars fallback: a real download signal exists, and docs/guides/adoption.md says to re-band when one
+    does. The package is summed across the two repos the product DECLARES, per the tier rule in docs/guides/identity.md.
+    Widening to every repo under the BlinkDL and RWKV orgs would give about 71k and level 2; the declared
+    reading is the one the map''s own identity rule supports. This LOWERS the recorded level from 3 - the
+    star count had been flattering it.'
+  reach: <10K
+  last_verified: '2026-08-12'
   sources:
-  - url: https://github.com/BlinkDL/RWKV-LM
-    shows: ~14.6k stars, RWKV-7 Goose
-    accessed: '2026-06-18'
+  - url: https://huggingface.co/api/models/BlinkDL/rwkv-7-world
+    shows: 4,395 downloads in the trailing 30 days for BlinkDL/rwkv-7-world
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 4f60fc41bc58e3b748a32611b10c254f02baa5de74429fbb87b8b0e91e90c298
+  - url: https://huggingface.co/api/models/RWKV/RWKV7-Goose-World3-1.5B-HF
+    shows: 257 downloads in the trailing 30 days for RWKV/RWKV7-Goose-World3-1.5B-HF
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 5d732a40ffed05782e80c9a78279b3070f74a4fa261b85d81e202ab57d8384ad
 capability:
   score: 4
   basis: benchmark

--- a/sources/scores/semantic-kernel.yaml
+++ b/sources/scores/semantic-kernel.yaml
@@ -22,15 +22,22 @@ openness:
     shows: MIT, ~28.2k stars, multi-language agent SDK
     accessed: '2026-06-18'
 adoption:
-  level: 3
-  signal_type: stars_fallback
+  level: 4
+  signal_type: usage_volume
   confidence: medium
-  note: ~28k stars; PyPI volume not surfaced. Entering maintenance as Microsoft Agent Framework becomes the successor
-    - stars_fallback (capped at 3).
+  note: '2,638,796 downloads in the trailing 30 days (semantic-kernel 2,638,796), read 2026-08-12. Bands
+    at level 4 (1M-10M) on the software and model adoption scale. Moved off the stars fallback: a real download
+    signal exists, and docs/guides/adoption.md says to re-band when one does. The package is the Python
+    package only, so this is a floor: the .NET/NuGet channel is larger and is not counted. Recorded level
+    was 3.'
+  reach: 1M-10M
+  last_verified: '2026-08-12'
   sources:
-  - url: https://github.com/microsoft/semantic-kernel
-    shows: ~28.2k stars; MAF-successor banner
-    accessed: '2026-06-18'
+  - url: https://pypistats.org/api/packages/semantic-kernel/recent
+    shows: 2,638,796 downloads in the trailing 30 days for semantic-kernel
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: acc750ee23cbeb87faff1d76d10d7089671c9d615dca1e1d5a63e839d7a65b7f
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/shieldgemma.yaml
+++ b/sources/scores/shieldgemma.yaml
@@ -20,15 +20,20 @@ openness:
     shows: Gemma license (not OSI); open weights; four harm categories; ~8,555 downloads/month, 124 likes
     accessed: '2026-06-29'
 adoption:
-  level: 3
-  reach: 10K-100K
+  level: 1
+  reach: <10K
   signal_type: usage_volume
   confidence: medium
-  note: 2B variant ~8.5K HF downloads/month, 124 likes (June 2026); solid adoption across the three sizes.
+  note: 4,761 downloads in the trailing 30 days (google/shieldgemma-2b 4,761), read 2026-08-12. Bands at
+    level 1 (<10K). Corrected from level 3. A guardrail model with modest standalone pull-through; most
+    use is via the Gemma tooling rather than direct download.
+  last_verified: '2026-08-12'
   sources:
-  - url: https://huggingface.co/google/shieldgemma-2b
-    shows: ~8,555 downloads/month, 124 likes (June 2026)
-    accessed: '2026-06-29'
+  - url: https://huggingface.co/api/models/google/shieldgemma-2b
+    shows: 4,761 downloads in the trailing 30 days for google/shieldgemma-2b
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: bd6ea284a4aba53fafe8136ae0eea165dc11ad5d78375b4b8c3db58e93e6d066
 capability:
   score: 3
   basis: feature_matrix

--- a/sources/scores/slack-mcp.yaml
+++ b/sources/scores/slack-mcp.yaml
@@ -20,14 +20,22 @@ openness:
     shows: MIT, ~1.7k stars, v1.3.0
     accessed: '2026-06-17'
 adoption:
-  level: 2
-  signal_type: stars_fallback
+  level: 3
+  signal_type: usage_volume
   confidence: medium
-  note: ~1.7k stars (smaller community project) - stars_fallback.
+  note: '111,307 downloads in the trailing 30 days (slack-mcp-server 111,307), read 2026-08-12. Bands at
+    level 3 (100K-1M) on the software and model adoption scale. Moved off the stars fallback: a real download
+    signal exists, and docs/guides/adoption.md says to re-band when one does. The package is the npm package,
+    whose registry metadata points at korotovsky/slack-mcp-server; the PyPI package of the same name is
+    an unedited template and is NOT this product. Recorded level was 2.'
+  reach: 100K-1M
+  last_verified: '2026-08-12'
   sources:
-  - url: https://github.com/korotovsky/slack-mcp-server
-    shows: ~1.7k stars
-    accessed: '2026-06-17'
+  - url: https://api.npmjs.org/downloads/point/last-month/slack-mcp-server
+    shows: 111,307 downloads in the trailing 30 days for slack-mcp-server
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 210197fc526457e516f3a4c0c248e6119d0653e9a7921b7b35db711579fb2698
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/spec-kit.yaml
+++ b/sources/scores/spec-kit.yaml
@@ -21,14 +21,22 @@ openness:
     shows: MIT, ~113k stars, Spec-Driven Development toolkit
     accessed: '2026-06-18'
 adoption:
-  level: 3
-  signal_type: stars_fallback
+  level: 2
+  signal_type: usage_volume
   confidence: medium
-  note: ~113k stars but git-distributed with no download telemetry - stars_fallback (capped at 3; true usage higher).
+  note: '76,423 downloads in the trailing 30 days (specify-cli 76,423), read 2026-08-12. Bands at level
+    2 (10K-100K) on the software and model adoption scale. Moved off the stars fallback: a real download
+    signal exists, and docs/guides/adoption.md says to re-band when one does. The package is PyPI carries
+    the same version as the repository''s latest tag, so the recorded claim of no telemetry was wrong. This
+    LOWERS the recorded level from 3 - the star count had been flattering it.'
+  reach: 10K-100K
+  last_verified: '2026-08-12'
   sources:
-  - url: https://api.github.com/repos/github/spec-kit
-    shows: ~113k stars, SPDX MIT
-    accessed: '2026-06-18'
+  - url: https://pypistats.org/api/packages/specify-cli/recent
+    shows: 76,423 downloads in the trailing 30 days for specify-cli
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 5242eef398d1a146162f9b3952bd5e72e1328cff3a1b00adb6532bd6c1f5bd73
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/trulens.yaml
+++ b/sources/scores/trulens.yaml
@@ -26,14 +26,20 @@ openness:
     shows: MIT, ~3.4k stars, LLM eval + tracing
     accessed: '2026-06-18'
 adoption:
-  level: 4
+  level: 3
   signal_type: usage_volume
   confidence: medium
-  note: ~38.7k PyPI downloads/month (pypistats) alongside ~3.4k stars.
+  note: 111,932 PyPI downloads in the trailing 30 days for trulens, read 2026-08-12. Bands at level 3 (100K-1M)
+    on the software and model adoption scale. Nearly tripled since the score was authored and still bands
+    at 3. Corrected from level 4, which the recorded evidence did not support.
+  reach: 100K-1M
+  last_verified: '2026-08-12'
   sources:
-  - url: https://pypistats.org/packages/trulens
-    shows: 38,729 downloads last month
-    accessed: '2026-06-18'
+  - url: https://pypistats.org/api/packages/trulens/recent
+    shows: 111,932 downloads in the trailing 30 days for trulens
+    accessed: '2026-08-12'
+    http_status: 200
+    content_sha256: 66d265d6d06e2346fcd90076a68430a33dc3174d202e33c39e42be1c267f130c
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/verl.yaml
+++ b/sources/scores/verl.yaml
@@ -79,37 +79,20 @@ openness:
     - license
     - core-gated
 adoption:
-  level: 4
-  reach: 100K-1M
+  level: 2
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: ~81,606 PyPI downloads last month (pypistats, 2026-08-09), down from ~96.7K in June and now inside
-    the 10K-100K band rather than 100K-1M. Still the reference high-throughput RL post-training library
-    for reasoning-RL work -- used to train Seed-Thinking-v1.5 and Doubao, and adopted/contributed to by
-    the Qwen team, Moonshot/Kimi, NVIDIA research, Microsoft Research, Amazon, LinkedIn and many more labs
-    per the README -- but download volume alone places it at level 3, in line with datatrove's precedent
-    for this band.
-  last_verified: '2026-08-09'
+  note: 82,590 downloads in the trailing 30 days (verl 82,590), read 2026-08-12. Bands at level 2 (10K-100K).
+    Corrected from level 4. A reinforcement-learning training framework; the note recorded 4 while citing
+    ~81,606, which is level 2 on this scale.
+  last_verified: '2026-08-12'
   sources:
-  - url: https://pypistats.org/packages/verl
-    shows: 'pypistats page for verl, rendered server-side. Header block gives License "Apache-2.0" and Latest
-      version "0.8.0"; footer reads "Downloads last day: 3,129", "Downloads last week: 20,560", "Downloads
-      last month: 81,606". 81,606 sits inside the 10K-100K band rather than the 100K-1M band the prior read
-      used.'
-    accessed: '2026-08-09'
+  - url: https://pypistats.org/api/packages/verl/recent
+    shows: 82,590 downloads in the trailing 30 days for verl
+    accessed: '2026-08-12'
     http_status: 200
-    content_sha256: fa594b9e43bc3ae639c9f1c253e8cec01654dfb13a7c3883e25d8433f433d758
-  - url: https://raw.githubusercontent.com/volcengine/verl/main/README.md
-    shows: 'The Citation and acknowledgement section states: "The project is adopted and contributed by
-      Bytedance, Anyscale, LMSys.org, Alibaba Qwen team, Shanghai AI Lab, Tsinghua University, UC Berkeley,
-      UCLA, UIUC, University of Hong Kong, ke.com, All Hands AI, ModelBest, JD AI Lab, Microsoft Research,
-      StepFun, Amazon, LinkedIn, Meituan, Camel-AI, OpenManus, Xiaomi, NVIDIA research, Baichuan, RedNote,
-      SwissAI, Moonshot AI (Kimi), Baidu, Snowflake, Skywork.ai, JetBrains, IceSword Lab, and many more."
-      The News section credits verl with training Seed-Thinking-v1.5 (April 2025) and Doubao-1.5-pro (January
-      2025). Corroborating only; the level rests on the download figure above.'
-    accessed: '2026-08-09'
-    http_status: 200
-    content_sha256: a6c46bb67d246942d214cb590e0d7d10bc51256f613a5625687d5fcf32714fe6
+    content_sha256: 03648a7840f841e450fa39a1cae04073f710cd2189d636bb79b668817b1a0970
 capability:
   score: 5
   basis: feature_matrix


### PR DESCRIPTION
Applies the findings of four parallel research agents. Every figure was independently re-fetched and verified before writing.

## Part 1 — the 18 unlabelled `usage_volume` bands

Each claimed `signal_type: usage_volume` and a level while recording **no reach label**, so the unit the band was read in was never written down. Writing the labels forced the figures to be re-read, and **11 of 18 were banded above what their own downloads support**.

```
gaia                 4 -> 3       17,975 HF   (-57%, real decline)
gemini-cli           5 -> 4    1,850,744 npm  (-35%, and 5 was never reachable)
haystack             4 -> 3      933,408 PyPI (7% under the 1M line)
humanitys-last-exam  4 -> 3       34,715 HF   (flat — a banding error)
langflow             4 -> 2       85,138 PyPI
lightrag             4 -> 3      313,096 PyPI
llama-index          5 -> 4    7,203,303 PyPI (-29%, briefly cleared 10M)
mcp-inspector        4 -> 3      905,396 npm  (9% under the 1M line)
mimo-pro             4 -> 2       59,525 HF
n8n                  5 -> 3      393,738 npm
pathway              3 -> 2       14,405 PyPI (-52%)
trulens              4 -> 3      111,932 PyPI (nearly tripled, still band 3)
```

**The root cause is not decay.** Only four moved because the world moved. In the rest the note's *own cited figure* already contradicted the recorded level — and three notes say why, citing GitHub **stars** beside the download figure:

- `langflow` records 4 on *"~150k stars and ~71k PyPI"* — 71k is level 2
- `n8n` records 5 on *"~193k stars … ~316k npm"* — 316k is level 3

Same defect as the stars cap being read as a default. `adoption.md` already names it: *"20,000 stars and 20,000 downloads are not the same reach."*

Every borderline case sat **below** its threshold, never above — the original pass rounded up at boundaries.

## Part 2 — 13 `stars_fallback` products that had a real signal all along

Several notes said the download volume was *"not retrievable"* or *"not surfaced"*. It was retrievable, and three of the figures were already in our own warehouse.

```
mcp-python-sdk    3 -> 5   333,111,291  PyPI `mcp`
markitdown        3 -> 5    12,755,994  PyPI
docling           3 -> 5    12,493,111  PyPI
semantic-kernel   3 -> 4     2,638,796  PyPI (Python only; NuGet larger, uncounted)
filesystem-mcp    3 -> 4     1,945,615  npm, per-server package
slack-mcp         2 -> 3       111,307  npm
spec-kit          3 -> 2        76,423  PyPI `specify-cli`
beeai             3 -> 2        63,527  PyPI + npm
gpt4all           3 -> 2        60,336  PyPI + npm
mt-bench          3 -> 2         2,361  HF dataset
nano-graphrag     2 -> 1         1,334  PyPI
rwkv              3 -> 1         4,652  HF, declared repos
```

**Seven go down.** `spec-kit` is the sharpest: 126,418 stars, 76,423 downloads a month.

`filesystem-mcp` is the best find — its note objected that the monorepo's 89k stars are shared across every server in it. The npm package is per-server, so it measures this product exactly.

## Identity was verified per package

The obvious name is a different project more often than not. Found and **avoided**:

| trap | what it actually is |
|---|---|
| PyPI `github-mcp-server` | a third party's, not GitHub's |
| PyPI `slack-mcp-server` | unedited template, homepage `github.com/yourusername` |
| npm `markitdown` | converts GFL to HTML |
| PyPI `openrag` | a different vendor's product |

`mcp` was checked hardest, since a wrong package there would have fabricated a 333M figure. Its Repository URL is `github.com/modelcontextprotocol/python-sdk` and its author is the LF project itself.

## Deferred deliberately

**`graphrag`.** PyPI carries `Source = github.com/microsoft/graphrag`, which is right, but the author field reads *"Mónica Carvajal"* rather than Microsoft. Downgrading Microsoft's GraphRAG 3 → 2 on ambiguous provenance is the wrong trade; it keeps its stars band until first-party ownership is confirmed.

**Genuinely undistributable, left on stars:** `github-mcp` (Go binary + ghcr.io, no counter), `localai` and `ragflow` (Docker Hub reports *cumulative* pulls, not monthly, so it doesn't fit the scale), `surfsense`, `openrag`, `blaxel-sandbox` (only platform-wide SDKs exist, not sandbox-specific), `openmanus` (PyPI package is vestigial at 144/month, description literally "Add your description here").

## Blast radius: zero

Simulated across all 16 categories against `main`: **no category stage and no gap list changes.** Structural reason — stars cap at 3 and "mature" needs 4.5, so none of these products was contributing to `mature_open`.

## Test plan

- `pytest` — 461 passed
- `validate`, `check_recipe`, `check_rubric`, `check_components`, `check_verification`, `check_capability` — green
- All 31 carry `last_verified` plus `http_status` and `content_sha256` from a live read

One mechanic worth recording: the first attempt called `fetch()` for the digest and `requests.get()` for the body. The second request was rate-limited into an HTML error page while the digest read 200 — a digest attached to a body nobody parsed. `fetch()`'s own docstring warns about exactly this: *"Fetching a second time to save the body would break that."* Fixed by using its `body_dir`.