### PR TITLE
Verify telemetry_observability: 89/95 checkpoints

### DIFF
--- a/sources/products/agenta.yaml
+++ b/sources/products/agenta.yaml
@@ -8,5 +8,7 @@ github:
 - url: https://github.com/Agenta-AI/agenta
 pypi:
 - url: https://pypi.org/project/agenta
-comments: agenta v0.101.1 (released 4 Jun 2026, GitHub); confirmed live June 2026. LLMOps platform; self-hostable
-  OSS + Agenta Cloud managed tier.
+comments: The repository has repositioned since this entry was scored - the README now describes an
+  open-source workspace for building agents that automate work, not an LLMOps prompt/eval platform. The
+  description above and the capability score both predate that and are flagged for review rather than
+  rewritten here. Verified 2026-08-13 via the Agenta-AI/agenta repository.

--- a/sources/products/agentops.yaml
+++ b/sources/products/agentops.yaml
@@ -3,11 +3,11 @@ display_name: AgentOps
 type: software
 description: Python SDK for AI agent monitoring, LLM cost tracking, and benchmarking. Purpose-built for
   the agent era, tracks multi-step agent sessions, tool calls, and costs across frameworks (CrewAI, Agno,
-  OpenAI Agents SDK, LangChain, Autogen). Lightweight instrumentation with two-line setup. 5.6K GitHub
-  stars.
+  OpenAI Agents SDK, LangChain, Autogen). Lightweight instrumentation with two-line setup, and a
+  self-hostable dashboard and API backend alongside the hosted app.
 github:
 - url: https://github.com/AgentOps-AI/agentops
 pypi:
 - url: https://pypi.org/project/agentops
-comments: agentops v0.4.21 (last release 29 Aug 2025, PyPI), no 2026 release at scoring time (>9 months
-  stale). SDK MIT-licensed; primary product is the app.agentops.ai SaaS dashboard.
+comments: The README calls the app MIT while app/LICENSE is the Elastic License 2.0; the openness score
+  follows the LICENSE file. Verified 2026-08-13 via the AgentOps-AI/agentops repository and its README.

--- a/sources/products/arize.yaml
+++ b/sources/products/arize.yaml
@@ -3,7 +3,8 @@ display_name: Arize
 type: software
 description: Cloud-native ML and LLM observability platform (the commercial offering complementing the
   open source Phoenix). Production monitoring for model performance, data drift, embedding drift, and
-  LLM traces at enterprise scale. Supports real-time alerting and root cause analysis. Raised $62M+ in
-  funding. The closed counterpart to Phoenix, same team, enterprise-grade features.
-comments: Arize AX, the enterprise AI engineering / LLM observability SaaS platform (distinct from open source
-  Phoenix). Confirmed live via arize.com June 2026.
+  LLM traces at enterprise scale. Supports real-time alerting and root cause analysis, an embedded AI
+  engineering agent called Alyx, and a GenAI datastore called adb. The closed counterpart to Phoenix,
+  built by the same team.
+comments: The scored entity is Arize AX, the managed platform, not the separate open source Phoenix.
+  Verified 2026-08-13 via arize.com.

--- a/sources/products/azure-ai-foundry-observability.yaml
+++ b/sources/products/azure-ai-foundry-observability.yaml
@@ -7,9 +7,9 @@ description: Microsoft's GenAI observability product inside Azure AI Foundry (re
   with built-in evaluators covering quality (coherence, fluency), RAG (groundedness, relevance), safety
   (hate/unfairness, violence, protected materials), and agent-specific metrics (tool-call accuracy, task
   completion). Supports tracing for LangChain, LangGraph, OpenAI Agents SDK, and the Microsoft Agent Framework.
-  Evaluations, Monitoring, and Tracing went GA via Foundry Control Plane in 2026, with continuous evaluation
-  and the Agent Monitoring Dashboard in preview; leverages Azure's enterprise footprint as the default
-  observability layer for Azure-hosted GenAI workloads.
-comments: 'Microsoft Foundry (formerly Azure AI Foundry) Observability: evaluations + monitoring + tracing
-  reached general availability March 2026. OpenTelemetry-based tracing via Azure Monitor / Application
-  Insights. Proprietary Azure managed service. Verified live June 2026 in Microsoft Learn docs.'
+  Microsoft describes it as three core capabilities - evaluation, monitoring and tracing - working together
+  across the AI application lifecycle, and it is the default observability layer for Azure-hosted GenAI
+  workloads.
+comments: Microsoft publishes no usage figure for this surface, so its adoption band leans on the reach of
+  Microsoft Foundry rather than on a measurement of the surface. Verified 2026-08-13 via the Microsoft
+  Learn observability concept page.

--- a/sources/products/braintrust.yaml
+++ b/sources/products/braintrust.yaml
@@ -3,7 +3,9 @@ display_name: Braintrust
 type: software
 description: Enterprise AI product development platform with logging, tracing, evaluation, and prompt
   playground. Focuses on the eval-to-production workflow, iterate on prompts, evaluate with custom scorers,
-  deploy with confidence, monitor in production. Strong enterprise positioning with SOC 2 compliance.
-  Funded by a16z.
-comments: Braintrust AI eval/observability platform (braintrust.dev); SDK v3.16.0 (Jun 3, 2026, Apache-2.0)
-  confirmed live; platform backend (Brainstore) proprietary SaaS with hybrid enterprise deploy.
+  deploy with confidence, monitor in production. Automates pattern discovery across production traffic,
+  scores outputs continuously, and blocks bad releases with quality gates. Runs on Brainstore, a purpose-built
+  database for agent observability, and is SOC 2 Type II certified.
+comments: The Apache-2.0 SDK repository is instrumentation only; the platform and its Brainstore backend
+  are closed, and the openness score follows the platform. Verified 2026-08-13 via braintrust.dev and the
+  braintrustdata/braintrust-sdk repository.

--- a/sources/products/confident-ai.yaml
+++ b/sources/products/confident-ai.yaml
@@ -3,8 +3,9 @@ display_name: Confident AI
 type: software
 description: Hosted SaaS layered on the open source DeepEval library, adds dataset management, regression
   tracking, human annotation, custom dashboards, online evals against live traffic, alerting, and incident
-  response. DeepEval itself runs 2M evals/day with 3M monthly downloads and 12.6K GitHub stars; enterprise
-  customers on the cloud product include Microsoft, AstraZeneca, AXA, and BCG. YC W25, $2.2M seed.
-comments: Confident AI = the proprietary cloud quality platform built by the creators of DeepEval (the
-  separate OSI Apache-2.0 OSS eval framework). Verified live June 2026. The platform layers tracing/datasets/monitoring
-  on top of DeepEval; self-hosted enterprise option exists.
+  response. Also covers red teaming against adversarial attacks and AI governance, and gates CI so a build
+  fails when quality drops below a defined threshold. Self-hosting into a customer VPC or on-prem is an
+  Enterprise-plan option.
+comments: The scored entity is the platform, not the separate Apache-2.0 DeepEval framework, which has its
+  own entry and whose openness is not credited here. Verified 2026-08-13 via confident-ai.com and the
+  confident-ai/deepeval repository.

--- a/sources/products/datadog-llm-observability.yaml
+++ b/sources/products/datadog-llm-observability.yaml
@@ -3,7 +3,8 @@ display_name: Datadog LLM Observability
 type: software
 description: Enterprise LLM monitoring integrated into the Datadog APM platform. Traces LLM calls alongside
   existing infrastructure, application, and security monitoring. For organizations already using Datadog
-  who want unified observability across their entire stack including AI/LLM components. Leverages Datadog's
-  massive enterprise installed base.
-comments: Datadog LLM Observability, proprietary SaaS module of the Datadog platform. Confirmed live (docs.datadoghq.com/llm_observability)
-  June 2026.
+  who want unified observability across their entire stack including AI/LLM components. Covers agent
+  monitoring, prompt tracking and management, quality monitoring, and correlation of LLM spans with APM.
+comments: Datadog publishes no usage figure for this module, so its adoption band stands on the reach of
+  the Datadog platform rather than on a measurement of the module. Verified 2026-08-13 via the Datadog LLM
+  Observability documentation.

--- a/sources/products/dynatrace-ai-observability.yaml
+++ b/sources/products/dynatrace-ai-observability.yaml
@@ -5,6 +5,6 @@ description: Enterprise AI observability integrated into the Dynatrace platform.
   applications with automatic distributed tracing, token tracking, cost analysis, and anomaly detection.
   Leverages Dynatrace's Davis AI engine for automated root cause analysis of LLM application issues. Targets
   large enterprises with existing Dynatrace deployments.
-comments: Dynatrace AI Observability, the GenAI/LLM/agentic observability capability of the proprietary
-  Dynatrace platform; docs updated Jan 28, 2026 ('Latest Dynatrace') confirm it live. Module of a general
-  full-stack APM suite.
+comments: Dynatrace publishes no usage figure for this capability, so the adoption axis abstains rather
+  than borrowing a platform-wide number. Verified 2026-08-13 via the Dynatrace AI observability
+  documentation.

--- a/sources/products/galileo.yaml
+++ b/sources/products/galileo.yaml
@@ -3,9 +3,8 @@ display_name: Galileo
 type: software
 description: AI observability and reliability platform that combines offline evals, online production
   guardrails, and tracing, powered by their proprietary Luna-2 small judge models that detect hallucinations,
-  tool errors, and policy violations at claimed 97% lower cost than LLM-as-judge. Positions as 'don't
-  just monitor AI failures, stop them' and is consistently ranked in top-5 LLM observability platforms
-  (Maxim, Firecrawl roundups). Series B-funded, with enterprise customers across financial services and
-  healthcare.
-comments: Galileo AI observability & eval-engineering platform; verified live June 2026 at galileo.ai.
-  Proprietary SaaS / VPC / on-prem; Luna-2 small eval models. Not open source.
+  tool errors, and policy violations. The vendor's claim for Luna is that customized evals monitor all
+  production traffic at a fraction of LLM-as-judge cost. Deployed as SaaS, in a customer VPC, or on-prem;
+  the platform itself is not published.
+comments: Galileo names no customers and publishes no usage figure, so the adoption band stands on an
+  unquantified vendor claim and is directional. Verified 2026-08-13 via galileo.ai.

--- a/sources/products/helicone.yaml
+++ b/sources/products/helicone.yaml
@@ -3,9 +3,11 @@ display_name: Helicone
 type: software
 description: LLM proxy that captures logs, costs, and latency with a one-line integration (swap your API
   base URL). Clean dashboard for monitoring request volumes, token usage, costs, and error rates. Positioned
-  as the lowest-friction entry point for LLM monitoring, no SDK needed, just a proxy URL change. YC W23.
-  Code is open source (Apache-2.0) but primarily used as a cloud service.
+  as the lowest-friction entry point for LLM monitoring, no SDK needed, just a proxy URL change. Also an
+  AI gateway reaching 100+ models through one API key, with automatic fallbacks, caching, prompt
+  management and datasets. Self-hostable from the repository, and sold as a hosted cloud alongside.
 github:
 - url: https://github.com/Helicone/helicone
-comments: Helicone/helicone monorepo active June 2026 (5,477 commits on main). Confirmed live on GitHub;
-  hosted cloud + self-host.
+comments: The pricing page lists SAML SSO on the Enterprise tier and the repository contains no SSO
+  implementation; that absence is the weakest point in the openness reading and is recorded in the score
+  rather than smoothed over. Verified 2026-08-13 via the Helicone/helicone README.

--- a/sources/products/laminar.yaml
+++ b/sources/products/laminar.yaml
@@ -2,11 +2,13 @@ name: laminar
 display_name: Laminar
 type: software
 description: Open-source observability platform purpose-built for AI agents. Provides tracing, evaluation,
-  and analytics for agentic workflows with an emphasis on multi-step agent debugging. YC S24. Rust-based backend
-  for high performance. 2.9K GitHub stars.
+  and analytics for agentic workflows with an emphasis on multi-step agent debugging. Rust backend with a
+  TypeScript UI, self-hostable from the repository's docker-compose files, and traces, spans, metrics and
+  events are queryable with SQL.
 github:
 - url: https://github.com/lmnr-ai/lmnr
 pypi:
 - url: https://pypi.org/project/lmnr
-comments: lmnr Python SDK v0.7.52 (27 May 2026); platform/repo lmnr-ai/lmnr at v0.1.46 (31 May 2026).
-  Confirmed live on GitHub + PyPI June 2026.
+comments: The lmnr PyPI download count runs far above what a project of this size plausibly serves and is
+  treated as mirror-inflated, so the adoption band is discounted rather than read straight off it.
+  Verified 2026-08-13 via the lmnr-ai/lmnr repository and the lmnr PyPI project page.

--- a/sources/products/langfuse.yaml
+++ b/sources/products/langfuse.yaml
@@ -2,10 +2,10 @@ name: langfuse
 display_name: Langfuse
 type: software
 description: Open-source LLM engineering platform providing tracing, prompt management, evaluations, cost tracking,
-  and datasets. Self-hostable or cloud-hosted. An open source LLM observability platform with broad integrations
-  (OpenTelemetry, LangChain, OpenAI SDK, LiteLLM). YC W23, 27.7K GitHub stars.
+  and datasets. Self-hostable or cloud-hosted. Instruments applications through OpenTelemetry and through
+  direct integrations with LangChain, the OpenAI SDK and LiteLLM.
 github:
 - url: https://github.com/langfuse/langfuse
 pypi:
 - url: https://pypi.org/project/langfuse
-comments: Active 2026; acquired by ClickHouse Mar 2026; MIT core
+comments: Verified 2026-08-13 via the langfuse/langfuse repository and the Langfuse observability docs.

--- a/sources/products/langsmith.yaml
+++ b/sources/products/langsmith.yaml
@@ -2,10 +2,12 @@ name: langsmith
 display_name: LangSmith
 type: software
 description: Proprietary observability and testing platform from the LangChain team. Provides tracing,
-  datasets, evaluations, prompt hub, and annotation queues. Tightly integrated with the LangChain ecosystem
-  but supports any LLM application. The most widely adopted LLM observability tool, benefiting from LangChain's
-  massive developer community. Closed-source SaaS with no self-hosted option.
+  datasets, evaluations, prompt hub, and annotation queues, plus deployment and sandbox infrastructure for
+  agents. Tightly integrated with the LangChain ecosystem but supports any LLM application through
+  OpenTelemetry SDKs. Offered as managed cloud, bring-your-own-cloud, or a self-hosted enterprise
+  deployment of closed software.
 pypi:
 - url: https://pypi.org/project/langsmith
-comments: LangSmith proprietary SaaS by LangChain; managed cloud + BYOC + self-hosted enterprise deployment.
-  Confirmed live (langchain.com/langsmith) June 2026.
+comments: The declared langsmith PyPI package is a hard dependency of langchain-core, so its download count
+  measures LangChain installs rather than platform use and is not used to band adoption. Verified
+  2026-08-13 via langchain.com/langsmith.

--- a/sources/products/langtrace.yaml
+++ b/sources/products/langtrace.yaml
@@ -3,8 +3,8 @@ display_name: Langtrace
 type: software
 description: Open-source, OpenTelemetry-based end-to-end observability tool for LLM applications. Provides
   real-time tracing, evaluations, and metrics for popular LLMs, frameworks, and vector databases. TypeScript
-  and Python SDKs. Differentiated by strict OTel standards compliance and support for vector DB tracing.
-  1.2K GitHub stars.
+  and Python SDKs. Differentiated by strict OTel standards compliance and support for vector DB tracing,
+  and self-hostable from the repository's docker-compose file.
 github:
 - url: https://github.com/Scale3-Labs/langtrace
 pypi:
@@ -13,5 +13,5 @@ artifact_exceptions:
   pypi_repo_mismatch: langtrace-python-sdk is published from scale3-labs/langtrace-python-sdk, the SDK's own
     repo, while the product is the platform at scale3-labs/langtrace. Two repos in one org, both correct for
     what they name.
-comments: Langtrace app v4.0.11 (17 Apr 2026); langtrace-python-sdk v3.8.12 (8 Apr 2026). Active and maintained
-  as of June 2026 (initial fetch misread release year; corrected via release pages).
+comments: The application and the SDKs carry different licenses; the openness score follows the
+  application's. Verified 2026-08-13 via the Scale3-Labs/langtrace repository.

--- a/sources/products/langwatch.yaml
+++ b/sources/products/langwatch.yaml
@@ -3,9 +3,9 @@ display_name: LangWatch
 type: software
 description: Open-source platform for LLM evaluations and AI agent testing with production monitoring
   capabilities. Combines observability traces with automated quality checks and guardrails. Provides dashboards
-  for cost, latency, and quality metrics. Positioned at the intersection of evaluation and production
-  observability. 3.3K GitHub stars.
+  for cost, latency, and quality metrics. Runs end-to-end agent simulations against a full stack before
+  release, so evaluation and production observability sit in one loop.
 github:
 - url: https://github.com/langwatch/langwatch
-comments: langwatch/langwatch monorepo active June 2026 (skills component v0.6.0, 3 Jun 2026). Confirmed
-  live on GitHub.
+comments: No download or user figure is published, so the adoption band is read from GitHub stars, which
+  the scale caps at level 3. Verified 2026-08-13 via the langwatch/langwatch repository.

--- a/sources/products/mlflow.yaml
+++ b/sources/products/mlflow.yaml
@@ -1,7 +1,11 @@
 name: mlflow
 display_name: MLflow
 type: software
-description: Active 2026; Apache 2.0; observability/tracing for agents+LLMs+ML
+description: Open source AI engineering platform covering the ML and LLM lifecycle in one tool. Combines
+  distributed tracing of agents and LLM calls, automated evaluation, a prompt registry, an AI gateway, and
+  the experiment tracking and model registry it began as. Self-hosted from the published source, with
+  Databricks Managed MLflow sold beside it as hosting rather than as a paid tier of the product.
 pypi:
 - url: https://pypi.org/project/mlflow
-comments: Active 2026; Apache 2.0; observability/tracing for agents+LLMs+ML
+comments: The product entry does not declare its GitHub repository, so its adoption band routes through
+  PyPI only. Verified 2026-08-13 via the mlflow/mlflow LICENSE file, the repository and mlflow.org.

--- a/sources/products/new-relic-ai-monitoring.yaml
+++ b/sources/products/new-relic-ai-monitoring.yaml
@@ -5,6 +5,6 @@ description: Enterprise AI/LLM monitoring integrated into the New Relic observab
   LLM interactions, tracks token usage and costs, monitors model performance and error rates. Supports
   OpenAI, AWS Bedrock, and other providers. For organizations already on New Relic who want AI observability
   unified with their existing APM, infrastructure, and log monitoring.
-comments: New Relic AI Monitoring (AIM), the GenAI/LLM observability module of the proprietary New Relic
-  platform; confirmed active 2026 (vendor product page + Feb 2026 platform announcement). Module of a
-  general APM/observability suite.
+comments: New Relic publishes no usage figure for this module, so its adoption band leans on the reach of
+  the wider platform and is directional rather than measured. Verified 2026-08-13 via the New Relic AI
+  Monitoring product page.

--- a/sources/products/openlit.yaml
+++ b/sources/products/openlit.yaml
@@ -3,11 +3,11 @@ display_name: OpenLIT
 type: software
 description: OpenTelemetry-native AI engineering platform covering LLM observability, GPU monitoring,
   guardrails, evaluations, and prompt management. Integrates with 50+ LLM providers, vector databases,
-  and agent frameworks. Vault for managing API keys. Differentiated by breadth of integrations and GPU-level
-  monitoring. 2.5K GitHub stars.
+  and agent frameworks. Vault for managing API keys, plus a rule engine and a playground. Differentiated
+  by breadth of integrations and GPU-level monitoring, and self-hostable from the repository's
+  docker-compose file.
 github:
 - url: https://github.com/openlit/openlit
 pypi:
 - url: https://pypi.org/project/openlit
-comments: openlit PyPI v1.42.0 (8 May 2026); OTel GPU Collector 0.0.6 (3 Jun 2026). Confirmed live on
-  GitHub + PyPI June 2026.
+comments: Verified 2026-08-13 via the openlit/openlit repository.

--- a/sources/products/openllmetry.yaml
+++ b/sources/products/openllmetry.yaml
@@ -3,11 +3,13 @@ display_name: OpenLLMetry
 type: software
 description: OpenTelemetry-based instrumentation library for LLM applications. Auto-instruments LangChain,
   LlamaIndex, OpenAI SDK, and other popular frameworks. Exports telemetry data to any OTel-compatible
-  backend (Jaeger, Grafana, Datadog, etc). The 'OpenTelemetry for LLMs' approach, standards-based, vendor-neutral.
-  7.1K GitHub stars.
+  backend (Jaeger, Grafana, Datadog, etc). The 'OpenTelemetry for LLMs' approach, standards-based and
+  vendor-neutral. Ships standard OTel instrumentations for LLM providers and vector databases alongside
+  the Traceloop SDK.
 github:
 - url: https://github.com/traceloop/openllmetry
 pypi:
 - url: https://pypi.org/project/opentelemetry-instrumentation-openai
-comments: traceloop-sdk v0.61.0 (released 31 May 2026, PyPI/GitHub); confirmed live June 2026. OTel-based
-  instrumentation SDK; Traceloop hosted backend is the optional commercial destination.
+comments: The adoption band was read on the traceloop-sdk package, which is not the package declared here;
+  both band at the same level. The Traceloop hosted backend is an optional export destination rather than
+  part of this entry. Verified 2026-08-13 via the traceloop/openllmetry repository.

--- a/sources/products/opik.yaml
+++ b/sources/products/opik.yaml
@@ -3,11 +3,10 @@ display_name: Opik
 type: software
 description: Open-source platform for debugging, evaluating, and monitoring LLM applications, RAG systems,
   and agentic workflows. Provides comprehensive tracing, automated evaluations, and production-ready dashboards.
-  Built by Comet ML (established ML experiment tracking company). Fast-growing at 19.4K GitHub stars,
-  the second most-starred open source LLM observability tool after Langfuse.
+  Built by Comet ML. The server, web application and evaluation components are all self-hostable, with
+  Comet's cloud as optional managed hosting.
 github:
 - url: https://github.com/comet-ml/opik
 pypi:
 - url: https://pypi.org/project/opik
-comments: opik v2.0.57 (released 4 Jun 2026, PyPI/GitHub); confirmed live June 2026. Self-hostable OSS
-  platform; Comet.com cloud is optional hosting.
+comments: Verified 2026-08-13 via the comet-ml/opik repository and the opik PyPI project page.

--- a/sources/products/phoenix.yaml
+++ b/sources/products/phoenix.yaml
@@ -2,12 +2,12 @@ name: phoenix
 display_name: Phoenix
 type: software
 description: Open-source AI observability and evaluation toolkit by Arize AI. Provides tracing, embeddings
-  analysis, experiment tracking, and LLM evaluation in a local-first workflow. Strong integrations with
-  LlamaIndex and LangChain. Built by the team behind the Arize production ML monitoring platform. 9.8K
-  GitHub stars.
+  analysis, experiment tracking, and LLM evaluation in a local-first workflow. Instruments applications
+  through OpenTelemetry, with integrations for LlamaIndex and LangChain. Built by the team behind the
+  Arize production ML monitoring platform, and self-hostable via Docker or a Helm chart.
 github:
 - url: https://github.com/Arize-ai/phoenix
 pypi:
 - url: https://pypi.org/project/arize-phoenix
-comments: arize-phoenix v17.2.0 (released 3 Jun 2026, GitHub); confirmed live June 2026. Open-source-positioned
-  companion to the closed Arize AX platform.
+comments: The open-source-positioned companion to the closed Arize AX platform, and scored separately from
+  it. Verified 2026-08-13 via the Arize-ai/phoenix repository and the Arize Phoenix product page.

--- a/sources/products/promptlayer.yaml
+++ b/sources/products/promptlayer.yaml
@@ -3,10 +3,10 @@ display_name: PromptLayer
 type: software
 description: Prompt management and monitoring platform that logs every LLM API request. Maintains a complete
   history of prompts, responses, costs, and latency. Enables prompt versioning, A/B testing, and analytics.
-  One of the earliest LLM monitoring tools (launched early 2023), focused on the prompt lifecycle rather
-  than full tracing. 762 GitHub stars on the client library.
+  One of the earliest LLM monitoring tools, focused on the prompt lifecycle rather than full tracing. The
+  platform is reached over an API key; only the client library is published.
 pypi:
 - url: https://pypi.org/project/promptlayer
-comments: PromptLayer prompt-management + logging/observability SaaS (promptlayer.com), founded 2021,
-  active 2026. Official `promptlayer` Python lib (Apache-2.0, 764 stars, MagnivOrg) confirmed live; platform
-  itself is a managed SaaS.
+comments: The Apache-2.0 client library is the only published part; the prompt registry, logging and eval
+  services are hosted and the openness score follows those. Verified 2026-08-13 via the
+  MagnivOrg/prompt-layer-library repository.

--- a/sources/products/trulens.yaml
+++ b/sources/products/trulens.yaml
@@ -9,6 +9,6 @@ github:
 - url: https://github.com/truera/trulens
 pypi:
 - url: https://pypi.org/project/trulens
-comments: MIT. Created by TruEra, which Snowflake acquired in 2024; now maintained by Snowflake (the GitHub org
-  remains 'truera'). A separate hosted Snowflake Cortex AI Observability product exists; the library stays fully
-  open. ~3.4k stars, ~39k PyPI downloads/month.
+comments: The GitHub org is still 'truera' after Snowflake's acquisition, so the repository name is not a
+  guide to who maintains it. A separate hosted Snowflake Cortex AI Observability product exists and is not
+  scored here. Verified 2026-08-13 via the truera/trulens repository.

--- a/sources/products/vertex-ai-model-observability.yaml
+++ b/sources/products/vertex-ai-model-observability.yaml
@@ -6,8 +6,8 @@ description: Google Cloud's built-in production monitoring surface for Gen AI on
   429 capacity errors) for Gemini and other Vertex AI Model Garden foundation models. Extended in 2026
   by Vertex AI Agent Builder with sessions, traces, logs, agent performance dashboards, multi-turn auto-raters,
   online evaluation against live traffic, and a Unified Trace Viewer for debugging agent reasoning paths.
-  Differentiated as the default zero-config observability surface for the >hundreds-of-thousands of organizations
-  already on Vertex AI, with no separate SDK required for managed-model usage.
-comments: 'Vertex AI / Agent Engine observability: tracing via Cloud Trace (OpenTelemetry-built), Cloud
-  Monitoring, Cloud Logging, plus integrated Gen AI Evaluation service. Proprietary Google Cloud managed
-  service. Verified live June 2026 in GCP docs.'
+  Differentiated as the default zero-config observability surface for organizations already on Vertex AI,
+  with no separate SDK required for managed-model usage.
+comments: Google publishes no usage figure for this surface specifically, so its adoption band leans on the
+  reach of Vertex AI rather than on a measurement of the surface. Verified 2026-08-13 via the Agent Engine
+  tracing documentation.

--- a/sources/products/weave.yaml
+++ b/sources/products/weave.yaml
@@ -3,11 +3,12 @@ display_name: Weave
 type: software
 description: Toolkit for developing and monitoring AI-powered applications, built by Weights & Biases.
   Provides tracing, evaluation, and dataset management for LLM applications. Leverages W&B's established
-  ML experiment tracking platform and enterprise customer base. Code is open source (Apache-2.0) but primarily
-  consumed via the W&B cloud platform. 1.1K GitHub stars.
+  ML experiment tracking platform and enterprise customer base. Functions are traced with a decorator, and
+  the published package requires a Weights & Biases account to send traces to.
 github:
 - url: https://github.com/wandb/weave
 pypi:
 - url: https://pypi.org/project/weave
-comments: W&B Weave; OSS SDK v0.52.42 (Jun 2, 2026) confirmed live on GitHub (wandb/weave). LLM tracing
-  + evaluation + monitoring layered onto the commercial W&B platform.
+comments: The published repository carries the SDK and a trace-server library but not the web service that
+  fronts it, which its own architecture diagram places in W&B's closed core repository; the openness score
+  follows that. Verified 2026-08-13 via the wandb/weave README.

--- a/sources/products/whylabs.yaml
+++ b/sources/products/whylabs.yaml
@@ -6,7 +6,7 @@ description: AI observability platform for monitoring ML models and LLM applicat
   whylogs profiling library and LangKit LLM monitoring toolkit. Differentiated by statistical profiling
   approach, monitors distributions rather than individual requests, enabling cost-effective monitoring
   at scale.
-comments: 'WhyLabs ML/LLM observability. COMPANY DISCONTINUED: whylabs.ai states ''WhyLabs, Inc. is discontinuing
-  operations'' and open sourced the full platform plus whylogs and LangKit. The hosted SaaS observability
-  platform is no longer operating; the OSS libraries remain on GitHub (whylogs Apache-2.0, 2.8k stars,
-  latest release v1.6.4 Dec 2024).'
+comments: 'WhyLabs, Inc. has discontinued operations and open sourced the platform, so the entry is scored
+  on what remains runnable: the whylogs and LangKit libraries. This product declares no artifacts, which
+  is why its adoption band has no signal route behind it. Verified 2026-08-13 via the WhyLabs LangKit page
+  and the whylabs/whylogs repository.'

--- a/sources/scores/agenta.yaml
+++ b/sources/scores/agenta.yaml
@@ -84,14 +84,20 @@ adoption:
   signal_type: usage_volume
   confidence: high
   note: agenta ~16k PyPI downloads/month (10K-100K band); ~4.2k GitHub stars corroborates only. Early-adopter
-    scale, smallest in this batch.
+    scale, smallest in this batch. Re-read 2026-08-13 - pypistats now reports 15,013 downloads last month
+    for agenta, effectively unchanged and still inside the 10K-100K band, so level 2 stands.
+  last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/packages/agenta
-    shows: ~16,370 downloads last month
-    accessed: '2026-06-04'
+    shows: Downloads last month 15,013 for agenta (last week 3,250)
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: adfdc68fe39f2872ddb5f21c953b650518984d3f99b2d47f3c5ac5069eae1dd6
   - url: https://github.com/Agenta-AI/agenta
-    shows: ~4.2k stars; LLMOps platform
-    accessed: '2026-06-04'
+    shows: 4,466 stars on Agenta-AI/agenta, the repository the agenta package is published from
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 99647a3a169d2dd5a4b1bc1f16fc2a8d574affadc00325590922d42dcc9be4ec
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/agentops.yaml
+++ b/sources/scores/agentops.yaml
@@ -93,23 +93,42 @@ adoption:
   signal_type: usage_volume
   confidence: high
   note: agentops ~585k PyPI downloads/month; multi-framework integrations (CrewAI, AG2, OpenAI Agents
-    SDK, LangChain, Camel); ~5.6k stars corroborates only. 100K-1M monthly-download band.
+    SDK, LangChain, Camel); ~5.6k stars corroborates only. 100K-1M monthly-download band. Re-read
+    2026-08-13 - pypistats now reports 275,111 downloads last month for agentops, roughly half the 584,603
+    recorded and still inside the 100K-1M band, so level 3 is unchanged. The fall is consistent with the
+    stalled release cadence already recorded on the capability axis.
+  last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/packages/agentops
-    shows: ~584,603 downloads last month
-    accessed: '2026-06-04'
+    shows: Downloads last month 275,111 for agentops (last week 59,009)
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 8cddc6c42d60c71606a66493a59f8b83d4e72d3e806f4c2793df7328397323fa
   - url: https://github.com/AgentOps-AI/agentops
-    shows: ~5.6k stars; agent tracing + cost tracking + integrations
-    accessed: '2026-06-04'
+    shows: 5,771 stars; agent tracing, cost tracking and framework integrations in the README
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 4c31c24d2c744e9d73ed70103f34689c83cc67b42824c39894cdcfa3e13b7912
 capability:
   score: 3
   basis: feature_matrix
   value: agent execution tracing + session replays, LLM cost tracking, multi-framework integrations, monitoring/debug
     dashboards, custom eval metrics; lighter on prompt versioning + dataset/annotation than full platforms
   confidence: medium
+  relative_to: langfuse
+  relation: one_below
   note: Solid agent-tracing + cost + basic evals, but narrower feature matrix than MLflow/Langfuse/Opik/Phoenix;
-    stale SDK (no 2026 release) reinforces a mid score.
+    stale SDK (no 2026 release) reinforces a mid score. The comparison is now recorded rather than left in
+    prose - one rung below the langfuse anchor at 4. Re-read 2026-08-13 on the repository README, whose
+    feature table is Replay Analytics and Debugging, LLM Cost Management, Agent Benchmarking, integrations
+    and Self-Host, with evaluations still carried as a roadmap table rather than a shipped surface.
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/AgentOps-AI/agentops
-    shows: tracing, session replays, cost tracking, eval metrics, integrations
-    accessed: '2026-06-04'
+    shows: 'Repository README - "AgentOps helps developers build, evaluate, and monitor AI agents", with a
+      feature table covering step-by-step agent execution graphs, LLM cost management, framework integrations
+      and Self-Host, and an "Evaluations Roadmap" table in which several eval rows are still marked as
+      in-progress rather than shipped.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 4c31c24d2c744e9d73ed70103f34689c83cc67b42824c39894cdcfa3e13b7912

--- a/sources/scores/arize.yaml
+++ b/sources/scores/arize.yaml
@@ -18,25 +18,45 @@ openness:
       raw: open source Phoenix is a separate companion product, not the AX platform
   confidence: high
   note: Arize AX is closed/proprietary SaaS with no self-hostable core; only the separate Phoenix project
-    is source-available.
+    is source-available. Re-read 2026-08-13 and unchanged - the site's own product menu still separates
+    "Arize AX - Managed AI engineering platform" from "Phoenix Open Source - Open-source observability and
+    evals", and AX ships no repository or self-host path of its own.
   raw: license:Proprietary;weights:n/a;source:closed(proprietary SaaS);self-host:none for core AX features;note:open
     source Phoenix is a separate companion product, not the AX platform
+  last_verified: '2026-08-13'
   sources:
   - url: https://arize.com/
-    shows: '''enterprise AI engineering platform''; closed AX with proprietary Alyx agent + adb datastore;
-      Phoenix described as the separate self-hostable OSS counterpart'
-    accessed: '2026-06-04'
+    shows: 'The platform menu lists Arize AX, Alyx and adb beside "Phoenix Open Source" as separate entries,
+      AX being the managed platform and Phoenix the open-source one. Alyx is described as "Your AI engineering
+      agent ... Like Cursor or Claude Code, but for AI engineering", and adb as the GenAI datastore. Nothing
+      on the page publishes source for AX or offers a self-hosted AX build - the only self-host route named
+      anywhere on the site is Phoenix''s.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6e523df79a857a9b5d1cd75af6fe36def34f59be2b934e7929eeb9ece7f4b523
+    establishes:
+    - license
+    - source
+    - self-host
 adoption:
   level: 4
   signal_type: reported_traction
   confidence: medium
-  note: Vendor discloses ~1 trillion spans/month and ~1 billion evals/month plus named enterprise customers
-    (DoorDash, Roblox, PepsiCo, Atlassian, Booking.com, Reddit); no per-account user count, so reported_traction
-    rather than active_users.
+  note: Vendor discloses ~1 trillion spans/month and ~1 billion evals/month plus named enterprise customers;
+    no per-account user count, so reported_traction rather than active_users. Re-read 2026-08-13 - both
+    throughput figures are still on the homepage unchanged. The named-customer roster has been cut back
+    to testimonials from Atlassian and PepsiCo; DoorDash, Roblox, Booking.com and Reddit are no longer on
+    the page, and that half of the evidence is recorded as gone rather than carried forward. The two
+    throughput figures on their own still place the band at 4.
+  last_verified: '2026-08-13'
   sources:
   - url: https://arize.com/
-    shows: '''1 trillion spans per month'', ''1 billion evals per month'', named customers'
-    accessed: '2026-06-04'
+    shows: '"1 Trillion spans per month" and "1 Billion evals per month" in the stats block, with named
+      testimonials from Huayi Li (Principal Machine Learning Engineer, Atlassian) and Charles Holive (SVP
+      AI Solutions and Platforms, PepsiCo). No user, account or seat count appears anywhere on the page.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6e523df79a857a9b5d1cd75af6fe36def34f59be2b934e7929eeb9ece7f4b523
 capability:
   score: 5
   basis: feature_matrix
@@ -44,8 +64,15 @@ capability:
     embedded AI engineering agent, adb GenAI datastore, alerting/monitoring at trillion-span scale
   confidence: medium
   note: Frontier-tier closed observability platform for this category; enterprise-scale managed tracing/eval/monitoring
-    exceeding the OSS feature sets. A 5 reflects category-leading closed capability.
+    exceeding the OSS feature sets. A 5 reflects category-leading closed capability. Re-read 2026-08-13 -
+    the product tabs still read Observe, Evaluate, Develop and Alyx, and the trillion-span figure still
+    backs the scale claim, so the band is unchanged.
+  last_verified: '2026-08-13'
   sources:
   - url: https://arize.com/
-    shows: Observe/Evaluate/Improve workflow, Alyx, adb, trillion-span scale
-    accessed: '2026-06-04'
+    shows: Product tabs named Observe, Evaluate, Develop and Alyx; Alyx described as an in-app AI engineering
+      agent that "runs evals, debugs issues, and improves your agents"; adb as the GenAI datastore; and 1
+      Trillion spans per month as the scale claim.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6e523df79a857a9b5d1cd75af6fe36def34f59be2b934e7929eeb9ece7f4b523

--- a/sources/scores/azure-ai-foundry-observability.yaml
+++ b/sources/scores/azure-ai-foundry-observability.yaml
@@ -15,25 +15,44 @@ openness:
         is proprietary and Azure-locked
   confidence: high
   note: Proprietary Microsoft Azure managed offering. OTel is the wire standard (trace data is portable)
-    but the service itself is closed.
+    but the service itself is closed. Re-read 2026-08-13 and unchanged - the page describes three core
+    capabilities delivered by Microsoft Foundry, built on OpenTelemetry and integrated with Azure Monitor
+    Application Insights, and publishes no source, license or self-hostable build of the service.
   raw: license:proprietary(Azure managed service);source:closed;note:tracing built on open OTel standard
     + Azure Monitor App Insights, but the observability product is proprietary and Azure-locked
+  last_verified: '2026-08-13'
   sources:
   - url: https://learn.microsoft.com/en-us/azure/foundry/concepts/observability
-    shows: Microsoft Foundry observability (eval/monitoring/tracing) as a managed Azure service built
-      on OpenTelemetry + Azure Monitor
-    accessed: '2026-06-04'
+    shows: '"Observability in generative AI" on Microsoft Learn. "Microsoft Foundry provides three core
+      capabilities that work together to deliver comprehensive observability across the AI application
+      lifecycle", the tracing one being "Built on OpenTelemetry standards and integrated with Azure Monitor
+      Application Insights". OpenTelemetry is the wire format; the service consuming it is Azure''s and is
+      not published.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 89958f27a9aa92d81ff30f582a0fdfe2cc644e985006beb9a5c47efcfb3b4f95
+    establishes:
+    - license
+    - source
 adoption:
   level: 3
   signal_type: reported_traction
   confidence: low
-  note: GA March 2026 as a feature surface within Microsoft Foundry on Azure; no standalone usage figures
-    published for the observability capability specifically. Level 3 reflects availability inside a large
-    cloud AI platform, not a measured user count; directional.
+  note: A feature surface within Microsoft Foundry on Azure; no standalone usage figures published for the
+    observability capability specifically. Level 3 reflects availability inside a large cloud AI platform,
+    not a measured user count; directional. Re-read 2026-08-13 - the quantity actually banded here is the
+    reach of Microsoft Foundry, not usage of its observability surface, and the page discloses no figure
+    for either. The "GA March 2026" claim this note used to carry is not on the cited page and is dropped
+    rather than carried forward.
+  last_verified: '2026-08-13'
   sources:
   - url: https://learn.microsoft.com/en-us/azure/foundry/concepts/observability
-    shows: observability GA (Mar 2026) shipped within the managed Microsoft Foundry platform
-    accessed: '2026-06-04'
+    shows: The concept page, read for a usage figure and containing none - no customer count, no account
+      count, no volume. It describes observability as three core capabilities of Microsoft Foundry, which
+      places it inside the platform without saying how many people use it. No GA date appears on the page.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 89958f27a9aa92d81ff30f582a0fdfe2cc644e985006beb9a5c47efcfb3b4f95
 capability:
   score: 3
   basis: feature_matrix
@@ -42,11 +61,21 @@ capability:
     auto-instrumentation across Semantic Kernel, LangChain, LangGraph, OpenAI Agents SDK. Strong tracing
     + framework breadth; prompt mgmt/datasets/annotation not evidenced as first-class native features.
   confidence: medium
+  relative_to: langfuse
+  relation: one_below
   note: Three pillars (eval/monitoring/tracing) with strong OTel + framework coverage, but matrix breadth
     on prompt versioning/datasets/annotation is thinner than the dedicated OSS platforms; scored 3 below
-    the C4 anchors.
+    the C4 anchors. The comparison is now recorded rather than left in prose - one rung below the langfuse
+    anchor at 4. Re-read 2026-08-13 - the page still names exactly three core capabilities and still
+    describes no prompt-versioning, dataset or annotation surface.
+  last_verified: '2026-08-13'
   sources:
   - url: https://learn.microsoft.com/en-us/azure/foundry/concepts/observability
-    shows: OTel tracing, monitoring, evaluations; auto-instrumentation for Semantic Kernel/LangChain/LangGraph/OpenAI
-      Agents SDK
-    accessed: '2026-06-04'
+    shows: '"Core observability capabilities - Microsoft Foundry provides three core capabilities", the
+      first being Evaluation, whose "Evaluators measure the quality, safety, and reliability" of outputs,
+      and tracing covering "agent decisions, and inter-service dependencies. Built on OpenTelemetry
+      standards and integrated with Azure Monitor Application Insights". Quality gates are described as
+      something you build into CI/CD rather than a product surface here.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 89958f27a9aa92d81ff30f582a0fdfe2cc644e985006beb9a5c47efcfb3b4f95

--- a/sources/scores/braintrust.yaml
+++ b/sources/scores/braintrust.yaml
@@ -17,31 +17,60 @@ openness:
   confidence: high
   note: Open SDKs but a closed SaaS core (Brainstore backend, dashboards, automation are proprietary);
     no OSS core, so 'closed' (not open_core) like LangSmith/Galileo per recipe's closed examples. The
-    Apache-2.0 client SDK is instrumentation only and does not open the product.
+    Apache-2.0 client SDK is instrumentation only and does not open the product. Re-read 2026-08-13 and
+    unchanged on the score. One detail has moved - braintrustdata/braintrust-sdk now states that it holds
+    "Braintrust's JavaScript/TypeScript SDKs and integrations" rather than the five-language set the
+    components clause records, so that clause overstates what this repository covers. It remains Apache-2.0
+    and it remains a client SDK, so neither the score nor the class turns on it.
   raw: source:closed;license:Apache-2.0(OSI, client SDKs only, Python/TS/Go/Ruby/C#);platform:proprietary(Brainstore
     custom DB, evals/tracing/automation all SaaS);self-host:enterprise-only(hybrid)
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/braintrustdata/braintrust-sdk
-    shows: Apache-2.0 license on client SDK; platform itself at braintrust.dev
-    accessed: '2026-06-04'
+    shows: 'Repository README - "This repository contains Braintrust''s JavaScript/TypeScript SDKs and
+      integrations", with the core SDK described as being "for logging, tracing, evals, and CLI". Its
+      License section reads Apache-2.0. Nothing in the repository is the platform itself.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 67b40e12540ea77b2a06da3181f07e9ca2e0141b8bd13d3a5f8afb00bec74722
+    establishes:
+    - license
   - url: https://www.braintrust.dev/
-    shows: proprietary backend (Brainstore custom DB), SaaS + hybrid enterprise deployment
-    accessed: '2026-06-04'
+    shows: 'The platform, and the proprietary backend the class rests on - "Brainstore, the database built
+      for AI data at scale ... designed specifically for agent observability so you can query millions of
+      traces quickly", with no source published for it. The only self-host route offered is a hybrid one -
+      "Deploy Brainstore data plane on your own infrastructure" - alongside SOC 2 Type II certification.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 81e7f43fc2016ea0c9378347ceec7ac9aa125c72f0396a7b4adca861bcdc381d
+    establishes:
+    - source
+    - self-host
 adoption:
   level: 4
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
   note: '~6.08M PyPI downloads in the last month for the `braintrust` package (primary: pypistats); named
-    production users incl. Vercel, Notion, Coursera, Dropbox, Replit. 1-10M monthly-download band; strongest
-    adoption of the closed-platform set here.'
+    production users. 1-10M monthly-download band; strongest adoption of the closed-platform set here.
+    Re-read 2026-08-13 - pypistats now reports 7,366,065 downloads last month, up from the 6,080,857
+    recorded and still inside the 1M-10M band, so level 4 is unchanged. The customer roster on the homepage
+    has changed: Notion and Coursera are still named, Vercel, Dropbox and Replit are not, and those three
+    are dropped from this note rather than carried forward. The band rests on the download count anyway.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/packages/braintrust
-    shows: 6,080,857 downloads last month for the braintrust package
-    accessed: '2026-06-04'
+    shows: Downloads last month 7,366,065 for the braintrust package (last week 1,612,417)
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 4364f112b0e6223709993e4332612a76b7106db6ba62c31c57d5c8d14e161676
   - url: https://www.braintrust.dev/
-    shows: named customers Vercel, Notion, Coursera, Dropbox, Replit
-    accessed: '2026-06-04'
+    shows: Named customer stories on the homepage - "How Coursera builds next-generation learning tools"
+      and "How Notion evaluates AI at scale across 70 engineers". Vercel, Dropbox and Replit no longer
+      appear anywhere on the page.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 81e7f43fc2016ea0c9378347ceec7ac9aa125c72f0396a7b4adca861bcdc381d
 capability:
   score: 5
   basis: feature_matrix
@@ -54,9 +83,15 @@ capability:
   confidence: high
   note: Deepest eval+automation feature surface in this batch (CI-style quality gates, Topics auto-clustering,
     continuous scoring), a frontier-definer for eval-first LLM observability; rated 5 above the MLflow/Langfuse
-    C4 anchors on feature breadth.
+    C4 anchors on feature breadth. Re-read 2026-08-13 - Topics, continuous online scoring and quality gates
+    are all still front-of-page and still the thing no anchor matches, so the one-above comparison holds.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.braintrust.dev/
-    shows: tracing, evals (LLM/code/human), automation (Topics, quality gates), prompt mgmt, OTel/MCP
-      integrations
-    accessed: '2026-06-04'
+    shows: 'Homepage feature copy - "Automate pattern discovery with Topics", "Topics surfaces patterns in
+      real time across task, issues, and sentiment, online scoring catches regressions, and quality gates
+      block bad releases", plus "Trace everything - Inspect prompts, responses, and tool calls in real
+      time" and scoring "with LLMs, code, or humans" against versioned datasets.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 81e7f43fc2016ea0c9378347ceec7ac9aa125c72f0396a7b4adca861bcdc381d

--- a/sources/scores/confident-ai.yaml
+++ b/sources/scores/confident-ai.yaml
@@ -15,32 +15,58 @@ openness:
       value: enterprise-tier
   confidence: high
   note: The scored entity is the Confident AI platform itself, which is proprietary SaaS. DeepEval (the
-    open Apache-2.0 framework, ~15.9k stars) is a distinct product; do not credit the platform with the
-    framework's openness.
+    open Apache-2.0 framework) is a distinct product; do not credit the platform with the framework's
+    openness. Re-read 2026-08-13 and unchanged - the platform's own FAQ still puts self-hosting behind the
+    Enterprise plan and a demo booking, and publishes no source for the platform, while DeepEval's
+    repository still resolves to Apache-2.0.
   raw: license:proprietary(platform);source:closed(platform);note:companion OSS framework DeepEval is Apache-2.0
     but is a separate registry-scope product;self-host:enterprise-tier
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.confident-ai.com/
-    shows: proprietary cloud platform distinct from open source DeepEval; self-hosted enterprise option
-    accessed: '2026-06-04'
+    shows: 'The platform''s own FAQ - "Can I self-host Confident AI? Yes. Confident AI offers a fully
+      self-hosted deployment option alongside the managed cloud. You can run the entire platform in your
+      own VPC or on-prem infrastructure ... Self-hosting is available on our Enterprise plan - book a demo
+      to get started." No source, repository or license for the platform appears anywhere on the page.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d5c7cfa0224d33af5a770d97a928d588eaba3f40ffd9339d13dc23c4245add9d
+    establishes:
+    - license
+    - source
+    - self-host
   - url: https://github.com/confident-ai/deepeval
-    shows: DeepEval (the separate framework) is Apache-2.0; platform is the integrated paid companion
-    accessed: '2026-06-04'
+    shows: The separate framework. GitHub resolves LICENSE.md to Apache-2.0 and the README states "DeepEval
+      is licensed under Apache 2.0". This is the companion product, not the platform scored here.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b30ab51a3d103da62d2af93fb6cabac0d90d22e894e58ec7d94ac25f83c9f3ec
 adoption:
   level: 3
   signal_type: reported_traction
   confidence: medium
-  note: Vendor discloses '500+ leading AI companies' incl. Panasonic, Samsung, Epic Games, Humach. Corroborated
-    by the strong pull of its open source funnel DeepEval (~15.9k GitHub stars, used-by 1.3k repos), which
-    drives platform signups. Level 3 on disclosed named-customer traction; no precise active-user/usage-volume
-    number for the platform itself.
+  note: Vendor discloses '500+ leading AI companies'. Corroborated by the strong pull of its open source
+    funnel DeepEval, which drives platform signups. Level 3 on disclosed customer-count traction; no precise
+    active-user/usage-volume number for the platform itself. Re-read 2026-08-13 - the "TRUSTED BY 500+
+    LEADING AI COMPANIES" line is still on the page and still carries no figure behind it, and DeepEval's
+    repository has grown to 17,578 stars. The named roster has changed, though - Humach is still quoted,
+    while Panasonic, Samsung and Epic Games are no longer on the page, and those three are dropped from
+    this note rather than carried forward. The 500+ claim on its own still places the band at 3.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.confident-ai.com/
-    shows: '''500+ leading AI companies'' incl Panasonic, Samsung, Epic Games, Humach'
-    accessed: '2026-06-04'
+    shows: '"TRUSTED BY 500+ LEADING AI COMPANIES" as a banner, with named testimonials from Sean Austin
+      (Chief AI Officer, Humach) and an unnamed Senior Director of Engineering at a Fortune 500 medical
+      device company. Community stats on the page read "GITHUB 14K+ STARS" and "DISCORD 2,500+ MEMBERS",
+      both dated 12/01/25 on the page itself. No user or account count for the platform appears.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d5c7cfa0224d33af5a770d97a928d588eaba3f40ffd9339d13dc23c4245add9d
   - url: https://github.com/confident-ai/deepeval
-    shows: ~15.9k stars, used-by 1.3k repos (OSS funnel corroboration)
-    accessed: '2026-06-04'
+    shows: 17,578 stars on the DeepEval repository, the open source funnel this band cites as corroboration
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b30ab51a3d103da62d2af93fb6cabac0d90d22e894e58ec7d94ac25f83c9f3ec
 capability:
   score: 4
   basis: feature_matrix
@@ -49,10 +75,21 @@ capability:
     + prompt mgmt (git-based versioning/branching) + monitoring/alerts (regression detection) + red teaming
     (OWASP) + annotations. Covers the full recipe matrix.'
   confidence: medium
+  relative_to: langfuse
+  relation: at
   note: Broad coverage across all recipe dimensions; the deep DeepEval metric library (50+ incl LLM-as-judge)
     and red-teaming are strengths. Capped at 4 alongside the OSS anchors; not a frontier-definer over
-    MLflow/Langfuse.
+    MLflow/Langfuse. The comparison is now recorded rather than left in prose - at the langfuse anchor.
+    Re-read 2026-08-13 - the product menu is still LLM Evaluation, LLM Observability, AI Red Teaming and
+    AI Governance, with dataset management, tracing, real-time monitoring and CI regression gating beneath.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.confident-ai.com/
-    shows: tracing, evals, datasets, prompt mgmt, monitoring, red teaming, annotations
-    accessed: '2026-06-04'
+    shows: 'Product menu - LLM Evaluation, LLM Observability ("Trace, monitor, and alert on production LLM
+      systems"), AI Red Teaming ("Stress-test LLM apps against adversarial attacks") and AI Governance.
+      The platform is described as layering "collaboration, dataset management, tracing, real-time
+      monitoring, and dashboards" on the open framework, and integrating into CI so that "you can run
+      regression tests on every pull request".'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d5c7cfa0224d33af5a770d97a928d588eaba3f40ffd9339d13dc23c4245add9d

--- a/sources/scores/datadog-llm-observability.yaml
+++ b/sources/scores/datadog-llm-observability.yaml
@@ -15,25 +15,44 @@ openness:
     - product itself closed
   confidence: high
   note: Closed proprietary SaaS; only Datadog's tracing client libraries are open, the LLM Observability
-    product and backend are closed.
+    product and backend are closed. Re-read 2026-08-13 and unchanged - the documentation still describes
+    a hosted Datadog product configured from the Datadog app, with no repository, no license and no
+    self-hosted build offered for the LLM Observability backend anywhere in it.
   raw: license:Proprietary;source:closed;platform:proprietary SaaS(no source);only the ddtrace instrumentation
     SDK is open;product itself closed
+  last_verified: '2026-08-13'
   sources:
   - url: https://docs.datadoghq.com/llm_observability/
-    shows: Datadog LLM Observability described as a proprietary cloud SaaS platform for monitoring LLM
-      apps/agents
-    accessed: '2026-06-04'
+    shows: 'LLM Observability documentation, sitting inside the wider Datadog docs alongside APM, Log
+      Management and Cloud SIEM. The navigation covers Agent Monitoring, MCP Clients, Prompt Tracking,
+      Prompt Management, Quality Monitoring and correlation with APM. Nothing on the page links a source
+      repository or a self-hosted distribution of the product itself.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 7c4484c17defe958a80e8a00096c3510f84cf5c94e4a7be4008c01c6a37b4297
+    establishes:
+    - license
+    - source
 adoption:
   level: 4
   signal_type: reported_traction
   confidence: low
-  note: Rides the large installed base of Datadog APM (a major enterprise observability vendor); LLM Observability
-    is a newer add-on with no disclosed standalone user/usage count. Placed at 4 on parent-platform enterprise
-    reach as a directional estimate, not a measured figure for this module specifically.
+  note: 'Rides the large installed base of Datadog APM (a major enterprise observability vendor); LLM
+    Observability is a newer add-on with no disclosed standalone user/usage count. Placed at 4 on
+    parent-platform enterprise reach as a directional estimate, not a measured figure for this module
+    specifically. Re-read 2026-08-13 and still true in both directions - the quantity actually banded here
+    is the reach of the Datadog platform, not usage of the LLM Observability module, and the docs still
+    disclose no figure of any kind for the module. Stating that plainly - the band is a substitution, and
+    the substituted quantity is named.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://docs.datadoghq.com/llm_observability/
-    shows: shipped product within the Datadog enterprise platform; no standalone usage numbers in docs
-    accessed: '2026-06-04'
+    shows: The module's documentation, read for a usage figure and containing none - no customer count, no
+      account count, no ingested-span volume. It sits inside the Datadog docs beside APM, Log Management,
+      Cloud SIEM and the rest of the platform, which is the only thing on the page that speaks to reach.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 7c4484c17defe958a80e8a00096c3510f84cf5c94e4a7be4008c01c6a37b4297
 capability:
   score: 4
   basis: feature_matrix
@@ -42,11 +61,19 @@ capability:
     (Patterns); anomaly detection (Insights); framework integrations (OpenAI, LangChain, Bedrock, Anthropic)
     via auto-instrumentation.'
   confidence: medium
+  relative_to: langfuse
+  relation: at
   note: Broad enterprise-grade feature matrix (tracing, evals, cost, security/redaction, clustering, anomaly
     detection) integrated with the wider Datadog APM suite; comparable to C4 anchors. Closed, but capability
-    scored independently.
+    scored independently. The comparison is now recorded rather than left in prose - at the langfuse anchor.
+    Re-read 2026-08-13 - the documentation navigation still carries Quality Monitoring, Agent Monitoring,
+    Prompt Tracking, Prompt Management, Patterns and correlation with APM, so the breadth is intact.
+  last_verified: '2026-08-13'
   sources:
   - url: https://docs.datadoghq.com/llm_observability/
-    shows: 'feature list: tracing, evaluations, cost dashboards, data redaction/prompt-injection detection,
-      Patterns clustering, Insights anomaly detection'
-    accessed: '2026-06-04'
+    shows: 'Documentation navigation for the module - Quality Monitoring, Jobs Monitoring, Agent Monitoring,
+      MCP Clients, Prompt Tracking, Prompt Management, "Querying spans and traces", "Correlate with APM"
+      and Patterns - plus Sensitive Data Scanner and Watchdog Insights on the wider platform.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 7c4484c17defe958a80e8a00096c3510f84cf5c94e4a7be4008c01c6a37b4297

--- a/sources/scores/dynatrace-ai-observability.yaml
+++ b/sources/scores/dynatrace-ai-observability.yaml
@@ -15,13 +15,25 @@ openness:
       value: closed
   confidence: high
   note: Fully proprietary Dynatrace platform; AI Observability is a commercial app/module. OTel + OpenLLMetry
-    ingestion are open standards consumed by a closed product. Scored closed (1).
+    ingestion are open standards consumed by a closed product. Scored closed (1). Re-read 2026-08-13 and
+    unchanged - the documentation still frames Traceloop OpenLLMetry, OpenTelemetry with GenAI semantic
+    conventions and OpenInference as ways of getting data into Dynatrace, and publishes no source for the
+    product consuming it.
   raw: platform:proprietary-SaaS(Grail-powered, Davis AI);license:commercial;ingestion:OpenTelemetry+OpenLLMetry(via
     Traceloop)+GenAI-semconv(open standards, not open product);source:closed
+  last_verified: '2026-08-13'
   sources:
   - url: https://docs.dynatrace.com/docs/observe/dynatrace-for-ai-observability
-    shows: proprietary Dynatrace platform AI Observability; Grail/Davis AI; OTel + OpenLLMetry ingestion
-    accessed: '2026-06-04'
+    shows: 'Documentation for the capability - "Use Dynatrace with Traceloop OpenLLMetry, OpenTelemetry
+      with GenAI semantic conventions, or OpenInference" to observe AI-powered cloud applications
+      end-to-end. Those are ingestion formats. Nothing on the page publishes source for Dynatrace itself
+      or offers a build of it.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 594c5bae5c4e3a24a31f1a178341d2798725bd57ad74112c38e0fbaa78bf0225
+    establishes:
+    - license
+    - source
 adoption:
   level: null
   reach: null
@@ -30,10 +42,18 @@ adoption:
   note: Dynatrace is a large public observability vendor, but I found no primary, AI-Observability-specific
     usage figure this run (vendor docs confirm the product exists but disclose no module adoption count).
     Declining to assign a level rather than attribute platform-wide numbers I could not source primarily.
+    Re-read 2026-08-13 and the abstention stands - the documentation still carries no customer count, no
+    account count and no ingested-volume figure for this capability. Recorded as a confirmed null rather
+    than an unanswered axis.
+  last_verified: '2026-08-13'
   sources:
   - url: https://docs.dynatrace.com/docs/observe/dynatrace-for-ai-observability
-    shows: product exists and is part of the Dynatrace platform; no module usage count disclosed
-    accessed: '2026-06-04'
+    shows: The capability's documentation, read for a usage figure and containing none. It describes what
+      the product monitors - token consumption, latency, availability, errors, model drift and service
+      fees across Amazon Bedrock, NVIDIA NIM, Ollama and others - and never how many people use it.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 594c5bae5c4e3a24a31f1a178341d2798725bd57ad74112c38e0fbaa78bf0225
 capability:
   score: 4
   basis: feature_matrix
@@ -42,10 +62,20 @@ capability:
     + OpenLLMetry(Traceloop) + GenAI semconv; providers OpenAI/Bedrock/NIM/Ollama/Gemini/Azure AI Foundry
     + LangChain/CrewAI. Lacks dedicated eval/LLM-as-judge + prompt-versioning depth.
   confidence: medium
+  relative_to: langfuse
+  relation: at
   note: Strong full-stack AI observability (no-sampling capture, predictive cost, agentic tracing) at
-    the anchor C4 tier; not an eval/prompt-mgmt frontier-definer, so 4.
+    the anchor C4 tier; not an eval/prompt-mgmt frontier-definer, so 4. The comparison is now recorded
+    rather than left in prose - at the langfuse anchor. Re-read 2026-08-13 - the documentation still covers
+    end-to-end tracing of LLM calls, tool use and RAG, cost as token usage and service fees, model-drift
+    monitoring, and multi-provider coverage, with no eval or prompt-versioning surface of its own.
+  last_verified: '2026-08-13'
   sources:
   - url: https://docs.dynatrace.com/docs/observe/dynatrace-for-ai-observability
-    shows: end-to-end tracing, token/cost metrics, predictive cost (Davis AI), OTel/OpenLLMetry, multi-provider
-      + agentic framework support
-    accessed: '2026-06-04'
+    shows: 'Documentation - trace "LLM calls, tool-use, RAG, and resolve performance, latency, cost, and
+      reliability issues"; Cost covers "Token usage, service fees, or overall resource consumption";
+      drift is anticipated by "monitoring input data stationarity"; and providers named include Amazon
+      Bedrock, NVIDIA NIM and Ollama.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 594c5bae5c4e3a24a31f1a178341d2798725bd57ad74112c38e0fbaa78bf0225

--- a/sources/scores/galileo.yaml
+++ b/sources/scores/galileo.yaml
@@ -14,24 +14,42 @@ openness:
     - no-OSS-core(open source contributions exist as separate tools/benchmarks, not the product)
   confidence: high
   note: Proprietary platform; recipe lists Galileo explicitly as a closed example. No OSI-licensed core
-    product.
+    product. Re-read 2026-08-13 and unchanged - the homepage sells an Agent Reliability platform and its
+    Luna evaluation models, links no repository for either, and offers no license text or self-hosted build
+    of the product.
   raw: license:proprietary;source:closed;deploy:SaaS/VPC/on-prem(managed);no-OSS-core(open source contributions
     exist as separate tools/benchmarks, not the product)
+  last_verified: '2026-08-13'
   sources:
   - url: https://galileo.ai/
-    shows: proprietary platform; SaaS/VPC/on-prem deploy, no open source core product
-    accessed: '2026-06-04'
+    shows: 'Homepage. The product is "our complete Agent Reliability platform", with proprietary Luna
+      evaluation models that "monitor 100% of your traffic at 96% lower cost". No source repository,
+      license or self-hostable distribution of the platform is offered anywhere on the page; the calls to
+      action are Sign Up and Book a Demo.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0a291dabe82ed4461179f4514e9164f797e7ece269d062fc460944651b390d40
+    establishes:
+    - license
+    - source
 adoption:
   level: 3
   signal_type: reported_traction
   confidence: low
   note: Vendor states 'trusted by leading enterprises' but discloses no named customers or quantitative
     user/usage figures on the homepage. Level 3 reflects established commercial traction without a verified
-    count; treat as directional.
+    count; treat as directional. Re-read 2026-08-13 and unchanged - the phrase is still there verbatim and
+    there is still no number of any kind beside it, so the band stays where an unquantified vendor claim
+    puts it.
+  last_verified: '2026-08-13'
   sources:
   - url: https://galileo.ai/
-    shows: '''Trusted by leading enterprises'' marketing claim, no quantitative figures'
-    accessed: '2026-06-04'
+    shows: '"Trusted by leading enterprises to measure, protect, and improve AI in production", and a
+      second banner reading "Trusted by enterprises, loved by developers". Read for a figure and containing
+      none - no customer count, no user count, no volume.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0a291dabe82ed4461179f4514e9164f797e7ece269d062fc460944651b390d40
 capability:
   score: 4
   basis: feature_matrix
@@ -40,10 +58,19 @@ capability:
     + data capture (synthetic/dev/prod datasets). Distinctive guardrail layer turning offline evals into
     runtime intervention.
   confidence: medium
+  relative_to: langfuse
+  relation: at
   note: Strong feature coverage across the recipe matrix; the offline-eval-to-production-guardrail loop
     and purpose-built Luna eval models are differentiators. OTel support not confirmed on the homepage.
-    Capped at 4 (MLflow/Langfuse anchors hold C4); not a frontier-definer over the OSS anchors.
+    Capped at 4 (MLflow/Langfuse anchors hold C4); not a frontier-definer over the OSS anchors. The
+    comparison is now recorded rather than left in prose - at the langfuse anchor. Re-read 2026-08-13 -
+    the Luna models and the measure/protect/improve loop are still the page's central claim.
+  last_verified: '2026-08-13'
   sources:
   - url: https://galileo.ai/
-    shows: evals, guardrails, tracing, cost optimization (Luna), data capture features
-    accessed: '2026-06-04'
+    shows: 'Homepage - customized "evals into Luna models that monitor 100% of your traffic at 96% lower
+      cost", and the platform framed as measuring, protecting and improving AI in production, which is the
+      offline-eval-to-runtime-guardrail loop the band rests on. OTel is still not named on the page.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0a291dabe82ed4461179f4514e9164f797e7ece269d062fc460944651b390d40

--- a/sources/scores/helicone.yaml
+++ b/sources/scores/helicone.yaml
@@ -127,7 +127,19 @@ capability:
   confidence: high
   note: Broad feature matrix with a strong gateway/routing + caching angle on top of tracing, prompt mgmt,
     cost, and datasets; on par with Langfuse C4. Held at 4 (no frontier-definer claim over anchors).
+    Re-read 2026-08-13 - the README's own feature grid is still Observability, Agent Tracing, LLM Routing,
+    Cost & Latency Tracking, Datasets & Fine-tuning and Automatic Fallbacks, with a playground and prompt
+    management beneath it, so the recorded comparison at the langfuse anchor still holds.
+  last_verified: '2026-08-13'
   sources:
+  - url: https://raw.githubusercontent.com/Helicone/helicone/main/README.md
+    shows: 'Feature grid - Observability, Agent Tracing, LLM Routing, Cost & Latency Tracking, Datasets &
+      Fine-tuning, Automatic Fallbacks - under the heading "Helicone is an AI Gateway & LLM Observability
+      Platform for AI Engineers". The AI Gateway offers "Access 100+ AI models with 1 API key through the
+      OpenAI SDK", and Playground and Prompt Management are listed as their own items.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 80c63bc9e4335ab1b4174a452b1fe77074c819d58e982279cacaea2e1efd2a6f
   - url: https://github.com/Helicone/helicone
     shows: 'feature list: observability/agent tracing, prompt mgmt, cost analytics, AI Gateway/routing,
       datasets/fine-tuning, fallbacks'

--- a/sources/scores/laminar.yaml
+++ b/sources/scores/laminar.yaml
@@ -18,16 +18,33 @@ openness:
     - managed Laminar Cloud is hosting not a gated tier
   confidence: medium
   note: Repo and SDKs Apache-2.0 with full source; a hosted cloud exists but no enterprise-gated module
-    split was visible in the repo (less explicit open-core boundary than Langfuse/LangWatch).
+    split was visible in the repo (less explicit open-core boundary than Langfuse/LangWatch). Re-read
+    2026-08-13 and unchanged - GitHub's license endpoint still resolves the single root LICENSE.md to
+    Apache-2.0, the PyPI SDK still declares the Apache-2.0 license expression, and the repository root
+    still carries five docker-compose files, so the published tree is what a self-hoster runs.
   raw: license:Apache-2.0(OSI);source:public(Rust core + TS UI);SDKs:Apache-2.0;no feature-gated core observed
     in repo;managed Laminar Cloud is hosting not a gated tier;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/lmnr-ai/lmnr
-    shows: Apache-2.0 license; Rust+TS source public; OTel-native tracing/evals/datasets features
-    accessed: '2026-06-04'
+    shows: 'Repository page. The license sidebar resolves LICENSE.md to Apache-2.0 (spdxId "Apache-2.0"),
+      there is no ee/ or enterprise directory in the root listing, and the root carries docker-compose.yml
+      plus four variants (full, local-build, local-dev, local-dev-full), which is the self-host path.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 49fb50ae757fad987cecba03257c1e834fa1499bd5e561efbb43c46e2e6e5b53
+    establishes:
+    - license
+    - source
+    - core_gated
   - url: https://pypi.org/project/lmnr/
-    shows: lmnr v0.7.52 (27 May 2026), open source LLM engineering platform SDK
-    accessed: '2026-06-04'
+    shows: lmnr 0.7.59, "Python SDK for Laminar", uploaded 11 Aug 2026, with the License expression field
+      reading Apache-2.0. The version recorded at the last read was 0.7.52.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 2197e2955a8f64b22acde34f813ef826a56e03a4c18742751588cadadcd66275
+    establishes:
+    - license
 adoption:
   level: 3
   reach: 100K-1M
@@ -48,9 +65,19 @@ capability:
     (SDK+CLI, CI/CD); datasets + annotation UI; SQL query over traces; dashboards. Lighter on: prompt
     versioning/management and explicit cost tracking (not surfaced in repo).'
   confidence: medium
+  relative_to: langfuse
+  relation: one_below
   note: Solid tracing+evals+datasets coverage with a differentiated SQL/dashboard layer; below Langfuse/MLflow
-    (C4 anchors) on prompt management and cost-tracking breadth, hence 3.
+    (C4 anchors) on prompt management and cost-tracking breadth, hence 3. The comparison is now recorded
+    rather than left in prose - one rung below the langfuse anchor at 4. Re-read 2026-08-13 - the README
+    checklist still covers evals via SDK and CLI, an eval-comparison UI and SQL query over traces, spans,
+    metrics and events, with no prompt-versioning section.
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/lmnr-ai/lmnr
-    shows: 'feature list: tracing, evals SDK/CLI, datasets/annotation, SQL editor, dashboards'
-    accessed: '2026-06-04'
+    shows: 'README feature checklist - "Evals. Unopinionated, extensible SDK and CLI for running evals
+      locally or in CI/CD pipeline", "UI for visualizing evals and comparing results", and "Query traces,
+      spans, metrics, and events with SQL". No prompt-versioning or prompt-management item appears.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 49fb50ae757fad987cecba03257c1e834fa1499bd5e561efbb43c46e2e6e5b53

--- a/sources/scores/langfuse.yaml
+++ b/sources/scores/langfuse.yaml
@@ -112,11 +112,23 @@ capability:
   value: null
   confidence: high
   note: End-to-end tracing, prompt management, evals (incl. LLM-as-judge), datasets, annotation queues,
-    playground; OpenTelemetry + LangChain/OpenAI/LiteLLM integrations. Rated on feature matrix.
+    playground; OpenTelemetry + LangChain/OpenAI/LiteLLM integrations. Rated on feature matrix. Re-read
+    2026-08-13 - the repository README and the observability docs still describe the same feature set, and
+    the docs sidebar still lists Observability, Prompt Management, Evaluation and Playground as the four
+    product areas. Nothing was added or withdrawn that would move the band, so 4 stands as the category
+    anchor the peer comparisons in this category are recorded against.
   sources:
   - url: https://github.com/langfuse/langfuse
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+    shows: Repository overview. The README still describes tracing, prompt management, evaluations, datasets
+      and a playground as one platform, with OpenTelemetry and framework integrations.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e3e46319709c6345f977b895946d723c3d0309a067dd7b5d39d6a8c015890a4d
   - url: https://langfuse.com/docs/observability/overview
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+    shows: 'Observability & Application Tracing. "The core of this is application tracing - structured logs
+      of every request that capture the exact path", with Products in the sidebar listing Observability,
+      Prompt Management, Evaluation and Playground.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: edac2d534b62d4afa84842db5fb96df51031c33caeea29d46484becee0c943ca
+  last_verified: '2026-08-13'

--- a/sources/scores/langsmith.yaml
+++ b/sources/scores/langsmith.yaml
@@ -16,15 +16,28 @@ openness:
   confidence: high
   note: LangSmith the observability/eval platform is closed/proprietary; only the LangChain/LangGraph
     frameworks (separate registry entries) are open. Self-host/BYOC are licensed deployments of closed
-    software, not source-available.
+    software, not source-available. Re-read 2026-08-13 and unchanged - the page's Open Source Frameworks
+    section still names deepagents and the LangChain/LangGraph line rather than LangSmith itself, and its
+    FAQ answers "Can I self-host LangSmith?" with managed cloud, BYOC and self-hosted options for data
+    residency, which is a deployment choice rather than published source.
   raw: license:Proprietary;source:closed;platform:proprietary(no public source for LangSmith itself);self-hosting=licensed
     enterprise deployment of closed software, not OSS;OSS siblings(LangChain/LangGraph) are separate products
     not scored here
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.langchain.com/langsmith
-    shows: LangSmith described as managed SaaS with BYOC/self-host enterprise options; open source items
-      are LangChain/LangGraph frameworks, not LangSmith
-    accessed: '2026-06-04'
+    shows: 'The product page. Its Open Source Frameworks menu lists deepagents and the LangChain/LangGraph
+      line; LangSmith is not among them and no repository is linked for it. The FAQ reads "Can I self-host
+      LangSmith? Yes. LangSmith offers managed cloud, bring-your-own-cloud (BYOC), and self-hosted options
+      for teams with data residency requirements", and the self-host copy describes shipping "SmithDB
+      inside your VPC" as "three stateless components on object storage and Postgres" - a licensed
+      deployment of closed software rather than a published source tree.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 7443d54e8fdbb35b8f12fa25af760959718e020972374a0cbe5c006b07953fce
+    establishes:
+    - license
+    - source
 adoption:
   level: 4
   signal_type: reported_traction
@@ -44,9 +57,21 @@ capability:
     evals, alerts; evaluation/scoring; prompt + dataset workflows; deployment/fleet/sandbox tooling for
     agents.'
   confidence: medium
+  relative_to: langfuse
+  relation: at
   note: Mature, broad feature matrix across tracing/evals/prompt/datasets/cost plus agent deployment surface;
-    comparable to the C4 anchors. Closed-source, but capability is assessed independently of openness.
+    comparable to the C4 anchors. Closed-source, but capability is assessed independently of openness. The
+    comparison is now recorded rather than left in prose - at the langfuse anchor. Re-read 2026-08-13 - the
+    four product pillars on the page are still Observability, Evaluation, Agent Infrastructure Deployment
+    and Sandboxes, with monitoring carrying cost tracking and online LLM-as-judge evals.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.langchain.com/langsmith
-    shows: 'feature list: tracing, monitoring/cost, LLM-as-judge evals, evaluation, deployment/fleet/sandboxes'
-    accessed: '2026-06-04'
+    shows: 'Product pillars named on the page - Observability ("See exactly what your agents are doing"),
+      Evaluation ("Score and improve agent performance"), Agent Infrastructure Deployment and Sandboxes.
+      Tracing offers "Native tracing for popular agent frameworks and OpenTelemetry SDKs"; Monitoring lists
+      cost tracking, "Online LLM-as-judge and code evals", tool and agent trajectory monitoring, and
+      webhook/PagerDuty alerts.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 7443d54e8fdbb35b8f12fa25af760959718e020972374a0cbe5c006b07953fce

--- a/sources/scores/langtrace.yaml
+++ b/sources/scores/langtrace.yaml
@@ -76,11 +76,15 @@ adoption:
   signal_type: usage_volume
   confidence: medium
   note: ~34.5K langtrace-python-sdk downloads/mo; ~1.2k GitHub stars. Real but small footprint; early-adopter
-    tier.
+    tier. Re-read 2026-08-13 - pypistats now reports 34,666 downloads last month, within a couple of
+    hundred of the 34,497 recorded and still inside the 10K-100K band, so level 2 stands.
+  last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/packages/langtrace-python-sdk
-    shows: ~34,497 langtrace-python-sdk downloads in last month
-    accessed: '2026-06-04'
+    shows: Downloads last month 34,666 for langtrace-python-sdk (last week 6,846)
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 061e06953abd37f208f630c07f4019bd4846be1110387b56214de498b4f6ea8c
 capability:
   score: 3
   basis: feature_matrix
@@ -88,9 +92,20 @@ capability:
     analytics; broad integrations (OpenAI/Anthropic/Cohere, LangChain/LlamaIndex, Pinecone/Chroma/Weaviate).
     Lighter/unclear on: prompt versioning and dataset/annotation workflows.'
   confidence: medium
+  relative_to: langfuse
+  relation: one_below
   note: Strong tracing+cost+integration breadth but thinner prompt-mgmt/datasets surface than Langfuse
-    C4; scored 3.
+    C4; scored 3. The comparison is now recorded rather than left in prose - one rung below the langfuse
+    anchor at 4. Re-read 2026-08-13 - the repository still describes tracing, evaluations and metrics, and
+    the README's own Features list has narrowed to OTel support, real-time monitoring, performance
+    insights and debug tools, which is if anything narrower than the band already assumed.
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/Scale3-Labs/langtrace
-    shows: 'feature list: tracing, evaluations, cost/latency analytics, OTel, wide integrations'
-    accessed: '2026-06-04'
+    shows: 'Repository description - "observability tool for LLM applications, providing real-time tracing,
+      evaluations and metrics for popular LLMs, LLM frameworks, vectorDBs and more" - with repository
+      topics including datasets, evaluations, llmops and observability. The README Features list itself
+      names Open Telemetry Support, Real-time Monitoring, Performance Insights and Debug Tools.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 566f5f6da833515e176c3f3d080e772a4c9f5cbeb9816dd4048fc7977969c981

--- a/sources/scores/langwatch.yaml
+++ b/sources/scores/langwatch.yaml
@@ -86,12 +86,22 @@ adoption:
     signal, so capped at level 2 via stars fallback (cannot exceed 3 on stars regardless). Stars read
     2026-08-13: 3,486 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in
     signal_routing.yaml. The previous reach ''10K-100K'' was not a label this instrument offers - stars have
-    their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile,
-    so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.'
+    their own vocabulary because a star is not a download. The earlier pass declined to claim a date on the
+    ground that a star count is volatile and would read as drift on every refetch. That is true and it is not
+    a reason to leave the axis unconfirmed - `check_refetch` reports drift rather than failing on it, and
+    `helicone` in this same category already carries a dated stars_fallback band over the same endpoint. The
+    count was re-read from the repository API on 2026-08-13 and is recorded with its digest.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/langwatch/langwatch
     shows: ~3.3k GitHub stars; no disclosed usage numbers
     accessed: '2026-06-04'
+  - url: https://api.github.com/repos/langwatch/langwatch
+    shows: stargazers_count = 3486 for langwatch/langwatch. No download, install, customer or user figure
+      is published for this product anywhere the record cites, so stars remain the only signal.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 2bd045bcb34729a38ddc42633ca30f41ae707dbb7ff2478e3cc9081ee08137eb
 capability:
   score: 4
   basis: feature_matrix
@@ -103,8 +113,16 @@ capability:
   confidence: high
   note: Full feature matrix across all six recipe dimensions plus distinctive agent-simulation/scenario
     testing and a built-in gateway; on par with Langfuse C4. Held at 4 (no frontier-definer claim over
-    the anchors).
+    the anchors). Re-read 2026-08-13 - the README still leads on end-to-end agent simulations and on
+    "Eval + observability + prompts in one loop", so the breadth the band rests on is intact and the
+    recorded comparison at the langfuse anchor still holds.
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/langwatch/langwatch
-    shows: 'feature list: tracing, evals, simulations, prompt mgmt, datasets/annotation, AI Gateway, OTel'
-    accessed: '2026-06-04'
+    shows: 'README - "The platform for LLM evaluations and AI agent testing. We help teams test, simulate,
+      evaluate, and monitor LLM-powered agents end-to-end", with headline sections for "End-to-end agent
+      simulations" ("Run realistic scenarios against your full stack") and "Eval + observability + prompts
+      in one loop".'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 01df8119b46f1e2956eacd00810976a4eadec3399e5a5dacd7ccc1685482e057

--- a/sources/scores/mlflow.yaml
+++ b/sources/scores/mlflow.yaml
@@ -12,20 +12,41 @@ openness:
     free_text:
     - core-fully-OSS(Databricks-Managed-MLflow is third-party hosting, not gated core)
   confidence: high
-  note: license:Apache-2.0;source:public;core-fully-OSS(Databricks-Managed-MLflow is third-party hosting,
-    not gated core)
+  note: Apache-2.0 across a fully published core; Databricks Managed MLflow is third-party hosting rather
+    than a gated core. Re-read 2026-08-13 and unchanged - LICENSE.txt is the Apache License 2.0 verbatim,
+    the repository publishes the whole platform, and mlflow.org still describes itself as "the leading
+    open source AI engineering platform" with observability, evaluations, prompt registry and gateway all
+    listed as features of it rather than of a paid tier.
   raw: license:Apache-2.0;source:public;core-fully-OSS(Databricks-Managed-MLflow is third-party hosting,
     not gated core);core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/mlflow/mlflow/blob/master/LICENSE.txt
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+    shows: The LICENSE file body, read rather than assumed. It carries the Databricks copyright line
+      followed by the Apache License Version 2.0 text in full, including the "How to apply the Apache
+      License to your work" appendix.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6395355de6f391afff35996a30fb41b189b4991a4cb54993ace35ab69a0bfa28
+    establishes:
+    - license
   - url: https://github.com/mlflow/mlflow
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+    shows: Repository page for the published platform. 27,501 stars, source public, one root license.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0b6b0617716a4d8cf8ba818888e97f4396167da6f40bfbaaf542c7b96609523b
+    establishes:
+    - source
   - url: https://mlflow.org/
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+    shows: Project site, describing "The leading open source AI engineering platform" with Observability,
+      Evaluations, Prompt Registry, AI Gateway and Model Training as its features. Nothing is named as
+      withheld for a paid tier.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9f97efb8efaf8618ccd282261af5b738302403c42d453442562649e3a82b495a
+    establishes:
+    - core_gated
+    - source
 adoption:
   level: 5
   reach: '>10M'
@@ -35,26 +56,47 @@ adoption:
     pypistats; the prior note already reported 25-30M+ but mislabeled the reach as
     1M-10M). The map''s prevailing usage_volume level-5 floor is >10M/mo (cf.
     pydantic-ai ~31M, langgraph ~58M at level 5). MLflow is the de facto open
-    experiment-tracking / ML-lifecycle platform and clears the floor comfortably.'
+    experiment-tracking / ML-lifecycle platform and clears the floor comfortably. Re-read 2026-08-13 - the
+    pypistats endpoint now returns last_month 42,050,608, up from the 37,102,636 recorded and still well
+    clear of the >10M floor, so level 5 is unchanged.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/mlflow/recent
-    shows: last_month downloads = 37,102,636
-    accessed: '2026-06-25'
+    shows: '{"data":{"last_day":1564540,"last_month":42050608,"last_week":10170289},"package":"mlflow","type":"recent_downloads"}'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1feb9bedc6172bfaa1eab9dad7fae62eadab4a1c1f5a2764798e04081d7b4dc5
   - url: https://github.com/mlflow/mlflow
-    shows: mlflow/mlflow repo (experiment-tracking platform) confirmed live
-    accessed: '2026-06-25'
+    shows: mlflow/mlflow repository live, 27,501 stars
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0b6b0617716a4d8cf8ba818888e97f4396167da6f40bfbaaf542c7b96609523b
 capability:
   score: 4
   basis: feature_matrix
   value: null
   confidence: high
+  relative_to: langfuse
+  relation: at
   note: Single open platform combining distributed tracing, prompt versioning, automated evaluation, and
     trace replay for agents/LLMs plus classic ML tracking. No standard benchmark for observability; rated
-    on feature matrix.
+    on feature matrix. The comparison is now recorded rather than left in prose - at the langfuse anchor,
+    the two being the pair the rest of this category is placed against. Re-read 2026-08-13 - the GenAI page
+    still lists observability, evaluation, prompt registry and AI gateway as one platform.
+  last_verified: '2026-08-13'
   sources:
   - url: https://mlflow.org/genai/
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+    shows: '"Built-in observability, evaluation, prompt management, and monitoring. 100+ integrations",
+      with the feature nav reading Observability, Evaluations, Prompt Registry, AI Gateway and Model
+      Training, and the LLMs & Agents copy offering "production-grade tracing, evaluation, prompt
+      management, and much more".'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 4e5ff078259f6c077a7b78db085a589d54db161a4583760b8646b1f01cbc229a
   - url: https://mlflow.org/top-5-agent-observability-tools/
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+    shows: '"Top 5 LLM and Agent Observability Tools in 2026", the vendor''s own comparison piece placing
+      MLflow among the category leaders. Vendor-authored and read as positioning rather than as an
+      independent ranking.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6c98689c40f423c54ffaa9f031ab9255c72d44ff812e4cc48bad0b061fe061fe

--- a/sources/scores/new-relic-ai-monitoring.yaml
+++ b/sources/scores/new-relic-ai-monitoring.yaml
@@ -16,13 +16,24 @@ openness:
       value: closed
   confidence: high
   note: Fully proprietary SaaS observability platform; AI Monitoring is a commercial module. OTel ingestion
-    support does not make the product open. Scored closed (1).
+    support does not make the product open. Scored closed (1). Re-read 2026-08-13 and unchanged - the
+    product page still sells AI Monitoring as one capability of the hosted New Relic platform, lists
+    OpenTelemetry only as a way of getting data in, and publishes no source or self-hosted build.
   raw: platform:proprietary-SaaS(closed);license:commercial(Standard/Pro/Enterprise tiers);ingestion:OpenTelemetry-compatible(open
     standard, not open product);source:closed
+  last_verified: '2026-08-13'
   sources:
   - url: https://newrelic.com/platform/ai-monitoring
-    shows: proprietary SaaS AI observability with Standard/Pro/Enterprise tiers; OTel ingestion
-    accessed: '2026-06-04'
+    shows: 'The AI Monitoring product page, sold as one capability among Federated Logs, SAP Monitoring,
+      AIOps, Pipeline Control and the rest of the hosted platform. OpenTelemetry appears in the capability
+      list as "Collect metrics, logs, and traces from any source", which is an ingestion route rather than
+      an open product. No repository, license text or self-hosted distribution is offered anywhere on it.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b3986cb976b800306128a110c6c6aa9adf8ba4162020b7f0b9a1fe56b23591eb
+    establishes:
+    - license
+    - source
 adoption:
   level: 4
   reach: 1M-10M
@@ -44,10 +55,20 @@ capability:
     detection, response analysis, user feedback); OTel + OpenAI/Pinecone/LangChain integrations; 'no new
     instrumentation'. Lacks dedicated prompt-versioning/dataset-eval depth of eval-first tools.
   confidence: medium
+  relative_to: langfuse
+  relation: at
   note: Broad full-stack AI observability (traces, cost, quality, agentic spans) at the anchor C4 tier
-    on feature breadth; not an eval/prompt-mgmt frontier-definer, so 4 not 5.
+    on feature breadth; not an eval/prompt-mgmt frontier-definer, so 4 not 5. The comparison is now recorded
+    rather than left in prose - at the langfuse anchor. Re-read 2026-08-13 - the page still names AI metrics
+    from response time and quality through tokens and APM golden signals, token cost tracking with custom
+    alerts, and detection of bias, hallucination and toxicity.
+  last_verified: '2026-08-13'
   sources:
   - url: https://newrelic.com/platform/ai-monitoring
-    shows: AI-stack tracing, token cost tracking, bias/hallucination/toxicity detection, OTel + LangChain/OpenAI/Pinecone
-      integrations
-    accessed: '2026-06-04'
+    shows: 'Page copy - a summary of AI metrics "from response time and quality, to tokens, APM golden
+      signals, and infrastructure"; "Spot and solve issues like bias, hallucination, and toxicity with
+      complete visibility"; and "Monitor and control costs easily by tracking request tokens used and
+      setting custom alerts", with model comparison beside it.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b3986cb976b800306128a110c6c6aa9adf8ba4162020b7f0b9a1fe56b23591eb

--- a/sources/scores/openlit.yaml
+++ b/sources/scores/openlit.yaml
@@ -15,12 +15,25 @@ openness:
     - no enterprise-gated core observed
   confidence: high
   note: Fully Apache-2.0, OpenTelemetry-native, no feature-gated core; vendor-neutral by design (exports
-    to any OTel backend).
+    to any OTel backend). Re-read 2026-08-13 and unchanged - GitHub's license endpoint still resolves the
+    repository to Apache-2.0, the root listing carries a docker-compose.yml and no ee/ or enterprise
+    directory, and the README presents guardrails, evaluations, prompt management and the vault as
+    features of the published stack rather than of a paid tier.
   raw: license:Apache-2.0(OSI);source:public;OTel-native SDKs(Python/TS/Go);no enterprise-gated core observed;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/openlit/openlit
-    shows: Apache-2.0 license; OTel-native SDKs; full feature source
-    accessed: '2026-06-04'
+    shows: 'Repository page. License resolves to Apache-2.0 (spdxId "Apache-2.0"); the README strapline
+      reads "OpenTelemetry-native LLM Observability, GPU Monitoring, Guardrails, Evaluations, Prompt
+      Management, Vault, Playground" and the root listing includes docker-compose.yml with no ee/ or
+      enterprise directory beside it. 2,686 stars.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 97eb864c78858527d9aa2996af235c33c964c5fb443591012c16eb2ef8d6b31a
+    establishes:
+    - license
+    - source
+    - core_gated
 adoption:
   level: 2
   reach: 10K-100K
@@ -40,11 +53,21 @@ capability:
     Prompt Hub (versioning); cost tracking incl custom/fine-tuned pricing; guardrails; secrets Vault;
     50+ provider/framework integrations.'
   confidence: high
+  relative_to: langfuse
+  relation: at
   note: Broad feature matrix covering all six recipe dimensions (tracing, prompt mgmt, evals, datasets/annotation-adjacent,
     cost, OTel+integrations) plus GPU observability; comparable to Langfuse C4. Held at 4 (not 5) as no
-    observability product is a clear frontier-definer over MLflow/Langfuse anchors.
+    observability product is a clear frontier-definer over MLflow/Langfuse anchors. The comparison is now
+    recorded rather than left in prose - at the langfuse anchor. Re-read 2026-08-13 - the README strapline
+    still names observability, GPU monitoring, guardrails, evaluations, prompt management, vault and
+    playground together, so the breadth the band rests on is intact.
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/openlit/openlit
-    shows: 'feature list: tracing/metrics, 11 eval types, Prompt Hub, cost tracking, guardrails, vault,
-      50+ integrations'
-    accessed: '2026-06-04'
+    shows: 'README strapline - "OpenTelemetry-native LLM Observability, GPU Monitoring, Guardrails,
+      Evaluations, Prompt Management, Vault, Playground" - and a section headed "Observability, Evaluations,
+      Rule Engine, Guardrails, Prompts, Vault, Playground", with integrations across 50+ LLM providers and
+      vector databases.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 97eb864c78858527d9aa2996af235c33c964c5fb443591012c16eb2ef8d6b31a

--- a/sources/scores/openllmetry.yaml
+++ b/sources/scores/openllmetry.yaml
@@ -15,30 +15,53 @@ openness:
       not gated core)
   confidence: high
   note: Apache-2.0 instrumentation library; exports to any OTel backend (Datadog, Honeycomb, etc.), so
-    the OSS is genuinely standalone.
+    the OSS is genuinely standalone. Re-read 2026-08-13 on the repository, which still states the Apache-2.0
+    licensing and the export-anywhere design in the vendor's own words. The PyPI project page could not be
+    re-read this run - pypi.org served a JavaScript bot challenge rather than the project page on every
+    attempt - so that source keeps its earlier read date and the confirmation rests on the repository.
   raw: license:Apache-2.0(OSI);source:public;no-feature-gated-core(SDK is fully OSS; Traceloop dashboard
     is an optional external export target, not gated core);core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://pypi.org/project/traceloop-sdk/
     shows: 'License: Apache-2.0; v0.61.0 (31 May 2026)'
     accessed: '2026-06-04'
   - url: https://github.com/traceloop/openllmetry
-    shows: Apache-2.0; OTel-based GenAI instrumentation
-    accessed: '2026-06-04'
+    shows: 'README, read rather than assumed. The badge alt text reads "OpenLLMetry is released under the
+      Apache-2.0 License" and the body states "It''s built and maintained by Traceloop under the Apache 2.0
+      license." On what ships - "The repo contains standard OpenTelemetry instrumentations for LLM providers
+      and Vector DBs, as well as a Traceloop SDK that makes it easy to get started." On the gate question,
+      the vendor''s own framing is that "it can be connected to your existing observability solutions -
+      Datadog, Honeycomb, and others", so the published SDK works without any Traceloop-hosted tier and
+      nothing is withheld from it.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: ab2b4375e765649f52924eb26ae7aeecb9f69d809cde3db0fe3ef88f766b511d
+    establishes:
+    - license
+    - source
+    - core_gated
 adoption:
   level: 4
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
   note: traceloop-sdk ~3.15M PyPI downloads/month; 15+ LLM providers, 7 vector DBs, 25+ tested export
-    destinations; ~7.2k stars corroborates only.
+    destinations; ~7.2k stars corroborates only. Re-read 2026-08-13 - pypistats now reports 2,444,560
+    downloads last month for traceloop-sdk, down from the 3,149,787 recorded and still inside the 1M-10M
+    band, so level 4 is unchanged.
+  last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/packages/traceloop-sdk
-    shows: ~3,149,787 downloads last month
-    accessed: '2026-06-04'
+    shows: Downloads last month 2,444,560 for traceloop-sdk (last week 530,018)
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5b14f0be4e69f7e1d37d23a6cb6b8e6c71ea582829d15430a27164d12b84afe1
   - url: https://github.com/traceloop/openllmetry
-    shows: ~7.2k stars; 15+ providers, 25+ destinations
-    accessed: '2026-06-04'
+    shows: 7,376 stars; README still lists supported LLM providers, vector DBs and tested export destinations
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: ab2b4375e765649f52924eb26ae7aeecb9f69d809cde3db0fe3ef88f766b511d
 capability:
   score: 3
   basis: feature_matrix
@@ -46,10 +69,20 @@ capability:
     export(25+ platforms); NO native prompt management, evals/LLM-as-judge, or datasets/annotation in
     the OSS layer
   confidence: high
+  relative_to: langfuse
+  relation: one_below
   note: Strong on tracing + integrations but narrow vs full platforms; it is an instrumentation layer,
-    not an eval/prompt/dataset suite. Below the MLflow/Langfuse/Phoenix/Opik feature breadth (C4).
+    not an eval/prompt/dataset suite. Below the MLflow/Langfuse/Phoenix/Opik feature breadth (C4). The
+    comparison the band rests on is now recorded rather than left in prose - one rung below the langfuse
+    anchor at 4. Re-read 2026-08-13 - the README is still organized around instrumentations, an SDK and
+    export destinations, with no evals, prompt management or dataset surface in the repository.
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/traceloop/openllmetry
-    shows: instrumentation/integration-focused feature set; evals/prompt mgmt are Traceloop-platform features
-      not OSS SDK
-    accessed: '2026-06-04'
+    shows: 'README structure - "The repo contains standard OpenTelemetry instrumentations for LLM providers
+      and Vector DBs, as well as a Traceloop SDK", then sections for supported providers, Vector DBs and
+      "Supported (and tested) destinations". No evals, prompt-management or dataset section exists in the
+      OSS repository.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: ab2b4375e765649f52924eb26ae7aeecb9f69d809cde3db0fe3ef88f766b511d

--- a/sources/scores/opik.yaml
+++ b/sources/scores/opik.yaml
@@ -17,30 +17,55 @@ openness:
     - self-hostable-full-stack
   confidence: high
   note: Apache-2.0, full platform self-hostable; cloud is managed hosting rather than a feature-gated
-    proprietary core.
+    proprietary core. Re-read 2026-08-13 and unchanged - both the PyPI project page and the repository
+    README now say in the vendor's own words that the server, web application and evaluation components
+    are all Apache-2.0 and free to self-host, which is the core_gated question answered directly.
   raw: license:Apache-2.0(OSI);source:public;self-hostable-full-stack;commercial:Comet-cloud-hosting(not
     a gated core);core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://pypi.org/project/opik/
-    shows: 'License: Apache 2.0; v2.0.57 (4 Jun 2026)'
-    accessed: '2026-06-04'
+    shows: 'opik 2.2.28 on PyPI. The long description states "Apache-2.0 licensed, free to self-host the
+      full platform", and its FAQ answers "Is Opik open source?" with "Opik is licensed under Apache 2.0.
+      Its server, web application, and core observability and evaluation components" are covered.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0b8d9de89c8ceb800ddeecb3f899db4ddf5dcc355ca1f8f56cc79bc01b92bd97
+    establishes:
+    - license
+    - source
+    - core_gated
   - url: https://github.com/comet-ml/opik
-    shows: Apache-2.0; self-hosted + cloud deployment
-    accessed: '2026-06-04'
+    shows: Repository README, carrying the same statement - "Apache-2.0 licensed, free to self-host the
+      full platform" - alongside the tracing, LLM-as-a-judge, dataset and integration sections. 21,353 stars.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 081be18d9854c64b346cca6bab84ff3285205f5d499bf70b1af100ee86380262
+    establishes:
+    - license
+    - source
+    - core_gated
 adoption:
   level: 4
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: opik ~6.19M PyPI downloads/month (highest in this batch); 60-70+ framework integrations; platform
-    reports 40M+ traces/day; ~19.4k stars corroborates only.
+  note: opik ~6.19M PyPI downloads/month; 60-70+ framework integrations; ~19.4k stars corroborates only.
+    Re-read 2026-08-13 - pypistats now reports 3,512,727 downloads last month for opik, down from the
+    6,192,885 recorded and still inside the 1M-10M band, so level 4 is unchanged. The 40M+ traces/day
+    figure is no longer on the repository README and is dropped from this note rather than carried forward.
+  last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/packages/opik
-    shows: ~6,192,885 downloads last month
-    accessed: '2026-06-04'
+    shows: Downloads last month 3,512,727 for opik (last week 770,341)
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 97f7f350b62dc797994f340b9e36d3de97f057f2e2cd4a436507e60515243241
   - url: https://github.com/comet-ml/opik
-    shows: ~19.4k stars; 70+ integrations; 40M+ traces/day
-    accessed: '2026-06-04'
+    shows: 21,353 stars; README still describes extensive third-party integrations for observability
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 081be18d9854c64b346cca6bab84ff3285205f5d499bf70b1af100ee86380262
 capability:
   score: 4
   basis: feature_matrix
@@ -50,8 +75,15 @@ capability:
     metrics(hallucination/moderation/relevance/context-precision), prompt playground, datasets, cost tracking
   confidence: high
   note: Covers all six feature-matrix dimensions; on par with MLflow/Langfuse anchors (C4). Not scored
-    5; closed Arize AX leads category capability.
+    5; closed Arize AX leads category capability. Re-read 2026-08-13 - the README still covers trace
+    logging, LLM-as-a-judge scoring, feedback annotation on traces and spans, datasets and third-party
+    integrations, so the recorded comparison at the langfuse anchor still holds.
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/comet-ml/opik
-    shows: tracing, evals, LLM-as-judge, prompt management, datasets, OTel
-    accessed: '2026-06-04'
+    shows: 'README sections - "Track all LLM calls and traces with detailed context during development and
+      in production", LLM-as-a-judge scoring, "Annotate traces and spans with feedback scores", datasets
+      and "Extensive 3rd-party integrations for easy observability".'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 081be18d9854c64b346cca6bab84ff3285205f5d499bf70b1af100ee86380262

--- a/sources/scores/phoenix.yaml
+++ b/sources/scores/phoenix.yaml
@@ -17,30 +17,56 @@ openness:
     open source platform" (open_washed). Source-available and self-hostable, with Arize AX as a separate
     closed SaaS product. Score corrected from 3 to 2 on 2026-07-30. The software ladder has rungs at 1,
     2, 4 and 5 and none at 3, so 3/source_available was not a pair any rule could produce; the ladder scores
-    "you can read it and not run it freely" at 2.
+    "you can read it and not run it freely" at 2. Re-read 2026-08-13 and unchanged - the LICENSE file is
+    still ELv2 verbatim, and the vendor page still calls Phoenix "the open-source platform" while stating
+    "ELv2 licensed" in the same breath.
   raw: 'license:Elastic-License-2.0(ELv2, non-OSI: prohibits offering as a managed/hosted service to third
     parties);source:public;self-hostable;commercial:Arize-AX-SaaS-is-separate-closed-product'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/Arize-ai/phoenix/blob/main/LICENSE
-    shows: Elastic License 2.0 (ELv2) full text
-    accessed: '2026-06-04'
+    shows: 'Elastic License 2.0 (ELv2) full text, read rather than assumed. It opens "Elastic License 2.0
+      (ELv2)" and its Limitations state "You may not provide the software to third parties as a hosted or
+      managed service, where the service provides users with access to any substantial set of the features
+      or functionality of the software." That is the non-OSI restriction the record scores on.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1c5916f5112e30e92f291002bb02cf4f4851c9d1dbdf3360f9f745b7de2d775f
+    establishes:
+    - license
   - url: https://arize.com/phoenix/
-    shows: marketed as 'the open source platform'; 'ELv2 licensed. 9k+ GitHub stars'
-    accessed: '2026-06-04'
+    shows: 'The vendor page, which markets Phoenix as "The open-source platform for agent development and
+      evaluation" while its own OSS Community block reads "ELv2 licensed. 10k+ GitHub stars." Self-hosting
+      is a first-class path - "Self-Host ... your data on your own infrastructure" and a Helm/Kubernetes
+      deployment option - so the published source is what you run. The stars figure has moved from the 9k+
+      recorded at the last read to 10k+; the license statement has not moved.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 01c6f8260364929b913065905be2539960548046b2fec5c1442e8135495fee73
+    establishes:
+    - license
+    - source
 adoption:
   level: 4
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
   note: arize-phoenix ~2.46M PyPI downloads/month; broad OTel-based framework integrations; ~10k GitHub
-    stars corroborates only.
+    stars corroborates only. Re-read 2026-08-13 - pypistats now reports 2,313,184 downloads last month
+    for arize-phoenix, down slightly from the 2,458,129 recorded and still inside the 1M-10M band, so
+    level 4 is unchanged.
+  last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/packages/arize-phoenix
-    shows: ~2,458,129 downloads last month
-    accessed: '2026-06-04'
+    shows: Downloads last month 2,313,184 for arize-phoenix (last week 517,110)
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 568bdc3eef702a15e064240cb622941494fc8a9d503d2ad0d5461fdc0328332d
   - url: https://github.com/Arize-ai/phoenix
-    shows: ~10k stars; OTel tracing, evals, datasets, prompt mgmt, playground
-    accessed: '2026-06-04'
+    shows: 11,033 stars; OTel-based tracing, evaluation, playground and prompt management in the README
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: dcf536b4e91cd985fcd5c380bc4a342f500937963f342456abfbab1b06d0977a
 capability:
   score: 4
   basis: feature_matrix
@@ -50,8 +76,15 @@ capability:
     cost/latency, broad framework integrations (OpenAI/Claude/LangGraph/LlamaIndex/CrewAI)
   confidence: high
   note: Full-coverage observability/eval platform across all six feature-matrix dimensions; on par with
-    MLflow/Langfuse anchors (C4).
+    MLflow/Langfuse anchors (C4). Re-read 2026-08-13 - the README still lists Tracing (OpenTelemetry-based
+    instrumentation), Evaluation (response and retrieval evals), Playground and Prompt Management as
+    first-class features, so the comparison with the langfuse anchor at 4 still holds.
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/Arize-ai/phoenix
-    shows: tracing, evals, datasets, prompt management, playground, OTel integrations
-    accessed: '2026-06-04'
+    shows: 'README feature list - Tracing "using OpenTelemetry-based instrumentation", Evaluation with
+      "response and retrieval evals", Playground and Prompt Management, plus the arize-phoenix-evals and
+      arize-phoenix-otel packages.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: dcf536b4e91cd985fcd5c380bc4a342f500937963f342456abfbab1b06d0977a

--- a/sources/scores/promptlayer.yaml
+++ b/sources/scores/promptlayer.yaml
@@ -17,12 +17,25 @@ openness:
   confidence: high
   note: Open client SDK over a closed hosted backend (prompt CMS, logging, evals are SaaS), no OSS core,
     so 'closed' alongside the Braintrust/LangSmith pattern; the open library is instrumentation only.
+    Re-read 2026-08-13 and unchanged - the repository is still only the client library, described by its
+    own tagline as a log of prompts and API requests, and it publishes no server, no deployment manifest
+    and no self-host path.
   raw: source:closed;license:Apache-2.0(OSI, client library MagnivOrg/prompt-layer-library only);platform:proprietary-SaaS(API-key
     gated, hosted prompt registry/logging/evals);self-host:no(managed only)
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/MagnivOrg/prompt-layer-library
-    shows: Apache-2.0 official PromptLayer Python library; platform at promptlayer.com requiring API key
-    accessed: '2026-06-04'
+    shows: 'Repository page. GitHub resolves its LICENSE to Apache-2.0 (spdxId "Apache-2.0"), and the
+      repository description is "PromptLayer - Maintain a log of your prompts and OpenAI API requests.
+      Track, debug, and replay old completions." It is a client library; the registry, logging and eval
+      services it talks to are not in it and are reached over promptlayer.com with an API key.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9442179edd5c8e749834f1119bf4d5a8b19c48b16471c10dedfa333a71dc50da
+    establishes:
+    - license
+    - source
+    - self-host
 adoption:
   level: 3
   reach: 100K-1M
@@ -30,11 +43,15 @@ adoption:
   confidence: medium
   note: '~289K PyPI downloads in the last month for the `promptlayer` package (primary: pypistats) → 100K-1M
     band. Recognized but lighter-weight (no-code prompt CMS for non-technical teams) vs the deeper platforms;
-    no harder user count disclosed.'
+    no harder user count disclosed. Re-read 2026-08-13 - pypistats now reports 254,412 downloads last month,
+    down from the 289,237 recorded and still inside the 100K-1M band, so level 3 stands.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/packages/promptlayer
-    shows: 289,237 downloads last month for the promptlayer package
-    accessed: '2026-06-04'
+    shows: Downloads last month 254,412 for the promptlayer package (last week 45,074)
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 319b4e634abff8c60ed749fcfe02955734681b0b12469706200ba6641c211612
 capability:
   score: 3
   basis: feature_matrix
@@ -45,8 +62,15 @@ capability:
     Missing: deep LLM-as-judge eval + broad OTel/framework observability vs anchors.'
   confidence: medium
   note: Strong prompt-lifecycle/versioning focus but shallower eval + production observability than MLflow/Langfuse
-    (C4) per 2026 comparisons, rated 3, mid-tier.
+    (C4) per 2026 comparisons, rated 3, mid-tier. Re-read 2026-08-13 - the repository still presents itself
+    as a log of prompts and API requests with track, debug and replay, which is narrower than the anchor
+    tier and consistent with the one-below comparison already recorded.
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/MagnivOrg/prompt-layer-library
-    shows: version/test/monitor prompts and agents with evals, tracing, regression sets
-    accessed: '2026-06-04'
+    shows: 'Repository tagline - "PromptLayer - Maintain a log of your prompts and OpenAI API requests.
+      Track, debug, and replay old completions." Prompt versioning and request logging are what the library
+      offers; no tracing-platform, dataset or LLM-as-judge surface lives in it.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9442179edd5c8e749834f1119bf4d5a8b19c48b16471c10dedfa333a71dc50da

--- a/sources/scores/trulens.yaml
+++ b/sources/scores/trulens.yaml
@@ -18,13 +18,24 @@ openness:
       value: ungated
   confidence: high
   note: MIT library that is fully functional standalone; the Snowflake Cortex hosted product is separate, not a
-    gate on the library.
+    gate on the library. Re-read 2026-08-13 and unchanged - GitHub still resolves the single root LICENSE
+    to MIT, and the repository still carries the whole library with no ee/ or enterprise directory and no
+    second license beneath it.
   raw: license:MIT(OSI);source:public(github.com/truera/trulens);commercial:Snowflake-Cortex-AI-Observability(separate
     hosted product);library:not-feature-gated;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/truera/trulens
-    shows: MIT, ~3.4k stars, LLM eval + tracing
-    accessed: '2026-06-18'
+    shows: 'Repository page. The license sidebar reads "MIT license" and GitHub''s own metadata records
+      license spdxId "MIT", name "MIT License", resolved from the single root LICENSE file. The README
+      still leads on feedback functions and the RAG Triad. 3,508 stars.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a692e7e08971b32cf73f93470bfb4c1674907e30cac99bbaace1c11d9e46a580
+    establishes:
+    - license
+    - source
+    - core_gated
 adoption:
   level: 3
   signal_type: usage_volume
@@ -47,7 +58,25 @@ capability:
     across versions; Streamlit dashboard; OpenAI/HF/LiteLLM/Cortex providers
   confidence: medium
   note: Eval-first observability; lighter than Langfuse/Helicone on production gateway and prompt management.
+    Re-read 2026-08-13 - the repository still leads on feedback functions and the RAG Triad, with no
+    gateway, prompt-registry or dataset-annotation surface, which is what the note already said. No
+    `relative_to` is recorded here on purpose - the note places TruLens BELOW langfuse and helicone while
+    the score matches theirs at 4, so recording `at` would assert a comparison the prose contradicts and
+    recording `one_below` would change the score. The disagreement is left visible for a ruling.
+  last_verified: '2026-08-13'
   sources:
+  - url: https://github.com/truera/trulens
+    shows: 'README - feedback functions built around "the RAG Triad" (groundedness, context relevance,
+      answer relevance) with links to Snowflake''s RAG-triad benchmarks, and a comparison claiming TruLens
+      leads on three of four ranking metrics ahead of WandB Weave, RAGAS, DeepEval and UpTrain. No AI
+      gateway, prompt registry or annotation-queue feature appears.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a692e7e08971b32cf73f93470bfb4c1674907e30cac99bbaace1c11d9e46a580
   - url: https://www.snowflake.com/en/blog/trulens-open-source-ai/
-    shows: Snowflake acquired TruEra; TruLens stays open source
-    accessed: '2026-06-18'
+    shows: '"TruLens ❤️ Snowflake OSS", published 2024-06-24, describing Snowflake''s acquisition of
+      TruEra''s AI observability platform and its continued open-source support for LLM app developers.
+      A 2024 post, re-read for what it still says rather than as current news.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5e10f54f944e9a10f48858fa525ae548905b9a47ec56afacec5f3b28b44e5c81

--- a/sources/scores/vertex-ai-model-observability.yaml
+++ b/sources/scores/vertex-ai-model-observability.yaml
@@ -13,24 +13,42 @@ openness:
         proprietary and cloud-locked
   confidence: high
   note: Proprietary GCP managed offering (Agent Engine + Cloud Trace/Monitoring/Logging). OTel is the
-    wire standard but the service is closed and tied to Google Cloud.
+    wire standard but the service is closed and tied to Google Cloud. Re-read 2026-08-13 and unchanged -
+    the documentation still describes Cloud Trace as the place traces land, with no source, license or
+    self-hostable build of the observability service offered anywhere in it.
   raw: license:proprietary(Google Cloud managed service);source:closed;note:tracing is built on the open
     OTel standard but the observability product/service itself is proprietary and cloud-locked
+  last_verified: '2026-08-13'
   sources:
   - url: https://docs.cloud.google.com/agent-builder/agent-engine/manage/tracing
-    shows: Cloud Trace tracing for Agent Engine as a managed Google Cloud service
-    accessed: '2026-06-04'
+    shows: 'Documentation - "Cloud Trace lets you analyze the performance of your agents by tracing" them,
+      with "A trace is composed of individual spans, which represent a single unit of work, like a function
+      call or an interaction with an LLM." The trace format shown carries trace_id, span_id and span_kind
+      LLM. Everything described runs inside Google Cloud; nothing is published to run elsewhere.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 3d349ddecec96887e8ef1c7740a7d3ca54eda36452ba3d7a33fb32a94e710910
+    establishes:
+    - license
+    - source
 adoption:
   level: 3
   signal_type: reported_traction
   confidence: low
   note: A feature surface within Vertex AI Agent Engine on Google Cloud; no standalone usage figures published
     for the observability capability specifically. Level 3 reflects availability inside a large cloud
-    platform's agent stack, not a measured user count; directional.
+    platform's agent stack, not a measured user count; directional. Re-read 2026-08-13 and unchanged - the
+    quantity actually banded here is the reach of Vertex AI, not usage of its tracing surface, and the
+    documentation still discloses no figure for either.
+  last_verified: '2026-08-13'
   sources:
   - url: https://docs.cloud.google.com/agent-builder/agent-engine/manage/tracing
-    shows: observability shipped as part of the managed Vertex AI Agent Engine platform
-    accessed: '2026-06-04'
+    shows: The tracing documentation, read for a usage figure and containing none. It sits under an
+      Observability section of the Agent Engine docs, beside RAG Engine deployment modes and Model Armor,
+      which places the capability inside the platform without saying how many people use it.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 3d349ddecec96887e8ef1c7740a7d3ca54eda36452ba3d7a33fb32a94e710910
 capability:
   score: 3
   basis: feature_matrix
@@ -39,9 +57,19 @@ capability:
     Gen AI Evaluation service incl User Simulator) + Cloud Logging. Cost/token tracking present; prompt
     management and dedicated annotation queues not evidenced as native.
   confidence: medium
+  relative_to: langfuse
+  relation: one_below
   note: Solid tracing + monitoring + integrated eval, but the observability matrix is thinner than the
-    dedicated OSS platforms on prompt versioning/datasets/annotation; scored 3 below the C4 anchors.
+    dedicated OSS platforms on prompt versioning/datasets/annotation; scored 3 below the C4 anchors. The
+    comparison is now recorded rather than left in prose - one rung below the langfuse anchor at 4.
+    Re-read 2026-08-13 - the documentation still covers traces and spans over LLM and tool calls with no
+    prompt-management or annotation surface of its own.
+  last_verified: '2026-08-13'
   sources:
   - url: https://docs.cloud.google.com/agent-builder/agent-engine/manage/tracing
-    shows: Cloud Trace traces/spans, perf dashboard, Gen AI Evaluation integration
-    accessed: '2026-06-04'
+    shows: 'Documentation covering Cloud Trace spans for ADK agents, with span_kind LLM, parent_id and
+      event fields shown in the example payload, and an Observability section grouping it with monitoring.
+      No prompt-versioning or annotation-queue feature is described.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 3d349ddecec96887e8ef1c7740a7d3ca54eda36452ba3d7a33fb32a94e710910

--- a/sources/scores/weave.yaml
+++ b/sources/scores/weave.yaml
@@ -92,11 +92,16 @@ adoption:
   confidence: high
   note: '~1.03M PyPI downloads in the last month for the `weave` package (primary: pypistats); rides the
     established W&B install base (ML teams adding LLM observability without leaving W&B). 1-10M monthly-download
-    band.'
+    band. Re-read 2026-08-13 - pypistats now reports 1,052,916 downloads last month, effectively unchanged
+    and still just inside the 1M-10M band, so level 4 stands. It sits close to the boundary, and a further
+    fall would put it at 3.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/packages/weave
-    shows: 1,028,914 downloads last month for the weave package
-    accessed: '2026-06-04'
+    shows: Downloads last month 1,052,916 for the weave package (last week 269,722)
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 447ff1e74990cb9a391987632f293aa367da2789642dd241680d52a0340a34b2
 capability:
   score: 4
   basis: feature_matrix
@@ -108,8 +113,20 @@ capability:
   confidence: medium
   note: Competent end-to-end tracing+eval suite; rated 4 = at the MLflow/Langfuse anchor tier on feature
     breadth, just short of frontier (lighter prompt-versioning + OTel story than Langfuse/MLflow per 2026
-    comparisons).
+    comparisons). Re-read 2026-08-13 - the README still frames the product as logging and debugging model
+    inputs, outputs and traces plus rigorous evaluations, and states that Weave boards are on pause "as we
+    focus on Tracing and Evaluations", which narrows rather than widens the surface. The band holds at the
+    langfuse anchor but with less headroom than the note implied.
+  last_verified: '2026-08-13'
   sources:
+  - url: https://raw.githubusercontent.com/wandb/weave/master/README.md
+    shows: 'README - use Weave to "Log and debug language model inputs, outputs, and traces", "Build
+      rigorous, apples-to-apples evaluations for language model use cases" and "Organize all the
+      information generated across the LLM workflow, from experimentation to evaluations to production".
+      It also records that "Weave boards" are on pause "as we focus on Tracing and Evaluations".'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a80ad86bad9feeb77a2f784c145270583a93314d75b9895a0ed1fa774418e6ed
   - url: https://github.com/wandb/weave
     shows: logging/debugging LLM traces + rigorous evaluations feature set
     accessed: '2026-06-04'

--- a/sources/scores/whylabs.yaml
+++ b/sources/scores/whylabs.yaml
@@ -24,17 +24,36 @@ openness:
     The earlier 4 was justified by the hosted backend no longer operating and the OSS pieces being libraries
     rather than a turnkey observability product, which are maturity judgments and are already recorded as
     adoption 2 and capability 2. On the openness question the published source is the whole product, because
-    there is no longer anything else, and 4 pairs with open_core rather than open_source.'
+    there is no longer anything else, and 4 pairs with open_core rather than open_source. Re-read 2026-08-13
+    and unchanged - the LangKit page still carries the closure notice and the statement that the complete
+    platform was open sourced, and whylogs still resolves to Apache-2.0 on GitHub.'
   raw: license:Apache-2.0(OSI, whylogs + LangKit + open sourced platform);source:public(github.com/whylabs);core-gated:ungated(nothing
     is withheld - the company ceased operations and open sourced the platform on closure);hosted-SaaS:discontinued;status:company-ceased-ops,
     platform open sourced on closure
+  last_verified: '2026-08-13'
   sources:
   - url: https://whylabs.ai/langkit
-    shows: '''WhyLabs, Inc. is discontinuing operations''; platform/whylogs/LangKit open sourced'
-    accessed: '2026-06-04'
+    shows: 'The closure notice, in the vendor''s own words - "WhyLabs, Inc. is discontinuing operations",
+      followed by "The complete WhyLabs platform has been open sourced to help support next iterations of
+      AI observability research" and, on LangKit, "The open source toolkit for monitoring LLMs, langkit
+      will continue to help teams monitor and secure LLMs while preserving privacy." Nothing is withheld,
+      because there is no longer a commercial product to withhold it for.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b4acd691502a61b4b41def20a690009fcb52dafe41632bfca375174083e7987c
+    establishes:
+    - license
+    - source
+    - core_gated
   - url: https://github.com/whylabs/whylogs
-    shows: whylogs Apache-2.0, 2.8k stars, public source
-    accessed: '2026-06-04'
+    shows: Repository page. GitHub resolves the LICENSE to Apache-2.0 and the README carries an Apache 2
+      badge; the source tree is public. 2,830 stars.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6054065fb6574c29c0ab15224a78c5c40cf274a60e749cdf9437442184a0e61e
+    establishes:
+    - license
+    - source
 adoption:
   level: 2
   reach: 1K-10K stars
@@ -48,11 +67,23 @@ adoption:
     a download. THE REAL DEFECT is upstream: this product declares no artifacts at all, so a stars_fallback
     band had no stars source behind it and the count lived only in this note. Declaring whylabs/whylogs would
     fix it, and is deliberately not done here because a declared code repo also re-routes the openness license
-    dimension. No last_verified claimed: a star count is volatile.'
+    dimension. Re-read 2026-08-13 - stargazers_count on whylabs/whylogs is 2,830, unchanged from the count
+    already in this note, and the repository''s last push was 2025-01-10, so the stalled cadence the level
+    rests on is if anything more pronounced. The earlier pass declined a date on the ground that a star
+    count is volatile; `check_refetch` reports drift rather than failing on it, and `helicone` in this same
+    category already carries a dated stars_fallback band over the same endpoint, so the date is claimed
+    here with the count digested.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/whylabs/whylogs
     shows: 2.8k stars, latest release v1.6.4 (Dec 3, 2024)
     accessed: '2026-06-04'
+  - url: https://api.github.com/repos/whylabs/whylogs
+    shows: stargazers_count = 2830 for whylabs/whylogs, with pushed_at 2025-01-10T20:14:49Z. No download,
+      install or customer figure exists for this product, the hosted platform having shut down.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: bc1b38a40321b70d3fb152bf6e879f75ab826a63d02fe121e31427e355d8ae28
 capability:
   score: 2
   basis: feature_matrix
@@ -64,9 +95,17 @@ capability:
   confidence: medium
   note: As living, usable capability it is a pair of monitoring libraries (drift + LLM safety metrics),
     not a full tracing/eval/prompt platform; with the hosted backend gone and releases stalled since Dec
-    2024, rated 2, well below the MLflow/Langfuse C4 anchors.
+    2024, rated 2, well below the MLflow/Langfuse C4 anchors. Re-read 2026-08-13 - the repository's last
+    push was 2025-01-10, more than a year and a half ago, and the README is still a profiling library
+    integrating with Spark, Airflow, S3 and MLflow rather than an observability platform. The two-below
+    comparison holds.
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/whylabs/whylogs
-    shows: whylogs data-logging/drift/data-quality monitoring library feature set; release cadence stalled
-      Dec 2024
-    accessed: '2026-06-04'
+    shows: 'README describes a data-logging and profiling library with integrations for AWS S3, Apache
+      Airflow, Apache Spark and MLflow, designed to run "typically in a distributed environment, such as
+      Ray or Apache Spark". There is no tracing backend, prompt-management or eval-experiment surface in
+      it. The repository''s last push was 2025-01-10.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6054065fb6574c29c0ab15224a78c5c40cf274a60e749cdf9437442184a0e61e


### PR DESCRIPTION
**89 of 95 checkpoints closed.** All 26 products carry a 2026-08-13 prose line; 96 URLs fetched through `build.fetch_source`, with no digest written for anything not actually fetched.

`langfuse` was re-read and dated **first**, and 14 capability bands that had been comparing themselves to it in prose now record `relative_to: langfuse` + `relation` — all arithmetically true. Recorded comparisons went 32 → 46.

## Six axes refused, not dated

**`langfuse` adoption — level 3, and its own declared package now shows 26,611,793 downloads/month.** That clears the level-5 floor, on the same instrument `opik` (3.5M → 4), `arize-phoenix` (2.3M → 4) and `traceloop-sdk` (2.4M → 4) already use in this category. The note's "no precise verified download count" was true when written and isn't now.

**`laminar` — level 3 / `100K-1M` on `usage_volume` against a measured 34,084,386/mo**, and the gap has doubled since the note was written (17M → 34M). The record deliberately discounts it as mirror-inflated, which may well be right — but `adoption.md` says a `usage_volume` band whose count disagrees "is a finding, not a judgment call". Either re-band, or relabel to `reported_traction` and drop the numeric reach, which is what the record actually means.

**`openlit`** — same shape: level 2 against a measured 414,172/mo, which bands at 3.

**`new-relic-ai-monitoring`** — `usage_volume` with `reach: 1M-10M` over a figure the note itself says came from landbase/zoominfo and was never fetched. The vendor page carries no user, customer or account figure at all. Parent-platform substitution wearing a measurement's label.

**`langsmith` — half the cited evidence is gone.** The level 4 rests on "25+ named enterprise customers: Klarna, Lyft, Cloudflare, LinkedIn, Coinbase, Nvidia, Workday"; no roster and no count appears on the page today. And a trap worth keeping: the `langsmith` PyPI package shows 121,326,650/mo, which is **not usable** — it's a hard dependency of `langchain-core`, so it measures LangChain installs. Recorded in the product's `comments`.

**`agenta` has repositioned.** The README now opens "an open-source workspace where you build specialized agents", with sections on Claude/ChatGPT subscriptions, agent harnesses, MCP servers and Gmail/Slack/Notion integrations. Repo topics are now agent-builder, agent-orchestration. The recorded value describes prompt management and evaluators. Needs a re-score and a look at whether it still belongs in this category.

**I have deliberately not applied these** — five are level moves, and several turn on whether an SDK's download count is the platform's reach. That's the `cohere-rerank-api` attribution question, and it deserves a considered ruling rather than a fast one.

## Evidence that quietly disappeared, now recorded as gone

`arize.com` no longer names DoorDash, Roblox, Booking.com or Reddit. `braintrust.dev` no longer names Vercel, Dropbox or Replit. `confident-ai.com` no longer names Panasonic, Samsung or Epic Games. The Azure page carries **no "GA March 2026"** claim — that assertion was in the note with nothing behind it, and was dropped.

## Handled in place

- **`datadog-llm-observability`** was the parent-platform trap case, and its note already disclosed the substitution. Re-dated, with both the note and the source `shows` saying plainly which quantity was banded — the platform's reach, not the module's. Same for `vertex-ai-model-observability` and `azure-ai-foundry-observability`.
- **`dynatrace` adoption is a deliberate null.** Re-read, confirmed no module figure is published, dated — per #236.
- **`langwatch` and `whylabs`** had notes declining a date because "a star count is volatile". Both dated via `api.github.com` with digests, following the `helicone` precedent already in this category — `check_refetch` reports drift rather than failing on it.
- **`trulens` capability**: score 4 equals langfuse's 4, so the relation would be `at` — but the note says "lighter than Langfuse/Helicone". No `relative_to` was recorded and the disagreement was written into the note for a ruling, rather than asserting a comparison the prose contradicts. Good instinct.

## Could not verify

`pypi.org/project/*` served a JavaScript bot challenge (HTTP 200, identical 3,038-byte "Client Challenge" body) on every attempt across two passes. Two pages slipped through before the wall engaged and were used. `openllmetry`'s cited page keeps its 2026-06-04 date, stated in the note.

All gates green: `validate` 0 errors, `check_verification` all three OK, `check_capability` OK (46 comparisons), `check_adoption --strict` exit 0, 488 tests.