### PR TITLE
Fix livebench's dataset URLs, and gate the artifact URL shape

### DIFF
--- a/sources/products/livebench.yaml
+++ b/sources/products/livebench.yaml
@@ -8,16 +8,16 @@ description: An open, contamination-limited LLM benchmark with objective ground-
 github:
 - url: https://github.com/livebench/livebench
 huggingface_dataset:
-- url: https://huggingface.co/livebench/math
-- url: https://huggingface.co/livebench/reasoning
-- url: https://huggingface.co/livebench/model_judgment
-- url: https://huggingface.co/livebench/coding
-- url: https://huggingface.co/livebench/data_analysis
-- url: https://huggingface.co/livebench/instruction_following
-- url: https://huggingface.co/livebench/language
-- url: https://huggingface.co/livebench/liveswebench
-- url: https://huggingface.co/livebench/model_answer
-- url: https://huggingface.co/livebench/liveswebench-patches
+- url: https://huggingface.co/datasets/livebench/math
+- url: https://huggingface.co/datasets/livebench/reasoning
+- url: https://huggingface.co/datasets/livebench/model_judgment
+- url: https://huggingface.co/datasets/livebench/coding
+- url: https://huggingface.co/datasets/livebench/data_analysis
+- url: https://huggingface.co/datasets/livebench/instruction_following
+- url: https://huggingface.co/datasets/livebench/language
+- url: https://huggingface.co/datasets/livebench/liveswebench
+- url: https://huggingface.co/datasets/livebench/model_answer
+- url: https://huggingface.co/datasets/livebench/liveswebench-patches
 comments: Questions and ground-truth answers public (Apache-2.0/MIT). ~1.2k stars; multi-category HF dataset downloads.
   Monthly rotation is freshness management, not gating.
 arxiv:

--- a/sources/scores/livebench.yaml
+++ b/sources/scores/livebench.yaml
@@ -62,12 +62,12 @@ adoption:
   signal_type: usage_volume
   confidence: medium
   note: '36,032 Hugging Face downloads in the trailing 30 days summed across the ten LiveBench category
-    corpora, read 2026-08-12 (livebench/math 6,923; livebench/reasoning 5,633; livebench/model_judgment
-    5,365; livebench/coding 4,761; livebench/data_analysis 4,270; livebench/instruction_following 4,250;
-    livebench/language 4,165; livebench/liveswebench 370; livebench/model_answer 150; livebench/liveswebench-patches
-    145). Bands at level 3 (10K-100K). All 10 repos are now DECLARED in the product file: the band was previously
-    read on the family while only one repo was declared, so it could not be re-derived by machine. Slugs
-    on this map are tier-level, and docs/guides/identity.md sums adoption across a tier’s releases.'
+    corpora, read 2026-08-12 (math 6,923; reasoning 5,633; model_judgment 5,365; coding 4,761; data_analysis
+    4,270; instruction_following 4,250; language 4,165; liveswebench 370; model_answer 150; liveswebench-patches
+    145). Bands at level 3 (10K-100K) on the dataset scale. All ten are now declared in the product file
+    with the /datasets/ path segment: they were first declared without it, which the registry drops silently,
+    so the artifacts were absent from currentai.registry.product_artifacts and no signal could route to
+    them.'
   reach: 10K-100K
   last_verified: '2026-08-12'
   sources:

--- a/tests/test_artifact_url_shape.py
+++ b/tests/test_artifact_url_shape.py
@@ -1,0 +1,82 @@
+"""A declared artifact URL must be resolvable in the form the fetchers use.
+
+This exists because a malformed URL fails SILENTLY and in the worst possible place: the
+product file looks right, `validate` passes, `check_artifacts` passes, CI goes green, the
+registry publishes — and the row is simply absent from `currentai.registry.product_artifacts`,
+so no signal ever routes to it and the product falls back to a weaker instrument forever.
+
+The Hugging Face path split is the specific trap. A model lives at
+`huggingface.co/<org>/<name>` and a dataset at `huggingface.co/datasets/<org>/<name>`. Get it
+wrong and the Hub answers 401 or 404 rather than redirecting, so the mistake reads as an
+access problem rather than a typo.
+
+It has now been made twice. The first was the Lucie source, found only because
+`check_refetch` re-fetched it and got a 401 from a URL "missing its /datasets/ segment". The
+second was ten LiveBench corpora declared on 2026-08-12 without the segment; they were caught
+only because the registry table came back holding two artifacts where the file declared
+twelve. Nothing in the repo compared the two.
+
+So the shape is asserted here, where it costs nothing, rather than discovered from a table
+that quietly disagrees with the file that fed it.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _artifacts():
+    for path in sorted((ROOT / "sources" / "products").glob("*.yaml")):
+        doc = yaml.safe_load(path.read_text()) or {}
+        for key in ("huggingface_model", "huggingface_dataset", "github", "pypi", "npm", "crates"):
+            for row in doc.get(key) or []:
+                yield path.stem, key, (row or {}).get("url") or ""
+
+
+@pytest.fixture(scope="module")
+def artifacts():
+    return list(_artifacts())
+
+
+def test_hugging_face_dataset_urls_carry_the_datasets_segment(artifacts):
+    """`huggingface_dataset` must point at /datasets/, and `huggingface_model` must not."""
+    offences = []
+    for slug, key, url in artifacts:
+        if key == "huggingface_dataset" and "huggingface.co/" in url and "/datasets/" not in url:
+            offences.append(f"{slug}: {key} {url} is missing the /datasets/ segment")
+        if key == "huggingface_model" and "/datasets/" in url:
+            offences.append(f"{slug}: {key} {url} points at a dataset")
+    assert not offences, (
+        "a malformed Hugging Face URL is dropped silently by the registry, so no signal ever "
+        "routes to the product:\n" + "\n".join(offences)
+    )
+
+
+def test_every_declared_artifact_url_matches_its_registry_host(artifacts):
+    """The key names the registry; the URL must actually be on it.
+
+    Cheap, and it catches the other half of the same mistake — a package declared under the
+    wrong key, which routes to a fetcher that will never find it.
+    """
+    hosts = {
+        "huggingface_model": "huggingface.co",
+        "huggingface_dataset": "huggingface.co",
+        "github": "github.com",
+        "pypi": "pypi.org",
+        "npm": "npmjs.com",
+        "crates": "crates.io",
+    }
+    offences = [
+        f"{slug}: {key} URL is not on {hosts[key]}: {url}"
+        for slug, key, url in artifacts
+        if hosts.get(key) and hosts[key] not in url
+    ]
+    assert not offences, "\n".join(offences)
+
+
+def test_the_walk_sees_the_whole_corpus(artifacts):
+    """Non-zero count guard: an empty walk passes both checks above trivially."""
+    assert len(artifacts) > 400, f"only walked {len(artifacts)} artifacts; the glob has drifted"


### PR DESCRIPTION
The ten LiveBench corpora I declared yesterday were written as `huggingface.co/livebench/math` rather than `huggingface.co/datasets/livebench/math`. A model lives at the first form, a dataset at the second — and the Hub answers **401 or 404 rather than redirecting**, so the mistake reads as an access problem rather than a typo.

## Why this is worth a gate rather than a fix

**It failed silently, in the worst possible place.** The file looked right. `validate` passed. `check_artifacts` passed. CI went green. The registry published.

And `currentai.registry.product_artifacts` came back holding **two** artifacts for `livebench` where the file declared **twelve**. Nothing in the repo compared the two — so a product can sit permanently on a weaker instrument because no signal can route to it, and nothing anywhere reports a problem.

It was caught only by querying the registry after the merge instead of trusting the green workflow. That's the rule this repo keeps re-learning: **a green workflow is not a changed table.**

## And it is the second time

The first was the Lucie source, found only because `check_refetch` re-fetched it and got a 401 from a URL *"missing its /datasets/ segment"*. That one was recorded in a note rather than a check, so it recurred — this time as ten URLs at once.

## The gate

`tests/test_artifact_url_shape.py`, three assertions at zero cost:

1. a `huggingface_dataset` URL carries `/datasets/`, and a `huggingface_model` URL does not
2. every artifact URL is on the registry its key names — catches a package declared under the wrong key and routed to a fetcher that will never find it
3. the walk is non-zero, since an empty walk passes both trivially

**Swept the corpus: `livebench` was the only offender, and it was mine.**

## livebench re-verified

36,032 downloads across all ten corpora → level 3 (10K-100K). Same figure as the hand-assembled sum yesterday, but now **machine-derivable from declared artifacts** rather than from a sum somebody put together by hand.

## Test plan

- `pytest` — **477 passed** (3 new)
- `validate`, `check_recipe`, `check_rubric`, `check_components`, `check_verification`, `check_artifacts`, `check_adoption` — all green