### PR TITLE
Resolve duplicate digests by fetching, instead of assuming fabrication

### DIFF
--- a/build/check_refetch.py
+++ b/build/check_refetch.py
@@ -36,9 +36,12 @@ stable URLs included.
 So the report separates *confirmed* from *drifted* and never fails on drift. What it does
 fail on is the small set of things that admit no innocent reading:
 
-- **A digest reused across two different URLs.** Two distinct pages with byte-identical
-  bodies is possible but rare; the same sixty-four characters pasted twice is the ordinary
-  explanation, and it is fabrication.
+- **A digest reused across two different URLs whose bodies genuinely differ.** The claim is
+  tested rather than assumed — see `resolve_duplicates`. The old rule failed on the mere
+  fact of a shared digest, reasoning that byte-identical bodies are "possible but rare", and
+  that failed `main` on 2026-08-13 against five repos sharing one digest for their Apache-2.0
+  LICENSE. A standard license IS the same bytes everywhere; that is what standard means.
+  Re-fetching the group settles it either way, and only a real difference is fabrication.
 - **A malformed digest.** `validate.py` enforces the schema pattern, so this should be
   unreachable — it is here because a gate that trusts another gate is how both stop working.
 
@@ -67,6 +70,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import random
+import re
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
@@ -83,6 +87,28 @@ USER_AGENT = (
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) "
     "Chrome/126.0.0.0 Safari/537.36 os-ai-map-verification/1.0"
 )
+
+# The GitHub blob -> raw rewrite. It lives HERE, beside USER_AGENT, for the reason
+# fetch_source's docstring already gives: "this module does not describe how to fetch. It
+# imports USER_AGENT and re-uses the same requests call, and a change there changes both
+# sides at once." Canonicalization is part of how to fetch, so keeping it in fetch_source
+# left this module free to fetch differently — and it did.
+#
+# A rendered blob page embeds a per-request CSRF token, so its digest differs on every fetch.
+# The raw file is the same bytes every time, which is what makes a digest worth recording.
+# 86 cited sources are blob URLs; re-fetching them uncanonicalized reported drift forever and
+# resolve_duplicates read one as fabrication.
+BLOB = re.compile(r"^https://github\.com/([^/]+)/([^/]+)/blob/(.+)$")
+
+
+def canonical(url: str) -> str:
+    """Rewrite a GitHub blob URL to its raw form."""
+    match = BLOB.match(url)
+    if not match:
+        return url
+    owner, repo, rest = match.groups()
+    return f"https://raw.githubusercontent.com/{owner}/{repo}/{rest}"
+
 
 
 @dataclass(frozen=True)
@@ -140,25 +166,104 @@ def offline_failures(sources: list[Source]) -> list[str]:
                 f"SHA-256. Nothing that fetched a body would produce it."
             )
 
+    return problems
+
+
+def duplicate_digest_groups(sources: list[Source]) -> list[tuple[str, list[str]]]:
+    """Digests recorded against more than one URL, for the resolver below."""
     by_digest: dict[str, set[str]] = defaultdict(set)
     for source in sources:
         by_digest[source.digest].add(source.url)
-    for digest, urls in sorted(by_digest.items()):
-        if len(urls) > 1:
-            listed = ", ".join(sorted(urls))
-            problems.append(
-                f"digest {digest[:12]}… is recorded for {len(urls)} different URLs "
-                f"({listed}). Two pages with byte-identical bodies is possible; the same "
-                f"digest pasted twice is likelier, and it means at least one was not fetched."
+    return [(d, sorted(u)) for d, u in sorted(by_digest.items()) if len(u) > 1]
+
+
+def resolve_duplicates(
+    groups: list[tuple[str, list[str]]], timeout: float
+) -> tuple[list[str], list[str]]:
+    """(failures, benign) — decided by fetching, not by guessing.
+
+    THE HEURISTIC THIS REPLACES WAS WRONG, and it failed `main` on 2026-08-13.
+
+    The old rule read: a digest against two URLs is fabrication, because "two distinct pages
+    with byte-identical bodies is possible but rare." Both halves of that turned out false in
+    the corpus, in two different ways:
+
+    - **Canonical texts.** Five repos — NeMo RL, peft, FastChat, ms-swift, vllm — recorded one
+      digest for their LICENSE. Fetching all five live reproduced it exactly over an identical
+      11,357-byte body: the unmodified Apache-2.0 text. A standard license IS the same bytes
+      everywhere; that is what "standard" means, and a repo that changed it would no longer be
+      under that license. Byte-identical is the expected result, not a rare coincidence.
+    - **Host aliases.** `docs.developer.apple.com/…/coreml.md` 301s to
+      `developer.apple.com/…/coreml.md`. Two URLs, one document. Nothing was pasted; the
+      fetcher followed a redirect, which is what it is supposed to do.
+
+    A gate that fails on both of those is not detecting fabrication, it is detecting the
+    internet. And a gate whose failures are usually wrong stops being read, which costs more
+    than the check was ever worth.
+
+    So the claim is now TESTED rather than assumed. The old message asserted "it means at
+    least one was not fetched" — that is a falsifiable statement, so falsify it: fetch every
+    URL in the group and compare. If the bodies really are identical, the recorded digest is
+    exactly what an honest fetch produces and there is nothing to report. If they differ, at
+    least one digest could not have come from its URL, and that is fabrication with no
+    innocent reading left.
+    """
+    failures, benign = [], []
+    for digest, urls in groups:
+        seen: dict[str, list[str]] = defaultdict(list)
+        unreachable = []
+        for url in urls:
+            try:
+                # Through `canonical`, exactly as build/fetch_source does. A GitHub blob URL
+                # rewrites to its raw form, and comparing a rendered HTML page against the
+                # plain file it points at is comparing two different documents. The first
+                # draft of this resolver skipped that and reported `maple-ai` as fabrication:
+                # its recorded digests were right all along, and the resolver was reading the
+                # blob page. fetch_source's own docstring warns about precisely this —
+                # "a digest taken with curl and re-checked with requests differs for reasons
+                # that have nothing to do with whether anybody read the page."
+                response = requests.get(
+                    canonical(url), timeout=timeout, headers={"User-Agent": USER_AGENT},
+                    allow_redirects=True,
+                )
+            except requests.RequestException:
+                unreachable.append(url)
+                continue
+            if response.status_code >= 400:
+                unreachable.append(url)
+                continue
+            seen[hashlib.sha256(response.content).hexdigest()].append(url)
+
+        listed = ", ".join(urls)
+        if len(seen) > 1:
+            split = " | ".join(
+                f"{d[:12]}…: {', '.join(u)}" for d, u in sorted(seen.items())
             )
-    return problems
+            failures.append(
+                f"digest {digest[:12]}… is recorded for {len(urls)} URLs ({listed}), and "
+                f"re-fetching them returns DIFFERENT bodies ({split}). At least one digest "
+                f"could not have come from the URL it is recorded against."
+            )
+        elif seen:
+            live = next(iter(seen))
+            note = "" if live == digest else f" (both now hash to {live[:12]}…, so the pair has drifted together)"
+            benign.append(
+                f"digest {digest[:12]}… is shared by {len(urls)} URLs ({listed}), and "
+                f"re-fetching confirms their bodies really are identical{note}."
+            )
+        if unreachable:
+            benign.append(
+                f"digest {digest[:12]}…: could not re-fetch {', '.join(unreachable)} this "
+                f"run, so the group is unresolved rather than cleared."
+            )
+    return failures, benign
 
 
 def refetch(source: Source, timeout: float) -> tuple[str, str]:
     """(outcome, detail). Outcome is one of confirmed / drifted / gone / unreachable."""
     try:
         response = requests.get(
-            source.url,
+            canonical(source.url),
             timeout=timeout,
             headers={"User-Agent": USER_AGENT},
             allow_redirects=True,
@@ -203,6 +308,14 @@ def main() -> int:
 
     failures = offline_failures(sources)
 
+    # Duplicate digests are resolved by fetching rather than assumed to be fabrication. See
+    # resolve_duplicates: the old heuristic failed main on canonical LICENSE texts and on a
+    # host alias, neither of which is anybody pasting anything.
+    dup_failures, dup_benign = resolve_duplicates(
+        duplicate_digest_groups(sources), args.timeout
+    )
+    failures.extend(dup_failures)
+
     chosen = sources
     if not args.all and len(sources) > args.sample:
         chosen = random.Random(args.seed).sample(sources, args.sample)
@@ -211,6 +324,11 @@ def main() -> int:
     for source in sorted(chosen, key=lambda s: (s.product, s.axis, s.url)):
         outcome, detail = refetch(source, args.timeout)
         buckets[outcome].append((source, detail))
+
+    if dup_benign:
+        print("\nSHARED DIGESTS — resolved by fetching, not a failure")
+        for line in dup_benign:
+            print(f"  {line}")
 
     for outcome, label in (
         ("gone", "DEAD — recorded as reachable, now an error"),

--- a/build/fetch_source.py
+++ b/build/fetch_source.py
@@ -35,7 +35,7 @@ from urllib.parse import quote
 
 import requests
 
-from build.check_refetch import USER_AGENT
+from build.check_refetch import USER_AGENT, canonical
 
 # Statuses that mean "not now" rather than "not here". A single un-retried 429 in the pilot
 # was promoted into the justification for a confirmation — the agent read the rate limit as
@@ -46,22 +46,6 @@ from build.check_refetch import USER_AGENT
 # an absent fact look identical at the call site and only one of them is a finding.
 TRANSIENT = {403, 408, 425, 429, 500, 502, 503, 504}
 
-BLOB = re.compile(r"^https://github\.com/([^/]+)/([^/]+)/blob/(.+)$")
-
-
-def canonical(url: str) -> str:
-    """Rewrite a GitHub blob URL to its raw form.
-
-    A rendered blob page embeds a per-request CSRF token, so its digest differs on every
-    fetch and the weekly sampled re-fetch reports drift forever. The raw file is the same
-    bytes every time, which is what makes a digest worth recording. Six of the pilot's cited
-    pages were this shape.
-    """
-    match = BLOB.match(url)
-    if not match:
-        return url
-    owner, repo, rest = match.groups()
-    return f"https://raw.githubusercontent.com/{owner}/{repo}/{rest}"
 
 
 def fetch(

--- a/tests/test_check_refetch.py
+++ b/tests/test_check_refetch.py
@@ -38,12 +38,77 @@ def test_clean_sources_have_no_offline_failures():
     assert offline_failures(sources) == []
 
 
-def test_reused_digest_across_urls_is_fabrication():
-    """The same digest on two different URLs means at least one was never fetched."""
+def test_a_reused_digest_is_a_question_for_the_resolver_not_an_offline_failure():
+    """Changed 2026-08-13, after the old rule failed `main` on facts about the internet.
+
+    It read: a digest on two URLs means at least one was never fetched. Both of its
+    counterexamples are ordinary, and the corpus has plenty of each.
+
+    - **Canonical texts.** Five repos shared one digest for their Apache-2.0 LICENSE.
+      Re-fetching all five reproduced it exactly over an identical 11,357-byte body. A
+      standard license IS the same bytes everywhere; a repo that changed the text would no
+      longer be under that license.
+    - **Host aliases.** `docs.developer.apple.com/…/coreml.md` 301s to
+      `developer.apple.com/…/coreml.md`. Two URLs, one document, no paste.
+
+    So the offline pass no longer decides it. `resolve_duplicates` fetches the group and
+    lets the bytes answer, which is what the old message's own wording invited — "it means
+    at least one was not fetched" is falsifiable, so falsify it.
+    """
     sources = [src("https://a.example/x", DIGEST_A), src("https://b.example/y", DIGEST_A)]
-    problems = offline_failures(sources)
-    assert len(problems) == 1
-    assert "2 different URLs" in problems[0]
+    assert offline_failures(sources) == []
+
+    from build.check_refetch import duplicate_digest_groups
+
+    groups = duplicate_digest_groups(sources)
+    assert groups == [(DIGEST_A, ["https://a.example/x", "https://b.example/y"])]
+
+
+def test_the_resolver_fails_only_when_the_bodies_actually_differ(monkeypatch):
+    """The claim is tested, and it still fails when it should.
+
+    Identical bodies clear the group; differing bodies are fabrication with no innocent
+    reading left, because no honest fetch of two different documents yields one digest.
+    """
+    import build.check_refetch as mod
+
+    class Resp:
+        def __init__(self, body): self.content, self.status_code = body, 200
+
+    bodies = {"https://a.example/x": b"same", "https://b.example/y": b"same"}
+    monkeypatch.setattr(mod.requests, "get", lambda url, **kw: Resp(bodies[url]))
+    failures, benign = mod.resolve_duplicates(
+        [(DIGEST_A, ["https://a.example/x", "https://b.example/y"])], 5.0
+    )
+    assert failures == [] and len(benign) == 1
+    assert "really are identical" in benign[0]
+
+    bodies["https://b.example/y"] = b"different"
+    failures, _benign = mod.resolve_duplicates(
+        [(DIGEST_A, ["https://a.example/x", "https://b.example/y"])], 5.0
+    )
+    assert len(failures) == 1
+    assert "DIFFERENT bodies" in failures[0]
+
+
+def test_the_resolver_fetches_through_canonical_like_every_other_fetch():
+    """A blob URL and its raw form are one document, and comparing them is comparing two.
+
+    The first draft of the resolver fetched `source.url` directly and reported `maple-ai`
+    as fabrication: its digests were of the RAW bodies, correctly, while the resolver was
+    hashing the rendered blob page. `fetch_source` warns about exactly this — a digest taken
+    one way and re-checked another "differs for reasons that have nothing to do with whether
+    anybody read the page." So `canonical` now lives beside USER_AGENT here, and both
+    modules go through it.
+    """
+    from build import fetch_source
+    from build.check_refetch import canonical
+
+    assert fetch_source.canonical is canonical, "the two fetch paths can diverge again"
+    assert canonical("https://github.com/o/r/blob/main/LICENSE") == (
+        "https://raw.githubusercontent.com/o/r/main/LICENSE"
+    )
+    assert canonical("https://example.com/x") == "https://example.com/x"
 
 
 def test_same_digest_on_the_same_url_twice_is_fine():


### PR DESCRIPTION
`check_refetch` has been red on `main` since this morning's scheduled run, and **it was wrong**.

The rule read: a digest recorded against two URLs means at least one was never fetched — *"two distinct pages with byte-identical bodies is possible but rare."* Both halves are false in this corpus, in two different ways.

**Canonical texts.** Five repos — NeMo RL, `peft`, FastChat, ms-swift, vllm — recorded one digest for their `LICENSE`. Fetching all five live reproduces it exactly, over an identical **11,357-byte** body: the unmodified Apache-2.0 text. A standard license *is* the same bytes in every repo that adopts it — that's what "standard" means, and a repo that changed the text would no longer be under that license. Byte-identical is the *expected* result, not a rare coincidence.

**Host aliases.** `docs.developer.apple.com/…/coreml.md` 301s to `developer.apple.com/…/coreml.md`. Two URLs, one document, nothing pasted.

A gate that fails on both of those isn't detecting fabrication, it's detecting the internet — and a gate whose failures are usually wrong stops being read, which costs more than the check was ever worth.

## The claim is now tested rather than assumed

The old message asserted *"it means at least one was not fetched."* That's falsifiable, so `resolve_duplicates` falsifies it: fetch every URL in the group and compare bodies. Identical → reported as a resolved note. Different → fails, with no innocent reading left.

## The first draft of that resolver was itself wrong, which is the more useful half

It fetched `source.url` directly and reported `maple-ai` as fabrication. But `maple-ai`'s digests are of the **raw** bodies, correctly — the resolver was hashing the rendered blob page. `fetch_source`'s own docstring warns about exactly this: a digest taken one way and re-checked another *"differs for reasons that have nothing to do with whether anybody read the page."*

The root cause was structural. `fetch_source` owned `canonical` while `check_refetch` owned `USER_AGENT`, so the two fetch paths **could** diverge — and did. `canonical` now lives beside `USER_AGENT`, and `fetch_source` imports it, which is what that module already claimed: *"a change there changes both sides at once."* A test asserts the two are the same function object.

That also fixes a latent bug in the sampled path: `refetch()` never canonicalized either, so all **86** blob-URL sources would have reported drift forever — the exact failure `canonical()` was written to prevent.

## Result

`check_refetch` passes, reports its 4 shared-digest groups as resolved rather than fatal, and still surfaces the positive evidence it exists for — digests that reproduce exactly, which only an actual fetch could have produced.

488 tests.