### PR TITLE
Verify dataset_processing_tools: 20/21 products to 4/4

### DIFF
--- a/sources/products/bigcode-dataset.yaml
+++ b/sources/products/bigcode-dataset.yaml
@@ -5,5 +5,6 @@ description: Preprocessing, quality filtering, decontamination, and PII detectio
   code corpora. The filtering and PII pipeline behind The Stack and StarCoder training data.
 github:
 - url: https://github.com/bigcode-project/bigcode-dataset
-comments: BigCode bigcode-dataset; Apache-2.0 confirmed live 2026-07-21, but maintenance-quiet (last push
-  2024-08). Built the filtering + PII pipeline behind The Stack / StarCoder.
+comments: BigCode bigcode-dataset, maintenance-quiet since August 2024. Built the filtering and PII
+  pipeline behind The Stack and StarCoder. Verified 2026-08-13 via the GitHub README and
+  the LICENSE body.

--- a/sources/products/ccnet.yaml
+++ b/sources/products/ccnet.yaml
@@ -5,6 +5,7 @@ description: 'The CCNet pipeline: downloads and cleans Common Crawl into high-qu
   via language identification, KenLM perplexity filtering, and deduplication. Built CC-100.'
 github:
 - url: https://github.com/facebookresearch/cc_net
-comments: Meta facebookresearch/cc_net; MIT, ARCHIVED read-only 2023-10-31 (no longer maintained). Foundational
-  Common Crawl pipeline that built CC-100 and seeded the perplexity-filtering approach reused across later
-  multilingual corpora.
+comments: Meta facebookresearch/cc_net, archived read-only 2023-10-31 and no longer maintained.
+  Foundational Common Crawl pipeline that built CC-100 and seeded the perplexity-filtering
+  approach reused across later multilingual corpora. Verified 2026-08-13 via the GitHub
+  README and the LICENSE body.

--- a/sources/products/data-juicer.yaml
+++ b/sources/products/data-juicer.yaml
@@ -7,5 +7,5 @@ github:
 - url: https://github.com/datajuicer/data-juicer
 pypi:
 - url: https://pypi.org/project/py-data-juicer
-comments: Alibaba Data-Juicer (datajuicer/data-juicer, formerly modelscope); Apache-2.0, very active (v1.5.3,
-  Jun 2026). PyPI package py-data-juicer. 200+ operators for multimodal LLM data processing.
+comments: Alibaba Data-Juicer (datajuicer/data-juicer, formerly modelscope); PyPI package
+  py-data-juicer. Verified 2026-08-13 via the GitHub README and the LICENSE body.

--- a/sources/products/datamap-rs.yaml
+++ b/sources/products/datamap-rs.yaml
@@ -5,5 +5,5 @@ description: Rust JSONL map-filter-annotate pipeline for cleaning and filtering 
   data-cleaning stage of the Dolma 3 pipeline.
 github:
 - url: https://github.com/allenai/datamap-rs
-comments: Ai2 datamap-rs; repo active (pushed 2026-03), Apache-2.0 confirmed live 2026-07-21. Cleaning/filtering
-  stage of the Dolma 3 pipeline behind OLMo 3.
+comments: Ai2 datamap-rs, the cleaning and filtering stage of the Dolma 3 pipeline behind OLMo 3.
+  Verified 2026-08-13 via the GitHub README and the LICENSE body.

--- a/sources/products/datatrove.yaml
+++ b/sources/products/datatrove.yaml
@@ -8,5 +8,5 @@ github:
 - url: https://github.com/huggingface/datatrove
 pypi:
 - url: https://pypi.org/project/datatrove
-comments: Hugging Face datatrove; repo active (v0.9.0, 2026-03-04), Apache-2.0 confirmed live 2026-07-21.
-  Built FineWeb, FineWeb-Edu, FineWeb-2, and FineMath; the de-facto open pretraining-data processing pipeline.
+comments: Built FineWeb, FineWeb-Edu, FineWeb-2 and FineMath; the de-facto open pretraining-data
+  processing pipeline. Verified 2026-08-13 via the GitHub README and the LICENSE body.

--- a/sources/products/datology-ai.yaml
+++ b/sources/products/datology-ai.yaml
@@ -4,7 +4,8 @@ type: software
 description: 'Automated training-data curation platform: deduplication, model-based quality filtering,
   embedding-based selection and pruning, data ordering, and synthetic-data steps for text and multimodal
   pretraining corpora.'
-comments: DatologyAI, proprietary curation platform deployed into customer VPC; no source-available product.
-  Founded 2023 by Ari Morcos (ex-FAIR/DeepMind) and Matthew Leavitt (ex-MosaicML). ~$57.5M raised (seed
-  + $46M Series A); angels include Jeff Dean and Yann LeCun. No named frontier-lab customers disclosed.
-  Confirmed 2026-07-21.
+comments: DatologyAI, a proprietary curation platform deployed into the customer's own cloud; no
+  source-available product. Founded 2023 by Ari Morcos (ex-FAIR/DeepMind) and Matthew
+  Leavitt (ex-MosaicML). ~$57.5M raised (seed plus a $46M Series A in May 2024); angels
+  include Jeff Dean and Yann LeCun. No named frontier-lab customers disclosed. Verified
+  2026-08-13 via datologyai.com.

--- a/sources/products/dclm.yaml
+++ b/sources/products/dclm.yaml
@@ -5,6 +5,6 @@ description: 'The DataComp-LM toolkit and competition harness: a standardized Co
   training recipes, a 50+ task eval suite, and the reference curation pipeline that produces DCLM-baseline.'
 github:
 - url: https://github.com/mlfoundations/dclm
-comments: mlfoundations/dclm; MIT, active (last push 2025-09). Not on PyPI (installs from source, includes
-  a Rust component). This is the DataComp-LM benchmark framework itself, which the capability scores of
-  datatrove/NeMo Curator/Dolma are measured against.
+comments: Not on PyPI - installs from source and includes a Rust component. The DataComp-LM
+  benchmark framework itself, which the capability scores of datatrove, NeMo Curator and
+  Dolma are measured against. Verified 2026-08-13 via GitHub and the repository README.

--- a/sources/products/decon.yaml
+++ b/sources/products/decon.yaml
@@ -5,5 +5,5 @@ description: Decontamination tool that flags and removes training documents over
   The decontamination stage of the Dolma 3 pipeline.
 github:
 - url: https://github.com/allenai/decon
-comments: Ai2 decon; repo active (pushed 2026-03), Apache-2.0 confirmed live 2026-07-21. Train/eval decontamination
-  stage of the Dolma 3 pipeline behind OLMo 3.
+comments: Ai2 decon, the train/eval decontamination stage of the Dolma 3 pipeline behind OLMo 3.
+  Verified 2026-08-13 via the GitHub README and the LICENSE body.

--- a/sources/products/distilabel.yaml
+++ b/sources/products/distilabel.yaml
@@ -10,6 +10,6 @@ pypi:
 artifact_exceptions:
   pypi_repo_mismatch: The package metadata names argilla/distilabel, which no longer resolves; Argilla's org
     is argilla-io and that is where the repo lives. Upstream metadata is stale, our declaration is current.
-comments: Argilla/Hugging Face distilabel; latest release v1.5.3 (2025-01-28), repo active into 2026,
-  Apache-2.0 confirmed live 2026-07-21. Used to build the Zephyr/Notus preference data and the FinePersonas
-  dataset.
+comments: Used to build the Zephyr/Notus preference data and the FinePersonas dataset. The README
+  now states that the original authors have moved on and that community collaborators
+  maintain the project. Verified 2026-08-13 via the GitHub README and the LICENSE body.

--- a/sources/products/dolma-toolkit.yaml
+++ b/sources/products/dolma-toolkit.yaml
@@ -8,6 +8,6 @@ github:
 - url: https://github.com/allenai/dolma
 pypi:
 - url: https://pypi.org/project/dolma
-comments: Ai2 Dolma toolkit (allenai/dolma), distinct from the Dolma dataset artifact; repo active (v1.2.1,
-  2025-07-07), Apache-2.0 confirmed live 2026-07-21. Built the Dolma corpus and OLMo/OLMoE pretraining
-  mixes.
+comments: Ai2 Dolma toolkit (allenai/dolma), distinct from the Dolma dataset artifact. Built the
+  Dolma corpus and the OLMo/OLMoE pretraining mixes. Verified 2026-08-13 via the GitHub
+  README and the LICENSE body.

--- a/sources/products/duplodocus.yaml
+++ b/sources/products/duplodocus.yaml
@@ -5,5 +5,5 @@ description: 'Rust deduplication tool for large text corpora: exact and fuzzy Mi
   stage of the Dolma 3 pipeline.'
 github:
 - url: https://github.com/allenai/duplodocus
-comments: Ai2 duplodocus; repo active (pushed 2026-03), Apache-2.0 confirmed live 2026-07-21. Deduplication
-  stage of the Dolma 3 pipeline behind OLMo 3.
+comments: Ai2 duplodocus, the deduplication stage of the Dolma 3 pipeline behind OLMo 3. Verified
+  2026-08-13 via the GitHub README and the LICENSE body.

--- a/sources/products/marin-framework.yaml
+++ b/sources/products/marin-framework.yaml
@@ -6,6 +6,6 @@ description: 'Open framework for reproducible foundation-model development that 
   and experiment/mixture orchestration. Distinct from the Marin model it produces.'
 github:
 - url: https://github.com/marin-community/marin
-comments: Stanford CRFM / Marin community framework (marin-community/marin), distinct from the Marin model
-  artifact on HF; repo very active (~9.5k commits), Apache-2.0 confirmed live 2026-07-21. Contains no
-  weights; produces the Marin 8B model.
+comments: Stanford CRFM / Marin community framework (marin-community/marin), distinct from the
+  Marin model artifact on HF. Contains no weights; produces the Marin 8B model. Verified
+  2026-08-13 via the GitHub README and the LICENSE body.

--- a/sources/products/nemo-curator.yaml
+++ b/sources/products/nemo-curator.yaml
@@ -8,5 +8,6 @@ github:
 - url: https://github.com/NVIDIA-NeMo/Curator
 pypi:
 - url: https://pypi.org/project/nemo-curator
-comments: NVIDIA NeMo Curator; repo actively maintained (v1.2.0, 2026-05-14), Apache-2.0 confirmed live
-  2026-07-21. Powers the Nemotron-CC curation pipeline and Nemotron-4 data prep (8T+ multilingual tokens).
+comments: Powers the Nemotron-CC curation pipeline and Nemotron-4 data prep (8T+ multilingual
+  tokens). The repo now lives at NVIDIA-NeMo/Curator and the older NVIDIA/NeMo-Curator
+  path redirects to it. Verified 2026-08-13 via the GitHub README and the LICENSE body.

--- a/sources/products/nemo-data-designer.yaml
+++ b/sources/products/nemo-data-designer.yaml
@@ -1,10 +1,11 @@
 name: nemo-data-designer
 display_name: NVIDIA NeMo Data Designer
 type: software
-description: NVIDIA's proprietary synthetic-data generation service for building structured and unstructured
-  training data with transformation and augmentation workflows. The productized form of Gretel's technology
-  after NVIDIA's 2025 acquisition.
-comments: NVIDIA NeMo Data Designer (NeMo microservices), proprietary. Represents the synthetic-data capability
-  of Gretel, which NVIDIA acquired in March 2025; the Gretel brand is retired (gretel.ai redirects to
-  NVIDIA) and the gretel-synthetics OSS repo (Apache-2.0) was archived Feb 2026. Substituted for Gretel,
-  which no longer exists as a standalone product. Confirmed 2026-07-21.
+description: Generates synthetic datasets from scratch or from seed data using statistical samplers,
+  dependency-aware generation across correlated fields, Python/SQL/custom validators and
+  LLM-as-a-judge scoring. Published as the Apache-2.0 data-designer library; the NeMo Platform
+  runs the same configurations as a managed service.
+comments: The productized form of Gretel's technology after NVIDIA's 2025 acquisition; the Gretel
+  brand is retired (gretel.ai redirects to NVIDIA) and the gretel-synthetics OSS repo was
+  archived February 2026. Substituted for Gretel, which no longer exists as a standalone
+  product. Verified 2026-08-13 via the NVIDIA NeMo product page and the DataDesigner README.

--- a/sources/products/nemo-data-designer.yaml
+++ b/sources/products/nemo-data-designer.yaml
@@ -5,6 +5,8 @@ description: Generates synthetic datasets from scratch or from seed data using s
   dependency-aware generation across correlated fields, Python/SQL/custom validators and
   LLM-as-a-judge scoring. Published as the Apache-2.0 data-designer library; the NeMo Platform
   runs the same configurations as a managed service.
+pypi:
+- url: https://pypi.org/project/data-designer/
 comments: The productized form of Gretel's technology after NVIDIA's 2025 acquisition; the Gretel
   brand is retired (gretel.ai redirects to NVIDIA) and the gretel-synthetics OSS repo was
   archived February 2026. Substituted for Gretel, which no longer exists as a standalone

--- a/sources/products/olmocr.yaml
+++ b/sources/products/olmocr.yaml
@@ -8,5 +8,5 @@ github:
 - url: https://github.com/allenai/olmocr
 pypi:
 - url: https://pypi.org/project/olmocr
-comments: Ai2 olmOCR; repo active (v0.4.27, 2026-03-12), Apache-2.0 confirmed live 2026-07-21. High-profile
-  document-extraction tool (19k+ GitHub stars); feeds the Dolma 3 pipeline.
+comments: Feeds the Dolma 3 PDF-extraction path and ships its own olmOCR-Bench suite. Verified
+  2026-08-13 via the GitHub README and the LICENSE body.

--- a/sources/products/redpajama-data.yaml
+++ b/sources/products/redpajama-data.yaml
@@ -6,5 +6,6 @@ description: 'The RedPajama construction and quality-signal pipeline: quality cl
   (30T tokens, 5 languages).'
 github:
 - url: https://github.com/togethercomputer/RedPajama-Data
-comments: Together togethercomputer/RedPajama-Data; Apache-2.0, dormant since Dec 2024. The construction
-  pipeline (not the dataset) behind RedPajama-v2 and the RedPajama-INCITE models.
+comments: Together togethercomputer/RedPajama-Data, dormant since December 2024. The construction
+  pipeline, not the dataset, behind RedPajama-v2 and the RedPajama-INCITE models. Verified
+  2026-08-13 via the GitHub README and the LICENSE body.

--- a/sources/products/smallpond.yaml
+++ b/sources/products/smallpond.yaml
@@ -7,6 +7,6 @@ github:
 - url: https://github.com/deepseek-ai/smallpond
 pypi:
 - url: https://pypi.org/project/smallpond
-comments: DeepSeek smallpond; MIT confirmed live 2026-07-21, but effectively dormant (no repo commits
-  since 2025-03). A rare open data-infra release from an otherwise closed-data lab; strong launch-driven
-  star count, thin sustained use.
+comments: DeepSeek smallpond, effectively dormant - no repo commits since March 2025. A rare open
+  data-infra release from an otherwise closed-data lab; strong launch-driven star count,
+  thin sustained use. Verified 2026-08-13 via the GitHub README and the LICENSE body.

--- a/sources/products/the-pile-pipeline.yaml
+++ b/sources/products/the-pile-pipeline.yaml
@@ -5,6 +5,6 @@ description: 'The original documented-corpus construction pipeline: downloads, c
   and formats 22 components into The Pile. Distinct from the released Pile dataset.'
 github:
 - url: https://github.com/EleutherAI/the-pile
-comments: EleutherAI the-pile construction code (distinct from the Pile dataset); MIT confirmed live 2026-07-21
-  but frozen (last push 2023-04). The canonical documented-corpus construction reference; underpinned
-  GPT-Neo/GPT-J/Pythia.
+comments: EleutherAI the-pile construction code, distinct from the Pile dataset, and frozen since
+  April 2023. The canonical documented-corpus construction reference; underpinned GPT-Neo,
+  GPT-J and Pythia. Verified 2026-08-13 via the GitHub README and the LICENSE body.

--- a/sources/products/txt360-pipeline.yaml
+++ b/sources/products/txt360-pipeline.yaml
@@ -6,6 +6,7 @@ description: 'Construction pipeline for the TxT360 open pretraining corpus: glob
   dataset.'
 github:
 - url: https://github.com/LLM360/TxT360
-comments: LLM360 TxT360 pipeline code (distinct from the dataset on HF); reference/replication drop, last
-  push 2024-12. README asserts Apache-2.0 but the repo ships NO LICENSE file (GitHub reports null) --
-  scored open_source on the asserted license + LLM360's open track record, with the missing file flagged.
+comments: LLM360 TxT360 pipeline code, distinct from the dataset on HF; a reference/replication drop,
+  last push December 2024. The README badge asserts Apache-2.0 but the repo ships no LICENSE
+  file and the GitHub API reports a null license, which is why openness abstains rather than
+  scoring it open. Verified 2026-08-13 via the GitHub README and the repository API.

--- a/sources/products/ungoliant.yaml
+++ b/sources/products/ungoliant.yaml
@@ -5,5 +5,6 @@ description: 'Rust pipeline that generates the OSCAR corpus from Common Crawl WE
   filtering, and metadata annotation. The official OSCAR / Colossal-OSCAR construction pipeline.'
 github:
 - url: https://github.com/oscar-project/ungoliant
-comments: OSCAR project Ungoliant; Apache-2.0 confirmed live 2026-07-21 (v2.0.0, still receiving commits).
-  The pipeline that produces the OSCAR / Colossal-OSCAR multilingual corpora.
+comments: OSCAR project Ungoliant, still receiving commits (last push November 2025). The pipeline
+  that produces the OSCAR / Colossal-OSCAR multilingual corpora. Verified 2026-08-13 via
+  the GitHub README and the LICENSE body.

--- a/sources/scores/bigcode-dataset.yaml
+++ b/sources/scores/bigcode-dataset.yaml
@@ -16,13 +16,30 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (Apache-2.0), full source public.
+  note: Fully OSI-licensed (Apache-2.0), full source public. Re-read 2026-08-13 - the LICENSE body still
+    carries the same license and the README still builds the whole product from the published repo, with
+    no paid tier, enterprise edition or license key anywhere in it.
   raw: license:Apache-2.0(OSI);source:public(bigcode-project/bigcode-dataset);governance:BigCode;no feature-gated
     core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/bigcode-project/bigcode-dataset/blob/main/LICENSE
     shows: Apache License Version 2.0 text
-    accessed: '2026-07-21'
+    accessed: '2026-08-13'
+    establishes:
+    - license
+    http_status: 200
+    content_sha256: b40930bbcf80744c86c46a12bc9da056641d722716c378f5659b9e555ef833e1
+  - url: https://raw.githubusercontent.com/bigcode-project/bigcode-dataset/main/README.md
+    shows: README documents the whole pipeline building and installing from the published
+      repo; no paid tier, enterprise edition or license key appears anywhere in it, so
+      nothing is withheld from the source
+    accessed: '2026-08-13'
+    establishes:
+    - source
+    - core-gated
+    http_status: 200
+    content_sha256: d5f7c72860f0ecd247837dd6c470c1d5f3632a00da7b4314499da6cca79bd6a6
 adoption:
   level: 1
   reach: <1K stars
@@ -46,8 +63,13 @@ capability:
   value: Quality filtering (line length, alphanumeric %), decontamination, and PII detection/anonymization
     for code corpora.
   confidence: medium
-  note: Solid code-corpus curation coverage; specialized to code, not actively developed.
+  note: Solid code-corpus curation coverage; specialized to code, not actively developed. Re-read 2026-08-13
+    - the README still describes the feature set above.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://github.com/bigcode-project/bigcode-dataset
-    shows: bigcode-dataset repo feature set confirmed
-    accessed: '2026-07-21'
+  - url: https://raw.githubusercontent.com/bigcode-project/bigcode-dataset/main/README.md
+    shows: README lists language selection, PII detection and anonymization, decontamination and the
+      line-length/alphanumeric quality filters used for The Stack and StarCoder
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d5f7c72860f0ecd247837dd6c470c1d5f3632a00da7b4314499da6cca79bd6a6

--- a/sources/scores/ccnet.yaml
+++ b/sources/scores/ccnet.yaml
@@ -13,35 +13,60 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (MIT), full source public.
+  note: Fully OSI-licensed (MIT), full source public. Re-read 2026-08-13 - the LICENSE body still carries
+    the same license and the README still builds the whole product from the published repo, with no paid
+    tier, enterprise edition or license key anywhere in it.
   raw: license:MIT(OSI);source:public;no feature-gated core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/facebookresearch/cc_net/blob/main/LICENSE
     shows: MIT License text
-    accessed: '2026-07-21'
+    accessed: '2026-08-13'
+    establishes:
+    - license
+    http_status: 200
+    content_sha256: 52412d7bc7ce4157ea628bbaacb8829e0a9cb3c58f57f99176126bc8cf2bfc85
+  - url: https://raw.githubusercontent.com/facebookresearch/cc_net/main/README.md
+    shows: README documents the whole pipeline building and installing from the published
+      repo; no paid tier, enterprise edition or license key appears anywhere in it, so
+      nothing is withheld from the source
+    accessed: '2026-08-13'
+    establishes:
+    - source
+    - core-gated
+    http_status: 200
+    content_sha256: 3b9abc643e55ae84fa42a6731dc34eecd9f1badcca15ed77a2f93e6ccc64498e
 adoption:
   level: 2
   reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: medium
-  note: '~1,000 GitHub stars; research repo, no PyPI package. Archived since 2023 but a foundational, widely-
-    reused pipeline. Stars read 2026-08-13: 1,045 across the 1 declared repo, which bands at 1K-10K stars,
-    level 2 on the stars scale in signal_routing.yaml. The previous reach ''<10K'' was not a label this
-    instrument offers - stars have their own vocabulary because a star is not a download. No last_verified
-    claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of
-    the axis was not re-read.'
+  note: 1,045 GitHub stars on facebookresearch/cc_net, read 2026-08-13 from the repository API. Bands at
+    level 2 (1K-10K stars) on the stars fallback scale in signal_routing.yaml, which caps at 3 because a
+    star is not a use. Archived read-only since October 2023 but foundational and widely reused; no PyPI
+    package, so stars are the only signal. The API response is digested here the way bigcode-dataset and
+    ungoliant already are in this category; a star count drifts, so a later digest mismatch reads as drift
+    rather than as fabrication.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://github.com/facebookresearch/cc_net
-    shows: ~1,000 stars; archived read-only 2023-10-31
-    accessed: '2026-07-21'
+  - url: https://api.github.com/repos/facebookresearch/cc_net
+    shows: stargazers_count = 1045 for facebookresearch/cc_net
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c921aef8b94dcdc6dcbc723af0b06dac7e9947d79d70088f848a6d4132021171
 capability:
   score: 3
   basis: feature_matrix
   value: Language ID + KenLM perplexity filtering + dedup to build monolingual corpora from Common Crawl;
     single-approach, foundational, now dated.
   confidence: medium
-  note: Historically foundational (CC-100), but a single-method pipeline and frozen since 2023.
+  note: Historically foundational (CC-100), but a single-method pipeline and frozen since 2023. Re-read
+    2026-08-13 - the README still describes the feature set above.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://github.com/facebookresearch/cc_net
-    shows: CCNet perplexity-filtering pipeline (built CC-100)
-    accessed: '2026-07-21'
+  - url: https://raw.githubusercontent.com/facebookresearch/cc_net/main/README.md
+    shows: README documents the language-ID plus KenLM perplexity plus dedup pipeline of the CCNet
+      paper; the repo is archived read-only
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 3b9abc643e55ae84fa42a6731dc34eecd9f1badcca15ed77a2f93e6ccc64498e

--- a/sources/scores/data-juicer.yaml
+++ b/sources/scores/data-juicer.yaml
@@ -13,12 +13,29 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (Apache-2.0), full source public.
+  note: Fully OSI-licensed (Apache-2.0), full source public. Re-read 2026-08-13 - the LICENSE body still
+    carries the same license and the README still builds the whole product from the published repo, with
+    no paid tier, enterprise edition or license key anywhere in it.
   raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/datajuicer/data-juicer/blob/main/LICENSE
     shows: Apache License Version 2.0 text
-    accessed: '2026-07-21'
+    accessed: '2026-08-13'
+    establishes:
+    - license
+    http_status: 200
+    content_sha256: 210c424889b0dcbf937be493d01fbf290e3e8bd6cad38445fef686116289f793
+  - url: https://raw.githubusercontent.com/datajuicer/data-juicer/main/README.md
+    shows: README documents the whole pipeline building and installing from the published
+      repo; no paid tier, enterprise edition or license key appears anywhere in it, so
+      nothing is withheld from the source
+    accessed: '2026-08-13'
+    establishes:
+    - source
+    - core-gated
+    http_status: 200
+    content_sha256: 92a323737f5130367a316baaa0d9577ba108a979ddc8b319b240737b5e83aadf
 adoption:
   level: 1
   reach: <10K
@@ -42,8 +59,13 @@ capability:
     data-centric challenges.
   confidence: medium
   note: Broadest operator coverage among the open tools; multimodal. Benchmark participation but no single
-    frontier-topping corpus of its own.
+    frontier-topping corpus of its own. Re-read 2026-08-13 - the README still describes the feature set
+    above.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://github.com/datajuicer/data-juicer
-    shows: 200+ operators for LLM data processing; active
-    accessed: '2026-07-21'
+  - url: https://raw.githubusercontent.com/datajuicer/data-juicer/main/README.md
+    shows: README still carries the 200+ operators badge and covers cleaning, deduplication, synthesis
+      and analysis across text and multimodal data
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 92a323737f5130367a316baaa0d9577ba108a979ddc8b319b240737b5e83aadf

--- a/sources/scores/datamap-rs.yaml
+++ b/sources/scores/datamap-rs.yaml
@@ -16,34 +16,59 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (Apache-2.0), full source public.
+  note: Fully OSI-licensed (Apache-2.0), full source public. Re-read 2026-08-13 - the LICENSE body still
+    carries the same license and the README still builds the whole product from the published repo, with
+    no paid tier, enterprise edition or license key anywhere in it.
   raw: license:Apache-2.0(OSI);source:public(allenai/datamap-rs);governance:Allen Institute for AI;no feature-gated
     core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/allenai/datamap-rs/blob/main/LICENSE
     shows: Apache License Version 2.0 text
-    accessed: '2026-07-21'
+    accessed: '2026-08-13'
+    establishes:
+    - license
+    http_status: 200
+    content_sha256: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
+  - url: https://raw.githubusercontent.com/allenai/datamap-rs/main/README.md
+    shows: README documents the whole pipeline building and installing from the published
+      repo; no paid tier, enterprise edition or license key appears anywhere in it, so
+      nothing is withheld from the source
+    accessed: '2026-08-13'
+    establishes:
+    - source
+    - core-gated
+    http_status: 200
+    content_sha256: 56ec67f99ee8e28d93af11b16afd262ec865f0b5a7bceb9a70b149f6946ca611
 adoption:
   level: 1
   reach: <1K stars
   signal_type: stars_fallback
   confidence: medium
-  note: 'New (2026) single-purpose Rust CLI, ~56 GitHub stars; real but niche, used in the Dolma 3 pipeline.
-    Stars read 2026-08-13: 56 across the 1 declared repo, which bands at <1K stars, level 1 on the stars scale
-    in signal_routing.yaml. The previous reach ''<10K'' was not a label this instrument offers - stars have
-    their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile,
-    so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.'
+  note: 56 GitHub stars on allenai/datamap-rs, read 2026-08-13 from the repository API. Bands at level 1
+    (<1K stars) on the stars fallback scale in signal_routing.yaml, which caps at 3 because a star is not
+    a use. A 2026 single-purpose Rust CLI used in the Dolma 3 pipeline; real but niche. The API response
+    is digested here the way bigcode-dataset and ungoliant already are in this category; a star count drifts,
+    so a later digest mismatch reads as drift rather than as fabrication.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://github.com/allenai/datamap-rs
-    shows: 56 stars
-    accessed: '2026-07-21'
+  - url: https://api.github.com/repos/allenai/datamap-rs
+    shows: stargazers_count = 56 for allenai/datamap-rs
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b368be2a01ab07d93942cc7fd8452e53b3f1300ceb796fa3af54693aa2d3c606
 capability:
   score: 3
   basis: feature_matrix
   value: Single-purpose JSONL map/filter/annotate cleaning stage; focused, not a full pipeline.
   confidence: medium
-  note: One capability slot (cleaning) of the Dolma 3 toolchain.
+  note: One capability slot (cleaning) of the Dolma 3 toolchain. Re-read 2026-08-13 - the README still describes
+    the feature set above.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://github.com/allenai/datamap-rs
-    shows: datamap-rs repo feature set confirmed
-    accessed: '2026-07-21'
+  - url: https://raw.githubusercontent.com/allenai/datamap-rs/main/README.md
+    shows: README documents a Rust JSONL map/filter/annotate pipeline with configurable per-document
+      processors, still one cleaning stage rather than a full pipeline
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 56ec67f99ee8e28d93af11b16afd262ec865f0b5a7bceb9a70b149f6946ca611

--- a/sources/scores/datatrove.yaml
+++ b/sources/scores/datatrove.yaml
@@ -18,13 +18,30 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (Apache-2.0), full source public, no proprietary core or managed gate.
+  note: Fully OSI-licensed (Apache-2.0), full source public, no proprietary core or managed gate. Re-read
+    2026-08-13 - the LICENSE body still carries the same license and the README still builds the whole product
+    from the published repo, with no paid tier, enterprise edition or license key anywhere in it.
   raw: license:Apache-2.0(OSI);source:public(huggingface/datatrove);governance:Hugging Face;no feature-gated
     core;managed-tier:none;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/huggingface/datatrove/blob/main/LICENSE
     shows: Apache License Version 2.0 text
-    accessed: '2026-07-21'
+    accessed: '2026-08-13'
+    establishes:
+    - license
+    http_status: 200
+    content_sha256: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
+  - url: https://raw.githubusercontent.com/huggingface/datatrove/main/README.md
+    shows: README documents the whole pipeline building and installing from the published
+      repo; no paid tier, enterprise edition or license key appears anywhere in it, so
+      nothing is withheld from the source
+    accessed: '2026-08-13'
+    establishes:
+    - source
+    - core-gated
+    http_status: 200
+    content_sha256: 65add2bcb9e8405396d81f2b6b7ae97a08afe67fc454c4508a11acf0122f5860
 adoption:
   level: 2
   reach: 10K-100K
@@ -48,9 +65,17 @@ capability:
     filter lifts MMLU ~33->37 and ARC ~46->57.
   confidence: high
   note: 'Benchmark-anchored on the output corpus (a proxy for the tool): FineWeb-Edu leads public pretraining
-    corpora on the FineWeb ablation suite.'
+    corpora on the FineWeb ablation suite. Re-read 2026-08-13 - the arXiv abstract still states that FineWeb
+    outperforms other open pretraining datasets and that FineWeb-Edu lifts MMLU and ARC sharply. The per-task
+    ablation numbers in the value above are plotted in the paper rather than printed on the abstract page,
+    so this re-read confirms the ranking claim rather than the exact figures.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2406.17557
-    shows: 'FineWeb ablation: FineWeb-Edu tops public datasets on an 8-task aggregate (identical 1.82B
-      model, equal tokens)'
-    accessed: '2026-07-21'
+    shows: FineWeb abstract - FineWeb produces better-performing LLMs than other open pretraining
+      datasets, and FineWeb-Edu lifts knowledge and reasoning benchmarks such as MMLU and ARC
+      dramatically. The per-task ablation figures behind the aggregate are plots in the paper
+      rather than text on this page.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a12bfcd47f835ad4a2c5630a228778370ed54509afa65bed1c6dfc264f2182da

--- a/sources/scores/datology-ai.yaml
+++ b/sources/scores/datology-ai.yaml
@@ -13,32 +13,49 @@ openness:
     - no OSS core
   confidence: high
   note: Fully proprietary automated-curation engine; the closed analogue to datatrove/NeMo Curator, science-of-data-curation
-    niche.
+    niche. Re-read 2026-08-13 - the site still describes a closed data refinery deployed into the customer's
+    own cloud, with no source, no self-host path and no published license.
   raw: license:Proprietary;source:closed;proprietary curation platform (VPC-deployed); no source available;
     no OSS core
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.datologyai.com
     shows: Proprietary automated data-curation platform, no source available
-    accessed: '2026-07-21'
+    accessed: '2026-08-13'
+    establishes:
+    - source
+    - license
+    http_status: 200
+    content_sha256: 2d28ac394aa59122b9a2c2a47b823a67b6882572f2e804a8bf5b1699eed64dc7
 adoption:
   level: 2
   reach: niche
   signal_type: reported_traction
   confidence: medium
   note: ~$57.5M raised with high-profile backers, but early-stage with no named frontier-lab deployments;
-    traction is credibility/funding rather than proven scale. Directional.
+    traction is credibility/funding rather than proven scale. Directional. Re-read 2026-08-13 - the article
+    still reports the $46M Series A and the $57.5M total. That is a May 2024 figure and the only funding
+    number this axis cites, so the level stays directional.
+  last_verified: '2026-08-13'
   sources:
   - url: https://aibusiness.com/data/startup-raises-46m-to-revolutionize-ai-dataset-curation
     shows: ~$46M Series A (total ~$57.5M) for automated data curation
-    accessed: '2026-07-21'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 8b88c2d372d9e37efb836b7dd23b726bb5de9584d302ee60c7acfd6be3490838
 capability:
   score: 3
   basis: feature_matrix
   value: Automated dedup, model-based filtering, embedding-based selection/pruning, ordering, and synthetic
     steps; specialized, no human-labeling/RLHF.
   confidence: medium
-  note: Strong specialized curation engine, narrow scope and early adoption.
+  note: Strong specialized curation engine, narrow scope and early adoption. Re-read 2026-08-13 - the site
+    still describes the same clean, curate, create and compose stages, with no human-labeling or RLHF offering.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.datologyai.com
-    shows: DatologyAI product/feature description
-    accessed: '2026-07-21'
+    shows: the data refinery is described as clean, curate, create and compose stages - dedup and
+      formatting removal, quality and taxonomy selection, synthetic generation and mixing
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 2d28ac394aa59122b9a2c2a47b823a67b6882572f2e804a8bf5b1699eed64dc7

--- a/sources/scores/dclm.yaml
+++ b/sources/scores/dclm.yaml
@@ -13,26 +13,48 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (MIT), full source public.
+  note: Fully OSI-licensed (MIT), full source public. Re-read 2026-08-13 - the LICENSE body still carries
+    the same license and the README still builds the whole product from the published repo, with no paid
+    tier, enterprise edition or license key anywhere in it.
   raw: license:MIT(OSI);source:public;no feature-gated core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/mlfoundations/dclm/blob/main/LICENSE
     shows: MIT License text
-    accessed: '2026-07-21'
+    accessed: '2026-08-13'
+    establishes:
+    - license
+    http_status: 200
+    content_sha256: f6f22e7ddf73c6acc94c82555d60f33f26df2aea3be34d65c2f10c9d9c95e3ff
+  - url: https://raw.githubusercontent.com/mlfoundations/dclm/main/README.md
+    shows: README documents the whole pipeline building and installing from the published
+      repo; no paid tier, enterprise edition or license key appears anywhere in it, so
+      nothing is withheld from the source
+    accessed: '2026-08-13'
+    establishes:
+    - source
+    - core-gated
+    http_status: 200
+    content_sha256: 21462d622ec7fe97c9299532feda5c9c5dc7d8d95807f5a92fa74a9e24ce9bfe
 adoption:
   level: 2
   reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: medium
-  note: '~1,454 GitHub stars; no PyPI package (source install). The reference DataComp-LM toolkit. Stars read
-    2026-08-13: 1,463 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in
-    signal_routing.yaml. The previous reach ''<10K'' was not a label this instrument offers - stars have their
-    own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a
-    digest of it would read as drift on every refetch, and the rest of the axis was not re-read.'
+  note: 1,463 GitHub stars on mlfoundations/dclm, read 2026-08-13 from the repository API. Bands at level
+    2 (1K-10K stars) on the stars fallback scale in signal_routing.yaml, which caps at 3 because a star
+    is not a use. No PyPI package is published, so the toolkit installs from source and stars are the only
+    signal; as the reference DataComp-LM harness its importance runs well ahead of its adoption, and the
+    level is directional. The API response is digested here the way bigcode-dataset and ungoliant already
+    are in this category; a star count drifts, so a later digest mismatch reads as drift rather than as
+    fabrication.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://github.com/mlfoundations/dclm
-    shows: 1,454 stars; not published to PyPI
-    accessed: '2026-07-21'
+  - url: https://api.github.com/repos/mlfoundations/dclm
+    shows: stargazers_count = 1463 for mlfoundations/dclm
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e85e8de3ba278a040a34ca6cec86887e7d11d9afef00834f346deaa09d1b2c0e
 capability:
   score: 5
   basis: benchmark
@@ -40,8 +62,14 @@ capability:
     7B model on 2.6T tokens reaches ~64% MMLU, beating RefinedWeb/C4/Dolma), so it defines the curation
     frontier the other tools are scored against.
   confidence: high
-  note: 'Benchmark-defining: DCLM-baseline is the reference-topping corpus of the DataComp-LM leaderboard.'
+  note: 'Benchmark-defining: DCLM-baseline is the reference-topping corpus of the DataComp-LM leaderboard.
+    Re-read 2026-08-13 - the arXiv abstract still reports the 64% MMLU result at 7B on 2.6T tokens and the
+    6.6-point lead over MAP-Neo.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2406.11794
-    shows: 'DataComp-LM: DCLM-baseline tops existing corpora; 7B/2.6T ~64% MMLU'
-    accessed: '2026-07-21'
+    shows: 'DataComp-LM abstract - DCLM-baseline trains a 7B model to 64% 5-shot MMLU on 2.6T tokens,
+      6.6 points above MAP-Neo, the previous open-data state of the art'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: f665620bfe7fe32ea36cf6f4daab947bd13e925c191d80444c02c8ceb14fd974

--- a/sources/scores/decon.yaml
+++ b/sources/scores/decon.yaml
@@ -16,34 +16,59 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (Apache-2.0), full source public.
+  note: Fully OSI-licensed (Apache-2.0), full source public. Re-read 2026-08-13 - the LICENSE body still
+    carries the same license and the README still builds the whole product from the published repo, with
+    no paid tier, enterprise edition or license key anywhere in it.
   raw: license:Apache-2.0(OSI);source:public(allenai/decon);governance:Allen Institute for AI;no feature-gated
     core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/allenai/decon/blob/main/LICENSE
     shows: Apache License Version 2.0 text
-    accessed: '2026-07-21'
+    accessed: '2026-08-13'
+    establishes:
+    - license
+    http_status: 200
+    content_sha256: 5b8ddfadb2d72c64c066821fdd424f5024ce2555e2808fb2bfb0856e65e65c7d
+  - url: https://raw.githubusercontent.com/allenai/decon/main/README.md
+    shows: README documents the whole pipeline building and installing from the published
+      repo; no paid tier, enterprise edition or license key appears anywhere in it, so
+      nothing is withheld from the source
+    accessed: '2026-08-13'
+    establishes:
+    - source
+    - core-gated
+    http_status: 200
+    content_sha256: d85e1eed763781ec01b923008c07a1bb0547f1b8cdc6f92b635c467f6b9fee68
 adoption:
   level: 1
   reach: <1K stars
   signal_type: stars_fallback
   confidence: medium
-  note: 'New (2026) single-purpose Rust CLI, ~35 GitHub stars; niche, used in the Dolma 3 pipeline. Stars read
-    2026-08-13: 36 across the 1 declared repo, which bands at <1K stars, level 1 on the stars scale in
-    signal_routing.yaml. The previous reach ''<10K'' was not a label this instrument offers - stars have their
-    own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a
-    digest of it would read as drift on every refetch, and the rest of the axis was not re-read.'
+  note: 36 GitHub stars on allenai/decon, read 2026-08-13 from the repository API. Bands at level 1 (<1K
+    stars) on the stars fallback scale in signal_routing.yaml, which caps at 3 because a star is not a use.
+    A 2026 single-purpose Rust CLI used in the Dolma 3 pipeline; niche. The API response is digested here
+    the way bigcode-dataset and ungoliant already are in this category; a star count drifts, so a later
+    digest mismatch reads as drift rather than as fabrication.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://github.com/allenai/decon
-    shows: 35 stars
-    accessed: '2026-07-21'
+  - url: https://api.github.com/repos/allenai/decon
+    shows: stargazers_count = 36 for allenai/decon
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 370848f63a496708bf9d1fd7c19b99c6a784b865aadee3c9e1353531feaaf55a
 capability:
   score: 3
   basis: feature_matrix
   value: Flags/removes train docs overlapping eval benchmarks; focused decontamination tool.
   confidence: medium
-  note: One capability slot (decontamination) of the Dolma 3 toolchain.
+  note: One capability slot (decontamination) of the Dolma 3 toolchain. Re-read 2026-08-13 - the README
+    still describes the feature set above.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://github.com/allenai/decon
-    shows: decon repo feature set confirmed
-    accessed: '2026-07-21'
+  - url: https://raw.githubusercontent.com/allenai/decon/main/README.md
+    shows: README documents token-based detection of training documents overlapping eval instances,
+      producing contamination reports and cleaned datasets
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d85e1eed763781ec01b923008c07a1bb0547f1b8cdc6f92b635c467f6b9fee68

--- a/sources/scores/distilabel.yaml
+++ b/sources/scores/distilabel.yaml
@@ -16,26 +16,46 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (Apache-2.0), full source public, no proprietary core.
+  note: Fully OSI-licensed (Apache-2.0), full source public, no proprietary core. Re-read 2026-08-13 - the
+    LICENSE body still carries the same license and the README still builds the whole product from the published
+    repo, with no paid tier, enterprise edition or license key anywhere in it.
   raw: license:Apache-2.0(OSI);source:public(argilla-io/distilabel);governance:Argilla/Hugging Face;no feature-gated
     core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/argilla-io/distilabel/blob/main/LICENSE
     shows: Apache License Version 2.0 text
-    accessed: '2026-07-21'
+    accessed: '2026-08-13'
+    establishes:
+    - license
+    http_status: 200
+    content_sha256: c7fe111b594f1e5d0e20edc35c8779490c76125484987b241c07ebac93c25ed7
+  - url: https://raw.githubusercontent.com/argilla-io/distilabel/main/README.md
+    shows: README documents the whole pipeline building and installing from the published
+      repo; no paid tier, enterprise edition or license key appears anywhere in it, so
+      nothing is withheld from the source
+    accessed: '2026-08-13'
+    establishes:
+    - source
+    - core-gated
+    http_status: 200
+    content_sha256: f69c2e49527588ee013624892d47237f1995b48fb1b85efc3075ca1ee69c07a8
 adoption:
   level: 2
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: '~6.5k PyPI downloads/month; established in the HF synthetic-data workflow but modest raw volume. Read
-    live 2026-08-13: 16,308 PyPI downloads in the trailing 30 days across the declared artifact(s), which
-    bands at 10K-100K, level 2. The previous reach ''1K-10K'' was a band off a different scale. No
-    last_verified claimed: only the figure was re-read, not the whole axis.'
+  note: 16,308 downloads in the trailing 30 days for distilabel, read 2026-08-13 from the pypistats API.
+    Bands at level 2 (10K-100K) on the software and model adoption scale. The previous reach '1K-10K' was
+    a band off a different scale. Established in the Hugging Face synthetic-data workflow, though the README
+    now says the original authors have moved on and community collaborators maintain the project.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://pypistats.org/packages/distilabel
-    shows: 'Downloads last month: 6,510'
-    accessed: '2026-07-21'
+  - url: https://pypistats.org/api/packages/distilabel/recent
+    shows: 16,308 downloads in the trailing 30 days for distilabel
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9a532424aa22518f1387258d359b9d46bd9978467bfe62eca00f626cd6597993
 capability:
   score: 4
   basis: training_value
@@ -45,13 +65,21 @@ capability:
     90.60; a distilabel-curated Orca-DPO set (46% of the data) beats full-data DPO on the Nous suite (54.04
     vs 53.51).
   confidence: medium
-  note: 'Indirect proxy: tool quality inferred from models where distilabel-curated data was the only
-    changed variable. Confidence capped because there is no head-to-head against other synthetic-data
-    frameworks.'
+  note: 'Indirect proxy: tool quality inferred from models where distilabel-curated data was the only changed
+    variable. Confidence capped because there is no head-to-head against other synthetic-data frameworks.
+    Re-read 2026-08-13 - both model cards still carry the numbers cited, 91.42 against 90.60 on AlpacaEval
+    and 54.04 against 53.51 on the Nous suite.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/argilla/notus-7b-v1
-    shows: 'Notus-7B (distilabel-recurated UltraFeedback): 91.42 AlpacaEval vs Zephyr 90.60'
-    accessed: '2026-07-21'
+    shows: 'Notus-7b-v1 (distilabel-recurated UltraFeedback) - 91.42 AlpacaEval against Zephyr-7b-beta
+      90.60 in the model card table'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: fe893fded6c16772e768c3f9f3339edeafaa93a6bce6a36c592c983806fbe416
   - url: https://huggingface.co/argilla/distilabeled-Hermes-2.5-Mistral-7B
-    shows: 'distilabel Orca-DPO curation (46% of data): 54.04 Nous avg vs 53.51 full-data DPO'
-    accessed: '2026-07-21'
+    shows: 'distilabel Orca-DPO curation, a 54% reduction in samples - 54.04 Nous average against 53.51
+      for the original full-data recipe'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 47a0ab9d93584d24398e807b4fecea91e51ec22880141059eb97e4df0277986b

--- a/sources/scores/dolma-toolkit.yaml
+++ b/sources/scores/dolma-toolkit.yaml
@@ -16,37 +16,65 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (Apache-2.0), full source public.
+  note: Fully OSI-licensed (Apache-2.0), full source public. Re-read 2026-08-13 - the LICENSE body still
+    carries the same license and the README still builds the whole product from the published repo, with
+    no paid tier, enterprise edition or license key anywhere in it.
   raw: license:Apache-2.0(OSI);source:public(allenai/dolma);governance:Allen Institute for AI;no feature-gated
     core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/allenai/dolma/blob/main/LICENSE
     shows: Apache License Version 2.0 text
-    accessed: '2026-07-21'
+    accessed: '2026-08-13'
+    establishes:
+    - license
+    http_status: 200
+    content_sha256: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
+  - url: https://raw.githubusercontent.com/allenai/dolma/main/README.md
+    shows: README documents the whole pipeline building and installing from the published
+      repo; no paid tier, enterprise edition or license key appears anywhere in it, so
+      nothing is withheld from the source
+    accessed: '2026-08-13'
+    establishes:
+    - source
+    - core-gated
+    http_status: 200
+    content_sha256: a4abd5c5baf3f9f57eb09e1332daeb3168d4d23429d6c474f8c9c57e908b144e
 adoption:
   level: 1
   reach: <10K
   signal_type: usage_volume
   confidence: high
-  note: '~5.1k PyPI downloads/month; the curation toolkit behind the Dolma corpus and OLMo family. Read live
-    2026-08-13: 4,390 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at
-    <10K, level 1. Level corrected from 2. The previous reach ''1K-10K'' was a band off a different scale. No
-    last_verified claimed: only the figure was re-read, not the whole axis.'
+  note: 4,390 downloads in the trailing 30 days for dolma, read 2026-08-13 from the pypistats API. Bands
+    at level 1 (<10K) on the software and model adoption scale, corrected from level 2. The curation toolkit
+    behind the Dolma corpus and the OLMo family, so its importance runs ahead of its raw volume.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://pypistats.org/packages/dolma
-    shows: 'Downloads last month: 5,097'
-    accessed: '2026-07-21'
+  - url: https://pypistats.org/api/packages/dolma/recent
+    shows: 4,390 downloads in the trailing 30 days for dolma
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6696ad3c661dd15027602f2fd1df3d7c3470fac93e15df4c1a1176a98f553c7d
 capability:
   score: 3
   basis: benchmark
+  relative_to: datatrove
+  relation: two_below
   value: Dolma, the corpus the toolkit builds, scores 35.0 CORE on DataComp-LM (7B-1x), below RefinedWeb
     (36.9) and well under DCLM-baseline, and is among the lower performers in the FineWeb ablation. A
     foundational, fully-documented open pipeline whose released output sits a tier below the current curation
     frontier.
   confidence: high
   note: 'Benchmark-anchored on the output corpus (proxy): capable and fully open, but its released corpus
-    trails the datatrove / NeMo Curator frontier on DCLM. Down from a feature-only read of 4.'
+    trails the datatrove / NeMo Curator frontier on DCLM. Down from a feature-only read of 4. Re-read 2026-08-13
+    against the DataComp-LM full text, where Table 2 still shows Dolma-V1 at 35.0 Core against RefinedWeb
+    36.9 at the 7B-1x scale. The cited abstract page never carried that table, so the source now points
+    at the HTML full text. The gap to the datatrove frontier is recorded as relative_to.'
+  last_verified: '2026-08-13'
   sources:
-  - url: https://arxiv.org/abs/2406.11794
-    shows: 'DataComp-LM Table 2: Dolma-V1 35.0 CORE vs RefinedWeb 36.9 at 7B-1x scale'
-    accessed: '2026-07-21'
+  - url: https://arxiv.org/html/2406.11794v3
+    shows: 'DataComp-LM Table 2 in the full text - Dolma-V1 scores 35.0 Core and 18.4 Extended at the
+      7B-1x scale, below RedPajama 35.3 and RefinedWeb 36.9'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 8938d7969b69269b54000eb3c42bf0bbef14981580547b3fb86c3c7f5d5a54ec

--- a/sources/scores/duplodocus.yaml
+++ b/sources/scores/duplodocus.yaml
@@ -16,34 +16,59 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (Apache-2.0), full source public.
+  note: Fully OSI-licensed (Apache-2.0), full source public. Re-read 2026-08-13 - the LICENSE body still
+    carries the same license and the README still builds the whole product from the published repo, with
+    no paid tier, enterprise edition or license key anywhere in it.
   raw: license:Apache-2.0(OSI);source:public(allenai/duplodocus);governance:Allen Institute for AI;no feature-gated
     core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/allenai/duplodocus/blob/main/LICENSE
     shows: Apache License Version 2.0 text
-    accessed: '2026-07-21'
+    accessed: '2026-08-13'
+    establishes:
+    - license
+    http_status: 200
+    content_sha256: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
+  - url: https://raw.githubusercontent.com/allenai/duplodocus/main/README.md
+    shows: README documents the whole pipeline building and installing from the published
+      repo; no paid tier, enterprise edition or license key appears anywhere in it, so
+      nothing is withheld from the source
+    accessed: '2026-08-13'
+    establishes:
+    - source
+    - core-gated
+    http_status: 200
+    content_sha256: 18f8045f83995f2cd9063ac47b100f510a1295c8a4fa3313cfccdadc1a328bf1
 adoption:
   level: 1
   reach: <1K stars
   signal_type: stars_fallback
   confidence: medium
-  note: 'New (2026) single-purpose Rust CLI, ~90 GitHub stars; niche, used in the Dolma 3 pipeline. Stars read
-    2026-08-13: 93 across the 1 declared repo, which bands at <1K stars, level 1 on the stars scale in
-    signal_routing.yaml. The previous reach ''<10K'' was not a label this instrument offers - stars have their
-    own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a
-    digest of it would read as drift on every refetch, and the rest of the axis was not re-read.'
+  note: 93 GitHub stars on allenai/duplodocus, read 2026-08-13 from the repository API. Bands at level 1
+    (<1K stars) on the stars fallback scale in signal_routing.yaml, which caps at 3 because a star is not
+    a use. A 2026 single-purpose Rust CLI used in the Dolma 3 pipeline; niche. The API response is digested
+    here the way bigcode-dataset and ungoliant already are in this category; a star count drifts, so a later
+    digest mismatch reads as drift rather than as fabrication.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://github.com/allenai/duplodocus
-    shows: 90 stars
-    accessed: '2026-07-21'
+  - url: https://api.github.com/repos/allenai/duplodocus
+    shows: stargazers_count = 93 for allenai/duplodocus
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: bc7a7225ab16d2597be31f1b5145b64b0c576e0134807c1c7a27374923c3a967
 capability:
   score: 3
   basis: feature_matrix
   value: Exact + fuzzy MinHash-LSH deduplication; focused single-purpose tool.
   confidence: medium
-  note: One capability slot (dedup) of the Dolma 3 toolchain.
+  note: One capability slot (dedup) of the Dolma 3 toolchain. Re-read 2026-08-13 - the README still describes
+    the feature set above.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://github.com/allenai/duplodocus
-    shows: duplodocus repo feature set confirmed
-    accessed: '2026-07-21'
+  - url: https://raw.githubusercontent.com/allenai/duplodocus/main/README.md
+    shows: README documents exact and MinHash-LSH fuzzy deduplication in memory- and disk-based
+      variants, a single-purpose dedup tool
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 18f8045f83995f2cd9063ac47b100f510a1295c8a4fa3313cfccdadc1a328bf1

--- a/sources/scores/marin-framework.yaml
+++ b/sources/scores/marin-framework.yaml
@@ -16,37 +16,62 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (Apache-2.0), full source public. Repo is the framework; the Marin model is
-    a separate artifact.
+  note: Fully OSI-licensed (Apache-2.0), full source public. Repo is the framework; the Marin model is a
+    separate artifact. Re-read 2026-08-13 - the LICENSE body still carries the same license and the README
+    still builds the whole product from the published repo, with no paid tier, enterprise edition or license
+    key anywhere in it.
   raw: license:Apache-2.0(OSI);source:public(marin-community/marin);governance:Marin community/Stanford
     CRFM;no feature-gated core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/marin-community/marin/blob/main/LICENSE
     shows: Apache License Version 2.0 text
-    accessed: '2026-07-21'
+    accessed: '2026-08-13'
+    establishes:
+    - license
+    http_status: 200
+    content_sha256: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
+  - url: https://raw.githubusercontent.com/marin-community/marin/main/README.md
+    shows: README documents the whole pipeline building and installing from the published
+      repo; no paid tier, enterprise edition or license key appears anywhere in it, so
+      nothing is withheld from the source
+    accessed: '2026-08-13'
+    establishes:
+    - source
+    - core-gated
+    http_status: 200
+    content_sha256: b70e415b672f9995436c6d77981e11081bbc6cebda8d8ac1885bb6b6545924fb
 adoption:
   level: 2
   reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: medium
-  note: '~1.2k GitHub stars and very active development; a research framework with adoption concentrated
-    around the Marin project rather than broad external use. Stars read 2026-08-13: 1,261 across the 1
-    declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The
-    previous reach ''<10K'' was not a label this instrument offers - stars have their own vocabulary because a
-    star is not a download. No last_verified claimed: a star count is volatile, so a digest of it would read
-    as drift on every refetch, and the rest of the axis was not re-read.'
+  note: 1,261 GitHub stars on marin-community/marin, read 2026-08-13 from the repository API. Bands at level
+    2 (1K-10K stars) on the stars fallback scale in signal_routing.yaml, which caps at 3 because a star
+    is not a use. A research framework with adoption concentrated around the Marin project rather than broad
+    external use, and no published package. The API response is digested here the way bigcode-dataset and
+    ungoliant already are in this category; a star count drifts, so a later digest mismatch reads as drift
+    rather than as fabrication.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://github.com/marin-community/marin
-    shows: 1.2k stars
-    accessed: '2026-07-21'
+  - url: https://api.github.com/repos/marin-community/marin
+    shows: stargazers_count = 1261 for marin-community/marin
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 3949155ba45e10ef4d2b58642c4fc964b4bc3c2d4f2dfdaa073d145897dca0cb
 capability:
   score: 4
   basis: feature_matrix
   value: End-to-end reproducible data curation + mixture orchestration + training/eval with step-dependency
     execution scaled to TPU clusters.
   confidence: medium
-  note: Broad end-to-end framework; adoption, not capability, is its weak axis.
+  note: Broad end-to-end framework; adoption, not capability, is its weak axis. Re-read 2026-08-13 - the
+    README still describes the feature set above.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://github.com/marin-community/marin
-    shows: marin-framework repo feature set confirmed
-    accessed: '2026-07-21'
+  - url: https://raw.githubusercontent.com/marin-community/marin/main/README.md
+    shows: README still describes one framework covering data curation, transformation, filtering,
+      tokenization, pretraining, posttraining and evaluation
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b70e415b672f9995436c6d77981e11081bbc6cebda8d8ac1885bb6b6545924fb

--- a/sources/scores/nemo-curator.yaml
+++ b/sources/scores/nemo-curator.yaml
@@ -16,12 +16,29 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (Apache-2.0), full source public. Vendor-backed but not gated.
+  note: Fully OSI-licensed (Apache-2.0), full source public. Vendor-backed but not gated. Re-read 2026-08-13
+    - the LICENSE body still carries the same license and the README still builds the whole product from
+    the published repo, with no paid tier, enterprise edition or license key anywhere in it.
   raw: license:Apache-2.0(OSI);source:public(NVIDIA/NeMo-Curator);governance:NVIDIA;no feature-gated core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/NVIDIA/NeMo-Curator/blob/main/LICENSE
     shows: Apache License Version 2.0 text
-    accessed: '2026-07-21'
+    accessed: '2026-08-13'
+    establishes:
+    - license
+    http_status: 200
+    content_sha256: 5ec35ae50c7dd084f7e18d375305012159dccf9bb77ddb3f488061d7fc2abdef
+  - url: https://raw.githubusercontent.com/NVIDIA-NeMo/Curator/main/README.md
+    shows: README documents the whole pipeline building and installing from the published
+      repo; no paid tier, enterprise edition or license key appears anywhere in it, so
+      nothing is withheld from the source
+    accessed: '2026-08-13'
+    establishes:
+    - source
+    - core-gated
+    http_status: 200
+    content_sha256: 5566f79f9b7dab43257604985b133039e4027438ed9dd959170c26b3077942ce
 adoption:
   level: 1
   reach: <10K
@@ -47,8 +64,15 @@ capability:
     ~4x more unique tokens than DCLM/FineWeb-Edu.
   confidence: high
   note: 'Benchmark-anchored on the output corpus (proxy): Nemotron-CC matches or beats the DCLM/FineWeb-Edu
-    frontier, especially at long-horizon token budgets.'
+    frontier, especially at long-horizon token budgets. Re-read 2026-08-13 - the arXiv abstract still reports
+    +5.6 MMLU over DCLM at 8B/1T, four times more unique real tokens than DCLM, and the 15T-token run beating
+    Llama 3.1 8B. The recorded comparison to dclm holds, both sitting at 5.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2412.02595
-    shows: Nemotron-CC-HQ +5.6 MMLU over DCLM at 8B/1T; 70.3 vs 65.3 MMLU at 15T tokens
-    accessed: '2026-07-21'
+    shows: Nemotron-CC abstract - a high-quality subset improves MMLU by 5.6 over DCLM at 8B/1T, the
+      full 6.3T-token set matches DCLM on MMLU with four times more unique real tokens, and an 8B
+      model trained on 15T tokens beats Llama 3.1 8B by +5 MMLU
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 4231d6de42496ec9f36b44c8be8bc791367ccbe5e5c41439d7e6077eebd0df98

--- a/sources/scores/nemo-data-designer.yaml
+++ b/sources/scores/nemo-data-designer.yaml
@@ -92,11 +92,19 @@ adoption:
 capability:
   score: 4
   basis: feature_matrix
-  value: Synthetic-data generation for structured/unstructured data with transformation and augmentation;
-    differential-privacy heritage from Gretel.
+  value: Synthetic-data generation for structured and unstructured data, building domain-specific datasets
+    from scratch for training and evaluating specialized agents.
   confidence: medium
-  note: Capable synthetic-data engine; scored on the current NVIDIA-productized form.
+  note: Capable synthetic-data engine; scored on the current NVIDIA-productized form. Re-read 2026-08-13
+    - the NVIDIA NeMo page still lists Data Designer under synthetic data generation. Its earlier claims
+    about transformation and augmentation workflows and a differential-privacy heritage from Gretel are
+    no longer on that page, so they were dropped from the value rather than carried forward. The band is
+    unchanged.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.nvidia.com/en-us/ai-data-science/products/nemo/
-    shows: NVIDIA NeMo Data Designer product/feature description
-    accessed: '2026-07-21'
+    shows: NeMo Data Designer is described as creating domain-specific synthetic datasets from scratch
+      for building and evaluating specialized agents
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 99f7a56d165b1dc6fbf406d9899f3864fe58b80f0eb7d31fcf306649b885272b

--- a/sources/scores/nemo-data-designer.yaml
+++ b/sources/scores/nemo-data-designer.yaml
@@ -80,15 +80,28 @@ openness:
     content_sha256: 57e66c991213a59848bc5e27b4eff0dc8306096adc8d43b881c6b6de301a818b
 adoption:
   level: 3
-  reach: niche
-  signal_type: reported_traction
-  confidence: low
-  note: Backed by NVIDIA and distributed through the NeMo platform; Gretel had a large synthetic-data
-    user base pre-acquisition. Directional; hard to separate from NeMo overall.
+  reach: 100K-1M
+  signal_type: usage_volume
+  confidence: high
+  note: '416,634 downloads in the trailing 30 days on the declared PyPI artifact `data-designer`,
+    read live 2026-08-13. Bands at 100K-1M, level 3. LEVEL UNCHANGED - what changed is that it is now
+    RECOMPUTABLE. The record previously read `reported_traction` at the same level against a page that
+    publishes no figure at all, so nothing could confirm or refute it; a model can now derive this one
+    independently and disagree with it. The package is unambiguously the product''s own rather than a
+    same-named stranger: NVIDIA-NeMo/DataDesigner''s README quick start is `pip install data-designer`,
+    and for a Python library PyPI is the primary channel, not a minority one.'
+  last_verified: '2026-08-13'
   sources:
-  - url: https://www.nvidia.com/en-us/ai-data-science/products/nemo/
-    shows: NeMo synthetic-data / Data Designer service under the NVIDIA NeMo platform
-    accessed: '2026-07-21'
+  - url: https://pypistats.org/api/packages/data-designer/recent
+    shows: 'last_month 416,634 (last_week 145,088; last_day 24,257)'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a57243860147ece39542a0ad55de6958bb1488cf83b676a94cae6ca286a2b8d8
+  - url: https://raw.githubusercontent.com/NVIDIA-NeMo/DataDesigner/main/README.md
+    shows: 'quick start reads `pip install data-designer`, tying the PyPI package to this product'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9accba59e9b3c83360b79d4d70b4fe6b5df275e44c294d38b1ab6a6c892d5b8e
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/olmocr.yaml
+++ b/sources/scores/olmocr.yaml
@@ -16,13 +16,30 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (Apache-2.0), full source public.
+  note: Fully OSI-licensed (Apache-2.0), full source public. Re-read 2026-08-13 - the LICENSE body still
+    carries the same license and the README still builds the whole product from the published repo, with
+    no paid tier, enterprise edition or license key anywhere in it.
   raw: license:Apache-2.0(OSI);source:public(allenai/olmocr);governance:Allen Institute for AI;no feature-gated
     core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/allenai/olmocr/blob/main/LICENSE
     shows: Apache License Version 2.0 text
-    accessed: '2026-07-21'
+    accessed: '2026-08-13'
+    establishes:
+    - license
+    http_status: 200
+    content_sha256: 62fb8a3a9621dc2388174caaabe9c2317b694bb9a1d46c98bcf5655b68f51be3
+  - url: https://raw.githubusercontent.com/allenai/olmocr/main/README.md
+    shows: README documents the whole pipeline building and installing from the published
+      repo; no paid tier, enterprise edition or license key appears anywhere in it, so
+      nothing is withheld from the source
+    accessed: '2026-08-13'
+    establishes:
+    - source
+    - core-gated
+    http_status: 200
+    content_sha256: 1383b3f0f5a10cc9a7eebab46e929cddaedf370a80d17b379d21dc380b31ada3
 adoption:
   level: 2
   reach: 10K-100K
@@ -41,16 +58,27 @@ adoption:
 capability:
   score: 4
   basis: benchmark
-  value: olmOCR 2 (v0.4.0) scores 82.4 on olmOCR-Bench, ahead of Marker (76.1), MinerU (75.2), Mistral
-    OCR (72.0), and GPT-4o (69.9); on the third-party OmniDocBench it is mid-pack (~85.7, near GPT-4o)
-    behind MinerU2.5-Pro and Gemini-3 Pro.
+  value: olmOCR v0.4.0 scores 82.4 on olmOCR-Bench, ahead of Marker 1.10.1 (76.1), MinerU 2.5.4 (75.2) and
+    Mistral OCR (72.0), but now behind Chandra OCR 0.1.0 (83.1) and Infinity-Parser 7B (82.5); on the third-party
+    OmniDocBench it is mid-pack (85.74), behind MinerU-2.5 (93.04), Gemini 3 Pro (92.91) and GPT-5.2 (86.59).
   confidence: high
-  note: 'Benchmark-anchored: leads open document-extraction tools on olmOCR-Bench but sits mid-pack on
-    the neutral OmniDocBench, so near-SOTA rather than SOTA. Snapshot; extraction leaderboards move.'
+  note: 'Benchmark-anchored: leads open document-extraction tools on olmOCR-Bench but sits mid-pack on the
+    neutral OmniDocBench, so near-SOTA rather than SOTA. Snapshot; extraction leaderboards move. Re-read
+    2026-08-13 - the olmOCR-Bench table has dropped GPT-4o and now places Chandra OCR and Infinity-Parser
+    above olmOCR, and OmniDocBench lists olmOCR at 85.74. The band stays at 4, which the note already read
+    as near-SOTA rather than SOTA.'
+  last_verified: '2026-08-13'
   sources:
-  - url: https://github.com/allenai/olmocr
-    shows: 'olmOCR 2 (v0.4.0): 82.4 on olmOCR-Bench, ahead of Marker/MinerU/Mistral OCR/GPT-4o'
-    accessed: '2026-07-21'
-  - url: https://github.com/opendatalab/OmniDocBench
-    shows: 'OmniDocBench: olmOCR ~85.7, mid-pack behind MinerU2.5-Pro and Gemini-3 Pro'
-    accessed: '2026-07-21'
+  - url: https://raw.githubusercontent.com/allenai/olmocr/main/README.md
+    shows: 'olmOCR-Bench table in the README - olmOCR v0.4.0 scores 82.4, ahead of Marker 1.10.1 76.1,
+      MinerU 2.5.4 75.2 and Mistral OCR 72.0, but now behind Chandra OCR 0.1.0 83.1 and
+      Infinity-Parser 7B 82.5. GPT-4o has been dropped from the table.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1383b3f0f5a10cc9a7eebab46e929cddaedf370a80d17b379d21dc380b31ada3
+  - url: https://raw.githubusercontent.com/opendatalab/OmniDocBench/main/README.md
+    shows: 'OmniDocBench leaderboard - olmOCR 85.74 overall, mid-pack behind MinerU-2.5 93.04,
+      Gemini 3 Pro 92.91 and GPT-5.2 86.59, and level with Mistral OCR 85.66'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1c3f6f7e0dc6027e96161fd368f68b41b1e797b2329a4decbefdd4f2d2ec31eb

--- a/sources/scores/redpajama-data.yaml
+++ b/sources/scores/redpajama-data.yaml
@@ -13,35 +13,60 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (Apache-2.0), full source public.
+  note: Fully OSI-licensed (Apache-2.0), full source public. Re-read 2026-08-13 - the LICENSE body still
+    carries the same license and the README still builds the whole product from the published repo, with
+    no paid tier, enterprise edition or license key anywhere in it.
   raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/togethercomputer/RedPajama-Data/blob/main/LICENSE
     shows: Apache License Version 2.0 text
-    accessed: '2026-07-21'
+    accessed: '2026-08-13'
+    establishes:
+    - license
+    http_status: 200
+    content_sha256: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
+  - url: https://raw.githubusercontent.com/togethercomputer/RedPajama-Data/main/README.md
+    shows: README documents the whole pipeline building and installing from the published
+      repo; no paid tier, enterprise edition or license key appears anywhere in it, so
+      nothing is withheld from the source
+    accessed: '2026-08-13'
+    establishes:
+    - source
+    - core-gated
+    http_status: 200
+    content_sha256: fdcf4b7907eade3e747f3c707c34f3a76738c4a353c11fc4219b7fa591797169
 adoption:
   level: 2
   reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: medium
-  note: '~4,969 GitHub stars; pipeline repo, no PyPI package. Widely referenced quality-signal pipeline;
-    dormant since Dec 2024. Stars read 2026-08-13: 4,977 across the 1 declared repo, which bands at 1K-10K
-    stars, level 2 on the stars scale in signal_routing.yaml. The previous reach ''<10K'' was not a label this
-    instrument offers - stars have their own vocabulary because a star is not a download. No last_verified
-    claimed: a star count is volatile, so a digest of it would read as drift on every refetch, and the rest of
-    the axis was not re-read.'
+  note: 4,977 GitHub stars on togethercomputer/RedPajama-Data, read 2026-08-13 from the repository API.
+    Bands at level 2 (1K-10K stars) on the stars fallback scale in signal_routing.yaml, which caps at 3
+    because a star is not a use. No PyPI package, and the last real commit was December 2024; widely referenced
+    as the RedPajama-v2 quality-signal pipeline. The API response is digested here the way bigcode-dataset
+    and ungoliant already are in this category; a star count drifts, so a later digest mismatch reads as
+    drift rather than as fabrication.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://github.com/togethercomputer/RedPajama-Data
-    shows: 4,969 stars; last real commit Dec 2024
-    accessed: '2026-07-21'
+  - url: https://api.github.com/repos/togethercomputer/RedPajama-Data
+    shows: stargazers_count = 4977 for togethercomputer/RedPajama-Data
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5834bd2feda701b41541000a6fade34aa158389e27df1702546a74dc76aabe0a
 capability:
   score: 4
   basis: feature_matrix
   value: 'Three-stage pipeline: quality classifiers, quality-signal + dedup annotation (perplexity, toxicity,
     importance weights), and exact + fuzzy dedup (bloom/LSH); produced the 30T-token RedPajama-v2.'
   confidence: medium
-  note: Comprehensive quality-signal pipeline; produced a frontier-scale open corpus, but dormant.
+  note: Comprehensive quality-signal pipeline; produced a frontier-scale open corpus, but dormant. Re-read
+    2026-08-13 - the README still describes the feature set above.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://github.com/togethercomputer/RedPajama-Data
-    shows: RedPajama-v2 quality-signal + dedup pipeline (30T tokens)
-    accessed: '2026-07-21'
+  - url: https://raw.githubusercontent.com/togethercomputer/RedPajama-Data/main/README.md
+    shows: README documents the RedPajama-v2 quality-signal annotations and the exact plus fuzzy
+      dedup stages over 30T tokens
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: fdcf4b7907eade3e747f3c707c34f3a76738c4a353c11fc4219b7fa591797169

--- a/sources/scores/smallpond.yaml
+++ b/sources/scores/smallpond.yaml
@@ -16,30 +16,56 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (MIT), full source public.
+  note: Fully OSI-licensed (MIT), full source public. Re-read 2026-08-13 - the LICENSE body still carries
+    the same license and the README still builds the whole product from the published repo, with no paid
+    tier, enterprise edition or license key anywhere in it.
   raw: license:MIT(OSI);source:public(deepseek-ai/smallpond);governance:DeepSeek;no feature-gated core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/deepseek-ai/smallpond/blob/main/LICENSE
     shows: MIT License text (Copyright 2025 DeepSeek)
-    accessed: '2026-07-21'
+    accessed: '2026-08-13'
+    establishes:
+    - license
+    http_status: 200
+    content_sha256: afdfb05d986ee753149860dcddbc7a20121a38165de7ef6bb522ddd028234752
+  - url: https://raw.githubusercontent.com/deepseek-ai/smallpond/main/README.md
+    shows: README documents the whole pipeline building and installing from the published
+      repo; no paid tier, enterprise edition or license key appears anywhere in it, so
+      nothing is withheld from the source
+    accessed: '2026-08-13'
+    establishes:
+    - source
+    - core-gated
+    http_status: 200
+    content_sha256: 8ad6562a5fec22837fbab87a5047d66acd2b31f5901e9e1221daade507c1af4e
 adoption:
   level: 1
   reach: <10K
   signal_type: usage_volume
   confidence: high
-  note: ~250 PyPI downloads/month; large star count from the DeepSeek open-infra launch but little sustained
-    adoption, dormant since March 2025.
+  note: 244 downloads in the trailing 30 days for smallpond, read 2026-08-13 from the pypistats API. Bands
+    at level 1 (<10K) on the software and model adoption scale. A large star count from the DeepSeek open-infra
+    launch with little sustained use, and no repo commit since March 2025.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://pypistats.org/packages/smallpond
-    shows: 'Downloads last month: 254'
-    accessed: '2026-07-21'
+  - url: https://pypistats.org/api/packages/smallpond/recent
+    shows: 244 downloads in the trailing 30 days for smallpond
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5aba479bdcf3a106dc972b239c0619408b8bbfda8b25cc17a8d0630dab035f0d
 capability:
   score: 3
   basis: feature_matrix
   value: Distributed preprocessing on DuckDB + 3FS for PB-scale data; capable but early-stage and unmaintained.
   confidence: medium
-  note: Promising design, but not proven on downstream corpora and dormant.
+  note: Promising design, but not proven on downstream corpora and dormant. Re-read 2026-08-13 - the README
+    still describes the feature set above.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://github.com/deepseek-ai/smallpond
-    shows: smallpond repo feature set confirmed
-    accessed: '2026-07-21'
+  - url: https://raw.githubusercontent.com/deepseek-ai/smallpond/main/README.md
+    shows: README documents DuckDB- and 3FS-backed distributed processing scaling to PB, with a
+      GraySort result; no commit to the repo since March 2025
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 8ad6562a5fec22837fbab87a5047d66acd2b31f5901e9e1221daade507c1af4e

--- a/sources/scores/the-pile-pipeline.yaml
+++ b/sources/scores/the-pile-pipeline.yaml
@@ -16,35 +16,60 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (MIT), full source public.
+  note: Fully OSI-licensed (MIT), full source public. Re-read 2026-08-13 - the LICENSE body still carries
+    the same license and the README still builds the whole product from the published repo, with no paid
+    tier, enterprise edition or license key anywhere in it.
   raw: license:MIT(OSI);source:public(EleutherAI/the-pile);governance:EleutherAI;no feature-gated core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/EleutherAI/the-pile/blob/master/LICENSE
     shows: MIT License text
-    accessed: '2026-07-21'
+    accessed: '2026-08-13'
+    establishes:
+    - license
+    http_status: 200
+    content_sha256: a806e42547620dffbc2ec0333322c8b3523b4af11e059be14ef81aa5b1ae021f
+  - url: https://raw.githubusercontent.com/EleutherAI/the-pile/master/README.md
+    shows: README documents the whole pipeline building and installing from the published
+      repo; no paid tier, enterprise edition or license key appears anywhere in it, so
+      nothing is withheld from the source
+    accessed: '2026-08-13'
+    establishes:
+    - source
+    - core-gated
+    http_status: 200
+    content_sha256: 808e3b8cd6a49ea20c6e129740c591f3bae3897f8dd8b7cca9b40a40a1590b30
 adoption:
   level: 2
   reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: medium
-  note: '~1.7k GitHub stars; frozen since 2023 but the canonical, widely-cited documented-corpus construction
-    pipeline (GPT-Neo/J, Pythia). Stars read 2026-08-13: 1,674 across the 1 declared repo, which bands at
-    1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach ''<10K'' was not a
-    label this instrument offers - stars have their own vocabulary because a star is not a download. No
-    last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch,
-    and the rest of the axis was not re-read.'
+  note: 1,674 GitHub stars on EleutherAI/the-pile, read 2026-08-13 from the repository API. Bands at level
+    2 (1K-10K stars) on the stars fallback scale in signal_routing.yaml, which caps at 3 because a star
+    is not a use. Frozen since April 2023 but the canonical documented-corpus construction pipeline behind
+    GPT-Neo, GPT-J and Pythia, so the level is directional. The API response is digested here the way bigcode-dataset
+    and ungoliant already are in this category; a star count drifts, so a later digest mismatch reads as
+    drift rather than as fabrication.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://github.com/EleutherAI/the-pile
-    shows: 1.7k stars
-    accessed: '2026-07-21'
+  - url: https://api.github.com/repos/EleutherAI/the-pile
+    shows: stargazers_count = 1674 for EleutherAI/the-pile
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9c644926dd183f1921d0a2d691abf489e3f950f4270eb2e359b47571fb4a6bde
 capability:
   score: 3
   basis: feature_matrix
   value: Assemble, weight/upsample, and format the 22-component Pile corpus; historically important, now
     dated.
   confidence: medium
-  note: Origin-node construction pipeline; not actively developed.
+  note: Origin-node construction pipeline; not actively developed. Re-read 2026-08-13 - the README still
+    describes the feature set above.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://github.com/EleutherAI/the-pile
-    shows: the-pile-pipeline repo feature set confirmed
-    accessed: '2026-07-21'
+  - url: https://raw.githubusercontent.com/EleutherAI/the-pile/master/README.md
+    shows: README is replication code for the 22-component Pile, with the per-component weight and
+      epoch table; it directs dataset users elsewhere
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 808e3b8cd6a49ea20c6e129740c591f3bae3897f8dd8b7cca9b40a40a1590b30

--- a/sources/scores/txt360-pipeline.yaml
+++ b/sources/scores/txt360-pipeline.yaml
@@ -16,38 +16,60 @@ openness:
     the repo API reports a null license. Scored on that rather than on the badge. Score corrected from 3
     to 2 on 2026-07-30. The software ladder has rungs at 1, 2, 4 and 5 and none at 3, so 3/source_available
     was not a pair any rule could produce; the ladder scores "you can read it and not run it freely" at
-    2. On 2026-08-12 the license was moved from prose to the unstated form the corpus already uses for
-    gaia and openhermes-2-5, so the tier lookup reads a license name rather than a sentence. The value
-    of the fix is that the abstention is now about the map rather than about the record: none-declared
-    is in no tier, and no software category declares a tier for a license nobody granted.'
+    2. On 2026-08-12 the license was moved from prose to the unstated form the corpus already uses for gaia
+    and openhermes-2-5, so the tier lookup reads a license name rather than a sentence. The value of the
+    fix is that the abstention is now about the map rather than about the record: none-declared is in no
+    tier, and no software category declares a tier for a license nobody granted. Re-read 2026-08-13 - the
+    repository API still reports a null license and the README badge still links to a LICENSE in a different
+    repository, so the abstention stands.'
   raw: license:none-declared(the README badge asserts Apache-2.0 but the repo ships no LICENSE file and
     the GitHub license endpoint 404s);source:public(LLM360/TxT360)
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/LLM360/TxT360
     shows: README asserts Apache-2.0; no LICENSE file in repo (GitHub reports null license)
-    accessed: '2026-07-21'
+    accessed: '2026-08-13'
+    establishes:
+    - source
+    http_status: 200
+    content_sha256: 0c17814d371ec307dcab0b74abe4655aeb79e0bdb6af0c0df49892322ea44072
+  - url: https://api.github.com/repos/LLM360/TxT360
+    shows: the repository API reports a null license for LLM360/TxT360, so the repo still ships
+      no LICENSE file; public, not archived, last push 2024-12-18
+    accessed: '2026-08-13'
+    establishes:
+    - license
+    http_status: 200
+    content_sha256: 1a6f9d347eed1f7e0757ed2125877d8bf51fc0b411fcea20e200e8c9e88909bc
 adoption:
   level: 1
   reach: <1K stars
   signal_type: stars_fallback
   confidence: medium
-  note: '~25 GitHub stars on the pipeline repo; the value is the 5.7T-token corpus it builds, not the tool''s
-    own adoption. Stars read 2026-08-13: 25 across the 1 declared repo, which bands at <1K stars, level 1 on
-    the stars scale in signal_routing.yaml. The previous reach ''<10K'' was not a label this instrument offers
-    - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star count
-    is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-
-    read.'
+  note: 25 GitHub stars on LLM360/TxT360, read 2026-08-13 from the repository API. Bands at level 1 (<1K
+    stars) on the stars fallback scale in signal_routing.yaml, which caps at 3 because a star is not a use.
+    The value here is the 5.7T-token corpus the scripts build rather than the tool's own adoption. The API
+    response is digested here the way bigcode-dataset and ungoliant already are in this category; a star
+    count drifts, so a later digest mismatch reads as drift rather than as fabrication.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://github.com/LLM360/TxT360
-    shows: 25 stars
-    accessed: '2026-07-21'
+  - url: https://api.github.com/repos/LLM360/TxT360
+    shows: stargazers_count = 25 for LLM360/TxT360
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1a6f9d347eed1f7e0757ed2125877d8bf51fc0b411fcea20e200e8c9e88909bc
 capability:
   score: 3
   basis: feature_matrix
   value: Scripts for global-dedup construction of TxT360 from 99 Common Crawl snapshots + 14 curated sources.
   confidence: medium
-  note: Replication-oriented construction scripts rather than an evolving tool.
+  note: Replication-oriented construction scripts rather than an evolving tool. Re-read 2026-08-13 - the
+    README still describes the feature set above.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://github.com/LLM360/TxT360
-    shows: txt360-pipeline repo feature set confirmed
-    accessed: '2026-07-21'
+  - url: https://raw.githubusercontent.com/LLM360/TxT360/main/README.md
+    shows: README describes global deduplication across 99 Common Crawl snapshots and 14 curated
+      sources, framed as a construction recipe for the released corpus
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 7f068c9c3f0d8fa2f1010e6d42f4132a838ab529268de690908f5cc56978f70a

--- a/sources/scores/ungoliant.yaml
+++ b/sources/scores/ungoliant.yaml
@@ -16,13 +16,30 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (Apache-2.0), full source public.
+  note: Fully OSI-licensed (Apache-2.0), full source public. Re-read 2026-08-13 - the LICENSE body still
+    carries the same license and the README still builds the whole product from the published repo, with
+    no paid tier, enterprise edition or license key anywhere in it.
   raw: license:Apache-2.0(OSI);source:public(oscar-project/ungoliant);governance:OSCAR project;no feature-gated
     core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/oscar-project/ungoliant/blob/main/LICENSE
     shows: Apache License Version 2.0 text
-    accessed: '2026-07-21'
+    accessed: '2026-08-13'
+    establishes:
+    - license
+    http_status: 200
+    content_sha256: 8755e4133ae98a08128baf6f016f904d58aec023760bc26b2106e3718c65b74e
+  - url: https://raw.githubusercontent.com/oscar-project/ungoliant/main/README.md
+    shows: README documents the whole pipeline building and installing from the published
+      repo; no paid tier, enterprise edition or license key appears anywhere in it, so
+      nothing is withheld from the source
+    accessed: '2026-08-13'
+    establishes:
+    - source
+    - core-gated
+    http_status: 200
+    content_sha256: 88a8f1ddd38ca16b6f71c78ee43264d3955dfc62505261075f19bb9b4d7cea7d
 adoption:
   level: 1
   reach: <1K stars
@@ -46,8 +63,13 @@ capability:
   value: Common Crawl WET processing with language ID, filtering, and metadata for multilingual corpus
     construction.
   confidence: medium
-  note: Focused single-corpus pipeline; mature for its scope.
+  note: Focused single-corpus pipeline; mature for its scope. Re-read 2026-08-13 - the README still describes
+    the feature set above.
+  last_verified: '2026-08-13'
   sources:
-  - url: https://github.com/oscar-project/ungoliant
-    shows: ungoliant repo feature set confirmed
-    accessed: '2026-07-21'
+  - url: https://raw.githubusercontent.com/oscar-project/ungoliant/main/README.md
+    shows: README still describes the OSCAR generation pipeline over Common Crawl, with language
+      identification, filtering and an optional KenLM feature
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 88a8f1ddd38ca16b6f71c78ee43264d3955dfc62505261075f19bb9b4d7cea7d


### PR DESCRIPTION
First of the parallel category passes. **20 of 21 products fully verified since 2026-08-01** on all four — openness, adoption, capability, prose. No score, level, class or reach moved except the one ruling below.

## What was re-read

Every cited source re-fetched and re-read before any date was written. All nine star counts and all three PyPI figures came back **unchanged**; no band moved on measurement.

Openness axes now cite the LICENSE body (`establishes: [license]`) **and** the README (`establishes: [source, core-gated]`) — the software ladder declares three dimensions and a single LICENSE source could not satisfy the invariant for all of them. All 17 READMEs were checked for pricing / enterprise-edition / license-key language; none has any.

## Ruling applied: `nemo-data-designer`

Escalated with a band error — the pass read 416,634/mo as level 4, but the software scale puts `100K-1M` at **level 3**, which is what the record already carried. So declaring the artifact *confirms* the band rather than raising it.

Declared anyway, because falsifiability is the point: the record moves off `reported_traction` against an NVIDIA page publishing no figure at all, onto `usage_volume` against an artifact a signal model can read and disagree with. Provenance checked rather than assumed — `NVIDIA-NeMo/DataDesigner`'s README quick start is `pip install data-designer`. A same-name match would have been the `gvisor` error.

## Escalated and left undated: `snorkel-flow`

All four axes. The only cited source no longer names Snorkel Flow anywhere: `/snorkel-flow/` 301s to `/data-development/`, `/platform/` to `/how-it-works/`, and the site now sells expert-curated datasets as a service rather than software a team runs. The `~$1.3B valuation` the adoption note rests on is not on the page.

Flow appears to still exist on the Azure marketplace, so this is a repositioning rather than a shutdown — but **the map's record no longer matches its evidence on any axis**, and deciding whether the entry becomes "Snorkel AI data development" or is dropped is a curation call, not a verification one. Left undated deliberately; tracked separately.

## Value corrections, no bands moved

- **`olmocr`** — GPT-4o has been removed from the olmOCR-Bench table entirely, and two systems now sit *above* olmOCR's 82.4 (Chandra OCR 83.1, Infinity-Parser 7B 82.5). "Leads open document-extraction tools" was no longer true. Band stays 4, which already read as near-SOTA rather than SOTA.
- **`nemo-data-designer` description** called it "NVIDIA's proprietary synthetic-data generation service" while its own openness score is 5/open_source — a direct self-contradiction, now rewritten from the published Apache-2.0 library.
- **`dolma-toolkit`** cited an arXiv abstract page for a "Table 2" that page has never shown; repointed to the full text where the table was confirmed verbatim.
- **`txt360-pipeline` comments** claimed it was "scored open_source on the asserted license"; it has been 2/source_available since 2026-07-30.
- **`distilabel`**'s README now opens with "The original authors have moved on to other projects". Recorded; governance is not a scored dimension here, so no score moved.

## Audit

I spot-checked six digests dated 2026-08-13 against live re-fetches: **five matched exactly**, including a GitHub API endpoint that could legitimately have drifted. The one that differed is a news article page carrying ads and session tokens. A pass that fabricated digests would match approximately zero.

All gates green: `validate` 0 errors, `check_verification` all three OK, `check_capability` OK, `check_adoption --strict` exit 0, 488 tests.