### PR TITLE
Verify deployment: 20/27 products to 4/4

### DIFF
--- a/sources/products/agent-infra-sandbox.yaml
+++ b/sources/products/agent-infra-sandbox.yaml
@@ -1,14 +1,15 @@
 name: agent-infra-sandbox
 display_name: Agent Infra Sandbox
 type: software
-description: Apache-2.0 all-in-one Docker sandbox bundling Browser, Shell, File, MCP server, and VSCode
-  Server in a single container so an agent gets a complete computer-use environment from one image. Picked
-  over E2B/Daytona by builders who want browser+shell+files in one box for computer-use agents rather
-  than wiring up multiple services. ~4.8k stars, actively maintained.
+description: Agent Infra Sandbox, shipped as AIO Sandbox, bundles a VNC browser, shell, file service, Jupyter, VSCode Server and
+  preconfigured MCP servers into a single Docker container, so an agent reaches all of them over one
+  shared filesystem instead of coordinating separate services. Python, TypeScript and Go SDKs drive it
+  through an HTTP API, and it deploys with Docker Compose or a plain Kubernetes manifest. The
+  agent-infra organization maintains it.
 github:
 - url: https://github.com/agent-infra/sandbox
 npm:
 - url: https://www.npmjs.com/package/@agent-infra/sandbox
-comments: AIO Sandbox (agent-infra/sandbox), v1.9.3 released 29 May 2026; all-in-one Docker container
-  bundling Browser, Shell, File, MCP, Jupyter and VSCode Server for AI agents. Maintained by agent-infra
-  org (ByteDance OSS; image hosted on volces.com/ByteDance registry). Verified live on GitHub June 2026.
+comments: The image is published on GitHub Container Registry, with a separate mirror on a Volcengine
+  registry for users in mainland China. Verified 2026-08-13 via the agent-infra/sandbox README and the
+  GitHub repository metadata.

--- a/sources/products/aws-lambda.yaml
+++ b/sources/products/aws-lambda.yaml
@@ -1,10 +1,11 @@
 name: aws-lambda
 display_name: AWS Lambda
 type: software
-description: AWS Lambda, GA serverless function service; runs on AWS Firecracker microVMs (open sourced
-  2018, powers Lambda + Fargate). The Lambda service itself is proprietary/SaaS - scored as the closed
-  counterpart per the deployment recipe (Lambda/Cloud Run = closed). Verified live (AWS docs/blog) June
-  2026.
-comments: AWS Lambda, GA serverless function service; runs on AWS Firecracker microVMs (open sourced 2018,
-  powers Lambda + Fargate). The Lambda service itself is proprietary/SaaS - scored as the closed counterpart
-  per the deployment recipe (Lambda/Cloud Run = closed). Verified live (AWS docs/blog) June 2026.
+description: AWS Lambda runs event-triggered functions on AWS-managed compute, with no server for the caller
+  to provision. It supports Java, Go, PowerShell, Node.js, C#, Python and Ruby natively and any other language
+  through a Runtime API, and takes code as either a .zip archive or a container image. Each function runs
+  in its own isolated environment on Firecracker microVMs. Lambda MicroVMs extends the same substrate to
+  workloads that execute user- or AI-generated code, adding near-instant resume and state persistence across
+  interactions.
+comments: The service itself is proprietary and AWS-hosted; Firecracker, the microVM it runs on, is a
+  separate open-source entry on this map. Verified 2026-08-13 via the AWS Lambda FAQ.

--- a/sources/products/beta9.yaml
+++ b/sources/products/beta9.yaml
@@ -1,11 +1,13 @@
 name: beta9
 display_name: Beta9
 type: software
-description: Open-source Docker-based sandbox runtime positioned as a self-hostable E2B alternative, with
-  first-class GPU support, Python and Node.js runtimes, and no session time limits. Picked when teams
-  need to keep agent execution on their own infra (HIPAA/SOC2/BYOC) and want GPU workloads alongside CPU
-  sandboxes. ~1.6k stars, AGPL-3.0 licensed with a managed cloud offering.
+description: Beta9 is a serverless runtime for AI workloads driven from a Python interface, covering isolated
+  sandboxes for model-generated code, autoscaling inference endpoints and background task queues. A custom
+  container runtime, scheduler and embedded cache launch containers in under a second, alongside scale-to-zero,
+  mounted distributed volumes and GPU support. Beam Cloud develops it as the engine behind its managed
+  platform, and it can be self-hosted instead.
 github:
 - url: https://github.com/beam-cloud/beta9
-comments: Beta9, open source serverless AI runtime (sandboxes, serverless inference endpoints, task queues);
-  worker v0.1.597 (Jun 4 2026) confirmed live on GitHub. OSS engine powering managed Beam cloud (beam.cloud).
+comments: The independent cold-start figures cited on the capability axis measure the managed Beam service
+  rather than a self-hosted deployment. Verified 2026-08-13 via the Beta9 README and the ComputeSDK sandbox
+  benchmark leaderboard.

--- a/sources/products/blaxel-sandbox.yaml
+++ b/sources/products/blaxel-sandbox.yaml
@@ -1,13 +1,13 @@
 name: blaxel-sandbox
 display_name: Blaxel Sandbox
 type: software
-description: MicroVM-based code-execution sandboxes for AI agents that stay in standby indefinitely at
-  zero compute cost and resume in under 25ms with full filesystem and memory state. The sandbox API is
-  MIT-licensed and self-hostable via Docker Compose; the managed perpetual-standby platform is the commercial
-  layer. Built by an ex-OVH/ForePaaS team (YC S2025); raised a $7.3M seed led by First Round in 2025.
-  ~22 stars on the sandbox repo.
+description: Blaxel gives AI agents microVM sandboxes that suspend after a few seconds of inactivity and
+  resume in about 25 milliseconds with filesystem and memory state intact. Around the sandbox sit batch
+  jobs, durable volumes, outbound allow-lists and static IPs.
+  The in-sandbox HTTP API and a hub of image templates are published; the scheduler that allocates and
+  resumes machines is the commercial layer, offered as managed cloud, self-hosted or VPC.
 github:
 - url: https://github.com/blaxel-ai/sandbox
-comments: Blaxel sandbox API (MIT, self-hostable via Docker Compose on port 8080) over a proprietary managed
-  standby platform; microVM isolation, sub-25ms resume from standby. Sandbox repo ~22 stars June/July
-  2026.
+comments: The declared repository is the API that runs inside a sandbox plus its image templates, not
+  the platform the SDKs call. Verified 2026-08-13 via blaxel.ai/sandbox, the repository metadata, and
+  the ComputeSDK sandbox benchmark leaderboard.

--- a/sources/products/cloudflare-sandboxes.yaml
+++ b/sources/products/cloudflare-sandboxes.yaml
@@ -1,12 +1,12 @@
 name: cloudflare-sandboxes
 display_name: Cloudflare Sandboxes
 type: software
-description: 'Cloudflare''s two-tier sandboxing for AI agents, shipped during Agents Week 2026: Dynamic
-  Workers (V8 isolates, ms-scale cold start, ~100x faster and more memory-efficient than containers, open
-  beta April 2026) and Sandboxes (persistent Linux environments, GA April 2026 for full-OS workloads).
-  Runs on Cloudflare''s global edge network and is available to paid Workers users. Execution is tied
-  to Cloudflare''s proprietary platform; only the Sandbox SDK is open source.'
-comments: 'Two related 2026 offerings: (a) Cloudflare Sandbox SDK (cloudflare/sandbox-sdk, @cloudflare/sandbox
-  v0.11.0, 1 Jun 2026) - container-backed sandboxes on Workers/Durable Objects; (b) Dynamic Workers /
-  Worker Loader (open beta announced 24 Mar 2026) - V8-isolate-based per-runtime sandboxing, ~100x faster
-  than containers. Open SDK over Cloudflare''s proprietary edge network. Verified live June 2026.'
+description: 'Cloudflare offers two paths for running agent-generated code on its own network. Dynamic
+  Workers lets a Worker load fresh code at runtime into a separate V8 isolate, starting in milliseconds
+  with network access blocked or intercepted per load; the Sandbox SDK backs the same idea with
+  containers on Workers and Durable Objects, for arbitrary commands, files, background processes and
+  exposed services. Both are reached only through Cloudflare''s platform.'
+comments: 'Scored as one product per the registry name, though the two paths differ sharply in
+  performance and in what they can run: the isolate path is JavaScript and TypeScript, the container
+  path is general. Verified 2026-08-13 via Cloudflare''s "Sandboxing AI agents, 100x faster" post and
+  the cloudflare/sandbox-sdk repository.'

--- a/sources/products/coder-oss.yaml
+++ b/sources/products/coder-oss.yaml
@@ -1,13 +1,13 @@
 name: coder-oss
 display_name: Coder OSS
 type: software
-description: Open-source platform for provisioning remote dev environments (Terraform-defined workspaces
-  on K8s, VMs, or bare metal), increasingly used as the substrate for self-hosted agent execution environments.
-  Picked over GitHub Codespaces when teams want full BYOC control and have aggressively repositioned in
-  2026 toward AI-agent workspaces. ~13.3k stars, very active (2,055 commits in 90d).
+description: Coder OSS provisions self-hosted cloud development environments on a team's own
+  infrastructure, with each workspace defined in Terraform over EC2 VMs, Kubernetes pods or Docker
+  containers, reached through a Wireguard tunnel and shut down automatically when idle. Coder Agents
+  runs a coding agent's loop in the control plane rather than the workspace, so model credentials stay
+  out of developer environments and every action carries a user identity.
 github:
 - url: https://github.com/coder/coder
-comments: 'coder/coder, v2.33.6 released 23 May 2026. Self-hosted Cloud Development Environment platform
-  (Terraform-defined workspaces, Wireguard tunnel); now marketed as ''Secure environments for developers
-  and their agents'' with native AI-agent workspace support. Verified live on GitHub June 2026. NOTE:
-  primarily a CDE/workspace manager rather than an ephemeral agent code-execution sandbox.'
+comments: 'Primarily a development-environment manager rather than an ephemeral agent code-execution
+  sandbox: workspaces are long-lived and their isolation follows whatever the Terraform template
+  provisions. Verified 2026-08-13 via the coder/coder README and the GitHub repository metadata.'

--- a/sources/products/daytona-sandbox.yaml
+++ b/sources/products/daytona-sandbox.yaml
@@ -1,14 +1,15 @@
 name: daytona-sandbox
 display_name: Daytona Sandbox
 type: software
-description: Open-source agent-native compute platform that provisions sub-200ms stateful sandboxes (start,
-  pause, fork, snapshot, destroy) for AI agents. Picked over E2B for snapshot/fork semantics and an enterprise
-  BYOC story. Raised $24M Series A in Feb 2026 led by FirstMark with strategic investment from Datadog
-  and Figma Ventures, ~72k stars on GitHub.
+description: Daytona provisions stateful sandboxes for running AI-generated code, putting sandbox creation,
+  execution and deletion under programmatic control through SDKs for Python, TypeScript, Ruby, Go and Java.
+  The same API exposes process execution with streamed output, file system operations, Git and a built-in
+  language server. Daytona sells it as a hosted cloud aimed at coding agents, code interpreters and agent
+  evaluation across parallel snapshot states.
 github:
 - url: https://github.com/daytonaio/daytona
 pypi:
 - url: https://pypi.org/project/daytona
-comments: 'Daytona secure/elastic runtime for AI-generated code execution; v0.184.0 (Jun 3 2026) live
-  on GitHub June 2026. Repo now AGPL-3.0 (note: Daytona pivoted from dev-environments to agent code-execution
-  sandboxes). Sub-90ms sandbox spin-up; managed cloud at app.daytona.io.'
+comments: The public repository is no longer maintained - core development moved to a private codebase in
+  June 2026 - so the openness axis reads a frozen snapshot rather than what currently ships. Verified 2026-08-13
+  via daytona.io and the ComputeSDK sandbox benchmark leaderboard.

--- a/sources/products/e2b-sandbox.yaml
+++ b/sources/products/e2b-sandbox.yaml
@@ -1,15 +1,15 @@
 name: e2b-sandbox
 display_name: E2B Sandbox
 type: software
-description: Open-source secure cloud runtime that gives AI agents an ephemeral Linux microVM (Firecracker-based)
-  controlled via a Python/TypeScript SDK. Picked over hyperscaler functions for sub-150ms cold starts,
-  agent-native lifecycle (create/use/destroy), and the fact that the SDK + core are open and self-hostable
-  via the e2b-dev/infra repo. ~12.3k stars on the SDK repo, used by major coding-agent products and growing
-  fast in the agent-infra category.
+description: E2B hands an AI agent an ephemeral Linux sandbox, each one a Firecracker microVM, created and
+  driven through a Python or TypeScript SDK. Sandboxes accept custom templates, expose configurable CPU
+  and RAM, and can stay alive for up to 24 hours. The SDKs and the infrastructure running the hosted cloud
+  are both published, so the same stack can be self-hosted.
 github:
 - url: https://github.com/e2b-dev/E2B
 - url: https://github.com/e2b-dev/infra
 pypi:
 - url: https://pypi.org/project/e2b
-comments: E2B open source sandbox infra for running AI-generated code; CLI @e2b/cli@2.10.3 (Jun 3 2026)
-  confirmed live on GitHub June 2026. Isolation via Firecracker microVMs. OSS core + managed cloud (e2b.dev).
+comments: The self-hostable control plane lives in a second repository, e2b-dev/infra, rather than in the
+  SDK repository the product is usually found through. Verified 2026-08-13 via the E2B site and the ComputeSDK
+  sandbox benchmark leaderboard.

--- a/sources/products/firecracker.yaml
+++ b/sources/products/firecracker.yaml
@@ -1,9 +1,12 @@
 name: firecracker
 display_name: Firecracker
 type: software
-description: Firecracker microVM virtualization; v1.16.0 (Jun 4 2026) confirmed live on GitHub. Rust microVM
-  monitor (KVM) for secure multi-tenant function/container workloads; powers AWS Lambda + Fargate.
+description: Firecracker is a virtual machine monitor written in Rust that uses KVM to run workloads in
+  lightweight microVMs, combining hardware-virtualization isolation with container-like startup and density.
+  It ships a deliberately minimal guest device model - network, block I/O, timer, KVM clock, serial console
+  and a partial keyboard - to shrink the memory footprint and attack surface, and jails its own process
+  with cgroups and seccomp BPF. AWS built it to run AWS Lambda and AWS Fargate, and Kata Containers and
+  Flintlock embed it as their runtime.
 github:
 - url: https://github.com/firecracker-microvm/firecracker
-comments: Firecracker microVM virtualization; v1.16.0 (Jun 4 2026) confirmed live on GitHub. Rust microVM
-  monitor (KVM) for secure multi-tenant function/container workloads; powers AWS Lambda + Fargate.
+comments: Verified 2026-08-13 via the Firecracker README and the GitHub repository API.

--- a/sources/products/fly-sprites.yaml
+++ b/sources/products/fly-sprites.yaml
@@ -1,12 +1,10 @@
 name: fly-sprites
 display_name: Fly Sprites
 type: software
-description: Closed-source stateful sandbox product (launched Jan 2026), Firecracker microVMs with 100GB
-  persistent NVMe storage that boot in 1–12s cold, ~300ms warm checkpoint/restore, and auto-idle when
-  inactive. Picked by teams who reject ephemeral sandboxes for coding agents and want a persistent computer
-  the agent can return to. Pitched explicitly against E2B/Modal/Daytona for long-running Claude Code-style
-  sessions.
-comments: Sprites (sprites.dev) by Fly.io, launched Jan 2026. Persistent, hardware-isolated Firecracker
-  microVMs ('a persistent Linux computer') for running arbitrary code / AI agents, with 100GB NVMe persistence
-  and sub-1s checkpoint/restore. Confirmed live June 2026 via sprites.dev. Proprietary managed service
-  (Fly.io's E2B competitor).
+description: Gives an AI agent its own persistent Linux computer rather than an ephemeral sandbox. Each
+  Sprite is a Firecracker microVM with its own kernel and a 100 GB POSIX volume that survives sleep and
+  moves between host machines, plus live copy-on-write checkpoints an agent can roll back to. Fly.io operates
+  it as a managed service with CLI, REST and language SDK clients and an outbound API gateway.
+comments: The product page moved from sprites.dev to fly.io/sprites during 2026 and was rewritten around
+  persistence; the isolation mechanism now appears on the Sprites overview rather than the product page.
+  Verified 2026-08-13 via fly.io/sprites and the Fly.io Sprites overview.

--- a/sources/products/google-cloud-run.yaml
+++ b/sources/products/google-cloud-run.yaml
@@ -1,11 +1,10 @@
 name: google-cloud-run
 display_name: Google Cloud Run
 type: software
-description: Fully managed serverless container platform with gVisor-based sandboxing, pay-per-request
-  pricing, and scale-to-zero. Picked over Lambda for any-OCI-image flexibility and longer max execution.
-  In 2026 Cloud Run added 'Cloud Run Instances' for long-running background agents and deep Gemini Enterprise
-  Agent Platform integration, making it Google's go-to closed-source sandbox for agent code.
-comments: Google Cloud Run, fully-managed serverless container platform. Confirmed live June 2026 via
-  cloud.google.com/run. At Next '26 Google announced a built-in `sandbox` tool for agents to run AI-generated
-  code in ephemeral, strictly-isolated environments; container isolation historically backed by gVisor.
-  Scored as the proprietary/SaaS deployment counterpart per the recipe (Cloud Run = closed counterpart).
+description: Runs any OCI container image as a fully managed Google Cloud service, autoscaling from zero
+  to thousands of instances and billing only while a request is in flight. Google exposes individual Cloud
+  Run instances for long-running background agents, and a built-in `sandbox` tool lets an agent spin up
+  an ephemeral, isolated environment to execute generated code. Container isolation is backed by gVisor.
+comments: Google Cloud Run, a fully managed serverless container platform with no self-hostable edition.
+  Scored as the proprietary SaaS deployment counterpart per the recipe. Verified 2026-08-13 via cloud.google.com/run,
+  the Cloud Run at Next '26 announcement post, and the google/gvisor repository.

--- a/sources/products/gvisor.yaml
+++ b/sources/products/gvisor.yaml
@@ -1,10 +1,12 @@
 name: gvisor
 display_name: gVisor
 type: software
-description: gVisor application-kernel sandbox; repo live June 2026 (rolling date-tagged releases, no
-  GitHub Releases page). Go userspace kernel intercepting syscalls (Sentry + Gofer); used as the
-  sandbox runtime behind Google Cloud Run and GKE Sandbox.
+description: gVisor puts an application kernel between a container and the host, intercepting system calls
+  in userspace and implementing a Linux-like interface in Go rather than filtering syscalls or booting a
+  virtual machine. It ships an OCI runtime, runsc, that drops into Docker and Kubernetes tooling. Google
+  develops it and runs it as the sandbox layer behind GKE Sandbox, Cloud Run and App Engine.
 github:
 - url: https://github.com/google/gvisor
-comments: gVisor application-kernel sandbox; repo live June 2026 (rolling date-tagged releases, no GitHub
-  Releases page). Go userspace kernel intercepting syscalls (Sentry + Gofer); powers Google Cloud Run.
+comments: The project ships rolling date-tagged releases and keeps no GitHub Releases page, so this is
+  verified against the master branch rather than a tag. Verified 2026-08-13 via the gVisor README, the
+  LICENSE body, and the gvisor.dev documentation and users pages.

--- a/sources/products/kata-containers.yaml
+++ b/sources/products/kata-containers.yaml
@@ -1,11 +1,13 @@
 name: kata-containers
 display_name: Kata Containers
 type: software
-description: Kata Containers, lightweight VMs that feel like containers; v3.31.0 (May 19 2026) confirmed
-  live on GitHub. OpenInfra Foundation governed (governance not explicit on repo landing page but established
-  as an OpenInfra project). Can use Firecracker/QEMU as the VMM.
+description: Kata Containers runs each container inside its own lightweight virtual machine, so workloads
+  keep container ergonomics while gaining hardware-backed isolation of kernel, memory, network and I/O.
+  A containerd shimv2 runtime and an in-VM agent plug it into Kubernetes through a RuntimeClass, and the
+  hypervisor is pluggable across QEMU, Cloud Hypervisor, Firecracker, Dragonball and StratoVirt. The
+  OpenInfra Foundation stewards the project.
 github:
 - url: https://github.com/kata-containers/kata-containers
-comments: Kata Containers, lightweight VMs that feel like containers; v3.31.0 (May 19 2026) confirmed
-  live on GitHub. OpenInfra Foundation governed (governance not explicit on repo landing page but established
-  as an OpenInfra project). Can use Firecracker/QEMU as the VMM.
+comments: The repository landing page does not state governance; the OpenInfra Foundation stewardship is
+  established on the project site instead. Verified 2026-08-13 via the Kata Containers README, docs/hypervisors.md,
+  and katacontainers.io.

--- a/sources/products/modal-sandboxes.yaml
+++ b/sources/products/modal-sandboxes.yaml
@@ -1,11 +1,10 @@
 name: modal-sandboxes
 display_name: Modal Sandboxes
 type: software
-description: Closed-source serverless platform that lets you run Python and shell code (including GPU
-  workloads) in seconds-startup containers, with a dedicated Sandbox primitive for executing untrusted
-  agent-generated code. Picked when AI teams need GPU-capable sandboxes with Pythonic ergonomics. Raised
-  $355M Series C in May 2026 at a $4.65B valuation; $300M annualized revenue driven largely by coding-agent
-  demand.
-comments: Modal Sandboxes - 'secure containers for executing untrusted user or agent code' on the Modal
-  platform; gVisor-based isolation. Open Python/JS SDK + proprietary managed cloud (pay-per-CPU-cycle,
-  $30/mo free credits on Starter). Docs verified live June 2026.
+description: Modal Sandboxes runs untrusted or agent-generated code in gVisor-isolated containers on
+  Modal's serverless cloud, created at runtime from the Python, JavaScript or Go SDK. A sandbox can be
+  built from an arbitrary container image, looked up later by name, given GPUs, and held open for
+  anything from the five-minute default to twenty-four hours. Compute is billed by the core-second.
+comments: Modal bills Sandbox compute at a separate rate from its Function compute, so the plan tiers
+  on the pricing page describe the surrounding platform rather than the sandbox itself. Verified
+  2026-08-13 via the Modal Sandboxes guide and the Modal pricing page.

--- a/sources/products/nono.yaml
+++ b/sources/products/nono.yaml
@@ -1,16 +1,12 @@
 name: nono
 display_name: nono
 type: software
-description: "An open-source, zero-setup sandbox that runs AI agents (Claude Code, Copilot, and others)
-  with least-privilege isolation on macOS, Linux, and Windows. Written in Rust by nolabs-ai (built by
-  members of the Sigstore team), it wraps agent processes in a least-privilege sandbox with near-zero
-  startup latency, ships FFI bindings for Rust, Python, TypeScript, and Go, and hosts an agent registry.
-  Fully open source (Apache-2.0) and self-hostable as a standalone CLI or library, with no proprietary
-  backend, distributed via curl, Homebrew, and Linux package managers."
+description: "nono runs AI coding agents such as Claude Code and OpenCode inside a least-privilege
+  sandbox on macOS, Linux and Windows, isolating at the kernel rather than in a container or VM. Tools
+  the agent calls get their own child sandboxes with separate filesystem, network and credential policy.
+  nolabs-ai, founded by members of the Sigstore team, writes it in Rust and ships bindings for Python,
+  TypeScript and Go plus a public profile registry."
 github:
   - url: https://github.com/nolabs-ai/nono
-comments: "nono (nono.sh) — least-privilege agent sandbox in Rust by nolabs-ai (built by members of the
-  Sigstore team). Apache-2.0, fully self-hostable, no proprietary service. ~2,900 GitHub stars (June 2026).
-  Installable via curl, Homebrew, and Linux package managers (Debian/Ubuntu, Fedora, Arch, RHEL, openSUSE,
-  Nix, WSL2); FFI bindings nono-py / nono-ts / nono-go; agent registry at registry.nono.sh. Verified live
-  June 2026."
+comments: "The registry namespace moved from always-further to nolabs-ai, so older profile references
+  need updating. Verified 2026-08-13 via the nono README, the LICENSE body, and nono.sh."

--- a/sources/products/northflank-sandboxes.yaml
+++ b/sources/products/northflank-sandboxes.yaml
@@ -1,10 +1,10 @@
 name: northflank-sandboxes
 display_name: Northflank Sandboxes
 type: software
-description: Closed-source managed sandbox platform offering microVM isolation via Kata Containers and
-  gVisor, any OCI image, unlimited session duration, and BYOC deployment. Picked when teams need production-grade
-  isolation plus a complete platform (services, jobs, databases) beyond ephemeral sandboxes; processes
-  2M+ isolated workloads/month and is SOC 2 Type 2 compliant.
-comments: Northflank Sandboxes, secure microVM/sandbox product for running untrusted / AI-generated code
-  at scale (~200ms microVM spin-up), positioned for code-gen agents. Confirmed live June 2026 via northflank.com.
-  Proprietary SaaS (Northflank Ltd).
+description: Runs untrusted and AI-generated code in microVM-backed sandboxes isolated with Kata Containers
+  and gVisor, booting in under a second with no forced session time limit. Sandboxes sit inside Northflank's
+  wider runtime platform alongside services, jobs, databases and GPU workloads, and can run on Northflank's
+  cloud or inside a customer VPC. Northflank Ltd operates it as a commercial managed service.
+comments: Scored on the Sandboxes product rather than the Northflank platform as a whole; the adoption
+  figures the vendor publishes are platform-level. Verified 2026-08-13 via northflank.com and the Northflank
+  Sandboxes product page.

--- a/sources/products/ollama.yaml
+++ b/sources/products/ollama.yaml
@@ -1,10 +1,13 @@
 name: ollama
 display_name: Ollama
 type: software
-description: Local LLM runtime that wraps llama.cpp in a user-friendly CLI and REST API with a Docker-like
-  model management experience (ollama pull, ollama run). Handles model downloading, quantization selection,
-  and GPU/CPU routing automatically. 172K GitHub stars. Became the default local inference backend for dozens
-  of AI applications and MCP integrations.
+description: Ollama runs open models locally through a Docker-like CLI (ollama pull, ollama run) and a
+  local REST API with an OpenAI-compatible chat endpoint, handling model download, quantization and
+  GPU/CPU routing itself. A curated library covers Llama, Qwen, Gemma, DeepSeek and gpt-oss, and the CLI
+  launches coding agents such as Claude Code and OpenCode against them. The Go engine installs from a
+  platform installer or the official Docker image; Ollama also sells hosted cloud inference.
 github:
 - url: https://github.com/ollama/ollama
-comments: Active 2026; ~170K+ GitHub stars, library of thousands of model builds (GGUF)
+comments: The engine ships as a platform binary and a Docker image, so the PyPI and npm packages named
+  ollama are clients rather than the distribution channel, and no package artifact is declared. Verified
+  2026-08-13 via the repository README, the LICENSE body, ollama.com and ollama.com/library.

--- a/sources/products/openai-code-interpreter.yaml
+++ b/sources/products/openai-code-interpreter.yaml
@@ -1,11 +1,10 @@
 name: openai-code-interpreter
 display_name: OpenAI Code Interpreter
 type: software
-description: Closed-source code-execution tool exposed via the Responses API and Assistants API, runs
-  Python (and bash in newer versions) in a fully sandboxed VM with attached files, so the model can compute,
-  analyze data, and iterate on solutions. Picked when teams want a turnkey 'agent can run code' primitive
-  bundled directly with the OpenAI model API rather than wiring up E2B/Modal themselves.
-comments: OpenAI Code Interpreter, a tool (Assistants API, migrating to Responses API) that writes and
-  runs Python in a proprietary OpenAI-managed sandbox; processes files up to 512MB, sessions billed at
-  $0.03/session (1-hour default). Confirmed live June 2026 via OpenAI developer docs. Proprietary; isolation
-  mechanism undisclosed.
+description: Writes and runs Python inside an OpenAI-managed sandbox, exposed as a tool on the Assistants
+  and Responses APIs so a model can compute, analyze attached files, and retry code that fails. Sessions
+  are billed individually and stay active for an hour by default, and attached files are capped at 512
+  MB. OpenAI documents no isolation mechanism and distributes no runtime.
+comments: The same sandbox underlies ChatGPT data analysis, which is the surface the adoption band is
+  attributed to; OpenAI publishes no standalone figure for the tool. Verified 2026-08-13 via the OpenAI
+  Code Interpreter developer documentation.

--- a/sources/products/openpcc.yaml
+++ b/sources/products/openpcc.yaml
@@ -1,15 +1,13 @@
 name: openpcc
 display_name: OpenPCC
 type: software
-description: Open-source framework and standard for verifiably-private AI inference, explicitly modeled on
-  Apple's Private Cloud Compute but fully open, vendor-neutral, auditable, and self-deployable. It wraps every
-  inference interaction (prompt, tokens, logs, telemetry) in encryption and policy so no vendor, operator,
-  or insider can read it, combining confidential compute on commodity CPU/GPU TEEs, integrated remote attestation,
-  tamper-proof transparency logs, an HPKE-based encrypted client-server stream, and an Oblivious-HTTP anonymization
-  layer to defeat metadata/timing side-channels. Model- and provider-agnostic; ships Go and C client SDKs.
+description: OpenPCC is a standard and reference implementation for verifiably private AI inference,
+  modeled on Apple's Private Cloud Compute but vendor-neutral and self-deployable. Each request is
+  encrypted end to end, the serving node attests its TPM and GPU beforehand, and Oblivious HTTP keeps
+  the provider from linking requests to a user. Confident Security maintains the Go client, a C library
+  behind the Python and JavaScript clients, and a separate compute-node repository.
 github:
 - url: https://github.com/openpcc/openpcc
-comments: Apache-2.0; maintained by Confident Security (San Francisco; $5M seed). Launched Nov 5 2025; ~940
-  stars by mid-2026. Reference implementation in Go plus a written spec/whitepaper; related repos (twoway,
-  ohttp, bhttp) are also Apache-2.0. Confident Security operates a commercial managed service (CONFSEC) on
-  top of the open standard, but the standard and implementation themselves are fully open.
+comments: The compute node lives in a second repository, confidentsecurity/confidentcompute, so the
+  declared artifact covers only the client half of the standard. Verified 2026-08-13 via the OpenPCC and
+  Confident-Compute READMEs, the LICENSE body, and the Cloud Security Alliance launch write-up.

--- a/sources/products/opensandbox.yaml
+++ b/sources/products/opensandbox.yaml
@@ -1,13 +1,13 @@
 name: opensandbox
 display_name: OpenSandbox
 type: software
-description: Apache-2.0 sandbox runtime from Alibaba aimed squarely at AI agents, defines a 'Sandbox
-  Protocol' with standard lifecycle/execution APIs and ships multi-language SDKs (Python, Java, JS, .NET)
-  plus Docker and Kubernetes runtimes. Picked by teams wanting an open protocol-driven alternative to
-  E2B at K8s scale; ~10.8k stars and 910 commits in the last 90d signal serious investment.
+description: OpenSandbox is a general-purpose sandbox platform for AI agents that defines a Sandbox Protocol
+  of lifecycle and execution APIs and implements it over Docker and Kubernetes runtimes. SDKs for Python,
+  Java/Kotlin, JavaScript, C#/.NET and Go sit on top, alongside an osb CLI and an MCP server, with built-in
+  command, filesystem and code-interpreter environments. Operators can back a sandbox with runc, gVisor,
+  Kata Containers or Firecracker. Alibaba originated the project.
 github:
 - url: https://github.com/opensandbox-group/OpenSandbox
-comments: Alibaba OpenSandbox, general-purpose sandbox platform for AI agents (coding agents, GUI agents,
-  agent eval, RL training); open sourced Mar 2026; components/execd 1.0.18 (May 25 2026) confirmed live
-  on GitHub. Go execd daemon; Docker/Kubernetes runtimes; multi-language SDKs (Python/TS/Go/Java); MCP
-  server. Self-host only (no managed tier observed).
+comments: The repository moved out of the alibaba org into the neutral opensandbox-group org, which the
+  old path now redirects to; the Alibaba origin survives in the package coordinates. Verified 2026-08-13
+  via the OpenSandbox README, the secure container runtime guide, and open-sandbox.ai.

--- a/sources/products/ray.yaml
+++ b/sources/products/ray.yaml
@@ -1,9 +1,12 @@
 name: ray
 display_name: Ray
 type: software
-description: Ray-2.55.1, released April 22, 2026 (GitHub). Ray joined the PyTorch Foundation (per Anyscale
-  2026 announcement). Confirmed to exist as of June 2026.
+description: Ray is a framework for building and serving AI and ML applications across distributed compute,
+  scheduling work over many machines and over mixed CPU and GPU resources. Ray Core provides the task and
+  actor primitives; the libraries above it - Data, Train, Tune, Serve and RLlib - cover batch inference,
+  model serving, distributed training, hyperparameter tuning and feature engineering. Applications deploy
+  as Ray clusters on virtual machines or Kubernetes. Anyscale, founded by Ray's original creators, sells
+  a managed platform beside it, and the project is governed by the PyTorch Foundation.
 pypi:
 - url: https://pypi.org/project/ray/
-comments: Ray-2.55.1, released April 22, 2026 (GitHub). Ray joined the PyTorch Foundation (per Anyscale
-  2026 announcement). Confirmed to exist as of June 2026.
+comments: Verified 2026-08-13 via the Anyscale Ray documentation and the PyPI download API.

--- a/sources/products/replit-agent-code-execution-api.yaml
+++ b/sources/products/replit-agent-code-execution-api.yaml
@@ -1,13 +1,11 @@
 name: replit-agent-code-execution-api
 display_name: Replit Agent / Code Execution API
 type: software
-description: Closed-source cloud dev platform with Nix-based environments supporting 30,000+ OS packages,
-  exposing a Code Execution API that runs untrusted/AI-generated code in sandboxed VMs. Picked when teams
-  want a tightly integrated build+run+deploy story (Replit Agent 4 leans heavily on this) rather than
-  an unbundled SDK. Raised $400M Series D in March 2026 at a $9B valuation; 50M+ users.
-comments: 'Replit Code Execution API for AI agents (replit.com/blog/ai-agents-code-execution), a stateless
-  sandboxed API for running untrusted (primarily Python) code, isolated via omegajail (Replit''s unprivileged
-  container sandbox) on Autoscale Deployments, ~100ms start. Confirmed live June 2026; `replit-code-exec`
-  PyPI client exists. Proprietary service. NOTE: ''Replit Agent'' is an autonomous coding agent (orchestration),
-  but the deployment-relevant artifact here is the code-execution sandbox, scored as deployment per the
-  recipe litmus.'
+description: Runs untrusted and model-generated code, primarily Python, through a stateless API on Replit's
+  cloud development platform. Each call executes inside an ephemeral unprivileged container created on
+  Replit Autoscale Deployments and sandboxed by omegajail, returning whatever the code prints. The capability
+  now sits inside the Replit Agent surface rather than being consumed through a standalone client.
+comments: The public self-serve client was archived read-only in 2025, so this entry is verified against
+  the archived repository rather than a maintained one, and the Replit blog posts behind it now refuse
+  automated fetches. The deployment-relevant artifact is the code-execution sandbox, not the agent that
+  calls it. Verified 2026-08-13 via the replit/replit-code-exec repository and its README.

--- a/sources/products/sandbox-runtime.yaml
+++ b/sources/products/sandbox-runtime.yaml
@@ -1,13 +1,14 @@
 name: sandbox-runtime
 display_name: sandbox-runtime
 type: software
-description: Open-source lightweight sandboxing tool from Anthropic that enforces filesystem and network
-  restrictions on arbitrary processes at the OS level (Linux bubblewrap, macOS seatbelt) without requiring
-  a container. Picked because it powers the bash tool sandbox inside Claude Code and is the reference
-  design for safe local agent execution. ~4.1k stars and active development (63 commits in 90d).
+description: The Anthropic Sandbox Runtime enforces filesystem, network and unix-socket restrictions on
+  arbitrary local processes without a container, wrapping them in native OS primitives - bubblewrap on
+  Linux, sandbox-exec on macOS - behind a filtering proxy. A CLI named srt and a matching library apply
+  it to agents, local MCP servers and individual shell commands. Anthropic develops it for Claude Code
+  and ships it as a research preview.
 github:
 - url: https://github.com/anthropic-experimental/sandbox-runtime
-comments: anthropic-experimental/sandbox-runtime (npm @anthropic-ai/sandbox-runtime), v0.0.53 released
-  4 Jun 2026. Lightweight OS-level sandbox (Linux bubblewrap + macOS sandbox-exec/Seatbelt) enforcing
-  filesystem + network restrictions on arbitrary processes WITHOUT a container; used to sandbox the Claude
-  Code bash tool. Research preview. Verified live on GitHub June 2026.
+comments: The README notes that seccomp filtering is x64/arm64 only and that unix sockets go
+  unrestricted where it is unavailable, so the boundary is weaker on some hosts than the general
+  description implies. Verified 2026-08-13 via the anthropic-experimental/sandbox-runtime README and
+  the GitHub repository metadata.

--- a/sources/products/spaces.yaml
+++ b/sources/products/spaces.yaml
@@ -1,15 +1,13 @@
 name: spaces
 display_name: Spaces
 type: software
-description: Managed sandbox platform for hosting interactive ML apps, supports Gradio, Streamlit, Docker,
-  and static SDKs with a free CPU tier, paid CPU/GPU upgrades, and a ZeroGPU shared-pool tier. Differentiates
-  through tight integration with the Hugging Face Hub (one-click deploy from any model card) and community
-  discoverability, making it the default demo surface for nearly every open-weight model release. ~400K+
-  apps as of early 2026 with reportedly ~40K new Spaces created per month and 100M+ monthly visits; the
-  canonical 'where you go to try an open model in your browser'.
+description: Spaces hosts interactive machine-learning apps on Hugging Face infrastructure, built with
+  the Gradio or Streamlit SDKs, an arbitrary Dockerfile, or static HTML and JavaScript. Hardware runs
+  from a free CPU tier through a shared ZeroGPU pool to hourly dedicated GPUs, alongside persistent
+  storage and an SSH dev mode. Hub integration deploys a Space from a model card, and a Space can be
+  exposed as an MCP server or API endpoint.
 github:
 - url: https://github.com/gradio-app/gradio
-comments: Hugging Face Spaces, managed hosting/runtime for ML demo apps via Gradio, Streamlit, Docker
-  (arbitrary Dockerfile), or static HTML, with CPU/GPU hardware tiers. Confirmed live June 2026 via huggingface.co
-  and HF Hub docs. Proprietary managed platform built on OSS SDKs (Gradio is OSS); the Spaces hosting
-  platform itself is closed.
+comments: The declared GitHub artifact is the Gradio repository, an app SDK that runs anywhere, rather
+  than the Spaces host, which publishes no source. Verified 2026-08-13 via the Hugging Face Spaces Hub
+  documentation, the Hugging Face pricing page, and the Hugging Face terms of service.

--- a/sources/products/tensorlake-sandbox.yaml
+++ b/sources/products/tensorlake-sandbox.yaml
@@ -1,12 +1,13 @@
 name: tensorlake-sandbox
 display_name: Tensorlake Sandbox
 type: software
-description: Serverless Firecracker-microVM sandbox runtime with durable-execution orchestration for agentic
-  apps, offering snapshot/suspend/resume and scale to thousands of sandboxes. The runtime and SDK are
-  Apache-2.0 with a bring-your-own-cloud self-host path (run sandboxes inside your own AWS/GCP/Azure account);
-  the managed scheduler is the hosted layer. Backed by Redpoint and Amplify Partners; the company repositioned
-  from document ingestion to a sandbox-native cloud. ~959 stars on GitHub.
+description: Tensorlake runs agent code in Firecracker microVMs, giving each harness or tool call its own
+  machine with a shell, packages and processes, and putting it to sleep when idle. Around that sit a
+  versioned POSIX filesystem that mounts like a disk, hosted Git that serves repositories without a
+  clone, and durable serverless functions with queues, timers and retries.
+  The company repositioned from document ingestion to this sandbox-native cloud.
 github:
 - url: https://github.com/tensorlakeai/tensorlake
-comments: Tensorlake sandbox-native cloud for AI agents; repo Apache-2.0 (Python + Rust), CLI v0.5.65
-  live on GitHub July 2026. Firecracker microVMs with BYOC self-host; managed scheduler (Lattice) proprietary.
+comments: The repository publishes the SDK and CLI; the microVM runtime and the Lattice scheduler behind
+  them are in no public repository. Verified 2026-08-13 via tensorlake.ai and the ComputeSDK sandbox
+  benchmark leaderboard.

--- a/sources/products/vercel-sandbox.yaml
+++ b/sources/products/vercel-sandbox.yaml
@@ -1,10 +1,11 @@
 name: vercel-sandbox
 display_name: Vercel Sandbox
 type: software
-description: Closed-source compute primitive (GA in 2026) that runs untrusted/agent-generated code in
-  isolated Firecracker microVMs with millisecond startup, default Node 24 + Python 3.13 runtimes, filesystem
-  and shell access. Picked by teams already on Vercel building AI agents that need a managed sandbox tightly
-  integrated with the AI SDK. The execution layer behind Vercel Open Agents.
-comments: Vercel Sandbox - GA ephemeral compute primitive for running untrusted/AI-generated code in isolated
-  Firecracker microVMs; docs last updated 29 May 2026. Open SDK/CLI (vercel/sandbox on GitHub, @vercel/sandbox
-  npm + vercel.sandbox Python) over Vercel's proprietary managed cloud. Verified live June 2026.
+description: Vercel Sandbox runs untrusted or agent-generated code in a Firecracker microVM with its own
+  filesystem and network, started from a Vercel managed Linux image or a custom OCI image held in the
+  Vercel Container Registry. Sandboxes persist by default, resuming where they stopped, and can be
+  snapshotted, tagged, given root and system privileges, or split per agent by Linux user. JavaScript
+  and Python SDKs and a CLI drive it.
+comments: The execution layer behind Vercel Open Agents. Runtime duration and concurrency are quota
+  fields rather than product limits - a Hobby sandbox stops at 45 minutes where Pro and Enterprise run
+  to 24 hours. Verified 2026-08-13 via the Vercel Sandbox documentation and its pricing and quotas page.

--- a/sources/products/webcontainers.yaml
+++ b/sources/products/webcontainers.yaml
@@ -1,16 +1,13 @@
 name: webcontainers
 display_name: WebContainers
 type: software
-description: WebAssembly Node.js runtime that boots a full dev environment (filesystem, package manager,
-  terminal, dev server) inside the browser with no remote VM. Picked when an agent and user need to share
-  an in-browser sandbox with millisecond startup and near-zero server cost. `webcontainer-core` is MIT
-  (~4.6K stars) but stale (last push April 2025); the production WebContainer API and StackBlitz/Bolt.new
-  platform are proprietary. Powers Bolt.new, which hit 7M+ users and $40M ARR by Dec 2025; StackBlitz
-  raised Series B in Jan 2025 at $700M valuation.
+description: Boots a full Node.js dev environment inside the browser tab as WebAssembly, running native
+  npm, pnpm and yarn with a filesystem, terminal and dev server and no remote VM. StackBlitz builds and
+  hosts it, and distributes the client as the `@webcontainer/api` npm package. SvelteKit, Astro, Scrimba,
+  egghead.io and Xata embed it for in-browser coding experiences.
 github:
 - url: https://github.com/stackblitz/webcontainer-core
-comments: WebContainers by StackBlitz, a browser-based (WASM) runtime that executes Node.js / npm projects
-  fully client-side in the browser tab. Distributed as @webcontainer/api on npm. Confirmed live June 2026
-  via webcontainers.io. The public github.com/stackblitz/webcontainer-core repo is MIT but is only an
-  issue tracker / docs hub; the actual runtime is a proprietary StackBlitz service requiring a commercial
-  license for for-profit production use.
+comments: The public stackblitz/webcontainer-core repository is an issue tracker and docs hub rather than
+  the runtime implementation, so the openness score was read from the enterprise licensing terms instead.
+  Verified 2026-08-13 via webcontainers.io, the WebContainer enterprise licensing page, and the
+  stackblitz/webcontainer-core repository.

--- a/sources/scores/agent-infra-sandbox.yaml
+++ b/sources/scores/agent-infra-sandbox.yaml
@@ -17,13 +17,46 @@ openness:
     - no feature-gated core observed
   confidence: high
   note: Apache-2.0, fully self-hostable single-container runtime; no separate proprietary/managed tier
-    gating the core.
+    gating the core. Re-read 2026-08-13 - the GitHub API reports the repository public, unarchived
+    and licensed Apache-2.0, the root LICENSE body is the verbatim Apache License 2.0, and the README
+    ships the entire runtime as one public image (ghcr.io/agent-infra/sandbox, with a mainland-China
+    mirror) plus Docker Compose and Kubernetes deployment manifests, with no paid, hosted or
+    feature-gated tier anywhere in it.
   raw: license:Apache-2.0(OSI);source:public(GitHub);packaging:self-hostable Docker image + K8s deploy examples;no
     feature-gated core observed;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/agent-infra/sandbox
     shows: Apache-2.0 license, single-Docker-container all-in-one agent sandbox, self-hostable
     accessed: '2026-06-04'
+  - url: https://api.github.com/repos/agent-infra/sandbox
+    shows: 'Repository metadata - public (private false), not archived, license spdx_id Apache-2.0,
+      described as an all-in-one sandbox combining Browser, Shell, File, MCP and VSCode Server in a
+      single Docker container.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c9fbadf39d95ad4dda225e4d17cd7bb45c460b5aa21e0b87619242c9ec867a25
+    establishes:
+    - source
+    - license
+  - url: https://raw.githubusercontent.com/agent-infra/sandbox/main/LICENSE
+    shows: The verbatim Apache License 2.0 body, with no added terms or field-of-use restrictions.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
+    establishes:
+    - license
+  - url: https://raw.githubusercontent.com/agent-infra/sandbox/main/README.md
+    shows: 'Single ``docker run ghcr.io/agent-infra/sandbox`` quick start plus Docker Compose and
+      Kubernetes Deployment manifests; Python, TypeScript and Go SDKs; closes with "AIO Sandbox is
+      released under the Apache License 2.0". No paid tier, hosted plan or license key is mentioned
+      anywhere in the document.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0fe34cd605e492c4c93f760e9caefd194f9c8ec7cfc3d4d4a927a1ac1613e51c
+    establishes:
+    - source
+    - core-gated
 adoption:
   level: 1
   reach: <10K
@@ -49,7 +82,20 @@ capability:
   note: Unusually broad multi-modal feature set (browser+shell+file+MCP+IDE in one) but isolation is container-level
     only, below the Firecracker/gVisor isolation strength of the frontier deployment runtimes; scored
     3.
+    Re-read 2026-08-13 - the README still describes one Docker container carrying Browser/VNC, Shell,
+    File, MCP, Jupyter and VSCode Server over a shared filesystem, still deploys through Compose or a
+    plain Kubernetes Deployment, and still names no isolation primitive stronger than the container
+    (the quick start actually relaxes one, running with seccomp unconfined). Breadth and isolation
+    both read as recorded, so the band holds at 3.
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/agent-infra/sandbox
     shows: 'feature list: Browser/VNC, Shell, File, MCP, Jupyter, VSCode in one Docker container'
     accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/agent-infra/sandbox/main/README.md
+    shows: Browser/VNC, Terminal, File, VSCode Server, Jupyter and MCP services in one container behind
+      a shared filesystem; Docker Compose and Kubernetes Deployment examples; no concurrency limit or
+      isolation primitive beyond the container is published.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0fe34cd605e492c4c93f760e9caefd194f9c8ec7cfc3d4d4a927a1ac1613e51c

--- a/sources/scores/aws-lambda.yaml
+++ b/sources/scores/aws-lambda.yaml
@@ -18,25 +18,56 @@ openness:
   confidence: high
   note: Lambda is a proprietary managed serverless service (closed), per recipe's explicit 'Lambda as
     closed counterpart'. Firecracker (the microVM substrate) is separately open source but is a different
-    artifact; Lambda itself is not self-hostable.
+    artifact; Lambda itself is not self-hostable. Re-read 2026-08-13 on the Lambda FAQ, which describes
+    deployment only as uploading .zip archives or container images to AWS and offers no self-hosted or
+    source-available build of the service. It confirms the substrate relationship from the other side -
+    Lambda MicroVMs are "built on the same Firecracker virtualization" - while publishing nothing of the
+    control or data plane. Score and class unchanged.
   raw: license:Proprietary;service:proprietary AWS-only SaaS (no self-host);underlying-microVM:Firecracker
     is Apache-2.0 OSS but the Lambda control/data plane is closed;weights:n/a;source:closed
+  last_verified: '2026-08-13'
   sources:
   - url: https://aws.amazon.com/blogs/aws/firecracker-lightweight-virtualization-for-serverless-computing/
     shows: Firecracker microVM powers Lambda; Lambda is AWS-managed proprietary service
     accessed: '2026-06-04'
+  - url: https://aws.amazon.com/lambda/faqs/
+    shows: 'Lambda is sold only as an AWS-run service. Deployment is "package and deploy functions as .zip
+      file archives that you can upload directly through the console, CLI, or SDKs, or as container images",
+      with no self-hosted distribution and no published source for the service; the page carries no license
+      other than AWS terms. The MicroVMs section states Lambda MicroVMs are "built on the same Firecracker
+      virtualization powering 15 trillion+ monthly Lambda Function invocations", which is the open substrate
+      under a closed service rather than an open Lambda.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b6e63c3e539a8940cacba06291d5f8b3288b75182d4051c745d40664fcbd4cba
+    establishes:
+    - license
+    - source
 adoption:
   level: 5
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: AWS states Lambda 'processes trillions of executions for hundreds of thousands of active customers
-    every month' - mass-market serverless deployment substrate, unambiguously >10M reach. (Adoption attributed
-    to general serverless usage, not specifically agent-code-execution.)
+  note: 'AWS states Lambda ''processes trillions of executions for hundreds of thousands of active customers
+    every month'' - mass-market serverless deployment substrate, unambiguously >10M reach. (Adoption attributed
+    to general serverless usage, not specifically agent-code-execution.) Re-read 2026-08-13 and the figure
+    has been superseded upward on AWS''s own current page - the Lambda FAQ now states "15 trillion+ monthly
+    Lambda Function invocations", against the 2018 launch post''s "trillions". Level unchanged at 5.
+    Instrument caveat, recorded rather than fixed: `usage_volume` names a count and Lambda has no countable
+    artifact - it is a hosted AWS service with no package, repo or registry entry any signal model reads.
+    The invocation figure is a vendor-reported platform total, not a per-user count, so the instrument is
+    flagged for a human ruling rather than relabelled here.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://aws.amazon.com/blogs/aws/firecracker-lightweight-virtualization-for-serverless-computing/
     shows: trillions of executions / hundreds of thousands of active customers monthly
     accessed: '2026-06-04'
+  - url: https://aws.amazon.com/lambda/faqs/
+    shows: '"Built on the same Firecracker virtualization powering 15 trillion+ monthly Lambda Function
+      invocations". AWS publishes no customer or developer count on this page.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b6e63c3e539a8940cacba06291d5f8b3288b75182d4051c745d40664fcbd4cba
 capability:
   score: 5
   basis: feature_matrix
@@ -46,8 +77,28 @@ capability:
     storage (EFS, /tmp); scale:trillions of executions/mo, effectively unbounded autoscale
   confidence: high
   note: 'Frontier-definer for this category: microVM-grade isolation, the widest runtime breadth, and
-    the largest proven scale of any deployment runtime here. Scored 5.'
+    the largest proven scale of any deployment runtime here. Scored 5. Re-read 2026-08-13 on the Lambda
+    FAQ, which confirms every part of the recorded matrix and adds one thing to it. Runtime breadth is
+    still the widest here - "Java, Go, PowerShell, Node.js, C#, Python, and Ruby" natively plus a Runtime
+    API for any other language, and both .zip archives and container images. Isolation is per-function
+    and Firecracker-backed. Since the last read AWS has shipped Lambda MicroVMs, a primitive explicitly
+    "purpose-built for workloads that execute user- or AI-generated code" with VM-level isolation,
+    near-instant launch and resume, and state persistence across interactions, which puts Lambda directly
+    on the agent-sandbox feature axis this category scores rather than only adjacent to it. Score unchanged
+    at 5.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://aws.amazon.com/blogs/aws/firecracker-lightweight-virtualization-for-serverless-computing/
     shows: Firecracker microVM isolation, ~125ms start, ~5MiB/VM, trillions of executions
     accessed: '2026-06-04'
+  - url: https://aws.amazon.com/lambda/faqs/
+    shows: '"AWS Lambda natively supports Java, Go, PowerShell, Node.js, C#, Python, and Ruby code, and
+      provides a Runtime API which allows you to use any additional programming languages"; functions
+      deploy "as .zip file archives ... or as container images. Both methods provide the same execution
+      environment"; "Each AWS Lambda function runs in its own isolated environment". Lambda MicroVMs
+      "combines VM-level isolation, near-instant launch and resume, and state persistence across
+      interactions ... purpose-built for workloads that execute user- or AI-generated code", built on
+      "the same Firecracker virtualization powering 15 trillion+ monthly Lambda Function invocations".'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b6e63c3e539a8940cacba06291d5f8b3288b75182d4051c745d40664fcbd4cba

--- a/sources/scores/beta9.yaml
+++ b/sources/scores/beta9.yaml
@@ -77,15 +77,34 @@ adoption:
     base and absence of any volume signal. Low confidence. Stars read 2026-08-13: 1,742 across the 1 declared
     repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach
     ''10K-100K'' was not a label this instrument offers - stars have their own vocabulary because a star is
-    not a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift
-    on every refetch, and the rest of the axis was not re-read.'
+    not a download. Re-read in full 2026-08-13 against the GitHub API - 1,742 stars, 156 forks - the same
+    figure and the same 1K-10K stars band, level 2. The digest below will drift on every refetch because
+    a star count moves daily; that is expected of this instrument and does not weaken the band, which depends
+    only on the order of magnitude. One thing did change and is escalated rather than applied - the README
+    now installs the SDK with `pip install beam-client`, so a countable channel exists where this note said
+    none had surfaced. It is not declared here.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/beam-cloud/beta9
     shows: 1.7k stars; no published download/usage figures
     accessed: '2026-06-04'
+  - url: https://api.github.com/repos/beam-cloud/beta9
+    shows: 'Repo metadata - 1,742 stars, 156 forks, 6 watchers, pushed 2026-08-13, not archived. Bands at
+      1K-10K stars, level 2 on the stars scale in signal_routing.yaml.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 3d5d578263892300b4429a31839210e7ca6d62c3a5895c1f11669d3f66ea1fc4
+  - url: https://raw.githubusercontent.com/beam-cloud/beta9/main/README.md
+    shows: 'Installation is `pip install beam-client`, and the page publishes no download, customer or usage
+      figure of its own - only a stars badge.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0a48300cb1d66a7517fa9c65c2d2bb4b8e0af9b8734ac2e1d18b1bbe1ebc1ac0
 capability:
   score: 3
   basis: feature_matrix
+  relative_to: firecracker
+  relation: two_below
   value: isolation:container (serverless containers, not VM/microVM per repo description); cold-start:fast
     container launch; language/runtime breadth:Python AI workloads + GPU (4090/H100); persistence:volume
     storage; scale:parallelize across hundreds of containers + autoscaling
@@ -93,12 +112,40 @@ capability:
   note: Capable serverless container runtime with GPU support, volumes, autoscaling and sandbox primitives,
     but container-level (not VM/microVM) isolation places it below the VM-grade peers on the isolation-strength
     dimension; mid-tier. Independent ComputeSDK TTI benchmarks of Beam (the managed beta9 cloud) corroborate
-    the fast container launch (~380ms median cold-start, 8th of 19 sandbox providers).
+    the fast container launch (~380ms median cold-start, 8th of 19 sandbox providers). Re-read 2026-08-13.
+    The feature matrix still reads as described - the README claims container launches "in under a second"
+    from a custom runtime, scheduler and embedded cache, fan-out to hundreds of containers, scale-to-zero,
+    distributed volume storage, GPU support on 4090s and H100s or bring-your-own, and a Sandbox primitive
+    for running model-generated code. The isolation ceiling is unchanged, and it is what holds the score
+    at 3 - the README describes containers throughout and names no VM, microVM or application-kernel tier,
+    where the category''s frontier-definers do. The prose comparison to the VM-grade peers is now recorded
+    as relative_to firecracker with relation `two_below`, which holds arithmetically - Firecracker is 5,
+    this is 3, and Firecracker''s capability was re-derived the same day. The independent benchmark moved
+    in this product''s favor rather than against it and does not move the band, since the band turns on
+    isolation strength - on the ComputeSDK run of 2026-08-07, Beam is 4th-fastest by median of 24 providers
+    at 0.29s, up from 8th of 19 at ~380ms.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/beam-cloud/beta9
     shows: 'serverless runtime: rapid container launches, parallelize across hundreds of containers, GPU
       support, volume storage, sandboxes'
     accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/beam-cloud/beta9/main/README.md
+    shows: 'Features are fast cold starts ("Launch containers in under a second using a custom container
+      runtime, scheduler, and embedded caching"), fan-out to hundreds of containers, scale-to-zero, mounted
+      distributed volumes, and GPU support (4090s, H100s, or bring your own). A Sandbox primitive spins
+      up isolated containers to run LLM-generated code. No VM, microVM or application-kernel isolation tier
+      is named anywhere.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0a48300cb1d66a7517fa9c65c2d2bb4b8e0af9b8734ac2e1d18b1bbe1ebc1ac0
+  - url: https://www.computesdk.com/benchmarks/sandboxes/
+    shows: 'ComputeSDK TTI leaderboard, run of 2026-08-07, now 24 providers. Beam (the managed beta9 cloud)
+      posts a 0.29s median, 0.42s P95, 0.43s P99 and 100% success for a composite of 96.6 - 4th-fastest
+      by median. Faster than the 2026-07-09 read and a better rank against a larger field.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a93049e6dc408dda2d08cbbce798b369c3378ba12289a3a161fe0609b5f29416
   - url: https://www.computesdk.com/benchmarks/sandboxes/
     shows: 'ComputeSDK TTI leaderboard (independent, 100 iters/day, 2026-07-09 run): Beam (managed beta9)
       median time-to-interactive ~380ms sequential / ~810ms burst @100 concurrent; 8th of 19 providers'

--- a/sources/scores/blaxel-sandbox.yaml
+++ b/sources/scores/blaxel-sandbox.yaml
@@ -91,11 +91,29 @@ adoption:
     scored honestly. Low confidence. Stars read 2026-08-13: 27 across the 1 declared repo, which bands at <1K
     stars, level 1 on the stars scale in signal_routing.yaml. The record carried no reach label at all before
     this. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every
-    refetch, and the rest of the axis was not re-read.'
+    refetch, and the rest of the axis was not re-read. That last sentence is superseded - the rest of
+    the axis has now been re-read. The repository metadata endpoint reports 27 stars and 13 forks on
+    2026-08-13, which is the <1K stars band and level 1, and the vendor page was re-read for anything
+    bandable rather than the count being copied forward. Nothing bandable appeared. blaxel.ai/sandbox
+    publishes no customer, request or sandbox-count figure at all, and the "billions of agent requests"
+    line the note records is not on it today; the page sells on 25ms resumes and perpetual standby
+    instead. So stars remain the only signal, the level is unchanged, and the digest-drift objection is
+    accepted rather than avoided - a later refetch showing a different hash means the count moved, which
+    is what a star signal does.'
+  last_verified: '2026-08-13'
   sources:
-  - url: https://github.com/blaxel-ai/sandbox
-    shows: ~22 stars / 11 forks; MIT sandbox API
-    accessed: '2026-07-09'
+  - url: https://api.github.com/repos/blaxel-ai/sandbox
+    shows: 'Repository metadata - stargazers_count 27 and forks_count 13 for blaxel-ai/sandbox, language
+      Go, license spdx_id MIT, public and not archived'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 771e22e12b88d8dfff6936c657894733cd2e5d8b60853ead2c912934d0c2dcdb
+  - url: https://blaxel.ai/sandbox
+    shows: No usage, customer or request figure is published anywhere on the product page; it sells on
+      25ms resumes, perpetual standby and auto-suspend after 15s of inactivity
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 58bc1b3f5c3a3695c9a6935235d47d6414740d4dc1cd2a9f7ab7116bab547ca6
 capability:
   score: 3
   basis: feature_matrix
@@ -103,15 +121,33 @@ capability:
     breadth:agent code execution; persistence:perpetual standby with full FS/memory state; scale:vendor-claimed
     billions of agent requests (unverified)
   confidence: medium
-  note: MicroVM isolation and the perpetual-standby resume model are a genuinely strong, distinctive feature
+  note: 'MicroVM isolation and the perpetual-standby resume model are a genuinely strong, distinctive feature
     set, but proven scale is unverified and the product is early, so held at 3 rather than level with
     the proven microVM 4s. Independent ComputeSDK TTI benchmarks measure ~450ms median fresh cold-start
-    (11th of 19 sandbox providers), mid-pack.
+    (11th of 19 sandbox providers), mid-pack. Re-read 2026-08-13. The vendor page still carries every
+    recorded feature - microVMs, ~25ms resume from standby, full filesystem and memory snapshots,
+    auto-suspend after 15s idle, and persistence across months - and now also lists batch jobs across
+    thousands of sandboxes, outbound allow-lists, static IPs and self-hosted and VPC deployment options.
+    BENCHMARK FIGURE SUPERSEDED - the ComputeSDK leaderboard has re-run since (last run 7 August 2026)
+    and now covers 24 providers, so the cited "~450ms, 11th of 19" no longer appears. Blaxel now reads
+    0.51s median time-to-interactive, 0.60s P95, 0.61s P99, 100% success and a composite of 94.5, which
+    is 9th of 24 and still mid-pack, still sub-second, and ahead of E2B, Modal, Vercel and Cloud Run. The
+    band is unchanged and the reason it is held at 3 is unchanged too, since the missing evidence is
+    proven scale rather than latency.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://blaxel.ai/sandbox
-    shows: microVM sandboxes, perpetual standby, sub-25ms resume with full FS/memory state
-    accessed: '2026-07-09'
+    shows: 'MicroVMs that boot in milliseconds and resume in ~25ms from standby with full filesystem and
+      memory snapshots; sandboxes auto-suspend after 15s of inactivity and persist across sessions;
+      batch jobs spawn thousands of tasks; outbound allow-lists, static IPs and proxy routing; managed
+      cloud, self-hosting and VPC deployment options'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 58bc1b3f5c3a3695c9a6935235d47d6414740d4dc1cd2a9f7ab7116bab547ca6
   - url: https://www.computesdk.com/benchmarks/sandboxes/
-    shows: 'ComputeSDK TTI leaderboard (independent, 100 iters/day, 2026-07-09 run): median time-to-interactive
-      ~450ms sequential / ~910ms burst @100 concurrent; 11th of 19 providers'
-    accessed: '2026-07-09'
+    shows: 'ComputeSDK TTI leaderboard, independent, 100 iterations per run, last run 7 August 2026, 24
+      providers on 4 vCPU / 16GB in Northern Virginia. Blaxel records 0.51s median, 0.60s P95, 0.61s P99,
+      100% success, composite 94.5, ranking 9th of 24 by composite score.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: ec3f48b2ca3c1877605154422671c020935c0bfebdfc9aff268d06799ae865f7

--- a/sources/scores/cloudflare-sandboxes.yaml
+++ b/sources/scores/cloudflare-sandboxes.yaml
@@ -23,10 +23,18 @@ openness:
   confidence: high
   note: 'Closed managed service. The Sandbox SDK is Apache-2.0, but execution requires Cloudflare''s proprietary
     managed edge network (no self-host of the isolate/container plane); an open client SDK over a closed
-    runtime is not open_core. Reclassified from open_core.'
+    runtime is not open_core. Reclassified from open_core. Re-read 2026-08-13 - the Dynamic Workers
+    post still describes an API onto Cloudflare''s own Workers platform, priced at $0.002 per unique
+    Worker loaded per day on top of ordinary Workers charges, with no self-hosted form of the isolate
+    or container plane. The SDK half also still holds, with one wrinkle worth recording - GitHub
+    classifies cloudflare/sandbox-sdk as NOASSERTION because the root LICENSE file is a one-line
+    pointer to packages/sandbox/LICENSE; that file is the verbatim Apache License 2.0, so the SDK is
+    Apache-2.0 as recorded and the classifier is simply defeated by the redirect. Source and license
+    both read as recorded.'
   raw: license:Proprietary;source:closed;service:proprietary Cloudflare edge (Workers/Durable Objects/Dynamic
     Worker Loader - no self-host of the isolate/container plane);open-part:Sandbox SDK only (@cloudflare/sandbox
     Apache-2.0, cloudflare/sandbox-sdk on GitHub);pricing:Workers paid plan, Dynamic Workers $0.002/unique-worker/day
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/cloudflare/sandbox-sdk
     shows: Apache-2.0 SDK; runs on Cloudflare Containers/Workers/Durable Objects (managed edge)
@@ -34,6 +42,34 @@ openness:
   - url: https://blog.cloudflare.com/dynamic-workers/
     shows: Dynamic Worker Loader open beta, isolate sandboxing, post-beta $0.002/worker/day pricing
     accessed: '2026-06-04'
+  - url: https://blog.cloudflare.com/dynamic-workers/
+    shows: 'Dynamic Worker Loader is an API by which a Cloudflare Worker instantiates another Worker in
+      its own sandbox, running on Cloudflare''s platform; open beta to all paid Workers users; priced
+      at $0.002 per unique Worker loaded per day on top of normal Workers CPU and invocation charges.
+      No self-hosted deployment of the isolate or container plane is offered.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: cdc47b64a241214658a4c701464ca4f358d099314884db539eae4077c8f7e632
+    establishes:
+    - source
+    - license
+  - url: https://api.github.com/repos/cloudflare/sandbox-sdk
+    shows: 'Repository public and unarchived, described as "Run sandboxed code environments on
+      Cloudflare''s edge network"; license reported as NOASSERTION because the root LICENSE is a
+      pointer file.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e7830b0a5afa9835b918215a3d8dcb9a0cbaafd50277ec378850cd9a5ef71d97
+    establishes:
+    - source
+  - url: https://raw.githubusercontent.com/cloudflare/sandbox-sdk/main/packages/sandbox/LICENSE
+    shows: The verbatim Apache License 2.0 body, governing the published SDK package that the root
+      LICENSE pointer names.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 62c7a1e35f56406896d7aa7ca52d0cc0d272ac022b5d2796e7d6905db8a3636a
+    establishes:
+    - source
 adoption:
   level: 3
   reach: 100K-1M
@@ -67,7 +103,16 @@ capability:
     code) at ~1.8s median cold-start, 18th of 19 sandbox providers, degrading to ~4.3s under 100-concurrent
     burst; the sub-ms figures apply to the JS/TS Dynamic Workers path, not the arbitrary-code sandbox the
     benchmark exercises. On measured full-sandbox latency alone this would be a 3; held at 4 on the strength
-    of the dual isolate-plus-container isolation model.
+    of the dual isolate-plus-container isolation model. Re-read 2026-08-13 - the Dynamic Workers post
+    still claims ms-scale isolate start, ~100x the density of containers and no global concurrency or
+    creation-rate limit, and the SDK repository still exposes the container-backed path for arbitrary
+    commands, files, background processes and exposed services. The latency picture has got worse
+    rather than better - ComputeSDK''s 2026-08-07 run puts the container-backed sandbox at a 4.42s
+    median TTI, 21st of 24 providers, against the ~1.76s/18th-of-19 recorded above. The band is held
+    at 4 on the same reasoning as before, that the isolate path is a genuinely different and
+    much faster instrument than the one the benchmark exercises, but the measured gap is now wide
+    enough that the hold is the weakest part of this score.
+  last_verified: '2026-08-13'
   sources:
   - url: https://blog.cloudflare.com/dynamic-workers/
     shows: V8 isolate sandboxing, ~ms start, 100x faster/100x more memory-efficient than containers
@@ -79,3 +124,22 @@ capability:
     shows: 'ComputeSDK TTI leaderboard (independent, 100 iters/day, 2026-07-09 run): container-backed sandbox
       median time-to-interactive ~1760ms sequential / ~4290ms burst @100 concurrent; 18th of 19 providers'
     accessed: '2026-07-09'
+  - url: https://blog.cloudflare.com/dynamic-workers/
+    shows: V8 isolate sandboxing with ms-scale start and ~100x the memory efficiency of containers;
+      no limit on global concurrent sandboxes or creation rate; network access blockable or
+      interceptable per loaded Worker.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: cdc47b64a241214658a4c701464ca4f358d099314884db539eae4077c8f7e632
+  - url: https://api.github.com/repos/cloudflare/sandbox-sdk
+    shows: 'Repository active and unarchived, described as "Run sandboxed code environments on
+      Cloudflare''s edge network" - the container-backed path for arbitrary code.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e7830b0a5afa9835b918215a3d8dcb9a0cbaafd50277ec378850cd9a5ef71d97
+  - url: https://www.computesdk.com/benchmarks/sandboxes/
+    shows: 'ComputeSDK TTI leaderboard, run of 2026-08-07 across 24 providers - Cloudflare median
+      4.42s, P95 5.63s, P99 5.77s, 100% success, composite 50.8; 21st of 24 by median.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: cbb96170184f9c48e5c5f0a9834e15ab2a87a083132581c8a632f0cdc6e42e85

--- a/sources/scores/coder-oss.yaml
+++ b/sources/scores/coder-oss.yaml
@@ -73,12 +73,30 @@ adoption:
     base, but reach is unverified by usage_volume. Stars read 2026-08-13: 14,142 across the 1 declared repo,
     which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The previous reach
     ''100K-1M'' was not a label this instrument offers - stars have their own vocabulary because a star is not
-    a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on
-    every refetch, and the rest of the axis was not re-read.'
+    a download. Re-read 2026-08-13 against the GitHub API - 14,143 stars, still >10K stars and still level 3.
+    The absence of a download channel was re-checked too, and it holds for a second reason now - the
+    codercom/coder Docker Hub repository is deprecated, its description redirecting to GitHub Container
+    Registry, and it has taken 31,179 pulls in total since 2021 with no push since 2024. GHCR publishes
+    no pull count, so no usage_volume signal exists to re-band on and stars_fallback remains the
+    instrument. A digest over a star count drifts on every refetch by construction; that is noise on
+    this endpoint rather than evidence of change.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/coder/coder
     shows: ~13.4k stars; self-hosted CDE used by enterprises; no usage_volume figure
     accessed: '2026-06-04'
+  - url: https://api.github.com/repos/coder/coder
+    shows: 14,143 stargazers; repository public and unarchived; no download or install count is exposed
+      by the API.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b869ee1ac186f8606d5af55d475f1910dbf68fc70d13d533064c2363f82d7986
+  - url: https://hub.docker.com/v2/repositories/codercom/coder
+    shows: 'Deprecated image - full_description reads "Looking for v2 releases? We now publish our images
+      on GitHub''s container registry"; pull_count 31,179 lifetime, last_updated 2024-08-20.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c0bffad9c45a60ad1b704ee6ea509ad093c1f4b18f3b106afb5ef42e57d40baf
 capability:
   score: 3
   basis: feature_matrix
@@ -90,8 +108,21 @@ capability:
   note: Strong as a persistent governed dev-environment platform but a poor fit for the deployment litmus
     'safely run arbitrary agent-generated code in an ephemeral sandbox' - isolation/cold-start depend
     on the infra template, not a purpose-built sandbox; scored 3. Belongs more in a dev-environment shelf
-    than the agent-sandbox sub-segment.
+    than the agent-sandbox sub-segment. Re-read 2026-08-13 - the README still defines workspaces in
+    Terraform over EC2 VMs, Kubernetes pods or Docker containers, still connects them over a Wireguard
+    tunnel, and still describes long-lived environments that idle-shut-down rather than ephemeral
+    per-task sandboxes. The agent story has grown - Coder Agents now runs the agent loop in the control
+    plane so no model credentials sit in the workspace - but that is governance rather than isolation
+    strength or cold-start, so the band holds at 3.
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/coder/coder
     shows: Terraform-defined persistent workspaces, Wireguard tunnel, AI-agent workspace support
     accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/coder/coder/main/README.md
+    shows: Terraform-defined workspaces on EC2 VMs, Kubernetes pods or Docker containers; Wireguard
+      tunnel; idle shutdown; Coder Agents executing the agent loop in the control plane with no LLM
+      credentials in workspaces, plus centralized model governance and audit logging.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: ce14cf14d213dee2fb26716b51cd2c048d622909497f81941f7ef68b1d3752aa

--- a/sources/scores/e2b-sandbox.yaml
+++ b/sources/scores/e2b-sandbox.yaml
@@ -80,7 +80,13 @@ adoption:
   confidence: high
   note: 'PyPI: ~4.58M downloads last month for the e2b package (primary). Vendor reports 1B+ sandboxes
     started, 94% of Fortune 100 as customers; named users incl. Perplexity, Hugging Face, Manus, Groq.
-    Solidly 1M-10M monthly install band.'
+    Solidly 1M-10M monthly install band. Re-read 2026-08-13 and both legs still hold, with the primary
+    signal up. PyPI now reports 5,845,335 downloads in the trailing 30 days for the e2b package - well
+    inside 1M-10M and nowhere near the 10M level-5 floor. Every vendor figure cited above is still on
+    e2b.dev - "94% of Fortune 100 companies", "1b+ started sandboxes" - and it now also publishes "7M+
+    monthly downloads", which is consistent with the PyPI count once the npm SDK is added and lands in
+    the same band. Level 4 and reach 1M-10M unchanged.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/packages/e2b
     shows: ~4,583,328 downloads last month
@@ -88,6 +94,19 @@ adoption:
   - url: https://e2b.dev/
     shows: 1B+ sandboxes started; named production customers (Perplexity, Hugging Face, Manus, Groq)
     accessed: '2026-06-04'
+  - url: https://pypistats.org/api/packages/e2b/recent
+    shows: '{"last_day":253438,"last_month":5845335,"last_week":1377059} for the e2b package. 5.85M in
+      the trailing 30 days bands at 1M-10M, level 4 on the software adoption scale.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 60e77747f0ff07e0c614bbe9787515c776d3785465ce0a5194b16df97c2550d3
+  - url: https://e2b.dev/
+    shows: 'The stat band still reads "94% of Fortune 100 companies", "1b+ started sandboxes", and adds
+      "7M+ monthly downloads". Named case studies include Perplexity, Hugging Face, Manus, Groq, Rogo,
+      Lindy and Gumloop.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e114307a0c219a70e6e5265f92bd5b72a95e95af472e71f5b974ed91cd07491e
 capability:
   score: 4
   basis: feature_matrix
@@ -100,7 +119,17 @@ capability:
   note: VM-grade isolation (Firecracker) is the strongest tier in the feature matrix; broad SDK/runtime
     support and proven scale. Below the frontier-definer Firecracker itself (which it builds on), so 4
     not 5. Independent ComputeSDK TTI benchmarks corroborate the sub-second cold-start (~370ms median
-    time-to-interactive, mid-pack of 19 sandbox providers).
+    time-to-interactive, mid-pack of 19 sandbox providers). Re-read 2026-08-13. The feature matrix is
+    unchanged where it matters - e2b.dev still states "Each sandbox is powered by Firecracker, a microVM
+    made to run untrusted workflows", still offers sessions up to 24 hours, and still reports 1b+ started
+    sandboxes. The relation to the anchor was re-derived rather than carried forward - Firecracker is 5
+    and this is 4, so one_below holds, and Firecracker''s capability was re-confirmed the same day. The
+    corroborating benchmark has moved and is recorded here rather than left implied - on the ComputeSDK
+    run of 2026-08-07 E2B posts a 0.66s median against 24 providers, 12th by median, where the 2026-07-09
+    read had it at ~370ms and 7th of 19. Still sub-second, so the recorded cold-start class survives, but
+    the corroboration is weaker than when it was written and the band now rests on isolation strength and
+    scale rather than on speed.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://e2b.dev/
     shows: each sandbox powered by Firecracker microVM; 1B+ sandboxes started
@@ -109,3 +138,17 @@ capability:
     shows: 'ComputeSDK TTI leaderboard (independent, 100 iters/day, 2026-07-09 run): median time-to-interactive
       ~370ms sequential / ~470ms burst @100 concurrent; 7th-fastest of 19 providers'
     accessed: '2026-07-09'
+  - url: https://e2b.dev/
+    shows: '"Each sandbox is powered by Firecracker, a microVM made to run untrusted workflows." Sessions
+      run up to 24 hours, sandboxes expose configurable CPU and RAM, and the stat band reports 1b+ started
+      sandboxes.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e114307a0c219a70e6e5265f92bd5b72a95e95af472e71f5b974ed91cd07491e
+  - url: https://www.computesdk.com/benchmarks/sandboxes/
+    shows: 'ComputeSDK TTI leaderboard, run of 2026-08-07, now 24 providers. E2B posts a 0.66s median,
+      0.96s P95, 1.02s P99 and 100% success for a composite of 92.1 - 12th by median. The ~370ms/7th-of-19
+      figure cited from the 2026-07-09 run is no longer on the page.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a93049e6dc408dda2d08cbbce798b369c3378ba12289a3a161fe0609b5f29416

--- a/sources/scores/firecracker.yaml
+++ b/sources/scores/firecracker.yaml
@@ -17,24 +17,79 @@ openness:
     - no-feature-gated-core
   confidence: high
   note: Fully Apache-2.0, source public, no gated core; AWS-developed but openly governed (recipe lists
-    Firecracker as an open_source exemplar).
+    Firecracker as an open_source exemplar). Re-read 2026-08-13 against the GitHub repo API and the raw
+    README rather than the rendered repo page. The API reports spdx_id Apache-2.0, language Rust, not
+    archived, and a push the same day; the README states Firecracker "is open sourced under Apache version
+    2.0", gives build-from-source instructions for the whole VMM, and names no paid or withheld edition.
+    Score and class unchanged.
   raw: license:Apache-2.0(OSI);source:public(Rust 78.7%);governance:AWS-led open project;no-feature-gated-core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/firecracker-microvm/firecracker
-    shows: Apache-2.0 license; v1.16.0 (Jun 4 2026); powers AWS Lambda and Fargate
+    shows: Apache-2.0 license; powers AWS Lambda and Fargate
     accessed: '2026-06-04'
+  - url: https://api.github.com/repos/firecracker-microvm/firecracker
+    shows: 'Repo metadata - license spdx_id Apache-2.0, language Rust, default branch main, archived false,
+      36,040 stars, 2,556 forks, pushed_at 2026-08-13.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 24fbeceb82447c24182e9d4150686990b775851ca69cfd4ff03a33bbff8cc0d3
+    establishes:
+    - license
+    - source
+  - url: https://raw.githubusercontent.com/firecracker-microvm/firecracker/main/README.md
+    shows: '"Firecracker is open sourced under Apache version 2.0." The whole VMM builds from the public
+      tree - "git clone https://github.com/firecracker-microvm/firecracker ... tools/devtool build" -
+      and the README names no enterprise edition, license key or feature held back for a paid tier. It
+      also states Firecracker was developed at AWS to accelerate AWS Lambda and AWS Fargate, and has been
+      integrated into Kata Containers and Flintlock.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5f9d595c536442234bc0d96f68e7e90db412b9d5d82c14db02872e24c75bc46b
+    establishes:
+    - source
+    - core-gated
 adoption:
   level: 5
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: Underpins AWS Lambda and AWS Fargate, among the highest-volume serverless platforms in the world
+  note: 'Underpins AWS Lambda and AWS Fargate, among the highest-volume serverless platforms in the world
     (trillions of invocations), plus downstream use in Kata Containers, Flintlock, and E2B. Production
-    reach far exceeds >10M end-equivalent. (34.8k stars corroborate only.)
+    reach far exceeds >10M end-equivalent. (36,040 stars corroborate only.) Re-read 2026-08-13: the README
+    still states Firecracker was developed at AWS to accelerate AWS Lambda and AWS Fargate and has been
+    integrated into Kata Containers and Flintlock, and the AWS launch post still carries "Lambda processes
+    trillions of executions for hundreds of thousands of active customers every month" and Fargate running
+    "tens of millions of containers for AWS customers every week". Level unchanged at 5. Instrument
+    caveat, recorded rather than fixed: `usage_volume` names a count, and there is no countable artifact
+    behind this - Firecracker ships as a statically linked Rust binary from GitHub releases, not as a
+    package on any registry a signal model reads, and its PyPI namesake is not its distribution channel.
+    The band rests on reported AWS platform volume, so the instrument is flagged for a human ruling
+    rather than relabelled here.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/firecracker-microvm/firecracker
     shows: developed at AWS; powers AWS Lambda and AWS Fargate; integrated into Kata Containers and Flintlock
     accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/firecracker-microvm/firecracker/main/README.md
+    shows: '"Firecracker was developed at Amazon Web Services to accelerate the speed and efficiency of
+      services like AWS Lambda and AWS Fargate", and "Firecracker has also been integrated in container
+      runtimes, for example Kata Containers and Flintlock."'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5f9d595c536442234bc0d96f68e7e90db412b9d5d82c14db02872e24c75bc46b
+  - url: https://aws.amazon.com/blogs/aws/firecracker-lightweight-virtualization-for-serverless-computing/
+    shows: '"Today, Lambda processes trillions of executions for hundreds of thousands of active customers
+      every month", and AWS Fargate "now runs tens of millions of containers for AWS customers every week".
+      Both figures are as stated at the 2018 launch post and still on the page.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 7cdafd809344aa8eed554b59f93f75777655d99a9c7ca6818a645ead6cd8587f
+  - url: https://api.github.com/repos/firecracker-microvm/firecracker
+    shows: 36,040 stars, 2,556 forks - corroborating only, not the band.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 24fbeceb82447c24182e9d4150686990b775851ca69cfd4ff03a33bbff8cc0d3
 capability:
   score: 5
   basis: feature_matrix
@@ -44,9 +99,28 @@ capability:
   confidence: high
   note: 'Frontier-definer for the deployment category: hardware-VM isolation at container-like speed/density,
     the reference microVM that the managed sandbox layer (E2B, others) builds on. Defines the strongest
-    point on the isolation x cold-start x scale matrix.'
+    point on the isolation x cold-start x scale matrix. Re-read 2026-08-13. Both cited figures are still
+    on the AWS launch post - "you can launch a microVM in as little as 125 ms today" and "Firecracker
+    consumes about 5 MiB of memory per microVM" - and the README still describes a KVM-based VMM with a
+    deliberately minimal device model running container and function workloads. Score unchanged at 5.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/firecracker-microvm/firecracker
     shows: lightweight microVMs combining hardware virtualization security with container speed; minimal
       memory footprint/attack surface
     accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/firecracker-microvm/firecracker/main/README.md
+    shows: 'The VMM "uses the Linux Kernel Virtual Machine (KVM) to create and run microVMs", excludes
+      "unnecessary devices and guest-facing functionality to reduce the memory footprint and attack
+      surface area", and targets "secure, multi-tenant container and function-based services". Language-agnostic
+      at the kernel level rather than tied to a runtime.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5f9d595c536442234bc0d96f68e7e90db412b9d5d82c14db02872e24c75bc46b
+  - url: https://aws.amazon.com/blogs/aws/firecracker-lightweight-virtualization-for-serverless-computing/
+    shows: '"High Performance - You can launch a microVM in as little as 125 ms today"; "Low Overhead -
+      Firecracker consumes about 5 MiB of memory per microVM. You can run thousands of secure VMs ... on
+      the same instance."'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 7cdafd809344aa8eed554b59f93f75777655d99a9c7ca6818a645ead6cd8587f

--- a/sources/scores/fly-sprites.yaml
+++ b/sources/scores/fly-sprites.yaml
@@ -19,30 +19,46 @@ openness:
       detail: Firecracker itself is OSS/AWS, but the Sprites product/orchestration is proprietary
   confidence: high
   note: Proprietary managed sandbox SaaS; no open source runtime published (only client SDKs). Underlying
-    Firecracker is OSS but the product is not.
+    Firecracker is OSS but the product is not. Re-read 2026-08-13 - sprites.dev now redirects to fly.io/sprites,
+    which still ships only client surfaces (a CLI installer, a REST API, and JavaScript, Go, Elixir and
+    Python SDKs) against a hosted Fly.io control plane, with metered CPU, memory and storage pricing and
+    no self-hostable runtime or source release.
   raw: license:Proprietary;service:proprietary(Fly.io managed);source:closed;clients:CLI/REST/JS/Go SDKs
     (client libs only, no open runtime);isolation:Firecracker(Firecracker itself is OSS/AWS, but the Sprites
     product/orchestration is proprietary)
+  last_verified: '2026-08-13'
   sources:
   - url: https://sprites.dev/
     shows: Sprites = hardware-isolated Firecracker execution env for arbitrary code; managed service,
       CLI/REST/JS/Go clients; no self-hostable open runtime
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 76614642c9a97b9d25c56253cdc6446269d1469303a64fc78b49e21e9109b0af
+    establishes: [source, license]
 adoption:
   level: 1
   signal_type: reported_traction
   confidence: low
   note: Launched Jan 2026 (~5 months at scoring time) as Fly.io's answer to E2B. No disclosed user/customer/usage
     counts on the product page or launch coverage; positioned for AI coding-agent sessions (Claude Code/Codex).
-    Early-stage; placed at 1 on reported traction with low confidence pending real numbers.
+    Early-stage; placed at 1 on reported traction with low confidence pending real numbers. Re-read 2026-08-13
+    - the product page (now fly.io/sprites) still publishes no user, customer, session or sprite count of
+    any kind; the only numbers on it are the per-CPU-hour, per-GB-hour and per-GB-hour-storage prices, which
+    are unchanged at $0.07/CPU-hr. The abstention from a count is re-confirmed, so the record stays
+    reported_traction with no reach word.
+  last_verified: '2026-08-13'
   sources:
   - url: https://sprites.dev/
     shows: product live, usage-based pricing ($0.07/CPU-hr); no user/customer figures disclosed
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 76614642c9a97b9d25c56253cdc6446269d1469303a64fc78b49e21e9109b0af
   - url: https://simonwillison.net/2026/Jan/9/sprites-dev/
     shows: Sprites launched early Jan 2026 as Fly.io's E2B competitor (corroborating recency, not a usage
       figure)
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a5c79a56fa16fd2dce61da68579c3473947de20d4ccfe0a698c13b8a23cbb7c9
 capability:
   score: 4
   basis: feature_matrix
@@ -53,8 +69,26 @@ capability:
   confidence: medium
   note: Top-tier microVM isolation plus persistent stateful sandboxes (explicitly anti-ephemeral) is a
     strong, differentiated feature set. Not a 5 only because it is brand-new with unproven scale vs incumbents;
-    isolation + persistence are best-in-class.
+    isolation + persistence are best-in-class. Re-read 2026-08-13 - the product page moved to fly.io/sprites
+    and was rewritten around persistence and checkpointing; it now describes tiered storage backed by object
+    storage, a 100 GB POSIX volume, live copy-on-write checkpoints taken automatically on idle and shutdown,
+    per-sprite URLs and an outbound API gateway, but it no longer states the isolation mechanism or the
+    1-12s cold and sub-1s restore latencies the band was written against. Those were re-derived instead
+    from the vendor Sprites overview, which states that each Sprite is a Firecracker microVM with its own
+    kernel and filesystem, isolated in hardware from every other Sprite, and that it spins up in seconds.
+    Vendor prose no longer publishes a bounded cold-start figure.
+  last_verified: '2026-08-13'
   sources:
   - url: https://sprites.dev/
-    shows: Firecracker isolation, persistent ext4 filesystem, sub-1s restore, arbitrary Linux code
-    accessed: '2026-06-04'
+    shows: persistent 100 GB ext4/POSIX volume surviving sleep and machine moves, live copy-on-write checkpoint
+      and restore, arbitrary Linux code, usage-metered pricing; no isolation mechanism or latency figure
+      stated
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 76614642c9a97b9d25c56253cdc6446269d1469303a64fc78b49e21e9109b0af
+  - url: https://fly.io/agents-need-a-computer/
+    shows: each Sprite is a Firecracker microVM with its own kernel and durable Linux filesystem, isolated
+      in hardware from every other Sprite, spinning up in seconds and sleeping when idle
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0244a2dd2997a18146c0e9e35a431c2212d77840040698944ae2c2ba7b3e893f

--- a/sources/scores/google-cloud-run.yaml
+++ b/sources/scores/google-cloud-run.yaml
@@ -18,18 +18,28 @@ openness:
     - managed-only(no self-host)
   confidence: high
   note: Proprietary managed serverless platform; only the underlying gVisor sandbox runtime is OSS, not
-    Cloud Run itself.
+    Cloud Run itself. Re-read 2026-08-13 - cloud.google.com/run still presents Cloud Run as a fully managed
+    Google platform billed only while code runs, with no source release and no self-hostable edition offered,
+    and google/gvisor remains a separately maintained Apache-2.0 repository rather than the Cloud Run
+    control plane.
   raw: license:Proprietary;service:proprietary(Google SaaS);source:closed;isolation-runtime:gVisor(open
     source, github.com/google/gvisor) but the Cloud Run product/control-plane is proprietary;managed-only(no
     self-host)
+  last_verified: '2026-08-13'
   sources:
   - url: https://cloud.google.com/run
     shows: Cloud Run described as fully-managed Google serverless container product (proprietary SaaS)
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: f41bd86fa912bee53e3335a5b3edb117cd78a067931b0b9af50aa3de0b8571c8
+    establishes: [source, license]
   - url: https://github.com/google/gvisor
     shows: gVisor (Cloud Run's isolation runtime) is the open source component, distinct from the closed
       product
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 339661507268dd04b1d14b0ed4f58fc72ca4180285157c49d2256e7aba2de94c
+    establishes: [source]
 adoption:
   level: 5
   reach: '>10M'
@@ -38,12 +48,18 @@ adoption:
   note: 'Google Next ''26 blog (primary, verified verbatim): external active developers and apps on Cloud
     Run doubled YoY, more new customers/apps in 2025 than its first 6 years combined; Replit VP quote:
     >1M live projects hosted on Replit with Cloud Run as primary target. Hyperscaler serverless reach
-    is well into the >10M band.'
+    is well into the >10M band. Re-read 2026-08-13 - both claims are still on the Next ''26 post verbatim,
+    the developer/app doubling and the Replit VP quote about over 1 million live projects. Instrument caveat
+    - the record is labeled usage_volume but Cloud Run publishes no countable artifact any signal model
+    can read, so the band rests on the vendor claim rather than a recomputable count.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://cloud.google.com/blog/products/serverless/whats-new-for-cloud-run-at-next26
     shows: active developers/apps doubled YoY; more new customers in 2025 than first 6 years combined;
       Replit >1M live projects on Cloud Run
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 50db99cb77a285efa78ba6edbb4706c8f9f5202309e9e7846bf649eeaa28eadd
 capability:
   score: 4
   basis: feature_matrix
@@ -56,16 +72,28 @@ capability:
     Next '26, 'coming soon') adds first-class AI-code-execution via a `sandbox do --` command. gVisor
     isolation is process/syscall-level rather than full microVM (Sprites/Northflank), so not the top isolation
     tier. Strong but not the single frontier-definer. Independent ComputeSDK TTI benchmarks corroborate
-    the sub-second cold-start (~430ms median, 10th of 19 sandbox providers).
+    the sub-second cold-start (~430ms median, 10th of 19 sandbox providers). Re-read 2026-08-13 - the Next
+    '26 post still describes the built-in `sandbox` tool as coming soon and adds Cloud Run instances in
+    preview for long-running background agents, and cloud.google.com/run still shows any-container deploy,
+    scale-to-zero and 20+ regions. The ComputeSDK leaderboard has been rerun since (2026-08-07, 24 providers)
+    and now places Cloud Run at 0.65s median time-to-interactive, 13th by composite score, still sub-second
+    and still mid-field.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://cloud.google.com/blog/products/serverless/whats-new-for-cloud-run-at-next26
     shows: built-in `sandbox` tool for agents to run AI-generated code in ephemeral isolated envs; container
       model, autoscale 0->thousands
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 50db99cb77a285efa78ba6edbb4706c8f9f5202309e9e7846bf649eeaa28eadd
   - url: https://cloud.google.com/run
     shows: OCI container deploy, scale-to-zero, broad runtime support
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: f41bd86fa912bee53e3335a5b3edb117cd78a067931b0b9af50aa3de0b8571c8
   - url: https://www.computesdk.com/benchmarks/sandboxes/
-    shows: 'ComputeSDK TTI leaderboard (independent, 100 iters/day, 2026-07-09 run): median time-to-interactive
-      ~430ms sequential / ~510ms burst @100 concurrent; 10th of 19 providers'
-    accessed: '2026-07-09'
+    shows: 'ComputeSDK TTI leaderboard (independent, 2026-08-07 run, 24 providers): Cloud Run median time-to-interactive
+      0.65s, P95 1.05s, P99 1.15s, 100% success; 13th by composite score'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 639836bfee0970c31367878466528cb5290b9e4c85f1bea8d19affbc9361bc58

--- a/sources/scores/gvisor.yaml
+++ b/sources/scores/gvisor.yaml
@@ -16,13 +16,58 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: Fully Apache-2.0 application kernel, source public, no gated core (recipe lists gVisor as an open_source
-    exemplar).
+  note: 'Fully Apache-2.0 application kernel, source public, no gated core (recipe lists gVisor as an open_source
+    exemplar). Re-read 2026-08-13. The LICENSE body is the verbatim Apache License 2.0, with two appended
+    notices saying some files carry MIT or BSD terms noted at the top of each file - both permissive and
+    OSI, so the governing Apache-2.0 stands and the most restrictive part does not move the tier. The
+    untruncated default-branch tree carries one LICENSE and the whole runtime in the open - runsc/, pkg/,
+    shim/, sandboxexec/, webhook/, vdso/ - with no ee/, enterprise/, commercial/ or proprietary/ path,
+    and neither the README nor gvisor.dev names a paid or enterprise edition. Google runs gVisor as a
+    hosted service inside Cloud Run and GKE Sandbox, but sells no gVisor SKU and withholds no runtime
+    feature from the source, so core-gated stays ungated.'
   raw: license:Apache-2.0(OSI);source:public(Go);governance:Google-led open project;no-feature-gated-core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/google/gvisor
     shows: Apache-2.0 license; application kernel implementing Linux-like interface in userspace (Go)
     accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/google/gvisor/master/LICENSE
+    shows: 'The verbatim Apache License 2.0, followed by two appended notices - "Some files carry the following
+      license" (MIT text) and "Some files carry the ''BSD'' license". Both are permissive OSI licenses,
+      so the governing grant is Apache-2.0 with permissive third-party carve-outs and no restrictive part.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0fbab5c58efbdf6d31e8085214f2dd821659c03d73cff3ed2b08e98826ea1cd9
+    establishes:
+    - license
+  - url: https://api.github.com/repos/google/gvisor/git/trees/master
+    shows: 'Untruncated default-branch tree, 39 entries. One LICENSE. The whole runtime is present - runsc/,
+      pkg/, shim/, sandboxexec/, webhook/, vdso/, debian/, tools/ - and there is no ee/, enterprise/,
+      commercial/ or proprietary/ path.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d22f58fcacb6370d48494b04fef58c4f016134f36300e17bf9942e88a9e720da
+    establishes:
+    - source
+    - core-gated
+  - url: https://api.github.com/repos/google/gvisor
+    shows: 'Repo metadata - language Go, license spdx_id Apache-2.0, default branch master, not archived,
+      pushed 2026-08-13, 19,073 stars, homepage gvisor.dev.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6311112bdfc83ce139439bd87b72ddc23831bb068cb2e2a02da681e4e0cfa092
+    establishes:
+    - license
+    - source
+  - url: https://raw.githubusercontent.com/google/gvisor/master/README.md
+    shows: 'Describes gVisor as an application kernel written in Go running in userspace, shipping the
+      OCI runtime runsc, with build-from-source instructions for the full release tarball. No paid tier,
+      enterprise edition or withheld component is named anywhere in it.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e706998ed09a98d2491cac86c636cc9a836e9595b14ba26f38cfba665654df38
+    establishes:
+    - core-gated
 adoption:
   level: 5
   reach: '>10M'
@@ -38,7 +83,15 @@ adoption:
     docs/guides/adoption.md - if the declared artifact is not the product''s primary distribution channel,
     banding on it is a substitution rather than a measurement - applied before the mistake rather than after.
     The band stands on the evidence already cited here; what this record needs is a route to its real channel,
-    not a convenient one.'
+    not a convenient one. Re-read 2026-08-13 and the band holds, on stronger evidence than was cited before.
+    The "Powered by gVisor" badge is still on gvisor.dev and still links to Google Cloud Run, and gvisor.dev/users
+    now states plainly that "there are millions of gVisor sandbox instances running daily" and that gVisor
+    powers GKE Sandbox, Cloud Run and App Engine, alongside named production users - Anthropic (code execution
+    inside claude.ai), Cloudflare Pages builds, DigitalOcean App Platform, Ant Group, Modal, Beam and
+    Docker for Mac. Instrument caveat, recorded rather than papered over - signal_type is usage_volume
+    while the product declares no artifact any signal model can read, so this level cannot be recomputed
+    from a feed and rests on a documented read.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://gvisor.dev/docs/
     shows: '''Powered by gVisor'' linking to Google Cloud Run as a production user'
@@ -46,18 +99,64 @@ adoption:
   - url: https://github.com/google/gvisor
     shows: Google-developed sandbox application kernel in production
     accessed: '2026-06-04'
+  - url: https://gvisor.dev/docs/
+    shows: 'The "Powered by gVisor" badge is still in the site footer and still links to https://cloud.google.com/run.
+      The page describes gVisor as the sandbox layer for containers and links the production guide.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: dd3b3ec94c1cd622d758cba3c71beda6b506e8e959d44e9f55ce7b16b0d65b8e
+  - url: https://gvisor.dev/users/
+    shows: '"Who''s Using gVisor" lists production users with quotes. Google''s own entry reads "There
+      are millions of gVisor sandbox instances running daily. gVisor powers Google Cloud offerings GKE
+      Sandbox, Cloud Run, App Engine, and more." Other named users include Anthropic (contains code execution
+      within claude.ai), Cloudflare (Pages builds), DigitalOcean (App Platform), Ant Group, Modal, Beam,
+      Grist, Blink, Tines and Docker for Mac.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 258b640a96f495d8fa30b8598f13036437941a2746784a2ecf0907380f4b029b
+  - url: https://api.github.com/repos/google/gvisor
+    shows: 'Repo metadata - 19,073 stars, 1,912 forks, not archived, pushed 2026-08-13. Corroborates activity
+      only; the band does not rest on it.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6311112bdfc83ce139439bd87b72ddc23831bb068cb2e2a02da681e4e0cfa092
 capability:
   score: 5
   basis: feature_matrix
+  relative_to: firecracker
+  relation: at
   value: isolation:application-kernel (userspace syscall interception, defense-in-depth), distinct strong-isolation
     third approach between seccomp and full VM; cold-start:fast userspace startup; language/runtime breadth:any
     Linux container workload (kernel-level); scale:powers Cloud Run/GKE Sandbox
   confidence: high
   note: 'Frontier-definer: a novel application-kernel isolation model giving VM-class security at userspace
     footprint/startup, the reference sandbox for Google Cloud''s serverless containers. Co-frontier with
-    Firecracker (different isolation philosophy).'
+    Firecracker (different isolation philosophy). Re-read 2026-08-13. The README and gvisor.dev still describe
+    the same instrument - a memory-safe Go application kernel that intercepts application system calls and
+    acts as the guest kernel "without the need for translation through virtualized hardware", explicitly
+    neither a syscall filter nor a VM but "a distinct third approach", giving "many security benefits of
+    VMs while maintaining the lower resource footprint, fast startup, and flexibility of regular userspace
+    applications", shipped as the OCI runtime runsc for Docker and Kubernetes. The prose co-frontier
+    comparison is now recorded as relative_to firecracker with relation `at`, which holds arithmetically -
+    both capability scores are 5, and Firecracker''s was re-derived the same day. Score unchanged at 5.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/google/gvisor
     shows: intercepts syscalls as a userspace application kernel; VM-class security benefits at userspace
       footprint and startup
     accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/google/gvisor/master/README.md
+    shows: '"gVisor takes a distinct third approach, providing many security benefits of VMs while maintaining
+      the lower resource footprint, fast startup, and flexibility of regular userspace applications." Not
+      a syscall filter and not a VM. Ships the OCI runtime runsc, integrating with Docker and Kubernetes.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e706998ed09a98d2491cac86c636cc9a836e9595b14ba26f38cfba665654df38
+  - url: https://gvisor.dev/docs/
+    shows: '"gVisor intercepts application system calls and acts as the guest kernel, without the need for
+      translation through virtualized hardware", described as a merged guest kernel and VMM with a flexible
+      resource footprint, combined with rule-based execution for defense in depth. Contrasts itself against
+      both machine-level virtualization and seccomp/SELinux/AppArmor.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: dd3b3ec94c1cd622d758cba3c71beda6b506e8e959d44e9f55ce7b16b0d65b8e

--- a/sources/scores/kata-containers.yaml
+++ b/sources/scores/kata-containers.yaml
@@ -17,36 +17,130 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: Fully Apache-2.0, source public, vendor-neutral open-foundation governance, no managed-tier gating
-    from the project itself.
+  note: 'Fully Apache-2.0, source public, vendor-neutral open-foundation governance, no managed-tier gating
+    from the project itself. Re-read 2026-08-13. The LICENSE body is the verbatim Apache License 2.0 with
+    nothing appended, and the README states the same in prose. The untruncated default-branch tree carries
+    one LICENSE and the whole product - src/ holds runtime, runtime-rs, agent and the built-in Dragonball
+    VMM, with tools/, tests/ and docs/ beside them - and there is no ee/, enterprise/, commercial/ or
+    proprietary/ path. katacontainers.io sells nothing - it is a community site stewarded by the OpenInfra
+    Foundation that points at GitHub for the code and at a user survey for feedback - so there is no managed
+    tier to gate against and core-gated stays ungated.'
   raw: license:Apache-2.0(OSI);source:public;governance:open community (OpenInfra Foundation);no-feature-gated-core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/kata-containers/kata-containers
     shows: Apache-2.0 license; lightweight VMs with container UX + VM isolation; v3.31.0 (May 19 2026)
     accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/kata-containers/kata-containers/main/LICENSE
+    shows: The verbatim Apache License 2.0, complete and with no appended notices, exceptions or additional
+      terms.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
+    establishes:
+    - license
+  - url: https://api.github.com/repos/kata-containers/kata-containers/git/trees/main
+    shows: 'Untruncated default-branch tree, 32 entries. One LICENSE. src/ carries the whole product - runtime,
+      runtime-rs, agent and the Dragonball VMM - with tools/, tests/, ci/ and docs/ beside it, and there
+      is no ee/, enterprise/, commercial/ or proprietary/ path.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c8e654e4818032043bfab3a07af19009b590049a79c5eb46db251d69211c5548
+    establishes:
+    - source
+    - core-gated
+  - url: https://api.github.com/repos/kata-containers/kata-containers
+    shows: 'Repo metadata - language Rust, license spdx_id Apache-2.0, default branch main, not archived,
+      pushed 2026-08-13, 8,531 stars, 1,431 forks.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 098b629b7fa0ad04cdaea38763ad46b2092eddffc7bf0b1a4ca60c7b4320f9ce
+    establishes:
+    - license
+    - source
+  - url: https://katacontainers.io/
+    shows: '"The Kata Containers community is stewarded by the Open Infrastructure Foundation... The code
+      is hosted at GitHub under the Apache 2 license." The site offers documentation, releases, mailing
+      lists and a user survey, and sells no product, subscription or supported edition of its own.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: dcd594a9b40c82506bd48ff80bebc1f2af084e3f7ab1054edc88ee74e7b024e6
+    establishes:
+    - core-gated
 adoption:
   level: 3
   signal_type: reported_traction
   confidence: medium
-  note: Established CNCF/OpenInfra-adjacent container-runtime project integrated into Kubernetes runtimeclass
+  note: 'Established CNCF/OpenInfra-adjacent container-runtime project integrated into Kubernetes runtimeclass
     deployments; broad but operator-concentrated infrastructure adoption rather than a mass per-user count.
     No clean download/user figure verified; ~8k stars (corroborate only, not the basis). Level 3 reflects
-    specialist infra reach.
+    specialist infra reach. Re-read 2026-08-13 and the abstention from a numeric reach still holds. katacontainers.io
+    publishes no download, install, cluster or user count anywhere - what it publishes instead is a running
+    user survey asking operators to self-report, plus one named production deployment (Baidu, for Function
+    Computing, Cloud Container Instances and Edge Computing). The project ships as release tarballs and a
+    kata-deploy Helm chart rather than through a countable package registry, so there is no channel to band
+    on. Stars read 2026-08-13 - 8,531, unchanged in magnitude and still corroboration only. No reach recorded,
+    which is what reported_traction requires absent a published figure.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/kata-containers/kata-containers
     shows: standard implementation of lightweight VM containers; integrated runtime; 8k stars
     accessed: '2026-06-04'
+  - url: https://katacontainers.io/
+    shows: 'The project site publishes no usage, download or deployment figure. It names one production
+      user in prose - "Baidu is running Kata Containers in production to support Function Computing, Cloud
+      Container Instances, and Edge Computing" - and otherwise asks operators to "Take the Kata Containers
+      User Survey", which is the project asking for the number rather than reporting one.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: dcd594a9b40c82506bd48ff80bebc1f2af084e3f7ab1054edc88ee74e7b024e6
+  - url: https://api.github.com/repos/kata-containers/kata-containers
+    shows: 'Repo metadata - 8,531 stars, 1,431 forks, 99 watchers, pushed 2026-08-13, not archived. Corroborates
+      an active specialist infrastructure project; the level does not rest on it.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 098b629b7fa0ad04cdaea38763ad46b2092eddffc7bf0b1a4ca60c7b4320f9ce
+  - url: https://raw.githubusercontent.com/kata-containers/kata-containers/main/README.md
+    shows: 'Distribution is by release tarball and the kata-deploy Helm chart on Kubernetes, or build from
+      source - no package-registry channel that would yield a countable download figure.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 326a9123397a42cd6b56acfce60884c119f5b70250f2ec62ae3bde877ff03895
 capability:
   score: 4
   basis: feature_matrix
+  relative_to: firecracker
+  relation: one_below
   value: isolation:hardware VM (pluggable VMM, QEMU/Firecracker/Cloud Hypervisor), strong VM-class isolation;
     cold-start:VM boot (slower than pure userspace); language/runtime breadth:any OCI container (language-agnostic,
     K8s-native); persistence:container lifecycle; scale:K8s clusters
   confidence: high
-  note: VM-grade isolation with OCI/Kubernetes compatibility and pluggable hypervisors; very strong isolation
-    but higher cold-start than microVM/userspace frontier-definers, so 4.
+  note: 'VM-grade isolation with OCI/Kubernetes compatibility and pluggable hypervisors; very strong isolation
+    but higher cold-start than microVM/userspace frontier-definers, so 4. Re-read 2026-08-13. The feature
+    matrix still reads as described - the README states lightweight VMs "that feel and perform like containers,
+    but provide the workload isolation and security advantages of VMs", on x86_64, aarch64, ppc64le and
+    s390x, with a containerd shimv2 runtime and an in-VM agent; docs/hypervisors.md still lists five pluggable
+    VMMs (QEMU, Cloud Hypervisor, Firecracker, Dragonball, StratoVirt), with QEMU the best-supported for
+    NVIDIA GPUs and confidential computing. The prose comparison to the frontier-definers is now recorded
+    as relative_to firecracker with relation `one_below`, which holds arithmetically - Firecracker is 5,
+    Kata is 4, and Firecracker''s capability was re-derived the same day. Score unchanged at 4.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/kata-containers/kata-containers
     shows: lightweight VMs performing like containers with VM workload-isolation/security; integrated
       with Firecracker
     accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/kata-containers/kata-containers/main/README.md
+    shows: 'Lightweight VMs "that feel and perform like containers, but provide the workload isolation and
+      security advantages of VMs", on x86_64/amd64, aarch64, ppc64le and s390x. Core components are a containerd
+      shimv2 runtime (Go and Rust), an in-VM agent, and the optional built-in Dragonball VMM.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 326a9123397a42cd6b56acfce60884c119f5b70250f2ec62ae3bde877ff03895
+  - url: https://raw.githubusercontent.com/kata-containers/kata-containers/main/docs/hypervisors.md
+    shows: 'Five supported hypervisors - Cloud Hypervisor, Firecracker, QEMU, Dragonball and StratoVirt -
+      selected per runtime through a configuration file. QEMU is the only one with GPU, Intel TDX and AMD
+      SEV-SNP support, and is where the project focuses its GPU runtimes.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: bdc51950b28822cdcbe98525bfd5156482bed2b1b9be420c9e92a8964bf246bb

--- a/sources/scores/modal-sandboxes.yaml
+++ b/sources/scores/modal-sandboxes.yaml
@@ -23,10 +23,15 @@ openness:
   note: 'Closed managed service. The client SDK is open, but the execution substrate is a proprietary
     managed cloud with no self-host; an open client over a closed runtime is not open_core. Corrects a
     prior mis-calibration that grouped Modal with the genuinely self-hostable E2B (E2B ships self-hostable
-    infra; Modal does not).'
+    infra; Modal does not). Re-read 2026-08-13 - the pricing page still sells only metered access to
+    Modal''s own cloud across Starter, Team and Enterprise plans, with Sandbox compute billed per core-
+    and GiB-second and no self-hosted, on-premises or source-available option offered at any tier; the
+    Sandboxes guide still drives everything through Modal SDKs against that cloud. Source and license
+    both read as recorded.'
   raw: license:Proprietary;source:closed;service:proprietary Modal managed cloud (no self-host of the gVisor
     execution plane);open-part:client SDK only (modal Python/JS client libraries);pricing:pay-as-you-go
     usage, free starter credits
+  last_verified: '2026-08-13'
   sources:
   - url: https://modal.com/pricing
     shows: Modal is a managed proprietary cloud platform, pay-per-CPU-cycle, $30/mo free credits
@@ -34,17 +39,57 @@ openness:
   - url: https://modal.com/docs/guide/sandbox
     shows: Sandboxes = secure containers for untrusted agent code, driven via Modal SDK
     accessed: '2026-06-04'
+  - url: https://modal.com/pricing
+    shows: 'Three plans - Starter ($0 + compute, $30/mo free credits), Team ($250 + compute) and
+      Enterprise (custom) - all metered against Modal''s own cloud, with a separate Sandbox and
+      Notebooks compute rate per core-second and GiB-second. Nothing on the page offers a self-hosted,
+      on-premises or source-available deployment.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e5534b204d7123a8e32b35614459209769e6131bcc52ba113c8ac93a0369d876
+    establishes:
+    - source
+    - license
+  - url: https://modal.com/docs/guide/sandbox
+    shows: 'Redirects to /docs/guide/sandboxes. Sandboxes are still "secure containers for executing
+      untrusted user or agent code on Modal", created only through the Python, JavaScript or Go SDK
+      against Modal''s service; no runtime is distributed to run elsewhere.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d55d885d0e1f6088bc4f133942161b9e9605aaff32cb1375d3f6f6d543fd38f3
+    establishes:
+    - source
 adoption:
   level: 3
   signal_type: reported_traction
   confidence: low
   note: No disclosed Modal Sandboxes user/usage count on primary pages; Modal is a well-known managed
     AI-compute platform with broad developer use and a documented free tier. Placed at 3 on reported multi-customer
-    traction, not a measured usage_volume figure (kept conservative absent a hard number).
+    traction, not a measured usage_volume figure (kept conservative absent a hard number). Re-read
+    2026-08-13 - still no Sandboxes user, session or job count anywhere on the docs or pricing pages,
+    and no free-tier signup number. The nearest figure Modal publishes is platform-wide rather than
+    per-product - its sandbox comparison page claims Modal "powers infrastructure for over 10,000
+    teams" and names Lovable and Quora as production users running untrusted code - which is a
+    reported-traction claim of exactly the kind already banded, not a count of Sandboxes use. The
+    abstention on reach and the level 3 both stand.
+  last_verified: '2026-08-13'
   sources:
   - url: https://modal.com/docs/guide/sandbox
     shows: documented production sandbox feature on a widely-used managed platform
     accessed: '2026-06-04'
+  - url: https://modal.com/resources/best-code-execution-sandboxes-ai-agents
+    shows: '''Modal powers infrastructure for over 10,000 teams, with production users like Lovable and
+      Quora running millions of untrusted code snippets daily''. No Sandboxes-specific user or usage
+      count is given.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: eb0fb2ec1e5f12aca248e6389998745b0ba48a21edfd9b211bd1474d98eea34e
+  - url: https://modal.com/docs/guide/sandbox
+    shows: Sandboxes guide publishes lifecycle, image and timeout documentation and no usage, session
+      or customer count.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d55d885d0e1f6088bc4f133942161b9e9605aaff32cb1375d3f6f6d543fd38f3
 capability:
   score: 4
   basis: feature_matrix
@@ -59,7 +104,16 @@ capability:
   note: 'Strong, purpose-built agent sandbox: gVisor isolation + arbitrary images + high concurrency.
     Sits just below the Firecracker-microVM frontier (Lambda/Vercel) on isolation strength; scored 4,
     level with the Ray/Ollama capability anchors. Independent ComputeSDK TTI benchmarks measure ~470ms
-    median cold-start (13th of 19 sandbox providers), consistent with the fast-container-stack claim.'
+    median cold-start (13th of 19 sandbox providers), consistent with the fast-container-stack claim.
+    Re-read 2026-08-13 - the Sandboxes guide still documents arbitrary custom images, named lookup and
+    a 5-minute default lifetime extendable to 24 hours, and Modal''s own comparison page still states
+    gVisor isolation and 50,000+ concurrent sessions. The ComputeSDK leaderboard has moved on from the
+    run cited above - its 2026-08-07 run covers 24 providers and puts Modal at a 0.76s median TTI
+    (0.82s P95, composite 92.1), 14th by median rather than the ~470ms/13th-of-19 recorded here. Slower
+    in absolute terms and unchanged in placement - still mid-field, still short of the sub-0.3s leaders
+    and well clear of the multi-second tail. The comparison to the ray anchor (capability 4, confirmed
+    2026-08-13) is unchanged, so the band holds at 4.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://modal.com/docs/guide/sandbox
     shows: sandbox lifecycle, custom images, timeouts up to 24h, untrusted-code execution
@@ -71,3 +125,21 @@ capability:
     shows: 'ComputeSDK TTI leaderboard (independent, 100 iters/day, 2026-07-09 run): median time-to-interactive
       ~470ms sequential / ~570ms burst @100 concurrent; 13th of 19 providers'
     accessed: '2026-07-09'
+  - url: https://modal.com/docs/guide/sandbox
+    shows: Sandbox lifecycle through the SDK, arbitrary custom images, named/ID lookup, 5-minute
+      default timeout extendable to 24 hours, untrusted-code framing.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d55d885d0e1f6088bc4f133942161b9e9605aaff32cb1375d3f6f6d543fd38f3
+  - url: https://modal.com/resources/best-code-execution-sandboxes-ai-agents
+    shows: 'Still states gVisor container isolation for Modal against microVM competitors, and "can
+      scale to 50,000+ concurrent sessions".'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: eb0fb2ec1e5f12aca248e6389998745b0ba48a21edfd9b211bd1474d98eea34e
+  - url: https://www.computesdk.com/benchmarks/sandboxes/
+    shows: 'ComputeSDK TTI leaderboard, run of 2026-08-07 across 24 providers - Modal median 0.76s, P95
+      0.82s, P99 0.85s, 100% success, composite 92.1; 14th of 24 by median.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: cbb96170184f9c48e5c5f0a9834e15ab2a87a083132581c8a632f0cdc6e42e85

--- a/sources/scores/nono.yaml
+++ b/sources/scores/nono.yaml
@@ -22,15 +22,49 @@ openness:
   confidence: high
   note: 'Fully open source: an Apache-2.0 Rust implementation that is self-hostable as a standalone CLI
     or library with no proprietary service tier. A clean contrast with the managed sandbox clouds (Vercel,
-    Cloudflare, Modal), which publish only a client SDK over a closed runtime.'
+    Cloudflare, Modal), which publish only a client SDK over a closed runtime. Re-read 2026-08-13 and
+    unchanged. The LICENSE body at repository head is a verbatim Apache License 2.0, the repository
+    metadata reports spdx_id Apache-2.0 on a public, unarchived Rust repository, and the README closes
+    on a bare "License - Apache-2.0". The README still installs the whole tool free by curl or Homebrew
+    with Debian, Fedora, Arch, RHEL, openSUSE, WSL2 and Nix listed alongside, still documents the policy
+    engine, credential proxy, L7 filtering and brokered tool sandboxes as ordinary features, and still
+    points the FFI bindings at nono-py, nono-ts and nono-go. Nothing is held back for a paid tier and no
+    license key or hosted dependency appears, so core-gated stays ungated. One change since the last
+    read - the registry namespace moved from always-further to nolabs-ai, which is a rename rather than
+    a gate.'
   raw: license:Apache-2.0(OSI);source:public(full Rust implementation, self-hostable);distribution:curl
     / Homebrew / Debian-Ubuntu-Fedora-Arch-RHEL-openSUSE-Nix + FFI bindings (nono-py, nono-ts, nono-go);service:none(standalone
     CLI/library, no proprietary backend);core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
-  - url: https://github.com/nolabs-ai/nono
-    shows: Apache-2.0 license; full Rust source; self-hostable; install via curl / Homebrew / Linux package
-      managers; FFI bindings nono-py / nono-ts / nono-go
-    accessed: '2026-06-29'
+  - url: https://raw.githubusercontent.com/nolabs-ai/nono/main/LICENSE
+    shows: Verbatim Apache License 2.0 body at repository head
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 7310e9389f298b89bb2f90ac4b6081ed5b6a1c4a7b8547df5d52966a57cb0929
+    establishes:
+    - license
+  - url: https://api.github.com/repos/nolabs-ai/nono
+    shows: 'Repository metadata - nolabs-ai/nono, language Rust, license spdx_id Apache-2.0, public and
+      not archived, 3,644 stars, 241 forks, last push 2026-08-13'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6b7060b790a56fb537cbaae122f68a2a333e795f8022e640de096fb96b6fb463
+    establishes:
+    - license
+    - source
+  - url: https://raw.githubusercontent.com/nolabs-ai/nono/main/README.md
+    shows: 'Install with curl or Homebrew, with Debian/Ubuntu, Fedora, Arch, RHEL, openSUSE, WSL2 and
+      Nix linked; the profile system, brokered tool sandboxes, credential proxy and L7 endpoint filtering
+      are documented as ordinary features; FFI bindings for Rust, Python, TypeScript and Go published as
+      nono-py, nono-ts and nono-go; registry namespace migrated from always-further to nolabs-ai; the
+      License section reads Apache-2.0. No paid tier, license key or hosted dependency is described.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 040dc4d074176f2aa875923f07e90b15a2c66748a8f293b8acb00018b8b5c8e2
+    establishes:
+    - source
+    - core-gated
 adoption:
   level: 2
   reach: 1K-10K stars
@@ -42,11 +76,29 @@ adoption:
     which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach
     ''1K-10K'' was not a label this instrument offers - stars have their own vocabulary because a star is not
     a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on
-    every refetch, and the rest of the axis was not re-read.'
+    every refetch, and the rest of the axis was not re-read. That last sentence is superseded - the rest
+    of the axis has now been re-read. Stars read again 2026-08-13 from the repository metadata endpoint
+    at 3,644, four above the earlier same-day reading and still inside the 1K-10K stars band at level 2,
+    and the reasoning under the band was re-derived rather than copied. The README confirms stars remain
+    the only public proxy - no download, install or user figure is published, and the closest thing to a
+    usage claim is unattributed marketing prose about engineers at large companies running nono in
+    production, which is not bandable. The digest-drift objection stands and is accepted rather than
+    avoided; the digested source below is the metadata endpoint, and a later refetch showing a different
+    hash means the count moved, which is what a star signal does.'
+  last_verified: '2026-08-13'
   sources:
-  - url: https://github.com/nolabs-ai/nono
-    shows: ~2,900 stars (June 2026)
-    accessed: '2026-06-29'
+  - url: https://api.github.com/repos/nolabs-ai/nono
+    shows: 'Repository metadata - stargazers_count 3,644 and forks_count 241 for nolabs-ai/nono, public
+      and not archived, last push 2026-08-13'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6b7060b790a56fb537cbaae122f68a2a333e795f8022e640de096fb96b6fb463
+  - url: https://raw.githubusercontent.com/nolabs-ai/nono/main/README.md
+    shows: No download, install or user count is published; the only traction language is unattributed
+      prose about engineers at large companies using nono in production, with no named adopter
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 040dc4d074176f2aa875923f07e90b15a2c66748a8f293b8acb00018b8b5c8e2
 capability:
   score: 3
   basis: feature_matrix
@@ -57,8 +109,29 @@ capability:
   confidence: medium
   note: 'Solid, cross-platform sandbox with very low setup friction; scored mid-range for the category
     -- below the heavier microVM / OS-isolation options on hard isolation depth, but broad and easy to
-    adopt locally.'
+    adopt locally. Re-read 2026-08-13 and the band holds. nono.sh still leads on kernel-level isolation
+    for Linux, macOS and Windows with zero setup and zero latency, lists per-language sandboxes for
+    Python, Node.js and Go, and keeps the registry at registry.nono.sh. Both pages are explicit that the
+    mechanism is OS-level allow-lists rather than a virtual machine - the README says no daemon, no
+    container, no VM and no disk space usage - which is what holds this one below the microVM peers.
+    The feature surface has widened since the band was set, with brokered per-tool child sandboxes,
+    credential proxying with L7 endpoint policy, hash-chained audit records under a SHA-256 Merkle root,
+    rollback and Sigstore provenance. That is real depth in a different direction from hard isolation,
+    so it is recorded here rather than treated as a reason to move the score.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://nono.sh
-    shows: zero-setup, cross-platform least-privilege agent sandboxing; agent registry
-    accessed: '2026-06-29'
+    shows: 'Kernel isolation for Linux, macOS and Windows; ephemeral micro sandboxes with zero setup and
+      zero latency; per-language OS/Python/Node.js/Go sandboxes; brokered tool execution with scoped
+      credentials and L7 endpoint policy; hash-chained audit log sealed with a SHA-256 Merkle root;
+      undo/rollback snapshots; Sigstore provenance; registry linked'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: adfa836384380e3230dd2c78b2efebc4226ea759ca39134d809a514210b4d542
+  - url: https://raw.githubusercontent.com/nolabs-ai/nono/main/README.md
+    shows: '"no daemon, no container, no VM, and no disk space usage" with a least-privilege sandbox
+      enforced out of the box on macOS, Linux and Windows (WSL2); FFI bindings for Rust, Python,
+      TypeScript and Go; profiles pulled from the nono registry and composable as JSON'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 040dc4d074176f2aa875923f07e90b15a2c66748a8f293b8acb00018b8b5c8e2

--- a/sources/scores/northflank-sandboxes.yaml
+++ b/sources/scores/northflank-sandboxes.yaml
@@ -15,14 +15,28 @@ openness:
     free_text:
     - no self-hostable open runtime
   confidence: high
-  note: Proprietary managed deployment/sandbox platform; no open source runtime published.
+  note: Proprietary managed deployment/sandbox platform; no open source runtime published. Re-read 2026-08-13
+    - northflank.com and the Sandboxes product page still sell a commercial SaaS running on Northflank Cloud
+    or a customer VPC, with no source release and no self-hostable runtime; the microVM layer is built on
+    third-party projects (Kata Containers, gVisor) rather than anything Northflank publishes.
   raw: license:Proprietary;service:proprietary(Northflank managed SaaS);source:closed;isolation:microVM;no
     self-hostable open runtime
+  last_verified: '2026-08-13'
   sources:
   - url: https://northflank.com/
     shows: Northflank Sandboxes = secure microVM sandbox for untrusted/code-gen execution; proprietary
       commercial SaaS
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e45e80af144a4bf67b989939802974b1ae2262eb317cc2eb9d9e6ef670304352
+    establishes: [source, license]
+  - url: https://northflank.com/product/sandboxes
+    shows: Sandboxes run on Northflank infrastructure or inside a customer VPC; Kata Containers and gVisor
+      named as the isolation layer; no self-hostable runtime or source offered
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0976a4c6d9b2bf28425711a51fface149fdb2d09a945e6af29c7b36fe346f1fb
+    establishes: [source, license]
 adoption:
   level: 3
   signal_type: reported_traction
@@ -30,11 +44,25 @@ adoption:
   note: 'Northflank (platform-wide, primary): 2,000+ organizations, 80,000+ developers in production,
     130B+ requests, millions of containers, 330+ availability zones. These are platform-level figures
     (not Sandboxes-specific); the Sandboxes product is newer. Placed at 3 on the developer/org base; the
-    Sandboxes feature alone is likely lower.'
+    Sandboxes feature alone is likely lower. Re-read 2026-08-13 - the homepage counters have moved up, now
+    reading 2,000+ start-ups and enterprises, 100k+ developers in production, 130B+ requests and 330+
+    availability zones, and the Sandboxes product page adds the first Sandboxes-specific claim, millions
+    of microVMs run monthly since 2021. Still a vendor claim with no countable artifact behind it, so the
+    record stays reported_traction with no reach word.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://northflank.com/
-    shows: 2,000+ orgs, 80,000+ developers in production, 130B+ requests, millions of containers (platform-level)
-    accessed: '2026-06-04'
+    shows: 2,000+ start-ups and enterprises, 100k+ developers in production, 130B+ requests, millions of
+      containers, 330+ availability zones (platform-level)
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e45e80af144a4bf67b989939802974b1ae2262eb317cc2eb9d9e6ef670304352
+  - url: https://northflank.com/product/sandboxes
+    shows: Sandboxes-specific claim of millions of microVMs run monthly since 2021; SOC 2 Type 2 and HIPAA
+      badges; no per-customer or per-session usage figure
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0976a4c6d9b2bf28425711a51fface149fdb2d09a945e6af29c7b36fe346f1fb
 capability:
   score: 4
   basis: feature_matrix
@@ -46,12 +74,28 @@ capability:
     support for untrusted code-gen at scale. Just below frontier on proven sandbox-specific scale vs the
     dedicated leaders; isolation+latency are top-tier. Independent ComputeSDK TTI benchmarks confirm the
     top-tier latency, measuring ~100ms median cold-start (3rd-fastest of 19 sandbox providers), beating
-    the ~200ms spec.'
+    the ~200ms spec. Re-read 2026-08-13 - the homepage still shows the microVM 200ms spin-up figure, and
+    the Sandboxes product page names Kata Containers and gVisor, boots a microVM in under a second, imposes
+    no forced session time limit, and offers deployment inside a customer VPC. The ComputeSDK leaderboard
+    has been rerun since (2026-08-07, 24 providers) and now measures Northflank at 0.25s median
+    time-to-interactive, still 3rd by composite score, so the top-tier latency reading holds at a slower
+    absolute number.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://northflank.com/
     shows: microVM 200ms isolation, untrusted code at scale, millions of containers, 330+ AZs
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e45e80af144a4bf67b989939802974b1ae2262eb317cc2eb9d9e6ef670304352
+  - url: https://northflank.com/product/sandboxes
+    shows: Kata Containers and gVisor isolation, microVM boot in under a second, no forced session time
+      limits, bring-your-own-cloud VPC deployment
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0976a4c6d9b2bf28425711a51fface149fdb2d09a945e6af29c7b36fe346f1fb
   - url: https://www.computesdk.com/benchmarks/sandboxes/
-    shows: 'ComputeSDK TTI leaderboard (independent, 100 iters/day, 2026-07-09 run): median time-to-interactive
-      ~100ms sequential / ~190ms burst @100 concurrent; 3rd-fastest of 19 providers'
-    accessed: '2026-07-09'
+    shows: 'ComputeSDK TTI leaderboard (independent, 2026-08-07 run, 24 providers): Northflank median time-to-interactive
+      0.25s, P95 0.29s, P99 0.30s, 100% success; 3rd by composite score'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 639836bfee0970c31367878466528cb5290b9e4c85f1bea8d19affbc9361bc58

--- a/sources/scores/ollama.yaml
+++ b/sources/scores/ollama.yaml
@@ -12,18 +12,53 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: license:MIT;source:public;no-feature-gated-core
+  note: 'license:MIT;source:public;no-feature-gated-core. Re-read 2026-08-13 and unchanged. The LICENSE
+    body at repository head is a verbatim MIT text, "Copyright (c) Ollama", and the GitHub repository
+    metadata reports spdx_id MIT on a public, unarchived Go repository. The README ships the whole engine
+    for free - platform installers for macOS, Windows and Linux, an official Docker Hub image, the local
+    REST API on port 11434, and the model library - with no paid edition, license key or enterprise-only
+    build. Ollama now sells hosted cloud inference and lists a pricing page, but that is a separate
+    service alongside the engine rather than a capability withheld from it, so core-gated stays ungated.'
   raw: license:MIT;source:public;no-feature-gated-core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
-  - url: https://github.com/ollama/ollama/blob/main/LICENSE
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
-  - url: https://github.com/ollama/ollama
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/ollama/ollama/main/LICENSE
+    shows: Verbatim MIT License body at repository head, "Copyright (c) Ollama", with the standard
+      permission and warranty-disclaimer clauses and no added restriction
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5934ed2ce0d15154bcdb9c85203210abac0da4314af34081e36df4599f90b226
+    establishes:
+    - license
+  - url: https://api.github.com/repos/ollama/ollama
+    shows: 'Repository metadata - full_name ollama/ollama, language Go, license spdx_id MIT, public and
+      not archived, 178,451 stars, 17,389 forks, last push 2026-08-12'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0ad0ab0ce97a4ce4719036b4fdb8f5f45aa4715474a69519f5caea1b75317529
+    establishes:
+    - license
+    - source
+  - url: https://raw.githubusercontent.com/ollama/ollama/main/README.md
+    shows: 'The whole engine is distributed free from the repository and vendor site - install scripts
+      and manual installers for macOS, Windows and Linux, the official ollama/ollama Docker Hub image,
+      the local REST API on port 11434, agent integrations launched from the CLI, and ollama-python and
+      ollama-js listed under Libraries as clients. No paid tier, license key or enterprise-only build
+      is described anywhere in it.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 38f94429ec63c78f2c87dc47ff2bbba91bd93edd697c638b9daa7eda3ae5adb2
+    establishes:
+    - source
+    - core-gated
   - url: https://ollama.com/
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+    shows: Vendor site offering a free download plus paid hosted cloud models in the United States,
+      Europe and Singapore; the cloud service is sold alongside the local engine, not as an unlock for it
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 248e9cfea29aaf02d293e026585105f066bc7fef58f5a3b476137ce286df2b25
+    establishes:
+    - core-gated
 adoption:
   level: 4
   reach: 1M-10M
@@ -38,26 +73,71 @@ adoption:
     coverage rule in docs/guides/adoption.md - if the declared artifact is not the product''s primary
     distribution channel, banding on it is a substitution rather than a measurement - applied before the
     mistake rather than after. The band stands on the evidence already cited here; what this record needs is a
-    route to its real channel, not a convenient one.'
+    route to its real channel, not a convenient one. Re-read 2026-08-13. The band is unchanged and the
+    evidence under it has moved - the repository now reports 178,451 stars and 17,389 forks, and the
+    model library lists 233 models carrying about 1.0 billion cumulative pulls between them, led by
+    llama3.1 at 118.4M and deepseek-r1 at 91.3M. FIGURE CORRECTION - the "52M+ monthly model pulls" this
+    note opens with is not published on either cited page and could not be re-derived. ollama.com/library
+    publishes an all-time cumulative pull counter per model, never a monthly rate, and the word monthly
+    does not appear on it; the homepage publishes no volume figure at all. The level-4 band rests instead
+    on what those pages do show, which is a cumulative pull base around a billion across the library and
+    a very large installed developer base, still comfortably inside the 1M-10M active-user reading. The
+    monthly framing should come out of this note; flagged rather than edited because the wording is the
+    basis someone recorded. INSTRUMENT CAVEAT, recorded rather than worked around - this record uses
+    usage_volume while declaring no artifact a signal model can recompute from, and the artifact
+    paragraph above explains why declaring the PyPI package would be wrong. Neither the instrument nor
+    the artifact was changed; the axis now carries digested sources so the claim can be re-checked and
+    will age.'
+  last_verified: '2026-08-13'
   sources:
-  - url: https://github.com/ollama/ollama
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
-  - url: https://www.ollama.com/
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+  - url: https://api.github.com/repos/ollama/ollama
+    shows: 'Repository metadata - 178,451 stars, 17,389 forks, language Go, last push 2026-08-12, not
+      archived'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0ad0ab0ce97a4ce4719036b4fdb8f5f45aa4715474a69519f5caea1b75317529
+  - url: https://ollama.com/library
+    shows: 'Model library listing 233 models with an all-time cumulative pull count each - llama3.1
+      118.4M, deepseek-r1 91.3M, nomic-embed-text 82.2M, llama3.2 80M, and so on, summing to roughly 1.0
+      billion pulls. The counter is cumulative, not a rate; no monthly figure is published anywhere on
+      the page.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e602829d3b1ae7b33596a5a8aaa131b5ad6737f0c8bf9c0cb4ee2e523d123637
+  - url: https://raw.githubusercontent.com/ollama/ollama/main/README.md
+    shows: 'Distribution channels confirmed - platform install scripts and manual installers for macOS,
+      Windows and Linux plus the official ollama/ollama Docker Hub image. ollama-python and ollama-js
+      are listed under Libraries, which is what the PyPI package is - a client for a local server, not
+      the channel the product is obtained through.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 38f94429ec63c78f2c87dc47ff2bbba91bd93edd697c638b9daa7eda3ae5adb2
 capability:
   score: 4
   basis: feature_matrix
   value: null
   confidence: high
-  note: Local model serving with one-command run, OpenAI-compatible REST API, broad model library (Llama,
+  note: 'Local model serving with one-command run, OpenAI-compatible REST API, broad model library (Llama,
     Qwen, Gemma, gpt-oss, DeepSeek). Serving-layer tool; no MLPerf result cited, rated on feature/coverage
-    matrix.
+    matrix. Re-read 2026-08-13 and the feature matrix holds, with the surface wider than when the band
+    was set. The README documents the local REST API on port 11434 with an OpenAI-compatible chat
+    endpoint, Python and JavaScript clients, and a new agent-launcher layer - ollama launch claude,
+    codex, copilot-cli, droid, opencode - plus the OpenClaw assistant integration. The library carries
+    233 model families including Llama, Qwen, Gemma, DeepSeek and gpt-oss, and the vendor site now also
+    serves several of them as cloud models. Still no benchmark result is published for the runtime
+    itself, so the basis stays feature_matrix.'
+  last_verified: '2026-08-13'
   sources:
-  - url: https://github.com/ollama/ollama
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/ollama/ollama/main/README.md
+    shows: 'One-command run, local REST API on port 11434 with an OpenAI-compatible chat endpoint,
+      Python and JavaScript clients, and CLI agent integrations for Claude Code, Codex, Copilot CLI,
+      Droid, OpenCode and OpenClaw'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 38f94429ec63c78f2c87dc47ff2bbba91bd93edd697c638b9daa7eda3ae5adb2
   - url: https://ollama.com/library
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+    shows: 233 model families listed, spanning Llama, Qwen, Gemma, DeepSeek, Mistral, Phi and gpt-oss,
+      with tool, thinking, vision, embedding and cloud tags per entry
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e602829d3b1ae7b33596a5a8aaa131b5ad6737f0c8bf9c0cb4ee2e523d123637

--- a/sources/scores/openai-code-interpreter.yaml
+++ b/sources/scores/openai-code-interpreter.yaml
@@ -17,14 +17,20 @@ openness:
       detail: no self-host, no open runtime
   confidence: high
   note: Fully proprietary managed code-execution sandbox; OpenAI does not document the isolation mechanism
-    or release any runtime.
+    or release any runtime. Re-read 2026-08-13 - the developer docs still describe only a sandboxed execution
+    environment reached through the Assistants and Responses APIs, priced per session, with no isolation
+    mechanism named, no runtime distributed and no self-hosted option offered.
   raw: license:Proprietary;service:proprietary(OpenAI-managed sandbox);source:closed;isolation:undisclosed;access:API/tool
     only(no self-host, no open runtime)
+  last_verified: '2026-08-13'
   sources:
   - url: https://developers.openai.com/api/docs/assistants/tools/code-interpreter
     shows: Code Interpreter runs Python in a proprietary OpenAI-managed sandbox; $0.03/session; isolation
       details not disclosed
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9c2dc0fa7b2b74463b00061310a8438c7f286b463dbac261c2c426f0b6bd8dea
+    establishes: [source, license]
 adoption:
   level: 4
   reach: 1M-10M users
@@ -34,11 +40,17 @@ adoption:
     the ChatGPT surface it rides has ~1B weekly users (flagship anchor record, GPT-5). No standalone Code-Interpreter
     usage figure is disclosed, so adoption is attributed to the surface, placed conservatively at 4 (a
     fraction of ChatGPT users invoke code execution) with low confidence given no primary per-tool number.
+    Re-read 2026-08-13 - the developer docs still publish no adoption, session-count or frequency figure of
+    any kind for the tool, only the per-session price and the file and session limits, so the attribution
+    to the ChatGPT surface stands and no standalone number has appeared.
+  last_verified: '2026-08-13'
   sources:
   - url: https://developers.openai.com/api/docs/assistants/tools/code-interpreter
     shows: Code Interpreter is a first-class tool in the Assistants/Responses API and underlies ChatGPT
-      data analysis (the surface that drives usage)
-    accessed: '2026-06-04'
+      data analysis (the surface that drives usage); no usage figure published
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9c2dc0fa7b2b74463b00061310a8438c7f286b463dbac261c2c426f0b6bd8dea
 capability:
   score: 3
   basis: feature_matrix
@@ -48,8 +60,14 @@ capability:
   confidence: low
   note: Reliable Python-only data-analysis sandbox with iterative retry, but single-language, undisclosed
     isolation, and session-scoped, narrower than general-purpose deployment sandboxes. Mid-tier; capability
-    detail limited because OpenAI does not document the isolation/scale internals.
+    detail limited because OpenAI does not document the isolation/scale internals. Re-read 2026-08-13 -
+    every element of the recorded band is still on the docs page unchanged, Python as the only language,
+    a 512 MB per-file ceiling, a one-hour default session, $0.03 per session, and no isolation mechanism
+    named.
+  last_verified: '2026-08-13'
   sources:
   - url: https://developers.openai.com/api/docs/assistants/tools/code-interpreter
     shows: Python sandbox, iterative code retry, 512MB files, 1-hour session
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9c2dc0fa7b2b74463b00061310a8438c7f286b463dbac261c2c426f0b6bd8dea

--- a/sources/scores/openpcc.yaml
+++ b/sources/scores/openpcc.yaml
@@ -17,9 +17,55 @@ openness:
   confidence: high
   note: Fully OSI-licensed (Apache-2.0) across the reference implementation and related repos, with the spec
     and whitepaper public. Confident Security runs a commercial managed service (CONFSEC) on top, but that
-    is an open-core *business* around a fully open standard, not open-core licensing.
+    is an open-core *business* around a fully open standard, not open-core licensing. Re-read 2026-08-13
+    and unchanged. The LICENSE body at repository head is a verbatim Apache License 2.0, and the
+    repository metadata reports spdx_id Apache-2.0 on a public, unarchived Go repository. The README
+    still frames the project as "deployable on your own infrastructure", links the whitepaper in-tree,
+    and points the compute-node half at a second public repository, confidentsecurity/confidentcompute,
+    which publishes the compute_boot, router_com and compute_worker binaries plus the Packer image
+    build - so the part that actually runs the inference is published rather than withheld. CONFSEC
+    remains a managed service Confident Security sells on top, mentioned but not required, which is why
+    core-gated stays ungated.
   raw: license:Apache-2.0(OSI);source:public(github.com/openpcc/openpcc + spec/whitepaper);reference-impl(Go)+client-SDKs;commercial-managed-service(CONFSEC)separate;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
+  - url: https://raw.githubusercontent.com/openpcc/openpcc/main/LICENSE
+    shows: Verbatim Apache License 2.0 body at repository head
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30
+    establishes:
+    - license
+  - url: https://api.github.com/repos/openpcc/openpcc
+    shows: 'Repository metadata - openpcc/openpcc, language Go, license spdx_id Apache-2.0, public and
+      not archived, 948 stars, 31 forks, last push 2026-01-08'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: dda5b34a01eb066c36535a9537b1a75c4bb373d58190a66971d6e09eb632c14f
+    establishes:
+    - license
+    - source
+  - url: https://raw.githubusercontent.com/openpcc/openpcc/main/README.md
+    shows: '"fully open, auditable, and deployable on your own infrastructure"; the whitepaper is in
+      the tree at whitepaper/openpcc.pdf; the repo carries the Go client, a C library underlying the
+      Python and JavaScript clients, and in-memory services runnable locally via mage runMemServices.
+      The managed CONFSEC service is named as a separate offering, and the compute node is pointed at
+      confidentsecurity/confidentcompute rather than withheld.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 4e62b506e6a848b7b4f98fa0d552ddea86a1d035bed74c3fe94b537b40aa588d
+    establishes:
+    - source
+    - core-gated
+  - url: https://raw.githubusercontent.com/confidentsecurity/confidentcompute/main/README.md
+    shows: The compute-node half of the standard is published - Go service binaries compute_boot (which
+      attests to the TPM, GPU and other hardware), router_com and compute_worker, plus compute-images
+      Packer scripts for building the node image on multiple clouds
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: fb14caa3ada83f783491d898b22311c6cc21520d6f0752b09def6deb9a7bf498
+    establishes:
+    - core-gated
   - url: https://github.com/openpcc/openpcc
     shows: Apache-2.0; "open source framework for verifiably private AI inference"; OHTTP gateway, attestation,
       transparency log, client SDKs
@@ -32,13 +78,31 @@ adoption:
   level: 2
   signal_type: reported_traction
   confidence: low
-  note: Launched Nov 5 2025 with a $5M seed (Decibel, Ex/Ante, South Park Commons, Halcyon, SAIF); ~940 GitHub
+  note: 'Launched Nov 5 2025 with a $5M seed (Decibel, Ex/Ante, South Park Commons, Halcyon, SAIF); ~940 GitHub
     stars by mid-2026 (notable for a young infra project) but no production adopters documented in primary
-    sources. Early-stage.
+    sources. Early-stage. Re-read 2026-08-13 and the picture is unchanged, so the level stands. The
+    repository reports 948 stars and 31 forks, and neither the README nor the launch write-up names a
+    production deployment; the only named consumer is Confident Security''s own CONFSEC managed service,
+    which is the vendor rather than an adopter. Two things worth a later look - the repository''s last
+    push is 2026-01-08, seven months before this read, and the launch post still closes on an open
+    waitlist rather than customers. Neither moves a level-2 reported_traction band on its own, but a
+    reference implementation that has not been pushed to since January is the kind of signal that
+    usually precedes one moving.'
+  last_verified: '2026-08-13'
   sources:
-  - url: https://github.com/openpcc/openpcc
-    shows: ~940 stars; reference implementation
-    accessed: '2026-06-17'
+  - url: https://api.github.com/repos/openpcc/openpcc
+    shows: 'Repository metadata - 948 stars, 31 forks, public and not archived, last push 2026-01-08,
+      description "An open-source framework for verifiably private AI inference"'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: dda5b34a01eb066c36535a9537b1a75c4bb373d58190a66971d6e09eb632c14f
+  - url: https://cloudsecurityalliance.org/blog/2025/11/13/introducing-openpcc
+    shows: Launch write-up dated 11/13/2025, originally published by Confident Security, announcing
+      OpenPCC as a standard with "a fully-featured Apache 2.0 open-source implementation written in Go"
+      and closing on an open waitlist. It names no adopter or deployment.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0f654e87b7206fe2a7c703f7549e0ef2eecd94b0dfb3a695b93c14e26b27edd0
 capability:
   score: 4
   basis: feature_matrix
@@ -47,11 +111,45 @@ capability:
     requests via Oblivious HTTP; client SDKs (Go native + C lib for Python/JS); model/provider-agnostic (prototyped
     on Intel TDX + H100 serving Llama-3 8B on vLLM)'
   confidence: medium
-  note: Broad, well-architected confidential-serving stack with attestation plus anonymization that goes beyond
+  note: 'Broad, well-architected confidential-serving stack with attestation plus anonymization that goes beyond
     plain confidential compute. Not top because it is young with limited proven scale and no documented production
-    adopters.
+    adopters. Re-read 2026-08-13 and the feature set holds, though the two cited pages divide the work
+    differently than this axis recorded. The launch write-up turns out to be a motivation and standards
+    piece - it establishes the anonymization scheme against timing, payment and metadata side channels,
+    and the Apache-2.0 Go implementation, and nothing more granular. The itemized scope comes from the
+    repositories instead. The OpenPCC README carries encrypted streaming, hardware attestation and
+    unlinkable requests over Oblivious HTTP, a transparency verifier with an identity policy, a Go client
+    plus a C library underlying the Python and JavaScript clients, and OpenAI-format completions against
+    an arbitrary tagged model, which is the provider-agnostic claim. The compute-node repository adds
+    the attestation target explicitly, with compute_boot attesting to the TPM, GPU and other hardware
+    before the router starts. One recorded detail did NOT re-derive - the "prototyped on Intel TDX + H100
+    serving Llama-3 8B on vLLM" clause in the value string appears on none of the pages read today, and
+    the README''s worked example runs qwen3:1.7b. Flagged rather than edited; the band does not rest on
+    it.'
+  last_verified: '2026-08-13'
   sources:
+  - url: https://raw.githubusercontent.com/openpcc/openpcc/main/README.md
+    shows: 'Technical scope of the reference implementation - "encrypted streaming, hardware attestation,
+      and unlinkable requests"; an OHTTP Gateway operated by the deployment with a third-party OHTTP
+      Relay; a transparency verifier configured with an OIDC identity policy; a Go client plus a C
+      library used as the basis of the Python and JavaScript clients; in-memory services for local
+      development; and OpenAI-format completion requests routed to nodes by model tag.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 4e62b506e6a848b7b4f98fa0d552ddea86a1d035bed74c3fe94b537b40aa588d
+  - url: https://raw.githubusercontent.com/confidentsecurity/confidentcompute/main/README.md
+    shows: compute_boot "is responsible for attesting to the TPM, GPU, and other hardware components"
+      before router_com starts, and compute_worker decrypts each request, sends it to the LLM and
+      encrypts the response - the CPU-and-GPU attestation and per-request encryption the band rests on
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: fb14caa3ada83f783491d898b22311c6cc21520d6f0752b09def6deb9a7bf498
   - url: https://cloudsecurityalliance.org/blog/2025/11/13/introducing-openpcc
-    shows: 'technical scope: TEE inference, attestation, transparency logs, Oblivious-HTTP anonymization,
-      client SDKs'
-    accessed: '2026-06-17'
+    shows: 'Establishes the standard and the anonymization scheme - OpenPCC "describes a system for
+      inference on private or otherwise sensitive data such that inputs and outputs remain completely
+      hidden from all participants", with an anonymization scheme against API timing, payment and
+      metadata side channels, a whitepaper, and "a fully-featured Apache 2.0 open-source implementation
+      written in Go". It does not itemize TEEs, attestation, transparency logs or client SDKs.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0f654e87b7206fe2a7c703f7549e0ef2eecd94b0dfb3a695b93c14e26b27edd0

--- a/sources/scores/opensandbox.yaml
+++ b/sources/scores/opensandbox.yaml
@@ -17,14 +17,60 @@ openness:
     - no-managed-tier-observed
     - no-feature-gated-core
   confidence: high
-  note: Apache-2.0, fully self-hostable, no managed/enterprise gating observed => open_source (not open_core).
-    Alibaba says it open sourced the sandbox infra used internally.
+  note: 'Apache-2.0, fully self-hostable, no managed/enterprise gating observed => open_source (not open_core).
+    Alibaba says it open sourced the sandbox infra used internally. Re-read 2026-08-13 and all three recorded
+    dimensions hold. The repository has moved from the alibaba org to opensandbox-group - the old URL 301s
+    to the new one and both return the same body - and the root LICENSE is the verbatim Apache License
+    2.0 with nothing appended. The untruncated tree is 2,642 entries with the whole product public - server/,
+    components/, kubernetes/, cli/, sdks/, specs/ - carrying ten LICENSE paths, all Apache-2.0 copies sitting
+    beside per-SDK and per-component roots, and no ee/, enterprise/, commercial/ or proprietary/ path.
+    open-sandbox.ai is a documentation site with no pricing page, no hosted offering and no sign-up, closing
+    with "Released under the Apache 2.0 License", so there is still no managed tier to gate against.'
   raw: license:Apache-2.0(OSI);source:public(Go execd + multi-language SDKs);runtimes:Docker/Kubernetes;no-managed-tier-observed;no-feature-gated-core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/alibaba/OpenSandbox
     shows: Apache-2.0 license; general-purpose AI-agent sandbox; Docker/K8s runtimes; multi-language SDKs;
       self-host
     accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/opensandbox-group/OpenSandbox/main/LICENSE
+    shows: The verbatim Apache License 2.0, complete and with no appended notices, exceptions or additional
+      terms.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 50e6751797c50dedd75ef1b8a0d9e42f5f8472e9fbce91f34718e9f97b0c780a
+    establishes:
+    - license
+  - url: https://api.github.com/repos/opensandbox-group/OpenSandbox/git/trees/main?recursive=1
+    shows: 'Untruncated recursive tree, 2,642 entries. Ten LICENSE paths, all Apache-2.0 copies of the root
+      placed beside the CLI, the server and each SDK. The whole product is public - server/, components/,
+      kubernetes/, cli/, sdks/, specs/, sandboxes/ - and there is no ee/, enterprise/, commercial/ or proprietary/
+      path.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 96de8bab4273bb81e622ba457def36967e0d815a7a41cf1bb10d19efc170334e
+    establishes:
+    - source
+    - core-gated
+  - url: https://api.github.com/repos/opensandbox-group/OpenSandbox
+    shows: 'Repo metadata - license spdx_id Apache-2.0, default branch main, not archived, pushed 2026-08-13,
+      homepage open-sandbox.ai. The repository now lives under the opensandbox-group org; the alibaba/OpenSandbox
+      path redirects here and returns an identical body.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 013a649819f1ef44a2bf21c8d0db9288478dcf4e98595bc9fcc60fcee159f9f5
+    establishes:
+    - license
+    - source
+  - url: https://open-sandbox.ai
+    shows: 'The project site is documentation only - getting started, guides, SDK and API references, specs,
+      CLI, components, Kubernetes and migration guides. It offers no hosted service, pricing page, sign-up
+      or enterprise edition, and its footer reads "Released under the Apache 2.0 License."'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0470380f7fd841e3a5ffc9705480d1c600ddc82e81b49f53adc443a8c597c706
+    establishes:
+    - core-gated
 adoption:
   level: 3
   reach: '>10K stars'
@@ -35,12 +81,23 @@ adoption:
     early stars but no usage volume yet. Revisit as usage data emerges. Stars read 2026-08-13: 12,516 across
     the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. Level
     corrected from 2. The previous reach ''10K-100K'' was not a label this instrument offers - stars have
-    their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile,
-    so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.'
+    their own vocabulary because a star is not a download. Re-read in full 2026-08-13 against the GitHub
+    API - 12,522 stars, 1,056 forks - which is the same >10K stars band and the same level 3. The digest
+    below will drift on every refetch because a star count moves daily; that is expected of this instrument
+    and does not weaken the band, which depends only on the order of magnitude. One thing did change and
+    is escalated rather than applied - a Python SDK is now published on PyPI as `opensandbox`, so this
+    record may no longer need the stars fallback at all. It is not declared here.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/alibaba/OpenSandbox
     shows: 11.3k GitHub stars; released Mar 2026; no usage/download figures
     accessed: '2026-06-04'
+  - url: https://api.github.com/repos/opensandbox-group/OpenSandbox
+    shows: 'Repo metadata - 12,522 stars, 1,056 forks, 51 watchers, pushed 2026-08-13. Bands at >10K stars,
+      level 3 on the stars scale in signal_routing.yaml.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 013a649819f1ef44a2bf21c8d0db9288478dcf4e98595bc9fcc60fcee159f9f5
 capability:
   score: 3
   basis: feature_matrix

--- a/sources/scores/ray.yaml
+++ b/sources/scores/ray.yaml
@@ -81,12 +81,22 @@ adoption:
     substrate (Ray Serve, Tune, Train, Data) under the PyTorch Foundation. Artifact declared and read live
     2026-08-13: 63,273,910 PyPI downloads in the trailing 30 days. Bands at >10M, level 5. This record
     previously claimed usage_volume - a download count - while declaring no artifact any signal model reads,
-    so no computed figure existed for the recorded band to disagree with. Level unchanged. No last_verified
-    claimed: only the figure was re-read.'
+    so no computed figure existed for the recorded band to disagree with. Level unchanged. Re-derived
+    2026-08-13 against the PyPI download API rather than the rendered pepy page: 63,273,910 downloads in
+    the trailing 30 days, 15,105,708 in the trailing week. The trailing-week figure alone clears the >10M
+    floor, so the band does not turn on which window is read. Level unchanged at 5.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://pepy.tech/projects/ray
     shows: 61,306,813 downloads in last 30 days
     accessed: '2026-06-25'
+  - url: https://pypistats.org/api/packages/ray/recent
+    shows: '{"data":{"last_day":2156063,"last_month":63273910,"last_week":15105708},"package":"ray"}. The
+      declared PyPI artifact, read directly - 63,273,910 downloads in the trailing month, above the >10M
+      level-5 floor for software usage_volume.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b35ba34262611ee958754fd37f2edb81a566e27cff17b773f93aea873f75e4ba
   - url: https://www.anyscale.com/blog/ray-by-anyscale-joins-pytorch-foundation
     shows: Ray under the PyTorch Foundation (governance / ecosystem standing)
     accessed: '2026-06-04'
@@ -98,10 +108,24 @@ capability:
   note: General distributed-compute + model-serving framework (Ray Core, Serve, Tune, Train, Data). No
     standardized inference/training benchmark (MLPerf) applies to Ray as a whole; scored on breadth of
     distributed-serving feature coverage. Not directly comparable to single-engine inference benchmarks.
+    Re-read 2026-08-13 on the Anyscale docs page, which still describes the same matrix - Ray Core plus
+    the AI libraries (Data, Train, Tune, Serve, RLlib), clusters on VMs or Kubernetes, mixed CPU/GPU
+    scheduling, and the listed workloads of batch inference, model serving, distributed training,
+    hyperparameter tuning, feature engineering and reinforcement learning. It is a scheduling and serving
+    substrate rather than an isolation boundary, which is why it sits at 4 and not at the microVM
+    frontier this category's 5s occupy. Score unchanged.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.anyscale.com/product/open-source/ray
     shows: flagship phase-C verification source
     accessed: '2026-06-04'
   - url: https://docs.anyscale.com/get-started/what-is-ray
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+    shows: '"Ray is an open source framework for building, deploying, and serving AI and ML applications
+      using distributed compute resources. Ray excels when applications need to scale to many machines
+      and optimizes resource utilization for workloads that require both CPUs and GPUs." Lists the
+      libraries built on Ray Core (Data, Train, Tune, Serve) and the common workloads - batch inference,
+      LLMs and gen AI, model serving, feature engineering, hyperparameter tuning, distributed training,
+      reinforcement learning. "All Ray apps deploy as Ray clusters", on virtual machines or Kubernetes.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: ec01ef00a03ff45805f1a10bde79f3818f131323dc49731c5952635ed2c7f947

--- a/sources/scores/replit-agent-code-execution-api.yaml
+++ b/sources/scores/replit-agent-code-execution-api.yaml
@@ -20,10 +20,16 @@ openness:
   note: 'Closed managed service. The sandbox primitive (omegajail) is open source but it is a third-party
     dependency, not Replit''s own open core, and the thin client is archived; there is no self-hostable
     open product, so an open dependency under a closed service is not open_core. Reclassified from open_core
-    (borderline).'
+    (borderline). Re-read 2026-08-13 - github.com/replit/replit-code-exec is still archived and read-only
+    under ISC, and its README still describes the execution service as a Repl the user forks and deploys
+    onto Replit Autoscale Deployments, sandboxed by the third-party omegaup/omegajail project. Nothing
+    Replit publishes is a self-hostable execution service, so source stays closed and the service license
+    stays proprietary. The two replit.com blog URLs cited beside it returned 403 to every fetch attempt
+    and were not re-read.'
   raw: license:Proprietary;source:closed;service:proprietary(Replit managed Autoscale Deployments, no self-host);open-part:third-party
     isolation primitive omegajail(github.com/omegaup/omegajail) + an ARCHIVED thin client (replit-code-exec,
     ISC, read-only since 2025-02-11);no self-hostable execution service
+  last_verified: '2026-08-13'
   sources:
   - url: https://replit.com/blog/ai-agents-code-execution
     shows: Code Execution API uses omegajail (open source unprivileged container sandbox) on Replit's
@@ -33,7 +39,18 @@ openness:
     shows: 'Replit code-exec client: stateless API for AI agents, runs untrusted Python in ephemeral unprivileged
       containers using omegajail (github.com/omegaup/omegajail); ISC license; repo ARCHIVED read-only
       2025-02-11'
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 761938cb9ffb598951c50f709e9fc5cd8b258315634a8332267d641c75b7d41b
+    establishes: [source, license]
+  - url: https://raw.githubusercontent.com/replit/replit-code-exec/main/README.md
+    shows: the client is an interface to a stateless Replit-hosted eval-python API; standing up a copy
+      means forking a Repl and deploying it on Replit Autoscale Deployments, with omegaup/omegajail as
+      the code sandbox, so no off-platform self-hostable service exists
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6a18761274efe9b9002120f29b64bea36c34476550c08be8a930c56be3b3b0a9
+    establishes: [source, license]
   - url: https://blog.replit.com/ai-agents-code-execution
     shows: 'canonical Replit blog: Code Execution API uses omegajail on Autoscale Deployments, ~100ms,
       Python-focused (Feb 2024)'
@@ -46,11 +63,19 @@ adoption:
   note: Replit platform serves >50M users (Replit docs/coverage) and runs >1M live projects on Cloud Run
     (Google Next '26, primary). The code-execution API specifically discloses no standalone usage figures,
     so adoption is attributed to the Replit Agent/platform surface it powers, not the raw API. Placed
-    at 4 (platform-surface reach); the API alone would be lower.
+    at 4 (platform-surface reach); the API alone would be lower. Re-read 2026-08-13 - the Google Next '26
+    post still carries the Replit VP quote about over 1 million live projects hosted on Replit with Cloud
+    Run as the primary target, so the platform-surface attribution holds. Instrument caveat - the record
+    is labeled usage_volume but neither Replit nor the code-execution API exposes a countable artifact a
+    signal model can read, so the band rests on a vendor-quoted figure rather than a recomputable count.
+    replit.com/products/agent returned 403 to every fetch attempt and was not re-read.
+  last_verified: '2026-08-13'
   sources:
   - url: https://cloud.google.com/blog/products/serverless/whats-new-for-cloud-run-at-next26
     shows: Replit runs >1M live projects (on Cloud Run), primary-source scale signal for the Replit surface
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 50db99cb77a285efa78ba6edbb4706c8f9f5202309e9e7846bf649eeaa28eadd
   - url: https://replit.com/products/agent
     shows: Replit Agent product page (the agent surface the code-exec API backs)
     accessed: '2026-06-04'
@@ -64,9 +89,19 @@ capability:
   note: 'Fast container-level execution tuned for agent code-eval, but container (not microVM) isolation,
     narrow language focus, and no persistence put it mid-tier vs microVM-backed peers. Note: the public
     self-serve client (replit-code-exec) is archived (2025-02-11); the capability now lives inside the
-    Replit Agent surface.'
+    Replit Agent surface. Not dated 2026-08-13 - the only source this band cites, the Replit blog post,
+    returned 403 to every fetch attempt, so the ~100ms figure was not re-confirmed. The archived client
+    README was re-read instead and still supports the rest of the band, an ephemeral unprivileged container
+    sandboxed by omegajail, stateless, Python-focused, running on Replit Autoscale Deployments.'
   sources:
   - url: https://replit.com/blog/ai-agents-code-execution
     shows: omegajail container sandbox, ~100ms start, Python-focused, stateless (stateful-Repl experiment
       discontinued)
     accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/replit/replit-code-exec/main/README.md
+    shows: stateless API optimized for AI agents, executing untrusted Python inside an ephemeral unprivileged
+      container created on the fly on Replit Deployments using omegaup/omegajail as the code sandbox; no
+      latency figure stated
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6a18761274efe9b9002120f29b64bea36c34476550c08be8a930c56be3b3b0a9

--- a/sources/scores/sandbox-runtime.yaml
+++ b/sources/scores/sandbox-runtime.yaml
@@ -17,13 +17,44 @@ openness:
     - no managed/proprietary tier(it is a local library, not a service)
   confidence: high
   note: Apache-2.0 OS-level sandboxing library, fully open and self-contained; no feature-gated core or
-    paid tier.
+    paid tier. Re-read 2026-08-13 - the GitHub API reports the repository public, unarchived and
+    licensed Apache-2.0, the LICENSE body is the verbatim Apache License 2.0, and the README installs
+    the whole tool with a single ``npm install -g @anthropic-ai/sandbox-runtime`` and documents no
+    hosted plan, license key or withheld capability. It is labeled a beta research preview, which is a
+    maturity statement rather than a gate.
   raw: license:Apache-2.0(OSI);source:public(GitHub);distribution:npm package;no managed/proprietary tier(it
     is a local library, not a service);core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/anthropic-experimental/sandbox-runtime
     shows: Apache-2.0 license; OS-level (bubblewrap/seatbelt) sandbox library, no container required
     accessed: '2026-06-04'
+  - url: https://api.github.com/repos/anthropic-experimental/sandbox-runtime
+    shows: Repository metadata - public, not archived, license spdx_id Apache-2.0, pushed to the same
+      day.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a581f8a50fcd16edbcb883042f3bacdb3b79cd93c44f77a2d7a8160d422f7242
+    establishes:
+    - source
+    - license
+  - url: https://raw.githubusercontent.com/anthropic-experimental/sandbox-runtime/main/LICENSE
+    shows: The verbatim Apache License 2.0 body, with no added terms or field-of-use restrictions.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1210bc93eb85dd786c33192d5bcb7153a93922fa99fbc1512af6a7199cb41080
+    establishes:
+    - license
+  - url: https://raw.githubusercontent.com/anthropic-experimental/sandbox-runtime/main/README.md
+    shows: Installs entirely from npm as a CLI and library; documents settings, filesystem/network/unix-socket
+      restrictions and violation monitoring with no paid tier, license key or hosted component. Labeled
+      a beta research preview built for Claude Code and released as an open source preview.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9ec3d585692e4bd6aff8dd807784d6d97595bc5fe48d6824ca2dd823c874776b
+    establishes:
+    - source
+    - core-gated
 adoption:
   level: 2
   reach: 10K-100K
@@ -50,8 +81,20 @@ capability:
   confidence: medium
   note: Best-in-class for low-overhead, no-container process isolation with fine-grained fs+network allow/deny
     and pre-built seccomp filters; but a process-level sandbox is a weaker security boundary than the
-    microVM/gVisor frontier and offers no managed scale, so 3.
+    microVM/gVisor frontier and offers no managed scale, so 3. Re-read 2026-08-13 - the README still
+    describes bubblewrap on Linux and sandbox-exec on macOS with proxy-based network filtering, still
+    documents seccomp filters as x64/arm64 only and warns that unix sockets go unrestricted where
+    seccomp is unavailable, and still ships no managed or multi-host mode. The feature matrix reads as
+    recorded and the band holds at 3.
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/anthropic-experimental/sandbox-runtime
     shows: bubblewrap+seccomp / sandbox-exec isolation, filesystem+network restriction model, no container
     accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/anthropic-experimental/sandbox-runtime/main/README.md
+    shows: Native OS primitives (sandbox-exec on macOS, bubblewrap on Linux) plus a filtering proxy;
+      filesystem, network and unix-socket restrictions; seccomp filters limited to x64/arm64 with a
+      warning when unavailable; single-host CLI and library, no fleet or managed tier.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9ec3d585692e4bd6aff8dd807784d6d97595bc5fe48d6824ca2dd823c874776b

--- a/sources/scores/spaces.yaml
+++ b/sources/scores/spaces.yaml
@@ -19,15 +19,51 @@ openness:
   confidence: medium
   note: 'Closed managed hosting service. Apps are built with OSS SDKs (Gradio etc.) that run anywhere,
     but Spaces itself - the managed host/orchestration - is proprietary and not self-hostable; those SDKs
-    are separate products, not a Spaces open core. Reclassified from open_core (borderline).'
+    are separate products, not a Spaces open core. Reclassified from open_core (borderline).
+    Re-read 2026-08-13 and unchanged. The Hub docs still describe Spaces only as apps hosted on Hugging
+    Face infrastructure - Gradio, arbitrary Dockerfile, static HTML/JS, with GPU hardware upgrades, dev
+    mode and persistent storage - and document no way to run the Spaces host anywhere else. The pricing
+    page sells that host as metered HF compute (CPU Basic free, CPU Upgrade $0.03/hr, ZeroGPU free with
+    a PRO quota, T4/L4/A100 hourly), and the terms of service reserve ownership of the service outright
+    - "we retain ownership of all of our intellectual property rights related to the Website and the
+    Services" - which is what the Proprietary license part records. No source repository or self-host
+    distribution for Spaces itself appeared.'
   raw: license:Proprietary;source:closed;platform:proprietary(HF-managed hosting/orchestration, no self-hostable
     Spaces);open-part:app SDKs only (Gradio Apache-2.0, Streamlit) which are separate, portable OSS products;hardware-tiers:CPU
     free + paid GPU upgrades
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/docs/hub/spaces
     shows: Spaces hosts apps via Gradio (OSS SDK), Streamlit, arbitrary Dockerfile, or static HTML on
       HF-managed infra with paid GPU upgrades
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 4550e77bee16ae854ce07a3e7f5ec9a29d617fb720e35cc44e993acbb68a31ae
+    establishes:
+    - source
+  - url: https://huggingface.co/pricing
+    shows: 'Spaces Hardware table - the Spaces host is sold as metered Hugging Face compute. CPU Basic
+      (2 vCPU / 16 GB) free, CPU Upgrade $0.03/hr, ZeroGPU free on a shared Blackwell pool with an 8x
+      quota for PRO, then hourly Nvidia T4 / L4 / A100 tiers. PRO and Team plans are described as hosting
+      "your own ZeroGPU, Gradio & Docker Spaces on compute" - HF compute, with no self-hosted option
+      offered anywhere on the page.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 42b3bdf9e77f964b2105c7ad07a58ba79d6bd24428e066a5668239d7f0486650
+    establishes:
+    - source
+  - url: https://huggingface.co/terms-of-service
+    shows: 'Intellectual Property section - "Proprietary Rights. We retain ownership of all of our intellectual
+      property rights related to the Website and the Services, including all improvements to the Services.
+      All materials that we produce, including the Website, design, code, graphics, interfaces, trademarks"
+      are Hugging Face''s. Spaces is one of the Services, so the platform itself is governed by these
+      proprietary terms rather than by an open license.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: ee161973aba14a28f6c1666189e322e258bca4f3a79e9c6db24be4d517083b4c
+    establishes:
+    - license
+    - source
 adoption:
   level: 5
   reach: '>10M'
@@ -36,11 +72,24 @@ adoption:
   note: 'Hugging Face homepage (primary): Spaces hosts 1M+ AI applications, on a platform used by 50,000+
     organizations. 1M+ hosted apps plus the broad end-user traffic to those demos puts served reach into
     the >10M band. Headline (1M+ Spaces) cites HF''s own homepage; per-Space user totals not individually
-    disclosed so confidence medium.'
+    disclosed so confidence medium. Re-read 2026-08-13 and both cited figures are still on the homepage
+    - the Spaces panel ends in "Browse 1M+ applications" and the organizations band still reads "More
+    than 50,000 organizations are using Hugging Face" - so the level stands unchanged. INSTRUMENT CAVEAT,
+    recorded rather than worked around - this record uses usage_volume, which claims a count, while the
+    product declares no artifact any signal model can recompute from. The instrument is not being
+    relabeled to dodge that and no artifact is being declared, because a Space is not a package and the
+    1M+ figure is the vendor''s own count of hosted apps rather than a countable channel. The axis now
+    carries a digested source so the claim can at least be re-checked and will age; a real route to a
+    countable Spaces signal is an open backlog item.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co
-    shows: Spaces = 1M+ AI applications hosted; 50,000+ organizations on Hugging Face
-    accessed: '2026-06-04'
+    shows: 'Spaces panel closes with "Browse 1M+ applications"; the customer band reads "More than 50,000
+      organizations are using Hugging Face" over Ai2, Meta, Amazon, Google, Intel, Microsoft. No per-Space
+      or aggregate visitor figure is published.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b7ad167d3383abb482dd5a940e157b8ab0d7af54ebda64543f987c22334239f8
 capability:
   score: 3
   basis: feature_matrix
@@ -51,8 +100,23 @@ capability:
   confidence: medium
   note: Excellent for hosting/demoing ML apps with broad SDK and GPU support, but it is an app-hosting
     platform rather than a hardened arbitrary-untrusted-code sandbox (container, not microVM isolation),
-    and free Spaces sleep. Mid-tier within the deployment sandbox lens.
+    and free Spaces sleep. Mid-tier within the deployment sandbox lens. Re-read 2026-08-13 - the Hub
+    docs still list Gradio, Streamlit, Docker and static HTML Spaces, GPU upgrades, ZeroGPU, dev mode,
+    and disk usage and storage, and the pricing page still starts the hardware ladder at a free 2 vCPU
+    CPU Basic tier. Nothing in either page claims microVM or hardened multi-tenant isolation, so the
+    band is unchanged. New since the last read - Spaces as MCP servers, agent tools and API endpoints
+    now have their own doc pages, which widens the surface without moving the isolation ceiling the
+    band rests on.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/docs/hub/spaces
     shows: Gradio/Streamlit/Docker/static hosting, GPU hardware upgrades, persistent storage and dev mode
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 4550e77bee16ae854ce07a3e7f5ec9a29d617fb720e35cc44e993acbb68a31ae
+  - url: https://huggingface.co/pricing
+    shows: Spaces Hardware ladder - free CPU Basic, $0.03/hr CPU Upgrade, free ZeroGPU shared pool, then
+      hourly T4 / L4 / A100 tiers
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 42b3bdf9e77f964b2105c7ad07a58ba79d6bd24428e066a5668239d7f0486650

--- a/sources/scores/tensorlake-sandbox.yaml
+++ b/sources/scores/tensorlake-sandbox.yaml
@@ -103,15 +103,32 @@ capability:
     sandboxes; persistence:snapshot/suspend/resume + durable-execution orchestration; scale:reported thousands
     of concurrent sandboxes
   confidence: medium
-  note: Firecracker microVM isolation plus durable-execution orchestration and snapshot/resume make for
+  note: 'Firecracker microVM isolation plus durable-execution orchestration and snapshot/resume make for
     a rich agent-runtime feature set, level with the microVM peers. Independent ComputeSDK TTI benchmarks
     measure ~460ms median cold-start (12th of 19 sandbox providers), mid-pack and consistent with the
-    sub-second claim.
+    sub-second claim. NOT VERIFIED ON 2026-08-13 - deliberately left undated and escalated, because the
+    benchmark half of this band no longer reads as recorded. The ComputeSDK leaderboard has re-run since
+    (last run 7 August 2026) and now covers 24 providers. Tensorlake reads 1.35s median time-to-interactive,
+    1.44s P95, 1.44s P99, composite 86.1, 15th of 24 - not ~460ms and not 12th of 19. That is roughly
+    three times the recorded figure and it contradicts the "cold-start - sub-second" clause in the value
+    string above, which was the measured half of a band otherwise resting on feature breadth. Note also
+    that 460ms is the number the vendor site itself animates in its demo, so the earlier record may have
+    read the vendor claim and the leaderboard as agreeing when only one of them was measured. The feature
+    half does still hold - tensorlake.ai still leads on Firecracker isolation with each tool call and
+    harness in its own microVM, snapshots with pause/fork/resume, versioned mountable volumes, durable
+    serverless functions with queues, timers and retries, and cloud dev boxes. Whether a 1.35s
+    time-to-interactive should pull this off 4 is a score decision and is not being taken here.'
   sources:
   - url: https://www.tensorlake.ai/
     shows: Firecracker microVM sandboxes, snapshot/suspend/resume, durable execution, scale to thousands
-    accessed: '2026-07-09'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 7522474f25c2864dae63f26e180926d421d634994f2ba2b3f4405d4882578456
   - url: https://www.computesdk.com/benchmarks/sandboxes/
-    shows: 'ComputeSDK TTI leaderboard (independent, 100 iters/day, 2026-07-09 run): median time-to-interactive
-      ~460ms sequential / ~960ms burst @100 concurrent; 12th of 19 providers'
-    accessed: '2026-07-09'
+    shows: 'ComputeSDK TTI leaderboard, independent, 100 iterations per run, last run 7 August 2026, 24
+      providers on 4 vCPU / 16GB in Northern Virginia. Tensorlake records 1.35s median, 1.44s P95, 1.44s
+      P99, 100% success, composite 86.1, ranking 15th of 24 by composite score. The previously cited
+      ~460ms / 12th of 19 reading is not on the page.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: ec3f48b2ca3c1877605154422671c020935c0bfebdfc9aff268d06799ae865f7

--- a/sources/scores/vercel-sandbox.yaml
+++ b/sources/scores/vercel-sandbox.yaml
@@ -21,14 +21,38 @@ openness:
   note: 'Closed managed service. The SDK/CLI are open, but they are only a client for Vercel''s proprietary
     microVM cloud, which cannot be self-hosted; an open client over a closed runtime is not open_core (the
     core is proprietary). Reclassified from open_core; sits with the other proprietary sandbox clouds (Google
-    Cloud Run, Fly Sprites, Northflank).'
+    Cloud Run, Fly Sprites, Northflank). Re-read 2026-08-13 - the docs still place every sandbox in a
+    Firecracker microVM on Vercel''s own infrastructure, reached only through Vercel OIDC tokens or
+    Vercel access tokens, and the pricing and quotas page meters the product across Hobby, Pro and
+    Enterprise plans with no self-hosted or source-available option at any of them. Source and license
+    both read as recorded.'
   raw: source:closed;service:proprietary Vercel Fluid-compute managed cloud (no self-host of the Firecracker
     microVM plane);open-part:client SDK/CLI only (@vercel/sandbox JS + Python, vercel/sandbox on GitHub);license:Proprietary,
     proprietary service
+  last_verified: '2026-08-13'
   sources:
   - url: https://vercel.com/docs/sandbox
     shows: Firecracker microVM isolation; SDK/CLI on GitHub vercel/sandbox; managed Vercel cloud, pay-for-active-CPU
     accessed: '2026-06-04'
+  - url: https://vercel.com/docs/sandbox
+    shows: 'Each sandbox runs in a Firecracker microVM on Vercel; authentication is by Vercel OIDC
+      token or Vercel access token; images come from Vercel Managed Images or the Vercel Container
+      Registry. Only the SDKs and CLI are pointed at GitHub - the runtime itself is not distributed.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: ef69310b3232ecb49c4b22f28faa447ab75449570f53695e3f0e5665e9c6f36c
+    establishes:
+    - source
+  - url: https://vercel.com/docs/sandbox/pricing
+    shows: 'Usage metered on Hobby, Pro and Enterprise plans across active CPU, provisioned memory,
+      sandbox creations, data transfer and snapshot storage. No self-hosted, on-premises or
+      source-available tier appears anywhere on the page.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6f67c48d77bef2d130322d7f4c16d252204c3e968d9a8f629f74ad971ba766c1
+    establishes:
+    - source
+    - license
 adoption:
   level: 4
   reach: 1M-10M

--- a/sources/scores/webcontainers.yaml
+++ b/sources/scores/webcontainers.yaml
@@ -25,18 +25,37 @@ openness:
   confidence: high
   note: The MIT 'open' repo holds no implementation; the runtime is closed and gated by a commercial
     license for production use. Best classed source_available leaning closed; flag open_washed for the
-    MIT-issue-tracker-as-open source framing.
+    MIT-issue-tracker-as-open source framing. Re-read 2026-08-13 - stackblitz/webcontainer-core is still
+    MIT and still holds no runtime implementation, its last push predating this check by well over a year,
+    and the WebContainer enterprise licensing page still states that prototypes and proofs of concept need
+    no commercial license while production use in a commercial, for-profit setting does. That page no longer
+    states the 10k-requests-per-month threshold the recorded detail cites.
   raw: source:partial;public-repo:webcontainer-core is MIT but issue-tracker only (no runtime source);actual-runtime:proprietary(StackBlitz);license-terms:Proprietary,
     free for OSS/prototypes, commercial license required for for-profit production(charge beyond 10k API
     req/mo);distribution:@webcontainer/api npm (proprietary binary)
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/stackblitz/webcontainer-core
     shows: MIT repo is a central hub for issues/bug reports, not the runtime implementation
-    accessed: '2026-06-04'
-  - url: https://www.npmjs.com/package/@webcontainer/api
-    shows: WebContainer API distributed as npm package; commercial license required for for-profit production
-      use (free for OSS/POC, charge beyond 10k req/mo)
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: ce5ff93731e216464b087350af07f7dd155ce5e4b8ae9188f88dedc7d5c14518
+    establishes: [source]
+  - url: https://registry.npmjs.org/@webcontainer/api
+    shows: '@webcontainer/api is the published client package for the runtime, pointing back at stackblitz/webcontainer-core;
+      the package manifest carries MIT while the runtime it calls is a StackBlitz-hosted service'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d14b05851da03cc3ae27e09ec5143439740b9debb99d09233e1f903faf9fd366
+    establishes: [source]
+  - url: https://webcontainers.io/enterprise
+    shows: prototypes and proofs of concept require no commercial license, but production use of the API
+      in a commercial for-profit setting does, and access may be revoked for use in violation of those
+      terms; no request-count threshold is stated
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 40ef1df1874e3ea160f0facfcfca4e2179de739cbd7ac86efdfa00f6779b1d6d
+    establishes: [license-terms]
 adoption:
   level: 3
   signal_type: reported_traction
@@ -44,11 +63,18 @@ adoption:
   note: Powers StackBlitz's own IDE and is embedded by named projects (SvelteKit, Astro, Scrimba, egghead.io,
     Xata) for in-browser code experiences. No disclosed download/MAU figure on the primary pages; placed
     at 3 on named-integration reported traction. No hard usage_volume number found, so confidence low.
+    Re-read 2026-08-13 - webcontainers.io still names the same integrations and adds Suborbital, re-tune
+    and Touchy Studios, and still publishes no download, user or session figure. The npm client package
+    does carry a countable download series, which is a candidate signal the record does not currently use;
+    it is left as reported_traction pending a ruling on whether npm is the product primary channel.
+  last_verified: '2026-08-13'
   sources:
   - url: https://webcontainers.io/
-    shows: WebContainers used by SvelteKit, Astro, Scrimba, egghead.io, Xata (named integrations); no
-      quantitative usage figure
-    accessed: '2026-06-04'
+    shows: WebContainers used by SvelteKit, Astro, Scrimba, egghead.io, Xata, Suborbital, re-tune and
+      Touchy Studios (named integrations); no quantitative usage figure
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9b41968dec5ce3c459e6f6cf23a757f6db3d3b9b9d12169a6da573f12d8358df
 capability:
   score: 3
   basis: feature_matrix
@@ -59,8 +85,14 @@ capability:
   confidence: medium
   note: Unique in-browser execution with instant start and zero server cost, but Node/JS-only and not
     a general-purpose server-side code sandbox for arbitrary languages, a different (narrower) capability
-    profile than microVM/container peers. Mid-tier within deployment.
+    profile than microVM/container peers. Mid-tier within deployment. Re-read 2026-08-13 - webcontainers.io
+    still claims native npm, pnpm and yarn running in the browser up to 10x faster than local, support in
+    all major browsers, disposable environments for any modern framework, and Wasm out of the box, with
+    nothing added that would broaden it toward general server-side execution.
+  last_verified: '2026-08-13'
   sources:
   - url: https://webcontainers.io/
     shows: runs Node.js/npm and WASM fully in-browser, 'up to 10x faster than local', any modern framework
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9b41968dec5ce3c459e6f6cf23a757f6db3d3b9b9d12169a6da573f12d8358df


### PR DESCRIPTION
**90 of 99 checkpoints closed**, 20 of 27 products fully verified. The nine refusals are the interesting part and are listed below — each is a finding, not an omission.

Anchors first: `firecracker`, `aws-lambda`, `ray` re-read and dated before their three dependents. Three prose comparisons recorded structurally (`gvisor` `at`, `kata-containers` `one_below`, `beta9` `two_below`, all against firecracker).

`aws-lambda` has shipped **Lambda MicroVMs**, "purpose-built for workloads that execute user- or AI-generated code", and the FAQ now states **15 trillion+ monthly invocations** against the 2018 post's "trillions".

## Nine axes refused, not dated

| axis | why |
|---|---|
| `daytona-sandbox` adoption | PyPI 10,089,811/mo crosses the level-5 floor by 0.9%; recorded 4 |
| `daytona-sandbox` capability | evidence gone — cited repo is a README stub; ComputeSDK rerun shows 1.97s median vs ~140ms cited |
| `vercel-sandbox` adoption | npm 13,197,882/mo against a `1M-10M` label |
| `vercel-sandbox` capability | the stated reason for holding it below Lambda has gone — docs now say any Linux distro, custom OCI images, 24h/10,000 concurrent vs the record's "up to 45min" |
| `cloudflare-sandboxes` adoption | npm 1,136,848/mo against a `100K-1M` label |
| `sandbox-runtime` adoption | npm 1,000,104/mo against a `10K-100K` label — two bands off |
| `opensandbox` capability | **understated** — gVisor plus three Kata configs are documented runtimes; record says "container, not VM/microVM" |
| `tensorlake-sandbox` capability | cited leaderboard figure contradicted ~3x by the 2026-08-07 rerun |
| `replit-agent-code-execution-api` capability | Replit 403s all automated fetches; everything except the `~100ms` figure re-derived from the GitHub README |

**I have deliberately not applied these.** Most are level moves on npm/PyPI figures, and npm is unbridged — before moving a band on one, someone should confirm the package is the product's *primary* channel rather than a widely-depended-on shim. That check is what stopped `gvisor` from dropping 5 → 1 this morning.

## Also worth a ruling

**`spaces` declares `gradio-app/gradio` as its GitHub artifact** — and `gradio` is a separate product on the map. That is over-attribution by construction. Recommend refusing or re-pointing it.

**Seven products record `usage_volume` with nothing any signal model reads**: `aws-lambda`, `firecracker`, `gvisor`, `google-cloud-run`, `spaces`, `ollama`, `replit`. Nothing was relabelled and no artifact invented — all now pass `check_instrument` via the digested-source branch, with the caveat written into each note. `google-cloud-run` and `replit` are the clearest `reported_traction` candidates: both rest on vendor prose ("developers doubled", "over 1 million live projects"), not counts.

**`gvisor` PyPI stayed undeclared**, as instructed — and its real adoption evidence turned out stronger anyway: gvisor.dev/users states "millions of gVisor sandbox instances running daily" and names Anthropic, Cloudflare, DigitalOcean, Ant Group, Modal.

**The ComputeSDK leaderboard was rerun** on 2026-08-07 (24 providers vs 19). Every capability note in this category cited the old run; all re-derived, only tensorlake's band contradicted.

## Digest audit

The pass re-fetched all 41 distinct stable-host digests it had recorded: **32 matched byte-for-byte**. All nine mismatches are `api.github.com` star counters plus one README whose repo took a commit at 17:33 UTC today, after the fetch. No fabrication.

All gates green: `validate` 0 errors, `check_verification` all three OK, `check_capability` OK, `check_adoption --strict` exit 0, 488 tests.