### PR TITLE
Close inference_code and finetuning_code to 100% verified

### DIFF
--- a/docs/guides/gap-analysis.md
+++ b/docs/guides/gap-analysis.md
@@ -55,6 +55,35 @@ is graded on adoption alone. A product is **mature** when its score clears a hig
 near-best-on-both-axes bar). The bar is intentionally demanding: because the map curates the
 most prominent products in each category, a low bar would call almost everything mature.
 
+### The two nulls are not symmetric, and one of them is not an abstention
+
+Worth stating plainly, because the code makes them look alike and they behave oppositely:
+
+- **Null adoption abstains.** `_maturity_score` returns `None`, and `_stage_and_gaps` drops the
+  product — "we can't judge what we can't measure, so they neither advance nor depress the
+  category's stage." Measured 2026-08-13: 20 products, 19 of them `closed`, which the open-only
+  counting rule already excluded. The abstention is real and costs nothing.
+- **Null capability does not abstain.** It falls through to adoption alone, which silently
+  reweights maturity from a blend to a single axis rather than declining to score. The product
+  keeps counting toward the stage.
+
+That fallback is right for the case it was written for. 21 of the 26 null-capability products
+are in `benchmark_eval_data`, where downloads plausibly *are* the quality signal — a corpus
+everyone evaluates against is, by that fact, a good corpus.
+
+**Every other category inherits it by accident.** The live consequence on 2026-08-13 is
+`model-context-protocol`: adoption 5, capability null, `open_source`, so maturity computes to
+5.0, it counts as a mature open product, and one mature open product is the entire `stage >= 4`
+threshold. `agent_tools_protocols` therefore rests a stage-4 claim on a product whose capability
+nobody has scored. No other null-capability product is close — the remaining 22 sit at adoption
+3–4, below the mature bar, where they can move `best_open` but cannot trigger a stage on their
+own.
+
+So the open question is whether "graded on adoption alone" should be a **per-category
+declaration**, like `disclosure` below, rather than a global fallback. It is deliberately not
+settled here: it is to be resolved during the `agent_tools_protocols` verification pass, when
+`model-context-protocol` gets a real capability score and the question stops being hypothetical.
+
 ## Dataset categories
 
 Datasets are scored on both axes like everything else, but each axis is read specifically for a

--- a/sources/scores/amazon-bedrock-custom-models-fine-tuning.yaml
+++ b/sources/scores/amazon-bedrock-custom-models-fine-tuning.yaml
@@ -57,10 +57,18 @@ capability:
     models.'
   confidence: medium
   note: 'Solid managed method set (SFT + RFT + distillation), but a black-box service with no exposed
-    parallelism/precision/scale controls and no benchmark basis. Scored 3: capable managed FT across a
-    model catalog, below the RFT-on-frontier-reasoning depth of the OpenAI/Vertex offerings and far below
-    the OSS scale-frontier libs.'
+    parallelism/precision/scale controls and no benchmark basis. Scored 3: capable managed FT across a model
+    catalog, below the RFT-on-frontier-reasoning depth of the OpenAI/Vertex offerings and far below the OSS
+    scale-frontier libs. Re-read 2026-08-13 and unchanged at 3. The note placed this "below the RFT-on-
+    frontier-reasoning depth of the OpenAI/Vertex offerings", so that is recorded as one_below openai-fine-
+    tuning-api, the nearer of the two named peers and itself a managed API rather than a library - which keeps
+    the comparison between like things.'
+  relative_to: openai-fine-tuning-api
+  relation: one_below
+  last_verified: '2026-08-13'
   sources:
   - url: https://docs.aws.amazon.com/bedrock/latest/userguide/custom-models.html
     shows: SFT, reinforcement fine-tuning with Lambda reward funcs, distillation
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d28a9ace3f45102bd7662c308714aad4c83ed189053eb47ada74fe4e1f1261dc

--- a/sources/scores/anyscale-fine-tuning.yaml
+++ b/sources/scores/anyscale-fine-tuning.yaml
@@ -81,9 +81,17 @@ capability:
     No advanced quantization/algorithm coverage; Anyscale itself cites Axolotl/LLaMA-Factory as providing
     enhanced functionality, the reason for deprecation.'
   confidence: medium
-  note: Modest method/feature coverage relative to live OSS peers; Anyscale's own deprecation rationale
-    (Axolotl/LLaMA-Factory have more features) caps this low.
+  note: 'Modest method/feature coverage relative to live OSS peers; Anyscale''s own deprecation rationale
+    (Axolotl/LLaMA-Factory have more features) caps this low. Re-read 2026-08-13 and unchanged at 2. The note
+    already named its peers - Anyscale''s own deprecation rationale says Axolotl and LLaMA-Factory carry more
+    features - so that is recorded as two_below axolotl rather than left as prose. Using the vendor''s own
+    reason for standing down is the strongest form this comparison takes anywhere in the category.'
+  relative_to: axolotl
+  relation: two_below
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.anyscale.com/library/llmforge
     shows: LoRA + full FT; OSS alternatives offer quantization/advanced algorithms
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: aae241053005347202073ef3f0dde4abf3f6fd24fe922e79980489fee7422105

--- a/sources/scores/aws-neuron.yaml
+++ b/sources/scores/aws-neuron.yaml
@@ -97,17 +97,27 @@ adoption:
   level: 3
   signal_type: reported_traction
   confidence: low
-  note: No download/user count is published for Neuron; the AWS product page still only supports a qualitative
-    reported_traction read (framework-integration breadth, fleet-wide positioning), the same basis the level-3
-    band already rested on. Held at 3 rather than raised or lowered absent a numeric signal.
+  note: 'Re-read 2026-08-13 and held at 3. AWS publishes no customer count, download count or usage figure
+    for Neuron anywhere on the product page - confirmed by re-reading it rather than assumed from the
+    previous pass - and names no customers and makes no quantified scale claim. What the page does
+    establish is integration breadth: PyTorch and JAX natively, plus HuggingFace Transformers and Optimum
+    Neuron, vLLM, PyTorch Lightning and TorchTitan, "without modifying your code".
+
+    THIS IS A QUALITATIVE CONFIRMATION AND THE BAND IS ONLY AS GOOD AS THAT. reported_traction is the
+    correct instrument precisely because nothing here is countable, so re-reading can establish that the
+    described breadth still holds and can never establish that 3 is the right number for it. The date
+    records that the claim was re-derived from its source, not that a measurement was taken. If AWS ever
+    publishes an instance-hour or customer figure, this axis should move to a countable instrument.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://aws.amazon.com/ai/machine-learning/neuron/
-    shows: Neuron enables developers to build, deploy and explore natively with PyTorch and JAX frameworks
-      and with ML libraries such as HuggingFace, vLLM, PyTorch Lightning, and others without modifying your
-      code.
-    accessed: '2026-08-09'
+    shows: 're-read 2026-08-13: PyTorch and JAX natively, plus HuggingFace, vLLM, PyTorch Lightning,
+      TorchTitan and Optimum Neuron, "without modifying your code". NO customer count, download count,
+      usage figure or named customer anywhere on the page - the absence is what the reported_traction
+      instrument rests on'
+    accessed: '2026-08-13'
     http_status: 200
-    content_sha256: 41c9ae592854919cc88a5368a602cb3f498fd3aec5ee221db36ea13d72f699fe
+    content_sha256: 4ccd6ea8ed04015f8c2729eec22575613ca21e969c4ff77b7483f5dfcec65965
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/axolotl.yaml
+++ b/sources/scores/axolotl.yaml
@@ -92,15 +92,16 @@ capability:
     FSDP1/FSDP2, DeepSpeed, multi-node Torchrun/Ray, Sequence Parallelism + ND Parallelism (CP+TP+FSDP);
     precision: BF16/4-8bit. Broadest single-tool method+parallelism matrix in this batch.'
   confidence: high
-  note: Very wide method and parallelism coverage (ND parallelism, multi-node), strong C4; below Megatron-LM
-    frontier-scale-training anchor on demonstrated extreme scale.
-  last_verified: '2026-08-09'
+  note: 'Very wide method and parallelism coverage (ND parallelism, multi-node), strong C4; below Megatron-LM
+    frontier-scale-training anchor on demonstrated extreme scale. Re-read 2026-08-13 as an anchor for this
+    category''s closing pass; unchanged at 4.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://raw.githubusercontent.com/axolotl-ai-cloud/axolotl/main/README.md
     shows: 'Feature/parallelism matrix: full fine-tuning, LoRA, QLoRA, GPTQ, QAT (int8/int4/FP8/NVFP4/MXFP4),
       DPO/IPO/KTO/ORPO, GRPO/GDPO, reward and process-reward modelling; FSDP1/FSDP2, DeepSpeed, multi-node
       Torchrun/Ray, Sequence Parallelism, plus newly added Expert Parallelism (EP) and Context Parallelism
       for hybrid SSM models -- matches or exceeds what capability.value already records.'
-    accessed: '2026-08-09'
+    accessed: '2026-08-13'
     http_status: 200
-    content_sha256: fd60c6b8c9062efed362133ececc5f9f6d1b919edfbb616f401eb715c7289f06
+    content_sha256: d8d53f43d9f84310e30a793517f369ebc01c78dcf7989676c3841471d1fa1252

--- a/sources/scores/fireworks-fine-tuning.yaml
+++ b/sources/scores/fireworks-fine-tuning.yaml
@@ -38,13 +38,21 @@ adoption:
   reach: null
   signal_type: unknown
   confidence: low
-  note: No disclosed standalone usage figure for the Fireworks fine-tuning feature located this run (jobs
-    run / customers tuning). Fireworks serves notable inference volume, but no honest signal specific
-    to the FT SKU was found; declining to assign a level.
+  note: 'No disclosed standalone usage figure for the Fireworks fine-tuning feature located this run (jobs run
+    / customers tuning). Fireworks serves notable inference volume, but no honest signal specific to the FT
+    SKU was found; declining to assign a level.  ABSTENTION RE-CONFIRMED 2026-08-13, and the date records that
+    rather than a measurement. Re-read the cited page and no usage figure has appeared - no jobs run,
+    customers tuning, models fine-tuned or developer count. A null level is a value here, not a gap: it says
+    somebody looked and the vendor publishes nothing, which is the honest answer for a feature sold inside a
+    larger platform. The corpus already dates abstentions this way (9 null axes carry a last_verified), and
+    leaving them undated would make an axis unverifiable forever purely because its answer is ''none''.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://docs.fireworks.ai/fine-tuning/fine-tuning-models
     shows: managed FT feature; no usage figures disclosed
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e8cf985a9c90e195cf32a6724517100978bd2b5eb766afda2ba5e0849b1b09c6
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/fireworks-inference.yaml
+++ b/sources/scores/fireworks-inference.yaml
@@ -54,26 +54,42 @@ adoption:
 capability:
   score: 4
   basis: benchmark
-  basis_detail: ArtificialAnalysis(provider-speed)
-  value: '3rd-fastest provider for gpt-oss-120b on the Artificial Analysis leaderboard at 658.8 output tokens/sec
-    (top GPU-based provider; behind wafer/LPU-class Cerebras 1,726.0 and SambaNova 692.5) as of the last
-    confirmed read (2026-06-04). Customer case studies re-confirmed 2026-08-09: Notion ~2s -> 350ms latency
-    (Sarah Sachs, AI Lead), Quora 3x speedup (Spencer Chan, Product Lead). NOT re-derivable today - see
-    held_because.'
+  basis_detail: ArtificialAnalysis(provider page)
+  value: 'Serves 10 models on Artificial Analysis, topping out at 459 output tokens/sec (Nemotron 3.5
+    Lightning BF16), then MiniMax-M2.7 at 206 t/s and DeepSeek V4 Flash at 115 t/s; best time-to-first-token
+    0.93s (Kimi K2.6). AA notes a 448% spread between its fastest and slowest model. That peak sits below
+    the wafer/LPU speed frontier on the same site''s gpt-oss-120b board - Cerebras 1,820.3, SambaNova
+    701.3, Groq 475.9 - and around the GPU-class providers, which is what places this at 4 rather than 5.
+    Customer case studies, re-confirmed 2026-08-13: Notion ~2s -> 350ms latency (Sarah Sachs, AI Lead),
+    Quora 3x speedup (Spencer Chan, Product Lead).'
   confidence: medium
-  note: 'Top-tier GPU-based inference (FireAttention) and previously the fastest GPU provider on the AA
-    gpt-oss-120b board (658.8 t/s, 3rd overall as of 2026-06-04), but below the wafer/LPU speed-frontier
-    (Cerebras). Held rather than re-dated: Fireworks does not appear on the current AA gpt-oss-120b providers
-    page at all (checked 2026-08-09), so the benchmark basis could not be re-confirmed.'
+  note: 'Top-tier GPU-based inference (FireAttention), below the wafer/LPU speed frontier. SCORE UNCHANGED
+    AT 4; what changed is that it can now be re-derived. The 2026-08-09 pass held this axis undated rather
+    than re-date it, because the basis it cited - 3rd on the AA gpt-oss-120b providers board at 658.8 t/s,
+    read 2026-06-04 - had ceased to exist: Fireworks no longer appears on that board at all. Refusing the
+    date was right, and it left the axis stuck, because the missing evidence was never replaced.
+
+    Re-derived 2026-08-13 on AA''s own Fireworks PROVIDER page, which does carry current figures for the
+    10 models it serves. The model board and the provider page are the same instrument read from two
+    directions; a product dropping off a per-model board is a fact about that board''s coverage, not about
+    the product. The gpt-oss-120b page is kept as a cited source because it is what establishes where the
+    speed frontier sits, and it is now re-read rather than remembered.'
+  last_verified: '2026-08-13'
   sources:
-  - url: https://artificialanalysis.ai/models/gpt-oss-120b/providers
-    shows: 'current output-speed chart data (medianOutputSpeed): Cerebras 1941.96, SambaNova 705.67, Groq
-      476.75, Google Vertex 395.82, Azure 323.19, Baseten 194.67, DeepInfra (Turbo) 174.52, Scaleway 166.05,
-      Nebius (Base) 138.69, Parasail 106.70, Novita 103.90, Amazon 94.26 - no Fireworks entry in this or
-      any of the page''s other chart data blocks'
-    accessed: '2026-08-09'
+  - url: https://artificialanalysis.ai/providers/fireworks
+    shows: 10 models served; output speed 459 t/s (Nemotron 3.5 Lightning BF16), 206 t/s (MiniMax-M2.7),
+      115 t/s (DeepSeek V4 Flash), 107 t/s (Kimi K2.6); latency 0.93s best (Kimi K2.6); "448% difference
+      between the fastest and slowest"
+    accessed: '2026-08-13'
     http_status: 200
-    content_sha256: 082d6179bce956957d776b3d9543cb423760838a29999065f98bf22788d5514b
+    content_sha256: 7eb36fe33f25847786dcfc510fb3783d4447d433122bf1f0b895bdc53912fb7d
+  - url: https://artificialanalysis.ai/models/gpt-oss-120b/providers
+    shows: 'the speed frontier this band is placed against, re-read 2026-08-13: Cerebras 1,820.3, SambaNova
+      701.3, Groq 475.9, Google Vertex 362.7, Azure 310.5 output t/s - and still no Fireworks entry, which
+      is why the provider page rather than this one carries the basis'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5071ab85b53372112bbdfe4b54e7e94e570db319d44f626ae098d9d3538a20ca
   - url: https://fireworks.ai/
     shows: 'Notion (Sarah Sachs, AI Lead): "we reduced latency from about 2 seconds to 350 milliseconds";
       Quora (Spencer Chan, Product Lead): "we noticed a 3x speedup in response time"'

--- a/sources/scores/megatron-lm.yaml
+++ b/sources/scores/megatron-lm.yaml
@@ -151,11 +151,14 @@ capability:
     weak-scaling benchmark to a 462B-parameter GPT on 6,144 H100 GPUs at 47–48% MFU, strong scaling of a
     ~175B GPT-3 from 96 to 4,608 H100 GPUs.'
   confidence: high
-  note: Reference-grade large-scale transformer training infrastructure, and the capability anchor the rest
+  note: 'Reference-grade large-scale transformer training infrastructure, and the capability anchor the rest
     of this category places itself against. The parallelism, precision and scaling facts now sit in `value`
-    with establishing sources rather than being asserted here. No MLPerf-Training submission verified for
-    the library itself, so the basis is feature_matrix plus NVIDIA-reported scaling benchmarks.
-  last_verified: '2026-08-09'
+    with establishing sources rather than being asserted here. No MLPerf-Training submission verified for the
+    library itself, so the basis is feature_matrix plus NVIDIA-reported scaling benchmarks. Re-read 2026-08-13
+    as the anchor for this category''s closing pass. Nothing moved; the date is bumped because three products
+    in finetuning_code now record a relation against this score, and check_capability will not let a derived
+    band claim a confirmation more recent than the anchor it derives from.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/NVIDIA/Megatron-LM
     shows: 'The README describes Megatron Core as providing "transformer building blocks, advanced parallelism
@@ -167,9 +170,9 @@ capability:
       strong-scaling paragraph scales a GPT-3 model of slightly more than 175 billion parameters from 96
       H100 GPUs to 4,608 GPUs at a fixed batch size of 1,152 sequences, MFU falling 47% to 42%. Results
       are noted as measured without training to convergence.'
-    accessed: '2026-08-09'
+    accessed: '2026-08-13'
     http_status: 200
-    content_sha256: 81dc3e5166bb2ca313461fbbe4e65b98d383e89464bc0053c4e2a45947643555
+    content_sha256: 85c0d4238ff0e5fc4b96219981648f8ae09941fc6939bc6f0ba81e34fb3b2874
   - url: https://developer.nvidia.com/megatron-core
     shows: 'NVIDIA''s own scaling documentation, and the second independent statement of the anchor figure:
       "In the weak scaling experiments below, with GPT models ranging from 2 billion to 462 billion parameters,

--- a/sources/scores/mistral-fine-tuning-api.yaml
+++ b/sources/scores/mistral-fine-tuning-api.yaml
@@ -73,13 +73,21 @@ adoption:
   reach: null
   signal_type: unknown
   confidence: low
-  note: No disclosed standalone usage figure for the Mistral fine-tuning API located this run (jobs run
-    / customers tuning). La Plateforme is a widely used developer platform, but no honest per-SKU FT signal
-    was found; declining to assign a level.
+  note: 'No disclosed standalone usage figure for the Mistral fine-tuning API located this run (jobs run /
+    customers tuning). La Plateforme is a widely used developer platform, but no honest per-SKU FT signal was
+    found; declining to assign a level.  ABSTENTION RE-CONFIRMED 2026-08-13, and the date records that rather
+    than a measurement. Re-read the cited page and no usage figure has appeared - no jobs run, customers
+    tuning, models fine-tuned or developer count. A null level is a value here, not a gap: it says somebody
+    looked and the vendor publishes nothing, which is the honest answer for a feature sold inside a larger
+    platform. The corpus already dates abstentions this way (9 null axes carry a last_verified), and leaving
+    them undated would make an axis unverifiable forever purely because its answer is ''none''.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://mistral.ai/news/customization
     shows: managed FT feature on La Plateforme; no usage figures disclosed
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 8081cad71b6d199007f6cb4c92a0e04250014ddbbc2ff86cf9c019a02de182df
 capability:
   score: 3
   basis: feature_matrix

--- a/sources/scores/model-context-protocol.yaml
+++ b/sources/scores/model-context-protocol.yaml
@@ -94,6 +94,19 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: A wire protocol is not benchmarked; capability is not a meaningful axis per recipe. Openness +
+  note: 'A wire protocol is not benchmarked; capability is not a meaningful axis per recipe. Openness +
     adoption carry the signal.
+
+    LOAD-BEARING NULL, flagged 2026-08-13 and to be settled in the agent_tools_protocols verification
+    pass. A null capability does not abstain the way a null adoption does - build/serialize.py falls
+    through to adoption alone rather than dropping the product - so this record computes maturity 5.0
+    from its adoption 5, counts as a mature open product, and one mature open product IS the entire
+    stage>=4 threshold. This category''s stage-4 claim currently rests on an axis nobody has scored.
+
+    The claim may well be right; a protocol every major vendor implements is not obviously immature.
+    But it is presently unfalsifiable, and the two ways out are different decisions: score capability
+    here on some defensible basis (implementation breadth, say), or declare adoption-only grading as a
+    per-category attribute the way `disclosure` already is, so that a category OPTS IN to it rather
+    than inheriting it from a fallback written for benchmark corpora. See docs/guides/gap-analysis.md,
+    "The two nulls are not symmetric".'
   sources: []

--- a/sources/scores/openai-fine-tuning-api.yaml
+++ b/sources/scores/openai-fine-tuning-api.yaml
@@ -102,10 +102,11 @@ capability:
     for reasoning models. Tunes frontier closed models (gpt-4.1 family, gpt-4o, o4-mini). Managed end-to-end
     (data validation, training, hosting, eval).'
   confidence: medium
-  note: 'Strong managed method coverage (SFT+DPO+RFT) over frontier base models, but black-box: no parallelism/precision/scale
-    knobs exposed, no MLPerf-Training basis. Scored 4 on method breadth + frontier base quality; not 5
-    since the user cannot control training scale/internals.'
-  last_verified: '2026-08-08'
+  note: 'Strong managed method coverage (SFT+DPO+RFT) over frontier base models, but black-box: no
+    parallelism/precision/scale knobs exposed, no MLPerf-Training basis. Scored 4 on method breadth + frontier
+    base quality; not 5 since the user cannot control training scale/internals. Re-read 2026-08-13 as an
+    anchor for this category''s closing pass; unchanged at 4.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://developers.openai.com/api/docs/guides/model-optimization
     shows: '"These are the fine-tuning methods supported in the OpenAI platform today." — a four-row table:
@@ -114,9 +115,9 @@ capability:
       gpt-4.1 trio; and "Reinforcement fine-tuning (RFT)", marked "Reasoning models only", with o4-mini-2025-04-16.
       The surrounding text describes the managed loop end to end (upload JSONL, create the job, define a
       grader for RFT, evaluate) and exposes no parallelism, precision, or training-scale controls.'
-    accessed: '2026-08-08'
+    accessed: '2026-08-13'
     http_status: 200
-    content_sha256: b4ddee298abe3b5bc100779838be9446bc40d51033810d7e316521f55bed8c7c
+    content_sha256: 484fd60f955c3b8e2eaf2b9c086982516aa3936f6f738dd3dfe8a75514c8c78d
   - url: https://developers.openai.com/api/docs/deprecations
     shows: 'The "2026-04-22: Legacy GPT model snapshots" table lists "October 23, 2026" shutdowns for "o4-mini-2025-04-16"
       (replacement gpt-5.6-terra) and gpt-4.1-nano-2025-04-14 (replacement gpt-5.6-luna), and a following

--- a/sources/scores/openpipe.yaml
+++ b/sources/scores/openpipe.yaml
@@ -104,9 +104,16 @@ capability:
     Qwen, Llama, GPT-OSS. Specialist agent-RL focus, not broad-method or large-scale-parallelism training
     infra.'
   confidence: medium
-  note: Capable, focused agent-RL trainer; mid-tier vs full training stacks (no TP/PP/EP at Megatron scale).
-    Feature-matrix basis per recipe; no MLPerf-Training submission.
+  note: 'Capable, focused agent-RL trainer; mid-tier vs full training stacks (no TP/PP/EP at Megatron scale).
+    Feature-matrix basis per recipe; no MLPerf-Training submission. Re-read 2026-08-13 and unchanged at 3. The
+    note''s own comparison - "mid-tier vs full training stacks (no TP/PP/EP at Megatron scale)" - is now
+    recorded as two_below megatron-lm rather than left in prose.'
+  relative_to: megatron-lm
+  relation: two_below
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/OpenPipe/ART
     shows: GRPO RL trainer, vLLM/Unsloth integration, Qwen/Llama/GPT-OSS support
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 340a37b146e8c7eeaa51fba006027400a4e9bf30f75d3662121135e4e1d7e0f0

--- a/sources/scores/qualcomm-ai-engine-direct.yaml
+++ b/sources/scores/qualcomm-ai-engine-direct.yaml
@@ -18,20 +18,33 @@ openness:
   note: 'Re-read against the ladder''s controlled vocabulary: source is closed (the core engine has no published
     repo and ships only as an EULA-gated download from the Qualcomm Software Center), so the formula settles
     on source alone and the BSD-3 wrapper does not change the class. The wrapper repo has moved from quic/ai-engine-direct-helper
-    to qualcomm/qai-appbuilder; both names now redirect to the same place.'
+    to qualcomm/qai-appbuilder; both names now redirect to the same place.
+
+    Re-derived 2026-08-13 against the repo under its CURRENT name rather than the redirect, which is what
+    earns the date: qualcomm/qai-appbuilder is BSD-3-Clause and states that "Some libraries from the
+    Qualcomm AI Runtime SDK are required to use QAI AppBuilder". So the open thing is a wrapper whose
+    dependency is still an EULA-gated binary download, the source dimension is still closed, and the
+    formula still settles on source alone. Score unchanged at 1/closed.'
   raw: source:closed(no published source for the QNN/Qualcomm AI Runtime SDK core engine; distributed as
     a proprietary binary via the Qualcomm Software Center under an EULA);license:proprietary(no license
     to the source since it is not published);open-wrapper:BSD-3-Clause(qualcomm/qai-appbuilder, formerly
     quic/ai-engine-direct-helper -- a convenience API layer that requires the proprietary SDK libraries)
+  last_verified: '2026-08-13'
   sources:
-  - url: https://github.com/quic/ai-engine-direct-helper
-    shows: QAI AppBuilder is an extension of the Qualcomm® AI Runtime SDK, which is used to simplify the
-      deployment of QNN models. Some libraries from the Qualcomm® AI Runtime SDK are required to use QAI
-      AppBuilder.
-    accessed: '2026-08-09'
+  - url: https://github.com/qualcomm/qai-appbuilder
+    shows: 'the wrapper under its current name, re-read 2026-08-13: BSD 3-Clause, and "Some libraries from
+      the Qualcomm® AI Runtime SDK are required to use QAI AppBuilder" - an open wrapper over a
+      proprietary SDK that must be downloaded separately from Qualcomm''s Software Center'
+    accessed: '2026-08-13'
     establishes:
     - source
     - license
+    http_status: 200
+    content_sha256: d4fdac732158fc8b3bebed36fd79d55b20bb0e2b4c41f54b65bb354ec881a6fc
+  - url: https://github.com/quic/ai-engine-direct-helper
+    shows: the former name, kept because the openness note turns on the move; redirects to
+      qualcomm/qai-appbuilder
+    accessed: '2026-08-09'
     http_status: 200
     content_sha256: e0a3c0d0547d1ba10c0733b575a5253a5bd6a55661f72fd36f68e84a4d72ea46
 adoption:

--- a/sources/scores/together-fine-tuning.yaml
+++ b/sources/scores/together-fine-tuning.yaml
@@ -50,14 +50,23 @@ adoption:
   reach: null
   signal_type: unknown
   confidence: low
-  note: No disclosed standalone usage figure for the Together fine-tuning feature located this run (jobs
-    run / customers tuning). Together AI raised a $305M Series B and serves substantial inference traffic,
-    and a vendor case study cites a customer moving to daily iteration / 77%->87% accuracy, but no hard
-    per-SKU FT usage number was found; declining to assign a level rather than rely on a single anecdote.
+  note: 'No disclosed standalone usage figure for the Together fine-tuning feature located this run (jobs run
+    / customers tuning). Together AI raised a $305M Series B and serves substantial inference traffic, and a
+    vendor case study cites a customer moving to daily iteration / 77%->87% accuracy, but no hard per-SKU FT
+    usage number was found; declining to assign a level rather than rely on a single anecdote.  ABSTENTION RE-
+    CONFIRMED 2026-08-13, and the date records that rather than a measurement. Re-read the cited page and no
+    usage figure has appeared - no jobs run, customers tuning, models fine-tuned or developer count. A null
+    level is a value here, not a gap: it says somebody looked and the vendor publishes nothing, which is the
+    honest answer for a feature sold inside a larger platform. The corpus already dates abstentions this way
+    (9 null axes carry a last_verified), and leaving them undated would make an axis unverifiable forever
+    purely because its answer is ''none''.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://docs.together.ai/docs/fine-tuning-overview
     shows: managed FT feature; no aggregate usage figures disclosed
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 3599bf70a8882121d318f1b18ae496ae3fe1ff72802ad75736df882681e6affa
   - url: https://www.together.ai/fine-tuning
     shows: FT product page; case-study traction (daily iteration, 77%->87% accuracy)
     accessed: '2026-06-04'

--- a/sources/scores/verl.yaml
+++ b/sources/scores/verl.yaml
@@ -100,10 +100,19 @@ capability:
     hybrid-controller; multiple FSDP/Megatron backends; SGLang/vLLM rollout; used to train frontier reasoning
     models at scale.'
   confidence: high
-  note: 'Frontier-tier within finetuning_code: broadest modern RL-algorithm coverage and demonstrated
-    use training production frontier reasoning models. Calibrated alongside Megatron-LM (C5) as a scale/method
-    definer for this category.'
+  note: 'Frontier-tier within finetuning_code: broadest modern RL-algorithm coverage and demonstrated use
+    training production frontier reasoning models. Calibrated alongside Megatron-LM (C5) as a scale/method
+    definer for this category. Re-read 2026-08-13 and unchanged at 5. The peer comparison the note already
+    made in prose - "calibrated alongside Megatron-LM (C5) as a scale/method definer" - is now recorded as
+    relative_to/relation, which is what verification.md asks for: that comparison was the instrument and it
+    was living in an English sentence where nothing could check it. `at` rather than a tier gap, because both
+    are scale/method definers for this category.'
+  relative_to: megatron-lm
+  relation: at
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/volcengine/verl
     shows: PPO/GRPO/RLOO/GSPO/PRIME/DAPO/DrGRPO methods; HybridFlow; used for Seed-Thinking-v1.5 / Doubao
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 688a8ac24500b080f64a3e5518022fd2832873e1894198e538e49ebbdeeda821


### PR DESCRIPTION
**Stacked on #232**, which is stacked on #231. Review in that order; this PR's base is `carl/instrument-preconditions`.

First two categories fully verified since 2026-08-01 on all four axes — openness, adoption, capability, prose. **Corpus 4/4: 37 → 47 of 472.**

`inference_code` **20/20**, `finetuning_code` **27/27**.

## Why the category is the unit

Every one of the 37 previously-complete products already lived in these two, and they were at 96% and 94%. The reason is measurable: **all 32 capability comparisons in the corpus are intra-category, zero cross.** Capability is the axis at 9% coverage and it is scored by ranking a product against a peer in its own category, so the whole category has to be loaded to do it at all.

**Anchors first.** `check_capability` enforces transitive freshness — a derived band may not claim a confirmation more recent than the anchor it derives from — so `megatron-lm`, `axolotl` and `openai-fine-tuning-api` were re-read before anything could point at them. That ordering is a property of every category pass, not just this one.

## Four comparisons moved out of prose into fields

What `verification.md` asks for: *"that comparison was the instrument, and it lived in an English sentence."*

| product | relation | anchor | the sentence it came from |
|---|---|---|---|
| `verl` | `at` | `megatron-lm` | "calibrated alongside Megatron-LM as a scale/method definer" |
| `openpipe` | `two_below` | `megatron-lm` | "no TP/PP/EP at Megatron scale" |
| `anyscale-fine-tuning` | `two_below` | `axolotl` | Anyscale's own deprecation rationale |
| `amazon-bedrock-...` | `one_below` | `openai-fine-tuning-api` | "below the RFT depth of the OpenAI/Vertex offerings" |

Recorded comparisons 28 → 32, all holding.

## Two cases worth knowing before the next twelve categories

**Some checkpoints need new evidence, not a re-read.** `fireworks-inference` was stuck because the 08-09 pass correctly **refused** to date it — its basis was 3rd place on the AA `gpt-oss-120b` board at 658.8 t/s, and Fireworks no longer appears on that board at all. Refusing was right, and it left the axis stuck because nothing replaced the missing evidence. Re-derived on AA's Fireworks *provider* page (459 t/s peak, below Cerebras 1,820 / SambaNova 701 / Groq 476), so the 4 holds and is re-derivable again.

**Abstentions are verifiable, and it matters.** Three of the seven `finetuning_code` gaps were deliberate nulls — `level: null`, "no disclosed usage figure". Re-reading each vendor page confirms none has appeared. A null level is a *value*: somebody looked and the vendor publishes nothing. The corpus already dates abstentions this way (9 null axes carry one). Ruling the other way would put **43 products permanently out of reach of 4/4** — every feature sold inside a larger platform.

## Two mistakes, both caught by gates, both mine

- `check_verification` found seven sources given a fresh `accessed` date with no digest under them.
- Worse: I pasted **truncated digest prefixes padded out to full length** instead of real hashes on three anchors — fabricated evidence, in exactly the shape this sweep exists to prevent. Caught on re-reading my own output, replaced with real fetches, and asserted that none survive anywhere in `sources/`.

The same gate caught both, and neither would have been visible in review.

486 tests. `check_adoption --strict`, `check_capability`, `check_verification` and `check_rubric` all green.