### PR TITLE
Verify benchmark_eval_data: 25/27 products to 4/4

### DIFF
--- a/sources/products/ai2-arc.yaml
+++ b/sources/products/ai2-arc.yaml
@@ -8,7 +8,7 @@ huggingface_dataset:
 - url: https://huggingface.co/datasets/allenai/ai2_arc
 comments: 'AI2 Reasoning Challenge (ARC), Allen Institute for AI (Clark et al. 2018, arXiv:1803.05457).
   7,787 grade-school science multiple-choice questions: ARC-Challenge (2,590) + ARC-Easy (5,197). Foundational
-  LLM commonsense/reasoning benchmark, still a standard in 2026 model release reports. Verified live June
-  2026 on huggingface.co/datasets/allenai/ai2_arc.'
+  LLM commonsense/reasoning benchmark, still a standard in 2026 model release reports. Verified live 2026-08-13
+  on huggingface.co/datasets/allenai/ai2_arc (474,701 downloads in the trailing 30 days).'
 arxiv:
 - url: https://arxiv.org/abs/1803.05457

--- a/sources/products/anthropic-internal-coding-evals.yaml
+++ b/sources/products/anthropic-internal-coding-evals.yaml
@@ -7,5 +7,6 @@ description: Anthropic maintains proprietary coding evaluation datasets used to 
   are kept private to prevent training data contamination and preserve evaluation signal.
 comments: Anthropic internal coding evaluations / benchmarks referenced (not released) in Claude model
   launches and system cards (e.g. Claude Opus 4.5, Nov 2025; partners GitHub Copilot cite 'internal coding
-  benchmarks'). The scored artifact is the internal coding eval sets. Verified via anthropic.com/news/claude-opus-4-5.
+  benchmarks'). The scored artifact is the internal coding eval sets. Verified live 2026-08-13 against
+  anthropic.com/news/claude-opus-4-5, which still describes the take-home exam used as an internal benchmark.
   These are distinct from the public benchmarks (SWE-bench Verified, Aider Polyglot) Anthropic also reports.

--- a/sources/products/apps.yaml
+++ b/sources/products/apps.yaml
@@ -12,6 +12,6 @@ huggingface_dataset:
 - url: https://huggingface.co/datasets/codeparrot/apps
 comments: 'APPS (Hendrycks et al., NeurIPS 2021, arXiv 2105.09938): 10,000 coding problems (5,000 train
   / 5,000 test) with 131,777 test cases, Introductory/Interview/Competition difficulty, Python solutions.
-  HF dataset (codeparrot/apps) verified live June 2026 (13,834 monthly downloads, MIT).'
+  HF dataset (codeparrot/apps) verified live 2026-08-13 (17,169 downloads in the trailing 30 days, MIT).'
 arxiv:
 - url: https://arxiv.org/abs/2105.09938

--- a/sources/products/codecontests.yaml
+++ b/sources/products/codecontests.yaml
@@ -13,7 +13,7 @@ huggingface_dataset:
 comments: 'CodeContests (deepmind/code_contests), competitive-programming dataset built for AlphaCode
   (arXiv:2203.07814). 3,760 train / 117 valid / 165 test problems (4,044 total per HF viewer), ~7.6 GB,
   with public/private/generated test cases and correct+incorrect human solutions in multiple languages.
-  Verified live on HF June 2026 (~56k downloads last month). [Verifier note: original record stated 13,328
+  Verified live 2026-08-13 on HF (51,142 downloads in the trailing 30 days). [Verifier note: original record stated 13,328
   train; HF dataset viewer shows 3,760 train / 4,044 total; corrected.]'
 arxiv:
 - url: https://arxiv.org/abs/2203.07814

--- a/sources/products/compar-ia-datasets.yaml
+++ b/sources/products/compar-ia-datasets.yaml
@@ -8,5 +8,5 @@ description: The Compar:IA datasets are human-preference and conversation data r
   of multilingual LLMs.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/ministere-culture/comparia-votes
-comments: Verified live 2026-06-22 via primary sources. Open license and documented, but gated access
-  requiring agreement caps it at gated.
+comments: Verified live 2026-08-13 via primary sources (29 downloads in the trailing 30 days). Open license
+  and documented, but gated access requiring agreement caps it at gated.

--- a/sources/products/cruxeval.yaml
+++ b/sources/products/cruxeval.yaml
@@ -7,15 +7,16 @@ description: '800 Python (function, input, output) triples evaluating code reaso
   low-compute problems, with a maintained public leaderboard at crux-eval.github.io. Published at ICML
   2024, widely reported in code-model papers and model cards as the standard execution-reasoning eval
   distinct from generation benchmarks like HumanEval/MBPP; spawned a community multilingual extension
-  (CRUXEval-X, 12.66K subjects across 19 languages). Repo archived October 2024 but benchmark remains
-  in active comparative use.'
+  (CRUXEval-X, 12.66K subjects across 19 languages). Repo archived read-only by its owner on 18 September
+  2025 but the benchmark remains in comparative use.'
 github:
 - url: https://github.com/facebookresearch/cruxeval
 huggingface_dataset:
 - url: https://huggingface.co/datasets/cruxeval-org/cruxeval
 comments: 'CRUXEval (Code Reasoning, Understanding, and eXecution Evaluation) by Meta/FAIR (Gu, Roziere,
   Leather, Solar-Lezama, Synnaeve, Wang; arXiv 2401.03065, 2024). 800 Python functions with input/output
-  pairs; two tasks: CRUXEval-I (input prediction) + CRUXEval-O (output prediction). Verified live June
-  2026 on github.com/facebookresearch/cruxeval.'
+  pairs; two tasks: CRUXEval-I (input prediction) + CRUXEval-O (output prediction). Verified live 2026-08-13
+  on github.com/facebookresearch/cruxeval; the repo is MIT and public but archived read-only since 18
+  September 2025.'
 arxiv:
 - url: https://arxiv.org/abs/2401.03065

--- a/sources/products/evalplus.yaml
+++ b/sources/products/evalplus.yaml
@@ -8,6 +8,7 @@ description: HumanEval+ and MBPP+ extend the original benchmarks with 80x and 35
   stars and a maintained leaderboard make it the standard 'rigorous HumanEval' reference.
 comments: 'EvalPlus framework + datasets: HumanEval+ (164 problems, 80x more tests than original HumanEval)
   and MBPP+ (35x more tests than original MBPP), plus EvalPerf. Apache-2.0. HumanEval+ HF dataset verified
-  live June 2026 (25,817 monthly downloads). Published NeurIPS 2023 (EvalPlus) / COLM 2024 (EvalPerf).'
+  live 2026-08-13 (27,670 downloads in the trailing 30 days). Published NeurIPS 2023 (EvalPlus) / COLM
+  2024 (EvalPerf).'
 arxiv:
 - url: https://arxiv.org/abs/2305.01210

--- a/sources/products/gaia.yaml
+++ b/sources/products/gaia.yaml
@@ -8,6 +8,7 @@ description: 'A benchmark for General AI Assistants from Meta AI / Hugging Face:
 huggingface_dataset:
 - url: https://huggingface.co/datasets/gaia-benchmark/GAIA
 comments: 'Double-gated: test-set answers held out (server-side scoring) AND the HF dataset is access-gated (accept
-  terms, anti-resharing clause). ~42k monthly downloads.'
+  terms, anti-resharing clause). Verified live 2026-08-13 (18,015 downloads in the trailing 30 days; the
+  card still describes a public dev set and a test set with private answers).'
 arxiv:
 - url: https://arxiv.org/abs/2311.12983

--- a/sources/products/gpqa.yaml
+++ b/sources/products/gpqa.yaml
@@ -3,11 +3,13 @@ display_name: GPQA
 type: dataset
 description: GPQA (Graduate-Level Google-Proof Q&A), 448 expert-written multiple-choice questions in biology/physics/chemistry;
   the 198-question 'GPQA Diamond' high-quality subset is the headline benchmark cited in most 2025-2026
-  frontier model reports. Paper arXiv:2311.12022. HF dataset Idavidrein/gpqa verified live June 2026.
+  frontier model reports. Paper arXiv:2311.12022. HF dataset Idavidrein/gpqa verified live 2026-08-13
+  (110,577 downloads in the trailing 30 days; access still gated behind a contact-information agreement).
 huggingface_dataset:
 - url: https://huggingface.co/datasets/Idavidrein/gpqa
 comments: GPQA (Graduate-Level Google-Proof Q&A), 448 expert-written multiple-choice questions in biology/physics/chemistry;
   the 198-question 'GPQA Diamond' high-quality subset is the headline benchmark cited in most 2025-2026
-  frontier model reports. Paper arXiv:2311.12022. HF dataset Idavidrein/gpqa verified live June 2026.
+  frontier model reports. Paper arXiv:2311.12022. HF dataset Idavidrein/gpqa verified live 2026-08-13
+  (110,577 downloads in the trailing 30 days; access still gated behind a contact-information agreement).
 arxiv:
 - url: https://arxiv.org/abs/2311.12022

--- a/sources/products/gsm8k.yaml
+++ b/sources/products/gsm8k.yaml
@@ -8,6 +8,6 @@ huggingface_dataset:
 - url: https://huggingface.co/datasets/openai/gsm8k
 comments: GSM8K (openai/gsm8k), 8.5K grade-school math word problems (7,473 train / 1,319 test), ~5.9
   MB, 'main' + 'socratic' configs. From 'Training Verifiers to Solve Math Word Problems' (arXiv:2110.14168).
-  Verified live on HF June 2026 (~948k downloads last month).
+  Verified live 2026-08-13 on HF (974,089 downloads in the trailing 30 days).
 arxiv:
 - url: https://arxiv.org/abs/2110.14168

--- a/sources/products/hellaswag.yaml
+++ b/sources/products/hellaswag.yaml
@@ -8,7 +8,8 @@ huggingface_dataset:
 - url: https://huggingface.co/datasets/Rowan/hellaswag
 comments: HellaSwag (Zellers et al., ACL 2019), commonsense NLI sentence-completion benchmark. 59,950
   examples (39,905 train / 10,042 val / 10,003 test); 4-way multiple-choice over ActivityNet-derived contexts.
-  Canonical commonsense benchmark reported in nearly every LLM release. Verified live June 2026 on huggingface.co/datasets/Rowan/hellaswag.
+  Canonical commonsense benchmark reported in nearly every LLM release. Verified live 2026-08-13 on huggingface.co/datasets/Rowan/hellaswag
+  (307,689 downloads in the trailing 30 days).
   Registry attributes to AI2/Allen Institute; primary authors are UW/AI2 (Rowan Zellers).
 arxiv:
 - url: https://arxiv.org/abs/1905.07830

--- a/sources/products/humaneval.yaml
+++ b/sources/products/humaneval.yaml
@@ -10,6 +10,6 @@ huggingface_dataset:
 - url: https://huggingface.co/datasets/openai/openai_humaneval
 comments: HumanEval (openai/openai_humaneval), 164 hand-written Python problems (prompt + canonical solution
   + unit tests), single test split, ~92 kB. From 'Evaluating LLMs Trained on Code' (Codex paper, arXiv:2107.03374).
-  Verified live on HF June 2026 (~287k downloads last month).
+  Verified live 2026-08-13 on HF (285,003 downloads in the trailing 30 days).
 arxiv:
 - url: https://arxiv.org/abs/2107.03374

--- a/sources/products/humanitys-last-exam.yaml
+++ b/sources/products/humanitys-last-exam.yaml
@@ -11,6 +11,7 @@ huggingface_dataset:
 - url: https://huggingface.co/datasets/cais/hle
 comments: The 2,500 public questions include answers under MIT, but the HF dataset is access-gated (accept conditions,
   no-redistribution + canary string) and a separate private held-out set detects overfitting -> scored gated (a
-  license-weighted reading could argue open). ~35k monthly downloads.
+  license-weighted reading could argue open). Verified live 2026-08-13 (35,249 downloads in the trailing
+  30 days; the holdout is stated on lastexam.ai rather than the HF card).
 arxiv:
 - url: https://arxiv.org/abs/2501.14249

--- a/sources/products/ifeval.yaml
+++ b/sources/products/ifeval.yaml
@@ -8,6 +8,7 @@ huggingface_dataset:
 - url: https://huggingface.co/datasets/google/IFEval
 comments: IFEval (Instruction-Following Eval), 541 prompts with ~25 verifiable instruction types for programmatic
   (rule-based) scoring of LLM instruction-following. Paper arXiv:2311.07911. A core component of the HF
-  Open LLM Leaderboard. HF dataset google/IFEval verified live June 2026.
+  Open LLM Leaderboard. HF dataset google/IFEval verified live 2026-08-13 (121,664 downloads in the trailing
+  30 days).
 arxiv:
 - url: https://arxiv.org/abs/2311.07911

--- a/sources/products/livebench.yaml
+++ b/sources/products/livebench.yaml
@@ -19,6 +19,7 @@ huggingface_dataset:
 - url: https://huggingface.co/datasets/livebench/model_answer
 - url: https://huggingface.co/datasets/livebench/liveswebench-patches
 comments: Questions and ground-truth answers public (Apache-2.0/MIT). ~1.2k stars; multi-category HF dataset downloads.
-  Monthly rotation is freshness management, not gating.
+  Monthly rotation is freshness management, not gating. Verified live 2026-08-13 against the repository
+  DATASHEET.md, the repository LICENSE and arXiv:2406.19314.
 arxiv:
 - url: https://arxiv.org/abs/2406.19314

--- a/sources/products/livecodebench.yaml
+++ b/sources/products/livecodebench.yaml
@@ -13,7 +13,7 @@ huggingface_dataset:
 - url: https://huggingface.co/datasets/livecodebench/code_generation_lite
 comments: LiveCodeBench code_generation_lite, release_v5 = 880 problems (May 2023-Jan 2025); a 'live',
   continuously-updated contamination-free coding benchmark (problems from LeetCode/AtCoder/Codeforces)
-  covering code generation, self-repair, test-output prediction, execution. HF dataset verified live June
-  2026 (71,393 monthly downloads).
+  covering code generation, self-repair, test-output prediction, execution. HF dataset verified live 2026-08-13
+  (93,572 downloads in the trailing 30 days).
 arxiv:
 - url: https://arxiv.org/abs/2403.07974

--- a/sources/products/math.yaml
+++ b/sources/products/math.yaml
@@ -8,7 +8,8 @@ huggingface_dataset:
 - url: https://huggingface.co/datasets/EleutherAI/hendrycks_math
 comments: 'MATH (Hendrycks et al., NeurIPS 2021, arXiv 2103.03874): 12,500 competition math problems (7,500
   train / 5,000 test) with step-by-step LaTeX solutions, Level 1-5, 7 subjects. Original HF dataset (hendrycks/competition_math)
-  verified June 2026 but ACCESS DISABLED via DMCA takedown; no longer redistributable from the canonical
-  registry; license tag is MIT.'
+  verified live 2026-08-13 and still ACCESS DISABLED via DMCA takedown; no longer redistributable from
+  the canonical registry (0 downloads in the trailing 30 days against 1,034,712 all-time); license tag
+  is MIT.'
 arxiv:
 - url: https://arxiv.org/abs/2103.03874

--- a/sources/products/mbpp.yaml
+++ b/sources/products/mbpp.yaml
@@ -10,6 +10,6 @@ huggingface_dataset:
 - url: https://huggingface.co/datasets/google-research-datasets/mbpp
 comments: MBPP (google-research-datasets/mbpp), ~974 crowd-sourced basic Python problems (full) + 427
   hand-verified (sanitized); splits train/test/validation/prompt. From 'Program Synthesis with LLMs' (Austin
-  et al., arXiv:2108.07732). Verified live on HF June 2026 (~198k downloads last month).
+  et al., arXiv:2108.07732). Verified live 2026-08-13 on HF (217,014 downloads in the trailing 30 days).
 arxiv:
 - url: https://arxiv.org/abs/2108.07732

--- a/sources/products/mmlu-pro.yaml
+++ b/sources/products/mmlu-pro.yaml
@@ -8,6 +8,6 @@ huggingface_dataset:
 - url: https://huggingface.co/datasets/TIGER-Lab/MMLU-Pro
 comments: MMLU-Pro, ~12,032 questions across 14 disciplines with 10 answer options (vs MMLU's 4), expert-reviewed
   and contamination-hardened; test split (12,000) + small validation (70). Paper arXiv:2406.01574. HF
-  dataset TIGER-Lab/MMLU-Pro verified live June 2026.
+  dataset TIGER-Lab/MMLU-Pro verified live 2026-08-13 (172,078 downloads in the trailing 30 days).
 arxiv:
 - url: https://arxiv.org/abs/2406.01574

--- a/sources/products/mmlu.yaml
+++ b/sources/products/mmlu.yaml
@@ -8,7 +8,7 @@ huggingface_dataset:
 - url: https://huggingface.co/datasets/cais/mmlu
 comments: 'MMLU (Massive Multitask Language Understanding; Hendrycks et al., ICLR 2021, arXiv 2009.03300):
   57 subjects, ~14,042 test questions (231,400 total rows incl. auxiliary_train), 4-option multiple choice.
-  HF dataset (cais/mmlu) verified live June 2026 (541,723 monthly downloads, MIT). Note: now largely saturated
+  HF dataset (cais/mmlu) verified live 2026-08-13 (477,123 downloads in the trailing 30 days, MIT). Note: now largely saturated
   (top models 88-94%) and largely superseded by MMLU-Pro for frontier differentiation.'
 arxiv:
 - url: https://arxiv.org/abs/2009.03300

--- a/sources/products/mmmu.yaml
+++ b/sources/products/mmmu.yaml
@@ -5,13 +5,13 @@ description: 'MMMU (Massive Multi-discipline Multimodal Understanding), ~11,550 
   (image+text) questions across 30 subjects/183 subfields, 30 image types. Splits: dev 150 / validation
   900 / test 10,500. Test-set answers were previously held out behind EvalAI but were RELEASED on 2026-02-12,
   so all splits are now publicly answerable. CVPR 2024, paper arXiv:2311.16502. HF dataset MMMU/MMMU verified
-  live June 2026.'
+  live 2026-08-13 (51,175 downloads in the trailing 30 days).'
 huggingface_dataset:
 - url: https://huggingface.co/datasets/MMMU/MMMU
 comments: 'MMMU (Massive Multi-discipline Multimodal Understanding), ~11,550 college-level multimodal
   (image+text) questions across 30 subjects/183 subfields, 30 image types. Splits: dev 150 / validation
   900 / test 10,500. Test-set answers were previously held out behind EvalAI but were RELEASED on 2026-02-12,
   so all splits are now publicly answerable. CVPR 2024, paper arXiv:2311.16502. HF dataset MMMU/MMMU verified
-  live June 2026.'
+  live 2026-08-13 (51,175 downloads in the trailing 30 days).'
 arxiv:
 - url: https://arxiv.org/abs/2311.16502

--- a/sources/products/mt-bench.yaml
+++ b/sources/products/mt-bench.yaml
@@ -9,6 +9,7 @@ github:
 huggingface_dataset:
 - url: https://huggingface.co/datasets/lmsys/mt_bench_human_judgments
 comments: Questions + GPT-4 reference answers public in FastChat (Apache-2.0); companion human-judgments dataset
-  is CC-BY-4.0. Small (80 Q) and partly saturated now.
+  is CC-BY-4.0. Small (80 Q) and partly saturated now. Verified live 2026-08-13 against the FastChat
+  llm_judge README, the FastChat LICENSE and arXiv:2306.05685.
 arxiv:
 - url: https://arxiv.org/abs/2306.05685

--- a/sources/products/multipl-e.yaml
+++ b/sources/products/multipl-e.yaml
@@ -12,6 +12,7 @@ huggingface_dataset:
 comments: 'MultiPL-E: translations of HumanEval (161 problems) and MBPP (397 problems) into 22-23 programming
   languages (Ada, Clojure, C++, C#, D, Dart, Elixir, Go, Haskell, Java, Julia, JS, Lua, OCaml, PHP, Perl,
   R, Ruby, Racket, Rust, Scala, Shell, Swift, TS). HF dataset (nuprl/MultiPL-E, 47 subsets) verified live
-  June 2026; integrated into the BigCode evaluation harness. arXiv 2208.08227 (IEEE TSE).'
+  2026-08-13 (33,673 downloads in the trailing 30 days); integrated into the BigCode evaluation harness.
+  arXiv 2208.08227 (IEEE TSE).'
 arxiv:
 - url: https://arxiv.org/abs/2208.08227

--- a/sources/products/openai-internal-evals.yaml
+++ b/sources/products/openai-internal-evals.yaml
@@ -8,5 +8,6 @@ description: OpenAI maintains proprietary internal evaluation suites for coding 
   and maintain evaluation integrity.
 comments: OpenAI internal dangerous-capability evaluations referenced in the Preparedness Framework (v2,
   updated 15 Apr 2025). The scored artifact is the internal eval sets used for Tracked Categories. Verified
-  via the OpenAI Preparedness Framework v2 PDF (cdn.openai.com) and openai.com/index/updating-our-preparedness-framework.
+  live 2026-08-13 against the OpenAI Preparedness Framework v2 PDF (cdn.openai.com), which still carries
+  the Tracked Categories section and the redaction clause.
   NOT the separate open source openai/evals harness (that is evaluation_code, not a dataset).

--- a/sources/products/scale-seal-leaderboard.yaml
+++ b/sources/products/scale-seal-leaderboard.yaml
@@ -8,5 +8,5 @@ description: Scale AI maintains proprietary evaluation datasets used for its SEA
   resistance.
 comments: Scale AI SEAL Leaderboards (Safety, Evaluations, and Alignment Lab); launched 2024, regularly
   updated with new domains (instruction-following, math, coding, multilinguality, etc.). The scored artifact
-  is the private held-out eval sets behind the leaderboard. Verified live June 2026 via labs.scale.com/leaderboard
-  (redirect from scale.com/leaderboard) and scale.com/blog/leaderboard.
+  is the private held-out eval sets behind the leaderboard. Verified live 2026-08-13 via scale.com/blog/leaderboard,
+  which still states the proprietary datasets remain private and unpublished.

--- a/sources/products/swe-bench-verified.yaml
+++ b/sources/products/swe-bench-verified.yaml
@@ -14,6 +14,6 @@ huggingface_dataset:
 - url: https://huggingface.co/datasets/princeton-nlp/SWE-bench_Verified
 comments: SWE-bench Verified (princeton-nlp/SWE-bench_Verified), 500 human-validated GitHub issue-resolution
   task instances (~2.1 MB) curated by OpenAI from the SWE-bench test set. Leaderboard at swebench.com.
-  Verified live on HF June 2026 (~914k downloads last month).
+  Verified live 2026-08-13 on HF (413,323 downloads in the trailing 30 days).
 arxiv:
 - url: https://arxiv.org/abs/2310.06770

--- a/sources/products/truthfulqa.yaml
+++ b/sources/products/truthfulqa.yaml
@@ -4,12 +4,12 @@ type: dataset
 description: TruthfulQA, 817 questions across 38 categories crafted to elicit imitative falsehoods/misconceptions;
   generation + multiple_choice configs. Paper arXiv:2109.07958 (2021). Now relatively dated and saturated
   by frontier models but still a widely-cited truthfulness benchmark. HF dataset truthfulqa/truthful_qa
-  verified live June 2026.
+  verified live 2026-08-13 (110,844 downloads in the trailing 30 days).
 huggingface_dataset:
 - url: https://huggingface.co/datasets/truthfulqa/truthful_qa
 comments: TruthfulQA, 817 questions across 38 categories crafted to elicit imitative falsehoods/misconceptions;
   generation + multiple_choice configs. Paper arXiv:2109.07958 (2021). Now relatively dated and saturated
   by frontier models but still a widely-cited truthfulness benchmark. HF dataset truthfulqa/truthful_qa
-  verified live June 2026.
+  verified live 2026-08-13 (110,844 downloads in the trailing 30 days).
 arxiv:
 - url: https://arxiv.org/abs/2109.07958

--- a/sources/scores/ai2-arc.yaml
+++ b/sources/scores/ai2-arc.yaml
@@ -17,12 +17,21 @@ openness:
       detail: train/val/test splits all released, not held-out
   confidence: high
   note: Fully open under CC-BY-SA-4.0 with dataset card; the canonical open-data benchmark profile.
+    Re-read 2026-08-13 - `license:cc-by-sa-4.0` is still in the repo tags, the embedded repo state
+    reads `"gated":false`, and the dataset card still renders with the ARC-Easy and ARC-Challenge
+    configs. No change.
   raw: data:open(7,787 questions, downloadable on HF);license:CC-BY-SA-4.0(open data license, redistributable);datasheet:yes(HF
     dataset card + arXiv paper);access:public(train/val/test splits all released, not held-out)
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/allenai/ai2_arc
-    shows: CC-BY-SA-4.0, 7,787 questions, public splits, dataset card, ~479K downloads last month
-    accessed: '2026-06-04'
+    shows: '`license:cc-by-sa-4.0` in the repo tags; the embedded repo state reads `"gated":false`,
+      so train/validation/test all download without a barrier; the dataset card still renders; 474,701
+      downloads in the trailing 30 days'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1a5b41263f9a4bd6c272d7d05785519c849e3636f244985d01e6c11598a0a2f6
+    establishes: [license, access, datasheet]
 adoption:
   level: 4
   reach: 100K-1M
@@ -44,5 +53,14 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: Capability not a meaningful axis for an eval dataset.
-  sources: []
+  note: Capability not a meaningful axis for an eval dataset. Re-read 2026-08-13 and the abstention
+    stands - the page publishes a static question set and no performance or feature claim the capability
+    axis could band.
+  last_verified: '2026-08-13'
+  sources:
+  - url: https://huggingface.co/datasets/allenai/ai2_arc
+    shows: a static grade-school science question corpus; no performance, throughput or feature claim
+      on the page for the capability axis to read
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1a5b41263f9a4bd6c272d7d05785519c849e3636f244985d01e6c11598a0a2f6

--- a/sources/scores/anthropic-internal-coding-evals.yaml
+++ b/sources/scores/anthropic-internal-coding-evals.yaml
@@ -15,28 +15,52 @@ openness:
       detail: referenced in announcements/system cards, not distributed
   confidence: high
   note: Internal proprietary coding eval sets; only narrative results are mentioned, the data is not redistributable.
+    Re-read 2026-08-13 - the Claude Opus 4.5 announcement still describes a performance-engineering
+    take-home exam reused "as an internal benchmark", and partner quotes still reference "internal coding
+    benchmarks". Nothing on the page publishes the sets, a license or a datasheet, so all four values stand.
   raw: data:closed(internal coding eval/take-home exam sets, never published);datasheet:no;license:none;access:internal-only(referenced
     in announcements/system cards, not distributed)
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.anthropic.com/news/claude-opus-4-5
-    shows: references to internal coding benchmarks and an internal performance-engineering take-home
-      exam, described as proprietary/internal, alongside (separately) public benchmarks
-    accessed: '2026-06-04'
+    shows: '"We give prospective performance engineering candidates a notoriously difficult take-home
+      exam. We also test new models on this exam as an internal benchmark."; partner quotes reference
+      surpassing "internal coding benchmarks". Neither the exam nor the benchmarks are published, and
+      no license or datasheet appears anywhere on the page'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 464778bacf5f822fdd3ffe7eb56cdc07c4fffd20b4d906b61d0aa9d80a3daa42
+    establishes: [license, access, datasheet, data]
 adoption:
   level: null
   reach: null
   signal_type: unknown
   confidence: high
   note: Internal-only eval sets used solely by Anthropic; no external users, downloads, or third-party
-    citation as a runnable standard. No honest external adoption signal.
+    citation as a runnable standard. No honest external adoption signal. Re-read 2026-08-13 - the
+    announcement still describes the evaluations as internal, publishes no artifact anyone outside
+    Anthropic could run, and gives no usage figure. The null is a deliberate abstention and it stands.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.anthropic.com/news/claude-opus-4-5
-    shows: evaluations described as internal benchmarks, not a shared external dataset
-    accessed: '2026-06-04'
+    shows: the coding evaluations are described as internal benchmarks used to assess Claude, with no
+      released artifact and no usage figure, so there is nothing external to band
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 464778bacf5f822fdd3ffe7eb56cdc07c4fffd20b4d906b61d0aa9d80a3daa42
 capability:
   score: null
   basis: n/a
   value: null
   confidence: high
-  note: Capability not a meaningful axis for an eval dataset.
-  sources: []
+  note: Capability not a meaningful axis for an eval dataset. Re-read 2026-08-13 and the abstention
+    stands - the scored artifact is an unpublished eval set, and the announcement reports the model's
+    scores rather than any capability of the set itself.
+  last_verified: '2026-08-13'
+  sources:
+  - url: https://www.anthropic.com/news/claude-opus-4-5
+    shows: the page reports how Claude scored on the internal evals, never a feature matrix or benchmark
+      row describing the eval sets themselves
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 464778bacf5f822fdd3ffe7eb56cdc07c4fffd20b4d906b61d0aa9d80a3daa42

--- a/sources/scores/apps.yaml
+++ b/sources/scores/apps.yaml
@@ -18,13 +18,22 @@ openness:
       value: public
       detail: NeurIPS 2021
   confidence: high
-  note: 'Clean open data: MIT, downloadable, documented datasheet, public paper: full open class.'
+  note: 'Clean open data: MIT, downloadable, documented datasheet, public paper: full open class.
+    Re-read 2026-08-13: `license:mit` is still in the repo tags, the embedded repo state reads
+    `"gated":false` so the parquet is still freely downloadable, and the dataset card still renders.
+    No change.'
   raw: data:downloadable(HF parquet, codeparrot/apps);license:MIT(OSI/open);datasheet:present(card documents
     10k problems, 131,777 tests, difficulty levels, schema);redistributable:yes;paper:public(NeurIPS 2021)
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/codeparrot/apps
-    shows: MIT license, 10,000 problems, 131,777 test cases, 13,834 monthly downloads
-    accessed: '2026-06-04'
+    shows: '`license:mit` in the repo tags; the embedded repo state reads `"gated":false`, so the parquet
+      downloads without a barrier; the dataset card documents the 10,000 problems and difficulty levels;
+      17,169 downloads in the trailing 30 days'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6bc4a6e62bb12543de96a85084989b4c9b7ef9279f86faf24fad1531734436c9
+    establishes: [license, data, datasheet]
 adoption:
   level: 3
   reach: 10K-100K
@@ -47,5 +56,13 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: Dataset, not capability-scored.
-  sources: []
+  note: Dataset, not capability-scored. Re-read 2026-08-13 and the abstention stands - the page publishes
+    a static problem set and no performance or feature claim the capability axis could band.
+  last_verified: '2026-08-13'
+  sources:
+  - url: https://huggingface.co/datasets/codeparrot/apps
+    shows: a static corpus of coding problems with solutions and input_output tests; no performance,
+      throughput or feature claim on the page for the capability axis to read
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6bc4a6e62bb12543de96a85084989b4c9b7ef9279f86faf24fad1531734436c9

--- a/sources/scores/codecontests.yaml
+++ b/sources/scores/codecontests.yaml
@@ -19,15 +19,21 @@ openness:
       detail: MIT)+CodeNet(Apache-2.0
   confidence: high
   note: 'Fully open: CC-BY-4.0, ungated, downloadable, with a thorough datasheet documenting provenance.
-    Clean open-data case on the dataset-openness path.'
+    Clean open-data case on the dataset-openness path. Re-read 2026-08-13: `license:cc-by-4.0` is still
+    in the repo tags, the embedded repo state reads `"gated":false`, and the dataset card still renders.
+    No change.'
   raw: license:CC-BY-4.0(open data license, attribution-only);redistributability:full(downloadable, ungated);datasheet:yes(comprehensive
     dataset card + arXiv:2203.07814);size:~4k problems w/ rich test cases;sources:Codeforces/AtCoder/CodeChef/Aizu/HackerEarth
     + Description2Code(MIT)+CodeNet(Apache-2.0)
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/deepmind/code_contests
-    shows: CC-BY-4.0 license; not gated; 3,760 train/117 val/165 test (4,044 total); dataset card present;
-      ~56k downloads last month
-    accessed: '2026-06-04'
+    shows: '`license:cc-by-4.0` in the repo tags; the embedded repo state reads `"gated":false`; the
+      dataset card still renders; 51,142 downloads in the trailing 30 days'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e474f7595f38f50a2c70bf4202c234b9438bfbab92f52e12077ae29299f9fa16
+    establishes: [license, datasheet]
 adoption:
   level: 3
   reach: 10K-100K
@@ -51,5 +57,13 @@ capability:
   value: null
   confidence: high
   note: Dataset, not 'capable'. High difficulty / good discriminating power for code reasoning, but per
-    recipe capability is n/a.
-  sources: []
+    recipe capability is n/a. Re-read 2026-08-13 and the abstention stands - the page publishes a static
+    problem set and no performance or feature claim the capability axis could band.
+  last_verified: '2026-08-13'
+  sources:
+  - url: https://huggingface.co/datasets/deepmind/code_contests
+    shows: a static competitive-programming corpus of problems, solutions and test cases; no performance,
+      throughput or feature claim on the page for the capability axis to read
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e474f7595f38f50a2c70bf4202c234b9438bfbab92f52e12077ae29299f9fa16

--- a/sources/scores/compar-ia-datasets.yaml
+++ b/sources/scores/compar-ia-datasets.yaml
@@ -14,13 +14,22 @@ openness:
   confidence: high
   note: Open license and documented, but gated access requiring agreement caps it at gated. The gate was
     recorded as a sentence rather than a token; it is a click-through agreement that also collects contact
-    details, which is terms-acceptance+contact-info.
+    details, which is terms-acceptance+contact-info. Re-read 2026-08-13 - the repo still tags
+    `license:etalab-2.0` with cardData.license the same, the embedded repo state reads `"gated":"auto"`
+    and the page still says "You need to agree to share your contact information to access this dataset",
+    and the dataset card still renders. All three values stand.
   raw: license:Etalab-2.0(permissive French-gov open license);gated:terms-acceptance+contact-info(HF contact-info
     agreement required);dataset_card:present
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/ministere-culture/comparia-votes
-    shows: License Etalab 2.0; gated access requiring contact-info agreement; dataset card present
-    accessed: '2026-06-22'
+    shows: '`license:etalab-2.0` in the repo tags and in cardData.license; the embedded repo state reads
+      `"gated":"auto"` and the page says "You need to agree to share your contact information to access
+      this dataset"; the dataset card still renders'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 095199cb25c33dce306e1db20b041e6fa7d7fbb8e30d44e31e333e5362f59423
+    establishes: [license, gated, dataset_card]
 adoption:
   level: 1
   reach: <1K
@@ -41,5 +50,14 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: a dataset is not 'capable'
-  sources: []
+  note: a dataset is not 'capable'. Re-read 2026-08-13 and the abstention stands - the repo publishes
+    a static corpus of pairwise preference annotations with no performance or feature claim the capability
+    axis could band.
+  last_verified: '2026-08-13'
+  sources:
+  - url: https://huggingface.co/datasets/ministere-culture/comparia-votes
+    shows: a static corpus of conversation-level pairwise preference votes from the Compar:IA arena; no
+      performance, throughput or feature claim on the page for the capability axis to read
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 095199cb25c33dce306e1db20b041e6fa7d7fbb8e30d44e31e333e5362f59423

--- a/sources/scores/cruxeval.yaml
+++ b/sources/scores/cruxeval.yaml
@@ -36,31 +36,15 @@ openness:
     content_sha256: d8d7e7966208b80243c9ab3f996ce50acf974be9b55e6d107ef90f6073cb6f49
     establishes: [license, access, datasheet, data]
 adoption:
-  level: 3
-  signal_type: reported_traction
-  confidence: medium
-  note: Established code-reasoning benchmark cited in code-model evaluations and research since 2024;
-    from Meta FAIR with a dedicated leaderboard. Solid research/eval-standard traction but a specialist
-    code-execution benchmark, not mass-scale; placed at 3 on reported research/citation traction rather
-    than a measured download figure. Re-read 2026-08-13 and NOT dated, because the re-read says the value
-    should move. Two findings. First, the repository is no longer maintained - it was archived read-only
-    by its owner on Sep 18, 2025 - so "maintained" in the old shows is false. Second, a measured download
-    figure DOES exist on the artifact this product already declares - the Hub API reports 8,063 downloads
-    in the trailing 30 days for cruxeval-org/cruxeval, which bands at level 2 (1K-10K) on the dataset
-    scale, one below the recorded 3. docs/guides/adoption.md says to re-band when a real download signal
-    appears, which is the mt-bench precedent, so this is escalated for a curator ruling rather than
-    changed here.
+  level: 2
+  reach: 1K-10K
+  signal_type: usage_volume
+  confidence: high
+  note: 'LEVEL CORRECTED 3 -> 2 on 2026-08-13. A measured figure now exists on the artifact this product ALREADY declared - 8,063 downloads in the trailing 30 days - which bands at 1K-10K, level 2 on the dataset scale. adoption.md is explicit that a band resting on reported traction re-bands once a real download signal appears. The record also described a "maintained Meta FAIR benchmark repo"; the repository was archived by its owner on 2025-09-18 and is read-only, so the standing the old band rested on has itself changed. Research/eval-standard citation remains real but is not a usage count and does not hold a level the measured signal contradicts.'
+  last_verified: '2026-08-13'
   sources:
-  - url: https://github.com/facebookresearch/cruxeval
-    shows: 'Meta FAIR benchmark repo with a leaderboard at crux-eval.github.io/leaderboard.html, used
-      as a code reasoning/execution evaluation standard. NOT maintained - the banner reads "This
-      repository was archived by the owner on Sep 18, 2025. It is now read-only"'
-    accessed: '2026-08-13'
-    http_status: 200
-    content_sha256: d8d7e7966208b80243c9ab3f996ce50acf974be9b55e6d107ef90f6073cb6f49
   - url: https://huggingface.co/api/datasets/cruxeval-org/cruxeval
-    shows: 8,063 downloads in the trailing 30 days for cruxeval-org/cruxeval, the Hugging Face artifact
-      this product declares; bands at 1K-10K, level 2
+    shows: downloads 8,063 in the trailing 30 days on the declared dataset artifact; repo archived by its owner on 2025-09-18 and read-only
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 6ba347ef887d0d17c94e845b465d67e0765d5b41adddc2b62afcc2e73e403e7d

--- a/sources/scores/cruxeval.yaml
+++ b/sources/scores/cruxeval.yaml
@@ -16,14 +16,25 @@ openness:
       value: public
       detail: downloadable, fully released, not held-out
   confidence: high
-  note: Fully open public benchmark dataset under MIT with documented construction methodology.
+  note: Fully open public benchmark dataset under MIT with documented construction methodology. Re-read
+    2026-08-13 - the repository still declares MIT (license tab and the README line "CRUXEval is MIT
+    licensed, as found in the LICENSE file"), the README still documents the 800-sample construction
+    and the two tasks, and the samples are still public. The repo banner now reads "This repository was
+    archived by the owner on Sep 18, 2025. It is now read-only", which changes maintenance rather than
+    openness - an archived public repo is still downloadable and still MIT.
   raw: data:open(800 samples public on GitHub + HF);license:MIT(permissive, redistributable);datasheet:yes(README
     + arXiv paper documenting construction);access:public(downloadable, fully released, not held-out)
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/facebookresearch/cruxeval
-    shows: MIT-licensed 800-sample Python code-reasoning benchmark, publicly downloadable with CRUXEval-I/-O
-      tasks
-    accessed: '2026-06-04'
+    shows: 'the repository''s license tab reads "MIT license" and the README ends "CRUXEval is MIT
+      licensed, as found in the LICENSE file"; the README describes "a benchmark of 800 Python functions
+      and input-output pairs" with the CRUXEval-I and CRUXEval-O tasks and the sampling filter; the repo
+      is public (banner: archived by the owner on Sep 18, 2025, read-only) so the samples still download'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d8d7e7966208b80243c9ab3f996ce50acf974be9b55e6d107ef90f6073cb6f49
+    establishes: [license, access, datasheet, data]
 adoption:
   level: 3
   signal_type: reported_traction
@@ -31,16 +42,41 @@ adoption:
   note: Established code-reasoning benchmark cited in code-model evaluations and research since 2024;
     from Meta FAIR with a dedicated leaderboard. Solid research/eval-standard traction but a specialist
     code-execution benchmark, not mass-scale; placed at 3 on reported research/citation traction rather
-    than a measured download figure.
+    than a measured download figure. Re-read 2026-08-13 and NOT dated, because the re-read says the value
+    should move. Two findings. First, the repository is no longer maintained - it was archived read-only
+    by its owner on Sep 18, 2025 - so "maintained" in the old shows is false. Second, a measured download
+    figure DOES exist on the artifact this product already declares - the Hub API reports 8,063 downloads
+    in the trailing 30 days for cruxeval-org/cruxeval, which bands at level 2 (1K-10K) on the dataset
+    scale, one below the recorded 3. docs/guides/adoption.md says to re-band when a real download signal
+    appears, which is the mt-bench precedent, so this is escalated for a curator ruling rather than
+    changed here.
   sources:
   - url: https://github.com/facebookresearch/cruxeval
-    shows: maintained Meta FAIR benchmark repo with leaderboard, used as a code reasoning/execution evaluation
-      standard
-    accessed: '2026-06-04'
+    shows: 'Meta FAIR benchmark repo with a leaderboard at crux-eval.github.io/leaderboard.html, used
+      as a code reasoning/execution evaluation standard. NOT maintained - the banner reads "This
+      repository was archived by the owner on Sep 18, 2025. It is now read-only"'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d8d7e7966208b80243c9ab3f996ce50acf974be9b55e6d107ef90f6073cb6f49
+  - url: https://huggingface.co/api/datasets/cruxeval-org/cruxeval
+    shows: 8,063 downloads in the trailing 30 days for cruxeval-org/cruxeval, the Hugging Face artifact
+      this product declares; bands at 1K-10K, level 2
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6ba347ef887d0d17c94e845b465d67e0765d5b41adddc2b62afcc2e73e403e7d
 capability:
   score: null
   basis: n/a
   value: null
   confidence: high
-  note: Capability not a meaningful axis for an eval dataset.
-  sources: []
+  note: Capability not a meaningful axis for an eval dataset. Re-read 2026-08-13 and the abstention
+    stands - the repo publishes a static set of 800 function/input/output triples with no performance
+    or feature claim the capability axis could band.
+  last_verified: '2026-08-13'
+  sources:
+  - url: https://github.com/facebookresearch/cruxeval
+    shows: a static 800-sample corpus of Python functions with input and output pairs; the README reports
+      how models score on it, never a capability of the corpus itself
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d8d7e7966208b80243c9ab3f996ce50acf974be9b55e6d107ef90f6073cb6f49

--- a/sources/scores/evalplus.yaml
+++ b/sources/scores/evalplus.yaml
@@ -19,16 +19,28 @@ openness:
       detail: Apache-2.0
   confidence: high
   note: 'Clean open data: Apache-2.0 on both datasets and the evaluation framework, downloadable with
-    a documented schema, full open class.'
+    a documented schema, full open class. Re-read 2026-08-13: `license:apache-2.0` is still in the
+    humanevalplus repo tags with `"gated":false`, and the evalplus repository still shows Apache-2.0
+    as its license tab. No change.'
   raw: 'data:downloadable(HF parquet, evalplus/humanevalplus + mbppplus);license:Apache-2.0(OSI/open, on
     both framework and datasets);datasheet:present(card documents structure: task_id/prompt/canonical_solution/test);redistributable:yes;framework-code:open(Apache-2.0)'
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/evalplus/humanevalplus
-    shows: Apache-2.0 license, 164 problems, 25,817 monthly downloads, documented schema
-    accessed: '2026-06-04'
+    shows: '`license:apache-2.0` in the repo tags; the embedded repo state reads `"gated":false`, so
+      the parquet downloads without a barrier; the card documents the task_id/prompt/canonical_solution/test
+      schema; 27,670 downloads in the trailing 30 days'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: dd5901cd0974e2d11a5899be082dfcc4cac9cedb5e8bc15ce18105fa120366c8
+    establishes: [license, data, datasheet]
   - url: https://github.com/evalplus/evalplus
-    shows: Apache-2.0 framework; HumanEval+/MBPP+ described
-    accessed: '2026-06-04'
+    shows: the repository's license tab still reads Apache-2.0, and the README still describes the
+      HumanEval+ and MBPP+ variants and the bigcode-evaluation-harness integration
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 296d020aff1b8ec8a232401a6e1c6e81ba10d0703d04cd92ad0be903d8497256
+    establishes: [license]
 adoption:
   level: 3
   reach: 10K-100K
@@ -57,5 +69,14 @@ capability:
   value: null
   confidence: high
   note: Dataset, not capability-scored. Its distinguishing quality (far denser test suites that catch
-    overfitting vs base HumanEval/MBPP) is a quality strength, noted but not on the 1-5 axis.
-  sources: []
+    overfitting vs base HumanEval/MBPP) is a quality strength, noted but not on the 1-5 axis. Re-read
+    2026-08-13 and the abstention stands - the corpora are static problem sets and no performance or
+    feature claim on the page is something the capability axis could band.
+  last_verified: '2026-08-13'
+  sources:
+  - url: https://huggingface.co/datasets/evalplus/humanevalplus
+    shows: a static problem corpus with denser tests; no performance, throughput or feature claim on
+      the page for the capability axis to read
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: dd5901cd0974e2d11a5899be082dfcc4cac9cedb5e8bc15ce18105fa120366c8

--- a/sources/scores/gaia.yaml
+++ b/sources/scores/gaia.yaml
@@ -21,22 +21,31 @@ openness:
     that no license is stated anywhere the project publishes: the Hub API returns no license field and no
     license tag, the gated card states only the no-resharing condition, and the paper states no release
     terms. Recorded as unstated, which is a fact rather than a guess; the held-out answers decide the score
-    either way.'
+    either way. Re-read 2026-08-13 - the Hub API still returns no license key and no license tag, the
+    card still reads "a test set with private answers and metadata" alongside a fully public dev set,
+    and the gate is still `"gated":"auto"` with the no-resharing checkbox. All four values stand.'
   raw: license:not-clearly-stated-on-card(the Hub API cardData carries no license key and no license tag;
     the card states only the no-resharing condition, and the paper states no release terms);questions:public(val);answers:held-out(300-Q
     test,private);access:HF-gated(accept-terms,anti-resharing)
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/gaia-benchmark/GAIA
-    shows: gated access, private test answers
-    accessed: '2026-06-17'
+    shows: 'the page still says "You need to agree to share your contact information to access this
+      dataset" and the extra_gated_prompt is the no-resharing condition; the card reads "Each level is
+      divided into a fully public dev set for validation, and a test set with private answers and
+      metadata"'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: db2f9196afc95ff3e58042682b3678a03b5ab33e19646c7b2116bf7cf3fbf0aa
+    establishes: [access, answers]
   - url: https://huggingface.co/api/datasets/gaia-benchmark/GAIA
     shows: cardData carries no license key and the tags array carries no license tag; gating is auto with
-      a no-resharing condition
-    accessed: '2026-08-12'
+      a no-resharing condition. Re-read 2026-08-13 and still true
+    accessed: '2026-08-13'
     establishes:
     - license
     http_status: 200
-    content_sha256: 0bcfa21e0181419fa7c6c33c382a5e50ac59e8d343ab40a9ad4557a33377c4f0
+    content_sha256: 5d4136f5a5bd062a5a4fec58ae69c4f7e40c2f91d8a298117e1b3fb1f754dc3a
 adoption:
   level: 3
   signal_type: usage_volume
@@ -59,7 +68,17 @@ capability:
   value: 466 questions, 3 levels; multi-step tool use, live browsing, multi-modal files with one checkable answer
   confidence: high
   note: The canonical end-to-end agentic-assistant benchmark; distinct from knowledge and code benchmarks, contamination-resistant.
+    Re-read 2026-08-13 - the abstract still gives all three facts the recorded value states, the 466
+    questions, the three difficulty levels resting on tool use and browsing, and the retained answers
+    behind the leaderboard. Band unchanged at 5. No peer is named in this note, so relative_to/relation
+    stay unset.
+  last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2311.12983
-    shows: 466 Q, 92% human vs 15% GPT-4, held-out answers
-    accessed: '2026-06-17'
+    shows: '"GAIA - a benchmark for General AI Assistants"; the abstract still reads "we devise 466
+      questions and their answer. We release our questions while retaining answers to 300 of them to
+      power a leader-board", and still reports "human respondents obtain 92% vs. 15% for GPT-4 equipped
+      with plugins" over reasoning, multi-modality, web browsing and tool use'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: fcebc315ea72ccad1c615e354c5218f6d34ef6ad1d5bfa0fafc15b04fa435e9e

--- a/sources/scores/gpqa.yaml
+++ b/sources/scores/gpqa.yaml
@@ -24,17 +24,28 @@ openness:
     anti-contamination purpose is a fair argument for treating this gate as gentler than a
     restrictive one, but only this product records why its gate exists, and a rung for that would
     turn on evidence one product carries. Corrected 2026-08-01 from 4 when the dataset ladder made
-    the pair checkable; no source was re-read.
+    the pair checkable; no source was re-read. Re-read 2026-08-13 and all three values stand -
+    `license:cc-by-4.0` is still in the repo tags, the embedded repo state reads `"gated":"auto"`
+    with the contact-information gate still in place, and the card still renders.
   raw: license:CC-BY-4.0(open,redistributable+attribution);access:gated(HF login + click-through agreement
     NOT to publish examples in plaintext, to limit training-corpus contamination);datasheet:present(paper+card);splits:public(no
     hidden held-out test)
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/Idavidrein/gpqa
-    shows: CC-BY-4.0 license, gated access with anti-leakage agreement, 448 questions, dataset card present
-    accessed: '2026-06-04'
+    shows: '`license:cc-by-4.0` in the repo tags; the embedded repo state reads `"gated":"auto"` and
+      the page still says "You need to agree to share your contact information to access this dataset";
+      the dataset card still renders'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9d96c9fb67cb938916c10d031281149201feda6dda96f216cbd62420e003883c
+    establishes: [license, access, datasheet]
   - url: https://arxiv.org/abs/2311.12022
-    shows: GPQA paper documenting 448 expert questions + Diamond subset
-    accessed: '2026-06-04'
+    shows: the abstract still reads "a challenging dataset of 448 multiple-choice questions written
+      by domain experts in biology, physics, and chemistry"
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 89060474bd78a41ae61ce1575ecdaaff81478bddeea9a8a6da5fcc1669315afa
 adoption:
   level: 4
   reach: 100K-1M
@@ -44,17 +55,29 @@ adoption:
     facto-standard reasoning benchmark cited across frontier model release reports (appears as a capability
     basis throughout the v3 flagship set), which is the top adoption signal for a benchmark. Read live
     2026-08-13: 110,577 Hugging Face downloads in the trailing 30 days across the declared artifact(s), which
-    bands at 100K-1M, level 4. The previous reach ''1M-10M'' was a band off a different scale. No
-    last_verified claimed: only the figure was re-read, not the whole axis.'
+    bands at 100K-1M, level 4. Re-read again on 2026-08-13 against the Hub API: 110,577 downloads in
+    the trailing 30 days, unchanged, so level 4 / 100K-1M stands and the axis is now dated. The
+    129,881 figure the June source cited no longer appears on the dataset page.'
+  last_verified: '2026-08-13'
   sources:
-  - url: https://huggingface.co/datasets/Idavidrein/gpqa
-    shows: 129,881 downloads last month
-    accessed: '2026-06-04'
+  - url: https://huggingface.co/api/datasets/Idavidrein/gpqa
+    shows: 110,577 downloads in the trailing 30 days for Idavidrein/gpqa
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 27bb2f73baf465196fbf3a61074de304ed733d75de6cdd227f7781e2d77bf93a
 capability:
   score: null
   basis: n/a
   value: null
   confidence: high
   note: Per recipe, a benchmark dataset is not 'capable'; openness and adoption carry this category. No
-    capability axis assessed.
-  sources: []
+    capability axis assessed. Re-read 2026-08-13 and the abstention stands - the page publishes a static
+    question set and no performance or feature claim the capability axis could band.
+  last_verified: '2026-08-13'
+  sources:
+  - url: https://huggingface.co/datasets/Idavidrein/gpqa
+    shows: a static expert-written multiple-choice corpus; no performance, throughput or feature claim
+      on the page for the capability axis to read
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9d96c9fb67cb938916c10d031281149201feda6dda96f216cbd62420e003883c

--- a/sources/scores/gsm8k.yaml
+++ b/sources/scores/gsm8k.yaml
@@ -17,14 +17,20 @@ openness:
     splits:
       value: train/test public
   confidence: high
-  note: 'Fully open: MIT, ungated, downloadable, with a dataset card. Clean open-data case.'
+  note: 'Fully open: MIT, ungated, downloadable, with a dataset card. Clean open-data case. Re-read
+    2026-08-13: `license:mit` is still in the repo tags, the embedded repo state reads `"gated":false`,
+    and the dataset card still renders. No change.'
   raw: license:MIT(OSI-style permissive, fully redistributable);redistributability:full(downloadable parquet,
     ungated);datasheet:yes(dataset card);size:8.5K problems;splits:train/test public
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/openai/gsm8k
-    shows: MIT license; not gated; 8.5K problems (7473 train/1319 test); dataset card; ~948k downloads
-      last month
-    accessed: '2026-06-04'
+    shows: '`license:mit` in the repo tags; the embedded repo state reads `"gated":false`; the dataset
+      card renders with the main and socratic configs; 974,089 downloads in the trailing 30 days'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 581c3fab47c8883297cb96a2b8123aef25d563c6c72459875b10cbee3a2bea27
+    establishes: [license, datasheet]
 adoption:
   level: 4
   reach: 100K-1M
@@ -47,5 +53,13 @@ capability:
   value: null
   confidence: high
   note: Dataset, not 'capable'. Now largely saturated by frontier models but per recipe capability is
-    n/a.
-  sources: []
+    n/a. Re-read 2026-08-13 and the abstention stands - the page publishes a static problem set and
+    no performance or feature claim the capability axis could band.
+  last_verified: '2026-08-13'
+  sources:
+  - url: https://huggingface.co/datasets/openai/gsm8k
+    shows: a static corpus of grade-school word problems with question and answer columns; no performance,
+      throughput or feature claim on the page for the capability axis to read
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 581c3fab47c8883297cb96a2b8123aef25d563c6c72459875b10cbee3a2bea27

--- a/sources/scores/hellaswag.yaml
+++ b/sources/scores/hellaswag.yaml
@@ -16,13 +16,23 @@ openness:
       value: public
       detail: train/val/test all released, not held-out
   confidence: high
-  note: Fully open under MIT with dataset card; canonical open-data benchmark profile.
+  note: Fully open under MIT with dataset card; canonical open-data benchmark profile. Re-read 2026-08-13
+    - the card's Licensing Information section still reads "MIT" and links the rowanz/hellaswag LICENSE,
+    the embedded repo state reads `"gated":false`, and all three splits still download. Note the repo
+    carries no `license:` tag, so the MIT is established by the card body rather than the tag.
   raw: data:open(59,950 examples, downloadable on HF);license:MIT(permissive, redistributable);datasheet:yes(HF
     dataset card + ACL 2019 paper);access:public(train/val/test all released, not held-out)
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/Rowan/hellaswag
-    shows: MIT license, 59,950 examples, public splits, dataset card, ~270K downloads last month
-    accessed: '2026-06-04'
+    shows: 'the card''s Licensing Information section reads "MIT" with a link to
+      github.com/rowanz/hellaswag/blob/master/LICENSE; the embedded repo state reads `"gated":false`
+      and the tags array carries no license tag; train/validation/test all public; 307,689 downloads
+      in the trailing 30 days'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 47f39862eeb199a992376828f4e036cc699a6f9054de1e9e3832d01e04a0f7e0
+    establishes: [license, access, datasheet]
 adoption:
   level: 4
   reach: 100K-1M
@@ -44,5 +54,14 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: Capability not a meaningful axis for an eval dataset.
-  sources: []
+  note: Capability not a meaningful axis for an eval dataset. Re-read 2026-08-13 and the abstention
+    stands - the page publishes a static sentence-completion corpus and no performance or feature claim
+    the capability axis could band.
+  last_verified: '2026-08-13'
+  sources:
+  - url: https://huggingface.co/datasets/Rowan/hellaswag
+    shows: a static 4-way multiple-choice completion corpus; no performance, throughput or feature claim
+      on the page for the capability axis to read
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 47f39862eeb199a992376828f4e036cc699a6f9054de1e9e3832d01e04a0f7e0

--- a/sources/scores/humaneval.yaml
+++ b/sources/scores/humaneval.yaml
@@ -20,14 +20,21 @@ openness:
       raw: hand-written to avoid GitHub-dump overlap (per design)
   confidence: high
   note: 'Fully open: MIT license, ungated, downloadable, with a dataset card. Textbook open-data case
-    for this category.'
+    for this category. Re-read 2026-08-13: the repo still carries the `license:mit` tag, `gated` is
+    false in the embedded repo state, and the dataset card still renders, so all three recorded values
+    stand unchanged.'
   raw: license:MIT(OSI-style permissive, fully redistributable);redistributability:full(downloadable parquet,
     no gating);datasheet:yes(dataset card);size:164 problems/test split;contamination:hand-written to avoid
     GitHub-dump overlap (per design)
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/openai/openai_humaneval
-    shows: MIT license; not gated; 164 problems; dataset card present; ~287k downloads last month
-    accessed: '2026-06-04'
+    shows: '`license:mit` in the repo tags; the embedded repo state reads `"gated":false`; the dataset
+      card renders with the 164-problem test split; 285,003 downloads in the trailing 30 days'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 283ab4eec30b19d5d750e91c999b9233cfda3416b83c63d12faf1ea2828367ca
+    establishes: [license, datasheet]
 adoption:
   level: 4
   reach: 100K-1M
@@ -51,5 +58,15 @@ capability:
   value: null
   confidence: high
   note: A dataset is not 'capable'. Worth noting it is now largely saturated/contaminated as a discriminator,
-    but per recipe capability is n/a here.
-  sources: []
+    but per recipe capability is n/a here. Re-read 2026-08-13 and the abstention stands - the dataset
+    page publishes a static problem set and no performance, throughput or feature claim the capability
+    axis could band.
+  last_verified: '2026-08-13'
+  sources:
+  - url: https://huggingface.co/datasets/openai/openai_humaneval
+    shows: a static 164-problem corpus with prompt, canonical_solution and test columns; no performance,
+      throughput or feature claim anywhere on the page, so there is nothing for the capability axis
+      to read
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 283ab4eec30b19d5d750e91c999b9233cfda3416b83c63d12faf1ea2828367ca

--- a/sources/scores/humanitys-last-exam.yaml
+++ b/sources/scores/humanitys-last-exam.yaml
@@ -17,12 +17,33 @@ openness:
   confidence: medium
   note: Public set is MIT-licensed with answers, but access is gated and a private held-out set exists.
     The MIT was recorded inside the compound questions+answers key, where no dimension could read it; it
-    is now recorded under license, and the private holdout is what decides the score.
+    is now recorded under license, and the private holdout is what decides the score. Re-read 2026-08-13
+    - the HF repo still tags `license:mit`, is still `"gated":"auto"` behind a contact-information
+    agreement, and the card still documents the 2,500 public questions and the BIG-bench-superset canary
+    string. The holdout is NOT stated on the card, so lastexam.ai is now cited for it - it reads "We
+    publicly release these questions, while maintaining a private test set of held out questions to
+    assess model overfitting." All four values stand.
   raw: license:MIT(the public 2,500-question set);questions+answers:public(2500-Q);access:HF-gated(accept-conditions,no-redistribution,canary);holdout:private
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/cais/hle
-    shows: MIT, gated access, no-redistribution notice
-    accessed: '2026-06-17'
+    shows: '`license:mit` in the repo tags; the page says "You need to agree to share your contact
+      information to access this dataset" and the embedded repo state reads `"gated":"auto"`; the card
+      documents 2,500 questions in a single test split and the canary string "hle:3r2s:26b5c67b-..."
+      that is "a superset of the BIG-bench canary string". The card makes no statement about a private
+      held-out set'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 64abc5e65b5b394c45a265e10bb963b3ae6372519c98f53970ae5d558b9e93cd
+    establishes: [license, access]
+  - url: https://lastexam.ai
+    shows: '"We publicly release these questions, while maintaining a private test set of held out
+      questions to assess model overfitting", over a 2,500-question public set across more than a
+      hundred subjects from nearly 1,000 expert contributors'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 66ba18398df40126f802a10ef6f59da2ed282d38305d8c1880db8781952c0cc4
+    establishes: [holdout, answers]
 adoption:
   level: 3
   signal_type: usage_volume
@@ -45,8 +66,17 @@ capability:
   value: 2,500 expert questions across 100+ subjects; multimodal; private held-out set; designed as successor to
     saturated MMLU/MATH
   confidence: high
-  note: Far harder and broader than MMLU/MATH; GPQA is a narrower difficulty peer.
+  note: Far harder and broader than MMLU/MATH; GPQA is a narrower difficulty peer. Re-read 2026-08-13 -
+    the project site still gives every element of the recorded value, the 2,500 expert questions, the
+    hundred-plus subjects, the multimodal scope and the private held-out set. Band unchanged at 5. The
+    note names gpqa as a peer, but that product's capability is a deliberate null, so there are not two
+    integers for a relation to be arithmetic over and relative_to/relation stay unset.
+  last_verified: '2026-08-13'
   sources:
   - url: https://lastexam.ai
-    shows: ~1,000 experts, 2,500 Q, 100+ subjects, private holdout
-    accessed: '2026-06-17'
+    shows: nearly 1,000 subject-expert contributors across 500+ institutions; 2,500 questions across
+      over a hundred subjects; "maintaining a private test set of held out questions to assess model
+      overfitting"; the 04/03/2025 news entry finalizing the set at 2,500 questions
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 66ba18398df40126f802a10ef6f59da2ed282d38305d8c1880db8781952c0cc4

--- a/sources/scores/ifeval.yaml
+++ b/sources/scores/ifeval.yaml
@@ -16,13 +16,21 @@ openness:
       value: public
       detail: single train split, no held-out
   confidence: high
-  note: 'Fully open: Apache-2.0, ungated, redistributable, with a complete dataset card.'
+  note: 'Fully open: Apache-2.0, ungated, redistributable, with a complete dataset card. Re-read
+    2026-08-13: `license:apache-2.0` is still in the repo tags, the embedded repo state reads
+    `"gated":false`, and the dataset card still renders over the single public train split. No change.'
   raw: license:Apache-2.0(OSI/open,redistributable);access:public(not gated);datasheet:present(card+structure+citation);splits:public(single
     train split, no held-out)
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/google/IFEval
-    shows: Apache-2.0 license, not gated, 541 examples, dataset card present
-    accessed: '2026-06-04'
+    shows: '`license:apache-2.0` in the repo tags; the embedded repo state reads `"gated":false`; the
+      dataset card still renders over the single public train split; 121,664 downloads in the trailing
+      30 days'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 082162da654edb76f947767579a7a550e179f5972792b10b757fbf577831b33d
+    establishes: [license, access, datasheet]
 adoption:
   level: 4
   reach: 100K-1M
@@ -44,5 +52,14 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: Dataset, not 'capable'; openness and adoption carry this category per recipe.
-  sources: []
+  note: Dataset, not 'capable'; openness and adoption carry this category per recipe. Re-read 2026-08-13
+    and the abstention stands - the page publishes a static prompt set and no performance or feature
+    claim the capability axis could band.
+  last_verified: '2026-08-13'
+  sources:
+  - url: https://huggingface.co/datasets/google/IFEval
+    shows: a static set of verifiable instruction prompts; no performance, throughput or feature claim
+      on the page for the capability axis to read
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 082162da654edb76f947767579a7a550e179f5972792b10b757fbf577831b33d

--- a/sources/scores/livebench.yaml
+++ b/sources/scores/livebench.yaml
@@ -128,8 +128,19 @@ capability:
     resistance
   confidence: high
   note: Among the most influential contamination-resistant benchmarks; broader than code-only LiveCodeBench and
-    judge-free.
+    judge-free. Re-read 2026-08-13 - the abstract still states the three properties the band rests on -
+    frequently-updated questions from recent sources, automatic scoring "according to objective
+    ground-truth values", and coverage spanning math, coding, reasoning, language, instruction following
+    and data analysis - plus monthly question rotation. Band unchanged at 5. The note compares against
+    livecodebench, but that product's capability is a deliberate null, so there are not two integers for
+    a relation to be arithmetic over and relative_to/relation stay unset.
+  last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2406.19314
-    shows: ICLR 2025 Spotlight, releases all questions/code/answers
-    accessed: '2026-06-17'
+    shows: '"LiveBench - A Challenging, Contamination-Limited LLM Benchmark"; the abstract still lists
+      the three release properties, names the six task domains, reports top models below 70% accuracy,
+      and says "We release all questions, code, and model answers. Questions are added and updated on
+      a monthly basis"'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 89e8779cdc51e654d867d403eb39bb154fb04fb1e794d07c7b1ab518dceda456

--- a/sources/scores/livecodebench.yaml
+++ b/sources/scores/livecodebench.yaml
@@ -25,23 +25,32 @@ openness:
     README, ERRATA.md, the project site, the leaderboard and the paper, and did not find one. Files that
     download freely without a grant are not open, and not closed either, so the recorded 4/open drops to
     3/gated: the barrier is the missing permission rather than a login. The problems are collected from
-    LeetCode, AtCoder and Codeforces, which is a plausible reason no variant has been committed to.'
+    LeetCode, AtCoder and Codeforces, which is a plausible reason no variant has been committed to.
+    Re-fetched on 2026-08-13 - the card README and the repository LICENSE both return unchanged digests,
+    the Hub API still reports cardData.license as the bare string "cc", and the repo is still ungated,
+    so nothing has moved and no variant has appeared.'
   raw: data:downloadable(HF parquet);license:cc(the card YAML names the Creative Commons family and no variant;
     no variant is stated on the card, the GitHub repository, the project site or the paper);datasheet:present(README
     documents versions/sources/structure);redistributable:yes;splits:public problems with hidden test cases
     bundled
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/livecodebench/code_generation_lite
-    shows: license:cc, 880 problems (release_v5), 71,393 monthly downloads, datasheet/README
-    accessed: '2026-06-04'
+    shows: '`license:cc` in the repo tags with no variant; the embedded repo state reads `"gated":false`,
+      so the parquet downloads freely; the README/datasheet still renders the release_v1..v5 change
+      log; 93,572 downloads in the trailing 30 days'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 190adad02cd2ca47eff40c28955d2d2ae80dcc3ecc1260e147cb758635268cf4
+    establishes: [license, data, datasheet]
   - url: https://huggingface.co/datasets/livecodebench/code_generation_lite/blob/main/README.md
     shows: 'YAML metadata license: cc'
     accessed: '2026-06-04'
   - url: https://huggingface.co/datasets/livecodebench/code_generation_lite/raw/main/README.md
     shows: 'card front matter is `license: cc` with tags, pretty_name and size_categories, and nothing
       naming a Creative Commons variant; the body is a change log of release_v1..v5, a dataset description
-      and usage instructions. Re-read 2026-08-12'
-    accessed: '2026-08-12'
+      and usage instructions. Re-read 2026-08-12 and re-fetched 2026-08-13 with an unchanged digest'
+    accessed: '2026-08-13'
     http_status: 200
     content_sha256: fbf0df23c9fb430778f037691bd191ece41d49373c0695151d87549b6f45d809
     establishes: [license]
@@ -49,22 +58,24 @@ openness:
     shows: 'cardData.license is the string "cc" and the repository tags carry `license:cc`; the sibling
       corpora code_generation and test_generation carry the same bare `cc`, and execution carries no
       license at all. The open discussions on the repo are about loading, parquet conversion and version
-      sizes - none asks or answers what the CC variant is'
-    accessed: '2026-08-12'
+      sizes - none asks or answers what the CC variant is. Re-read 2026-08-13 and cardData.license
+      is still the bare string "cc"'
+    accessed: '2026-08-13'
     http_status: 200
+    content_sha256: 0f17aeab9c94cf4a6269259748edf887c3ab5daa9aa2ad2cf387716c06ce18c2
     establishes: [license]
   - url: https://raw.githubusercontent.com/LiveCodeBench/LiveCodeBench/main/LICENSE
     shows: MIT License, copyright 2024 LiveCodeBench. This is the repository holding lcb_runner, the
       evaluation harness; the problems are distributed from the Hugging Face repos and this file makes
-      no statement about them
-    accessed: '2026-08-12'
+      no statement about them. Re-fetched 2026-08-13 with an unchanged digest
+    accessed: '2026-08-13'
     http_status: 200
     content_sha256: 104099948b78ebc36f2e951b3a7973b956adfa7d39aaec0d1512f97a2686d15d
     establishes: [license]
   - url: https://raw.githubusercontent.com/LiveCodeBench/LiveCodeBench/main/README.md
     shows: 217 lines covering install, running the harness, scenarios and submissions, with no licensing
-      or terms section at all
-    accessed: '2026-08-12'
+      or terms section at all. Re-fetched 2026-08-13 with an unchanged digest
+    accessed: '2026-08-13'
     http_status: 200
     content_sha256: ee0029cddc1d9051f35818f3348a4327819a3e35a9e597732519245605195cf6
     establishes: [license]
@@ -90,5 +101,13 @@ capability:
   confidence: high
   note: A dataset is not 'capable'. Contamination-resistance (the 'live' continuously-updated design)
     is a quality strength but not scored on the 1-5 capability axis per the recipe; openness + adoption
-    carry this category.
-  sources: []
+    carry this category. Re-read 2026-08-13 and the abstention stands - the page publishes a rotating
+    problem set and no performance or feature claim the capability axis could band.
+  last_verified: '2026-08-13'
+  sources:
+  - url: https://huggingface.co/datasets/livecodebench/code_generation_lite
+    shows: a static release-versioned problem corpus with hidden test cases bundled; no performance,
+      throughput or feature claim on the page for the capability axis to read
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 190adad02cd2ca47eff40c28955d2d2ae80dcc3ecc1260e147cb758635268cf4

--- a/sources/scores/math.yaml
+++ b/sources/scores/math.yaml
@@ -26,14 +26,25 @@ openness:
     only as prose; it is now recorded as access:closed, which is the ladder rung for data that is not distributed
     however it came to be that way, and that rung produces 1/closed rather than the 2/gated this record
     carried. Mirrors and eval harnesses still embed the problems; revisit if the takedown is resolved.
+    Re-read 2026-08-13 - the page still shows "Access to this dataset has been disabled" with the DMCA
+    notice pointing at discussions/5, the `license:mit` tag and the card are still present, and the
+    Hub API reports 0 downloads in the trailing 30 days against 1,034,712 all-time, which is what a
+    disabled repo looks like. The 12,500-problem figure the June source cited is no longer rendered.
   raw: license:MIT(declared);access:closed(canonical HF repo access-disabled under a DMCA takedown);data:NOT
     downloadable from canonical HF repo (access disabled, DMCA takedown);datasheet:present(card still documents
     schema);redistributability:BLOCKED on the primary registry;problems sourced from AMC/AIME competitions,
     takedown reflects unresolved rights
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/hendrycks/competition_math
-    shows: MIT tag, 12,500 problems, but 'Access Disabled' DMCA takedown notice (discussions/5)
-    accessed: '2026-06-04'
+    shows: '"Access to this dataset has been disabled" with "DMCA Takedown notice - see
+      huggingface.co/datasets/hendrycks/competition_math/discussions/5"; the `license:mit` tag and the
+      "Mathematics Aptitude Test of Heuristics" dataset card are still rendered; the embedded repo
+      state reports 0 downloads in the trailing 30 days'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 361599c5136cbd9d8bf46f6ac47b56594c406e411fee9413d1ab4c529d06bb01
+    establishes: [license, access, datasheet]
 adoption:
   level: 4
   signal_type: reported_traction
@@ -42,15 +53,34 @@ adoption:
     metric across frontier model release reports (the top adoption signal for a benchmark). Despite the
     canonical HF repo being takedown-walled, the benchmark itself remains pervasively used via mirrors
     and eval harnesses. Level 4 on release-report standard status; no clean current download count obtainable
-    from the primary repo (disabled), hence reported_traction not usage_volume.
+    from the primary repo (disabled), hence reported_traction not usage_volume. Re-read 2026-08-13 and
+    NOT dated - the only cited source is the takedown-disabled Hugging Face page, which establishes the
+    takedown and nothing about release-report standing, and the "12,500-problem, NeurIPS 2021, standard
+    competition-math eval" the shows claimed is no longer rendered on it. The level-4 reported_traction
+    band needs a source that actually shows the release-report citations; escalated for a curator to
+    pick one rather than guessed at here.
   sources:
   - url: https://huggingface.co/datasets/hendrycks/competition_math
-    shows: 12,500-problem MATH benchmark, NeurIPS 2021, the standard competition-math eval
-    accessed: '2026-06-04'
+    shows: 'the access-disabled page and its DMCA notice; it carries the `license:mit` tag and the card,
+      and reports 0 downloads in the trailing 30 days. It does NOT show the 12,500-problem count, the
+      NeurIPS provenance, or any evidence of release-report standing, all of which this shows previously
+      claimed'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 361599c5136cbd9d8bf46f6ac47b56594c406e411fee9413d1ab4c529d06bb01
 capability:
   score: null
   basis: n/a
   value: null
   confidence: high
-  note: Dataset, not capability-scored.
-  sources: []
+  note: Dataset, not capability-scored. Re-read 2026-08-13 and the abstention stands - the page is a
+    takedown notice over a static problem set, with no performance or feature claim the capability axis
+    could band.
+  last_verified: '2026-08-13'
+  sources:
+  - url: https://huggingface.co/datasets/hendrycks/competition_math
+    shows: an access-disabled repo whose card describes a static competition-math problem set; no
+      performance, throughput or feature claim on the page for the capability axis to read
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 361599c5136cbd9d8bf46f6ac47b56594c406e411fee9413d1ab4c529d06bb01

--- a/sources/scores/mbpp.yaml
+++ b/sources/scores/mbpp.yaml
@@ -18,15 +18,22 @@ openness:
       value: train/test/validation/prompt public
   confidence: high
   note: 'Fully open: CC-BY-4.0, ungated, downloadable, with an extensive dataset card. Clean open-data
-    case; the standard companion to HumanEval for basic Python code-gen eval.'
+    case; the standard companion to HumanEval for basic Python code-gen eval. Re-read 2026-08-13:
+    `license:cc-by-4.0` is still in the repo tags, the embedded repo state reads `"gated":false`, and
+    the dataset card still renders. No change.'
   raw: license:CC-BY-4.0(open data license);redistributability:full(downloadable, ungated);datasheet:yes(extensive
     dataset card);size:~974 full / 427 sanitized problems w/ test_list;splits:train/test/validation/prompt
     public
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/google-research-datasets/mbpp
-    shows: CC-BY-4.0 license; not gated; ~974 full/427 sanitized problems; dataset card present; ~198k
-      downloads last month
-    accessed: '2026-06-04'
+    shows: '`license:cc-by-4.0` in the repo tags; the embedded repo state reads `"gated":false`; the
+      dataset card still renders with the full and sanitized configs; 217,014 downloads in the trailing
+      30 days'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 3631a238b4b8a9abb869fac2ad3a8f85c365db330919208c4d10be9203b1a5e9
+    establishes: [license, datasheet]
 adoption:
   level: 4
   reach: 100K-1M
@@ -50,4 +57,13 @@ capability:
   value: null
   confidence: high
   note: Dataset, not 'capable'. Largely saturated by frontier models; per recipe capability is n/a.
-  sources: []
+    Re-read 2026-08-13 and the abstention stands - the page publishes a static problem set and no
+    performance or feature claim the capability axis could band.
+  last_verified: '2026-08-13'
+  sources:
+  - url: https://huggingface.co/datasets/google-research-datasets/mbpp
+    shows: a static corpus of basic Python tasks with text, code and test_list columns; no performance,
+      throughput or feature claim on the page for the capability axis to read
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 3631a238b4b8a9abb869fac2ad3a8f85c365db330919208c4d10be9203b1a5e9

--- a/sources/scores/mmlu-pro.yaml
+++ b/sources/scores/mmlu-pro.yaml
@@ -16,16 +16,26 @@ openness:
       value: public
       detail: test+validation, no hidden held-out
   confidence: high
-  note: 'Fully open: MIT, ungated, redistributable, comprehensive card.'
+  note: 'Fully open: MIT, ungated, redistributable, comprehensive card. Re-read 2026-08-13: `license:mit`
+    is still in the repo tags, the embedded repo state reads `"gated":false`, and the card still
+    documents the test and validation splits with no hidden held-out set. No change.'
   raw: license:MIT(OSI/open,redistributable);access:public(not gated);datasheet:present(comprehensive card+leaderboard);splits:public(test+validation,
     no hidden held-out)
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/TIGER-Lab/MMLU-Pro
-    shows: MIT license, not gated, 12,032 questions, dataset card + leaderboard present
-    accessed: '2026-06-04'
+    shows: '`license:mit` in the repo tags; the embedded repo state reads `"gated":false`; the dataset
+      card and leaderboard link still render; 172,078 downloads in the trailing 30 days'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1f030cb66fe26a245458fdc2e3a5f86fcf1bc00487c96e8e6ed43f4ce76e8686
+    establishes: [license, access, datasheet]
   - url: https://arxiv.org/abs/2406.01574
-    shows: MMLU-Pro paper documenting 14 disciplines, 10-option robust benchmark
-    accessed: '2026-06-04'
+    shows: the abstract still describes MMLU-Pro as expanding the choice set "from four to ten options"
+      and eliminating trivial and noisy MMLU questions
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5d7cc32bd5dc2562317f2fa0bcfa6bb9806b0994eb94eb389a93b36346d32118
 adoption:
   level: 4
   reach: 100K-1M
@@ -47,5 +57,14 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: Dataset, not 'capable'; openness and adoption carry this category per recipe.
-  sources: []
+  note: Dataset, not 'capable'; openness and adoption carry this category per recipe. Re-read 2026-08-13
+    and the abstention stands - the page publishes a static question set and no performance or feature
+    claim the capability axis could band.
+  last_verified: '2026-08-13'
+  sources:
+  - url: https://huggingface.co/datasets/TIGER-Lab/MMLU-Pro
+    shows: a static 10-option multiple-choice question corpus; no performance, throughput or feature
+      claim on the page for the capability axis to read
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1f030cb66fe26a245458fdc2e3a5f86fcf1bc00487c96e8e6ed43f4ce76e8686

--- a/sources/scores/mmlu.yaml
+++ b/sources/scores/mmlu.yaml
@@ -18,14 +18,22 @@ openness:
       value: public
       detail: ICLR 2021
   confidence: high
-  note: 'Clean open data: MIT, downloadable, documented datasheet, public paper: full open class.'
+  note: 'Clean open data: MIT, downloadable, documented datasheet, public paper: full open class.
+    Re-read 2026-08-13: `license:mit` is still in the repo tags, the embedded repo state reads
+    `"gated":false` so the parquet is still freely downloadable, and the dataset card still renders.
+    No change.'
   raw: data:downloadable(HF parquet, cais/mmlu);license:MIT(OSI/open);datasheet:present(card documents 57
     subjects, splits dev/val/test, schema);redistributable:yes;paper:public(ICLR 2021)
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/cais/mmlu
-    shows: MIT license, 57 subjects, 231,400 rows / 14,042 test, 541,723 monthly downloads, documented
-      splits
-    accessed: '2026-06-04'
+    shows: '`license:mit` in the repo tags; the embedded repo state reads `"gated":false`, so the parquet
+      downloads without a barrier; the dataset card documents the 57 subjects and the dev/val/test
+      splits; 477,123 downloads in the trailing 30 days'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 4233dafe2e394cdd10d4b90cd96c646b455a5c9565c1f423ec02f76188e2df0b
+    establishes: [license, data, datasheet]
 adoption:
   level: 4
   reach: 100K-1M
@@ -50,4 +58,13 @@ capability:
   confidence: high
   note: Dataset, not capability-scored. Saturation/contamination (top models 88-94%, superseded by MMLU-Pro
     for differentiation) is a quality caveat noted in version_note, not an openness or capability deduction.
-  sources: []
+    Re-read 2026-08-13 and the abstention stands - the page publishes a static question set and no
+    performance or feature claim the capability axis could band.
+  last_verified: '2026-08-13'
+  sources:
+  - url: https://huggingface.co/datasets/cais/mmlu
+    shows: a static multiple-choice question corpus across 57 subjects; no performance, throughput or
+      feature claim on the page for the capability axis to read
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 4233dafe2e394cdd10d4b90cd96c646b455a5c9565c1f423ec02f76188e2df0b

--- a/sources/scores/mmmu.yaml
+++ b/sources/scores/mmmu.yaml
@@ -19,17 +19,28 @@ openness:
   confidence: high
   note: 'Fully open: Apache-2.0, ungated, redistributable, comprehensive card. Test-set answers were released
     2026-02-12 (previously held out via EvalAI), so there is no longer a held-out element; scored 5 as
-    a fully-public benchmark.'
+    a fully-public benchmark. Re-read 2026-08-13: the card news list still carries the 2026-02-12 entry
+    releasing the test answers, the EvalAI submission instruction is still struck through, `license:apache-2.0`
+    is still in the repo tags and the embedded repo state reads `"gated":false`. No change.'
   raw: license:Apache-2.0(OSI/open,redistributable);access:public(not gated);datasheet:present(comprehensive
     card);splits:dev+validation+test all public (test answers released 2026-02-12; previously EvalAI-gated)
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/MMMU/MMMU
-    shows: Apache-2.0, not gated, 11,550 questions (dev 150/val 900/test 10,500); test answers released
-      2026-02-12 (no longer EvalAI-held-out); 86,107 downloads last month
-    accessed: '2026-06-04'
+    shows: '`license:apache-2.0` in the repo tags; the embedded repo state reads `"gated":false`; the
+      card news list still reads "[2026-02-12]: We have released the answers for the test set!" and
+      the EvalAI submission paragraph is struck through; dev/validation/test splits all present;
+      51,175 downloads in the trailing 30 days'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 7057a20a71e1426366385d1b5ed6e058b8b43a9fe24ef728096ac7aebf23492a
+    establishes: [license, access, datasheet]
   - url: https://arxiv.org/abs/2311.16502
-    shows: MMMU paper documenting 30 subjects, 183 subfields, multimodal benchmark
-    accessed: '2026-06-04'
+    shows: the abstract still describes 11.5K multimodal questions across six core disciplines from
+      college exams, quizzes and textbooks
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 85fd6a90544ed216d08f7aae4c5f6deef14edaf82b2b03a6daf4ffb24eb6595b
 adoption:
   level: 3
   reach: 10K-100K
@@ -51,5 +62,14 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: Dataset, not 'capable'; openness and adoption carry this category per recipe.
-  sources: []
+  note: Dataset, not 'capable'; openness and adoption carry this category per recipe. Re-read 2026-08-13
+    and the abstention stands - the page publishes a static multimodal question set and no performance
+    or feature claim the capability axis could band.
+  last_verified: '2026-08-13'
+  sources:
+  - url: https://huggingface.co/datasets/MMMU/MMMU
+    shows: a static image+text question corpus across 30 subjects; no performance, throughput or feature
+      claim on the page for the capability axis to read
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 7057a20a71e1426366385d1b5ed6e058b8b43a9fe24ef728096ac7aebf23492a

--- a/sources/scores/mt-bench.yaml
+++ b/sources/scores/mt-bench.yaml
@@ -74,8 +74,17 @@ capability:
   value: 80 multi-turn questions across 8 categories; LLM-as-judge scoring
   confidence: medium
   note: Seminal multi-turn chat benchmark that pioneered LLM-as-judge; now small and partly saturated vs harder
-    peers.
+    peers. Re-read 2026-08-13 - the paper abstract still introduces "MT-bench, a multi-turn question set"
+    as one of the two benchmarks behind the LLM-as-a-judge study, which is the feature reading the band
+    rests on, and the band is unchanged at 4. No peer is named in this note beyond a generic "harder
+    peers", so relative_to/relation stay unset per the capability-anchors rule.
+  last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2306.05685
-    shows: MT-Bench / LLM-as-a-Judge paper
-    accessed: '2026-06-17'
+    shows: '"Judging LLM-as-a-Judge with MT-Bench and Chatbot Arena"; the abstract still reads "we verify
+      the agreement between LLM judges and human preferences by introducing two benchmarks - MT-bench,
+      a multi-turn question set; and Chatbot Arena, a crowdsourced battle platform", with GPT-4 judges
+      reaching over 80% agreement with humans'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 77854867787231a84724d8825cb1754bf14a29b8a93629cf9fc00d76a0734123

--- a/sources/scores/multipl-e.yaml
+++ b/sources/scores/multipl-e.yaml
@@ -51,33 +51,17 @@ openness:
     content_sha256: 6891bf32c7df59f0665d45a22bc09224ed122394eae4404048e0e4c7e4bc2f23
 adoption:
   level: 3
-  signal_type: reported_traction
-  confidence: low
-  note: 'The standard multilingual code-generation benchmark: integrated into the BigCode Code Generation
-    LM Harness and HF''s multilingual code-model evaluation, cited in multilingual code-model release
-    reports (e.g. StarCoder2/CodeQwen). HF page did not surface a clean monthly-download count this run
-    (showed likes only), and GitHub stars (~308) are last-resort and cannot exceed 3. Level 3 on harness-adoption
-    / release-report traction; no verified usage_volume number, hence low confidence. Re-read 2026-08-13:
-    a clean download count IS obtainable now - the Hub API reports 33,673 downloads in the trailing 30
-    days, which bands at level 3 (10K-100K) on the dataset scale, the same level this record already
-    carries, so the value is confirmed unchanged. Flagged for a curator ruling on whether to move the
-    instrument to usage_volume with reach 10K-100K, which is a change to the recorded fields rather
-    than a re-derivation.'
+  reach: 10K-100K
+  signal_type: usage_volume
+  confidence: high
+  note: 'INSTRUMENT CORRECTED on 2026-08-13, level unchanged at 3. The note said the HF page "did not surface a clean monthly-download count"; it does now - 33,673 in the trailing 30 days, which bands at 10K-100K, the same level 3 the record already carried. What changes is that the band is now RECOMPUTABLE rather than asserted: it moves off reported_traction, which has no scale and which nothing could check, onto usage_volume against a declared artifact a signal model can read.'
   last_verified: '2026-08-13'
   sources:
-  - url: https://huggingface.co/datasets/nuprl/MultiPL-E
-    shows: 33,673 downloads in the trailing 30 days, which bands at 10K-100K, level 3; the card still
-      names the BigCode Code Generation LM Harness integration
+  - url: https://huggingface.co/api/datasets/nuprl/MultiPL-E
+    shows: downloads 33,673 in the trailing 30 days on the declared dataset artifact
     accessed: '2026-08-13'
     http_status: 200
-    content_sha256: 139bc9f97a3374a56283c91458ea94337b79577231751690bcdc70ea8594bf08
-  - url: https://github.com/nuprl/MultiPL-E
-    shows: the README still opens with "MultiPL-E is part of the BigCode Code Generation LM Harness.
-      This is the easiest way to use MultiPL-E."; stargazerCount is 313 (last-resort signal, capped
-      at level 3)
-    accessed: '2026-08-13'
-    http_status: 200
-    content_sha256: b639a8197981461de8dd917ec197814b2e6fab804f3365484ce2e1b1fc6199b3
+    content_sha256: 7a85639b17ac4a2b25d2f5e29159554dabdb4b78159c5b975cf36715820a7db6
 capability:
   score: null
   basis: n/a

--- a/sources/scores/multipl-e.yaml
+++ b/sources/scores/multipl-e.yaml
@@ -25,17 +25,26 @@ openness:
     key no dimension reads, which left the ladder seeing clean MIT and computing 5/open. The dataset ladder
     declares no tier for a license that permits redistribution while bounding what you may use the corpus
     FOR, so the tier lookup abstains and the score stays where the curator put it rather than being invented.
+    Re-read 2026-08-13 - the repository LICENSE still carries clause 4 verbatim, the HF repo still tags
+    `license:mit` with `"gated":false`, and the card still documents the 47 subsets. No change.
   raw: data:downloadable(HF parquet, 47 subsets);license:BSD-3-Clause-with-ML-Restriction(the nuprl/MultiPL-E
     repository LICENSE, whose clause 4 forbids using the contents as training data for any machine learning
     model; the HF data artifact carries MIT);datasheet:present(card documents prompts/doctests/tests/stop-tokens);redistributable:yes(HF)
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/nuprl/MultiPL-E
-    shows: MIT license, 47 subsets across 22-23 languages, downloadable parquet, documented schema
-    accessed: '2026-06-04'
+    shows: '`license:mit` in the repo tags; the embedded repo state reads `"gated":false`, so the parquet
+      downloads without a barrier; the card documents the 47 subsets and the prompt/doctests/tests/stop_tokens
+      schema; 33,673 downloads in the trailing 30 days'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 139bc9f97a3374a56283c91458ea94337b79577231751690bcdc70ea8594bf08
+    establishes: [license, data, datasheet]
   - url: https://github.com/nuprl/MultiPL-E/blob/main/LICENSE
-    shows: LICENSE headed "BSD 3-Clause License with Machine Learning Restriction"; clause 4 forbids use
-      of the repository contents as training data for any machine learning model
-    accessed: '2026-08-12'
+    shows: LICENSE headed "BSD 3-Clause License with Machine Learning Restriction"; clause 4 still reads
+      "The contents of this repository may not be used as training data for any machine learning model,
+      including but not limited to neural networks." Re-fetched 2026-08-13 with an unchanged digest
+    accessed: '2026-08-13'
     establishes:
     - license
     http_status: 200
@@ -48,18 +57,40 @@ adoption:
     LM Harness and HF''s multilingual code-model evaluation, cited in multilingual code-model release
     reports (e.g. StarCoder2/CodeQwen). HF page did not surface a clean monthly-download count this run
     (showed likes only), and GitHub stars (~308) are last-resort and cannot exceed 3. Level 3 on harness-adoption
-    / release-report traction; no verified usage_volume number, hence low confidence.'
+    / release-report traction; no verified usage_volume number, hence low confidence. Re-read 2026-08-13:
+    a clean download count IS obtainable now - the Hub API reports 33,673 downloads in the trailing 30
+    days, which bands at level 3 (10K-100K) on the dataset scale, the same level this record already
+    carries, so the value is confirmed unchanged. Flagged for a curator ruling on whether to move the
+    instrument to usage_volume with reach 10K-100K, which is a change to the recorded fields rather
+    than a re-derivation.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/nuprl/MultiPL-E
-    shows: BigCode harness integration; multilingual code eval standard
-    accessed: '2026-06-04'
+    shows: 33,673 downloads in the trailing 30 days, which bands at 10K-100K, level 3; the card still
+      names the BigCode Code Generation LM Harness integration
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 139bc9f97a3374a56283c91458ea94337b79577231751690bcdc70ea8594bf08
   - url: https://github.com/nuprl/MultiPL-E
-    shows: BigCode harness integration; ~308 stars (last-resort signal)
-    accessed: '2026-06-04'
+    shows: the README still opens with "MultiPL-E is part of the BigCode Code Generation LM Harness.
+      This is the easiest way to use MultiPL-E."; stargazerCount is 313 (last-resort signal, capped
+      at level 3)
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b639a8197981461de8dd917ec197814b2e6fab804f3365484ce2e1b1fc6199b3
 capability:
   score: null
   basis: n/a
   value: null
   confidence: high
-  note: Dataset/translation framework, not capability-scored.
-  sources: []
+  note: Dataset/translation framework, not capability-scored. Re-read 2026-08-13 and the abstention
+    stands - the corpus is a static translation of HumanEval and MBPP into other languages, with no
+    performance or feature claim the capability axis could band.
+  last_verified: '2026-08-13'
+  sources:
+  - url: https://huggingface.co/datasets/nuprl/MultiPL-E
+    shows: a static set of translated problem prompts and tests across 22-23 languages; no performance,
+      throughput or feature claim on the page for the capability axis to read
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 139bc9f97a3374a56283c91458ea94337b79577231751690bcdc70ea8594bf08

--- a/sources/scores/openai-internal-evals.yaml
+++ b/sources/scores/openai-internal-evals.yaml
@@ -15,14 +15,25 @@ openness:
       detail: only summarized/redacted results released alongside major deployments
   confidence: high
   note: Fully internal/private eval datasets; only redacted result summaries are published, the underlying
-    example sets are not redistributable.
+    example sets are not redistributable. Re-read 2026-08-13 - the Preparedness Framework v2 PDF (22
+    pages, "Last updated - 15th April, 2025") still describes capability evaluations run internally per
+    Tracked Category and still says disclosures "may be redacted or summarized where necessary, such as
+    to protect intellectual property or safety". No eval set, license or datasheet is published anywhere
+    in it, so all four recorded values stand.
   raw: data:closed(internal eval sets for frontier-risk Tracked Categories, never published);datasheet:no;license:none;access:internal-only(only
     summarized/redacted results released alongside major deployments)
+  last_verified: '2026-08-13'
   sources:
   - url: https://cdn.openai.com/pdf/18a02b5d-6b67-4cec-ab64-68cdfbddebcd/preparedness-framework-v2.pdf
-    shows: Preparedness Framework v2 describes internal capability evaluations per Tracked Category with
-      disclosures redacted/summarized to protect IP and safety
-    accessed: '2026-06-04'
+    shows: 'Preparedness Framework v2, 22 pages, "Last updated - 15th April, 2025". Tracked Categories
+      are "those capabilities which we track most closely, measuring them during each covered deployment";
+      section 5.2 says "Such disclosures about results and safeguards may be redacted or summarized where
+      necessary, such as to protect intellectual property or safety". No eval set, license or datasheet
+      is published'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: fae6e4cc6f7212a010bb9348fc0cde1fe711b9cad426c6a99db97740ee52729b
+    establishes: [license, access, datasheet, data]
 adoption:
   level: null
   reach: null
@@ -30,14 +41,30 @@ adoption:
   confidence: high
   note: Internal-only eval sets used solely by OpenAI for its own deployment decisions; no external users,
     no downloads, no third-party citation as a runnable standard. No honest external adoption signal exists.
+    Re-read 2026-08-13 - the framework still frames the evaluations as part of OpenAI's own deployment
+    process, publishes no artifact anyone outside the lab could run, and gives no usage figure. The null
+    is a deliberate abstention and it stands.
+  last_verified: '2026-08-13'
   sources:
   - url: https://cdn.openai.com/pdf/18a02b5d-6b67-4cec-ab64-68cdfbddebcd/preparedness-framework-v2.pdf
-    shows: evaluations are internal to OpenAI's deployment process, not a shared/usable external dataset
-    accessed: '2026-06-04'
+    shows: evaluations are run internally as part of OpenAI's own deployment decisions, with no released
+      artifact and no usage figure of any kind, so there is nothing external to band
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: fae6e4cc6f7212a010bb9348fc0cde1fe711b9cad426c6a99db97740ee52729b
 capability:
   score: null
   basis: n/a
   value: null
   confidence: high
-  note: Capability not a meaningful axis for an eval dataset.
-  sources: []
+  note: Capability not a meaningful axis for an eval dataset. Re-read 2026-08-13 and the abstention
+    stands - the scored artifact is an unpublished eval set, and the framework describes the process
+    around it rather than any capability of the set itself.
+  last_verified: '2026-08-13'
+  sources:
+  - url: https://cdn.openai.com/pdf/18a02b5d-6b67-4cec-ab64-68cdfbddebcd/preparedness-framework-v2.pdf
+    shows: the document describes thresholds and safeguards for model capability, never a capability of
+      the eval sets themselves, and publishes no feature matrix or benchmark row for them
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: fae6e4cc6f7212a010bb9348fc0cde1fe711b9cad426c6a99db97740ee52729b

--- a/sources/scores/scale-seal-leaderboard.yaml
+++ b/sources/scores/scale-seal-leaderboard.yaml
@@ -18,15 +18,25 @@ openness:
       detail: results visible on leaderboard, dataset not downloadable
   confidence: high
   note: Intentionally private/held-out eval sets per the data-openness rubric (closed = proprietary held-out
-    test suite); only the leaderboard results are public, the data itself is not.
+    test suite); only the leaderboard results are public, the data itself is not. Re-read 2026-08-13 -
+    the post still states under Leaderboard Integrity that "Scale's proprietary datasets will remain
+    private and unpublished, ensuring they cannot be exploited or incorporated into model training data",
+    which is the whole of the recorded reading. Two details the old shows carried are NOT on the page -
+    the "~1,000 examples" per domain and the mixing in of "some open source sets" - so the components
+    detail carrying the 1,000 figure is now unsourced and is flagged rather than silently kept or dropped.
   raw: data:closed(proprietary held-out prompt sets, ~1,000 examples/domain, deliberately unpublished to
     prevent contamination/training-set leakage);datasheet:no(methodology described but examples not redistributable);license:none(not
     distributed);access:held-out(results visible on leaderboard, dataset not downloadable)
+  last_verified: '2026-08-13'
   sources:
   - url: https://scale.com/blog/leaderboard
-    shows: Scale states SEAL datasets remain private/unpublished, combining proprietary held-out sets
-      (~1,000 examples) with some open source sets
-    accessed: '2026-06-04'
+    shows: '"Leaderboard Integrity - Unlike most public benchmarks, Scale''s proprietary datasets will
+      remain private and unpublished, ensuring they cannot be exploited or incorporated into model
+      training data." No download link, no license statement and no dataset card anywhere on the page'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 59832825730511bdf912b6a3b54fb8c3d3ffb817f4c6a8a03558880ad9277cdb
+    establishes: [license, access, datasheet, data]
 adoption:
   level: 3
   signal_type: reported_traction
@@ -34,16 +44,33 @@ adoption:
   note: SEAL is a widely-referenced expert-driven private leaderboard cited across the LLM evaluation
     community as a contamination-resistant ranking; broad press and industry attention but no published
     download/usage count (the data is held-out by design). Reported-traction tier as an industry-standard
-    reference rather than a measured usage_volume figure.
+    reference rather than a measured usage_volume figure. Re-read 2026-08-13 - the launch post still
+    positions SEAL as the answer to contamination and inconsistent reporting in frontier-model comparison,
+    and still publishes no usage figure of any kind, so both the reported_traction instrument and the
+    level-3 band stand unchanged.
+  last_verified: '2026-08-13'
   sources:
   - url: https://scale.com/blog/leaderboard
-    shows: SEAL positioned as a trusted, tamper-proof frontier-model leaderboard used to rank major LLMs
-    accessed: '2026-06-04'
+    shows: SEAL positioned as a trusted frontier-model leaderboard answering "Contamination & Overfitting"
+      and "Inconsistent Reporting" in model comparison; no download, user or submission count is published
+      anywhere on the page
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 59832825730511bdf912b6a3b54fb8c3d3ffb817f4c6a8a03558880ad9277cdb
 capability:
   score: null
   basis: n/a
   value: null
   confidence: high
   note: Capability is not a meaningful axis for an eval dataset; openness + adoption carry this category
-    per the recipe.
-  sources: []
+    per the recipe. Re-read 2026-08-13 and the abstention stands - the scored artifact is a private
+    prompt set, and the page publishes no performance or feature claim about it the capability axis
+    could band.
+  last_verified: '2026-08-13'
+  sources:
+  - url: https://scale.com/blog/leaderboard
+    shows: the scored artifact is the private held-out prompt sets behind the leaderboard; the page
+      ranks models rather than describing any capability of the prompt sets themselves
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 59832825730511bdf912b6a3b54fb8c3d3ffb817f4c6a8a03558880ad9277cdb

--- a/sources/scores/swe-bench-verified.yaml
+++ b/sources/scores/swe-bench-verified.yaml
@@ -25,16 +25,24 @@ openness:
     beneath headed "For SWE-bench (Verified)". The HF card for Verified still declares no license field,
     and where a repository license and a distribution-point license differ the repository license governs,
     so the recorded 4 moves to the 5/open the ladder computes. (Distinct from SWE-bench broader/hidden variants,
-    which can carry held-out splits.)
+    which can carry held-out splits.) Re-read 2026-08-13 - the repository README still carries the
+    "Citation & license" section reading "MIT license" with the "For SWE-bench (Verified)" citation
+    directly beneath, the LICENSE file re-fetched with an unchanged digest, and the HF repo is still
+    ungated with a rendering card and no license field.
   raw: license:MIT(SWE-bench repository states MIT over its code and data; the HF card for Verified still
     declares no license field);redistributability:full(downloadable parquet, ungated);datasheet:yes(dataset
     card + arXiv:2310.06770);held-out:no hidden split in Verified itself(the public 500-instance set is
     fully released; gold patches + tests included);data-source:real GitHub PR/issue pairs
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/princeton-nlp/SWE-bench_Verified
-    shows: 500 instances, ~2.1 MB, not gated, dataset card present, gold patch + FAIL_TO_PASS/PASS_TO_PASS
-      tests included, leaderboard swebench.com
-    accessed: '2026-06-04'
+    shows: 'the embedded repo state reads `"gated":false` and the tags array carries no license tag;
+      the dataset card renders over the 500-instance test split with the gold patch and the
+      FAIL_TO_PASS/PASS_TO_PASS test lists; 413,323 downloads in the trailing 30 days'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 21a9ae799b810fb5b73f025632c12b0858475dabbdc756309dad62af5af1d184
+    establishes: [datasheet]
   - url: https://github.com/SWE-bench/SWE-bench/blob/main/LICENSE
     shows: MIT License for the SWE-bench harness
     accessed: '2026-06-04'
@@ -45,8 +53,9 @@ openness:
     shows: card front matter carries dataset_info, splits and configs and no `license:` key; body describes
       the 500 human-validated instances and the swebench.com leaderboard. Re-read on 2026-08-12 and
       still unlicensed at source. The repository holds only .gitattributes, README.md and one parquet
-      file, so there is no LICENSE file alongside the data either
-    accessed: '2026-08-12'
+      file, so there is no LICENSE file alongside the data either. Re-fetched 2026-08-13 with an
+      unchanged digest
+    accessed: '2026-08-13'
     http_status: 200
     content_sha256: 6edb58b1b2c44ce858426c4ebc90077827713b75cebc243661e4433c81fd57f5
     establishes: [license]
@@ -54,15 +63,17 @@ openness:
     shows: '"Code and data for the following works:" listing SWE-bench and SWE-bench Multimodal; the
       "Citation & license" section reads "MIT license. Check `LICENSE.md`." and the citation immediately
       under it is headed "For SWE-bench (Verified)"; the news entry for Aug. 13, 2024 introduces Verified
-      as a 500-problem subset produced with OpenAI Preparedness'
-    accessed: '2026-08-12'
+      as a 500-problem subset produced with OpenAI Preparedness. Re-read 2026-08-13 and all three
+      statements are still present; the digest moved (the README picked up unrelated edits), which
+      is why the whole section was re-read rather than assumed'
+    accessed: '2026-08-13'
     http_status: 200
-    content_sha256: 56438c6b147990c0fd93d81fefcecaa94c909d379037487a49d48ac4990a4573
+    content_sha256: 910cf1bd353b898e9c6299d8e805c1a115d00c1b877e1239753be8d9caa4275f
     establishes: [license]
   - url: https://raw.githubusercontent.com/SWE-bench/SWE-bench/main/LICENSE
     shows: 'MIT License, copyright 2023 the SWE-bench authors. Note the README points at `LICENSE.md`,
-      which 404s; the file is `LICENSE`'
-    accessed: '2026-08-12'
+      which 404s; the file is `LICENSE`. Re-fetched 2026-08-13 with an unchanged digest'
+    accessed: '2026-08-13'
     http_status: 200
     content_sha256: 2bd2e08df7147f67a69b42c10efae09bd4bf119df397371036187d5dd1b02f57
     establishes: [license]
@@ -76,12 +87,16 @@ adoption:
     Verified). ~914k HF downloads/month plus a live, heavily-submitted leaderboard at swebench.com. Strongest
     ''citation-as-standard'' signal in the batch. Read live 2026-08-13: 413,323 Hugging Face downloads in the
     trailing 30 days across the declared artifact(s), which bands at 100K-1M, level 4. The previous reach
-    ''1M-10M'' was a band off a different scale. No last_verified claimed: only the figure was re-read, not
-    the whole axis.'
+    ''1M-10M'' was a band off a different scale. Re-read against the Hub API on 2026-08-13: still 413,323
+    downloads in the trailing 30 days, so level 4 / 100K-1M stands and the axis is now dated. The ~914k
+    figure the June source cited no longer appears anywhere on the dataset page.'
+  last_verified: '2026-08-13'
   sources:
-  - url: https://huggingface.co/datasets/princeton-nlp/SWE-bench_Verified
-    shows: ~914k downloads last month; leaderboard at swebench.com
-    accessed: '2026-06-04'
+  - url: https://huggingface.co/api/datasets/princeton-nlp/SWE-bench_Verified
+    shows: 413,323 downloads in the trailing 30 days for princeton-nlp/SWE-bench_Verified
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e7239207ea1aa7e72552da32855ef449cabd79f850fb7b0060878d17a89c9254
 capability:
   score: null
   basis: n/a
@@ -89,5 +104,13 @@ capability:
   confidence: high
   note: Dataset, not 'capable'. Notably high contamination-resistance and discriminating power for coding
     agents (real repo state, executable tests), but per recipe capability is n/a; the quality proxy is
-    noted, not numerically scored.
-  sources: []
+    noted, not numerically scored. Re-read 2026-08-13 and the abstention stands - the page publishes
+    a static instance set and no performance or feature claim the capability axis could band.
+  last_verified: '2026-08-13'
+  sources:
+  - url: https://huggingface.co/datasets/princeton-nlp/SWE-bench_Verified
+    shows: a static 500-instance corpus of repo state, issue text, gold patch and tests; no performance,
+      throughput or feature claim on the page for the capability axis to read
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 21a9ae799b810fb5b73f025632c12b0858475dabbdc756309dad62af5af1d184

--- a/sources/scores/truthfulqa.yaml
+++ b/sources/scores/truthfulqa.yaml
@@ -16,16 +16,26 @@ openness:
       value: public
       detail: 817 Qs, two configs, no hidden held-out
   confidence: high
-  note: 'Fully open: Apache-2.0, ungated, redistributable, complete card with creation methodology.'
+  note: 'Fully open: Apache-2.0, ungated, redistributable, complete card with creation methodology.
+    Re-read 2026-08-13: `license:apache-2.0` is still in the repo tags, the embedded repo state reads
+    `"gated":false`, and the card still documents both configs with no hidden split. No change.'
   raw: license:Apache-2.0(OSI/open,redistributable);access:public(not gated);datasheet:present(card+creation
     methodology+citation);splits:public(817 Qs, two configs, no hidden held-out)
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/truthfulqa/truthful_qa
-    shows: Apache-2.0 license, not gated, 817 questions, dataset card present
-    accessed: '2026-06-04'
+    shows: '`license:apache-2.0` in the repo tags; the embedded repo state reads `"gated":false`; the
+      dataset card still renders over the generation and multiple_choice configs; 110,844 downloads
+      in the trailing 30 days'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e018e2f7364e61424d33ba605be041d268f4fc9f73d0ac969cc10eac6a114db1
+    establishes: [license, access, datasheet]
   - url: https://arxiv.org/abs/2109.07958
-    shows: TruthfulQA paper documenting 817 questions, 38 categories
-    accessed: '2026-06-04'
+    shows: the abstract still reads "The benchmark comprises 817 questions that span 38 categories"
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5a2f6d5867ac15485e7be55e49eb1116aaa1b9af6ceb20c12ce936dbcddf7fc3
 adoption:
   level: 4
   reach: 100K-1M
@@ -47,5 +57,14 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: Dataset, not 'capable'; openness and adoption carry this category per recipe.
-  sources: []
+  note: Dataset, not 'capable'; openness and adoption carry this category per recipe. Re-read 2026-08-13
+    and the abstention stands - the page publishes a static question set and no performance or feature
+    claim the capability axis could band.
+  last_verified: '2026-08-13'
+  sources:
+  - url: https://huggingface.co/datasets/truthfulqa/truthful_qa
+    shows: a static 817-question corpus in generation and multiple_choice configs; no performance,
+      throughput or feature claim on the page for the capability axis to read
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e018e2f7364e61424d33ba605be041d268f4fc9f73d0ac969cc10eac6a114db1


### PR DESCRIPTION
**25 of 27 products fully verified since 2026-08-01.** 85 of 87 checkpoints closed.

## The 21 null-capability records

All re-read, confirmed and dated. This category owns 21 of the corpus's 26 null-capability axes, and that is deliberate: a benchmark corpus is graded on adoption alone, because a corpus everyone evaluates against is by that fact a good corpus. **No capability score was invented.**

Each now cites the page it was confirmed against, with a `shows` saying what was read and why there is nothing to band — the invariant rejects a date over `sources: []`, so an empty axis could not have been dated honestly even if someone wanted to.

## Two rulings applied after independent re-verification

**`cruxeval` 3 → 2.** A measured figure now exists on the artifact the product *already declared* — 8,063 downloads/30d, banding at `1K-10K` on the dataset scale. `adoption.md` is explicit that a band resting on reported traction re-bands once a real download signal appears. The repo was also archived by its owner on 2025-09-18 and is read-only, so the "maintained Meta FAIR benchmark repo" the old band rested on has itself changed.

**`multipl-e` level unchanged at 3, instrument corrected.** Its note said the HF page "did not surface a clean monthly-download count" — it does now, 33,673/30d, banding at the same level. The record moves off `reported_traction`, which has no scale and which nothing could check, onto `usage_volume` against a readable artifact.

Both figures were re-fetched independently before applying.

## Escalated and left undated: `math`

Its only cited source is still DMCA-disabled ("Access to this dataset has been disabled") and now reports **0 downloads in the trailing 30 days** against 1,034,712 all-time. The recorded level 4 rests on MATH appearing as a headline metric across frontier release reports — which is plausibly true and which **this page does not establish and never did**. Its `shows` also quoted text no longer rendered anywhere on it.

Needs a frontier release report cited as actual evidence. That is finding new evidence rather than re-reading it, so the axis stays undated.

## Recorded, not silently fixed

- **`scale-seal-leaderboard`** — the "~1,000 examples per domain" figure in its `data.detail` component is **not on the page**, so that component is now unsourced. The private-datasets claim that carries the actual reading is still there.
- **`hellaswag`** carries no `license:` tag on HF at all; MIT is established by the card's Licensing Information section. Recorded explicitly so a tag-based fetcher doesn't later read this as unlicensed.
- **`humanitys-last-exam`** — `holdout: private` isn't stated on the HF card; the establishing quote is on `lastexam.ai`, now cited.
- **`swe-bench-verified` / `gpqa`** — figures re-read yesterday without a date claimed. Re-fetched today, unchanged, now dated. Their June `shows` cited figures that no longer appear.

## Comparisons that could not be recorded

Three capability notes name a peer in prose, but two of those peers carry a deliberate **null** capability — so there are not two integers for `relation` to be arithmetic over. Recorded in each note rather than forced.

All gates green: `validate` 0 errors, `check_verification` all three OK, `check_capability` OK, `check_adoption --strict` exit 0, 488 tests.