### PR TITLE
Gate the instrument claim, not just the band label

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -80,6 +80,19 @@ jobs:
       # could check it.
       - name: Adoption gate (every band exists on its instrument's scale)
         run: uv run python -m build.check_adoption --strict
+
+      # check_adoption above gates the LABEL. This gates the CLAIM underneath it: a record has
+      # to be re-checkable by somebody other than its author, either by recomputation (an
+      # artifact some signal model reads) or by re-fetch (a source with a date and a digest).
+      # Failing BOTH is the finding. 40 records do, and every one passes check_adoption green
+      # because its label is perfectly valid.
+      #
+      # Non-strict on purpose, exactly as check_adoption shipped: the backlog predates the
+      # rule being written down, and a gate that fails on day one teaches people to skip it.
+      # `adoption.md` had recorded this class as 48 products on 2026-08-10 and it grew while
+      # sitting in prose, which is the argument for counting it here instead.
+      - name: Instrument gate (every signal_type claim has what it needs to be falsifiable)
+        run: uv run python -m build.check_instrument
       - name: Serialize dry-run
         run: uv run python -m build.serialize --date ci-dry-run
 

--- a/build/check_instrument.py
+++ b/build/check_instrument.py
@@ -1,0 +1,210 @@
+"""Does each adoption record have what its own instrument requires?
+
+## The gap this closes, and why the previous gate could not see it
+
+`check_adoption` compares a recorded `(level, reach)` against the scale its instrument
+declares. It went to zero findings on 2026-08-13 and gates strict in CI. That check is about
+the LABEL.
+
+Nothing checks the INSTRUMENT. `signal_type` is a claim about how the band was read, and
+`docs/guides/adoption.md` states what the claim means: "A `usage_volume` band **claims to be
+a download count**." Measured 2026-08-13, **56 products claim exactly that with no artifact
+any signal model can read** — 12 declare npm or crates, which no model reads, and 44 declare
+nothing at all. Twelve of the 56 sit at level 5: `mcp-typescript-sdk`, `openclaw`, `langchain`,
+`ray`, `firecracker`, `aws-lambda`.
+
+Every one of them passes `check_adoption --strict` green, because `>10M` is a perfectly valid
+label. The label is checkable; the claim underneath it is not. That is the same failure the
+adoption sweep spent three days on, moved up one level: first labels nobody could check, now
+instruments nobody could check.
+
+It had also already been written down. `adoption.md` records the class as **48** products,
+measured 2026-08-10. It is 56 now. A finding in prose grows; a finding in a gate does not.
+
+## One rule, two ways to satisfy it
+
+**An adoption record must be re-checkable by somebody other than its author.** There are
+exactly two ways to be, and an instrument decides which is PREFERRED, never which is required:
+
+1. **Recomputation** — the product declares an artifact of a kind some signal model reads, so
+   a model can derive the number independently. Strictly the better route: it is automatic,
+   and it can disagree with the recorded band.
+2. **Re-fetch** — a cited source carries an `accessed` date AND a `content_sha256`, so
+   `check_refetch` can pull it again and report drift.
+
+A record failing BOTH is unfalsifiable, and that is the only thing this gate calls a finding.
+
+The first draft of this check required route 1 for `usage_volume` outright, and its own test
+caught the error. 15 of the 55 records with no readable artifact already carry a digested
+source — `agent-infra-sandbox` cites `api.npmjs.org/downloads/point/last-month` showing 4,670
+downloads, with a digest. That claim is perfectly checkable; it just is not re-derivable by a
+pipeline that reads no npm. Failing it would have told 15 authors their careful evidence did
+not count. **40 records, not 55, are genuinely unbacked.**
+
+None of the routing is hardcoded here. `sources/signal_routing.yaml` already declares which
+source feeds which `signal_type` and whether it is `bridged`; `artifact_key` (added for this
+check) names what a product must declare for that source to have anything to read. Mirroring
+any of it in Python is the drift `check_parity` exists to catch one axis over.
+
+## Why the escape hatch stays closed
+
+Without the evidence leg, any unbacked record could satisfy this gate by relabelling itself
+`reported_traction` — moving an unverifiable claim into the one instrument with no scale at
+all, which is strictly worse than where it started. With it, relabelling costs a dated,
+digested source, and a record that already has one is legitimately re-checkable whatever its
+instrument says. Measured 2026-08-13: 95 of 110 `reported_traction` records do not pay it yet.
+
+What no gate can decide is whether a declared artifact is the product's PRIMARY channel — the
+under-coverage judgment in `adoption.md`, and the reason a relabel can still be the wrong call
+for honest-looking reasons.
+
+## A known cost of route 2
+
+A digest over a COUNT endpoint drifts every time the count moves, so `check_refetch` will
+report drift that means nothing. Drift on a vendor claim page is informative; drift on
+`api.npmjs.org/downloads/point/last-month` is just Tuesday. That is an argument for bridging
+npm (issue #163) rather than for rejecting the evidence, and it is recorded here so the
+refetch noise is a known consequence rather than a surprise.
+
+## What this deliberately does NOT check
+
+Whether the recorded figure is CURRENT (`check_freshness`), whether the band matches the scale
+(`check_adoption`), or whether a declared artifact is the product's PRIMARY channel — that is
+the under-coverage judgment in `adoption.md`, and no gate can make it.
+
+## Exit status
+
+0 unless `--strict`, matching `check_adoption`'s first three days. The backlog predates the
+rule being written down, and a gate that fails on day one teaches people to skip it. Turn on
+`--strict` once it is cleared.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from build.validate import load_sources
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def instrument_rules(root: Path = ROOT) -> tuple[dict[str, set[str]], dict[str, list[str]]]:
+    """(signal_type -> artifact keys that satisfy it, signal_type -> required evidence fields).
+
+    Both read straight off `sources/signal_routing.yaml`. A source counts toward an
+    instrument's artifact precondition only when it is `bridged` — an unbridged route is
+    declared, but nothing reads it, so declaring an npm package does not make a download
+    count re-derivable. That distinction is the entire point: `mcp-typescript-sdk` declares
+    an npm package and records level 5 `usage_volume`, and no model can confirm or refute it.
+    """
+    from build.serialize_rubric import load_routing
+
+    routing = load_routing(root)
+    sources = routing.get("sources") or {}
+    routes = ((routing.get("dimensions") or {}).get("adoption") or {}).get("routes") or []
+
+    artifacts: dict[str, set[str]] = {}
+    evidence: dict[str, list[str]] = {}
+    for route in routes:
+        signal_type = route.get("signal_type")
+        if not signal_type:
+            continue
+        if route.get("requires_evidence"):
+            evidence[signal_type] = list(route["requires_evidence"])
+        source = sources.get(route.get("source") or "") or {}
+        if source.get("bridged") and source.get("artifact_key"):
+            artifacts.setdefault(signal_type, set()).add(source["artifact_key"])
+    return artifacts, evidence
+
+
+def is_recomputable(product: dict, artifacts: set[str]) -> bool:
+    """Route 1: some signal model can derive this number independently."""
+    return any(product.get(key) for key in artifacts)
+
+
+def is_refetchable(adoption: dict, required: list[str]) -> bool:
+    """Route 2: one source carries every field needed to pull it again and compare.
+
+    Every field must sit on the SAME source. An `accessed` date on one and a digest on
+    another proves nothing about either — the pair is what makes a re-fetch comparable.
+    """
+    return any(
+        all(src.get(field) for field in required)
+        for src in adoption.get("sources") or []
+    )
+
+
+def collect(sources: dict, root: Path = ROOT) -> tuple[list[str], int]:
+    artifacts, evidence = instrument_rules(root)
+    # The evidence fields are the same for every instrument that declares them, and they are
+    # what route 2 means in general, so a record on ANY instrument may satisfy the gate that
+    # way. Read from routing rather than restated, and defaulted only if nothing declares it.
+    refetch_fields = next(iter(evidence.values()), ["accessed", "content_sha256"])
+
+    findings: list[str] = []
+    examined = 0
+
+    for slug, score in sorted(sources["scores"].items()):
+        adoption = (score or {}).get("adoption") or {}
+        signal = adoption.get("signal_type") or ""
+        if adoption.get("level") is None or signal in ("", "unknown"):
+            continue
+        product = sources["products"].get(slug) or {}
+        examined += 1
+
+        if is_recomputable(product, artifacts.get(signal, set())):
+            continue
+        if is_refetchable(adoption, refetch_fields):
+            continue
+
+        if signal in artifacts:
+            declared = sorted(
+                k for k in ("npm", "crates", "docker") if product.get(k)
+            ) or ["nothing countable"]
+            findings.append(
+                f"{slug}: records {signal} at level {adoption['level']}, which claims a "
+                f"count, but declares {', '.join(declared)} and cites no source carrying "
+                f"{' + '.join(refetch_fields)}. Declare one of {sorted(artifacts[signal])} "
+                f"so a model can recompute it, or digest the source you read"
+            )
+        else:
+            findings.append(
+                f"{slug}: records {signal} at level {adoption['level']}, which can never be "
+                f"recomputed, and cites no source carrying {' + '.join(refetch_fields)} — "
+                f"the claim cannot be re-checked and will not age"
+            )
+    return findings, examined
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--strict", action="store_true", help="exit 1 on any finding")
+    parser.add_argument("--verbose", action="store_true", help="print every finding")
+    args = parser.parse_args()
+
+    sources = load_sources(ROOT)
+    findings, examined = collect(sources)
+
+    # A corpus walk that silently narrows passes green. Two did, earlier in this repo.
+    if examined < 300:
+        print(
+            f"check_instrument: only examined {examined} products; the walk has drifted",
+            file=sys.stderr,
+        )
+        return 1
+
+    shown = findings if args.verbose else findings[:15]
+    for line in shown:
+        print(f"  x {line}")
+    if len(findings) > len(shown):
+        print(f"  ... and {len(findings) - len(shown)} more (--verbose for all)")
+
+    status = "OK" if not findings else f"{len(findings)} instruments unsupported"
+    print(f"\ncheck_instrument  {examined} adoption records  [{status}]")
+    return 1 if findings and args.strict else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/guides/adoption.md
+++ b/docs/guides/adoption.md
@@ -199,6 +199,56 @@ load-bearing rule in this guide:
 - An `active_users` band claims a count of people, on the scale above. It may be compared only
   against another user count.
 
+### The instrument is itself a claim, and it needs backing
+
+`check_adoption` gates the **label**. `build/check_instrument.py` gates the **instrument**: a
+`signal_type` asserts *how* a band was read, and that assertion needs whatever would make it
+falsifiable.
+
+**One rule, two ways to satisfy it.** A record must be re-checkable by somebody other than its
+author, and there are exactly two ways to be:
+
+| route | how | who can use it |
+|---|---|---|
+| **recomputation** | declares an artifact of a kind some signal model **reads**, so a model derives the number independently | `usage_volume` (pypi, HF model/dataset, arxiv), `stars_fallback` (github) |
+| **re-fetch** | one source carries an `accessed` date **and** a `content_sha256`, so `check_refetch` pulls it again and reports drift | any instrument |
+
+The instrument decides which route is *preferred*, never which is *required*. Recomputation is
+strictly better — it is automatic, and it can disagree with the recorded band — but a digested
+source is a real check, and a record failing **both** is the only thing the gate calls a finding.
+
+None of it is hardcoded in the checker. `signal_routing.yaml` declares which source feeds which
+instrument and whether it is `bridged`; `artifact_key` names what a product must declare for
+that source to have anything to read, and `requires_evidence` carries the re-fetch fields.
+
+**The first draft required recomputation for `usage_volume` outright, and its own test caught
+the error.** 15 of the 55 unrouted records already carry a digested source —
+`agent-infra-sandbox` cites `api.npmjs.org/downloads/point/last-month` showing 4,670 downloads,
+with a digest. That claim is perfectly checkable; it just is not re-derivable by a pipeline that
+reads no npm. Failing it would have told 15 authors their careful evidence did not count.
+
+**Why the escape hatch stays shut.** Without the re-fetch leg, an unbacked record could pass by
+relabelling itself `reported_traction` — moving an unverifiable claim into the one instrument
+with no scale at all. With it, relabelling costs a dated, digested source. What no gate can
+decide is whether a declared artifact is the product's *primary* channel; that is the
+under-coverage judgment below, and it is why a relabel can still be wrong for honest-looking
+reasons.
+
+**A known cost of the re-fetch route.** A digest over a *count* endpoint drifts every time the
+count moves, so `check_refetch` reports drift that means nothing. Drift on a vendor claim page
+is informative; drift on `api.npmjs.org/downloads/point/last-month` is just Tuesday. That is an
+argument for bridging npm (#163), not for rejecting the evidence.
+
+Measured 2026-08-13, the backlog: **40** `usage_volume` records failing both routes, **95**
+`reported_traction` and **20** `active_users` with no digest, **6** `stars_fallback` with no
+repo. Every one passes `check_adoption --strict` green, because their labels are valid. The
+label was checkable; the claim underneath it was not.
+
+This class had been written down before. The section below recorded it as **48** products on
+2026-08-10, and it grew to 55 in prose. Hence a gate.
+
+---
+
 Both of the latter were skipped entirely by `check_adoption` until 2026-08-13, on the ground
 that comparing them against a download count is a category error. That was correct, and it is
 also what hid the problem — 22 of 23 `active_users` records and 68 of 110 `reported_traction`

--- a/sources/products/command-r.yaml
+++ b/sources/products/command-r.yaml
@@ -7,6 +7,9 @@ description: Cohere's enterprise foundation model line, currently anchored by Co
   or two H100s. Positioned for sovereign AI and enterprise RAG with native support for 48 languages and
   explicit grounding spans linking every factual claim to source documents. Earlier Command R+ (104B,
   2024) is the predecessor; with Command A+ the line has flipped from API-only to open-weights.
+huggingface_model:
+- url: https://huggingface.co/CohereLabs/command-a-plus-05-2026-bf16
+- url: https://huggingface.co/CohereLabs/c4ai-command-r-v01
 comments: 'Cohere c4ai-command-r-plus: 104B instruct/chat model, 128K context, RAG + multi-step tool use,
   10 languages. Original release Apr 2024 (newer 08-2024 revision exists). Verified live on HF June 2026
   (gated, contact-info required). License CC-BY-NC (non-commercial, non-OSI). Correctly an instruct model,

--- a/sources/products/crewai.yaml
+++ b/sources/products/crewai.yaml
@@ -2,4 +2,6 @@ name: crewai
 display_name: CrewAI
 type: software
 description: Active 2026; ~52.4k GitHub stars (late May 2026)
+pypi:
+- url: https://pypi.org/project/crewai/
 comments: Active 2026; ~52.4k GitHub stars (late May 2026)

--- a/sources/products/langchain.yaml
+++ b/sources/products/langchain.yaml
@@ -2,4 +2,6 @@ name: langchain
 display_name: LangChain
 type: software
 description: Active 2026; MIT core (langchain-core, langgraph, integrations); LangSmith is commercial
+pypi:
+- url: https://pypi.org/project/langchain/
 comments: Active 2026; MIT core (langchain-core, langgraph, integrations); LangSmith is commercial

--- a/sources/products/litellm.yaml
+++ b/sources/products/litellm.yaml
@@ -7,4 +7,6 @@ description: Python SDK and proxy server (AI gateway) that exposes a single Open
   with spend controls; ~48k GitHub stars and adopted as enterprise gateway by many AI platform teams.
 github:
 - url: https://github.com/BerriAI/litellm
+pypi:
+- url: https://pypi.org/project/litellm/
 comments: v1.84.5 (June 4, 2026)

--- a/sources/products/minimax.yaml
+++ b/sources/products/minimax.yaml
@@ -7,6 +7,8 @@ aliases:
 description: 'MiniMax M3 launched 1 Jun 2026: API-first at launch with MiniMax Sparse Attention, 1M-token context,
   native multimodal. Open weights have since been released on Hugging Face (ungated, ~131k downloads/month) under
   a custom minimax-community license; training data and pipeline remain closed.'
+huggingface_model:
+- url: https://huggingface.co/MiniMaxAI/MiniMax-M3
 comments: 'MiniMax M3 launched 1 Jun 2026: API-first at launch with MiniMax Sparse Attention, 1M-token context,
   native multimodal. Open weights have since been released on Hugging Face (ungated, ~131k downloads/month)
   under a custom minimax-community license; training data and pipeline remain closed. Consolidated on 2026-07-29

--- a/sources/products/ray.yaml
+++ b/sources/products/ray.yaml
@@ -3,5 +3,7 @@ display_name: Ray
 type: software
 description: Ray-2.55.1, released April 22, 2026 (GitHub). Ray joined the PyTorch Foundation (per Anyscale
   2026 announcement). Confirmed to exist as of June 2026.
+pypi:
+- url: https://pypi.org/project/ray/
 comments: Ray-2.55.1, released April 22, 2026 (GitHub). Ray joined the PyTorch Foundation (per Anyscale
   2026 announcement). Confirmed to exist as of June 2026.

--- a/sources/scores/command-r.yaml
+++ b/sources/scores/command-r.yaml
@@ -24,13 +24,23 @@ openness:
     shows: License CC-BY-NC + Acceptable Use Policy, gated access, 104B instruct model
     accessed: '2026-06-04'
 adoption:
-  level: 1
-  reach: <10K
+  level: 3
+  reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: ~3,258 HF downloads/mo on the original checkpoint (gated + superseded by 08-2024 revision + newer
-    Command models). Non-commercial license and 104B size cap self-host adoption; some legacy use via
-    Cohere API. Hobbyist/legacy scale on the download signal.
+  note: '~3,258 HF downloads/mo on the original checkpoint (gated + superseded by 08-2024 revision + newer
+    Command models). Non-commercial license and 104B size cap self-host adoption; some legacy use via Cohere
+    API. Hobbyist/legacy scale on the download signal. Artifact declared and read live 2026-08-13: 109,596
+    Hugging Face downloads in the trailing 30 days. Bands at 100K-1M, level 3. This record previously claimed
+    usage_volume - a download count - while declaring no artifact any signal model reads, so no computed
+    figure existed for the recorded band to disagree with. LEVEL CORRECTED FROM 1, by two bands, and the cause
+    is the max-across-releases rule in identity.md rather than a mismeasurement. The old note banded on the
+    2024 Command R+ checkpoint at ~3,258/mo, a superseded SKU, while the product''s own description says the
+    line is now anchored by Command A+. Declared artifacts are command-a-plus-05-2026-bf16 (84,821) and c4ai-
+    command-r-v01 (24,775), summed per sum_across_artifacts. DELIBERATELY EXCLUDED: command-a-vision-07-2025,
+    the transcribe models and the embed models, which are separate Cohere product lines rather than SKUs of
+    this one - including them would be over-attribution. No last_verified claimed: only the figure was re-
+    read.'
   sources:
   - url: https://huggingface.co/CohereLabs/c4ai-command-r-plus
     shows: 3,258 downloads/month, gated, newer revision available

--- a/sources/scores/crewai.yaml
+++ b/sources/scores/crewai.yaml
@@ -78,12 +78,16 @@ openness:
     - license
     - source
 adoption:
-  level: 4
-  reach: 1M-10M
+  level: 5
+  reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: 27M+ cumulative PyPI downloads with ~5M in the last month, 2B+ agent executions in past 12 months.
-    Monthly download volume places it in the 1-10M range.
+  note: '27M+ cumulative PyPI downloads with ~5M in the last month, 2B+ agent executions in past 12 months.
+    Monthly download volume places it in the 1-10M range. Artifact declared and read live 2026-08-13:
+    17,374,215 PyPI downloads in the trailing 30 days. Bands at >10M, level 5. This record previously claimed
+    usage_volume - a download count - while declaring no artifact any signal model reads, so no computed
+    figure existed for the recorded band to disagree with. Level corrected from 4. No last_verified claimed:
+    only the figure was re-read.'
   sources:
   - url: https://www.getpanto.ai/blog/crewai-platform-statistics
     shows: flagship phase-C verification source

--- a/sources/scores/gvisor.yaml
+++ b/sources/scores/gvisor.yaml
@@ -28,9 +28,17 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: Underpins Google Cloud Run ('Powered by gVisor' on gvisor.dev) and is the sandbox layer for GKE
-    Sandbox / App Engine / Cloud Functions, billions of container executions across Google Cloud. Reach
-    far exceeds >10M end-equivalent. (18.5k stars corroborate only.)
+  note: 'Underpins Google Cloud Run (''Powered by gVisor'' on gvisor.dev) and is the sandbox layer for GKE
+    Sandbox / App Engine / Cloud Functions, billions of container executions across Google Cloud. Reach far
+    exceeds >10M end-equivalent. (18.5k stars corroborate only.) ARTIFACT DELIBERATELY NOT DECLARED, checked
+    2026-08-13. A PyPI package named `gvisor` exists and is genuinely this project''s, so declaring it would
+    satisfy check_instrument and would be wrong. gVisor is a Go application-kernel shipped as a binary (runsc)
+    and consumed through container runtimes; the PyPI package sees 223 downloads a month. Banding on it would
+    take this record from 5 to 1 on a channel almost nobody uses. That is the under-coverage rule in
+    docs/guides/adoption.md - if the declared artifact is not the product''s primary distribution channel,
+    banding on it is a substitution rather than a measurement - applied before the mistake rather than after.
+    The band stands on the evidence already cited here; what this record needs is a route to its real channel,
+    not a convenient one.'
   sources:
   - url: https://gvisor.dev/docs/
     shows: '''Powered by gVisor'' linking to Google Cloud Run as a production user'

--- a/sources/scores/langchain.yaml
+++ b/sources/scores/langchain.yaml
@@ -74,8 +74,13 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: LangChain + LangGraph open source frameworks surpassed 1B cumulative downloads with 90M+ combined
-    monthly downloads. Monthly volume exceeds 10M, placing it at the top band.
+  note: 'LangChain + LangGraph open source frameworks surpassed 1B cumulative downloads with 90M+ combined
+    monthly downloads. Monthly volume exceeds 10M, placing it at the top band. Artifact declared and read live
+    2026-08-13: 281,508,705 PyPI downloads in the trailing 30 days. Bands at >10M, level 5. This record
+    previously claimed usage_volume - a download count - while declaring no artifact any signal model reads,
+    so no computed figure existed for the recorded band to disagree with. PyPI is LangChain''s primary channel
+    and the package is the product, not an SDK for a hosted service. Level unchanged; what changed is that a
+    model can now recompute it. No last_verified claimed: only the figure was re-read.'
   sources:
   - url: https://www.langchain.com/langchain
     shows: flagship phase-C verification source

--- a/sources/scores/litellm.yaml
+++ b/sources/scores/litellm.yaml
@@ -96,12 +96,17 @@ openness:
       under the settled rule is NOT evidence for or against core-gated and is not what the 4 rests on.
     accessed: '2026-06-04'
 adoption:
-  level: 3
-  reach: 100K-1M
+  level: 5
+  reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: Used-by 21.7k dependent repos on GitHub; ~49.2k stars, 1,342 releases. Treated as 100K-1M range
-    on dependent/usage volume; stars not the basis.
+  note: 'Used-by 21.7k dependent repos on GitHub; ~49.2k stars, 1,342 releases. Treated as 100K-1M range on
+    dependent/usage volume; stars not the basis. Artifact declared and read live 2026-08-13: 741,403,911 PyPI
+    downloads in the trailing 30 days. Bands at >10M, level 5. This record previously claimed usage_volume - a
+    download count - while declaring no artifact any signal model reads, so no computed figure existed for the
+    recorded band to disagree with. Level corrected from 3, by two bands. The figure is internally consistent
+    across windows (207.8M weekly, 28.5M daily) - litellm is a proxy library pulled on nearly every CI run
+    that touches a model provider. No last_verified claimed: only the figure was re-read.'
   sources:
   - url: https://github.com/BerriAI/litellm
     shows: flagship phase-C verification source

--- a/sources/scores/minimax.yaml
+++ b/sources/scores/minimax.yaml
@@ -34,8 +34,14 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: HF model card reports ~693,331 downloads in the last month (100K-1M band); additionally served via OpenRouter
-    and free in coding tools (Kilo Code). Headline figure is the HF monthly download count.
+  note: 'HF model card reports ~693,331 downloads in the last month (100K-1M band); additionally served via
+    OpenRouter and free in coding tools (Kilo Code). Headline figure is the HF monthly download count.
+    Artifact declared and read live 2026-08-13: 169,325 Hugging Face downloads in the trailing 30 days. Bands
+    at 100K-1M, level 3. This record previously claimed usage_volume - a download count - while declaring no
+    artifact any signal model reads, so no computed figure existed for the recorded band to disagree with.
+    Declared artifact is MiniMaxAI/MiniMax-M3, the release the product record says currently governs. Level
+    unchanged; the note''s previous ~693k figure was not re-derivable by anything. No last_verified claimed:
+    only the figure was re-read.'
   sources:
   - url: https://huggingface.co/MiniMaxAI/MiniMax-M2.5
     shows: ~693,331 downloads last month on the official HF model page

--- a/sources/scores/ollama.yaml
+++ b/sources/scores/ollama.yaml
@@ -29,8 +29,16 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: Reported 52M+ monthly model pulls in early 2026; 170K+ GitHub stars. Pull/usage volume places
-    it in the 1-10M+ active-user range; rated 4 conservatively on monthly pull volume (not stars).
+  note: 'Reported 52M+ monthly model pulls in early 2026; 170K+ GitHub stars. Pull/usage volume places it in
+    the 1-10M+ active-user range; rated 4 conservatively on monthly pull volume (not stars). ARTIFACT
+    DELIBERATELY NOT DECLARED, checked 2026-08-13. A PyPI package named `ollama` exists and is genuinely this
+    project''s, so declaring it would satisfy check_instrument and would be wrong. Ollama is distributed as a
+    platform binary and a Docker image; the PyPI package is a client SDK for talking to a local server, not
+    how Ollama is obtained. 20.3M/mo is a large number attached to the wrong question. That is the under-
+    coverage rule in docs/guides/adoption.md - if the declared artifact is not the product''s primary
+    distribution channel, banding on it is a substitution rather than a measurement - applied before the
+    mistake rather than after. The band stands on the evidence already cited here; what this record needs is a
+    route to its real channel, not a convenient one.'
   sources:
   - url: https://github.com/ollama/ollama
     shows: flagship phase-C verification source

--- a/sources/scores/promptfoo.yaml
+++ b/sources/scores/promptfoo.yaml
@@ -27,8 +27,16 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: ~1.18M npm downloads/mo (May 4-Jun 2 2026); 21.9k stars; project states it powers LLM apps serving
-    10M+ users in production. Headline = npm registry primary source; 1-10M band.
+  note: '~1.18M npm downloads/mo (May 4-Jun 2 2026); 21.9k stars; project states it powers LLM apps serving
+    10M+ users in production. Headline = npm registry primary source; 1-10M band. ARTIFACT DELIBERATELY NOT
+    DECLARED, checked 2026-08-13. A PyPI package named `promptfoo` exists and is genuinely this project''s, so
+    declaring it would satisfy check_instrument and would be wrong. promptfoo is an npm-first CLI; its PyPI
+    package sees 13,629 downloads a month against an npm channel nothing here reads. Banding on PyPI would
+    drop this record from 4 to 2 on a minority channel. That is the under-coverage rule in
+    docs/guides/adoption.md - if the declared artifact is not the product''s primary distribution channel,
+    banding on it is a substitution rather than a measurement - applied before the mistake rather than after.
+    The band stands on the evidence already cited here; what this record needs is a route to its real channel,
+    not a convenient one.'
   sources:
   - url: https://api.npmjs.org/downloads/point/last-month/promptfoo
     shows: 1,176,340 monthly npm downloads

--- a/sources/scores/ray.yaml
+++ b/sources/scores/ray.yaml
@@ -74,13 +74,15 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: 'Re-scored 4->5. The prior record had no verified download count
-    (reported_traction). Direct registry data now shows ray at 61.31M PyPI
-    downloads in the last 30 days, comfortably above the map''s prevailing
-    usage_volume level-5 floor of >10M/mo (and above even the stricter 50M floor the
-    HF-stack files use, cf. pytorch ~88.6M, triton ~64.7M at level 5). Ray is the
-    standard open distributed-compute / model-serving substrate (Ray Serve, Tune,
-    Train, Data) under the PyTorch Foundation.'
+  note: 'Re-scored 4->5. The prior record had no verified download count (reported_traction). Direct registry
+    data now shows ray at 61.31M PyPI downloads in the last 30 days, comfortably above the map''s prevailing
+    usage_volume level-5 floor of >10M/mo (and above even the stricter 50M floor the HF-stack files use, cf.
+    pytorch ~88.6M, triton ~64.7M at level 5). Ray is the standard open distributed-compute / model-serving
+    substrate (Ray Serve, Tune, Train, Data) under the PyTorch Foundation. Artifact declared and read live
+    2026-08-13: 63,273,910 PyPI downloads in the trailing 30 days. Bands at >10M, level 5. This record
+    previously claimed usage_volume - a download count - while declaring no artifact any signal model reads,
+    so no computed figure existed for the recorded band to disagree with. Level unchanged. No last_verified
+    claimed: only the figure was re-read.'
   sources:
   - url: https://pepy.tech/projects/ray
     shows: 61,306,813 downloads in last 30 days

--- a/sources/signal_routing.yaml
+++ b/sources/signal_routing.yaml
@@ -37,39 +37,52 @@ verified_on: '2026-07-28'
 # registry; a source with no key cannot be used until a bridge exists.
 sources:
   github:
+    artifact_key: github
     table: currentai.signal_github.repo_state
     key: product_slug
     evidence_url: https://github.com/{repo}
     bridged: true
   huggingface_model:
+    artifact_key: huggingface_model
     table: currentai.signal_huggingface.hub_state
     key: product_slug
     filter: artifact_kind = 'huggingface_model'
     evidence_url: https://huggingface.co/{artifact_id}
     bridged: true
   huggingface_dataset:
+    artifact_key: huggingface_dataset
     table: currentai.signal_huggingface.hub_state
     key: product_slug
     filter: artifact_kind = 'huggingface_dataset'
     evidence_url: https://huggingface.co/datasets/{artifact_id}
     bridged: true
   pypi:
+    artifact_key: pypi
     table: currentai.signal_pypi.package_downloads
     key: product_slug
     evidence_url: https://pypistats.org/packages/{package}
     bridged: true
   npm:
+    artifact_key: npm
     table: null
     key: null
     evidence_url: https://www.npmjs.com/package/{package}
     bridged: false
     bridge_note: >
-      12 products declare an npm package and no signal model reads the npm registry, so their
-      adoption falls through to the stars scale and its cap of 3 - four of them, including
-      `gemini-cli` and `openclaw`, record 5. npm download counts are a direct analogue of the
-      pypi route, so this is a missing model rather than a missing method. Declared here so
-      the gap is a backlog entry instead of a silent cap.
+      13 products declare an npm package and no signal model reads the npm registry. npm
+      download counts are a direct analogue of the pypi route, so this is a missing model
+      rather than a missing method. Declared here so the gap is a backlog entry rather than
+      an invisible one.
+
+      CORRECTED 2026-08-13. This note used to say those products "fall through to the stars
+      scale and its cap of 3", which is not what happened and was the more comfortable
+      reading. 11 of the 13 record `usage_volume` - they claim a DOWNLOAD COUNT on a registry
+      nothing in the pipeline can read, `mcp-typescript-sdk` and `openclaw` at level 5. An
+      unbridged route does not produce a capped band; it produces an unfalsifiable one,
+      because there is no computed figure for the recorded one to disagree with.
+      `build/check_instrument.py` now gates the general case.
   crates:
+    artifact_key: crates
     table: null
     key: null
     evidence_url: https://crates.io/crates/{package}
@@ -78,6 +91,7 @@ sources:
       One product (`yomo`) declares a crates package. Same shape as npm: crates.io publishes
       download counts and no model reads them.
   semanticscholar:
+    artifact_key: arxiv
     table: currentai.signal_semanticscholar.paper_citations
     key: product_slug
     evidence_url: https://www.semanticscholar.org/paper/{paper_id}
@@ -331,6 +345,9 @@ dimensions:
       #
       # No cap. Unlike stars, this measures use directly; it is unmeasurable by
       # machine, which is a question about confidence rather than about ceiling.
+      # Same reasoning as reported_traction below: no artifact can back a hand-read MAU
+      # disclosure, so the claim has to be re-checkable and has to age instead.
+      requires_evidence: [accessed, content_sha256]
       unit: monthly active users of the surface the product is, or that it powers
       bands:
       - {level: 5, above: 10000000, reach: '>10M users'}
@@ -379,6 +396,18 @@ dimensions:
       # an empty bands list and has used exactly these since before this route existed.
       # Sharing them rather than minting a parallel set is the same reasoning as
       # declaring any scale once.
+      # What this instrument must have instead of an artifact. It claims no count, so
+      # nothing can recompute it; the only thing that can keep it honest is that the claim
+      # is re-checkable and AGES. A digest gives both - `check_refetch` re-fetches a sample
+      # and reports drift, and drift on a vendor claim page is informative rather than
+      # noise: it means the claim may have moved and should be re-read.
+      #
+      # This is the price of the instrument, and it exists so that switching TO
+      # reported_traction is not free. Without it, a `usage_volume` record with nothing
+      # countable behind it could satisfy check_instrument by relabelling itself into the
+      # one instrument with no scale at all, which would move an unverifiable claim
+      # somewhere even less checked. Measured 2026-08-13: 95 of 110 records fall short.
+      requires_evidence: [accessed, content_sha256]
       vocabulary: [niche, broad, mass-market]
       vocabulary_note: >
         `reach` is OPTIONAL on this instrument and omitting it is the honest default -

--- a/tests/test_check_instrument.py
+++ b/tests/test_check_instrument.py
@@ -1,0 +1,111 @@
+"""The instrument's own precondition, and the escape hatch it has to close.
+
+`check_adoption` gates the label. These gate the claim underneath it. See
+`build/check_instrument.py` for why the two counting instruments and the two claiming ones
+need different things.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from build.check_instrument import collect, instrument_rules
+from build.validate import load_sources
+
+
+@pytest.fixture(scope="module")
+def sources():
+    return load_sources(Path("."))
+
+
+def test_the_rules_are_read_from_routing_and_not_mirrored_in_python():
+    """Every precondition traces to `sources/signal_routing.yaml`.
+
+    The checker deliberately has no opinion of its own about which sources exist. Mirroring
+    that list in Python is the hand-copied-logic drift `check_parity` exists to catch one
+    axis over, and this repo has hit it four times.
+    """
+    artifacts, evidence = instrument_rules()
+
+    # Counting instruments resolve to the artifact keys a product must declare.
+    assert artifacts["usage_volume"] == {
+        "pypi", "huggingface_model", "huggingface_dataset", "arxiv",
+    }
+    assert artifacts["stars_fallback"] == {"github"}
+
+    # The two that can never be recomputed have no artifact rule and an evidence rule instead.
+    assert "active_users" not in artifacts and "reported_traction" not in artifacts
+    assert evidence["reported_traction"] == ["accessed", "content_sha256"]
+    assert evidence["active_users"] == ["accessed", "content_sha256"]
+
+
+def test_an_unbridged_source_does_not_satisfy_recomputation():
+    """Declaring an npm package does not make a download count RE-DERIVABLE.
+
+    This is the distinction the whole check rests on. `signal_routing.yaml` declares npm and
+    crates with `bridged: false` — the route exists, nothing reads it. `mcp-typescript-sdk`
+    declares an npm package and records `usage_volume` at level 5, and no model in the
+    pipeline can confirm or refute that number.
+
+    The routing file's own note used to say these products "fall through to the stars scale
+    and its cap of 3", which was the comfortable reading and not what happened: 11 of the 13
+    npm products record `usage_volume` instead.
+
+    They are not thereby unfalsifiable, which is the correction that reshaped this gate. Most
+    of them cite a digested npm API response and are re-checkable by re-fetch; what they are
+    not is re-derivable by a pipeline that reads no npm. Route 1 is closed to them and route 2
+    is open, and the gate cares only that one of the two is.
+    """
+    artifacts, _ = instrument_rules()
+    assert "npm" not in artifacts["usage_volume"]
+    assert "crates" not in artifacts["usage_volume"]
+
+
+def test_relabelling_to_reported_traction_does_not_buy_a_pass(sources):
+    """The escape hatch, closed.
+
+    Without an evidence precondition, any `usage_volume` record with nothing countable behind
+    it could satisfy this gate by editing one field — landing in the one instrument with no
+    scale at all, where nothing checks its level either. That would move an unverifiable claim
+    somewhere strictly less checked and call it a fix.
+
+    Asserted by construction rather than by counting: take a record the gate actually fails,
+    relabel it the way a lazy fix would, and confirm it still fails.
+
+    Note what is NOT claimed. A record that already carries a dated, digested source may
+    legitimately record `reported_traction`, and 15 of the unrouted `usage_volume` records do
+    carry one. Whether such a record SHOULD relabel rather than declare its artifact is the
+    primary-channel judgment in `adoption.md`, which no gate can make.
+    """
+    offenders, _ = collect(sources)
+    assert offenders, "nothing to relabel; this test needs a live example"
+
+    failing = {f.split(":", 1)[0] for f in offenders}
+    slug = next(
+        s for s in failing
+        if ((sources["scores"].get(s) or {}).get("adoption") or {}).get("signal_type")
+        == "usage_volume"
+    )
+    patched = {
+        **sources,
+        "scores": {
+            **sources["scores"],
+            slug: {
+                **sources["scores"][slug],
+                "adoption": {**sources["scores"][slug]["adoption"],
+                             "signal_type": "reported_traction"},
+            },
+        },
+    }
+    findings, _ = collect(patched)
+    assert any(f.startswith(f"{slug}:") for f in findings), (
+        f"{slug} escaped the gate by relabelling itself reported_traction"
+    )
+
+
+def test_the_walk_covers_the_corpus(sources):
+    """A corpus walk that silently narrows passes green. Two did, earlier in this repo."""
+    _findings, examined = collect(sources)
+    assert examined > 400, f"only examined {examined} adoption records"


### PR DESCRIPTION
**Stacked on #231** — review that first; this PR's base is `carl/adoption-scales`.

## The gap

`check_adoption` gates the **label** and now gates strict. Nothing gated the **claim underneath it**. `signal_type` asserts *how* a band was read, and `adoption.md` defines what that means: "A `usage_volume` band **claims to be a download count**."

40 records claimed exactly that with nothing anyone could check. Every one passes `check_adoption --strict` green, because `>10M` is a perfectly valid label. Same failure as the rest of this sweep, one level up: first labels nobody could check, now instruments nobody could check.

It had already been written down — `adoption.md` recorded the class as **48** products on 2026-08-10, and it grew while sitting in prose.

## One rule, two satisfiers

A record must be re-checkable by somebody other than its author:

| route | how |
|---|---|
| **recomputation** | declares an artifact of a kind some signal model *reads*, so a model derives the number independently and can disagree with the band |
| **re-fetch** | one source carries an `accessed` date **and** a `content_sha256`, so `check_refetch` pulls it again and reports drift |

The instrument decides which is *preferred*, never which is *required*. Failing **both** is the finding.

**The first draft got this wrong and its own test caught it.** It required recomputation for `usage_volume` outright — failing 55 records, 15 of which already carry digested evidence. `agent-infra-sandbox` cites `api.npmjs.org/downloads/point/last-month` showing 4,670 downloads, with a digest. That claim is perfectly checkable; it just isn't re-derivable by a pipeline that reads no npm. Failing it would have told 15 authors their careful evidence didn't count.

The re-fetch leg is also what keeps the gate unescapable — without it, any unbacked record could pass by relabelling itself `reported_traction`, landing in the one instrument with no scale at all. A test asserts that by construction.

Nothing is mirrored in Python: `signal_routing.yaml` gains `artifact_key` and `requires_evidence`, and a test asserts the rules resolve from routing rather than literals.

## The artifact pass — and the three it refused

Declared and re-read live: `langchain` (281M/mo), `ray` (63M), `litellm` (741M, **3→5**), `crewai` (17M, 4→5), `minimax`, `command-r` (**1→3**, max-across-releases — it was banding on a superseded 2024 checkpoint).

**Refused, with the reasoning written into each record:**

| product | PyPI/mo | why it would be wrong |
|---|---|---|
| `gvisor` | 223 | a Go kernel shipped as `runsc` — would take level **5 → 1** |
| `ollama` | 20.3M | a client SDK for a local server, not how Ollama is obtained |
| `promptfoo` | 13,629 | npm-first CLI — would take **4 → 2** |

The under-coverage rule applied *before* the mistake. Worth noting as a hazard the gate creates: automated name-matching offered 25 candidates and most were junk — `minimax` matched a game-search library, `perspectiveapi` a third-party wrapper, `aws-lambda` somebody's helper, `perplexica` matched a weather package called Vane. A gate satisfiable by declaring any same-named package would have made this corpus confidently worse.

Also corrected: npm's `bridge_note` claimed its products "fall through to the stars scale and its cap of 3." They don't — 11 of 13 record `usage_volume`. An unbridged route doesn't produce a capped band, it produces an unrouted one.

## Backlog stays open, on purpose

**155 findings**, non-strict, exactly as `check_adoption` shipped. They spread across **12 of 16 categories and are zero in the two that are fully verified** — so they will be cleared by the category-completion passes rather than by a separate axis sweep, and `--strict` switches on when the last category closes.

A re-read of all 217 cited sources found the shape of that work: **55** records have a cited figure still present on the page, **11** have every figure gone, and **72** cite a source whose `shows:` quotes no figure at all — those cannot be verified without new evidence, only made re-fetchable.

486 tests. `check_adoption --strict` still green.