### PR TITLE
Close the measured adoption backlog, and move two Docker products off the stars cap

### DIFF
--- a/sources/scores/aegis-guard.yaml
+++ b/sources/scores/aegis-guard.yaml
@@ -23,16 +23,20 @@ openness:
       built on LlamaGuard/Llama2-7B
     accessed: '2026-06-29'
 adoption:
-  level: 2
-  reach: 10K-100K
+  level: 1
+  reach: <10K
   signal_type: usage_volume
   confidence: low
-  note: NVIDIA safety classifier with a documented dataset and NeMo integration; modest standalone HF
-    adoption, distributed largely via NVIDIA's stack.
+  note: 4,303 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (nvidia/Aegis-AI-Content-Safety-LlamaGuard-Defensive-1.0 4,303). Bands at level 1 (<10K) on the software
+    and model adoption scale. Corrected from level 2, which the declared artifacts do not support.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://huggingface.co/nvidia/Aegis-AI-Content-Safety-LlamaGuard-Defensive-1.0
-    shows: NVIDIA Aegis content-safety classifier; 13 categories
-    accessed: '2026-06-29'
+  - url: https://huggingface.co/api/models/nvidia/Aegis-AI-Content-Safety-LlamaGuard-Defensive-1.0
+    shows: 4,303 downloads in the trailing 30 days for nvidia/Aegis-AI-Content-Safety-LlamaGuard-Defensive-1.0
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 63af8d1b3273ece735a12d45d7af3ca11b05e70dd39076ab6f2c9bb3cfc607a7
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/apertus.yaml
+++ b/sources/scores/apertus.yaml
@@ -61,18 +61,20 @@ openness:
     content_sha256: 713a1393fe21e68bf2fffbcd11d9f4d395aacf16b55fc9852f511ee4549cb579
     establishes: [data]
 adoption:
-  level: 2
-  reach: 10K-100K
+  level: 1
+  reach: <10K
   signal_type: usage_volume
   confidence: medium
-  note: Newer release (Sep 2025) with strong institutional/sovereign-AI interest but modest raw download
-    volume; swiss-ai/Apertus-70B-2509 shows ~1.5K downloads/month and 149 likes on HF (June 2026); cumulative
-    across the 8B/70B base+Instruct SKUs lands in the 10K-100K band. Distributed via Swisscom, Hugging
-    Face, and the Public AI network. Comparable adoption tier to Falcon 3 / Yi-1.5.
+  note: 546 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (swiss-ai/Apertus-70B-2509 546). Bands at level 1 (<10K) on the software and model adoption scale. Corrected
+    from level 2, which the declared artifacts do not support.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://huggingface.co/swiss-ai/Apertus-70B-2509
-    shows: ~1,462 downloads/month, 149 likes (June 2026)
-    accessed: '2026-06-08'
+  - url: https://huggingface.co/api/models/swiss-ai/Apertus-70B-2509
+    shows: 546 downloads in the trailing 30 days for swiss-ai/Apertus-70B-2509
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9fa185ea1eff42b68e584158bedd5dbd8b0facc71da717696554357ed82ccad0
 capability:
   score: 3
   basis: benchmark

--- a/sources/scores/compar-ia-datasets.yaml
+++ b/sources/scores/compar-ia-datasets.yaml
@@ -22,15 +22,20 @@ openness:
     shows: License Etalab 2.0; gated access requiring contact-info agreement; dataset card present
     accessed: '2026-06-22'
 adoption:
-  level: 2
-  reach: niche
+  level: 1
+  reach: <1K
   signal_type: usage_volume
   confidence: high
-  note: comparia-votes ~155 and comparia-conversations ~202 downloads last month on Hugging Face.
+  note: 31 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (ministere-culture/comparia-votes
+    31). Bands at level 1 (<1K) on the dataset adoption scale, whose top band is >1M. Corrected from level
+    2, which the declared artifacts do not support.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://huggingface.co/datasets/ministere-culture/comparia-votes
-    shows: 155 downloads last month
-    accessed: '2026-06-22'
+  - url: https://huggingface.co/api/datasets/ministere-culture/comparia-votes
+    shows: 31 downloads in the trailing 30 days for ministere-culture/comparia-votes
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: dc823c0409d697015d29db5f47fb6ee110474f7ced34a1b5f89e31227c7023c8
 capability:
   score: null
   basis: n/a

--- a/sources/scores/composio.yaml
+++ b/sources/scores/composio.yaml
@@ -86,25 +86,20 @@ openness:
     - license
     - source
 adoption:
-  level: 4
-  reach: 1M-10M
+  level: 3
+  reach: 100K-1M
   signal_type: usage_volume
   confidence: medium
-  note: 'CORRECTION (adversarial verify 2026-06-04): prior record claimed no primary download figure and
-    capped at stars_fallback level 3. pypistats now shows the composio PyPI package at ~3.17M downloads
-    in the last month (a measured usage_volume signal in the 1M-10M band), so upgraded to level 4 / usage_volume
-    and the stars_fallback cap is removed. Corroborated by ~28.6k GitHub stars and framework integrations
-    (OpenAI, Anthropic, LangChain, LlamaIndex) plus the hosted platform.'
+  note: 194,657 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (composio-core 194,657). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected
+    from level 4, which the declared artifacts do not support.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://pypistats.org/packages/composio
-    shows: ~3,166,911 (3.17M) monthly PyPI downloads
-    accessed: '2026-06-04'
-  - url: https://github.com/ComposioHQ/composio
-    shows: ~28.6k stars, integrations across major agent frameworks
-    accessed: '2026-06-04'
-  - url: https://pypi.org/project/composio/
-    shows: active package, latest v0.13.1 (May 2026); confirms maintenance
-    accessed: '2026-06-04'
+  - url: https://pypistats.org/api/packages/composio-core/recent
+    shows: 194,657 downloads in the trailing 30 days for composio-core
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c459ac619d97bdc45e0f5c1956f736986a7fc4fbfca43dfc4300a2ddaa4ec836
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/data-juicer.yaml
+++ b/sources/scores/data-juicer.yaml
@@ -20,15 +20,20 @@ openness:
     shows: Apache License Version 2.0 text
     accessed: '2026-07-21'
 adoption:
-  level: 2
-  reach: 1K-10K
+  level: 1
+  reach: <10K
   signal_type: usage_volume
   confidence: high
-  note: ~3.1k PyPI downloads/month (py-data-juicer) and ~6.7k GitHub stars; actively developed.
+  note: 2,962 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (py-data-juicer 2,962). Bands at level 1 (<10K) on the software and model adoption scale. Corrected
+    from level 2, which the declared artifacts do not support.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://pypistats.org/packages/py-data-juicer
-    shows: 'Downloads last month: ~3,107'
-    accessed: '2026-07-21'
+  - url: https://pypistats.org/api/packages/py-data-juicer/recent
+    shows: 2,962 downloads in the trailing 30 days for py-data-juicer
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: eaa1f81789a0024761112d9997242290456808a3f7351e6514b040fb1421955c
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/datatrove.yaml
+++ b/sources/scores/datatrove.yaml
@@ -26,16 +26,20 @@ openness:
     shows: Apache License Version 2.0 text
     accessed: '2026-07-21'
 adoption:
-  level: 3
+  level: 2
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: ~55k PyPI downloads/month; the reference pipeline for the FineWeb dataset family and widely reused
-    across open pretraining-data efforts.
+  note: 65,009 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (datatrove 65,009). Bands at level 2 (10K-100K) on the software and model adoption scale. Corrected
+    from level 3, which the declared artifacts do not support.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://pypistats.org/packages/datatrove
-    shows: 'Downloads last month: 55,132'
-    accessed: '2026-07-21'
+  - url: https://pypistats.org/api/packages/datatrove/recent
+    shows: 65,009 downloads in the trailing 30 days for datatrove
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: aeb080fc7f264200be714cbbe14d09d1acc9b57dca4de55eee422914b7d04c9c
 capability:
   score: 5
   basis: benchmark

--- a/sources/scores/deepseek.yaml
+++ b/sources/scores/deepseek.yaml
@@ -37,24 +37,47 @@ openness:
     shows: flagship phase-C verification source
     accessed: '2026-06-04'
 adoption:
-  level: 5
-  reach: '>10M'
+  level: 4
+  reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: 'ATOM Report (Apr 2026): China open models reached ~1.15B cumulative HF downloads with DeepSeek a primary
-    driver; DeepSeek-V3.2 widely served (OpenRouter, multiple inference providers) with sustained post-launch production
-    usage and frontier-at-10x-lower-cost positioning. Real usage well into the >10M-equivalent band across web app
-    + API + derivatives.'
+  note: 5,180,104 downloads in the trailing 30 days summed across the 6 declared artifact(s), read 2026-08-13
+    (deepseek-ai/DeepSeek-V3.2 1,093,344; deepseek-ai/DeepSeek-V3-Base 31,718; deepseek-ai/DeepSeek-V4-Pro
+    1,411,583; deepseek-ai/DeepSeek-V4-Flash 2,283,943; deepseek-ai/DeepSeek-V4-Pro-Base 14,769; deepseek-ai/DeepSeek-V4-Flash-Base
+    344,747). Bands at level 4 (1M-10M) on the software and model adoption scale. Corrected from level 5,
+    which the declared artifacts do not support.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://arxiv.org/html/2604.07190v1
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
-  - url: https://openrouter.ai/deepseek/deepseek-v3.2
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
-  - url: https://introl.com/blog/deepseek-v3-2-open-source-ai-cost-advantage
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+  - url: https://huggingface.co/api/models/deepseek-ai/DeepSeek-V3.2
+    shows: 1,093,344 downloads in the trailing 30 days for deepseek-ai/DeepSeek-V3.2
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: eb2fe531a6e5fa227b2e329dcdc3dd31c9bf8652ef065ed2a47ea426d15aff34
+  - url: https://huggingface.co/api/models/deepseek-ai/DeepSeek-V3-Base
+    shows: 31,718 downloads in the trailing 30 days for deepseek-ai/DeepSeek-V3-Base
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b53d64959451ed9931df9dd160cc0211ee3a6fef64567fa3fcdbae60c4299699
+  - url: https://huggingface.co/api/models/deepseek-ai/DeepSeek-V4-Pro
+    shows: 1,411,583 downloads in the trailing 30 days for deepseek-ai/DeepSeek-V4-Pro
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 30a1dcc082abb2949d9cb6ef57432b2c0bc26ca6c83e3c714eb120d9a6516221
+  - url: https://huggingface.co/api/models/deepseek-ai/DeepSeek-V4-Flash
+    shows: 2,283,943 downloads in the trailing 30 days for deepseek-ai/DeepSeek-V4-Flash
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 55c2eda9e4d9c6219c327dde073eacb12f3e98f5217266c9eda5ff7ec648a280
+  - url: https://huggingface.co/api/models/deepseek-ai/DeepSeek-V4-Pro-Base
+    shows: 14,769 downloads in the trailing 30 days for deepseek-ai/DeepSeek-V4-Pro-Base
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a7f2243ccecaaa0b3ed5a1ffc61fc5dbfbb35a7a59e6f7b4df96f07181cd5f73
+  - url: https://huggingface.co/api/models/deepseek-ai/DeepSeek-V4-Flash-Base
+    shows: 344,747 downloads in the trailing 30 days for deepseek-ai/DeepSeek-V4-Flash-Base
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6825c66170ae03a87108ed48aaee3e1ffe33a84f32b13c7151283f11fc5ea179
 capability:
   score: 5
   basis: benchmark

--- a/sources/scores/dolci.yaml
+++ b/sources/scores/dolci.yaml
@@ -17,15 +17,20 @@ openness:
     shows: ODC-BY license, ungated, dataset card
     accessed: '2026-07-04'
 adoption:
-  level: 3
-  reach: 10K-100K
+  level: 2
+  reach: 1K-10K
   signal_type: usage_volume
   confidence: high
-  note: 12,526 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 3,807 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (allenai/Dolci-Instruct-SFT 3,807). Bands at level 2 (1K-10K) on the dataset adoption scale, whose top
+    band is >1M. Corrected from level 3, which the declared artifacts do not support.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/allenai/Dolci-Instruct-SFT
-    shows: downloads field = 12,526 (30-day)
-    accessed: '2026-07-04'
+    shows: 3,807 downloads in the trailing 30 days for allenai/Dolci-Instruct-SFT
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6bac695382fe352c090bc36077a8cdb97186c826decc67b1313856770f092f98
 capability:
   score: 5
   basis: training_value

--- a/sources/scores/dolma-3.yaml
+++ b/sources/scores/dolma-3.yaml
@@ -17,15 +17,20 @@ openness:
     shows: ODC-BY license, ungated, dataset card
     accessed: '2026-07-04'
 adoption:
-  level: 4
-  reach: 100K-1M
+  level: 3
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 158,294 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 36,467 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (allenai/dolma3_pool 36,467). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band
+    is >1M. Corrected from level 4, which the declared artifacts do not support.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://huggingface.co/api/datasets/allenai/dolma3_mix-6T-1025-7B
-    shows: downloads field = 158,294 (30-day)
-    accessed: '2026-07-04'
+  - url: https://huggingface.co/api/datasets/allenai/dolma3_pool
+    shows: 36,467 downloads in the trailing 30 days for allenai/dolma3_pool
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5de85dbe965ca9b20b0c658d367662bd83c441e3d47b40137816d440a88d6c7c
 capability:
   score: 5
   basis: training_value

--- a/sources/scores/gpt-researcher.yaml
+++ b/sources/scores/gpt-researcher.yaml
@@ -23,19 +23,20 @@ openness:
     shows: Apache-2.0, public source, v3.5.0 May 28 2026, 27.5k stars (verified)
     accessed: '2026-06-04'
 adoption:
-  level: 3
-  reach: 100K-1M
+  level: 2
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: medium
-  note: ~105,483 PyPI downloads last month (gpt-researcher); 'used by' 261 dependent repos; 27.5k stars
-    corroborate. Places it in the 100K-1M reach band on monthly download volume.
+  note: 80,472 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (gpt-researcher 80,472). Bands at level 2 (10K-100K) on the software and model adoption scale. Corrected
+    from level 3, which the declared artifacts do not support.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://pypistats.org/packages/gpt-researcher
-    shows: 105,483 downloads last month
-    accessed: '2026-06-04'
-  - url: https://github.com/assafelovic/gpt-researcher
-    shows: 261 dependent repos, 27.5k stars
-    accessed: '2026-06-04'
+  - url: https://pypistats.org/api/packages/gpt-researcher/recent
+    shows: 80,472 downloads in the trailing 30 days for gpt-researcher
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: bd0e6196bb6b82c101587b05a7cc499f63071433b7ef92e92401f1ad9c6a18c2
 capability:
   score: 3
   basis: feature_matrix

--- a/sources/scores/granite-guardian.yaml
+++ b/sources/scores/granite-guardian.yaml
@@ -23,16 +23,20 @@ openness:
       14 likes
     accessed: '2026-06-29'
 adoption:
-  level: 2
-  reach: 10K-100K
+  level: 1
+  reach: <10K
   signal_type: usage_volume
   confidence: medium
-  note: ~1.4K HF downloads/month on the 3.2-5B variant (June 2026); cumulative across the Guardian family
-    is higher. Enterprise-leaning distribution via watsonx.
+  note: 1,837 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (ibm-granite/granite-guardian-3.2-5b 1,837). Bands at level 1 (<10K) on the software and model adoption
+    scale. Corrected from level 2, which the declared artifacts do not support.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://huggingface.co/ibm-granite/granite-guardian-3.2-5b
-    shows: ~1,377 downloads/month, 14 likes (June 2026)
-    accessed: '2026-06-29'
+  - url: https://huggingface.co/api/models/ibm-granite/granite-guardian-3.2-5b
+    shows: 1,837 downloads in the trailing 30 days for ibm-granite/granite-guardian-3.2-5b
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: cd00b2c6bb279ca6c9961fb516843354fdf5fcf7c343a4a720561d9f7ec5fdcb
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/hermes-3-dataset.yaml
+++ b/sources/scores/hermes-3-dataset.yaml
@@ -17,15 +17,20 @@ openness:
     shows: Apache-2.0 license, ungated, dataset card
     accessed: '2026-07-04'
 adoption:
-  level: 2
-  reach: 1K-10K
+  level: 1
+  reach: <1K
   signal_type: usage_volume
   confidence: high
-  note: 1,414 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 688 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (NousResearch/Hermes-3-Dataset 688). Bands at level 1 (<1K) on the dataset adoption scale, whose top
+    band is >1M. Corrected from level 2, which the declared artifacts do not support.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/NousResearch/Hermes-3-Dataset
-    shows: downloads field = 1,414 (30-day)
-    accessed: '2026-07-04'
+    shows: 688 downloads in the trailing 30 days for NousResearch/Hermes-3-Dataset
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5e9534af8b603e19e8c5f3c963d7f8694ae2491b37e3b28b359a6c84db84c5e2
 capability:
   score: 4
   basis: training_value

--- a/sources/scores/internlm.yaml
+++ b/sources/scores/internlm.yaml
@@ -36,20 +36,20 @@ openness:
     shows: InternLM2.5-7B base model card with benchmark results
     accessed: '2026-06-04'
 adoption:
-  level: 2
-  reach: 10K-100K
+  level: 1
+  reach: <10K
   signal_type: usage_volume
   confidence: medium
-  note: HF monthly downloads modest in 2026 (3,521/mo for the 7B base, confirmed 2026-06-04) as a 2024-era model;
-    distributed via HF, Ollama, ModelScope. Cumulative reach across the InternLM2.5 family + mirrors sits in the
-    early-adopter band; specialist/research uptake, not production scale.
+  note: 3,095 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (internlm/internlm2_5-7b 3,095). Bands at level 1 (<10K) on the software and model adoption scale. Corrected
+    from level 2, which the declared artifacts do not support.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://huggingface.co/internlm/internlm2_5-7b
-    shows: 3,521 downloads last month
-    accessed: '2026-06-04'
-  - url: https://ollama.com/internlm/internlm2.5
-    shows: InternLM2.5 distributed via Ollama
-    accessed: '2026-06-04'
+  - url: https://huggingface.co/api/models/internlm/internlm2_5-7b
+    shows: 3,095 downloads in the trailing 30 days for internlm/internlm2_5-7b
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 53db38845403a603b29a19fc8f466f1e27f655ff467c993ba5fba95df26df4f6
 capability:
   score: 2
   basis: benchmark

--- a/sources/scores/khoj.yaml
+++ b/sources/scores/khoj.yaml
@@ -30,16 +30,20 @@ openness:
     shows: official notice that Khoj Cloud was sunset 2026-04-15 and Khoj "remains fully open source"
     accessed: '2026-06-17'
 adoption:
-  level: 3
-  reach: ~26k PyPI downloads/month
+  level: 2
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: medium
-  note: ~35k GitHub stars plus ~26k PyPI downloads/month (pypistats) - real install volume (usage_volume,
-    not stars-only), but modest in absolute terms, so mid-tier. Hosted cloud is now discontinued.
+  note: 19,532 PyPI downloads in the trailing 30 days for khoj, read 2026-08-13. Bands at level 2 (10K-100K)
+    on the software and model adoption scale. Corrected from level 3, which the declared artifact does not
+    support.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://pypistats.org/packages/khoj
-    shows: ~26,054 downloads last month
-    accessed: '2026-06-17'
+  - url: https://pypistats.org/api/packages/khoj/recent
+    shows: 19,532 downloads in the trailing 30 days for khoj
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 4cc696880071d82fc383bf3f67fde0c2eb2b23a975eb391d5f3a23f28815fb71
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/litgpt.yaml
+++ b/sources/scores/litgpt.yaml
@@ -53,35 +53,20 @@ openness:
     http_status: 200
     content_sha256: 4ab6c08da06acf15b4ed318465efd2d9de4b82f7e6c19ded7d27c540976f4e8a
 adoption:
-  level: 3
+  level: 2
   reach: 10K-100K
   signal_type: usage_volume
   confidence: medium
-  note: ~15.1k PyPI downloads last month (primary); 13.6k GitHub stars (corroborating only). Modest but
-    real recurring usage keeps it at the low end of medium; level 3 on monthly download volume, not stars.
-  last_verified: '2026-08-09'
+  note: 15,680 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (litgpt 15,680). Bands at level 2 (10K-100K) on the software and model adoption scale. Corrected from
+    level 3, which the declared artifacts do not support.
+  last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/litgpt/recent
-    shows: The whole body is {"data":{"last_day":327,"last_month":15077,"last_week":4274},"package":"litgpt","type":"recent_downloads"},
-      meaning 15,077 downloads in the last month, up from the ~14,230 recorded in June and still inside
-      the 10K-100K adoption band.
-    accessed: '2026-08-09'
+    shows: 15,680 downloads in the trailing 30 days for litgpt
+    accessed: '2026-08-13'
     http_status: 200
-    content_sha256: 4af2ee439898c8933b711865e2549d9a12b92b7443d646b6e79f901f71273d81
-  - url: https://github.com/Lightning-AI/litgpt
-    shows: The repo's sidebar fields read stargazerCount 13612 and forksCount 1483 (up from the previously
-      recorded 13.4k stars), corroborating that the project is still actively watched. Not used as the adoption
-      basis.
-    accessed: '2026-08-09'
-    http_status: 200
-    content_sha256: 5e66cbea2d8c5ea68045b684031e57e7209374f7320ebaff1f1ddb1032e8178d
-  - url: https://pypi.org/project/litgpt/
-    shows: 'The package header reads "litgpt 0.5.13", the License section states "LitGPT is released under
-      the Apache 2.0 license", and the release panel reads "Released: Jul 3, 2026", confirming the download
-      figure belongs to an actively released package rather than a residual one.'
-    accessed: '2026-08-09'
-    http_status: 200
-    content_sha256: f802933c256fba7a2d46163d5e686dd03b565da2283618454b4893d345d72079
+    content_sha256: f1e9fbfd4d9373162333c05baef37d4cccd1c6c178bfbd6fcbb44074f8a70845
 capability:
   score: 3
   basis: feature_matrix

--- a/sources/scores/livecodebench.yaml
+++ b/sources/scores/livecodebench.yaml
@@ -69,22 +69,20 @@ openness:
     content_sha256: ee0029cddc1d9051f35818f3348a4327819a3e35a9e597732519245605195cf6
     establishes: [license]
 adoption:
-  level: 4
-  reach: 1M-10M
+  level: 3
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: medium
-  note: 71,393 monthly HF downloads (primary). De facto standard contamination-free coding benchmark;
-    LiveCodeBench appears as a headline coding metric in frontier model release reports (e.g. DeepSeek-V4-Pro
-    reports LiveCodeBench Pass@1 93.5 in the frozen flagship set). 'Usage' here is downloads + benchmark
-    citation, not end-users; placed at 4 on download volume plus release-report standard status, which
-    is the top adoption signal for a benchmark.
+  note: 91,719 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (livecodebench/code_generation_lite 91,719). Bands at level 3 (10K-100K) on the dataset adoption scale,
+    whose top band is >1M. Corrected from level 4, which the declared artifacts do not support.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://huggingface.co/datasets/livecodebench/code_generation_lite
-    shows: 71,393 monthly downloads
-    accessed: '2026-06-04'
-  - url: https://livecodebench.github.io/
-    shows: contamination-free coding benchmark across generation/self-repair/execution
-    accessed: '2026-06-04'
+  - url: https://huggingface.co/api/datasets/livecodebench/code_generation_lite
+    shows: 91,719 downloads in the trailing 30 days for livecodebench/code_generation_lite
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a55c771a033b0b53b9d92409bf8339d5347aa710073659ffe211cb1d3b2302e4
 capability:
   score: null
   basis: n/a

--- a/sources/scores/llama-guard.yaml
+++ b/sources/scores/llama-guard.yaml
@@ -25,16 +25,20 @@ openness:
       307 likes
     accessed: '2026-06-29'
 adoption:
-  level: 4
-  reach: 1M-10M
+  level: 3
+  reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: ~237K Hugging Face downloads/month on the 8B variant (June 2026), the most-adopted open guardrail
-    model; widely embedded as a moderation layer.
+  note: 164,619 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (meta-llama/Llama-Guard-3-8B 164,619). Bands at level 3 (100K-1M) on the software and model adoption
+    scale. Corrected from level 4, which the declared artifacts do not support.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://huggingface.co/meta-llama/Llama-Guard-3-8B
-    shows: ~237,092 downloads/month, 307 likes (June 2026)
-    accessed: '2026-06-29'
+  - url: https://huggingface.co/api/models/meta-llama/Llama-Guard-3-8B
+    shows: 164,619 downloads in the trailing 30 days for meta-llama/Llama-Guard-3-8B
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: af299c9f359756a68a7295bafa548ed6d733887c2a877416f75fabbdd7bfca8e
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/llama-instruct.yaml
+++ b/sources/scores/llama-instruct.yaml
@@ -30,22 +30,20 @@ openness:
     shows: live card; license=Llama 3.1 Community License w/ 700M MAU cap; 11,077,966 downloads last month
     accessed: '2026-06-04'
 adoption:
-  level: 5
-  reach: '>10M'
+  level: 4
+  reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: >-
-    Weights open under Meta's non-OSI Llama 3.1 Community License, with its 700M-MAU commercial
-    cap. Commonly marketed as open. Moved from 2/restricted on 2026-08-01 by the universal license
-    scale, which caps a bounded commercial license at 3 rather than 2. The test at that boundary
-    is whether the license permits commercial use AT ALL: this one does, for everyone inside the
-    bound. A license that forbids commerce outright - CC-BY-NC, Mistral Non-Production - stays at
-    2. Nine other products carry a bounded license and all now score 3; four of them were already
-    recorded there, which is the inconsistency this resolves.
+  note: 7,345,657 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (meta-llama/Llama-3.1-8B-Instruct 7,345,657). Bands at level 4 (1M-10M) on the software and model adoption
+    scale. Corrected from level 5, which the declared artifacts do not support.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
-    shows: 11,077,966 downloads last month
-    accessed: '2026-06-04'
+  - url: https://huggingface.co/api/models/meta-llama/Llama-3.1-8B-Instruct
+    shows: 7,345,657 downloads in the trailing 30 days for meta-llama/Llama-3.1-8B-Instruct
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 01f9bc862a4f86d79417f098181a5e58c67f88998679a5efe144f59a11c4430d
 capability:
   score: 3
   basis: benchmark

--- a/sources/scores/llama-prompt-guard.yaml
+++ b/sources/scores/llama-prompt-guard.yaml
@@ -22,16 +22,20 @@ openness:
       downloads/month, 149 likes
     accessed: '2026-06-29'
 adoption:
-  level: 4
+  level: 3
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: 86M variant ~90.4K HF downloads/month (June 2026); widely used as a low-latency injection filter,
-    including inside LlamaFirewall.
+  note: 111,334 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (meta-llama/Llama-Prompt-Guard-2-86M 111,334). Bands at level 3 (100K-1M) on the software and model
+    adoption scale. Corrected from level 4, which the declared artifacts do not support.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://huggingface.co/meta-llama/Llama-Prompt-Guard-2-86M
-    shows: ~90,441 downloads/month, 149 likes (June 2026)
-    accessed: '2026-06-29'
+  - url: https://huggingface.co/api/models/meta-llama/Llama-Prompt-Guard-2-86M
+    shows: 111,334 downloads in the trailing 30 days for meta-llama/Llama-Prompt-Guard-2-86M
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a594da1ec8e70a2c8b897994c7d8ab75323f0b89e5428b4dc84cf4a8f23c4e4c
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/localai.yaml
+++ b/sources/scores/localai.yaml
@@ -38,17 +38,24 @@ openness:
     content_sha256: 6ef142557058a6a02274d19b448082c83e9bb84566c8d2c093de9bf86c8dcb80
 adoption:
   level: 3
-  signal_type: stars_fallback
+  signal_type: usage_volume
   confidence: medium
-  note: 48,349 GitHub stars as of 2026-08-09; no clean download telemetry for a self-hosted server, so stars_fallback
-    applies (capped at 3, per the adoption banding rule).
-  last_verified: '2026-08-09'
+  note: 'About 156,880 downloads a month across the product’s real distribution channels, read 2026-08-13
+    (Docker Hub 6,411,259 cumulative since 2023-03-18, about 156,880 a month). Bands at level 3 (100K-1M).
+    LocalAI is distributed as a Docker image; it publishes no first-party PyPI or npm package. Moved off
+    the stars fallback under the under-coverage rule in docs/guides/adoption.md: banding on a channel the
+    product does not ship through is a substitution rather than a measurement. The level is UNCHANGED at
+    3 - the stars cap happened to give the right answer here - but it now rests on a measured figure instead
+    of a capped proxy. The Docker component is a lifetime average, not a trailing-30-day count, so this
+    is a floor.'
+  last_verified: '2026-08-13'
+  reach: 100K-1M
   sources:
-  - url: https://github.com/mudler/LocalAI
-    shows: aria-label="48349 users starred this repository"
-    accessed: '2026-08-09'
+  - url: https://hub.docker.com/v2/repositories/localai/localai/
+    shows: 6,411,259 cumulative pulls of localai/localai
+    accessed: '2026-08-13'
     http_status: 200
-    content_sha256: 6ef142557058a6a02274d19b448082c83e9bb84566c8d2c093de9bf86c8dcb80
+    content_sha256: 7d0a2bfff9c13e1e35ac9bb191c5e493cd13534596c8eae77131eb576adbfbb3
 capability:
   score: 5
   basis: feature_matrix

--- a/sources/scores/lucie-7b.yaml
+++ b/sources/scores/lucie-7b.yaml
@@ -68,20 +68,26 @@ openness:
     http_status: 200
     content_sha256: 2943dcf52d6e8f8ff3a631bb99bc6b48bb75c5015eac8c5fc7f29d9f0848dc41
 adoption:
-  level: 2
-  reach: 10K-100K
+  level: 1
+  reach: <10K
   signal_type: usage_volume
   confidence: medium
-  note: Niche sovereign/French open-LLM audience. HF Lucie-7B ~780 downloads/month and 31 likes (Jul
-    2026); collection upvotes modest. Comparable adoption tier to Apertus / Falcon-class fully-open
-    European releases rather than Llama/Qwen scale.
+  note: 1,945 downloads in the trailing 30 days summed across the 2 declared artifact(s), read 2026-08-13
+    (OpenLLM-France/Lucie-7B 1,315; OpenLLM-France/Lucie-7B-Instruct-v1.1 630). Bands at level 1 (<10K)
+    on the software and model adoption scale. Corrected from level 2, which the declared artifacts do not
+    support.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://huggingface.co/OpenLLM-France/Lucie-7B
-    shows: ~780 downloads/month, 31 likes (as of 2026-07-19)
-    accessed: '2026-07-19'
-  - url: https://huggingface.co/collections/OpenLLM-France/lucie-llm
-    shows: official Lucie LLM collection (base, instruct, dataset, paper)
-    accessed: '2026-07-19'
+  - url: https://huggingface.co/api/models/OpenLLM-France/Lucie-7B
+    shows: 1,315 downloads in the trailing 30 days for OpenLLM-France/Lucie-7B
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5f3f27e43082f9addf5a4d352b60c32bd0806c69f3dc2b6e6b75178c7dcaf938
+  - url: https://huggingface.co/api/models/OpenLLM-France/Lucie-7B-Instruct-v1.1
+    shows: 630 downloads in the trailing 30 days for OpenLLM-France/Lucie-7B-Instruct-v1.1
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: daea16a5f6dcc1bc6ae21e514cacdf06e44b9f71f50d6cd927b31d5b516adeaf
 capability:
   score: 2
   basis: benchmark

--- a/sources/scores/nemo-curator.yaml
+++ b/sources/scores/nemo-curator.yaml
@@ -23,16 +23,20 @@ openness:
     shows: Apache License Version 2.0 text
     accessed: '2026-07-21'
 adoption:
-  level: 2
-  reach: 1K-10K
+  level: 1
+  reach: <10K
   signal_type: usage_volume
   confidence: high
-  note: ~5.6k PyPI downloads/month; NVIDIA-backed and the pipeline behind the Nemotron-CC family, but
-    modest raw download volume.
+  note: 4,075 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (nemo-curator 4,075). Bands at level 1 (<10K) on the software and model adoption scale. Corrected from
+    level 2, which the declared artifacts do not support.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://pypistats.org/packages/nemo-curator
-    shows: 'Downloads last month: 5,618'
-    accessed: '2026-07-21'
+  - url: https://pypistats.org/api/packages/nemo-curator/recent
+    shows: 4,075 downloads in the trailing 30 days for nemo-curator
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: dc1ab53641060ca8b22f2ee98cb263b2448698ae48529ccc9b4f09282749682d
 capability:
   score: 5
   basis: benchmark

--- a/sources/scores/olmo.yaml
+++ b/sources/scores/olmo.yaml
@@ -47,16 +47,25 @@ openness:
     content_sha256: e8e02a24fb65c9b97ede3bc582e78689a9a12c0ca7f16effc953e5a57bbd24f3
     establishes: [weights, license]
 adoption:
-  level: 4
-  reach: 1M-10M
+  level: 3
+  reach: 100K-1M
   signal_type: usage_volume
   confidence: medium
-  note: Succeeds OLMo 2 (the OLMo family measured ~14.8M cumulative HF downloads in early 2026). The reference fully-open
-    model in research/interpretability circles; below the Qwen/Llama scale.
+  note: 146,145 downloads in the trailing 30 days summed across the 2 declared artifact(s), read 2026-08-13
+    (allenai/Olmo-3-1125-32B 43,671; allenai/Olmo-3-1025-7B 102,474). Bands at level 3 (100K-1M) on the
+    software and model adoption scale. Corrected from level 4, which the declared artifacts do not support.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://allenai.org/blog/olmo3
-    shows: flagship fully-open release; broad research uptake
-    accessed: '2026-06-30'
+  - url: https://huggingface.co/api/models/allenai/Olmo-3-1125-32B
+    shows: 43,671 downloads in the trailing 30 days for allenai/Olmo-3-1125-32B
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 774b1b37fcdd1a22544f57b26efc8d75710850c7d8930e1a5247d753584887e5
+  - url: https://huggingface.co/api/models/allenai/Olmo-3-1025-7B
+    shows: 102,474 downloads in the trailing 30 days for allenai/Olmo-3-1025-7B
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 53f69c16d3f17df85b179763281369d29e9dea58c2991e0924e8d86182ad5848
 capability:
   score: 4
   basis: benchmark

--- a/sources/scores/olmocr.yaml
+++ b/sources/scores/olmocr.yaml
@@ -24,16 +24,20 @@ openness:
     shows: Apache License Version 2.0 text
     accessed: '2026-07-21'
 adoption:
-  level: 3
+  level: 2
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: ~22k PyPI downloads/month and 19k+ GitHub stars; a leading open document-extraction tool, used
-    in the Dolma 3 data path.
+  note: 22,925 PyPI downloads in the trailing 30 days for olmocr, read 2026-08-13. Bands at level 2 (10K-100K)
+    on the software and model adoption scale. Corrected from level 3, which the declared artifact does not
+    support.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://pypistats.org/packages/olmocr
-    shows: 'Downloads last month: 21,753'
-    accessed: '2026-07-21'
+  - url: https://pypistats.org/api/packages/olmocr/recent
+    shows: 22,925 downloads in the trailing 30 days for olmocr
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: bb20341457a175680a368fcc852c01c24115f79f75407a8eb51434d1105d2bcd
 capability:
   score: 4
   basis: benchmark

--- a/sources/scores/olmoe-instruct.yaml
+++ b/sources/scores/olmoe-instruct.yaml
@@ -33,16 +33,26 @@ openness:
       checkpoints
     accessed: '2026-06-25'
 adoption:
-  level: 3
+  level: 2
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: ~37.9k HF downloads/month on the instruct SKU; 96 likes. Solid reach for a fully-open
-    research MoE.
+  note: 28,149 downloads in the trailing 30 days summed across the 2 declared artifact(s), read 2026-08-13
+    (allenai/OLMoE-1B-7B-0924-Instruct 26,721; allenai/OLMoE-mix-0924 1,428). Bands at level 2 (10K-100K)
+    on the software and model adoption scale. Corrected from level 3, which the declared artifacts do not
+    support.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://huggingface.co/allenai/OLMoE-1B-7B-0924-Instruct
-    shows: ~37,880 downloads last month; 96 likes
-    accessed: '2026-06-25'
+  - url: https://huggingface.co/api/models/allenai/OLMoE-1B-7B-0924-Instruct
+    shows: 26,721 downloads in the trailing 30 days for allenai/OLMoE-1B-7B-0924-Instruct
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: ee1398b873dd594a3f0334f1168dab153f62c2900468095d59e522eb27b5a08f
+  - url: https://huggingface.co/api/datasets/allenai/OLMoE-mix-0924
+    shows: 1,428 downloads in the trailing 30 days for allenai/OLMoE-mix-0924
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 7f34d9aa457daed314d4db450c123c135f4a61b208696f5eab2cf00a11364896
 capability:
   score: 2
   basis: benchmark

--- a/sources/scores/open-webui.yaml
+++ b/sources/scores/open-webui.yaml
@@ -29,17 +29,20 @@ openness:
     shows: v0.9.6 latest release, self-hosted AI interface
     accessed: '2026-06-04'
 adoption:
-  level: 4
-  reach: 1M-10M
+  level: 3
+  reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: ~1.72M PyPI downloads last month (pypistats, primary); vendor reports 290M cumulative downloads
-    and 420K community members. De facto leading self-hosted LLM chat UI; firmly in 1-10M band on monthly
-    install volume (stars 140k corroborate only).
+  note: 879,127 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (open-webui 879,127). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected
+    from level 4, which the declared artifacts do not support.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://pypistats.org/packages/open-webui
-    shows: 1,717,371 downloads last month
-    accessed: '2026-06-04'
+  - url: https://pypistats.org/api/packages/open-webui/recent
+    shows: 879,127 downloads in the trailing 30 days for open-webui
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: cbc0df85af0e683e7063f02d9c33e1a677409ac058d62a02ef3ce638001e6349
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/phi-instruct.yaml
+++ b/sources/scores/phi-instruct.yaml
@@ -24,16 +24,20 @@ openness:
     shows: live card; license=MIT; 3.8B instruct; 1,537,561 downloads last month
     accessed: '2026-06-04'
 adoption:
-  level: 4
-  reach: 1M-10M
+  level: 3
+  reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: ~1.54M downloads last month on HF; widely distributed via Azure AI Foundry / Ollama for on-device + local
-    inference. Solidly in the 1-10M band.
+  note: 429,490 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (microsoft/Phi-4-mini-instruct 429,490). Bands at level 3 (100K-1M) on the software and model adoption
+    scale. Corrected from level 4, which the declared artifacts do not support.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://huggingface.co/microsoft/Phi-4-mini-instruct
-    shows: 1,537,561 downloads last month
-    accessed: '2026-06-04'
+  - url: https://huggingface.co/api/models/microsoft/Phi-4-mini-instruct
+    shows: 429,490 downloads in the trailing 30 days for microsoft/Phi-4-mini-instruct
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: f520a05970012b1e8b0eae049187f5eda6c5205b715eb650ddc383893a558322
 capability:
   score: 2
   basis: benchmark

--- a/sources/scores/phi.yaml
+++ b/sources/scores/phi.yaml
@@ -30,20 +30,20 @@ openness:
     shows: flagship phase-C verification source
     accessed: '2026-06-04'
 adoption:
-  level: 4
-  reach: 1M-10M
+  level: 3
+  reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: Phi-4 is a widely downloaded small model on Hugging Face, distributed via Azure AI Foundry, Ollama, and
-    many local-inference stacks; download volume for the Phi-4 line is in the millions range. Level 4 reflects broad
-    small-model adoption.
+  note: 626,702 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (microsoft/phi-4 626,702). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected
+    from level 4, which the declared artifacts do not support.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://venturebeat.com/ai/microsoft-makes-powerful-phi-4-model-fully-open-source-on-hugging-face
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
-  - url: https://artificialanalysis.ai/models/phi-4
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+  - url: https://huggingface.co/api/models/microsoft/phi-4
+    shows: 626,702 downloads in the trailing 30 days for microsoft/phi-4
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: acc97b7d7cf7aa29e07aa0b2c9e1ad8342fefed545a6fc502fb7268ed855c460
 capability:
   score: 3
   basis: benchmark

--- a/sources/scores/pythia.yaml
+++ b/sources/scores/pythia.yaml
@@ -59,20 +59,20 @@ openness:
     content_sha256: e5da5801a6a437bf051cdaa442810bf7d832b3b3b7a8af62546755322fdb2a0f
     establishes: [weights, license]
 adoption:
-  level: 3
-  reach: 100K-1M
+  level: 2
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 'Heavily used as a research/interpretability benchmark suite (de facto standard for training-dynamics studies);
-    cited extensively. Hugging Face download volume across the 16 models is in the 100k-1M aggregate range, meaningful
-    for research but not production deployment. Honest signal: research adoption, not end-user scale.'
+  note: 30,007 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (EleutherAI/pythia-12b 30,007). Bands at level 2 (10K-100K) on the software and model adoption scale.
+    Corrected from level 3, which the declared artifacts do not support.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://huggingface.co/EleutherAI/pythia-6.9b
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
-  - url: https://www.eleuther.ai/papers-blog/pythia-a-suite-for-analyzing-large-language-modelsacross-training-and-scaling
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+  - url: https://huggingface.co/api/models/EleutherAI/pythia-12b
+    shows: 30,007 downloads in the trailing 30 days for EleutherAI/pythia-12b
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 877612ac2b240f01cb265af7d577b7a461e434fa9ab8fe42b61b6fa68bbd9ee5
 capability:
   score: 1
   basis: benchmark

--- a/sources/scores/ragflow.yaml
+++ b/sources/scores/ragflow.yaml
@@ -25,13 +25,30 @@ openness:
     accessed: '2026-06-18'
 adoption:
   level: 3
-  signal_type: stars_fallback
+  signal_type: usage_volume
   confidence: medium
-  note: ~83k stars; Docker-distributed with no download metric retrieved - stars_fallback (capped at 3).
+  note: 'About 129,133 downloads a month across the product’s real distribution channels, read 2026-08-13
+    (Docker Hub 3,590,166 cumulative since 2023-12-12, about 112,087 a month; ragflow-sdk 17,046 in the
+    trailing 30 days). Bands at level 3 (100K-1M). RAGFlow ships as a Docker Compose stack; ragflow-sdk
+    on PyPI is an API client rather than the server, so it measures a different thing and is added only
+    as a minor component. Moved off the stars fallback under the under-coverage rule in docs/guides/adoption.md:
+    banding on a channel the product does not ship through is a substitution rather than a measurement.
+    The level is UNCHANGED at 3 - the stars cap happened to give the right answer here - but it now rests
+    on a measured figure instead of a capped proxy. The Docker component is a lifetime average, not a trailing-30-day
+    count, so this is a floor.'
+  reach: 100K-1M
+  last_verified: '2026-08-13'
   sources:
-  - url: https://ragflow.io
-    shows: official site, InfiniFlow, self-host + cloud
-    accessed: '2026-06-18'
+  - url: https://hub.docker.com/v2/repositories/infiniflow/ragflow/
+    shows: 3,590,166 cumulative pulls of infiniflow/ragflow
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 095ef0ed513ee365aae263321c77599f65537b6f30a29eea5e584be1231b937b
+  - url: https://pypistats.org/api/packages/ragflow-sdk/recent
+    shows: 17,046 downloads in the trailing 30 days for ragflow-sdk
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 465245cf97ae8442f7e3a072ca91a6df1c2d135be904b006807329b1381eaec5
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/swift.yaml
+++ b/sources/scores/swift.yaml
@@ -76,33 +76,20 @@ openness:
     - license
     - source
 adoption:
-  level: 4
+  level: 3
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: ~110k PyPI downloads last month (primary). Broad coverage (600+ text + 300+ multimodal models
-    incl. Qwen3, DeepSeek, Llama, GLM) and strong uptake in the Chinese/ModelScope ecosystem. Lower bound
-    of the 100K-1M band; level 4 on sustained monthly download volume.
-  last_verified: '2026-08-08'
+  note: 122,381 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (ms-swift 122,381). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected from
+    level 4, which the declared artifacts do not support.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://pypistats.org/packages/ms-swift
-    shows: 'pypistats page for ms-swift, rendered server-side: ''Downloads last day: 3,070'', ''Downloads
-      last week: 23,151'', ''Downloads last month: 121,346''. Header meta gives Author ''DAMO ModelScope
-      teams'', License ''Apache License 2.0'', Latest version ''4.4.2''. 121,346 sits inside the 100K-1M
-      band that level 4 rests on.'
-    accessed: '2026-08-08'
+  - url: https://pypistats.org/api/packages/ms-swift/recent
+    shows: 122,381 downloads in the trailing 30 days for ms-swift
+    accessed: '2026-08-13'
     http_status: 200
-    content_sha256: 9068fed9cb14dbc4a991b45464e0dec777710df8ceca5d912ea8d9ee89c74d09
-  - url: https://github.com/modelscope/ms-swift
-    shows: README Introduction states support for '600+ text-only large models and 400+ multimodal large
-      models', naming Qwen3, Qwen3.5, InternLM3, GLM4.5, Mistral, DeepSeek-R1, Llama4, Qwen3-VL, Qwen3-Omni,
-      Kimi-K3, InternVL3.5, DeepSeek-VL2, and claims 'Day-0 support for popular models'. Repository header
-      shows 15.1k stars, 1.6k forks, 3,549 commits, 563 open issues and 89 open pull requests, and the News
-      list runs to 2026.07.22 - the breadth-of-coverage half of the adoption note, and evidence the project
-      is actively used and maintained.
-    accessed: '2026-08-08'
-    http_status: 200
-    content_sha256: 3ebedde37c3a9b86af0ec620f17352ab2a83cd2fe5570a88944d7dfae7aea582
+    content_sha256: 97668a69ac3da07ea1d85760fa748f4feb8f55b777e0b6be9462065aaaac49b0
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/wildguard.yaml
+++ b/sources/scores/wildguard.yaml
@@ -53,15 +53,20 @@ openness:
     establishes:
     - code
 adoption:
-  level: 4
+  level: 3
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: ~265K HF downloads/month (June 2026); one of the most-downloaded open guardrail models.
+  note: 121,205 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (allenai/wildguard 121,205). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected
+    from level 4, which the declared artifacts do not support.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://huggingface.co/allenai/wildguard
-    shows: ~265,259 downloads/month, 52 likes (June 2026)
-    accessed: '2026-06-29'
+  - url: https://huggingface.co/api/models/allenai/wildguard
+    shows: 121,205 downloads in the trailing 30 days for allenai/wildguard
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b3c6a6b4d0ba7f39b95b6d981f25d7edd3ed1b2a5ad0474f4eb0a93f23b42623
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/zephyr.yaml
+++ b/sources/scores/zephyr.yaml
@@ -31,18 +31,36 @@ openness:
     shows: Apache-2.0; contains all training code to replicate zephyr-7b-beta
     accessed: '2026-06-25'
 adoption:
-  level: 4
-  reach: 1M-10M
+  level: 3
+  reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: ~164.9k HF downloads/month on zephyr-7b-beta with 1.85k likes -- a late-2023
-    model still pulling meaningful volume as a lightweight fully-open 7B baseline. The
-    underlying datasets remain active (ultrachat_200k ~57.7k/mo). The 141B ORPO variant
-    is effectively dormant (~52/mo). Level 4 on the leading SKU's sustained monthly volume.
+  note: 232,148 downloads in the trailing 30 days summed across the 4 declared artifact(s), read 2026-08-13
+    (HuggingFaceH4/zephyr-7b-beta 142,355; HuggingFaceH4/zephyr-orpo-141b-A35b-v0.1 91; HuggingFaceH4/ultrachat_200k
+    73,327; HuggingFaceH4/ultrafeedback_binarized 16,375). Bands at level 3 (100K-1M) on the software and
+    model adoption scale. Corrected from level 4, which the declared artifacts do not support.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://huggingface.co/HuggingFaceH4/zephyr-7b-beta
-    shows: ~164,917 downloads last month; 1.85k likes
-    accessed: '2026-06-25'
+  - url: https://huggingface.co/api/models/HuggingFaceH4/zephyr-7b-beta
+    shows: 142,355 downloads in the trailing 30 days for HuggingFaceH4/zephyr-7b-beta
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 89427cdf13143eea59f02c65463d14e580ef578ee59840944edad4512ab25e50
+  - url: https://huggingface.co/api/models/HuggingFaceH4/zephyr-orpo-141b-A35b-v0.1
+    shows: 91 downloads in the trailing 30 days for HuggingFaceH4/zephyr-orpo-141b-A35b-v0.1
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 47e3d9cf2c8020fc69b61a65f3b7d25d8f60b29e3bb9c31e4206546b5cc89c22
+  - url: https://huggingface.co/api/datasets/HuggingFaceH4/ultrachat_200k
+    shows: 73,327 downloads in the trailing 30 days for HuggingFaceH4/ultrachat_200k
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 4e919d43fdc08e40082d432ea506c07f839e5a991c46a904a1a7001a3236be1e
+  - url: https://huggingface.co/api/datasets/HuggingFaceH4/ultrafeedback_binarized
+    shows: 16,375 downloads in the trailing 30 days for HuggingFaceH4/ultrafeedback_binarized
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d881aa403109378f86edb6b91e66d6062204fb84e7a93d8831a47b3da99a5dd6
 capability:
   score: 2
   basis: benchmark


### PR DESCRIPTION
Closes the work list #223 opened, and which `docs/guides/adoption.md` already documented:

> *"49 of the 60 products whose recorded band exceeded the computed one declared `usage_volume` while their own notes cited figures that matched the warehouse almost exactly. The measurement was never in dispute. The band did not follow from the evidence the score itself recorded."*

## 31 products re-read live

Against every artifact they **declare**, not against the 2026-08-08 warehouse snapshot that identified them. That distinction earned its keep: `gpt-oss-safeguard` was flagged from a stale 97,591 as a two-level drop, and is actually **100,632** — which clears the 100K line and confirms at 3.

```
deepseek           5 -> 4    5,180,104      phi                4 -> 3    626,702
llama-instruct     5 -> 4    7,345,657      phi-instruct       4 -> 3    429,490
open-webui         4 -> 3      879,127      zephyr             4 -> 3    232,148
composio           4 -> 3      194,657      llama-guard        4 -> 3    164,619
olmo               4 -> 3      146,145      swift              4 -> 3    122,381
wildguard          4 -> 3      121,205      llama-prompt-guard 4 -> 3    111,334
livecodebench      4 -> 3       91,719      dolma-3            4 -> 3     36,467
gpt-researcher     3 -> 2       80,472      datatrove          3 -> 2     65,009
pythia             3 -> 2       30,007      olmoe-instruct     3 -> 2     28,149
olmocr             3 -> 2       22,925      khoj               3 -> 2     19,532
litgpt             3 -> 2       15,680      dolci              3 -> 2      3,807
aegis-guard        2 -> 1        4,303      nemo-curator       2 -> 1      4,075
internlm           2 -> 1        3,095      data-juicer        2 -> 1      2,962
lucie-7b           2 -> 1        1,945      granite-guardian   2 -> 1      1,837
hermes-3-dataset   2 -> 1          688      apertus            2 -> 1        546
compar-ia-datasets 2 -> 1           31
```

**Confirmed unchanged on a live read** — the outcome that says the record was right: `codegemma` (28,295) and `codellama` (110,069), both flagged by the warehouse only because it still sees one repo where the file now declares five and four, plus `gpt-oss-safeguard`.

**Nothing was left unverified.** `olmocr` and `khoj` hit pypistats rate limits on the first pass and were **retried rather than skipped** — both turned out to be overstated too. A 429 is not evidence of absence.

## Two Docker products move off the stars cap without changing level

Applying the under-coverage rule established for n8n:

```
localai   L3 -> L3 (100K-1M)  ~156,880/mo   stars_fallback -> usage_volume
ragflow   L3 -> L3 (100K-1M)  ~129,133/mo   stars_fallback -> usage_volume
```

Both were banded on GitHub stars while shipping as Docker images. The stars cap of 3 happened to give the right answer, so **no number moves** — but the level now rests on a measured figure rather than a capped proxy. Docker Hub reports only cumulative pulls, so each is a lifetime average and therefore a **floor**, recorded that way in both notes.

`github-mcp` and `surfsense` stay on stars: no Docker Hub repository, only GitHub release assets — the unbridged route in #163.

## One category stage moves

```
dataset_processing_tools:  stage 3 -> stage 2
```

**The first stage change in this whole audit**, and it's real rather than an artifact.

| product | maturity before | after | why |
|---|---|---|---|
| **datatrove** | **3.8** | **3.2** | adoption 3 → 2 on 65,009 PyPI |
| olmocr | 3.4 | 3.4 | capability holds it |
| nemo-data-designer | 3.4 | 3.4 | unchanged |

`datatrove` was the category's best open product. Stage 3 requires `best_open ≥ 3.5`; its adoption was overstated by one band, maturity falls to 3.2, and no other open product reaches 3.5.

**`datatrove` is a Python library and PyPI *is* its primary channel**, so there's no under-coverage defect of the kind that corrected n8n. The category's best open option is genuinely less mature than the map claimed.

## Test plan

- `pytest` — **477 passed**
- all nine gates green
- `check_adoption` off-scale: **85 → 73**
- every figure carries `http_status` + `content_sha256` from a live read via `build.fetch_source`