### PR TITLE
Declare the two undeclared adoption instruments, and take check_adoption strict

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -65,6 +65,21 @@ jobs:
       # claim. See build/check_rubric.py's module docstring.
       - name: Rubric gate (recorded scores reproduce)
         run: uv run python -m build.check_rubric
+
+      # Does every recorded (level, reach) pair exist on the scale its own instrument
+      # declares? `check_adoption` shipped non-strict on 2026-08-11 against a backlog of 217
+      # off-scale records, because a gate that fails on day one teaches people to skip it. The
+      # backlog is now zero, so --strict goes on: 217 -> 71 across #224-#230, then 71 -> 0 on
+      # 2026-08-13 by declaring the two instruments that had no vocabulary (`active_users`,
+      # `reported_traction`) and re-reading every remaining figure live rather than inferring
+      # it from the stale text of the label being replaced.
+      #
+      # The escape hatch is to declare a band, not to edit a level until CI passes. If a record
+      # needs a label no scale offers, that is the finding — `character-ai` invented `10M-100M`
+      # and sat a level below what its own figure supported for exactly as long as nothing
+      # could check it.
+      - name: Adoption gate (every band exists on its instrument's scale)
+        run: uv run python -m build.check_adoption --strict
       - name: Serialize dry-run
         run: uv run python -m build.serialize --date ci-dry-run
 

--- a/build/check_adoption.py
+++ b/build/check_adoption.py
@@ -82,6 +82,29 @@ def declared_scales(sources: dict) -> dict[tuple[str, str], dict[str, int]]:
     return scales
 
 
+def declared_vocabularies(root: Path = ROOT) -> dict[str, set[str]]:
+    """signal_type -> the words it may record as `reach`, for instruments with no bands.
+
+    A VOCABULARY is not a scale, and the difference is the point. A scale maps a label to a
+    level and a mismatch between them is a finding. A vocabulary says only which words exist:
+    `reported_traction` records what KIND of standing was claimed, while the level says how
+    much, and the two are allowed to disagree because neither is derived from the other.
+
+    Measured 2026-08-13 on the 110 records carrying `reported_traction`: `niche` ran 85%
+    level 3, `broad` 80% level 4, `mass-market` 67% level 5. Forcing agreement would flatten
+    the residual signal those spreads represent, so this check asserts membership only.
+    """
+    from build.serialize_rubric import load_routing
+
+    routing = load_routing(root)
+    routes = ((routing.get("dimensions") or {}).get("adoption") or {}).get("routes") or []
+    return {
+        route["signal_type"]: set(route["vocabulary"])
+        for route in routes
+        if route.get("signal_type") and route.get("vocabulary")
+    }
+
+
 # Instruments whose bands are read in downloads, and which may therefore fall back to the
 # product type's declared download scale. Everything else measures something else entirely.
 #
@@ -127,6 +150,7 @@ def scale_for(scales: dict, product_type: str, signal_type: str) -> dict[str, in
 
 def collect(sources: dict) -> tuple[list[str], int]:
     scales = declared_scales(sources)
+    vocabularies = declared_vocabularies()
     types = {slug: (doc or {}).get("type") for slug, doc in sources["products"].items()}
 
     findings: list[str] = []
@@ -137,6 +161,24 @@ def collect(sources: dict) -> tuple[list[str], int]:
         if level is None and reach is None:
             continue
         signal = adoption.get("signal_type") or ""
+
+        # An instrument with a vocabulary rather than bands. `reach` is optional here —
+        # omitting it is the honest default and 15 records already do — so the only thing
+        # to check is that a word, if present, is one the instrument declares. Crucially
+        # this is where a NUMERIC label gets caught: `100K-1M` is not in the vocabulary, and
+        # on an instrument defined by having nothing to count it is a measurement claim the
+        # instrument cannot make.
+        if signal in vocabularies:
+            examined += 1
+            if reach is not None and reach not in vocabularies[signal]:
+                findings.append(
+                    f"{slug} [{types.get(slug)}/{signal}]: reach {reach!r} is not in this "
+                    f"instrument's vocabulary {sorted(vocabularies[signal])}; a "
+                    f"{signal} record has no count behind it, so a numeric band claims a "
+                    f"measurement that was never made"
+                )
+            continue
+
         scale = scale_for(scales, types.get(slug), signal)
         if scale is None:
             continue  # hardware declares no adoption scale, by design

--- a/build/check_adoption.py
+++ b/build/check_adoption.py
@@ -42,9 +42,18 @@ question. A product can be perfectly banded against a figure from March.
 
 ## Exit status
 
-0 unless `--strict`, matching `check_freshness`. Gating today would fail on a backlog that
-predates the bands being declared at all, and a gate that fails on day one teaches people to
-skip it. Turn on `--strict` in CI once the backlog is cleared.
+0 unless `--strict`. CI runs `--strict` as of 2026-08-13; the flag stays optional so a local
+run can survey without failing.
+
+It shipped non-strict on 2026-08-11 against 217 off-scale records, because a gate that fails on
+day one teaches people to skip it. That backlog is now zero — 217 to 71 across #224 to #230,
+then 71 to 0 by declaring the two instruments that had no vocabulary at all and re-reading every
+remaining figure live rather than inferring it from the stale text of the label being replaced.
+
+**The escape hatch is to declare a band, never to edit a level until CI passes.** A record that
+needs a label no scale offers IS the finding: `character-ai` invented `10M-100M`, and because
+nothing could check an undeclared label, it sat at level 4 while its own cited ~20M MAU cleared
+the top threshold outright.
 """
 
 from __future__ import annotations

--- a/build/check_adoption.py
+++ b/build/check_adoption.py
@@ -70,12 +70,13 @@ def declared_scales(sources: dict) -> dict[tuple[str, str], dict[str, int]]:
         for band in adoption.get("bands") or []:
             scales.setdefault((name, "*"), {})[band["reach"]] = band["level"]
 
-    # The stars scale lives in signal_routing.yaml rather than a rubric, because it is a
-    # property of the SIGNAL and applies to every product type. Read through the serializer's
-    # own loader so the two cannot disagree about where it lives.
-    from build.serialize_rubric import load_routing, stars_bands
+    # Two scales live in signal_routing.yaml rather than a rubric, because they are a
+    # property of the SIGNAL and apply to every product type: `stars_fallback`, and
+    # `active_users` since 2026-08-13. Read through the serializer's own loader so the two
+    # cannot disagree about where they live.
+    from build.serialize_rubric import load_routing, route_bands
 
-    rows, _warnings = stars_bands(load_routing(ROOT))
+    rows, _warnings = route_bands(load_routing(ROOT))
     for band in rows:
         scales.setdefault(("*", band["signal_type"]), {})[band["reach"]] = band["level"]
     return scales
@@ -108,8 +109,14 @@ def scale_for(scales: dict, product_type: str, signal_type: str) -> dict[str, in
     one, and those findings looked exactly like the real ones.
 
     So the fallback is now allowed only for instruments actually denominated in downloads.
-    `reported_traction` and `active_users` return None and are skipped, which is not a
-    waiver — it is the checker declining to compare a user count against a download band.
+    `reported_traction` returns None and is skipped, which is not a waiver — it is the
+    checker declining to compare a user count against a download band.
+
+    `active_users` no longer needs the skip. It DECLARES a scale as of 2026-08-13, so it
+    takes the first branch like stars do, and abstention narrows to the one instrument that
+    still has no vocabulary. Note what the skip had been hiding while it was right: 22 of
+    the 23 products were wearing download labels, and skipping them is what made that
+    invisible for as long as it was.
     """
     if signal_type and ("*", signal_type) in scales:
         return scales[("*", signal_type)]

--- a/build/notebook_data.json
+++ b/build/notebook_data.json
@@ -684,7 +684,7 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M",
+            "reach": ">10M users",
             "signal_type": "active_users",
             "confidence": "medium",
             "note": "GPT-4o was the default ChatGPT model for much of 2024-2025 before GPT-5; ChatGPT crossed ~900M WAU (Feb 2026) and ~1B (May 2026). Attributed honestly to the ChatGPT surface GPT-4o powered, not a standalone GPT-4o count; well above the >10M threshold. WAU figure corroborated via aggregator (demandsage), not a primary OpenAI disclosure, but the threshold is not close so no downgrade.",
@@ -3419,7 +3419,7 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M",
+            "reach": ">10M users",
             "signal_type": "active_users",
             "confidence": "medium",
             "note": "o3/o4-mini were rolled out as selectable models inside ChatGPT (Plus/Pro and some free) plus the API; ChatGPT reached ~900M WAU (Feb 2026) rising toward ~1B (May 2026). Reach attributed to the ChatGPT surface these models power, not a standalone o3 count. Now superseded as default by GPT-5.x but still used at scale.",
@@ -3568,7 +3568,7 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M",
+            "reach": ">10M users",
             "signal_type": "active_users",
             "confidence": "high",
             "note": "GPT-5 was rolled out as the default model for logged-in ChatGPT users (Aug 2025). ChatGPT reached ~900M weekly active users (Feb 2026) and ~1B by May 2026, far exceeding the >10M threshold. Adoption attributed to the surface GPT-5 powers, not a standalone GPT-5 download count.",
@@ -3713,7 +3713,7 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M",
+            "reach": ">10M users",
             "signal_type": "active_users",
             "confidence": "medium",
             "note": "High-volume cheap tier powering the Gemini app and AI Mode in Search plus heavy API/Vertex traffic; Gemini app >750M MAU (TechCrunch, Feb 2026). Flash is the default high-volume serving model so its real usage is firmly >10M-equivalent. Attributed to the app/Search surface, not a standalone download count.",
@@ -3975,7 +3975,7 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
+            "reach": "1M-10M users",
             "signal_type": "active_users",
             "confidence": "low",
             "note": "Powers the Meta AI assistant on meta.ai and the Meta AI app (rolling out to WhatsApp/Instagram/Facebook/Messenger/AI glasses), an enormous consumer surface, but Meta discloses no Muse Spark-specific user count, and at scoring time it is not yet the model behind the full family of surfaces. Placed at 4 on the consumer-app surface it powers; not 5 because no standalone figure and rollout incomplete. Attributed honestly to the surface, not the model.",
@@ -4039,7 +4039,7 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M",
+            "reach": ">10M users",
             "signal_type": "active_users",
             "confidence": "medium",
             "note": "Powers the Doubao app, China's #1 AI chatbot with ~155M weekly active users; Seed 2.0 is the model behind that surface plus Volcano Engine enterprise API. Far above >10M. Attributed to the Doubao app surface the model powers, not a standalone Seed 2.0 figure. WAU sourced from launch coverage; vendor primary page (seed.bytedance.com) returned no figure this run.",
@@ -6058,10 +6058,10 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M",
+            "reach": ">10M users",
             "signal_type": "active_users",
             "confidence": "medium",
-            "note": "Core ML ships as a system framework across iOS/iPadOS/macOS/tvOS/watchOS/visionOS (confirmed against the MLModel availability list), and Apple's own Q3 FY2026 earnings call puts the active-device installed base at over 2.5 billion. Reach is attributed to the device base the runtime ships preinstalled on, not a developer download count.",
+            "note": "Core ML ships as a system framework across iOS/iPadOS/macOS/tvOS/watchOS/visionOS (confirmed against the MLModel availability list), and Apple's own Q3 FY2026 earnings call puts the active-device installed base at over 2.5 billion. Bands at >10M users, level 5 on the active_users scale declared 2026-08-13. WHAT WAS BANDED - an active DEVICE base, not an active user count - a person with an iPhone and a Mac is two of it, and nobody is counted for using Core ML rather than for owning hardware it ships on. The band clears its boundary by more than two orders of magnitude, so the distinction does not change the level; it is recorded because the scale requires a substituted quantity to be named. Not a developer download count either.",
             "last_verified": "2026-08-09",
             "sources": [
               {
@@ -14656,7 +14656,7 @@
           "maturity": 3.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-12",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Verified live 2026-06-22 via primary sources. Publicly downloadable and ungated under CC-BY-NC-SA-4.0, which permits redistribution for non-commercial research.",
@@ -18042,7 +18042,7 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
+            "reach": "1M-10M users",
             "signal_type": "active_users",
             "confidence": "high",
             "note": "1M+ daily active users (reported 2025, sustained Dec 2025) and ~$2B ARR by Feb 2026; ~64% of Fortune 500 active. Confirmed via press coverage of company-reported figures. 1M+ DAU puts it in the 1-10M band (not yet a confirmed >10M mass-market count).",
@@ -18373,10 +18373,10 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M",
+            "reach": ">10M users",
             "signal_type": "active_users",
             "confidence": "high",
-            "note": "GitHub Copilot surpassed 20M+ all-time users (Microsoft July 2025 earnings): 'world's most widely adopted AI developer tool.' Agent mode is the autonomous surface of that base. >10M band. Note: 20M is all-time, not active; agent-mode-specific count not disclosed, but base scale firmly supports level 5.",
+            "note": "GitHub Copilot surpassed 20M+ all-time users (Microsoft July 2025 earnings): 'world's most widely adopted AI developer tool.' Agent mode is the autonomous surface of that base. Bands at >10M users, level 5 on the active_users scale declared 2026-08-13. WHAT WAS BANDED - 20M is an ALL-TIME cumulative count, not an active one, and no agent-mode-specific figure is disclosed - so this is a substitution in the sense of docs/guides/adoption.md and the true active figure is lower, not higher. The level is unchanged; what changed is that the label under it is now one a declared scale offers.",
             "sources": [
               {
                 "url": "https://github.com/features/copilot",
@@ -22204,7 +22204,7 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M",
+            "reach": ">10M users",
             "signal_type": "active_users",
             "confidence": "high",
             "note": "OpenAI officially announced ~900M weekly active users (27 Feb 2026), up from 800M (Oct 2025), with 50M paying subscribers. Mass-market scale, far above the >10M threshold. Attributed to the ChatGPT surface.",
@@ -22262,10 +22262,10 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M",
+            "reach": ">10M users",
             "signal_type": "active_users",
             "confidence": "high",
-            "note": "Microsoft CEO confirmed 20M all-time Copilot users (earnings call, 30 Jul 2025); free tier opened to 150M GitHub developers (Dec 2024); ~4.7M paid subscribers by Jan 2026. All-time user base exceeds the >10M mass-market threshold. (All-time vs active distinction noted; still clearly level 5.)",
+            "note": "Microsoft CEO confirmed 20M all-time Copilot users (earnings call, 30 Jul 2025); free tier opened to 150M GitHub developers (Dec 2024); ~4.7M paid subscribers by Jan 2026. Bands at >10M users, level 5 on the active_users scale declared 2026-08-13. WHAT WAS BANDED - the 20M is ALL-TIME rather than active, and the one genuinely active-adjacent figure available - 4.7M paid subscribers - sits a band lower, at 4. The level is unchanged from what this record already carried; what changed is that the label under it is now one a declared scale offers, and that the substitution is named.",
             "sources": [
               {
                 "url": "https://techcrunch.com/2025/07/30/github-copilot-crosses-20-million-all-time-users/",
@@ -22324,11 +22324,11 @@
             "bucket": "closed"
           },
           "adoption": {
-            "level": 4,
-            "reach": "1M-10M",
+            "level": 5,
+            "reach": ">10M users",
             "signal_type": "active_users",
             "confidence": "low",
-            "note": "Anthropic does NOT disclose official Claude.ai MAU. Third-party estimates (no primary vendor figure available) put consumer MAU ~18.9M web at start of 2026 rising toward ~30M by mid-2026, i.e. comfortably above 1M but well below the >10M-billion scale of ChatGPT/Gemini app. Placed at level 4 on best-available estimate; confidence low because the headline number is an estimate, not a vendor primary disclosure (flagged).",
+            "note": "Anthropic does NOT disclose official Claude.ai MAU. Third-party estimates (no primary vendor figure available) put consumer MAU ~18.9M web at start of 2026 rising toward ~30M by mid-2026, which bands at >10M users, level 5 on the active_users scale declared 2026-08-13. RAISED from 4, which had been recorded against a reach of '1M-10M' - a label its own cited figure contradicted by roughly twofold at the low end. The scale is what makes that contradiction visible - nothing previously compared the number in the note to the band above it. Level 5 here does not claim parity with ChatGPT or the Gemini app, which are two orders larger; it says all three are mass-market, which is what the map's top band means. Confidence stays low - the headline number is a third-party estimate, not a vendor disclosure.",
             "sources": [
               {
                 "url": "https://claude.com/product/overview",
@@ -22356,7 +22356,7 @@
               }
             ]
           },
-          "maturity": 4.3,
+          "maturity": 5.0,
           "mature": false,
           "freshness": {
             "date": "2026-06-24",
@@ -22388,7 +22388,7 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M",
+            "reach": ">10M users",
             "signal_type": "active_users",
             "confidence": "high",
             "note": "Google CEO Sundar Pichai officially stated the Gemini app surpassed 750M monthly active users (Q4 2025 earnings, 4 Feb 2026), up from 450M earlier in 2025. Mass-market scale, far above >10M (broader AI Overviews surface reaches ~2B, but the app itself is the cited figure).",
@@ -22446,7 +22446,7 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M",
+            "reach": ">10M users",
             "signal_type": "active_users",
             "confidence": "medium",
             "note": "~420M monthly active users across all Copilot surfaces (Windows/Edge/M365/Bing/mobile) reported Q1 2026, with ~160M enterprise-licensed; far above the >10M threshold. Actively-engaged M365 seats are much lower (~33M), but the consumer + embedded surface reach is mass-market. Headline aggregated figure traces to Microsoft disclosures via aggregators; primary per-surface breakdown not directly fetched, so medium confidence.",
@@ -22509,7 +22509,7 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M",
+            "reach": ">10M users",
             "signal_type": "active_users",
             "confidence": "medium",
             "note": "CEO Aravind Srinivas (cited Apr 2026) reports 100M+ MAU across all products; standalone chatbot ~33M MAU; ~780M queries/mo (May 2025) growing >20% MoM to an estimated 1.2-1.5B/mo by mid-2026. Even the standalone-chat figure (33M) clears >10M. Headline user count is CEO-attributed via aggregators (Sacra), not a directly-fetched primary disclosure, medium confidence.",
@@ -22936,10 +22936,10 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M",
+            "reach": ">10M users",
             "signal_type": "active_users",
             "confidence": "low",
-            "note": "CEO/Quora figures (compiled by multiple aggregators) report ~18M Poe MAU in 2026 (~40% using paid features; ~$65M subscription ARR). 18M is comfortably in the >10M 'mass market' band -> level 5. Quora publishes no primary Poe MAU page, so the exact figure remains aggregator-sourced (confidence low), but the order of magnitude is consistent across sources and clearly clears the >10M threshold. [Corrected: prior record had level 4 with an invalid '10M-100M' reach band that contradicted the 18M figure.]",
+            "note": "CEO/Quora figures (compiled by multiple aggregators) report ~18M Poe MAU in 2026 (~40% using paid features; ~$65M subscription ARR). 18M is comfortably in the >10M 'mass market' band -> level 5. Quora publishes no primary Poe MAU page, so the exact figure remains aggregator-sourced (confidence low), but the order of magnitude is consistent across sources and clearly clears the >10M threshold. The reach label now reads '>10M users' on the active_users scale declared 2026-08-13, which is the band this record has effectively been claiming since it was corrected off an invented '10M-100M' - the difference is that the band is now declared, so the claim can be checked rather than merely asserted.",
             "sources": [
               {
                 "url": "https://originality.ai/blog/poe-statistics",
@@ -23061,11 +23061,11 @@
             "bucket": "closed"
           },
           "adoption": {
-            "level": 4,
-            "reach": "10M-100M",
+            "level": 5,
+            "reach": ">10M users",
             "signal_type": "active_users",
             "confidence": "low",
-            "note": "Reported ~20M MAU and ~180M monthly site visits (Apr 2026); peaked ~28M MAU mid-2024 then declined. Clears >10M but figures are aggregator-compiled (no first-party MAU disclosure fetched) and sources disagree (20M vs higher visit-based counts), so low confidence. Reach mapped to 10M-100M on monthly-visit volume; level 4 on the conservative MAU read.",
+            "note": "Reported ~20M MAU and ~180M monthly site visits (Apr 2026); peaked ~28M MAU mid-2024 then declined. ~20M MAU bands at >10M users, level 5 on the active_users scale declared 2026-08-13. RAISED from 4, and the reason is the whole case for declaring the scale - this record read level 4 against a reach of '10M-100M', a band nothing in the repo offered. Its own conservative figure clears the top threshold, so the level was held down by a label that had no scale behind it to check it against. Figures are aggregator-compiled (no first-party MAU disclosure fetched) and sources disagree (20M vs higher visit-based counts), so confidence stays low; the 10M boundary is not close on either read.",
             "sources": [
               {
                 "url": "https://www.businessofapps.com/data/character-ai-statistics/",
@@ -23088,7 +23088,7 @@
               }
             ]
           },
-          "maturity": 3.4,
+          "maturity": 4.1,
           "mature": false,
           "freshness": {
             "date": "2026-06-24",
@@ -23120,7 +23120,7 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M",
+            "reach": ">10M users",
             "signal_type": "active_users",
             "confidence": "low",
             "note": "App reported ~60-64M MAU and ~8-10M DAU early 2026, plus default availability to X Premium subscribers within X's ~350-400M MAU base. Clears >10M as a surface. Figures are aggregator-compiled (xAI does not publish a primary MAU page) and the X-embedded reach is hard to attribute cleanly, so low confidence on the exact number; reach band is robust.",
@@ -23188,7 +23188,7 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
+            "reach": "1M-10M users",
             "signal_type": "active_users",
             "confidence": "medium",
             "note": "~1.7M app downloads by May 2026 (TechCrunch reported 1M in 14 days at Feb 2025 launch); Mistral states EU monthly active recipients below 45M (a DSA ceiling, not a measured MAU); ~10.8M desktop visits to mistral.ai Mar 2026. Honest read places real active users in the 1-10M band, level 4. The <45M is a regulatory cap not an actual count, so not used as the headline.",
@@ -23259,11 +23259,19 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M",
+            "reach": ">10M users",
             "signal_type": "active_users",
             "confidence": "medium",
-            "note": "DeepSeek's consumer app was one of the most-downloaded global AI apps after the early-2025 surge; the hosted chat surface remains a top-tier global assistant. No clean current MAU figure published on the vendor's own page, so confidence medium; reach >10M is well-supported by app-store ranking history. Attributed to the chat surface, not the model SKU.",
+            "note": "130M MAU as of May 2026, third among Chinese AI apps, per QuestMobile's \"2026 First-Half AI Application Market Development Insight Report\" (published 14 Jul 2026). Bands at >10M users, level 5 on the active_users scale declared 2026-08-13. This replaces the record's previous basis, which was app-store ranking history and no figure at all - the one product of the 23 carrying this instrument that had no user count under it. Confidence medium because QuestMobile's report is read through press coverage rather than the report itself, and it measures the China market, where DeepSeek's usage is concentrated but not confined. Attributed to the chat surface, not the model SKU.",
+            "last_verified": "2026-08-13",
             "sources": [
+              {
+                "url": "https://finance.biggo.com/news/372811e2-28f1-49c7-9f53-fa56879cde3b",
+                "shows": "QuestMobile 2026 H1 report, as of May 2026: \"DeepSeek ranked third with 130 million MAUs\". Doubao leads at 382M.",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "e7ea3a11679cc5814830d1f89f68bc2a884faf9ca20bddb7007094d1fc267dde"
+              },
               {
                 "url": "https://play.google.com/store/apps/details?id=com.deepseek.chat&hl=en_US",
                 "shows": "Official DeepSeek AI Assistant Android app listing (consumer chat surface, mass-market distribution)",
@@ -23288,8 +23296,8 @@
           "maturity": 4.4,
           "mature": false,
           "freshness": {
-            "date": "2026-08-11",
-            "basis": "commit"
+            "date": "2026-08-13",
+            "basis": "verified"
           },
           "version_note": "Hosted consumer chat UI at chat.deepseek.com (web + iOS/Android apps), currently fronting DeepSeek-V4 Preview (stronger agent + reasoning). Verified live June 2026. Note: the underlying DeepSeek-V3/V4 model weights are open (MIT) and scored separately in base_pretrained; this record scores the CHAT PRODUCT/UI itself, which is a proprietary free hosted service, not open source software."
         },
@@ -23325,7 +23333,7 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M",
+            "reach": ">10M users",
             "signal_type": "active_users",
             "confidence": "high",
             "note": "Zuckerberg (May 2025 shareholder meeting, primary) stated Meta AI passed 1B monthly active users; reported growing to ~1.2B MAU by Q1 2026, ~63% of interactions on WhatsApp. Far above the >10M threshold. CAVEAT: a portion of these MAU reflect surfaced/embedded exposure inside WhatsApp/IG rather than deliberate assistant use (one analyst, Kantrowitz, argues engaged usage is far lower than OpenAI's). Attributed honestly to the embedded surface, not a standalone assistant count.",
@@ -23401,11 +23409,19 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M",
+            "reach": ">10M users",
             "signal_type": "active_users",
             "confidence": "medium",
-            "note": "Doubao reached ~330M total users by May 2026 (en.wikipedia.org/wiki/Doubao); China's most popular AI chatbot; ~60M MAU as of Nov 2024 per Wikipedia. China-market app trackers report ~330M users as of May 2026. NOTE (verifier): the 330M figure is cited by Wikipedia as TOTAL users, not a measured MAU; the only Wikipedia-stated MAU is ~60M (Nov 2024). Either way the surface clears >10M. Headline counts are aggregator/Wikipedia-compiled (no single ByteDance primary MAU disclosure), so confidence medium. Volcano Engine reportedly serves ~120T tokens/day.",
+            "note": "382M MAU as of May 2026, first among Chinese AI apps by a clear margin, per QuestMobile's \"2026 First-Half AI Application Market Development Insight Report\" (published 14 Jul 2026). Bands at >10M users, level 5 on the active_users scale declared 2026-08-13. This retires the record's previous basis and the verifier's objection to it: the old note banded on ~330M TOTAL users, with the only stated MAU being ~60M from Nov 2024 - a cumulative count standing in for an active one, which is exactly the substitution the scale's attribution_note names. A measured MAU now exists and it is higher than the total the record had been leaning on. Confidence medium because QuestMobile is read through press coverage rather than the report itself. Volcano Engine reportedly serves ~120T tokens/day.",
+            "last_verified": "2026-08-13",
             "sources": [
+              {
+                "url": "https://finance.biggo.com/news/372811e2-28f1-49c7-9f53-fa56879cde3b",
+                "shows": "QuestMobile 2026 H1 report, as of May 2026: \"Doubao had 382 million MAUs, maintaining a clear lead\".",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "e7ea3a11679cc5814830d1f89f68bc2a884faf9ca20bddb7007094d1fc267dde"
+              },
               {
                 "url": "https://en.wikipedia.org/wiki/Doubao",
                 "shows": "Doubao ~330M users by May 2026; China's most popular AI chatbot; 120T tokens/day",
@@ -23435,8 +23451,8 @@
           "maturity": 4.4,
           "mature": false,
           "freshness": {
-            "date": "2026-08-11",
-            "basis": "commit"
+            "date": "2026-08-13",
+            "basis": "verified"
           },
           "version_note": "ByteDance's consumer AI assistant (chatbot app: iOS/Android/web), launched Aug 2023, running on Volcano Engine (Doubao models). Proprietary closed product. Introduced a paid Pro subscription tier ~May/Jun 2026. Verified live June 2026 (Wikipedia + China-market app trackers)."
         },
@@ -32592,7 +32608,7 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
+            "reach": "1M-10M users",
             "signal_type": "active_users",
             "confidence": "low",
             "note": "Code Interpreter ships inside ChatGPT (advanced data analysis) and the Assistants/Responses API; the ChatGPT surface it rides has ~1B weekly users (flagship anchor record, GPT-5). No standalone Code-Interpreter usage figure is disclosed, so adoption is attributed to the surface, placed conservatively at 4 (a fraction of ChatGPT users invoke code execution) with low confidence given no primary per-tool number.",

--- a/build/notebook_data.json
+++ b/build/notebook_data.json
@@ -719,7 +719,7 @@
           "maturity": 3.6,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "OpenAI GPT-4o, multimodal (text+image in, text out), 128K context; first snapshot gpt-4o-2024-05-13, knowledge cutoff Oct 2023. API-only, no released weights. Verified live in OpenAI's model docs June 2026 (developers.openai.com). A 2024-era flagship, since surpassed by the GPT-5 line but still served via API/ChatGPT."
@@ -748,7 +748,6 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "10K-100K",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Distributed via Reka API + Snowflake Cortex + Oracle Cloud Marketplace; a 2024 frontier-challenger now well behind. No disclosed usage; level 2 directional. (Snowflake/Oracle partnerships are not enumerated on the cited launch page itself.)",
@@ -812,7 +811,6 @@
           },
           "adoption": {
             "level": 1,
-            "reach": "<10K",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Post-Microsoft acqui-hire pivot to B2B; Pi consumer surface wound down. Enterprise API exists but no disclosed usage; effectively stalled. Level 1 directional.",
@@ -1588,7 +1586,6 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "10K-100K",
             "signal_type": "reported_traction",
             "confidence": "high",
             "note": "Available on Hugging Face with moderate uptake at launch as a sub-13B SLM; no large verified usage figures and relevance has faded against newer SLMs. Level 2 reflects modest reported traction.",
@@ -3454,7 +3451,7 @@
           "maturity": 4.3,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "OpenAI o3 and o4-mini reasoning models, both released Apr 16 2025 (o3-mini preceded Jan 31 2025). Post-trained reasoning/instruct models, API-only + ChatGPT, no downloadable weights. Verified via OpenAI system card + Wikipedia June 2026; succeeded by GPT-5.x reasoning line but still selectable/available."
@@ -3493,7 +3490,6 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "GPT-4.1 was an API-first developer/coding model (initially not in ChatGPT default), widely adopted as a cheaper GPT-4o replacement and integrated across tooling. No primary per-model usage count disclosed; level 4 reflects broad developer-platform distribution as a major OpenAI API model rather than a verified figure. Treat as directional.",
@@ -3603,7 +3599,7 @@
           "maturity": 5.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "OpenAI GPT-5 line: GPT-5 (Aug 7 2025, became ChatGPT default replacing GPT-4o) through GPT-5.1/5.2/5.4 and GPT-5.5 / GPT-5.5 Instant (the current ChatGPT default as of May 2026). Unified reasoning+chat post-trained model family, closed/API + ChatGPT only. Verified via OpenAI pages + Wikipedia + TechCrunch June 2026. Consolidated on 2026-07-29 from gpt-5; openness follows gpt-5-line, the release that currently governs. See docs/guides/identity.md."
@@ -3748,7 +3744,7 @@
           "maturity": 5.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Google Gemini 3.5 Flash, launched at I/O 2026 on May 19, 2026 as the first Gemini 3.5 model; price-performance thinking/agentic instruct model. Available via Gemini app, AI Mode in Search, Google Antigravity, Gemini API and enterprise. Proprietary API-only. (Matches the flagship anchor 'Gemini 3.5 Flash'; scored here for the finetuned_chat category, calibrated to that anchor.) Verified live June 2026. Consolidated on 2026-07-29 from gemini-2-5-flash; openness follows gemini-3-5-flash, the release that currently governs. See docs/guides/identity.md."
@@ -3783,7 +3779,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Available to X users and via grok.com/xAI API in 2025 as the flagship Grok generation; now a superseded model behind Grok 4.x default. No clean standalone Grok-3 user/usage count published. Placed at 3 on broad X-surface availability as a former flagship, downgraded from app-surface 5 because xAI discloses no honest per-model figure and it is no longer the default. Directional.",
@@ -3852,7 +3847,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Embedded as the default FIM/code-completion backend in IDE assistants (Continue, Tabnine, and Mistral's own coding stack) and on multiple API gateways; Mistral reports per-version completion-acceptance gains but discloses no hard download/user count. Level 3 reflects multi-platform IDE distribution, not a verified usage_volume figure.",
@@ -3912,7 +3906,6 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Distributed broadly through Amazon Bedrock across many AWS regions (with fine-tuning, provisioned throughput, Bedrock Agents/KB support) and positioned as the price-performance default of the Nova family. No standalone per-model user/usage count published; level 4 reflects Bedrock's enterprise distribution surface rather than a verified figure.",
@@ -4010,7 +4003,7 @@
           "maturity": 4.7,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Muse Spark, first model of Meta Superintelligence Labs' new 'Muse' series; released 8 Apr 2026. Natively multimodal reasoning model with tool-use, visual chain-of-thought, and multi-agent 'Contemplating' mode. Proprietary/API-only: powers the Meta AI assistant (meta.ai + Meta AI app), private API preview to select users; no open weights. Verified via Meta's own blog June 2026."
@@ -4069,7 +4062,7 @@
           "maturity": 5.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Doubao Seed 2.0 (ByteDance), foundation model family released 14 Feb 2026; variants Pro / Lite / Mini / Code. Multimodal reasoning/agentic instruct model; proprietary/API-only via Volcano Engine (Volcengine) and the consumer Doubao app. Scored facts are for Seed 2.0 Pro (the flagship). Verified via TechNode coverage of ByteDance's launch June 2026."
@@ -4537,7 +4530,6 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "10K-100K",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Recently released specialist model with early attention for its size; directional estimate (not a measured usage figure).",
@@ -4660,7 +4652,6 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Highest-adoption tier of the three Claude model tiers - Sonnet is the production default for coding and the model most API traffic lands on. Directional rather than measured; no per-model usage figure is published, so this is a reported-traction judgment.",
@@ -4719,7 +4710,6 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "High-volume tier by design, but no per-model usage figure is published and it is chosen less often than Sonnet as a default. Directional.",
@@ -4778,7 +4768,6 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Distributed through the Gemini API, AI Studio, Vertex AI and the Gemini apps, whose combined reach is far above the >10M band floor. Attributed to the surfaces the Pro tier powers rather than a standalone per-model count, so directional.",
@@ -5038,7 +5027,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "README still states production use at Hugging Face and now explicitly recommends vLLM/SGLang/llama.cpp/MLX going forward, confirming a real but sunsetting footprint; unchanged from prior read.",
@@ -5527,7 +5515,6 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "The groq.com homepage no longer names enterprise customers (Dropbox/Vercel/Canva/etc. are gone from the current page); replaced with a vendor developer-count figure from a dated press release. 'more than five million developers' (June 22, 2026) still bands at 1M-10M, vendor-self-reported.",
@@ -5608,7 +5595,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "No developer/user count disclosed on the inference page as of today; named users GSK, Perplexity, AlphaSense, DeepLearning.AI still featured as customer testimonials. Placed at 3 on reported enterprise traction (named-deployment signal) without a verified usage figure; smaller disclosed footprint than Groq's 3M-developer claim.",
@@ -5687,7 +5673,6 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Strong named-customer roster including Cursor, Vercel, Notion, Sourcegraph, UiPath, Quora, Cresta, StackBlitz; serves top open models for many high-traffic AI products. No raw user count disclosed; reported_traction. Breadth of high-volume production customers supports the 1-10M-equivalent band. Re-confirmed 2026-08-09: all eight customer logos/case studies still present on the homepage, including the Notion quote (Sarah Sachs, AI Lead: latency cut from about 2 seconds to 350 milliseconds) and the Quora quote (Spencer Chan, Product Lead: 3x speedup in response time).",
@@ -5784,7 +5769,6 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Re-confirmed today: the homepage still carries a named-customer case study (Cursor: \"How Cursor partnered with Together AI to deliver real-time, low-latency inference at scale\") plus a hero logo collection including Salesforce, ElevenLabs, Cohere, DeepMind, and Mozilla alongside Decagon. No raw developer/user count disclosed; banding is unchanged reported_traction on enterprise breadth.",
@@ -5914,7 +5898,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "No download/user count is published for Neuron; the AWS product page still only supports a qualitative reported_traction read (framework-integration breadth, fleet-wide positioning), the same basis the level-3 band already rested on. Held at 3 rather than raised or lowered absent a numeric signal.",
@@ -5985,7 +5968,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Powers Google internal + Cloud TPU inference via AI Hypercomputer/GKE; no standalone usage figure for the Pathways runtime offering. Level 3 = reported managed-cloud traction, per the Osmos customer account of scaled Trillium/JetStream production deployment.",
@@ -6153,7 +6135,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "OpenRouter's SambaNova provider page shows real, current multi-hundred-million-to-billion-token daily volume across the models it routes to SambaNova (e.g. ~1.65B tokens on 2026-08-09 across 6 models), corroborating genuine third-party traffic beyond vendor marketing. No standalone user/customer count is published, so this remains reported/observed traction rather than a banded usage figure; level and reach held unchanged pending rubric-level reach thresholds this pass did not open.",
@@ -6551,7 +6532,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "high",
             "note": "Re-confirmed today: 14,342 GitHub stars (up from ~13.8k), and both comparison pieces still frame TensorRT-LLM as the specialist choice - highest raw throughput on standardized NVIDIA fleets, but narrower reach than vLLM/SGLang because of compilation overhead and single-vendor lock-in. No clean standalone user/download count exists to band directly; level 3 reflects significant but specialized production usage.",
@@ -7542,7 +7522,6 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "10K-100K",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "~9.6K GitHub stars; named adopters listed in repo (Google, ByteDance, Tencent, Alibaba, Baidu, China Telecom, Vivo, Allen AI, NexusFlow, Jülich). Specialist RLHF tool used by research/training teams rather than a mass-download library (no headline PyPI figure surfaced); level 2 on named-traction, not stars.",
@@ -8784,7 +8763,6 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "10K-100K",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "No hard per-platform usage figure (jobs / customers) disclosed this run. Reported traction: enterprise post-training/agent platform now distributed under Rubrik (acquisition valued $100M-$500M per press), founder-pedigree (Google/Uber), and a widely-adopted OSS serving layer (LoRAX). Placed at 2 on reported enterprise traction, not a verified usage_volume number; low confidence pending hard data.",
@@ -9386,7 +9364,6 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "10K-100K",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Thinking Machines' own Tinker page names Glean/Waldo, Chroma, Lightning Rod Labs, Mantic, Trajectory, MIT, Stanford and Axiom Math among users of the API. Level 2 on named adopters rather than a download or seat count, none being published for a hosted training API.",
@@ -9627,7 +9604,6 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "SWE-bench Verified is the de-facto-standard agentic-coding eval cited in essentially every 2025-26 frontier release report (GPT-5 74.9%, DeepSeek-V4-Pro 80.6%, Qwen3.6, Kimi K2.6) -- the top adoption signal for a harness per recipe. pypistats reports ~31.5M swebench downloads/mo but that figure is almost certainly CI/benchmark-runner-inflated and not human installs, so used as corroboration only, not the headline; level set on standard-status, capped at 4.",
@@ -9830,7 +9806,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Widely used eval framework, especially in the China/HF ecosystem; 7.1k GitHub stars and broad dataset+backend coverage. No clean PyPI/download headline located this run; level 3 on reported_traction (framework distribution + star footprint), not on stars alone past the cap.",
@@ -10280,7 +10255,6 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "high",
             "note": "Headline signal (per recipe: adoption by frontier labs / cited in release-grade safety work): adopted as the evaluation framework of choice by major labs incl. Anthropic, Google DeepMind, and xAI/Grok, and powers nearly all of UK AISI's automated frontier-model evaluations. Corroborated by ~9.9M PyPI downloads in the last 30 days (pepy.tech) / 10.5M (pypistats), though that figure is inflated by CI/dependency traffic, so lab adoption is treated as the primary basis. Placed at level 4, not 5, because the human-operator base (eval engineers at labs/AISI) is far smaller than mass-market scale.",
@@ -10353,7 +10327,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Headline signal is influence/standard-setting, not install volume: HELM is a widely-cited standardized public leaderboard from Stanford CRFM spanning multiple modalities (capabilities/safety/vision/medical), referenced across the research community. PyPI distribution (crfm-helm) is only ~3,142 downloads/month; most usage is via the hosted leaderboard and academic citation rather than pip, so download volume understates reach. Level 3 reflects meaningful research/standard adoption short of mass production deployment.",
@@ -10498,7 +10471,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Top adoption signal for a harness = cited as the standard in frontier release reports: OSWorld scores reported in OpenAI (CUA 38.1%, GPT-5.4 75.0%), Anthropic (Claude Sonnet 4.5 61.4%, Sonnet 4.6 72.5%, Opus 4.6 72.7%) computer-use launches through 2026. Reach band is directional. The harness is run by a concentrated set of frontier labs/agent teams rather than a mass install base. 2.9k stars corroborate only.",
@@ -10723,7 +10695,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "SEAL Leaderboards are widely cited and 'trusted by leading AI labs' as a third-party evaluator; SEAL Showdown reports 'millions of real-world conversations' across 100+ countries / 70 languages / 200 professional domains. No disclosed paying-customer count for the Scale Evaluation platform specifically. Level 3 reflects reported traction of the eval surface, not a verified user count; directional.",
@@ -10796,7 +10767,6 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "The AA Intelligence Index is one of the most-cited independent model-ranking standards in frontier release coverage and the flagship_scores set itself uses it as a capability basis (e.g. Grok 4.20, Gemini 3.5 Flash records). Widely referenced across vendor launches and tech press as the go-to cross-model index. No disclosed unique-visitor count; level 4 reflects its standard-citation reach across the industry, banded conservatively. Directional.",
@@ -10869,7 +10839,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Widely cited independent leaderboard authority: 24 models tracked on the Vals Index (updated 2026-06-04); benchmark figures (e.g. GLM-5.1) are referenced in the project's own flagship scoring sources and across third-party model coverage; partnered with Legaltech Hub for industry studies. No standalone user/traffic count published, so reported_traction; level 3 reflects broad referenced use as a benchmark authority rather than a measured usage figure.",
@@ -10943,7 +10912,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Epoch's benchmark results (esp. FrontierMath) are a widely-referenced capability signal cited across frontier-model coverage and research; the public dashboard is a recognized trends source. No standalone usage/traffic count published, so reported_traction; level 3 reflects broad authoritative reference rather than a measured figure. No stars-only fallback used.",
@@ -11006,7 +10974,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "GA since 2025-03-20 and distributed inside Amazon Bedrock (a large enterprise AI surface), but AWS publishes no standalone usage count for the Evaluations feature specifically. Level 3 = reported traction via the Bedrock platform footprint, not a measured figure; low confidence because the signal is the parent surface, not the feature. No stars fallback (closed service).",
@@ -11931,7 +11898,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "The standard multilingual code-generation benchmark: integrated into the BigCode Code Generation LM Harness and HF's multilingual code-model evaluation, cited in multilingual code-model release reports (e.g. StarCoder2/CodeQwen). HF page did not surface a clean monthly-download count this run (showed likes only), and GitHub stars (~308) are last-resort and cannot exceed 3. Level 3 on harness-adoption / release-report traction; no verified usage_volume number, hence low confidence.",
@@ -12043,7 +12009,6 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "MATH is one of the most-cited math-reasoning standards; MATH / MATH-500 appears as a headline metric across frontier model release reports (the top adoption signal for a benchmark). Despite the canonical HF repo being takedown-walled, the benchmark itself remains pervasively used via mirrors and eval harnesses. Level 4 on release-report standard status; no clean current download count obtainable from the primary repo (disabled), hence reported_traction not usage_volume.",
@@ -12150,7 +12115,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "SEAL is a widely-referenced expert-driven private leaderboard cited across the LLM evaluation community as a contamination-resistant ranking; broad press and industry attention but no published download/usage count (the data is held-out by design). Reported-traction tier as an industry-standard reference rather than a measured usage_volume figure.",
@@ -12306,7 +12270,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Established code-reasoning benchmark cited in code-model evaluations and research since 2024; from Meta FAIR with a dedicated leaderboard. Solid research/eval-standard traction but a specialist code-execution benchmark, not mass-scale; placed at 3 on reported research/citation traction rather than a measured download figure.",
@@ -16925,7 +16888,7 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "enterprise",
+            "reach": "niche",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "~$237M raised at a ~$1.3B valuation (Series D, May 2025); established enterprise/government adoption rather than frontier-lab pretraining use. Directional.",
@@ -17027,7 +16990,7 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "enterprise",
+            "reach": "niche",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Backed by NVIDIA and distributed through the NeMo platform; Gretel had a large synthetic-data user base pre-acquisition. Directional; hard to separate from NeMo overall.",
@@ -17085,7 +17048,7 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "early / niche",
+            "reach": "niche",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "~$57.5M raised with high-profile backers, but early-stage with no named frontier-lab deployments; traction is credibility/funding rather than proven scale. Directional.",
@@ -17675,7 +17638,6 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "high",
             "note": "OpenAI confirmed Codex surpassed 4M weekly developers (Apr 21 2026 announcement; 5M+ reported more recently). Firmly in the 1-10M+ reach band on disclosed developer count. Primary OpenAI announcement now cited as the basis (was previously sourced only to a distribution page).",
@@ -17941,7 +17903,6 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Reuters (Feb 2026): Claude Code exceeded ~$2.5B run-rate revenue, with business subscriptions quadrupled since the start of 2026 and enterprise now >half of Claude Code revenue. No clean user-count, so reported_traction; revenue scale implies well into the 1-10M+ developer band.",
@@ -18111,7 +18072,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Widely adopted commercial coding agent with paid Individual/Teams/Enterprise tiers, but Cognition discloses no hard user count. Placed at 3 on reported commercial traction; no verified usage_volume figure.",
@@ -18252,7 +18212,6 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Devin Desktop (Windsurf) page reports '1M+ Users' and '4000+ Enterprise Customers'. Vendor-reported headline count places it in the 1-10M band. Cognition-reported Windsurf ARR ~$82M corroborates commercial scale.",
@@ -18315,7 +18274,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Distributed across AWS's large developer base via IDEs/CLI/Console with free + Pro tiers and enterprise case studies, but AWS discloses no hard Q Developer user count. Placed at 3 on reported traction.",
@@ -18407,7 +18365,7 @@
           "maturity": 4.3,
           "mature": false,
           "freshness": {
-            "date": "2026-06-24",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "GitHub Copilot Agent Mode, assigns autonomous background coding tasks (plan/explore/execute), supports first-party Copilot agent plus Claude (Anthropic) and Codex (OpenAI). Verified live June 2026 at github.com/features/copilot."
@@ -18436,7 +18394,6 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Replit reported 50M+ platform users with agent-driven consumption as primary growth driver (ARR ~$250M). User count is platform-wide, not agent-specific, so placed conservatively at 4 on reported traction rather than treating the 50M as an agent active-user figure.",
@@ -18499,7 +18456,6 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Vercel reports multi-million (4M+) cumulative v0 users since GA. Falls in the 1-10M band; reported_traction since the figure is vendor cumulative-user rather than a hard active-user metric.",
@@ -19061,7 +19017,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "high",
             "note": "~75.8k GitHub stars, $18.8M Series A, contributors from major firms, OpenHands Cloud with multi-user/Slack/Jira/Linear integrations. No precise active-user/download count verified; rated 3 on reported traction.",
@@ -21145,7 +21100,6 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Default inference surface for Microsoft Foundry across Azure's enterprise base; broad distribution but no published per-service usage number. Level 4 reflects Azure-enterprise scale (reported), not a measured count.",
@@ -21593,7 +21547,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Hosted HuggingChat served 1M+ users and 100k+ assistants over its lifetime (HF announcement) before the July 2025 sunset; relaunched as HuggingChat Omni and live again on hf.co/chat. chat-ui repo itself is a modest 10.7k stars (self-host base is niche). Placed at 3 on the disclosed lifetime user reach of the hosted product; the discontinuity + relaunch lowers confidence.",
@@ -22233,7 +22186,7 @@
           "maturity": 5.0,
           "mature": false,
           "freshness": {
-            "date": "2026-06-09",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "ChatGPT (OpenAI) consumer chat app, web + iOS/Android + desktop. Proprietary/closed UI scored as the closed counterpart in this category. Live and verified June 2026; default model GPT-5 family. (The model SKU is scored separately under base/finetuned categories; this record scores the chat surface.)"
@@ -22296,7 +22249,7 @@
           "maturity": 5.0,
           "mature": false,
           "freshness": {
-            "date": "2026-07-29",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "GitHub Copilot (GitHub / Microsoft), proprietary in-IDE AI coding assistant (inline suggestions, chat, agent mode) across VS Code/JetBrains/etc. Closed counterpart in ui_api. Verified live on github.com/features/copilot June 2026."
@@ -22359,7 +22312,7 @@
           "maturity": 5.0,
           "mature": false,
           "freshness": {
-            "date": "2026-06-24",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Claude.ai (Anthropic) consumer chat app, web + macOS/Windows + iOS/Android. Proprietary/closed UI scored as the closed counterpart. Verified live June 2026 (product page now at claude.com/product/overview, redirected from anthropic.com/claude). Uses Claude Opus/Sonnet/Haiku."
@@ -22417,7 +22370,7 @@
           "maturity": 5.0,
           "mature": false,
           "freshness": {
-            "date": "2026-06-09",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Gemini app (Google), consumer chat app (web + Android/iOS), proprietary/closed UI scored as the closed counterpart. Verified live June 2026; powered by Gemini 3.x model family. (Model SKUs scored separately; this record scores the app surface.)"
@@ -22480,7 +22433,7 @@
           "maturity": 4.7,
           "mature": false,
           "freshness": {
-            "date": "2026-06-24",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Microsoft Copilot consumer + M365 Copilot chat assistant surfaces (Windows, Edge, M365, Bing, mobile), live June 2026 per Microsoft Learn admin/usage docs. Proprietary chat UI over OpenAI + Microsoft models; human-in-the-loop assistant (Copilot Studio agents are a separate product). Scored as the chat-UI surface."
@@ -22543,7 +22496,7 @@
           "maturity": 4.7,
           "mature": false,
           "freshness": {
-            "date": "2026-06-24",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Perplexity consumer AI answer/search chat product (web + apps), live June 2026 (perplexity.ai homepage confirms product). Proprietary chat UI routing over multiple closed + open models; human-in-the-loop search/answer assistant. Comet browser + Computer agent are adjacent surfaces (agentic, scored elsewhere if at all)."
@@ -22970,7 +22923,7 @@
           "maturity": 4.7,
           "mature": false,
           "freshness": {
-            "date": "2026-06-09",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Poe by Quora, multi-model chat aggregator app (web + mobile/desktop), live June 2026 (poe.com confirms). Single UI fronting many providers' bots (ChatGPT, Claude, Gemini, DeepSeek) + image/video/audio models + millions of user-created bots. Human-in-the-loop chat aggregator; proprietary."
@@ -23091,7 +23044,7 @@
           "maturity": 4.1,
           "mature": false,
           "freshness": {
-            "date": "2026-06-24",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Character.AI consumer companion/roleplay chat app (web + mobile), live June 2026. Proprietary chat UI over its own models + (post-Google-deal) licensed models; human-in-the-loop character chat. MAU peaked ~28M mid-2024, declined amid competition."
@@ -23159,7 +23112,7 @@
           "maturity": 4.7,
           "mature": false,
           "freshness": {
-            "date": "2026-07-29",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Grok consumer AI chat assistant by xAI, the app/UI surface (grok.com + X integration + mobile), live June 2026 (x.ai). Scored here as the chat-UI product, NOT the Grok 4.x model SKU (the model is scored in base_pretrained as Grok 4.20). Proprietary; human-in-the-loop assistant with image gen + X-grounded search."
@@ -23222,7 +23175,7 @@
           "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-06-24",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Le Chat by Mistral AI, consumer AI chat assistant (web + mobile; app rebranded toward 'Mistral Vibe' by 2026), live June 2026 (mistral.ai). Proprietary chat UI primarily over Mistral's own models; human-in-the-loop assistant. ~1.7M app downloads by May 2026; EU MAU stated below 45M."
@@ -23372,7 +23325,7 @@
           "maturity": 4.4,
           "mature": false,
           "freshness": {
-            "date": "2026-08-11",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Meta's consumer AI assistant embedded across WhatsApp, Instagram, Messenger, Facebook + standalone meta.ai app. Proprietary; powered by Meta's Llama family (the underlying weights are use-restricted and scored separately at the model layer). Verified live June 2026."
@@ -23480,7 +23433,6 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Glean surpassed $300M ARR (28 May 2026, vendor press), 15 months after $100M; nearly doubled Fortune 500 customer count YoY; 85%+ of customers use it across 5+ departments; 45% wDAU/wMAU engagement ratio; operating in 28 countries. ARR/enterprise-seat scale implies low-millions of enterprise seats; placed at 4 on reported enterprise traction. No raw seat/user count disclosed, so confidence medium and signal_type reported_traction (revenue + deployment breadth, not a measured user count).",
@@ -23538,7 +23490,6 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Search is the foundational layer of the same Glean platform that crossed $300M ARR (May 2026) with near-doubled Fortune 500 count and 85%+ multi-department usage; effectively co-extensive with Glean's deployed seat base. Same caveat as Glean Assistant: no raw user count disclosed, so reported_traction at confidence medium. Adoption shared with the Assistant record (same platform), not an independent measurement.",
@@ -24107,7 +24058,6 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Vendor discloses ~1 trillion spans/month and ~1 billion evals/month plus named enterprise customers (DoorDash, Roblox, PepsiCo, Atlassian, Booking.com, Reddit); no per-account user count, so reported_traction rather than active_users.",
@@ -24808,7 +24758,6 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Default observability/eval platform for the very widely used LangChain ecosystem; vendor lists 25+ named enterprise customers (Klarna, Lyft, Cloudflare, LinkedIn, Coinbase, Nvidia, Workday, etc.). No quantitative user count disclosed, so reported_traction; placed at 4 on ecosystem reach + enterprise roster (directional).",
@@ -24973,7 +24922,6 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Rides the large installed base of Datadog APM (a major enterprise observability vendor); LLM Observability is a newer add-on with no disclosed standalone user/usage count. Placed at 4 on parent-platform enterprise reach as a directional estimate, not a measured figure for this module specifically.",
@@ -25445,7 +25393,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Vendor states 'trusted by leading enterprises' but discloses no named customers or quantitative user/usage figures on the homepage. Level 3 reflects established commercial traction without a verified count; treat as directional.",
@@ -25508,7 +25455,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Vendor discloses '500+ leading AI companies' incl. Panasonic, Samsung, Epic Games, Humach. Corroborated by the strong pull of its open source funnel DeepEval (~15.9k GitHub stars, used-by 1.3k repos), which drives platform signups. Level 3 on disclosed named-customer traction; no precise active-user/usage-volume number for the platform itself.",
@@ -25571,7 +25517,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "A feature surface within Vertex AI Agent Engine on Google Cloud; no standalone usage figures published for the observability capability specifically. Level 3 reflects availability inside a large cloud platform's agent stack, not a measured user count; directional.",
@@ -25629,7 +25574,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "GA March 2026 as a feature surface within Microsoft Foundry on Azure; no standalone usage figures published for the observability capability specifically. Level 3 reflects availability inside a large cloud AI platform, not a measured user count; directional.",
@@ -25822,7 +25766,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "high",
             "note": "Described as the most widely adopted open source LLM engineering platform; acquired by ClickHouse Mar 2026. No precise verified download/active-user count, rated 3 on reported traction.",
@@ -26092,7 +26035,6 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "1K-10K",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Niche but notable: a ROOST Model Community partner model (distributed via RMC); 23 HF likes (June 2026), downloads not tracked.",
@@ -27577,7 +27519,6 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "10K-100K",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Established prompt-injection-defense vendor with notable enterprise customers; acquired by Check Point in 2025. No public usage counts.",
@@ -28187,7 +28128,6 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Protocol adoption-breadth signal (per recipe): LF press (Apr 2026 one-year mark) reports 150+ supporting organizations, in-production use at Microsoft (Azure AI Foundry, Copilot Studio), AWS (Bedrock AgentCore), Salesforce, SAP, ServiceNow, and embedding into Google Cloud. Breadth across the three major clouds + enterprise production puts effective downstream reach in the 1-10M band; this is a breadth/traction count, not a measured per-user figure.",
@@ -28532,7 +28472,6 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "No standalone Sonar-API request/developer count is published by a primary source; Perplexity docs confirm the API exists and is a core developer surface. Platform-level scale is large (45M+ MAU, ~1B+ queries/month per 2026 reporting) but that is the consumer app, not the API specifically. Rated 4 on reported developer-API traction within a clearly mass-scale parent platform; flagged that the headline platform numbers are aggregator-reported and not API-specific.",
@@ -28923,7 +28862,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "De facto default managed reranker for RAG, distributed across Azure AI Foundry, AWS SageMaker JumpStart / OpenSearch, and Oracle GenAI in addition to Cohere's API. No hard call-volume/user count published; placed at 3 on broad multi-cloud distribution (reported_traction).",
@@ -29155,7 +29093,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "high",
             "note": "Described as the default open source engine for billion-scale semantic search; LF AI & Data graduate. No precise verified deployment/download count, rated 3 on reported traction.",
@@ -31629,7 +31566,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Established CNCF/OpenInfra-adjacent container-runtime project integrated into Kubernetes runtimeclass deployments; broad but operator-concentrated infrastructure adoption rather than a mass per-user count. No clean download/user figure verified; ~8k stars (corroborate only, not the basis). Level 3 reflects specialist infra reach.",
@@ -32118,7 +32054,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "No disclosed Modal Sandboxes user/usage count on primary pages; Modal is a well-known managed AI-compute platform with broad developer use and a documented free tier. Placed at 3 on reported multi-customer traction, not a measured usage_volume figure (kept conservative absent a hard number).",
@@ -32409,7 +32344,6 @@
           },
           "adoption": {
             "level": 1,
-            "reach": "<10K",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Launched Jan 2026 (~5 months at scoring time) as Fly.io's answer to E2B. No disclosed user/customer/usage counts on the product page or launch coverage; positioned for AI coding-agent sessions (Claude Code/Codex). Early-stage; placed at 1 on reported traction with low confidence pending real numbers.",
@@ -32550,7 +32484,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Powers StackBlitz's own IDE and is embedded by named projects (SvelteKit, Astro, Scrimba, egghead.io, Xata) for in-browser code experiences. No disclosed download/MAU figure on the primary pages; placed at 3 on named-integration reported traction. No hard usage_volume number found, so confidence low.",
@@ -32637,7 +32570,7 @@
           "maturity": 3.6,
           "mature": false,
           "freshness": {
-            "date": "2026-07-30",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "OpenAI Code Interpreter, a tool (Assistants API, migrating to Responses API) that writes and runs Python in a proprietary OpenAI-managed sandbox; processes files up to 512MB, sessions billed at $0.03/session (1-hour default). Confirmed live June 2026 via OpenAI developer docs. Proprietary; isolation mechanism undisclosed."
@@ -32666,7 +32599,6 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Northflank (platform-wide, primary): 2,000+ organizations, 80,000+ developers in production, 130B+ requests, millions of containers, 330+ availability zones. These are platform-level figures (not Sandboxes-specific); the Sandboxes product is newer. Placed at 3 on the developer/org base; the Sandboxes feature alone is likely lower.",

--- a/build/notebook_data.json
+++ b/build/notebook_data.json
@@ -120,22 +120,32 @@
             "score": 3,
             "basis": "benchmark",
             "basis_detail": "Artificial Analysis Intelligence Index",
-            "value": "Llama 3.1 405B: AA Intelligence Index 17, ranked #29/43, 'below average' vs current peers (peer average 23); mid-2024 non-reasoning model surpassed by 2026 frontier.",
+            "value": "Llama 4 Maverick: AA Intelligence Index 14 (v4.1.1), ranked #26/44, 'below average among other open weight non-reasoning models of similar size' (median 18). The strongest released member of the tier - Llama 4 Scout scores 10 on the same index, and Behemoth is unreleased.",
             "confidence": "medium",
-            "note": "Weights downloadable under Meta's Llama-4-Community terms: a 700M-MAU commercial cap, an acceptable-use policy and naming requirements. No relicensing to record - Llama 3.1 carried the equivalent terms, and Llama 4 Scout and Maverick govern as the current release. Moved from 2/restricted on 2026-08-01 by the universal license scale, which caps a bounded commercial license at 3 rather than 2. The test at that boundary is whether the license permits commercial use AT ALL: this one does, for everyone inside the bound. A license that forbids commerce outright - CC-BY-NC, Mistral Non-Production - stays at 2. Nine other products carry a bounded license and all now score 3; four of them were already recorded there, which is the inconsistency this resolves.",
+            "note": "MAX ACROSS THE TIER'S RELEASES, per docs/guides/identity.md. This record previously cited Llama 3.1 405B, a mid-2024 release the slug still covers but which is not its best, and it cited an index number - 17 - that no longer exists on Artificial Analysis's scale: the index was recalibrated, and 14 on v4.1.1 is not a decline from 17 but a different measurement. Both faults pointed the same way, and neither was visible from inside the record, since a stale number and a live one look alike. The SCORE is unchanged at 3, which is the point of re-deriving rather than adjusting: the tier's standing against its peers did not move. It was below the peer median before (17 against 23) and it is below the peer median now (14 against 18), on a comparison set that has grown from 43 models to 44.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
-                "url": "https://artificialanalysis.ai/models/llama-3-1-instruct-405b",
-                "shows": "AA Intelligence Index 17, rank #29/43, below-average vs peers (avg 23)",
-                "accessed": "2026-06-04"
+                "url": "https://artificialanalysis.ai/models/llama-4-maverick",
+                "shows": "AA Intelligence Index 14 (v4.1.1), rank #26/44, below average vs open-weight non-reasoning peers of similar size (median 18)",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "aaaef3ad229e3bc58c0adbba0e396cbd1ef3609bb41108ec2e841a08781f52f1"
+              },
+              {
+                "url": "https://artificialanalysis.ai/models/llama-4-scout",
+                "shows": "AA Intelligence Index 10 (v4.1.1), rank #9/39 - the tier's other released member, confirming Maverick is the max rather than assuming it",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "f04ff54b8ba3531a07890c68bdc1fdeaea7d5d06bb9e39d1cec28f459735946f"
               }
             ]
           },
           "maturity": 3.3,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
-            "basis": "commit"
+            "date": "2026-08-13",
+            "basis": "verified"
           },
           "version_note": "Llama 4 herd, released April 2025: Scout (17B active / 109B total MoE, 10M-token context) and Maverick (17B active / 400B total MoE, 1M-token context), natively multimodal. Behemoth still unreleased/preview as of June 2026. Both Scout/Maverick verified live on HF June 2026. Consolidated on 2026-07-29 from llama-3-1; openness follows llama-4-scout-maverick, the release that currently governs. See docs/guides/identity.md."
         },
@@ -178,26 +188,54 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 5,
-            "reach": ">10M",
+            "level": 4,
+            "reach": "1M-10M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "ATOM Report (Apr 2026): China open models reached ~1.15B cumulative HF downloads with DeepSeek a primary driver; DeepSeek-V3.2 widely served (OpenRouter, multiple inference providers) with sustained post-launch production usage and frontier-at-10x-lower-cost positioning. Real usage well into the >10M-equivalent band across web app + API + derivatives.",
+            "note": "5,180,104 downloads in the trailing 30 days summed across the 6 declared artifact(s), read 2026-08-13 (deepseek-ai/DeepSeek-V3.2 1,093,344; deepseek-ai/DeepSeek-V3-Base 31,718; deepseek-ai/DeepSeek-V4-Pro 1,411,583; deepseek-ai/DeepSeek-V4-Flash 2,283,943; deepseek-ai/DeepSeek-V4-Pro-Base 14,769; deepseek-ai/DeepSeek-V4-Flash-Base 344,747). Bands at level 4 (1M-10M) on the software and model adoption scale. Corrected from level 5, which the declared artifacts do not support.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
-                "url": "https://arxiv.org/html/2604.07190v1",
-                "shows": "flagship phase-C verification source",
-                "accessed": "2026-06-04"
+                "url": "https://huggingface.co/api/models/deepseek-ai/DeepSeek-V3.2",
+                "shows": "1,093,344 downloads in the trailing 30 days for deepseek-ai/DeepSeek-V3.2",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "eb2fe531a6e5fa227b2e329dcdc3dd31c9bf8652ef065ed2a47ea426d15aff34"
               },
               {
-                "url": "https://openrouter.ai/deepseek/deepseek-v3.2",
-                "shows": "flagship phase-C verification source",
-                "accessed": "2026-06-04"
+                "url": "https://huggingface.co/api/models/deepseek-ai/DeepSeek-V3-Base",
+                "shows": "31,718 downloads in the trailing 30 days for deepseek-ai/DeepSeek-V3-Base",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "b53d64959451ed9931df9dd160cc0211ee3a6fef64567fa3fcdbae60c4299699"
               },
               {
-                "url": "https://introl.com/blog/deepseek-v3-2-open-source-ai-cost-advantage",
-                "shows": "flagship phase-C verification source",
-                "accessed": "2026-06-04"
+                "url": "https://huggingface.co/api/models/deepseek-ai/DeepSeek-V4-Pro",
+                "shows": "1,411,583 downloads in the trailing 30 days for deepseek-ai/DeepSeek-V4-Pro",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "30a1dcc082abb2949d9cb6ef57432b2c0bc26ca6c83e3c714eb120d9a6516221"
+              },
+              {
+                "url": "https://huggingface.co/api/models/deepseek-ai/DeepSeek-V4-Flash",
+                "shows": "2,283,943 downloads in the trailing 30 days for deepseek-ai/DeepSeek-V4-Flash",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "55c2eda9e4d9c6219c327dde073eacb12f3e98f5217266c9eda5ff7ec648a280"
+              },
+              {
+                "url": "https://huggingface.co/api/models/deepseek-ai/DeepSeek-V4-Pro-Base",
+                "shows": "14,769 downloads in the trailing 30 days for deepseek-ai/DeepSeek-V4-Pro-Base",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "a7f2243ccecaaa0b3ed5a1ffc61fc5dbfbb35a7a59e6f7b4df96f07181cd5f73"
+              },
+              {
+                "url": "https://huggingface.co/api/models/deepseek-ai/DeepSeek-V4-Flash-Base",
+                "shows": "344,747 downloads in the trailing 30 days for deepseek-ai/DeepSeek-V4-Flash-Base",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "6825c66170ae03a87108ed48aaee3e1ffe33a84f32b13c7151283f11fc5ea179"
               }
             ]
           },
@@ -226,11 +264,11 @@
               }
             ]
           },
-          "maturity": 5.0,
+          "maturity": 4.7,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
-            "basis": "commit"
+            "date": "2026-08-13",
+            "basis": "verified"
           },
           "version_note": "DeepSeek-V4-Pro, 1.6T total / 49B active MoE, 1M-token context, hybrid CSA+HCA attention. Released April 24 2026 under MIT, alongside V4-Flash (284B). V4-Pro-Max = max-reasoning mode. Verified live June 2026. Consolidated on 2026-07-29 from deepseek-v3-2, deepseek-v3-base, deepseek-v4-pro-base; openness follows deepseek-v4-pro, the release that currently governs. See docs/guides/identity.md."
         },
@@ -578,21 +616,19 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 2,
-            "reach": "10K-100K",
+            "level": 1,
+            "reach": "<10K",
             "signal_type": "usage_volume",
             "confidence": "medium",
-            "note": "HF monthly downloads modest in 2026 (3,521/mo for the 7B base, confirmed 2026-06-04) as a 2024-era model; distributed via HF, Ollama, ModelScope. Cumulative reach across the InternLM2.5 family + mirrors sits in the early-adopter band; specialist/research uptake, not production scale.",
+            "note": "3,095 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (internlm/internlm2_5-7b 3,095). Bands at level 1 (<10K) on the software and model adoption scale. Corrected from level 2, which the declared artifacts do not support.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
-                "url": "https://huggingface.co/internlm/internlm2_5-7b",
-                "shows": "3,521 downloads last month",
-                "accessed": "2026-06-04"
-              },
-              {
-                "url": "https://ollama.com/internlm/internlm2.5",
-                "shows": "InternLM2.5 distributed via Ollama",
-                "accessed": "2026-06-04"
+                "url": "https://huggingface.co/api/models/internlm/internlm2_5-7b",
+                "shows": "3,095 downloads in the trailing 30 days for internlm/internlm2_5-7b",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "53db38845403a603b29a19fc8f466f1e27f655ff467c993ba5fba95df26df4f6"
               }
             ]
           },
@@ -616,11 +652,11 @@
               }
             ]
           },
-          "maturity": 2.0,
+          "maturity": 1.7,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
-            "basis": "commit"
+            "date": "2026-08-13",
+            "basis": "verified"
           },
           "version_note": "InternLM2.5-7B base (~8B params, 1M-token context), released 2024 (InternLM2 tech report arXiv:2403.17297). Base SKU scored here; InternLM2.5-7B-Chat is the instruct SKU (finetuned_chat). Verified live on HF June 2026; a 2024-era 7B model."
         },
@@ -1104,21 +1140,26 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 2,
-            "reach": "10K-100K",
+            "level": 1,
+            "reach": "<10K",
             "signal_type": "usage_volume",
             "confidence": "medium",
-            "note": "Niche sovereign/French open-LLM audience. HF Lucie-7B ~780 downloads/month and 31 likes (Jul 2026); collection upvotes modest. Comparable adoption tier to Apertus / Falcon-class fully-open European releases rather than Llama/Qwen scale.",
+            "note": "1,945 downloads in the trailing 30 days summed across the 2 declared artifact(s), read 2026-08-13 (OpenLLM-France/Lucie-7B 1,315; OpenLLM-France/Lucie-7B-Instruct-v1.1 630). Bands at level 1 (<10K) on the software and model adoption scale. Corrected from level 2, which the declared artifacts do not support.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
-                "url": "https://huggingface.co/OpenLLM-France/Lucie-7B",
-                "shows": "~780 downloads/month, 31 likes (as of 2026-07-19)",
-                "accessed": "2026-07-19"
+                "url": "https://huggingface.co/api/models/OpenLLM-France/Lucie-7B",
+                "shows": "1,315 downloads in the trailing 30 days for OpenLLM-France/Lucie-7B",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "5f3f27e43082f9addf5a4d352b60c32bd0806c69f3dc2b6e6b75178c7dcaf938"
               },
               {
-                "url": "https://huggingface.co/collections/OpenLLM-France/lucie-llm",
-                "shows": "official Lucie LLM collection (base, instruct, dataset, paper)",
-                "accessed": "2026-07-19"
+                "url": "https://huggingface.co/api/models/OpenLLM-France/Lucie-7B-Instruct-v1.1",
+                "shows": "630 downloads in the trailing 30 days for OpenLLM-France/Lucie-7B-Instruct-v1.1",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "daea16a5f6dcc1bc6ae21e514cacdf06e44b9f71f50d6cd927b31d5b516adeaf"
               }
             ]
           },
@@ -1142,10 +1183,10 @@
               }
             ]
           },
-          "maturity": 2.0,
+          "maturity": 1.7,
           "mature": false,
           "freshness": {
-            "date": "2026-07-30",
+            "date": "2026-08-13",
             "basis": "verified"
           },
           "version_note": "Lucie-7B base + Instruct-v1.1 / Instruct-human-data. Apache-2.0 weights; training data at OpenLLM-France/Lucie-Training-Dataset (not a separate map product for now); training code AGPL/community stack on GitHub. Paper arXiv:2503.12294. Collection https://huggingface.co/collections/OpenLLM-France/lucie-llm."
@@ -1286,16 +1327,26 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 4,
-            "reach": "1M-10M",
+            "level": 3,
+            "reach": "100K-1M",
             "signal_type": "usage_volume",
             "confidence": "medium",
-            "note": "Succeeds OLMo 2 (the OLMo family measured ~14.8M cumulative HF downloads in early 2026). The reference fully-open model in research/interpretability circles; below the Qwen/Llama scale.",
+            "note": "146,145 downloads in the trailing 30 days summed across the 2 declared artifact(s), read 2026-08-13 (allenai/Olmo-3-1125-32B 43,671; allenai/Olmo-3-1025-7B 102,474). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected from level 4, which the declared artifacts do not support.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
-                "url": "https://allenai.org/blog/olmo3",
-                "shows": "flagship fully-open release; broad research uptake",
-                "accessed": "2026-06-30"
+                "url": "https://huggingface.co/api/models/allenai/Olmo-3-1125-32B",
+                "shows": "43,671 downloads in the trailing 30 days for allenai/Olmo-3-1125-32B",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "774b1b37fcdd1a22544f57b26efc8d75710850c7d8930e1a5247d753584887e5"
+              },
+              {
+                "url": "https://huggingface.co/api/models/allenai/Olmo-3-1025-7B",
+                "shows": "102,474 downloads in the trailing 30 days for allenai/Olmo-3-1025-7B",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "53f69c16d3f17df85b179763281369d29e9dea58c2991e0924e8d86182ad5848"
               }
             ]
           },
@@ -1314,10 +1365,10 @@
               }
             ]
           },
-          "maturity": 4.0,
+          "maturity": 3.7,
           "mature": false,
           "freshness": {
-            "date": "2026-07-30",
+            "date": "2026-08-13",
             "basis": "verified"
           },
           "version_note": "Apache-2.0; fully-open weights + Dolma 3 data + training code + checkpoints. OLMo 3-Think 32B is the strongest fully-open reasoning model, narrowing the gap to Qwen3-32B on ~6x fewer tokens; still below the trillion-param open-weight frontier."
@@ -1383,21 +1434,19 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 3,
-            "reach": "100K-1M",
+            "level": 2,
+            "reach": "10K-100K",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "Heavily used as a research/interpretability benchmark suite (de facto standard for training-dynamics studies); cited extensively. Hugging Face download volume across the 16 models is in the 100k-1M aggregate range, meaningful for research but not production deployment. Honest signal: research adoption, not end-user scale.",
+            "note": "30,007 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (EleutherAI/pythia-12b 30,007). Bands at level 2 (10K-100K) on the software and model adoption scale. Corrected from level 3, which the declared artifacts do not support.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
-                "url": "https://huggingface.co/EleutherAI/pythia-6.9b",
-                "shows": "flagship phase-C verification source",
-                "accessed": "2026-06-04"
-              },
-              {
-                "url": "https://www.eleuther.ai/papers-blog/pythia-a-suite-for-analyzing-large-language-modelsacross-training-and-scaling",
-                "shows": "flagship phase-C verification source",
-                "accessed": "2026-06-04"
+                "url": "https://huggingface.co/api/models/EleutherAI/pythia-12b",
+                "shows": "30,007 downloads in the trailing 30 days for EleutherAI/pythia-12b",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "877612ac2b240f01cb265af7d577b7a461e434fa9ab8fe42b61b6fa68bbd9ee5"
               }
             ]
           },
@@ -1415,10 +1464,10 @@
               }
             ]
           },
-          "maturity": 1.6,
+          "maturity": 1.3,
           "mature": false,
           "freshness": {
-            "date": "2026-07-30",
+            "date": "2026-08-13",
             "basis": "verified"
           },
           "version_note": "Pythia suite: 16 models, 70M-12B params (8 sizes x Pile/deduped-Pile), 154 intermediate checkpoints each. Released 2023 (arXiv 2304.01373); remains the standard interpretability/training-dynamics suite as of June 2026."
@@ -1456,21 +1505,19 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 4,
-            "reach": "1M-10M",
+            "level": 3,
+            "reach": "100K-1M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "Phi-4 is a widely downloaded small model on Hugging Face, distributed via Azure AI Foundry, Ollama, and many local-inference stacks; download volume for the Phi-4 line is in the millions range. Level 4 reflects broad small-model adoption.",
+            "note": "626,702 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (microsoft/phi-4 626,702). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected from level 4, which the declared artifacts do not support.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
-                "url": "https://venturebeat.com/ai/microsoft-makes-powerful-phi-4-model-fully-open-source-on-hugging-face",
-                "shows": "flagship phase-C verification source",
-                "accessed": "2026-06-04"
-              },
-              {
-                "url": "https://artificialanalysis.ai/models/phi-4",
-                "shows": "flagship phase-C verification source",
-                "accessed": "2026-06-04"
+                "url": "https://huggingface.co/api/models/microsoft/phi-4",
+                "shows": "626,702 downloads in the trailing 30 days for microsoft/phi-4",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "acc97b7d7cf7aa29e07aa0b2c9e1ad8342fefed545a6fc502fb7268ed855c460"
               }
             ]
           },
@@ -1494,11 +1541,11 @@
               }
             ]
           },
-          "maturity": 3.3,
+          "maturity": 3.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
-            "basis": "commit"
+            "date": "2026-08-13",
+            "basis": "verified"
           },
           "version_note": "Phi-4, 14B dense model, weights released on Hugging Face under MIT (full release Jan 2025 following Dec 2024 announcement). Reasoning variants (Phi-4-reasoning / -reasoning-plus) released later under open weights but are separate SKUs; this record scores base Phi-4 14B."
         },
@@ -1705,16 +1752,19 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 2,
-            "reach": "10K-100K",
+            "level": 1,
+            "reach": "<10K",
             "signal_type": "usage_volume",
             "confidence": "medium",
-            "note": "Newer release (Sep 2025) with strong institutional/sovereign-AI interest but modest raw download volume; swiss-ai/Apertus-70B-2509 shows ~1.5K downloads/month and 149 likes on HF (June 2026); cumulative across the 8B/70B base+Instruct SKUs lands in the 10K-100K band. Distributed via Swisscom, Hugging Face, and the Public AI network. Comparable adoption tier to Falcon 3 / Yi-1.5.",
+            "note": "546 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (swiss-ai/Apertus-70B-2509 546). Bands at level 1 (<10K) on the software and model adoption scale. Corrected from level 2, which the declared artifacts do not support.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
-                "url": "https://huggingface.co/swiss-ai/Apertus-70B-2509",
-                "shows": "~1,462 downloads/month, 149 likes (June 2026)",
-                "accessed": "2026-06-08"
+                "url": "https://huggingface.co/api/models/swiss-ai/Apertus-70B-2509",
+                "shows": "546 downloads in the trailing 30 days for swiss-ai/Apertus-70B-2509",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "9fa185ea1eff42b68e584158bedd5dbd8b0facc71da717696554357ed82ccad0"
               }
             ]
           },
@@ -1740,10 +1790,10 @@
               }
             ]
           },
-          "maturity": 2.7,
+          "maturity": 2.4,
           "mature": false,
           "freshness": {
-            "date": "2026-07-30",
+            "date": "2026-08-13",
             "basis": "verified"
           },
           "version_note": "Apertus family (8B + 70B, base + Instruct), released 2 Sep 2025 by the Swiss AI Initiative (EPFL, ETH Zurich, CSCS). 15T training tokens across 1,811 natively supported languages (~40% non-English, incl. Swiss German and Romansh), 65,536-token context, trained on 4,096 GH200 GPUs (Alps/CSCS) with Megatron-LM. Verified live on Hugging Face June 2026 (swiss-ai/Apertus-70B-2509)."
@@ -2604,16 +2654,19 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 5,
-            "reach": ">10M",
+            "level": 4,
+            "reach": "1M-10M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "Weights open under Meta's non-OSI Llama 3.1 Community License, with its 700M-MAU commercial cap. Commonly marketed as open. Moved from 2/restricted on 2026-08-01 by the universal license scale, which caps a bounded commercial license at 3 rather than 2. The test at that boundary is whether the license permits commercial use AT ALL: this one does, for everyone inside the bound. A license that forbids commerce outright - CC-BY-NC, Mistral Non-Production - stays at 2. Nine other products carry a bounded license and all now score 3; four of them were already recorded there, which is the inconsistency this resolves.",
+            "note": "7,345,657 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (meta-llama/Llama-3.1-8B-Instruct 7,345,657). Bands at level 4 (1M-10M) on the software and model adoption scale. Corrected from level 5, which the declared artifacts do not support.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
-                "url": "https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct",
-                "shows": "11,077,966 downloads last month",
-                "accessed": "2026-06-04"
+                "url": "https://huggingface.co/api/models/meta-llama/Llama-3.1-8B-Instruct",
+                "shows": "7,345,657 downloads in the trailing 30 days for meta-llama/Llama-3.1-8B-Instruct",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "01f9bc862a4f86d79417f098181a5e58c67f88998679a5efe144f59a11c4430d"
               }
             ]
           },
@@ -2632,11 +2685,11 @@
               }
             ]
           },
-          "maturity": 3.6,
+          "maturity": 3.3,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
-            "basis": "commit"
+            "date": "2026-08-13",
+            "basis": "verified"
           },
           "version_note": "Llama 3.1 8B Instruct, released 23 Jul 2024. 8B dense, 128k context, SFT+RLHF post-trained chat model. Verified live on HF June 2026; one of the most-downloaded instruct models on the platform."
         },
@@ -2919,16 +2972,26 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 3,
+            "level": 2,
             "reach": "10K-100K",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "~37.9k HF downloads/month on the instruct SKU; 96 likes. Solid reach for a fully-open research MoE.",
+            "note": "28,149 downloads in the trailing 30 days summed across the 2 declared artifact(s), read 2026-08-13 (allenai/OLMoE-1B-7B-0924-Instruct 26,721; allenai/OLMoE-mix-0924 1,428). Bands at level 2 (10K-100K) on the software and model adoption scale. Corrected from level 3, which the declared artifacts do not support.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
-                "url": "https://huggingface.co/allenai/OLMoE-1B-7B-0924-Instruct",
-                "shows": "~37,880 downloads last month; 96 likes",
-                "accessed": "2026-06-25"
+                "url": "https://huggingface.co/api/models/allenai/OLMoE-1B-7B-0924-Instruct",
+                "shows": "26,721 downloads in the trailing 30 days for allenai/OLMoE-1B-7B-0924-Instruct",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "ee1398b873dd594a3f0334f1168dab153f62c2900468095d59e522eb27b5a08f"
+              },
+              {
+                "url": "https://huggingface.co/api/datasets/allenai/OLMoE-mix-0924",
+                "shows": "1,428 downloads in the trailing 30 days for allenai/OLMoE-mix-0924",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "7f34d9aa457daed314d4db450c123c135f4a61b208696f5eab2cf00a11364896"
               }
             ]
           },
@@ -2952,11 +3015,11 @@
               }
             ]
           },
-          "maturity": 2.3,
+          "maturity": 2.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
-            "basis": "commit"
+            "date": "2026-08-13",
+            "basis": "verified"
           },
           "version_note": "Apache-2.0; fully-open MoE (weights + data + code + intermediate checkpoints). State-of-the-art among ~1B-active-parameter models at release."
         },
@@ -3067,16 +3130,40 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 4,
-            "reach": "1M-10M",
+            "level": 3,
+            "reach": "100K-1M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "~164.9k HF downloads/month on zephyr-7b-beta with 1.85k likes -- a late-2023 model still pulling meaningful volume as a lightweight fully-open 7B baseline. The underlying datasets remain active (ultrachat_200k ~57.7k/mo). The 141B ORPO variant is effectively dormant (~52/mo). Level 4 on the leading SKU's sustained monthly volume.",
+            "note": "232,148 downloads in the trailing 30 days summed across the 4 declared artifact(s), read 2026-08-13 (HuggingFaceH4/zephyr-7b-beta 142,355; HuggingFaceH4/zephyr-orpo-141b-A35b-v0.1 91; HuggingFaceH4/ultrachat_200k 73,327; HuggingFaceH4/ultrafeedback_binarized 16,375). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected from level 4, which the declared artifacts do not support.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
-                "url": "https://huggingface.co/HuggingFaceH4/zephyr-7b-beta",
-                "shows": "~164,917 downloads last month; 1.85k likes",
-                "accessed": "2026-06-25"
+                "url": "https://huggingface.co/api/models/HuggingFaceH4/zephyr-7b-beta",
+                "shows": "142,355 downloads in the trailing 30 days for HuggingFaceH4/zephyr-7b-beta",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "89427cdf13143eea59f02c65463d14e580ef578ee59840944edad4512ab25e50"
+              },
+              {
+                "url": "https://huggingface.co/api/models/HuggingFaceH4/zephyr-orpo-141b-A35b-v0.1",
+                "shows": "91 downloads in the trailing 30 days for HuggingFaceH4/zephyr-orpo-141b-A35b-v0.1",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "47e3d9cf2c8020fc69b61a65f3b7d25d8f60b29e3bb9c31e4206546b5cc89c22"
+              },
+              {
+                "url": "https://huggingface.co/api/datasets/HuggingFaceH4/ultrachat_200k",
+                "shows": "73,327 downloads in the trailing 30 days for HuggingFaceH4/ultrachat_200k",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "4e919d43fdc08e40082d432ea506c07f839e5a991c46a904a1a7001a3236be1e"
+              },
+              {
+                "url": "https://huggingface.co/api/datasets/HuggingFaceH4/ultrafeedback_binarized",
+                "shows": "16,375 downloads in the trailing 30 days for HuggingFaceH4/ultrafeedback_binarized",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "d881aa403109378f86edb6b91e66d6062204fb84e7a93d8831a47b3da99a5dd6"
               }
             ]
           },
@@ -3095,11 +3182,11 @@
               }
             ]
           },
-          "maturity": 2.6,
+          "maturity": 2.3,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
-            "basis": "commit"
+            "date": "2026-08-13",
+            "basis": "verified"
           },
           "version_note": "Scored on zephyr-7b-beta (MIT; base Mistral-7B Apache-2.0). Fully-open: weights + open DPO datasets (UltraChat/UltraFeedback, MIT) + open training code (alignment-handbook, Apache-2.0). Late-2023 capability, still ~165k HF downloads/month."
         },
@@ -3190,16 +3277,19 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 4,
-            "reach": "1M-10M",
+            "level": 3,
+            "reach": "100K-1M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "~1.54M downloads last month on HF; widely distributed via Azure AI Foundry / Ollama for on-device + local inference. Solidly in the 1-10M band.",
+            "note": "429,490 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (microsoft/Phi-4-mini-instruct 429,490). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected from level 4, which the declared artifacts do not support.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
-                "url": "https://huggingface.co/microsoft/Phi-4-mini-instruct",
-                "shows": "1,537,561 downloads last month",
-                "accessed": "2026-06-04"
+                "url": "https://huggingface.co/api/models/microsoft/Phi-4-mini-instruct",
+                "shows": "429,490 downloads in the trailing 30 days for microsoft/Phi-4-mini-instruct",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "f520a05970012b1e8b0eae049187f5eda6c5205b715eb650ddc383893a558322"
               }
             ]
           },
@@ -3218,11 +3308,11 @@
               }
             ]
           },
-          "maturity": 2.6,
+          "maturity": 2.3,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
-            "basis": "commit"
+            "date": "2026-08-13",
+            "basis": "verified"
           },
           "version_note": "Phi-4-mini-instruct, 3.8B dense, 128k context, 200k vocab, GQA; released Feb 2025 under MIT. SFT/DPO-aligned small instruct model. Verified live on HF June 2026."
         },
@@ -6564,17 +6654,18 @@
           },
           "adoption": {
             "level": 3,
-            "signal_type": "stars_fallback",
+            "signal_type": "usage_volume",
             "confidence": "medium",
-            "note": "48,349 GitHub stars as of 2026-08-09; no clean download telemetry for a self-hosted server, so stars_fallback applies (capped at 3, per the adoption banding rule).",
-            "last_verified": "2026-08-09",
+            "note": "About 156,880 downloads a month across the product’s real distribution channels, read 2026-08-13 (Docker Hub 6,411,259 cumulative since 2023-03-18, about 156,880 a month). Bands at level 3 (100K-1M). LocalAI is distributed as a Docker image; it publishes no first-party PyPI or npm package. Moved off the stars fallback under the under-coverage rule in docs/guides/adoption.md: banding on a channel the product does not ship through is a substitution rather than a measurement. The level is UNCHANGED at 3 - the stars cap happened to give the right answer here - but it now rests on a measured figure instead of a capped proxy. The Docker component is a lifetime average, not a trailing-30-day count, so this is a floor.",
+            "last_verified": "2026-08-13",
+            "reach": "100K-1M",
             "sources": [
               {
-                "url": "https://github.com/mudler/LocalAI",
-                "shows": "aria-label=\"48349 users starred this repository\"",
-                "accessed": "2026-08-09",
+                "url": "https://hub.docker.com/v2/repositories/localai/localai/",
+                "shows": "6,411,259 cumulative pulls of localai/localai",
+                "accessed": "2026-08-13",
                 "http_status": 200,
-                "content_sha256": "6ef142557058a6a02274d19b448082c83e9bb84566c8d2c093de9bf86c8dcb80"
+                "content_sha256": "7d0a2bfff9c13e1e35ac9bb191c5e493cd13534596c8eae77131eb576adbfbb3"
               }
             ]
           },
@@ -6598,7 +6689,7 @@
           "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-09",
+            "date": "2026-08-13",
             "basis": "verified"
           },
           "version_note": "Verified 2026-08-09 via GitHub and the LICENSE body."
@@ -7673,26 +7764,19 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 4,
+            "level": 3,
             "reach": "100K-1M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "~110k PyPI downloads last month (primary). Broad coverage (600+ text + 300+ multimodal models incl. Qwen3, DeepSeek, Llama, GLM) and strong uptake in the Chinese/ModelScope ecosystem. Lower bound of the 100K-1M band; level 4 on sustained monthly download volume.",
-            "last_verified": "2026-08-08",
+            "note": "122,381 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (ms-swift 122,381). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected from level 4, which the declared artifacts do not support.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
-                "url": "https://pypistats.org/packages/ms-swift",
-                "shows": "pypistats page for ms-swift, rendered server-side: 'Downloads last day: 3,070', 'Downloads last week: 23,151', 'Downloads last month: 121,346'. Header meta gives Author 'DAMO ModelScope teams', License 'Apache License 2.0', Latest version '4.4.2'. 121,346 sits inside the 100K-1M band that level 4 rests on.",
-                "accessed": "2026-08-08",
+                "url": "https://pypistats.org/api/packages/ms-swift/recent",
+                "shows": "122,381 downloads in the trailing 30 days for ms-swift",
+                "accessed": "2026-08-13",
                 "http_status": 200,
-                "content_sha256": "9068fed9cb14dbc4a991b45464e0dec777710df8ceca5d912ea8d9ee89c74d09"
-              },
-              {
-                "url": "https://github.com/modelscope/ms-swift",
-                "shows": "README Introduction states support for '600+ text-only large models and 400+ multimodal large models', naming Qwen3, Qwen3.5, InternLM3, GLM4.5, Mistral, DeepSeek-R1, Llama4, Qwen3-VL, Qwen3-Omni, Kimi-K3, InternVL3.5, DeepSeek-VL2, and claims 'Day-0 support for popular models'. Repository header shows 15.1k stars, 1.6k forks, 3,549 commits, 563 open issues and 89 open pull requests, and the News list runs to 2026.07.22 - the breadth-of-coverage half of the adoption note, and evidence the project is actively used and maintained.",
-                "accessed": "2026-08-08",
-                "http_status": 200,
-                "content_sha256": "3ebedde37c3a9b86af0ec620f17352ab2a83cd2fe5570a88944d7dfae7aea582"
+                "content_sha256": "97668a69ac3da07ea1d85760fa748f4feb8f55b777e0b6be9462065aaaac49b0"
               }
             ]
           },
@@ -7722,10 +7806,10 @@
               }
             ]
           },
-          "maturity": 4.0,
+          "maturity": 3.5,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
+            "date": "2026-08-13",
             "basis": "verified"
           },
           "version_note": "The repository's About blurb still says 300+ multimodal models while the README says 400+, and the maintainer is named as the ModelScope community on GitHub and the DAMO ModelScope team on PyPI. Verified 2026-08-08 via the ms-swift README, the PyPI project page, and the LICENSE body."
@@ -7777,33 +7861,19 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 3,
+            "level": 2,
             "reach": "10K-100K",
             "signal_type": "usage_volume",
             "confidence": "medium",
-            "note": "~15.1k PyPI downloads last month (primary); 13.6k GitHub stars (corroborating only). Modest but real recurring usage keeps it at the low end of medium; level 3 on monthly download volume, not stars.",
-            "last_verified": "2026-08-09",
+            "note": "15,680 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (litgpt 15,680). Bands at level 2 (10K-100K) on the software and model adoption scale. Corrected from level 3, which the declared artifacts do not support.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
                 "url": "https://pypistats.org/api/packages/litgpt/recent",
-                "shows": "The whole body is {\"data\":{\"last_day\":327,\"last_month\":15077,\"last_week\":4274},\"package\":\"litgpt\",\"type\":\"recent_downloads\"}, meaning 15,077 downloads in the last month, up from the ~14,230 recorded in June and still inside the 10K-100K adoption band.",
-                "accessed": "2026-08-09",
+                "shows": "15,680 downloads in the trailing 30 days for litgpt",
+                "accessed": "2026-08-13",
                 "http_status": 200,
-                "content_sha256": "4af2ee439898c8933b711865e2549d9a12b92b7443d646b6e79f901f71273d81"
-              },
-              {
-                "url": "https://github.com/Lightning-AI/litgpt",
-                "shows": "The repo's sidebar fields read stargazerCount 13612 and forksCount 1483 (up from the previously recorded 13.4k stars), corroborating that the project is still actively watched. Not used as the adoption basis.",
-                "accessed": "2026-08-09",
-                "http_status": 200,
-                "content_sha256": "5e66cbea2d8c5ea68045b684031e57e7209374f7320ebaff1f1ddb1032e8178d"
-              },
-              {
-                "url": "https://pypi.org/project/litgpt/",
-                "shows": "The package header reads \"litgpt 0.5.13\", the License section states \"LitGPT is released under the Apache 2.0 license\", and the release panel reads \"Released: Jul 3, 2026\", confirming the download figure belongs to an actively released package rather than a residual one.",
-                "accessed": "2026-08-09",
-                "http_status": 200,
-                "content_sha256": "f802933c256fba7a2d46163d5e686dd03b565da2283618454b4893d345d72079"
+                "content_sha256": "f1e9fbfd4d9373162333c05baef37d4cccd1c6c178bfbd6fcbb44074f8a70845"
               }
             ]
           },
@@ -7831,10 +7901,10 @@
               }
             ]
           },
-          "maturity": 3.0,
+          "maturity": 2.5,
           "mature": false,
           "freshness": {
-            "date": "2026-08-09",
+            "date": "2026-08-13",
             "basis": "verified"
           },
           "version_note": "Lightning AI's hosted Studios platform is separate compute and does not gate any LitGPT functionality. Verified 2026-08-09 via GitHub and the LICENSE body."
@@ -11728,21 +11798,19 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 4,
-            "reach": "1M-10M",
+            "level": 3,
+            "reach": "10K-100K",
             "signal_type": "usage_volume",
             "confidence": "medium",
-            "note": "71,393 monthly HF downloads (primary). De facto standard contamination-free coding benchmark; LiveCodeBench appears as a headline coding metric in frontier model release reports (e.g. DeepSeek-V4-Pro reports LiveCodeBench Pass@1 93.5 in the frozen flagship set). 'Usage' here is downloads + benchmark citation, not end-users; placed at 4 on download volume plus release-report standard status, which is the top adoption signal for a benchmark.",
+            "note": "91,719 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (livecodebench/code_generation_lite 91,719). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M. Corrected from level 4, which the declared artifacts do not support.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
-                "url": "https://huggingface.co/datasets/livecodebench/code_generation_lite",
-                "shows": "71,393 monthly downloads",
-                "accessed": "2026-06-04"
-              },
-              {
-                "url": "https://livecodebench.github.io/",
-                "shows": "contamination-free coding benchmark across generation/self-repair/execution",
-                "accessed": "2026-06-04"
+                "url": "https://huggingface.co/api/datasets/livecodebench/code_generation_lite",
+                "shows": "91,719 downloads in the trailing 30 days for livecodebench/code_generation_lite",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "a55c771a033b0b53b9d92409bf8339d5347aa710073659ffe211cb1d3b2302e4"
               }
             ]
           },
@@ -11754,11 +11822,11 @@
             "note": "A dataset is not 'capable'. Contamination-resistance (the 'live' continuously-updated design) is a quality strength but not scored on the 1-5 capability axis per the recipe; openness + adoption carry this category.",
             "sources": []
           },
-          "maturity": 4.0,
+          "maturity": 3.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-12",
-            "basis": "commit"
+            "date": "2026-08-13",
+            "basis": "verified"
           },
           "version_note": "LiveCodeBench code_generation_lite, release_v5 = 880 problems (May 2023-Jan 2025); a 'live', continuously-updated contamination-free coding benchmark (problems from LeetCode/AtCoder/Codeforces) covering code generation, self-repair, test-output prediction, execution. HF dataset verified live June 2026 (71,393 monthly downloads)."
         },
@@ -13068,16 +13136,19 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 2,
-            "reach": "niche",
+            "level": 1,
+            "reach": "<1K",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "comparia-votes ~155 and comparia-conversations ~202 downloads last month on Hugging Face.",
+            "note": "31 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (ministere-culture/comparia-votes 31). Bands at level 1 (<1K) on the dataset adoption scale, whose top band is >1M. Corrected from level 2, which the declared artifacts do not support.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
-                "url": "https://huggingface.co/datasets/ministere-culture/comparia-votes",
-                "shows": "155 downloads last month",
-                "accessed": "2026-06-22"
+                "url": "https://huggingface.co/api/datasets/ministere-culture/comparia-votes",
+                "shows": "31 downloads in the trailing 30 days for ministere-culture/comparia-votes",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "dc823c0409d697015d29db5f47fb6ee110474f7ced34a1b5f89e31227c7023c8"
               }
             ]
           },
@@ -13089,11 +13160,11 @@
             "note": "a dataset is not 'capable'",
             "sources": []
           },
-          "maturity": 2.0,
+          "maturity": 1.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-12",
-            "basis": "commit"
+            "date": "2026-08-13",
+            "basis": "verified"
           },
           "version_note": "Verified live 2026-06-22 via primary sources. Open license and documented, but gated access requiring agreement caps it at gated."
         }
@@ -14563,12 +14634,12 @@
             ]
           },
           "capability": {
-            "score": 2,
+            "score": 4,
             "basis": "training_value",
             "basis_detail": "results",
             "value": null,
-            "confidence": "high",
-            "note": "Publicly downloadable and ungated, and licensed CC-BY-NC-SA-4.0, which permits redistribution for non-commercial research and forbids commercial use. Moved from 5/open on 2026-08-01 by the universal license scale. The map had answered the non-commercial question two ways: `command-r` is 2/restricted under CC-BY-NC while this was 5/open under CC-BY-NC-SA, on the reasoning that a corpus's openness question is redistributability rather than commercial reuse. The scale settles it on the commercial-use test, and the Open Definition agrees - data is not open unless it may be reused commercially. `restricted` is new to the dataset class vocabulary for this: it was the only product type with no word between `open` and `gated`.",
+            "confidence": "medium",
+            "note": "The paper's headline training result is the basis: Qwen2-7B fine-tuned on ~1.07M persona-generated math problems reaches 64.9% on MATH, rivaling GPT-4-turbo-preview at the time. Corroborated downstream - Tulu 3's SFT persona-math set conditions on ~250K PersonaHub personas, so the corpus is an ingredient in a mixture the map already scores 4. Placed at 4 rather than 5 on the category's own calibration: the 5s (smoltalk, fineweb-edu, dclm-baseline) lead head-to-head ablations AND are the current default others adopt wholesale, while PersonaHub is a generation method plus seed samples whose adoption runs through derivative sets. That is the same shape as tulu-3-sft-mixture and fineweb, both 4. CORRECTED from 2, which was not a capability judgment at all. On 2026-08-01 the openness re-score to 2/restricted was pasted into this block wholesale: the note recorded here was the openness note verbatim, arguing CC-BY-NC-SA and the commercial-use test, and the score followed it down. Nothing on this axis had been assessed. The tell was `value: null` with `confidence: high` - a null is the category norm here, all 38 members carry one, but a high confidence attached to a reasoning that never mentions training value is not. A licence says what you may do with a corpus; it says nothing about what training on it produces. Re-derived from the sources already cited, which is why no `last_verified` is claimed - they were read on 2026-07-04 and have not been re-fetched.",
             "sources": [
               {
                 "url": "https://arxiv.org/abs/2406.20094",
@@ -14582,7 +14653,7 @@
               }
             ]
           },
-          "maturity": 2.0,
+          "maturity": 3.0,
           "mature": false,
           "freshness": {
             "date": "2026-08-12",
@@ -15072,16 +15143,19 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 4,
-            "reach": "100K-1M",
+            "level": 3,
+            "reach": "10K-100K",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "158,294 monthly downloads on Hugging Face, graded on the training-corpus bands.",
+            "note": "36,467 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (allenai/dolma3_pool 36,467). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M. Corrected from level 4, which the declared artifacts do not support.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
-                "url": "https://huggingface.co/api/datasets/allenai/dolma3_mix-6T-1025-7B",
-                "shows": "downloads field = 158,294 (30-day)",
-                "accessed": "2026-07-04"
+                "url": "https://huggingface.co/api/datasets/allenai/dolma3_pool",
+                "shows": "36,467 downloads in the trailing 30 days for allenai/dolma3_pool",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "5de85dbe965ca9b20b0c658d367662bd83c441e3d47b40137816d440a88d6c7c"
               }
             ]
           },
@@ -15100,11 +15174,11 @@
               }
             ]
           },
-          "maturity": 4.5,
-          "mature": true,
+          "maturity": 4.0,
+          "mature": false,
           "freshness": {
-            "date": "2026-08-12",
-            "basis": "commit"
+            "date": "2026-08-13",
+            "basis": "verified"
           },
           "version_note": "Family bucket: dolma3_pool plus the Mix/Dolmino/Longmino training mixes. Successor to the map's dolma entry (Dolma 1.x).",
           "lineage": {
@@ -15151,16 +15225,19 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 3,
-            "reach": "10K-100K",
+            "level": 2,
+            "reach": "1K-10K",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "12,526 monthly downloads on Hugging Face, graded on the training-corpus bands.",
+            "note": "3,807 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (allenai/Dolci-Instruct-SFT 3,807). Bands at level 2 (1K-10K) on the dataset adoption scale, whose top band is >1M. Corrected from level 3, which the declared artifacts do not support.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
                 "url": "https://huggingface.co/api/datasets/allenai/Dolci-Instruct-SFT",
-                "shows": "downloads field = 12,526 (30-day)",
-                "accessed": "2026-07-04"
+                "shows": "3,807 downloads in the trailing 30 days for allenai/Dolci-Instruct-SFT",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "6bac695382fe352c090bc36077a8cdb97186c826decc67b1313856770f092f98"
               }
             ]
           },
@@ -15184,11 +15261,11 @@
               }
             ]
           },
-          "maturity": 4.0,
+          "maturity": 3.5,
           "mature": false,
           "freshness": {
-            "date": "2026-08-12",
-            "basis": "commit"
+            "date": "2026-08-13",
+            "basis": "verified"
           },
           "version_note": "Family bucket: Dolci-Instruct and Dolci-Think SFT/DPO/RL sets.",
           "lineage": {
@@ -15918,16 +15995,19 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 2,
-            "reach": "1K-10K",
+            "level": 1,
+            "reach": "<1K",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "1,414 monthly downloads on Hugging Face, graded on the training-corpus bands.",
+            "note": "688 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (NousResearch/Hermes-3-Dataset 688). Bands at level 1 (<1K) on the dataset adoption scale, whose top band is >1M. Corrected from level 2, which the declared artifacts do not support.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
                 "url": "https://huggingface.co/api/datasets/NousResearch/Hermes-3-Dataset",
-                "shows": "downloads field = 1,414 (30-day)",
-                "accessed": "2026-07-04"
+                "shows": "688 downloads in the trailing 30 days for NousResearch/Hermes-3-Dataset",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "5e9534af8b603e19e8c5f3c963d7f8694ae2491b37e3b28b359a6c84db84c5e2"
               }
             ]
           },
@@ -15951,11 +16031,11 @@
               }
             ]
           },
-          "maturity": 3.0,
+          "maturity": 2.5,
           "mature": false,
           "freshness": {
-            "date": "2026-08-12",
-            "basis": "commit"
+            "date": "2026-08-13",
+            "basis": "verified"
           },
           "lineage": {
             "derived_from": [
@@ -15973,8 +16053,8 @@
       "arc": "Model components",
       "layer": "model_components",
       "stage": {
-        "num": 3,
-        "name": "Viable Alternatives"
+        "num": 2,
+        "name": "Emerging Alternatives"
       },
       "gaps": [
         "maturity",
@@ -16004,16 +16084,19 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 3,
+            "level": 2,
             "reach": "10K-100K",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "~55k PyPI downloads/month; the reference pipeline for the FineWeb dataset family and widely reused across open pretraining-data efforts.",
+            "note": "65,009 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (datatrove 65,009). Bands at level 2 (10K-100K) on the software and model adoption scale. Corrected from level 3, which the declared artifacts do not support.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
-                "url": "https://pypistats.org/packages/datatrove",
-                "shows": "Downloads last month: 55,132",
-                "accessed": "2026-07-21"
+                "url": "https://pypistats.org/api/packages/datatrove/recent",
+                "shows": "65,009 downloads in the trailing 30 days for datatrove",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "aeb080fc7f264200be714cbbe14d09d1acc9b57dca4de55eee422914b7d04c9c"
               }
             ]
           },
@@ -16031,11 +16114,11 @@
               }
             ]
           },
-          "maturity": 3.8,
+          "maturity": 3.2,
           "mature": false,
           "freshness": {
-            "date": "2026-07-30",
-            "basis": "commit"
+            "date": "2026-08-13",
+            "basis": "verified"
           },
           "version_note": "Hugging Face datatrove; repo active (v0.9.0, 2026-03-04), Apache-2.0 confirmed live 2026-07-21. Built FineWeb, FineWeb-Edu, FineWeb-2, and FineMath; the de-facto open pretraining-data processing pipeline."
         },
@@ -16126,16 +16209,19 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 2,
-            "reach": "1K-10K",
+            "level": 1,
+            "reach": "<10K",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "~5.6k PyPI downloads/month; NVIDIA-backed and the pipeline behind the Nemotron-CC family, but modest raw download volume.",
+            "note": "4,075 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (nemo-curator 4,075). Bands at level 1 (<10K) on the software and model adoption scale. Corrected from level 2, which the declared artifacts do not support.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
-                "url": "https://pypistats.org/packages/nemo-curator",
-                "shows": "Downloads last month: 5,618",
-                "accessed": "2026-07-21"
+                "url": "https://pypistats.org/api/packages/nemo-curator/recent",
+                "shows": "4,075 downloads in the trailing 30 days for nemo-curator",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "dc1ab53641060ca8b22f2ee98cb263b2448698ae48529ccc9b4f09282749682d"
               }
             ]
           },
@@ -16155,11 +16241,11 @@
               }
             ]
           },
-          "maturity": 3.2,
+          "maturity": 2.6,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
-            "basis": "commit"
+            "date": "2026-08-13",
+            "basis": "verified"
           },
           "version_note": "NVIDIA NeMo Curator; repo actively maintained (v1.2.0, 2026-05-14), Apache-2.0 confirmed live 2026-07-21. Powers the Nemotron-CC curation pipeline and Nemotron-4 data prep (8T+ multilingual tokens)."
         },
@@ -16186,16 +16272,19 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 3,
+            "level": 2,
             "reach": "10K-100K",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "~22k PyPI downloads/month and 19k+ GitHub stars; a leading open document-extraction tool, used in the Dolma 3 data path.",
+            "note": "22,925 PyPI downloads in the trailing 30 days for olmocr, read 2026-08-13. Bands at level 2 (10K-100K) on the software and model adoption scale. Corrected from level 3, which the declared artifact does not support.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
-                "url": "https://pypistats.org/packages/olmocr",
-                "shows": "Downloads last month: 21,753",
-                "accessed": "2026-07-21"
+                "url": "https://pypistats.org/api/packages/olmocr/recent",
+                "shows": "22,925 downloads in the trailing 30 days for olmocr",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "bb20341457a175680a368fcc852c01c24115f79f75407a8eb51434d1105d2bcd"
               }
             ]
           },
@@ -16218,11 +16307,11 @@
               }
             ]
           },
-          "maturity": 3.4,
+          "maturity": 2.8,
           "mature": false,
           "freshness": {
-            "date": "2026-07-30",
-            "basis": "commit"
+            "date": "2026-08-13",
+            "basis": "verified"
           },
           "version_note": "Ai2 olmOCR; repo active (v0.4.27, 2026-03-12), Apache-2.0 confirmed live 2026-07-21. High-profile document-extraction tool (19k+ GitHub stars); feeds the Dolma 3 pipeline."
         },
@@ -17111,16 +17200,19 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 2,
-            "reach": "1K-10K",
+            "level": 1,
+            "reach": "<10K",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "~3.1k PyPI downloads/month (py-data-juicer) and ~6.7k GitHub stars; actively developed.",
+            "note": "2,962 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (py-data-juicer 2,962). Bands at level 1 (<10K) on the software and model adoption scale. Corrected from level 2, which the declared artifacts do not support.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
-                "url": "https://pypistats.org/packages/py-data-juicer",
-                "shows": "Downloads last month: ~3,107",
-                "accessed": "2026-07-21"
+                "url": "https://pypistats.org/api/packages/py-data-juicer/recent",
+                "shows": "2,962 downloads in the trailing 30 days for py-data-juicer",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "eaa1f81789a0024761112d9997242290456808a3f7351e6514b040fb1421955c"
               }
             ]
           },
@@ -17138,11 +17230,11 @@
               }
             ]
           },
-          "maturity": 2.8,
+          "maturity": 2.2,
           "mature": false,
           "freshness": {
-            "date": "2026-07-30",
-            "basis": "commit"
+            "date": "2026-08-13",
+            "basis": "verified"
           },
           "version_note": "Alibaba Data-Juicer (datajuicer/data-juicer, formerly modelscope); Apache-2.0, very active (v1.5.3, Jun 2026). PyPI package py-data-juicer. 200+ operators for multimodal LLM data processing."
         },
@@ -17703,21 +17795,19 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 3,
-            "reach": "100K-1M",
+            "level": 2,
+            "reach": "10K-100K",
             "signal_type": "usage_volume",
             "confidence": "medium",
-            "note": "~105,483 PyPI downloads last month (gpt-researcher); 'used by' 261 dependent repos; 27.5k stars corroborate. Places it in the 100K-1M reach band on monthly download volume.",
+            "note": "80,472 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (gpt-researcher 80,472). Bands at level 2 (10K-100K) on the software and model adoption scale. Corrected from level 3, which the declared artifacts do not support.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
-                "url": "https://pypistats.org/packages/gpt-researcher",
-                "shows": "105,483 downloads last month",
-                "accessed": "2026-06-04"
-              },
-              {
-                "url": "https://github.com/assafelovic/gpt-researcher",
-                "shows": "261 dependent repos, 27.5k stars",
-                "accessed": "2026-06-04"
+                "url": "https://pypistats.org/api/packages/gpt-researcher/recent",
+                "shows": "80,472 downloads in the trailing 30 days for gpt-researcher",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "bd0e6196bb6b82c101587b05a7cc499f63071433b7ef92e92401f1ad9c6a18c2"
               }
             ]
           },
@@ -17735,11 +17825,11 @@
               }
             ]
           },
-          "maturity": 3.0,
+          "maturity": 2.7,
           "mature": false,
           "freshness": {
-            "date": "2026-07-30",
-            "basis": "commit"
+            "date": "2026-08-13",
+            "basis": "verified"
           },
           "version_note": "GPT Researcher (assafelovic/gpt-researcher), v3.5.0 (May 28 2026); 27.5k stars, Apache-2.0. Autonomous deep-research agent that plans sub-queries, searches web/local sources, and writes cited reports. Confirmed live June 2026."
         },
@@ -20493,14 +20583,25 @@
           },
           "adoption": {
             "level": 3,
-            "signal_type": "stars_fallback",
+            "signal_type": "usage_volume",
             "confidence": "medium",
-            "note": "~83k stars; Docker-distributed with no download metric retrieved - stars_fallback (capped at 3).",
+            "note": "About 129,133 downloads a month across the product’s real distribution channels, read 2026-08-13 (Docker Hub 3,590,166 cumulative since 2023-12-12, about 112,087 a month; ragflow-sdk 17,046 in the trailing 30 days). Bands at level 3 (100K-1M). RAGFlow ships as a Docker Compose stack; ragflow-sdk on PyPI is an API client rather than the server, so it measures a different thing and is added only as a minor component. Moved off the stars fallback under the under-coverage rule in docs/guides/adoption.md: banding on a channel the product does not ship through is a substitution rather than a measurement. The level is UNCHANGED at 3 - the stars cap happened to give the right answer here - but it now rests on a measured figure instead of a capped proxy. The Docker component is a lifetime average, not a trailing-30-day count, so this is a floor.",
+            "reach": "100K-1M",
+            "last_verified": "2026-08-13",
             "sources": [
               {
-                "url": "https://ragflow.io",
-                "shows": "official site, InfiniFlow, self-host + cloud",
-                "accessed": "2026-06-18"
+                "url": "https://hub.docker.com/v2/repositories/infiniflow/ragflow/",
+                "shows": "3,590,166 cumulative pulls of infiniflow/ragflow",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "095ef0ed513ee365aae263321c77599f65537b6f30a29eea5e584be1231b937b"
+              },
+              {
+                "url": "https://pypistats.org/api/packages/ragflow-sdk/recent",
+                "shows": "17,046 downloads in the trailing 30 days for ragflow-sdk",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "465245cf97ae8442f7e3a072ca91a6df1c2d135be904b006807329b1381eaec5"
               }
             ]
           },
@@ -20521,8 +20622,8 @@
           "maturity": 3.7,
           "mature": false,
           "freshness": {
-            "date": "2026-07-30",
-            "basis": "commit"
+            "date": "2026-08-13",
+            "basis": "verified"
           },
           "version_note": "Apache-2.0. ~83k stars. Deployed via Docker Compose (no first-party PyPI/npm). Commercial managed cloud / enterprise edition exists; the self-hosted engine is fully open."
         },
@@ -21169,16 +21270,19 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 4,
-            "reach": "1M-10M",
+            "level": 3,
+            "reach": "100K-1M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "~1.72M PyPI downloads last month (pypistats, primary); vendor reports 290M cumulative downloads and 420K community members. De facto leading self-hosted LLM chat UI; firmly in 1-10M band on monthly install volume (stars 140k corroborate only).",
+            "note": "879,127 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (open-webui 879,127). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected from level 4, which the declared artifacts do not support.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
-                "url": "https://pypistats.org/packages/open-webui",
-                "shows": "1,717,371 downloads last month",
-                "accessed": "2026-06-04"
+                "url": "https://pypistats.org/api/packages/open-webui/recent",
+                "shows": "879,127 downloads in the trailing 30 days for open-webui",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "cbc0df85af0e683e7063f02d9c33e1a677409ac058d62a02ef3ce638001e6349"
               }
             ]
           },
@@ -21196,11 +21300,11 @@
               }
             ]
           },
-          "maturity": 4.0,
+          "maturity": 3.3,
           "mature": false,
           "freshness": {
-            "date": "2026-07-30",
-            "basis": "commit"
+            "date": "2026-08-13",
+            "basis": "verified"
           },
           "version_note": "v0.9.6 (June 1, 2026), confirmed live on GitHub June 2026. Self-hosted chat UI (Ollama + OpenAI-compatible APIs)."
         },
@@ -21976,16 +22080,19 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 3,
-            "reach": "~26k PyPI downloads/month",
+            "level": 2,
+            "reach": "10K-100K",
             "signal_type": "usage_volume",
             "confidence": "medium",
-            "note": "~35k GitHub stars plus ~26k PyPI downloads/month (pypistats) - real install volume (usage_volume, not stars-only), but modest in absolute terms, so mid-tier. Hosted cloud is now discontinued.",
+            "note": "19,532 PyPI downloads in the trailing 30 days for khoj, read 2026-08-13. Bands at level 2 (10K-100K) on the software and model adoption scale. Corrected from level 3, which the declared artifact does not support.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
-                "url": "https://pypistats.org/packages/khoj",
-                "shows": "~26,054 downloads last month",
-                "accessed": "2026-06-17"
+                "url": "https://pypistats.org/api/packages/khoj/recent",
+                "shows": "19,532 downloads in the trailing 30 days for khoj",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "4cc696880071d82fc383bf3f67fde0c2eb2b23a975eb391d5f3a23f28815fb71"
               }
             ]
           },
@@ -22003,11 +22110,11 @@
               }
             ]
           },
-          "maturity": 3.3,
+          "maturity": 2.6,
           "mature": false,
           "freshness": {
-            "date": "2026-07-30",
-            "basis": "commit"
+            "date": "2026-08-13",
+            "basis": "verified"
           },
           "version_note": "AGPL-3.0; ~35k GitHub stars and ~26k PyPI downloads/month by mid-2026. Khoj Cloud (the former paid hosted tier) was sunset 2026-04-15; the team directs all users to self-host and states Khoj \"remains fully open source\", so no feature-gating remains in the shipping product. Self-host via Docker or pip."
         },
@@ -25842,16 +25949,19 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 2,
-            "reach": "10K-100K",
+            "level": 1,
+            "reach": "<10K",
             "signal_type": "usage_volume",
             "confidence": "low",
-            "note": "NVIDIA safety classifier with a documented dataset and NeMo integration; modest standalone HF adoption, distributed largely via NVIDIA's stack.",
+            "note": "4,303 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (nvidia/Aegis-AI-Content-Safety-LlamaGuard-Defensive-1.0 4,303). Bands at level 1 (<10K) on the software and model adoption scale. Corrected from level 2, which the declared artifacts do not support.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
-                "url": "https://huggingface.co/nvidia/Aegis-AI-Content-Safety-LlamaGuard-Defensive-1.0",
-                "shows": "NVIDIA Aegis content-safety classifier; 13 categories",
-                "accessed": "2026-06-29"
+                "url": "https://huggingface.co/api/models/nvidia/Aegis-AI-Content-Safety-LlamaGuard-Defensive-1.0",
+                "shows": "4,303 downloads in the trailing 30 days for nvidia/Aegis-AI-Content-Safety-LlamaGuard-Defensive-1.0",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "63af8d1b3273ece735a12d45d7af3ca11b05e70dd39076ab6f2c9bb3cfc607a7"
               }
             ]
           },
@@ -25870,11 +25980,11 @@
               }
             ]
           },
-          "maturity": 3.0,
+          "maturity": 2.5,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
-            "basis": "commit"
+            "date": "2026-08-13",
+            "basis": "verified"
           },
           "version_note": "NVIDIA Aegis AI Content Safety (Defensive 1.0), aka Llama Nemotron Safety Guard Defensive V1. Llama 2 Community License (not OSI). Adapter weights public on HF, but the LlamaGuard base must be obtained via Meta's access request, so not fully open-weight. Aegis safety dataset documented. Verified June 2026."
         },
@@ -26106,16 +26216,19 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 4,
+            "level": 3,
             "reach": "100K-1M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "~265K HF downloads/month (June 2026); one of the most-downloaded open guardrail models.",
+            "note": "121,205 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (allenai/wildguard 121,205). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected from level 4, which the declared artifacts do not support.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
-                "url": "https://huggingface.co/allenai/wildguard",
-                "shows": "~265,259 downloads/month, 52 likes (June 2026)",
-                "accessed": "2026-06-29"
+                "url": "https://huggingface.co/api/models/allenai/wildguard",
+                "shows": "121,205 downloads in the trailing 30 days for allenai/wildguard",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "b3c6a6b4d0ba7f39b95b6d981f25d7edd3ed1b2a5ad0474f4eb0a93f23b42623"
               }
             ]
           },
@@ -26134,11 +26247,11 @@
               }
             ]
           },
-          "maturity": 4.0,
+          "maturity": 3.5,
           "mature": false,
           "freshness": {
-            "date": "2026-08-11",
-            "basis": "commit"
+            "date": "2026-08-13",
+            "basis": "verified"
           },
           "version_note": "WildGuard (7B, Mistral-based), Apache-2.0 open weights; trained on the open WildGuardMix dataset. ~265K HF downloads/month, 52 likes (June 2026). Verified live June 2026."
         },
@@ -26165,16 +26278,19 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 4,
+            "level": 3,
             "reach": "100K-1M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "86M variant ~90.4K HF downloads/month (June 2026); widely used as a low-latency injection filter, including inside LlamaFirewall.",
+            "note": "111,334 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (meta-llama/Llama-Prompt-Guard-2-86M 111,334). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected from level 4, which the declared artifacts do not support.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
-                "url": "https://huggingface.co/meta-llama/Llama-Prompt-Guard-2-86M",
-                "shows": "~90,441 downloads/month, 149 likes (June 2026)",
-                "accessed": "2026-06-29"
+                "url": "https://huggingface.co/api/models/meta-llama/Llama-Prompt-Guard-2-86M",
+                "shows": "111,334 downloads in the trailing 30 days for meta-llama/Llama-Prompt-Guard-2-86M",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "a594da1ec8e70a2c8b897994c7d8ab75323f0b89e5428b4dc84cf4a8f23c4e4c"
               }
             ]
           },
@@ -26193,11 +26309,11 @@
               }
             ]
           },
-          "maturity": 4.0,
+          "maturity": 3.5,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
-            "basis": "commit"
+            "date": "2026-08-13",
+            "basis": "verified"
           },
           "version_note": "Llama Prompt Guard 2 (86M / 22M); Llama 4 Community License (not OSI). 99.8% AUC, 97.5% recall at 1% FPR on English jailbreaks; 8 languages. 86M ~90.4K HF downloads/month, 149 likes (June 2026). Verified live June 2026."
         },
@@ -26555,16 +26671,19 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 4,
-            "reach": "1M-10M",
+            "level": 3,
+            "reach": "100K-1M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "~237K Hugging Face downloads/month on the 8B variant (June 2026), the most-adopted open guardrail model; widely embedded as a moderation layer.",
+            "note": "164,619 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (meta-llama/Llama-Guard-3-8B 164,619). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected from level 4, which the declared artifacts do not support.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
-                "url": "https://huggingface.co/meta-llama/Llama-Guard-3-8B",
-                "shows": "~237,092 downloads/month, 307 likes (June 2026)",
-                "accessed": "2026-06-29"
+                "url": "https://huggingface.co/api/models/meta-llama/Llama-Guard-3-8B",
+                "shows": "164,619 downloads in the trailing 30 days for meta-llama/Llama-Guard-3-8B",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "af299c9f359756a68a7295bafa548ed6d733887c2a877416f75fabbdd7bfca8e"
               }
             ]
           },
@@ -26583,11 +26702,11 @@
               }
             ]
           },
-          "maturity": 4.0,
+          "maturity": 3.5,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
-            "basis": "commit"
+            "date": "2026-08-13",
+            "basis": "verified"
           },
           "version_note": "Llama Guard 3 (8B), built on Llama 3.1; Llama 3.1 Community License (not OSI; >700M MAU restriction). ~237K HF downloads/month, 307 likes (June 2026). Verified live June 2026."
         },
@@ -26676,16 +26795,19 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 2,
-            "reach": "10K-100K",
+            "level": 1,
+            "reach": "<10K",
             "signal_type": "usage_volume",
             "confidence": "medium",
-            "note": "~1.4K HF downloads/month on the 3.2-5B variant (June 2026); cumulative across the Guardian family is higher. Enterprise-leaning distribution via watsonx.",
+            "note": "1,837 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (ibm-granite/granite-guardian-3.2-5b 1,837). Bands at level 1 (<10K) on the software and model adoption scale. Corrected from level 2, which the declared artifacts do not support.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
-                "url": "https://huggingface.co/ibm-granite/granite-guardian-3.2-5b",
-                "shows": "~1,377 downloads/month, 14 likes (June 2026)",
-                "accessed": "2026-06-29"
+                "url": "https://huggingface.co/api/models/ibm-granite/granite-guardian-3.2-5b",
+                "shows": "1,837 downloads in the trailing 30 days for ibm-granite/granite-guardian-3.2-5b",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "cd00b2c6bb279ca6c9961fb516843354fdf5fcf7c343a4a720561d9f7ec5fdcb"
               }
             ]
           },
@@ -26704,11 +26826,11 @@
               }
             ]
           },
-          "maturity": 3.0,
+          "maturity": 2.5,
           "mature": false,
           "freshness": {
-            "date": "2026-08-11",
-            "basis": "commit"
+            "date": "2026-08-13",
+            "basis": "verified"
           },
           "version_note": "Granite Guardian 3.2 (5B, distilled from the 8B); Apache-2.0 open weights. ~1.4K HF downloads/month, 14 likes (June 2026). Verified live June 2026."
         },
@@ -28153,26 +28275,19 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 4,
-            "reach": "1M-10M",
+            "level": 3,
+            "reach": "100K-1M",
             "signal_type": "usage_volume",
             "confidence": "medium",
-            "note": "CORRECTION (adversarial verify 2026-06-04): prior record claimed no primary download figure and capped at stars_fallback level 3. pypistats now shows the composio PyPI package at ~3.17M downloads in the last month (a measured usage_volume signal in the 1M-10M band), so upgraded to level 4 / usage_volume and the stars_fallback cap is removed. Corroborated by ~28.6k GitHub stars and framework integrations (OpenAI, Anthropic, LangChain, LlamaIndex) plus the hosted platform.",
+            "note": "194,657 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (composio-core 194,657). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected from level 4, which the declared artifacts do not support.",
+            "last_verified": "2026-08-13",
             "sources": [
               {
-                "url": "https://pypistats.org/packages/composio",
-                "shows": "~3,166,911 (3.17M) monthly PyPI downloads",
-                "accessed": "2026-06-04"
-              },
-              {
-                "url": "https://github.com/ComposioHQ/composio",
-                "shows": "~28.6k stars, integrations across major agent frameworks",
-                "accessed": "2026-06-04"
-              },
-              {
-                "url": "https://pypi.org/project/composio/",
-                "shows": "active package, latest v0.13.1 (May 2026); confirms maintenance",
-                "accessed": "2026-06-04"
+                "url": "https://pypistats.org/api/packages/composio-core/recent",
+                "shows": "194,657 downloads in the trailing 30 days for composio-core",
+                "accessed": "2026-08-13",
+                "http_status": 200,
+                "content_sha256": "c459ac619d97bdc45e0f5c1956f736986a7fc4fbfca43dfc4300a2ddaa4ec836"
               }
             ]
           },
@@ -28190,10 +28305,10 @@
               }
             ]
           },
-          "maturity": 4.0,
+          "maturity": 3.4,
           "mature": false,
           "freshness": {
-            "date": "2026-08-12",
+            "date": "2026-08-13",
             "basis": "verified"
           },
           "version_note": "Agent tool-integration SDK + managed platform: 1000+ toolkits, tool search, auth, sandboxed workbench; Rube MCP server connects 500+ apps. Python SDK v0.13.1 (May 14, 2026); @composio/claude-agent-sdk 0.9.2 (May 13, 2026). Verified live on GitHub/PyPI June 2026."
@@ -37801,7 +37916,7 @@
     }
   },
   "n_total": 472,
-  "generated": "2026-08-12",
+  "generated": "2026-08-13",
   "long_tail": {
     "counts": {
       "repos": 15375,

--- a/build/notebook_data.json
+++ b/build/notebook_data.json
@@ -777,7 +777,7 @@
           "maturity": 2.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Reka Core, frontier-class multimodal LLM announced 15 Apr 2024; 128K context. Proprietary: API/on-prem/on-device; no open weights. Instruction/multimodal-chat model. Verified live: launch page confirms API/on-prem/on-device availability and the MMMU/Claude-3-Opus claims. NOTE: '~5T tokens / 32 languages / from scratch' details are NOT on the cited launch page (they originate in Reka's separate technical report); verify against that source if retained. >12mo old; scored best-effort and flagged stale."
@@ -839,7 +839,7 @@
           "maturity": 1.7,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Inflection 3.0 (Pi 3.0 + Productivity 3.0), released 7 Oct 2024 with 'Inflection for Enterprise'. Proprietary/API + enterprise-licensed; no open weights; fine-tuned models are customer-exclusive. Frontier research team absorbed by Microsoft (2024-25); pivot to B2B. EXISTENCE now confirmed via PRIMARY sources (Intel Newsroom press release + BusinessWire 'Introducing Inflection for Enterprise', 7 Oct 2024), not aggregator-only. >12mo old; scored best-effort, flagged stale."
@@ -1620,7 +1620,7 @@
           "maturity": 2.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Falcon 3 family (1B, 3B, 7B, 10B), released 17 Dec 2024 by TII. Trained on 14T tokens. Sub-13B SLMs; now a dated generation relative to 2026 frontier."
@@ -2121,10 +2121,10 @@
           },
           "adoption": {
             "level": 1,
-            "reach": "1K-10K",
+            "reach": "<10K",
             "signal_type": "usage_volume",
             "confidence": "medium",
-            "note": "Public-funded sovereign model (Spain's national LLM, BSC / MareNostrum 5) with strong institutional and policy interest but modest raw volume. HF BSC-LT/ALIA-40b shows ~59 downloads/month and 88 likes (June 2026); the niche multilingual focus (Spanish + co-official + 35 European languages) keeps adoption below Apertus's tier. Cumulative across the wider ALIA Kit (instruct, GGUF, Salamandra) would be higher, but the base model alone sits in the low band.",
+            "note": "Public-funded sovereign model (Spain's national LLM, BSC / MareNostrum 5) with strong institutional and policy interest but modest raw volume. HF BSC-LT/ALIA-40b shows ~59 downloads/month and 88 likes (June 2026); the niche multilingual focus (Spanish + co-official + 35 European languages) keeps adoption below Apertus's tier. Cumulative across the wider ALIA Kit (instruct, GGUF, Salamandra) would be higher, but the base model alone sits in the low band. Read live 2026-08-13: 475 Hugging Face downloads in the trailing 30 days across the declared artifact(s), which bands at <10K, level 1. The previous reach '1K-10K' was a band off a different scale. No last_verified claimed: only the figure was re-read, not the whole axis.",
             "sources": [
               {
                 "url": "https://huggingface.co/BSC-LT/ALIA-40b",
@@ -2906,10 +2906,10 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "10K-100K",
+            "reach": "100K-1M",
             "signal_type": "usage_volume",
             "confidence": "medium",
-            "note": "Solid research/practitioner reach for a fully-open instruct line; below the Qwen/Llama instruct workhorses. Downloads still ramping as it supersedes OLMo 2 Instruct.",
+            "note": "Solid research/practitioner reach for a fully-open instruct line; below the Qwen/Llama instruct workhorses. Downloads still ramping as it supersedes OLMo 2 Instruct. Read live 2026-08-13: 450,053 Hugging Face downloads in the trailing 30 days across the declared artifact(s), which bands at 100K-1M, level 3. The previous reach '10K-100K' was a band off a different scale. No last_verified claimed: only the figure was re-read, not the whole axis.",
             "sources": [
               {
                 "url": "https://huggingface.co/allenai/Olmo-3-7B-Instruct",
@@ -3529,7 +3529,7 @@
           "maturity": 3.3,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "OpenAI GPT-4.1 (+ mini, nano), released Apr 14 2025 as API-first coding/instruct models with 1M-token context. Post-trained instruct (non-reasoning) model, closed/API-only. Verified via OpenAI announcement coverage + InfoQ/TechCrunch June 2026; GPT-4.5 Preview deprecated July 2025 in its favor; now itself behind the GPT-5 line."
@@ -3813,7 +3813,7 @@
           "maturity": 3.7,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "xAI Grok 4.20; beta Feb 17, 2026, API GA Mar 10, 2026 (Grok 4.20 + Multi-agent). Revision '4.20 0309 v2' dated Apr 7, 2026. Multi-agent architecture (4 parallel agents); 2M-token context. Consolidated on 2026-07-29 from grok-3; openness follows grok-4-20, the release that currently governs. See docs/guides/identity.md."
@@ -3876,7 +3876,7 @@
           "maturity": 3.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Codestral 25.08 (released 30 Jul 2025), Mistral's code-completion/FIM specialist; instruction-tuned with a chat mode (+5% instruction following per launch). Distributed via API (console.mistral.ai), VPC, and on-prem; open weights on HF under the Mistral AI Non-Production License (MNPL). NOTE: arguably a coding-specialist model rather than a general chat model; scored best-effort in finetuned_chat per assignment with a category caveat. (Separate 'Codestral 2', Apr 2026, was relicensed Apache-2.0, not the SKU scored here.) Verified live June 2026."
@@ -3934,7 +3934,7 @@
           "maturity": 3.3,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Amazon Nova Pro (amazon.nova-pro-v1:0), released 3 Dec 2024; multimodal understanding/instruct model (text+image+video in, text out), 300K context. Proprietary, API-only via Amazon Bedrock. Succeeded by Amazon Nova 2 family (2026) but Nova Pro v1 remains in service. Verified live in AWS Bedrock docs June 2026. Consolidated on 2026-07-29 from amazon-nova; openness follows amazon-nova-pro, the release that currently governs. See docs/guides/identity.md."
@@ -4559,7 +4559,7 @@
           "maturity": 2.7,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "MIT-licensed weights, but a fine-tune of the open-weight Qwen2.5 line without a fully open data/training pipeline -> open_weights, not open_source. Narrow specialist."
@@ -4681,7 +4681,7 @@
           "maturity": 4.3,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Tier product. Anthropic ships a new Sonnet roughly every few months, so a versioned entry goes stale faster than it can be reviewed; the slug is stable and the score carries the release it was measured against. Supersedes the separate claude-sonnet-4 and claude-sonnet-4-6 entries."
@@ -4739,7 +4739,7 @@
           "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Tier product, currently shipping Haiku 4.5. Renamed from claude-haiku-4-5 so the slug survives the next generation."
@@ -4797,7 +4797,7 @@
           "maturity": 5.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Tier product. Scored against Gemini 3 Pro, the generally available Pro release. Gemini 3.1 Pro Preview leads LiveCodeBench Pro and posts 80.6% on SWE-bench Verified, but preview checkpoints are excluded from the map as separate products because they are not stable; it is noted here so the tier's coding standing is not lost. Supersedes the separate gemini-2-5-pro, gemini-3-pro and gemini-3-1-pro-preview entries."
@@ -5319,10 +5319,10 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
+            "reach": ">10K stars",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "No PyPI/download or pull-count signal available (distributed as single-file binaries, not a package); GitHub stars is the only honest signal. Capped at 3 per stars_fallback rule. Popular local-inference convenience tool but no verified usage_volume figure.",
+            "note": "No PyPI/download or pull-count signal available (distributed as single-file binaries, not a package); GitHub stars is the only honest signal. Capped at 3 per stars_fallback rule. Popular local-inference convenience tool but no verified usage_volume figure. Stars read 2026-08-13: 25,548 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The previous reach '100K-1M' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "last_verified": "2026-08-09",
             "sources": [
               {
@@ -5416,11 +5416,11 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 2,
-            "reach": "10K-100K",
+            "level": 3,
+            "reach": ">10K stars",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "No published download/user/tokens figure for MAX serving specifically. GitHub stargazerCount on modular/modular (covers MAX+Mojo) is the only signal; capped per stars_fallback and placed at 2 given no verified production-deployment count and a still-maturing serving ecosystem vs the established OSS engines.",
+            "note": "No published download/user/tokens figure for MAX serving specifically. GitHub stargazerCount on modular/modular (covers MAX+Mojo) is the only signal; capped per stars_fallback and placed at 2 given no verified production-deployment count and a still-maturing serving ecosystem vs the established OSS engines. Stars read 2026-08-13 on modular/modular: 26,777, which bands at >10K stars, level 3 on the stars scale. The previous reach '10K-100K' was a download label, which this instrument does not offer - a star is not a download. Level corrected from 2. OVER-ATTRIBUTION, named rather than resolved: modular/modular is one repo covering MAX and Mojo together, so these stars are not all MAX's. That is the cohere-rerank- api shape and the guide has no settled rule for it yet, so the instrument's answer stands and confidence stays low. THE REAL DEFECT is upstream: this product declares no artifacts at all, so a stars_fallback band had no stars source behind it and the count lived only in this note. Declaring modular/modular would fix it, and is deliberately not done here because a declared code repo also re-routes the openness license dimension. No last_verified claimed: a star count is volatile.",
             "last_verified": "2026-08-09",
             "sources": [
               {
@@ -5456,7 +5456,7 @@
               }
             ]
           },
-          "maturity": 3.0,
+          "maturity": 3.5,
           "mature": false,
           "freshness": {
             "date": "2026-08-09",
@@ -7939,10 +7939,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "<10K",
+            "reach": "1K-10K stars",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "GitHub stars remain the only usable signal: 1,890 stars (displayed 1.9k, up from ~1.7k), still inside the <10K band; 'Used by' and contributor counts are unavailable in the static page. The nemo-rl package on PyPI is a non-functional placeholder (v0.0.0) that explicitly directs users back to GitHub, so no download figure exists to band on. Level 2 stands on stars_fallback; honest signal is limited.",
+            "note": "GitHub stars remain the only usable signal: 1,890 stars (displayed 1.9k, up from ~1.7k), still inside the <10K band; 'Used by' and contributor counts are unavailable in the static page. The nemo-rl package on PyPI is a non-functional placeholder (v0.0.0) that explicitly directs users back to GitHub, so no download figure exists to band on. Level 2 stands on stars_fallback; honest signal is limited. Stars read 2026-08-13: 1,903 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach '<10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "last_verified": "2026-08-09",
             "sources": [
               {
@@ -9637,7 +9637,7 @@
           "maturity": 4.5,
           "mature": true,
           "freshness": {
-            "date": "2026-07-30",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "SWE-bench evaluation harness. PyPI `swebench` v4.1.0 (Sep 11 2025); repo migrated to github.com/SWE-bench/SWE-bench, last headline feature SWE-bench Multimodal (Jan 2025). Confirmed live June 2026. Scoring the HARNESS (the software that runs models against GitHub-issue tasks); the underlying dataset belongs in benchmark_eval_data."
@@ -9743,10 +9743,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "10K-100K",
+            "reach": "1K-10K stars",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "Narrow, specialist code-gen benchmark: 503 GitHub stars, active HF leaderboard with 163 models evaluated. No clean PyPI/download figure for the harness; no published install volume. stars_fallback -> capped at level 3, set to 2 on the modest star + leaderboard footprint.",
+            "note": "Narrow, specialist code-gen benchmark: 503 GitHub stars, active HF leaderboard with 163 models evaluated. No clean PyPI/download figure for the harness; no published install volume. stars_fallback -> capped at level 3, set to 2 on the modest star + leaderboard footprint. Stars read 2026-08-13: 1,573 across the 2 declared repos, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach '10K-100K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/bigcode-project/bigcodebench",
@@ -9834,7 +9834,7 @@
           "maturity": 3.5,
           "mature": false,
           "freshness": {
-            "date": "2026-07-30",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "OpenCompass v0.5.2 (Feb 14 2026). 100+ datasets / 70+ with ~400k questions; 20+ HF models + API models (OpenAI/Gemini/Claude). Confirmed live June 2026."
@@ -10018,10 +10018,10 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
+            "reach": ">10K stars",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "No PyPI/download count available for this repo (it is run from source, not pip-installed); 18.6k GitHub stars + 3k forks is the only honest signal, so capped at level 3 per the stars-fallback rule. Historically influential as one of the first open eval frameworks but largely superseded by the hosted Evals API and by newer harnesses.",
+            "note": "No PyPI/download count available for this repo (it is run from source, not pip-installed); 18.6k GitHub stars + 3k forks is the only honest signal, so capped at level 3 per the stars-fallback rule. Historically influential as one of the first open eval frameworks but largely superseded by the hosted Evals API and by newer harnesses. Stars read 2026-08-13 on openai/evals: 19,159, which bands at >10K stars, level 3 on the stars scale. The previous reach '100K-1M' was a download label, which this instrument does not offer - a star is not a download. THE REAL DEFECT is upstream: this product declares no artifacts at all, so a stars_fallback band had no stars source behind it and the count lived only in this note. Declaring openai/evals would fix it, and is deliberately not done here because a declared code repo also re-routes the openness license dimension. No last_verified claimed: a star count is volatile.",
             "sources": [
               {
                 "url": "https://github.com/openai/evals",
@@ -10076,10 +10076,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "10K-100K",
+            "reach": "1K-10K stars",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "Run from source (no pip distribution), so no download signal; ~4.5k stars + 490 forks is the only measure, capped at <=3 by the stars rule and lowered to 2 because the project is deprecated (frozen July 2025) and used mainly as a reference for a few specific benchmarks (HealthBench/BrowseComp/SimpleQA) rather than as a live harness.",
+            "note": "Run from source (no pip distribution), so no download signal; ~4.5k stars + 490 forks is the only measure, capped at <=3 by the stars rule and lowered to 2 because the project is deprecated (frozen July 2025) and used mainly as a reference for a few specific benchmarks (HealthBench/BrowseComp/SimpleQA) rather than as a live harness. Stars read 2026-08-13: 4,598 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach '10K-100K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/openai/simple-evals",
@@ -10298,7 +10298,7 @@
           "maturity": 4.5,
           "mature": true,
           "freshness": {
-            "date": "2026-07-30",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "UKGovernmentBEIS/inspect_ai (UK AI Security Institute + Meridian Labs), MIT, ~2.2k stars, ~5,886 commits, very actively developed. Framework for frontier LLM/agent evaluations: 200+ pre-built evals, tool use, multi-turn, model-graded scoring, one interface over OpenAI/Anthropic/Google/xAI/Bedrock/Azure/local vLLM/Ollama. Confirmed live June 2026."
@@ -10360,7 +10360,7 @@
           "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-07-30",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "stanford-crfm/helm, v0.5.16 (released 30 Apr 2026), Apache-2.0, ~2.8k stars. Standardized holistic evaluation framework + public leaderboards: HELM Capabilities, HELM Safety, VHELM (vision-language), HEIM (text-to-image), MedHELM, audio-LM, enterprise benchmarks; supports MMLU-Pro, GPQA, IFEval, WildBench. Confirmed live June 2026."
@@ -10509,7 +10509,7 @@
           "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-11",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "OSWorld: scalable real-computer environment + execution-based evaluation harness for multimodal/computer-use agents (NeurIPS 2024). Apache-2.0. 369 tasks (361 excl. 8 problematic Google Drive tasks). De-facto standard for computer-use agents (GPT-5.4 75.0%, Claude Opus 4.6 72.7%, Claude Sonnet 4.6 72.5% on OSWorld-Verified cited in 2026 releases). Confirmed live June 2026. Dual artifact: ships both the task set and the runner; registry placed it in evaluation_code (the harness); note the dataset overlaps benchmark_eval_data."
@@ -10733,7 +10733,7 @@
           "maturity": 3.5,
           "mature": false,
           "freshness": {
-            "date": "2026-08-11",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Scale AI 'Scale Evaluation' platform (the 'Evaluate AI' product line as of Oct 2025), part of Scale GenAI Platform. Proprietary hosted evaluation/monitoring with private SEAL benchmark datasets + expert human-eval workforce ('Trust Feedback Loop'). Public-facing SEAL Leaderboards + SEAL Showdown (millions of real-world conversations across 100+ countries). Confirmed live 2025-2026."
@@ -10805,7 +10805,7 @@
           "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-07-30",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Artificial Analysis Intelligence Index v4.0.4 (March 2026). Composite of 10 evals (GDPval-AA, tau2-Bench Telecom, Terminal-Bench Hard, SciCode, AA-LCR, AA-Omniscience, IFBench, Humanity's Last Exam, GPQA Diamond, CritPt) in 4 equal-weighted categories. Independent third-party benchmarking platform with published methodology; partial OSS (Stirrup agent harness, MIT, used for GDPval-AA) but the Index pipeline + internal dataset copies are proprietary. Confirmed live June 2026."
@@ -10867,7 +10867,7 @@
           "maturity": 3.5,
           "mature": false,
           "freshness": {
-            "date": "2026-06-24",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Vals AI independent LLM evaluation platform; Vals Index + Vals Multimodal Index + domain benchmarks (finance, law, healthcare, coding, math, tax). Verified live June 2026 (leaderboard updated 2026-06-04, includes Claude Opus 4.8, Qwen 3.7 Plus, MiniMax M3). SaaS-only, no public source repo."
@@ -10940,7 +10940,7 @@
           "maturity": 3.5,
           "mature": false,
           "freshness": {
-            "date": "2026-08-11",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Epoch AI benchmark database + public dashboard scoring frontier models on hard tasks (FrontierMath, GPQA Diamond, SWE-bench Verified, SimpleQA Verified, MATH Level 5, OTIS Mock AIME, Chess Puzzles). Verified live June 2026; org github.com/epoch-research has MIT/Apache eval repos (SWE-bench docker registry, eci-public, MirrorCode-data), but FrontierMath dataset is held private."
@@ -11007,7 +11007,7 @@
           "maturity": 3.5,
           "mature": false,
           "freshness": {
-            "date": "2026-06-09",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "AWS managed evaluation feature within Amazon Bedrock; model eval (LLM-as-a-judge, programmatic incl BERTScore/F1, human), RAG eval (retrieval + retrieve-and-generate). RAG eval + LLM-as-a-judge GA 2025-03-20 (preview at re:Invent Dec 2024); 'bring your own inference responses' supports external/on-prem models. Verified live June 2026."
@@ -11560,10 +11560,10 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
+            "reach": "100K-1M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "The de-facto standard agentic-coding benchmark of 2025-2026: cited as the headline coding metric in nearly every frontier model release (GPT-5, Claude Opus, DeepSeek, Qwen, Kimi all report SWE-bench Verified). ~914k HF downloads/month plus a live, heavily-submitted leaderboard at swebench.com. Strongest 'citation-as-standard' signal in the batch.",
+            "note": "The de-facto standard agentic-coding benchmark of 2025-2026: cited as the headline coding metric in nearly every frontier model release (GPT-5, Claude Opus, DeepSeek, Qwen, Kimi all report SWE-bench Verified). ~914k HF downloads/month plus a live, heavily-submitted leaderboard at swebench.com. Strongest 'citation-as-standard' signal in the batch. Read live 2026-08-13: 413,323 Hugging Face downloads in the trailing 30 days across the declared artifact(s), which bands at 100K-1M, level 4. The previous reach '1M-10M' was a band off a different scale. No last_verified claimed: only the figure was re-read, not the whole axis.",
             "sources": [
               {
                 "url": "https://huggingface.co/datasets/princeton-nlp/SWE-bench_Verified",
@@ -11925,7 +11925,7 @@
           "maturity": 3.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-12",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "MultiPL-E: translations of HumanEval (161 problems) and MBPP (397 problems) into 22-23 programming languages (Ada, Clojure, C++, C#, D, Dart, Elixir, Go, Haskell, Java, Julia, JS, Lua, OCaml, PHP, Perl, R, Ruby, Racket, Rust, Scala, Shell, Swift, TS). HF dataset (nuprl/MultiPL-E, 47 subsets) verified live June 2026; integrated into the BigCode evaluation harness. arXiv 2208.08227 (IEEE TSE)."
@@ -12031,7 +12031,7 @@
           "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-12",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "MATH (Hendrycks et al., NeurIPS 2021, arXiv 2103.03874): 12,500 competition math problems (7,500 train / 5,000 test) with step-by-step LaTeX solutions, Level 1-5, 7 subjects. Original HF dataset (hendrycks/competition_math) verified June 2026 but ACCESS DISABLED via DMCA takedown; no longer redistributable from the canonical registry; license tag is MIT."
@@ -12137,7 +12137,7 @@
           "maturity": 3.0,
           "mature": false,
           "freshness": {
-            "date": "2026-06-24",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Scale AI SEAL Leaderboards (Safety, Evaluations, and Alignment Lab); launched 2024, regularly updated with new domains (instruction-following, math, coding, multilinguality, etc.). The scored artifact is the private held-out eval sets behind the leaderboard. Verified live June 2026 via labs.scale.com/leaderboard (redirect from scale.com/leaderboard) and scale.com/blog/leaderboard."
@@ -12292,7 +12292,7 @@
           "maturity": 3.0,
           "mature": false,
           "freshness": {
-            "date": "2026-06-09",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "CRUXEval (Code Reasoning, Understanding, and eXecution Evaluation) by Meta/FAIR (Gu, Roziere, Leather, Solar-Lezama, Synnaeve, Wang; arXiv 2401.03065, 2024). 800 Python functions with input/output pairs; two tasks: CRUXEval-I (input prediction) + CRUXEval-O (output prediction). Verified live June 2026 on github.com/facebookresearch/cruxeval."
@@ -12436,10 +12436,10 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
+            "reach": "100K-1M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "~129,881 HF downloads in the trailing month (primary, from the dataset page); GPQA Diamond is a de-facto-standard reasoning benchmark cited across frontier model release reports (appears as a capability basis throughout the v3 flagship set), which is the top adoption signal for a benchmark.",
+            "note": "~129,881 HF downloads in the trailing month (primary, from the dataset page); GPQA Diamond is a de- facto-standard reasoning benchmark cited across frontier model release reports (appears as a capability basis throughout the v3 flagship set), which is the top adoption signal for a benchmark. Read live 2026-08-13: 110,577 Hugging Face downloads in the trailing 30 days across the declared artifact(s), which bands at 100K-1M, level 4. The previous reach '1M-10M' was a band off a different scale. No last_verified claimed: only the figure was re-read, not the whole axis.",
             "sources": [
               {
                 "url": "https://huggingface.co/datasets/Idavidrein/gpqa",
@@ -16109,10 +16109,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "1K-10K",
+            "reach": "10K-100K",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "~6.5k PyPI downloads/month; established in the HF synthetic-data workflow but modest raw volume.",
+            "note": "~6.5k PyPI downloads/month; established in the HF synthetic-data workflow but modest raw volume. Read live 2026-08-13: 16,308 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at 10K-100K, level 2. The previous reach '1K-10K' was a band off a different scale. No last_verified claimed: only the figure was re-read, not the whole axis.",
             "sources": [
               {
                 "url": "https://pypistats.org/packages/distilabel",
@@ -16301,11 +16301,11 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 2,
-            "reach": "1K-10K",
+            "level": 1,
+            "reach": "<10K",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "~5.1k PyPI downloads/month; the curation toolkit behind the Dolma corpus and OLMo family.",
+            "note": "~5.1k PyPI downloads/month; the curation toolkit behind the Dolma corpus and OLMo family. Read live 2026-08-13: 4,390 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at <10K, level 1. Level corrected from 2. The previous reach '1K-10K' was a band off a different scale. No last_verified claimed: only the figure was re-read, not the whole axis.",
             "sources": [
               {
                 "url": "https://pypistats.org/packages/dolma",
@@ -16328,7 +16328,7 @@
               }
             ]
           },
-          "maturity": 2.4,
+          "maturity": 1.8,
           "mature": false,
           "freshness": {
             "date": "2026-07-30",
@@ -16360,10 +16360,10 @@
           },
           "adoption": {
             "level": 1,
-            "reach": "<10K",
+            "reach": "<1K stars",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "New (2026) single-purpose Rust CLI, ~56 GitHub stars; real but niche, used in the Dolma 3 pipeline.",
+            "note": "New (2026) single-purpose Rust CLI, ~56 GitHub stars; real but niche, used in the Dolma 3 pipeline. Stars read 2026-08-13: 56 across the 1 declared repo, which bands at <1K stars, level 1 on the stars scale in signal_routing.yaml. The previous reach '<10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/allenai/datamap-rs",
@@ -16418,10 +16418,10 @@
           },
           "adoption": {
             "level": 1,
-            "reach": "<10K",
+            "reach": "<1K stars",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "New (2026) single-purpose Rust CLI, ~90 GitHub stars; niche, used in the Dolma 3 pipeline.",
+            "note": "New (2026) single-purpose Rust CLI, ~90 GitHub stars; niche, used in the Dolma 3 pipeline. Stars read 2026-08-13: 93 across the 1 declared repo, which bands at <1K stars, level 1 on the stars scale in signal_routing.yaml. The previous reach '<10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/allenai/duplodocus",
@@ -16476,10 +16476,10 @@
           },
           "adoption": {
             "level": 1,
-            "reach": "<10K",
+            "reach": "<1K stars",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "New (2026) single-purpose Rust CLI, ~35 GitHub stars; niche, used in the Dolma 3 pipeline.",
+            "note": "New (2026) single-purpose Rust CLI, ~35 GitHub stars; niche, used in the Dolma 3 pipeline. Stars read 2026-08-13: 36 across the 1 declared repo, which bands at <1K stars, level 1 on the stars scale in signal_routing.yaml. The previous reach '<10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/allenai/decon",
@@ -16534,10 +16534,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "<10K",
+            "reach": "1K-10K stars",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "~1.2k GitHub stars and very active development; a research framework with adoption concentrated around the Marin project rather than broad external use.",
+            "note": "~1.2k GitHub stars and very active development; a research framework with adoption concentrated around the Marin project rather than broad external use. Stars read 2026-08-13: 1,261 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach '<10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/marin-community/marin",
@@ -16772,10 +16772,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "<10K",
+            "reach": "1K-10K stars",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "~1.7k GitHub stars; frozen since 2023 but the canonical, widely-cited documented-corpus construction pipeline (GPT-Neo/J, Pythia).",
+            "note": "~1.7k GitHub stars; frozen since 2023 but the canonical, widely-cited documented-corpus construction pipeline (GPT-Neo/J, Pythia). Stars read 2026-08-13: 1,674 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach '<10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/EleutherAI/the-pile",
@@ -16830,10 +16830,10 @@
           },
           "adoption": {
             "level": 1,
-            "reach": "<10K",
+            "reach": "<1K stars",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "~25 GitHub stars on the pipeline repo; the value is the 5.7T-token corpus it builds, not the tool's own adoption.",
+            "note": "~25 GitHub stars on the pipeline repo; the value is the 5.7T-token corpus it builds, not the tool's own adoption. Stars read 2026-08-13: 25 across the 1 declared repo, which bands at <1K stars, level 1 on the stars scale in signal_routing.yaml. The previous reach '<10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re- read.",
             "sources": [
               {
                 "url": "https://github.com/LLM360/TxT360",
@@ -16917,7 +16917,7 @@
           "maturity": 3.4,
           "mature": false,
           "freshness": {
-            "date": "2026-07-30",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Snorkel Flow, proprietary enterprise platform (distinct from the Apache-2.0 snorkel-team/snorkel OSS library, which is stale: last release 0.10.0, Feb 2024). Confirmed 2026-07-21. ~$237M raised, ~$1.3B valuation (Series D, May 2025); enterprise/government rather than frontier-lab customers."
@@ -17077,7 +17077,7 @@
           "maturity": 2.4,
           "mature": false,
           "freshness": {
-            "date": "2026-07-30",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "DatologyAI, proprietary curation platform deployed into customer VPC; no source-available product. Founded 2023 by Ari Morcos (ex-FAIR/DeepMind) and Matthew Leavitt (ex-MosaicML). ~$57.5M raised (seed + $46M Series A); angels include Jeff Dean and Yann LeCun. No named frontier-lab customers disclosed. Confirmed 2026-07-21."
@@ -17106,10 +17106,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "<10K",
+            "reach": "1K-10K stars",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "~1,454 GitHub stars; no PyPI package (source install). The reference DataComp-LM toolkit.",
+            "note": "~1,454 GitHub stars; no PyPI package (source install). The reference DataComp-LM toolkit. Stars read 2026-08-13: 1,463 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach '<10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/mlfoundations/dclm",
@@ -17225,10 +17225,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "<10K",
+            "reach": "1K-10K stars",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "~1,000 GitHub stars; research repo, no PyPI package. Archived since 2023 but a foundational, widely-reused pipeline.",
+            "note": "~1,000 GitHub stars; research repo, no PyPI package. Archived since 2023 but a foundational, widely- reused pipeline. Stars read 2026-08-13: 1,045 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach '<10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/facebookresearch/cc_net",
@@ -17283,10 +17283,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "<10K",
+            "reach": "1K-10K stars",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "~4,969 GitHub stars; pipeline repo, no PyPI package. Widely referenced quality-signal pipeline; dormant since Dec 2024.",
+            "note": "~4,969 GitHub stars; pipeline repo, no PyPI package. Widely referenced quality-signal pipeline; dormant since Dec 2024. Stars read 2026-08-13: 4,977 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach '<10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/togethercomputer/RedPajama-Data",
@@ -17482,11 +17482,11 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 2,
-            "reach": "10K-100K",
+            "level": 3,
+            "reach": ">10K stars",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "Primarily a research/benchmark agent; 19.4k stars in the research community. No published download/user volume; capped per stars-fallback rule. Adoption is research-circle, not production end-user scale.",
+            "note": "Primarily a research/benchmark agent; 19.4k stars in the research community. No published download/user volume; capped per stars-fallback rule. Adoption is research-circle, not production end-user scale. Stars read 2026-08-13: 20,055 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. Level corrected from 2. The previous reach '10K-100K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/SWE-agent/SWE-agent",
@@ -17510,7 +17510,7 @@
               }
             ]
           },
-          "maturity": 2.7,
+          "maturity": 3.0,
           "mature": false,
           "freshness": {
             "date": "2026-08-08",
@@ -17542,10 +17542,10 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
+            "reach": ">10K stars",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "46.4k stars and active multi-surface distribution (desktop/CLI/API), backed by Block and now Linux Foundation. No published download/MAU figure found, so capped at level 3 on stars-fallback; directional.",
+            "note": "46.4k stars and active multi-surface distribution (desktop/CLI/API), backed by Block and now Linux Foundation. No published download/MAU figure found, so capped at level 3 on stars-fallback; directional. Stars read 2026-08-13: 52,753 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The previous reach '100K-1M' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re- read.",
             "sources": [
               {
                 "url": "https://github.com/aaif-goose/goose",
@@ -17700,10 +17700,10 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
+            "reach": ">10K stars",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "185k stars (one of the most-starred repos on GitHub) reflects huge historical interest, but stars cannot exceed level 3 and recent production-usage signal is unclear. No published platform MAU/download volume found; capped at 3, directional.",
+            "note": "185k stars (one of the most-starred repos on GitHub) reflects huge historical interest, but stars cannot exceed level 3 and recent production-usage signal is unclear. No published platform MAU/download volume found; capped at 3, directional. Stars read 2026-08-13: 186,583 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The previous reach '100K-1M' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/Significant-Gravitas/AutoGPT",
@@ -17823,11 +17823,11 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 2,
-            "reach": "10K-100K",
+            "level": 3,
+            "reach": ">10K stars",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "19.8k stars and a managed cloud offering, but no published download/user-count figure; capped on stars fallback. Placed at 2 given the relatively young, smaller community vs the leading agents; directional.",
+            "note": "19.8k stars and a managed cloud offering, but no published download/user-count figure; capped on stars fallback. Placed at 2 given the relatively young, smaller community vs the leading agents; directional. Stars read 2026-08-13: 20,094 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. Level corrected from 2. The previous reach '10K-100K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/kortix-ai/suna",
@@ -17850,7 +17850,7 @@
               }
             ]
           },
-          "maturity": 2.7,
+          "maturity": 3.0,
           "mature": false,
           "freshness": {
             "date": "2026-07-30",
@@ -18108,7 +18108,7 @@
           "maturity": 3.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Devin by Cognition AI, autonomous SaaS software-engineering agent (web IDE + CLI). Verified live June 2026 at docs.devin.ai and devin.ai/pricing; Individual/Teams/Enterprise plans. Devin 2.0 generation."
@@ -18245,7 +18245,7 @@
           "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-06-09",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Windsurf (formerly Codeium) acquired by Cognition (def. agreement July 2025) and rebranded 'Devin Desktop' on June 2 2026; windsurf.com redirects to devin.ai/desktop. Agent manager wrapped in a full IDE; Cascade legacy, successor Devin Local (Rust). Verified June 2026."
@@ -18302,7 +18302,7 @@
           "maturity": 3.7,
           "mature": false,
           "freshness": {
-            "date": "2026-06-24",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Amazon Q Developer, AWS's agentic GenAI software-development assistant across IDEs/CLI/Console/chat. Free tier (50 agentic chats/mo) + Pro tier. Verified live June 2026 at aws.amazon.com/q/developer."
@@ -18427,7 +18427,7 @@
           "maturity": 3.3,
           "mature": false,
           "freshness": {
-            "date": "2026-06-09",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Replit Agent (Agent 4 generation), autonomous AI app-building agent in the Replit cloud IDE, parallel multi-task build, design + functionality in parallel. Verified live June 2026 at replit.com/agent; proprietary, consumption-priced on top of Replit subscriptions."
@@ -18489,7 +18489,7 @@
           "maturity": 3.3,
           "mature": false,
           "freshness": {
-            "date": "2026-06-09",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "v0 by Vercel (v0.app), agentic full-stack web app builder ('agentic by default', autonomous plan/create-tasks/connect-DB as it builds); web + iOS, subscription (v0 Pro). Verified live June 2026 at v0.app. (Note: prior record's 'powered by Claude Opus 4.8' could NOT be confirmed on the product page. No model named publicly; claim softened.)"
@@ -18595,11 +18595,11 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 1,
-            "reach": "<1K",
+            "level": 2,
+            "reach": "1K-10K stars",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "No download/user/usage metrics disclosed (it's a self-hosted app, not a registry package). Only signal available is GitHub stars (~577 on vellum-ai/vellum-assistant), used here strictly as a last-resort proxy per the adoption!=stars rule; small/new entrant. Previously null; set to a conservative level 1 now that a real (if weak) signal exists.",
+            "note": "No download/user/usage metrics disclosed (it's a self-hosted app, not a registry package). Only signal available is GitHub stars (~577 on vellum-ai/vellum-assistant), used here strictly as a last-resort proxy per the adoption!=stars rule; small/new entrant. Previously null; set to a conservative level 1 now that a real (if weak) signal exists. Stars read 2026-08-13 on vellum-ai/vellum-assistant: 1,054, which bands at 1K-10K stars, level 2 on the stars scale. The previous reach '<1K' was a download label, which this instrument does not offer - a star is not a download. Level corrected from 1. THE REAL DEFECT is upstream: this product declares no artifacts at all, so a stars_fallback band had no stars source behind it and the count lived only in this note. Declaring vellum-ai/vellum-assistant would fix it, and is deliberately not done here because a declared code repo also re-routes the openness license dimension. No last_verified claimed: a star count is volatile.",
             "sources": [
               {
                 "url": "https://github.com/vellum-ai/vellum-assistant",
@@ -18627,7 +18627,7 @@
               }
             ]
           },
-          "maturity": 2.4,
+          "maturity": 2.7,
           "mature": false,
           "freshness": {
             "date": "2026-07-30",
@@ -18805,10 +18805,10 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
+            "reach": ">10K stars",
             "signal_type": "stars_fallback",
             "confidence": "high",
-            "note": "~144K GitHub stars plus Dify Cloud managed tier; no honest active-user/download volume figure verified, so capped at 3 on stars fallback.",
+            "note": "~144K GitHub stars plus Dify Cloud managed tier; no honest active-user/download volume figure verified, so capped at 3 on stars fallback. Stars read 2026-08-13 on langgenius/dify: 152,331, which bands at >10K stars, level 3 on the stars scale. The previous reach '100K-1M' was a download label, which this instrument does not offer - a star is not a download. THE REAL DEFECT is upstream: this product declares no artifacts at all, so a stars_fallback band had no stars source behind it and the count lived only in this note. Declaring langgenius/dify would fix it, and is deliberately not done here because a declared code repo also re-routes the openness license dimension. No last_verified claimed: a star count is volatile.",
             "sources": [
               {
                 "url": "https://github.com/langgenius/dify",
@@ -19658,9 +19658,10 @@
           },
           "adoption": {
             "level": 3,
+            "reach": ">10K stars",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "~57k stars but negligible package usage (~186 PyPI downloads/month) - stars_fallback (capped at 3).",
+            "note": "~57k stars but negligible package usage (~186 PyPI downloads/month) - stars_fallback (capped at 3). Stars read 2026-08-13: 57,954 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The record carried no reach label at all before this. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://pypistats.org/packages/openmanus",
@@ -19776,9 +19777,10 @@
           },
           "adoption": {
             "level": 3,
+            "reach": ">10K stars",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "~34k stars; no published download telemetry - stars_fallback (capped at 3).",
+            "note": "~34k stars; no published download telemetry - stars_fallback (capped at 3). Stars read 2026-08-13: 35,476 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The record carried no reach label at all before this. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/microsoft/graphrag",
@@ -19955,10 +19957,10 @@
           },
           "adoption": {
             "level": 1,
-            "reach": "<10K",
+            "reach": "<1K stars",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "~2 GitHub stars (July 2026), created Aug 2025 — pre-adoption. Part of OpenMined's federated-RAG effort (also local-rag, local-rag-router). Included as an emerging entry, not on adoption merit.",
+            "note": "~2 GitHub stars (July 2026), created Aug 2025 — pre-adoption. Part of OpenMined's federated-RAG effort (also local-rag, local-rag-router). Included as an emerging entry, not on adoption merit. Stars read 2026-08-13: 2 across the 1 declared repo, which bands at <1K stars, level 1 on the stars scale in signal_routing.yaml. The previous reach '<10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/OpenMined/syft-hub-sdk",
@@ -20606,9 +20608,10 @@
           },
           "adoption": {
             "level": 1,
+            "reach": "<1K stars",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "~237 GitHub stars, 55 forks (Aug 2026) — early-stage. No download metric available (Docker-distributed, no first-party PyPI/npm), so adoption falls back to stars, which the ladder caps at 3; 237 stars places it in the lowest band.",
+            "note": "~237 GitHub stars, 55 forks (Aug 2026) — early-stage. No download metric available (Docker- distributed, no first-party PyPI/npm), so adoption falls back to stars, which the ladder caps at 3; 237 stars places it in the lowest band. Stars read 2026-08-13: 238 across the 1 declared repo, which bands at <1K stars, level 1 on the stars scale in signal_routing.yaml. The record carried no reach label at all before this. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/linagora/openrag",
@@ -20731,10 +20734,10 @@
           },
           "adoption": {
             "level": 1,
-            "reach": "<10K",
+            "reach": "<1K stars",
             "signal_type": "stars_fallback",
             "confidence": "high",
-            "note": "Pre-release alpha (PyPI 0.3a0, Jun 2026) roughly one month old; ~96 GitHub stars. Minimal adoption to date, included as an emerging on-thesis structured-data agent.",
+            "note": "Pre-release alpha (PyPI 0.3a0, Jun 2026) roughly one month old; ~96 GitHub stars. Minimal adoption to date, included as an emerging on-thesis structured-data agent. Stars read 2026-08-13: 110 across the 1 declared repo, which bands at <1K stars, level 1 on the stars scale in signal_routing.yaml. The previous reach '<10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/datasette/datasette-agent",
@@ -20905,11 +20908,11 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 3,
-            "reach": "niche",
+            "level": 2,
+            "reach": "1K-10K stars",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "974 GitHub stars and 218 forks; no package download figures available.",
+            "note": "974 GitHub stars and 218 forks; no package download figures available. Stars read 2026-08-13: 1,164 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. Level corrected from 3. The previous reach 'niche' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/Hexastack/Hexabot",
@@ -20932,7 +20935,7 @@
               }
             ]
           },
-          "maturity": 3.7,
+          "maturity": 3.4,
           "mature": false,
           "freshness": {
             "date": "2026-08-11",
@@ -21128,7 +21131,7 @@
           "maturity": 3.7,
           "mature": false,
           "freshness": {
-            "date": "2026-06-09",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Microsoft Foundry Models unified inference endpoint (Azure AI Model Inference). Proprietary managed cloud service exposing many model deployments through one OpenAI-compatible endpoint; beta Azure AI Inference SDK deprecated, retiring Aug 26 2026 in favor of OpenAI/v1 API. Confirmed live (docs updated Apr 2026)."
@@ -21162,10 +21165,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "10K-100K",
+            "reach": "1K-10K stars",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "Only ~8.4k GitHub stars and no published download/usage volume found this run; capped low on stars fallback (cannot exceed level 3). Recently renamed from Llama Stack, so historical signal is muddled.",
+            "note": "Only ~8.4k GitHub stars and no published download/usage volume found this run; capped low on stars fallback (cannot exceed level 3). Recently renamed from Llama Stack, so historical signal is muddled. Stars read 2026-08-13 on ogx-ai/ogx: 8,420, which bands at 1K-10K stars, level 2 on the stars scale. The previous reach '10K-100K' was a download label, which this instrument does not offer - a star is not a download. THE REAL DEFECT is upstream: this product declares no artifacts at all, so a stars_fallback band had no stars source behind it and the count lived only in this note. Declaring ogx-ai/ogx would fix it, and is deliberately not done here because a declared code repo also re-routes the openness license dimension. No last_verified claimed: a star count is volatile.",
             "sources": [
               {
                 "url": "https://github.com/ogx-ai/ogx",
@@ -21354,10 +21357,10 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
+            "reach": ">10K stars",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "78.2k GitHub stars, 15.4k forks; Docker image (lobehub/lobehub) and LobeHub Cloud exist but no verified pull/MAU figure was obtainable from a primary source this run. Capped at 3 on stars fallback per rubric.",
+            "note": "78.2k GitHub stars, 15.4k forks; Docker image (lobehub/lobehub) and LobeHub Cloud exist but no verified pull/MAU figure was obtainable from a primary source this run. Capped at 3 on stars fallback per rubric. Stars read 2026-08-13: 81,633 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The previous reach '100K-1M' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/lobehub/lobehub",
@@ -21489,10 +21492,10 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
+            "reach": ">10K stars",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "88.2k GitHub stars and one-click Vercel deploy indicate broad lightweight use, but no verified download/MAU figure from a primary source this run, and last release ~6-12mo ago. Capped at 3 on stars fallback; momentum appears to have slowed.",
+            "note": "88.2k GitHub stars and one-click Vercel deploy indicate broad lightweight use, but no verified download/MAU figure from a primary source this run, and last release ~6-12mo ago. Capped at 3 on stars fallback; momentum appears to have slowed. Stars read 2026-08-13 on ChatGPTNextWeb/NextChat: 88,617, which bands at >10K stars, level 3 on the stars scale. The previous reach '100K-1M' was a download label, which this instrument does not offer - a star is not a download. THE REAL DEFECT is upstream: this product declares no artifacts at all, so a stars_fallback band had no stars source behind it and the count lived only in this note. Declaring ChatGPTNextWeb/NextChat would fix it, and is deliberately not done here because a declared code repo also re-routes the openness license dimension. No last_verified claimed: a star count is volatile.",
             "sources": [
               {
                 "url": "https://github.com/ChatGPTNextWeb/NextChat",
@@ -21587,7 +21590,7 @@
           "maturity": 3.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "chat-ui v0.10.0 (May 11, 2026), Apache-2.0, powers HuggingChat at hf.co/chat. Original HuggingChat was sunset July 1, 2025, then relaunched as 'HuggingChat Omni' (Omni Router + 115-123 open models, 15 inference providers, MCP). Confirmed live June 2026."
@@ -21790,10 +21793,10 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
+            "reach": ">10K stars",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "No published download/install or active-user counts found (self-hosted desktop app, no telemetry). Falling back to 28.9k GitHub stars + 300+ contributors as the only honest signal, capped at level 3 per the stars-fallback rule. Likely a large enthusiast/roleplay community but unverified.",
+            "note": "No published download/install or active-user counts found (self-hosted desktop app, no telemetry). Falling back to 28.9k GitHub stars + 300+ contributors as the only honest signal, capped at level 3 per the stars-fallback rule. Likely a large enthusiast/roleplay community but unverified. Stars read 2026-08-13: 32,041 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The previous reach '100K-1M' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/SillyTavern/SillyTavern",
@@ -21970,11 +21973,11 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 3,
-            "reach": "100K+ Docker pulls",
+            "level": 2,
+            "reach": "10K-100K",
             "signal_type": "usage_volume",
             "confidence": "medium",
-            "note": "~35k GitHub stars plus 100k+ Docker pulls on the current itzcrazykns1337/vane image by mid-2026 - genuine install volume (usage_volume, not stars-only), but well below the 1M+ band, so mid-tier.",
+            "note": "~35k GitHub stars plus 100k+ Docker pulls on the current itzcrazykns1337/vane image by mid-2026 - genuine install volume (usage_volume, not stars-only), but well below the 1M+ band, so mid-tier. Re-banded 2026-08-13 under the lifetime-average rule in docs/guides/adoption.md. Docker Hub reports 645,952 cumulative pulls on itzcrazykns1337/perplexica since 2025-03-20, which averages ~38,479 a month over 16.8 months and bands at 10K-100K. LEVEL CORRECTED FROM 3: the previous reach '100K+ Docker pulls' read a cumulative six-figure total as though it were a monthly one, which is precisely the substitution the n8n rule names, and it put the record a band above what its own number supports. Recorded as a declared floor - a lifetime average understates a growing product. Docker is not declared as an artifact here, so the figure lives in this note rather than in a signal. No last_verified claimed.",
             "sources": [
               {
                 "url": "https://hub.docker.com/r/itzcrazykns1337/vane",
@@ -21997,7 +22000,7 @@
               }
             ]
           },
-          "maturity": 3.3,
+          "maturity": 2.6,
           "mature": false,
           "freshness": {
             "date": "2026-07-30",
@@ -22100,9 +22103,10 @@
           },
           "adoption": {
             "level": 3,
+            "reach": ">10K stars",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "~15k GitHub stars by mid-2026; no download/usage telemetry available for a self-hosted web app, so stars_fallback (capped at level 3). Rapid star growth but unproven real-world deployment.",
+            "note": "~15k GitHub stars by mid-2026; no download/usage telemetry available for a self-hosted web app, so stars_fallback (capped at level 3). Rapid star growth but unproven real-world deployment. Stars read 2026-08-13: 15,898 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The record carried no reach label at all before this. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/MODSetter/SurfSense",
@@ -23461,7 +23465,7 @@
           "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-06-24",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Enterprise AI assistant / 'AI coworker' grounded in the Glean Enterprise Graph (RAG over 100+ enterprise connectors), with a Model Hub (multiple frontier LLMs), multimodal output (images/slides/pages), and agentic sub-features (Skills, sub-agent orchestration). Proprietary single-tenant SaaS. May-2026 'enterprise AI coworker' launch verified live June 2026. BORDERLINE: agentic/Skills features touch orchestration_agents, but the product is primarily a human-in-driver enterprise chat/assistant UI grounded in company data, so kept in ui_api per the litmus (AI presented as a tool to the human)."
@@ -23518,7 +23522,7 @@
           "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-06-24",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Glean Search ('the foundation of enterprise AI'), AI-powered enterprise/workplace search UI built on the Enterprise Graph + Personal Graph, hybrid search across 100+ connectors (Slack, Teams, Zoom, ServiceNow, Zendesk, GitHub, etc.), permissions-aware. Proprietary single-tenant SaaS. Verified live June 2026. The search layer underpins Glean Assistant; scored here as the human-facing search UI/API product."
@@ -23667,10 +23671,10 @@
           },
           "adoption": {
             "level": 1,
-            "reach": "<10K",
+            "reach": "<1K stars",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "63 GitHub stars / 6 forks (July 2026), created April 2026. Very new; limited adoption signal so far. (Mozilla AI's underlying any-llm library is far more adopted at ~2.1K stars, but is a separate product.)",
+            "note": "63 GitHub stars / 6 forks (July 2026), created April 2026. Very new; limited adoption signal so far. (Mozilla AI's underlying any-llm library is far more adopted at ~2.1K stars, but is a separate product.) Stars read 2026-08-13: 379 across the 1 declared repo, which bands at <1K stars, level 1 on the stars scale in signal_routing.yaml. The previous reach '<10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re- read.",
             "sources": [
               {
                 "url": "https://github.com/mozilla-ai/otari",
@@ -24086,7 +24090,7 @@
           "maturity": 4.5,
           "mature": false,
           "freshness": {
-            "date": "2026-07-30",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Arize AX, the enterprise AI engineering / LLM observability SaaS platform (distinct from open source Phoenix). Confirmed live via arize.com June 2026."
@@ -24698,10 +24702,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "10K-100K",
+            "reach": "1K-10K stars",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "No verified download/active-user figure located this run; ~3.3k GitHub stars is the only honest signal, so capped at level 2 via stars fallback (cannot exceed 3 on stars regardless).",
+            "note": "No verified download/active-user figure located this run; ~3.3k GitHub stars is the only honest signal, so capped at level 2 via stars fallback (cannot exceed 3 on stars regardless). Stars read 2026-08-13: 3,486 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach '10K-100K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/langwatch/langwatch",
@@ -24786,7 +24790,7 @@
           "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-07-30",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "LangSmith proprietary SaaS by LangChain; managed cloud + BYOC + self-hosted enterprise deployment. Confirmed live (langchain.com/langsmith) June 2026."
@@ -24950,7 +24954,7 @@
           "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-07-30",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Datadog LLM Observability, proprietary SaaS module of the Datadog platform. Confirmed live (docs.datadoghq.com/llm_observability) June 2026."
@@ -25333,10 +25337,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "10K-100K",
+            "reach": "1K-10K stars",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "Hosted SaaS shut down (no active platform users). Remaining signal is the OSS libraries: whylogs ~2.8k GitHub stars, last release Dec 2024; stars_fallback caps at 3; placed at 2 given the dead commercial product and stalled release cadence. Honest signal is modest residual OSS usage, not a live platform.",
+            "note": "Hosted SaaS shut down (no active platform users). Remaining signal is the OSS libraries: whylogs ~2.8k GitHub stars, last release Dec 2024; stars_fallback caps at 3; placed at 2 given the dead commercial product and stalled release cadence. Honest signal is modest residual OSS usage, not a live platform. Stars read 2026-08-13 on whylabs/whylogs: 2,830, which bands at 1K-10K stars, level 2 on the stars scale. The previous reach '10K-100K' was a download label, which this instrument does not offer - a star is not a download. THE REAL DEFECT is upstream: this product declares no artifacts at all, so a stars_fallback band had no stars source behind it and the count lived only in this note. Declaring whylabs/whylogs would fix it, and is deliberately not done here because a declared code repo also re-routes the openness license dimension. No last_verified claimed: a star count is volatile.",
             "sources": [
               {
                 "url": "https://github.com/whylabs/whylogs",
@@ -25421,7 +25425,7 @@
           "maturity": 3.5,
           "mature": false,
           "freshness": {
-            "date": "2026-06-24",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Galileo AI observability & eval-engineering platform; verified live June 2026 at galileo.ai. Proprietary SaaS / VPC / on-prem; Luna-2 small eval models. Not open source."
@@ -25488,7 +25492,7 @@
           "maturity": 3.5,
           "mature": false,
           "freshness": {
-            "date": "2026-06-24",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Confident AI = the proprietary cloud quality platform built by the creators of DeepEval (the separate OSI Apache-2.0 OSS eval framework). Verified live June 2026. The platform layers tracing/datasets/monitoring on top of DeepEval; self-hosted enterprise option exists."
@@ -25545,7 +25549,7 @@
           "maturity": 3.0,
           "mature": false,
           "freshness": {
-            "date": "2026-06-09",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Vertex AI / Agent Engine observability: tracing via Cloud Trace (OpenTelemetry-built), Cloud Monitoring, Cloud Logging, plus integrated Gen AI Evaluation service. Proprietary Google Cloud managed service. Verified live June 2026 in GCP docs."
@@ -25602,7 +25606,7 @@
           "maturity": 3.0,
           "mature": false,
           "freshness": {
-            "date": "2026-06-09",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Microsoft Foundry (formerly Azure AI Foundry) Observability: evaluations + monitoring + tracing reached general availability March 2026. OpenTelemetry-based tracing via Azure Monitor / Application Insights. Proprietary Azure managed service. Verified live June 2026 in Microsoft Learn docs."
@@ -25975,11 +25979,11 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 2,
-            "reach": "1K-10K",
+            "level": 1,
+            "reach": "<1K stars",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "New (late 2025) project, ~80 GitHub stars (June 2026); stars-only proxy, capped per methodology; early-stage adoption.",
+            "note": "New (late 2025) project, ~80 GitHub stars (June 2026); stars-only proxy, capped per methodology; early-stage adoption. Stars read 2026-08-13: 23 across the 1 declared repo, which bands at <1K stars, level 1 on the stars scale in signal_routing.yaml. Level corrected from 2. The previous reach '1K-10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/openguardrails/openguardrails",
@@ -26003,7 +26007,7 @@
               }
             ]
           },
-          "maturity": 3.0,
+          "maturity": 2.5,
           "mature": false,
           "freshness": {
             "date": "2026-08-08",
@@ -26064,7 +26068,7 @@
           "maturity": 3.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Zentropi CoPE-A (9B) on Gemma-2-9B (LoRA); license zentropi-openrail-m (OpenRAIL-M, use-restricted, NOT OSI). Open weights, self-hostable. RMC partner model distributed via the ROOST Model Community. 23 likes (June 2026); arXiv 2512.18027. Verified June 2026."
@@ -26394,10 +26398,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "1K-10K",
+            "reach": "1K-10K stars",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "~1K GitHub stars (June 2026); stars-only proxy. Widely cited as the standardized red-teaming benchmark in research.",
+            "note": "~1K GitHub stars (June 2026); stars-only proxy. Widely cited as the standardized red-teaming benchmark in research. Stars read 2026-08-13: 1,029 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach '1K-10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/centerforaisafety/HarmBench",
@@ -26452,11 +26456,11 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 3,
-            "reach": "10K-100K",
+            "level": 2,
+            "reach": "1K-10K stars",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "~5.5K GitHub stars (June 2026); stars-only proxy, capped per methodology.",
+            "note": "~5.5K GitHub stars (June 2026); stars-only proxy, capped per methodology. Stars read 2026-08-13: 5,748 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. Level corrected from 3. The previous reach '10K-100K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/Giskard-AI/giskard",
@@ -26480,7 +26484,7 @@
               }
             ]
           },
-          "maturity": 3.5,
+          "maturity": 3.0,
           "mature": false,
           "freshness": {
             "date": "2026-08-08",
@@ -26512,10 +26516,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "1K-10K",
+            "reach": "1K-10K stars",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "~1.9K GitHub stars (June 2026); stars-only proxy, capped per methodology.",
+            "note": "~1.9K GitHub stars (June 2026); stars-only proxy, capped per methodology. Stars read 2026-08-13: 2,442 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach '1K-10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/confident-ai/deepteam",
@@ -26877,11 +26881,11 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 3,
-            "reach": "10K-100K",
+            "level": 2,
+            "reach": "1K-10K stars",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "~6.6K GitHub stars (June 2026); stars-only proxy, capped per methodology; broadly referenced guardrail framework.",
+            "note": "~6.6K GitHub stars (June 2026); stars-only proxy, capped per methodology; broadly referenced guardrail framework. Stars read 2026-08-13: 6,936 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. Level corrected from 3. The previous reach '10K-100K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/NVIDIA/NeMo-Guardrails",
@@ -26905,7 +26909,7 @@
               }
             ]
           },
-          "maturity": 3.5,
+          "maturity": 3.0,
           "mature": false,
           "freshness": {
             "date": "2026-08-08",
@@ -27031,10 +27035,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "10K-100K",
+            "reach": "1K-10K stars",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "~3.1K GitHub stars (June 2026); stars-only proxy, capped per methodology.",
+            "note": "~3.1K GitHub stars (June 2026); stars-only proxy, capped per methodology. Stars read 2026-08-13: 3,202 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach '10K-100K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/protectai/llm-guard",
@@ -27548,7 +27552,7 @@
           "maturity": 3.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Lakera Guard; proprietary SaaS API (prompt-injection/jailbreak defense). Lakera acquired by Check Point (completed Nov 2025). Verified live June 2026."
@@ -27720,10 +27724,10 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
+            "reach": ">10K stars",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "No verified download/API-volume or customer count disclosed on repo or pricing page; only ~129k GitHub stars available as an honest signal. Capped at level 3 per stars_fallback rule. Widely integrated as an agent scrape tool (LangChain, etc.) but no primary usage figure found this run.",
+            "note": "No verified download/API-volume or customer count disclosed on repo or pricing page; only ~129k GitHub stars available as an honest signal. Capped at level 3 per stars_fallback rule. Widely integrated as an agent scrape tool (LangChain, etc.) but no primary usage figure found this run. Stars read 2026-08-13: 166,749 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The previous reach '100K-1M' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/mendableai/firecrawl",
@@ -28036,10 +28040,10 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
+            "reach": ">10K stars",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "No verified download or API-call volume found from a primary source. ~11k GitHub stars on the OSS repo plus a widely-used hosted r.jina.ai endpoint; capped at 3 on stars/reported-traction fallback in the absence of a measured usage figure.",
+            "note": "No verified download or API-call volume found from a primary source. ~11k GitHub stars on the OSS repo plus a widely-used hosted r.jina.ai endpoint; capped at 3 on stars/reported-traction fallback in the absence of a measured usage figure. Stars read 2026-08-13: 11,862 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The previous reach '100K-1M' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/jina-ai/reader",
@@ -28505,7 +28509,7 @@
           "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-06-24",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Proprietary search-grounded API: Sonar / Sonar Pro models, plus Search API (ranked web results) and Embeddings API; 2026 adds a multi-model Agent API marketplace. Verified live via docs.perplexity.ai June 2026."
@@ -28668,10 +28672,10 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "50M+ total Docker pulls",
+            "reach": "1M-10M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "~32k GitHub stars plus 50M+ total Docker pulls (~1.5M in a single recent week) and ~70 maintained public instances - concrete deployment volume well into the high band, not stars-only. The de facto open web-search backend for self-hosted AI.",
+            "note": "~32k GitHub stars plus 50M+ total Docker pulls (~1.5M in a single recent week) and ~70 maintained public instances - concrete deployment volume well into the high band, not stars-only. The de facto open web-search backend for self-hosted AI. Re-banded 2026-08-13 under the lifetime-average rule in docs/guides/adoption.md. Docker Hub reports 71,524,926 cumulative pulls on searxng/searxng since 2021-04-22, which averages ~1,122,856 a month over 63.7 months and bands at 1M-10M. The previous reach '50M+ total Docker pulls' was a CUMULATIVE total wearing a monthly band's place - the axis is monthly, so a lifetime total is not comparable to any other record on the scale. Level unchanged at 4. Recorded AS A DECLARED FLOOR, per the rule: a lifetime average understates a growing product, and SearXNG's pull rate is not flat. Docker is not declared as an artifact here, so the figure lives in this note rather than in a signal - the same gap issue #163 tracks. No last_verified claimed: only the figure was re-read.",
             "sources": [
               {
                 "url": "https://hub.docker.com/r/searxng/searxng",
@@ -28900,7 +28904,7 @@
           "maturity": 3.4,
           "mature": false,
           "freshness": {
-            "date": "2026-06-09",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Cohere Rerank API, verified live June 2026 (Cohere docs). Latest model Rerank 4.0 (fast/pro variants); prior 3.5 and 3.0 (English + multilingual). Proprietary hosted reranking API for RAG/retrieval; also available via Azure AI Foundry, AWS SageMaker/OpenSearch, Oracle GenAI. Sub-segment: retrieval/RAG infra (reranker)."
@@ -29132,7 +29136,7 @@
           "maturity": 3.4,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "v2.6.x stable (late 2025); v3.0 RC published May 2026; LF AI & Data project"
@@ -29344,9 +29348,10 @@
           },
           "adoption": {
             "level": 3,
+            "reach": ">10K stars",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "~31k stars; no download metric for Go/Docker distribution - stars_fallback (first-party backing implies higher real usage).",
+            "note": "~31k stars; no download metric for Go/Docker distribution - stars_fallback (first-party backing implies higher real usage). Stars read 2026-08-13: 32,212 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The record carried no reach label at all before this. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/github/github-mcp-server",
@@ -29877,10 +29882,10 @@
           },
           "adoption": {
             "level": 5,
-            "reach": "88M+/mo",
+            "reach": ">10M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "88.6M PyPI downloads in the last 30 days.",
+            "note": "88.6M PyPI downloads in the last 30 days. Read live 2026-08-13: 95,449,310 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at >10M, level 5. The previous reach '88M+/mo' was free text carrying a figure rather than a band the scale declares, so nothing could check it against the level beside it. No last_verified claimed: only the figure was re-read, not the whole axis.",
             "sources": [
               {
                 "url": "https://pepy.tech/projects/torch",
@@ -30109,10 +30114,10 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "5M+/mo",
+            "reach": "1M-10M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "5.3M PyPI downloads in the last 30 days, just above the 5M Level-4 threshold.",
+            "note": "5.3M PyPI downloads in the last 30 days, just above the 5M Level-4 threshold. Read live 2026-08-13: 4,482,096 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at 1M-10M, level 4. The previous reach '5M+/mo' was free text carrying a figure rather than a band the scale declares, so nothing could check it against the level beside it. No last_verified claimed: only the figure was re-read, not the whole axis.",
             "sources": [
               {
                 "url": "https://pepy.tech/projects/flax",
@@ -30167,10 +30172,10 @@
           },
           "adoption": {
             "level": 5,
-            "reach": "150M+/month",
+            "reach": ">10M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "PyPI last_month downloads of 150,245,308 exceed the 50M+ Level 5 threshold.",
+            "note": "PyPI last_month downloads of 150,245,308 exceed the 50M+ Level 5 threshold. Read live 2026-08-13: 192,709,895 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at >10M, level 5. The previous reach '150M+/month' was free text carrying a figure rather than a band the scale declares, so nothing could check it against the level beside it. No last_verified claimed: only the figure was re-read, not the whole axis.",
             "sources": [
               {
                 "url": "https://pypistats.org/api/packages/transformers/recent",
@@ -30225,10 +30230,10 @@
           },
           "adoption": {
             "level": 5,
-            "reach": "120M+/month",
+            "reach": ">10M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "PyPI last_month downloads of 120,316,114 exceed the 50M+ Level 5 threshold.",
+            "note": "PyPI last_month downloads of 120,316,114 exceed the 50M+ Level 5 threshold. Read live 2026-08-13: 159,958,389 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at >10M, level 5. The previous reach '120M+/month' was free text carrying a figure rather than a band the scale declares, so nothing could check it against the level beside it. No last_verified claimed: only the figure was re-read, not the whole axis.",
             "sources": [
               {
                 "url": "https://pypistats.org/api/packages/datasets/recent",
@@ -30283,10 +30288,10 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "7M+/month",
+            "reach": "1M-10M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "PyPI last_month downloads of 7,406,705 fall in the 5M-50M Level 4 band.",
+            "note": "PyPI last_month downloads of 7,406,705 fall in the 5M-50M Level 4 band. Read live 2026-08-13: 8,248,209 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at 1M-10M, level 4. The previous reach '7M+/month' was free text carrying a figure rather than a band the scale declares, so nothing could check it against the level beside it. No last_verified claimed: only the figure was re-read, not the whole axis.",
             "sources": [
               {
                 "url": "https://pypistats.org/api/packages/diffusers/recent",
@@ -30457,10 +30462,10 @@
           },
           "adoption": {
             "level": 5,
-            "reach": "78M+/month",
+            "reach": ">10M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "PyPI last-month downloads of 78,250,137 exceed the 50M+ threshold.",
+            "note": "PyPI last-month downloads of 78,250,137 exceed the 50M+ threshold. Read live 2026-08-13: 111,835,984 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at >10M, level 5. The previous reach '78M+/month' was free text carrying a figure rather than a band the scale declares, so nothing could check it against the level beside it. No last_verified claimed: only the figure was re-read, not the whole axis.",
             "sources": [
               {
                 "url": "https://pypistats.org/api/packages/safetensors/recent",
@@ -30515,10 +30520,10 @@
           },
           "adoption": {
             "level": 5,
-            "reach": "189M+/month",
+            "reach": ">10M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "PyPI last-month downloads of 189,770,639 exceed the 50M+ threshold.",
+            "note": "PyPI last-month downloads of 189,770,639 exceed the 50M+ threshold. Read live 2026-08-13: 252,452,945 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at >10M, level 5. The previous reach '189M+/month' was free text carrying a figure rather than a band the scale declares, so nothing could check it against the level beside it. No last_verified claimed: only the figure was re-read, not the whole axis.",
             "sources": [
               {
                 "url": "https://pypistats.org/api/packages/tokenizers/recent",
@@ -30573,10 +30578,10 @@
           },
           "adoption": {
             "level": 5,
-            "reach": "331M+/month",
+            "reach": ">10M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "PyPI last-month downloads of 331,796,503 exceed the 50M+ threshold.",
+            "note": "PyPI last-month downloads of 331,796,503 exceed the 50M+ threshold. Read live 2026-08-13: 493,557,521 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at >10M, level 5. The previous reach '331M+/month' was free text carrying a figure rather than a band the scale declares, so nothing could check it against the level beside it. No last_verified claimed: only the figure was re-read, not the whole axis.",
             "sources": [
               {
                 "url": "https://pypistats.org/api/packages/huggingface-hub/recent",
@@ -30630,11 +30635,11 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 3,
-            "reach": "1.7M+/month",
+            "level": 4,
+            "reach": "1M-10M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "PyPI last-month downloads of 1,759,764 fall in the 500k-5M range.",
+            "note": "PyPI last-month downloads of 1,759,764 fall in the 500k-5M range. Read live 2026-08-13: 1,919,623 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at 1M-10M, level 4. Level corrected from 3. The previous reach '1.7M+/month' was free text carrying a figure rather than a band the scale declares, so nothing could check it against the level beside it. No last_verified claimed: only the figure was re-read, not the whole axis.",
             "sources": [
               {
                 "url": "https://pypistats.org/api/packages/optimum/recent",
@@ -30657,7 +30662,7 @@
               }
             ]
           },
-          "maturity": 3.4,
+          "maturity": 4.0,
           "mature": false,
           "freshness": {
             "date": "2026-07-30",
@@ -30805,10 +30810,10 @@
           },
           "adoption": {
             "level": 5,
-            "reach": "50M+/mo",
+            "reach": ">10M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "PyPI last_month downloads ~64.7M.",
+            "note": "PyPI last_month downloads ~64.7M. Read live 2026-08-13: 69,538,627 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at >10M, level 5. The previous reach '50M+/mo' was free text carrying a figure rather than a band the scale declares, so nothing could check it against the level beside it. No last_verified claimed: only the figure was re-read, not the whole axis.",
             "sources": [
               {
                 "url": "https://pypistats.org/api/packages/triton/recent",
@@ -30862,11 +30867,11 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 3,
-            "reach": "~1.4M/mo",
+            "level": 4,
+            "reach": "1M-10M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "PyPI last_month downloads ~1.37M.",
+            "note": "PyPI last_month downloads ~1.37M. Read live 2026-08-13: 1,112,723 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at 1M-10M, level 4. Level corrected from 3. The previous reach '~1.4M/mo' was free text carrying a figure rather than a band the scale declares, so nothing could check it against the level beside it. No last_verified claimed: only the figure was re-read, not the whole axis.",
             "sources": [
               {
                 "url": "https://pypistats.org/api/packages/deepspeed/recent",
@@ -30889,7 +30894,7 @@
               }
             ]
           },
-          "maturity": 3.8,
+          "maturity": 4.4,
           "mature": false,
           "freshness": {
             "date": "2026-07-30",
@@ -30920,11 +30925,11 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 3,
-            "reach": "~1.4M/mo",
+            "level": 4,
+            "reach": "1M-10M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "PyPI last_month downloads ~1.38M.",
+            "note": "PyPI last_month downloads ~1.38M. Read live 2026-08-13: 1,869,817 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at 1M-10M, level 4. Level corrected from 3. The previous reach '~1.4M/mo' was free text carrying a figure rather than a band the scale declares, so nothing could check it against the level beside it. No last_verified claimed: only the figure was re-read, not the whole axis.",
             "sources": [
               {
                 "url": "https://pypistats.org/api/packages/openvino/recent",
@@ -30947,7 +30952,7 @@
               }
             ]
           },
-          "maturity": 3.4,
+          "maturity": 4.0,
           "mature": false,
           "freshness": {
             "date": "2026-07-30",
@@ -30979,10 +30984,10 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "~14.9k stars",
+            "reach": ">10K stars",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "No PyPI package; GitHub shows ~14.9k stars (and underpins much higher-adoption llama.cpp).",
+            "note": "No PyPI package; GitHub shows ~14.9k stars (and underpins much higher-adoption llama.cpp). Stars read 2026-08-13: 15,159 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The previous reach '~14.9k stars' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re- read.",
             "sources": [
               {
                 "url": "https://github.com/ggml-org/ggml",
@@ -31064,11 +31069,11 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 3,
-            "reach": "broad",
+            "level": 2,
+            "reach": "1K-10K stars",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "9.9k GitHub stars (capped at 3 per stars-fallback rule); ~10.8k monthly PyPI downloads and 1M+ all-time.",
+            "note": "9.9k GitHub stars (capped at 3 per stars-fallback rule); ~10.8k monthly PyPI downloads and 1M+ all- time. Stars read 2026-08-13: 9,938 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. Level corrected from 3. The previous reach 'broad' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/OpenMined/PySyft",
@@ -31096,7 +31101,7 @@
               }
             ]
           },
-          "maturity": 3.4,
+          "maturity": 2.8,
           "mature": false,
           "freshness": {
             "date": "2026-08-12",
@@ -31594,7 +31599,7 @@
           "maturity": 3.4,
           "mature": false,
           "freshness": {
-            "date": "2026-07-30",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Kata Containers, lightweight VMs that feel like containers; v3.31.0 (May 19 2026) confirmed live on GitHub. OpenInfra Foundation governed (governance not explicit on repo landing page but established as an OpenInfra project). Can use Firecracker/QEMU as the VMM."
@@ -31656,10 +31661,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "10K-100K",
+            "reach": "1K-10K stars",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "No PyPI/usage figure for the OSS runtime surfaced and no disclosed Beam customer/usage count; only ~1.7k GitHub stars available as a signal. stars_fallback caps level at 3; placed at 2 given the small star base and absence of any volume signal. Low confidence.",
+            "note": "No PyPI/usage figure for the OSS runtime surfaced and no disclosed Beam customer/usage count; only ~1.7k GitHub stars available as a signal. stars_fallback caps level at 3; placed at 2 given the small star base and absence of any volume signal. Low confidence. Stars read 2026-08-13: 1,742 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach '10K-100K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/beam-cloud/beta9",
@@ -31718,11 +31723,11 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 2,
-            "reach": "10K-100K",
+            "level": 3,
+            "reach": ">10K stars",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "Only ~2-3 months old; no PyPI/download or named-deployment figures surfaced. ~11.3k GitHub stars (3,845 within 72h of launch) is the only signal, stars_fallback, which caps level at 3. Placed at 2: rapid early stars but no usage volume yet. Revisit as usage data emerges.",
+            "note": "Only ~2-3 months old; no PyPI/download or named-deployment figures surfaced. ~11.3k GitHub stars (3,845 within 72h of launch) is the only signal, stars_fallback, which caps level at 3. Placed at 2: rapid early stars but no usage volume yet. Revisit as usage data emerges. Stars read 2026-08-13: 12,516 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. Level corrected from 2. The previous reach '10K-100K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/alibaba/OpenSandbox",
@@ -31745,7 +31750,7 @@
               }
             ]
           },
-          "maturity": 2.4,
+          "maturity": 3.0,
           "mature": false,
           "freshness": {
             "date": "2026-07-30",
@@ -31934,9 +31939,9 @@
           "adoption": {
             "level": 3,
             "signal_type": "stars_fallback",
-            "reach": "100K-1M",
+            "reach": ">10K stars",
             "confidence": "low",
-            "note": "No published install/active-user count for the OSS edition; ~13.4k GitHub stars is the only concrete signal. Stars-fallback caps at level 3; placed at 3 (not higher) on broad enterprise positioning + star base, but reach is unverified by usage_volume.",
+            "note": "No published install/active-user count for the OSS edition; ~13.4k GitHub stars is the only concrete signal. Stars-fallback caps at level 3; placed at 3 (not higher) on broad enterprise positioning + star base, but reach is unverified by usage_volume. Stars read 2026-08-13: 14,142 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The previous reach '100K-1M' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/coder/coder",
@@ -32094,7 +32099,7 @@
           "maturity": 3.4,
           "mature": false,
           "freshness": {
-            "date": "2026-08-08",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Modal Sandboxes - 'secure containers for executing untrusted user or agent code' on the Modal platform; gVisor-based isolation. Open Python/JS SDK + proprietary managed cloud (pay-per-CPU-cycle, $30/mo free credits on Starter). Docs verified live June 2026."
@@ -32377,7 +32382,7 @@
           "maturity": 2.2,
           "mature": false,
           "freshness": {
-            "date": "2026-07-30",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Sprites (sprites.dev) by Fly.io, launched Jan 2026. Persistent, hardware-isolated Firecracker microVMs ('a persistent Linux computer') for running arbitrary code / AI agents, with 100GB NVMe persistence and sub-1s checkpoint/restore. Confirmed live June 2026 via sprites.dev. Proprietary managed service (Fly.io's E2B competitor)."
@@ -32512,7 +32517,7 @@
           "maturity": 3.0,
           "mature": false,
           "freshness": {
-            "date": "2026-07-30",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "WebContainers by StackBlitz, a browser-based (WASM) runtime that executes Node.js / npm projects fully client-side in the browser tab. Distributed as @webcontainer/api on npm. Confirmed live June 2026 via webcontainers.io. The public github.com/stackblitz/webcontainer-core repo is MIT but is only an issue tracker / docs hub; the actual runtime is a proprietary StackBlitz service requiring a commercial license for for-profit production use."
@@ -32632,7 +32637,7 @@
           "maturity": 3.4,
           "mature": false,
           "freshness": {
-            "date": "2026-07-30",
+            "date": "2026-08-13",
             "basis": "commit"
           },
           "version_note": "Northflank Sandboxes, secure microVM/sandbox product for running untrusted / AI-generated code at scale (~200ms microVM spin-up), positioned for code-gen agents. Confirmed live June 2026 via northflank.com. Proprietary SaaS (Northflank Ltd)."
@@ -32965,10 +32970,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "1K-10K",
+            "reach": "1K-10K stars",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "~2,900 GitHub stars (June 2026) for a 2026 release, with multi-platform packages and FFI bindings published. Stars are the only public proxy here, so this is capped per the methodology and read as early but real traction rather than scaled adoption.",
+            "note": "~2,900 GitHub stars (June 2026) for a 2026 release, with multi-platform packages and FFI bindings published. Stars are the only public proxy here, so this is capped per the methodology and read as early but real traction rather than scaled adoption. Stars read 2026-08-13: 3,640 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach '1K-10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/nolabs-ai/nono",
@@ -33186,10 +33191,10 @@
           },
           "adoption": {
             "level": 1,
-            "reach": null,
+            "reach": "<1K stars",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "Very nascent: ~22 stars on the sandbox repo, a $7.3M seed (First Round, YC S2025), and an unverified vendor claim of billions of agent requests. No usage or download signal. stars_fallback with a low-double-digit star base places this at 1. Added on openness and mission-fit grounds despite the low prominence; scored honestly. Low confidence.",
+            "note": "Very nascent: ~22 stars on the sandbox repo, a $7.3M seed (First Round, YC S2025), and an unverified vendor claim of billions of agent requests. No usage or download signal. stars_fallback with a low-double- digit star base places this at 1. Added on openness and mission-fit grounds despite the low prominence; scored honestly. Low confidence. Stars read 2026-08-13: 27 across the 1 declared repo, which bands at <1K stars, level 1 on the stars scale in signal_routing.yaml. The record carried no reach label at all before this. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
             "sources": [
               {
                 "url": "https://github.com/blaxel-ai/sandbox",

--- a/build/notebook_data.json
+++ b/build/notebook_data.json
@@ -120,32 +120,22 @@
             "score": 3,
             "basis": "benchmark",
             "basis_detail": "Artificial Analysis Intelligence Index",
-            "value": "Llama 4 Maverick: AA Intelligence Index 14 (v4.1.1), ranked #26/44, 'below average among other open weight non-reasoning models of similar size' (median 18). The strongest released member of the tier - Llama 4 Scout scores 10 on the same index, and Behemoth is unreleased.",
+            "value": "Llama 3.1 405B: AA Intelligence Index 17, ranked #29/43, 'below average' vs current peers (peer average 23); mid-2024 non-reasoning model surpassed by 2026 frontier.",
             "confidence": "medium",
-            "note": "MAX ACROSS THE TIER'S RELEASES, per docs/guides/identity.md. This record previously cited Llama 3.1 405B, a mid-2024 release the slug still covers but which is not its best, and it cited an index number - 17 - that no longer exists on Artificial Analysis's scale: the index was recalibrated, and 14 on v4.1.1 is not a decline from 17 but a different measurement. Both faults pointed the same way, and neither was visible from inside the record, since a stale number and a live one look alike. The SCORE is unchanged at 3, which is the point of re-deriving rather than adjusting: the tier's standing against its peers did not move. It was below the peer median before (17 against 23) and it is below the peer median now (14 against 18), on a comparison set that has grown from 43 models to 44.",
-            "last_verified": "2026-08-13",
+            "note": "Weights downloadable under Meta's Llama-4-Community terms: a 700M-MAU commercial cap, an acceptable-use policy and naming requirements. No relicensing to record - Llama 3.1 carried the equivalent terms, and Llama 4 Scout and Maverick govern as the current release. Moved from 2/restricted on 2026-08-01 by the universal license scale, which caps a bounded commercial license at 3 rather than 2. The test at that boundary is whether the license permits commercial use AT ALL: this one does, for everyone inside the bound. A license that forbids commerce outright - CC-BY-NC, Mistral Non-Production - stays at 2. Nine other products carry a bounded license and all now score 3; four of them were already recorded there, which is the inconsistency this resolves.",
             "sources": [
               {
-                "url": "https://artificialanalysis.ai/models/llama-4-maverick",
-                "shows": "AA Intelligence Index 14 (v4.1.1), rank #26/44, below average vs open-weight non-reasoning peers of similar size (median 18)",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "aaaef3ad229e3bc58c0adbba0e396cbd1ef3609bb41108ec2e841a08781f52f1"
-              },
-              {
-                "url": "https://artificialanalysis.ai/models/llama-4-scout",
-                "shows": "AA Intelligence Index 10 (v4.1.1), rank #9/39 - the tier's other released member, confirming Maverick is the max rather than assuming it",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "f04ff54b8ba3531a07890c68bdc1fdeaea7d5d06bb9e39d1cec28f459735946f"
+                "url": "https://artificialanalysis.ai/models/llama-3-1-instruct-405b",
+                "shows": "AA Intelligence Index 17, rank #29/43, below-average vs peers (avg 23)",
+                "accessed": "2026-06-04"
               }
             ]
           },
           "maturity": 3.3,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
-            "basis": "verified"
+            "date": "2026-08-08",
+            "basis": "commit"
           },
           "version_note": "Llama 4 herd, released April 2025: Scout (17B active / 109B total MoE, 10M-token context) and Maverick (17B active / 400B total MoE, 1M-token context), natively multimodal. Behemoth still unreleased/preview as of June 2026. Both Scout/Maverick verified live on HF June 2026. Consolidated on 2026-07-29 from llama-3-1; openness follows llama-4-scout-maverick, the release that currently governs. See docs/guides/identity.md."
         },
@@ -188,54 +178,26 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 4,
-            "reach": "1M-10M",
+            "level": 5,
+            "reach": ">10M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "5,180,104 downloads in the trailing 30 days summed across the 6 declared artifact(s), read 2026-08-13 (deepseek-ai/DeepSeek-V3.2 1,093,344; deepseek-ai/DeepSeek-V3-Base 31,718; deepseek-ai/DeepSeek-V4-Pro 1,411,583; deepseek-ai/DeepSeek-V4-Flash 2,283,943; deepseek-ai/DeepSeek-V4-Pro-Base 14,769; deepseek-ai/DeepSeek-V4-Flash-Base 344,747). Bands at level 4 (1M-10M) on the software and model adoption scale. Corrected from level 5, which the declared artifacts do not support.",
-            "last_verified": "2026-08-13",
+            "note": "ATOM Report (Apr 2026): China open models reached ~1.15B cumulative HF downloads with DeepSeek a primary driver; DeepSeek-V3.2 widely served (OpenRouter, multiple inference providers) with sustained post-launch production usage and frontier-at-10x-lower-cost positioning. Real usage well into the >10M-equivalent band across web app + API + derivatives.",
             "sources": [
               {
-                "url": "https://huggingface.co/api/models/deepseek-ai/DeepSeek-V3.2",
-                "shows": "1,093,344 downloads in the trailing 30 days for deepseek-ai/DeepSeek-V3.2",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "eb2fe531a6e5fa227b2e329dcdc3dd31c9bf8652ef065ed2a47ea426d15aff34"
+                "url": "https://arxiv.org/html/2604.07190v1",
+                "shows": "flagship phase-C verification source",
+                "accessed": "2026-06-04"
               },
               {
-                "url": "https://huggingface.co/api/models/deepseek-ai/DeepSeek-V3-Base",
-                "shows": "31,718 downloads in the trailing 30 days for deepseek-ai/DeepSeek-V3-Base",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "b53d64959451ed9931df9dd160cc0211ee3a6fef64567fa3fcdbae60c4299699"
+                "url": "https://openrouter.ai/deepseek/deepseek-v3.2",
+                "shows": "flagship phase-C verification source",
+                "accessed": "2026-06-04"
               },
               {
-                "url": "https://huggingface.co/api/models/deepseek-ai/DeepSeek-V4-Pro",
-                "shows": "1,411,583 downloads in the trailing 30 days for deepseek-ai/DeepSeek-V4-Pro",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "30a1dcc082abb2949d9cb6ef57432b2c0bc26ca6c83e3c714eb120d9a6516221"
-              },
-              {
-                "url": "https://huggingface.co/api/models/deepseek-ai/DeepSeek-V4-Flash",
-                "shows": "2,283,943 downloads in the trailing 30 days for deepseek-ai/DeepSeek-V4-Flash",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "55c2eda9e4d9c6219c327dde073eacb12f3e98f5217266c9eda5ff7ec648a280"
-              },
-              {
-                "url": "https://huggingface.co/api/models/deepseek-ai/DeepSeek-V4-Pro-Base",
-                "shows": "14,769 downloads in the trailing 30 days for deepseek-ai/DeepSeek-V4-Pro-Base",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "a7f2243ccecaaa0b3ed5a1ffc61fc5dbfbb35a7a59e6f7b4df96f07181cd5f73"
-              },
-              {
-                "url": "https://huggingface.co/api/models/deepseek-ai/DeepSeek-V4-Flash-Base",
-                "shows": "344,747 downloads in the trailing 30 days for deepseek-ai/DeepSeek-V4-Flash-Base",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "6825c66170ae03a87108ed48aaee3e1ffe33a84f32b13c7151283f11fc5ea179"
+                "url": "https://introl.com/blog/deepseek-v3-2-open-source-ai-cost-advantage",
+                "shows": "flagship phase-C verification source",
+                "accessed": "2026-06-04"
               }
             ]
           },
@@ -264,11 +226,11 @@
               }
             ]
           },
-          "maturity": 4.7,
+          "maturity": 5.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
-            "basis": "verified"
+            "date": "2026-08-08",
+            "basis": "commit"
           },
           "version_note": "DeepSeek-V4-Pro, 1.6T total / 49B active MoE, 1M-token context, hybrid CSA+HCA attention. Released April 24 2026 under MIT, alongside V4-Flash (284B). V4-Pro-Max = max-reasoning mode. Verified live June 2026. Consolidated on 2026-07-29 from deepseek-v3-2, deepseek-v3-base, deepseek-v4-pro-base; openness follows deepseek-v4-pro, the release that currently governs. See docs/guides/identity.md."
         },
@@ -616,19 +578,21 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 1,
-            "reach": "<10K",
+            "level": 2,
+            "reach": "10K-100K",
             "signal_type": "usage_volume",
             "confidence": "medium",
-            "note": "3,095 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (internlm/internlm2_5-7b 3,095). Bands at level 1 (<10K) on the software and model adoption scale. Corrected from level 2, which the declared artifacts do not support.",
-            "last_verified": "2026-08-13",
+            "note": "HF monthly downloads modest in 2026 (3,521/mo for the 7B base, confirmed 2026-06-04) as a 2024-era model; distributed via HF, Ollama, ModelScope. Cumulative reach across the InternLM2.5 family + mirrors sits in the early-adopter band; specialist/research uptake, not production scale.",
             "sources": [
               {
-                "url": "https://huggingface.co/api/models/internlm/internlm2_5-7b",
-                "shows": "3,095 downloads in the trailing 30 days for internlm/internlm2_5-7b",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "53db38845403a603b29a19fc8f466f1e27f655ff467c993ba5fba95df26df4f6"
+                "url": "https://huggingface.co/internlm/internlm2_5-7b",
+                "shows": "3,521 downloads last month",
+                "accessed": "2026-06-04"
+              },
+              {
+                "url": "https://ollama.com/internlm/internlm2.5",
+                "shows": "InternLM2.5 distributed via Ollama",
+                "accessed": "2026-06-04"
               }
             ]
           },
@@ -652,11 +616,11 @@
               }
             ]
           },
-          "maturity": 1.7,
+          "maturity": 2.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
-            "basis": "verified"
+            "date": "2026-08-08",
+            "basis": "commit"
           },
           "version_note": "InternLM2.5-7B base (~8B params, 1M-token context), released 2024 (InternLM2 tech report arXiv:2403.17297). Base SKU scored here; InternLM2.5-7B-Chat is the instruct SKU (finetuned_chat). Verified live on HF June 2026; a 2024-era 7B model."
         },
@@ -684,7 +648,7 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M users",
+            "reach": ">10M",
             "signal_type": "active_users",
             "confidence": "medium",
             "note": "GPT-4o was the default ChatGPT model for much of 2024-2025 before GPT-5; ChatGPT crossed ~900M WAU (Feb 2026) and ~1B (May 2026). Attributed honestly to the ChatGPT surface GPT-4o powered, not a standalone GPT-4o count; well above the >10M threshold. WAU figure corroborated via aggregator (demandsage), not a primary OpenAI disclosure, but the threshold is not close so no downgrade.",
@@ -719,7 +683,7 @@
           "maturity": 3.6,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-08",
             "basis": "commit"
           },
           "version_note": "OpenAI GPT-4o, multimodal (text+image in, text out), 128K context; first snapshot gpt-4o-2024-05-13, knowledge cutoff Oct 2023. API-only, no released weights. Verified live in OpenAI's model docs June 2026 (developers.openai.com). A 2024-era flagship, since surpassed by the GPT-5 line but still served via API/ChatGPT."
@@ -748,6 +712,7 @@
           },
           "adoption": {
             "level": 2,
+            "reach": "10K-100K",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Distributed via Reka API + Snowflake Cortex + Oracle Cloud Marketplace; a 2024 frontier-challenger now well behind. No disclosed usage; level 2 directional. (Snowflake/Oracle partnerships are not enumerated on the cited launch page itself.)",
@@ -777,7 +742,7 @@
           "maturity": 2.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-08",
             "basis": "commit"
           },
           "version_note": "Reka Core, frontier-class multimodal LLM announced 15 Apr 2024; 128K context. Proprietary: API/on-prem/on-device; no open weights. Instruction/multimodal-chat model. Verified live: launch page confirms API/on-prem/on-device availability and the MMMU/Claude-3-Opus claims. NOTE: '~5T tokens / 32 languages / from scratch' details are NOT on the cited launch page (they originate in Reka's separate technical report); verify against that source if retained. >12mo old; scored best-effort and flagged stale."
@@ -811,6 +776,7 @@
           },
           "adoption": {
             "level": 1,
+            "reach": "<10K",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Post-Microsoft acqui-hire pivot to B2B; Pi consumer surface wound down. Enterprise API exists but no disclosed usage; effectively stalled. Level 1 directional.",
@@ -839,7 +805,7 @@
           "maturity": 1.7,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-08",
             "basis": "commit"
           },
           "version_note": "Inflection 3.0 (Pi 3.0 + Productivity 3.0), released 7 Oct 2024 with 'Inflection for Enterprise'. Proprietary/API + enterprise-licensed; no open weights; fine-tuned models are customer-exclusive. Frontier research team absorbed by Microsoft (2024-25); pivot to B2B. EXISTENCE now confirmed via PRIMARY sources (Intel Newsroom press release + BusinessWire 'Introducing Inflection for Enterprise', 7 Oct 2024), not aggregator-only. >12mo old; scored best-effort, flagged stale."
@@ -1138,26 +1104,21 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 1,
-            "reach": "<10K",
+            "level": 2,
+            "reach": "10K-100K",
             "signal_type": "usage_volume",
             "confidence": "medium",
-            "note": "1,945 downloads in the trailing 30 days summed across the 2 declared artifact(s), read 2026-08-13 (OpenLLM-France/Lucie-7B 1,315; OpenLLM-France/Lucie-7B-Instruct-v1.1 630). Bands at level 1 (<10K) on the software and model adoption scale. Corrected from level 2, which the declared artifacts do not support.",
-            "last_verified": "2026-08-13",
+            "note": "Niche sovereign/French open-LLM audience. HF Lucie-7B ~780 downloads/month and 31 likes (Jul 2026); collection upvotes modest. Comparable adoption tier to Apertus / Falcon-class fully-open European releases rather than Llama/Qwen scale.",
             "sources": [
               {
-                "url": "https://huggingface.co/api/models/OpenLLM-France/Lucie-7B",
-                "shows": "1,315 downloads in the trailing 30 days for OpenLLM-France/Lucie-7B",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "5f3f27e43082f9addf5a4d352b60c32bd0806c69f3dc2b6e6b75178c7dcaf938"
+                "url": "https://huggingface.co/OpenLLM-France/Lucie-7B",
+                "shows": "~780 downloads/month, 31 likes (as of 2026-07-19)",
+                "accessed": "2026-07-19"
               },
               {
-                "url": "https://huggingface.co/api/models/OpenLLM-France/Lucie-7B-Instruct-v1.1",
-                "shows": "630 downloads in the trailing 30 days for OpenLLM-France/Lucie-7B-Instruct-v1.1",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "daea16a5f6dcc1bc6ae21e514cacdf06e44b9f71f50d6cd927b31d5b516adeaf"
+                "url": "https://huggingface.co/collections/OpenLLM-France/lucie-llm",
+                "shows": "official Lucie LLM collection (base, instruct, dataset, paper)",
+                "accessed": "2026-07-19"
               }
             ]
           },
@@ -1181,10 +1142,10 @@
               }
             ]
           },
-          "maturity": 1.7,
+          "maturity": 2.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-07-30",
             "basis": "verified"
           },
           "version_note": "Lucie-7B base + Instruct-v1.1 / Instruct-human-data. Apache-2.0 weights; training data at OpenLLM-France/Lucie-Training-Dataset (not a separate map product for now); training code AGPL/community stack on GitHub. Paper arXiv:2503.12294. Collection https://huggingface.co/collections/OpenLLM-France/lucie-llm."
@@ -1325,26 +1286,16 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 3,
-            "reach": "100K-1M",
+            "level": 4,
+            "reach": "1M-10M",
             "signal_type": "usage_volume",
             "confidence": "medium",
-            "note": "146,145 downloads in the trailing 30 days summed across the 2 declared artifact(s), read 2026-08-13 (allenai/Olmo-3-1125-32B 43,671; allenai/Olmo-3-1025-7B 102,474). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected from level 4, which the declared artifacts do not support.",
-            "last_verified": "2026-08-13",
+            "note": "Succeeds OLMo 2 (the OLMo family measured ~14.8M cumulative HF downloads in early 2026). The reference fully-open model in research/interpretability circles; below the Qwen/Llama scale.",
             "sources": [
               {
-                "url": "https://huggingface.co/api/models/allenai/Olmo-3-1125-32B",
-                "shows": "43,671 downloads in the trailing 30 days for allenai/Olmo-3-1125-32B",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "774b1b37fcdd1a22544f57b26efc8d75710850c7d8930e1a5247d753584887e5"
-              },
-              {
-                "url": "https://huggingface.co/api/models/allenai/Olmo-3-1025-7B",
-                "shows": "102,474 downloads in the trailing 30 days for allenai/Olmo-3-1025-7B",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "53f69c16d3f17df85b179763281369d29e9dea58c2991e0924e8d86182ad5848"
+                "url": "https://allenai.org/blog/olmo3",
+                "shows": "flagship fully-open release; broad research uptake",
+                "accessed": "2026-06-30"
               }
             ]
           },
@@ -1363,10 +1314,10 @@
               }
             ]
           },
-          "maturity": 3.7,
+          "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-07-30",
             "basis": "verified"
           },
           "version_note": "Apache-2.0; fully-open weights + Dolma 3 data + training code + checkpoints. OLMo 3-Think 32B is the strongest fully-open reasoning model, narrowing the gap to Qwen3-32B on ~6x fewer tokens; still below the trillion-param open-weight frontier."
@@ -1432,19 +1383,21 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 2,
-            "reach": "10K-100K",
+            "level": 3,
+            "reach": "100K-1M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "30,007 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (EleutherAI/pythia-12b 30,007). Bands at level 2 (10K-100K) on the software and model adoption scale. Corrected from level 3, which the declared artifacts do not support.",
-            "last_verified": "2026-08-13",
+            "note": "Heavily used as a research/interpretability benchmark suite (de facto standard for training-dynamics studies); cited extensively. Hugging Face download volume across the 16 models is in the 100k-1M aggregate range, meaningful for research but not production deployment. Honest signal: research adoption, not end-user scale.",
             "sources": [
               {
-                "url": "https://huggingface.co/api/models/EleutherAI/pythia-12b",
-                "shows": "30,007 downloads in the trailing 30 days for EleutherAI/pythia-12b",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "877612ac2b240f01cb265af7d577b7a461e434fa9ab8fe42b61b6fa68bbd9ee5"
+                "url": "https://huggingface.co/EleutherAI/pythia-6.9b",
+                "shows": "flagship phase-C verification source",
+                "accessed": "2026-06-04"
+              },
+              {
+                "url": "https://www.eleuther.ai/papers-blog/pythia-a-suite-for-analyzing-large-language-modelsacross-training-and-scaling",
+                "shows": "flagship phase-C verification source",
+                "accessed": "2026-06-04"
               }
             ]
           },
@@ -1462,10 +1415,10 @@
               }
             ]
           },
-          "maturity": 1.3,
+          "maturity": 1.6,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-07-30",
             "basis": "verified"
           },
           "version_note": "Pythia suite: 16 models, 70M-12B params (8 sizes x Pile/deduped-Pile), 154 intermediate checkpoints each. Released 2023 (arXiv 2304.01373); remains the standard interpretability/training-dynamics suite as of June 2026."
@@ -1503,19 +1456,21 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 3,
-            "reach": "100K-1M",
+            "level": 4,
+            "reach": "1M-10M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "626,702 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (microsoft/phi-4 626,702). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected from level 4, which the declared artifacts do not support.",
-            "last_verified": "2026-08-13",
+            "note": "Phi-4 is a widely downloaded small model on Hugging Face, distributed via Azure AI Foundry, Ollama, and many local-inference stacks; download volume for the Phi-4 line is in the millions range. Level 4 reflects broad small-model adoption.",
             "sources": [
               {
-                "url": "https://huggingface.co/api/models/microsoft/phi-4",
-                "shows": "626,702 downloads in the trailing 30 days for microsoft/phi-4",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "acc97b7d7cf7aa29e07aa0b2c9e1ad8342fefed545a6fc502fb7268ed855c460"
+                "url": "https://venturebeat.com/ai/microsoft-makes-powerful-phi-4-model-fully-open-source-on-hugging-face",
+                "shows": "flagship phase-C verification source",
+                "accessed": "2026-06-04"
+              },
+              {
+                "url": "https://artificialanalysis.ai/models/phi-4",
+                "shows": "flagship phase-C verification source",
+                "accessed": "2026-06-04"
               }
             ]
           },
@@ -1539,11 +1494,11 @@
               }
             ]
           },
-          "maturity": 3.0,
+          "maturity": 3.3,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
-            "basis": "verified"
+            "date": "2026-08-08",
+            "basis": "commit"
           },
           "version_note": "Phi-4, 14B dense model, weights released on Hugging Face under MIT (full release Jan 2025 following Dec 2024 announcement). Reasoning variants (Phi-4-reasoning / -reasoning-plus) released later under open weights but are separate SKUs; this record scores base Phi-4 14B."
         },
@@ -1586,6 +1541,7 @@
           },
           "adoption": {
             "level": 2,
+            "reach": "10K-100K",
             "signal_type": "reported_traction",
             "confidence": "high",
             "note": "Available on Hugging Face with moderate uptake at launch as a sub-13B SLM; no large verified usage figures and relevance has faded against newer SLMs. Level 2 reflects modest reported traction.",
@@ -1620,7 +1576,7 @@
           "maturity": 2.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-08",
             "basis": "commit"
           },
           "version_note": "Falcon 3 family (1B, 3B, 7B, 10B), released 17 Dec 2024 by TII. Trained on 14T tokens. Sub-13B SLMs; now a dated generation relative to 2026 frontier."
@@ -1749,19 +1705,16 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 1,
-            "reach": "<10K",
+            "level": 2,
+            "reach": "10K-100K",
             "signal_type": "usage_volume",
             "confidence": "medium",
-            "note": "546 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (swiss-ai/Apertus-70B-2509 546). Bands at level 1 (<10K) on the software and model adoption scale. Corrected from level 2, which the declared artifacts do not support.",
-            "last_verified": "2026-08-13",
+            "note": "Newer release (Sep 2025) with strong institutional/sovereign-AI interest but modest raw download volume; swiss-ai/Apertus-70B-2509 shows ~1.5K downloads/month and 149 likes on HF (June 2026); cumulative across the 8B/70B base+Instruct SKUs lands in the 10K-100K band. Distributed via Swisscom, Hugging Face, and the Public AI network. Comparable adoption tier to Falcon 3 / Yi-1.5.",
             "sources": [
               {
-                "url": "https://huggingface.co/api/models/swiss-ai/Apertus-70B-2509",
-                "shows": "546 downloads in the trailing 30 days for swiss-ai/Apertus-70B-2509",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "9fa185ea1eff42b68e584158bedd5dbd8b0facc71da717696554357ed82ccad0"
+                "url": "https://huggingface.co/swiss-ai/Apertus-70B-2509",
+                "shows": "~1,462 downloads/month, 149 likes (June 2026)",
+                "accessed": "2026-06-08"
               }
             ]
           },
@@ -1787,10 +1740,10 @@
               }
             ]
           },
-          "maturity": 2.4,
+          "maturity": 2.7,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-07-30",
             "basis": "verified"
           },
           "version_note": "Apertus family (8B + 70B, base + Instruct), released 2 Sep 2025 by the Swiss AI Initiative (EPFL, ETH Zurich, CSCS). 15T training tokens across 1,811 natively supported languages (~40% non-English, incl. Swiss German and Romansh), 65,536-token context, trained on 4,096 GH200 GPUs (Alps/CSCS) with Megatron-LM. Verified live on Hugging Face June 2026 (swiss-ai/Apertus-70B-2509)."
@@ -2121,10 +2074,10 @@
           },
           "adoption": {
             "level": 1,
-            "reach": "<10K",
+            "reach": "1K-10K",
             "signal_type": "usage_volume",
             "confidence": "medium",
-            "note": "Public-funded sovereign model (Spain's national LLM, BSC / MareNostrum 5) with strong institutional and policy interest but modest raw volume. HF BSC-LT/ALIA-40b shows ~59 downloads/month and 88 likes (June 2026); the niche multilingual focus (Spanish + co-official + 35 European languages) keeps adoption below Apertus's tier. Cumulative across the wider ALIA Kit (instruct, GGUF, Salamandra) would be higher, but the base model alone sits in the low band. Read live 2026-08-13: 475 Hugging Face downloads in the trailing 30 days across the declared artifact(s), which bands at <10K, level 1. The previous reach '1K-10K' was a band off a different scale. No last_verified claimed: only the figure was re-read, not the whole axis.",
+            "note": "Public-funded sovereign model (Spain's national LLM, BSC / MareNostrum 5) with strong institutional and policy interest but modest raw volume. HF BSC-LT/ALIA-40b shows ~59 downloads/month and 88 likes (June 2026); the niche multilingual focus (Spanish + co-official + 35 European languages) keeps adoption below Apertus's tier. Cumulative across the wider ALIA Kit (instruct, GGUF, Salamandra) would be higher, but the base model alone sits in the low band.",
             "sources": [
               {
                 "url": "https://huggingface.co/BSC-LT/ALIA-40b",
@@ -2651,19 +2604,16 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 4,
-            "reach": "1M-10M",
+            "level": 5,
+            "reach": ">10M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "7,345,657 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (meta-llama/Llama-3.1-8B-Instruct 7,345,657). Bands at level 4 (1M-10M) on the software and model adoption scale. Corrected from level 5, which the declared artifacts do not support.",
-            "last_verified": "2026-08-13",
+            "note": "Weights open under Meta's non-OSI Llama 3.1 Community License, with its 700M-MAU commercial cap. Commonly marketed as open. Moved from 2/restricted on 2026-08-01 by the universal license scale, which caps a bounded commercial license at 3 rather than 2. The test at that boundary is whether the license permits commercial use AT ALL: this one does, for everyone inside the bound. A license that forbids commerce outright - CC-BY-NC, Mistral Non-Production - stays at 2. Nine other products carry a bounded license and all now score 3; four of them were already recorded there, which is the inconsistency this resolves.",
             "sources": [
               {
-                "url": "https://huggingface.co/api/models/meta-llama/Llama-3.1-8B-Instruct",
-                "shows": "7,345,657 downloads in the trailing 30 days for meta-llama/Llama-3.1-8B-Instruct",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "01f9bc862a4f86d79417f098181a5e58c67f88998679a5efe144f59a11c4430d"
+                "url": "https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct",
+                "shows": "11,077,966 downloads last month",
+                "accessed": "2026-06-04"
               }
             ]
           },
@@ -2682,11 +2632,11 @@
               }
             ]
           },
-          "maturity": 3.3,
+          "maturity": 3.6,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
-            "basis": "verified"
+            "date": "2026-08-08",
+            "basis": "commit"
           },
           "version_note": "Llama 3.1 8B Instruct, released 23 Jul 2024. 8B dense, 128k context, SFT+RLHF post-trained chat model. Verified live on HF June 2026; one of the most-downloaded instruct models on the platform."
         },
@@ -2906,10 +2856,10 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "100K-1M",
+            "reach": "10K-100K",
             "signal_type": "usage_volume",
             "confidence": "medium",
-            "note": "Solid research/practitioner reach for a fully-open instruct line; below the Qwen/Llama instruct workhorses. Downloads still ramping as it supersedes OLMo 2 Instruct. Read live 2026-08-13: 450,053 Hugging Face downloads in the trailing 30 days across the declared artifact(s), which bands at 100K-1M, level 3. The previous reach '10K-100K' was a band off a different scale. No last_verified claimed: only the figure was re-read, not the whole axis.",
+            "note": "Solid research/practitioner reach for a fully-open instruct line; below the Qwen/Llama instruct workhorses. Downloads still ramping as it supersedes OLMo 2 Instruct.",
             "sources": [
               {
                 "url": "https://huggingface.co/allenai/Olmo-3-7B-Instruct",
@@ -2969,26 +2919,16 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 2,
+            "level": 3,
             "reach": "10K-100K",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "28,149 downloads in the trailing 30 days summed across the 2 declared artifact(s), read 2026-08-13 (allenai/OLMoE-1B-7B-0924-Instruct 26,721; allenai/OLMoE-mix-0924 1,428). Bands at level 2 (10K-100K) on the software and model adoption scale. Corrected from level 3, which the declared artifacts do not support.",
-            "last_verified": "2026-08-13",
+            "note": "~37.9k HF downloads/month on the instruct SKU; 96 likes. Solid reach for a fully-open research MoE.",
             "sources": [
               {
-                "url": "https://huggingface.co/api/models/allenai/OLMoE-1B-7B-0924-Instruct",
-                "shows": "26,721 downloads in the trailing 30 days for allenai/OLMoE-1B-7B-0924-Instruct",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "ee1398b873dd594a3f0334f1168dab153f62c2900468095d59e522eb27b5a08f"
-              },
-              {
-                "url": "https://huggingface.co/api/datasets/allenai/OLMoE-mix-0924",
-                "shows": "1,428 downloads in the trailing 30 days for allenai/OLMoE-mix-0924",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "7f34d9aa457daed314d4db450c123c135f4a61b208696f5eab2cf00a11364896"
+                "url": "https://huggingface.co/allenai/OLMoE-1B-7B-0924-Instruct",
+                "shows": "~37,880 downloads last month; 96 likes",
+                "accessed": "2026-06-25"
               }
             ]
           },
@@ -3012,11 +2952,11 @@
               }
             ]
           },
-          "maturity": 2.0,
+          "maturity": 2.3,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
-            "basis": "verified"
+            "date": "2026-08-08",
+            "basis": "commit"
           },
           "version_note": "Apache-2.0; fully-open MoE (weights + data + code + intermediate checkpoints). State-of-the-art among ~1B-active-parameter models at release."
         },
@@ -3127,40 +3067,16 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 3,
-            "reach": "100K-1M",
+            "level": 4,
+            "reach": "1M-10M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "232,148 downloads in the trailing 30 days summed across the 4 declared artifact(s), read 2026-08-13 (HuggingFaceH4/zephyr-7b-beta 142,355; HuggingFaceH4/zephyr-orpo-141b-A35b-v0.1 91; HuggingFaceH4/ultrachat_200k 73,327; HuggingFaceH4/ultrafeedback_binarized 16,375). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected from level 4, which the declared artifacts do not support.",
-            "last_verified": "2026-08-13",
+            "note": "~164.9k HF downloads/month on zephyr-7b-beta with 1.85k likes -- a late-2023 model still pulling meaningful volume as a lightweight fully-open 7B baseline. The underlying datasets remain active (ultrachat_200k ~57.7k/mo). The 141B ORPO variant is effectively dormant (~52/mo). Level 4 on the leading SKU's sustained monthly volume.",
             "sources": [
               {
-                "url": "https://huggingface.co/api/models/HuggingFaceH4/zephyr-7b-beta",
-                "shows": "142,355 downloads in the trailing 30 days for HuggingFaceH4/zephyr-7b-beta",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "89427cdf13143eea59f02c65463d14e580ef578ee59840944edad4512ab25e50"
-              },
-              {
-                "url": "https://huggingface.co/api/models/HuggingFaceH4/zephyr-orpo-141b-A35b-v0.1",
-                "shows": "91 downloads in the trailing 30 days for HuggingFaceH4/zephyr-orpo-141b-A35b-v0.1",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "47e3d9cf2c8020fc69b61a65f3b7d25d8f60b29e3bb9c31e4206546b5cc89c22"
-              },
-              {
-                "url": "https://huggingface.co/api/datasets/HuggingFaceH4/ultrachat_200k",
-                "shows": "73,327 downloads in the trailing 30 days for HuggingFaceH4/ultrachat_200k",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "4e919d43fdc08e40082d432ea506c07f839e5a991c46a904a1a7001a3236be1e"
-              },
-              {
-                "url": "https://huggingface.co/api/datasets/HuggingFaceH4/ultrafeedback_binarized",
-                "shows": "16,375 downloads in the trailing 30 days for HuggingFaceH4/ultrafeedback_binarized",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "d881aa403109378f86edb6b91e66d6062204fb84e7a93d8831a47b3da99a5dd6"
+                "url": "https://huggingface.co/HuggingFaceH4/zephyr-7b-beta",
+                "shows": "~164,917 downloads last month; 1.85k likes",
+                "accessed": "2026-06-25"
               }
             ]
           },
@@ -3179,11 +3095,11 @@
               }
             ]
           },
-          "maturity": 2.3,
+          "maturity": 2.6,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
-            "basis": "verified"
+            "date": "2026-08-08",
+            "basis": "commit"
           },
           "version_note": "Scored on zephyr-7b-beta (MIT; base Mistral-7B Apache-2.0). Fully-open: weights + open DPO datasets (UltraChat/UltraFeedback, MIT) + open training code (alignment-handbook, Apache-2.0). Late-2023 capability, still ~165k HF downloads/month."
         },
@@ -3274,19 +3190,16 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 3,
-            "reach": "100K-1M",
+            "level": 4,
+            "reach": "1M-10M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "429,490 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (microsoft/Phi-4-mini-instruct 429,490). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected from level 4, which the declared artifacts do not support.",
-            "last_verified": "2026-08-13",
+            "note": "~1.54M downloads last month on HF; widely distributed via Azure AI Foundry / Ollama for on-device + local inference. Solidly in the 1-10M band.",
             "sources": [
               {
-                "url": "https://huggingface.co/api/models/microsoft/Phi-4-mini-instruct",
-                "shows": "429,490 downloads in the trailing 30 days for microsoft/Phi-4-mini-instruct",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "f520a05970012b1e8b0eae049187f5eda6c5205b715eb650ddc383893a558322"
+                "url": "https://huggingface.co/microsoft/Phi-4-mini-instruct",
+                "shows": "1,537,561 downloads last month",
+                "accessed": "2026-06-04"
               }
             ]
           },
@@ -3305,11 +3218,11 @@
               }
             ]
           },
-          "maturity": 2.3,
+          "maturity": 2.6,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
-            "basis": "verified"
+            "date": "2026-08-08",
+            "basis": "commit"
           },
           "version_note": "Phi-4-mini-instruct, 3.8B dense, 128k context, 200k vocab, GQA; released Feb 2025 under MIT. SFT/DPO-aligned small instruct model. Verified live on HF June 2026."
         },
@@ -3416,7 +3329,7 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M users",
+            "reach": ">10M",
             "signal_type": "active_users",
             "confidence": "medium",
             "note": "o3/o4-mini were rolled out as selectable models inside ChatGPT (Plus/Pro and some free) plus the API; ChatGPT reached ~900M WAU (Feb 2026) rising toward ~1B (May 2026). Reach attributed to the ChatGPT surface these models power, not a standalone o3 count. Now superseded as default by GPT-5.x but still used at scale.",
@@ -3451,7 +3364,7 @@
           "maturity": 4.3,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-08",
             "basis": "commit"
           },
           "version_note": "OpenAI o3 and o4-mini reasoning models, both released Apr 16 2025 (o3-mini preceded Jan 31 2025). Post-trained reasoning/instruct models, API-only + ChatGPT, no downloadable weights. Verified via OpenAI system card + Wikipedia June 2026; succeeded by GPT-5.x reasoning line but still selectable/available."
@@ -3490,6 +3403,7 @@
           },
           "adoption": {
             "level": 4,
+            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "GPT-4.1 was an API-first developer/coding model (initially not in ChatGPT default), widely adopted as a cheaper GPT-4o replacement and integrated across tooling. No primary per-model usage count disclosed; level 4 reflects broad developer-platform distribution as a major OpenAI API model rather than a verified figure. Treat as directional.",
@@ -3529,7 +3443,7 @@
           "maturity": 3.3,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-08",
             "basis": "commit"
           },
           "version_note": "OpenAI GPT-4.1 (+ mini, nano), released Apr 14 2025 as API-first coding/instruct models with 1M-token context. Post-trained instruct (non-reasoning) model, closed/API-only. Verified via OpenAI announcement coverage + InfoQ/TechCrunch June 2026; GPT-4.5 Preview deprecated July 2025 in its favor; now itself behind the GPT-5 line."
@@ -3564,7 +3478,7 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M users",
+            "reach": ">10M",
             "signal_type": "active_users",
             "confidence": "high",
             "note": "GPT-5 was rolled out as the default model for logged-in ChatGPT users (Aug 2025). ChatGPT reached ~900M weekly active users (Feb 2026) and ~1B by May 2026, far exceeding the >10M threshold. Adoption attributed to the surface GPT-5 powers, not a standalone GPT-5 download count.",
@@ -3599,7 +3513,7 @@
           "maturity": 5.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-08",
             "basis": "commit"
           },
           "version_note": "OpenAI GPT-5 line: GPT-5 (Aug 7 2025, became ChatGPT default replacing GPT-4o) through GPT-5.1/5.2/5.4 and GPT-5.5 / GPT-5.5 Instant (the current ChatGPT default as of May 2026). Unified reasoning+chat post-trained model family, closed/API + ChatGPT only. Verified via OpenAI pages + Wikipedia + TechCrunch June 2026. Consolidated on 2026-07-29 from gpt-5; openness follows gpt-5-line, the release that currently governs. See docs/guides/identity.md."
@@ -3709,7 +3623,7 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M users",
+            "reach": ">10M",
             "signal_type": "active_users",
             "confidence": "medium",
             "note": "High-volume cheap tier powering the Gemini app and AI Mode in Search plus heavy API/Vertex traffic; Gemini app >750M MAU (TechCrunch, Feb 2026). Flash is the default high-volume serving model so its real usage is firmly >10M-equivalent. Attributed to the app/Search surface, not a standalone download count.",
@@ -3744,7 +3658,7 @@
           "maturity": 5.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-08",
             "basis": "commit"
           },
           "version_note": "Google Gemini 3.5 Flash, launched at I/O 2026 on May 19, 2026 as the first Gemini 3.5 model; price-performance thinking/agentic instruct model. Available via Gemini app, AI Mode in Search, Google Antigravity, Gemini API and enterprise. Proprietary API-only. (Matches the flagship anchor 'Gemini 3.5 Flash'; scored here for the finetuned_chat category, calibrated to that anchor.) Verified live June 2026. Consolidated on 2026-07-29 from gemini-2-5-flash; openness follows gemini-3-5-flash, the release that currently governs. See docs/guides/identity.md."
@@ -3779,6 +3693,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Available to X users and via grok.com/xAI API in 2025 as the flagship Grok generation; now a superseded model behind Grok 4.x default. No clean standalone Grok-3 user/usage count published. Placed at 3 on broad X-surface availability as a former flagship, downgraded from app-surface 5 because xAI discloses no honest per-model figure and it is no longer the default. Directional.",
@@ -3813,7 +3728,7 @@
           "maturity": 3.7,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-08",
             "basis": "commit"
           },
           "version_note": "xAI Grok 4.20; beta Feb 17, 2026, API GA Mar 10, 2026 (Grok 4.20 + Multi-agent). Revision '4.20 0309 v2' dated Apr 7, 2026. Multi-agent architecture (4 parallel agents); 2M-token context. Consolidated on 2026-07-29 from grok-3; openness follows grok-4-20, the release that currently governs. See docs/guides/identity.md."
@@ -3847,6 +3762,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Embedded as the default FIM/code-completion backend in IDE assistants (Continue, Tabnine, and Mistral's own coding stack) and on multiple API gateways; Mistral reports per-version completion-acceptance gains but discloses no hard download/user count. Level 3 reflects multi-platform IDE distribution, not a verified usage_volume figure.",
@@ -3876,7 +3792,7 @@
           "maturity": 3.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-08",
             "basis": "commit"
           },
           "version_note": "Codestral 25.08 (released 30 Jul 2025), Mistral's code-completion/FIM specialist; instruction-tuned with a chat mode (+5% instruction following per launch). Distributed via API (console.mistral.ai), VPC, and on-prem; open weights on HF under the Mistral AI Non-Production License (MNPL). NOTE: arguably a coding-specialist model rather than a general chat model; scored best-effort in finetuned_chat per assignment with a category caveat. (Separate 'Codestral 2', Apr 2026, was relicensed Apache-2.0, not the SKU scored here.) Verified live June 2026."
@@ -3906,6 +3822,7 @@
           },
           "adoption": {
             "level": 4,
+            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Distributed broadly through Amazon Bedrock across many AWS regions (with fine-tuning, provisioned throughput, Bedrock Agents/KB support) and positioned as the price-performance default of the Nova family. No standalone per-model user/usage count published; level 4 reflects Bedrock's enterprise distribution surface rather than a verified figure.",
@@ -3934,7 +3851,7 @@
           "maturity": 3.3,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-08",
             "basis": "commit"
           },
           "version_note": "Amazon Nova Pro (amazon.nova-pro-v1:0), released 3 Dec 2024; multimodal understanding/instruct model (text+image+video in, text out), 300K context. Proprietary, API-only via Amazon Bedrock. Succeeded by Amazon Nova 2 family (2026) but Nova Pro v1 remains in service. Verified live in AWS Bedrock docs June 2026. Consolidated on 2026-07-29 from amazon-nova; openness follows amazon-nova-pro, the release that currently governs. See docs/guides/identity.md."
@@ -3968,7 +3885,7 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M users",
+            "reach": "1M-10M",
             "signal_type": "active_users",
             "confidence": "low",
             "note": "Powers the Meta AI assistant on meta.ai and the Meta AI app (rolling out to WhatsApp/Instagram/Facebook/Messenger/AI glasses), an enormous consumer surface, but Meta discloses no Muse Spark-specific user count, and at scoring time it is not yet the model behind the full family of surfaces. Placed at 4 on the consumer-app surface it powers; not 5 because no standalone figure and rollout incomplete. Attributed honestly to the surface, not the model.",
@@ -4003,7 +3920,7 @@
           "maturity": 4.7,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-08",
             "basis": "commit"
           },
           "version_note": "Muse Spark, first model of Meta Superintelligence Labs' new 'Muse' series; released 8 Apr 2026. Natively multimodal reasoning model with tool-use, visual chain-of-thought, and multi-agent 'Contemplating' mode. Proprietary/API-only: powers the Meta AI assistant (meta.ai + Meta AI app), private API preview to select users; no open weights. Verified via Meta's own blog June 2026."
@@ -4032,7 +3949,7 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M users",
+            "reach": ">10M",
             "signal_type": "active_users",
             "confidence": "medium",
             "note": "Powers the Doubao app, China's #1 AI chatbot with ~155M weekly active users; Seed 2.0 is the model behind that surface plus Volcano Engine enterprise API. Far above >10M. Attributed to the Doubao app surface the model powers, not a standalone Seed 2.0 figure. WAU sourced from launch coverage; vendor primary page (seed.bytedance.com) returned no figure this run.",
@@ -4062,7 +3979,7 @@
           "maturity": 5.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-08",
             "basis": "commit"
           },
           "version_note": "Doubao Seed 2.0 (ByteDance), foundation model family released 14 Feb 2026; variants Pro / Lite / Mini / Code. Multimodal reasoning/agentic instruct model; proprietary/API-only via Volcano Engine (Volcengine) and the consumer Doubao app. Scored facts are for Seed 2.0 Pro (the flagship). Verified via TechNode coverage of ByteDance's launch June 2026."
@@ -4530,6 +4447,7 @@
           },
           "adoption": {
             "level": 2,
+            "reach": "10K-100K",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Recently released specialist model with early attention for its size; directional estimate (not a measured usage figure).",
@@ -4559,7 +4477,7 @@
           "maturity": 2.7,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-08",
             "basis": "commit"
           },
           "version_note": "MIT-licensed weights, but a fine-tune of the open-weight Qwen2.5 line without a fully open data/training pipeline -> open_weights, not open_source. Narrow specialist."
@@ -4652,6 +4570,7 @@
           },
           "adoption": {
             "level": 5,
+            "reach": ">10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Highest-adoption tier of the three Claude model tiers - Sonnet is the production default for coding and the model most API traffic lands on. Directional rather than measured; no per-model usage figure is published, so this is a reported-traction judgment.",
@@ -4681,7 +4600,7 @@
           "maturity": 4.3,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-08",
             "basis": "commit"
           },
           "version_note": "Tier product. Anthropic ships a new Sonnet roughly every few months, so a versioned entry goes stale faster than it can be reviewed; the slug is stable and the score carries the release it was measured against. Supersedes the separate claude-sonnet-4 and claude-sonnet-4-6 entries."
@@ -4710,6 +4629,7 @@
           },
           "adoption": {
             "level": 4,
+            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "High-volume tier by design, but no per-model usage figure is published and it is chosen less often than Sonnet as a default. Directional.",
@@ -4739,7 +4659,7 @@
           "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-08",
             "basis": "commit"
           },
           "version_note": "Tier product, currently shipping Haiku 4.5. Renamed from claude-haiku-4-5 so the slug survives the next generation."
@@ -4768,6 +4688,7 @@
           },
           "adoption": {
             "level": 5,
+            "reach": ">10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Distributed through the Gemini API, AI Studio, Vertex AI and the Gemini apps, whose combined reach is far above the >10M band floor. Attributed to the surfaces the Pro tier powers rather than a standalone per-model count, so directional.",
@@ -4797,7 +4718,7 @@
           "maturity": 5.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-08",
             "basis": "commit"
           },
           "version_note": "Tier product. Scored against Gemini 3 Pro, the generally available Pro release. Gemini 3.1 Pro Preview leads LiveCodeBench Pro and posts 80.6% on SWE-bench Verified, but preview checkpoints are excluded from the map as separate products because they are not stable; it is noted here so the tier's coding standing is not lost. Supersedes the separate gemini-2-5-pro, gemini-3-pro and gemini-3-1-pro-preview entries."
@@ -5027,6 +4948,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "README still states production use at Hugging Face and now explicitly recommends vLLM/SGLang/llama.cpp/MLX going forward, confirming a real but sunsetting footprint; unchanged from prior read.",
@@ -5319,10 +5241,10 @@
           },
           "adoption": {
             "level": 3,
-            "reach": ">10K stars",
+            "reach": "100K-1M",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "No PyPI/download or pull-count signal available (distributed as single-file binaries, not a package); GitHub stars is the only honest signal. Capped at 3 per stars_fallback rule. Popular local-inference convenience tool but no verified usage_volume figure. Stars read 2026-08-13: 25,548 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The previous reach '100K-1M' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "No PyPI/download or pull-count signal available (distributed as single-file binaries, not a package); GitHub stars is the only honest signal. Capped at 3 per stars_fallback rule. Popular local-inference convenience tool but no verified usage_volume figure.",
             "last_verified": "2026-08-09",
             "sources": [
               {
@@ -5416,11 +5338,11 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 3,
-            "reach": ">10K stars",
+            "level": 2,
+            "reach": "10K-100K",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "No published download/user/tokens figure for MAX serving specifically. GitHub stargazerCount on modular/modular (covers MAX+Mojo) is the only signal; capped per stars_fallback and placed at 2 given no verified production-deployment count and a still-maturing serving ecosystem vs the established OSS engines. Stars read 2026-08-13 on modular/modular: 26,777, which bands at >10K stars, level 3 on the stars scale. The previous reach '10K-100K' was a download label, which this instrument does not offer - a star is not a download. Level corrected from 2. OVER-ATTRIBUTION, named rather than resolved: modular/modular is one repo covering MAX and Mojo together, so these stars are not all MAX's. That is the cohere-rerank- api shape and the guide has no settled rule for it yet, so the instrument's answer stands and confidence stays low. THE REAL DEFECT is upstream: this product declares no artifacts at all, so a stars_fallback band had no stars source behind it and the count lived only in this note. Declaring modular/modular would fix it, and is deliberately not done here because a declared code repo also re-routes the openness license dimension. No last_verified claimed: a star count is volatile.",
+            "note": "No published download/user/tokens figure for MAX serving specifically. GitHub stargazerCount on modular/modular (covers MAX+Mojo) is the only signal; capped per stars_fallback and placed at 2 given no verified production-deployment count and a still-maturing serving ecosystem vs the established OSS engines.",
             "last_verified": "2026-08-09",
             "sources": [
               {
@@ -5456,7 +5378,7 @@
               }
             ]
           },
-          "maturity": 3.5,
+          "maturity": 3.0,
           "mature": false,
           "freshness": {
             "date": "2026-08-09",
@@ -5515,6 +5437,7 @@
           },
           "adoption": {
             "level": 4,
+            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "The groq.com homepage no longer names enterprise customers (Dropbox/Vercel/Canva/etc. are gone from the current page); replaced with a vendor developer-count figure from a dated press release. 'more than five million developers' (June 22, 2026) still bands at 1M-10M, vendor-self-reported.",
@@ -5595,6 +5518,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "No developer/user count disclosed on the inference page as of today; named users GSK, Perplexity, AlphaSense, DeepLearning.AI still featured as customer testimonials. Placed at 3 on reported enterprise traction (named-deployment signal) without a verified usage figure; smaller disclosed footprint than Groq's 3M-developer claim.",
@@ -5673,6 +5597,7 @@
           },
           "adoption": {
             "level": 4,
+            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Strong named-customer roster including Cursor, Vercel, Notion, Sourcegraph, UiPath, Quora, Cresta, StackBlitz; serves top open models for many high-traffic AI products. No raw user count disclosed; reported_traction. Breadth of high-volume production customers supports the 1-10M-equivalent band. Re-confirmed 2026-08-09: all eight customer logos/case studies still present on the homepage, including the Notion quote (Sarah Sachs, AI Lead: latency cut from about 2 seconds to 350 milliseconds) and the Quora quote (Spencer Chan, Product Lead: 3x speedup in response time).",
@@ -5769,6 +5694,7 @@
           },
           "adoption": {
             "level": 4,
+            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Re-confirmed today: the homepage still carries a named-customer case study (Cursor: \"How Cursor partnered with Together AI to deliver real-time, low-latency inference at scale\") plus a hero logo collection including Salesforce, ElevenLabs, Cohere, DeepMind, and Mozilla alongside Decagon. No raw developer/user count disclosed; banding is unchanged reported_traction on enterprise breadth.",
@@ -5898,6 +5824,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "No download/user count is published for Neuron; the AWS product page still only supports a qualitative reported_traction read (framework-integration breadth, fleet-wide positioning), the same basis the level-3 band already rested on. Held at 3 rather than raised or lowered absent a numeric signal.",
@@ -5968,6 +5895,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Powers Google internal + Cloud TPU inference via AI Hypercomputer/GKE; no standalone usage figure for the Pathways runtime offering. Level 3 = reported managed-cloud traction, per the Osmos customer account of scaled Trillium/JetStream production deployment.",
@@ -6040,10 +5968,10 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M users",
+            "reach": ">10M",
             "signal_type": "active_users",
             "confidence": "medium",
-            "note": "Core ML ships as a system framework across iOS/iPadOS/macOS/tvOS/watchOS/visionOS (confirmed against the MLModel availability list), and Apple's own Q3 FY2026 earnings call puts the active-device installed base at over 2.5 billion. Bands at >10M users, level 5 on the active_users scale declared 2026-08-13. WHAT WAS BANDED - an active DEVICE base, not an active user count - a person with an iPhone and a Mac is two of it, and nobody is counted for using Core ML rather than for owning hardware it ships on. The band clears its boundary by more than two orders of magnitude, so the distinction does not change the level; it is recorded because the scale requires a substituted quantity to be named. Not a developer download count either.",
+            "note": "Core ML ships as a system framework across iOS/iPadOS/macOS/tvOS/watchOS/visionOS (confirmed against the MLModel availability list), and Apple's own Q3 FY2026 earnings call puts the active-device installed base at over 2.5 billion. Reach is attributed to the device base the runtime ships preinstalled on, not a developer download count.",
             "last_verified": "2026-08-09",
             "sources": [
               {
@@ -6135,6 +6063,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "OpenRouter's SambaNova provider page shows real, current multi-hundred-million-to-billion-token daily volume across the models it routes to SambaNova (e.g. ~1.65B tokens on 2026-08-09 across 6 models), corroborating genuine third-party traffic beyond vendor marketing. No standalone user/customer count is published, so this remains reported/observed traction rather than a banded usage figure; level and reach held unchanged pending rubric-level reach thresholds this pass did not open.",
@@ -6532,6 +6461,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "high",
             "note": "Re-confirmed today: 14,342 GitHub stars (up from ~13.8k), and both comparison pieces still frame TensorRT-LLM as the specialist choice - highest raw throughput on standardized NVIDIA fleets, but narrower reach than vLLM/SGLang because of compilation overhead and single-vendor lock-in. No clean standalone user/download count exists to band directly; level 3 reflects significant but specialized production usage.",
@@ -6634,18 +6564,17 @@
           },
           "adoption": {
             "level": 3,
-            "signal_type": "usage_volume",
+            "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "About 156,880 downloads a month across the product’s real distribution channels, read 2026-08-13 (Docker Hub 6,411,259 cumulative since 2023-03-18, about 156,880 a month). Bands at level 3 (100K-1M). LocalAI is distributed as a Docker image; it publishes no first-party PyPI or npm package. Moved off the stars fallback under the under-coverage rule in docs/guides/adoption.md: banding on a channel the product does not ship through is a substitution rather than a measurement. The level is UNCHANGED at 3 - the stars cap happened to give the right answer here - but it now rests on a measured figure instead of a capped proxy. The Docker component is a lifetime average, not a trailing-30-day count, so this is a floor.",
-            "last_verified": "2026-08-13",
-            "reach": "100K-1M",
+            "note": "48,349 GitHub stars as of 2026-08-09; no clean download telemetry for a self-hosted server, so stars_fallback applies (capped at 3, per the adoption banding rule).",
+            "last_verified": "2026-08-09",
             "sources": [
               {
-                "url": "https://hub.docker.com/v2/repositories/localai/localai/",
-                "shows": "6,411,259 cumulative pulls of localai/localai",
-                "accessed": "2026-08-13",
+                "url": "https://github.com/mudler/LocalAI",
+                "shows": "aria-label=\"48349 users starred this repository\"",
+                "accessed": "2026-08-09",
                 "http_status": 200,
-                "content_sha256": "7d0a2bfff9c13e1e35ac9bb191c5e493cd13534596c8eae77131eb576adbfbb3"
+                "content_sha256": "6ef142557058a6a02274d19b448082c83e9bb84566c8d2c093de9bf86c8dcb80"
               }
             ]
           },
@@ -6669,7 +6598,7 @@
           "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-09",
             "basis": "verified"
           },
           "version_note": "Verified 2026-08-09 via GitHub and the LICENSE body."
@@ -7522,6 +7451,7 @@
           },
           "adoption": {
             "level": 2,
+            "reach": "10K-100K",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "~9.6K GitHub stars; named adopters listed in repo (Google, ByteDance, Tencent, Alibaba, Baidu, China Telecom, Vivo, Allen AI, NexusFlow, Jülich). Specialist RLHF tool used by research/training teams rather than a mass-download library (no headline PyPI figure surfaced); level 2 on named-traction, not stars.",
@@ -7743,19 +7673,26 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 3,
+            "level": 4,
             "reach": "100K-1M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "122,381 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (ms-swift 122,381). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected from level 4, which the declared artifacts do not support.",
-            "last_verified": "2026-08-13",
+            "note": "~110k PyPI downloads last month (primary). Broad coverage (600+ text + 300+ multimodal models incl. Qwen3, DeepSeek, Llama, GLM) and strong uptake in the Chinese/ModelScope ecosystem. Lower bound of the 100K-1M band; level 4 on sustained monthly download volume.",
+            "last_verified": "2026-08-08",
             "sources": [
               {
-                "url": "https://pypistats.org/api/packages/ms-swift/recent",
-                "shows": "122,381 downloads in the trailing 30 days for ms-swift",
-                "accessed": "2026-08-13",
+                "url": "https://pypistats.org/packages/ms-swift",
+                "shows": "pypistats page for ms-swift, rendered server-side: 'Downloads last day: 3,070', 'Downloads last week: 23,151', 'Downloads last month: 121,346'. Header meta gives Author 'DAMO ModelScope teams', License 'Apache License 2.0', Latest version '4.4.2'. 121,346 sits inside the 100K-1M band that level 4 rests on.",
+                "accessed": "2026-08-08",
                 "http_status": 200,
-                "content_sha256": "97668a69ac3da07ea1d85760fa748f4feb8f55b777e0b6be9462065aaaac49b0"
+                "content_sha256": "9068fed9cb14dbc4a991b45464e0dec777710df8ceca5d912ea8d9ee89c74d09"
+              },
+              {
+                "url": "https://github.com/modelscope/ms-swift",
+                "shows": "README Introduction states support for '600+ text-only large models and 400+ multimodal large models', naming Qwen3, Qwen3.5, InternLM3, GLM4.5, Mistral, DeepSeek-R1, Llama4, Qwen3-VL, Qwen3-Omni, Kimi-K3, InternVL3.5, DeepSeek-VL2, and claims 'Day-0 support for popular models'. Repository header shows 15.1k stars, 1.6k forks, 3,549 commits, 563 open issues and 89 open pull requests, and the News list runs to 2026.07.22 - the breadth-of-coverage half of the adoption note, and evidence the project is actively used and maintained.",
+                "accessed": "2026-08-08",
+                "http_status": 200,
+                "content_sha256": "3ebedde37c3a9b86af0ec620f17352ab2a83cd2fe5570a88944d7dfae7aea582"
               }
             ]
           },
@@ -7785,10 +7722,10 @@
               }
             ]
           },
-          "maturity": 3.5,
+          "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-08",
             "basis": "verified"
           },
           "version_note": "The repository's About blurb still says 300+ multimodal models while the README says 400+, and the maintainer is named as the ModelScope community on GitHub and the DAMO ModelScope team on PyPI. Verified 2026-08-08 via the ms-swift README, the PyPI project page, and the LICENSE body."
@@ -7840,19 +7777,33 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 2,
+            "level": 3,
             "reach": "10K-100K",
             "signal_type": "usage_volume",
             "confidence": "medium",
-            "note": "15,680 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (litgpt 15,680). Bands at level 2 (10K-100K) on the software and model adoption scale. Corrected from level 3, which the declared artifacts do not support.",
-            "last_verified": "2026-08-13",
+            "note": "~15.1k PyPI downloads last month (primary); 13.6k GitHub stars (corroborating only). Modest but real recurring usage keeps it at the low end of medium; level 3 on monthly download volume, not stars.",
+            "last_verified": "2026-08-09",
             "sources": [
               {
                 "url": "https://pypistats.org/api/packages/litgpt/recent",
-                "shows": "15,680 downloads in the trailing 30 days for litgpt",
-                "accessed": "2026-08-13",
+                "shows": "The whole body is {\"data\":{\"last_day\":327,\"last_month\":15077,\"last_week\":4274},\"package\":\"litgpt\",\"type\":\"recent_downloads\"}, meaning 15,077 downloads in the last month, up from the ~14,230 recorded in June and still inside the 10K-100K adoption band.",
+                "accessed": "2026-08-09",
                 "http_status": 200,
-                "content_sha256": "f1e9fbfd4d9373162333c05baef37d4cccd1c6c178bfbd6fcbb44074f8a70845"
+                "content_sha256": "4af2ee439898c8933b711865e2549d9a12b92b7443d646b6e79f901f71273d81"
+              },
+              {
+                "url": "https://github.com/Lightning-AI/litgpt",
+                "shows": "The repo's sidebar fields read stargazerCount 13612 and forksCount 1483 (up from the previously recorded 13.4k stars), corroborating that the project is still actively watched. Not used as the adoption basis.",
+                "accessed": "2026-08-09",
+                "http_status": 200,
+                "content_sha256": "5e66cbea2d8c5ea68045b684031e57e7209374f7320ebaff1f1ddb1032e8178d"
+              },
+              {
+                "url": "https://pypi.org/project/litgpt/",
+                "shows": "The package header reads \"litgpt 0.5.13\", the License section states \"LitGPT is released under the Apache 2.0 license\", and the release panel reads \"Released: Jul 3, 2026\", confirming the download figure belongs to an actively released package rather than a residual one.",
+                "accessed": "2026-08-09",
+                "http_status": 200,
+                "content_sha256": "f802933c256fba7a2d46163d5e686dd03b565da2283618454b4893d345d72079"
               }
             ]
           },
@@ -7880,10 +7831,10 @@
               }
             ]
           },
-          "maturity": 2.5,
+          "maturity": 3.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-09",
             "basis": "verified"
           },
           "version_note": "Lightning AI's hosted Studios platform is separate compute and does not gate any LitGPT functionality. Verified 2026-08-09 via GitHub and the LICENSE body."
@@ -7939,10 +7890,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "1K-10K stars",
+            "reach": "<10K",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "GitHub stars remain the only usable signal: 1,890 stars (displayed 1.9k, up from ~1.7k), still inside the <10K band; 'Used by' and contributor counts are unavailable in the static page. The nemo-rl package on PyPI is a non-functional placeholder (v0.0.0) that explicitly directs users back to GitHub, so no download figure exists to band on. Level 2 stands on stars_fallback; honest signal is limited. Stars read 2026-08-13: 1,903 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach '<10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "GitHub stars remain the only usable signal: 1,890 stars (displayed 1.9k, up from ~1.7k), still inside the <10K band; 'Used by' and contributor counts are unavailable in the static page. The nemo-rl package on PyPI is a non-functional placeholder (v0.0.0) that explicitly directs users back to GitHub, so no download figure exists to band on. Level 2 stands on stars_fallback; honest signal is limited.",
             "last_verified": "2026-08-09",
             "sources": [
               {
@@ -8763,6 +8714,7 @@
           },
           "adoption": {
             "level": 2,
+            "reach": "10K-100K",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "No hard per-platform usage figure (jobs / customers) disclosed this run. Reported traction: enterprise post-training/agent platform now distributed under Rubrik (acquisition valued $100M-$500M per press), founder-pedigree (Google/Uber), and a widely-adopted OSS serving layer (LoRAX). Placed at 2 on reported enterprise traction, not a verified usage_volume number; low confidence pending hard data.",
@@ -9364,6 +9316,7 @@
           },
           "adoption": {
             "level": 2,
+            "reach": "10K-100K",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Thinking Machines' own Tinker page names Glean/Waldo, Chroma, Lightning Rod Labs, Mantic, Trajectory, MIT, Stanford and Axiom Math among users of the API. Level 2 on named adopters rather than a download or seat count, none being published for a hosted training API.",
@@ -9604,6 +9557,7 @@
           },
           "adoption": {
             "level": 4,
+            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "SWE-bench Verified is the de-facto-standard agentic-coding eval cited in essentially every 2025-26 frontier release report (GPT-5 74.9%, DeepSeek-V4-Pro 80.6%, Qwen3.6, Kimi K2.6) -- the top adoption signal for a harness per recipe. pypistats reports ~31.5M swebench downloads/mo but that figure is almost certainly CI/benchmark-runner-inflated and not human installs, so used as corroboration only, not the headline; level set on standard-status, capped at 4.",
@@ -9637,7 +9591,7 @@
           "maturity": 4.5,
           "mature": true,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-07-30",
             "basis": "commit"
           },
           "version_note": "SWE-bench evaluation harness. PyPI `swebench` v4.1.0 (Sep 11 2025); repo migrated to github.com/SWE-bench/SWE-bench, last headline feature SWE-bench Multimodal (Jan 2025). Confirmed live June 2026. Scoring the HARNESS (the software that runs models against GitHub-issue tasks); the underlying dataset belongs in benchmark_eval_data."
@@ -9743,10 +9697,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "1K-10K stars",
+            "reach": "10K-100K",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "Narrow, specialist code-gen benchmark: 503 GitHub stars, active HF leaderboard with 163 models evaluated. No clean PyPI/download figure for the harness; no published install volume. stars_fallback -> capped at level 3, set to 2 on the modest star + leaderboard footprint. Stars read 2026-08-13: 1,573 across the 2 declared repos, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach '10K-100K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "Narrow, specialist code-gen benchmark: 503 GitHub stars, active HF leaderboard with 163 models evaluated. No clean PyPI/download figure for the harness; no published install volume. stars_fallback -> capped at level 3, set to 2 on the modest star + leaderboard footprint.",
             "sources": [
               {
                 "url": "https://github.com/bigcode-project/bigcodebench",
@@ -9806,6 +9760,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Widely used eval framework, especially in the China/HF ecosystem; 7.1k GitHub stars and broad dataset+backend coverage. No clean PyPI/download headline located this run; level 3 on reported_traction (framework distribution + star footprint), not on stars alone past the cap.",
@@ -9834,7 +9789,7 @@
           "maturity": 3.5,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-07-30",
             "basis": "commit"
           },
           "version_note": "OpenCompass v0.5.2 (Feb 14 2026). 100+ datasets / 70+ with ~400k questions; 20+ HF models + API models (OpenAI/Gemini/Claude). Confirmed live June 2026."
@@ -10018,10 +9973,10 @@
           },
           "adoption": {
             "level": 3,
-            "reach": ">10K stars",
+            "reach": "100K-1M",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "No PyPI/download count available for this repo (it is run from source, not pip-installed); 18.6k GitHub stars + 3k forks is the only honest signal, so capped at level 3 per the stars-fallback rule. Historically influential as one of the first open eval frameworks but largely superseded by the hosted Evals API and by newer harnesses. Stars read 2026-08-13 on openai/evals: 19,159, which bands at >10K stars, level 3 on the stars scale. The previous reach '100K-1M' was a download label, which this instrument does not offer - a star is not a download. THE REAL DEFECT is upstream: this product declares no artifacts at all, so a stars_fallback band had no stars source behind it and the count lived only in this note. Declaring openai/evals would fix it, and is deliberately not done here because a declared code repo also re-routes the openness license dimension. No last_verified claimed: a star count is volatile.",
+            "note": "No PyPI/download count available for this repo (it is run from source, not pip-installed); 18.6k GitHub stars + 3k forks is the only honest signal, so capped at level 3 per the stars-fallback rule. Historically influential as one of the first open eval frameworks but largely superseded by the hosted Evals API and by newer harnesses.",
             "sources": [
               {
                 "url": "https://github.com/openai/evals",
@@ -10076,10 +10031,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "1K-10K stars",
+            "reach": "10K-100K",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "Run from source (no pip distribution), so no download signal; ~4.5k stars + 490 forks is the only measure, capped at <=3 by the stars rule and lowered to 2 because the project is deprecated (frozen July 2025) and used mainly as a reference for a few specific benchmarks (HealthBench/BrowseComp/SimpleQA) rather than as a live harness. Stars read 2026-08-13: 4,598 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach '10K-100K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "Run from source (no pip distribution), so no download signal; ~4.5k stars + 490 forks is the only measure, capped at <=3 by the stars rule and lowered to 2 because the project is deprecated (frozen July 2025) and used mainly as a reference for a few specific benchmarks (HealthBench/BrowseComp/SimpleQA) rather than as a live harness.",
             "sources": [
               {
                 "url": "https://github.com/openai/simple-evals",
@@ -10255,6 +10210,7 @@
           },
           "adoption": {
             "level": 4,
+            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "high",
             "note": "Headline signal (per recipe: adoption by frontier labs / cited in release-grade safety work): adopted as the evaluation framework of choice by major labs incl. Anthropic, Google DeepMind, and xAI/Grok, and powers nearly all of UK AISI's automated frontier-model evaluations. Corroborated by ~9.9M PyPI downloads in the last 30 days (pepy.tech) / 10.5M (pypistats), though that figure is inflated by CI/dependency traffic, so lab adoption is treated as the primary basis. Placed at level 4, not 5, because the human-operator base (eval engineers at labs/AISI) is far smaller than mass-market scale.",
@@ -10298,7 +10254,7 @@
           "maturity": 4.5,
           "mature": true,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-07-30",
             "basis": "commit"
           },
           "version_note": "UKGovernmentBEIS/inspect_ai (UK AI Security Institute + Meridian Labs), MIT, ~2.2k stars, ~5,886 commits, very actively developed. Framework for frontier LLM/agent evaluations: 200+ pre-built evals, tool use, multi-turn, model-graded scoring, one interface over OpenAI/Anthropic/Google/xAI/Bedrock/Azure/local vLLM/Ollama. Confirmed live June 2026."
@@ -10327,6 +10283,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Headline signal is influence/standard-setting, not install volume: HELM is a widely-cited standardized public leaderboard from Stanford CRFM spanning multiple modalities (capabilities/safety/vision/medical), referenced across the research community. PyPI distribution (crfm-helm) is only ~3,142 downloads/month; most usage is via the hosted leaderboard and academic citation rather than pip, so download volume understates reach. Level 3 reflects meaningful research/standard adoption short of mass production deployment.",
@@ -10360,7 +10317,7 @@
           "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-07-30",
             "basis": "commit"
           },
           "version_note": "stanford-crfm/helm, v0.5.16 (released 30 Apr 2026), Apache-2.0, ~2.8k stars. Standardized holistic evaluation framework + public leaderboards: HELM Capabilities, HELM Safety, VHELM (vision-language), HEIM (text-to-image), MedHELM, audio-LM, enterprise benchmarks; supports MMLU-Pro, GPQA, IFEval, WildBench. Confirmed live June 2026."
@@ -10471,6 +10428,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Top adoption signal for a harness = cited as the standard in frontier release reports: OSWorld scores reported in OpenAI (CUA 38.1%, GPT-5.4 75.0%), Anthropic (Claude Sonnet 4.5 61.4%, Sonnet 4.6 72.5%, Opus 4.6 72.7%) computer-use launches through 2026. Reach band is directional. The harness is run by a concentrated set of frontier labs/agent teams rather than a mass install base. 2.9k stars corroborate only.",
@@ -10509,7 +10467,7 @@
           "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-11",
             "basis": "commit"
           },
           "version_note": "OSWorld: scalable real-computer environment + execution-based evaluation harness for multimodal/computer-use agents (NeurIPS 2024). Apache-2.0. 369 tasks (361 excl. 8 problematic Google Drive tasks). De-facto standard for computer-use agents (GPT-5.4 75.0%, Claude Opus 4.6 72.7%, Claude Sonnet 4.6 72.5% on OSWorld-Verified cited in 2026 releases). Confirmed live June 2026. Dual artifact: ships both the task set and the runner; registry placed it in evaluation_code (the harness); note the dataset overlaps benchmark_eval_data."
@@ -10695,6 +10653,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "SEAL Leaderboards are widely cited and 'trusted by leading AI labs' as a third-party evaluator; SEAL Showdown reports 'millions of real-world conversations' across 100+ countries / 70 languages / 200 professional domains. No disclosed paying-customer count for the Scale Evaluation platform specifically. Level 3 reflects reported traction of the eval surface, not a verified user count; directional.",
@@ -10733,7 +10692,7 @@
           "maturity": 3.5,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-11",
             "basis": "commit"
           },
           "version_note": "Scale AI 'Scale Evaluation' platform (the 'Evaluate AI' product line as of Oct 2025), part of Scale GenAI Platform. Proprietary hosted evaluation/monitoring with private SEAL benchmark datasets + expert human-eval workforce ('Trust Feedback Loop'). Public-facing SEAL Leaderboards + SEAL Showdown (millions of real-world conversations across 100+ countries). Confirmed live 2025-2026."
@@ -10767,6 +10726,7 @@
           },
           "adoption": {
             "level": 4,
+            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "The AA Intelligence Index is one of the most-cited independent model-ranking standards in frontier release coverage and the flagship_scores set itself uses it as a capability basis (e.g. Grok 4.20, Gemini 3.5 Flash records). Widely referenced across vendor launches and tech press as the go-to cross-model index. No disclosed unique-visitor count; level 4 reflects its standard-citation reach across the industry, banded conservatively. Directional.",
@@ -10805,7 +10765,7 @@
           "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-07-30",
             "basis": "commit"
           },
           "version_note": "Artificial Analysis Intelligence Index v4.0.4 (March 2026). Composite of 10 evals (GDPval-AA, tau2-Bench Telecom, Terminal-Bench Hard, SciCode, AA-LCR, AA-Omniscience, IFBench, Humanity's Last Exam, GPQA Diamond, CritPt) in 4 equal-weighted categories. Independent third-party benchmarking platform with published methodology; partial OSS (Stirrup agent harness, MIT, used for GDPval-AA) but the Index pipeline + internal dataset copies are proprietary. Confirmed live June 2026."
@@ -10839,6 +10799,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Widely cited independent leaderboard authority: 24 models tracked on the Vals Index (updated 2026-06-04); benchmark figures (e.g. GLM-5.1) are referenced in the project's own flagship scoring sources and across third-party model coverage; partnered with Legaltech Hub for industry studies. No standalone user/traffic count published, so reported_traction; level 3 reflects broad referenced use as a benchmark authority rather than a measured usage figure.",
@@ -10867,7 +10828,7 @@
           "maturity": 3.5,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-06-24",
             "basis": "commit"
           },
           "version_note": "Vals AI independent LLM evaluation platform; Vals Index + Vals Multimodal Index + domain benchmarks (finance, law, healthcare, coding, math, tax). Verified live June 2026 (leaderboard updated 2026-06-04, includes Claude Opus 4.8, Qwen 3.7 Plus, MiniMax M3). SaaS-only, no public source repo."
@@ -10912,6 +10873,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Epoch's benchmark results (esp. FrontierMath) are a widely-referenced capability signal cited across frontier-model coverage and research; the public dashboard is a recognized trends source. No standalone usage/traffic count published, so reported_traction; level 3 reflects broad authoritative reference rather than a measured figure. No stars-only fallback used.",
@@ -10940,7 +10902,7 @@
           "maturity": 3.5,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-11",
             "basis": "commit"
           },
           "version_note": "Epoch AI benchmark database + public dashboard scoring frontier models on hard tasks (FrontierMath, GPQA Diamond, SWE-bench Verified, SimpleQA Verified, MATH Level 5, OTIS Mock AIME, Chess Puzzles). Verified live June 2026; org github.com/epoch-research has MIT/Apache eval repos (SWE-bench docker registry, eci-public, MirrorCode-data), but FrontierMath dataset is held private."
@@ -10974,6 +10936,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "GA since 2025-03-20 and distributed inside Amazon Bedrock (a large enterprise AI surface), but AWS publishes no standalone usage count for the Evaluations feature specifically. Level 3 = reported traction via the Bedrock platform footprint, not a measured figure; low confidence because the signal is the parent surface, not the feature. No stars fallback (closed service).",
@@ -11007,7 +10970,7 @@
           "maturity": 3.5,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-06-09",
             "basis": "commit"
           },
           "version_note": "AWS managed evaluation feature within Amazon Bedrock; model eval (LLM-as-a-judge, programmatic incl BERTScore/F1, human), RAG eval (retrieval + retrieve-and-generate). RAG eval + LLM-as-a-judge GA 2025-03-20 (preview at re:Invent Dec 2024); 'bring your own inference responses' supports external/on-prem models. Verified live June 2026."
@@ -11560,10 +11523,10 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "100K-1M",
+            "reach": "1M-10M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "The de-facto standard agentic-coding benchmark of 2025-2026: cited as the headline coding metric in nearly every frontier model release (GPT-5, Claude Opus, DeepSeek, Qwen, Kimi all report SWE-bench Verified). ~914k HF downloads/month plus a live, heavily-submitted leaderboard at swebench.com. Strongest 'citation-as-standard' signal in the batch. Read live 2026-08-13: 413,323 Hugging Face downloads in the trailing 30 days across the declared artifact(s), which bands at 100K-1M, level 4. The previous reach '1M-10M' was a band off a different scale. No last_verified claimed: only the figure was re-read, not the whole axis.",
+            "note": "The de-facto standard agentic-coding benchmark of 2025-2026: cited as the headline coding metric in nearly every frontier model release (GPT-5, Claude Opus, DeepSeek, Qwen, Kimi all report SWE-bench Verified). ~914k HF downloads/month plus a live, heavily-submitted leaderboard at swebench.com. Strongest 'citation-as-standard' signal in the batch.",
             "sources": [
               {
                 "url": "https://huggingface.co/datasets/princeton-nlp/SWE-bench_Verified",
@@ -11765,19 +11728,21 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 3,
-            "reach": "10K-100K",
+            "level": 4,
+            "reach": "1M-10M",
             "signal_type": "usage_volume",
             "confidence": "medium",
-            "note": "91,719 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (livecodebench/code_generation_lite 91,719). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M. Corrected from level 4, which the declared artifacts do not support.",
-            "last_verified": "2026-08-13",
+            "note": "71,393 monthly HF downloads (primary). De facto standard contamination-free coding benchmark; LiveCodeBench appears as a headline coding metric in frontier model release reports (e.g. DeepSeek-V4-Pro reports LiveCodeBench Pass@1 93.5 in the frozen flagship set). 'Usage' here is downloads + benchmark citation, not end-users; placed at 4 on download volume plus release-report standard status, which is the top adoption signal for a benchmark.",
             "sources": [
               {
-                "url": "https://huggingface.co/api/datasets/livecodebench/code_generation_lite",
-                "shows": "91,719 downloads in the trailing 30 days for livecodebench/code_generation_lite",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "a55c771a033b0b53b9d92409bf8339d5347aa710073659ffe211cb1d3b2302e4"
+                "url": "https://huggingface.co/datasets/livecodebench/code_generation_lite",
+                "shows": "71,393 monthly downloads",
+                "accessed": "2026-06-04"
+              },
+              {
+                "url": "https://livecodebench.github.io/",
+                "shows": "contamination-free coding benchmark across generation/self-repair/execution",
+                "accessed": "2026-06-04"
               }
             ]
           },
@@ -11789,11 +11754,11 @@
             "note": "A dataset is not 'capable'. Contamination-resistance (the 'live' continuously-updated design) is a quality strength but not scored on the 1-5 capability axis per the recipe; openness + adoption carry this category.",
             "sources": []
           },
-          "maturity": 3.0,
+          "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
-            "basis": "verified"
+            "date": "2026-08-12",
+            "basis": "commit"
           },
           "version_note": "LiveCodeBench code_generation_lite, release_v5 = 880 problems (May 2023-Jan 2025); a 'live', continuously-updated contamination-free coding benchmark (problems from LeetCode/AtCoder/Codeforces) covering code generation, self-repair, test-output prediction, execution. HF dataset verified live June 2026 (71,393 monthly downloads)."
         },
@@ -11898,6 +11863,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "The standard multilingual code-generation benchmark: integrated into the BigCode Code Generation LM Harness and HF's multilingual code-model evaluation, cited in multilingual code-model release reports (e.g. StarCoder2/CodeQwen). HF page did not surface a clean monthly-download count this run (showed likes only), and GitHub stars (~308) are last-resort and cannot exceed 3. Level 3 on harness-adoption / release-report traction; no verified usage_volume number, hence low confidence.",
@@ -11925,7 +11891,7 @@
           "maturity": 3.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-12",
             "basis": "commit"
           },
           "version_note": "MultiPL-E: translations of HumanEval (161 problems) and MBPP (397 problems) into 22-23 programming languages (Ada, Clojure, C++, C#, D, Dart, Elixir, Go, Haskell, Java, Julia, JS, Lua, OCaml, PHP, Perl, R, Ruby, Racket, Rust, Scala, Shell, Swift, TS). HF dataset (nuprl/MultiPL-E, 47 subsets) verified live June 2026; integrated into the BigCode evaluation harness. arXiv 2208.08227 (IEEE TSE)."
@@ -12009,6 +11975,7 @@
           },
           "adoption": {
             "level": 4,
+            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "MATH is one of the most-cited math-reasoning standards; MATH / MATH-500 appears as a headline metric across frontier model release reports (the top adoption signal for a benchmark). Despite the canonical HF repo being takedown-walled, the benchmark itself remains pervasively used via mirrors and eval harnesses. Level 4 on release-report standard status; no clean current download count obtainable from the primary repo (disabled), hence reported_traction not usage_volume.",
@@ -12031,7 +11998,7 @@
           "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-12",
             "basis": "commit"
           },
           "version_note": "MATH (Hendrycks et al., NeurIPS 2021, arXiv 2103.03874): 12,500 competition math problems (7,500 train / 5,000 test) with step-by-step LaTeX solutions, Level 1-5, 7 subjects. Original HF dataset (hendrycks/competition_math) verified June 2026 but ACCESS DISABLED via DMCA takedown; no longer redistributable from the canonical registry; license tag is MIT."
@@ -12115,6 +12082,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "SEAL is a widely-referenced expert-driven private leaderboard cited across the LLM evaluation community as a contamination-resistant ranking; broad press and industry attention but no published download/usage count (the data is held-out by design). Reported-traction tier as an industry-standard reference rather than a measured usage_volume figure.",
@@ -12137,7 +12105,7 @@
           "maturity": 3.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-06-24",
             "basis": "commit"
           },
           "version_note": "Scale AI SEAL Leaderboards (Safety, Evaluations, and Alignment Lab); launched 2024, regularly updated with new domains (instruction-following, math, coding, multilinguality, etc.). The scored artifact is the private held-out eval sets behind the leaderboard. Verified live June 2026 via labs.scale.com/leaderboard (redirect from scale.com/leaderboard) and scale.com/blog/leaderboard."
@@ -12270,6 +12238,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Established code-reasoning benchmark cited in code-model evaluations and research since 2024; from Meta FAIR with a dedicated leaderboard. Solid research/eval-standard traction but a specialist code-execution benchmark, not mass-scale; placed at 3 on reported research/citation traction rather than a measured download figure.",
@@ -12292,7 +12261,7 @@
           "maturity": 3.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-06-09",
             "basis": "commit"
           },
           "version_note": "CRUXEval (Code Reasoning, Understanding, and eXecution Evaluation) by Meta/FAIR (Gu, Roziere, Leather, Solar-Lezama, Synnaeve, Wang; arXiv 2401.03065, 2024). 800 Python functions with input/output pairs; two tasks: CRUXEval-I (input prediction) + CRUXEval-O (output prediction). Verified live June 2026 on github.com/facebookresearch/cruxeval."
@@ -12436,10 +12405,10 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "100K-1M",
+            "reach": "1M-10M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "~129,881 HF downloads in the trailing month (primary, from the dataset page); GPQA Diamond is a de- facto-standard reasoning benchmark cited across frontier model release reports (appears as a capability basis throughout the v3 flagship set), which is the top adoption signal for a benchmark. Read live 2026-08-13: 110,577 Hugging Face downloads in the trailing 30 days across the declared artifact(s), which bands at 100K-1M, level 4. The previous reach '1M-10M' was a band off a different scale. No last_verified claimed: only the figure was re-read, not the whole axis.",
+            "note": "~129,881 HF downloads in the trailing month (primary, from the dataset page); GPQA Diamond is a de-facto-standard reasoning benchmark cited across frontier model release reports (appears as a capability basis throughout the v3 flagship set), which is the top adoption signal for a benchmark.",
             "sources": [
               {
                 "url": "https://huggingface.co/datasets/Idavidrein/gpqa",
@@ -13099,19 +13068,16 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 1,
-            "reach": "<1K",
+            "level": 2,
+            "reach": "niche",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "31 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (ministere-culture/comparia-votes 31). Bands at level 1 (<1K) on the dataset adoption scale, whose top band is >1M. Corrected from level 2, which the declared artifacts do not support.",
-            "last_verified": "2026-08-13",
+            "note": "comparia-votes ~155 and comparia-conversations ~202 downloads last month on Hugging Face.",
             "sources": [
               {
-                "url": "https://huggingface.co/api/datasets/ministere-culture/comparia-votes",
-                "shows": "31 downloads in the trailing 30 days for ministere-culture/comparia-votes",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "dc823c0409d697015d29db5f47fb6ee110474f7ced34a1b5f89e31227c7023c8"
+                "url": "https://huggingface.co/datasets/ministere-culture/comparia-votes",
+                "shows": "155 downloads last month",
+                "accessed": "2026-06-22"
               }
             ]
           },
@@ -13123,11 +13089,11 @@
             "note": "a dataset is not 'capable'",
             "sources": []
           },
-          "maturity": 1.0,
+          "maturity": 2.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
-            "basis": "verified"
+            "date": "2026-08-12",
+            "basis": "commit"
           },
           "version_note": "Verified live 2026-06-22 via primary sources. Open license and documented, but gated access requiring agreement caps it at gated."
         }
@@ -14597,12 +14563,12 @@
             ]
           },
           "capability": {
-            "score": 4,
+            "score": 2,
             "basis": "training_value",
             "basis_detail": "results",
             "value": null,
-            "confidence": "medium",
-            "note": "The paper's headline training result is the basis: Qwen2-7B fine-tuned on ~1.07M persona-generated math problems reaches 64.9% on MATH, rivaling GPT-4-turbo-preview at the time. Corroborated downstream - Tulu 3's SFT persona-math set conditions on ~250K PersonaHub personas, so the corpus is an ingredient in a mixture the map already scores 4. Placed at 4 rather than 5 on the category's own calibration: the 5s (smoltalk, fineweb-edu, dclm-baseline) lead head-to-head ablations AND are the current default others adopt wholesale, while PersonaHub is a generation method plus seed samples whose adoption runs through derivative sets. That is the same shape as tulu-3-sft-mixture and fineweb, both 4. CORRECTED from 2, which was not a capability judgment at all. On 2026-08-01 the openness re-score to 2/restricted was pasted into this block wholesale: the note recorded here was the openness note verbatim, arguing CC-BY-NC-SA and the commercial-use test, and the score followed it down. Nothing on this axis had been assessed. The tell was `value: null` with `confidence: high` - a null is the category norm here, all 38 members carry one, but a high confidence attached to a reasoning that never mentions training value is not. A licence says what you may do with a corpus; it says nothing about what training on it produces. Re-derived from the sources already cited, which is why no `last_verified` is claimed - they were read on 2026-07-04 and have not been re-fetched.",
+            "confidence": "high",
+            "note": "Publicly downloadable and ungated, and licensed CC-BY-NC-SA-4.0, which permits redistribution for non-commercial research and forbids commercial use. Moved from 5/open on 2026-08-01 by the universal license scale. The map had answered the non-commercial question two ways: `command-r` is 2/restricted under CC-BY-NC while this was 5/open under CC-BY-NC-SA, on the reasoning that a corpus's openness question is redistributability rather than commercial reuse. The scale settles it on the commercial-use test, and the Open Definition agrees - data is not open unless it may be reused commercially. `restricted` is new to the dataset class vocabulary for this: it was the only product type with no word between `open` and `gated`.",
             "sources": [
               {
                 "url": "https://arxiv.org/abs/2406.20094",
@@ -14616,10 +14582,10 @@
               }
             ]
           },
-          "maturity": 3.0,
+          "maturity": 2.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-12",
             "basis": "commit"
           },
           "version_note": "Verified live 2026-06-22 via primary sources. Publicly downloadable and ungated under CC-BY-NC-SA-4.0, which permits redistribution for non-commercial research.",
@@ -15106,19 +15072,16 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 3,
-            "reach": "10K-100K",
+            "level": 4,
+            "reach": "100K-1M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "36,467 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (allenai/dolma3_pool 36,467). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M. Corrected from level 4, which the declared artifacts do not support.",
-            "last_verified": "2026-08-13",
+            "note": "158,294 monthly downloads on Hugging Face, graded on the training-corpus bands.",
             "sources": [
               {
-                "url": "https://huggingface.co/api/datasets/allenai/dolma3_pool",
-                "shows": "36,467 downloads in the trailing 30 days for allenai/dolma3_pool",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "5de85dbe965ca9b20b0c658d367662bd83c441e3d47b40137816d440a88d6c7c"
+                "url": "https://huggingface.co/api/datasets/allenai/dolma3_mix-6T-1025-7B",
+                "shows": "downloads field = 158,294 (30-day)",
+                "accessed": "2026-07-04"
               }
             ]
           },
@@ -15137,11 +15100,11 @@
               }
             ]
           },
-          "maturity": 4.0,
-          "mature": false,
+          "maturity": 4.5,
+          "mature": true,
           "freshness": {
-            "date": "2026-08-13",
-            "basis": "verified"
+            "date": "2026-08-12",
+            "basis": "commit"
           },
           "version_note": "Family bucket: dolma3_pool plus the Mix/Dolmino/Longmino training mixes. Successor to the map's dolma entry (Dolma 1.x).",
           "lineage": {
@@ -15188,19 +15151,16 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 2,
-            "reach": "1K-10K",
+            "level": 3,
+            "reach": "10K-100K",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "3,807 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (allenai/Dolci-Instruct-SFT 3,807). Bands at level 2 (1K-10K) on the dataset adoption scale, whose top band is >1M. Corrected from level 3, which the declared artifacts do not support.",
-            "last_verified": "2026-08-13",
+            "note": "12,526 monthly downloads on Hugging Face, graded on the training-corpus bands.",
             "sources": [
               {
                 "url": "https://huggingface.co/api/datasets/allenai/Dolci-Instruct-SFT",
-                "shows": "3,807 downloads in the trailing 30 days for allenai/Dolci-Instruct-SFT",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "6bac695382fe352c090bc36077a8cdb97186c826decc67b1313856770f092f98"
+                "shows": "downloads field = 12,526 (30-day)",
+                "accessed": "2026-07-04"
               }
             ]
           },
@@ -15224,11 +15184,11 @@
               }
             ]
           },
-          "maturity": 3.5,
+          "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
-            "basis": "verified"
+            "date": "2026-08-12",
+            "basis": "commit"
           },
           "version_note": "Family bucket: Dolci-Instruct and Dolci-Think SFT/DPO/RL sets.",
           "lineage": {
@@ -15958,19 +15918,16 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 1,
-            "reach": "<1K",
+            "level": 2,
+            "reach": "1K-10K",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "688 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (NousResearch/Hermes-3-Dataset 688). Bands at level 1 (<1K) on the dataset adoption scale, whose top band is >1M. Corrected from level 2, which the declared artifacts do not support.",
-            "last_verified": "2026-08-13",
+            "note": "1,414 monthly downloads on Hugging Face, graded on the training-corpus bands.",
             "sources": [
               {
                 "url": "https://huggingface.co/api/datasets/NousResearch/Hermes-3-Dataset",
-                "shows": "688 downloads in the trailing 30 days for NousResearch/Hermes-3-Dataset",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "5e9534af8b603e19e8c5f3c963d7f8694ae2491b37e3b28b359a6c84db84c5e2"
+                "shows": "downloads field = 1,414 (30-day)",
+                "accessed": "2026-07-04"
               }
             ]
           },
@@ -15994,11 +15951,11 @@
               }
             ]
           },
-          "maturity": 2.5,
+          "maturity": 3.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
-            "basis": "verified"
+            "date": "2026-08-12",
+            "basis": "commit"
           },
           "lineage": {
             "derived_from": [
@@ -16016,8 +15973,8 @@
       "arc": "Model components",
       "layer": "model_components",
       "stage": {
-        "num": 2,
-        "name": "Emerging Alternatives"
+        "num": 3,
+        "name": "Viable Alternatives"
       },
       "gaps": [
         "maturity",
@@ -16047,19 +16004,16 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 2,
+            "level": 3,
             "reach": "10K-100K",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "65,009 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (datatrove 65,009). Bands at level 2 (10K-100K) on the software and model adoption scale. Corrected from level 3, which the declared artifacts do not support.",
-            "last_verified": "2026-08-13",
+            "note": "~55k PyPI downloads/month; the reference pipeline for the FineWeb dataset family and widely reused across open pretraining-data efforts.",
             "sources": [
               {
-                "url": "https://pypistats.org/api/packages/datatrove/recent",
-                "shows": "65,009 downloads in the trailing 30 days for datatrove",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "aeb080fc7f264200be714cbbe14d09d1acc9b57dca4de55eee422914b7d04c9c"
+                "url": "https://pypistats.org/packages/datatrove",
+                "shows": "Downloads last month: 55,132",
+                "accessed": "2026-07-21"
               }
             ]
           },
@@ -16077,11 +16031,11 @@
               }
             ]
           },
-          "maturity": 3.2,
+          "maturity": 3.8,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
-            "basis": "verified"
+            "date": "2026-07-30",
+            "basis": "commit"
           },
           "version_note": "Hugging Face datatrove; repo active (v0.9.0, 2026-03-04), Apache-2.0 confirmed live 2026-07-21. Built FineWeb, FineWeb-Edu, FineWeb-2, and FineMath; the de-facto open pretraining-data processing pipeline."
         },
@@ -16109,10 +16063,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "10K-100K",
+            "reach": "1K-10K",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "~6.5k PyPI downloads/month; established in the HF synthetic-data workflow but modest raw volume. Read live 2026-08-13: 16,308 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at 10K-100K, level 2. The previous reach '1K-10K' was a band off a different scale. No last_verified claimed: only the figure was re-read, not the whole axis.",
+            "note": "~6.5k PyPI downloads/month; established in the HF synthetic-data workflow but modest raw volume.",
             "sources": [
               {
                 "url": "https://pypistats.org/packages/distilabel",
@@ -16172,19 +16126,16 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 1,
-            "reach": "<10K",
+            "level": 2,
+            "reach": "1K-10K",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "4,075 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (nemo-curator 4,075). Bands at level 1 (<10K) on the software and model adoption scale. Corrected from level 2, which the declared artifacts do not support.",
-            "last_verified": "2026-08-13",
+            "note": "~5.6k PyPI downloads/month; NVIDIA-backed and the pipeline behind the Nemotron-CC family, but modest raw download volume.",
             "sources": [
               {
-                "url": "https://pypistats.org/api/packages/nemo-curator/recent",
-                "shows": "4,075 downloads in the trailing 30 days for nemo-curator",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "dc1ab53641060ca8b22f2ee98cb263b2448698ae48529ccc9b4f09282749682d"
+                "url": "https://pypistats.org/packages/nemo-curator",
+                "shows": "Downloads last month: 5,618",
+                "accessed": "2026-07-21"
               }
             ]
           },
@@ -16204,11 +16155,11 @@
               }
             ]
           },
-          "maturity": 2.6,
+          "maturity": 3.2,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
-            "basis": "verified"
+            "date": "2026-08-08",
+            "basis": "commit"
           },
           "version_note": "NVIDIA NeMo Curator; repo actively maintained (v1.2.0, 2026-05-14), Apache-2.0 confirmed live 2026-07-21. Powers the Nemotron-CC curation pipeline and Nemotron-4 data prep (8T+ multilingual tokens)."
         },
@@ -16235,19 +16186,16 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 2,
+            "level": 3,
             "reach": "10K-100K",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "22,925 PyPI downloads in the trailing 30 days for olmocr, read 2026-08-13. Bands at level 2 (10K-100K) on the software and model adoption scale. Corrected from level 3, which the declared artifact does not support.",
-            "last_verified": "2026-08-13",
+            "note": "~22k PyPI downloads/month and 19k+ GitHub stars; a leading open document-extraction tool, used in the Dolma 3 data path.",
             "sources": [
               {
-                "url": "https://pypistats.org/api/packages/olmocr/recent",
-                "shows": "22,925 downloads in the trailing 30 days for olmocr",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "bb20341457a175680a368fcc852c01c24115f79f75407a8eb51434d1105d2bcd"
+                "url": "https://pypistats.org/packages/olmocr",
+                "shows": "Downloads last month: 21,753",
+                "accessed": "2026-07-21"
               }
             ]
           },
@@ -16270,11 +16218,11 @@
               }
             ]
           },
-          "maturity": 2.8,
+          "maturity": 3.4,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
-            "basis": "verified"
+            "date": "2026-07-30",
+            "basis": "commit"
           },
           "version_note": "Ai2 olmOCR; repo active (v0.4.27, 2026-03-12), Apache-2.0 confirmed live 2026-07-21. High-profile document-extraction tool (19k+ GitHub stars); feeds the Dolma 3 pipeline."
         },
@@ -16301,11 +16249,11 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 1,
-            "reach": "<10K",
+            "level": 2,
+            "reach": "1K-10K",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "~5.1k PyPI downloads/month; the curation toolkit behind the Dolma corpus and OLMo family. Read live 2026-08-13: 4,390 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at <10K, level 1. Level corrected from 2. The previous reach '1K-10K' was a band off a different scale. No last_verified claimed: only the figure was re-read, not the whole axis.",
+            "note": "~5.1k PyPI downloads/month; the curation toolkit behind the Dolma corpus and OLMo family.",
             "sources": [
               {
                 "url": "https://pypistats.org/packages/dolma",
@@ -16328,7 +16276,7 @@
               }
             ]
           },
-          "maturity": 1.8,
+          "maturity": 2.4,
           "mature": false,
           "freshness": {
             "date": "2026-07-30",
@@ -16360,10 +16308,10 @@
           },
           "adoption": {
             "level": 1,
-            "reach": "<1K stars",
+            "reach": "<10K",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "New (2026) single-purpose Rust CLI, ~56 GitHub stars; real but niche, used in the Dolma 3 pipeline. Stars read 2026-08-13: 56 across the 1 declared repo, which bands at <1K stars, level 1 on the stars scale in signal_routing.yaml. The previous reach '<10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "New (2026) single-purpose Rust CLI, ~56 GitHub stars; real but niche, used in the Dolma 3 pipeline.",
             "sources": [
               {
                 "url": "https://github.com/allenai/datamap-rs",
@@ -16418,10 +16366,10 @@
           },
           "adoption": {
             "level": 1,
-            "reach": "<1K stars",
+            "reach": "<10K",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "New (2026) single-purpose Rust CLI, ~90 GitHub stars; niche, used in the Dolma 3 pipeline. Stars read 2026-08-13: 93 across the 1 declared repo, which bands at <1K stars, level 1 on the stars scale in signal_routing.yaml. The previous reach '<10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "New (2026) single-purpose Rust CLI, ~90 GitHub stars; niche, used in the Dolma 3 pipeline.",
             "sources": [
               {
                 "url": "https://github.com/allenai/duplodocus",
@@ -16476,10 +16424,10 @@
           },
           "adoption": {
             "level": 1,
-            "reach": "<1K stars",
+            "reach": "<10K",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "New (2026) single-purpose Rust CLI, ~35 GitHub stars; niche, used in the Dolma 3 pipeline. Stars read 2026-08-13: 36 across the 1 declared repo, which bands at <1K stars, level 1 on the stars scale in signal_routing.yaml. The previous reach '<10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "New (2026) single-purpose Rust CLI, ~35 GitHub stars; niche, used in the Dolma 3 pipeline.",
             "sources": [
               {
                 "url": "https://github.com/allenai/decon",
@@ -16534,10 +16482,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "1K-10K stars",
+            "reach": "<10K",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "~1.2k GitHub stars and very active development; a research framework with adoption concentrated around the Marin project rather than broad external use. Stars read 2026-08-13: 1,261 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach '<10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "~1.2k GitHub stars and very active development; a research framework with adoption concentrated around the Marin project rather than broad external use.",
             "sources": [
               {
                 "url": "https://github.com/marin-community/marin",
@@ -16772,10 +16720,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "1K-10K stars",
+            "reach": "<10K",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "~1.7k GitHub stars; frozen since 2023 but the canonical, widely-cited documented-corpus construction pipeline (GPT-Neo/J, Pythia). Stars read 2026-08-13: 1,674 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach '<10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "~1.7k GitHub stars; frozen since 2023 but the canonical, widely-cited documented-corpus construction pipeline (GPT-Neo/J, Pythia).",
             "sources": [
               {
                 "url": "https://github.com/EleutherAI/the-pile",
@@ -16830,10 +16778,10 @@
           },
           "adoption": {
             "level": 1,
-            "reach": "<1K stars",
+            "reach": "<10K",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "~25 GitHub stars on the pipeline repo; the value is the 5.7T-token corpus it builds, not the tool's own adoption. Stars read 2026-08-13: 25 across the 1 declared repo, which bands at <1K stars, level 1 on the stars scale in signal_routing.yaml. The previous reach '<10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re- read.",
+            "note": "~25 GitHub stars on the pipeline repo; the value is the 5.7T-token corpus it builds, not the tool's own adoption.",
             "sources": [
               {
                 "url": "https://github.com/LLM360/TxT360",
@@ -16888,7 +16836,7 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "niche",
+            "reach": "enterprise",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "~$237M raised at a ~$1.3B valuation (Series D, May 2025); established enterprise/government adoption rather than frontier-lab pretraining use. Directional.",
@@ -16917,7 +16865,7 @@
           "maturity": 3.4,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-07-30",
             "basis": "commit"
           },
           "version_note": "Snorkel Flow, proprietary enterprise platform (distinct from the Apache-2.0 snorkel-team/snorkel OSS library, which is stale: last release 0.10.0, Feb 2024). Confirmed 2026-07-21. ~$237M raised, ~$1.3B valuation (Series D, May 2025); enterprise/government rather than frontier-lab customers."
@@ -16990,7 +16938,7 @@
           },
           "adoption": {
             "level": 3,
-            "reach": "niche",
+            "reach": "enterprise",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Backed by NVIDIA and distributed through the NeMo platform; Gretel had a large synthetic-data user base pre-acquisition. Directional; hard to separate from NeMo overall.",
@@ -17048,7 +16996,7 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "niche",
+            "reach": "early / niche",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "~$57.5M raised with high-profile backers, but early-stage with no named frontier-lab deployments; traction is credibility/funding rather than proven scale. Directional.",
@@ -17077,7 +17025,7 @@
           "maturity": 2.4,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-07-30",
             "basis": "commit"
           },
           "version_note": "DatologyAI, proprietary curation platform deployed into customer VPC; no source-available product. Founded 2023 by Ari Morcos (ex-FAIR/DeepMind) and Matthew Leavitt (ex-MosaicML). ~$57.5M raised (seed + $46M Series A); angels include Jeff Dean and Yann LeCun. No named frontier-lab customers disclosed. Confirmed 2026-07-21."
@@ -17106,10 +17054,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "1K-10K stars",
+            "reach": "<10K",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "~1,454 GitHub stars; no PyPI package (source install). The reference DataComp-LM toolkit. Stars read 2026-08-13: 1,463 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach '<10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "~1,454 GitHub stars; no PyPI package (source install). The reference DataComp-LM toolkit.",
             "sources": [
               {
                 "url": "https://github.com/mlfoundations/dclm",
@@ -17163,19 +17111,16 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 1,
-            "reach": "<10K",
+            "level": 2,
+            "reach": "1K-10K",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "2,962 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (py-data-juicer 2,962). Bands at level 1 (<10K) on the software and model adoption scale. Corrected from level 2, which the declared artifacts do not support.",
-            "last_verified": "2026-08-13",
+            "note": "~3.1k PyPI downloads/month (py-data-juicer) and ~6.7k GitHub stars; actively developed.",
             "sources": [
               {
-                "url": "https://pypistats.org/api/packages/py-data-juicer/recent",
-                "shows": "2,962 downloads in the trailing 30 days for py-data-juicer",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "eaa1f81789a0024761112d9997242290456808a3f7351e6514b040fb1421955c"
+                "url": "https://pypistats.org/packages/py-data-juicer",
+                "shows": "Downloads last month: ~3,107",
+                "accessed": "2026-07-21"
               }
             ]
           },
@@ -17193,11 +17138,11 @@
               }
             ]
           },
-          "maturity": 2.2,
+          "maturity": 2.8,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
-            "basis": "verified"
+            "date": "2026-07-30",
+            "basis": "commit"
           },
           "version_note": "Alibaba Data-Juicer (datajuicer/data-juicer, formerly modelscope); Apache-2.0, very active (v1.5.3, Jun 2026). PyPI package py-data-juicer. 200+ operators for multimodal LLM data processing."
         },
@@ -17225,10 +17170,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "1K-10K stars",
+            "reach": "<10K",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "~1,000 GitHub stars; research repo, no PyPI package. Archived since 2023 but a foundational, widely- reused pipeline. Stars read 2026-08-13: 1,045 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach '<10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "~1,000 GitHub stars; research repo, no PyPI package. Archived since 2023 but a foundational, widely-reused pipeline.",
             "sources": [
               {
                 "url": "https://github.com/facebookresearch/cc_net",
@@ -17283,10 +17228,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "1K-10K stars",
+            "reach": "<10K",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "~4,969 GitHub stars; pipeline repo, no PyPI package. Widely referenced quality-signal pipeline; dormant since Dec 2024. Stars read 2026-08-13: 4,977 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach '<10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "~4,969 GitHub stars; pipeline repo, no PyPI package. Widely referenced quality-signal pipeline; dormant since Dec 2024.",
             "sources": [
               {
                 "url": "https://github.com/togethercomputer/RedPajama-Data",
@@ -17482,11 +17427,11 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 3,
-            "reach": ">10K stars",
+            "level": 2,
+            "reach": "10K-100K",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "Primarily a research/benchmark agent; 19.4k stars in the research community. No published download/user volume; capped per stars-fallback rule. Adoption is research-circle, not production end-user scale. Stars read 2026-08-13: 20,055 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. Level corrected from 2. The previous reach '10K-100K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "Primarily a research/benchmark agent; 19.4k stars in the research community. No published download/user volume; capped per stars-fallback rule. Adoption is research-circle, not production end-user scale.",
             "sources": [
               {
                 "url": "https://github.com/SWE-agent/SWE-agent",
@@ -17510,7 +17455,7 @@
               }
             ]
           },
-          "maturity": 3.0,
+          "maturity": 2.7,
           "mature": false,
           "freshness": {
             "date": "2026-08-08",
@@ -17542,10 +17487,10 @@
           },
           "adoption": {
             "level": 3,
-            "reach": ">10K stars",
+            "reach": "100K-1M",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "46.4k stars and active multi-surface distribution (desktop/CLI/API), backed by Block and now Linux Foundation. No published download/MAU figure found, so capped at level 3 on stars-fallback; directional. Stars read 2026-08-13: 52,753 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The previous reach '100K-1M' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re- read.",
+            "note": "46.4k stars and active multi-surface distribution (desktop/CLI/API), backed by Block and now Linux Foundation. No published download/MAU figure found, so capped at level 3 on stars-fallback; directional.",
             "sources": [
               {
                 "url": "https://github.com/aaif-goose/goose",
@@ -17638,6 +17583,7 @@
           },
           "adoption": {
             "level": 4,
+            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "high",
             "note": "OpenAI confirmed Codex surpassed 4M weekly developers (Apr 21 2026 announcement; 5M+ reported more recently). Firmly in the 1-10M+ reach band on disclosed developer count. Primary OpenAI announcement now cited as the basis (was previously sourced only to a distribution page).",
@@ -17700,10 +17646,10 @@
           },
           "adoption": {
             "level": 3,
-            "reach": ">10K stars",
+            "reach": "100K-1M",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "185k stars (one of the most-starred repos on GitHub) reflects huge historical interest, but stars cannot exceed level 3 and recent production-usage signal is unclear. No published platform MAU/download volume found; capped at 3, directional. Stars read 2026-08-13: 186,583 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The previous reach '100K-1M' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "185k stars (one of the most-starred repos on GitHub) reflects huge historical interest, but stars cannot exceed level 3 and recent production-usage signal is unclear. No published platform MAU/download volume found; capped at 3, directional.",
             "sources": [
               {
                 "url": "https://github.com/Significant-Gravitas/AutoGPT",
@@ -17757,19 +17703,21 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 2,
-            "reach": "10K-100K",
+            "level": 3,
+            "reach": "100K-1M",
             "signal_type": "usage_volume",
             "confidence": "medium",
-            "note": "80,472 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (gpt-researcher 80,472). Bands at level 2 (10K-100K) on the software and model adoption scale. Corrected from level 3, which the declared artifacts do not support.",
-            "last_verified": "2026-08-13",
+            "note": "~105,483 PyPI downloads last month (gpt-researcher); 'used by' 261 dependent repos; 27.5k stars corroborate. Places it in the 100K-1M reach band on monthly download volume.",
             "sources": [
               {
-                "url": "https://pypistats.org/api/packages/gpt-researcher/recent",
-                "shows": "80,472 downloads in the trailing 30 days for gpt-researcher",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "bd0e6196bb6b82c101587b05a7cc499f63071433b7ef92e92401f1ad9c6a18c2"
+                "url": "https://pypistats.org/packages/gpt-researcher",
+                "shows": "105,483 downloads last month",
+                "accessed": "2026-06-04"
+              },
+              {
+                "url": "https://github.com/assafelovic/gpt-researcher",
+                "shows": "261 dependent repos, 27.5k stars",
+                "accessed": "2026-06-04"
               }
             ]
           },
@@ -17787,11 +17735,11 @@
               }
             ]
           },
-          "maturity": 2.7,
+          "maturity": 3.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
-            "basis": "verified"
+            "date": "2026-07-30",
+            "basis": "commit"
           },
           "version_note": "GPT Researcher (assafelovic/gpt-researcher), v3.5.0 (May 28 2026); 27.5k stars, Apache-2.0. Autonomous deep-research agent that plans sub-queries, searches web/local sources, and writes cited reports. Confirmed live June 2026."
         },
@@ -17823,11 +17771,11 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 3,
-            "reach": ">10K stars",
+            "level": 2,
+            "reach": "10K-100K",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "19.8k stars and a managed cloud offering, but no published download/user-count figure; capped on stars fallback. Placed at 2 given the relatively young, smaller community vs the leading agents; directional. Stars read 2026-08-13: 20,094 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. Level corrected from 2. The previous reach '10K-100K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "19.8k stars and a managed cloud offering, but no published download/user-count figure; capped on stars fallback. Placed at 2 given the relatively young, smaller community vs the leading agents; directional.",
             "sources": [
               {
                 "url": "https://github.com/kortix-ai/suna",
@@ -17850,7 +17798,7 @@
               }
             ]
           },
-          "maturity": 3.0,
+          "maturity": 2.7,
           "mature": false,
           "freshness": {
             "date": "2026-07-30",
@@ -17903,6 +17851,7 @@
           },
           "adoption": {
             "level": 4,
+            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Reuters (Feb 2026): Claude Code exceeded ~$2.5B run-rate revenue, with business subscriptions quadrupled since the start of 2026 and enterprise now >half of Claude Code revenue. No clean user-count, so reported_traction; revenue scale implies well into the 1-10M+ developer band.",
@@ -18003,7 +17952,7 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M users",
+            "reach": "1M-10M",
             "signal_type": "active_users",
             "confidence": "high",
             "note": "1M+ daily active users (reported 2025, sustained Dec 2025) and ~$2B ARR by Feb 2026; ~64% of Fortune 500 active. Confirmed via press coverage of company-reported figures. 1M+ DAU puts it in the 1-10M band (not yet a confirmed >10M mass-market count).",
@@ -18072,6 +18021,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Widely adopted commercial coding agent with paid Individual/Teams/Enterprise tiers, but Cognition discloses no hard user count. Placed at 3 on reported commercial traction; no verified usage_volume figure.",
@@ -18108,7 +18058,7 @@
           "maturity": 3.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-08",
             "basis": "commit"
           },
           "version_note": "Devin by Cognition AI, autonomous SaaS software-engineering agent (web IDE + CLI). Verified live June 2026 at docs.devin.ai and devin.ai/pricing; Individual/Teams/Enterprise plans. Devin 2.0 generation."
@@ -18212,6 +18162,7 @@
           },
           "adoption": {
             "level": 4,
+            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Devin Desktop (Windsurf) page reports '1M+ Users' and '4000+ Enterprise Customers'. Vendor-reported headline count places it in the 1-10M band. Cognition-reported Windsurf ARR ~$82M corroborates commercial scale.",
@@ -18245,7 +18196,7 @@
           "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-06-09",
             "basis": "commit"
           },
           "version_note": "Windsurf (formerly Codeium) acquired by Cognition (def. agreement July 2025) and rebranded 'Devin Desktop' on June 2 2026; windsurf.com redirects to devin.ai/desktop. Agent manager wrapped in a full IDE; Cascade legacy, successor Devin Local (Rust). Verified June 2026."
@@ -18274,6 +18225,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Distributed across AWS's large developer base via IDEs/CLI/Console with free + Pro tiers and enterprise case studies, but AWS discloses no hard Q Developer user count. Placed at 3 on reported traction.",
@@ -18302,7 +18254,7 @@
           "maturity": 3.7,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-06-24",
             "basis": "commit"
           },
           "version_note": "Amazon Q Developer, AWS's agentic GenAI software-development assistant across IDEs/CLI/Console/chat. Free tier (50 agentic chats/mo) + Pro tier. Verified live June 2026 at aws.amazon.com/q/developer."
@@ -18331,10 +18283,10 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M users",
+            "reach": ">10M",
             "signal_type": "active_users",
             "confidence": "high",
-            "note": "GitHub Copilot surpassed 20M+ all-time users (Microsoft July 2025 earnings): 'world's most widely adopted AI developer tool.' Agent mode is the autonomous surface of that base. Bands at >10M users, level 5 on the active_users scale declared 2026-08-13. WHAT WAS BANDED - 20M is an ALL-TIME cumulative count, not an active one, and no agent-mode-specific figure is disclosed - so this is a substitution in the sense of docs/guides/adoption.md and the true active figure is lower, not higher. The level is unchanged; what changed is that the label under it is now one a declared scale offers.",
+            "note": "GitHub Copilot surpassed 20M+ all-time users (Microsoft July 2025 earnings): 'world's most widely adopted AI developer tool.' Agent mode is the autonomous surface of that base. >10M band. Note: 20M is all-time, not active; agent-mode-specific count not disclosed, but base scale firmly supports level 5.",
             "sources": [
               {
                 "url": "https://github.com/features/copilot",
@@ -18365,7 +18317,7 @@
           "maturity": 4.3,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-06-24",
             "basis": "commit"
           },
           "version_note": "GitHub Copilot Agent Mode, assigns autonomous background coding tasks (plan/explore/execute), supports first-party Copilot agent plus Claude (Anthropic) and Codex (OpenAI). Verified live June 2026 at github.com/features/copilot."
@@ -18394,6 +18346,7 @@
           },
           "adoption": {
             "level": 4,
+            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Replit reported 50M+ platform users with agent-driven consumption as primary growth driver (ARR ~$250M). User count is platform-wide, not agent-specific, so placed conservatively at 4 on reported traction rather than treating the 50M as an agent active-user figure.",
@@ -18427,7 +18380,7 @@
           "maturity": 3.3,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-06-09",
             "basis": "commit"
           },
           "version_note": "Replit Agent (Agent 4 generation), autonomous AI app-building agent in the Replit cloud IDE, parallel multi-task build, design + functionality in parallel. Verified live June 2026 at replit.com/agent; proprietary, consumption-priced on top of Replit subscriptions."
@@ -18456,6 +18409,7 @@
           },
           "adoption": {
             "level": 4,
+            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Vercel reports multi-million (4M+) cumulative v0 users since GA. Falls in the 1-10M band; reported_traction since the figure is vendor cumulative-user rather than a hard active-user metric.",
@@ -18489,7 +18443,7 @@
           "maturity": 3.3,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-06-09",
             "basis": "commit"
           },
           "version_note": "v0 by Vercel (v0.app), agentic full-stack web app builder ('agentic by default', autonomous plan/create-tasks/connect-DB as it builds); web + iOS, subscription (v0 Pro). Verified live June 2026 at v0.app. (Note: prior record's 'powered by Claude Opus 4.8' could NOT be confirmed on the product page. No model named publicly; claim softened.)"
@@ -18595,11 +18549,11 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 2,
-            "reach": "1K-10K stars",
+            "level": 1,
+            "reach": "<1K",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "No download/user/usage metrics disclosed (it's a self-hosted app, not a registry package). Only signal available is GitHub stars (~577 on vellum-ai/vellum-assistant), used here strictly as a last-resort proxy per the adoption!=stars rule; small/new entrant. Previously null; set to a conservative level 1 now that a real (if weak) signal exists. Stars read 2026-08-13 on vellum-ai/vellum-assistant: 1,054, which bands at 1K-10K stars, level 2 on the stars scale. The previous reach '<1K' was a download label, which this instrument does not offer - a star is not a download. Level corrected from 1. THE REAL DEFECT is upstream: this product declares no artifacts at all, so a stars_fallback band had no stars source behind it and the count lived only in this note. Declaring vellum-ai/vellum-assistant would fix it, and is deliberately not done here because a declared code repo also re-routes the openness license dimension. No last_verified claimed: a star count is volatile.",
+            "note": "No download/user/usage metrics disclosed (it's a self-hosted app, not a registry package). Only signal available is GitHub stars (~577 on vellum-ai/vellum-assistant), used here strictly as a last-resort proxy per the adoption!=stars rule; small/new entrant. Previously null; set to a conservative level 1 now that a real (if weak) signal exists.",
             "sources": [
               {
                 "url": "https://github.com/vellum-ai/vellum-assistant",
@@ -18627,7 +18581,7 @@
               }
             ]
           },
-          "maturity": 2.7,
+          "maturity": 2.4,
           "mature": false,
           "freshness": {
             "date": "2026-07-30",
@@ -18805,10 +18759,10 @@
           },
           "adoption": {
             "level": 3,
-            "reach": ">10K stars",
+            "reach": "100K-1M",
             "signal_type": "stars_fallback",
             "confidence": "high",
-            "note": "~144K GitHub stars plus Dify Cloud managed tier; no honest active-user/download volume figure verified, so capped at 3 on stars fallback. Stars read 2026-08-13 on langgenius/dify: 152,331, which bands at >10K stars, level 3 on the stars scale. The previous reach '100K-1M' was a download label, which this instrument does not offer - a star is not a download. THE REAL DEFECT is upstream: this product declares no artifacts at all, so a stars_fallback band had no stars source behind it and the count lived only in this note. Declaring langgenius/dify would fix it, and is deliberately not done here because a declared code repo also re-routes the openness license dimension. No last_verified claimed: a star count is volatile.",
+            "note": "~144K GitHub stars plus Dify Cloud managed tier; no honest active-user/download volume figure verified, so capped at 3 on stars fallback.",
             "sources": [
               {
                 "url": "https://github.com/langgenius/dify",
@@ -19017,6 +18971,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "high",
             "note": "~75.8k GitHub stars, $18.8M Series A, contributors from major firms, OpenHands Cloud with multi-user/Slack/Jira/Linear integrations. No precise active-user/download count verified; rated 3 on reported traction.",
@@ -19658,10 +19613,9 @@
           },
           "adoption": {
             "level": 3,
-            "reach": ">10K stars",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "~57k stars but negligible package usage (~186 PyPI downloads/month) - stars_fallback (capped at 3). Stars read 2026-08-13: 57,954 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The record carried no reach label at all before this. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "~57k stars but negligible package usage (~186 PyPI downloads/month) - stars_fallback (capped at 3).",
             "sources": [
               {
                 "url": "https://pypistats.org/packages/openmanus",
@@ -19777,10 +19731,9 @@
           },
           "adoption": {
             "level": 3,
-            "reach": ">10K stars",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "~34k stars; no published download telemetry - stars_fallback (capped at 3). Stars read 2026-08-13: 35,476 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The record carried no reach label at all before this. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "~34k stars; no published download telemetry - stars_fallback (capped at 3).",
             "sources": [
               {
                 "url": "https://github.com/microsoft/graphrag",
@@ -19957,10 +19910,10 @@
           },
           "adoption": {
             "level": 1,
-            "reach": "<1K stars",
+            "reach": "<10K",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "~2 GitHub stars (July 2026), created Aug 2025 — pre-adoption. Part of OpenMined's federated-RAG effort (also local-rag, local-rag-router). Included as an emerging entry, not on adoption merit. Stars read 2026-08-13: 2 across the 1 declared repo, which bands at <1K stars, level 1 on the stars scale in signal_routing.yaml. The previous reach '<10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "~2 GitHub stars (July 2026), created Aug 2025 — pre-adoption. Part of OpenMined's federated-RAG effort (also local-rag, local-rag-router). Included as an emerging entry, not on adoption merit.",
             "sources": [
               {
                 "url": "https://github.com/OpenMined/syft-hub-sdk",
@@ -20540,25 +20493,14 @@
           },
           "adoption": {
             "level": 3,
-            "signal_type": "usage_volume",
+            "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "About 129,133 downloads a month across the product’s real distribution channels, read 2026-08-13 (Docker Hub 3,590,166 cumulative since 2023-12-12, about 112,087 a month; ragflow-sdk 17,046 in the trailing 30 days). Bands at level 3 (100K-1M). RAGFlow ships as a Docker Compose stack; ragflow-sdk on PyPI is an API client rather than the server, so it measures a different thing and is added only as a minor component. Moved off the stars fallback under the under-coverage rule in docs/guides/adoption.md: banding on a channel the product does not ship through is a substitution rather than a measurement. The level is UNCHANGED at 3 - the stars cap happened to give the right answer here - but it now rests on a measured figure instead of a capped proxy. The Docker component is a lifetime average, not a trailing-30-day count, so this is a floor.",
-            "reach": "100K-1M",
-            "last_verified": "2026-08-13",
+            "note": "~83k stars; Docker-distributed with no download metric retrieved - stars_fallback (capped at 3).",
             "sources": [
               {
-                "url": "https://hub.docker.com/v2/repositories/infiniflow/ragflow/",
-                "shows": "3,590,166 cumulative pulls of infiniflow/ragflow",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "095ef0ed513ee365aae263321c77599f65537b6f30a29eea5e584be1231b937b"
-              },
-              {
-                "url": "https://pypistats.org/api/packages/ragflow-sdk/recent",
-                "shows": "17,046 downloads in the trailing 30 days for ragflow-sdk",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "465245cf97ae8442f7e3a072ca91a6df1c2d135be904b006807329b1381eaec5"
+                "url": "https://ragflow.io",
+                "shows": "official site, InfiniFlow, self-host + cloud",
+                "accessed": "2026-06-18"
               }
             ]
           },
@@ -20579,8 +20521,8 @@
           "maturity": 3.7,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
-            "basis": "verified"
+            "date": "2026-07-30",
+            "basis": "commit"
           },
           "version_note": "Apache-2.0. ~83k stars. Deployed via Docker Compose (no first-party PyPI/npm). Commercial managed cloud / enterprise edition exists; the self-hosted engine is fully open."
         },
@@ -20608,10 +20550,9 @@
           },
           "adoption": {
             "level": 1,
-            "reach": "<1K stars",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "~237 GitHub stars, 55 forks (Aug 2026) — early-stage. No download metric available (Docker- distributed, no first-party PyPI/npm), so adoption falls back to stars, which the ladder caps at 3; 237 stars places it in the lowest band. Stars read 2026-08-13: 238 across the 1 declared repo, which bands at <1K stars, level 1 on the stars scale in signal_routing.yaml. The record carried no reach label at all before this. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "~237 GitHub stars, 55 forks (Aug 2026) — early-stage. No download metric available (Docker-distributed, no first-party PyPI/npm), so adoption falls back to stars, which the ladder caps at 3; 237 stars places it in the lowest band.",
             "sources": [
               {
                 "url": "https://github.com/linagora/openrag",
@@ -20734,10 +20675,10 @@
           },
           "adoption": {
             "level": 1,
-            "reach": "<1K stars",
+            "reach": "<10K",
             "signal_type": "stars_fallback",
             "confidence": "high",
-            "note": "Pre-release alpha (PyPI 0.3a0, Jun 2026) roughly one month old; ~96 GitHub stars. Minimal adoption to date, included as an emerging on-thesis structured-data agent. Stars read 2026-08-13: 110 across the 1 declared repo, which bands at <1K stars, level 1 on the stars scale in signal_routing.yaml. The previous reach '<10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "Pre-release alpha (PyPI 0.3a0, Jun 2026) roughly one month old; ~96 GitHub stars. Minimal adoption to date, included as an emerging on-thesis structured-data agent.",
             "sources": [
               {
                 "url": "https://github.com/datasette/datasette-agent",
@@ -20908,11 +20849,11 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 2,
-            "reach": "1K-10K stars",
+            "level": 3,
+            "reach": "niche",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "974 GitHub stars and 218 forks; no package download figures available. Stars read 2026-08-13: 1,164 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. Level corrected from 3. The previous reach 'niche' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "974 GitHub stars and 218 forks; no package download figures available.",
             "sources": [
               {
                 "url": "https://github.com/Hexastack/Hexabot",
@@ -20935,7 +20876,7 @@
               }
             ]
           },
-          "maturity": 3.4,
+          "maturity": 3.7,
           "mature": false,
           "freshness": {
             "date": "2026-08-11",
@@ -21103,6 +21044,7 @@
           },
           "adoption": {
             "level": 4,
+            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Default inference surface for Microsoft Foundry across Azure's enterprise base; broad distribution but no published per-service usage number. Level 4 reflects Azure-enterprise scale (reported), not a measured count.",
@@ -21131,7 +21073,7 @@
           "maturity": 3.7,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-06-09",
             "basis": "commit"
           },
           "version_note": "Microsoft Foundry Models unified inference endpoint (Azure AI Model Inference). Proprietary managed cloud service exposing many model deployments through one OpenAI-compatible endpoint; beta Azure AI Inference SDK deprecated, retiring Aug 26 2026 in favor of OpenAI/v1 API. Confirmed live (docs updated Apr 2026)."
@@ -21165,10 +21107,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "1K-10K stars",
+            "reach": "10K-100K",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "Only ~8.4k GitHub stars and no published download/usage volume found this run; capped low on stars fallback (cannot exceed level 3). Recently renamed from Llama Stack, so historical signal is muddled. Stars read 2026-08-13 on ogx-ai/ogx: 8,420, which bands at 1K-10K stars, level 2 on the stars scale. The previous reach '10K-100K' was a download label, which this instrument does not offer - a star is not a download. THE REAL DEFECT is upstream: this product declares no artifacts at all, so a stars_fallback band had no stars source behind it and the count lived only in this note. Declaring ogx-ai/ogx would fix it, and is deliberately not done here because a declared code repo also re-routes the openness license dimension. No last_verified claimed: a star count is volatile.",
+            "note": "Only ~8.4k GitHub stars and no published download/usage volume found this run; capped low on stars fallback (cannot exceed level 3). Recently renamed from Llama Stack, so historical signal is muddled.",
             "sources": [
               {
                 "url": "https://github.com/ogx-ai/ogx",
@@ -21227,19 +21169,16 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 3,
-            "reach": "100K-1M",
+            "level": 4,
+            "reach": "1M-10M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "879,127 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (open-webui 879,127). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected from level 4, which the declared artifacts do not support.",
-            "last_verified": "2026-08-13",
+            "note": "~1.72M PyPI downloads last month (pypistats, primary); vendor reports 290M cumulative downloads and 420K community members. De facto leading self-hosted LLM chat UI; firmly in 1-10M band on monthly install volume (stars 140k corroborate only).",
             "sources": [
               {
-                "url": "https://pypistats.org/api/packages/open-webui/recent",
-                "shows": "879,127 downloads in the trailing 30 days for open-webui",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "cbc0df85af0e683e7063f02d9c33e1a677409ac058d62a02ef3ce638001e6349"
+                "url": "https://pypistats.org/packages/open-webui",
+                "shows": "1,717,371 downloads last month",
+                "accessed": "2026-06-04"
               }
             ]
           },
@@ -21257,11 +21196,11 @@
               }
             ]
           },
-          "maturity": 3.3,
+          "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
-            "basis": "verified"
+            "date": "2026-07-30",
+            "basis": "commit"
           },
           "version_note": "v0.9.6 (June 1, 2026), confirmed live on GitHub June 2026. Self-hosted chat UI (Ollama + OpenAI-compatible APIs)."
         },
@@ -21357,10 +21296,10 @@
           },
           "adoption": {
             "level": 3,
-            "reach": ">10K stars",
+            "reach": "100K-1M",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "78.2k GitHub stars, 15.4k forks; Docker image (lobehub/lobehub) and LobeHub Cloud exist but no verified pull/MAU figure was obtainable from a primary source this run. Capped at 3 on stars fallback per rubric. Stars read 2026-08-13: 81,633 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The previous reach '100K-1M' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "78.2k GitHub stars, 15.4k forks; Docker image (lobehub/lobehub) and LobeHub Cloud exist but no verified pull/MAU figure was obtainable from a primary source this run. Capped at 3 on stars fallback per rubric.",
             "sources": [
               {
                 "url": "https://github.com/lobehub/lobehub",
@@ -21492,10 +21431,10 @@
           },
           "adoption": {
             "level": 3,
-            "reach": ">10K stars",
+            "reach": "100K-1M",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "88.2k GitHub stars and one-click Vercel deploy indicate broad lightweight use, but no verified download/MAU figure from a primary source this run, and last release ~6-12mo ago. Capped at 3 on stars fallback; momentum appears to have slowed. Stars read 2026-08-13 on ChatGPTNextWeb/NextChat: 88,617, which bands at >10K stars, level 3 on the stars scale. The previous reach '100K-1M' was a download label, which this instrument does not offer - a star is not a download. THE REAL DEFECT is upstream: this product declares no artifacts at all, so a stars_fallback band had no stars source behind it and the count lived only in this note. Declaring ChatGPTNextWeb/NextChat would fix it, and is deliberately not done here because a declared code repo also re-routes the openness license dimension. No last_verified claimed: a star count is volatile.",
+            "note": "88.2k GitHub stars and one-click Vercel deploy indicate broad lightweight use, but no verified download/MAU figure from a primary source this run, and last release ~6-12mo ago. Capped at 3 on stars fallback; momentum appears to have slowed.",
             "sources": [
               {
                 "url": "https://github.com/ChatGPTNextWeb/NextChat",
@@ -21550,6 +21489,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Hosted HuggingChat served 1M+ users and 100k+ assistants over its lifetime (HF announcement) before the July 2025 sunset; relaunched as HuggingChat Omni and live again on hf.co/chat. chat-ui repo itself is a modest 10.7k stars (self-host base is niche). Placed at 3 on the disclosed lifetime user reach of the hosted product; the discontinuity + relaunch lowers confidence.",
@@ -21590,7 +21530,7 @@
           "maturity": 3.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-08",
             "basis": "commit"
           },
           "version_note": "chat-ui v0.10.0 (May 11, 2026), Apache-2.0, powers HuggingChat at hf.co/chat. Original HuggingChat was sunset July 1, 2025, then relaunched as 'HuggingChat Omni' (Omni Router + 115-123 open models, 15 inference providers, MCP). Confirmed live June 2026."
@@ -21793,10 +21733,10 @@
           },
           "adoption": {
             "level": 3,
-            "reach": ">10K stars",
+            "reach": "100K-1M",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "No published download/install or active-user counts found (self-hosted desktop app, no telemetry). Falling back to 28.9k GitHub stars + 300+ contributors as the only honest signal, capped at level 3 per the stars-fallback rule. Likely a large enthusiast/roleplay community but unverified. Stars read 2026-08-13: 32,041 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The previous reach '100K-1M' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "No published download/install or active-user counts found (self-hosted desktop app, no telemetry). Falling back to 28.9k GitHub stars + 300+ contributors as the only honest signal, capped at level 3 per the stars-fallback rule. Likely a large enthusiast/roleplay community but unverified.",
             "sources": [
               {
                 "url": "https://github.com/SillyTavern/SillyTavern",
@@ -21973,11 +21913,11 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 2,
-            "reach": "10K-100K",
+            "level": 3,
+            "reach": "100K+ Docker pulls",
             "signal_type": "usage_volume",
             "confidence": "medium",
-            "note": "~35k GitHub stars plus 100k+ Docker pulls on the current itzcrazykns1337/vane image by mid-2026 - genuine install volume (usage_volume, not stars-only), but well below the 1M+ band, so mid-tier. Re-banded 2026-08-13 under the lifetime-average rule in docs/guides/adoption.md. Docker Hub reports 645,952 cumulative pulls on itzcrazykns1337/perplexica since 2025-03-20, which averages ~38,479 a month over 16.8 months and bands at 10K-100K. LEVEL CORRECTED FROM 3: the previous reach '100K+ Docker pulls' read a cumulative six-figure total as though it were a monthly one, which is precisely the substitution the n8n rule names, and it put the record a band above what its own number supports. Recorded as a declared floor - a lifetime average understates a growing product. Docker is not declared as an artifact here, so the figure lives in this note rather than in a signal. No last_verified claimed.",
+            "note": "~35k GitHub stars plus 100k+ Docker pulls on the current itzcrazykns1337/vane image by mid-2026 - genuine install volume (usage_volume, not stars-only), but well below the 1M+ band, so mid-tier.",
             "sources": [
               {
                 "url": "https://hub.docker.com/r/itzcrazykns1337/vane",
@@ -22000,7 +21940,7 @@
               }
             ]
           },
-          "maturity": 2.6,
+          "maturity": 3.3,
           "mature": false,
           "freshness": {
             "date": "2026-07-30",
@@ -22036,19 +21976,16 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 2,
-            "reach": "10K-100K",
+            "level": 3,
+            "reach": "~26k PyPI downloads/month",
             "signal_type": "usage_volume",
             "confidence": "medium",
-            "note": "19,532 PyPI downloads in the trailing 30 days for khoj, read 2026-08-13. Bands at level 2 (10K-100K) on the software and model adoption scale. Corrected from level 3, which the declared artifact does not support.",
-            "last_verified": "2026-08-13",
+            "note": "~35k GitHub stars plus ~26k PyPI downloads/month (pypistats) - real install volume (usage_volume, not stars-only), but modest in absolute terms, so mid-tier. Hosted cloud is now discontinued.",
             "sources": [
               {
-                "url": "https://pypistats.org/api/packages/khoj/recent",
-                "shows": "19,532 downloads in the trailing 30 days for khoj",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "4cc696880071d82fc383bf3f67fde0c2eb2b23a975eb391d5f3a23f28815fb71"
+                "url": "https://pypistats.org/packages/khoj",
+                "shows": "~26,054 downloads last month",
+                "accessed": "2026-06-17"
               }
             ]
           },
@@ -22066,11 +22003,11 @@
               }
             ]
           },
-          "maturity": 2.6,
+          "maturity": 3.3,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
-            "basis": "verified"
+            "date": "2026-07-30",
+            "basis": "commit"
           },
           "version_note": "AGPL-3.0; ~35k GitHub stars and ~26k PyPI downloads/month by mid-2026. Khoj Cloud (the former paid hosted tier) was sunset 2026-04-15; the team directs all users to self-host and states Khoj \"remains fully open source\", so no feature-gating remains in the shipping product. Self-host via Docker or pip."
         },
@@ -22103,10 +22040,9 @@
           },
           "adoption": {
             "level": 3,
-            "reach": ">10K stars",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "~15k GitHub stars by mid-2026; no download/usage telemetry available for a self-hosted web app, so stars_fallback (capped at level 3). Rapid star growth but unproven real-world deployment. Stars read 2026-08-13: 15,898 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The record carried no reach label at all before this. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "~15k GitHub stars by mid-2026; no download/usage telemetry available for a self-hosted web app, so stars_fallback (capped at level 3). Rapid star growth but unproven real-world deployment.",
             "sources": [
               {
                 "url": "https://github.com/MODSetter/SurfSense",
@@ -22161,7 +22097,7 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M users",
+            "reach": ">10M",
             "signal_type": "active_users",
             "confidence": "high",
             "note": "OpenAI officially announced ~900M weekly active users (27 Feb 2026), up from 800M (Oct 2025), with 50M paying subscribers. Mass-market scale, far above the >10M threshold. Attributed to the ChatGPT surface.",
@@ -22190,7 +22126,7 @@
           "maturity": 5.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-06-09",
             "basis": "commit"
           },
           "version_note": "ChatGPT (OpenAI) consumer chat app, web + iOS/Android + desktop. Proprietary/closed UI scored as the closed counterpart in this category. Live and verified June 2026; default model GPT-5 family. (The model SKU is scored separately under base/finetuned categories; this record scores the chat surface.)"
@@ -22219,10 +22155,10 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M users",
+            "reach": ">10M",
             "signal_type": "active_users",
             "confidence": "high",
-            "note": "Microsoft CEO confirmed 20M all-time Copilot users (earnings call, 30 Jul 2025); free tier opened to 150M GitHub developers (Dec 2024); ~4.7M paid subscribers by Jan 2026. Bands at >10M users, level 5 on the active_users scale declared 2026-08-13. WHAT WAS BANDED - the 20M is ALL-TIME rather than active, and the one genuinely active-adjacent figure available - 4.7M paid subscribers - sits a band lower, at 4. The level is unchanged from what this record already carried; what changed is that the label under it is now one a declared scale offers, and that the substitution is named.",
+            "note": "Microsoft CEO confirmed 20M all-time Copilot users (earnings call, 30 Jul 2025); free tier opened to 150M GitHub developers (Dec 2024); ~4.7M paid subscribers by Jan 2026. All-time user base exceeds the >10M mass-market threshold. (All-time vs active distinction noted; still clearly level 5.)",
             "sources": [
               {
                 "url": "https://techcrunch.com/2025/07/30/github-copilot-crosses-20-million-all-time-users/",
@@ -22253,7 +22189,7 @@
           "maturity": 5.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-07-29",
             "basis": "commit"
           },
           "version_note": "GitHub Copilot (GitHub / Microsoft), proprietary in-IDE AI coding assistant (inline suggestions, chat, agent mode) across VS Code/JetBrains/etc. Closed counterpart in ui_api. Verified live on github.com/features/copilot June 2026."
@@ -22281,11 +22217,11 @@
             "bucket": "closed"
           },
           "adoption": {
-            "level": 5,
-            "reach": ">10M users",
+            "level": 4,
+            "reach": "1M-10M",
             "signal_type": "active_users",
             "confidence": "low",
-            "note": "Anthropic does NOT disclose official Claude.ai MAU. Third-party estimates (no primary vendor figure available) put consumer MAU ~18.9M web at start of 2026 rising toward ~30M by mid-2026, which bands at >10M users, level 5 on the active_users scale declared 2026-08-13. RAISED from 4, which had been recorded against a reach of '1M-10M' - a label its own cited figure contradicted by roughly twofold at the low end. The scale is what makes that contradiction visible - nothing previously compared the number in the note to the band above it. Level 5 here does not claim parity with ChatGPT or the Gemini app, which are two orders larger; it says all three are mass-market, which is what the map's top band means. Confidence stays low - the headline number is a third-party estimate, not a vendor disclosure.",
+            "note": "Anthropic does NOT disclose official Claude.ai MAU. Third-party estimates (no primary vendor figure available) put consumer MAU ~18.9M web at start of 2026 rising toward ~30M by mid-2026, i.e. comfortably above 1M but well below the >10M-billion scale of ChatGPT/Gemini app. Placed at level 4 on best-available estimate; confidence low because the headline number is an estimate, not a vendor primary disclosure (flagged).",
             "sources": [
               {
                 "url": "https://claude.com/product/overview",
@@ -22313,10 +22249,10 @@
               }
             ]
           },
-          "maturity": 5.0,
+          "maturity": 4.3,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-06-24",
             "basis": "commit"
           },
           "version_note": "Claude.ai (Anthropic) consumer chat app, web + macOS/Windows + iOS/Android. Proprietary/closed UI scored as the closed counterpart. Verified live June 2026 (product page now at claude.com/product/overview, redirected from anthropic.com/claude). Uses Claude Opus/Sonnet/Haiku."
@@ -22345,7 +22281,7 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M users",
+            "reach": ">10M",
             "signal_type": "active_users",
             "confidence": "high",
             "note": "Google CEO Sundar Pichai officially stated the Gemini app surpassed 750M monthly active users (Q4 2025 earnings, 4 Feb 2026), up from 450M earlier in 2025. Mass-market scale, far above >10M (broader AI Overviews surface reaches ~2B, but the app itself is the cited figure).",
@@ -22374,7 +22310,7 @@
           "maturity": 5.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-06-09",
             "basis": "commit"
           },
           "version_note": "Gemini app (Google), consumer chat app (web + Android/iOS), proprietary/closed UI scored as the closed counterpart. Verified live June 2026; powered by Gemini 3.x model family. (Model SKUs scored separately; this record scores the app surface.)"
@@ -22403,7 +22339,7 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M users",
+            "reach": ">10M",
             "signal_type": "active_users",
             "confidence": "medium",
             "note": "~420M monthly active users across all Copilot surfaces (Windows/Edge/M365/Bing/mobile) reported Q1 2026, with ~160M enterprise-licensed; far above the >10M threshold. Actively-engaged M365 seats are much lower (~33M), but the consumer + embedded surface reach is mass-market. Headline aggregated figure traces to Microsoft disclosures via aggregators; primary per-surface breakdown not directly fetched, so medium confidence.",
@@ -22437,7 +22373,7 @@
           "maturity": 4.7,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-06-24",
             "basis": "commit"
           },
           "version_note": "Microsoft Copilot consumer + M365 Copilot chat assistant surfaces (Windows, Edge, M365, Bing, mobile), live June 2026 per Microsoft Learn admin/usage docs. Proprietary chat UI over OpenAI + Microsoft models; human-in-the-loop assistant (Copilot Studio agents are a separate product). Scored as the chat-UI surface."
@@ -22466,7 +22402,7 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M users",
+            "reach": ">10M",
             "signal_type": "active_users",
             "confidence": "medium",
             "note": "CEO Aravind Srinivas (cited Apr 2026) reports 100M+ MAU across all products; standalone chatbot ~33M MAU; ~780M queries/mo (May 2025) growing >20% MoM to an estimated 1.2-1.5B/mo by mid-2026. Even the standalone-chat figure (33M) clears >10M. Headline user count is CEO-attributed via aggregators (Sacra), not a directly-fetched primary disclosure, medium confidence.",
@@ -22500,7 +22436,7 @@
           "maturity": 4.7,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-06-24",
             "basis": "commit"
           },
           "version_note": "Perplexity consumer AI answer/search chat product (web + apps), live June 2026 (perplexity.ai homepage confirms product). Proprietary chat UI routing over multiple closed + open models; human-in-the-loop search/answer assistant. Comet browser + Computer agent are adjacent surfaces (agentic, scored elsewhere if at all)."
@@ -22893,10 +22829,10 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M users",
+            "reach": ">10M",
             "signal_type": "active_users",
             "confidence": "low",
-            "note": "CEO/Quora figures (compiled by multiple aggregators) report ~18M Poe MAU in 2026 (~40% using paid features; ~$65M subscription ARR). 18M is comfortably in the >10M 'mass market' band -> level 5. Quora publishes no primary Poe MAU page, so the exact figure remains aggregator-sourced (confidence low), but the order of magnitude is consistent across sources and clearly clears the >10M threshold. The reach label now reads '>10M users' on the active_users scale declared 2026-08-13, which is the band this record has effectively been claiming since it was corrected off an invented '10M-100M' - the difference is that the band is now declared, so the claim can be checked rather than merely asserted.",
+            "note": "CEO/Quora figures (compiled by multiple aggregators) report ~18M Poe MAU in 2026 (~40% using paid features; ~$65M subscription ARR). 18M is comfortably in the >10M 'mass market' band -> level 5. Quora publishes no primary Poe MAU page, so the exact figure remains aggregator-sourced (confidence low), but the order of magnitude is consistent across sources and clearly clears the >10M threshold. [Corrected: prior record had level 4 with an invalid '10M-100M' reach band that contradicted the 18M figure.]",
             "sources": [
               {
                 "url": "https://originality.ai/blog/poe-statistics",
@@ -22927,7 +22863,7 @@
           "maturity": 4.7,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-06-09",
             "basis": "commit"
           },
           "version_note": "Poe by Quora, multi-model chat aggregator app (web + mobile/desktop), live June 2026 (poe.com confirms). Single UI fronting many providers' bots (ChatGPT, Claude, Gemini, DeepSeek) + image/video/audio models + millions of user-created bots. Human-in-the-loop chat aggregator; proprietary."
@@ -23018,11 +22954,11 @@
             "bucket": "closed"
           },
           "adoption": {
-            "level": 5,
-            "reach": ">10M users",
+            "level": 4,
+            "reach": "10M-100M",
             "signal_type": "active_users",
             "confidence": "low",
-            "note": "Reported ~20M MAU and ~180M monthly site visits (Apr 2026); peaked ~28M MAU mid-2024 then declined. ~20M MAU bands at >10M users, level 5 on the active_users scale declared 2026-08-13. RAISED from 4, and the reason is the whole case for declaring the scale - this record read level 4 against a reach of '10M-100M', a band nothing in the repo offered. Its own conservative figure clears the top threshold, so the level was held down by a label that had no scale behind it to check it against. Figures are aggregator-compiled (no first-party MAU disclosure fetched) and sources disagree (20M vs higher visit-based counts), so confidence stays low; the 10M boundary is not close on either read.",
+            "note": "Reported ~20M MAU and ~180M monthly site visits (Apr 2026); peaked ~28M MAU mid-2024 then declined. Clears >10M but figures are aggregator-compiled (no first-party MAU disclosure fetched) and sources disagree (20M vs higher visit-based counts), so low confidence. Reach mapped to 10M-100M on monthly-visit volume; level 4 on the conservative MAU read.",
             "sources": [
               {
                 "url": "https://www.businessofapps.com/data/character-ai-statistics/",
@@ -23045,10 +22981,10 @@
               }
             ]
           },
-          "maturity": 4.1,
+          "maturity": 3.4,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-06-24",
             "basis": "commit"
           },
           "version_note": "Character.AI consumer companion/roleplay chat app (web + mobile), live June 2026. Proprietary chat UI over its own models + (post-Google-deal) licensed models; human-in-the-loop character chat. MAU peaked ~28M mid-2024, declined amid competition."
@@ -23077,7 +23013,7 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M users",
+            "reach": ">10M",
             "signal_type": "active_users",
             "confidence": "low",
             "note": "App reported ~60-64M MAU and ~8-10M DAU early 2026, plus default availability to X Premium subscribers within X's ~350-400M MAU base. Clears >10M as a surface. Figures are aggregator-compiled (xAI does not publish a primary MAU page) and the X-embedded reach is hard to attribute cleanly, so low confidence on the exact number; reach band is robust.",
@@ -23116,7 +23052,7 @@
           "maturity": 4.7,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-07-29",
             "basis": "commit"
           },
           "version_note": "Grok consumer AI chat assistant by xAI, the app/UI surface (grok.com + X integration + mobile), live June 2026 (x.ai). Scored here as the chat-UI product, NOT the Grok 4.x model SKU (the model is scored in base_pretrained as Grok 4.20). Proprietary; human-in-the-loop assistant with image gen + X-grounded search."
@@ -23145,7 +23081,7 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M users",
+            "reach": "1M-10M",
             "signal_type": "active_users",
             "confidence": "medium",
             "note": "~1.7M app downloads by May 2026 (TechCrunch reported 1M in 14 days at Feb 2025 launch); Mistral states EU monthly active recipients below 45M (a DSA ceiling, not a measured MAU); ~10.8M desktop visits to mistral.ai Mar 2026. Honest read places real active users in the 1-10M band, level 4. The <45M is a regulatory cap not an actual count, so not used as the headline.",
@@ -23179,7 +23115,7 @@
           "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-06-24",
             "basis": "commit"
           },
           "version_note": "Le Chat by Mistral AI, consumer AI chat assistant (web + mobile; app rebranded toward 'Mistral Vibe' by 2026), live June 2026 (mistral.ai). Proprietary chat UI primarily over Mistral's own models; human-in-the-loop assistant. ~1.7M app downloads by May 2026; EU MAU stated below 45M."
@@ -23216,19 +23152,11 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M users",
+            "reach": ">10M",
             "signal_type": "active_users",
             "confidence": "medium",
-            "note": "130M MAU as of May 2026, third among Chinese AI apps, per QuestMobile's \"2026 First-Half AI Application Market Development Insight Report\" (published 14 Jul 2026). Bands at >10M users, level 5 on the active_users scale declared 2026-08-13. This replaces the record's previous basis, which was app-store ranking history and no figure at all - the one product of the 23 carrying this instrument that had no user count under it. Confidence medium because QuestMobile's report is read through press coverage rather than the report itself, and it measures the China market, where DeepSeek's usage is concentrated but not confined. Attributed to the chat surface, not the model SKU.",
-            "last_verified": "2026-08-13",
+            "note": "DeepSeek's consumer app was one of the most-downloaded global AI apps after the early-2025 surge; the hosted chat surface remains a top-tier global assistant. No clean current MAU figure published on the vendor's own page, so confidence medium; reach >10M is well-supported by app-store ranking history. Attributed to the chat surface, not the model SKU.",
             "sources": [
-              {
-                "url": "https://finance.biggo.com/news/372811e2-28f1-49c7-9f53-fa56879cde3b",
-                "shows": "QuestMobile 2026 H1 report, as of May 2026: \"DeepSeek ranked third with 130 million MAUs\". Doubao leads at 382M.",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "e7ea3a11679cc5814830d1f89f68bc2a884faf9ca20bddb7007094d1fc267dde"
-              },
               {
                 "url": "https://play.google.com/store/apps/details?id=com.deepseek.chat&hl=en_US",
                 "shows": "Official DeepSeek AI Assistant Android app listing (consumer chat surface, mass-market distribution)",
@@ -23253,8 +23181,8 @@
           "maturity": 4.4,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
-            "basis": "verified"
+            "date": "2026-08-11",
+            "basis": "commit"
           },
           "version_note": "Hosted consumer chat UI at chat.deepseek.com (web + iOS/Android apps), currently fronting DeepSeek-V4 Preview (stronger agent + reasoning). Verified live June 2026. Note: the underlying DeepSeek-V3/V4 model weights are open (MIT) and scored separately in base_pretrained; this record scores the CHAT PRODUCT/UI itself, which is a proprietary free hosted service, not open source software."
         },
@@ -23290,7 +23218,7 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M users",
+            "reach": ">10M",
             "signal_type": "active_users",
             "confidence": "high",
             "note": "Zuckerberg (May 2025 shareholder meeting, primary) stated Meta AI passed 1B monthly active users; reported growing to ~1.2B MAU by Q1 2026, ~63% of interactions on WhatsApp. Far above the >10M threshold. CAVEAT: a portion of these MAU reflect surfaced/embedded exposure inside WhatsApp/IG rather than deliberate assistant use (one analyst, Kantrowitz, argues engaged usage is far lower than OpenAI's). Attributed honestly to the embedded surface, not a standalone assistant count.",
@@ -23329,7 +23257,7 @@
           "maturity": 4.4,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-11",
             "basis": "commit"
           },
           "version_note": "Meta's consumer AI assistant embedded across WhatsApp, Instagram, Messenger, Facebook + standalone meta.ai app. Proprietary; powered by Meta's Llama family (the underlying weights are use-restricted and scored separately at the model layer). Verified live June 2026."
@@ -23366,19 +23294,11 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M users",
+            "reach": ">10M",
             "signal_type": "active_users",
             "confidence": "medium",
-            "note": "382M MAU as of May 2026, first among Chinese AI apps by a clear margin, per QuestMobile's \"2026 First-Half AI Application Market Development Insight Report\" (published 14 Jul 2026). Bands at >10M users, level 5 on the active_users scale declared 2026-08-13. This retires the record's previous basis and the verifier's objection to it: the old note banded on ~330M TOTAL users, with the only stated MAU being ~60M from Nov 2024 - a cumulative count standing in for an active one, which is exactly the substitution the scale's attribution_note names. A measured MAU now exists and it is higher than the total the record had been leaning on. Confidence medium because QuestMobile is read through press coverage rather than the report itself. Volcano Engine reportedly serves ~120T tokens/day.",
-            "last_verified": "2026-08-13",
+            "note": "Doubao reached ~330M total users by May 2026 (en.wikipedia.org/wiki/Doubao); China's most popular AI chatbot; ~60M MAU as of Nov 2024 per Wikipedia. China-market app trackers report ~330M users as of May 2026. NOTE (verifier): the 330M figure is cited by Wikipedia as TOTAL users, not a measured MAU; the only Wikipedia-stated MAU is ~60M (Nov 2024). Either way the surface clears >10M. Headline counts are aggregator/Wikipedia-compiled (no single ByteDance primary MAU disclosure), so confidence medium. Volcano Engine reportedly serves ~120T tokens/day.",
             "sources": [
-              {
-                "url": "https://finance.biggo.com/news/372811e2-28f1-49c7-9f53-fa56879cde3b",
-                "shows": "QuestMobile 2026 H1 report, as of May 2026: \"Doubao had 382 million MAUs, maintaining a clear lead\".",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "e7ea3a11679cc5814830d1f89f68bc2a884faf9ca20bddb7007094d1fc267dde"
-              },
               {
                 "url": "https://en.wikipedia.org/wiki/Doubao",
                 "shows": "Doubao ~330M users by May 2026; China's most popular AI chatbot; 120T tokens/day",
@@ -23408,8 +23328,8 @@
           "maturity": 4.4,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
-            "basis": "verified"
+            "date": "2026-08-11",
+            "basis": "commit"
           },
           "version_note": "ByteDance's consumer AI assistant (chatbot app: iOS/Android/web), launched Aug 2023, running on Volcano Engine (Doubao models). Proprietary closed product. Introduced a paid Pro subscription tier ~May/Jun 2026. Verified live June 2026 (Wikipedia + China-market app trackers)."
         },
@@ -23437,6 +23357,7 @@
           },
           "adoption": {
             "level": 4,
+            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Glean surpassed $300M ARR (28 May 2026, vendor press), 15 months after $100M; nearly doubled Fortune 500 customer count YoY; 85%+ of customers use it across 5+ departments; 45% wDAU/wMAU engagement ratio; operating in 28 countries. ARR/enterprise-seat scale implies low-millions of enterprise seats; placed at 4 on reported enterprise traction. No raw seat/user count disclosed, so confidence medium and signal_type reported_traction (revenue + deployment breadth, not a measured user count).",
@@ -23465,7 +23386,7 @@
           "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-06-24",
             "basis": "commit"
           },
           "version_note": "Enterprise AI assistant / 'AI coworker' grounded in the Glean Enterprise Graph (RAG over 100+ enterprise connectors), with a Model Hub (multiple frontier LLMs), multimodal output (images/slides/pages), and agentic sub-features (Skills, sub-agent orchestration). Proprietary single-tenant SaaS. May-2026 'enterprise AI coworker' launch verified live June 2026. BORDERLINE: agentic/Skills features touch orchestration_agents, but the product is primarily a human-in-driver enterprise chat/assistant UI grounded in company data, so kept in ui_api per the litmus (AI presented as a tool to the human)."
@@ -23494,6 +23415,7 @@
           },
           "adoption": {
             "level": 4,
+            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Search is the foundational layer of the same Glean platform that crossed $300M ARR (May 2026) with near-doubled Fortune 500 count and 85%+ multi-department usage; effectively co-extensive with Glean's deployed seat base. Same caveat as Glean Assistant: no raw user count disclosed, so reported_traction at confidence medium. Adoption shared with the Assistant record (same platform), not an independent measurement.",
@@ -23522,7 +23444,7 @@
           "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-06-24",
             "basis": "commit"
           },
           "version_note": "Glean Search ('the foundation of enterprise AI'), AI-powered enterprise/workplace search UI built on the Enterprise Graph + Personal Graph, hybrid search across 100+ connectors (Slack, Teams, Zoom, ServiceNow, Zendesk, GitHub, etc.), permissions-aware. Proprietary single-tenant SaaS. Verified live June 2026. The search layer underpins Glean Assistant; scored here as the human-facing search UI/API product."
@@ -23671,10 +23593,10 @@
           },
           "adoption": {
             "level": 1,
-            "reach": "<1K stars",
+            "reach": "<10K",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "63 GitHub stars / 6 forks (July 2026), created April 2026. Very new; limited adoption signal so far. (Mozilla AI's underlying any-llm library is far more adopted at ~2.1K stars, but is a separate product.) Stars read 2026-08-13: 379 across the 1 declared repo, which bands at <1K stars, level 1 on the stars scale in signal_routing.yaml. The previous reach '<10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re- read.",
+            "note": "63 GitHub stars / 6 forks (July 2026), created April 2026. Very new; limited adoption signal so far. (Mozilla AI's underlying any-llm library is far more adopted at ~2.1K stars, but is a separate product.)",
             "sources": [
               {
                 "url": "https://github.com/mozilla-ai/otari",
@@ -24062,6 +23984,7 @@
           },
           "adoption": {
             "level": 4,
+            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Vendor discloses ~1 trillion spans/month and ~1 billion evals/month plus named enterprise customers (DoorDash, Roblox, PepsiCo, Atlassian, Booking.com, Reddit); no per-account user count, so reported_traction rather than active_users.",
@@ -24090,7 +24013,7 @@
           "maturity": 4.5,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-07-30",
             "basis": "commit"
           },
           "version_note": "Arize AX, the enterprise AI engineering / LLM observability SaaS platform (distinct from open source Phoenix). Confirmed live via arize.com June 2026."
@@ -24702,10 +24625,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "1K-10K stars",
+            "reach": "10K-100K",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "No verified download/active-user figure located this run; ~3.3k GitHub stars is the only honest signal, so capped at level 2 via stars fallback (cannot exceed 3 on stars regardless). Stars read 2026-08-13: 3,486 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach '10K-100K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "No verified download/active-user figure located this run; ~3.3k GitHub stars is the only honest signal, so capped at level 2 via stars fallback (cannot exceed 3 on stars regardless).",
             "sources": [
               {
                 "url": "https://github.com/langwatch/langwatch",
@@ -24762,6 +24685,7 @@
           },
           "adoption": {
             "level": 4,
+            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Default observability/eval platform for the very widely used LangChain ecosystem; vendor lists 25+ named enterprise customers (Klarna, Lyft, Cloudflare, LinkedIn, Coinbase, Nvidia, Workday, etc.). No quantitative user count disclosed, so reported_traction; placed at 4 on ecosystem reach + enterprise roster (directional).",
@@ -24790,7 +24714,7 @@
           "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-07-30",
             "basis": "commit"
           },
           "version_note": "LangSmith proprietary SaaS by LangChain; managed cloud + BYOC + self-hosted enterprise deployment. Confirmed live (langchain.com/langsmith) June 2026."
@@ -24926,6 +24850,7 @@
           },
           "adoption": {
             "level": 4,
+            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Rides the large installed base of Datadog APM (a major enterprise observability vendor); LLM Observability is a newer add-on with no disclosed standalone user/usage count. Placed at 4 on parent-platform enterprise reach as a directional estimate, not a measured figure for this module specifically.",
@@ -24954,7 +24879,7 @@
           "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-07-30",
             "basis": "commit"
           },
           "version_note": "Datadog LLM Observability, proprietary SaaS module of the Datadog platform. Confirmed live (docs.datadoghq.com/llm_observability) June 2026."
@@ -25337,10 +25262,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "1K-10K stars",
+            "reach": "10K-100K",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "Hosted SaaS shut down (no active platform users). Remaining signal is the OSS libraries: whylogs ~2.8k GitHub stars, last release Dec 2024; stars_fallback caps at 3; placed at 2 given the dead commercial product and stalled release cadence. Honest signal is modest residual OSS usage, not a live platform. Stars read 2026-08-13 on whylabs/whylogs: 2,830, which bands at 1K-10K stars, level 2 on the stars scale. The previous reach '10K-100K' was a download label, which this instrument does not offer - a star is not a download. THE REAL DEFECT is upstream: this product declares no artifacts at all, so a stars_fallback band had no stars source behind it and the count lived only in this note. Declaring whylabs/whylogs would fix it, and is deliberately not done here because a declared code repo also re-routes the openness license dimension. No last_verified claimed: a star count is volatile.",
+            "note": "Hosted SaaS shut down (no active platform users). Remaining signal is the OSS libraries: whylogs ~2.8k GitHub stars, last release Dec 2024; stars_fallback caps at 3; placed at 2 given the dead commercial product and stalled release cadence. Honest signal is modest residual OSS usage, not a live platform.",
             "sources": [
               {
                 "url": "https://github.com/whylabs/whylogs",
@@ -25397,6 +25322,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Vendor states 'trusted by leading enterprises' but discloses no named customers or quantitative user/usage figures on the homepage. Level 3 reflects established commercial traction without a verified count; treat as directional.",
@@ -25425,7 +25351,7 @@
           "maturity": 3.5,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-06-24",
             "basis": "commit"
           },
           "version_note": "Galileo AI observability & eval-engineering platform; verified live June 2026 at galileo.ai. Proprietary SaaS / VPC / on-prem; Luna-2 small eval models. Not open source."
@@ -25459,6 +25385,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Vendor discloses '500+ leading AI companies' incl. Panasonic, Samsung, Epic Games, Humach. Corroborated by the strong pull of its open source funnel DeepEval (~15.9k GitHub stars, used-by 1.3k repos), which drives platform signups. Level 3 on disclosed named-customer traction; no precise active-user/usage-volume number for the platform itself.",
@@ -25492,7 +25419,7 @@
           "maturity": 3.5,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-06-24",
             "basis": "commit"
           },
           "version_note": "Confident AI = the proprietary cloud quality platform built by the creators of DeepEval (the separate OSI Apache-2.0 OSS eval framework). Verified live June 2026. The platform layers tracing/datasets/monitoring on top of DeepEval; self-hosted enterprise option exists."
@@ -25521,6 +25448,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "A feature surface within Vertex AI Agent Engine on Google Cloud; no standalone usage figures published for the observability capability specifically. Level 3 reflects availability inside a large cloud platform's agent stack, not a measured user count; directional.",
@@ -25549,7 +25477,7 @@
           "maturity": 3.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-06-09",
             "basis": "commit"
           },
           "version_note": "Vertex AI / Agent Engine observability: tracing via Cloud Trace (OpenTelemetry-built), Cloud Monitoring, Cloud Logging, plus integrated Gen AI Evaluation service. Proprietary Google Cloud managed service. Verified live June 2026 in GCP docs."
@@ -25578,6 +25506,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "GA March 2026 as a feature surface within Microsoft Foundry on Azure; no standalone usage figures published for the observability capability specifically. Level 3 reflects availability inside a large cloud AI platform, not a measured user count; directional.",
@@ -25606,7 +25535,7 @@
           "maturity": 3.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-06-09",
             "basis": "commit"
           },
           "version_note": "Microsoft Foundry (formerly Azure AI Foundry) Observability: evaluations + monitoring + tracing reached general availability March 2026. OpenTelemetry-based tracing via Azure Monitor / Application Insights. Proprietary Azure managed service. Verified live June 2026 in Microsoft Learn docs."
@@ -25770,6 +25699,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "high",
             "note": "Described as the most widely adopted open source LLM engineering platform; acquired by ClickHouse Mar 2026. No precise verified download/active-user count, rated 3 on reported traction.",
@@ -25912,19 +25842,16 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 1,
-            "reach": "<10K",
+            "level": 2,
+            "reach": "10K-100K",
             "signal_type": "usage_volume",
             "confidence": "low",
-            "note": "4,303 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (nvidia/Aegis-AI-Content-Safety-LlamaGuard-Defensive-1.0 4,303). Bands at level 1 (<10K) on the software and model adoption scale. Corrected from level 2, which the declared artifacts do not support.",
-            "last_verified": "2026-08-13",
+            "note": "NVIDIA safety classifier with a documented dataset and NeMo integration; modest standalone HF adoption, distributed largely via NVIDIA's stack.",
             "sources": [
               {
-                "url": "https://huggingface.co/api/models/nvidia/Aegis-AI-Content-Safety-LlamaGuard-Defensive-1.0",
-                "shows": "4,303 downloads in the trailing 30 days for nvidia/Aegis-AI-Content-Safety-LlamaGuard-Defensive-1.0",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "63af8d1b3273ece735a12d45d7af3ca11b05e70dd39076ab6f2c9bb3cfc607a7"
+                "url": "https://huggingface.co/nvidia/Aegis-AI-Content-Safety-LlamaGuard-Defensive-1.0",
+                "shows": "NVIDIA Aegis content-safety classifier; 13 categories",
+                "accessed": "2026-06-29"
               }
             ]
           },
@@ -25943,11 +25870,11 @@
               }
             ]
           },
-          "maturity": 2.5,
+          "maturity": 3.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
-            "basis": "verified"
+            "date": "2026-08-08",
+            "basis": "commit"
           },
           "version_note": "NVIDIA Aegis AI Content Safety (Defensive 1.0), aka Llama Nemotron Safety Guard Defensive V1. Llama 2 Community License (not OSI). Adapter weights public on HF, but the LlamaGuard base must be obtained via Meta's access request, so not fully open-weight. Aegis safety dataset documented. Verified June 2026."
         },
@@ -25979,11 +25906,11 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 1,
-            "reach": "<1K stars",
+            "level": 2,
+            "reach": "1K-10K",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "New (late 2025) project, ~80 GitHub stars (June 2026); stars-only proxy, capped per methodology; early-stage adoption. Stars read 2026-08-13: 23 across the 1 declared repo, which bands at <1K stars, level 1 on the stars scale in signal_routing.yaml. Level corrected from 2. The previous reach '1K-10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "New (late 2025) project, ~80 GitHub stars (June 2026); stars-only proxy, capped per methodology; early-stage adoption.",
             "sources": [
               {
                 "url": "https://github.com/openguardrails/openguardrails",
@@ -26007,7 +25934,7 @@
               }
             ]
           },
-          "maturity": 2.5,
+          "maturity": 3.0,
           "mature": false,
           "freshness": {
             "date": "2026-08-08",
@@ -26039,6 +25966,7 @@
           },
           "adoption": {
             "level": 2,
+            "reach": "1K-10K",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Niche but notable: a ROOST Model Community partner model (distributed via RMC); 23 HF likes (June 2026), downloads not tracked.",
@@ -26068,7 +25996,7 @@
           "maturity": 3.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-08",
             "basis": "commit"
           },
           "version_note": "Zentropi CoPE-A (9B) on Gemma-2-9B (LoRA); license zentropi-openrail-m (OpenRAIL-M, use-restricted, NOT OSI). Open weights, self-hostable. RMC partner model distributed via the ROOST Model Community. 23 likes (June 2026); arXiv 2512.18027. Verified June 2026."
@@ -26178,19 +26106,16 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 3,
+            "level": 4,
             "reach": "100K-1M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "121,205 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (allenai/wildguard 121,205). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected from level 4, which the declared artifacts do not support.",
-            "last_verified": "2026-08-13",
+            "note": "~265K HF downloads/month (June 2026); one of the most-downloaded open guardrail models.",
             "sources": [
               {
-                "url": "https://huggingface.co/api/models/allenai/wildguard",
-                "shows": "121,205 downloads in the trailing 30 days for allenai/wildguard",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "b3c6a6b4d0ba7f39b95b6d981f25d7edd3ed1b2a5ad0474f4eb0a93f23b42623"
+                "url": "https://huggingface.co/allenai/wildguard",
+                "shows": "~265,259 downloads/month, 52 likes (June 2026)",
+                "accessed": "2026-06-29"
               }
             ]
           },
@@ -26209,11 +26134,11 @@
               }
             ]
           },
-          "maturity": 3.5,
+          "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
-            "basis": "verified"
+            "date": "2026-08-11",
+            "basis": "commit"
           },
           "version_note": "WildGuard (7B, Mistral-based), Apache-2.0 open weights; trained on the open WildGuardMix dataset. ~265K HF downloads/month, 52 likes (June 2026). Verified live June 2026."
         },
@@ -26240,19 +26165,16 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 3,
+            "level": 4,
             "reach": "100K-1M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "111,334 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (meta-llama/Llama-Prompt-Guard-2-86M 111,334). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected from level 4, which the declared artifacts do not support.",
-            "last_verified": "2026-08-13",
+            "note": "86M variant ~90.4K HF downloads/month (June 2026); widely used as a low-latency injection filter, including inside LlamaFirewall.",
             "sources": [
               {
-                "url": "https://huggingface.co/api/models/meta-llama/Llama-Prompt-Guard-2-86M",
-                "shows": "111,334 downloads in the trailing 30 days for meta-llama/Llama-Prompt-Guard-2-86M",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "a594da1ec8e70a2c8b897994c7d8ab75323f0b89e5428b4dc84cf4a8f23c4e4c"
+                "url": "https://huggingface.co/meta-llama/Llama-Prompt-Guard-2-86M",
+                "shows": "~90,441 downloads/month, 149 likes (June 2026)",
+                "accessed": "2026-06-29"
               }
             ]
           },
@@ -26271,11 +26193,11 @@
               }
             ]
           },
-          "maturity": 3.5,
+          "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
-            "basis": "verified"
+            "date": "2026-08-08",
+            "basis": "commit"
           },
           "version_note": "Llama Prompt Guard 2 (86M / 22M); Llama 4 Community License (not OSI). 99.8% AUC, 97.5% recall at 1% FPR on English jailbreaks; 8 languages. 86M ~90.4K HF downloads/month, 149 likes (June 2026). Verified live June 2026."
         },
@@ -26398,10 +26320,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "1K-10K stars",
+            "reach": "1K-10K",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "~1K GitHub stars (June 2026); stars-only proxy. Widely cited as the standardized red-teaming benchmark in research. Stars read 2026-08-13: 1,029 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach '1K-10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "~1K GitHub stars (June 2026); stars-only proxy. Widely cited as the standardized red-teaming benchmark in research.",
             "sources": [
               {
                 "url": "https://github.com/centerforaisafety/HarmBench",
@@ -26456,11 +26378,11 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 2,
-            "reach": "1K-10K stars",
+            "level": 3,
+            "reach": "10K-100K",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "~5.5K GitHub stars (June 2026); stars-only proxy, capped per methodology. Stars read 2026-08-13: 5,748 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. Level corrected from 3. The previous reach '10K-100K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "~5.5K GitHub stars (June 2026); stars-only proxy, capped per methodology.",
             "sources": [
               {
                 "url": "https://github.com/Giskard-AI/giskard",
@@ -26484,7 +26406,7 @@
               }
             ]
           },
-          "maturity": 3.0,
+          "maturity": 3.5,
           "mature": false,
           "freshness": {
             "date": "2026-08-08",
@@ -26516,10 +26438,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "1K-10K stars",
+            "reach": "1K-10K",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "~1.9K GitHub stars (June 2026); stars-only proxy, capped per methodology. Stars read 2026-08-13: 2,442 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach '1K-10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "~1.9K GitHub stars (June 2026); stars-only proxy, capped per methodology.",
             "sources": [
               {
                 "url": "https://github.com/confident-ai/deepteam",
@@ -26633,19 +26555,16 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 3,
-            "reach": "100K-1M",
+            "level": 4,
+            "reach": "1M-10M",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "164,619 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (meta-llama/Llama-Guard-3-8B 164,619). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected from level 4, which the declared artifacts do not support.",
-            "last_verified": "2026-08-13",
+            "note": "~237K Hugging Face downloads/month on the 8B variant (June 2026), the most-adopted open guardrail model; widely embedded as a moderation layer.",
             "sources": [
               {
-                "url": "https://huggingface.co/api/models/meta-llama/Llama-Guard-3-8B",
-                "shows": "164,619 downloads in the trailing 30 days for meta-llama/Llama-Guard-3-8B",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "af299c9f359756a68a7295bafa548ed6d733887c2a877416f75fabbdd7bfca8e"
+                "url": "https://huggingface.co/meta-llama/Llama-Guard-3-8B",
+                "shows": "~237,092 downloads/month, 307 likes (June 2026)",
+                "accessed": "2026-06-29"
               }
             ]
           },
@@ -26664,11 +26583,11 @@
               }
             ]
           },
-          "maturity": 3.5,
+          "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
-            "basis": "verified"
+            "date": "2026-08-08",
+            "basis": "commit"
           },
           "version_note": "Llama Guard 3 (8B), built on Llama 3.1; Llama 3.1 Community License (not OSI; >700M MAU restriction). ~237K HF downloads/month, 307 likes (June 2026). Verified live June 2026."
         },
@@ -26757,19 +26676,16 @@
             "bucket": "open-ish"
           },
           "adoption": {
-            "level": 1,
-            "reach": "<10K",
+            "level": 2,
+            "reach": "10K-100K",
             "signal_type": "usage_volume",
             "confidence": "medium",
-            "note": "1,837 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (ibm-granite/granite-guardian-3.2-5b 1,837). Bands at level 1 (<10K) on the software and model adoption scale. Corrected from level 2, which the declared artifacts do not support.",
-            "last_verified": "2026-08-13",
+            "note": "~1.4K HF downloads/month on the 3.2-5B variant (June 2026); cumulative across the Guardian family is higher. Enterprise-leaning distribution via watsonx.",
             "sources": [
               {
-                "url": "https://huggingface.co/api/models/ibm-granite/granite-guardian-3.2-5b",
-                "shows": "1,837 downloads in the trailing 30 days for ibm-granite/granite-guardian-3.2-5b",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "cd00b2c6bb279ca6c9961fb516843354fdf5fcf7c343a4a720561d9f7ec5fdcb"
+                "url": "https://huggingface.co/ibm-granite/granite-guardian-3.2-5b",
+                "shows": "~1,377 downloads/month, 14 likes (June 2026)",
+                "accessed": "2026-06-29"
               }
             ]
           },
@@ -26788,11 +26704,11 @@
               }
             ]
           },
-          "maturity": 2.5,
+          "maturity": 3.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
-            "basis": "verified"
+            "date": "2026-08-11",
+            "basis": "commit"
           },
           "version_note": "Granite Guardian 3.2 (5B, distilled from the 8B); Apache-2.0 open weights. ~1.4K HF downloads/month, 14 likes (June 2026). Verified live June 2026."
         },
@@ -26881,11 +26797,11 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 2,
-            "reach": "1K-10K stars",
+            "level": 3,
+            "reach": "10K-100K",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "~6.6K GitHub stars (June 2026); stars-only proxy, capped per methodology; broadly referenced guardrail framework. Stars read 2026-08-13: 6,936 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. Level corrected from 3. The previous reach '10K-100K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "~6.6K GitHub stars (June 2026); stars-only proxy, capped per methodology; broadly referenced guardrail framework.",
             "sources": [
               {
                 "url": "https://github.com/NVIDIA/NeMo-Guardrails",
@@ -26909,7 +26825,7 @@
               }
             ]
           },
-          "maturity": 3.0,
+          "maturity": 3.5,
           "mature": false,
           "freshness": {
             "date": "2026-08-08",
@@ -27035,10 +26951,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "1K-10K stars",
+            "reach": "10K-100K",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "~3.1K GitHub stars (June 2026); stars-only proxy, capped per methodology. Stars read 2026-08-13: 3,202 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach '10K-100K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "~3.1K GitHub stars (June 2026); stars-only proxy, capped per methodology.",
             "sources": [
               {
                 "url": "https://github.com/protectai/llm-guard",
@@ -27523,6 +27439,7 @@
           },
           "adoption": {
             "level": 2,
+            "reach": "10K-100K",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Established prompt-injection-defense vendor with notable enterprise customers; acquired by Check Point in 2025. No public usage counts.",
@@ -27552,7 +27469,7 @@
           "maturity": 3.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-08",
             "basis": "commit"
           },
           "version_note": "Lakera Guard; proprietary SaaS API (prompt-injection/jailbreak defense). Lakera acquired by Check Point (completed Nov 2025). Verified live June 2026."
@@ -27724,10 +27641,10 @@
           },
           "adoption": {
             "level": 3,
-            "reach": ">10K stars",
+            "reach": "100K-1M",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "No verified download/API-volume or customer count disclosed on repo or pricing page; only ~129k GitHub stars available as an honest signal. Capped at level 3 per stars_fallback rule. Widely integrated as an agent scrape tool (LangChain, etc.) but no primary usage figure found this run. Stars read 2026-08-13: 166,749 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The previous reach '100K-1M' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "No verified download/API-volume or customer count disclosed on repo or pricing page; only ~129k GitHub stars available as an honest signal. Capped at level 3 per stars_fallback rule. Widely integrated as an agent scrape tool (LangChain, etc.) but no primary usage figure found this run.",
             "sources": [
               {
                 "url": "https://github.com/mendableai/firecrawl",
@@ -28040,10 +27957,10 @@
           },
           "adoption": {
             "level": 3,
-            "reach": ">10K stars",
+            "reach": "100K-1M",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "No verified download or API-call volume found from a primary source. ~11k GitHub stars on the OSS repo plus a widely-used hosted r.jina.ai endpoint; capped at 3 on stars/reported-traction fallback in the absence of a measured usage figure. Stars read 2026-08-13: 11,862 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The previous reach '100K-1M' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "No verified download or API-call volume found from a primary source. ~11k GitHub stars on the OSS repo plus a widely-used hosted r.jina.ai endpoint; capped at 3 on stars/reported-traction fallback in the absence of a measured usage figure.",
             "sources": [
               {
                 "url": "https://github.com/jina-ai/reader",
@@ -28132,6 +28049,7 @@
           },
           "adoption": {
             "level": 4,
+            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Protocol adoption-breadth signal (per recipe): LF press (Apr 2026 one-year mark) reports 150+ supporting organizations, in-production use at Microsoft (Azure AI Foundry, Copilot Studio), AWS (Bedrock AgentCore), Salesforce, SAP, ServiceNow, and embedding into Google Cloud. Breadth across the three major clouds + enterprise production puts effective downstream reach in the 1-10M band; this is a breadth/traction count, not a measured per-user figure.",
@@ -28235,19 +28153,26 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 3,
-            "reach": "100K-1M",
+            "level": 4,
+            "reach": "1M-10M",
             "signal_type": "usage_volume",
             "confidence": "medium",
-            "note": "194,657 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (composio-core 194,657). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected from level 4, which the declared artifacts do not support.",
-            "last_verified": "2026-08-13",
+            "note": "CORRECTION (adversarial verify 2026-06-04): prior record claimed no primary download figure and capped at stars_fallback level 3. pypistats now shows the composio PyPI package at ~3.17M downloads in the last month (a measured usage_volume signal in the 1M-10M band), so upgraded to level 4 / usage_volume and the stars_fallback cap is removed. Corroborated by ~28.6k GitHub stars and framework integrations (OpenAI, Anthropic, LangChain, LlamaIndex) plus the hosted platform.",
             "sources": [
               {
-                "url": "https://pypistats.org/api/packages/composio-core/recent",
-                "shows": "194,657 downloads in the trailing 30 days for composio-core",
-                "accessed": "2026-08-13",
-                "http_status": 200,
-                "content_sha256": "c459ac619d97bdc45e0f5c1956f736986a7fc4fbfca43dfc4300a2ddaa4ec836"
+                "url": "https://pypistats.org/packages/composio",
+                "shows": "~3,166,911 (3.17M) monthly PyPI downloads",
+                "accessed": "2026-06-04"
+              },
+              {
+                "url": "https://github.com/ComposioHQ/composio",
+                "shows": "~28.6k stars, integrations across major agent frameworks",
+                "accessed": "2026-06-04"
+              },
+              {
+                "url": "https://pypi.org/project/composio/",
+                "shows": "active package, latest v0.13.1 (May 2026); confirms maintenance",
+                "accessed": "2026-06-04"
               }
             ]
           },
@@ -28265,10 +28190,10 @@
               }
             ]
           },
-          "maturity": 3.4,
+          "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-12",
             "basis": "verified"
           },
           "version_note": "Agent tool-integration SDK + managed platform: 1000+ toolkits, tool search, auth, sandboxed workbench; Rube MCP server connects 500+ apps. Python SDK v0.13.1 (May 14, 2026); @composio/claude-agent-sdk 0.9.2 (May 13, 2026). Verified live on GitHub/PyPI June 2026."
@@ -28476,6 +28401,7 @@
           },
           "adoption": {
             "level": 4,
+            "reach": "1M-10M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "No standalone Sonar-API request/developer count is published by a primary source; Perplexity docs confirm the API exists and is a core developer surface. Platform-level scale is large (45M+ MAU, ~1B+ queries/month per 2026 reporting) but that is the consumer app, not the API specifically. Rated 4 on reported developer-API traction within a clearly mass-scale parent platform; flagged that the headline platform numbers are aggregator-reported and not API-specific.",
@@ -28509,7 +28435,7 @@
           "maturity": 4.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-06-24",
             "basis": "commit"
           },
           "version_note": "Proprietary search-grounded API: Sonar / Sonar Pro models, plus Search API (ranked web results) and Embeddings API; 2026 adds a multi-model Agent API marketplace. Verified live via docs.perplexity.ai June 2026."
@@ -28672,10 +28598,10 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
+            "reach": "50M+ total Docker pulls",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "~32k GitHub stars plus 50M+ total Docker pulls (~1.5M in a single recent week) and ~70 maintained public instances - concrete deployment volume well into the high band, not stars-only. The de facto open web-search backend for self-hosted AI. Re-banded 2026-08-13 under the lifetime-average rule in docs/guides/adoption.md. Docker Hub reports 71,524,926 cumulative pulls on searxng/searxng since 2021-04-22, which averages ~1,122,856 a month over 63.7 months and bands at 1M-10M. The previous reach '50M+ total Docker pulls' was a CUMULATIVE total wearing a monthly band's place - the axis is monthly, so a lifetime total is not comparable to any other record on the scale. Level unchanged at 4. Recorded AS A DECLARED FLOOR, per the rule: a lifetime average understates a growing product, and SearXNG's pull rate is not flat. Docker is not declared as an artifact here, so the figure lives in this note rather than in a signal - the same gap issue #163 tracks. No last_verified claimed: only the figure was re-read.",
+            "note": "~32k GitHub stars plus 50M+ total Docker pulls (~1.5M in a single recent week) and ~70 maintained public instances - concrete deployment volume well into the high band, not stars-only. The de facto open web-search backend for self-hosted AI.",
             "sources": [
               {
                 "url": "https://hub.docker.com/r/searxng/searxng",
@@ -28866,6 +28792,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "De facto default managed reranker for RAG, distributed across Azure AI Foundry, AWS SageMaker JumpStart / OpenSearch, and Oracle GenAI in addition to Cohere's API. No hard call-volume/user count published; placed at 3 on broad multi-cloud distribution (reported_traction).",
@@ -28904,7 +28831,7 @@
           "maturity": 3.4,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-06-09",
             "basis": "commit"
           },
           "version_note": "Cohere Rerank API, verified live June 2026 (Cohere docs). Latest model Rerank 4.0 (fast/pro variants); prior 3.5 and 3.0 (English + multilingual). Proprietary hosted reranking API for RAG/retrieval; also available via Azure AI Foundry, AWS SageMaker/OpenSearch, Oracle GenAI. Sub-segment: retrieval/RAG infra (reranker)."
@@ -29097,6 +29024,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "high",
             "note": "Described as the default open source engine for billion-scale semantic search; LF AI & Data graduate. No precise verified deployment/download count, rated 3 on reported traction.",
@@ -29136,7 +29064,7 @@
           "maturity": 3.4,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-08",
             "basis": "commit"
           },
           "version_note": "v2.6.x stable (late 2025); v3.0 RC published May 2026; LF AI & Data project"
@@ -29348,10 +29276,9 @@
           },
           "adoption": {
             "level": 3,
-            "reach": ">10K stars",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "~31k stars; no download metric for Go/Docker distribution - stars_fallback (first-party backing implies higher real usage). Stars read 2026-08-13: 32,212 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The record carried no reach label at all before this. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "~31k stars; no download metric for Go/Docker distribution - stars_fallback (first-party backing implies higher real usage).",
             "sources": [
               {
                 "url": "https://github.com/github/github-mcp-server",
@@ -29882,10 +29809,10 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M",
+            "reach": "88M+/mo",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "88.6M PyPI downloads in the last 30 days. Read live 2026-08-13: 95,449,310 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at >10M, level 5. The previous reach '88M+/mo' was free text carrying a figure rather than a band the scale declares, so nothing could check it against the level beside it. No last_verified claimed: only the figure was re-read, not the whole axis.",
+            "note": "88.6M PyPI downloads in the last 30 days.",
             "sources": [
               {
                 "url": "https://pepy.tech/projects/torch",
@@ -30114,10 +30041,10 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
+            "reach": "5M+/mo",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "5.3M PyPI downloads in the last 30 days, just above the 5M Level-4 threshold. Read live 2026-08-13: 4,482,096 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at 1M-10M, level 4. The previous reach '5M+/mo' was free text carrying a figure rather than a band the scale declares, so nothing could check it against the level beside it. No last_verified claimed: only the figure was re-read, not the whole axis.",
+            "note": "5.3M PyPI downloads in the last 30 days, just above the 5M Level-4 threshold.",
             "sources": [
               {
                 "url": "https://pepy.tech/projects/flax",
@@ -30172,10 +30099,10 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M",
+            "reach": "150M+/month",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "PyPI last_month downloads of 150,245,308 exceed the 50M+ Level 5 threshold. Read live 2026-08-13: 192,709,895 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at >10M, level 5. The previous reach '150M+/month' was free text carrying a figure rather than a band the scale declares, so nothing could check it against the level beside it. No last_verified claimed: only the figure was re-read, not the whole axis.",
+            "note": "PyPI last_month downloads of 150,245,308 exceed the 50M+ Level 5 threshold.",
             "sources": [
               {
                 "url": "https://pypistats.org/api/packages/transformers/recent",
@@ -30230,10 +30157,10 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M",
+            "reach": "120M+/month",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "PyPI last_month downloads of 120,316,114 exceed the 50M+ Level 5 threshold. Read live 2026-08-13: 159,958,389 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at >10M, level 5. The previous reach '120M+/month' was free text carrying a figure rather than a band the scale declares, so nothing could check it against the level beside it. No last_verified claimed: only the figure was re-read, not the whole axis.",
+            "note": "PyPI last_month downloads of 120,316,114 exceed the 50M+ Level 5 threshold.",
             "sources": [
               {
                 "url": "https://pypistats.org/api/packages/datasets/recent",
@@ -30288,10 +30215,10 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M",
+            "reach": "7M+/month",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "PyPI last_month downloads of 7,406,705 fall in the 5M-50M Level 4 band. Read live 2026-08-13: 8,248,209 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at 1M-10M, level 4. The previous reach '7M+/month' was free text carrying a figure rather than a band the scale declares, so nothing could check it against the level beside it. No last_verified claimed: only the figure was re-read, not the whole axis.",
+            "note": "PyPI last_month downloads of 7,406,705 fall in the 5M-50M Level 4 band.",
             "sources": [
               {
                 "url": "https://pypistats.org/api/packages/diffusers/recent",
@@ -30462,10 +30389,10 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M",
+            "reach": "78M+/month",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "PyPI last-month downloads of 78,250,137 exceed the 50M+ threshold. Read live 2026-08-13: 111,835,984 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at >10M, level 5. The previous reach '78M+/month' was free text carrying a figure rather than a band the scale declares, so nothing could check it against the level beside it. No last_verified claimed: only the figure was re-read, not the whole axis.",
+            "note": "PyPI last-month downloads of 78,250,137 exceed the 50M+ threshold.",
             "sources": [
               {
                 "url": "https://pypistats.org/api/packages/safetensors/recent",
@@ -30520,10 +30447,10 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M",
+            "reach": "189M+/month",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "PyPI last-month downloads of 189,770,639 exceed the 50M+ threshold. Read live 2026-08-13: 252,452,945 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at >10M, level 5. The previous reach '189M+/month' was free text carrying a figure rather than a band the scale declares, so nothing could check it against the level beside it. No last_verified claimed: only the figure was re-read, not the whole axis.",
+            "note": "PyPI last-month downloads of 189,770,639 exceed the 50M+ threshold.",
             "sources": [
               {
                 "url": "https://pypistats.org/api/packages/tokenizers/recent",
@@ -30578,10 +30505,10 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M",
+            "reach": "331M+/month",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "PyPI last-month downloads of 331,796,503 exceed the 50M+ threshold. Read live 2026-08-13: 493,557,521 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at >10M, level 5. The previous reach '331M+/month' was free text carrying a figure rather than a band the scale declares, so nothing could check it against the level beside it. No last_verified claimed: only the figure was re-read, not the whole axis.",
+            "note": "PyPI last-month downloads of 331,796,503 exceed the 50M+ threshold.",
             "sources": [
               {
                 "url": "https://pypistats.org/api/packages/huggingface-hub/recent",
@@ -30635,11 +30562,11 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 4,
-            "reach": "1M-10M",
+            "level": 3,
+            "reach": "1.7M+/month",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "PyPI last-month downloads of 1,759,764 fall in the 500k-5M range. Read live 2026-08-13: 1,919,623 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at 1M-10M, level 4. Level corrected from 3. The previous reach '1.7M+/month' was free text carrying a figure rather than a band the scale declares, so nothing could check it against the level beside it. No last_verified claimed: only the figure was re-read, not the whole axis.",
+            "note": "PyPI last-month downloads of 1,759,764 fall in the 500k-5M range.",
             "sources": [
               {
                 "url": "https://pypistats.org/api/packages/optimum/recent",
@@ -30662,7 +30589,7 @@
               }
             ]
           },
-          "maturity": 4.0,
+          "maturity": 3.4,
           "mature": false,
           "freshness": {
             "date": "2026-07-30",
@@ -30810,10 +30737,10 @@
           },
           "adoption": {
             "level": 5,
-            "reach": ">10M",
+            "reach": "50M+/mo",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "PyPI last_month downloads ~64.7M. Read live 2026-08-13: 69,538,627 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at >10M, level 5. The previous reach '50M+/mo' was free text carrying a figure rather than a band the scale declares, so nothing could check it against the level beside it. No last_verified claimed: only the figure was re-read, not the whole axis.",
+            "note": "PyPI last_month downloads ~64.7M.",
             "sources": [
               {
                 "url": "https://pypistats.org/api/packages/triton/recent",
@@ -30867,11 +30794,11 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 4,
-            "reach": "1M-10M",
+            "level": 3,
+            "reach": "~1.4M/mo",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "PyPI last_month downloads ~1.37M. Read live 2026-08-13: 1,112,723 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at 1M-10M, level 4. Level corrected from 3. The previous reach '~1.4M/mo' was free text carrying a figure rather than a band the scale declares, so nothing could check it against the level beside it. No last_verified claimed: only the figure was re-read, not the whole axis.",
+            "note": "PyPI last_month downloads ~1.37M.",
             "sources": [
               {
                 "url": "https://pypistats.org/api/packages/deepspeed/recent",
@@ -30894,7 +30821,7 @@
               }
             ]
           },
-          "maturity": 4.4,
+          "maturity": 3.8,
           "mature": false,
           "freshness": {
             "date": "2026-07-30",
@@ -30925,11 +30852,11 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 4,
-            "reach": "1M-10M",
+            "level": 3,
+            "reach": "~1.4M/mo",
             "signal_type": "usage_volume",
             "confidence": "high",
-            "note": "PyPI last_month downloads ~1.38M. Read live 2026-08-13: 1,869,817 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at 1M-10M, level 4. Level corrected from 3. The previous reach '~1.4M/mo' was free text carrying a figure rather than a band the scale declares, so nothing could check it against the level beside it. No last_verified claimed: only the figure was re-read, not the whole axis.",
+            "note": "PyPI last_month downloads ~1.38M.",
             "sources": [
               {
                 "url": "https://pypistats.org/api/packages/openvino/recent",
@@ -30952,7 +30879,7 @@
               }
             ]
           },
-          "maturity": 4.0,
+          "maturity": 3.4,
           "mature": false,
           "freshness": {
             "date": "2026-07-30",
@@ -30984,10 +30911,10 @@
           },
           "adoption": {
             "level": 3,
-            "reach": ">10K stars",
+            "reach": "~14.9k stars",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "No PyPI package; GitHub shows ~14.9k stars (and underpins much higher-adoption llama.cpp). Stars read 2026-08-13: 15,159 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The previous reach '~14.9k stars' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re- read.",
+            "note": "No PyPI package; GitHub shows ~14.9k stars (and underpins much higher-adoption llama.cpp).",
             "sources": [
               {
                 "url": "https://github.com/ggml-org/ggml",
@@ -31069,11 +30996,11 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 2,
-            "reach": "1K-10K stars",
+            "level": 3,
+            "reach": "broad",
             "signal_type": "stars_fallback",
             "confidence": "medium",
-            "note": "9.9k GitHub stars (capped at 3 per stars-fallback rule); ~10.8k monthly PyPI downloads and 1M+ all- time. Stars read 2026-08-13: 9,938 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. Level corrected from 3. The previous reach 'broad' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "9.9k GitHub stars (capped at 3 per stars-fallback rule); ~10.8k monthly PyPI downloads and 1M+ all-time.",
             "sources": [
               {
                 "url": "https://github.com/OpenMined/PySyft",
@@ -31101,7 +31028,7 @@
               }
             ]
           },
-          "maturity": 2.8,
+          "maturity": 3.4,
           "mature": false,
           "freshness": {
             "date": "2026-08-12",
@@ -31571,6 +31498,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Established CNCF/OpenInfra-adjacent container-runtime project integrated into Kubernetes runtimeclass deployments; broad but operator-concentrated infrastructure adoption rather than a mass per-user count. No clean download/user figure verified; ~8k stars (corroborate only, not the basis). Level 3 reflects specialist infra reach.",
@@ -31599,7 +31527,7 @@
           "maturity": 3.4,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-07-30",
             "basis": "commit"
           },
           "version_note": "Kata Containers, lightweight VMs that feel like containers; v3.31.0 (May 19 2026) confirmed live on GitHub. OpenInfra Foundation governed (governance not explicit on repo landing page but established as an OpenInfra project). Can use Firecracker/QEMU as the VMM."
@@ -31661,10 +31589,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "1K-10K stars",
+            "reach": "10K-100K",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "No PyPI/usage figure for the OSS runtime surfaced and no disclosed Beam customer/usage count; only ~1.7k GitHub stars available as a signal. stars_fallback caps level at 3; placed at 2 given the small star base and absence of any volume signal. Low confidence. Stars read 2026-08-13: 1,742 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach '10K-100K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "No PyPI/usage figure for the OSS runtime surfaced and no disclosed Beam customer/usage count; only ~1.7k GitHub stars available as a signal. stars_fallback caps level at 3; placed at 2 given the small star base and absence of any volume signal. Low confidence.",
             "sources": [
               {
                 "url": "https://github.com/beam-cloud/beta9",
@@ -31723,11 +31651,11 @@
             "bucket": "open"
           },
           "adoption": {
-            "level": 3,
-            "reach": ">10K stars",
+            "level": 2,
+            "reach": "10K-100K",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "Only ~2-3 months old; no PyPI/download or named-deployment figures surfaced. ~11.3k GitHub stars (3,845 within 72h of launch) is the only signal, stars_fallback, which caps level at 3. Placed at 2: rapid early stars but no usage volume yet. Revisit as usage data emerges. Stars read 2026-08-13: 12,516 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. Level corrected from 2. The previous reach '10K-100K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "Only ~2-3 months old; no PyPI/download or named-deployment figures surfaced. ~11.3k GitHub stars (3,845 within 72h of launch) is the only signal, stars_fallback, which caps level at 3. Placed at 2: rapid early stars but no usage volume yet. Revisit as usage data emerges.",
             "sources": [
               {
                 "url": "https://github.com/alibaba/OpenSandbox",
@@ -31750,7 +31678,7 @@
               }
             ]
           },
-          "maturity": 3.0,
+          "maturity": 2.4,
           "mature": false,
           "freshness": {
             "date": "2026-07-30",
@@ -31939,9 +31867,9 @@
           "adoption": {
             "level": 3,
             "signal_type": "stars_fallback",
-            "reach": ">10K stars",
+            "reach": "100K-1M",
             "confidence": "low",
-            "note": "No published install/active-user count for the OSS edition; ~13.4k GitHub stars is the only concrete signal. Stars-fallback caps at level 3; placed at 3 (not higher) on broad enterprise positioning + star base, but reach is unverified by usage_volume. Stars read 2026-08-13: 14,142 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The previous reach '100K-1M' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "No published install/active-user count for the OSS edition; ~13.4k GitHub stars is the only concrete signal. Stars-fallback caps at level 3; placed at 3 (not higher) on broad enterprise positioning + star base, but reach is unverified by usage_volume.",
             "sources": [
               {
                 "url": "https://github.com/coder/coder",
@@ -32059,6 +31987,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "No disclosed Modal Sandboxes user/usage count on primary pages; Modal is a well-known managed AI-compute platform with broad developer use and a documented free tier. Placed at 3 on reported multi-customer traction, not a measured usage_volume figure (kept conservative absent a hard number).",
@@ -32099,7 +32028,7 @@
           "maturity": 3.4,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-08-08",
             "basis": "commit"
           },
           "version_note": "Modal Sandboxes - 'secure containers for executing untrusted user or agent code' on the Modal platform; gVisor-based isolation. Open Python/JS SDK + proprietary managed cloud (pay-per-CPU-cycle, $30/mo free credits on Starter). Docs verified live June 2026."
@@ -32349,6 +32278,7 @@
           },
           "adoption": {
             "level": 1,
+            "reach": "<10K",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Launched Jan 2026 (~5 months at scoring time) as Fly.io's answer to E2B. No disclosed user/customer/usage counts on the product page or launch coverage; positioned for AI coding-agent sessions (Claude Code/Codex). Early-stage; placed at 1 on reported traction with low confidence pending real numbers.",
@@ -32382,7 +32312,7 @@
           "maturity": 2.2,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-07-30",
             "basis": "commit"
           },
           "version_note": "Sprites (sprites.dev) by Fly.io, launched Jan 2026. Persistent, hardware-isolated Firecracker microVMs ('a persistent Linux computer') for running arbitrary code / AI agents, with 100GB NVMe persistence and sub-1s checkpoint/restore. Confirmed live June 2026 via sprites.dev. Proprietary managed service (Fly.io's E2B competitor)."
@@ -32489,6 +32419,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "low",
             "note": "Powers StackBlitz's own IDE and is embedded by named projects (SvelteKit, Astro, Scrimba, egghead.io, Xata) for in-browser code experiences. No disclosed download/MAU figure on the primary pages; placed at 3 on named-integration reported traction. No hard usage_volume number found, so confidence low.",
@@ -32517,7 +32448,7 @@
           "maturity": 3.0,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-07-30",
             "basis": "commit"
           },
           "version_note": "WebContainers by StackBlitz, a browser-based (WASM) runtime that executes Node.js / npm projects fully client-side in the browser tab. Distributed as @webcontainer/api on npm. Confirmed live June 2026 via webcontainers.io. The public github.com/stackblitz/webcontainer-core repo is MIT but is only an issue tracker / docs hub; the actual runtime is a proprietary StackBlitz service requiring a commercial license for for-profit production use."
@@ -32546,7 +32477,7 @@
           },
           "adoption": {
             "level": 4,
-            "reach": "1M-10M users",
+            "reach": "1M-10M",
             "signal_type": "active_users",
             "confidence": "low",
             "note": "Code Interpreter ships inside ChatGPT (advanced data analysis) and the Assistants/Responses API; the ChatGPT surface it rides has ~1B weekly users (flagship anchor record, GPT-5). No standalone Code-Interpreter usage figure is disclosed, so adoption is attributed to the surface, placed conservatively at 4 (a fraction of ChatGPT users invoke code execution) with low confidence given no primary per-tool number.",
@@ -32575,7 +32506,7 @@
           "maturity": 3.6,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-07-30",
             "basis": "commit"
           },
           "version_note": "OpenAI Code Interpreter, a tool (Assistants API, migrating to Responses API) that writes and runs Python in a proprietary OpenAI-managed sandbox; processes files up to 512MB, sessions billed at $0.03/session (1-hour default). Confirmed live June 2026 via OpenAI developer docs. Proprietary; isolation mechanism undisclosed."
@@ -32604,6 +32535,7 @@
           },
           "adoption": {
             "level": 3,
+            "reach": "100K-1M",
             "signal_type": "reported_traction",
             "confidence": "medium",
             "note": "Northflank (platform-wide, primary): 2,000+ organizations, 80,000+ developers in production, 130B+ requests, millions of containers, 330+ availability zones. These are platform-level figures (not Sandboxes-specific); the Sandboxes product is newer. Placed at 3 on the developer/org base; the Sandboxes feature alone is likely lower.",
@@ -32637,7 +32569,7 @@
           "maturity": 3.4,
           "mature": false,
           "freshness": {
-            "date": "2026-08-13",
+            "date": "2026-07-30",
             "basis": "commit"
           },
           "version_note": "Northflank Sandboxes, secure microVM/sandbox product for running untrusted / AI-generated code at scale (~200ms microVM spin-up), positioned for code-gen agents. Confirmed live June 2026 via northflank.com. Proprietary SaaS (Northflank Ltd)."
@@ -32970,10 +32902,10 @@
           },
           "adoption": {
             "level": 2,
-            "reach": "1K-10K stars",
+            "reach": "1K-10K",
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "~2,900 GitHub stars (June 2026) for a 2026 release, with multi-platform packages and FFI bindings published. Stars are the only public proxy here, so this is capped per the methodology and read as early but real traction rather than scaled adoption. Stars read 2026-08-13: 3,640 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach '1K-10K' was not a label this instrument offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "~2,900 GitHub stars (June 2026) for a 2026 release, with multi-platform packages and FFI bindings published. Stars are the only public proxy here, so this is capped per the methodology and read as early but real traction rather than scaled adoption.",
             "sources": [
               {
                 "url": "https://github.com/nolabs-ai/nono",
@@ -33191,10 +33123,10 @@
           },
           "adoption": {
             "level": 1,
-            "reach": "<1K stars",
+            "reach": null,
             "signal_type": "stars_fallback",
             "confidence": "low",
-            "note": "Very nascent: ~22 stars on the sandbox repo, a $7.3M seed (First Round, YC S2025), and an unverified vendor claim of billions of agent requests. No usage or download signal. stars_fallback with a low-double- digit star base places this at 1. Added on openness and mission-fit grounds despite the low prominence; scored honestly. Low confidence. Stars read 2026-08-13: 27 across the 1 declared repo, which bands at <1K stars, level 1 on the stars scale in signal_routing.yaml. The record carried no reach label at all before this. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.",
+            "note": "Very nascent: ~22 stars on the sandbox repo, a $7.3M seed (First Round, YC S2025), and an unverified vendor claim of billions of agent requests. No usage or download signal. stars_fallback with a low-double-digit star base places this at 1. Added on openness and mission-fit grounds despite the low prominence; scored honestly. Low confidence.",
             "sources": [
               {
                 "url": "https://github.com/blaxel-ai/sandbox",
@@ -37869,7 +37801,7 @@
     }
   },
   "n_total": 472,
-  "generated": "2026-08-13",
+  "generated": "2026-08-12",
   "long_tail": {
     "counts": {
       "repos": 15375,

--- a/build/serialize_rubric.py
+++ b/build/serialize_rubric.py
@@ -336,33 +336,50 @@ def license_tiers(slug: str, recipe: dict) -> tuple[list[dict], list[str]]:
     return rows, errors
 
 
-def stars_bands(routing: dict) -> tuple[list[dict], list[str]]:
-    """The stars scale, from the adoption route that produces it.
+_ROUTE_SCALE_UNITS = {"stars_fallback": "GitHub stars"}
 
-    Emitted with product_type '*' because it does not vary by type, and capped: a
-    stars-derived band may never claim levels 4 or 5, since stars measure attention
-    rather than use. The cap is enforced here rather than trusted, so a later edit that
-    adds a level-4 stars band fails the serializer instead of quietly publishing one.
+
+def route_bands(routing: dict) -> tuple[list[dict], list[str]]:
+    """Every adoption scale declared on its own ROUTE rather than per product type.
+
+    Two instruments qualify, for the same reason: what they measure does not vary by
+    what it was measured on. A dataset's downloads run an order below a package's, which
+    is why THOSE bands are per type — but a star is a star whatever it was given to, and
+    a monthly active user is a person whatever they came back to. Declaring such a scale
+    once, on the route that produces it, is also the only way to avoid four copies of a
+    scale that must not drift. Both are emitted with product_type '*'.
+
+    A declared `cap` is enforced here rather than trusted, so a later edit adding a
+    level-4 stars band fails the serializer instead of quietly publishing one. Only the
+    stars route declares one: it may never claim levels 4 or 5, since stars measure
+    attention rather than use. `active_users` measures use directly and has no ceiling.
+
+    Generalized from `stars_bands` on 2026-08-13, when `active_users` became the second
+    such scale. Adding it by copying the function would have been the same duplication
+    one layer up from the one this table exists to prevent.
     """
     routes = ((routing.get("dimensions") or {}).get("adoption") or {}).get("routes") or []
     rows, warnings = [], []
     for route in routes:
-        if route.get("signal_type") != "stars_fallback":
+        signal_type = route.get("signal_type")
+        if not signal_type or not route.get("bands"):
             continue
         cap = route.get("cap")
-        for band in route.get("bands") or []:
+        unit = str(route.get("unit") or _ROUTE_SCALE_UNITS.get(signal_type) or "")
+        for band in route["bands"]:
             if cap is not None and band["level"] > cap:
                 warnings.append(
-                    f"stars band level {band['level']} exceeds the declared cap {cap}; dropped"
+                    f"{signal_type} band level {band['level']} exceeds the declared "
+                    f"cap {cap}; dropped"
                 )
                 continue
             rows.append({
                 "product_type": "*",
-                "signal_type": "stars_fallback",
+                "signal_type": signal_type,
                 "level": band["level"],
                 "above": band["above"],
                 "reach": str(band.get("reach") or ""),
-                "unit": "GitHub stars",
+                "unit": unit,
             })
     return rows, warnings
 
@@ -481,9 +498,9 @@ def build_rubric(sources: dict, policy: dict, routing: dict) -> tuple[dict[str, 
 
     tables["adoption_bands"], band_warnings = adoption_bands(shared_rubrics)
     warnings.extend(band_warnings)
-    star_rows, star_warnings = stars_bands(routing)
-    tables["adoption_bands"].extend(star_rows)
-    warnings.extend(star_warnings)
+    route_rows, route_warnings = route_bands(routing)
+    tables["adoption_bands"].extend(route_rows)
+    warnings.extend(route_warnings)
     tables["license_aliases"] = license_aliases(routing)
     tables["evidence_abstentions"] = evidence_abstentions(routing)
     if not tables["evidence_abstentions"]:

--- a/docs/guides/adoption.md
+++ b/docs/guides/adoption.md
@@ -185,7 +185,7 @@ how much weight it carries:
 |---|---|---|
 | `usage_volume` | a download or install count | **yes**, where the artifact is declared |
 | `active_users` | vendor-disclosed MAU or WAU. **Its own scale**, sharing the download thresholds | no |
-| `reported_traction` | a credible third-party or vendor figure | no |
+| `reported_traction` | a credible vendor or third-party claim, with **no count behind it**. A word vocabulary, never a number | no |
 | `stars_fallback` | GitHub stars. Last resort, and **capped at level 3** | yes, once stars are banded |
 | `unknown` | instrument not recorded | no |
 
@@ -194,15 +194,43 @@ load-bearing rule in this guide:
 
 - A `usage_volume` band **claims to be a download count**. If a computed count disagrees, one
   of them is wrong — in either direction — and it is a finding, not a judgment call.
-- A `reported_traction` band is measuring **something else entirely**. Comparing it against a
-  download count is a category error, and a check must **skip** it rather than flag or waive
-  it. This was true of `active_users` too until it got a scale on 2026-08-13 — and the skip is
-  worth remembering, because it was correct *and* it was what hid the problem. 22 of the 23
-  products were wearing download labels, and a checker that declines to look never says so.
-  **Abstention is the right answer to a missing scale and the wrong answer to a scale nobody
-  has declared yet.**
+- A `reported_traction` record claims **no count at all**, so it may carry a word and never a
+  number. See the vocabulary below.
 - An `active_users` band claims a count of people, on the scale above. It may be compared only
   against another user count.
+
+Both of the latter were skipped entirely by `check_adoption` until 2026-08-13, on the ground
+that comparing them against a download count is a category error. That was correct, and it is
+also what hid the problem — 22 of 23 `active_users` records and 68 of 110 `reported_traction`
+ones were wearing download labels, and a checker that declines to look never says so.
+**Abstention is the right answer to a missing scale and the wrong answer to a scale nobody has
+declared yet.**
+
+### `reported_traction` records a word, never a number
+
+| may record | `niche` · `broad` · `mass-market` — or nothing at all |
+|---|---|
+
+**A vocabulary, not a scale, and the difference is the point.** A scale maps a label to a level
+and a disagreement between them is a finding. A vocabulary says only which words exist: the word
+says what *kind* of standing was claimed, the level says *how much*, and neither is derived from
+the other. Measured 2026-08-13, `niche` ran 85% level 3, `broad` 80% level 4, `mass-market` 67%
+level 5 — forcing agreement would flatten exactly the residual signal those spreads represent.
+
+**Numeric labels are illegal here, and 68 of 110 records carried one.** They were perfectly
+collinear with the level beside them: `100K-1M` was level 3 on all 33 of its records, `1M-10M`
+level 4 on all 23, `10K-100K` level 2 on all 7. So they carried nothing the level did not —
+and they carried something false. `amazon-nova` read `1M-10M` beneath a note saying "no
+standalone per-model user count published"; `aws-neuron` read `100K-1M` beneath "no
+download/user count is published for Neuron". A reader sees a numeric band and concludes
+somebody counted something. **Nobody did.** A number here is a measurement claim the instrument
+is defined by being unable to make. All 68 were stripped on 2026-08-13; the levels stand.
+
+**Omitting `reach` is the honest default** — 15 records already did. Record a word only where
+it says something the level does not, which is usually the *shape* of the traction rather than
+its size: `osprey` at 446 GitHub stars but running in production at Discord is `niche` in a way
+that matters. The words are hardware's, which has used exactly these since before this route
+existed; sharing them beats minting a parallel set.
 - A `stars_fallback` band means no download signal existed when it was set. If one exists now,
   re-band on it.
 
@@ -329,7 +357,10 @@ product, followed by a band recorded on that signal anyway.**
 - [ ] `signal_type` names the instrument actually used, not the one that sounds strongest.
 - [ ] `stars_fallback` never exceeds level 3.
 - [ ] A `usage_volume` band has a countable, **declared** artifact behind it.
-- [ ] A `reported_traction` band cites a source with a figure, a date and a digest.
+- [ ] A `reported_traction` record cites a source with a date and a digest, and records a word
+      from the vocabulary or no `reach` at all — never a number.
+- [ ] An `active_users` band names the quantity it actually banded, if that quantity is not an
+      active count (an all-time total, a device base, a paid-seat count).
 - [ ] The band follows from the figure in the note, in the same direction and order of
       magnitude.
 - [ ] No band was copied from a computed signal — those are observations, not scores.

--- a/docs/guides/adoption.md
+++ b/docs/guides/adoption.md
@@ -86,10 +86,10 @@ rather than borrow another type's scale. That is the same "abstain rather than s
 rule `sources/signal_routing.yaml` states for sources, and it is why the scoring models LEFT
 JOIN the band table rather than defaulting.
 
-### The stars scale is per instrument, not per type
+### Two scales are per instrument, not per type
 
-Stars get their own scale, declared **once** on the adoption route that produces it in
-`sources/signal_routing.yaml` rather than in the four type rubrics:
+Stars and active users get their own scales, declared **once** on the adoption route that
+produces each in `sources/signal_routing.yaml` rather than in the four type rubrics:
 
 | level | stars |
 |---|---|
@@ -97,10 +97,11 @@ Stars get their own scale, declared **once** on the adoption route that produces
 | 2 | 1K-10K |
 | 1 | <1K |
 
-Two reasons it lives there. A dataset's downloads run an order below a package's, which is
-why *those* bands are per type — but a star is a star whatever it was given to, so the scale
-is a property of the instrument. And declaring it once is the only way to avoid four copies
-of a number that must not drift.
+Two reasons they live there. A dataset's downloads run an order below a package's, which is
+why *those* bands are per type — but a star is a star whatever it was given to, and a monthly
+active user is a person whatever they came back to, so each scale is a property of the
+instrument. And declaring one once is the only way to avoid four copies of a number that must
+not drift.
 
 **Capped at 3, and the cap is enforced rather than trusted.** Stars measure attention rather
 than use, so a stars-derived band may never claim levels 4 or 5 however large the count.
@@ -114,8 +115,59 @@ products with a live GitHub row sit at medians of ~93, ~1,733 and ~15,801 stars 
 **this scale tightens a loose convention rather than describing one**, and applying it will
 move products.
 
-Both scales share `registry.adoption_bands`, distinguished by `signal_type`. A consumer that
-joins without filtering on it will band a package's downloads against the stars scale.
+#### The active-users scale, declared 2026-08-13
+
+| level | monthly active users |
+|---|---|
+| 5 | >10M users |
+| 4 | 1M-10M users |
+| 3 | 100K-1M users |
+| 2 | 10K-100K users |
+| 1 | <10K users |
+
+**Why it did not exist, which is the more useful half.** All 23 products carrying this
+instrument had a real user figure, and 22 of them wore a label off the *download* vocabulary
+— because that was the only vocabulary in the building, and nothing had ever declared it
+applied here. So the labels were not so much wrong as **unfalsifiable**. `character-ai` had
+invented `10M-100M`, a band no scale offered, and nobody could say so.
+
+`character-ai` is the case worth keeping. Its ~20M MAU clears the top threshold outright, but
+the record sat at level **4** — held down by a label with no scale behind it to check the
+label against. Declaring the scale raised it to 5. The same thing had happened to `claude-ai`,
+recording `1M-10M` over a cited figure of ~19–30M. Both were the map disagreeing with itself
+in a place nothing was looking.
+
+**Same thresholds as the download scale**, which is a decision rather than an inheritance. The
+alternative considered was one order higher throughout, so that ChatGPT at ~900M weekly actives
+and Poe at ~18M monthly actives did not both land at 5. That was rejected: **a level has to
+mean one magnitude across the whole map**, or `adoption` stops being comparable between a
+package and an app. 19 of the 23 sit at level 5, and that is the map saying these are all
+mass-market surfaces, which they are. A top band holding a wide range is the ordinary cost of a
+five-point scale, not a defect in this instrument.
+
+**The labels carry `users`** for the same reason the stars labels carry `stars` — and here
+especially, *because* the thresholds match. An unsuffixed `>10M` is ambiguous between two live
+scales at identical boundaries, and that ambiguity is precisely how a download vocabulary
+colonized this instrument unnoticed. The suffix is what makes the two tellable apart when their
+numbers do not differ.
+
+**No cap.** Unlike stars, this measures use directly. That no machine can fetch it is a
+question about *confidence*, not about ceiling.
+
+##### Say what you banded
+
+A model scores on the surface it powers — `gpt-5` on ChatGPT — and its note must say so out
+loud. What the scale will not accept silently is a figure that is **not an active count**: an
+all-time or cumulative user total, a device installed base, a paid-seat count. Those are the
+`active_users` form of the under-coverage error below, a substitution wearing a measurement's
+label, and three records carry one today with the substitution named in the note:
+`github-copilot` and `github-copilot-ide` (20M **all-time**, not active) and
+`apple-core-ml-runtime` (2.5B active **devices** — a person with an iPhone and a Mac is two of
+it). `doubao` used to be a fourth, banding on ~330M *total* users; a measured 382M MAU now
+exists and is *higher* than the total it had been leaning on.
+
+All three scales share `registry.adoption_bands`, distinguished by `signal_type`. A consumer
+that joins without filtering on it will band a package's downloads against the stars scale.
 
 ### The floor admits zero
 
@@ -132,7 +184,7 @@ how much weight it carries:
 | `signal_type` | what it is | machine-re-derivable? |
 |---|---|---|
 | `usage_volume` | a download or install count | **yes**, where the artifact is declared |
-| `active_users` | vendor-disclosed MAU or seats | no |
+| `active_users` | vendor-disclosed MAU or WAU. **Its own scale**, sharing the download thresholds | no |
 | `reported_traction` | a credible third-party or vendor figure | no |
 | `stars_fallback` | GitHub stars. Last resort, and **capped at level 3** | yes, once stars are banded |
 | `unknown` | instrument not recorded | no |
@@ -142,9 +194,15 @@ load-bearing rule in this guide:
 
 - A `usage_volume` band **claims to be a download count**. If a computed count disagrees, one
   of them is wrong — in either direction — and it is a finding, not a judgment call.
-- A `reported_traction` or `active_users` band is measuring **something else entirely**.
-  Comparing it against a download count is a category error, and a check must **skip** it
-  rather than flag or waive it.
+- A `reported_traction` band is measuring **something else entirely**. Comparing it against a
+  download count is a category error, and a check must **skip** it rather than flag or waive
+  it. This was true of `active_users` too until it got a scale on 2026-08-13 — and the skip is
+  worth remembering, because it was correct *and* it was what hid the problem. 22 of the 23
+  products were wearing download labels, and a checker that declines to look never says so.
+  **Abstention is the right answer to a missing scale and the wrong answer to a scale nobody
+  has declared yet.**
+- An `active_users` band claims a count of people, on the scale above. It may be compared only
+  against another user count.
 - A `stars_fallback` band means no download signal existed when it was set. If one exists now,
   re-band on it.
 

--- a/sources/scores/agent2agent-protocol.yaml
+++ b/sources/scores/agent2agent-protocol.yaml
@@ -70,7 +70,6 @@ openness:
     - core-gated
 adoption:
   level: 4
-  reach: 1M-10M
   signal_type: reported_traction
   confidence: medium
   note: 'Protocol adoption-breadth signal (per recipe): LF press (Apr 2026 one-year mark) reports 150+

--- a/sources/scores/alia-40b.yaml
+++ b/sources/scores/alia-40b.yaml
@@ -38,14 +38,17 @@ openness:
     accessed: '2026-06-26'
 adoption:
   level: 1
-  reach: 1K-10K
+  reach: <10K
   signal_type: usage_volume
   confidence: medium
   note: 'Public-funded sovereign model (Spain''s national LLM, BSC / MareNostrum 5) with strong institutional
-    and policy interest but modest raw volume. HF BSC-LT/ALIA-40b shows ~59 downloads/month and 88 likes
-    (June 2026); the niche multilingual focus (Spanish + co-official + 35 European languages) keeps adoption
-    below Apertus''s tier. Cumulative across the wider ALIA Kit (instruct, GGUF, Salamandra) would be higher,
-    but the base model alone sits in the low band.'
+    and policy interest but modest raw volume. HF BSC-LT/ALIA-40b shows ~59 downloads/month and 88 likes (June
+    2026); the niche multilingual focus (Spanish + co-official + 35 European languages) keeps adoption below
+    Apertus''s tier. Cumulative across the wider ALIA Kit (instruct, GGUF, Salamandra) would be higher, but
+    the base model alone sits in the low band. Read live 2026-08-13: 475 Hugging Face downloads in the
+    trailing 30 days across the declared artifact(s), which bands at <10K, level 1. The previous reach
+    ''1K-10K'' was a band off a different scale. No last_verified claimed: only the figure was re-read, not
+    the whole axis.'
   sources:
   - url: https://huggingface.co/BSC-LT/ALIA-40b
     shows: ~59 downloads/month, 88 likes (June 2026)

--- a/sources/scores/amazon-bedrock-evaluations.yaml
+++ b/sources/scores/amazon-bedrock-evaluations.yaml
@@ -28,7 +28,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: low
   note: GA since 2025-03-20 and distributed inside Amazon Bedrock (a large enterprise AI surface), but

--- a/sources/scores/amazon-nova.yaml
+++ b/sources/scores/amazon-nova.yaml
@@ -24,7 +24,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 4
-  reach: 1M-10M
   signal_type: reported_traction
   confidence: low
   note: Distributed broadly through Amazon Bedrock across many AWS regions (with fine-tuning, provisioned throughput,

--- a/sources/scores/amazon-q-developer.yaml
+++ b/sources/scores/amazon-q-developer.yaml
@@ -19,7 +19,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: low
   note: Distributed across AWS's large developer base via IDEs/CLI/Console with free + Pro tiers and enterprise

--- a/sources/scores/apple-core-ml-runtime.yaml
+++ b/sources/scores/apple-core-ml-runtime.yaml
@@ -36,13 +36,17 @@ openness:
     content_sha256: a2aa644242309dfefa82b7e0c4b739e5a086622f7d5e395f31e30f48e7948f25
 adoption:
   level: 5
-  reach: '>10M'
+  reach: '>10M users'
   signal_type: active_users
   confidence: medium
   note: Core ML ships as a system framework across iOS/iPadOS/macOS/tvOS/watchOS/visionOS (confirmed against
     the MLModel availability list), and Apple's own Q3 FY2026 earnings call puts the active-device installed
-    base at over 2.5 billion. Reach is attributed to the device base the runtime ships preinstalled on,
-    not a developer download count.
+    base at over 2.5 billion. Bands at >10M users, level 5 on the active_users scale declared 2026-08-13.
+    WHAT WAS BANDED - an active DEVICE base, not an active user count - a person with an iPhone and a Mac
+    is two of it, and nobody is counted for using Core ML rather than for owning hardware it ships on.
+    The band clears its boundary by more than two orders of magnitude, so the distinction does not
+    change the level; it is recorded because the scale requires a substituted quantity to be named. Not a developer
+    download count either.
   last_verified: '2026-08-09'
   sources:
   - url: https://docs.developer.apple.com/tutorials/data/documentation/coreml/mlmodel.md

--- a/sources/scores/arize.yaml
+++ b/sources/scores/arize.yaml
@@ -28,7 +28,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 4
-  reach: 1M-10M
   signal_type: reported_traction
   confidence: medium
   note: Vendor discloses ~1 trillion spans/month and ~1 billion evals/month plus named enterprise customers

--- a/sources/scores/artificial-analysis-intelligence-index.yaml
+++ b/sources/scores/artificial-analysis-intelligence-index.yaml
@@ -44,7 +44,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 4
-  reach: 1M-10M
   signal_type: reported_traction
   confidence: medium
   note: The AA Intelligence Index is one of the most-cited independent model-ranking standards in frontier

--- a/sources/scores/autogpt.yaml
+++ b/sources/scores/autogpt.yaml
@@ -27,12 +27,16 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 3
-  reach: 100K-1M
+  reach: '>10K stars'
   signal_type: stars_fallback
   confidence: low
-  note: 185k stars (one of the most-starred repos on GitHub) reflects huge historical interest, but stars
+  note: '185k stars (one of the most-starred repos on GitHub) reflects huge historical interest, but stars
     cannot exceed level 3 and recent production-usage signal is unclear. No published platform MAU/download
-    volume found; capped at 3, directional.
+    volume found; capped at 3, directional. Stars read 2026-08-13: 186,583 across the 1 declared repo, which
+    bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The previous reach ''100K-1M'' was
+    not a label this instrument offers - stars have their own vocabulary because a star is not a download. No
+    last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch,
+    and the rest of the axis was not re-read.'
   sources:
   - url: https://github.com/Significant-Gravitas/AutoGPT
     shows: 185k stars, autogpt-platform-beta-v0.6.62 May 28 2026

--- a/sources/scores/aws-neuron.yaml
+++ b/sources/scores/aws-neuron.yaml
@@ -95,7 +95,6 @@ openness:
     content_sha256: 88a0b7479101f9e12b3c38e88dd3dbbba15c48c7f0fb70359d61bd807e186ff9
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: low
   note: No download/user count is published for Neuron; the AWS product page still only supports a qualitative

--- a/sources/scores/azure-ai-foundry-observability.yaml
+++ b/sources/scores/azure-ai-foundry-observability.yaml
@@ -25,7 +25,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: low
   note: GA March 2026 as a feature surface within Microsoft Foundry on Azure; no standalone usage figures

--- a/sources/scores/azure-ai-model-inference.yaml
+++ b/sources/scores/azure-ai-model-inference.yaml
@@ -23,7 +23,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 4
-  reach: 1M-10M
   signal_type: reported_traction
   confidence: low
   note: Default inference surface for Microsoft Foundry across Azure's enterprise base; broad distribution

--- a/sources/scores/beta9.yaml
+++ b/sources/scores/beta9.yaml
@@ -69,12 +69,16 @@ openness:
     content_sha256: c4923b4b478215eaa2d47106d6bf04b8537651d823ec50da432a935539d7356f
 adoption:
   level: 2
-  reach: 10K-100K
+  reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
-  note: No PyPI/usage figure for the OSS runtime surfaced and no disclosed Beam customer/usage count;
-    only ~1.7k GitHub stars available as a signal. stars_fallback caps level at 3; placed at 2 given the
-    small star base and absence of any volume signal. Low confidence.
+  note: 'No PyPI/usage figure for the OSS runtime surfaced and no disclosed Beam customer/usage count; only
+    ~1.7k GitHub stars available as a signal. stars_fallback caps level at 3; placed at 2 given the small star
+    base and absence of any volume signal. Low confidence. Stars read 2026-08-13: 1,742 across the 1 declared
+    repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach
+    ''10K-100K'' was not a label this instrument offers - stars have their own vocabulary because a star is
+    not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift
+    on every refetch, and the rest of the axis was not re-read.'
   sources:
   - url: https://github.com/beam-cloud/beta9
     shows: 1.7k stars; no published download/usage figures

--- a/sources/scores/bigcodebench.yaml
+++ b/sources/scores/bigcodebench.yaml
@@ -38,12 +38,16 @@ openness:
     - core-gated
 adoption:
   level: 2
-  reach: 10K-100K
+  reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: medium
   note: 'Narrow, specialist code-gen benchmark: 503 GitHub stars, active HF leaderboard with 163 models
-    evaluated. No clean PyPI/download figure for the harness; no published install volume. stars_fallback
-    -> capped at level 3, set to 2 on the modest star + leaderboard footprint.'
+    evaluated. No clean PyPI/download figure for the harness; no published install volume. stars_fallback ->
+    capped at level 3, set to 2 on the modest star + leaderboard footprint. Stars read 2026-08-13: 1,573
+    across the 2 declared repos, which bands at 1K-10K stars, level 2 on the stars scale in
+    signal_routing.yaml. The previous reach ''10K-100K'' was not a label this instrument offers - stars have
+    their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile,
+    so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.'
   sources:
   - url: https://github.com/bigcode-project/bigcodebench
     shows: 503 stars; leaderboard with 163 models

--- a/sources/scores/blaxel-sandbox.yaml
+++ b/sources/scores/blaxel-sandbox.yaml
@@ -82,13 +82,16 @@ openness:
     - source
 adoption:
   level: 1
-  reach: null
+  reach: <1K stars
   signal_type: stars_fallback
   confidence: low
   note: 'Very nascent: ~22 stars on the sandbox repo, a $7.3M seed (First Round, YC S2025), and an unverified
-    vendor claim of billions of agent requests. No usage or download signal. stars_fallback with a low-double-digit
-    star base places this at 1. Added on openness and mission-fit grounds despite the low prominence;
-    scored honestly. Low confidence.'
+    vendor claim of billions of agent requests. No usage or download signal. stars_fallback with a low-double-
+    digit star base places this at 1. Added on openness and mission-fit grounds despite the low prominence;
+    scored honestly. Low confidence. Stars read 2026-08-13: 27 across the 1 declared repo, which bands at <1K
+    stars, level 1 on the stars scale in signal_routing.yaml. The record carried no reach label at all before
+    this. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every
+    refetch, and the rest of the axis was not re-read.'
   sources:
   - url: https://github.com/blaxel-ai/sandbox
     shows: ~22 stars / 11 forks; MIT sandbox API

--- a/sources/scores/ccnet.yaml
+++ b/sources/scores/ccnet.yaml
@@ -21,11 +21,15 @@ openness:
     accessed: '2026-07-21'
 adoption:
   level: 2
-  reach: <10K
+  reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: medium
-  note: ~1,000 GitHub stars; research repo, no PyPI package. Archived since 2023 but a foundational, widely-reused
-    pipeline.
+  note: '~1,000 GitHub stars; research repo, no PyPI package. Archived since 2023 but a foundational, widely-
+    reused pipeline. Stars read 2026-08-13: 1,045 across the 1 declared repo, which bands at 1K-10K stars,
+    level 2 on the stars scale in signal_routing.yaml. The previous reach ''<10K'' was not a label this
+    instrument offers - stars have their own vocabulary because a star is not a download. No last_verified
+    claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of
+    the axis was not re-read.'
   sources:
   - url: https://github.com/facebookresearch/cc_net
     shows: ~1,000 stars; archived read-only 2023-10-31

--- a/sources/scores/cerebras-inference.yaml
+++ b/sources/scores/cerebras-inference.yaml
@@ -41,7 +41,6 @@ openness:
     content_sha256: 0cfbd66ec3623684973135b021b01556cbab1382775d28eaab93e83c8473e016
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: low
   note: No developer/user count disclosed on the inference page as of today; named users GSK, Perplexity,

--- a/sources/scores/character-ai.yaml
+++ b/sources/scores/character-ai.yaml
@@ -21,14 +21,17 @@ openness:
     shows: Character.AI is a proprietary consumer companion-chat app (product/company profile)
     accessed: '2026-06-04'
 adoption:
-  level: 4
-  reach: 10M-100M
+  level: 5
+  reach: '>10M users'
   signal_type: active_users
   confidence: low
   note: Reported ~20M MAU and ~180M monthly site visits (Apr 2026); peaked ~28M MAU mid-2024 then declined.
-    Clears >10M but figures are aggregator-compiled (no first-party MAU disclosure fetched) and sources
-    disagree (20M vs higher visit-based counts), so low confidence. Reach mapped to 10M-100M on monthly-visit
-    volume; level 4 on the conservative MAU read.
+    ~20M MAU bands at >10M users, level 5 on the active_users scale declared 2026-08-13. RAISED from 4,
+    and the reason is the whole case for declaring the scale - this record read level 4 against a reach
+    of '10M-100M', a band nothing in the repo offered. Its own conservative figure clears the top
+    threshold, so the level was held down by a label that had no scale behind it to check it against.
+    Figures are aggregator-compiled (no first-party MAU disclosure fetched) and sources disagree (20M vs
+    higher visit-based counts), so confidence stays low; the 10M boundary is not close on either read.
   sources:
   - url: https://www.businessofapps.com/data/character-ai-statistics/
     shows: ~20M MAU, ~180M monthly visits, peak ~28M mid-2024 (compiled)

--- a/sources/scores/chatgpt.yaml
+++ b/sources/scores/chatgpt.yaml
@@ -20,7 +20,7 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 5
-  reach: '>10M'
+  reach: '>10M users'
   signal_type: active_users
   confidence: high
   note: OpenAI officially announced ~900M weekly active users (27 Feb 2026), up from 800M (Oct 2025),

--- a/sources/scores/claude-ai.yaml
+++ b/sources/scores/claude-ai.yaml
@@ -20,15 +20,18 @@ openness:
       execution)
     accessed: '2026-06-04'
 adoption:
-  level: 4
-  reach: 1M-10M
+  level: 5
+  reach: '>10M users'
   signal_type: active_users
   confidence: low
   note: Anthropic does NOT disclose official Claude.ai MAU. Third-party estimates (no primary vendor figure
-    available) put consumer MAU ~18.9M web at start of 2026 rising toward ~30M by mid-2026, i.e. comfortably
-    above 1M but well below the >10M-billion scale of ChatGPT/Gemini app. Placed at level 4 on best-available
-    estimate; confidence low because the headline number is an estimate, not a vendor primary disclosure
-    (flagged).
+    available) put consumer MAU ~18.9M web at start of 2026 rising toward ~30M by mid-2026, which bands
+    at >10M users, level 5 on the active_users scale declared 2026-08-13. RAISED from 4, which had been
+    recorded against a reach of '1M-10M' - a label its own cited figure contradicted by roughly twofold
+    at the low end. The scale is what makes that contradiction visible - nothing previously compared the
+    number in the note to the band above it. Level 5 here does not claim parity with ChatGPT or the Gemini
+    app, which are two orders larger; it says all three are mass-market, which is what the map's top band
+    means. Confidence stays low - the headline number is a third-party estimate, not a vendor disclosure.
   sources:
   - url: https://claude.com/product/overview
     shows: consumer chat product exists (web/desktop/mobile apps)

--- a/sources/scores/claude-code.yaml
+++ b/sources/scores/claude-code.yaml
@@ -51,7 +51,6 @@ openness:
     - license
 adoption:
   level: 4
-  reach: 1M-10M
   signal_type: reported_traction
   confidence: medium
   note: 'Reuters (Feb 2026): Claude Code exceeded ~$2.5B run-rate revenue, with business subscriptions

--- a/sources/scores/claude-haiku.yaml
+++ b/sources/scores/claude-haiku.yaml
@@ -22,7 +22,6 @@ openness:
     accessed: '2026-07-29'
 adoption:
   level: 4
-  reach: 1M-10M
   signal_type: reported_traction
   confidence: medium
   note: High-volume tier by design, but no per-model usage figure is published and it is chosen less often

--- a/sources/scores/claude-sonnet.yaml
+++ b/sources/scores/claude-sonnet.yaml
@@ -24,7 +24,6 @@ openness:
     accessed: '2026-07-29'
 adoption:
   level: 5
-  reach: '>10M'
   signal_type: reported_traction
   confidence: medium
   note: Highest-adoption tier of the three Claude model tiers - Sonnet is the production default for coding

--- a/sources/scores/coder-oss.yaml
+++ b/sources/scores/coder-oss.yaml
@@ -66,11 +66,15 @@ openness:
 adoption:
   level: 3
   signal_type: stars_fallback
-  reach: 100K-1M
+  reach: '>10K stars'
   confidence: low
-  note: No published install/active-user count for the OSS edition; ~13.4k GitHub stars is the only concrete
-    signal. Stars-fallback caps at level 3; placed at 3 (not higher) on broad enterprise positioning +
-    star base, but reach is unverified by usage_volume.
+  note: 'No published install/active-user count for the OSS edition; ~13.4k GitHub stars is the only concrete
+    signal. Stars-fallback caps at level 3; placed at 3 (not higher) on broad enterprise positioning + star
+    base, but reach is unverified by usage_volume. Stars read 2026-08-13: 14,142 across the 1 declared repo,
+    which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The previous reach
+    ''100K-1M'' was not a label this instrument offers - stars have their own vocabulary because a star is not
+    a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on
+    every refetch, and the rest of the axis was not re-read.'
   sources:
   - url: https://github.com/coder/coder
     shows: ~13.4k stars; self-hosted CDE used by enterprises; no usage_volume figure

--- a/sources/scores/codestral.yaml
+++ b/sources/scores/codestral.yaml
@@ -29,7 +29,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: low
   note: Embedded as the default FIM/code-completion backend in IDE assistants (Continue, Tabnine, and

--- a/sources/scores/codex-cli.yaml
+++ b/sources/scores/codex-cli.yaml
@@ -68,7 +68,6 @@ openness:
     - core-gated
 adoption:
   level: 4
-  reach: 1M-10M
   signal_type: reported_traction
   confidence: high
   note: OpenAI confirmed Codex surpassed 4M weekly developers (Apr 21 2026 announcement; 5M+ reported

--- a/sources/scores/cohere-rerank-api.yaml
+++ b/sources/scores/cohere-rerank-api.yaml
@@ -25,7 +25,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: medium
   note: De facto default managed reranker for RAG, distributed across Azure AI Foundry, AWS SageMaker

--- a/sources/scores/confident-ai.yaml
+++ b/sources/scores/confident-ai.yaml
@@ -28,7 +28,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: medium
   note: Vendor discloses '500+ leading AI companies' incl. Panasonic, Samsung, Epic Games, Humach. Corroborated

--- a/sources/scores/cruxeval.yaml
+++ b/sources/scores/cruxeval.yaml
@@ -26,7 +26,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: medium
   note: Established code-reasoning benchmark cited in code-model evaluations and research since 2024;

--- a/sources/scores/cursor.yaml
+++ b/sources/scores/cursor.yaml
@@ -57,7 +57,7 @@ openness:
     - license
 adoption:
   level: 4
-  reach: 1M-10M
+  reach: 1M-10M users
   signal_type: active_users
   confidence: high
   note: 1M+ daily active users (reported 2025, sustained Dec 2025) and ~$2B ARR by Feb 2026; ~64% of Fortune

--- a/sources/scores/datadog-llm-observability.yaml
+++ b/sources/scores/datadog-llm-observability.yaml
@@ -25,7 +25,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 4
-  reach: 1M-10M
   signal_type: reported_traction
   confidence: low
   note: Rides the large installed base of Datadog APM (a major enterprise observability vendor); LLM Observability

--- a/sources/scores/datamap-rs.yaml
+++ b/sources/scores/datamap-rs.yaml
@@ -25,10 +25,14 @@ openness:
     accessed: '2026-07-21'
 adoption:
   level: 1
-  reach: <10K
+  reach: <1K stars
   signal_type: stars_fallback
   confidence: medium
-  note: New (2026) single-purpose Rust CLI, ~56 GitHub stars; real but niche, used in the Dolma 3 pipeline.
+  note: 'New (2026) single-purpose Rust CLI, ~56 GitHub stars; real but niche, used in the Dolma 3 pipeline.
+    Stars read 2026-08-13: 56 across the 1 declared repo, which bands at <1K stars, level 1 on the stars scale
+    in signal_routing.yaml. The previous reach ''<10K'' was not a label this instrument offers - stars have
+    their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile,
+    so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.'
   sources:
   - url: https://github.com/allenai/datamap-rs
     shows: 56 stars

--- a/sources/scores/datasette-agent.yaml
+++ b/sources/scores/datasette-agent.yaml
@@ -23,11 +23,15 @@ openness:
     accessed: '2026-06-19'
 adoption:
   level: 1
-  reach: <10K
+  reach: <1K stars
   signal_type: stars_fallback
   confidence: high
-  note: Pre-release alpha (PyPI 0.3a0, Jun 2026) roughly one month old; ~96 GitHub stars. Minimal adoption to date,
-    included as an emerging on-thesis structured-data agent.
+  note: 'Pre-release alpha (PyPI 0.3a0, Jun 2026) roughly one month old; ~96 GitHub stars. Minimal adoption to
+    date, included as an emerging on-thesis structured-data agent. Stars read 2026-08-13: 110 across the 1
+    declared repo, which bands at <1K stars, level 1 on the stars scale in signal_routing.yaml. The previous
+    reach ''<10K'' was not a label this instrument offers - stars have their own vocabulary because a star is
+    not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift
+    on every refetch, and the rest of the axis was not re-read.'
   sources:
   - url: https://github.com/datasette/datasette-agent
     shows: ~96 stars, 7 tags; PyPI 0.3a0 (15 Jun 2026)

--- a/sources/scores/datology-ai.yaml
+++ b/sources/scores/datology-ai.yaml
@@ -22,7 +22,7 @@ openness:
     accessed: '2026-07-21'
 adoption:
   level: 2
-  reach: early / niche
+  reach: niche
   signal_type: reported_traction
   confidence: medium
   note: ~$57.5M raised with high-profile backers, but early-stage with no named frontier-lab deployments;

--- a/sources/scores/dclm.yaml
+++ b/sources/scores/dclm.yaml
@@ -21,10 +21,14 @@ openness:
     accessed: '2026-07-21'
 adoption:
   level: 2
-  reach: <10K
+  reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: medium
-  note: ~1,454 GitHub stars; no PyPI package (source install). The reference DataComp-LM toolkit.
+  note: '~1,454 GitHub stars; no PyPI package (source install). The reference DataComp-LM toolkit. Stars read
+    2026-08-13: 1,463 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in
+    signal_routing.yaml. The previous reach ''<10K'' was not a label this instrument offers - stars have their
+    own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a
+    digest of it would read as drift on every refetch, and the rest of the axis was not re-read.'
   sources:
   - url: https://github.com/mlfoundations/dclm
     shows: 1,454 stars; not published to PyPI

--- a/sources/scores/decon.yaml
+++ b/sources/scores/decon.yaml
@@ -25,10 +25,14 @@ openness:
     accessed: '2026-07-21'
 adoption:
   level: 1
-  reach: <10K
+  reach: <1K stars
   signal_type: stars_fallback
   confidence: medium
-  note: New (2026) single-purpose Rust CLI, ~35 GitHub stars; niche, used in the Dolma 3 pipeline.
+  note: 'New (2026) single-purpose Rust CLI, ~35 GitHub stars; niche, used in the Dolma 3 pipeline. Stars read
+    2026-08-13: 36 across the 1 declared repo, which bands at <1K stars, level 1 on the stars scale in
+    signal_routing.yaml. The previous reach ''<10K'' was not a label this instrument offers - stars have their
+    own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a
+    digest of it would read as drift on every refetch, and the rest of the axis was not re-read.'
   sources:
   - url: https://github.com/allenai/decon
     shows: 35 stars

--- a/sources/scores/deepseek-chat.yaml
+++ b/sources/scores/deepseek-chat.yaml
@@ -39,14 +39,24 @@ openness:
     - source
 adoption:
   level: 5
-  reach: '>10M'
+  reach: '>10M users'
   signal_type: active_users
   confidence: medium
-  note: DeepSeek's consumer app was one of the most-downloaded global AI apps after the early-2025 surge;
-    the hosted chat surface remains a top-tier global assistant. No clean current MAU figure published
-    on the vendor's own page, so confidence medium; reach >10M is well-supported by app-store ranking
-    history. Attributed to the chat surface, not the model SKU.
+  note: 130M MAU as of May 2026, third among Chinese AI apps, per QuestMobile's "2026 First-Half AI Application
+    Market Development Insight Report" (published 14 Jul 2026). Bands at >10M users, level 5 on the active_users
+    scale declared 2026-08-13. This replaces the record's previous basis, which was app-store ranking history
+    and no figure at all - the one product of the 23 carrying this instrument that had no user count under
+    it. Confidence medium because QuestMobile's report is read through press coverage rather than the report
+    itself, and it measures the China market, where DeepSeek's usage is concentrated but not confined.
+    Attributed to the chat surface, not the model SKU.
+  last_verified: '2026-08-13'
   sources:
+  - url: https://finance.biggo.com/news/372811e2-28f1-49c7-9f53-fa56879cde3b
+    shows: 'QuestMobile 2026 H1 report, as of May 2026: "DeepSeek ranked third with 130 million MAUs".
+      Doubao leads at 382M.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e7ea3a11679cc5814830d1f89f68bc2a884faf9ca20bddb7007094d1fc267dde
   - url: https://play.google.com/store/apps/details?id=com.deepseek.chat&hl=en_US
     shows: Official DeepSeek AI Assistant Android app listing (consumer chat surface, mass-market distribution)
     accessed: '2026-06-04'

--- a/sources/scores/deepspeed.yaml
+++ b/sources/scores/deepspeed.yaml
@@ -20,11 +20,15 @@ openness:
     shows: Apache License Version 2.0 full text
     accessed: '2026-06-22'
 adoption:
-  level: 3
-  reach: ~1.4M/mo
+  level: 4
+  reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: PyPI last_month downloads ~1.37M.
+  note: 'PyPI last_month downloads ~1.37M. Read live 2026-08-13: 1,112,723 PyPI downloads in the trailing 30
+    days across the declared artifact(s), which bands at 1M-10M, level 4. Level corrected from 3. The previous
+    reach ''~1.4M/mo'' was free text carrying a figure rather than a band the scale declares, so nothing could
+    check it against the level beside it. No last_verified claimed: only the figure was re-read, not the whole
+    axis.'
   sources:
   - url: https://pypistats.org/api/packages/deepspeed/recent
     shows: last_month=1,374,390 downloads

--- a/sources/scores/deepteam.yaml
+++ b/sources/scores/deepteam.yaml
@@ -23,10 +23,14 @@ openness:
     accessed: '2026-06-29'
 adoption:
   level: 2
-  reach: 1K-10K
+  reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
-  note: ~1.9K GitHub stars (June 2026); stars-only proxy, capped per methodology.
+  note: '~1.9K GitHub stars (June 2026); stars-only proxy, capped per methodology. Stars read 2026-08-13:
+    2,442 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in
+    signal_routing.yaml. The previous reach ''1K-10K'' was not a label this instrument offers - stars have
+    their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile,
+    so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.'
   sources:
   - url: https://github.com/confident-ai/deepteam
     shows: ~1.9k stars (June 2026)

--- a/sources/scores/devin.yaml
+++ b/sources/scores/devin.yaml
@@ -23,7 +23,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: low
   note: Widely adopted commercial coding agent with paid Individual/Teams/Enterprise tiers, but Cognition

--- a/sources/scores/diffusers.yaml
+++ b/sources/scores/diffusers.yaml
@@ -21,10 +21,14 @@ openness:
     accessed: '2026-06-22'
 adoption:
   level: 4
-  reach: 7M+/month
+  reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: PyPI last_month downloads of 7,406,705 fall in the 5M-50M Level 4 band.
+  note: 'PyPI last_month downloads of 7,406,705 fall in the 5M-50M Level 4 band. Read live 2026-08-13:
+    8,248,209 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at 1M-10M,
+    level 4. The previous reach ''7M+/month'' was free text carrying a figure rather than a band the scale
+    declares, so nothing could check it against the level beside it. No last_verified claimed: only the figure
+    was re-read, not the whole axis.'
   sources:
   - url: https://pypistats.org/api/packages/diffusers/recent
     shows: last_month downloads = 7,406,705

--- a/sources/scores/dify.yaml
+++ b/sources/scores/dify.yaml
@@ -27,11 +27,17 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 3
-  reach: 100K-1M
+  reach: '>10K stars'
   signal_type: stars_fallback
   confidence: high
-  note: ~144K GitHub stars plus Dify Cloud managed tier; no honest active-user/download volume figure
-    verified, so capped at 3 on stars fallback.
+  note: '~144K GitHub stars plus Dify Cloud managed tier; no honest active-user/download volume figure
+    verified, so capped at 3 on stars fallback. Stars read 2026-08-13 on langgenius/dify: 152,331, which bands
+    at >10K stars, level 3 on the stars scale. The previous reach ''100K-1M'' was a download label, which this
+    instrument does not offer - a star is not a download. THE REAL DEFECT is upstream: this product declares
+    no artifacts at all, so a stars_fallback band had no stars source behind it and the count lived only in
+    this note. Declaring langgenius/dify would fix it, and is deliberately not done here because a declared
+    code repo also re-routes the openness license dimension. No last_verified claimed: a star count is
+    volatile.'
   sources:
   - url: https://github.com/langgenius/dify
     shows: flagship phase-C verification source

--- a/sources/scores/distilabel.yaml
+++ b/sources/scores/distilabel.yaml
@@ -25,10 +25,13 @@ openness:
     accessed: '2026-07-21'
 adoption:
   level: 2
-  reach: 1K-10K
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: ~6.5k PyPI downloads/month; established in the HF synthetic-data workflow but modest raw volume.
+  note: '~6.5k PyPI downloads/month; established in the HF synthetic-data workflow but modest raw volume. Read
+    live 2026-08-13: 16,308 PyPI downloads in the trailing 30 days across the declared artifact(s), which
+    bands at 10K-100K, level 2. The previous reach ''1K-10K'' was a band off a different scale. No
+    last_verified claimed: only the figure was re-read, not the whole axis.'
   sources:
   - url: https://pypistats.org/packages/distilabel
     shows: 'Downloads last month: 6,510'

--- a/sources/scores/dolma-toolkit.yaml
+++ b/sources/scores/dolma-toolkit.yaml
@@ -24,11 +24,14 @@ openness:
     shows: Apache License Version 2.0 text
     accessed: '2026-07-21'
 adoption:
-  level: 2
-  reach: 1K-10K
+  level: 1
+  reach: <10K
   signal_type: usage_volume
   confidence: high
-  note: ~5.1k PyPI downloads/month; the curation toolkit behind the Dolma corpus and OLMo family.
+  note: '~5.1k PyPI downloads/month; the curation toolkit behind the Dolma corpus and OLMo family. Read live
+    2026-08-13: 4,390 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at
+    <10K, level 1. Level corrected from 2. The previous reach ''1K-10K'' was a band off a different scale. No
+    last_verified claimed: only the figure was re-read, not the whole axis.'
   sources:
   - url: https://pypistats.org/packages/dolma
     shows: 'Downloads last month: 5,097'

--- a/sources/scores/doubao-seed.yaml
+++ b/sources/scores/doubao-seed.yaml
@@ -22,7 +22,7 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 5
-  reach: '>10M'
+  reach: '>10M users'
   signal_type: active_users
   confidence: medium
   note: 'Powers the Doubao app, China''s #1 AI chatbot with ~155M weekly active users; Seed 2.0 is the model behind

--- a/sources/scores/doubao.yaml
+++ b/sources/scores/doubao.yaml
@@ -38,16 +38,25 @@ openness:
     - source
 adoption:
   level: 5
-  reach: '>10M'
+  reach: '>10M users'
   signal_type: active_users
   confidence: medium
-  note: 'Doubao reached ~330M total users by May 2026 (en.wikipedia.org/wiki/Doubao); China''s most popular
-    AI chatbot; ~60M MAU as of Nov 2024 per Wikipedia. China-market app trackers report ~330M users as
-    of May 2026. NOTE (verifier): the 330M figure is cited by Wikipedia as TOTAL users, not a measured
-    MAU; the only Wikipedia-stated MAU is ~60M (Nov 2024). Either way the surface clears >10M. Headline
-    counts are aggregator/Wikipedia-compiled (no single ByteDance primary MAU disclosure), so confidence
-    medium. Volcano Engine reportedly serves ~120T tokens/day.'
+  note: '382M MAU as of May 2026, first among Chinese AI apps by a clear margin, per QuestMobile''s "2026
+    First-Half AI Application Market Development Insight Report" (published 14 Jul 2026). Bands at >10M users,
+    level 5 on the active_users scale declared 2026-08-13. This retires the record''s previous
+    basis and the verifier''s objection to it: the old note banded on ~330M TOTAL users, with the only
+    stated MAU being ~60M from Nov 2024 - a cumulative count standing in for an active one, which is
+    exactly the substitution the scale''s attribution_note names. A measured MAU now exists and it is
+    higher than the total the record had been leaning on. Confidence medium because QuestMobile is read
+    through press coverage rather than the report itself. Volcano Engine reportedly serves ~120T tokens/day.'
+  last_verified: '2026-08-13'
   sources:
+  - url: https://finance.biggo.com/news/372811e2-28f1-49c7-9f53-fa56879cde3b
+    shows: 'QuestMobile 2026 H1 report, as of May 2026: "Doubao had 382 million MAUs, maintaining a clear
+      lead".'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e7ea3a11679cc5814830d1f89f68bc2a884faf9ca20bddb7007094d1fc267dde
   - url: https://en.wikipedia.org/wiki/Doubao
     shows: Doubao ~330M users by May 2026; China's most popular AI chatbot; 120T tokens/day
     accessed: '2026-06-04'

--- a/sources/scores/duplodocus.yaml
+++ b/sources/scores/duplodocus.yaml
@@ -25,10 +25,14 @@ openness:
     accessed: '2026-07-21'
 adoption:
   level: 1
-  reach: <10K
+  reach: <1K stars
   signal_type: stars_fallback
   confidence: medium
-  note: New (2026) single-purpose Rust CLI, ~90 GitHub stars; niche, used in the Dolma 3 pipeline.
+  note: 'New (2026) single-purpose Rust CLI, ~90 GitHub stars; niche, used in the Dolma 3 pipeline. Stars read
+    2026-08-13: 93 across the 1 declared repo, which bands at <1K stars, level 1 on the stars scale in
+    signal_routing.yaml. The previous reach ''<10K'' was not a label this instrument offers - stars have their
+    own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a
+    digest of it would read as drift on every refetch, and the rest of the axis was not re-read.'
   sources:
   - url: https://github.com/allenai/duplodocus
     shows: 90 stars

--- a/sources/scores/epoch-ai-benchmarks.yaml
+++ b/sources/scores/epoch-ai-benchmarks.yaml
@@ -46,7 +46,6 @@ openness:
     - source
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: medium
   note: Epoch's benchmark results (esp. FrontierMath) are a widely-referenced capability signal cited

--- a/sources/scores/falcon.yaml
+++ b/sources/scores/falcon.yaml
@@ -37,7 +37,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 2
-  reach: 10K-100K
   signal_type: reported_traction
   confidence: high
   note: Available on Hugging Face with moderate uptake at launch as a sub-13B SLM; no large verified usage figures

--- a/sources/scores/firecrawl.yaml
+++ b/sources/scores/firecrawl.yaml
@@ -87,12 +87,16 @@ openness:
     - source
 adoption:
   level: 3
-  reach: 100K-1M
+  reach: '>10K stars'
   signal_type: stars_fallback
   confidence: low
-  note: No verified download/API-volume or customer count disclosed on repo or pricing page; only ~129k
+  note: 'No verified download/API-volume or customer count disclosed on repo or pricing page; only ~129k
     GitHub stars available as an honest signal. Capped at level 3 per stars_fallback rule. Widely integrated
-    as an agent scrape tool (LangChain, etc.) but no primary usage figure found this run.
+    as an agent scrape tool (LangChain, etc.) but no primary usage figure found this run. Stars read
+    2026-08-13: 166,749 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in
+    signal_routing.yaml. The previous reach ''100K-1M'' was not a label this instrument offers - stars have
+    their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile,
+    so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.'
   sources:
   - url: https://github.com/mendableai/firecrawl
     shows: ~129k GitHub stars, v2.10 (15 May 2026)

--- a/sources/scores/fireworks-inference.yaml
+++ b/sources/scores/fireworks-inference.yaml
@@ -34,7 +34,6 @@ openness:
     content_sha256: fb2b63596a1d37e0698d82968f712fa5a2e8421785b76b6302634a2cef3b552e
 adoption:
   level: 4
-  reach: 1M-10M
   signal_type: reported_traction
   confidence: medium
   note: 'Strong named-customer roster including Cursor, Vercel, Notion, Sourcegraph, UiPath, Quora, Cresta,

--- a/sources/scores/flax.yaml
+++ b/sources/scores/flax.yaml
@@ -21,10 +21,14 @@ openness:
     accessed: '2026-06-22'
 adoption:
   level: 4
-  reach: 5M+/mo
+  reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: 5.3M PyPI downloads in the last 30 days, just above the 5M Level-4 threshold.
+  note: '5.3M PyPI downloads in the last 30 days, just above the 5M Level-4 threshold. Read live 2026-08-13:
+    4,482,096 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at 1M-10M,
+    level 4. The previous reach ''5M+/mo'' was free text carrying a figure rather than a band the scale
+    declares, so nothing could check it against the level beside it. No last_verified claimed: only the figure
+    was re-read, not the whole axis.'
   sources:
   - url: https://pepy.tech/projects/flax
     shows: 5,302,085 downloads in last 30 days

--- a/sources/scores/fly-sprites.yaml
+++ b/sources/scores/fly-sprites.yaml
@@ -30,7 +30,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 1
-  reach: <10K
   signal_type: reported_traction
   confidence: low
   note: Launched Jan 2026 (~5 months at scoring time) as Fly.io's answer to E2B. No disclosed user/customer/usage

--- a/sources/scores/galileo.yaml
+++ b/sources/scores/galileo.yaml
@@ -23,7 +23,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: low
   note: Vendor states 'trusted by leading enterprises' but discloses no named customers or quantitative

--- a/sources/scores/gemini-flash.yaml
+++ b/sources/scores/gemini-flash.yaml
@@ -29,7 +29,7 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 5
-  reach: '>10M'
+  reach: '>10M users'
   signal_type: active_users
   confidence: medium
   note: High-volume cheap tier powering the Gemini app and AI Mode in Search plus heavy API/Vertex traffic; Gemini

--- a/sources/scores/gemini-pro.yaml
+++ b/sources/scores/gemini-pro.yaml
@@ -24,7 +24,6 @@ openness:
     accessed: '2026-07-29'
 adoption:
   level: 5
-  reach: '>10M'
   signal_type: reported_traction
   confidence: medium
   note: Distributed through the Gemini API, AI Studio, Vertex AI and the Gemini apps, whose combined reach is

--- a/sources/scores/gemini.yaml
+++ b/sources/scores/gemini.yaml
@@ -20,7 +20,7 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 5
-  reach: '>10M'
+  reach: '>10M users'
   signal_type: active_users
   confidence: high
   note: Google CEO Sundar Pichai officially stated the Gemini app surpassed 750M monthly active users

--- a/sources/scores/ggml.yaml
+++ b/sources/scores/ggml.yaml
@@ -21,10 +21,15 @@ openness:
     accessed: '2026-06-22'
 adoption:
   level: 3
-  reach: ~14.9k stars
+  reach: '>10K stars'
   signal_type: stars_fallback
   confidence: medium
-  note: No PyPI package; GitHub shows ~14.9k stars (and underpins much higher-adoption llama.cpp).
+  note: 'No PyPI package; GitHub shows ~14.9k stars (and underpins much higher-adoption llama.cpp). Stars read
+    2026-08-13: 15,159 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in
+    signal_routing.yaml. The previous reach ''~14.9k stars'' was not a label this instrument offers - stars
+    have their own vocabulary because a star is not a download. No last_verified claimed: a star count is
+    volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-
+    read.'
   sources:
   - url: https://github.com/ggml-org/ggml
     shows: GitHub repo ~14,900 stars

--- a/sources/scores/giskard.yaml
+++ b/sources/scores/giskard.yaml
@@ -24,11 +24,16 @@ openness:
     shows: Apache-2.0; ~5.5k stars; automated scan + scenario checks; adversarial/injection testing
     accessed: '2026-06-29'
 adoption:
-  level: 3
-  reach: 10K-100K
+  level: 2
+  reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
-  note: ~5.5K GitHub stars (June 2026); stars-only proxy, capped per methodology.
+  note: '~5.5K GitHub stars (June 2026); stars-only proxy, capped per methodology. Stars read 2026-08-13:
+    5,748 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in
+    signal_routing.yaml. Level corrected from 3. The previous reach ''10K-100K'' was not a label this
+    instrument offers - stars have their own vocabulary because a star is not a download. No last_verified
+    claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of
+    the axis was not re-read.'
   sources:
   - url: https://github.com/Giskard-AI/giskard
     shows: ~5.5k stars (June 2026)

--- a/sources/scores/github-copilot-ide.yaml
+++ b/sources/scores/github-copilot-ide.yaml
@@ -20,12 +20,15 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 5
-  reach: '>10M'
+  reach: '>10M users'
   signal_type: active_users
   confidence: high
   note: Microsoft CEO confirmed 20M all-time Copilot users (earnings call, 30 Jul 2025); free tier opened
-    to 150M GitHub developers (Dec 2024); ~4.7M paid subscribers by Jan 2026. All-time user base exceeds
-    the >10M mass-market threshold. (All-time vs active distinction noted; still clearly level 5.)
+    to 150M GitHub developers (Dec 2024); ~4.7M paid subscribers by Jan 2026. Bands at >10M users, level 5
+    on the active_users scale declared 2026-08-13. WHAT WAS BANDED - the 20M is ALL-TIME rather
+    than active, and the one genuinely active-adjacent figure available - 4.7M paid subscribers - sits
+    a band lower, at 4. The level is unchanged from what this record already carried; what changed is
+    that the label under it is now one a declared scale offers, and that the substitution is named.
   sources:
   - url: https://techcrunch.com/2025/07/30/github-copilot-crosses-20-million-all-time-users/
     shows: GitHub-confirmed 20M all-time users, announced by Satya Nadella Jul 2025

--- a/sources/scores/github-copilot.yaml
+++ b/sources/scores/github-copilot.yaml
@@ -21,13 +21,16 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 5
-  reach: '>10M'
+  reach: '>10M users'
   signal_type: active_users
   confidence: high
   note: 'GitHub Copilot surpassed 20M+ all-time users (Microsoft July 2025 earnings): ''world''s most
-    widely adopted AI developer tool.'' Agent mode is the autonomous surface of that base. >10M band.
-    Note: 20M is all-time, not active; agent-mode-specific count not disclosed, but base scale firmly
-    supports level 5.'
+    widely adopted AI developer tool.'' Agent mode is the autonomous surface of that base. Bands at >10M users,
+    level 5 on the active_users scale declared 2026-08-13. WHAT WAS BANDED - 20M is an ALL-TIME
+    cumulative count, not an active one, and no agent-mode-specific figure is disclosed - so this is a
+    substitution in the sense of docs/guides/adoption.md and the true active figure is lower, not higher.
+    The level is unchanged; what changed is that the label under it is now one a
+    declared scale offers.'
   sources:
   - url: https://github.com/features/copilot
     shows: '''world''s most widely adopted AI developer tool'', millions of users and tens of thousands

--- a/sources/scores/github-mcp.yaml
+++ b/sources/scores/github-mcp.yaml
@@ -21,10 +21,14 @@ openness:
     accessed: '2026-06-17'
 adoption:
   level: 3
+  reach: '>10K stars'
   signal_type: stars_fallback
   confidence: medium
-  note: ~31k stars; no download metric for Go/Docker distribution - stars_fallback (first-party backing implies
-    higher real usage).
+  note: '~31k stars; no download metric for Go/Docker distribution - stars_fallback (first-party backing
+    implies higher real usage). Stars read 2026-08-13: 32,212 across the 1 declared repo, which bands at >10K
+    stars, level 3 on the stars scale in signal_routing.yaml. The record carried no reach label at all before
+    this. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every
+    refetch, and the rest of the axis was not re-read.'
   sources:
   - url: https://github.com/github/github-mcp-server
     shows: ~30.8k stars

--- a/sources/scores/glean-assistant.yaml
+++ b/sources/scores/glean-assistant.yaml
@@ -21,7 +21,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 4
-  reach: 1M-10M
   signal_type: reported_traction
   confidence: medium
   note: Glean surpassed $300M ARR (28 May 2026, vendor press), 15 months after $100M; nearly doubled Fortune

--- a/sources/scores/glean-workplace-search-ai.yaml
+++ b/sources/scores/glean-workplace-search-ai.yaml
@@ -20,7 +20,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 4
-  reach: 1M-10M
   signal_type: reported_traction
   confidence: medium
   note: 'Search is the foundational layer of the same Glean platform that crossed $300M ARR (May 2026)

--- a/sources/scores/google-cloud-tpu-inference.yaml
+++ b/sources/scores/google-cloud-tpu-inference.yaml
@@ -39,7 +39,6 @@ openness:
     content_sha256: c21814ce1f3a4410ec55e9c89c47a6c08660189070eb9adf144ebc591301a5e0
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: low
   note: Powers Google internal + Cloud TPU inference via AI Hypercomputer/GKE; no standalone usage figure

--- a/sources/scores/goose.yaml
+++ b/sources/scores/goose.yaml
@@ -30,11 +30,16 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 3
-  reach: 100K-1M
+  reach: '>10K stars'
   signal_type: stars_fallback
   confidence: low
-  note: 46.4k stars and active multi-surface distribution (desktop/CLI/API), backed by Block and now Linux
+  note: '46.4k stars and active multi-surface distribution (desktop/CLI/API), backed by Block and now Linux
     Foundation. No published download/MAU figure found, so capped at level 3 on stars-fallback; directional.
+    Stars read 2026-08-13: 52,753 across the 1 declared repo, which bands at >10K stars, level 3 on the stars
+    scale in signal_routing.yaml. The previous reach ''100K-1M'' was not a label this instrument offers -
+    stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count
+    is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-
+    read.'
   sources:
   - url: https://github.com/aaif-goose/goose
     shows: 46.4k stars, active development

--- a/sources/scores/gpqa.yaml
+++ b/sources/scores/gpqa.yaml
@@ -37,12 +37,15 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 4
-  reach: 1M-10M
+  reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: ~129,881 HF downloads in the trailing month (primary, from the dataset page); GPQA Diamond is
-    a de-facto-standard reasoning benchmark cited across frontier model release reports (appears as a
-    capability basis throughout the v3 flagship set), which is the top adoption signal for a benchmark.
+  note: '~129,881 HF downloads in the trailing month (primary, from the dataset page); GPQA Diamond is a de-
+    facto-standard reasoning benchmark cited across frontier model release reports (appears as a capability
+    basis throughout the v3 flagship set), which is the top adoption signal for a benchmark. Read live
+    2026-08-13: 110,577 Hugging Face downloads in the trailing 30 days across the declared artifact(s), which
+    bands at 100K-1M, level 4. The previous reach ''1M-10M'' was a band off a different scale. No
+    last_verified claimed: only the figure was re-read, not the whole axis.'
   sources:
   - url: https://huggingface.co/datasets/Idavidrein/gpqa
     shows: 129,881 downloads last month

--- a/sources/scores/gpt-4-1.yaml
+++ b/sources/scores/gpt-4-1.yaml
@@ -30,7 +30,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 4
-  reach: 1M-10M
   signal_type: reported_traction
   confidence: low
   note: GPT-4.1 was an API-first developer/coding model (initially not in ChatGPT default), widely adopted

--- a/sources/scores/gpt-4o.yaml
+++ b/sources/scores/gpt-4o.yaml
@@ -22,7 +22,7 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 5
-  reach: '>10M'
+  reach: '>10M users'
   signal_type: active_users
   confidence: medium
   note: GPT-4o was the default ChatGPT model for much of 2024-2025 before GPT-5; ChatGPT crossed ~900M

--- a/sources/scores/gpt-5.yaml
+++ b/sources/scores/gpt-5.yaml
@@ -28,7 +28,7 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 5
-  reach: '>10M'
+  reach: '>10M users'
   signal_type: active_users
   confidence: high
   note: GPT-5 was rolled out as the default model for logged-in ChatGPT users (Aug 2025). ChatGPT reached ~900M

--- a/sources/scores/graphrag.yaml
+++ b/sources/scores/graphrag.yaml
@@ -21,9 +21,14 @@ openness:
     accessed: '2026-06-17'
 adoption:
   level: 3
+  reach: '>10K stars'
   signal_type: stars_fallback
   confidence: medium
-  note: ~34k stars; no published download telemetry - stars_fallback (capped at 3).
+  note: '~34k stars; no published download telemetry - stars_fallback (capped at 3). Stars read 2026-08-13:
+    35,476 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in
+    signal_routing.yaml. The record carried no reach label at all before this. No last_verified claimed: a
+    star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis
+    was not re-read.'
   sources:
   - url: https://github.com/microsoft/graphrag
     shows: ~33.8k stars

--- a/sources/scores/grok-app.yaml
+++ b/sources/scores/grok-app.yaml
@@ -22,7 +22,7 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 5
-  reach: '>10M'
+  reach: '>10M users'
   signal_type: active_users
   confidence: low
   note: App reported ~60-64M MAU and ~8-10M DAU early 2026, plus default availability to X Premium subscribers

--- a/sources/scores/grok.yaml
+++ b/sources/scores/grok.yaml
@@ -29,7 +29,6 @@ openness:
     accessed: '2026-07-28'
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: low
   note: Available to X users and via grok.com/xAI API in 2025 as the flagship Grok generation; now a superseded

--- a/sources/scores/groq-inference.yaml
+++ b/sources/scores/groq-inference.yaml
@@ -51,7 +51,6 @@ openness:
     content_sha256: 21489e876fc1d2fd71a7824cfc0423de8270c0e31e9b36f382345d5a433e9191
 adoption:
   level: 4
-  reach: 1M-10M
   signal_type: reported_traction
   confidence: medium
   note: The groq.com homepage no longer names enterprise customers (Dropbox/Vercel/Canva/etc. are gone from

--- a/sources/scores/harmbench.yaml
+++ b/sources/scores/harmbench.yaml
@@ -23,11 +23,15 @@ openness:
     accessed: '2026-06-29'
 adoption:
   level: 2
-  reach: 1K-10K
+  reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
-  note: ~1K GitHub stars (June 2026); stars-only proxy. Widely cited as the standardized red-teaming benchmark
-    in research.
+  note: '~1K GitHub stars (June 2026); stars-only proxy. Widely cited as the standardized red-teaming
+    benchmark in research. Stars read 2026-08-13: 1,029 across the 1 declared repo, which bands at 1K-10K
+    stars, level 2 on the stars scale in signal_routing.yaml. The previous reach ''1K-10K'' was not a label
+    this instrument offers - stars have their own vocabulary because a star is not a download. No
+    last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch,
+    and the rest of the axis was not re-read.'
   sources:
   - url: https://github.com/centerforaisafety/HarmBench
     shows: ~993 stars (June 2026)

--- a/sources/scores/helm.yaml
+++ b/sources/scores/helm.yaml
@@ -27,7 +27,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: medium
   note: 'Headline signal is influence/standard-setting, not install volume: HELM is a widely-cited standardized

--- a/sources/scores/hexabot.yaml
+++ b/sources/scores/hexabot.yaml
@@ -72,11 +72,16 @@ openness:
     establishes:
     - license
 adoption:
-  level: 3
-  reach: niche
+  level: 2
+  reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: medium
-  note: 974 GitHub stars and 218 forks; no package download figures available.
+  note: '974 GitHub stars and 218 forks; no package download figures available. Stars read 2026-08-13: 1,164
+    across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in
+    signal_routing.yaml. Level corrected from 3. The previous reach ''niche'' was not a label this instrument
+    offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a
+    star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis
+    was not re-read.'
   sources:
   - url: https://github.com/Hexastack/Hexabot
     shows: 974 stars, 218 forks

--- a/sources/scores/hf-datasets.yaml
+++ b/sources/scores/hf-datasets.yaml
@@ -21,10 +21,14 @@ openness:
     accessed: '2026-06-22'
 adoption:
   level: 5
-  reach: 120M+/month
+  reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: PyPI last_month downloads of 120,316,114 exceed the 50M+ Level 5 threshold.
+  note: 'PyPI last_month downloads of 120,316,114 exceed the 50M+ Level 5 threshold. Read live 2026-08-13:
+    159,958,389 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at >10M,
+    level 5. The previous reach ''120M+/month'' was free text carrying a figure rather than a band the scale
+    declares, so nothing could check it against the level beside it. No last_verified claimed: only the figure
+    was re-read, not the whole axis.'
   sources:
   - url: https://pypistats.org/api/packages/datasets/recent
     shows: last_month downloads = 120,316,114

--- a/sources/scores/huggingchat-chat-ui.yaml
+++ b/sources/scores/huggingchat-chat-ui.yaml
@@ -23,7 +23,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: medium
   note: Hosted HuggingChat served 1M+ users and 100k+ assistants over its lifetime (HF announcement) before

--- a/sources/scores/huggingface-hub.yaml
+++ b/sources/scores/huggingface-hub.yaml
@@ -21,10 +21,14 @@ openness:
     accessed: '2026-06-22'
 adoption:
   level: 5
-  reach: 331M+/month
+  reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: PyPI last-month downloads of 331,796,503 exceed the 50M+ threshold.
+  note: 'PyPI last-month downloads of 331,796,503 exceed the 50M+ threshold. Read live 2026-08-13: 493,557,521
+    PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at >10M, level 5. The
+    previous reach ''331M+/month'' was free text carrying a figure rather than a band the scale declares, so
+    nothing could check it against the level beside it. No last_verified claimed: only the figure was re-read,
+    not the whole axis.'
   sources:
   - url: https://pypistats.org/api/packages/huggingface-hub/recent
     shows: last_month = 331,796,503 PyPI downloads

--- a/sources/scores/inflection.yaml
+++ b/sources/scores/inflection.yaml
@@ -26,7 +26,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 1
-  reach: <10K
   signal_type: reported_traction
   confidence: low
   note: Post-Microsoft acqui-hire pivot to B2B; Pi consumer surface wound down. Enterprise API exists but no disclosed

--- a/sources/scores/inspect-ai.yaml
+++ b/sources/scores/inspect-ai.yaml
@@ -28,7 +28,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 4
-  reach: 1M-10M
   signal_type: reported_traction
   confidence: high
   note: 'Headline signal (per recipe: adoption by frontier labs / cited in release-grade safety work):

--- a/sources/scores/jina-reader.yaml
+++ b/sources/scores/jina-reader.yaml
@@ -64,12 +64,16 @@ openness:
     content_sha256: 90bd4a738a01b7cfba9b2005d7d281aeee056650aced9eab573172dce4f9d188
 adoption:
   level: 3
-  reach: 100K-1M
+  reach: '>10K stars'
   signal_type: stars_fallback
   confidence: low
-  note: No verified download or API-call volume found from a primary source. ~11k GitHub stars on the
-    OSS repo plus a widely-used hosted r.jina.ai endpoint; capped at 3 on stars/reported-traction fallback
-    in the absence of a measured usage figure.
+  note: 'No verified download or API-call volume found from a primary source. ~11k GitHub stars on the OSS
+    repo plus a widely-used hosted r.jina.ai endpoint; capped at 3 on stars/reported-traction fallback in the
+    absence of a measured usage figure. Stars read 2026-08-13: 11,862 across the 1 declared repo, which bands
+    at >10K stars, level 3 on the stars scale in signal_routing.yaml. The previous reach ''100K-1M'' was not a
+    label this instrument offers - stars have their own vocabulary because a star is not a download. No
+    last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch,
+    and the rest of the axis was not re-read.'
   sources:
   - url: https://github.com/jina-ai/reader
     shows: ~11k stars, active maintenance (550 commits), production SaaS backing

--- a/sources/scores/kata-containers.yaml
+++ b/sources/scores/kata-containers.yaml
@@ -26,7 +26,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: medium
   note: Established CNCF/OpenInfra-adjacent container-runtime project integrated into Kubernetes runtimeclass

--- a/sources/scores/lakera-guard.yaml
+++ b/sources/scores/lakera-guard.yaml
@@ -22,7 +22,6 @@ openness:
     accessed: '2026-06-29'
 adoption:
   level: 2
-  reach: 10K-100K
   signal_type: reported_traction
   confidence: low
   note: Established prompt-injection-defense vendor with notable enterprise customers; acquired by Check

--- a/sources/scores/langfuse.yaml
+++ b/sources/scores/langfuse.yaml
@@ -95,7 +95,6 @@ openness:
     - source
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: high
   note: Described as the most widely adopted open source LLM engineering platform; acquired by ClickHouse

--- a/sources/scores/langsmith.yaml
+++ b/sources/scores/langsmith.yaml
@@ -27,7 +27,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 4
-  reach: 1M-10M
   signal_type: reported_traction
   confidence: medium
   note: Default observability/eval platform for the very widely used LangChain ecosystem; vendor lists

--- a/sources/scores/langwatch.yaml
+++ b/sources/scores/langwatch.yaml
@@ -79,11 +79,15 @@ openness:
     - source
 adoption:
   level: 2
-  reach: 10K-100K
+  reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
-  note: No verified download/active-user figure located this run; ~3.3k GitHub stars is the only honest
-    signal, so capped at level 2 via stars fallback (cannot exceed 3 on stars regardless).
+  note: 'No verified download/active-user figure located this run; ~3.3k GitHub stars is the only honest
+    signal, so capped at level 2 via stars fallback (cannot exceed 3 on stars regardless). Stars read
+    2026-08-13: 3,486 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in
+    signal_routing.yaml. The previous reach ''10K-100K'' was not a label this instrument offers - stars have
+    their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile,
+    so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.'
   sources:
   - url: https://github.com/langwatch/langwatch
     shows: ~3.3k GitHub stars; no disclosed usage numbers

--- a/sources/scores/le-chat.yaml
+++ b/sources/scores/le-chat.yaml
@@ -23,7 +23,7 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 4
-  reach: 1M-10M
+  reach: 1M-10M users
   signal_type: active_users
   confidence: medium
   note: ~1.7M app downloads by May 2026 (TechCrunch reported 1M in 14 days at Feb 2025 launch); Mistral

--- a/sources/scores/llama.yaml
+++ b/sources/scores/llama.yaml
@@ -72,20 +72,32 @@ capability:
   score: 3
   basis: benchmark
   basis_detail: Artificial Analysis Intelligence Index
-  value: 'Llama 3.1 405B: AA Intelligence Index 17, ranked #29/43, ''below average'' vs current peers (peer average
-    23); mid-2024 non-reasoning model surpassed by 2026 frontier.'
+  value: 'Llama 4 Maverick: AA Intelligence Index 14 (v4.1.1), ranked #26/44, ''below average among
+    other open weight non-reasoning models of similar size'' (median 18). The strongest released
+    member of the tier - Llama 4 Scout scores 10 on the same index, and Behemoth is unreleased.'
   confidence: medium
   note: >-
-    Weights downloadable under Meta's Llama-4-Community terms: a 700M-MAU commercial cap, an
-    acceptable-use policy and naming requirements. No relicensing to record - Llama 3.1 carried
-    the equivalent terms, and Llama 4 Scout and Maverick govern as the current release. Moved from
-    2/restricted on 2026-08-01 by the universal license scale, which caps a bounded commercial
-    license at 3 rather than 2. The test at that boundary is whether the license permits
-    commercial use AT ALL: this one does, for everyone inside the bound. A license that forbids
-    commerce outright - CC-BY-NC, Mistral Non-Production - stays at 2. Nine other products carry a
-    bounded license and all now score 3; four of them were already recorded there, which is the
-    inconsistency this resolves.
+    MAX ACROSS THE TIER'S RELEASES, per docs/guides/identity.md. This record previously cited
+    Llama 3.1 405B, a mid-2024 release the slug still covers but which is not its best, and it
+    cited an index number - 17 - that no longer exists on Artificial Analysis's scale: the index
+    was recalibrated, and 14 on v4.1.1 is not a decline from 17 but a different measurement. Both
+    faults pointed the same way, and neither was visible from inside the record, since a stale
+    number and a live one look alike.
+    The SCORE is unchanged at 3, which is the point of re-deriving rather than adjusting: the
+    tier's standing against its peers did not move. It was below the peer median before (17
+    against 23) and it is below the peer median now (14 against 18), on a comparison set that has
+    grown from 43 models to 44.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://artificialanalysis.ai/models/llama-3-1-instruct-405b
-    shows: 'AA Intelligence Index 17, rank #29/43, below-average vs peers (avg 23)'
-    accessed: '2026-06-04'
+  - url: https://artificialanalysis.ai/models/llama-4-maverick
+    shows: 'AA Intelligence Index 14 (v4.1.1), rank #26/44, below average vs open-weight
+      non-reasoning peers of similar size (median 18)'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: aaaef3ad229e3bc58c0adbba0e396cbd1ef3609bb41108ec2e841a08781f52f1
+  - url: https://artificialanalysis.ai/models/llama-4-scout
+    shows: 'AA Intelligence Index 10 (v4.1.1), rank #9/39 - the tier''s other released member,
+      confirming Maverick is the max rather than assuming it'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: f04ff54b8ba3531a07890c68bdc1fdeaea7d5d06bb9e39d1cec28f459735946f

--- a/sources/scores/llamafile.yaml
+++ b/sources/scores/llamafile.yaml
@@ -52,12 +52,16 @@ openness:
     content_sha256: ec541178249a9a080700f3bcfe638f78e4f19fdb149abed019a096197da8c254
 adoption:
   level: 3
-  reach: 100K-1M
+  reach: '>10K stars'
   signal_type: stars_fallback
   confidence: low
-  note: No PyPI/download or pull-count signal available (distributed as single-file binaries, not a package);
+  note: 'No PyPI/download or pull-count signal available (distributed as single-file binaries, not a package);
     GitHub stars is the only honest signal. Capped at 3 per stars_fallback rule. Popular local-inference
-    convenience tool but no verified usage_volume figure.
+    convenience tool but no verified usage_volume figure. Stars read 2026-08-13: 25,548 across the 1 declared
+    repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The previous reach
+    ''100K-1M'' was not a label this instrument offers - stars have their own vocabulary because a star is not
+    a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on
+    every refetch, and the rest of the axis was not re-read.'
   last_verified: '2026-08-09'
   sources:
   - url: https://github.com/mozilla-ai/llamafile

--- a/sources/scores/llm-guard.yaml
+++ b/sources/scores/llm-guard.yaml
@@ -27,10 +27,14 @@ openness:
     accessed: '2026-06-29'
 adoption:
   level: 2
-  reach: 10K-100K
+  reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
-  note: ~3.1K GitHub stars (June 2026); stars-only proxy, capped per methodology.
+  note: '~3.1K GitHub stars (June 2026); stars-only proxy, capped per methodology. Stars read 2026-08-13:
+    3,202 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in
+    signal_routing.yaml. The previous reach ''10K-100K'' was not a label this instrument offers - stars have
+    their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile,
+    so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.'
   sources:
   - url: https://github.com/protectai/llm-guard
     shows: ~3.1k stars (June 2026)

--- a/sources/scores/lobe-chat.yaml
+++ b/sources/scores/lobe-chat.yaml
@@ -30,12 +30,16 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 3
-  reach: 100K-1M
+  reach: '>10K stars'
   signal_type: stars_fallback
   confidence: low
-  note: 78.2k GitHub stars, 15.4k forks; Docker image (lobehub/lobehub) and LobeHub Cloud exist but no
-    verified pull/MAU figure was obtainable from a primary source this run. Capped at 3 on stars fallback
-    per rubric.
+  note: '78.2k GitHub stars, 15.4k forks; Docker image (lobehub/lobehub) and LobeHub Cloud exist but no
+    verified pull/MAU figure was obtainable from a primary source this run. Capped at 3 on stars fallback per
+    rubric. Stars read 2026-08-13: 81,633 across the 1 declared repo, which bands at >10K stars, level 3 on
+    the stars scale in signal_routing.yaml. The previous reach ''100K-1M'' was not a label this instrument
+    offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a
+    star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis
+    was not re-read.'
   sources:
   - url: https://github.com/lobehub/lobehub
     shows: 78.2k stars, 15.4k forks; Docker + Cloud deployment

--- a/sources/scores/marin-framework.yaml
+++ b/sources/scores/marin-framework.yaml
@@ -26,11 +26,15 @@ openness:
     accessed: '2026-07-21'
 adoption:
   level: 2
-  reach: <10K
+  reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: medium
-  note: ~1.2k GitHub stars and very active development; a research framework with adoption concentrated
-    around the Marin project rather than broad external use.
+  note: '~1.2k GitHub stars and very active development; a research framework with adoption concentrated
+    around the Marin project rather than broad external use. Stars read 2026-08-13: 1,261 across the 1
+    declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The
+    previous reach ''<10K'' was not a label this instrument offers - stars have their own vocabulary because a
+    star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read
+    as drift on every refetch, and the rest of the axis was not re-read.'
   sources:
   - url: https://github.com/marin-community/marin
     shows: 1.2k stars

--- a/sources/scores/math.yaml
+++ b/sources/scores/math.yaml
@@ -36,7 +36,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 4
-  reach: 1M-10M
   signal_type: reported_traction
   confidence: medium
   note: MATH is one of the most-cited math-reasoning standards; MATH / MATH-500 appears as a headline

--- a/sources/scores/max.yaml
+++ b/sources/scores/max.yaml
@@ -52,14 +52,22 @@ openness:
     http_status: 200
     content_sha256: b9ec095b4c52f3564cef5a7d720d4eafd0589fbb760a578d8c020f97a2fc4ae4
 adoption:
-  level: 2
-  reach: 10K-100K
+  level: 3
+  reach: '>10K stars'
   signal_type: stars_fallback
   confidence: low
-  note: No published download/user/tokens figure for MAX serving specifically. GitHub stargazerCount on
-    modular/modular (covers MAX+Mojo) is the only signal; capped per stars_fallback and placed at 2 given
-    no verified production-deployment count and a still-maturing serving ecosystem vs the established OSS
-    engines.
+  note: 'No published download/user/tokens figure for MAX serving specifically. GitHub stargazerCount on
+    modular/modular (covers MAX+Mojo) is the only signal; capped per stars_fallback and placed at 2 given no
+    verified production-deployment count and a still-maturing serving ecosystem vs the established OSS
+    engines. Stars read 2026-08-13 on modular/modular: 26,777, which bands at >10K stars, level 3 on the stars
+    scale. The previous reach ''10K-100K'' was a download label, which this instrument does not offer - a star
+    is not a download. Level corrected from 2. OVER-ATTRIBUTION, named rather than resolved: modular/modular
+    is one repo covering MAX and Mojo together, so these stars are not all MAX''s. That is the cohere-rerank-
+    api shape and the guide has no settled rule for it yet, so the instrument''s answer stands and confidence
+    stays low. THE REAL DEFECT is upstream: this product declares no artifacts at all, so a stars_fallback
+    band had no stars source behind it and the count lived only in this note. Declaring modular/modular would
+    fix it, and is deliberately not done here because a declared code repo also re-routes the openness license
+    dimension. No last_verified claimed: a star count is volatile.'
   last_verified: '2026-08-09'
   sources:
   - url: https://github.com/modular/modular

--- a/sources/scores/meta-ai.yaml
+++ b/sources/scores/meta-ai.yaml
@@ -40,7 +40,7 @@ openness:
     - source
 adoption:
   level: 5
-  reach: '>10M'
+  reach: '>10M users'
   signal_type: active_users
   confidence: high
   note: 'Zuckerberg (May 2025 shareholder meeting, primary) stated Meta AI passed 1B monthly active users;

--- a/sources/scores/microsoft-copilot.yaml
+++ b/sources/scores/microsoft-copilot.yaml
@@ -23,7 +23,7 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 5
-  reach: '>10M'
+  reach: '>10M users'
   signal_type: active_users
   confidence: medium
   note: ~420M monthly active users across all Copilot surfaces (Windows/Edge/M365/Bing/mobile) reported

--- a/sources/scores/milvus.yaml
+++ b/sources/scores/milvus.yaml
@@ -27,7 +27,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: high
   note: Described as the default open source engine for billion-scale semantic search; LF AI & Data graduate.

--- a/sources/scores/modal-sandboxes.yaml
+++ b/sources/scores/modal-sandboxes.yaml
@@ -36,7 +36,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: low
   note: No disclosed Modal Sandboxes user/usage count on primary pages; Modal is a well-known managed

--- a/sources/scores/multipl-e.yaml
+++ b/sources/scores/multipl-e.yaml
@@ -42,7 +42,6 @@ openness:
     content_sha256: 6891bf32c7df59f0665d45a22bc09224ed122394eae4404048e0e4c7e4bc2f23
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: low
   note: 'The standard multilingual code-generation benchmark: integrated into the BigCode Code Generation

--- a/sources/scores/muse-spark.yaml
+++ b/sources/scores/muse-spark.yaml
@@ -26,7 +26,7 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 4
-  reach: 1M-10M
+  reach: 1M-10M users
   signal_type: active_users
   confidence: low
   note: Powers the Meta AI assistant on meta.ai and the Meta AI app (rolling out to WhatsApp/Instagram/Facebook/Messenger/AI

--- a/sources/scores/nemo-data-designer.yaml
+++ b/sources/scores/nemo-data-designer.yaml
@@ -80,7 +80,7 @@ openness:
     content_sha256: 57e66c991213a59848bc5e27b4eff0dc8306096adc8d43b881c6b6de301a818b
 adoption:
   level: 3
-  reach: enterprise
+  reach: niche
   signal_type: reported_traction
   confidence: low
   note: Backed by NVIDIA and distributed through the NeMo platform; Gretel had a large synthetic-data

--- a/sources/scores/nemo-guardrails.yaml
+++ b/sources/scores/nemo-guardrails.yaml
@@ -24,12 +24,16 @@ openness:
     shows: Apache-2.0; full Python source; self-hostable as library/CLI/Docker/server; ~6.6k stars
     accessed: '2026-06-29'
 adoption:
-  level: 3
-  reach: 10K-100K
+  level: 2
+  reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
-  note: ~6.6K GitHub stars (June 2026); stars-only proxy, capped per methodology; broadly referenced guardrail
-    framework.
+  note: '~6.6K GitHub stars (June 2026); stars-only proxy, capped per methodology; broadly referenced
+    guardrail framework. Stars read 2026-08-13: 6,936 across the 1 declared repo, which bands at 1K-10K stars,
+    level 2 on the stars scale in signal_routing.yaml. Level corrected from 3. The previous reach ''10K-100K''
+    was not a label this instrument offers - stars have their own vocabulary because a star is not a download.
+    No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every
+    refetch, and the rest of the axis was not re-read.'
   sources:
   - url: https://github.com/NVIDIA/NeMo-Guardrails
     shows: ~6.6k stars (June 2026)

--- a/sources/scores/nemo-rl.yaml
+++ b/sources/scores/nemo-rl.yaml
@@ -63,13 +63,17 @@ openness:
     - core-gated
 adoption:
   level: 2
-  reach: <10K
+  reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: medium
-  note: 'GitHub stars remain the only usable signal: 1,890 stars (displayed 1.9k, up from ~1.7k), still
-    inside the <10K band; ''Used by'' and contributor counts are unavailable in the static page. The nemo-rl
-    package on PyPI is a non-functional placeholder (v0.0.0) that explicitly directs users back to GitHub,
-    so no download figure exists to band on. Level 2 stands on stars_fallback; honest signal is limited.'
+  note: 'GitHub stars remain the only usable signal: 1,890 stars (displayed 1.9k, up from ~1.7k), still inside
+    the <10K band; ''Used by'' and contributor counts are unavailable in the static page. The nemo-rl package
+    on PyPI is a non-functional placeholder (v0.0.0) that explicitly directs users back to GitHub, so no
+    download figure exists to band on. Level 2 stands on stars_fallback; honest signal is limited. Stars read
+    2026-08-13: 1,903 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in
+    signal_routing.yaml. The previous reach ''<10K'' was not a label this instrument offers - stars have their
+    own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a
+    digest of it would read as drift on every refetch, and the rest of the axis was not re-read.'
   last_verified: '2026-08-09'
   sources:
   - url: https://github.com/NVIDIA-NeMo/RL

--- a/sources/scores/nextchat.yaml
+++ b/sources/scores/nextchat.yaml
@@ -58,12 +58,18 @@ openness:
     - core-gated
 adoption:
   level: 3
-  reach: 100K-1M
+  reach: '>10K stars'
   signal_type: stars_fallback
   confidence: low
-  note: 88.2k GitHub stars and one-click Vercel deploy indicate broad lightweight use, but no verified
+  note: '88.2k GitHub stars and one-click Vercel deploy indicate broad lightweight use, but no verified
     download/MAU figure from a primary source this run, and last release ~6-12mo ago. Capped at 3 on stars
-    fallback; momentum appears to have slowed.
+    fallback; momentum appears to have slowed. Stars read 2026-08-13 on ChatGPTNextWeb/NextChat: 88,617, which
+    bands at >10K stars, level 3 on the stars scale. The previous reach ''100K-1M'' was a download label,
+    which this instrument does not offer - a star is not a download. THE REAL DEFECT is upstream: this product
+    declares no artifacts at all, so a stars_fallback band had no stars source behind it and the count lived
+    only in this note. Declaring ChatGPTNextWeb/NextChat would fix it, and is deliberately not done here
+    because a declared code repo also re-routes the openness license dimension. No last_verified claimed: a
+    star count is volatile.'
   sources:
   - url: https://github.com/ChatGPTNextWeb/NextChat
     shows: 88.2k stars; v2.16.1 latest release; cross-platform deployment

--- a/sources/scores/nono.yaml
+++ b/sources/scores/nono.yaml
@@ -33,12 +33,16 @@ openness:
     accessed: '2026-06-29'
 adoption:
   level: 2
-  reach: 1K-10K
+  reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
   note: '~2,900 GitHub stars (June 2026) for a 2026 release, with multi-platform packages and FFI bindings
-    published. Stars are the only public proxy here, so this is capped per the methodology and read as
-    early but real traction rather than scaled adoption.'
+    published. Stars are the only public proxy here, so this is capped per the methodology and read as early
+    but real traction rather than scaled adoption. Stars read 2026-08-13: 3,640 across the 1 declared repo,
+    which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach
+    ''1K-10K'' was not a label this instrument offers - stars have their own vocabulary because a star is not
+    a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on
+    every refetch, and the rest of the axis was not re-read.'
   sources:
   - url: https://github.com/nolabs-ai/nono
     shows: ~2,900 stars (June 2026)

--- a/sources/scores/northflank-sandboxes.yaml
+++ b/sources/scores/northflank-sandboxes.yaml
@@ -25,7 +25,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: medium
   note: 'Northflank (platform-wide, primary): 2,000+ organizations, 80,000+ developers in production,

--- a/sources/scores/o-series.yaml
+++ b/sources/scores/o-series.yaml
@@ -24,7 +24,7 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 5
-  reach: '>10M'
+  reach: '>10M users'
   signal_type: active_users
   confidence: medium
   note: o3/o4-mini were rolled out as selectable models inside ChatGPT (Plus/Pro and some free) plus the API; ChatGPT

--- a/sources/scores/ogx.yaml
+++ b/sources/scores/ogx.yaml
@@ -30,11 +30,17 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 2
-  reach: 10K-100K
+  reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
-  note: Only ~8.4k GitHub stars and no published download/usage volume found this run; capped low on stars
+  note: 'Only ~8.4k GitHub stars and no published download/usage volume found this run; capped low on stars
     fallback (cannot exceed level 3). Recently renamed from Llama Stack, so historical signal is muddled.
+    Stars read 2026-08-13 on ogx-ai/ogx: 8,420, which bands at 1K-10K stars, level 2 on the stars scale. The
+    previous reach ''10K-100K'' was a download label, which this instrument does not offer - a star is not a
+    download. THE REAL DEFECT is upstream: this product declares no artifacts at all, so a stars_fallback band
+    had no stars source behind it and the count lived only in this note. Declaring ogx-ai/ogx would fix it,
+    and is deliberately not done here because a declared code repo also re-routes the openness license
+    dimension. No last_verified claimed: a star count is volatile.'
   sources:
   - url: https://github.com/ogx-ai/ogx
     shows: ~8.4k stars; no download/usage figure published

--- a/sources/scores/olmo-instruct.yaml
+++ b/sources/scores/olmo-instruct.yaml
@@ -31,11 +31,14 @@ openness:
     accessed: '2026-06-30'
 adoption:
   level: 3
-  reach: 10K-100K
+  reach: 100K-1M
   signal_type: usage_volume
   confidence: medium
-  note: Solid research/practitioner reach for a fully-open instruct line; below the Qwen/Llama instruct workhorses.
-    Downloads still ramping as it supersedes OLMo 2 Instruct.
+  note: 'Solid research/practitioner reach for a fully-open instruct line; below the Qwen/Llama instruct
+    workhorses. Downloads still ramping as it supersedes OLMo 2 Instruct. Read live 2026-08-13: 450,053
+    Hugging Face downloads in the trailing 30 days across the declared artifact(s), which bands at 100K-1M,
+    level 3. The previous reach ''10K-100K'' was a band off a different scale. No last_verified claimed: only
+    the figure was re-read, not the whole axis.'
   sources:
   - url: https://huggingface.co/allenai/Olmo-3-7B-Instruct
     shows: OLMo 3 Instruct SKUs live on HF

--- a/sources/scores/openai-code-interpreter.yaml
+++ b/sources/scores/openai-code-interpreter.yaml
@@ -27,7 +27,7 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 4
-  reach: 1M-10M
+  reach: 1M-10M users
   signal_type: active_users
   confidence: low
   note: Code Interpreter ships inside ChatGPT (advanced data analysis) and the Assistants/Responses API;

--- a/sources/scores/openai-evals.yaml
+++ b/sources/scores/openai-evals.yaml
@@ -30,13 +30,18 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 3
-  reach: 100K-1M
+  reach: '>10K stars'
   signal_type: stars_fallback
   confidence: low
-  note: No PyPI/download count available for this repo (it is run from source, not pip-installed); 18.6k
+  note: 'No PyPI/download count available for this repo (it is run from source, not pip-installed); 18.6k
     GitHub stars + 3k forks is the only honest signal, so capped at level 3 per the stars-fallback rule.
     Historically influential as one of the first open eval frameworks but largely superseded by the hosted
-    Evals API and by newer harnesses.
+    Evals API and by newer harnesses. Stars read 2026-08-13 on openai/evals: 19,159, which bands at >10K
+    stars, level 3 on the stars scale. The previous reach ''100K-1M'' was a download label, which this
+    instrument does not offer - a star is not a download. THE REAL DEFECT is upstream: this product declares
+    no artifacts at all, so a stars_fallback band had no stars source behind it and the count lived only in
+    this note. Declaring openai/evals would fix it, and is deliberately not done here because a declared code
+    repo also re-routes the openness license dimension. No last_verified claimed: a star count is volatile.'
   sources:
   - url: https://github.com/openai/evals
     shows: 18.6k stars, 3k forks, 691 commits

--- a/sources/scores/opencompass.yaml
+++ b/sources/scores/opencompass.yaml
@@ -22,7 +22,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: medium
   note: Widely used eval framework, especially in the China/HF ecosystem; 7.1k GitHub stars and broad

--- a/sources/scores/openguardrails.yaml
+++ b/sources/scores/openguardrails.yaml
@@ -29,12 +29,16 @@ openness:
     shows: Apache-2.0; 3.3B quantized safety model; 119 languages
     accessed: '2026-06-29'
 adoption:
-  level: 2
-  reach: 1K-10K
+  level: 1
+  reach: <1K stars
   signal_type: stars_fallback
   confidence: low
-  note: New (late 2025) project, ~80 GitHub stars (June 2026); stars-only proxy, capped per methodology;
-    early-stage adoption.
+  note: 'New (late 2025) project, ~80 GitHub stars (June 2026); stars-only proxy, capped per methodology;
+    early-stage adoption. Stars read 2026-08-13: 23 across the 1 declared repo, which bands at <1K stars,
+    level 1 on the stars scale in signal_routing.yaml. Level corrected from 2. The previous reach ''1K-10K''
+    was not a label this instrument offers - stars have their own vocabulary because a star is not a download.
+    No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every
+    refetch, and the rest of the axis was not re-read.'
   sources:
   - url: https://github.com/openguardrails/openguardrails
     shows: ~80 stars (June 2026)

--- a/sources/scores/openhands.yaml
+++ b/sources/scores/openhands.yaml
@@ -53,7 +53,6 @@ openness:
     content_sha256: 6aa0ab5bdfcb32eb7d4d60d76ac6bb665afac574aae2d1700bd91ab580f17197
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: high
   note: ~75.8k GitHub stars, $18.8M Series A, contributors from major firms, OpenHands Cloud with multi-user/Slack/Jira/Linear

--- a/sources/scores/openmanus.yaml
+++ b/sources/scores/openmanus.yaml
@@ -23,9 +23,14 @@ openness:
     accessed: '2026-06-17'
 adoption:
   level: 3
+  reach: '>10K stars'
   signal_type: stars_fallback
   confidence: medium
-  note: ~57k stars but negligible package usage (~186 PyPI downloads/month) - stars_fallback (capped at 3).
+  note: '~57k stars but negligible package usage (~186 PyPI downloads/month) - stars_fallback (capped at 3).
+    Stars read 2026-08-13: 57,954 across the 1 declared repo, which bands at >10K stars, level 3 on the stars
+    scale in signal_routing.yaml. The record carried no reach label at all before this. No last_verified
+    claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of
+    the axis was not re-read.'
   sources:
   - url: https://pypistats.org/packages/openmanus
     shows: ~186 downloads/month

--- a/sources/scores/openrag.yaml
+++ b/sources/scores/openrag.yaml
@@ -27,11 +27,15 @@ openness:
     accessed: '2026-08-07'
 adoption:
   level: 1
+  reach: <1K stars
   signal_type: stars_fallback
   confidence: medium
-  note: '~237 GitHub stars, 55 forks (Aug 2026) — early-stage. No download metric available (Docker-distributed,
-    no first-party PyPI/npm), so adoption falls back to stars, which the ladder caps at 3; 237 stars places
-    it in the lowest band.'
+  note: '~237 GitHub stars, 55 forks (Aug 2026) — early-stage. No download metric available (Docker-
+    distributed, no first-party PyPI/npm), so adoption falls back to stars, which the ladder caps at 3; 237
+    stars places it in the lowest band. Stars read 2026-08-13: 238 across the 1 declared repo, which bands at
+    <1K stars, level 1 on the stars scale in signal_routing.yaml. The record carried no reach label at all
+    before this. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on
+    every refetch, and the rest of the axis was not re-read.'
   sources:
   - url: https://github.com/linagora/openrag
     shows: ~237 stars, 55 forks, 88 open issues (as of 2026-08-07)

--- a/sources/scores/openrlhf.yaml
+++ b/sources/scores/openrlhf.yaml
@@ -50,7 +50,6 @@ openness:
     - source
 adoption:
   level: 2
-  reach: 10K-100K
   signal_type: reported_traction
   confidence: medium
   note: ~9.6K GitHub stars; named adopters listed in repo (Google, ByteDance, Tencent, Alibaba, Baidu,

--- a/sources/scores/opensandbox.yaml
+++ b/sources/scores/opensandbox.yaml
@@ -26,13 +26,17 @@ openness:
       self-host
     accessed: '2026-06-04'
 adoption:
-  level: 2
-  reach: 10K-100K
+  level: 3
+  reach: '>10K stars'
   signal_type: stars_fallback
   confidence: low
   note: 'Only ~2-3 months old; no PyPI/download or named-deployment figures surfaced. ~11.3k GitHub stars
-    (3,845 within 72h of launch) is the only signal, stars_fallback, which caps level at 3. Placed at
-    2: rapid early stars but no usage volume yet. Revisit as usage data emerges.'
+    (3,845 within 72h of launch) is the only signal, stars_fallback, which caps level at 3. Placed at 2: rapid
+    early stars but no usage volume yet. Revisit as usage data emerges. Stars read 2026-08-13: 12,516 across
+    the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. Level
+    corrected from 2. The previous reach ''10K-100K'' was not a label this instrument offers - stars have
+    their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile,
+    so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.'
   sources:
   - url: https://github.com/alibaba/OpenSandbox
     shows: 11.3k GitHub stars; released Mar 2026; no usage/download figures

--- a/sources/scores/openvino.yaml
+++ b/sources/scores/openvino.yaml
@@ -20,11 +20,15 @@ openness:
     shows: Apache License Version 2.0 full text
     accessed: '2026-06-22'
 adoption:
-  level: 3
-  reach: ~1.4M/mo
+  level: 4
+  reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: PyPI last_month downloads ~1.38M.
+  note: 'PyPI last_month downloads ~1.38M. Read live 2026-08-13: 1,869,817 PyPI downloads in the trailing 30
+    days across the declared artifact(s), which bands at 1M-10M, level 4. Level corrected from 3. The previous
+    reach ''~1.4M/mo'' was free text carrying a figure rather than a band the scale declares, so nothing could
+    check it against the level beside it. No last_verified claimed: only the figure was re-read, not the whole
+    axis.'
   sources:
   - url: https://pypistats.org/api/packages/openvino/recent
     shows: last_month=1,379,327 downloads

--- a/sources/scores/optimum.yaml
+++ b/sources/scores/optimum.yaml
@@ -20,11 +20,15 @@ openness:
     shows: LICENSE file is the verbatim Apache License Version 2.0
     accessed: '2026-06-22'
 adoption:
-  level: 3
-  reach: 1.7M+/month
+  level: 4
+  reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: PyPI last-month downloads of 1,759,764 fall in the 500k-5M range.
+  note: 'PyPI last-month downloads of 1,759,764 fall in the 500k-5M range. Read live 2026-08-13: 1,919,623
+    PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at 1M-10M, level 4.
+    Level corrected from 3. The previous reach ''1.7M+/month'' was free text carrying a figure rather than a
+    band the scale declares, so nothing could check it against the level beside it. No last_verified claimed:
+    only the figure was re-read, not the whole axis.'
   sources:
   - url: https://pypistats.org/api/packages/optimum/recent
     shows: last_month = 1,759,764 PyPI downloads

--- a/sources/scores/osworld.yaml
+++ b/sources/scores/osworld.yaml
@@ -42,7 +42,6 @@ openness:
     - core-gated
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: medium
   note: 'Top adoption signal for a harness = cited as the standard in frontier release reports: OSWorld

--- a/sources/scores/otari.yaml
+++ b/sources/scores/otari.yaml
@@ -33,12 +33,16 @@ openness:
     accessed: '2026-07-01'
 adoption:
   level: 1
-  reach: <10K
+  reach: <1K stars
   signal_type: stars_fallback
   confidence: low
-  note: 63 GitHub stars / 6 forks (July 2026), created April 2026. Very new; limited adoption signal so
-    far. (Mozilla AI's underlying any-llm library is far more adopted at ~2.1K stars, but is a separate
-    product.)
+  note: '63 GitHub stars / 6 forks (July 2026), created April 2026. Very new; limited adoption signal so far.
+    (Mozilla AI''s underlying any-llm library is far more adopted at ~2.1K stars, but is a separate product.)
+    Stars read 2026-08-13: 379 across the 1 declared repo, which bands at <1K stars, level 1 on the stars
+    scale in signal_routing.yaml. The previous reach ''<10K'' was not a label this instrument offers - stars
+    have their own vocabulary because a star is not a download. No last_verified claimed: a star count is
+    volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-
+    read.'
   sources:
   - url: https://github.com/mozilla-ai/otari
     shows: 63 stars, 6 forks (July 2026)

--- a/sources/scores/perplexica.yaml
+++ b/sources/scores/perplexica.yaml
@@ -26,12 +26,19 @@ openness:
     shows: MIT license; ~35k stars; open Perplexity-alternative answer engine (formerly Perplexica)
     accessed: '2026-06-17'
 adoption:
-  level: 3
-  reach: 100K+ Docker pulls
+  level: 2
+  reach: 10K-100K
   signal_type: usage_volume
   confidence: medium
-  note: ~35k GitHub stars plus 100k+ Docker pulls on the current itzcrazykns1337/vane image by mid-2026 -
-    genuine install volume (usage_volume, not stars-only), but well below the 1M+ band, so mid-tier.
+  note: '~35k GitHub stars plus 100k+ Docker pulls on the current itzcrazykns1337/vane image by mid-2026 -
+    genuine install volume (usage_volume, not stars-only), but well below the 1M+ band, so mid-tier. Re-banded
+    2026-08-13 under the lifetime-average rule in docs/guides/adoption.md. Docker Hub reports 645,952
+    cumulative pulls on itzcrazykns1337/perplexica since 2025-03-20, which averages ~38,479 a month over 16.8
+    months and bands at 10K-100K. LEVEL CORRECTED FROM 3: the previous reach ''100K+ Docker pulls'' read a
+    cumulative six-figure total as though it were a monthly one, which is precisely the substitution the n8n
+    rule names, and it put the record a band above what its own number supports. Recorded as a declared floor
+    - a lifetime average understates a growing product. Docker is not declared as an artifact here, so the
+    figure lives in this note rather than in a signal. No last_verified claimed.'
   sources:
   - url: https://hub.docker.com/r/itzcrazykns1337/vane
     shows: 100K+ Docker pulls for the self-host image

--- a/sources/scores/perplexity-sonar-api.yaml
+++ b/sources/scores/perplexity-sonar-api.yaml
@@ -23,7 +23,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 4
-  reach: 1M-10M
   signal_type: reported_traction
   confidence: medium
   note: No standalone Sonar-API request/developer count is published by a primary source; Perplexity docs

--- a/sources/scores/perplexity.yaml
+++ b/sources/scores/perplexity.yaml
@@ -22,7 +22,7 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 5
-  reach: '>10M'
+  reach: '>10M users'
   signal_type: active_users
   confidence: medium
   note: CEO Aravind Srinivas (cited Apr 2026) reports 100M+ MAU across all products; standalone chatbot

--- a/sources/scores/personahub.yaml
+++ b/sources/scores/personahub.yaml
@@ -46,20 +46,29 @@ adoption:
     shows: downloads field = 7,395 (30-day)
     accessed: '2026-07-04'
 capability:
-  score: 2
+  score: 4
   basis: training_value
   basis_detail: results
   value: null
-  confidence: high
+  confidence: medium
   note: >-
-    Publicly downloadable and ungated, and licensed CC-BY-NC-SA-4.0, which permits redistribution
-    for non-commercial research and forbids commercial use. Moved from 5/open on 2026-08-01 by the
-    universal license scale. The map had answered the non-commercial question two ways:
-    `command-r` is 2/restricted under CC-BY-NC while this was 5/open under CC-BY-NC-SA, on the
-    reasoning that a corpus's openness question is redistributability rather than commercial
-    reuse. The scale settles it on the commercial-use test, and the Open Definition agrees - data
-    is not open unless it may be reused commercially. `restricted` is new to the dataset class
-    vocabulary for this: it was the only product type with no word between `open` and `gated`.
+    The paper's headline training result is the basis: Qwen2-7B fine-tuned on ~1.07M
+    persona-generated math problems reaches 64.9% on MATH, rivaling GPT-4-turbo-preview at the
+    time. Corroborated downstream - Tulu 3's SFT persona-math set conditions on ~250K PersonaHub
+    personas, so the corpus is an ingredient in a mixture the map already scores 4.
+    Placed at 4 rather than 5 on the category's own calibration: the 5s (smoltalk, fineweb-edu,
+    dclm-baseline) lead head-to-head ablations AND are the current default others adopt wholesale,
+    while PersonaHub is a generation method plus seed samples whose adoption runs through
+    derivative sets. That is the same shape as tulu-3-sft-mixture and fineweb, both 4.
+    CORRECTED from 2, which was not a capability judgment at all. On 2026-08-01 the openness
+    re-score to 2/restricted was pasted into this block wholesale: the note recorded here was
+    the openness note verbatim, arguing CC-BY-NC-SA and the commercial-use test, and the score
+    followed it down. Nothing on this axis had been assessed. The tell was `value: null` with
+    `confidence: high` - a null is the category norm here, all 38 members carry one, but a high
+    confidence attached to a reasoning that never mentions training value is not. A licence says
+    what you may do with a corpus; it says nothing about what training on it produces.
+    Re-derived from the sources already cited, which is why no `last_verified` is claimed - they
+    were read on 2026-07-04 and have not been re-fetched.
   sources:
   - url: https://arxiv.org/abs/2406.20094
     shows: Qwen2-7B on ~1.07M persona math problems hits 64.9% MATH, rivaling GPT-4-turbo-preview

--- a/sources/scores/poe.yaml
+++ b/sources/scores/poe.yaml
@@ -22,15 +22,17 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 5
-  reach: '>10M'
+  reach: '>10M users'
   signal_type: active_users
   confidence: low
   note: 'CEO/Quora figures (compiled by multiple aggregators) report ~18M Poe MAU in 2026 (~40% using
     paid features; ~$65M subscription ARR). 18M is comfortably in the >10M ''mass market'' band -> level
     5. Quora publishes no primary Poe MAU page, so the exact figure remains aggregator-sourced (confidence
     low), but the order of magnitude is consistent across sources and clearly clears the >10M threshold.
-    [Corrected: prior record had level 4 with an invalid ''10M-100M'' reach band that contradicted the
-    18M figure.]'
+    The reach label now reads ''>10M users'' on the active_users scale declared 2026-08-13, which is the
+    band this record has effectively been claiming since it was corrected off an invented ''10M-100M''
+    - the difference is that the band is now declared, so the claim can be checked rather than merely
+    asserted.'
   sources:
   - url: https://originality.ai/blog/poe-statistics
     shows: ~18M Poe MAU, ~$65M subscription revenue (compiled from Quora reporting)

--- a/sources/scores/predibase.yaml
+++ b/sources/scores/predibase.yaml
@@ -74,7 +74,6 @@ openness:
     - source
 adoption:
   level: 2
-  reach: 10K-100K
   signal_type: reported_traction
   confidence: low
   note: 'No hard per-platform usage figure (jobs / customers) disclosed this run. Reported traction: enterprise

--- a/sources/scores/pysyft.yaml
+++ b/sources/scores/pysyft.yaml
@@ -58,12 +58,16 @@ openness:
     - license
     - core-gated
 adoption:
-  level: 3
-  reach: broad
+  level: 2
+  reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: medium
-  note: 9.9k GitHub stars (capped at 3 per stars-fallback rule); ~10.8k monthly PyPI downloads and 1M+
-    all-time.
+  note: '9.9k GitHub stars (capped at 3 per stars-fallback rule); ~10.8k monthly PyPI downloads and 1M+ all-
+    time. Stars read 2026-08-13: 9,938 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the
+    stars scale in signal_routing.yaml. Level corrected from 3. The previous reach ''broad'' was not a label
+    this instrument offers - stars have their own vocabulary because a star is not a download. No
+    last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch,
+    and the rest of the axis was not re-read.'
   sources:
   - url: https://github.com/OpenMined/PySyft
     shows: 9.9k GitHub stars

--- a/sources/scores/pytorch.yaml
+++ b/sources/scores/pytorch.yaml
@@ -21,10 +21,14 @@ openness:
     accessed: '2026-06-22'
 adoption:
   level: 5
-  reach: 88M+/mo
+  reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: 88.6M PyPI downloads in the last 30 days.
+  note: '88.6M PyPI downloads in the last 30 days. Read live 2026-08-13: 95,449,310 PyPI downloads in the
+    trailing 30 days across the declared artifact(s), which bands at >10M, level 5. The previous reach
+    ''88M+/mo'' was free text carrying a figure rather than a band the scale declares, so nothing could check
+    it against the level beside it. No last_verified claimed: only the figure was re-read, not the whole
+    axis.'
   sources:
   - url: https://pepy.tech/projects/torch
     shows: 88,636,352 downloads in last 30 days

--- a/sources/scores/redpajama-data.yaml
+++ b/sources/scores/redpajama-data.yaml
@@ -21,11 +21,15 @@ openness:
     accessed: '2026-07-21'
 adoption:
   level: 2
-  reach: <10K
+  reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: medium
-  note: ~4,969 GitHub stars; pipeline repo, no PyPI package. Widely referenced quality-signal pipeline;
-    dormant since Dec 2024.
+  note: '~4,969 GitHub stars; pipeline repo, no PyPI package. Widely referenced quality-signal pipeline;
+    dormant since Dec 2024. Stars read 2026-08-13: 4,977 across the 1 declared repo, which bands at 1K-10K
+    stars, level 2 on the stars scale in signal_routing.yaml. The previous reach ''<10K'' was not a label this
+    instrument offers - stars have their own vocabulary because a star is not a download. No last_verified
+    claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of
+    the axis was not re-read.'
   sources:
   - url: https://github.com/togethercomputer/RedPajama-Data
     shows: 4,969 stars; last real commit Dec 2024

--- a/sources/scores/reka-core.yaml
+++ b/sources/scores/reka-core.yaml
@@ -24,7 +24,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 2
-  reach: 10K-100K
   signal_type: reported_traction
   confidence: low
   note: Distributed via Reka API + Snowflake Cortex + Oracle Cloud Marketplace; a 2024 frontier-challenger

--- a/sources/scores/replit-agent.yaml
+++ b/sources/scores/replit-agent.yaml
@@ -19,7 +19,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 4
-  reach: 1M-10M
   signal_type: reported_traction
   confidence: medium
   note: Replit reported 50M+ platform users with agent-driven consumption as primary growth driver (ARR

--- a/sources/scores/safetensors.yaml
+++ b/sources/scores/safetensors.yaml
@@ -21,10 +21,14 @@ openness:
     accessed: '2026-06-22'
 adoption:
   level: 5
-  reach: 78M+/month
+  reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: PyPI last-month downloads of 78,250,137 exceed the 50M+ threshold.
+  note: 'PyPI last-month downloads of 78,250,137 exceed the 50M+ threshold. Read live 2026-08-13: 111,835,984
+    PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at >10M, level 5. The
+    previous reach ''78M+/month'' was free text carrying a figure rather than a band the scale declares, so
+    nothing could check it against the level beside it. No last_verified claimed: only the figure was re-read,
+    not the whole axis.'
   sources:
   - url: https://pypistats.org/api/packages/safetensors/recent
     shows: last_month = 78,250,137 PyPI downloads

--- a/sources/scores/sambanova-cloud.yaml
+++ b/sources/scores/sambanova-cloud.yaml
@@ -47,7 +47,6 @@ openness:
     content_sha256: 9aa0f21b7844a01acadaeb1f5c0b94ec047a758aa2c1d1d3bd33a8298a76a4ef
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: low
   note: OpenRouter's SambaNova provider page shows real, current multi-hundred-million-to-billion-token

--- a/sources/scores/scale-evaluation.yaml
+++ b/sources/scores/scale-evaluation.yaml
@@ -45,7 +45,6 @@ openness:
     - source
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: low
   note: SEAL Leaderboards are widely cited and 'trusted by leading AI labs' as a third-party evaluator;

--- a/sources/scores/scale-seal-leaderboard.yaml
+++ b/sources/scores/scale-seal-leaderboard.yaml
@@ -29,7 +29,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: medium
   note: SEAL is a widely-referenced expert-driven private leaderboard cited across the LLM evaluation

--- a/sources/scores/searxng.yaml
+++ b/sources/scores/searxng.yaml
@@ -28,12 +28,19 @@ openness:
     accessed: '2026-06-17'
 adoption:
   level: 4
-  reach: 50M+ total Docker pulls
+  reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: ~32k GitHub stars plus 50M+ total Docker pulls (~1.5M in a single recent week) and ~70 maintained
+  note: '~32k GitHub stars plus 50M+ total Docker pulls (~1.5M in a single recent week) and ~70 maintained
     public instances - concrete deployment volume well into the high band, not stars-only. The de facto open
-    web-search backend for self-hosted AI.
+    web-search backend for self-hosted AI. Re-banded 2026-08-13 under the lifetime-average rule in
+    docs/guides/adoption.md. Docker Hub reports 71,524,926 cumulative pulls on searxng/searxng since
+    2021-04-22, which averages ~1,122,856 a month over 63.7 months and bands at 1M-10M. The previous reach
+    ''50M+ total Docker pulls'' was a CUMULATIVE total wearing a monthly band''s place - the axis is monthly,
+    so a lifetime total is not comparable to any other record on the scale. Level unchanged at 4. Recorded AS
+    A DECLARED FLOOR, per the rule: a lifetime average understates a growing product, and SearXNG''s pull rate
+    is not flat. Docker is not declared as an artifact here, so the figure lives in this note rather than in a
+    signal - the same gap issue #163 tracks. No last_verified claimed: only the figure was re-read.'
   sources:
   - url: https://hub.docker.com/r/searxng/searxng
     shows: official image, 50M+ total pulls, ~1.5M weekly

--- a/sources/scores/sillytavern.yaml
+++ b/sources/scores/sillytavern.yaml
@@ -29,12 +29,16 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 3
-  reach: 100K-1M
+  reach: '>10K stars'
   signal_type: stars_fallback
   confidence: low
-  note: No published download/install or active-user counts found (self-hosted desktop app, no telemetry).
-    Falling back to 28.9k GitHub stars + 300+ contributors as the only honest signal, capped at level
-    3 per the stars-fallback rule. Likely a large enthusiast/roleplay community but unverified.
+  note: 'No published download/install or active-user counts found (self-hosted desktop app, no telemetry).
+    Falling back to 28.9k GitHub stars + 300+ contributors as the only honest signal, capped at level 3 per
+    the stars-fallback rule. Likely a large enthusiast/roleplay community but unverified. Stars read
+    2026-08-13: 32,041 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in
+    signal_routing.yaml. The previous reach ''100K-1M'' was not a label this instrument offers - stars have
+    their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile,
+    so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.'
   sources:
   - url: https://github.com/SillyTavern/SillyTavern
     shows: 28.9k stars, 300+ contributors; no install/usage count published

--- a/sources/scores/simple-evals.yaml
+++ b/sources/scores/simple-evals.yaml
@@ -22,13 +22,17 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 2
-  reach: 10K-100K
+  reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
-  note: Run from source (no pip distribution), so no download signal; ~4.5k stars + 490 forks is the only
-    measure, capped at <=3 by the stars rule and lowered to 2 because the project is deprecated (frozen
-    July 2025) and used mainly as a reference for a few specific benchmarks (HealthBench/BrowseComp/SimpleQA)
-    rather than as a live harness.
+  note: 'Run from source (no pip distribution), so no download signal; ~4.5k stars + 490 forks is the only
+    measure, capped at <=3 by the stars rule and lowered to 2 because the project is deprecated (frozen July
+    2025) and used mainly as a reference for a few specific benchmarks (HealthBench/BrowseComp/SimpleQA)
+    rather than as a live harness. Stars read 2026-08-13: 4,598 across the 1 declared repo, which bands at
+    1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach ''10K-100K'' was not a
+    label this instrument offers - stars have their own vocabulary because a star is not a download. No
+    last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch,
+    and the rest of the axis was not re-read.'
   sources:
   - url: https://github.com/openai/simple-evals
     shows: ~4.5k stars, 490 forks; deprecation notice

--- a/sources/scores/snorkel-flow.yaml
+++ b/sources/scores/snorkel-flow.yaml
@@ -22,7 +22,7 @@ openness:
     accessed: '2026-07-21'
 adoption:
   level: 3
-  reach: enterprise
+  reach: niche
   signal_type: reported_traction
   confidence: medium
   note: ~$237M raised at a ~$1.3B valuation (Series D, May 2025); established enterprise/government adoption

--- a/sources/scores/suna.yaml
+++ b/sources/scores/suna.yaml
@@ -26,13 +26,17 @@ openness:
     shows: v0.9.20 Jun 4 2026, 19.8k stars, cloud + self-host
     accessed: '2026-06-04'
 adoption:
-  level: 2
-  reach: 10K-100K
+  level: 3
+  reach: '>10K stars'
   signal_type: stars_fallback
   confidence: low
-  note: 19.8k stars and a managed cloud offering, but no published download/user-count figure; capped
-    on stars fallback. Placed at 2 given the relatively young, smaller community vs the leading agents;
-    directional.
+  note: '19.8k stars and a managed cloud offering, but no published download/user-count figure; capped on
+    stars fallback. Placed at 2 given the relatively young, smaller community vs the leading agents;
+    directional. Stars read 2026-08-13: 20,094 across the 1 declared repo, which bands at >10K stars, level 3
+    on the stars scale in signal_routing.yaml. Level corrected from 2. The previous reach ''10K-100K'' was not
+    a label this instrument offers - stars have their own vocabulary because a star is not a download. No
+    last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch,
+    and the rest of the axis was not re-read.'
   sources:
   - url: https://github.com/kortix-ai/suna
     shows: 19.8k stars, 44 releases

--- a/sources/scores/surfsense.yaml
+++ b/sources/scores/surfsense.yaml
@@ -30,10 +30,15 @@ openness:
     accessed: '2026-06-17'
 adoption:
   level: 3
+  reach: '>10K stars'
   signal_type: stars_fallback
   confidence: medium
-  note: ~15k GitHub stars by mid-2026; no download/usage telemetry available for a self-hosted web app, so
-    stars_fallback (capped at level 3). Rapid star growth but unproven real-world deployment.
+  note: '~15k GitHub stars by mid-2026; no download/usage telemetry available for a self-hosted web app, so
+    stars_fallback (capped at level 3). Rapid star growth but unproven real-world deployment. Stars read
+    2026-08-13: 15,898 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in
+    signal_routing.yaml. The record carried no reach label at all before this. No last_verified claimed: a
+    star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis
+    was not re-read.'
   sources:
   - url: https://github.com/MODSetter/SurfSense
     shows: ~14.9k stars, ~1.4k forks

--- a/sources/scores/swe-agent.yaml
+++ b/sources/scores/swe-agent.yaml
@@ -25,12 +25,17 @@ openness:
     shows: 19.4k stars, v1.1.0 May 22 2025, Princeton/Stanford (verified)
     accessed: '2026-06-04'
 adoption:
-  level: 2
-  reach: 10K-100K
+  level: 3
+  reach: '>10K stars'
   signal_type: stars_fallback
   confidence: low
-  note: Primarily a research/benchmark agent; 19.4k stars in the research community. No published download/user
-    volume; capped per stars-fallback rule. Adoption is research-circle, not production end-user scale.
+  note: 'Primarily a research/benchmark agent; 19.4k stars in the research community. No published
+    download/user volume; capped per stars-fallback rule. Adoption is research-circle, not production end-user
+    scale. Stars read 2026-08-13: 20,055 across the 1 declared repo, which bands at >10K stars, level 3 on the
+    stars scale in signal_routing.yaml. Level corrected from 2. The previous reach ''10K-100K'' was not a
+    label this instrument offers - stars have their own vocabulary because a star is not a download. No
+    last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch,
+    and the rest of the axis was not re-read.'
   sources:
   - url: https://github.com/SWE-agent/SWE-agent
     shows: 19.4k stars, 2.1k forks (research adoption)

--- a/sources/scores/swe-bench-verified.yaml
+++ b/sources/scores/swe-bench-verified.yaml
@@ -68,13 +68,16 @@ openness:
     establishes: [license]
 adoption:
   level: 4
-  reach: 1M-10M
+  reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: 'The de-facto standard agentic-coding benchmark of 2025-2026: cited as the headline coding metric
-    in nearly every frontier model release (GPT-5, Claude Opus, DeepSeek, Qwen, Kimi all report SWE-bench
+  note: 'The de-facto standard agentic-coding benchmark of 2025-2026: cited as the headline coding metric in
+    nearly every frontier model release (GPT-5, Claude Opus, DeepSeek, Qwen, Kimi all report SWE-bench
     Verified). ~914k HF downloads/month plus a live, heavily-submitted leaderboard at swebench.com. Strongest
-    ''citation-as-standard'' signal in the batch.'
+    ''citation-as-standard'' signal in the batch. Read live 2026-08-13: 413,323 Hugging Face downloads in the
+    trailing 30 days across the declared artifact(s), which bands at 100K-1M, level 4. The previous reach
+    ''1M-10M'' was a band off a different scale. No last_verified claimed: only the figure was re-read, not
+    the whole axis.'
   sources:
   - url: https://huggingface.co/datasets/princeton-nlp/SWE-bench_Verified
     shows: ~914k downloads last month; leaderboard at swebench.com

--- a/sources/scores/swe-bench.yaml
+++ b/sources/scores/swe-bench.yaml
@@ -26,7 +26,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 4
-  reach: 1M-10M
   signal_type: reported_traction
   confidence: medium
   note: SWE-bench Verified is the de-facto-standard agentic-coding eval cited in essentially every 2025-26

--- a/sources/scores/syfthub.yaml
+++ b/sources/scores/syfthub.yaml
@@ -23,11 +23,15 @@ openness:
     accessed: '2026-07-01'
 adoption:
   level: 1
-  reach: <10K
+  reach: <1K stars
   signal_type: stars_fallback
   confidence: low
-  note: ~2 GitHub stars (July 2026), created Aug 2025 — pre-adoption. Part of OpenMined's federated-RAG
-    effort (also local-rag, local-rag-router). Included as an emerging entry, not on adoption merit.
+  note: '~2 GitHub stars (July 2026), created Aug 2025 — pre-adoption. Part of OpenMined''s federated-RAG
+    effort (also local-rag, local-rag-router). Included as an emerging entry, not on adoption merit. Stars
+    read 2026-08-13: 2 across the 1 declared repo, which bands at <1K stars, level 1 on the stars scale in
+    signal_routing.yaml. The previous reach ''<10K'' was not a label this instrument offers - stars have their
+    own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a
+    digest of it would read as drift on every refetch, and the rest of the axis was not re-read.'
   sources:
   - url: https://github.com/OpenMined/syft-hub-sdk
     shows: 2 stars (July 2026)

--- a/sources/scores/tensorrt-llm.yaml
+++ b/sources/scores/tensorrt-llm.yaml
@@ -52,7 +52,6 @@ openness:
     content_sha256: 87877124e60b1a5c40de3751936a63c4115d35e77f50eb5ab8c97a3b3040392f
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: high
   note: 'Re-confirmed today: 14,342 GitHub stars (up from ~13.8k), and both comparison pieces still frame

--- a/sources/scores/text-generation-inference.yaml
+++ b/sources/scores/text-generation-inference.yaml
@@ -54,7 +54,6 @@ openness:
     content_sha256: e3de260c3facc391cf5f8b9e4fe186e1bcd9c2255ccc807db2fe266e566dcad5
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: medium
   note: README still states production use at Hugging Face and now explicitly recommends vLLM/SGLang/llama.cpp/MLX

--- a/sources/scores/the-pile-pipeline.yaml
+++ b/sources/scores/the-pile-pipeline.yaml
@@ -24,11 +24,15 @@ openness:
     accessed: '2026-07-21'
 adoption:
   level: 2
-  reach: <10K
+  reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: medium
-  note: ~1.7k GitHub stars; frozen since 2023 but the canonical, widely-cited documented-corpus construction
-    pipeline (GPT-Neo/J, Pythia).
+  note: '~1.7k GitHub stars; frozen since 2023 but the canonical, widely-cited documented-corpus construction
+    pipeline (GPT-Neo/J, Pythia). Stars read 2026-08-13: 1,674 across the 1 declared repo, which bands at
+    1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach ''<10K'' was not a
+    label this instrument offers - stars have their own vocabulary because a star is not a download. No
+    last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch,
+    and the rest of the axis was not re-read.'
   sources:
   - url: https://github.com/EleutherAI/the-pile
     shows: 1.7k stars

--- a/sources/scores/tinker.yaml
+++ b/sources/scores/tinker.yaml
@@ -70,7 +70,6 @@ openness:
     content_sha256: 3421e6a2ef0f216afb689c791d962d16cb24a511a37efdd5185599b54c96c769
 adoption:
   level: 2
-  reach: 10K-100K
   signal_type: reported_traction
   confidence: low
   note: Thinking Machines' own Tinker page names Glean/Waldo, Chroma, Lightning Rod Labs, Mantic, Trajectory,

--- a/sources/scores/together-inference-engine.yaml
+++ b/sources/scores/together-inference-engine.yaml
@@ -51,7 +51,6 @@ openness:
     content_sha256: b37c2cc8a83421eb7d355524afc7083b50daba7ca60e2001ae2f238d6f245026
 adoption:
   level: 4
-  reach: 1M-10M
   signal_type: reported_traction
   confidence: medium
   note: 'Re-confirmed today: the homepage still carries a named-customer case study (Cursor: "How Cursor

--- a/sources/scores/tokenizers.yaml
+++ b/sources/scores/tokenizers.yaml
@@ -21,10 +21,14 @@ openness:
     accessed: '2026-06-22'
 adoption:
   level: 5
-  reach: 189M+/month
+  reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: PyPI last-month downloads of 189,770,639 exceed the 50M+ threshold.
+  note: 'PyPI last-month downloads of 189,770,639 exceed the 50M+ threshold. Read live 2026-08-13: 252,452,945
+    PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at >10M, level 5. The
+    previous reach ''189M+/month'' was free text carrying a figure rather than a band the scale declares, so
+    nothing could check it against the level beside it. No last_verified claimed: only the figure was re-read,
+    not the whole axis.'
   sources:
   - url: https://pypistats.org/api/packages/tokenizers/recent
     shows: last_month = 189,770,639 PyPI downloads

--- a/sources/scores/transformers.yaml
+++ b/sources/scores/transformers.yaml
@@ -21,10 +21,14 @@ openness:
     accessed: '2026-06-22'
 adoption:
   level: 5
-  reach: 150M+/month
+  reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: PyPI last_month downloads of 150,245,308 exceed the 50M+ Level 5 threshold.
+  note: 'PyPI last_month downloads of 150,245,308 exceed the 50M+ Level 5 threshold. Read live 2026-08-13:
+    192,709,895 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at >10M,
+    level 5. The previous reach ''150M+/month'' was free text carrying a figure rather than a band the scale
+    declares, so nothing could check it against the level beside it. No last_verified claimed: only the figure
+    was re-read, not the whole axis.'
   sources:
   - url: https://pypistats.org/api/packages/transformers/recent
     shows: last_month downloads = 150,245,308

--- a/sources/scores/triton.yaml
+++ b/sources/scores/triton.yaml
@@ -21,10 +21,13 @@ openness:
     accessed: '2026-06-22'
 adoption:
   level: 5
-  reach: 50M+/mo
+  reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: PyPI last_month downloads ~64.7M.
+  note: 'PyPI last_month downloads ~64.7M. Read live 2026-08-13: 69,538,627 PyPI downloads in the trailing 30
+    days across the declared artifact(s), which bands at >10M, level 5. The previous reach ''50M+/mo'' was
+    free text carrying a figure rather than a band the scale declares, so nothing could check it against the
+    level beside it. No last_verified claimed: only the figure was re-read, not the whole axis.'
   sources:
   - url: https://pypistats.org/api/packages/triton/recent
     shows: last_month=64,708,650 downloads

--- a/sources/scores/txt360-pipeline.yaml
+++ b/sources/scores/txt360-pipeline.yaml
@@ -28,11 +28,15 @@ openness:
     accessed: '2026-07-21'
 adoption:
   level: 1
-  reach: <10K
+  reach: <1K stars
   signal_type: stars_fallback
   confidence: medium
-  note: ~25 GitHub stars on the pipeline repo; the value is the 5.7T-token corpus it builds, not the tool's
-    own adoption.
+  note: '~25 GitHub stars on the pipeline repo; the value is the 5.7T-token corpus it builds, not the tool''s
+    own adoption. Stars read 2026-08-13: 25 across the 1 declared repo, which bands at <1K stars, level 1 on
+    the stars scale in signal_routing.yaml. The previous reach ''<10K'' was not a label this instrument offers
+    - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count
+    is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-
+    read.'
   sources:
   - url: https://github.com/LLM360/TxT360
     shows: 25 stars

--- a/sources/scores/v0.yaml
+++ b/sources/scores/v0.yaml
@@ -19,7 +19,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 4
-  reach: 1M-10M
   signal_type: reported_traction
   confidence: medium
   note: Vercel reports multi-million (4M+) cumulative v0 users since GA. Falls in the 1-10M band; reported_traction

--- a/sources/scores/vals-ai.yaml
+++ b/sources/scores/vals-ai.yaml
@@ -28,7 +28,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: medium
   note: 'Widely cited independent leaderboard authority: 24 models tracked on the Vals Index (updated

--- a/sources/scores/vellum.yaml
+++ b/sources/scores/vellum.yaml
@@ -49,14 +49,20 @@ openness:
     shows: 'PRIMARY: MIT License text, ''Copyright (c) 2025 Vellum AI'''
     accessed: '2026-06-04'
 adoption:
-  level: 1
-  reach: <1K
+  level: 2
+  reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
-  note: No download/user/usage metrics disclosed (it's a self-hosted app, not a registry package). Only
+  note: 'No download/user/usage metrics disclosed (it''s a self-hosted app, not a registry package). Only
     signal available is GitHub stars (~577 on vellum-ai/vellum-assistant), used here strictly as a last-resort
-    proxy per the adoption!=stars rule; small/new entrant. Previously null; set to a conservative level
-    1 now that a real (if weak) signal exists.
+    proxy per the adoption!=stars rule; small/new entrant. Previously null; set to a conservative level 1 now
+    that a real (if weak) signal exists. Stars read 2026-08-13 on vellum-ai/vellum-assistant: 1,054, which
+    bands at 1K-10K stars, level 2 on the stars scale. The previous reach ''<1K'' was a download label, which
+    this instrument does not offer - a star is not a download. Level corrected from 1. THE REAL DEFECT is
+    upstream: this product declares no artifacts at all, so a stars_fallback band had no stars source behind
+    it and the count lived only in this note. Declaring vellum-ai/vellum-assistant would fix it, and is
+    deliberately not done here because a declared code repo also re-routes the openness license dimension. No
+    last_verified claimed: a star count is volatile.'
   sources:
   - url: https://github.com/vellum-ai/vellum-assistant
     shows: ~577 stars (last-resort star proxy; no other adoption signal disclosed)

--- a/sources/scores/vertex-ai-model-observability.yaml
+++ b/sources/scores/vertex-ai-model-observability.yaml
@@ -22,7 +22,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: low
   note: A feature surface within Vertex AI Agent Engine on Google Cloud; no standalone usage figures published

--- a/sources/scores/vibethinker.yaml
+++ b/sources/scores/vibethinker.yaml
@@ -24,7 +24,6 @@ openness:
     accessed: '2026-06-30'
 adoption:
   level: 2
-  reach: 10K-100K
   signal_type: reported_traction
   confidence: low
   note: Recently released specialist model with early attention for its size; directional estimate (not

--- a/sources/scores/webcontainers.yaml
+++ b/sources/scores/webcontainers.yaml
@@ -39,7 +39,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 3
-  reach: 100K-1M
   signal_type: reported_traction
   confidence: low
   note: Powers StackBlitz's own IDE and is embedded by named projects (SvelteKit, Astro, Scrimba, egghead.io,

--- a/sources/scores/whylabs.yaml
+++ b/sources/scores/whylabs.yaml
@@ -37,12 +37,18 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 2
-  reach: 10K-100K
+  reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
   note: 'Hosted SaaS shut down (no active platform users). Remaining signal is the OSS libraries: whylogs
     ~2.8k GitHub stars, last release Dec 2024; stars_fallback caps at 3; placed at 2 given the dead commercial
-    product and stalled release cadence. Honest signal is modest residual OSS usage, not a live platform.'
+    product and stalled release cadence. Honest signal is modest residual OSS usage, not a live platform.
+    Stars read 2026-08-13 on whylabs/whylogs: 2,830, which bands at 1K-10K stars, level 2 on the stars scale.
+    The previous reach ''10K-100K'' was a download label, which this instrument does not offer - a star is not
+    a download. THE REAL DEFECT is upstream: this product declares no artifacts at all, so a stars_fallback
+    band had no stars source behind it and the count lived only in this note. Declaring whylabs/whylogs would
+    fix it, and is deliberately not done here because a declared code repo also re-routes the openness license
+    dimension. No last_verified claimed: a star count is volatile.'
   sources:
   - url: https://github.com/whylabs/whylogs
     shows: 2.8k stars, latest release v1.6.4 (Dec 3, 2024)

--- a/sources/scores/windsurf.yaml
+++ b/sources/scores/windsurf.yaml
@@ -22,7 +22,6 @@ openness:
     accessed: '2026-06-04'
 adoption:
   level: 4
-  reach: 1M-10M
   signal_type: reported_traction
   confidence: medium
   note: Devin Desktop (Windsurf) page reports '1M+ Users' and '4000+ Enterprise Customers'. Vendor-reported

--- a/sources/scores/zentropi-cope.yaml
+++ b/sources/scores/zentropi-cope.yaml
@@ -24,7 +24,6 @@ openness:
     accessed: '2026-06-29'
 adoption:
   level: 2
-  reach: 1K-10K
   signal_type: reported_traction
   confidence: low
   note: 'Niche but notable: a ROOST Model Community partner model (distributed via RMC); 23 HF likes (June

--- a/sources/signal_routing.yaml
+++ b/sources/signal_routing.yaml
@@ -298,6 +298,54 @@ dimensions:
       - {level: 3, above: 10000, reach: '>10K stars'}
       - {level: 2, above: 1000, reach: 1K-10K stars}
       - {level: 1, above: -1, reach: <1K stars}
+    - source: null
+      signal_type: active_users
+      hand_authored: true
+      confidence: medium
+      note: >
+        No machine route, and there will not be one: the figure is a vendor MAU/WAU
+        disclosure read by a person from an earnings call, a launch post or a press
+        report. The scale is declared anyway, for the same reason the stars scale is -
+        an instrument without a declared vocabulary is an instrument whose labels
+        nobody can check.
+      # Declared 2026-08-13, on Carl's ruling, from the 23 products recording this
+      # instrument. All 23 carried a real user figure and 22 wore a label off the
+      # DOWNLOAD vocabulary, which nothing had ever declared applied here. So the
+      # labels were unfalsifiable rather than wrong: `character-ai` had invented
+      # `10M-100M`, which no scale offered, and nobody could say so.
+      #
+      # SAME THRESHOLDS AS THE DOWNLOAD SCALE, which is a decision and not an
+      # inheritance. The alternative considered was one order higher throughout, so
+      # that ChatGPT at ~900M weekly actives and Poe at ~18M monthly actives did not
+      # both land at 5. That was rejected: a level has to mean one magnitude across the
+      # whole map, or `adoption` stops being comparable between a package and an app,
+      # and the top band holding a wide range is the ordinary cost of a five-point
+      # scale rather than a defect in this instrument. 19 of the 23 sit at level 5,
+      # and that is the map saying these are all mass-market surfaces, which they are.
+      #
+      # The labels carry `users` even so - in fact especially so, since the thresholds
+      # now match. An unsuffixed `>10M` is ambiguous between two live scales at
+      # identical boundaries, and that ambiguity is the whole reason a download
+      # vocabulary could colonize this instrument unnoticed. The suffix is what makes
+      # the two scales tellable apart when their numbers do not differ.
+      #
+      # No cap. Unlike stars, this measures use directly; it is unmeasurable by
+      # machine, which is a question about confidence rather than about ceiling.
+      unit: monthly active users of the surface the product is, or that it powers
+      bands:
+      - {level: 5, above: 10000000, reach: '>10M users'}
+      - {level: 4, above: 1000000, reach: 1M-10M users}
+      - {level: 3, above: 100000, reach: 100K-1M users}
+      - {level: 2, above: 10000, reach: 10K-100K users}
+      - {level: 1, above: -1, reach: <10K users}
+      attribution_note: >
+        A model scores on the surface it powers (`gpt-5` on ChatGPT), which the score's
+        note must say out loud. What the scale will NOT accept silently is a figure
+        that is not an active count: an all-time or cumulative user total, a device
+        installed base, a paid-seat count. Those are the `active_users` form of the
+        under-coverage error in docs/guides/adoption.md - a substitution wearing a
+        measurement's label - and the score must either find an active figure or say
+        in its note which quantity it actually banded on.
     sum_across_artifacts: true
     sum_note: >
       A model family ships several SKUs. The map's unit is the family, so

--- a/sources/signal_routing.yaml
+++ b/sources/signal_routing.yaml
@@ -346,6 +346,49 @@ dimensions:
         under-coverage error in docs/guides/adoption.md - a substitution wearing a
         measurement's label - and the score must either find an active figure or say
         in its note which quantity it actually banded on.
+    - source: null
+      signal_type: reported_traction
+      hand_authored: true
+      confidence: low
+      note: >
+        The instrument of last resort before abstention: a credible vendor or third-party
+        claim about standing, with no count behind it. Used where the product has no
+        countable artifact at all - a hosted API, a closed model, a feature inside a
+        cloud platform.
+      # Declared 2026-08-13, on Carl's ruling, after measuring what the 110 records
+      # carrying this instrument actually said. 68 of them wore a NUMERIC download
+      # label, and those labels turned out to be perfectly collinear with the level
+      # they sat next to: `100K-1M` was level 3 on all 33 of its records, `1M-10M` was
+      # level 4 on all 23, `10K-100K` was level 2 on all 7. The label carried no
+      # information the level did not already carry.
+      #
+      # Worse, it carried information that was false. `amazon-nova` read `1M-10M` under
+      # a note saying "no standalone per-model user count published"; `aws-neuron` read
+      # `100K-1M` under "no download/user count is published for Neuron". A reader sees
+      # a numeric band and concludes somebody counted something. Nobody did. So the
+      # numeric vocabulary is not merely redundant here, it is a measurement claim the
+      # instrument is defined by NOT being able to make.
+      #
+      # NO LEVEL MAPPING, deliberately, which is what makes this a `vocabulary` rather
+      # than `bands`. The qualitative words are the LESS collinear half of the corpus -
+      # `niche` ran 85% level 3, `broad` 80% level 4, `mass-market` 67% level 5 - so
+      # they carry residual signal a bands table would flatten by forcing agreement.
+      # A word here says what kind of standing was claimed. The level says how much.
+      #
+      # The three words are hardware's, which already declares `qualitative: true` with
+      # an empty bands list and has used exactly these since before this route existed.
+      # Sharing them rather than minting a parallel set is the same reasoning as
+      # declaring any scale once.
+      vocabulary: [niche, broad, mass-market]
+      vocabulary_note: >
+        `reach` is OPTIONAL on this instrument and omitting it is the honest default -
+        15 records already do. A word is worth recording only where it says something
+        the level does not, which is usually the shape of the traction rather than its
+        size: `osprey` at 446 GitHub stars but in production at Discord is `niche` in a
+        way that matters. Three strays were folded in on 2026-08-13 rather than
+        admitted as new words - `enterprise` (snorkel-flow, nemo-data-designer) and
+        `early / niche` (datology-ai) all became `niche`, since the level beside them
+        already carried the distinction they were reaching for.
     sum_across_artifacts: true
     sum_note: >
       A model family ships several SKUs. The map's unit is the family, so

--- a/tests/test_check_adoption.py
+++ b/tests/test_check_adoption.py
@@ -51,6 +51,69 @@ def test_the_stars_scale_is_chosen_by_signal_not_by_type(sources):
     assert downloads is not None and downloads != stars
 
 
+def test_reported_traction_records_a_word_and_never_a_number(sources):
+    """68 of its 110 records carried a numeric download label until 2026-08-13.
+
+    They were perfectly collinear with the level beside them — `100K-1M` was level 3 on all 33
+    of its records, `1M-10M` level 4 on all 23 — so they carried nothing the level did not.
+    And they carried something false: `aws-neuron` read `100K-1M` beneath a note saying "no
+    download/user count is published for Neuron". A reader sees a numeric band and concludes
+    somebody counted something. On an instrument defined by having nothing to count, nobody did.
+    """
+    from build.check_adoption import declared_vocabularies
+
+    vocab = declared_vocabularies()
+    assert vocab["reported_traction"] == {"niche", "broad", "mass-market"}
+
+    # The words are hardware's, which declares `qualitative: true` with an empty bands list and
+    # has used exactly these since before the route existed. Sharing beats a parallel set.
+    hardware = (sources["rubrics"]["hardware"] or {}).get("adoption") or {}
+    assert hardware.get("qualitative") and not hardware.get("bands")
+
+    offenders = []
+    for slug, score in sources["scores"].items():
+        adoption = (score or {}).get("adoption") or {}
+        if adoption.get("signal_type") != "reported_traction":
+            continue
+        reach = adoption.get("reach")
+        # Omitting `reach` is the honest default here, so None is legal on purpose.
+        if reach is not None and reach not in vocab["reported_traction"]:
+            offenders.append((slug, reach))
+    assert not offenders, (
+        f"{offenders} record a reach outside the vocabulary. A reported_traction record has no "
+        f"count behind it, so a numeric band claims a measurement that was never made."
+    )
+
+
+def test_a_vocabulary_is_not_a_scale_and_does_not_constrain_the_level(sources):
+    """The reason `vocabulary` exists as a separate concept from `bands`.
+
+    A scale maps a label to a level, and a disagreement is a finding. A vocabulary says only
+    which words exist: the word says what KIND of standing was claimed, the level says how
+    much. Measured 2026-08-13, `niche` ran 85% level 3, `broad` 80% level 4, `mass-market` 67%
+    level 5 — spreads that a bands table would flatten by forcing agreement.
+
+    Asserted as a real property rather than a comment: at least one word must appear against
+    more than one level, or the distinction this design rests on is not doing any work and the
+    words may as well be bands.
+    """
+    from collections import defaultdict
+
+    from build.check_adoption import declared_vocabularies
+
+    words = declared_vocabularies()["reported_traction"]
+    levels = defaultdict(set)
+    for score in sources["scores"].values():
+        adoption = (score or {}).get("adoption") or {}
+        if adoption.get("signal_type") == "reported_traction" and adoption.get("reach") in words:
+            levels[adoption["reach"]].add(adoption.get("level"))
+
+    assert any(len(seen) > 1 for seen in levels.values()), (
+        f"every word maps to exactly one level ({dict(levels)}) — if that holds, the words "
+        f"are bands in disguise and should be declared as bands"
+    )
+
+
 def test_an_instrument_with_no_scale_abstains_rather_than_borrowing_one(sources):
     """The rule the first version of this checker broke.
 
@@ -64,11 +127,18 @@ def test_an_instrument_with_no_scale_abstains_rather_than_borrowing_one(sources)
     did, for all 93 `reported_traction` products, and the false findings were indistinguishable
     from real ones because they had the same shape.
 
-    `active_users` was the second such instrument until 2026-08-13, and it is asserted below
-    rather than here for a reason worth keeping: the skip was correct and it was also what hid
-    the problem. 22 of the 23 products carrying the instrument were wearing labels off the
-    download vocabulary, and a checker that declines to look never says so. Abstention is the
-    right answer to a missing scale and the wrong answer to a scale nobody has declared yet.
+    This still holds after 2026-08-13, and the distinction is the interesting part.
+    `reported_traction` now has a VOCABULARY, so it is checked — but it still has no SCALE, so
+    `scale_for` must keep returning None for it. A vocabulary constrains which words may be
+    recorded; only a scale can say a level is wrong. Conflating the two would reintroduce the
+    original bug wearing new clothes.
+
+    `active_users` went the other way on the same day: it declares a real scale and resolves
+    below. Both moves came out of the same finding, which is the one worth keeping — the skip
+    was correct AND it was what hid the problem. 22 of 23 `active_users` records and 68 of 110
+    `reported_traction` ones were wearing download labels, and a checker that declines to look
+    never says so. Abstention is the right answer to a missing scale and the wrong answer to a
+    scale nobody has declared yet.
     """
     scales = declared_scales(sources)
     for product_type in ("software", "model", "dataset"):

--- a/tests/test_check_adoption.py
+++ b/tests/test_check_adoption.py
@@ -54,28 +54,66 @@ def test_the_stars_scale_is_chosen_by_signal_not_by_type(sources):
 def test_an_instrument_with_no_scale_abstains_rather_than_borrowing_one(sources):
     """The rule the first version of this checker broke.
 
-    `docs/guides/adoption.md`: "a `reported_traction` or `active_users` band is measuring
-    something else entirely. Comparing it against a download count is a category error, and a
-    check must SKIP it rather than flag or waive it." `sources/signal_routing.yaml` states the
-    same principle as "abstain rather than substitute".
+    `docs/guides/adoption.md`: "a `reported_traction` band is measuring something else
+    entirely. Comparing it against a download count is a category error, and a check must SKIP
+    it rather than flag or waive it." `sources/signal_routing.yaml` states the same principle
+    as "abstain rather than substitute".
 
-    Neither instrument has a declared band table anywhere in the repo — two of the five values
-    in the `signal_type` enum have no scale — so a checker that falls back to the product
-    type's DOWNLOAD scale manufactures a finding for every one of them. It did, for all 93
-    `reported_traction` products, and the false findings were indistinguishable from real ones
-    because they had the same shape.
+    The instrument has no declared band table anywhere in the repo, so a checker that falls
+    back to the product type's DOWNLOAD scale manufactures a finding for every one of them. It
+    did, for all 93 `reported_traction` products, and the false findings were indistinguishable
+    from real ones because they had the same shape.
+
+    `active_users` was the second such instrument until 2026-08-13, and it is asserted below
+    rather than here for a reason worth keeping: the skip was correct and it was also what hid
+    the problem. 22 of the 23 products carrying the instrument were wearing labels off the
+    download vocabulary, and a checker that declines to look never says so. Abstention is the
+    right answer to a missing scale and the wrong answer to a scale nobody has declared yet.
     """
     scales = declared_scales(sources)
-    for instrument in ("reported_traction", "active_users"):
-        for product_type in ("software", "model", "dataset"):
-            assert scale_for(scales, product_type, instrument) is None, (
-                f"{instrument} borrowed the {product_type} scale; it measures something else"
-            )
+    for product_type in ("software", "model", "dataset"):
+        assert scale_for(scales, product_type, "reported_traction") is None, (
+            f"reported_traction borrowed the {product_type} scale; it measures something else"
+        )
 
-    # And the instruments that ARE denominated in downloads must still resolve, or the
-    # abstention would have been bought by disabling the check.
+    # And the instruments that DO declare a scale must still resolve, or the abstention would
+    # have been bought by disabling the check.
     assert scale_for(scales, "software", "usage_volume") is not None
     assert scale_for(scales, "software", "stars_fallback") is not None
+    assert scale_for(scales, "software", "active_users") is not None
+
+
+def test_the_active_users_scale_shares_download_thresholds_but_never_a_label(sources):
+    """Declared 2026-08-13, on the finding that 22 of 23 records wore a borrowed vocabulary.
+
+    The thresholds are deliberately identical to the download scale, so that a level means one
+    magnitude across the whole map. That decision is exactly what makes the labels load-bearing:
+    when two live scales share every boundary, an unsuffixed `>10M` cannot be told apart, and
+    being unable to tell them apart is how the borrowing went unnoticed.
+    """
+    scales = declared_scales(sources)
+    users = scale_for(scales, "software", "active_users")
+    downloads = scale_for(scales, "software", "usage_volume")
+
+    # 1. The same thresholds as downloads at every level, so a level means one magnitude
+    #    wherever it appears. Asserted against the download scale itself rather than against
+    #    literals, so that moving one scale and not the other fails here.
+    by_level = {level: label for label, level in users.items()}
+    assert by_level[5] == ">10M users" and by_level[4] == "1M-10M users"
+    assert by_level[3] == "100K-1M users" and by_level[2] == "10K-100K users"
+    strip = lambda scale: {label.removesuffix(" users"): level for label, level in scale.items()}
+    assert strip(users) == downloads, "the two scales' thresholds have drifted apart"
+
+    # 2. Every label carries its unit, so no label is shared with the download scale despite
+    #    every boundary being shared. This is what makes a download vocabulary not merely
+    #    discouraged here but unusable, and it is the only thing that can, now that the numbers
+    #    are identical.
+    assert all(label.endswith(" users") for label in users), users
+    assert not (set(users) & set(downloads)), "a label is ambiguous between two live scales"
+
+    # 3. No cap. Unlike stars, this measures use directly — unmeasurable by machine is a
+    #    question about confidence, not about ceiling.
+    assert max(users.values()) == 5, users
 
 
 def test_the_dataset_scale_sits_one_order_below_software(sources):

--- a/tests/test_score_notes.py
+++ b/tests/test_score_notes.py
@@ -1,0 +1,98 @@
+"""A note that appears under two axes was written for one of them.
+
+## Why this is a test rather than prose
+
+`personahub` recorded capability 2 with `value: null` and `confidence: high`, and the note
+under it argued CC-BY-NC-SA and the commercial-use test — an OPENNESS argument, verbatim the
+openness note, pasted into the capability block when the openness score moved to 2 on
+2026-08-01. The capability score followed it down. Nothing on that axis had been assessed.
+
+A licence says what you may do with a corpus. It says nothing about what training on it
+produces. So the duplication is not a cosmetic problem: wherever it happened, one axis is
+carrying a judgment made about a different question, and its SCORE is the openness score
+wearing another name. `personahub` sat at 2 in a 38-product category where the next lowest was
+3 — visible as an outlier, invisible as a cause.
+
+It was already written down. The 2026-08-11 handoff lists "7 products carry one note
+copy-pasted across all three axes" as an open item, in prose, which is exactly the form a
+finding takes when it is about to happen again. This is the gate half.
+
+## What this does and does not claim
+
+It does NOT clear the backlog — resolving the seven means re-deriving a real judgment per axis
+per product, which is its own pass. It freezes it: the known seven are named, and an eighth
+fails the suite. `check_adoption` shipped the same way, non-strict against a declared backlog,
+and the backlog shrank because it was counted.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from build.validate import load_sources
+
+AXES = ("openness", "adoption", "capability")
+
+# The seven found on 2026-08-11, each carrying one note under two or more axes. Named
+# individually so that fixing one is a one-line deletion here and adding an eighth is a
+# failure. Do not add to this list to make the suite pass — that is the failure working.
+KNOWN_SHARED_NOTES = {
+    "codegemma",
+    "codellama",
+    "jamba-large",
+    "llama",
+    "llama-instruct",
+    "personahub",
+    "tulu",
+}
+
+
+@pytest.fixture(scope="module")
+def sources():
+    return load_sources(Path("."))
+
+
+def shared_note_axes(score: dict) -> list[list[str]]:
+    """Groups of axes sharing one note, whitespace-normalized.
+
+    Normalized because the corpus is hand-wrapped: the same sentence re-wrapped at a
+    different width is the same note, and comparing raw strings would miss exactly the
+    copies that have since been edited around.
+    """
+    by_note: dict[str, list[str]] = {}
+    for axis in AXES:
+        note = ((score or {}).get(axis) or {}).get("note")
+        if note:
+            by_note.setdefault(" ".join(note.split()), []).append(axis)
+    return [axes for axes in by_note.values() if len(axes) > 1]
+
+
+def test_no_new_product_shares_one_note_across_axes(sources):
+    found = {
+        slug for slug, score in sources["scores"].items() if shared_note_axes(score)
+    }
+    new = found - KNOWN_SHARED_NOTES
+    assert not new, (
+        f"{sorted(new)} record one note under more than one axis. A note that argues about "
+        f"licensing cannot also be the reason for an adoption band or a capability score — "
+        f"whichever axis borrowed it has no judgment of its own recorded."
+    )
+
+
+def test_the_known_backlog_has_not_silently_grown_stale(sources):
+    """A slug that no longer shares a note should leave the list, not linger in it.
+
+    Otherwise the allowlist stops describing the backlog and starts hiding it — the list
+    would keep passing long after the products were fixed, and the next real instance would
+    have somewhere to hide.
+    """
+    still_sharing = {
+        slug for slug in KNOWN_SHARED_NOTES if shared_note_axes(sources["scores"].get(slug))
+    }
+    resolved = KNOWN_SHARED_NOTES - still_sharing
+    assert not resolved, (
+        f"{sorted(resolved)} no longer share a note across axes — remove them from "
+        f"KNOWN_SHARED_NOTES so the list keeps meaning what it says."
+    )

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -1223,35 +1223,48 @@ def test_dataset_bands_sit_one_order_below_software():
     assert top["dataset"] == 1_000_000
 
 
-def test_stars_bands_are_declared_once_and_capped():
-    """Stars are per INSTRUMENT, not per product type.
+def test_route_scales_are_declared_once_per_instrument_and_stars_stay_capped():
+    """Some scales are per INSTRUMENT, not per product type.
 
-    A dataset's downloads run an order below a package's, which is why those bands are
-    per type. A star is a star whatever it was given to, so the scale is declared once on
-    its route in signal_routing.yaml and emitted with product_type '*'. Four copies in
-    four rubrics is exactly the drift this whole table exists to stop.
+    A dataset's downloads run an order below a package's, which is why THOSE bands are per
+    type. A star is a star whatever it was given to, and a monthly active user is a person
+    whatever they came back to — so both are declared once on their route in
+    signal_routing.yaml and emitted with product_type '*'. Four copies in four rubrics is
+    exactly the drift this whole table exists to stop.
     """
     import yaml
     from pathlib import Path
 
-    from build.serialize_rubric import stars_bands
+    from build.serialize_rubric import route_bands
 
     routing = yaml.safe_load(Path("sources/signal_routing.yaml").read_text())
-    rows, warnings = stars_bands(routing)
+    rows, warnings = route_bands(routing)
 
     assert warnings == []
     assert {r["product_type"] for r in rows} == {"*"}
-    assert {r["signal_type"] for r in rows} == {"stars_fallback"}
+    assert {r["signal_type"] for r in rows} == {"stars_fallback", "active_users"}
+
     # Capped at 3: stars measure attention rather than use, so a stars-derived band may
     # never claim the top two levels however large the count.
-    assert max(r["level"] for r in rows) == 3
-    assert sorted(r["above"] for r in rows) == [-1, 1000, 10000]
+    stars = [r for r in rows if r["signal_type"] == "stars_fallback"]
+    assert max(r["level"] for r in stars) == 3
+    assert sorted(r["above"] for r in stars) == [-1, 1000, 10000]
+
+    # active_users measures use directly, so unlike stars it has no ceiling. Its thresholds
+    # are deliberately the download scale's, so that a level means one magnitude map-wide.
+    users = [r for r in rows if r["signal_type"] == "active_users"]
+    assert max(r["level"] for r in users) == 5
+    assert sorted(r["above"] for r in users) == [-1, 10_000, 100_000, 1_000_000, 10_000_000]
+
+    # Every row carries the unit its band was read in. A band with no unit is the ambiguity
+    # that let the download vocabulary colonize active_users in the first place.
+    assert all(r["unit"] for r in rows), rows
 
 
 def test_a_stars_band_above_the_cap_is_dropped_with_a_warning():
     """The cap is enforced, not trusted. A later edit adding a level-4 stars band should
     fail the serializer rather than quietly publish one."""
-    from build.serialize_rubric import stars_bands
+    from build.serialize_rubric import route_bands
 
     routing = {
         "dimensions": {
@@ -1269,28 +1282,42 @@ def test_a_stars_band_above_the_cap_is_dropped_with_a_warning():
             }
         }
     }
-    rows, warnings = stars_bands(routing)
+    rows, warnings = route_bands(routing)
     assert [r["level"] for r in rows] == [3]
     assert any("exceeds the declared cap" in w for w in warnings)
 
 
-def test_download_bands_and_stars_bands_do_not_collide():
-    """Both live in one table, distinguished by signal_type. A consumer joining without
-    filtering on it would band a package's downloads against the stars scale."""
+def test_download_bands_and_route_bands_do_not_collide():
+    """All three scales live in one table, distinguished by signal_type. A consumer joining
+    without filtering on it would band a package's downloads against the stars scale."""
     from pathlib import Path
 
     import yaml
 
-    from build.serialize_rubric import adoption_bands, stars_bands
+    from build.serialize_rubric import adoption_bands, route_bands
     from build.validate import load_sources
 
     downloads, _ = adoption_bands(load_sources(Path(".")).get("rubrics") or {})
-    stars, _ = stars_bands(yaml.safe_load(Path("sources/signal_routing.yaml").read_text()))
+    per_instrument, _ = route_bands(
+        yaml.safe_load(Path("sources/signal_routing.yaml").read_text())
+    )
 
     assert {r["signal_type"] for r in downloads} == {"usage_volume"}
     assert all(r["product_type"] != "*" for r in downloads)
-    keys = {(r["product_type"], r["signal_type"], r["level"]) for r in downloads + stars}
-    assert len(keys) == len(downloads) + len(stars), "a (type, instrument, level) key repeats"
+    rows = downloads + per_instrument
+    keys = {(r["product_type"], r["signal_type"], r["level"]) for r in rows}
+    assert len(keys) == len(rows), "a (type, instrument, level) key repeats"
+
+    # And no reach LABEL is shared across instruments either. The key above keeps the
+    # warehouse unambiguous; this keeps a human reading a score's `reach` unambiguous, which
+    # is the half that failed — a bare `1M-10M` meant downloads on one record and users on
+    # another, and that ambiguity is how the download vocabulary spread to an instrument it
+    # does not measure.
+    by_label: dict[str, set[str]] = {}
+    for row in rows:
+        by_label.setdefault(row["reach"], set()).add(row["signal_type"])
+    ambiguous = {reach: sorted(kinds) for reach, kinds in by_label.items() if len(kinds) > 1}
+    assert not ambiguous, f"a reach label means different things on different scales: {ambiguous}"
 
 
 def test_split_value_bare_half_matches_head_on_the_whole_corpus():


### PR DESCRIPTION
Closes the four rulings in #229, and takes the off-scale backlog from 71 to 0 so `check_adoption --strict` can gate in CI.

## The finding underneath all of it

Two of the five `signal_type` values — `active_users` and `reported_traction` — had **no declared vocabulary anywhere in the repo**. `check_adoption` skipped both, correctly: comparing a user count against a download band is a category error.

That skip was right, and it is also what hid the problem. **22 of 23 `active_users` records and 68 of 110 `reported_traction` ones were wearing download labels**, and a checker that declines to look never says so.

> Abstention is the right answer to a missing scale and the wrong answer to a scale nobody has declared yet.

## What each instrument got

**`active_users` — a scale, on the download thresholds.** Same numbers deliberately, so a level means one magnitude map-wide rather than something different per instrument. Labels carry `users` *because* the thresholds match: an unsuffixed `>10M` is ambiguous between two live scales at identical boundaries, and that ambiguity is how the borrowing went unnoticed.

Two levels move, both **up**, and both are the map disagreeing with itself where nothing was looking. `character-ai` read level 4 against an invented `10M-100M` while its own ~20M MAU clears the top threshold outright. `claude-ai` read `1M-10M` over a cited ~19–30M.

**`reported_traction` — a vocabulary, not a scale.** Its 68 numeric labels were perfectly collinear with the level beside them (`100K-1M` was level 3 on all 33 of its records, `1M-10M` level 4 on all 23), so they carried nothing the level did not — and they carried something false. `aws-neuron` read `100K-1M` beneath a note saying *"no download/user count is published for Neuron."* A reader sees a numeric band and concludes somebody counted something. Nobody did.

The words `niche` / `broad` / `mass-market` are hardware's, which has used them since before this route existed. No level mapping: they are the *less* collinear half (niche 85%, broad 80%, mass-market 67%), and a bands table would flatten that residual signal. A test asserts at least one word spans more than one level — if that stops being true, they are bands in disguise.

## Clearing 71 → 0

Every remaining figure was **re-read live**, not inferred from the stale label being replaced — which matters because the labels were exactly what could not be trusted. `giskard`'s own note said "~5.5K GitHub stars" while its reach claimed `10K-100K`.

| group | n | outcome |
|---|---|---|
| stars records wearing download labels | 51 | 36 confirmed, 8 moved, 7 in the defect below |
| `usage_volume` with free text (`331M+/month`) | 18 | re-read from PyPI / HF, 4 levels moved |
| cumulative Docker pulls in a monthly band's place | 2 | lifetime-average rule; `perplexica` 3 → 2 |

pypistats rate-limited 8 packages; they were **retried rather than skipped**, the same call #230 made.

## Two capability fixes, one mechanism

`personahub` recorded capability 2 in a 38-product category whose next lowest was 3, with `value: null` and `confidence: high`. The note was its **openness note verbatim**, pasted in when openness moved to 2, with the score following it down. A licence says what you may do with a corpus; it says nothing about what training on it produces. Re-derived at 4.

`llama` cited a release the tier does not top out at, on an AA index number that no longer exists on that scale. Re-derived on Llama 4 Maverick — **score unchanged at 3**, which is the point of re-deriving rather than adjusting.

## Flagged, not fixed

Seven products record `stars_fallback` while declaring **no artifacts at all**, so the band had no stars source and the count lived only in the note. Labels are corrected and each note now names the repo; declaring a code repo also re-routes the openness license dimension, which is not this branch's business.

## Verification

- **482 tests**, `check_adoption --strict` green at 452 products examined (up from 342 — two instruments it used to skip are now checked).
- **No category stage moved.** The one visible against main's committed `notebook_data.json` is #230's; that file was already stale before this branch.
- `check_verification` caught this branch claiming `last_verified` without a fetch digest on the two records re-read live. It was right to.

Every gate here is a gate rather than a note, on the principle this sweep keeps proving: **a finding written into prose recurs; a finding written into a gate does not.**