### PR TITLE
Verify training_synthetic_datasets: 144/149 checkpoints

### DIFF
--- a/sources/products/aya-collection.yaml
+++ b/sources/products/aya-collection.yaml
@@ -11,5 +11,5 @@ lineage:
   derived_from:
   - Aya crowdsourced annotations
   - templated NLP datasets
-comments: Verified live 2026-06-22 via primary sources. Ungated, Apache-2.0 licensed, with a complete
-  dataset card.
+comments: Verified live 2026-08-13 via primary sources. Ungated, Apache-2.0 licensed, with a complete dataset
+  card.

--- a/sources/products/c4.yaml
+++ b/sources/products/c4.yaml
@@ -15,5 +15,5 @@ lineage:
   trains:
   - T5
   - UL2
-comments: Verified live 2026-06-22 via primary sources. Permissively licensed (ODC-BY) and ungated with
-  a full dataset card.
+comments: Verified live 2026-08-13 via primary sources. Permissively licensed (ODC-BY) and ungated with a full
+  dataset card.

--- a/sources/products/common-corpus.yaml
+++ b/sources/products/common-corpus.yaml
@@ -13,5 +13,5 @@ lineage:
   - public domain and openly licensed sources
   trains:
   - Pleias models
-comments: Verified live 2026-06-22 via primary sources. Ungated with a full dataset card and built exclusively
+comments: Verified live 2026-08-13 via primary sources. Ungated with a full dataset card and built exclusively
   from uncopyrighted or openly licensed sources.

--- a/sources/products/cosmopedia.yaml
+++ b/sources/products/cosmopedia.yaml
@@ -13,5 +13,5 @@ lineage:
   - Mixtral-8x7B synthetic generation
   trains:
   - rwkv
-comments: Verified live 2026-06-22 via primary sources. Permissive Apache-2.0 license, ungated, full dataset
+comments: Verified live 2026-08-13 via primary sources. Permissive Apache-2.0 license, ungated, full dataset
   card and downloadable parquet files.

--- a/sources/products/culturax.yaml
+++ b/sources/products/culturax.yaml
@@ -11,5 +11,5 @@ lineage:
   derived_from:
   - mC4
   - OSCAR
-comments: Verified live 2026-06-22 via primary sources. Dataset card is rich but downloads require agreeing
+comments: Verified live 2026-08-13 via primary sources. Dataset card is rich but downloads require agreeing
   to share contact information (auto gate).

--- a/sources/products/dclm-baseline.yaml
+++ b/sources/products/dclm-baseline.yaml
@@ -20,5 +20,5 @@ lineage:
   - olmoe-instruct
   - marin
   - rwkv
-comments: Verified live 2026-06-22 via primary sources. Permissive CC-BY-4.0 license, ungated download,
-  with open code repo and dataset card.
+comments: Verified live 2026-08-13 via primary sources. Permissive CC-BY-4.0 license, ungated download, with
+  open code repo and dataset card.

--- a/sources/products/dolci.yaml
+++ b/sources/products/dolci.yaml
@@ -18,4 +18,5 @@ lineage:
   - open-instruct
   trains:
   - olmo-instruct
-comments: 'Family bucket: Dolci-Instruct and Dolci-Think SFT/DPO/RL sets.'
+comments: 'Family bucket: Dolci-Instruct and Dolci-Think SFT/DPO/RL sets. Verified live 2026-08-13 via primary
+  sources. ODC-BY licensed, ungated, with a full dataset card.'

--- a/sources/products/dolma-3.yaml
+++ b/sources/products/dolma-3.yaml
@@ -24,4 +24,5 @@ lineage:
   - olmo
   - olmo-instruct
 comments: 'Family bucket: dolma3_pool plus the Mix/Dolmino/Longmino training mixes. Successor to the map''s
-  dolma entry (Dolma 1.x).'
+  dolma entry (Dolma 1.x). Verified live 2026-08-13 via primary sources. ODC-BY licensed, ungated, with a full
+  dataset card.'

--- a/sources/products/dolma.yaml
+++ b/sources/products/dolma.yaml
@@ -22,5 +22,5 @@ lineage:
   - olmoe-instruct
   - marin
   - rwkv
-comments: Verified live 2026-06-22 via primary sources. Permissively licensed (ODC-BY), ungated download
-  with a full dataset card and replication toolkit.
+comments: Verified live 2026-08-13 via primary sources. Permissively licensed (ODC-BY), ungated download with
+  a full dataset card and replication toolkit.

--- a/sources/products/finemath.yaml
+++ b/sources/products/finemath.yaml
@@ -16,3 +16,4 @@ lineage:
   - apertus
   - marin
   - olmo
+comments: Verified live 2026-08-13 via primary sources. ODC-BY licensed, ungated, with a full dataset card.

--- a/sources/products/fineweb-2.yaml
+++ b/sources/products/fineweb-2.yaml
@@ -17,5 +17,5 @@ lineage:
   - apertus
   - smollm
   - alia-40b
-comments: Verified live 2026-06-22 via primary sources. Permissive ODC-BY license, ungated, with a dataset
+comments: Verified live 2026-08-13 via primary sources. Permissive ODC-BY license, ungated, with a dataset
   card spanning 1000+ languages.

--- a/sources/products/fineweb-edu.yaml
+++ b/sources/products/fineweb-edu.yaml
@@ -17,5 +17,5 @@ lineage:
   - smollm
   - alia-40b
   - rwkv
-comments: Verified live 2026-06-22 via primary sources. Permissive ODC-BY license with ungated download
-  and full dataset card.
+comments: Verified live 2026-08-13 via primary sources. Permissive ODC-BY license with ungated download and
+  full dataset card.

--- a/sources/products/fineweb.yaml
+++ b/sources/products/fineweb.yaml
@@ -13,5 +13,5 @@ lineage:
   - Common Crawl
   curated_with:
   - datatrove
-comments: Verified live 2026-06-22 via primary sources. Permissive ODC-BY license with ungated download
-  and a full dataset card.
+comments: Verified live 2026-08-13 via primary sources. Permissive ODC-BY license with ungated download and
+  a full dataset card.

--- a/sources/products/flan-collection.yaml
+++ b/sources/products/flan-collection.yaml
@@ -18,3 +18,5 @@ lineage:
   - tulu
   - olmo-instruct
   - marin
+comments: Verified live 2026-08-13 via primary sources. The Apache-2.0 recipe repo is public and the widely
+  used HF conversion is ungated, with a card that documents the conversion rather than the tasks.

--- a/sources/products/hermes-3-dataset.yaml
+++ b/sources/products/hermes-3-dataset.yaml
@@ -11,3 +11,4 @@ lineage:
   - Nous synthetic instruction generation
   trains:
   - hermes
+comments: Verified live 2026-08-13 via primary sources. Apache-2.0 licensed, ungated, with a full dataset card.

--- a/sources/products/hh-rlhf.yaml
+++ b/sources/products/hh-rlhf.yaml
@@ -12,5 +12,5 @@ huggingface_dataset:
 lineage:
   derived_from:
   - human preference annotations (Anthropic crowdworkers)
-comments: Verified live 2026-06-22 via primary sources. Publicly downloadable and ungated under the permissive
+comments: Verified live 2026-08-13 via primary sources. Publicly downloadable and ungated under the permissive
   MIT license.

--- a/sources/products/madlad-400.yaml
+++ b/sources/products/madlad-400.yaml
@@ -10,5 +10,5 @@ huggingface_dataset:
 lineage:
   derived_from:
   - Common Crawl
-comments: Verified live 2026-06-22 via primary sources. Ungated with a permissive open-data license and
-  a complete dataset card.
+comments: Verified live 2026-08-13 via primary sources. Ungated with a permissive open-data license and a complete
+  dataset card.

--- a/sources/products/nemotron-cc.yaml
+++ b/sources/products/nemotron-cc.yaml
@@ -16,4 +16,6 @@ lineage:
   trains:
   - nemotron
   - marin
-comments: 'Family bucket: Nemotron-CC v1/v2, Nemotron-CC-Math, Nemotron-Pretraining-Code, and Nemotron-Pretraining-Specialized.'
+comments: 'Family bucket: Nemotron-CC v1/v2, Nemotron-CC-Math, Nemotron-Pretraining-Code, and Nemotron-Pretraining-Specialized.
+  Verified live 2026-08-13 via primary sources. Manually gated behind an NVIDIA open-data agreement collecting
+  contact information.'

--- a/sources/products/oasst1.yaml
+++ b/sources/products/oasst1.yaml
@@ -14,3 +14,4 @@ lineage:
   trains:
   - tulu
   - olmo-instruct
+comments: Verified live 2026-08-13 via primary sources. Apache-2.0 licensed, ungated, with a full dataset card.

--- a/sources/products/openhermes-2-5.yaml
+++ b/sources/products/openhermes-2-5.yaml
@@ -13,5 +13,5 @@ lineage:
   - community datasets
   trains:
   - smollm
-comments: Verified live 2026-06-22 via primary sources. Publicly downloadable and ungated with a full
-  card, though an explicit license string is not stated on the card.
+comments: Verified live 2026-08-13 via primary sources. Publicly downloadable and ungated with a full card,
+  though an explicit license string is not stated on the card.

--- a/sources/products/openthoughts-114k.yaml
+++ b/sources/products/openthoughts-114k.yaml
@@ -16,5 +16,5 @@ lineage:
   - open-thoughts pipeline
   trains:
   - marin
-comments: Verified live 2026-06-22 via primary sources. Apache-2.0 licensed, ungated, with dataset card,
-  code repo, and paper.
+comments: Verified live 2026-08-13 via primary sources. Apache-2.0 licensed, ungated, with dataset card, code
+  repo, and paper.

--- a/sources/products/openwebmath.yaml
+++ b/sources/products/openwebmath.yaml
@@ -15,3 +15,5 @@ lineage:
   - olmoe-instruct
   - nemotron
   - starcoder2
+comments: Verified live 2026-08-13 via primary sources. ODC-BY 1.0 licensed alongside the Common Crawl ToU,
+  ungated, with a full dataset card.

--- a/sources/products/oscar-2301.yaml
+++ b/sources/products/oscar-2301.yaml
@@ -13,5 +13,5 @@ lineage:
   - Common Crawl
   curated_with:
   - ungoliant
-comments: Verified live 2026-06-22 via primary sources. Manually gated and the card states access is temporarily
+comments: Verified live 2026-08-13 via primary sources. Manually gated and the card states access is temporarily
   suspended pending clarification.

--- a/sources/products/personahub.yaml
+++ b/sources/products/personahub.yaml
@@ -13,5 +13,5 @@ huggingface_dataset:
 lineage:
   derived_from:
   - persona-driven synthesis (GPT-4o)
-comments: Verified live 2026-06-22 via primary sources. Publicly downloadable and ungated under CC-BY-NC-SA-4.0,
+comments: Verified live 2026-08-13 via primary sources. Publicly downloadable and ungated under CC-BY-NC-SA-4.0,
   which permits redistribution for non-commercial research.

--- a/sources/products/pes2o.yaml
+++ b/sources/products/pes2o.yaml
@@ -15,3 +15,4 @@ lineage:
   - olmoe-instruct
   - marin
   - nemotron
+comments: Verified live 2026-08-13 via primary sources. ODC-BY licensed, ungated, with a full dataset card.

--- a/sources/products/redpajama-data-v2.yaml
+++ b/sources/products/redpajama-data-v2.yaml
@@ -14,5 +14,5 @@ lineage:
   - Common Crawl
   curated_with:
   - ccnet
-comments: Verified live 2026-06-22 via primary sources. Ungated with a full dataset card; redistributable
-  per Common Crawl ToU with Apache-2.0 processing code.
+comments: Verified live 2026-08-13 via primary sources. Ungated with a full dataset card; redistributable per
+  Common Crawl ToU with Apache-2.0 processing code.

--- a/sources/products/refinedweb.yaml
+++ b/sources/products/refinedweb.yaml
@@ -14,5 +14,5 @@ lineage:
   - Macrodata Refinement pipeline
   trains:
   - Falcon 1/2
-comments: Verified live 2026-06-22 via primary sources. Permissive ODC-BY 1.0 license, ungated download,
-  with a dataset card (a public extract of the full corpus).
+comments: Verified live 2026-08-13 via primary sources. Permissive ODC-BY 1.0 license, ungated download, with
+  a dataset card (a public extract of the full corpus).

--- a/sources/products/smoltalk.yaml
+++ b/sources/products/smoltalk.yaml
@@ -18,4 +18,5 @@ lineage:
   trains:
   - smollm
   - marin
-comments: 'Family bucket: SmolTalk and SmolTalk2.'
+comments: 'Family bucket: SmolTalk and SmolTalk2. Verified live 2026-08-13 via primary sources. Ungated with
+  a full card; the four new subsets are Apache-2.0 and the rest keep their original licences.'

--- a/sources/products/stack-edu.yaml
+++ b/sources/products/stack-edu.yaml
@@ -15,3 +15,5 @@ lineage:
   trains:
   - smollm
   - olmo
+comments: Verified live 2026-08-13 via primary sources. Ungated with a full card; the data licence defers to
+  The Stack v2.

--- a/sources/products/starcoderdata.yaml
+++ b/sources/products/starcoderdata.yaml
@@ -20,4 +20,5 @@ lineage:
   - marin
   - olmoe-instruct
 comments: Derived from The Stack v1 (the map's the-stack-v2 entry covers the Stack family's current version;
-  v1 is its direct predecessor).
+  v1 is its direct predecessor). Verified live 2026-08-13 via primary sources. Downloading still requires accepting
+  the terms and sharing contact information, so access is gated.

--- a/sources/products/synth.yaml
+++ b/sources/products/synth.yaml
@@ -13,5 +13,5 @@ lineage:
   - open seed corpora (synthetic generation)
   trains:
   - Pleias models
-comments: Verified live 2026-06-22 via primary sources. Permissively licensed, ungated dataset with a
-  documented card.
+comments: Verified live 2026-08-13 via primary sources. Permissively licensed, ungated dataset with a documented
+  card.

--- a/sources/products/the-pile.yaml
+++ b/sources/products/the-pile.yaml
@@ -24,5 +24,5 @@ lineage:
   - the-pile-pipeline
   trains:
   - pythia
-comments: Covers the Pile family (original + deduplicated). Verified live 2026-07-04; canonical hosting
-  moved to the deduplicated repo after the original mirrors went offline.
+comments: Covers the Pile family (original + deduplicated). Verified live 2026-08-13; canonical hosting moved
+  to the deduplicated repo after the original mirrors went offline.

--- a/sources/products/the-stack-v2.yaml
+++ b/sources/products/the-stack-v2.yaml
@@ -16,5 +16,5 @@ lineage:
   trains:
   - starcoder2
   - smollm
-comments: Verified live 2026-06-22 via primary sources. Requires acceptance of terms and sharing contact
-  info before download, so access is gated.
+comments: Verified live 2026-08-13 via primary sources. Requires acceptance of terms and sharing contact info
+  before download, so access is gated.

--- a/sources/products/tulu-3-sft-mixture.yaml
+++ b/sources/products/tulu-3-sft-mixture.yaml
@@ -23,5 +23,5 @@ lineage:
   - apertus
   - marin
   - smollm
-comments: Verified live 2026-06-22 via primary sources. ODC-BY licensed and ungated with a full dataset
-  card, though some subsets carry non-commercial licenses.
+comments: Verified live 2026-08-13 via primary sources. ODC-BY licensed and ungated with a full dataset card,
+  though some subsets carry non-commercial licenses.

--- a/sources/products/txt360.yaml
+++ b/sources/products/txt360.yaml
@@ -21,4 +21,6 @@ lineage:
   - txt360-pipeline
   trains:
   - k2
-comments: 'Family bucket: TxT360 plus the Midas mid-training and 3efforts SFT extensions.'
+comments: 'Family bucket: TxT360 plus the Midas mid-training and 3efforts SFT extensions. Verified live 2026-08-13
+  via primary sources. ODC-BY licensed, ungated, with a full dataset card; the LLM360 path now redirects to
+  the IFM org.'

--- a/sources/products/ultrachat-200k.yaml
+++ b/sources/products/ultrachat-200k.yaml
@@ -12,3 +12,4 @@ lineage:
   trains:
   - zephyr
   - tinyllama-chat
+comments: Verified live 2026-08-13 via primary sources. MIT licensed, ungated, with a full dataset card.

--- a/sources/products/ultrafeedback.yaml
+++ b/sources/products/ultrafeedback.yaml
@@ -17,5 +17,5 @@ lineage:
   - zephyr
   - tinyllama-chat
   - olmoe-instruct
-comments: Verified live 2026-06-22 via primary sources. Publicly downloadable and ungated under the permissive
+comments: Verified live 2026-08-13 via primary sources. Publicly downloadable and ungated under the permissive
   MIT license.

--- a/sources/products/wildchat-1m.yaml
+++ b/sources/products/wildchat-1m.yaml
@@ -13,5 +13,5 @@ lineage:
   trains:
   - tulu
   - olmo-instruct
-comments: Verified live 2026-06-22 via primary sources. ODC-BY licensed and reported ungated by the HF
-  API, though Ai2 datasets sometimes show an access notice.
+comments: Verified live 2026-08-13 via primary sources. ODC-BY licensed and reported ungated by the HF API,
+  though Ai2 datasets sometimes show an access notice.

--- a/sources/scores/aya-collection.yaml
+++ b/sources/scores/aya-collection.yaml
@@ -10,22 +10,35 @@ openness:
     card:
       value: present
   confidence: high
-  note: Ungated, Apache-2.0 licensed, with a complete dataset card.
+  note: 'Ungated, Apache-2.0 licensed, with a complete dataset card. Re-read 2026-08-13: apache-2.0 on the
+    Hub, gated false, card intact.'
   raw: license:apache-2.0;gated:false;card:present
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/CohereLabs/aya_collection
     shows: Card describing 114+ languages, templated/translated subsets, Apache-2.0, ungated
-    accessed: '2026-06-22'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 92f9332bd6c9af1a301f6b2c5fc17c8a52d6d07d571bd1fa8d3c61af470cf51a
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 3
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 26,509 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 11,190 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (CohereLabs/aya_collection 11,190). Bands at level 3 (10K-100K) on the dataset adoption scale, whose
+    top band is >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/CohereLabs/aya_collection
-    shows: downloads field = 26,509 (30-day)
-    accessed: '2026-07-04'
+    shows: 11,190 downloads in the trailing 30 days for CohereLabs/aya_collection
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 3781d62d6d342f65e538604e5a327093067c20579245a3b000b1eee584581ee2
 capability:
   score: 4
   basis: training_value

--- a/sources/scores/c4.yaml
+++ b/sources/scores/c4.yaml
@@ -10,31 +10,50 @@ openness:
     dataset_card:
       value: 'yes'
   confidence: high
-  note: Permissively licensed (ODC-BY) and ungated with a full dataset card.
+  note: 'Permissively licensed (ODC-BY) and ungated with a full dataset card. Re-read 2026-08-13: odc-by
+    on the Hub, gated false, card intact.'
   raw: license:ODC-BY;ungated:yes;dataset_card:yes
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/allenai/c4
     shows: ODC-BY license, ungated access, dataset card, size variants
-    accessed: '2026-06-22'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5ea0be10dcb8e30ebaefb6a99eb92702547b87874c8379b7b179c83d091a4274
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 5
   reach: '>1M'
   signal_type: usage_volume
   confidence: high
-  note: 1,261,777 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 1,414,303 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (allenai/c4 1,414,303). Bands at level 5 (>1M) on the dataset adoption scale, whose top band is >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/allenai/c4
-    shows: downloads field = 1,261,777 (30-day)
-    accessed: '2026-07-04'
+    shows: 1,414,303 downloads in the trailing 30 days for allenai/c4
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a228671d649433f646666e556582af8e3c22272104e22934215fae3f3bb1043e
 capability:
   score: 3
   basis: training_value
   basis_detail: superseded
   value: null
   confidence: high
-  note: Powered T5 (2019) and UL2 (2022); now a baseline that FineWeb and DCLM beat, superseded by modern
-    filtered web corpora.
+  note: 'Powered T5 (2019) and UL2 (2022); now a baseline that FineWeb and DCLM beat, superseded by modern
+    filtered web corpora. Re-read 2026-08-13: the FineWeb listing still claims better-performing LLMs than
+    other open pretraining datasets, C4 among them, so the supersession stands.'
+  relative_to: fineweb
+  relation: one_below
+  last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2406.17557
-    shows: C4 is a baseline in the FineWeb ablations, which FineWeb outperforms overall
-    accessed: '2026-07-04'
+    shows: Abstract - FineWeb produces better-performing LLMs than other open pretraining datasets. The
+      C4 baseline row is in the paper body, not on this page
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a12bfcd47f835ad4a2c5630a228778370ed54509afa65bed1c6dfc264f2182da

--- a/sources/scores/common-corpus.yaml
+++ b/sources/scores/common-corpus.yaml
@@ -11,34 +11,57 @@ openness:
     dataset_card:
       value: 'yes'
   confidence: high
-  note: Ungated with a full dataset card and built exclusively from uncopyrighted or openly licensed sources.
+  note: 'Ungated with a full dataset card and built exclusively from uncopyrighted or openly licensed sources.
+    Re-read 2026-08-13: the card still states that all data is either uncopyrighted or freely licensed and
+    usable commercially, the per-row licence column carries only Public Domain, CC0, CC-BY-SA and open-source
+    licences, and the API reports gated false.'
   raw: license:open(uncopyrighted/freely-licensed only);ungated:yes;dataset_card:yes
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/PleIAs/common_corpus
     shows: open-license-only content, ungated access, dataset card, 2.27T tokens
-    accessed: '2026-06-22'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 66bf38e0bfbdab4f583b58f1fc86b54139e44408b24757ff356cabdc9bacdf4e
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 3
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 91,700 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 61,684 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (PleIAs/common_corpus 61,684). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top
+    band is >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/PleIAs/common_corpus
-    shows: downloads field = 91,700 (30-day)
-    accessed: '2026-07-04'
+    shows: 61,684 downloads in the trailing 30 days for PleIAs/common_corpus
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: f56dd7a3cac857572d9b8626c59c6d8f19066509ec8742edd8136d15a2589dd7
 capability:
   score: 3
   basis: training_value
   basis_detail: downstream
   value: null
   confidence: high
-  note: Trains the Pleias 1.0 SLM family and several European models (2024-25), but small demonstrator
-    models with no controlled ablation wins; leads on ethical sourcing rather than capability.
+  note: 'Trains the Pleias 1.0 SLM family and several European models (2024-25), but small demonstrator
+    models with no controlled ablation wins; leads on ethical sourcing rather than capability. Re-read 2026-08-13:
+    the paper still lists the Pleias 1.0 family and the European models trained on Common Corpus, and the
+    card still puts the corpus at 2.27 trillion tokens with no controlled ablation win claimed.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/html/2506.01732v1
     shows: Pleias 1.0 family and ~7 European models trained on Common Corpus
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 3be2b6059b40e7a214148e772458e40003bc71434466b91115c4f2169427c4c4
   - url: https://huggingface.co/blog/Pclanglais/common-corpus
-    shows: Common Corpus is the largest fully-open licensed pretraining corpus (2.27T tokens)
-    accessed: '2026-07-04'
+    shows: Common Corpus presented as the largest open licensed pretraining corpus; the 2.27T-token figure
+      is on the dataset card
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 652ad30c002134edea52ce23b7d884d28db5c40559934435c35a7c3075799aab

--- a/sources/scores/cosmopedia.yaml
+++ b/sources/scores/cosmopedia.yaml
@@ -12,33 +12,55 @@ openness:
     free_text:
     - parquet downloadable
   confidence: high
-  note: Permissive Apache-2.0 license, ungated, full dataset card and downloadable parquet files.
+  note: 'Permissive Apache-2.0 license, ungated, full dataset card and downloadable parquet files. Re-read
+    2026-08-13: apache-2.0 on the Hub, gated false, card and parquet files intact.'
   raw: license:apache-2.0;access:ungated;dataset_card:present;parquet downloadable
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/HuggingFaceTB/cosmopedia
     shows: Apache-2.0 license, 31M rows, full dataset card
-    accessed: '2026-06-22'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 2adb6e2ab87cf2cb87054c40a331bd7e68d157c98c19307e1251f97dddc6b089
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 3
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 16,870 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 22,057 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (HuggingFaceTB/cosmopedia 22,057). Bands at level 3 (10K-100K) on the dataset adoption scale, whose
+    top band is >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/HuggingFaceTB/cosmopedia
-    shows: downloads field = 16,870 (30-day)
-    accessed: '2026-07-04'
+    shows: 22,057 downloads in the trailing 30 days for HuggingFaceTB/cosmopedia
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9b22085c11f57ac65a1604181262ba94e4a40f42d2aa9a02764b92cb274eb69c
 capability:
   score: 3
   basis: training_value
   basis_detail: superseded
   value: null
   confidence: high
-  note: Cosmo-1B beats TinyLlama on ARC/MMLU but trails Phi-1.5; explicitly superseded by Cosmopedia v2.
+  note: 'Cosmo-1B beats TinyLlama on ARC/MMLU but trails Phi-1.5; explicitly superseded by Cosmopedia v2.
+    Re-read 2026-08-13: the Cosmopedia post still reports Cosmo-1B ahead of TinyLlama 1.1B on ARC-easy,
+    ARC-challenge, OpenBookQA and MMLU while noting performance gaps against Phi-1.5, and the v2 card is
+    still the named successor.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/blog/cosmopedia
-    shows: Cosmo-1B beats TinyLlama on ARC/OpenBookQA/MMLU, still trails Phi-1.5
-    accessed: '2026-07-04'
+    shows: Cosmo-1B performs better than TinyLlama 1.1B on ARC-easy, ARC-challenge, OpenBookQA and MMLU,
+      with gaps remaining against Phi-1.5
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 74babeb627b3168f04f097ad5b00b6430e52100d6f277fd5418a265035e59f73
   - url: https://huggingface.co/datasets/HuggingFaceTB/cosmopedia-v2
     shows: Cosmopedia v2 is the direct successor
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6ccdc5e994ff03a24242b3b2d43c143192e0a2e8c628c4d5de5f5d084f40e3ac

--- a/sources/scores/culturax.yaml
+++ b/sources/scores/culturax.yaml
@@ -11,35 +11,57 @@ openness:
     card:
       value: present
   confidence: high
-  note: Dataset card is rich but downloads require agreeing to share contact information (auto gate).
+  note: 'Dataset card is rich but downloads require agreeing to share contact information (auto gate). Re-read
+    2026-08-13: the Hub still requires agreeing to the conditions before access and the API reports gated
+    auto, and the card''s License Information section still defers to the mC4 and OSCAR-2301 terms.'
   raw: license:follows mC4 + OSCAR-2301 terms;gated:auto(contact-info agreement);card:present
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/uonlp/CulturaX
-    shows: Card with 6.3T tokens/167 languages, mC4+OSCAR license inheritance, gated access requiring
-      contact-info agreement
-    accessed: '2026-06-22'
+    shows: Card with 6.3T tokens/167 languages, mC4+OSCAR license inheritance, gated access requiring contact-info
+      agreement
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1e7d2a97ad8518497c6637294ba43c027060694462ff17f155c1c872efd01bbd
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 3
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 18,361 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 13,746 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (uonlp/CulturaX 13,746). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is
+    >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/uonlp/CulturaX
-    shows: downloads field = 18,361 (30-day)
-    accessed: '2026-07-04'
+    shows: 13,746 downloads in the trailing 30 days for uonlp/CulturaX
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 90751bf6ebb05536badb269c7743ccba8da9e181c0b391a9c474a940da877fc5
 capability:
   score: 3
   basis: training_value
   basis_detail: superseded
   value: null
   confidence: high
-  note: A strong 2023-24 default multilingual corpus, but explicitly beaten by FineWeb-2 in controlled
-    per-language ablations.
+  note: 'A strong 2023-24 default multilingual corpus, but explicitly beaten by FineWeb-2 in controlled
+    per-language ablations. Re-read 2026-08-13: the FineWeb-2 card still reports beating CulturaX on FineTasks,
+    and the CulturaX card still describes a 6.3T-token, 167-language corpus built from mC4 and OSCAR.'
+  relative_to: fineweb-2
+  relation: two_below
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/HuggingFaceFW/fineweb-2
     shows: FineWeb-2 outperforms CulturaX across diverse languages on FineTasks
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1932389936b358f00cb2ee418ade6b262e8676edb77998b570447c926b6fe7b9
   - url: https://huggingface.co/datasets/uonlp/CulturaX
     shows: CulturaX is a 6.3T-token, 167-language corpus built from mC4+OSCAR
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1e7d2a97ad8518497c6637294ba43c027060694462ff17f155c1c872efd01bbd

--- a/sources/scores/dclm-baseline.yaml
+++ b/sources/scores/dclm-baseline.yaml
@@ -12,35 +12,54 @@ openness:
     github:
       value: mlfoundations/dclm
   confidence: high
-  note: Permissive CC-BY-4.0 license, ungated download, with open code repo and dataset card.
+  note: 'Permissive CC-BY-4.0 license, ungated download, with open code repo and dataset card. Re-read 2026-08-13:
+    cc-by-4.0 on the Hub, gated false, card and linked mlfoundations/dclm repo intact.'
   raw: license:CC-BY-4.0;gated:false;dataset_card:present;github:mlfoundations/dclm
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/mlfoundations/dclm-baseline-1.0
     shows: Dataset card, CC-BY-4.0 license, ungated public download, GitHub link
-    accessed: '2026-06-22'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a7e05a69b8207fc30c123c5b2c80d4c70ef18e136c1dacc072f052cf31bc46b9
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 4
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: 440,189 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 309,488 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (mlfoundations/dclm-baseline-1.0 309,488). Bands at level 4 (100K-1M) on the dataset adoption scale,
+    whose top band is >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/mlfoundations/dclm-baseline-1.0
-    shows: downloads field = 440,189 (30-day)
-    accessed: '2026-07-04'
+    shows: 309,488 downloads in the trailing 30 days for mlfoundations/dclm-baseline-1.0
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: cdaf2b0d82ae078429c07a77fb1e51693c0dfb77e214438a2b6e77893925ff36
 capability:
   score: 5
   basis: training_value
   basis_detail: ablation
   value: null
   confidence: high
-  note: Leads the DataComp-LM leaderboard (beats C4/RefinedWeb/RedPajama/Dolma); current 2024-26 default
-    of OLMoE, Marin, SmolLM3, and RWKV.
+  note: 'Leads the DataComp-LM leaderboard (beats C4/RefinedWeb/RedPajama/Dolma); current 2024-26 default
+    of OLMoE, Marin, SmolLM3, and RWKV. Re-read 2026-08-13: the DCLM listing still reports 64% 5-shot MMLU
+    at 2.6T tokens and a 6.6-point MMLU gain over MAP-Neo, the prior open-data state of the art.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2406.11794
     shows: DCLM-Baseline 7B reaches 64% MMLU at 2.6T tokens; model-based filtering adds >6 MMLU over the
       best prior open corpus
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: f665620bfe7fe32ea36cf6f4daab947bd13e925c191d80444c02c8ceb14fd974
   - url: https://huggingface.co/datasets/mlfoundations/dclm-baseline-1.0
     shows: OLMoE, SmolLM3, Marin, and RWKV built on DCLM
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a7e05a69b8207fc30c123c5b2c80d4c70ef18e136c1dacc072f052cf31bc46b9

--- a/sources/scores/dolci.yaml
+++ b/sources/scores/dolci.yaml
@@ -10,12 +10,20 @@ openness:
     dataset_card:
       value: present
   confidence: high
-  note: ODC-BY, ungated, per-stage dataset cards.
+  note: 'ODC-BY, ungated, per-stage dataset cards. Re-read 2026-08-13: odc-by on the Hub, gated false, card
+    intact.'
   raw: license:ODC-BY;gated:false;dataset_card:present
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/allenai/Dolci-Instruct-SFT
     shows: ODC-BY license, ungated, dataset card
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 279407557f11985037149eecaef5ef6f9640914162167e53a0f0c4066e3a5baa
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 2
   reach: 1K-10K
@@ -37,13 +45,20 @@ capability:
   basis_detail: downstream
   value: null
   confidence: high
-  note: The current fully-open frontier post-training suite; OLMo 3-Think 32B leads the fully-open thinking-model
-    class in documented benchmarks.
+  note: 'The current fully-open frontier post-training suite; OLMo 3-Think 32B leads the fully-open thinking-model
+    class in documented benchmarks. Re-read 2026-08-13: the OLMo 3 announcement still reports OLMo 3-Think
+    32B leading the fully open thinking-model class, and the Dolci card still presents the suite as the
+    successor to the Tulu mixtures.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://allenai.org/blog/olmo3
     shows: 'OLMo 3-Think 32B (trained with Dolci) is the strongest fully-open thinking model: MATH 96.1,
       HumanEval+ 91.4, IFEval 89.0'
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e103633d087ef9092a2aee2dc599cf609ca13209d21a3a7b1ac45f1a5d01fe49
   - url: https://huggingface.co/datasets/allenai/Dolci-Instruct-SFT
     shows: Dolci is Ai2's OLMo 3 post-training suite, successor to the Tulu mixtures
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 279407557f11985037149eecaef5ef6f9640914162167e53a0f0c4066e3a5baa

--- a/sources/scores/dolma-3.yaml
+++ b/sources/scores/dolma-3.yaml
@@ -10,12 +10,20 @@ openness:
     dataset_card:
       value: present
   confidence: high
-  note: ODC-BY, ungated, fully documented pool and training mixes.
+  note: 'ODC-BY, ungated, fully documented pool and training mixes. Re-read 2026-08-13: odc-by on the Hub,
+    gated false, card intact.'
   raw: license:ODC-BY;gated:false;dataset_card:present
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/allenai/dolma3_pool
     shows: ODC-BY license, ungated, dataset card
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d1714d7409ac779557da778b8d5606328407b6e94bd5d633ab009c37eb8ce685
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 3
   reach: 10K-100K
@@ -37,9 +45,14 @@ capability:
   basis_detail: downstream
   value: null
   confidence: high
-  note: The current (2025) corpus behind OLMo 3, the strongest fully-open base and thinking models; uses
-    documented quality-aware upsampling and data-mix ablations.
+  note: 'The current (2025) corpus behind OLMo 3, the strongest fully-open base and thinking models; uses
+    documented quality-aware upsampling and data-mix ablations. Re-read 2026-08-13: the OLMo 3 announcement
+    still presents Dolma 3 as the corpus behind every OLMo 3 variant and OLMo 3-Base 32B as the strongest
+    fully open base model.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://allenai.org/blog/olmo3
     shows: Dolma 3 trains all OLMo 3 variants; OLMo 3-Base 32B is the strongest fully-open base model
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e103633d087ef9092a2aee2dc599cf609ca13209d21a3a7b1ac45f1a5d01fe49

--- a/sources/scores/dolma.yaml
+++ b/sources/scores/dolma.yaml
@@ -12,34 +12,56 @@ openness:
     code:
       value: apache-2.0-toolkit
   confidence: high
-  note: Permissively licensed (ODC-BY), ungated download with a full dataset card and replication toolkit.
+  note: 'Permissively licensed (ODC-BY), ungated download with a full dataset card and replication toolkit.
+    Re-read 2026-08-13: odc-by, gated false, card intact, and the allenai/dolma toolkit repo still public.'
   raw: license:ODC-BY;ungated:yes;dataset_card:yes;code:apache-2.0-toolkit
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/allenai/dolma
     shows: ODC-BY license, ungated access, dataset card, ~3T tokens
-    accessed: '2026-06-22'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: f7e7100a96a1c05cd2614c4ac4c2640ebf69f1708b04fce0792435a50d9fdf6f
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 2
   reach: 1K-10K
   signal_type: usage_volume
   confidence: high
-  note: 4,015 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 2,724 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (allenai/dolma 2,724). Bands at level 2 (1K-10K) on the dataset adoption scale, whose top band is >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/allenai/dolma
-    shows: downloads field = 4,015 (30-day)
-    accessed: '2026-07-04'
+    shows: 2,724 downloads in the trailing 30 days for allenai/dolma
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 364dbfecfba2f6cc23e7eeb6976c8f47a356d12c3de0ed9e7365c3e4a5bbae38
 capability:
   score: 3
   basis: training_value
   basis_detail: superseded
   value: null
   confidence: high
-  note: Proven training corpus for OLMo 1/2 and OLMoE, but loses to FineWeb in the canonical FineWeb ablation
-    and is superseded by Dolma 3.
+  note: 'Proven training corpus for OLMo 1/2 and OLMoE, but loses to FineWeb in the canonical FineWeb ablation
+    and is superseded by Dolma 3. Re-read 2026-08-13: the FineWeb listing still claims better-performing
+    LLMs than other open pretraining datasets, and the OLMo 3 announcement still runs on Dolma 3 rather
+    than this.'
+  relative_to: fineweb
+  relation: one_below
+  last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2406.17557
-    shows: FineWeb outperforms Dolma v1.6 and v1.7 in the 1.82B/350B ablation
-    accessed: '2026-07-04'
+    shows: Abstract - FineWeb produces better-performing LLMs than other open pretraining datasets. The
+      Dolma v1.6/v1.7 ablation rows are in the paper body, not on this page
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a12bfcd47f835ad4a2c5630a228778370ed54509afa65bed1c6dfc264f2182da
   - url: https://allenai.org/blog/olmo3
     shows: Dolma superseded by Dolma 3 for OLMo 3
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e103633d087ef9092a2aee2dc599cf609ca13209d21a3a7b1ac45f1a5d01fe49

--- a/sources/scores/finemath.yaml
+++ b/sources/scores/finemath.yaml
@@ -10,34 +10,53 @@ openness:
     dataset_card:
       value: present
   confidence: high
-  note: ODC-BY, ungated, full dataset card.
+  note: 'ODC-BY, ungated, full dataset card. Re-read 2026-08-13: odc-by on the Hub, gated false, card intact.'
   raw: license:ODC-BY;gated:false;dataset_card:present
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/HuggingFaceTB/finemath
     shows: ODC-BY license, ungated, dataset card
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 87c966a146400047c9e611ee52409d5bec6232079c0f2954bd23d9143f3f3acd
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 3
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 24,077 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 29,279 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (HuggingFaceTB/finemath 29,279). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top
+    band is >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/HuggingFaceTB/finemath
-    shows: downloads field = 24,077 (30-day)
-    accessed: '2026-07-04'
+    shows: 29,279 downloads in the trailing 30 days for HuggingFaceTB/finemath
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 16115b525f4a4064966bae9f0a157383dc1b16444d10ba452a3e5cc9941641b1
 capability:
   score: 5
   basis: training_value
   basis_detail: ablation
   value: null
   confidence: high
-  note: Leads controlled math ablations (FineMath-4+ ~2x GSM8K and ~6x MATH over InfiMM-WebMath, beats
-    OpenWebMath); current 2025 default in SmolLM3, Apertus, Marin, and OLMo 3.
+  note: 'Leads controlled math ablations (FineMath-4+ ~2x GSM8K and ~6x MATH over InfiMM-WebMath, beats
+    OpenWebMath); current 2025 default in SmolLM3, Apertus, Marin, and OLMo 3. Re-read 2026-08-13: the FineMath
+    card still reports the GSM8K and MATH gains over InfiMM-WebMath and OpenWebMath, and the SmolLM2 paper
+    still documents the ablation.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/HuggingFaceTB/finemath
     shows: FineMath-4+ achieves ~2x GSM8K and ~6x MATH over InfiMM-WebMath and beats OpenWebMath
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 87c966a146400047c9e611ee52409d5bec6232079c0f2954bd23d9143f3f3acd
   - url: https://arxiv.org/html/2502.02737v1
     shows: SmolLM2 paper details the FineMath ablation vs OpenWebMath/InfiMM-WebMath
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: be627c24bbc0d0c4084648798877bced224b189e12ca4c03a2e25e277986fbbb

--- a/sources/scores/fineweb-2.yaml
+++ b/sources/scores/fineweb-2.yaml
@@ -12,34 +12,55 @@ openness:
     languages:
       value: 1000+
   confidence: high
-  note: Permissive ODC-BY license, ungated, with a dataset card spanning 1000+ languages.
+  note: 'Permissive ODC-BY license, ungated, with a dataset card spanning 1000+ languages. Re-read 2026-08-13:
+    odc-by, gated false, and the multilingual card still spans 1000+ languages.'
   raw: license:ODC-BY;gated:false;dataset_card:present;languages:1000+
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/HuggingFaceFW/fineweb-2
     shows: Dataset page exists on public hub, ODC-BY, 1000+ languages
-    accessed: '2026-06-22'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1932389936b358f00cb2ee418ade6b262e8676edb77998b570447c926b6fe7b9
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 3
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 93,906 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 82,352 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (HuggingFaceFW/fineweb-2 82,352). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top
+    band is >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/HuggingFaceFW/fineweb-2
-    shows: downloads field = 93,906 (30-day)
-    accessed: '2026-07-04'
+    shows: 82,352 downloads in the trailing 30 days for HuggingFaceFW/fineweb-2
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 032ed748933288eb9c7821b413e13de24360a0a978b0cf477b81026b18248439
 capability:
   score: 5
   basis: training_value
   basis_detail: downstream
   value: null
   confidence: high
-  note: Primary web corpus for Apertus 8B/70B (2025), 1811 languages; the current multilingual default,
-    and its HQ variant leads multilingual data-selection work.
+  note: 'Primary web corpus for Apertus 8B/70B (2025), 1811 languages; the current multilingual default,
+    and its HQ variant leads multilingual data-selection work. Re-read 2026-08-13: the Apertus listing still
+    records 15T tokens over more than 1800 languages at 8B and 70B, and the FineWeb-2 card still reports
+    the FineTasks wins over CulturaX, mC4, CC-100 and HPLT.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2509.14233
-    shows: Apertus 8B/70B train on 15T tokens from 1811 languages via FineWeb-2/FineWeb-2-HQ
-    accessed: '2026-07-04'
+    shows: Abstract - Apertus 8B and 70B train on 15T tokens from over 1800 languages. The FineWeb-2 attribution
+      is in the paper body, not on this page
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 708c422a40898842cec08532b4f86917f8648837d96e5a3149aca899b6168d2a
   - url: https://huggingface.co/datasets/HuggingFaceFW/fineweb-2
     shows: FineWeb-2 outperforms CulturaX/mC4/CC-100/HPLT on FineTasks in controlled ablations
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1932389936b358f00cb2ee418ade6b262e8676edb77998b570447c926b6fe7b9

--- a/sources/scores/fineweb-edu.yaml
+++ b/sources/scores/fineweb-edu.yaml
@@ -12,34 +12,56 @@ openness:
     format:
       value: parquet
   confidence: high
-  note: Permissive ODC-BY license with ungated download and full dataset card.
+  note: 'Permissive ODC-BY license with ungated download and full dataset card. Re-read 2026-08-13: odc-by
+    on the Hub, gated false on the API, card intact.'
   raw: license:ODC-BY;gated:false;dataset_card:present;format:parquet
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/HuggingFaceFW/fineweb-edu
     shows: Dataset card present, ODC-BY license, public ungated download
-    accessed: '2026-06-22'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 129ceef57c14b00a83f0b837a4693a7d3c30fef2fc8e56a4b0839be39d99e519
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 4
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: 384,910 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 395,837 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (HuggingFaceFW/fineweb-edu 395,837). Bands at level 4 (100K-1M) on the dataset adoption scale, whose
+    top band is >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/HuggingFaceFW/fineweb-edu
-    shows: downloads field = 384,910 (30-day)
-    accessed: '2026-07-04'
+    shows: 395,837 downloads in the trailing 30 days for HuggingFaceFW/fineweb-edu
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5a10685bcab3d243109892516aad03867ccc7eaa98624a181e866a015942d63a
 capability:
   score: 5
   basis: training_value
   basis_detail: ablation
   value: null
   confidence: high
-  note: Dominates FineWeb and all peers on MMLU/ARC, matching full FineWeb with ~10x fewer tokens; current
-    default web corpus for SmolLM2/3 and Apertus.
+  note: 'Dominates FineWeb and all peers on MMLU/ARC, matching full FineWeb with ~10x fewer tokens; current
+    default web corpus for SmolLM2/3 and Apertus. Re-read 2026-08-13: the FineWeb listing still states that
+    LLMs pretrained on FineWeb-Edu do dramatically better on MMLU and ARC, and the SmolLM2 listing still
+    describes an 11T-token mix of web text with specialised math, code and instruction data.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2406.17557
-    shows: FineWeb-Edu matches full FineWeb on MMLU/ARC at ~10x fewer tokens
-    accessed: '2026-07-04'
+    shows: Abstract - LLMs pretrained on FineWeb-Edu, a 1.3T-token educational subset, do dramatically better
+      on MMLU and ARC. The ~10x token-efficiency figure is in the paper body, not on this page
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a12bfcd47f835ad4a2c5630a228778370ed54509afa65bed1c6dfc264f2182da
   - url: https://arxiv.org/abs/2502.02737
-    shows: SmolLM2 uses FineWeb-Edu as its English web component
-    accessed: '2026-07-04'
+    shows: Abstract - SmolLM2 is overtrained on ~11T tokens mixing web text with specialised math, code
+      and instruction data. The named FineWeb-Edu component is in the paper body, not on this page
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: f19a89b93bdd5a66445878803fa6ad900599fe4792c84080a02b4dae77699a1d

--- a/sources/scores/fineweb.yaml
+++ b/sources/scores/fineweb.yaml
@@ -12,32 +12,55 @@ openness:
     format:
       value: parquet
   confidence: high
-  note: Permissive ODC-BY license with ungated download and a full dataset card.
+  note: 'Permissive ODC-BY license with ungated download and a full dataset card. Re-read 2026-08-13: the
+    Hub still tags the release odc-by, the API reports gated false, and the card is intact, so licence,
+    availability and documentation are unchanged.'
   raw: license:ODC-BY;gated:false;dataset_card:present;format:parquet
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/HuggingFaceFW/fineweb
     shows: Dataset card present, ODC-BY license, public ungated download
-    accessed: '2026-06-22'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b0ff0817716949392d60da6d371225b56d8acf7ad74a01f590facffc399dfb69
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 4
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: 337,208 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 418,578 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (HuggingFaceFW/fineweb 418,578). Bands at level 4 (100K-1M) on the dataset adoption scale, whose top
+    band is >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/HuggingFaceFW/fineweb
-    shows: downloads field = 337,208 (30-day)
-    accessed: '2026-07-04'
+    shows: 418,578 downloads in the trailing 30 days for HuggingFaceFW/fineweb
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 832c71de7436632998ea10a8da34d982f975284817fa3ec502b997883acad48a
 capability:
   score: 4
   basis: training_value
   basis_detail: ablation
   value: null
   confidence: high
-  note: The FineWeb paper's 1.7B ablation beats C4, RefinedWeb, RedPajama, Dolma, The Pile, and OSCAR;
-    but its FineWeb-Edu subset is the preferred quality source.
+  note: 'The FineWeb paper''s 1.7B ablation beats C4, RefinedWeb, RedPajama, Dolma, The Pile, and OSCAR;
+    but its FineWeb-Edu subset is the preferred quality source. Re-read 2026-08-13: the arXiv listing still
+    describes FineWeb as a 15T-token Common Crawl dataset that produces better-performing LLMs than other
+    open pretraining datasets, and still introduces FineWeb-Edu as the filtered subset with dramatically
+    better MMLU and ARC results, which is the reason this sits a band below it.'
+  relative_to: fineweb-edu
+  relation: one_below
+  last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2406.17557
-    shows: FineWeb 1.7B ablation outperforms C4/RefinedWeb/RedPajama/Dolma/Pile/OSCAR on the aggregate
-      suite
-    accessed: '2026-07-04'
+    shows: Abstract - FineWeb, 15T tokens from 96 Common Crawl snapshots, produces better-performing LLMs
+      than other open pretraining datasets. The per-corpus ablation table is in the paper body, not on this
+      page
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a12bfcd47f835ad4a2c5630a228778370ed54509afa65bed1c6dfc264f2182da

--- a/sources/scores/flan-collection.yaml
+++ b/sources/scores/flan-collection.yaml
@@ -13,42 +13,69 @@ openness:
     dataset_card:
       value: partial
   confidence: medium
-  note: Released as an Apache-2.0 recipe/repo; the widely used HF conversion (ai2-adapt-dev) is ungated.
-    Underlying task datasets keep their own licenses, so the Apache-2.0 covers the recipe and not the
-    corpus - the license defers to its components, as `the-pile` and `stack-edu` do. Scored 4 until
-    2026-08-11 on a resolver that truncated the license at the first parenthesis and so read a clean
-    Apache-2.0; reading the whole value puts it on the deferred-license rung, and a partial card takes
-    it to 3.
+  note: 'Released as an Apache-2.0 recipe/repo; the widely used HF conversion (ai2-adapt-dev) is ungated.
+    Underlying task datasets keep their own licenses, so the Apache-2.0 covers the recipe and not the corpus
+    - the license defers to its components, as `the-pile` and `stack-edu` do. Scored 4 until 2026-08-11
+    on a resolver that truncated the license at the first parenthesis and so read a clean Apache-2.0; reading
+    the whole value puts it on the deferred-license rung, and a partial card takes it to 3. Re-read 2026-08-13:
+    the google-research/FLAN repo is still Apache-2.0 for the recipe code, and the ai2-adapt-dev conversion
+    is still ungated with a card that documents the conversion and defers the licence to the original FLAN
+    v2 repo.'
   raw: access:ungated(conversion);license:Apache-2.0(recipe)+per-task;dataset_card:partial
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/google-research/FLAN
     shows: Apache-2.0 FLAN v2 recipe
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 7e29c83b8490a842bceadca92df36b92585c2d4c3be8f5d3f7135f4b41c28f12
+    establishes:
+    - license
   - url: https://huggingface.co/datasets/ai2-adapt-dev/flan_v2_converted
     shows: ungated HF conversion used by Tulu/OLMo mixes
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 8e839f096209c4cebcb1c843de2aca9adbbb7ce12aa6710e8b5d36edeea66899
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 1
   reach: <1K
   signal_type: usage_volume
   confidence: high
-  note: 924 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 108 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (ai2-adapt-dev/flan_v2_converted 108). Bands at level 1 (<1K) on the dataset adoption scale, whose top
+    band is >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/ai2-adapt-dev/flan_v2_converted
-    shows: downloads field = 924 (30-day)
-    accessed: '2026-07-04'
+    shows: 108 downloads in the trailing 30 days for ai2-adapt-dev/flan_v2_converted
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 3aa4a59de3a4155671a5b289f73199e2df621236791c17999bb411804bca2c08
 capability:
   score: 3
   basis: training_value
   basis_detail: superseded
   value: null
   confidence: high
-  note: Strong historical comparative ablations (Flan 2022 beats P3/T0/SNI on the same T5-XL) and still
-    a component in Tulu 3, Dolci, and Marin's mixes, but dated as a standalone chat-era recipe.
+  note: 'Strong historical comparative ablations (Flan 2022 beats P3/T0/SNI on the same T5-XL) and still
+    a component in Tulu 3, Dolci, and Marin''s mixes, but dated as a standalone chat-era recipe. Re-read
+    2026-08-13: the Flan Collection listing still reports Flan-T5 outperforming prior work by 3-17%+ across
+    evaluation settings, and the Dolci SFT card still consumes FLAN v2.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2301.13688
-    shows: 'The Flan Collection: Flan 2022 leads P3++/Super-NatInst on MMLU/BBH (same T5-XL)'
-    accessed: '2026-07-04'
+    shows: Abstract - ablations on the Flan Collection show Flan-T5 outperforming prior work by 3-17%+ across
+      evaluation settings. The per-collection P3/Super-NaturalInstructions rows are in the paper body, not
+      on this page
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c87f46d42a0899f9db968728890fa3ac150e8163f206263fee7331d346d0ea77
   - url: https://huggingface.co/datasets/allenai/Dolci-Instruct-SFT
     shows: OLMo 3 Dolci still consumes FLAN v2 (89,981 prompts)
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 279407557f11985037149eecaef5ef6f9640914162167e53a0f0c4066e3a5baa

--- a/sources/scores/hermes-3-dataset.yaml
+++ b/sources/scores/hermes-3-dataset.yaml
@@ -10,12 +10,20 @@ openness:
     dataset_card:
       value: present
   confidence: high
-  note: Apache-2.0, ungated, dataset card.
+  note: 'Apache-2.0, ungated, dataset card. Re-read 2026-08-13: apache-2.0 on the Hub, gated false, card
+    intact.'
   raw: license:Apache-2.0;gated:false;dataset_card:present
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/NousResearch/Hermes-3-Dataset
     shows: Apache-2.0 license, ungated, dataset card
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e2124fd9a978079b84bb104998619814e4ab36206ec7addaa4618478499c49a7
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 1
   reach: <1K
@@ -37,12 +45,19 @@ capability:
   basis_detail: downstream
   value: null
   confidence: high
-  note: Proven value with documented Hermes 3 results and explicitly folded into Hermes 4 (2025), but
-    independent reuse is limited to community quantizers.
+  note: 'Proven value with documented Hermes 3 results and explicitly folded into Hermes 4 (2025), but independent
+    reuse is limited to community quantizers. Re-read 2026-08-13: the Hermes 4 report still states that
+    a significant portion of the Hermes 3 dataset was retained, and Table 5 of the Hermes 3 report still
+    has Hermes 3 ahead of Llama 3.1 Instruct on the majority of the seventeen benchmarks at all three sizes.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/pdf/2508.18255
     shows: 'Hermes 4 report: a significant portion of the Hermes 3 dataset was retained'
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 4894603dc7c8fe3f4757e3c7c3c9ac75c6dc41d8cd6e824de5bf9e2e8ced695c
   - url: https://arxiv.org/pdf/2408.11857
     shows: Hermes 3 beats Llama 3.1 Instruct on most benchmarks at 405B/70B/8B
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a9723f3f0128e076712da06a454fc3c64b8e70578c1e6001c457a92c9c46007a

--- a/sources/scores/hh-rlhf.yaml
+++ b/sources/scores/hh-rlhf.yaml
@@ -16,34 +16,55 @@ openness:
     size:
       value: 94.7MB
   confidence: high
-  note: Publicly downloadable and ungated under the permissive MIT license.
+  note: 'Publicly downloadable and ungated under the permissive MIT license. Re-read 2026-08-13: mit on
+    the Hub, gated false, card intact.'
   raw: license:mit;card:present;ungated:yes;rows:169,352;size:94.7MB
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/Anthropic/hh-rlhf
     shows: MIT license, ungated card, 169,352 rows, 94.7 MB
-    accessed: '2026-06-22'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 080aecc60ba4282a428da630fbc29575811329693817b2a0a8a5f5fc74b5a9ed
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 3
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 29,021 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 32,927 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (Anthropic/hh-rlhf 32,927). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band
+    is >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/Anthropic/hh-rlhf
-    shows: downloads field = 29,021 (30-day)
-    accessed: '2026-07-04'
+    shows: 32,927 downloads in the trailing 30 days for Anthropic/hh-rlhf
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 3c1767d6598a93849ec0c2fa8eef51b03c4b6e7be5c193e697384757c1b0d2ef
 capability:
   score: 3
   basis: training_value
   basis_detail: superseded
   value: null
   confidence: high
-  note: Documented 2022 RLHF results and huge historical influence, but dropped from frontier open preference
-    mixes (absent from Tulu 3 and OLMo 3 Dolci DPO).
+  note: 'Documented 2022 RLHF results and huge historical influence, but dropped from frontier open preference
+    mixes (absent from Tulu 3 and OLMo 3 Dolci DPO). Re-read 2026-08-13: the Anthropic listing still reports
+    RLHF on this data improving almost all NLP evaluations, and HH-RLHF is still absent from the Tulu 3
+    preference mixture card.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2204.05862
-    shows: Anthropic RLHF on HH data improves helpfulness Elo, TruthfulQA, BBQ (self-reported)
-    accessed: '2026-07-04'
+    shows: Abstract - RLHF on the HH preference data improves performance on almost all NLP evaluations.
+      The per-benchmark Elo, TruthfulQA and BBQ numbers are in the paper body, not on this page
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e8485045e8148841fdcbea46cd7837c6ed2e97d39c6f8d8675e81e0c3f72a25c
   - url: https://huggingface.co/datasets/allenai/llama-3.1-tulu-3-8b-preference-mixture
     shows: HH-RLHF is not used in the Tulu 3 preference mixture
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a5b9c4f74ae7294808f26cb81361cd4902eb6a7b84616f82588f159f49da34ce

--- a/sources/scores/madlad-400.yaml
+++ b/sources/scores/madlad-400.yaml
@@ -11,31 +11,49 @@ openness:
     card:
       value: present
   confidence: high
-  note: Ungated with a permissive open-data license and a complete dataset card.
+  note: 'Ungated with a permissive open-data license and a complete dataset card. Re-read 2026-08-13: the
+    Hub API still returns odc-by and gated false for allenai/MADLAD-400 with the card present.'
   raw: license:odc-by(API tag; card cites CC-BY-4.0);gated:false;card:present
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/allenai/MADLAD-400
     shows: gated = false, license = odc-by
-    accessed: '2026-06-22'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1162ab9cfd6417a623db287ab85d6a899e320430c9c166e8e055e34e8e1ea457
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 3
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 32,957 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 15,089 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (allenai/MADLAD-400 15,089). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band
+    is >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/allenai/MADLAD-400
-    shows: downloads field = 32,957 (30-day)
-    accessed: '2026-07-04'
+    shows: 15,089 downloads in the trailing 30 days for allenai/MADLAD-400
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1162ab9cfd6417a623db287ab85d6a899e320430c9c166e8e055e34e8e1ea457
 capability:
   score: 4
   basis: training_value
   basis_detail: downstream
   value: null
   confidence: high
-  note: Underpins Google's MADLAD-400 MT models (10.7B/8B, 2023) competitive with NLLB-54B; a strong documented
-    downstream training result, not the current leader.
+  note: 'Underpins Google''s MADLAD-400 MT models (10.7B/8B, 2023) competitive with NLLB-54B; a strong documented
+    downstream training result, not the current leader. Re-read 2026-08-13: Table 4 of the paper still shows
+    MT-10.7B averaging 31.8 BLEU against NLLB-54B''s 32.7 on WMT, which is the competitive-but-not-leading
+    result the band rests on.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://proceedings.neurips.cc/paper_files/paper/2023/file/d49042a5d49818711c401d34172f9900-Paper-Datasets_and_Benchmarks.pdf
     shows: MADLAD-400 10.7B MT model averages 31.8 BLEU vs NLLB-54B's 32.7 across 400+ languages
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: cbab6f50a7c4b77f7d0e5f0f1fb6e93c99e27da4e66b8f983653360b6a093ce6

--- a/sources/scores/nemotron-cc.yaml
+++ b/sources/scores/nemotron-cc.yaml
@@ -11,36 +11,57 @@ openness:
     dataset_card:
       value: present
   confidence: high
-  note: Manually gated behind the NVIDIA Data Agreement for Model Training; synthetic portions may inherit
-    generator-model license terms.
+  note: 'Manually gated behind the NVIDIA Data Agreement for Model Training; synthetic portions may inherit
+    generator-model license terms. Re-read 2026-08-13: the Hub still shows “You need to agree to share your
+    contact information to access this dataset” and the API reports gated manual under the NVIDIA open-data
+    terms.'
   raw: license:NVIDIA-Open-Data;gated:manual(model-training-use);dataset_card:present
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/nvidia/Nemotron-CC-v2
     shows: gated (manual), NVIDIA Open Data License, dataset card
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1f9e347d51771b831029e1baa663c31adea4b0b774f3380187f62aaeb3990c60
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 3
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 16,100 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 45,663 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (nvidia/Nemotron-CC-v2 45,663). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top
+    band is >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/nvidia/Nemotron-CC-v2
-    shows: downloads field = 16,100 (30-day)
-    accessed: '2026-07-04'
+    shows: 45,663 downloads in the trailing 30 days for nvidia/Nemotron-CC-v2
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: bddb99506d4c7fb39f2a2017d5391dbdf4bc80ee97b50634ab100b0ef0e75876
 capability:
   score: 5
   basis: training_value
   basis_detail: ablation
   value: null
   confidence: high
-  note: Wins vs DCLM at a long token horizon (Nemotron-CC-HQ +5.6 MMLU over DCLM; a 15T-token 8B beats
-    Llama 3.1 8B); current default for NVIDIA Nemotron models and Marin 8B late phases.
+  note: 'Wins vs DCLM at a long token horizon (Nemotron-CC-HQ +5.6 MMLU over DCLM; a 15T-token 8B beats
+    Llama 3.1 8B); current default for NVIDIA Nemotron models and Marin 8B late phases. Re-read 2026-08-13:
+    the Nemotron-CC listing still reports +5.6 MMLU over DCLM on the high-quality subset and an 8B trained
+    for 15T tokens beating Llama 3.1 8B by +5 MMLU, and the Marin retro report still records the switch
+    to Nemotron-CC in later phases.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2412.02595
-    shows: Nemotron-CC-HQ improves MMLU by 5.6 over DCLM; an 8B on 15T tokens beats Llama 3.1 8B by +5
-      MMLU
-    accessed: '2026-07-04'
+    shows: Nemotron-CC-HQ improves MMLU by 5.6 over DCLM; an 8B on 15T tokens beats Llama 3.1 8B by +5 MMLU
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 4231d6de42496ec9f36b44c8be8bc791367ccbe5e5c41439d7e6077eebd0df98
   - url: https://marin.readthedocs.io/en/latest/reports/marin-8b-retro/
     shows: Marin 8B adopted Nemotron-CC as its primary source in later phases
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: ef12b7a5e2815e65c6436d4fcadfd69c3d9b78b03718928e0bb19b22cd420f8e

--- a/sources/scores/oasst1.yaml
+++ b/sources/scores/oasst1.yaml
@@ -10,22 +10,35 @@ openness:
     dataset_card:
       value: present
   confidence: high
-  note: Apache-2.0, ungated, full dataset card.
+  note: 'Apache-2.0, ungated, full dataset card. Re-read 2026-08-13: apache-2.0 on the Hub, gated false,
+    card intact.'
   raw: license:Apache-2.0;gated:false;dataset_card:present
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/OpenAssistant/oasst1
     shows: Apache-2.0 license, ungated, dataset card
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 408bd27b170242cfb10373b5b33355c4e63b03b72f64c6a0fc67b7331e0066cb
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 3
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 15,736 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 20,967 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (OpenAssistant/oasst1 20,967). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top
+    band is >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/OpenAssistant/oasst1
-    shows: downloads field = 15,736 (30-day)
-    accessed: '2026-07-04'
+    shows: 20,967 downloads in the trailing 30 days for OpenAssistant/oasst1
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: ddc99182484d268a57102ac80740ac89622efbf989b812a4c05b8cd83661bf54
 capability:
   score: 3
   basis: training_value

--- a/sources/scores/openhermes-2-5.yaml
+++ b/sources/scores/openhermes-2-5.yaml
@@ -22,46 +22,69 @@ openness:
     without a terms section, the repository holds only .gitattributes, README.md and openhermes2_5.json
     so there is no LICENSE file, and the Hub API returns no license. Files that download freely without
     a grant are not open, and not closed either, so the recorded 5/open drops to 3/gated. The commonly cited
-    as permissive detail this record used to carry was a third-party reading and has been dropped.'
+    as permissive detail this record used to carry was a third-party reading and has been dropped. Re-read
+    2026-08-13: the card, its raw README and the Hub API all still carry no licence field, no licence section
+    and no licence tag, and the API reports gated false.'
   raw: license:not-clearly-stated-on-card(no license field in the card YAML, no license section in the card
     body, no LICENSE file in the repository and no license tag on the Hub API);card:present;ungated:yes;format:JSON/Parquet;rows:~1M
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/teknium/OpenHermes-2.5
     shows: Public ungated dataset card, ~1M rows, synthetic/GPT-4 tags
-    accessed: '2026-06-22'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 2efb56ae792898ddb1c34693d174654799ef050d66e0033611b1b0839d1ae08d
+    establishes:
+    - availability
+    - documentation
+    - license
   - url: https://huggingface.co/datasets/teknium/OpenHermes-2.5/raw/main/README.md
-    shows: 'card front matter is language, pretty_name and tags only, with no `license:` key; the 126-line
-      body covers the dataset description, the Lilac integration, the full list of constituent source
-      datasets, the sharegpt format and a citation, and contains no occurrence of "license" or "terms"'
-    accessed: '2026-08-12'
+    shows: card front matter is language, pretty_name and tags only, with no `license:` key; the 126-line
+      body covers the dataset description, the Lilac integration, the full list of constituent source datasets,
+      the sharegpt format and a citation, and contains no occurrence of "license" or "terms"
+    accessed: '2026-08-13'
     http_status: 200
     content_sha256: 92fd711b9f0f6f8c7312d18d93ad412af415cd25a207584554c8e72c0cfe9f64
-    establishes: [license]
+    establishes:
+    - license
+    - documentation
   - url: https://huggingface.co/api/datasets/teknium/OpenHermes-2.5
     shows: cardData carries no license and the repository has no `license:` tag; siblings are .gitattributes,
       README.md and openhermes2_5.json, so no LICENSE file ships with the data
-    accessed: '2026-08-12'
+    accessed: '2026-08-13'
     http_status: 200
-    establishes: [license]
+    establishes:
+    - availability
+    - license
+    content_sha256: c723e6000d4da3d6b6feeba4953647b8e924b22a3e6d3da4ae487dbf6ec9f835
 adoption:
   level: 3
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 14,982 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 17,420 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (teknium/OpenHermes-2.5 17,420). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top
+    band is >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/teknium/OpenHermes-2.5
-    shows: downloads field = 14,982 (30-day)
-    accessed: '2026-07-04'
+    shows: 17,420 downloads in the trailing 30 days for teknium/OpenHermes-2.5
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c723e6000d4da3d6b6feeba4953647b8e924b22a3e6d3da4ae487dbf6ec9f835
 capability:
   score: 3
   basis: training_value
   basis_detail: superseded
   value: null
   confidence: high
-  note: Attributed gains inside SmolTalk (MMLU/BBH/WinoGrande) but no standalone ablation; superseded
-    by Hermes 3 and survives as a 100k SmolTalk slice.
+  note: 'Attributed gains inside SmolTalk (MMLU/BBH/WinoGrande) but no standalone ablation; superseded by
+    Hermes 3 and survives as a 100k SmolTalk slice. Re-read 2026-08-13: the SmolLM2 paper still credits
+    a 100k OpenHermes-2.5 subset inside SmolTalk rather than any standalone ablation.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/html/2502.02737v1
     shows: SmolLM2 paper credits a 100k OpenHermes-2.5 subset with MMLU/WinoGrande/BBH gains
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: be627c24bbc0d0c4084648798877bced224b189e12ca4c03a2e25e277986fbbb

--- a/sources/scores/openthoughts-114k.yaml
+++ b/sources/scores/openthoughts-114k.yaml
@@ -12,12 +12,20 @@ openness:
     free_text:
     - GitHub repo + paper
   confidence: high
-  note: Apache-2.0 licensed, ungated, with dataset card, code repo, and paper.
+  note: 'Apache-2.0 licensed, ungated, with dataset card, code repo, and paper. Re-read 2026-08-13: apache-2.0
+    on the Hub, gated false, card plus the open-thoughts repo and paper links intact.'
   raw: license:apache-2.0;access:ungated;dataset_card:present;GitHub repo + paper
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/open-thoughts/OpenThoughts-114k
     shows: Apache-2.0 license, dataset card, GitHub and arXiv links
-    accessed: '2026-06-22'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 4f9e43637623c254b44ba44dc0d82465a353e08c7585e7767a4393dfdf9b0532
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 3
   reach: 10K-100K
@@ -34,12 +42,18 @@ capability:
   basis_detail: superseded
   value: null
   confidence: high
-  note: Strong early-2025 reasoning results (OpenThinker-32B led open-data MATH500/GPQA-D) but superseded
-    by OpenThoughts3-1.2M.
+  note: 'Strong early-2025 reasoning results (OpenThinker-32B led open-data MATH500/GPQA-D) but superseded
+    by OpenThoughts3-1.2M. Re-read 2026-08-13: the OpenThinker-32B card still reports MATH500 90.6 and GPQA-Diamond
+    61.6 against LIMO-32B, s1-32B and s1.1-32B, and the OpenThoughts blog still recommends OpenThoughts3-1.2M.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/open-thoughts/OpenThinker-32B
     shows: OpenThinker-32B hits MATH500 90.6 / GPQA-D 61.6, leading open-data peers
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: f2cec688bfd7fcdca016290a0c627811fbc7636b5465948855d0e96f9b12f6ae
   - url: https://www.openthoughts.ai/blog/ot3
     shows: OpenThoughts3-1.2M is the recommended SOTA open-data successor
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 69832614398381122ecf2756fbf977cda356f34bb039550967717468fd1bf245

--- a/sources/scores/openwebmath.yaml
+++ b/sources/scores/openwebmath.yaml
@@ -10,34 +10,57 @@ openness:
     dataset_card:
       value: present
   confidence: high
-  note: ODC-BY 1.0, ungated, full dataset card.
+  note: 'ODC-BY 1.0, ungated, full dataset card. Re-read 2026-08-13: the card''s License section still reads
+    ODC-By 1.0 alongside the Common Crawl ToU, the Hub metadata still tags odc-by, and the API reports gated
+    false.'
   raw: license:ODC-BY;gated:false;dataset_card:present
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/open-web-math/open-web-math
     shows: ODC-BY 1.0 license, ungated, dataset card
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 76eb95120b7d8a970c69a58ef702f3774deae1582d2c13aa4e32c3319f6f2044
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 3
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 31,502 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 33,285 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (open-web-math/open-web-math 33,285). Bands at level 3 (10K-100K) on the dataset adoption scale, whose
+    top band is >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/open-web-math/open-web-math
-    shows: downloads field = 31,502 (30-day)
-    accessed: '2026-07-04'
+    shows: 33,285 downloads in the trailing 30 days for open-web-math/open-web-math
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 8511f6d3e6cd1daacaacd19c2e8ae207513e2ac1fed26079f870a8107e7720c4
 capability:
   score: 3
   basis: training_value
   basis_detail: superseded
   value: null
   confidence: high
-  note: Proven math corpus (Llemma/Proof-Pile-2, OLMoE, StarCoder2 math supplement) but Oct-2023 vintage
-    and now the baseline that FineMath, MegaMath, and Nemotron-CC-Math beat in ablations.
+  note: 'Proven math corpus (Llemma/Proof-Pile-2, OLMoE, StarCoder2 math supplement) but Oct-2023 vintage
+    and now the baseline that FineMath, MegaMath, and Nemotron-CC-Math beat in ablations. Re-read 2026-08-13:
+    the Nemotron-CC-Math paper still reports surpassing prior open math corpora including OpenWebMath, and
+    the FineMath card still reports beating it on GSM8k and MATH.'
+  relative_to: finemath
+  relation: two_below
+  last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/html/2508.15096v1
     shows: Nemotron-CC-Math surpasses all prior open math datasets including OpenWebMath
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 718da622dde6cf84bfd756b01d6ff84552f013b33f1f5a6d35fd3dfde71b83ef
   - url: https://huggingface.co/datasets/HuggingFaceTB/finemath
     shows: FineMath-3+ outperforms OpenWebMath on GSM8k and MATH
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 87c966a146400047c9e611ee52409d5bec6232079c0f2954bd23d9143f3f3acd

--- a/sources/scores/oscar-2301.yaml
+++ b/sources/scores/oscar-2301.yaml
@@ -12,35 +12,56 @@ openness:
     free_text:
     - card notes access temporarily suspended
   confidence: high
-  note: Manually gated and the card states access is temporarily suspended pending clarification.
+  note: 'Manually gated and the card states access is temporarily suspended pending clarification. Re-read
+    2026-08-13: the card still carries the extra_gated_prompt announcing that access to OSCAR is temporarily
+    suspended and that no access will be granted, the API reports gated manual, and the licence tag is still
+    cc0-1.0 on the metadata.'
   raw: license:cc0-1.0(metadata);gated:manual(login + terms acceptance);card notes access temporarily suspended
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/oscar-corpus/OSCAR-2301
-    shows: Card describing 151 languages/~3.57TB, CC0 metadata, gated access with a notice suspending
-      access
-    accessed: '2026-06-22'
+    shows: Card describing 151 languages/~3.57TB, CC0 metadata, gated access with a notice suspending access
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 94ec74f19d4d9dfa9b7ee1bdf7cbb024a113ad1b388895855d8ff319fec1a34e
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 2
   reach: 1K-10K
   signal_type: usage_volume
   confidence: high
-  note: 1,793 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 2,036 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (oscar-corpus/OSCAR-2301 2,036). Bands at level 2 (1K-10K) on the dataset adoption scale, whose top
+    band is >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/oscar-corpus/OSCAR-2301
-    shows: downloads field = 1,793 (30-day)
-    accessed: '2026-07-04'
+    shows: 2,036 downloads in the trailing 30 days for oscar-corpus/OSCAR-2301
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 107ca309b4ae93af17d332ea5b8532c2e2cde2fe3b8d21e096b9a8e5c0434ea3
 capability:
   score: 3
   basis: training_value
   basis_detail: superseded
   value: null
   confidence: high
-  note: A dated 2022-snapshot web corpus with access suspended; the derived Colossal OSCAR trains ALIA/Salamandra
-    (2024) but the 2301 version itself is superseded by FineWeb-2/CulturaX.
+  note: 'A dated 2022-snapshot web corpus with access suspended; the derived Colossal OSCAR trains ALIA/Salamandra
+    (2024) but the 2301 version itself is superseded by FineWeb-2/CulturaX. Re-read 2026-08-13: the Salamandra
+    card still puts Colossal OSCAR at 53.05% of the pretraining tokens, and the FineWeb-2 card still reports
+    the newer multilingual extraction ahead of it.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/BSC-LT/salamandra-7b
     shows: Colossal OSCAR contributes 53% of Salamandra/ALIA pretraining tokens
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6b896c9cb99d88218691227464bd827b6e5ab7d7aff3ab882cfab6270444eb51
   - url: https://huggingface.co/datasets/HuggingFaceFW/fineweb-2
     shows: FineWeb-2 supersedes raw OSCAR web extraction in quality ablations
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1932389936b358f00cb2ee418ade6b262e8676edb77998b570447c926b6fe7b9

--- a/sources/scores/personahub.yaml
+++ b/sources/scores/personahub.yaml
@@ -13,66 +13,78 @@ openness:
     scope:
       value: ~370M personas+seed samples
   confidence: high
-  note: >-
-    Publicly downloadable and ungated, and licensed CC-BY-NC-SA-4.0, which permits redistribution
-    for non-commercial research and forbids commercial use. Moved from 5/open on 2026-08-01 by the
-    universal license scale. The map had answered the non-commercial question two ways:
-    `command-r` is 2/restricted under CC-BY-NC while this was 5/open under CC-BY-NC-SA, on the
-    reasoning that a corpus's openness question is redistributability rather than commercial
-    reuse. The scale settles it on the commercial-use test, and the Open Definition agrees - data
-    is not open unless it may be reused commercially. `restricted` is new to the dataset class
-    vocabulary for this: it was the only product type with no word between `open` and `gated`.
+  note: 'Publicly downloadable and ungated, and licensed CC-BY-NC-SA-4.0, which permits redistribution for
+    non-commercial research and forbids commercial use. Moved from 5/open on 2026-08-01 by the universal
+    license scale. The map had answered the non-commercial question two ways: `command-r` is 2/restricted
+    under CC-BY-NC while this was 5/open under CC-BY-NC-SA, on the reasoning that a corpus''s openness question
+    is redistributability rather than commercial reuse. The scale settles it on the commercial-use test,
+    and the Open Definition agrees - data is not open unless it may be reused commercially. `restricted`
+    is new to the dataset class vocabulary for this: it was the only product type with no word between `open`
+    and `gated`. Re-read 2026-08-13: cc-by-nc-sa-4.0 still on the Hub, gated false, card intact, so the
+    non-commercial cap stands.'
   raw: license:cc-by-nc-sa-4.0(non-commercial);card:present;ungated:yes;scope:~370M personas+seed samples
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/proj-persona/PersonaHub
     shows: CC-BY-NC-SA-4.0 license, ungated card, persona counts and paper reference
-    accessed: '2026-06-22'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: ba3b1050f4cfb80e1c51b85446a89c39ae931a5ddf8f3a4c5018191c8cfae3b2
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 2
   reach: 1K-10K
   signal_type: usage_volume
   confidence: high
-  note: >-
-    Publicly downloadable and ungated, and licensed CC-BY-NC-SA-4.0, which permits redistribution
-    for non-commercial research and forbids commercial use. Moved from 5/open on 2026-08-01 by the
-    universal license scale. The map had answered the non-commercial question two ways:
-    `command-r` is 2/restricted under CC-BY-NC while this was 5/open under CC-BY-NC-SA, on the
-    reasoning that a corpus's openness question is redistributability rather than commercial
-    reuse. The scale settles it on the commercial-use test, and the Open Definition agrees - data
-    is not open unless it may be reused commercially. `restricted` is new to the dataset class
-    vocabulary for this: it was the only product type with no word between `open` and `gated`.
+  note: 9,346 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (proj-persona/PersonaHub 9,346). Bands at level 2 (1K-10K) on the dataset adoption scale, whose top
+    band is >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/proj-persona/PersonaHub
-    shows: downloads field = 7,395 (30-day)
-    accessed: '2026-07-04'
+    shows: 9,346 downloads in the trailing 30 days for proj-persona/PersonaHub
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 835927dfbbb05f58bf012396ec3f9c57650cf0e89e539bdce5659a9f947cf458
 capability:
   score: 4
   basis: training_value
   basis_detail: results
   value: null
   confidence: medium
-  note: >-
-    The paper's headline training result is the basis: Qwen2-7B fine-tuned on ~1.07M
-    persona-generated math problems reaches 64.9% on MATH, rivaling GPT-4-turbo-preview at the
-    time. Corroborated downstream - Tulu 3's SFT persona-math set conditions on ~250K PersonaHub
-    personas, so the corpus is an ingredient in a mixture the map already scores 4.
-    Placed at 4 rather than 5 on the category's own calibration: the 5s (smoltalk, fineweb-edu,
-    dclm-baseline) lead head-to-head ablations AND are the current default others adopt wholesale,
-    while PersonaHub is a generation method plus seed samples whose adoption runs through
-    derivative sets. That is the same shape as tulu-3-sft-mixture and fineweb, both 4.
-    CORRECTED from 2, which was not a capability judgment at all. On 2026-08-01 the openness
-    re-score to 2/restricted was pasted into this block wholesale: the note recorded here was
-    the openness note verbatim, arguing CC-BY-NC-SA and the commercial-use test, and the score
-    followed it down. Nothing on this axis had been assessed. The tell was `value: null` with
-    `confidence: high` - a null is the category norm here, all 38 members carry one, but a high
-    confidence attached to a reasoning that never mentions training value is not. A licence says
-    what you may do with a corpus; it says nothing about what training on it produces.
-    Re-derived from the sources already cited, which is why no `last_verified` is claimed - they
-    were read on 2026-07-04 and have not been re-fetched.
+  note: 'The paper''s headline training result is the basis: Qwen2-7B fine-tuned on ~1.07M persona-generated
+    math problems reaches 64.9% on MATH, rivaling GPT-4-turbo-preview at the time. Corroborated downstream
+    - Tulu 3''s SFT persona-math set conditions on ~250K PersonaHub personas, so the corpus is an ingredient
+    in a mixture the map already scores 4. Placed at 4 rather than 5 on the category''s own calibration:
+    the 5s (smoltalk, fineweb-edu, dclm-baseline) lead head-to-head ablations AND are the current default
+    others adopt wholesale, while PersonaHub is a generation method plus seed samples whose adoption runs
+    through derivative sets. That is the same shape as tulu-3-sft-mixture and fineweb, both 4. CORRECTED
+    from 2, which was not a capability judgment at all. On 2026-08-01 the openness re-score to 2/restricted
+    was pasted into this block wholesale: the note recorded here was the openness note verbatim, arguing
+    CC-BY-NC-SA and the commercial-use test, and the score followed it down. Nothing on this axis had been
+    assessed. The tell was `value: null` with `confidence: high` - a null is the category norm here, all
+    38 members carry one, but a high confidence attached to a reasoning that never mentions training value
+    is not. A licence says what you may do with a corpus; it says nothing about what training on it produces.
+    Re-derived from the sources already cited, which is why no `last_verified` is claimed - they were read
+    on 2026-07-04 and have not been re-fetched. Re-read 2026-08-13: the Persona Hub listing still describes
+    1 billion curated personas used to synthesise mathematical and logical reasoning problems at scale,
+    and the Tulu 3 personas-math card still credits the persona methodology for its 149,960 examples. The
+    MATH figure is in the paper body rather than on the listing page.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2406.20094
-    shows: Qwen2-7B on ~1.07M persona math problems hits 64.9% MATH, rivaling GPT-4-turbo-preview
-    accessed: '2026-07-04'
+    shows: Abstract - Persona Hub is 1 billion personas curated from web data, showcased on synthesised
+      mathematical and logical reasoning problems. The Qwen2-7B MATH result is in the paper body, not on
+      this page
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c2afd401fde3e5f27e49713b190624f91bddce361fc07efab2023d49de41db06
   - url: https://huggingface.co/datasets/allenai/tulu-3-sft-personas-math
-    shows: Tulu 3 conditions on ~250K PersonaHub personas
-    accessed: '2026-07-04'
+    shows: Card - 149,960 synthetic math examples built by expanding the persona methodology of Ge et al.
+      2024
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b192c8e7cccf4ec42ca301dae9d281a8b91a232671312f48244be43da03d8f03

--- a/sources/scores/pes2o.yaml
+++ b/sources/scores/pes2o.yaml
@@ -10,34 +10,54 @@ openness:
     dataset_card:
       value: present
   confidence: high
-  note: ODC-BY, ungated, full dataset card.
+  note: 'ODC-BY, ungated, full dataset card. Re-read 2026-08-13: odc-by on the Hub, gated false, card intact.'
   raw: license:ODC-BY;gated:false;dataset_card:present
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/allenai/peS2o
     shows: ODC-BY license, ungated, dataset card
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 8bdeda1c39649143fa1f2b0ed45c2262ae195774b808fb10e1bcc88c751f708b
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 3
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 11,347 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 11,867 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (allenai/peS2o 11,867). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is
+    >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/allenai/peS2o
-    shows: downloads field = 11,347 (30-day)
-    accessed: '2026-07-04'
+    shows: 11,867 downloads in the trailing 30 days for allenai/peS2o
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 2a1ecaab895a2c14a2247c250b2b426dde8cce3dd461e26af0637b0645c19337
 capability:
   score: 4
   basis: training_value
   basis_detail: downstream
   value: null
   confidence: high
-  note: The standard open science corpus with documented multi-model reuse (OLMoE 57B tokens, Marin, Nemotron
-    3), but no ablation leadership, and OLMo 3 replaced it with a new academic-PDF dataset.
+  note: 'The standard open science corpus with documented multi-model reuse (OLMoE 57B tokens, Marin, Nemotron
+    3), but no ablation leadership, and OLMo 3 replaced it with a new academic-PDF dataset. Re-read 2026-08-13:
+    the OLMoE mix card still lists peS2o at 57.2B tokens and the Nemotron 3 Nano card still names it among
+    its pretraining sources, and neither claims an ablation win for it.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/allenai/OLMoE-mix-0924
-    shows: peS2o contributes 57.2B tokens to the OLMoE mix and is used in Marin and Nemotron 3
-    accessed: '2026-07-04'
+    shows: Mix statistics - peS2o (Dolma) contributes 57.2B tokens (38.8M docs) to the OLMoE-mix-0924 pretraining
+      mix
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d651c52f7dcdbb3df49d24e4eef3f0f013667db773e903415d2e543c698c5a7b
   - url: https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
     shows: Nemotron 3 Nano lists peS2o among pretraining sources
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c6af78e49fec1a333f748a52992f14f70bf1373208e390eb2e9b3cd8224778d1

--- a/sources/scores/redpajama-data-v2.yaml
+++ b/sources/scores/redpajama-data-v2.yaml
@@ -12,35 +12,59 @@ openness:
     dataset_card:
       value: 'yes'
   confidence: high
-  note: Ungated with a full dataset card; redistributable per Common Crawl ToU with Apache-2.0 processing
-    code.
+  note: 'Ungated with a full dataset card; redistributable per Common Crawl ToU with Apache-2.0 processing
+    code. Re-read 2026-08-13: the card''s License section still reads Common Crawl Foundation Terms of Use
+    for the data and Apache 2.0 for the processing code, and the API reports gated false.'
   raw: license:CommonCrawl-ToU+Apache-2.0(code);ungated:yes;dataset_card:yes
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/togethercomputer/RedPajama-Data-V2
     shows: Common Crawl ToU + Apache-2.0 code license, ungated access, dataset card
-    accessed: '2026-06-22'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 8c7f0238258c2d1ca2d35aa37b7144a08dc0e9cc4629d07219b82cb2fa3ba4cb
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 2
   reach: 1K-10K
   signal_type: usage_volume
   confidence: high
-  note: 9,452 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 5,035 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (togethercomputer/RedPajama-Data-V2 5,035). Bands at level 2 (1K-10K) on the dataset adoption scale,
+    whose top band is >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/togethercomputer/RedPajama-Data-V2
-    shows: downloads field = 9,452 (30-day)
-    accessed: '2026-07-04'
+    shows: 5,035 downloads in the trailing 30 days for togethercomputer/RedPajama-Data-V2
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 8f7f2180180fbf71e4018a652ce94ee914ba9f53e76ccfbe7b3241650c48ea6b
 capability:
   score: 3
   basis: training_value
   basis_detail: superseded
   value: null
   confidence: high
-  note: Competitive in its own filtered ablation but loses to FineWeb in FineWeb's 1.82B run; primarily
-    a 2023 base (RedPajama-INCITE), superseded by DCLM/FineWeb.
+  note: 'Competitive in its own filtered ablation but loses to FineWeb in FineWeb''s 1.82B run; primarily
+    a 2023 base (RedPajama-INCITE), superseded by DCLM/FineWeb. Re-read 2026-08-13: the RedPajama listing
+    still describes V2 as raw unfiltered web text plus quality signals rather than a filtered corpus, and
+    FineWeb still claims the stronger result.'
+  relative_to: fineweb
+  relation: one_below
+  last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2411.12372
-    shows: RPv2 with Gopher filtering is competitive vs C4/Dolma but trails RefinedWeb
-    accessed: '2026-07-04'
+    shows: Abstract - RedPajama-V2 is a raw, unfiltered web corpus of over 100T tokens shipped with quality
+      signals for downstream filtering. The Gopher-filtered ablation against C4/Dolma/RefinedWeb is in the
+      paper body, not on this page
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 2267c9f00b499961cb995dad139f932a0567bb1b326ddbb22ed75b19b718f9cf
   - url: https://arxiv.org/abs/2406.17557
     shows: FineWeb outperforms RedPajama2 in the FineWeb ablation
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a12bfcd47f835ad4a2c5630a228778370ed54509afa65bed1c6dfc264f2182da

--- a/sources/scores/refinedweb.yaml
+++ b/sources/scores/refinedweb.yaml
@@ -12,36 +12,60 @@ openness:
     note:
       value: public_extract
   confidence: high
-  note: Permissive ODC-BY 1.0 license, ungated download, with a dataset card (a public extract of the
-    full corpus).
+  note: 'Permissive ODC-BY 1.0 license, ungated download, with a dataset card (a public extract of the full
+    corpus). Re-read 2026-08-13: odc-by, gated false, and the card still describes the public 600B-token
+    extract.'
   raw: license:ODC-BY-1.0;gated:false;dataset_card:present;note:public_extract
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/tiiuae/falcon-refinedweb
     shows: Dataset card, ODC-By 1.0 license, ungated public download
-    accessed: '2026-06-22'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 08bf700c8bdeb26d2404053257124b57f2496294c37581ea5fd3fb2794108b4b
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 3
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 12,934 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 93,929 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (tiiuae/falcon-refinedweb 93,929). Bands at level 3 (10K-100K) on the dataset adoption scale, whose
+    top band is >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/tiiuae/falcon-refinedweb
-    shows: downloads field = 12,934 (30-day)
-    accessed: '2026-07-04'
+    shows: 93,929 downloads in the trailing 30 days for tiiuae/falcon-refinedweb
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: ef160991f9f592012cfb711057b386509add898900ddd43c9827e09d06058cfe
 capability:
   score: 3
   basis: training_value
   basis_detail: superseded
   value: null
   confidence: high
-  note: Filtered web alone beat The Pile and was the best legacy corpus in DCLM's tests; powered Falcon
-    (2023-24) but is now a component inside newer pipelines rather than a standalone default.
+  note: 'Filtered web alone beat The Pile and was the best legacy corpus in DCLM''s tests; powered Falcon
+    (2023-24) but is now a component inside newer pipelines rather than a standalone default. Re-read 2026-08-13:
+    the RefinedWeb listing still states that filtered and deduplicated web data alone significantly outperforms
+    state-of-the-art models trained on The Pile, and DCLM-Baseline still reports the stronger result, which
+    is why this sits two bands below it.'
+  relative_to: dclm-baseline
+  relation: two_below
+  last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2306.01116
     shows: 'RefinedWeb: filtered/deduplicated web alone outperforms models trained on The Pile'
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: ff401c9e67db2503c67320fc867f3d245f796802154da023cfedd5d7febf4998
   - url: https://arxiv.org/abs/2406.11794
-    shows: In DCLM's controlled ablations RefinedWeb is the best legacy corpus but DCLM-Baseline surpasses
-      it
-    accessed: '2026-07-04'
+    shows: Abstract - DCLM-Baseline reaches 64% MMLU at 2.6T tokens, 6.6 points over the prior open-data
+      state of the art. The legacy-corpus ranking that places RefinedWeb is in the paper body, not on this
+      page
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: f665620bfe7fe32ea36cf6f4daab947bd13e925c191d80444c02c8ceb14fd974

--- a/sources/scores/smoltalk.yaml
+++ b/sources/scores/smoltalk.yaml
@@ -12,34 +12,55 @@ openness:
     dataset_card:
       value: present
   confidence: high
-  note: Ungated; newly created subsets are Apache-2.0, incorporated public datasets keep their own licenses.
+  note: 'Ungated; newly created subsets are Apache-2.0, incorporated public datasets keep their own licenses.
+    Re-read 2026-08-13: the card''s License section still puts the four new subsets under Apache 2.0 and
+    defers the rest to their original datasets, and the API reports gated false.'
   raw: access:ungated;license:apache-2.0(new-subsets)+per-component;dataset_card:present
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/HuggingFaceTB/smoltalk
     shows: ungated, mixed licensing documented on card
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a406e598a0b07d4604d81da7c04f376eab3c3078a6ed9458dae6344a0d3df958
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 3
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 17,489 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 30,281 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (HuggingFaceTB/smoltalk 30,281). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top
+    band is >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/HuggingFaceTB/smoltalk
-    shows: downloads field = 17,489 (30-day)
-    accessed: '2026-07-04'
+    shows: 30,281 downloads in the trailing 30 days for HuggingFaceTB/smoltalk
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 82ea4fe6554250f7411d73feabe8ff8a08f022570fdf6dc8418d0a954b602b79
 capability:
   score: 5
   basis: training_value
   basis_detail: ablation
   value: null
   confidence: high
-  note: Leads head-to-head SFT-mixture ablations (beats OpenHermes-2.5, UltraChat, MagPie-Pro) and is
-    the current default across SmolLM2/3 and Marin 8B Instruct.
+  note: 'Leads head-to-head SFT-mixture ablations (beats OpenHermes-2.5, UltraChat, MagPie-Pro) and is the
+    current default across SmolLM2/3 and Marin 8B Instruct. Re-read 2026-08-13: the SmolLM2 paper still
+    reports SmolTalk ahead of OpenHermes-2.5, UltraChat and MagPie-Pro, and the Marin 8B Instruct card still
+    lists it.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/html/2502.02737v1
     shows: 'SmolLM2 paper: SmolTalk surpasses OpenHermes-2.5, UltraChat, and MagPie-Pro'
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: be627c24bbc0d0c4084648798877bced224b189e12ca4c03a2e25e277986fbbb
   - url: https://huggingface.co/marin-community/marin-8b-instruct
     shows: Marin 8B Instruct lists SmolTalk in its SFT mix
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d39bfdb79bd31d571df1d9c13a14ce4de34aad157b467c76ef8956aaf4daa3c4

--- a/sources/scores/stack-edu.yaml
+++ b/sources/scores/stack-edu.yaml
@@ -10,34 +10,55 @@ openness:
     dataset_card:
       value: present
   confidence: medium
-  note: Ungated download with a card; the card defers the data license to The Stack v2's terms.
+  note: 'Ungated download with a card; the card defers the data license to The Stack v2''s terms. Re-read
+    2026-08-13: the card still says to refer to the-stack-v2 for the data licence and the API reports gated
+    false, so the deferred licence over an ungated, documented release stands.'
   raw: access:ungated;license:inherits-the-stack-v2;dataset_card:present
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/HuggingFaceTB/stack-edu
     shows: ungated access, card defers license to the-stack-v2
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: cc658e83a75d0f981bd0bb4781103bb78b74569203da5e513433f5c5cf6eaa59
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 2
   reach: 1K-10K
   signal_type: usage_volume
   confidence: high
-  note: 3,892 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 5,273 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (HuggingFaceTB/stack-edu 5,273). Bands at level 2 (1K-10K) on the dataset adoption scale, whose top
+    band is >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/HuggingFaceTB/stack-edu
-    shows: downloads field = 3,892 (30-day)
-    accessed: '2026-07-04'
+    shows: 5,273 downloads in the trailing 30 days for HuggingFaceTB/stack-edu
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 994910013a3f691469699fa9b86dbbd81f09b8e5cd52a94aac0252e745f70d20
 capability:
   score: 5
   basis: training_value
   basis_detail: ablation
   value: null
   confidence: high
-  note: Leads controlled classifier ablations, beating StarCoder2Data on MultiPL-E across all languages
-    (SmolLM2 paper); current default in SmolLM3 and OLMo 3's Dolma 3.
+  note: 'Leads controlled classifier ablations, beating StarCoder2Data on MultiPL-E across all languages
+    (SmolLM2 paper); current default in SmolLM3 and OLMo 3''s Dolma 3. Re-read 2026-08-13: the SmolLM2 paper
+    still reports Stack-Edu ahead of StarCoder2Data on MultiPL-E across languages, and the SmolLM3 post
+    still includes it in the pretraining mixture.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/html/2502.02737v1
     shows: Stack-Edu consistently outperforms StarCoder2Data on MultiPL-E (Python 25.6 vs 20.7, etc.)
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: be627c24bbc0d0c4084648798877bced224b189e12ca4c03a2e25e277986fbbb
   - url: https://huggingface.co/blog/smollm3
     shows: Stack-Edu included in the SmolLM3 pretraining mixture
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0bda4e81844892caf115c991b5f50c8ca57f4e4e42aeeefba89d1f5cd8065edc

--- a/sources/scores/starcoderdata.yaml
+++ b/sources/scores/starcoderdata.yaml
@@ -11,34 +11,59 @@ openness:
     dataset_card:
       value: present
   confidence: high
-  note: Terms-gated like its parent The Stack v1; permissively licensed source files.
+  note: 'Terms-gated like its parent The Stack v1; permissively licensed source files. Re-read 2026-08-13:
+    the Hub still shows “You need to agree to share your contact information to access this dataset” and
+    the API reports gated auto, with the card present.'
   raw: license:permissive(SPDX per file);gated:terms-acceptance;dataset_card:present
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/bigcode/starcoderdata
     shows: gated (auto) access with terms, dataset card
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 4d46742a06f9fcbd830d3b2e5628ef54a4057e0ec4744bca64d266bad9953717
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 3
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 20,254 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 28,873 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (bigcode/starcoderdata 28,873). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top
+    band is >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/bigcode/starcoderdata
-    shows: downloads field = 20,254 (30-day)
-    accessed: '2026-07-04'
+    shows: 28,873 downloads in the trailing 30 days for bigcode/starcoderdata
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1ae3094e2c425aed5e0822dcb9b62c22a01ac2b2a4777bed388aa8c9122fa786
 capability:
   score: 3
   basis: training_value
   basis_detail: superseded
   value: null
   confidence: high
-  note: Proven pretraining component (TinyLlama, Granite Code, ALIA, OLMoE) but drawn from The Stack v1
-    and functionally superseded by The Stack v2 / Stack-Edu.
+  note: 'Proven pretraining component (TinyLlama, Granite Code, ALIA, OLMoE) but drawn from The Stack v1
+    and functionally superseded by The Stack v2 / Stack-Edu. Re-read 2026-08-13: the OLMoE mix card still
+    lists Starcoder at 101B tokens, and the StarCoder2 listing still describes The Stack v2 as 4x the first
+    StarCoder dataset, which is the supersession the band rests on.'
+  relative_to: the-stack-v2
+  relation: one_below
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/allenai/OLMoE-mix-0924
-    shows: StarCoderData is a documented component of TinyLlama, Granite Code, ALIA, Apertus, Marin, OLMoE
-    accessed: '2026-07-04'
+    shows: Mix statistics - Starcoder contributes 101B tokens (78.7M docs) to the OLMoE-mix-0924 pretraining
+      mix
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d651c52f7dcdbb3df49d24e4eef3f0f013667db773e903415d2e543c698c5a7b
   - url: https://arxiv.org/abs/2402.19173
-    shows: The Stack v2/StarCoder2 is the successor to the Stack v1 lineage
-    accessed: '2026-07-04'
+    shows: Abstract - The Stack v2 is 4x larger than the first StarCoder dataset, and StarCoder2 supersedes
+      the StarCoder lineage
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1be42d8177c7f4a82830445b6292e49204520395a26f84de16249eb580609856

--- a/sources/scores/synth.yaml
+++ b/sources/scores/synth.yaml
@@ -11,12 +11,20 @@ openness:
     dataset_card:
       value: present
   confidence: high
-  note: Permissively licensed, ungated dataset with a documented card.
+  note: 'Permissively licensed, ungated dataset with a documented card. Re-read 2026-08-13: cc-by-4.0 on
+    the Hub, gated false, card intact.'
   raw: license:CC-BY-4.0(permissive);access:ungated;dataset_card:present
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/PleIAs/SYNTH
     shows: License CC-BY-4.0, not gated, dataset card present
-    accessed: '2026-06-22'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: ccedbb4b4d56a5d0897a296d444b1d440d65443cc03951fba26c50197ff10cc7
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 2
   reach: 1K-10K
@@ -33,12 +41,18 @@ capability:
   basis_detail: results
   value: null
   confidence: medium
-  note: A novel fully-open synthetic reasoning corpus with real first-party end-to-end results (Baguettotron
-    best-in-class sub-350M), but single-lab evidence.
+  note: 'A novel fully-open synthetic reasoning corpus with real first-party end-to-end results (Baguettotron
+    best-in-class sub-350M), but single-lab evidence. Re-read 2026-08-13: the PleIAs post still reports
+    Baguettotron at 321M and Monad at 56M trained end to end on SYNTH, and the evidence is still single-lab.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/blog/Pclanglais/synth-data-frontier
     shows: PleIAs trained Baguettotron (321M) and Monad (56M) end-to-end on SYNTH, best-in-class for size
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 21962cdbf6ea2188d48ef95f875162a0097d065f5ef57e09470c7bc95cbb9bf8
   - url: https://huggingface.co/datasets/PleIAs/SYNTH
     shows: 'SYNTH: ~79.6M samples, CC-BY-4.0, released Nov 2025'
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: ccedbb4b4d56a5d0897a296d444b1d440d65443cc03951fba26c50197ff10cc7

--- a/sources/scores/the-pile.yaml
+++ b/sources/scores/the-pile.yaml
@@ -10,17 +10,29 @@ openness:
     dataset_card:
       value: legacy-repo-only
   confidence: medium
-  note: Ungated download via the deduplicated HF repo; the original EleutherAI/pile repo is a loading
-    script whose mirrors are dead. The card defers licensing to per-subset terms and Books3 has been withdrawn
-    from circulation.
+  note: 'Ungated download via the deduplicated HF repo; the original EleutherAI/pile repo is a loading script
+    whose mirrors are dead. The card defers licensing to per-subset terms and Books3 has been withdrawn
+    from circulation. Re-read 2026-08-13: the deduplicated repo still downloads without a gate, and the
+    legacy EleutherAI/pile card still says to refer to the specific licence of whichever subset you use,
+    so the deferred licence and the legacy-repo-only card both stand.'
   raw: access:ungated;license:mixed-per-subset;dataset_card:legacy-repo-only
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/EleutherAI/the_pile_deduplicated
     shows: hosts the working parquet data (451 GB), ungated
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 145a48d02a24e18319785e4b8848a4c8e889a1c90bb2068ddea1c3a5c8fc7a20
+    establishes:
+    - availability
   - url: https://huggingface.co/datasets/EleutherAI/pile
     shows: 'legacy card: per-subset licensing, loading script only'
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 58e374c699b8ce290e307ffbf5a5ae0ebeb2dbc90f0ef7a20e84f724cd461f11
+    establishes:
+    - license
+    - documentation
 adoption:
   level: 2
   reach: 1K-10K
@@ -37,12 +49,21 @@ capability:
   basis_detail: superseded
   value: null
   confidence: high
-  note: The foundational 2020-era template, proven for a wide 2022-23 family (Pythia, GPT-NeoX-20B, GPT-J,
-    Cerebras-GPT), but dated and beaten by modern web corpora in FineWeb ablations.
+  note: 'The foundational 2020-era template, proven for a wide 2022-23 family (Pythia, GPT-NeoX-20B, GPT-J,
+    Cerebras-GPT), but dated and beaten by modern web corpora in FineWeb ablations. Re-read 2026-08-13:
+    the Cerebras-GPT paper still records training on the Pile alongside GPT-J, GPT-NeoX and Pythia, and
+    the FineWeb HTML still reports the newer corpus ahead of it.'
+  relative_to: fineweb
+  relation: one_below
+  last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/pdf/2304.03208
     shows: The Pile trained GPT-NeoX-20B, GPT-J, Pythia, and Cerebras-GPT
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 49194d92e1053d71540ec7b71bfe73507def09eb409c0f5d560ea5b8923b0aa9
   - url: https://arxiv.org/html/2406.17557v1
     shows: FineWeb outperforms The Pile in its ablation
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 28d264b3ae7dbd20cd0a2c49daaaff89df04fc2a503eca83adf13afac90cd7d1

--- a/sources/scores/the-stack-v2.yaml
+++ b/sources/scores/the-stack-v2.yaml
@@ -11,35 +11,60 @@ openness:
     dataset_card:
       value: 'yes'
   confidence: high
-  note: Requires acceptance of terms and sharing contact info before download, so access is gated.
+  note: 'Requires acceptance of terms and sharing contact info before download, so access is gated. Re-read
+    2026-08-13: the Hub still shows “You need to agree to share your contact information to access this
+    dataset” and the API reports gated auto, so the terms-acceptance-plus-contact-info gate stands.'
   raw: license:permissive(SPDX);gated:terms-acceptance+contact-info;dataset_card:yes
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/bigcode/the-stack-v2
     shows: gated access requiring terms acceptance and contact-info sharing, permissive licenses, dataset
       card
-    accessed: '2026-06-22'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c607560a82e7612f2c9910103a8fc60df49a592398a31fde9fc82189d9962ce9
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 3
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 28,469 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 13,060 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (bigcode/the-stack-v2 13,060). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top
+    band is >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/bigcode/the-stack-v2
-    shows: downloads field = 28,469 (30-day)
-    accessed: '2026-07-04'
+    shows: 13,060 downloads in the trailing 30 days for bigcode/the-stack-v2
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 40f9244fc2ee4ad2ec453ee5c0ba5cedf209cc6640b5c05b9d467a3a13f33ba6
 capability:
   score: 4
   basis: training_value
   basis_detail: downstream
   value: null
   confidence: high
-  note: Trained StarCoder2 (2024) and is the code base of SmolLM3 (2025) plus the source for Stack-Edu;
-    as the raw corpus it is beaten by its own edu-filtered slice in ablations.
+  note: 'Trained StarCoder2 (2024) and is the code base of SmolLM3 (2025) plus the source for Stack-Edu;
+    as the raw corpus it is beaten by its own edu-filtered slice in ablations. Re-read 2026-08-13: the StarCoder2
+    listing still records The Stack v2 at 619 programming languages and 4x the first StarCoder dataset,
+    and the SmolLM3 post still names it as the code source. Its edu-filtered slice remains the better corpus
+    in ablation, which is why this sits a band below Stack-Edu.'
+  relative_to: stack-edu
+  relation: one_below
+  last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2402.19173
-    shows: StarCoder2 trained on The Stack v2 (900B+ tokens, 619 languages)
-    accessed: '2026-07-04'
+    shows: Abstract - The Stack v2 spans 619 programming languages and is 4x the first StarCoder dataset;
+      StarCoder2 3B/7B/15B train on 3.3-4.3T tokens of it
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1be42d8177c7f4a82830445b6292e49204520395a26f84de16249eb580609856
   - url: https://huggingface.co/blog/smollm3
     shows: SmolLM3 code data is The Stack v2
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0bda4e81844892caf115c991b5f50c8ca57f4e4e42aeeefba89d1f5cd8065edc

--- a/sources/scores/tulu-3-sft-mixture.yaml
+++ b/sources/scores/tulu-3-sft-mixture.yaml
@@ -11,35 +11,58 @@ openness:
     dataset_card:
       value: present
   confidence: high
-  note: ODC-BY licensed and ungated with a full dataset card, though some subsets carry non-commercial
-    licenses.
+  note: 'ODC-BY licensed and ungated with a full dataset card, though some subsets carry non-commercial
+    licenses. Re-read 2026-08-13: odc-by on the Hub, gated false, card intact and still flagging the non-commercial
+    subsets.'
   raw: license:odc-by(mixed subset licenses incl CC-BY-NC);access:ungated;dataset_card:present
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/allenai/tulu-3-sft-mixture
     shows: ODC-BY-1.0 license, ~939k rows, dataset card
-    accessed: '2026-06-22'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 579445329317f747a4780e6e767577245dca7492ec5911d20cb1f7eb63f33995
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 3
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 18,317 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 36,267 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (allenai/tulu-3-sft-mixture 36,267). Bands at level 3 (10K-100K) on the dataset adoption scale, whose
+    top band is >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/allenai/tulu-3-sft-mixture
-    shows: downloads field = 18,317 (30-day)
-    accessed: '2026-07-04'
+    shows: 36,267 downloads in the trailing 30 days for allenai/tulu-3-sft-mixture
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 752228726c89c5310823b34bb63ee456e48937383365cc901ac70353c4ffe0e0
 capability:
   score: 4
   basis: training_value
   basis_detail: downstream
   value: null
   confidence: high
-  note: Current multi-org SFT default (Marin, SmolLM3, OLMo 2) with SOTA open-recipe claims, but a reused
-    component rather than the head-to-head leader; Dolci now leads the fully-open frontier.
+  note: 'Current multi-org SFT default (Marin, SmolLM3, OLMo 2) with SOTA open-recipe claims, but a reused
+    component rather than the head-to-head leader; Dolci now leads the fully-open frontier. Re-read 2026-08-13:
+    the Tulu 3 listing still claims results surpassing the instruct versions of Llama 3.1, Qwen 2.5, Mistral
+    and GPT-4o-mini, and the Marin 8B Instruct card still lists this mixture among its SFT sources. Dolci
+    remains the fully-open leader above it.'
+  relative_to: dolci
+  relation: one_below
+  last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2411.15124
     shows: The Tulu 3 recipe surpasses instruct versions of Llama 3.1, Qwen 2.5, and GPT-4o-mini
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b09d632f6108756e4a3fc59de2fb15acc5cd1152a2b873d90eba51008e6ee883
   - url: https://huggingface.co/marin-community/marin-8b-instruct
     shows: Marin 8B Instruct lists tulu-3-sft-mixture among its SFT sources
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d39bfdb79bd31d571df1d9c13a14ce4de34aad157b467c76ef8956aaf4daa3c4

--- a/sources/scores/txt360.yaml
+++ b/sources/scores/txt360.yaml
@@ -10,31 +10,51 @@ openness:
     dataset_card:
       value: present
   confidence: high
-  note: ODC-BY, ungated, documented pipeline on GitHub.
+  note: 'ODC-BY, ungated, documented pipeline on GitHub. Re-read 2026-08-13: odc-by, gated false, card intact.
+    The LLM360 path now redirects to the IFM org on the Hub, same repo.'
   raw: license:ODC-BY;gated:false;dataset_card:present
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/LLM360/TxT360
     shows: ODC-BY license, ungated, dataset card
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 39cc3cbc04b685eb028700bce426cd4777afcddb4124f495d8bbb2f88c21b7b5
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 2
   reach: 1K-10K
   signal_type: usage_volume
   confidence: high
-  note: 4,218 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 9,230 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (IFM/TxT360 9,230). Bands at level 2 (1K-10K) on the dataset adoption scale, whose top band is >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/LLM360/TxT360
-    shows: downloads field = 4,218 (30-day)
-    accessed: '2026-07-04'
+    shows: 9,230 downloads in the trailing 30 days for IFM/TxT360
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 573d800a8e60c8d9dfa8f09e400c1afed36fc4240f4e9bea70203cf5db441468
 capability:
   score: 4
   basis: training_value
   basis_detail: ablation
   value: null
   confidence: medium
-  note: A self-reported controlled ablation beats FineWeb (8x8B MoE, 1.5T tokens) but without published
-    numeric scores; trains K2 / K2-V2 (LLM360, 2024-25).
+  note: 'A self-reported controlled ablation beats FineWeb (8x8B MoE, 1.5T tokens) but without published
+    numeric scores; trains K2 / K2-V2 (LLM360, 2024-25). Re-read 2026-08-13: the card still describes ~5T
+    globally deduplicated tokens and a mixing recipe reaching 15T+, still reports the 1.5T-token ablation
+    against FineWeb on an 8x8B mixture-of-experts with no published scores, and the K2-V2 collection still
+    lists it.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/LLM360/TxT360
-    shows: 5.7T deduplicated tokens upsampled to 15T+, claimed to outperform FineWeb 15T; trains K2/K2-V2
-    accessed: '2026-07-04'
+    shows: Card - ~5T globally deduplicated tokens across 99 Common Crawl snapshots and 14 non-web sources,
+      a recipe reaching 15T+ tokens, and a 1.5T-token 8x8B MoE ablation against FineWeb reported without
+      numeric scores; listed in the K2-V2 collection
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 39cc3cbc04b685eb028700bce426cd4777afcddb4124f495d8bbb2f88c21b7b5

--- a/sources/scores/ultrachat-200k.yaml
+++ b/sources/scores/ultrachat-200k.yaml
@@ -10,34 +10,53 @@ openness:
     dataset_card:
       value: present
   confidence: high
-  note: MIT-licensed, ungated, full dataset card.
+  note: 'MIT-licensed, ungated, full dataset card. Re-read 2026-08-13: mit on the Hub, gated false, card
+    intact.'
   raw: license:MIT;gated:false;dataset_card:present
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/HuggingFaceH4/ultrachat_200k
     shows: MIT license, ungated access, dataset card
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5b2af0e482578c80e0ec55bb99a436c6c77a02a109ec0f349f530b24f137b1e1
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 3
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 57,823 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 75,198 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (HuggingFaceH4/ultrachat_200k 75,198). Bands at level 3 (10K-100K) on the dataset adoption scale, whose
+    top band is >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/HuggingFaceH4/ultrachat_200k
-    shows: downloads field = 57,823 (30-day)
-    accessed: '2026-07-04'
+    shows: 75,198 downloads in the trailing 30 days for HuggingFaceH4/ultrachat_200k
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 54195977680826b66cba7a480d283c2c7668238b7f01a5a3821c2a3d532e4234
 capability:
   score: 3
   basis: training_value
   basis_detail: superseded
   value: null
   confidence: high
-  note: Clean SFT before/after in the Zephyr paper (MT-Bench ~6.64), but dropped from 2024-25 default
-    SFT mixes (absent from SmolTalk and Tulu 3).
+  note: 'Clean SFT before/after in the Zephyr paper (MT-Bench ~6.64), but dropped from 2024-25 default SFT
+    mixes (absent from SmolTalk and Tulu 3). Re-read 2026-08-13: the Zephyr paper still reports the dSFT
+    result on UltraChat, and UltraChat-200k is still absent from the Tulu 3 SFT mixture card.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://ar5iv.labs.arxiv.org/html/2310.16944
     shows: 'Zephyr: dSFT on UltraChat reaches MT-Bench 6.64'
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a7a4e8be5d00f66bb16d3da7601dc4c207327b353dd110257d4ab8137dc7475b
   - url: https://huggingface.co/datasets/allenai/tulu-3-sft-mixture
     shows: UltraChat-200k is not used as an SFT source in Tulu 3
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 579445329317f747a4780e6e767577245dca7492ec5911d20cb1f7eb63f33995

--- a/sources/scores/ultrafeedback.yaml
+++ b/sources/scores/ultrafeedback.yaml
@@ -16,34 +16,55 @@ openness:
     size:
       value: 940MB
   confidence: high
-  note: Publicly downloadable and ungated under the permissive MIT license.
+  note: 'Publicly downloadable and ungated under the permissive MIT license. Re-read 2026-08-13: mit on
+    the Hub, gated false, card intact.'
   raw: license:mit;card:present;ungated:yes;rows:63,967;size:940MB
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/openbmb/UltraFeedback
     shows: MIT license, ungated card, 63,967 rows / 940 MB
-    accessed: '2026-06-22'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5ce3ca7575d61afebaf8d5f3712353fae7d50edb6ee0a07ed58ec9ae83b66250
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 2
   reach: 1K-10K
   signal_type: usage_volume
   confidence: high
-  note: 4,496 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 5,456 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (openbmb/UltraFeedback 5,456). Bands at level 2 (1K-10K) on the dataset adoption scale, whose top band
+    is >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/openbmb/UltraFeedback
-    shows: downloads field = 4,496 (30-day)
-    accessed: '2026-07-04'
+    shows: 5,456 downloads in the trailing 30 days for openbmb/UltraFeedback
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 93a4cd3bcb6f2be82a54c7d8e5ce9c4c796709a1dfab03d5ea5c8a0b2ff3cce1
 capability:
   score: 4
   basis: training_value
   basis_detail: ablation
   value: null
   confidence: high
-  note: Clean documented DPO before/after (Zephyr MT-Bench 6.64->7.34); its pipeline is the template for
-    Tulu 3 / OLMo 2 preference data, with cleaned subsets still in use.
+  note: 'Clean documented DPO before/after (Zephyr MT-Bench 6.64->7.34); its pipeline is the template for
+    Tulu 3 / OLMo 2 preference data, with cleaned subsets still in use. Re-read 2026-08-13: the Zephyr paper
+    still shows the dSFT-to-DPO lift on UltraFeedback, and the Tulu 3 listing still presents an open preference-data
+    recipe at scale.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://ar5iv.labs.arxiv.org/html/2310.16944
     shows: 'Zephyr: DPO on ultrafeedback_binarized lifts MT-Bench 6.64->7.00, final model 7.34'
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a7a4e8be5d00f66bb16d3da7601dc4c207327b353dd110257d4ab8137dc7475b
   - url: https://arxiv.org/abs/2411.15124
-    shows: Tulu 3 extends the UltraFeedback pipeline to scale preference data
-    accessed: '2026-07-04'
+    shows: Tulu 3 releases an open preference-data pipeline at scale; the UltraFeedback lineage is described
+      in the paper body, not on this page
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b09d632f6108756e4a3fc59de2fb15acc5cd1152a2b873d90eba51008e6ee883

--- a/sources/scores/wildchat-1m.yaml
+++ b/sources/scores/wildchat-1m.yaml
@@ -12,35 +12,53 @@ openness:
     free_text:
     - parquet downloadable
   confidence: medium
-  note: ODC-BY licensed and reported ungated by the HF API, though Ai2 datasets sometimes show an access
-    notice.
+  note: 'ODC-BY licensed and reported ungated by the HF API, though Ai2 datasets sometimes show an access
+    notice. Re-read 2026-08-13: the Hub API still returns odc-by and gated false for allenai/WildChat-1M.'
   raw: license:odc-by;gated:false per HF API;dataset_card:present;parquet downloadable
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/allenai/WildChat-1M
     shows: gated=false, license=odc-by
-    accessed: '2026-06-22'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 624b5da277d9cd123d13f058dcc8b0c305874e494a578970501389d82ffbfac3
+    establishes:
+    - availability
+    - documentation
+    - license
 adoption:
   level: 3
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 31,364 monthly downloads on Hugging Face, graded on the training-corpus bands.
+  note: 19,540 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
+    (allenai/WildChat-1M 19,540). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band
+    is >1M.
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/allenai/WildChat-1M
-    shows: downloads field = 31,364 (30-day)
-    accessed: '2026-07-04'
+    shows: 19,540 downloads in the trailing 30 days for allenai/WildChat-1M
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 624b5da277d9cd123d13f058dcc8b0c305874e494a578970501389d82ffbfac3
 capability:
   score: 4
   basis: training_value
   basis_detail: downstream
   value: null
   confidence: medium
-  note: A sustained cross-recipe SFT ingredient (Tulu 3 2024, OLMo 3 Dolci 2025), but its own ablation
-    is weak/dated and it does not lead comparisons.
+  note: 'A sustained cross-recipe SFT ingredient (Tulu 3 2024, OLMo 3 Dolci 2025), but its own ablation
+    is weak/dated and it does not lead comparisons. Re-read 2026-08-13: the Tulu 3 SFT mixture card still
+    names WildChat as a source, and the WildChat paper still reports only its own modest 2023-baseline ablation.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/allenai/tulu-3-sft-mixture
     shows: Named source in the Tulu 3 SFT mixture
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 579445329317f747a4780e6e767577245dca7492ec5911d20cb1f7eb63f33995
   - url: https://arxiv.org/html/2405.01470v1
     shows: WildChat's own ablation (WildLlama) is modest vs 2023 baselines
-    accessed: '2026-07-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 673942fb1e21beb2ea649975a21771b9da226b6e01ac80d6996e62e3816a3e8b

--- a/tests/test_score_notes.py
+++ b/tests/test_score_notes.py
@@ -44,7 +44,6 @@ KNOWN_SHARED_NOTES = {
     "jamba-large",
     "llama",
     "llama-instruct",
-    "personahub",
     "tulu",
 }
 


### PR DESCRIPTION
**144 of 149 closed** — the largest single pass so far. All 117 cited URLs fetched through `build.fetch_source`; every re-dated source carries a real digest, and openness sources gained per-dimension `establishes`.

Eleven same-category capability comparisons that existed only in prose are now recorded as `relative_to` + `relation`, all arithmetically checked. Corpus-wide recorded comparisons: 36 → 47.

## Three level moves, escalated not applied

All three are the same shape — a stale figure now crossed a band boundary on the product's **already-declared** artifact:

| product | figure | recorded | recommended |
|---|---|---|---|
| `openthoughts-114k` | 107,269 (was 73,774) | 3 | **4** / `100K-1M` |
| `synth` | 10,111 (was 6,105) | 2 | **3** / `10K-100K` |
| `the-pile` | 13,360 (was 9,980) | 2 | **3** / `10K-100K` |

`synth` and `the-pile` clear their boundaries by 1% and 34% respectively, so both deserve a look at whether the crossing is real growth or noise before applying.

## Two axes refused

**`aya-collection` capability** — the cited blog no longer contains the "76.6% win-rate" figure or any Qwen 2.5 comparison. It now reports win rates of 60.4–70.6% against a different comparison set. The band of 4 still holds on the live evidence; the note and `shows` need correcting, and the second source is a Medium blog that 403s on every retry.

**`oasst1` capability** — `shows` claims "Guanaco/QLoRA fine-tuned on OASST1", but the cited arXiv **abstract** never mentions OASST1. The PDF does, twice: *"a 9k sample dataset (OASST1) outperformed a 450k sample dataset (FLAN v2…)"*. Repoint the URL to the PDF; the band is unaffected.

## A systemic citation problem worth a decision

**Ten arXiv `/abs/` sources were credited with figures that live only in the paper body.** The abstract page genuinely doesn't carry them. All ten `shows` were rewritten to state the abstract's own content and say where the figure actually lives — but the underlying question is whether `/abs` or `/pdf` is this corpus's citation convention. Right now it's neither consistently, and `/abs` cannot support most of what's cited to it.

Six other `shows` described figures their page doesn't carry: `personahub`'s Tulu 3 card says 149,960 examples built by expanding Ge et al.'s persona method, not "~250K PersonaHub personas"; the OLMoE-mix card documents only its own mix, not the TinyLlama/Granite/ALIA/Marin list credited to it; TxT360's card now says ~5T deduplicated tokens, not 5.7T, and the repo has moved to `IFM/TxT360`.

## One file outside the category

`tests/test_score_notes.py` — `personahub` removed from `KNOWN_SHARED_NOTES`. **Its adoption note was the openness note verbatim** — a second instance of the copy-paste defect, beyond the capability one fixed this morning — and rewriting the adoption note resolved it, which the staleness assertion then correctly failed on. That test was written this morning to make exactly this a one-line deletion, and it worked as designed.

All gates green: `validate` 0 errors, `check_verification` all three OK, `check_capability` OK (47 comparisons), `check_adoption --strict` exit 0, 488 tests.