### PR TITLE
Verify edge_hardware: 61/80 checkpoints

### DIFF
--- a/sources/products/axelera-metis-aipu.yaml
+++ b/sources/products/axelera-metis-aipu.yaml
@@ -8,5 +8,5 @@ description: An edge AI inference accelerator from Axelera AI (Netherlands), bui
   analytics and quality inspection.
 github:
 - url: https://github.com/axelera-ai-hub/voyager-sdk
-comments: Verified live 2026-06-22 via primary sources. Proprietary in-memory-compute silicon with a publicly
+comments: Verified live 2026-08-13 via primary sources. Proprietary in-memory-compute silicon with a publicly
   available Voyager SDK on GitHub and retail purchasing, but board design files are not open.

--- a/sources/products/beagley-ai.yaml
+++ b/sources/products/beagley-ai.yaml
@@ -8,6 +8,6 @@ description: An open source single-board computer (SBC) from the BeagleBoard.org
   is OSHWA-certified and targets vision, robotics, and smart cameras.
 github:
 - url: https://github.com/beagleboard/beagley-ai
-comments: Verified live 2026-06-22 via primary sources. Full board design files published under Creative
+comments: Verified live 2026-08-13 via primary sources. Full board design files published under Creative
   Commons and OSHWA-certified with an open toolchain and public datasheet, though proprietary AM67A silicon
   and firmware blobs are a caveat.

--- a/sources/products/google-coral-dev-board.yaml
+++ b/sources/products/google-coral-dev-board.yaml
@@ -8,5 +8,5 @@ description: A single-board computer from Google's Coral platform that pairs a r
   and supplied by Google.
 github:
 - url: https://github.com/google-coral/libedgetpu
-comments: Verified live 2026-06-22 via primary sources. Public datasheet and open runtime/TFLite path,
+comments: Verified live 2026-08-13 via primary sources. Public datasheet and open runtime/TFLite path,
   but the Edge TPU silicon and the model compiler are proprietary closed binaries.

--- a/sources/products/khadas-edge2.yaml
+++ b/sources/products/khadas-edge2.yaml
@@ -7,6 +7,6 @@ description: A credit-card-sized single-board computer (SBC) built around the Ro
   (Shenzhen Wesion), it runs Ubuntu and Android with mainline Armbian support.
 github:
 - url: https://github.com/khadas/fenix
-comments: Verified live 2026-06-22 via primary sources. Khadas publishes versioned board schematics and
+comments: Verified live 2026-08-13 via primary sources. Khadas publishes versioned board schematics and
   an open toolchain with mainline Armbian, but proprietary Rockchip silicon and required blobs keep it
   at open_toolchain.

--- a/sources/products/memryx-mx3.yaml
+++ b/sources/products/memryx-mx3.yaml
@@ -9,5 +9,5 @@ description: An edge AI accelerator from MemryX (USA) built on a dataflow archit
   tooling.
 github:
 - url: https://github.com/memryx/MxAccl
-comments: Verified live 2026-06-22 via primary sources. Proprietary dataflow silicon with public datasheets,
+comments: Verified live 2026-08-13 via primary sources. Proprietary dataflow silicon with public datasheets,
   retail availability, and several open source runtime/driver repos, though the compiler core is closed.

--- a/sources/products/nvidia-jetson-agx-orin.yaml
+++ b/sources/products/nvidia-jetson-agx-orin.yaml
@@ -7,5 +7,5 @@ description: NVIDIA's high-end edge-AI system-on-module (SoM), delivering up to 
   machines, able to run large LLMs/VLMs at the edge.
 github:
 - url: https://github.com/OE4T/meta-tegra
-comments: Verified live 2026-06-22 via primary sources. Public datasheets and commercially purchasable,
+comments: Verified live 2026-08-13 via primary sources. Public datasheets and commercially purchasable,
   but SDK relies on proprietary NVIDIA blobs under license, placing it in the documented tier.

--- a/sources/products/nvidia-jetson-orin-nano-super-developer-kit.yaml
+++ b/sources/products/nvidia-jetson-orin-nano-super-developer-kit.yaml
@@ -8,6 +8,6 @@ description: An entry-level edge-AI developer kit pairing the Jetson Orin Nano 8
   small LLMs and VLMs locally.
 github:
 - url: https://github.com/OE4T/meta-tegra
-comments: Verified live 2026-06-22 via primary sources. Public datasheets and globally purchasable, but
+comments: Verified live 2026-08-13 via primary sources. Public datasheets and globally purchasable, but
   the SDK requires proprietary NVIDIA drivers/blobs under license, so it sits in the documented tier despite
   the community OE4T BSP.

--- a/sources/products/nvidia-jetson-orin-nx.yaml
+++ b/sources/products/nvidia-jetson-orin-nx.yaml
@@ -7,5 +7,5 @@ description: A compact mid-range edge-AI system-on-module (SoM) in a 260-pin SO-
   is widely used in drones, cameras, and compact robotics for local LLM/vision workloads.
 github:
 - url: https://github.com/OE4T/meta-tegra
-comments: Verified live 2026-06-22 via primary sources. Public datasheets and purchasable through distributors,
+comments: Verified live 2026-08-13 via primary sources. Public datasheets and purchasable through distributors,
   but the SDK depends on proprietary NVIDIA blobs under license.

--- a/sources/products/orange-pi-5.yaml
+++ b/sources/products/orange-pi-5.yaml
@@ -8,6 +8,6 @@ description: A single-board computer (SBC) built around the Rockchip RK3588S SoC
   edge-AI boards.
 github:
 - url: https://github.com/orangepi-xunlong/orangepi-build
-comments: Verified live 2026-06-22 via primary sources. Proprietary Rockchip silicon with an open GPL-2.0
+comments: Verified live 2026-08-13 via primary sources. Proprietary Rockchip silicon with an open GPL-2.0
   BSP, public datasheet and schematics, and global retail availability, but bootable images depend on
   Rockchip firmware blobs.

--- a/sources/products/radxa-rock-5b.yaml
+++ b/sources/products/radxa-rock-5b.yaml
@@ -8,6 +8,6 @@ description: A single-board computer (SBC) built on the Rockchip RK3588 SoC, pai
   boards.
 github:
 - url: https://github.com/radxa-repo/bsp
-comments: Verified live 2026-06-22 via primary sources. Schematics and mechanical files are publicly downloadable
+comments: Verified live 2026-08-13 via primary sources. Schematics and mechanical files are publicly downloadable
   and the BSP is open, but the RK3588 needs proprietary Rockchip blobs and editable PCB source is not
   released.

--- a/sources/products/raspberry-pi-ai-hat-plus.yaml
+++ b/sources/products/raspberry-pi-ai-hat-plus.yaml
@@ -8,5 +8,5 @@ description: 'An AI accelerator HAT+ add-on board for the Raspberry Pi 5 that in
   meaningful NPU compute to a Pi 5.'
 github:
 - url: https://github.com/raspberrypi/hailort
-comments: Verified live 2026-06-22 via primary sources. Officially supported open Pi software stack and
+comments: Verified live 2026-08-13 via primary sources. Officially supported open Pi software stack and
   public product page, globally purchasable, but the underlying Hailo model-compiler toolchain is registration-gated.

--- a/sources/products/rockchip-rk3588.yaml
+++ b/sources/products/rockchip-rk3588.yaml
@@ -8,6 +8,6 @@ description: An application-processor SoC/chipset (not a board) made by Fuzhou R
   SBC SoC of its generation.
 github:
 - url: https://github.com/airockchip/rknn-toolkit2
-comments: Verified live 2026-06-22 via primary sources. Documentation is unusually open (full TRM and
+comments: Verified live 2026-08-13 via primary sources. Documentation is unusually open (full TRM and
   datasheet public) and the RKNN toolkit is openly distributed, but the SDK ships as prebuilt binaries
   under a proprietary license with closed firmware.

--- a/sources/products/sipeed-maixcam.yaml
+++ b/sources/products/sipeed-maixcam.yaml
@@ -8,5 +8,5 @@ description: A compact AI vision and audio dev board built around the SOPHGO SG2
   RISC-V edge-AI vision module with strong open tooling.
 github:
 - url: https://github.com/sipeed/MaixPy
-comments: Verified live 2026-06-22 via primary sources. Open Apache-2.0 SDKs, public schematics/datasheets,
+comments: Verified live 2026-08-13 via primary sources. Open Apache-2.0 SDKs, public schematics/datasheets,
   and global retail availability, though the SG2002 silicon itself is proprietary.

--- a/sources/products/ti-am67a.yaml
+++ b/sources/products/ti-am67a.yaml
@@ -8,5 +8,5 @@ description: A Texas Instruments edge-AI vision SoC built on a quad Arm Cortex-A
   is the chip behind the BeagleY-AI SBC.
 github:
 - url: https://github.com/TexasInstruments/edgeai-tidl-tools
-comments: Verified live 2026-06-22 via primary sources. Public datasheet and open SDK/TIDL tools on GitHub,
+comments: Verified live 2026-08-13 via primary sources. Public datasheet and open SDK/TIDL tools on GitHub,
   commercially active, but proprietary silicon and firmware keep it short of fully open hardware.

--- a/sources/scores/arduino-uno-q.yaml
+++ b/sources/scores/arduino-uno-q.yaml
@@ -39,19 +39,38 @@ adoption:
   signal_type: reported_traction
   confidence: high
   note: Sold globally through Arduino Store plus Digikey, Mouser, and RS Components, backed by Arduino's
-    large maker community.
+    large maker community. Re-read 2026-08-13 - the Arduino Store still sells both SKUs, at EUR59,90
+    (2GB) and EUR82,90 (4GB), and still carries a Distributors link, though it names no distributor on
+    the page, so the Digikey/Mouser/RS half of the note rests on the earlier read. Level and reach
+    unchanged.
+  last_verified: '2026-08-13'
   sources:
   - url: https://store.arduino.cc/pages/uno-q
-    shows: availability across Arduino Store and authorized distributors
-    accessed: '2026-06-22'
+    shows: UNO Q on sale at EUR59,90 and EUR82,90 with a Distributors link; "Arduino App Lab runs
+      directly on UNO Q"
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9053c146970f37f1fd2963d07fedff125f61bf2ae9646b13f05c0148f9099ddb
 capability:
   score: 3
   basis: feature_matrix
   value: QRB2210 quad-core 2.0 GHz + Adreno GPU; up to 4GB RAM; AI acceleration
   confidence: medium
   note: Capable Linux+MCU hybrid with GPU/ISP-based AI acceleration, but no published TOPS figure so throughput
-    is modest versus dedicated-NPU kits.
+    is modest versus dedicated-NPU kits. Re-derived 2026-08-13 - the product page still describes a
+    quad-core Qualcomm Dragonwing QRB2210 with a GPU and an STM32U585 MCU, 2GB or 4GB RAM, "integrated
+    AI acceleration" and "lightweight AI", and still publishes no TOPS number anywhere. The absence of a
+    figure is what keeps it below every dedicated-NPU part in this category and level with the other
+    general-purpose boards.
+  last_verified: '2026-08-13'
   sources:
+  - url: https://www.arduino.cc/product-uno-q
+    shows: '"a quad-core Qualcomm Dragonwing QRB2210 with GPU and an STM32U585 microcontroller, enabling
+      a unique combination of Linux apps, real-time control, and lightweight AI"; "You can select between
+      2GB and 4GB of RAM memory"; no TOPS figure is published'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d6776053a16bedd6bc297b796ce20f99533b3fa2a4605c8023b3264d65e079c6
   - url: https://store.arduino.cc/pages/uno-q
     shows: QRB2210 quad-core, 2GB/4GB RAM, AI-accelerated tasks
     accessed: '2026-06-22'

--- a/sources/scores/axelera-metis-aipu.yaml
+++ b/sources/scores/axelera-metis-aipu.yaml
@@ -23,35 +23,72 @@ openness:
       raw: open_market (webstore + partners)
   confidence: medium
   note: Proprietary in-memory-compute silicon with a publicly available Voyager SDK on GitHub and retail
-    purchasing, but board design files are not open.
+    purchasing, but board design files are not open. Re-read 2026-08-13 - axelera.ai still publishes
+    product briefs and a Shop, still describes D-IMC as its own silicon, and offers no board design
+    files anywhere in its document set; voyager-sdk is still a public repository shipping a v1.8
+    production release. No dimension moved.
   raw: schematics:none;toolchain:open (Voyager SDK on public GitHub);datasheets:brief (product pages/briefs
     public);blobs:required (proprietary AIPU silicon + firmware);retail:open_market (webstore + partners)
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.axelera.ai/
-    shows: Metis AIPU form factors, ~214 TOPS, Voyager SDK, webstore availability
-    accessed: '2026-06-22'
+    shows: Metis AIPU product pages and a Shop, "D-IMC technology performs matrix-vector multiplications
+      in-place, delivering 50+ TOPs per core" and "At 15 TOPs/W" - marketing briefs and a store, with
+      no board design files offered anywhere in the document set
+    accessed: '2026-08-13'
+    establishes:
+    - schematics
+    - datasheets
+    - blobs
+    - retail
+    http_status: 200
+    content_sha256: 1cbac435bb57fb831cfc088ab93b95edfdf022785053c407b19fd78c53dd2192
   - url: https://github.com/axelera-ai-hub/voyager-sdk
-    shows: publicly available Voyager SDK repo under Axelera's official org
-    accessed: '2026-06-22'
+    shows: public voyager-sdk repository under Axelera's own org, "This is a production-ready release
+      of Voyager SDK" at v1.8, with release notes and a compatibility matrix in-tree
+    accessed: '2026-08-13'
+    establishes:
+    - toolchain
+    http_status: 200
+    content_sha256: 559b91d229931fb3cdeceb79ef04bb76fa04381ba99c45edffc851c5dd26854f
 adoption:
   level: 3
   reach: niche
   signal_type: reported_traction
   confidence: medium
   note: Commercially available via webstore and partners with a public, versioned SDK, but a younger ecosystem
-    than Hailo/Coral.
+    than Hailo/Coral. Re-read 2026-08-13 - the SDK is at v1.8 with release notes and a release
+    compatibility matrix in-tree, the site still carries a Shop, and it now also announces an ASRock
+    Industrial collaboration integrating Metis AIPU cards into edge platforms. Level and reach unchanged.
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/axelera-ai-hub/voyager-sdk
-    shows: actively released SDK branches indicating developer traction
-    accessed: '2026-06-22'
+    shows: v1.8 production release with RELEASE_NOTES.md and RELEASE_COMPATIBILITY_MATRIX.md in-tree
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 559b91d229931fb3cdeceb79ef04bb76fa04381ba99c45edffc851c5dd26854f
+  - url: https://www.axelera.ai/
+    shows: a Shop link and an announcement that "ASRock Industrial ... integrates Axelera Metis AIPU
+      cards into ASRock Industrial's edge AI platforms"
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1cbac435bb57fb831cfc088ab93b95edfdf022785053c407b19fd78c53dd2192
 capability:
   score: 4
   basis: feature_matrix
   value: ~214 TOPS per quad-core Metis; PCIe x4 scales across 4 units; Voyager SDK with 100+ CV models
   confidence: medium
   note: High raw inference throughput via in-memory compute, currently oriented toward CNN/computer-vision
-    pipelines.
+    pipelines. Re-read 2026-08-13 - the site no longer prints the ~214 TOPS aggregate the recorded value
+    quotes; it now states "50+ TOPs per core" and "15 TOPs/W" for the quad-core Metis, and Voyager still
+    claims "100+ supported models". Four cores at 50+ TOPS is the same order as the recorded aggregate
+    and the band is unchanged, but the specific 214 figure is no longer citable and the wording of the
+    recorded value is flagged for a curator ruling.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.axelera.ai/
-    shows: ~214 TOPS Metis, PCIe scaling, Voyager SDK model coverage
-    accessed: '2026-06-22'
+    shows: '"delivering 50+ TOPs per core at FP32-equivalent accuracy with zero data movement", "At 15
+      TOPs/W", and "100+ supported models and a single toolchain" for Voyager'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1cbac435bb57fb831cfc088ab93b95edfdf022785053c407b19fd78c53dd2192

--- a/sources/scores/beagley-ai.yaml
+++ b/sources/scores/beagley-ai.yaml
@@ -21,28 +21,69 @@ openness:
       raw: required (TI DSP/WiFi firmware blobs a caveat)
   confidence: high
   note: Full board design files published under Creative Commons and OSHWA-certified with an open toolchain
-    and public datasheet, though proprietary AM67A silicon and firmware blobs are a caveat.
+    and public datasheet, though proprietary AM67A silicon and firmware blobs are a caveat. Re-read
+    2026-08-13 - the OSHWA certification directory still carries US002616 for BeagleY-AI (certified
+    2024-03-27) recording Hardware CC-BY-4.0, Software GPL and Documentation CC-BY-SA-4.0, the repo is
+    still CC-BY-4.0 and still links that certificate, the design page still says design materials and
+    license live in the BeagleY-AI git repository, and TI still publishes the AM67x datasheet (Rev. B)
+    openly. No dimension moved. One drift worth recording - the design page no longer prints the OSHWA
+    UID itself; the certificate and the repo README still do.
   raw: schematics:open (schematics + 3D/mechanical files, CC-BY/CC-BY-SA-4.0, OSHWA-certified US002616);toolchain:open
     (open Linux/U-Boot BSP);datasheets:public (public TI AM67A datasheet);blobs:required (TI DSP/WiFi firmware
     blobs a caveat)
+  last_verified: '2026-08-13'
   sources:
+  - url: https://certification.oshwa.org/us002616.html
+    shows: OSHWA UID US002616 for BeagleY-AI by the BeagleBoard.org Foundation, certified March 27 2024,
+      licences recorded as Hardware CC-BY-4.0, Software GPL, Documentation CC-BY-SA-4.0
+    accessed: '2026-08-13'
+    establishes:
+    - schematics
+    - toolchain
+    http_status: 200
+    content_sha256: 2863573852c2ebfa8cf746eef592e52abd6fd1434365bba08fa1b170536499bf
   - url: https://github.com/beagleboard/beagley-ai
-    shows: repo with design files, 3D models, OSHWA cert, schematic PDF, CC-BY-4.0 license
-    accessed: '2026-06-22'
+    shows: repository under a CC-BY-4.0 license with design and 3D directories and a link to
+      https://certification.oshwa.org/us002616.html
+    accessed: '2026-08-13'
+    establishes:
+    - schematics
+    http_status: 200
+    content_sha256: 183e772403b13f95f9d76e3d9e09bc849038d0484dd80f46b902a66c790d5bfc
   - url: https://docs.beagleboard.org/boards/beagley/ai/03-design.html
-    shows: CC-BY-SA-4.0 license, OSHWA cert US002616, open design-file hosting
-    accessed: '2026-06-22'
+    shows: '"This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 International
+      License" and "Design materials and license can be found in the BeagleY-AI git repository"; the
+      board carries 2x C7x DSPs with MMA and a Beagle BM3301 wireless module based on the TI CC3301,
+      the two firmware-bearing subsystems behind the recorded blob caveat'
+    accessed: '2026-08-13'
+    establishes:
+    - blobs
+    http_status: 200
+    content_sha256: bd680e33d099217f6507e6b74cb36f2eb817386f3b0d748b0e4aa5bba491c772
+  - url: https://www.ti.com/product/AM67A
+    shows: '"AM67x Processors datasheet (Rev. B)" published openly on the part page, status ACTIVE'
+    accessed: '2026-08-13'
+    establishes:
+    - datasheets
+    http_status: 200
+    content_sha256: 147b265e34a7b894413ce9cfc9883a4594de7d689d575a46948de2265eafaf9a
 adoption:
   level: 4
   reach: niche
   signal_type: reported_traction
   confidence: medium
   note: In stock at $71.99 with volume pricing at Seeed and orderable via TI, backed by the established
-    BeagleBoard.org community, though recent (2024) so installed base trails Raspberry Pi.
+    BeagleBoard.org community, though recent (2024) so installed base trails Raspberry Pi. Re-read
+    2026-08-13 - still in stock at Seeed, now listed at $70.00 rather than $71.99, and the AM67A it is
+    built on is still ACTIVE at TI with evaluation boards in stock. Level and reach unchanged; the price
+    figure in the note is a cent-level drift, corrected here rather than escalated.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.seeedstudio.com/BeagleYr-AI-beagleboard-orgr-4-TOPS-AI-Acceleration-powered-by-TI-AM67A.html
-    shows: $71.99, in stock, with volume pricing
-    accessed: '2026-06-22'
+    shows: $70.00, "In stock"
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c4c536f7f6f5746f1182721bf5c51bbad54a5f95181f75f0b25d0d408e77c6c9
 capability:
   score: 3
   basis: feature_matrix
@@ -50,8 +91,14 @@ capability:
     classification models
   confidence: high
   note: 4 TOPS plus an IMG BXS GPU suits edge vision and quantized CNNs, but fixed 4GB RAM and modest
-    TOPS rule out large LLMs.
+    TOPS rule out large LLMs. Re-derived 2026-08-13 - the board page still reads "Dual general-purpose
+    C7x DSP with Matrix Multiply Accelerator (MMA) capable of 4 TOPs" and 4GB LPDDR4, which sits below
+    the 6 TOPS RK3588 boards and well below the Jetson Orin line.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.beagleboard.org/boards/beagley-ai
-    shows: dual C7x DSP + MMA at 4 TOPS, 4GB LPDDR4, quad Cortex-A53
-    accessed: '2026-06-22'
+    shows: '"Dual general-purpose C7x DSP with Matrix Multiply Accelerator (MMA) capable of 4 TOPs";
+      4GB LPDDR4; Texas Instruments AM67A Arm-based vision processor'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: bdd173a87d3c94b1b3965b244c0e076b89045edeee1c54b2d4a015853d228d03

--- a/sources/scores/google-coral-dev-board.yaml
+++ b/sources/scores/google-coral-dev-board.yaml
@@ -51,8 +51,15 @@ capability:
   value: 4 TOPS (2 TOPS/W); int8-quantized models; TensorFlow Lite only
   confidence: high
   note: Modest 4 TOPS limited to int8 TFLite models; suited to small CNN inference rather than large or
-    generative models.
+    generative models. Re-derived 2026-08-13 - the datasheet (still at version 1.7) reads "4 trillion
+    operations per second (TOPS)", "2 TOPS per watt" and an Edge TPU that "performs 4 trillion operations
+    per second" with TensorFlow Lite models. That is the lowest AI throughput in this category apart
+    from sipeed-maixcam, and the TFLite-only path is what keeps it below the 6 TOPS RK3588 boards.
+  last_verified: '2026-08-13'
   sources:
   - url: https://coral.ai/docs/dev-board/datasheet/
-    shows: 4 TOPS, 2 TOPS/W, TFLite-focused Edge TPU
-    accessed: '2026-06-22'
+    shows: '"High-speed and low-power ML inferencing (4 TOPS @ 2 W)", "4 trillion operations per second
+      (TOPS)", "2 TOPS per watt", and an Edge TPU coprocessor used "with TensorFlow Lite models"'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b47ca1ecbc39b2f0c88cdbb55dd3c5053b77728971901027092192c617b494d2

--- a/sources/scores/khadas-edge2.yaml
+++ b/sources/scores/khadas-edge2.yaml
@@ -25,24 +25,73 @@ openness:
       raw: open_market (global)
   confidence: high
   note: Khadas publishes versioned board schematics and an open toolchain with mainline Armbian, but proprietary
-    Rockchip silicon and required blobs keep it at open_toolchain.
+    Rockchip silicon and required blobs keep it at open_toolchain. Re-read 2026-08-13 - the schematics
+    directory still lists edge2-sch-v11/v12/v13 plus silkscreen PDFs, Fenix is still GPL-2.0, the product
+    page still publishes the full RK3588S2 spec and carries Buy Now links, and Rockchip's rkbin still
+    ships the boot binaries as prebuilt files. The recorded datasheets detail names an S2 TRM; what is
+    re-readable today is Rockchip's public RK3588 brief datasheet plus Khadas's own published spec, which
+    is flagged in the pass report rather than silently rewritten. No dimension moved.
   raw: schematics:published (versioned PDFs published);toolchain:open (open GPL-2.0 Fenix + mainline Armbian);datasheets:public
     (public SoC TRM);blobs:required (Rockchip NPU/boot blobs required);retail:open_market (global)
+  last_verified: '2026-08-13'
   sources:
   - url: https://dl.khadas.com/products/edge2/schematics/
-    shows: versioned schematic PDFs (edge2-sch-v11/12/13)
-    accessed: '2026-06-22'
+    shows: directory index of /products/edge2/schematics/ listing edge2-sch-v11.pdf, edge2-sch-v12.pdf,
+      edge2-sch-v13.pdf and matching silkscreen PDFs
+    accessed: '2026-08-13'
+    establishes:
+    - schematics
+    http_status: 200
+    content_sha256: 32fb979dda95231cd393dee14d5a7c3c78e4bcf74164524ac216c880d4923be2
   - url: https://github.com/khadas/fenix
-    shows: Fenix build system (GPL-2.0) with Edge2 as a target
-    accessed: '2026-06-22'
+    shows: '"One-stop script set to build Ubuntu/Debian images" under a GPL-2.0 license'
+    accessed: '2026-08-13'
+    establishes:
+    - toolchain
+    http_status: 200
+    content_sha256: dfed2a94f2dc68ae9fbf5320d19d124d05d00ccbf1e9247c7c0f8a0c2b4721aa
+  - url: https://www.khadas.com/edge2
+    shows: full published RK3588S2 spec (6 TOPS NPU, Mali-G610 MC4, Basic 8GB / Pro 16GB LPDDR4X) with
+      Buy Now buttons and a Distributor Program link
+    accessed: '2026-08-13'
+    establishes:
+    - datasheets
+    - retail
+    http_status: 200
+    content_sha256: c337940ef0497a6efa3d2b77da5a44b2c3502a764107f68bf046abd6c8a98029
+  - url: https://github.com/rockchip-linux/rkbin
+    shows: Rockchip's own "Firmware and Tool Binarys" repository - prebuilt SPL/DDR/UsbPlug/BL31/BL32/OPTEE
+      boot binaries distributed as binaries rather than source
+    accessed: '2026-08-13'
+    establishes:
+    - blobs
+    http_status: 200
+    content_sha256: 43abb5977b081df3eaebfcdeb7f2bef288daab407fbf1b0f6935236c1e026cff
 adoption:
   level: 4
   reach: niche
   signal_type: reported_traction
   confidence: high
   note: Sold on Amazon US and Newegg (Basic and Pro), with an active community forum and mainline Armbian
-    support, but smaller than Raspberry Pi-class platforms.
+    support, but smaller than Raspberry Pi-class platforms. Re-read 2026-08-13 - the Amazon listing could
+    not be re-read (the host returns a "Click the button below to continue shopping" interstitial to an
+    automated fetch), so availability was re-derived from Khadas's own store, which sells both the Basic
+    8GB and Pro 16GB SKUs and runs a distributor programme. An independent Armbian community comparison
+    still ranks the Edge 2 Pro alongside the other RK3588 boards. Level and reach unchanged.
+  last_verified: '2026-08-13'
   sources:
+  - url: https://www.khadas.com/edge2
+    shows: Buy Now against Basic (8GB LPDDR4X + 32GB eMMC) and Pro (16GB + 64GB) SKUs, plus a Distributor
+      Program link
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c337940ef0497a6efa3d2b77da5a44b2c3502a764107f68bf046abd6c8a98029
+  - url: https://forum.armbian.com/topic/26398-video-comparing-rk3588-sbcs-nanopi-r6s-khadas-edge2-radxa-rock5b-mekotronics-r58-mini-r58x-4g-orange-pi-5/
+    shows: independent community comparison table placing "Khadas Edge 2 Pro, Rockchip RK3588S, 16 GB
+      LPDDR4X" against four other RK3588 boards
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 2db7eb01547612cc0257308c05c7d80607c84d2cb6b2d692a7121897a90456f3
   - url: https://www.amazon.com/khadas-Computer-RK3588S-Portable-Compact/dp/B0BFVSC2D5
     shows: Edge2 Pro 16GB retail listing on Amazon US
     accessed: '2026-06-22'
@@ -53,8 +102,14 @@ capability:
     via RKNN
   confidence: high
   note: The RK3588S2 NPU delivers 6 TOPS, handling real-time CV and small quantized LLMs, mid-tier versus
-    Jetson Orin.
+    Jetson Orin. Re-derived 2026-08-13 - the product page still reads "up to 6 TOPS" on the RK3588S2 NPU
+    with 8GB or 16GB LPDDR4X, which is level with orange-pi-5 (also 6 TOPS, also 3) and below radxa-rock-5b,
+    whose 32GB LPDDR5 option carries it to 4.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.khadas.com/edge2
-    shows: 6 TOPS NPU; 8GB/16GB LPDDR4X options
-    accessed: '2026-06-22'
+    shows: '"The RK3588S2 has a built-in NPU which provides up to 6 TOPS"; Basic 8GB / Pro 16GB 64-bit
+      LPDDR4X'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c337940ef0497a6efa3d2b77da5a44b2c3502a764107f68bf046abd6c8a98029

--- a/sources/scores/memryx-mx3.yaml
+++ b/sources/scores/memryx-mx3.yaml
@@ -21,35 +21,93 @@ openness:
       raw: open_market (Amazon/Mouser ~$149)
   confidence: high
   note: Proprietary dataflow silicon with public datasheets, retail availability, and several open source
-    runtime/driver repos, though the compiler core is closed.
+    runtime/driver repos, though the compiler core is closed. Re-read 2026-08-13 - the M.2 datasheet is
+    still published openly and still offers module specification, pinout, placement and strap-pin tables
+    and no board design files; MxAccl is still MPL-2.0 and still directs users to the MemryX SDK for
+    "precompiled libraries, drivers, and tools", which is the closed half of `toolchain - partial`. No
+    dimension moved.
   raw: schematics:none;toolchain:partial (open runtime (MxAccl) + utils + driver mirror, closed NeuralCompiler);datasheets:public;blobs:required
     (proprietary silicon);retail:open_market (Amazon/Mouser ~$149)
+  last_verified: '2026-08-13'
   sources:
   - url: https://developer.memryx.com/specs/M.2_datasheet.html
-    shows: 'MX3 M.2 datasheet: chip count, TOPS, data formats, power'
-    accessed: '2026-06-22'
+    shows: openly published MX3 M.2 module datasheet - "MemryX MX3 (x4)" AI processor, PCIe Gen 3 2-lane
+      interface, M.2-2280-D5-M form factor, operating range and CE/FCC Class A and RoHS compliance, plus
+      pinout, placement, power-rail, clock and strap-pin tables; no board design files are offered
+    accessed: '2026-08-13'
+    establishes:
+    - schematics
+    - datasheets
+    http_status: 200
+    content_sha256: 14d338f59a212d65ca4cae04933e6643e1cedba983b98f5ad9963f4bb88e9479
   - url: https://github.com/memryx/MxAccl
-    shows: open source MemryX C++ runtime library
-    accessed: '2026-06-22'
+    shows: '"open-source code for both the MemryX C++ runtime library and the acclBench benchmarking
+      tool" under MPL-2.0, with the SDK it depends on supplying "precompiled libraries, drivers, and
+      tools"'
+    accessed: '2026-08-13'
+    establishes:
+    - toolchain
+    - blobs
+    http_status: 200
+    content_sha256: 74aa33db22861ebf50548724dae3614917d9ac0453b02f0b28008d79f7fc097f
+  - url: https://www.tomshardware.com/tech-industry/artificial-intelligence/memryx-launches-usd149-mx3-m-2-ai-accelerator-module-capable-of-24-tops-compute-power
+    shows: '"The MX3 M.2 module is available for $149 USD, making it an affordable option for developers
+      and organizations seeking to add AI processing capabilities to edge devices"'
+    accessed: '2026-08-13'
+    establishes:
+    - retail
+    http_status: 200
+    content_sha256: 0918df1ac7c17e40b3119558e772225fd427599ea6f2fa5a993c419060d2f7c6
 adoption:
   level: 3
   reach: niche
   signal_type: reported_traction
   confidence: medium
   note: Low-cost retail availability (Amazon, Mouser), independent reviews, a 2025 industry award, and
-    an active GitHub org point to growing but emerging traction.
+    an active GitHub org point to growing but emerging traction. Re-read 2026-08-13 - the Tom's Hardware
+    launch coverage still stands and still puts the module at $149, and MxAccl is still a live public
+    repo. The article names no distributor, so the Amazon/Mouser half of the note rests on the earlier
+    read rather than on anything re-confirmed today. Level and reach unchanged.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.tomshardware.com/tech-industry/artificial-intelligence/memryx-launches-usd149-mx3-m-2-ai-accelerator-module-capable-of-24-tops-compute-power
-    shows: retail launch at $149 with broad distribution
-    accessed: '2026-06-22'
+    shows: '"The MX3 M.2 module is available for $149 USD"; a technology start-up originating from the
+      University of Michigan; no distributor is named'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0918df1ac7c17e40b3119558e772225fd427599ea6f2fa5a993c419060d2f7c6
+  - url: https://github.com/memryx/MxAccl
+    shows: live public repository for the MemryX C++ runtime and acclBench benchmarking tool
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 74aa33db22861ebf50548724dae3614917d9ac0453b02f0b28008d79f7fc097f
 capability:
   score: 3
   basis: feature_matrix
   value: 6 TOPS/chip, up to 24 TOPS (4-chip M.2); 4/8/16-bit weights + BFloat16; ~42M params per module
   confidence: high
   note: Moderate throughput with flexible precision, but on-chip parameter capacity caps deployable model
-    size.
+    size. Re-read 2026-08-13 - the M.2 datasheet no longer carries a TOPS figure, a data-format list or
+    a parameter-capacity number at all; its specification table is now system, electrical, mechanical,
+    environmental and compliance only. The throughput half of the recorded value was re-derived instead
+    from the launch coverage, which still reads "Each MX3 chip is said to deliver 6 TOPS ... offering a
+    total of up to 24 TOPS" and "particularly those optimized for 8-bit weights". The 4/8/16-bit plus
+    BFloat16 formats and the ~42M-parameter capacity are no longer supported by any cited source and are
+    flagged for a curator ruling. The band is unchanged - 24 TOPS still sits above the 6 TOPS SBCs and
+    below the Jetson Orin line.
+  last_verified: '2026-08-13'
   sources:
+  - url: https://www.tomshardware.com/tech-industry/artificial-intelligence/memryx-launches-usd149-mx3-m-2-ai-accelerator-module-capable-of-24-tops-compute-power
+    shows: '"Each MX3 chip is said to deliver 6 TOPS (Tera Operations Per Second), offering a total of
+      up to 24 TOPS of compute power"; four MX3 chips on a standard M.2 2280 module; "particularly those
+      optimized for 8-bit weights"'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0918df1ac7c17e40b3119558e772225fd427599ea6f2fa5a993c419060d2f7c6
   - url: https://developer.memryx.com/specs/M.2_datasheet.html
-    shows: per-chip/module TOPS, supported data formats, parameter capacity
-    accessed: '2026-06-22'
+    shows: '"MemryX MX3 (x4)" as the module''s AI processor and "The 4 MX3 chips appear as one logical
+      unit to the NeuralCompiler and runtime software stack"; the table no longer lists TOPS, data
+      formats or parameter capacity'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 14d338f59a212d65ca4cae04933e6643e1cedba983b98f5ad9963f4bb88e9479

--- a/sources/scores/nvidia-jetson-agx-orin.yaml
+++ b/sources/scores/nvidia-jetson-agx-orin.yaml
@@ -23,25 +23,53 @@ openness:
       raw: distributor (via distributors)
   confidence: high
   note: Public datasheets and commercially purchasable, but SDK relies on proprietary NVIDIA blobs under
-    license, placing it in the documented tier.
+    license, placing it in the documented tier. Re-read 2026-08-13 - the family page still publishes
+    module data sheets and points designers at the Product Design Guide rather than releasing the module's
+    own board files, still routes buyers through the Jetson partner ecosystem, and Jetson Linux 39.2.1
+    still ships kernel, UEFI bootloader and NVIDIA drivers under the NVIDIA Software License Agreement.
+    No dimension moved.
   raw: schematics:partial (module datasheet + carrier design guide public);toolchain:closed (JetPack/Jetson
     Linux proprietary (NVIDIA SLA));datasheets:public;blobs:required (proprietary drivers/bootloader);retail:distributor
     (via distributors)
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin
-    shows: 'Official spec: up to 275 TOPS, 2048-core Ampere GPU, 32/64GB LPDDR5, 699-pin module'
-    accessed: '2026-06-22'
+    shows: Up to 275 TOPS, 2048-core Ampere GPU with 64 Tensor Cores, 64GB/32GB 256-bit LPDDR5, 699-pin
+      Molex Mirror Mezz connector; "See Module Data Sheets"; "See the Product Design Guide for supported
+      UPHY configurations"; a Jetson partner ecosystem offering carrier boards and systems
+    accessed: '2026-08-13'
+    establishes:
+    - schematics
+    - datasheets
+    - retail
+    http_status: 200
+    content_sha256: 99efa728010da0ac785f54233fbef4e621123d6f61ca67f2df5deee3d3df3fe2
+  - url: https://developer.nvidia.com/embedded/jetson-linux
+    shows: NVIDIA Jetson Linux Driver Package 39.2.1 - "includes Linux Kernel, UEFI bootloader, NVIDIA
+      drivers, flashing utilities" - published under the NVIDIA Software License Agreement
+    accessed: '2026-08-13'
+    establishes:
+    - toolchain
+    - blobs
+    http_status: 200
+    content_sha256: 4915cb65cc6950978689d2412ffca1557126b2228f5fa4c877bfe1d56f75616e
 adoption:
   level: 3
   reach: niche
   signal_type: reported_traction
   confidence: medium
   note: Available as a dev kit and production module through NVIDIA's distributor network with a large
-    Jetson community, but the high price targets professional robotics.
+    Jetson community, but the high price targets professional robotics. Re-read 2026-08-13 - the family
+    page still lists the AGX Orin 64GB, 32GB and Industrial modules alongside the AGX Orin Developer Kit
+    and still routes purchase through the Jetson partner ecosystem. Reach unchanged.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin
-    shows: Module family page indicating production module and dev kit availability
-    accessed: '2026-06-22'
+    shows: '"Jetson AGX Orin is available in 64GB, 32GB, and Industrial versions" plus the AGX Orin Developer
+      Kit and a partner ecosystem of carrier boards and systems'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 99efa728010da0ac785f54233fbef4e621123d6f61ca67f2df5deee3d3df3fe2
 capability:
   score: 5
   basis: feature_matrix
@@ -49,8 +77,13 @@ capability:
     at the edge
   confidence: high
   note: Top-tier edge-AI compute; the 64GB/275 TOPS variant runs large models that exceed smaller Orin
-    modules.
+    modules. Re-derived 2026-08-13 from the same comparison table, which still reads 275 SPARSE INT8 TOPS
+    and 64GB 256-bit LPDDR5 for AGX Orin against 157 TOPS / 16GB for Orin NX and 67 TOPS / 8GB for Orin
+    Nano. It remains the top of the Orin line and the highest capability in this category.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin
-    shows: 275 TOPS and up to 64GB LPDDR5 spec
-    accessed: '2026-06-22'
+    shows: 275 SPARSE INT8 TOPS, 2048-core Ampere GPU with 64 Tensor Cores, 64GB 256-bit LPDDR5
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 99efa728010da0ac785f54233fbef4e621123d6f61ca67f2df5deee3d3df3fe2

--- a/sources/scores/nvidia-jetson-orin-nano-super-developer-kit.yaml
+++ b/sources/scores/nvidia-jetson-orin-nano-super-developer-kit.yaml
@@ -23,35 +23,75 @@ openness:
       raw: open_market (mass-market)
   confidence: high
   note: Public datasheets and globally purchasable, but the SDK requires proprietary NVIDIA drivers/blobs
-    under license, so it sits in the documented tier despite the community OE4T BSP.
+    under license, so it sits in the documented tier despite the community OE4T BSP. Re-read 2026-08-13 -
+    the developer-kit page still publishes a datasheet link and directs buyers to worldwide partners,
+    the Jetson Orin family page still points designers at the Product Design Guide rather than releasing
+    the kit's own board files, and Jetson Linux 39.2.1 still ships its kernel, UEFI bootloader and NVIDIA
+    drivers under the NVIDIA Software License Agreement. No dimension moved.
   raw: schematics:partial (carrier design guide public);toolchain:closed (JetPack/Jetson Linux free but
     NVIDIA-SLA proprietary);datasheets:public;blobs:required (proprietary GPU drivers/bootloader required);retail:open_market
     (mass-market)
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin/nano-super-developer-kit/
-    shows: 'Official spec: 67 INT8 TOPS, 1024-core Ampere GPU, 6-core A78AE, 8GB LPDDR5, $249'
-    accessed: '2026-06-22'
+    shows: 67 INT8 TOPS - 1024-core Ampere GPU with 32 tensor cores, 6-core Arm Cortex-A78AE, 8GB 128-bit
+      LPDDR5, a "View the Jetson Orin Nano Super Developer Kit Datasheet" link, and "purchased through
+      NVIDIA authorized distributors worldwide"
+    accessed: '2026-08-13'
+    establishes:
+    - datasheets
+    - retail
+    http_status: 200
+    content_sha256: bfc0f0b3900815dcad4c93c9b773b1eaafd9be69c143f0e1002f9fd1f507d952
+  - url: https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin
+    shows: '"See the Product Design Guide for supported UPHY configurations" and "See Module Data Sheets" -
+      a carrier design guide rather than the design of the board being sold'
+    accessed: '2026-08-13'
+    establishes:
+    - schematics
+    http_status: 200
+    content_sha256: 99efa728010da0ac785f54233fbef4e621123d6f61ca67f2df5deee3d3df3fe2
   - url: https://developer.nvidia.com/embedded/jetson-linux
-    shows: Jetson Linux (L4T) BSP under NVIDIA Software License Agreement
-    accessed: '2026-06-22'
+    shows: NVIDIA Jetson Linux Driver Package 39.2.1 - "includes Linux Kernel, UEFI bootloader, NVIDIA
+      drivers, flashing utilities" - published under the NVIDIA Software License Agreement
+    accessed: '2026-08-13'
+    establishes:
+    - toolchain
+    - blobs
+    http_status: 200
+    content_sha256: 4915cb65cc6950978689d2412ffca1557126b2228f5fa4c877bfe1d56f75616e
 adoption:
   level: 4
   reach: mass-market
   signal_type: reported_traction
   confidence: high
   note: Widely available developer kit at a low $249 price with a large NVIDIA Jetson developer community
-    and global distribution.
+    and global distribution. Re-read 2026-08-13 - the product page no longer prints any price at all,
+    so the $249 figure the note rests on is no longer published there; what the page still shows is
+    "the most powerful and affordable embedded computer for generative AI. It can be purchased through
+    NVIDIA authorized distributors worldwide", which is the distribution the mass-market reach was
+    banded on. Level and reach unchanged; the price figure is flagged for a curator ruling.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin/nano-super-developer-kit/
-    shows: Official $249 pricing and developer-kit positioning
-    accessed: '2026-06-22'
+    shows: '"It can be purchased through NVIDIA authorized distributors worldwide" plus a Where to Buy
+      partner list; no price is printed on the page'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: bfc0f0b3900815dcad4c93c9b773b1eaafd9be69c143f0e1002f9fd1f507d952
 capability:
   score: 3
   basis: feature_matrix
   value: 67 INT8 (sparse) TOPS; 8GB LPDDR5; runs small LLMs (~7B quantized) and VLMs locally
   confidence: high
   note: Solid entry-tier generative-AI compute, but 8GB RAM caps model size versus higher Orin tiers.
+    Re-derived 2026-08-13 against the spec table, which still reads 67 INT8 TOPS and 8GB 128-bit LPDDR5,
+    against the 157 TOPS / 16GB Orin NX and the 275 TOPS / 64GB AGX Orin on the same family page. The
+    entry position in the Orin line is unchanged.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin/nano-super-developer-kit/
-    shows: 67 INT8 TOPS and 8GB LPDDR5 spec
-    accessed: '2026-06-22'
+    shows: 67 INT8 TOPS, 1024-core Ampere GPU with 32 tensor cores, 8GB 128-bit LPDDR5, 6-core Cortex-A78AE
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: bfc0f0b3900815dcad4c93c9b773b1eaafd9be69c143f0e1002f9fd1f507d952

--- a/sources/scores/nvidia-jetson-orin-nx.yaml
+++ b/sources/scores/nvidia-jetson-orin-nx.yaml
@@ -23,33 +23,65 @@ openness:
       raw: distributor (via distributors)
   confidence: high
   note: Public datasheets and purchasable through distributors, but the SDK depends on proprietary NVIDIA
-    blobs under license.
+    blobs under license. Re-read 2026-08-13 - the family page still publishes module data sheets and
+    points designers at the Product Design Guide rather than releasing the module's own board files,
+    still routes buyers through the Jetson partner ecosystem, and Jetson Linux 39.2.1 still ships kernel,
+    UEFI bootloader and NVIDIA drivers under the NVIDIA Software License Agreement. No dimension moved.
   raw: schematics:partial (module datasheet + carrier design guide public);toolchain:closed (JetPack/Jetson
     Linux proprietary (NVIDIA SLA));datasheets:public;blobs:required (proprietary drivers/bootloader);retail:distributor
     (via distributors)
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin
-    shows: 'Official spec: up to 157 TOPS, 1792-core Ampere GPU, 8/16GB LPDDR5, 260-pin SO-DIMM'
-    accessed: '2026-06-22'
+    shows: Up to 157 TOPS, 1792-core Ampere GPU with 56 Tensor Cores, 16GB 128-bit LPDDR5, 260-pin SO-DIMM
+      connector; "See Module Data Sheets"; "See the Product Design Guide for supported UPHY configurations";
+      a Jetson partner ecosystem offering carrier boards and systems
+    accessed: '2026-08-13'
+    establishes:
+    - schematics
+    - datasheets
+    - retail
+    http_status: 200
+    content_sha256: 99efa728010da0ac785f54233fbef4e621123d6f61ca67f2df5deee3d3df3fe2
+  - url: https://developer.nvidia.com/embedded/jetson-linux
+    shows: NVIDIA Jetson Linux Driver Package 39.2.1 - "includes Linux Kernel, UEFI bootloader, NVIDIA
+      drivers, flashing utilities" - published under the NVIDIA Software License Agreement
+    accessed: '2026-08-13'
+    establishes:
+    - toolchain
+    - blobs
+    http_status: 200
+    content_sha256: 4915cb65cc6950978689d2412ffca1557126b2228f5fa4c877bfe1d56f75616e
 adoption:
   level: 3
   reach: niche
   signal_type: reported_traction
   confidence: medium
   note: Production SO-DIMM module sold through NVIDIA's distributor network with strong Jetson community;
-    popular in commercial drones/robotics but not mass-market.
+    popular in commercial drones/robotics but not mass-market. Re-read 2026-08-13 - the family page still
+    lists "Jetson Orin NX is available in 16GB and 8GB" as production modules routed through the Jetson
+    partner ecosystem, with no retail channel of its own. Reach unchanged.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin
-    shows: Module family page indicating production module availability
-    accessed: '2026-06-22'
+    shows: '"Jetson Orin NX is available in 16GB and 8GB" production modules, sold through the Jetson
+      partner ecosystem'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 99efa728010da0ac785f54233fbef4e621123d6f61ca67f2df5deee3d3df3fe2
 capability:
   score: 4
   basis: feature_matrix
   value: Up to 157 TOPS; 8GB or 16GB LPDDR5; runs mid-to-large LLMs/VLMs and multi-stream vision
   confidence: high
   note: Strong mid-range edge compute; the 16GB/157 TOPS variant handles sizeable models, below AGX Orin
-    but above Orin Nano.
+    but above Orin Nano. Re-derived 2026-08-13 from the same comparison table - 157 SPARSE INT8 TOPS and
+    16GB 128-bit LPDDR5 against AGX Orin's 275 TOPS / 64GB above it and Orin Nano's 67 TOPS / 8GB below.
+    The ordering within the Orin line is unchanged.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin
-    shows: 157 TOPS and up to 16GB LPDDR5 spec
-    accessed: '2026-06-22'
+    shows: 157 SPARSE INT8 TOPS, 1792-core Ampere GPU with 56 Tensor Cores, 16GB 128-bit LPDDR5
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 99efa728010da0ac785f54233fbef4e621123d6f61ca67f2df5deee3d3df3fe2

--- a/sources/scores/nxp-imx-8m-plus.yaml
+++ b/sources/scores/nxp-imx-8m-plus.yaml
@@ -38,19 +38,40 @@ adoption:
   signal_type: reported_traction
   confidence: high
   note: Widely deployed industrial processor with SoMs from multiple vendors (ADLINK, Toradex Verdin,
-    SolidRun) and broad distributor availability.
+    SolidRun) and broad distributor availability. Re-read 2026-08-13 - the Verdin iMX8M Plus is still a
+    live, configurable Toradex module with free Embedded Linux and FreeRTOS support and a product
+    availability commitment to 2036+. NXP's own product pages could not be re-read (www.nxp.com answers
+    404 to an automated fetch, including its own root), so the multi-vendor half of the note rests on the
+    earlier read. Level and reach unchanged.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.toradex.com/computer-on-modules/verdin-arm-family/nxp-imx-8m-plus
-    shows: Toradex Verdin SoM productizes the i.MX 8M Plus
-    accessed: '2026-06-22'
+    shows: '"NXP i.MX 8M Plus - Verdin iMX8M Plus System on Module" with a Configure Your Own path,
+      free Toradex support and maintenance for Embedded Linux and FreeRTOS, and product availability
+      listed as 2036+'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: f7721cb69e42ab9f12eecb6408dbb5a4b5c5148714831de1bac7b6e09b67b1df
 capability:
   score: 3
   basis: feature_matrix
   value: 2.3 TOPS NPU; quad Cortex-A53 + Cortex-M7; LPDDR4 support
   confidence: high
   note: 2.3 TOPS integrated NPU with dual-ISP vision is solid for industrial ML but lower throughput than
-    the 4-12 TOPS dedicated kits here.
+    the 4-12 TOPS dedicated kits here. Re-derived 2026-08-13 - the NXP fact sheet the value cited now
+    404s (www.nxp.com answers 404 to an automated fetch across every path tried, including its own root),
+    so the figure was re-confirmed against Toradex's Verdin iMX8M Plus page, which reads "Neural
+    Processing Unit (NPU) - up to 2.3 TOPS" with 4x Cortex-A53 at 1.8 GHz and a Cortex-M7F. That is
+    still below beagley-ai and ti-am67a at 4 TOPS and well below the Jetson Orin line, so the band is
+    unchanged. The dead NXP source is escalated rather than deleted.
+  last_verified: '2026-08-13'
   sources:
+  - url: https://www.toradex.com/computer-on-modules/verdin-arm-family/nxp-imx-8m-plus
+    shows: '"Neural Processing Unit (NPU) - up to 2.3 TOPS"; "i.MX 8M Plus applications processor with
+      up to 4x Cortex-A53 1.8 GHz processors"; "Cortex-M7 processor with speeds up to 800 MHz"'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: f7721cb69e42ab9f12eecb6408dbb5a4b5c5148714831de1bac7b6e09b67b1df
   - url: https://www.nxp.com/docs/en/fact-sheet/IMX8MPLUSFS.pdf
     shows: 'fact sheet: 2.3 TOPS NPU, CPU/ISP specs'
     accessed: '2026-06-22'

--- a/sources/scores/orange-pi-5.yaml
+++ b/sources/scores/orange-pi-5.yaml
@@ -25,24 +25,67 @@ openness:
       raw: open_market (global)
   confidence: high
   note: Proprietary Rockchip silicon with an open GPL-2.0 BSP, public datasheet and schematics, and global
-    retail availability, but bootable images depend on Rockchip firmware blobs.
+    retail availability, but bootable images depend on Rockchip firmware blobs. Re-read 2026-08-13 - the
+    official support page still offers a Schematic download alongside the user manual and Android/Linux
+    source, orangepi-build is still GPL-2.0 and still lists Orange Pi 5 under RK3588S, the product page
+    still carries AliExpress and Amazon store links, and Rockchip's rkbin repository still holds the
+    prebuilt DDR/SPL/BL31 boot binaries a bootable image needs. No dimension moved.
   raw: schematics:published (published PDF);toolchain:open (open GPL-2.0 BSP/build system);datasheets:public
     (public RK3588S);blobs:required (Rockchip firmware required);retail:open_market (global)
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/orangepi-xunlong/orangepi-build
-    shows: official GPL-2.0 build system supporting Orange Pi 5 / RK3588S
-    accessed: '2026-06-22'
+    shows: GPL-2.0 licensed "Orange Pi build for H2+, H3, H5, H6, H616, RK3328, RK3399 and RK3588(s)",
+      listing Orange Pi 5/5B/5Pro under Rockchip RK3588S
+    accessed: '2026-08-13'
+    establishes:
+    - toolchain
+    http_status: 200
+    content_sha256: 3538a07acad94c2a7bc3b272dd3fd501a68887c41ce61449521e9dec78c7a321
   - url: http://www.orangepi.org/html/hardWare/computerAndMicrocontrollers/service-and-support/Orange-pi-5.html
-    shows: official support page with schematic, manual, and source downloads
-    accessed: '2026-06-22'
+    shows: Official Resources list with Schematic, User Manual, Ubuntu/Debian/Android images, Android Source
+      Code and Linux Source code downloads
+    accessed: '2026-08-13'
+    establishes:
+    - schematics
+    http_status: 200
+    content_sha256: 7ec3c2f9804599a7c34cb88593e2fa8244a87ab7e97a4170d1d2dc3994445068
+  - url: http://www.orangepi.org/html/hardWare/computerAndMicrocontrollers/details/Orange-Pi-5.html
+    shows: Full published parameter table for the RK3588S (8nm LP, quad A76 + quad A55, Mali-G610 MC4,
+      6 TOPS NPU with INT4/INT8/INT16 support, 4/8/16GB LPDDR4/4X) and "Aliexpress Store BUY" / "Amazon
+      Store BUY" links
+    accessed: '2026-08-13'
+    establishes:
+    - datasheets
+    - retail
+    http_status: 200
+    content_sha256: 9477dddc0147a7932d0959d44d7e687e5d09d047b76aa181786e08c88917fc94
+  - url: https://github.com/rockchip-linux/rkbin
+    shows: Rockchip's own "Firmware and Tool Binarys" repository - prebuilt SPL/DDR/UsbPlug/BL31/BL32/OPTEE
+      boot binaries distributed as binaries rather than source
+    accessed: '2026-08-13'
+    establishes:
+    - blobs
+    http_status: 200
+    content_sha256: 43abb5977b081df3eaebfcdeb7f2bef288daab407fbf1b0f6935236c1e026cff
 adoption:
   level: 5
   reach: mass-market
   signal_type: reported_traction
   confidence: high
   note: Sold directly on AliExpress and Amazon at ~$69-$115 across multiple SKUs, with a large third-party
-    software/community ecosystem.
+    software/community ecosystem. Re-read 2026-08-13 - the Amazon listing could not be re-read (the host
+    returns a "Click the button below to continue shopping" interstitial to an automated fetch, not the
+    listing), so the availability check was re-derived from Orange Pi's own product page, which carries
+    live Aliexpress, Amazon and Xunlong store links and the 4/8/16GB SKUs. Level and reach unchanged.
+  last_verified: '2026-08-13'
   sources:
+  - url: http://www.orangepi.org/html/hardWare/computerAndMicrocontrollers/details/Orange-Pi-5.html
+    shows: '"Aliexpress Store BUY", "Amazon Store BUY", Xunlong Store and Orange Pi Store links against
+      the 4GB/8GB/16GB SKUs'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9477dddc0147a7932d0959d44d7e687e5d09d047b76aa181786e08c88917fc94
   - url: https://www.amazon.com/Orange-Pi-Frequency-Development-Android12/dp/B0BN16ZLXB
     shows: Orange Pi 5 retail listing on Amazon
     accessed: '2026-06-22'
@@ -52,8 +95,14 @@ capability:
   value: 6 TOPS NPU; up to 16GB LPDDR4/4X; runs quantized LLMs up to ~8B (W4A16) and CV models via RKNN/RKLLM
   confidence: high
   note: The RK3588S NPU does 6 TOPS with mixed-precision support and runs small on-device LLMs, but well
-    below discrete GPUs and dedicated NPUs.
+    below discrete GPUs and dedicated NPUs. Re-derived 2026-08-13 - the spec table still reads 6 TOPS
+    with INT4/INT8/INT16 mixed operation and 4/8/16GB LPDDR4/4X, which is the same tier as khadas-edge2
+    (also 6 TOPS RK3588S2) and well under the 67-275 TOPS Jetson Orin parts.
+  last_verified: '2026-08-13'
   sources:
   - url: http://www.orangepi.org/html/hardWare/computerAndMicrocontrollers/details/Orange-Pi-5.html
-    shows: 'official spec: RK3588S, 6 TOPS NPU, 4/8/16GB'
-    accessed: '2026-06-22'
+    shows: '"Built-in AI accelerator NPU with up to 6 TOPS, supports INT4/INT8/INT16 mixed operation";
+      RK3588S with 4GB/8GB/16GB LPDDR4/4X'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9477dddc0147a7932d0959d44d7e687e5d09d047b76aa181786e08c88917fc94

--- a/sources/scores/qualcomm-dragonwing-rb3-gen-2.yaml
+++ b/sources/scores/qualcomm-dragonwing-rb3-gen-2.yaml
@@ -38,19 +38,39 @@ adoption:
   signal_type: reported_traction
   confidence: medium
   note: Sold via Thundercomm and other distributors; first-class support in Edge Impulse, indicating an
-    established but specialist developer base.
+    established but specialist developer base. Re-read 2026-08-13 - Edge Impulse still lists the kit as
+    a supported board alongside the Dragonwing IQ-8275 and IQ-9075 EVKs, still says it is "fully
+    supported by Edge Impulse", and still documents a Qualcomm IM SDK GStreamer pipeline for it. The
+    Qualcomm developer page could not be re-read (it serves an empty client-rendered shell to a fetcher),
+    so the distributor half of the note rests on the earlier read. Level and reach unchanged.
+  last_verified: '2026-08-13'
   sources:
   - url: https://docs.edgeimpulse.com/hardware/boards/qualcomm-rb3-gen-2-dev-kit
-    shows: platform support in the Edge Impulse ecosystem
-    accessed: '2026-06-22'
+    shows: '"It''s fully supported by Edge Impulse - you''ll be able to sample raw data, build models",
+      listed among the Qualcomm Dragonwing boards with an IM SDK GStreamer pipeline page'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d1547897ef7df27c08f6f02952f0038debfa7f01cc9a4a7ab8f187c5a4a7faff
 capability:
   score: 4
   basis: feature_matrix
   value: 12 TOPS (Hexagon NPU); QCS6490 octa-core; multi-camera vision
   confidence: high
   note: 12 dense TOPS with octa-core CPU and dual-ISP vision puts it among the more capable edge-AI dev
-    kits here.
+    kits here. Re-derived 2026-08-13 from Edge Impulse's board page, which reads "a powerful Linux-based
+    development board based around the QCS6490 SoC. It has two built-in cameras, a Kryo 670 CPU, Adreno
+    643L GPU and 12 TOPS Hexagon 770 NPU". Qualcomm's own developer page could not be re-read (it serves
+    an empty client-rendered shell to a fetcher), so the figure was confirmed against the ecosystem
+    partner's documentation instead. 12 TOPS still sits above the 6 TOPS RK3588 boards and below the
+    Jetson Orin NX, so the band is unchanged.
+  last_verified: '2026-08-13'
   sources:
+  - url: https://docs.edgeimpulse.com/hardware/boards/qualcomm-rb3-gen-2-dev-kit
+    shows: '"based around the QCS6490 SoC. It has two built-in cameras, a Kryo 670 CPU, Adreno 643L GPU
+      and 12 TOPS Hexagon 770 NPU"'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d1547897ef7df27c08f6f02952f0038debfa7f01cc9a4a7ab8f187c5a4a7faff
   - url: https://www.qualcomm.com/developer/hardware/rb3-gen-2-development-kit
     shows: up to 12 dense TOPS, QCS6490 SoC specs
     accessed: '2026-06-22'

--- a/sources/scores/radxa-rock-5b.yaml
+++ b/sources/scores/radxa-rock-5b.yaml
@@ -21,35 +21,86 @@ openness:
       raw: open_market (global)
   confidence: high
   note: Schematics and mechanical files are publicly downloadable and the BSP is open, but the RK3588
-    needs proprietary Rockchip blobs and editable PCB source is not released.
+    needs proprietary Rockchip blobs and editable PCB source is not released. Re-read 2026-08-13 - the
+    Hardware Design section still offers v1.3/v1.42 schematic PDFs, SMD maps, 2D DXF and 3D STP plus CE
+    EMC test reports, and still publishes no editable PCB source; the Radxa BSP build tool is still
+    GPL-3.0; and Rockchip's rkbin still ships the DDR/BL31 boot binaries as prebuilt files. No dimension
+    moved.
   raw: schematics:published (PDF + SMD maps + DXF + 3D STP + CE/FCC public);toolchain:open (open BSP/kernel/U-Boot);blobs:required
     (Rockchip rkbin/DDR/TF-A required);retail:open_market (global)
+  last_verified: '2026-08-13'
   sources:
   - url: https://docs.radxa.com/en/rock5/rock5b/download
-    shows: downloadable schematic PDFs, SMD maps, DXF, 3D STP, CE/FCC reports
-    accessed: '2026-06-22'
+    shows: Hardware Design section listing "v1.3 Schematic pdf", "v1.42 Schematic pdf", "v1.3 SMD pdf",
+      "v1.3 2D Top&Bottom dxf", "v1.42 3D Figure stp" and a Quality certification section with CE EMC
+      test reports; no editable PCB source offered
+    accessed: '2026-08-13'
+    establishes:
+    - schematics
+    http_status: 200
+    content_sha256: 5be2c030020841b46a9db971a60695cb5e30415494eabed3d8d53e166dbd4ec5
   - url: https://github.com/radxa-repo/bsp
-    shows: official open Radxa BSP build tool with ROCK 5B profile
-    accessed: '2026-06-22'
+    shows: '"bsp - Radxa BSP Build Tool" under a GPL-3.0 license, 1,163 commits'
+    accessed: '2026-08-13'
+    establishes:
+    - toolchain
+    http_status: 200
+    content_sha256: ec98d2d600aa5285dc3de2c9f003ffd66c67a4b6c759fdc990b8bb23db326943
+  - url: https://github.com/rockchip-linux/rkbin
+    shows: Rockchip's own "Firmware and Tool Binarys" repository - prebuilt SPL/DDR/UsbPlug/BL31/BL32/OPTEE
+      boot binaries distributed as binaries rather than source
+    accessed: '2026-08-13'
+    establishes:
+    - blobs
+    http_status: 200
+    content_sha256: 43abb5977b081df3eaebfcdeb7f2bef288daab407fbf1b0f6935236c1e026cff
+  - url: https://ameridroid.com/products/rock5-model-b
+    shows: ROCK 5 Model B listed for sale at an authorized US distributor at $289.95 across three RAM
+      variants
+    accessed: '2026-08-13'
+    establishes:
+    - retail
+    http_status: 200
+    content_sha256: c7089f9d114cd738cbd5fb155da7279fe780ea6bf73f0cc19869a3c0a61a0f5c
 adoption:
   level: 5
   reach: mass-market
   signal_type: reported_traction
   confidence: high
   note: One of the most popular RK3588 SBCs, sold globally through authorized distributors with 15+ third-party
-    OS ports and an active community.
+    OS ports and an active community. Re-read 2026-08-13 - the ameriDroid listing is still live at $289.95
+    though every RAM variant currently reads "Sold out" at that distributor, and Radxa's own docs still
+    list the third-party OS ports (Armbian, Arch, DietPi, openFyde, Batocera, RebornOS and others). The
+    stock-out is one distributor's inventory rather than a discontinuation; level and reach unchanged.
+  last_verified: '2026-08-13'
   sources:
   - url: https://ameridroid.com/products/rock5-model-b
-    shows: live retail listing at an authorized US distributor
-    accessed: '2026-06-22'
+    shows: ROCK 5 Model B listing live at an authorized US distributor, $289.95, with "Sold out" against
+      the RAM variants
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c7089f9d114cd738cbd5fb155da7279fe780ea6bf73f0cc19869a3c0a61a0f5c
+  - url: https://docs.radxa.com/en/rock5/rock5b/download
+    shows: third-party OS images listed for ROCK 5B including Armbian, Arch Linux, DietPi, RebornOS,
+      openFyde and Batocera
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5be2c030020841b46a9db971a60695cb5e30415494eabed3d8d53e166dbd4ec5
 capability:
   score: 4
   basis: feature_matrix
   value: 6 TOPS NPU; up to 16GB LPDDR4X (5B) / 32GB LPDDR5 (5B+); RK3588 8-core CPU
   confidence: high
   note: 6 TOPS INT8 plus up to 16-32GB RAM runs quantized small/mid LLMs and real-time vision via RKNN,
-    strong for an edge SBC.
+    strong for an edge SBC. Re-derived 2026-08-13 - the introduction still reads "up to 6TOPs" with
+    INT4/INT8/INT16/FP16/BF16/TF32 support and 4/8/16 LPDDR4X on the 5B and 4/8/16/32 LPDDR5 on the 5B+.
+    The 32GB ceiling is what places it a step above the other 6 TOPS RK3588 boards here (orange-pi-5,
+    khadas-edge2, both at 3), and still below the Jetson Orin NX.
+  last_verified: '2026-08-13'
   sources:
   - url: https://docs.radxa.com/en/rock5/rock5b/getting-started/introduction
-    shows: 6 TOPS NPU; RAM up to 16GB (5B) / 32GB LPDDR5 (5B+)
-    accessed: '2026-06-22'
+    shows: '"NPU supports INT4/INT8/INT16/FP16/BF16 and TF32 acceleration with up to 6TOPs of computation
+      power"; 4/8/16 64-bit LPDDR4X and 4/8/16/32 64-bit LPDDR5'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c4082e4fc55f4b3f7e7e77341a5e53f58cd024a09dd9f9518eda4c8f05e14614

--- a/sources/scores/raspberry-pi-5.yaml
+++ b/sources/scores/raspberry-pi-5.yaml
@@ -37,8 +37,18 @@ adoption:
   signal_type: reported_traction
   confidence: high
   note: Flagship Raspberry Pi SBC sold globally through countless distributors with a huge community;
-    in production until at least January 2036.
+    in production until at least January 2036. Re-read 2026-08-13 - raspberrypi.com answered 403 to every
+    request across the session, so the check was re-derived from Raspberry Pi's own product brief on
+    datasheets.raspberrypi.com, published April 2026, which still commits to production until at least
+    January 2036 and still lists the full 1GB-16GB price ladder. Level and reach unchanged.
+  last_verified: '2026-08-13'
   sources:
+  - url: https://datasheets.raspberrypi.com/rpi5/raspberry-pi-5-product-brief.pdf
+    shows: '"Production lifetime - Raspberry Pi 5 will remain in production until at least January 2036";
+      list prices of $45 (1GB), $65 (2GB), $110 (4GB), $175 (8GB), $305 (16GB); published April 2026'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 10583c80f867e05af185742bb0f80448458c606a32dd3dbefbbcfca480b59ead
   - url: https://www.raspberrypi.com/products/raspberry-pi-5/
     shows: Official availability commitment and distribution
     accessed: '2026-06-22'
@@ -49,8 +59,19 @@ capability:
     on CPU
   confidence: high
   note: General-purpose SBC with no dedicated AI accelerator; on-device AI is modest unless paired with
-    an accelerator HAT.
+    an accelerator HAT. Re-derived 2026-08-13 from the April 2026 product brief, whose full feature list
+    runs GPU, video, RAM, wireless, storage, USB, Ethernet, MIPI, PCIe, power and header, and names no
+    NPU and no TOPS figure anywhere. That absence is the whole of the band - every other board in this
+    category records an accelerator, and this one records only 16GB of LPDDR4X behind a Cortex-A76.
+  last_verified: '2026-08-13'
   sources:
+  - url: https://datasheets.raspberrypi.com/rpi5/raspberry-pi-5-product-brief.pdf
+    shows: '"Broadcom BCM2712 2.4GHz quad-core 64-bit Arm Cortex-A76 CPU" with "VideoCore VII GPU" and
+      "LPDDR4X-4267 SDRAM (options for 1GB, 2GB, 4GB, 8GB and 16GB)"; the feature list names no NPU and
+      no TOPS figure'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 10583c80f867e05af185742bb0f80448458c606a32dd3dbefbbcfca480b59ead
   - url: https://www.raspberrypi.com/products/raspberry-pi-5/
     shows: CPU/GPU/RAM spec with no NPU/TOPS figure listed
     accessed: '2026-06-22'

--- a/sources/scores/raspberry-pi-ai-hat-plus.yaml
+++ b/sources/scores/raspberry-pi-ai-hat-plus.yaml
@@ -47,19 +47,34 @@ adoption:
   signal_type: reported_traction
   confidence: high
   note: First-party Raspberry Pi accessory sold through the global Pi distributor network with strong
-    community/tutorial coverage.
+    community/tutorial coverage. Re-read 2026-08-13 - the product page still reads "Available now from
+    $70", still carries Buy links against the 13 TOPS and 26 TOPS variants and an Approved Resellers
+    list, and now also commits to production until at least January 2030. Level and reach unchanged.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.raspberrypi.com/products/ai-hat/
-    shows: Official availability and pricing from $70
-    accessed: '2026-06-22'
+    shows: '"Available now from $70"; Buy links for the 13 TOPS and 26 TOPS variants; "Our Approved
+      Resellers"; "Raspberry Pi AI HAT+ will remain in production until at least January 2030"'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 203f416b3b2d79a5cdffbe31b30b8adce2b8793c53a22cfb21a09fe5982d5692
 capability:
   score: 3
   basis: feature_matrix
   value: 13 TOPS (Hailo-8L) or 26 TOPS (Hailo-8); vision inference; no onboard RAM (uses host Pi)
   confidence: high
   note: Mid-tier vision-focused NPU; strong for CNN inference but not large LLMs, and dependent on the
-    host Pi for memory.
+    host Pi for memory. Re-derived 2026-08-13 - the page still offers "Hailo-8 or Hailo-8L accelerator
+    offering 26 TOPS or 13 TOPS inferencing performance respectively" and still describes the workload
+    as camera post-processing (object detection, image segmentation, pose estimation) rather than
+    generative models. That places it above raspberry-pi-5 and the 6 TOPS RK3588 boards on throughput
+    and below the Jetson Orin parts on what it can actually run.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.raspberrypi.com/products/ai-hat/
-    shows: 26/13 TOPS Hailo accelerator spec and supported tasks
-    accessed: '2026-06-22'
+    shows: '"Hailo-8 or Hailo-8L accelerator offering 26 TOPS or 13 TOPS inferencing performance
+      respectively"; "fully integrated into Raspberry Pi''s camera software stack ... object detection,
+      image segmentation, and pose estimation"'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 203f416b3b2d79a5cdffbe31b30b8adce2b8793c53a22cfb21a09fe5982d5692

--- a/sources/scores/rockchip-rk3588.yaml
+++ b/sources/scores/rockchip-rk3588.yaml
@@ -19,27 +19,64 @@ openness:
   confidence: high
   note: Documentation is unusually open (full TRM and datasheet public) and the RKNN toolkit is openly
     distributed, but the SDK ships as prebuilt binaries under a proprietary license with closed firmware.
+    Re-read 2026-08-13 - the RK3588 brief datasheet is still downloadable straight from rock-chips.com
+    with no registration or NDA, the RKNN SDK licence in airockchip/rknn-toolkit2 is still the proprietary
+    "RKNN SDK License" (no reverse engineering, use restricted to Rockchip products), and rkbin still
+    distributes the DDR/BL31/OPTEE firmware as prebuilt binaries. No dimension moved.
   raw: toolchain:partial (NPU SDK on GitHub but proprietary RKNN license + prebuilt blobs, rknpu kernel
     driver open);datasheets:public (full TRM + datasheet public, no NDA);blobs:required (proprietary GPU/NPU
     firmware)
+  last_verified: '2026-08-13'
   sources:
-  - url: https://www.rock-chips.com/a/en/products/RK35_Series/2022/0926/1660.html
-    shows: 'official RK3588 page: 8-core A76+A55, 6 TOPS triple-core NPU, Mali-G610 MC4'
-    accessed: '2026-06-22'
+  - url: https://www.rock-chips.com/uploads/pdf/2022.8.26/192/RK3588%20Brief%20Datasheet.pdf
+    shows: Rockchip's own RK3588 brief datasheet, downloadable from rock-chips.com with no registration
+      or NDA - block diagram, quad Cortex-A76 + quad Cortex-A55, Mali-G610 MP4, High Performance NPU,
+      LPDDR4/LPDDR4X/LPDDR5 quad-channel
+    accessed: '2026-08-13'
+    establishes:
+    - datasheets
+    http_status: 200
+    content_sha256: 81aff61337ab10bf0f7c9234450703816037af169bf6657d3d62b868bd61fd1a
   - url: https://github.com/airockchip/rknn-toolkit2/blob/master/LICENSE
-    shows: SDK under a proprietary RKNN SDK License
-    accessed: '2026-06-22'
+    shows: '"RKNN SDK License" - a Rockchip proprietary agreement granting use only for applications
+      compatible with Rockchip products and forbidding decompiling or reverse-engineering the Software'
+    accessed: '2026-08-13'
+    establishes:
+    - toolchain
+    http_status: 200
+    content_sha256: d005b4a9a787ac1023fc7d353d9f263047e892b4edb9207303915e4a29b93c8e
+  - url: https://github.com/rockchip-linux/rkbin
+    shows: Rockchip's own "Firmware and Tool Binarys" repository - prebuilt SPL/DDR/UsbPlug/BL31/BL32/OPTEE
+      boot binaries distributed as binaries rather than source
+    accessed: '2026-08-13'
+    establishes:
+    - blobs
+    http_status: 200
+    content_sha256: 43abb5977b081df3eaebfcdeb7f2bef288daab407fbf1b0f6935236c1e026cff
+  - url: https://www.rock-chips.com/a/en/products/RK35_Series/2022/0926/1660.html
+    shows: '"6TOPS NPU, triple core, support int4/int8/int16/FP16/BF16/TF32 acceleration"; 8nm process,
+      quad-core Cortex-A76 + quad-core Cortex-A55; ARM Mali-G610 MC4'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b5ca75ad042e019b490b1627bd74996fe02a72a320a1d292db2accd549e0dd71
 adoption:
   level: 5
   reach: mass-market
   signal_type: reported_traction
   confidence: high
   note: Powers a very large multi-vendor set of SBCs and modules (Orange Pi, Radxa, Khadas, FriendlyELEC,
-    Firefly), widely available at retail and broadly supported in community Linux.
+    Firefly), widely available at retail and broadly supported in community Linux. Re-read 2026-08-13 -
+    the Armbian community comparison still tabulates five RK3588/RK3588S boards from five different
+    vendors, and three of them (orange-pi-5, radxa-rock-5b, khadas-edge2) are separately on this map and
+    were separately confirmed on sale today. Level and reach unchanged.
+  last_verified: '2026-08-13'
   sources:
   - url: https://forum.armbian.com/topic/26398-video-comparing-rk3588-sbcs-nanopi-r6s-khadas-edge2-radxa-rock5b-mekotronics-r58-mini-r58x-4g-orange-pi-5/
-    shows: independent comparison of many RK3588 SBCs from multiple vendors
-    accessed: '2026-06-22'
+    shows: comparison table of Khadas Edge 2 Pro, NanoPi R6S, Radxa Rock5B, Mekotronics R58 Mini and
+      R58X-4G and Orange Pi 5, all on Rockchip RK3588 or RK3588S
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 2db7eb01547612cc0257308c05c7d80607c84d2cb6b2d692a7121897a90456f3
 capability:
   score: 4
   basis: feature_matrix
@@ -47,8 +84,20 @@ capability:
     on-device LLMs via RKNN-LLM
   confidence: high
   note: The 6 TOPS NPU is genuine edge-AI capability and the RKLLM SDK runs quantized LLMs on-chip, but
-    modest versus dedicated accelerators.
+    modest versus dedicated accelerators. Re-derived 2026-08-13 - the RKLLM repository still ships an
+    RK3588-series runtime and toolkit with working w8a8 demos for Qwen2.5-VL-3B, Qwen3-VL-2B, InternVL3-1B
+    and DeepSeek-OCR, and Rockchip's own product page still reads 6 TOPS triple-core NPU. Generative
+    workloads actually running on-chip is what keeps this a step above the 6 TOPS boards built on it.
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/airockchip/rknn-llm
-    shows: official RKLLM SDK running LLMs on RK3588-series NPU
-    accessed: '2026-06-22'
+    shows: rkllm-toolkit and rkllm-runtime for the Rockchip NPU, with RK3588 Series listed and w8a8
+      demos for Qwen2.5-VL-3B, Qwen3-VL-2B, InternVL3-1B and DeepSeek-OCR
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 142f5003024aefe672326a42bce336888f7cacc10cc0ec89ca17d5f05b357cb2
+  - url: https://www.rock-chips.com/a/en/products/RK35_Series/2022/0926/1660.html
+    shows: '"6TOPS NPU, triple core, support int4/int8/int16/FP16/BF16/TF32 acceleration"'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b5ca75ad042e019b490b1627bd74996fe02a72a320a1d292db2accd549e0dd71

--- a/sources/scores/sipeed-maixcam.yaml
+++ b/sources/scores/sipeed-maixcam.yaml
@@ -25,35 +25,71 @@ openness:
       raw: open_market (global via AliExpress/Taobao)
   confidence: high
   note: Open Apache-2.0 SDKs, public schematics/datasheets, and global retail availability, though the
-    SG2002 silicon itself is proprietary.
+    SG2002 silicon itself is proprietary. Re-read 2026-08-13 - the wiki still links Schematic and
+    Datasheet downloads in its hardware resources, still points at the SOPHGO SG2002 as closed silicon,
+    still lists Sipeed Taobao and AliExpress purchase links, and MaixPy is still Apache-2.0. No dimension
+    moved.
   raw: schematics:published (available via wiki/GitHub);toolchain:open (fully open (MaixPy/MaixCDK, Apache-2.0));datasheets:public
     (public on wiki);blobs:required (SG2002 silicon proprietary);retail:open_market (global via AliExpress/Taobao)
+  last_verified: '2026-08-13'
   sources:
   - url: https://wiki.sipeed.com/hardware/en/maixcam/maixcam.html
-    shows: 'spec page: SG2002 RISC-V, 1 TOPS NPU, 256MB DDR3, open schematics/datasheets, MaixPy/MaixCDK'
-    accessed: '2026-06-22'
+    shows: hardware resources listing Schematic and Datasheet downloads; SOPHGO SG2002 with a 1GHz RISC-V
+      C906 and 256MB DDR3; "MaixCAM hardware info, more info please refer to CPU's datasheet"; Purchase
+      section with Sipeed Taobao and AliExpress links
+    accessed: '2026-08-13'
+    establishes:
+    - schematics
+    - datasheets
+    - blobs
+    - retail
+    http_status: 200
+    content_sha256: 98cfa748b6715a0a8eae56bb6520f503a18b33e43820f373258dd97469db62da
   - url: https://github.com/sipeed/MaixPy
-    shows: open source (Apache-2.0) Python SDK for MaixCAM
-    accessed: '2026-06-22'
+    shows: '"Apache License 2.0 Sipeed Ltd." on the MaixPy SDK, with MaixCAM listed as a supported
+      hardware platform'
+    accessed: '2026-08-13'
+    establishes:
+    - toolchain
+    http_status: 200
+    content_sha256: 9f3153bf0882136b3381b18bf489f117dea74ab7290624fc621fc6b36fb70209
 adoption:
   level: 3
   reach: niche
   signal_type: reported_traction
   confidence: medium
   note: Sold globally via AliExpress/Taobao with an active MaixPy/MaixHub community, but reach is concentrated
-    among hobbyist and RISC-V edge-AI developers.
+    among hobbyist and RISC-V edge-AI developers. Re-read 2026-08-13 - MaixPy is still active and now
+    banners a successor part ("MaixCam 2 is LIVE"), while still listing MaixCAM and MaixCAM-Pro as
+    supported platforms, and the wiki still carries live Taobao and AliExpress purchase links. Level and
+    reach unchanged; a successor generation shipping is worth watching for a later pass.
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/sipeed/MaixPy
-    shows: active open source repo and release cadence
-    accessed: '2026-06-22'
+    shows: active repository with MaixCAM, MaixCAM-Pro and MaixCAM2 as hardware platforms and a Releases
+      section
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9f3153bf0882136b3381b18bf489f117dea74ab7290624fc621fc6b36fb70209
+  - url: https://wiki.sipeed.com/hardware/en/maixcam/maixcam.html
+    shows: Purchase section with Sipeed Taobao and Sipeed AliExpress links
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 98cfa748b6715a0a8eae56bb6520f503a18b33e43820f373258dd97469db62da
 capability:
   score: 2
   basis: feature_matrix
   value: 1 TOPS INT8 NPU; RISC-V C906; 256MB DDR3
   confidence: high
   note: 1 TOPS and only 256MB RAM suit lightweight vision/audio models, the lowest compute tier among
-    these devices.
+    these devices. Re-derived 2026-08-13 - the spec table still reads "1TOPS@INT8, BF16 model support"
+    with a 1GHz RISC-V C906 and 256MB DDR3, which is still the smallest part in this category, below
+    google-coral-dev-board's 4 TOPS.
+  last_verified: '2026-08-13'
   sources:
   - url: https://wiki.sipeed.com/hardware/en/maixcam/maixcam.html
-    shows: 1 TOPS@INT8 NPU, RISC-V C906 1GHz, 256MB DDR3
-    accessed: '2026-06-22'
+    shows: '"1TOPS@INT8, BF16 model support, operators for popular models like Mobilenetv2, YOLOv5,
+      YOLOv8"; 1GHz RISC-V C906; 256MB DDR3'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 98cfa748b6715a0a8eae56bb6520f503a18b33e43820f373258dd97469db62da

--- a/sources/scores/ti-am67a.yaml
+++ b/sources/scores/ti-am67a.yaml
@@ -25,36 +25,73 @@ openness:
       raw: distributor (active via TI and partners)
   confidence: high
   note: Public datasheet and open SDK/TIDL tools on GitHub, commercially active, but proprietary silicon
-    and firmware keep it short of fully open hardware.
+    and firmware keep it short of fully open hardware. Re-read 2026-08-13 - the part page still reads
+    ACTIVE, still publishes "AM67x Processors datasheet (Rev. B)" openly, still offers evaluation boards
+    in stock with an Order now path, still links Jacinto 7 LPDDR4 board design and layout guidelines
+    rather than the design of any product board, and still ships a FIRMWARE-BUILDER-AM67A alongside the
+    Linux SDKs; edgeai-tidl-tools is still a public repository. No dimension moved.
   raw: schematics:partial (reference designs (BeagleY-AI board files open));toolchain:open (open SDK + TIDL
     tools + Edge AI Studio);datasheets:public (Rev B);blobs:required (proprietary silicon + TIDL firmware);retail:distributor
     (active via TI and partners)
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.ti.com/product/AM67A
-    shows: 'official page: 4 TOPS C7x+MMA, quad A53, public datasheet, ACTIVE status, SDKs'
-    accessed: '2026-06-22'
+    shows: status ACTIVE; "AM67x Processors datasheet (Rev. B)"; "Jacinto 7 LPDDR4 Board Design and
+      Layout Guidelines (Rev. F)" and evaluation boards rather than product board files; Order now with
+      evaluation boards "In stock"; FIRMWARE-BUILDER-AM67A and PROCESSOR-SDK Linux/Android SDKs
+    accessed: '2026-08-13'
+    establishes:
+    - schematics
+    - datasheets
+    - blobs
+    - retail
+    http_status: 200
+    content_sha256: 147b265e34a7b894413ce9cfc9883a4594de7d689d575a46948de2265eafaf9a
   - url: https://github.com/TexasInstruments/edgeai-tidl-tools
-    shows: open source TIDL deep-learning toolchain for AM67A-class processors
-    accessed: '2026-06-22'
+    shows: public "Edgeai TIDL Tools and Examples" repository, 736 commits, with a Supported Devices
+      and Compatibility table and a LICENSE in-tree
+    accessed: '2026-08-13'
+    establishes:
+    - toolchain
+    http_status: 200
+    content_sha256: 8d14944f1a52942d6632cedaff3b02631744e3347c7852b795278e6ce07a7b8c
 adoption:
   level: 3
   reach: broad
   signal_type: reported_traction
   confidence: high
   note: ACTIVE production part available from TI and distributors, and the basis of the widely sold BeagleY-AI
-    board, giving solid commercial and community reach.
+    board, giving solid commercial and community reach. Re-read 2026-08-13 - BeagleY-AI still names the
+    "Texas Instruments AM67A Arm-based vision processor" as its processor and is still in stock at Seeed,
+    and TI's own part page still reads ACTIVE with evaluation boards in stock. Level and reach unchanged.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.beagleboard.org/boards/beagley-ai
-    shows: AM67A powers the BeagleY-AI SBC
-    accessed: '2026-06-22'
+    shows: '"Texas Instruments AM67A Arm-based vision processor" as the BeagleY-AI processor, with the
+      dual C7x DSP and MMA rated at 4 TOPs'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: bdd173a87d3c94b1b3965b244c0e076b89045edeee1c54b2d4a015853d228d03
+  - url: https://www.ti.com/product/AM67A
+    shows: status ACTIVE with evaluation boards "In stock" and an Order now path
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 147b265e34a7b894413ce9cfc9883a4594de7d689d575a46948de2265eafaf9a
 capability:
   score: 4
   basis: feature_matrix
   value: 4 TOPS (dual C7x+MMA); quad A53 1.4 GHz; up to 8GB LPDDR4
   confidence: high
   note: 4 TOPS plus a strong vision/ISP pipeline and 8GB memory make it a capable dedicated edge-AI vision
-    SoC.
+    SoC. Re-derived 2026-08-13 - the part page still reads "up to 4 TOPS total" from 2x C7x DSP with MMA,
+    quad Cortex-A53 at up to 1.4GHz, max LPDDR4 size of 8GB and a 600MP/s ISP feeding four cameras. It
+    sits a step above beagley-ai, the 4 TOPS board built on it, because the SoC supports 8GB where that
+    board fixes 4GB.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.ti.com/product/AM67A
-    shows: 4 TOPS deep-learning, quad A53, 8GB LPDDR4, 600MP/s ISP
-    accessed: '2026-06-22'
+    shows: '"up to 4 TOPS total" from 2x C7x DSPs with MMA at up to 1.0GHz; quad-core Cortex-A53 at up
+      to 1.4GHz; "Max LPDDR4 size of 8GB"; 600MP/s ISP'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 147b265e34a7b894413ce9cfc9883a4594de7d689d575a46948de2265eafaf9a


### PR DESCRIPTION
**61 of 80 closed.** All 48 cited URLs fetched and read from saved bodies; no digest written that didn't come from a fetch. Adoption bands untouched — all 20 keep their qualitative reach, which is what `hardware.yaml` declares.

The 19 refusals are almost all **the vendor web, not the corpus**, and they cluster in a way worth seeing.

## Recorded values contradicted by their own cited sources

- **`raspberry-pi-5`** records `schematics: published (reduced published)`. Raspberry Pi publishes no Pi 5 schematics — the Pi 4 reduced-schematics PDF is live, the Pi 5 equivalent 404s under every name tried, and the product page lists only a product brief, mechanical drawing and getting-started docs. Recommend `partial`; **score would drop 4 → 3**.
- **`raspberry-pi-ai-hat-plus` cascades from it** — it records `accessory-host: open_toolchain (Raspberry Pi 5, which scores 4)`. If the Pi 5 becomes 3/documented, the value becomes `documented`, which the ladder declares but gives no rung, so the HAT abstains and needs a deferral or a ruling.
- **`google-coral-dev-board`** records `schematics: none`, contradicted by the cited datasheet page itself, which offers baseboard schematics, Altium files, an Allegro layout and a 3D STEP — and dates them to version 1.2, **August 2019**. This was wrong from the first pass, not rot. Recommend `published`, but note the consequence: `{published, partial}` matches no rung, so Coral would *abstain* rather than move to 4.
- **`arduino-uno-q`** records `toolchain: open` with no evidence, and its level 5 depends on it. The cited FAQ answers "Is UNO Q open source?" with *"schematics and gerbers"* only; the App Lab page states no licence and `github.com/arduino/app-lab` is 404.

Three of those four are ladder problems as much as data problems — the honest correction lands on a value the rung table doesn't cover.

## Hosts that refuse an automated fetch

- **`hailo-8` and `hailo-10h` are 0/8.** `hailo.ai` returned 403 to roughly forty attempts. Every recorded dimension on both products sits behind that host. Needs a UA/fetcher change or a substitute primary.
- **`www.nxp.com` answers 404 to everything, including its own root.** Adoption and capability were re-derived from Toradex's Verdin page and dated; openness and prose weren't.
- **Qualcomm's RB3 Gen 2 page** returns 200 with an 8.7 KB client-rendered shell. Same split.
- **Amazon bot-walls both listings it's cited for** (`orange-pi-5`, `khadas-edge2`). Those sources kept their old dates and fetchable substitutes were added — the vendors' own store pages. Flagging the substitution for review.

## `google-coral-dev-board` adoption — platform wind-down

The `shows` claims a "maintained official runtime repo"; GitHub says *"archived by the owner on Oct 14, 2025"*. The note's own claim that the older edgetpu repo was archived "with libedgetpu now maintained" no longer holds — **both** Coral repos are archived. Recommend re-banding 4/broad downward.

## Figures that have vanished from their pages

Recorded in the notes, values left alone: Jetson Orin Nano Super's **$249** price is gone (NVIDIA prints no price now, and both the note and the description quote it); Axelera's **~214 TOPS** is gone (now "50+ TOPs per core"); MemryX's M.2 datasheet **no longer lists TOPS, data formats or parameter capacity at all**, so 4/8/16-bit + BFloat16 and ~42M params are now unsupported by any cited source. BeagleY-AI's price moved $71.99 → $70.00 (corrected in place). Sipeed now banners a MaixCAM2 successor.

## Process note worth acting on

The agent found its scratchpad files **overwritten mid-run by a parallel agent** using the same filenames. It moved to a private subdirectory and re-fetched everything, so every digest in this diff comes from that clean second run — but the SOP should namespace scratchpad paths per agent. I'll fix that before the next wave.

All gates green: `validate` 0 errors, `check_verification` all three OK, `check_capability` OK, `check_adoption --strict` exit 0, 488 tests.