### PR TITLE
Verify evaluation_code: 103/104 axes

### DIFF
--- a/sources/products/alpacaeval.yaml
+++ b/sources/products/alpacaeval.yaml
@@ -6,4 +6,6 @@ description: 'Automatic LLM-judge evaluator for instruction-following models: an
   a length-controlled win-rate to debias for output length (raising correlation with Chatbot Arena to ~0.98).'
 github:
 - url: https://github.com/tatsu-lab/alpaca_eval
-comments: Apache-2.0. ~2k stars. A full eval runs in ~5 min for under ~$10.
+comments: Apache-2.0 (single LICENSE file; the README's CC-BY-NC data badge links to the sibling alpaca_farm
+  repo, not to anything here). ~2k stars, last pushed Aug 2025. A full eval runs in ~5 min for under ~$10.
+  Verified live 2026-08-13 via primary sources.

--- a/sources/products/amazon-bedrock-evaluations.yaml
+++ b/sources/products/amazon-bedrock-evaluations.yaml
@@ -12,4 +12,4 @@ description: 'Managed evaluation service inside Amazon Bedrock for scoring found
 comments: AWS managed evaluation feature within Amazon Bedrock; model eval (LLM-as-a-judge, programmatic
   incl BERTScore/F1, human), RAG eval (retrieval + retrieve-and-generate). RAG eval + LLM-as-a-judge GA
   2025-03-20 (preview at re:Invent Dec 2024); 'bring your own inference responses' supports external/on-prem
-  models. Verified live June 2026.
+  models. Verified live 2026-08-13 via primary sources.

--- a/sources/products/artificial-analysis-intelligence-index.yaml
+++ b/sources/products/artificial-analysis-intelligence-index.yaml
@@ -1,12 +1,14 @@
 name: artificial-analysis-intelligence-index
 display_name: Artificial Analysis Intelligence Index
 type: software
-description: 'Independent benchmarking service that runs 10+ academic and agentic evals (MMLU, GPQA, long-context,
-  etc.) against every major model and publishes the Intelligence Index, a composite score with 95% CIs. Picked
+description: 'Independent benchmarking service that runs nine academic and agentic evals (GPQA Diamond,
+  long-context, terminal and agent tasks) against every major model and publishes the Intelligence Index,
+  a composite score with 95% CIs. Picked
   as a neutral third-party leaderboard for model selection: Index v3 covers 300+ models across 100+ providers.
   Raised a seed round via the Nat Friedman / Daniel Gross AIGrant program.'
-comments: Artificial Analysis Intelligence Index v4.0.4 (March 2026). Composite of 10 evals (GDPval-AA,
-  tau2-Bench Telecom, Terminal-Bench Hard, SciCode, AA-LCR, AA-Omniscience, IFBench, Humanity's Last Exam,
-  GPQA Diamond, CritPt) in 4 equal-weighted categories. Independent third-party benchmarking platform
-  with published methodology; partial OSS (Stirrup agent harness, MIT, used for GDPval-AA) but the Index
-  pipeline + internal dataset copies are proprietary. Confirmed live June 2026.
+comments: Artificial Analysis Intelligence Index v4.1.1. Composite of 9 evals (GDPval-AA v2, tau-cubed
+  Banking, Terminal-Bench v2.1, SciCode, AA-LCR, AA-Omniscience, Humanity's Last Exam, GPQA Diamond, CritPt)
+  across four weighted categories - Agents 34%, Coding 24%, Scientific Reasoning 24%, General 18%. Independent
+  third-party benchmarking platform with published methodology; partial OSS (Stirrup agent harness, MIT,
+  behind GDPval-AA v2, AA-Briefcase and Harvey LAB-AA) but the Index pipeline + internal dataset copies
+  are proprietary. Verified live 2026-08-13 via primary sources.

--- a/sources/products/bigcodebench.yaml
+++ b/sources/products/bigcodebench.yaml
@@ -10,6 +10,8 @@ github:
 - url: https://github.com/bigcode-project/bigcodebench
 - url: https://github.com/bigcode-project/bigcode-evaluation-harness
 comments: 'BigCodeBench v0.2.4 (Mar 2 2025); 1140 software-engineering programming tasks (Complete + Instruct
-  splits); active HF leaderboard, 163 models evaluated. Confirmed live June 2026. Borderline: it is primarily
+  splits); active HF leaderboard, 163 models evaluated. Verified live 2026-08-13 via primary sources; the
+  harness repo has since been archived read-only (last push 2026-01-03) while bigcode-evaluation-harness
+  stays open. Borderline: it is primarily
   a single benchmark+its harness; the dataset itself maps to benchmark_eval_data, but the runnable harness
   fits here.'

--- a/sources/products/chatbot-arena.yaml
+++ b/sources/products/chatbot-arena.yaml
@@ -1,12 +1,13 @@
 name: chatbot-arena
 display_name: Chatbot Arena
 type: software
-description: Hosted human-preference LLM evaluation platform; rebranded LMSYS Chatbot Arena -> LMArena
-  -> Arena (arena.ai; lmarena.ai 301-redirects to arena.ai as of June 2026). The PRODUCT is the hosted
-  leaderboard/battle platform (closed). Its historical OSS code is FastChat (Apache-2.0) but stale (v0.2.36,
-  Feb 2024); auxiliary OSS eval tooling Arena-Hard-Auto (Apache-2.0) is maintained. Confirmed live June
-  2026.
+description: Hosted arena that ranks language models on blind pairwise human preference, converting crowd
+  votes into an Elo-style leaderboard that vendors cite in launch posts. Where a harness scores a model
+  against fixed tasks, this scores it against another model as judged by whoever is at the keyboard.
+  The platform itself is closed; its historical implementation, FastChat, and an automatic-judge companion,
+  Arena-Hard-Auto, are both Apache-2.0.
 comments: Hosted human-preference LLM evaluation platform; rebranded LMSYS Chatbot Arena -> LMArena ->
-  Arena (arena.ai; lmarena.ai 301-redirects to arena.ai as of June 2026). The PRODUCT is the hosted leaderboard/battle
+  Arena (arena.ai; lmarena.ai 301-redirects to arena.ai). The PRODUCT is the hosted leaderboard/battle
   platform (closed). Its historical OSS code is FastChat (Apache-2.0) but stale (v0.2.36, Feb 2024); auxiliary
-  OSS eval tooling Arena-Hard-Auto (Apache-2.0) is maintained. Confirmed live June 2026.
+  OSS eval tooling Arena-Hard-Auto (Apache-2.0) reached v2.0 in Apr 2025 and has not been pushed since
+  Jun 2025. Verified live 2026-08-13 via primary sources.

--- a/sources/products/compar-ia.yaml
+++ b/sources/products/compar-ia.yaml
@@ -8,5 +8,6 @@ description: Compar:IA is an open source LLM comparison 'arena' created by the F
   French) human-preference and alignment datasets; it is self-hostable.
 github:
 - url: https://github.com/betagouv/ComparIA
-comments: Verified live 2026-06-22 via primary sources. Permissive OSI license with full public source
-  code.
+comments: Verified live 2026-08-13 via primary sources. Permissive OSI license with full public source
+  code. The README now reports over 700,000 conversations and 250,000 votes, and a second instance,
+  AI-arenaen, running in Denmark.

--- a/sources/products/deepeval.yaml
+++ b/sources/products/deepeval.yaml
@@ -3,11 +3,11 @@ display_name: DeepEval
 type: software
 description: Pytest-style evaluation framework for LLM apps with 40+ built-in metrics including G-Eval,
   hallucination, faithfulness and RAG-specific scores. Picked for CI/CD integration; drops into existing
-  test suites and gates merges on metric thresholds. 15.6k stars, 263 contributors, 561 commits in last
-  90 days, the most active open source eval framework on GitHub.
+  test suites and gates merges on metric thresholds. 17.6k stars and 1.8k forks, still one of the most
+  actively committed open source eval frameworks on GitHub.
 github:
 - url: https://github.com/confident-ai/deepeval
 pypi:
 - url: https://pypi.org/project/deepeval
 comments: DeepEval v4.0.5 ('Opus 4.8 Day-0 Support', May 28 2026). OSS eval framework (Apache-2.0) with
-  commercial Confident AI cloud platform. Confirmed live June 2026.
+  commercial Confident AI cloud platform. Verified live 2026-08-13 via primary sources.

--- a/sources/products/epoch-ai-benchmarks.yaml
+++ b/sources/products/epoch-ai-benchmarks.yaml
@@ -6,7 +6,9 @@ description: Independent benchmarking lab that runs and maintains canonical lead
   Picked when researchers want the authoritative scoreboard for a specific benchmark; Epoch's SWE-bench
   Verified leaderboard is the one frontier labs reference in announcements. Funded by Open Philanthropy
   and lab partners.
-comments: Epoch AI benchmark database + public dashboard scoring frontier models on hard tasks (FrontierMath,
-  GPQA Diamond, SWE-bench Verified, SimpleQA Verified, MATH Level 5, OTIS Mock AIME, Chess Puzzles). Verified
-  live June 2026; org github.com/epoch-research has MIT/Apache eval repos (SWE-bench docker registry,
-  eci-public, MirrorCode-data), but FrontierMath dataset is held private.
+comments: Epoch AI benchmark database + public dashboard scoring frontier models on hard tasks (FrontierMath
+  Tiers 1-3 and Tier 4, GPQA Diamond, SWE-bench Verified, MirrorCode, SimpleQA Verified, MATH Level 5,
+  OTIS Mock AIME, Chess Puzzles, EBR-bench, Mystery Game Puzzles). Verified live 2026-08-13 via primary
+  sources; org github.com/epoch-research has 33 public repos with MIT/Apache eval components (SWE-bench
+  docker registry, eci-public, MirrorCode), but no unified harness and the FrontierMath problems are held
+  private.

--- a/sources/products/helm.yaml
+++ b/sources/products/helm.yaml
@@ -4,13 +4,13 @@ type: software
 description: Holistic Evaluation of Language Models, Python framework for reproducible, transparent evaluation
   of foundation models including LLMs and multimodal models, organized around scenarios, adapters, and
   metrics. Picked for academic-grade reproducibility and breadth (accuracy, robustness, fairness, bias,
-  toxicity). 2.8k stars, 128 contributors, 151 commits in last 90 days; Stanford has announced HELM will
-  enter maintenance mode June 2026.
+  toxicity). 2.9k stars; HELM entered maintenance mode on 1 June 2026, so the leaderboards keep running
+  while the framework stops gaining features.
 github:
 - url: https://github.com/stanford-crfm/helm
 pypi:
 - url: https://pypi.org/project/crfm-helm
-comments: 'stanford-crfm/helm, v0.5.16 (released 30 Apr 2026), Apache-2.0, ~2.8k stars. Standardized holistic
+comments: 'stanford-crfm/helm, v0.5.16 (released 30 Apr 2026), Apache-2.0, 2.9k stars. Standardized holistic
   evaluation framework + public leaderboards: HELM Capabilities, HELM Safety, VHELM (vision-language),
-  HEIM (text-to-image), MedHELM, audio-LM, enterprise benchmarks; supports MMLU-Pro, GPQA, IFEval, WildBench.
-  Confirmed live June 2026.'
+  HEIM (text-to-image), MedHELM, audio-LM, ToRR, enterprise benchmarks; supports MMLU-Pro, GPQA, IFEval,
+  WildBench. Verified live 2026-08-13 via primary sources; in maintenance mode since 1 June 2026.'

--- a/sources/products/inspect-ai.yaml
+++ b/sources/products/inspect-ai.yaml
@@ -4,11 +4,11 @@ type: software
 description: Frontier-AI evaluation framework with one interface over OpenAI, Anthropic, Google, xAI,
   Bedrock and local vLLM/Ollama backends, plus a collection of 200+ pre-built evals (Inspect Evals) co-maintained
   with Arcadia Impact and the Vector Institute. Picked by AISI, EU AI Office, and many frontier labs as
-  the standard for safety/dangerous-capability evaluations. 2.1k stars but extremely active, 1,333 commits
-  in last 90 days, 227 contributors.
+  the standard for safety/dangerous-capability evaluations. 2.5k stars but extremely active, with commits
+  landing daily.
 github:
 - url: https://github.com/UKGovernmentBEIS/inspect_ai
-comments: 'UKGovernmentBEIS/inspect_ai (UK AI Security Institute + Meridian Labs), MIT, ~2.2k stars, ~5,886
-  commits, very actively developed. Framework for frontier LLM/agent evaluations: 200+ pre-built evals,
-  tool use, multi-turn, model-graded scoring, one interface over OpenAI/Anthropic/Google/xAI/Bedrock/Azure/local
-  vLLM/Ollama. Confirmed live June 2026.'
+comments: 'UKGovernmentBEIS/inspect_ai (UK AI Security Institute + Meridian Labs), MIT, 2.5k stars, very
+  actively developed. Framework for frontier LLM/agent evaluations: 200+ pre-built evals, tool use, multi-turn,
+  model-graded scoring, one interface over OpenAI/Anthropic/Google/xAI/Bedrock/Azure/local vLLM/Ollama.
+  Verified live 2026-08-13 via primary sources.'

--- a/sources/products/lighteval.yaml
+++ b/sources/products/lighteval.yaml
@@ -4,11 +4,11 @@ type: software
 description: Lightweight successor to the eval harness HF used internally; supports vLLM, transformers,
   TGI and OpenAI-compatible backends with a focus on speed and easy custom metric authoring. Picked when
   teams want a fast, hackable runner that integrates cleanly with the HF ecosystem (datasets, accelerate).
-  2.4k stars, 120 contributors, 17 commits in last 90 days; powers parts of the Open LLM Leaderboard v2.
+  2.5k stars and 1000+ shipped tasks; powers parts of the Open LLM Leaderboard v2.
 github:
 - url: https://github.com/huggingface/lighteval
 pypi:
 - url: https://pypi.org/project/lighteval
-comments: lighteval v0.13.0 (24 Nov 2025), latest GitHub release; confirmed live on GitHub June 2026.
+comments: lighteval v0.13.0 (24 Nov 2025), latest GitHub release; Verified live 2026-08-13 via primary sources.
   All-in-one LLM eval toolkit from HF's Leaderboard & Evals team; powers the HF Open LLM Leaderboard.
   Columbia extension (model.code.evaluation) caveat applies.

--- a/sources/products/lm-evaluation-harness.yaml
+++ b/sources/products/lm-evaluation-harness.yaml
@@ -4,10 +4,10 @@ type: software
 description: Unified framework for evaluating language models on 200+ academic NLP benchmarks (MMLU, ARC,
   GSM8K, HellaSwag, etc.) with a single config-driven CLI. Picked as the canonical reference harness;
   it powers the Hugging Face Open LLM Leaderboard and is the standard tool for reporting reproducible
-  benchmark numbers in papers. 12.6k GitHub stars, 392 contributors, 58 commits in last 90 days.
+  benchmark numbers in papers. 13.6k GitHub stars and 3.5k forks; the repo is still receiving commits.
 github:
 - url: https://github.com/EleutherAI/lm-evaluation-harness
 pypi:
 - url: https://pypi.org/project/lm-eval
-comments: lm-eval v0.4.12 (May 11 2026); confirmed live June 2026. Backend for HuggingFace Open LLM Leaderboard.
+comments: lm-eval v0.4.12 (May 11 2026); Verified live 2026-08-13 via primary sources. Backend for HuggingFace Open LLM Leaderboard.
   The de-facto-standard model-eval harness.

--- a/sources/products/open-llm-leaderboard.yaml
+++ b/sources/products/open-llm-leaderboard.yaml
@@ -4,5 +4,6 @@ type: software
 description: Hugging Face's flagship public leaderboard for comparing open LLMs on a fixed, reproducible benchmark
   suite run on a shared cluster. v2 (2024) raised difficulty with IFEval, BBH, MATH-L5, GPQA, MuSR, and MMLU-Pro.
   It evaluated 13,000+ models and drew 2M+ visitors before being archived.
-comments: ARCHIVED/retired (announced 2025-03-13); HF redirected users to the OpenEvals hub. HF Space was Apache-2.0;
-  backend used lm-evaluation-harness (v1) and lighteval (v2). Listed for historical significance.
+comments: ARCHIVED/retired (announced 2025-03-13); HF redirected users to the OpenEvals hub. HF Space is Apache-2.0
+  and still public and running, at 14.1k likes; backend used lm-evaluation-harness (v1) and lighteval (v2).
+  Listed for historical significance. Verified live 2026-08-13 via primary sources.

--- a/sources/products/openai-evals-api-dashboard.yaml
+++ b/sources/products/openai-evals-api-dashboard.yaml
@@ -8,5 +8,5 @@ description: Managed evaluation product inside the OpenAI Platform, Evals API pl
 comments: 'Hosted, proprietary evaluation product on the OpenAI platform (API + web dashboard), distinct
   from the open source openai/evals repo. Lets developers define grading criteria, upload JSONL test sets,
   run against Chat Completions/Responses APIs, and inspect pass/fail + cost metrics. BEING SUNSET: dashboard
-  read-only 31 Oct 2026, full shutdown 30 Nov 2026 (OpenAI recommends Datasets as replacement). Confirmed
-  live June 2026 via OpenAI developer docs.'
+  read-only 31 Oct 2026, full shutdown 30 Nov 2026 (OpenAI recommends Datasets as replacement).
+  Verified live 2026-08-13 via OpenAI developer docs.'

--- a/sources/products/openai-evals.yaml
+++ b/sources/products/openai-evals.yaml
@@ -3,9 +3,9 @@ display_name: OpenAI Evals
 type: software
 description: Framework for evaluating LLMs and LLM systems plus a registry of community-contributed benchmarks,
   published as the original 2023 reference implementation for eval-driven development. Picked because
-  it is the canonical starting point referenced in OpenAI's own docs and many derivative harnesses. 18.5k
-  stars but development has effectively slowed (2 commits in last 90 days) as work migrated to the closed
-  OpenAI Dashboard Evals API.
-comments: openai/evals GitHub repo (MIT, 18.6k stars, ~691 commits). Open-source framework for evaluating
-  LLMs with a community benchmark registry. Confirmed live on GitHub June 2026; bundled eval datasets
-  carry their own per-dataset licenses (CC/Apache/CC0).
+  it is the canonical starting point referenced in OpenAI's own docs and many derivative harnesses. 19.2k
+  stars but development has effectively stopped - the repo has not been pushed since April 2026 - as work
+  migrated to the closed OpenAI Evals API, itself now on a sunset path.
+comments: openai/evals GitHub repo (MIT, 19.2k stars, 3.1k forks). Open-source framework for evaluating
+  LLMs with a community benchmark registry. Verified live 2026-08-13 via primary sources; bundled eval
+  datasets carry their own per-dataset licenses (CC/Apache/CC0), carved out in LICENSE.md.

--- a/sources/products/opencompass.yaml
+++ b/sources/products/opencompass.yaml
@@ -3,9 +3,9 @@ display_name: OpenCompass
 type: software
 description: Comprehensive evaluation platform supporting 100+ datasets across Llama, Mistral, GPT-4,
   Claude, Qwen, GLM and more, with subjective (arena-style) and objective scoring modes. Picked over lm-eval-harness
-  for Chinese-language and multimodal coverage; backed by Shanghai AI Lab and updated weekly. 7k+ GitHub
-  stars, 162 contributors, 25 commits in last 90 days.
+  for Chinese-language and multimodal coverage; backed by Shanghai AI Lab and updated weekly. 7.3k GitHub
+  stars and 837 forks, still receiving commits.
 github:
 - url: https://github.com/open-compass/opencompass
 comments: OpenCompass v0.5.2 (Feb 14 2026). 100+ datasets / 70+ with ~400k questions; 20+ HF models +
-  API models (OpenAI/Gemini/Claude). Confirmed live June 2026.
+  API models (OpenAI/Gemini/Claude). Verified live 2026-08-13 via primary sources.

--- a/sources/products/osworld.yaml
+++ b/sources/products/osworld.yaml
@@ -3,12 +3,13 @@ display_name: OSWorld
 type: software
 description: Scalable, real-computer environment for benchmarking multimodal agents on 369 open-ended tasks
   across Ubuntu, Windows and macOS; agents drive a virtual desktop and are scored by execution-based test scripts.
-  Picked because Claude Computer Use and OpenAI Operator both publish OSWorld scores. 2.9k stars, 86 contributors,
-  55 commits in last 90 days.
+  Picked because Claude Computer Use and OpenAI Operator both publish OSWorld scores. 3.1k stars, still
+  actively committed.
 github:
 - url: https://github.com/xlang-ai/OSWorld
 comments: 'OSWorld: scalable real-computer environment + execution-based evaluation harness for multimodal/computer-use
   agents (NeurIPS 2024). Apache-2.0. 369 tasks (361 excl. 8 problematic Google Drive tasks). De-facto
   standard for computer-use agents (GPT-5.4 75.0%, Claude Opus 4.6 72.7%, Claude Sonnet 4.6 72.5% on OSWorld-Verified
-  cited in 2026 releases). Confirmed live June 2026. Dual artifact: ships both the task set and the runner;
+  cited in 2026 releases). Verified live 2026-08-13 via primary sources; the project site os-world.github.io
+  now redirects to osworld-v1.xlang.ai. Dual artifact: ships both the task set and the runner;
   registry placed it in evaluation_code (the harness); note the dataset overlaps benchmark_eval_data.'

--- a/sources/products/patronus-evaluation-platform.yaml
+++ b/sources/products/patronus-evaluation-platform.yaml
@@ -8,4 +8,5 @@ description: Managed evaluation platform built around proprietary judge models, 
 comments: Patronus AI hosted GenAI evaluation/optimization platform ('Core Platform'); open source client
   SDKs (patronus-py, latest v0.1.25 Jan 2026; patronus-api-node) that connect to proprietary hosted infra.
   Built-in evaluators Lynx (hallucination), Glider; experiments, production monitoring/tracing, Percival,
-  RL Envs. Confirmed live June 2026.
+  RL Envs. Verified live 2026-08-13 via primary sources; the patronus-py SDK repo has not been pushed
+  since Jan 2026 and carries no license file.

--- a/sources/products/promptfoo.yaml
+++ b/sources/products/promptfoo.yaml
@@ -1,9 +1,13 @@
 name: promptfoo
 display_name: promptfoo
 type: software
-description: promptfoo v0.121.14 (Jun 2 2026). CLI + library for LLM eval and red-teaming; now part of
-  OpenAI but remains MIT-licensed open source. Confirmed live June 2026.
+description: Declarative CLI and Node library that tests prompts, agents and RAG pipelines from a YAML
+  config, comparing model outputs side by side and running the same assertions in CI. It also ships a
+  red-teaming mode that scans an application for jailbreaks and other vulnerabilities, which most eval
+  harnesses leave out. Promptfoo became part of OpenAI and remains MIT-licensed; the project reports 24.2k
+  GitHub stars.
 github:
 - url: https://github.com/promptfoo/promptfoo
 comments: promptfoo v0.121.14 (Jun 2 2026). CLI + library for LLM eval and red-teaming; now part of OpenAI
-  but remains MIT-licensed open source. Confirmed live June 2026.
+  but remains MIT-licensed open source. Distributed npm-first, so the PyPI package is a minority channel
+  and is deliberately not declared as an artifact. Verified live 2026-08-13 via primary sources.

--- a/sources/products/ragas.yaml
+++ b/sources/products/ragas.yaml
@@ -4,13 +4,14 @@ type: software
 description: Evaluation framework purpose-built for Retrieval-Augmented Generation pipelines with 30+
   metrics covering retrieval quality (context precision/recall), generation faithfulness, and answer relevance.
   Picked when the system under test is RAG; Ragas decomposes pipeline failure into retrieval vs. generation
-  buckets in a way general harnesses do not. 14k stars, 240 contributors.
+  buckets in a way general harnesses do not. 15.3k stars; the project now sits under the vibrantlabsai
+  GitHub org.
 github:
 - url: https://github.com/vibrantlabsai/ragas
 pypi:
 - url: https://pypi.org/project/ragas
-comments: 'explodinggradients/ragas, v0.4.3 (released 13 Jan 2026), Apache-2.0, ~14.2k stars. Toolkit
-  for evaluating LLM/RAG applications: LLM-based + traditional metrics, synthetic test-set generation,
-  LangChain/observability integrations. Confirmed live on GitHub + PyPI June 2026. Note: maintainer Exploding
-  Gradients also runs a commercial app.ragas.io cloud tier (open-core), though the core library is fully
-  OSI.'
+comments: 'vibrantlabsai/ragas (formerly explodinggradients/ragas), v0.4.3 (released 13 Jan 2026), Apache-2.0,
+  15.3k stars. Toolkit for evaluating LLM/RAG applications: LLM-based + traditional metrics, synthetic
+  test-set generation, LangChain/observability integrations. Verified live 2026-08-13 on GitHub + PyPI;
+  the repo has not been pushed since Feb 2026. Note: the maintainer also runs a commercial app.ragas.io
+  cloud tier (open-core), though the core library is fully OSI.'

--- a/sources/products/scale-evaluation.yaml
+++ b/sources/products/scale-evaluation.yaml
@@ -9,4 +9,4 @@ description: Enterprise evaluation and red-teaming service combining expert huma
 comments: Scale AI 'Scale Evaluation' platform (the 'Evaluate AI' product line as of Oct 2025), part of
   Scale GenAI Platform. Proprietary hosted evaluation/monitoring with private SEAL benchmark datasets
   + expert human-eval workforce ('Trust Feedback Loop'). Public-facing SEAL Leaderboards + SEAL Showdown
-  (millions of real-world conversations across 100+ countries). Confirmed live 2025-2026.
+  (millions of real-world conversations across 100+ countries). Verified live 2026-08-13 via primary sources.

--- a/sources/products/simple-evals.yaml
+++ b/sources/products/simple-evals.yaml
@@ -3,11 +3,11 @@ display_name: simple-evals
 type: software
 description: OpenAI's lightweight reference harness used to produce the model cards for GPT-4o, o1, and
   successors. Includes MMLU, MATH, GPQA, MGSM, DROP, HumanEval and SimpleQA. Picked when researchers
-  want the exact numbers OpenAI reports rather than community variants. 4.5k stars, used as the authoritative
+  want the exact numbers OpenAI reports rather than community variants. 4.6k stars, used as the authoritative
   reproduction script for GPT scorecards.
 github:
 - url: https://github.com/openai/simple-evals
-comments: openai/simple-evals GitHub repo (MIT, ~4.5k stars). Lightweight zero-shot/CoT eval library bundling
+comments: openai/simple-evals GitHub repo (MIT, 4.6k stars). Lightweight zero-shot/CoT eval library bundling
   MMLU, MATH, GPQA, DROP, MGSM, HumanEval, SimpleQA, BrowseComp, HealthBench. DEPRECATED July 2025; no
   longer updated for new models/benchmarks; only HealthBench/BrowseComp/SimpleQA reference impls maintained.
-  Confirmed live (deprecated) June 2026.
+  Verified live 2026-08-13 via primary sources (still deprecated).

--- a/sources/products/simpleaudit.yaml
+++ b/sources/products/simpleaudit.yaml
@@ -7,5 +7,6 @@ description: SimpleAudit is a lightweight, local-first framework for multilingua
   healthcare, and epistemic (broken-premise) testing. It is a verified Digital Public Good.
 github:
 - url: https://github.com/kelkalot/simpleaudit
-comments: Verified live 2026-06-22 via primary sources. Permissive OSI (MIT) license with full public
-  source.
+comments: Verified live 2026-08-13 via primary sources. Permissive OSI (MIT) license with full public
+  source. The README has since added a validation section reporting AUROC 0.89-1.00 for separating safe
+  from unsafe targets, and a comparison against Petri.

--- a/sources/products/swe-bench.yaml
+++ b/sources/products/swe-bench.yaml
@@ -3,7 +3,7 @@ display_name: SWE-bench
 type: software
 description: 'Docker-based evaluation harness that benchmarks coding agents on 2,294 real GitHub issues from
   12 popular Python repositories, producing pass-rate scores against held-out tests. Picked because every frontier
-  lab (Anthropic, OpenAI, Google) reports SWE-bench Verified scores. ~5k stars on GitHub and Epoch AI maintains
+  lab (Anthropic, OpenAI, Google) reports SWE-bench Verified scores. 5.6k stars on GitHub and Epoch AI maintains
   an authoritative leaderboard. Note: OpenAI''s April 2026 audit flagged that 59.4% of the hardest unsolved
   problems in SWE-bench Verified had flawed test cases; they now prefer the harder SWE-bench Pro and SWE-bench
   Bash variants for frontier evaluation.'
@@ -12,5 +12,5 @@ github:
 pypi:
 - url: https://pypi.org/project/swebench
 comments: SWE-bench evaluation harness. PyPI `swebench` v4.1.0 (Sep 11 2025); repo migrated to github.com/SWE-bench/SWE-bench,
-  last headline feature SWE-bench Multimodal (Jan 2025). Confirmed live June 2026. Scoring the HARNESS
+  last headline feature SWE-bench Multimodal (Jan 2025). Verified live 2026-08-13 via primary sources. Scoring the HARNESS
   (the software that runs models against GitHub-issue tasks); the underlying dataset belongs in benchmark_eval_data.

--- a/sources/products/vals-ai.yaml
+++ b/sources/products/vals-ai.yaml
@@ -5,6 +5,9 @@ description: Domain-specialist benchmarking service that runs proprietary, held-
   law, software, and healthcare tasks, including a private Canadian-court-case QA benchmark and the Vals
   Index. Picked by enterprises that need closed/private benchmarks because public benchmarks suffer from
   contamination. Publishes a leaderboard of all major frontier models scored on these private sets.
-comments: Vals AI independent LLM evaluation platform; Vals Index + Vals Multimodal Index + domain benchmarks
-  (finance, law, healthcare, coding, math, tax). Verified live June 2026 (leaderboard updated 2026-06-04,
-  includes Claude Opus 4.8, Qwen 3.7 Plus, MiniMax M3). SaaS-only, no public source repo.
+comments: Vals AI independent LLM evaluation platform; Vals Index + RSI Index + Vals Multimodal Index
+  + domain benchmarks (finance, law, healthcare, coding, math, education, cybersecurity, games).
+  Verified live 2026-08-13 via primary sources - 43 models tested, several results dated the same day. The evaluation
+  service itself is SaaS-only, but Vals has since open-sourced two supporting repos, Valkyrie (AGPL-3.0,
+  agentic-benchmark runner) and model-library (MIT); the openness score has not yet been reconciled with
+  that.

--- a/sources/products/vertex-ai-gen-ai-evaluation-service.yaml
+++ b/sources/products/vertex-ai-gen-ai-evaluation-service.yaml
@@ -12,4 +12,5 @@ description: 'Managed evaluation service on Vertex AI (now part of Gemini Enterp
   applications.'
 comments: Google Cloud Vertex AI managed Gen AI evaluation service; evaluates models, agents, and RAG.
   Computation-based metrics, model-based/autorater (managed rubric-based + custom judge models), pointwise
-  + pairwise (AutoSxS). Part of Gemini Enterprise Agent Platform. Verified live June 2026 (docs current).
+  + pairwise (AutoSxS). Part of Gemini Enterprise Agent Platform. Verified live 2026-08-13 via primary
+  sources (docs current).

--- a/sources/scores/alpacaeval.yaml
+++ b/sources/scores/alpacaeval.yaml
@@ -13,12 +13,37 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: Fully Apache-2.0.
+  last_verified: '2026-08-13'
+  note: Fully Apache-2.0. Re-read 2026-08-13 - the license endpoint reports Apache-2.0 against a single
+    LICENSE file, and a directory listing of the repo shows no DATA_LICENSE beside it. Worth recording
+    because the README's header carries a 'Data License CC By NC 4.0' badge, but both badges link to
+    the sibling tatsu-lab/alpaca_farm repo rather than to anything in this one, so the NC term is not
+    a license this product makes you accept. The README installs and runs the whole evaluator locally
+    with no paid tier.
   raw: license:Apache-2.0(OSI);source:public;no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://github.com/tatsu-lab/alpaca_eval
     shows: Apache-2.0, ~2.0k stars
     accessed: '2026-06-17'
+  - url: https://api.github.com/repos/tatsu-lab/alpaca_eval/license
+    shows: GitHub's license endpoint reports spdx_id Apache-2.0 for tatsu-lab/alpaca_eval at path LICENSE,
+      and returns the Apache-2.0 body. The repo's root listing carries no second license file.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 52ed013ccd784fedadc9da5bd63d1542e5756f7807f18cec89ac95fde733ac2b
+    establishes:
+    - license
+  - url: https://raw.githubusercontent.com/tatsu-lab/alpaca_eval/main/README.md
+    shows: README installs the evaluator with `pip install alpaca-eval` or straight from the git repo
+      and runs it against the reader's own model outputs, printing a leaderboard locally; the annotator
+      configs and reference outputs ship in the package. The only external cost named is the reader's
+      own OpenAI credits, roughly $10 a run. No paid tier, hosted edition or license key appears in it.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 27576663fb6f13adf5b3adea8d7840f47ffe366fca74177fe6aac92e8b6ff11c
+    establishes:
+    - source
+    - core-gated
 adoption:
   level: 2
   signal_type: stars_fallback
@@ -40,8 +65,19 @@ capability:
   basis: feature_matrix
   value: LLM-as-judge win-rate; length-controlled metric; reference-model comparison; leaderboard
   confidence: medium
+  last_verified: '2026-08-13'
   note: De-facto standard for its niche with an influential LC metric; narrower than multi-task harnesses.
+    Feature matrix re-read 2026-08-13 and unchanged - length-controlled win rates are still the default,
+    the reference-model comparison and leaderboard are still there. No `relative_to` is recorded because
+    the note names no peer, only a class of harness.
   sources:
   - url: https://github.com/tatsu-lab/alpaca_eval
     shows: AlpacaEval 2.0 LC win-rate
     accessed: '2026-06-17'
+  - url: https://raw.githubusercontent.com/tatsu-lab/alpaca_eval/main/README.md
+    shows: '''Length-controlled Win Rates are out and used by default'', raising correlation with Chatbot
+      Arena from 0.93 to 0.98; LLM-as-judge auto-annotator against a reference baseline, plus a public
+      leaderboard and tooling for building and analyzing new automatic evaluators.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 27576663fb6f13adf5b3adea8d7840f47ffe366fca74177fe6aac92e8b6ff11c

--- a/sources/scores/amazon-bedrock-evaluations.yaml
+++ b/sources/scores/amazon-bedrock-evaluations.yaml
@@ -15,7 +15,10 @@ openness:
       value: pay-as-you-go
       detail: judge-model inference + AWS-managed human workforce
   confidence: high
+  last_verified: '2026-08-13'
   note: Proprietary AWS managed service; no source, no self-host, runs as billed Bedrock evaluation jobs.
+    Re-read 2026-08-13 - the product page still offers only AWS-hosted evaluation jobs with a link to
+    Bedrock pricing, mentions no source code and no self-host option, and offers no license to anything.
   raw: license:proprietary(AWS managed service);source:closed;deployment:cloud-only(AWS-hosted eval jobs,
     S3 I/O);billing:pay-as-you-go(judge-model inference + AWS-managed human workforce)
   sources:
@@ -26,18 +29,43 @@ openness:
   - url: https://aws.amazon.com/bedrock/evaluations/
     shows: AWS-hosted feature, AWS-managed human evaluator workforce option, directs to pricing page
     accessed: '2026-06-04'
+  - url: https://aws.amazon.com/bedrock/evaluations/
+    shows: 'Re-read 2026-08-13: an AWS-hosted evaluation capability inside Amazon Bedrock, offering LLM-as-a-Judge,
+      programmatic and human evaluation, with AWS able to ''engage a team managed by AWS to perform the
+      human evaluation''. The page links to Bedrock pricing. No source code, repository or self-host option
+      is mentioned anywhere on it, and no license is offered.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 497a0b9715a40cf67566a85976e07341a9a1c944621d678bd70c463be217b863
+    establishes:
+    - source
+    - license
 adoption:
   level: 3
   signal_type: reported_traction
   confidence: low
+  last_verified: '2026-08-13'
   note: GA since 2025-03-20 and distributed inside Amazon Bedrock (a large enterprise AI surface), but
     AWS publishes no standalone usage count for the Evaluations feature specifically. Level 3 = reported
     traction via the Bedrock platform footprint, not a measured figure; low confidence because the signal
-    is the parent surface, not the feature. No stars fallback (closed service).
+    is the parent surface, not the feature. No stars fallback (closed service). Re-read 2026-08-13 - looked
+    on both the GA post and the product page for an evaluation-job count, a customer count or any usage
+    statistic and found none, so the level's basis is unchanged.
   sources:
   - url: https://aws.amazon.com/blogs/machine-learning/evaluate-models-or-rag-systems-using-amazon-bedrock-evaluations-now-generally-available/
     shows: GA announcement (2025-03-20) of model + RAG evaluations as a broadly available Bedrock feature
     accessed: '2026-06-04'
+  - url: https://aws.amazon.com/blogs/machine-learning/evaluate-models-or-rag-systems-using-amazon-bedrock-evaluations-now-generally-available/
+    shows: 'Re-read 2026-08-13: the GA announcement for model and RAG evaluations is still published and
+      still carries no usage, customer or job-count figure.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5dc48da40f91c8b507c404bbe1f85f434c9afd8ede884216e6b57512636f92e5
+  - url: https://aws.amazon.com/bedrock/evaluations/
+    shows: 'Re-read 2026-08-13: no published usage or customer count for the Evaluations feature.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 497a0b9715a40cf67566a85976e07341a9a1c944621d678bd70c463be217b863
 capability:
   score: 4
   basis: feature_matrix
@@ -46,14 +74,28 @@ capability:
     UX (helpfulness/coherence/relevance), instruction-compliance, safety (harmfulness/stereotyping/refusal);
     model-backend breadth = Bedrock + external/on-prem via BYO responses.'
   confidence: medium
+  last_verified: '2026-08-13'
   note: Broad managed eval suite covering model + RAG + agent, judge/programmatic/human modes, and four
     metric families with BYO-responses portability. Comprehensive but a custom-dataset eval product, not
-    a standardized public benchmark leaderboard; placed at 4.
+    a standardized public benchmark leaderboard; placed at 4. Feature matrix re-read 2026-08-13 and unchanged.
   sources:
   - url: https://aws.amazon.com/bedrock/evaluations/
     shows: model eval (LLM-as-judge/programmatic/human) + RAG eval (retrieval, retrieve-and-generate)
       with safety/quality metrics
     accessed: '2026-06-04'
+  - url: https://aws.amazon.com/bedrock/evaluations/
+    shows: 'Re-read 2026-08-13: LLM-as-a-Judge over custom prompt datasets, programmatic metrics including
+      BERTScore and F1, human evaluation with your own or an AWS-managed workforce, and both retrieval
+      and retrieve-and-generate RAG evaluation.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 497a0b9715a40cf67566a85976e07341a9a1c944621d678bd70c463be217b863
+  - url: https://aws.amazon.com/blogs/machine-learning/evaluate-models-or-rag-systems-using-amazon-bedrock-evaluations-now-generally-available/
+    shows: 'Re-read 2026-08-13: the four metric areas (quality, user experience, instruction compliance,
+      safety) and the citation precision and coverage metrics are still documented.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5dc48da40f91c8b507c404bbe1f85f434c9afd8ede884216e6b57512636f92e5
   - url: https://aws.amazon.com/blogs/machine-learning/evaluate-models-or-rag-systems-using-amazon-bedrock-evaluations-now-generally-available/
     shows: four metric areas (quality/UX/instruction-compliance/safety) and citation precision/coverage
       metrics

--- a/sources/scores/artificial-analysis-intelligence-index.yaml
+++ b/sources/scores/artificial-analysis-intelligence-index.yaml
@@ -21,6 +21,7 @@ openness:
     free_text:
     - the full Intelligence Index harness is not open
   confidence: high
+  last_verified: '2026-08-13'
   note: 'Methodology is well documented and one component harness (Stirrup) is MIT, but the Index itself
     (pipeline, internal dataset copies, grader config) is proprietary. The earlier note reasoned "not source_available
     since the core isn''t published", which reads source_available as a stronger claim than this ladder
@@ -28,7 +29,13 @@ openness:
     of ten evals. Class corrected from open_core on 2026-07-30. In this ladder open_core means an OSI core
     with functionality withheld for a paid tier, and there is no open core here, only an open periphery.
     A repo that exists while the runtime does not ship is source:partial, which the ladder scores 2/source_available.
-    The score itself was already 2.'
+    The score itself was already 2. Re-read 2026-08-13 and the dimension holds, but two recorded details
+    have gone stale and should be corrected in a components edit. The methodology page is now v4.1.1 with
+    NINE evals rather than ten, and the four categories are no longer equally weighted (Agents 34%, Coding
+    24%, Scientific Reasoning 24%, General 18%). Stirrup now backs more than one eval - GDPval-AA v2, AA-Briefcase
+    and Harvey LAB-AA - so ''covers one of ten evals'' understates it. Neither change touches `source`:
+    Artificial Analysis still states ''We maintain internal copies of all evaluation datasets'' and still
+    publishes no end-to-end Index pipeline, so a repo exists while the runtime does not ship.'
   raw: platform:closed(proprietary benchmarking site + methodology); source:partial(Stirrup covers one of
     ten evals; the Index pipeline does not ship); methodology:documented(public methodology page, per-eval
     breakdown, temp/token params); datasets:closed(maintains internal copies of all eval datasets); harness:partial-open(Stirrup
@@ -42,15 +49,37 @@ openness:
   - url: https://github.com/ArtificialAnalysis/Stirrup
     shows: Stirrup MIT-licensed agent harness, 413 stars (the only open component)
     accessed: '2026-06-04'
+  - url: https://artificialanalysis.ai/methodology/intelligence-benchmarking
+    shows: 'Re-read 2026-08-13. Intelligence Index v4.1.1, nine evals across four unequally weighted categories
+      - Agents 34%, Coding 24%, Scientific Reasoning 24%, General 18% - namely GDPval-AA v2, tau-cubed
+      Banking, Terminal-Bench v2.1, SciCode, AA-LCR, AA-Omniscience, Humanity''s Last Exam, GPQA Diamond
+      and CritPt. ''We maintain internal copies of all evaluation datasets''. Stirrup is named as ''our
+      open source agentic harness'' for GDPval-AA v2, AA-Briefcase and Harvey LAB-AA. The Index pipeline
+      itself is not published.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 28dbab4467e0dcf4f509bfb51f365af7f28526b02ca02fae9e86e7689e9bd521
+    establishes:
+    - source
+  - url: https://api.github.com/repos/ArtificialAnalysis/Stirrup/license
+    shows: GitHub's license endpoint reports spdx_id MIT for ArtificialAnalysis/Stirrup - the one open
+      component - and returns the MIT text as the LICENSE body. 546 stars.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b12e30fb50593e509e2cdf8b84a1b1b606ae70afd8bc0ae9ba9aa5827ec1d569
+    establishes:
+    - source
 adoption:
   level: 4
   signal_type: reported_traction
   confidence: medium
+  last_verified: '2026-08-13'
   note: The AA Intelligence Index is one of the most-cited independent model-ranking standards in frontier
     release coverage and the flagship_scores set itself uses it as a capability basis (e.g. Grok 4.20,
     Gemini 3.5 Flash records). Widely referenced across vendor launches and tech press as the go-to cross-model
     index. No disclosed unique-visitor count; level 4 reflects its standard-citation reach across the
-    industry, banded conservatively. Directional.
+    industry, banded conservatively. Directional. Re-read 2026-08-13 - the live Index is still running
+    and still publishes no visitor, subscriber or API-usage figure, so the basis of the level is unchanged.
   sources:
   - url: https://artificialanalysis.ai/
     shows: live Intelligence Index leaderboard positioned as the cross-model standard reference
@@ -58,18 +87,35 @@ adoption:
   - url: https://artificialanalysis.ai/methodology/intelligence-benchmarking
     shows: independent standardized index cited as the reference methodology
     accessed: '2026-06-04'
+  - url: https://artificialanalysis.ai/
+    shows: 'Re-read 2026-08-13: the live cross-model Intelligence Index leaderboard is still published
+      and still carries no unique-visitor, subscriber or usage count.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e718e2c4fbe94a1de20e00a9a37353d06ba75508ba735617100bb73bf2d68636
+  - url: https://artificialanalysis.ai/methodology/intelligence-benchmarking
+    shows: 'Re-read 2026-08-13: methodology v4.1.1, still published in full as the reference for the index.
+      No adoption or traffic figure appears on it.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 28dbab4467e0dcf4f509bfb51f365af7f28526b02ca02fae9e86e7689e9bd521
 capability:
   score: 4
   basis: feature_matrix
-  value: 'benchmark/task coverage: 10-eval composite across Agents/Coding/General/Scientific (GDPval-AA,
-    tau2-Telecom, Terminal-Bench Hard, SciCode, AA-LCR, AA-Omniscience, IFBench, HLE, GPQA Diamond, CritPt);
-    model-backend breadth: 150+ models scored independently; agentic-eval support: yes (GDPval-AA via
-    Stirrup, Terminal-Bench Hard, tau2); reproducibility: standardized params + internal dataset copies
-    (contamination-resistant) but not externally reproducible'
+  value: 'benchmark/task coverage: 9-eval composite (v4.1.1) across Agents/Coding/Scientific Reasoning/General
+    (GDPval-AA v2, tau-cubed Banking, Terminal-Bench v2.1, SciCode, AA-LCR, AA-Omniscience, HLE, GPQA
+    Diamond, CritPt); model-backend breadth: 150+ models scored independently; agentic-eval support: yes
+    (GDPval-AA v2 via Stirrup, Terminal-Bench, tau-cubed); reproducibility: standardized params + internal
+    dataset copies (contamination-resistant) but not externally reproducible'
   confidence: high
+  last_verified: '2026-08-13'
   note: 'Frontier-grade composite coverage spanning agentic/coding/general/scientific with contamination-resistant
     internal datasets and standardized running. Strong capability. Not a 5: it is a curated index/methodology
-    rather than an open community harness, and held-out/proprietary running limits external reproducibility.'
+    rather than an open community harness, and held-out/proprietary running limits external reproducibility.
+    Re-read 2026-08-13 and the band is unchanged, but the value was stale and is corrected here: the index
+    moved from v4.0.4 to v4.1.1, from ten evals to nine (IFBench dropped, tau2-Telecom replaced by tau-cubed
+    Banking, Terminal-Bench Hard by Terminal-Bench v2.1), and the four categories are now weighted 34/24/24/18
+    rather than equally.'
   sources:
   - url: https://artificialanalysis.ai/methodology/intelligence-benchmarking
     shows: 10-eval composite, 4 equal-weighted categories, standardized params, internal dataset copies
@@ -77,3 +123,11 @@ capability:
   - url: https://artificialanalysis.ai/
     shows: 150+ models ranked on the Intelligence Index
     accessed: '2026-06-04'
+  - url: https://artificialanalysis.ai/methodology/intelligence-benchmarking
+    shows: 'Intelligence Index v4.1.1: nine evals - GDPval-AA v2, tau-cubed Banking, Terminal-Bench v2.1,
+      SciCode, AA-LCR, AA-Omniscience, HLE, GPQA Diamond, CritPt - across Agents 34%, Coding 24%, Scientific
+      Reasoning 24%, General 18%. Standardized params and internal dataset copies; Stirrup is the open
+      agentic harness behind GDPval-AA v2, AA-Briefcase and Harvey LAB-AA.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 28dbab4467e0dcf4f509bfb51f365af7f28526b02ca02fae9e86e7689e9bd521

--- a/sources/scores/bigcodebench.yaml
+++ b/sources/scores/bigcodebench.yaml
@@ -15,7 +15,11 @@ openness:
     free_text:
     - execution harness + leaderboard public
   confidence: high
-  note: Apache-2.0, fully public; OSI -> open_source.
+  last_verified: '2026-08-13'
+  note: Apache-2.0, fully public; OSI -> open_source. Re-read 2026-08-13 - the license endpoint still
+    reports Apache-2.0 and the README still offers `--execution local`. The repo has since been ARCHIVED
+    (read-only, last push 2026-01-03), which freezes the source rather than withdrawing it, so both `source`
+    and `core-gated` are unchanged.
   raw: license:Apache-2.0(OSI);source:public(GitHub);execution harness + leaderboard public;core-gated:ungated(no
     paid tier or license key, harness runs locally with --execution local)
   sources:
@@ -36,6 +40,24 @@ openness:
     content_sha256: 4aa8cbfa3111e92db886583d554a3c9e8f14561d47261d6441c069835e3bdc28
     establishes:
     - core-gated
+  - url: https://api.github.com/repos/bigcode-project/bigcodebench/license
+    shows: GitHub's license endpoint reports spdx_id Apache-2.0 for bigcode-project/bigcodebench and returns
+      the Apache-2.0 text as the LICENSE body.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 3ba3f912356b99d0ec10ae73ccbea48484efd7c182db1f9feda26d0a56ffdf45
+    establishes:
+    - license
+  - url: https://raw.githubusercontent.com/bigcode-project/bigcodebench/main/README.md
+    shows: 'Re-read 2026-08-13: the evaluation command still declares `--execution [e2b|gradio|local]`,
+      so the harness still runs end to end on the reader''s own machine, and nothing in the README offers
+      a paid tier, a commercial edition or a license key.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 4aa8cbfa3111e92db886583d554a3c9e8f14561d47261d6441c069835e3bdc28
+    establishes:
+    - source
+    - core-gated
 adoption:
   level: 2
   reach: 1K-10K stars
@@ -46,8 +68,11 @@ adoption:
     capped at level 3, set to 2 on the modest star + leaderboard footprint. Stars read 2026-08-13: 1,573
     across the 2 declared repos, which bands at 1K-10K stars, level 2 on the stars scale in
     signal_routing.yaml. The previous reach ''10K-100K'' was not a label this instrument offers - stars have
-    their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile,
-    so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.'
+    their own vocabulary because a star is not a download. Re-read against the GitHub API for both declared
+    repos on 2026-08-13 - bigcodebench 519 stars and bigcode-evaluation-harness 1,054, 1,573 together, so
+    the band is unchanged. The bigcodebench repo is now archived and read-only (last push 2026-01-03),
+    which is a reason the star count will stop moving rather than a reason to move the level.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/bigcode-project/bigcodebench
     shows: 503 stars; leaderboard with 163 models
@@ -55,15 +80,38 @@ adoption:
   - url: https://huggingface.co/spaces/bigcode/bigcodebench-leaderboard
     shows: active leaderboard ranking evaluated models
     accessed: '2026-06-04'
+  - url: https://api.github.com/repos/bigcode-project/bigcodebench
+    shows: stargazers_count = 519, forks 75, archived = true, pushed_at 2026-01-03 for bigcode-project/bigcodebench
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: bebda17678b2d1c7f8b2deb692937ead3b4e73a135683940be4db6f947762561
+  - url: https://api.github.com/repos/bigcode-project/bigcode-evaluation-harness
+    shows: stargazers_count = 1,054, forks 261 for bigcode-project/bigcode-evaluation-harness, the second
+      declared repo
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: f36d7d39467a86266ac743ad9e39ac8eea1e94c8b7ec9ec7d1cd89aaf24fa1ed
 capability:
   score: 3
   basis: feature_matrix
   value: 1140 function-level code-gen tasks with diverse library calls + complex instructions; two splits
     (Complete/Instruct); execution-based scoring; single-domain (code generation) vs multi-benchmark harnesses
   confidence: medium
+  relative_to: opencompass
+  relation: one_below
+  last_verified: '2026-08-13'
   note: Solid, rigorous code-gen eval but single-benchmark scope -- below the broad multi-task harnesses
-    (lm-eval, OpenCompass) on coverage breadth.
+    (lm-eval, OpenCompass) on coverage breadth. Feature matrix re-read 2026-08-13 and unchanged - the
+    README still describes 1140 tasks and the Complete/Instruct splits. The peer comparison in that sentence
+    is now recorded structurally against OpenCompass, whose 4 sits one rung above this 3.
   sources:
   - url: https://github.com/bigcode-project/bigcodebench
     shows: 1140 tasks, Complete/Instruct splits, execution-based eval
     accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/bigcode-project/bigcodebench/main/README.md
+    shows: '''a new benchmark for code generation with 1140 software-engineering-oriented programming
+      tasks''; Complete and Instruct splits described; generation and execution-based grading run through
+      `--split [complete|instruct]`.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 4aa8cbfa3111e92db886583d554a3c9e8f14561d47261d6441c069835e3bdc28

--- a/sources/scores/chatbot-arena.yaml
+++ b/sources/scores/chatbot-arena.yaml
@@ -21,6 +21,7 @@ openness:
     free_text:
     - ranking methodology + crowd-vote dataset not fully open
   confidence: medium
+  last_verified: '2026-08-13'
   note: 'Scored as the hosted platform: the live evaluation product, its vote stream and the current ranking
     pipeline are closed, while substantial OSS heritage (FastChat) and an OSS automatic-eval companion (Arena-Hard-Auto)
     exist. The OSS code is stale relative to the operating platform, which is what makes this source_available
@@ -28,7 +29,10 @@ openness:
     from open_core on 2026-07-30. In this ladder open_core means an OSI core with functionality withheld
     for a paid tier, and there is no open core here, only an open periphery. A repo that exists while the
     runtime does not ship is source:partial, which the ladder scores 2/source_available. The score itself
-    was already 2.'
+    was already 2. Re-read 2026-08-13 and unchanged. FastChat still says it powers the arena and its newest
+    release is still v0.2.36 from February 2024, so the staleness the class rests on has widened rather
+    than closed. The hosted platform''s canonical domain is now arena.ai, with lmarena.ai redirecting
+    to it, and the ranking pipeline behind it still does not ship.'
   raw: platform:closed(hosted arena.ai, proprietary live leaderboard + private vote data); source:partial(FastChat
     is a real arena implementation but stale relative to the operating platform; the current ranking pipeline
     does not ship); reference-code:FastChat Apache-2.0 (powers Chatbot Arena but stale, last release Feb
@@ -46,15 +50,39 @@ openness:
     shows: hosted 'Official AI Ranking & LLM Leaderboard' with Battle Mode; conversations disclosed to
       providers (proprietary platform)
     accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/lm-sys/FastChat/main/README.md
+    shows: 'README still opens ''FastChat powers Chatbot Arena (lmarena.ai), serving over 10 million chat
+      requests for 70+ LLMs'' and documents launching an arena instance locally. Apache-2.0. The repo''s
+      newest release is v0.2.36, published 2024-02-11, so the published arena implementation is more than
+      two years behind the operating platform: a real implementation, not the running one.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: fba2bace33da09a922bfb8f2f49463f958c7cecfdb77a98a07c04e758a09b694
+    establishes:
+    - source
+  - url: https://arena.ai/
+    shows: 'Re-read 2026-08-13: still the hosted ranking and battle platform, and now the canonical domain
+      - lmarena.ai 301-redirects here. It offers no repository, no self-hostable ranking pipeline and
+      no license to the evaluation code, and states that conversations are disclosed to the relevant AI
+      providers.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 3961d21eeadc354e9fb8622a2371ea206f9a6b30f509892498a48f6fe0b443e0
+    establishes:
+    - source
 adoption:
   level: 4
   reach: 1M-10M
   signal_type: usage_volume
   confidence: medium
+  last_verified: '2026-08-13'
   note: FastChat README (primary) states Chatbot Arena has served 'over 10 million chat requests for 70+
     LLMs'; Arena Elo is the most-cited human-preference leaderboard in frontier model releases (LMArena
     Elo appears across vendor launch posts). Headline = the 10M+ chat-request figure (primary, FastChat
-    repo). Banded 1M-10M conservatively on request volume; could be higher cumulatively.
+    repo). Banded 1M-10M conservatively on request volume; could be higher cumulatively. Re-read 2026-08-13
+    - the FastChat README still carries the same 10M chat requests and 1.5M human votes figures, unchanged
+    since 2024, and the platform is still operating at arena.ai. The band is confirmed, and the figure
+    behind it is a frozen one, which is why it stays banded conservatively.
   sources:
   - url: https://github.com/lm-sys/FastChat
     shows: '''serving over 10 million chat requests for 70+ LLMs'''
@@ -62,6 +90,19 @@ adoption:
   - url: https://arena.ai/
     shows: hosted live leaderboard / battle platform in active operation June 2026
     accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/lm-sys/FastChat/main/README.md
+    shows: '''FastChat powers Chatbot Arena (lmarena.ai), serving over 10 million chat requests for 70+
+      LLMs'' and ''Chatbot Arena has collected over 1.5M human votes from side-by-side LLM battles''.
+      39.5k stars on the repo.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: fba2bace33da09a922bfb8f2f49463f958c7cecfdb77a98a07c04e758a09b694
+  - url: https://arena.ai/
+    shows: hosted live leaderboard and battle platform still in active operation 2026-08-13; no standalone
+      user or traffic figure is published on it.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 3961d21eeadc354e9fb8622a2371ea206f9a6b30f509892498a48f6fe0b443e0
 capability:
   score: 4
   basis: feature_matrix
@@ -70,9 +111,12 @@ capability:
     (preference-based, not task-execution); reproducibility: Arena-Hard-Auto provides an automatic-judge
     approximation'
   confidence: medium
+  last_verified: '2026-08-13'
   note: Reference platform for human-preference evaluation and the de-facto Elo standard cited everywhere;
     not a 5 because as eval CODE it is largely closed/hosted and narrower than execution-based harnesses
-    on agentic/task coverage. Capability assessed on its evaluation methodology breadth.
+    on agentic/task coverage. Capability assessed on its evaluation methodology breadth. Feature matrix
+    re-read 2026-08-13 and unchanged - Arena-Hard-Auto v2.0 still ships 500 hard queries plus 250 creative
+    writing ones with GPT-4.1 and Gemini-2.5 judges, and the hosted arena still runs blind pairwise battles.
   sources:
   - url: https://github.com/lmarena/arena-hard-auto
     shows: 500 SWE/math queries + 250 creative prompts, GPT-4.1/Gemini-2.5 judges, highest correlation
@@ -81,3 +125,11 @@ capability:
   - url: https://arena.ai/
     shows: battle-mode pairwise comparison across many models
     accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/lmarena/arena-hard-auto/main/README.md
+    shows: '''V2.0 contains 500 fresh, challenging real-world user queries ... and 250 creative writing
+      queries sourced from Chatbot Arena. We employs automatic judges, GPT-4.1 and Gemini-2.5''; the README
+      also claims the ''highest correlation and separability to LMArena ... among popular open-ended LLM
+      benchmarks''.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: f0563c344399179df0fb7abbb2503762b0446584ace78039f1f792058e0ab0dc

--- a/sources/scores/compar-ia.yaml
+++ b/sources/scores/compar-ia.yaml
@@ -14,7 +14,11 @@ openness:
     free_text:
     - self-hostable
   confidence: high
-  note: Permissive OSI license with full public source code.
+  last_verified: '2026-08-13'
+  note: Permissive OSI license with full public source code. Re-read 2026-08-13 - the LICENSE body is
+    still the Apache 2.0 text, and the README still bills the project as 'The open-source LLM arena.
+    Deploy it for your organisation, sector, or language', with Docker self-hosting instructions for the
+    whole platform and no paid tier to withhold anything for.
   raw: license:Apache-2.0(OSI; verified LICENSE body);source:public;self-hostable;core-gated:ungated(publicly
     funded, README documents full Docker self-hosting)
   sources:
@@ -38,6 +42,24 @@ openness:
     http_status: 200
     content_sha256: cc2e4c8623b499641a1bae909b31531cfa770a9342ae9c56f0067dd642d6bb8d
     establishes:
+    - core-gated
+  - url: https://raw.githubusercontent.com/betagouv/ComparIA/develop/LICENSE
+    shows: 'Re-read 2026-08-13: the LICENSE body is still ''Apache License, Version 2.0''.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
+    establishes:
+    - license
+  - url: https://raw.githubusercontent.com/betagouv/ComparIA/develop/README.md
+    shows: 'Re-read 2026-08-13: README still leads ''The open-source LLM arena. Deploy it for your organisation,
+      sector, or language'', still documents ''Self-host with Docker (single server, automatic HTTPS via
+      Caddy)'' for the whole platform, and still says ''The whole platform is open source''. No commercial
+      tier, license key or enterprise edition appears in it.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: cc2e4c8623b499641a1bae909b31531cfa770a9342ae9c56f0067dd642d6bb8d
+    establishes:
+    - source
     - core-gated
 adoption:
   level: 3
@@ -65,8 +87,24 @@ capability:
   value: Blind pairwise model arena across 30+ models with preference voting, leaderboards, EcoLogits
     environmental tracking, multilingual deployment, and open dataset export.
   confidence: high
+  relative_to: chatbot-arena
+  relation: at
+  last_verified: '2026-08-13'
   note: Broad arena feature set comparable to LMArena plus environmental tracking and dataset generation.
+    Feature matrix re-read 2026-08-13 and unchanged - blind pairwise voting, a public leaderboard shipped
+    Nov 2025, published open datasets on Hugging Face, data.gouv.fr and Mozilla, Docker self-hosting,
+    and EcoLogits still on the roadmap board as a maintained component. The comparison to LMArena the
+    note already draws is now recorded structurally against chatbot-arena, both at 4.
   sources:
   - url: https://github.com/betagouv/ComparIA
     shows: 'Feature list: model comparison, voting, EcoLogits, dataset publishing, self-hosting'
     accessed: '2026-06-22'
+  - url: https://raw.githubusercontent.com/betagouv/ComparIA/develop/README.md
+    shows: '''compar:IA is a blind arena for large language models. You type a prompt, two anonymous models
+      reply, and you vote for the answer you prefer''; teaching aims include ''the energy cost of generative
+      AI''; the first public leaderboard shipped Nov 2025; datasets are published to Hugging Face, data.gouv.fr
+      and the Mozilla Data Collective; a second instance, AI-arenaen, runs in Denmark; Docker self-hosting
+      documented; an EcoLogits update is listed on the roadmap.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: cc2e4c8623b499641a1bae909b31531cfa770a9342ae9c56f0067dd642d6bb8d

--- a/sources/scores/deepeval.yaml
+++ b/sources/scores/deepeval.yaml
@@ -16,9 +16,12 @@ openness:
       detail: Confident AI is a separate hosted platform scored as its own product, the library evaluates
         locally without an account, no enterprise directory in the repo
   confidence: high
+  last_verified: '2026-08-13'
   note: Apache-2.0 library whose metrics and test runs execute locally with no account. Confident AI is
     a separate hosted platform, scored on the map as its own product; selling it alongside does not gate
-    the library, and no component is withheld from the published source.
+    the library, and no component is withheld from the published source. Re-read 2026-08-13 - the license
+    endpoint still reports Apache-2.0 and the README still says the metrics run locally with the Confident
+    AI account offered as optional reporting.
   raw: license:Apache-2.0(OSI, OSS framework);source:public(GitHub);commercial-tier:Confident AI managed
     eval/observability cloud on top;core-gated:ungated(Confident AI is a separate hosted platform scored
     as its own product, the library evaluates locally without an account, no enterprise directory in the
@@ -50,13 +53,34 @@ openness:
     establishes:
     - core-gated
     - license
+  - url: https://api.github.com/repos/confident-ai/deepeval/license
+    shows: GitHub's license endpoint reports spdx_id Apache-2.0 for confident-ai/deepeval and returns the
+      Apache-2.0 text as the LICENSE body.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: fce0f7773bfa80380f3085b7698bd56ec424593da2e6fef9317e6c710cadbe89
+    establishes:
+    - license
+  - url: https://raw.githubusercontent.com/confident-ai/deepeval/main/README.md
+    shows: 'Re-read 2026-08-13: the README still states the metrics ''run locally on your machine'' and
+      still frames the Confident AI account as optional reporting that ''is free, takes no additional
+      code to setup''. No metric is described as paid, licensed or enterprise-only.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 88d983b58c4725a6aaa88488a79029acc9e41046c0095fb15a492b643fa5b949
+    establishes:
+    - source
+    - core-gated
 adoption:
   level: 4
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
+  last_verified: '2026-08-13'
   note: ~4.63M monthly PyPI downloads (deepeval); 15.9k stars, used-by 1.3k projects. Headline = PyPI
-    primary source; download volume places it firmly in the 1-10M band.
+    primary source; download volume places it firmly in the 1-10M band. Re-read 2026-08-13 - the pypistats
+    API now reports 6,218,151 deepeval downloads in the trailing 30 days, still inside the same 1M-10M
+    band, and the repo is at 17.6k stars.
   sources:
   - url: https://pypistats.org/packages/deepeval
     shows: ~4,628,371 monthly PyPI downloads
@@ -64,15 +88,32 @@ adoption:
   - url: https://github.com/confident-ai/deepeval
     shows: 15.9k stars; used by 1.3k projects
     accessed: '2026-06-04'
+  - url: https://pypistats.org/api/packages/deepeval/recent
+    shows: last_month = 6,218,151 downloads of the deepeval package (last_week 1,181,537, last_day 229,027)
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: dc83521478cd771edde0748faece945c94189193079ab35ce3d4a8816f12f6a6
 capability:
   score: 4
   basis: feature_matrix
   value: broad LLM-app eval metrics (G-Eval LLM-as-judge, answer relevancy, faithfulness, task completion,
     hallucination), RAG + agentic + conversational coverage, pytest-style harness, agentic-eval support
   confidence: high
+  relative_to: lm-evaluation-harness
+  relation: one_below
+  last_verified: '2026-08-13'
   note: Strong, broad app/RAG/agentic eval coverage with LLM-as-judge -- top-tier for product-eval, just
-    below the academic-benchmark standards (lm-eval) on benchmark-standardization breadth.
+    below the academic-benchmark standards (lm-eval) on benchmark-standardization breadth. Feature matrix
+    re-read 2026-08-13 and unchanged; the comparison to lm-eval the note already made is now recorded
+    structurally.
   sources:
   - url: https://github.com/confident-ai/deepeval
     shows: G-Eval, RAG/agentic/conversational metrics, pytest-style eval
     accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/confident-ai/deepeval/main/README.md
+    shows: README describes the framework as 'similar to Pytest but specialized for unit testing LLM apps'
+      and documents G-Eval, Task Completion, Faithfulness, Hallucination, MCP Task Completion, conversational
+      turn metrics and red-teaming - the RAG, agentic and conversational spread the band rests on.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 88d983b58c4725a6aaa88488a79029acc9e41046c0095fb15a492b643fa5b949

--- a/sources/scores/epoch-ai-benchmarks.yaml
+++ b/sources/scores/epoch-ai-benchmarks.yaml
@@ -19,9 +19,14 @@ openness:
     free_text:
     - no-unified-OSI-harness-product
   confidence: medium
+  last_verified: '2026-08-13'
   note: 'Mixed-tier: public results dashboard plus some MIT/Apache-licensed eval components, but the headline
     benchmark (FrontierMath) is deliberately private and there is no single OSI-licensed end-to-end harness,
-    closer to source_available than fully open_source.'
+    closer to source_available than fully open_source. Re-read 2026-08-13 and unchanged. The org listing
+    still shows a scatter of separately-licensed component repos - SWE-bench and SWE-bench-c7d4d9d4 (MIT),
+    eci-public (MIT), MirrorCode (MIT) with MirrorCode-data carrying no license, epochutils, ftm, benchmark-stitching
+    - and no unified harness among the 33. FrontierMath is still ''a benchmark of several hundred unpublished,
+    highly challenging mathematics problems''. Source stays partial.'
   raw: dashboard:public(free to browse);eval-code:partial-open(several org repos MIT/Apache - SWE-bench
     docker registry, eci-public, MirrorCode-data);benchmark-data:mixed(FrontierMath gated/private to prevent
     contamination; some public);no-unified-OSI-harness-product;source:partial(public dashboard and MIT component
@@ -44,19 +49,48 @@ openness:
     accessed: '2026-08-11'
     establishes:
     - source
+  - url: https://api.github.com/orgs/epoch-research/repos
+    shows: '33 public repos in the epoch-research org. Licensed eval components include SWE-bench and
+      SWE-bench-c7d4d9d4 (MIT), eci-public (MIT), MirrorCode (MIT), benchmark-stitching (MIT), epochutils
+      (MIT), ftm (MIT) and timelines-direct-approach (Apache-2.0); MirrorCode-data and many others carry
+      no license at all. There is no single end-to-end harness repo among them.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 04d116304264a51ecde5660e26f718f424101ec7fc25551d77f9fcbd4df7d19f
+    establishes:
+    - source
+  - url: https://epoch.ai/frontiermath
+    shows: 'Re-read 2026-08-13: still ''A benchmark of several hundred unpublished, highly challenging
+      mathematics problems'', with Tiers 1-3 and Tier 4 deliberately withheld, so the headline benchmark
+      behind the dashboard still cannot be run by a reader.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 4a967d0a80e23496af0898979877b10ee40a79ff36432c59a8629acc47f835f6
+    establishes:
+    - source
 adoption:
   level: 3
   signal_type: reported_traction
   confidence: medium
+  last_verified: '2026-08-13'
   note: Epoch's benchmark results (esp. FrontierMath) are a widely-referenced capability signal cited
     across frontier-model coverage and research; the public dashboard is a recognized trends source. No
     standalone usage/traffic count published, so reported_traction; level 3 reflects broad authoritative
-    reference rather than a measured figure. No stars-only fallback used.
+    reference rather than a measured figure. No stars-only fallback used. Re-read 2026-08-13 - the dashboard
+    is still free to browse and now spans roughly 60 benchmarks across Epoch-run, creator-run and developer-run
+    sets. It still publishes no visitor or usage count of any kind, so the level's basis is unchanged.
   sources:
   - url: https://epoch.ai/benchmarks
     shows: public database of leading-model benchmark results positioned as authoritative AI-capability
       tracker
     accessed: '2026-06-04'
+  - url: https://epoch.ai/benchmarks
+    shows: 'Re-read 2026-08-13: free public dashboard letting a reader ''explore trends in AI capabilities
+      across time, by benchmark, or by model'', spanning roughly 60 benchmarks in three groups. No traffic,
+      visitor or usage figure is published on it.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 05cf0f548e1d61fe4914055c2aca1febbac1bf4f476328bab38e86573d048367
 capability:
   score: 4
   basis: feature_matrix
@@ -65,11 +99,25 @@ capability:
     major frontier labs; reproducibility via contamination-resistant held-out math; agentic eval = coding
     (SWE-bench) but primarily static-task scoring.'
   confidence: medium
+  relative_to: lm-evaluation-harness
+  relation: one_below
+  last_verified: '2026-08-13'
   note: Strong feature_matrix on hard/frontier benchmark coverage and trusted standardized results, especially
     math. Not a general agentic-eval harness; held-out design limits self-serve reproducibility. Placed
-    at 4, authoritative but not a frontier-defining general harness like lm-eval-harness.
+    at 4, authoritative but not a frontier-defining general harness like lm-eval-harness. Feature matrix
+    re-read 2026-08-13 and if anything wider - the Epoch-run set is now eleven benchmarks, adding MirrorCode,
+    Earthborne Rangers and Mystery Game Puzzles and splitting FrontierMath into Tier 4 (v2) and Tiers
+    1-3 (v2). The comparison to lm-eval-harness the note already makes is now recorded structurally.
   sources:
   - url: https://epoch.ai/benchmarks
     shows: 'operated benchmarks list: FrontierMath, GPQA Diamond, SWE-bench Verified, SimpleQA Verified,
       MATH Level 5, OTIS Mock AIME, Chess Puzzles'
     accessed: '2026-06-04'
+  - url: https://epoch.ai/benchmarks
+    shows: 'Epoch AI-run benchmarks as listed 2026-08-13: FrontierMath Tier 4 (v2), FrontierMath Tiers
+      1-3 (v2), SWE-bench Verified, MirrorCode, Chess Puzzles, Earthborne Rangers (EBR-bench), Mystery
+      Game Puzzles, SimpleQA Verified, GPQA Diamond, OTIS Mock AIME 2024-2025 and MATH Level 5, plus an
+      expansion of FrontierMath into 50 unsolved research problems.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 05cf0f548e1d61fe4914055c2aca1febbac1bf4f476328bab38e86573d048367

--- a/sources/scores/helm.yaml
+++ b/sources/scores/helm.yaml
@@ -17,7 +17,11 @@ openness:
     free_text:
     - no gated core
   confidence: high
+  last_verified: '2026-08-13'
   note: Fully OSI (Apache-2.0); framework, standardized data formats, web UI, and leaderboards all public.
+    Re-read 2026-08-13 - the license endpoint still reports Apache-2.0 and the README still documents
+    reproducing every published leaderboard from the framework itself. HELM entered maintenance mode on
+    2026-06-01, which slows the code without withdrawing or gating any of it.
   raw: license:Apache-2.0(OSI);source:public(framework + standardized datasets + web UI + leaderboard code);governance:Stanford
     CRFM(academic); no gated core;core-gated:ungated
   sources:
@@ -25,16 +29,40 @@ openness:
     shows: Apache-2.0 license; holistic eval framework with standardized datasets, web UI, leaderboards;
       v0.5.16; 2.8k stars
     accessed: '2026-06-04'
+  - url: https://api.github.com/repos/stanford-crfm/helm/license
+    shows: GitHub's license endpoint reports spdx_id Apache-2.0 for stanford-crfm/helm and returns the
+      Apache-2.0 text as the LICENSE body.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5cfe39272d6f06a2ce38e0a41f119b99e0fc77c9f548b3347cabab9aa55bac07
+    establishes:
+    - license
+  - url: https://raw.githubusercontent.com/stanford-crfm/helm/main/README.md
+    shows: README describes HELM as 'an open source Python framework created by the Center for Research
+      on Foundation Models (CRFM) at Stanford', ships the web leaderboard UI in the same repo, and documents
+      reproducing the published leaderboards from the framework. It carries a maintenance-mode note dated
+      2026-06-01 and no pricing, paid tier, enterprise edition or license key.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 465390a907127138096869b49fd79c817392f5404d23d98161d881f2e408a303
+    establishes:
+    - source
+    - core-gated
 adoption:
   level: 3
   signal_type: reported_traction
   confidence: medium
+  last_verified: '2026-08-13'
   note: 'Headline signal is influence/standard-setting, not install volume: HELM is a widely-cited standardized
     public leaderboard from Stanford CRFM spanning multiple modalities (capabilities/safety/vision/medical),
     referenced across the research community. PyPI distribution (crfm-helm) is only ~3,142 downloads/month;
     most usage is via the hosted leaderboard and academic citation rather than pip, so download volume
     understates reach. Level 3 reflects meaningful research/standard adoption short of mass production
-    deployment.'
+    deployment. Re-read 2026-08-13 - the README still lists the flagship HELM Capabilities, Safety, VHELM,
+    HEIM, ToRR, MedHELM and audio leaderboards with their papers, and crfm-helm is now at 5,097 downloads
+    a month. That download figure would band at level 1 on its own; it is deliberately not the instrument
+    here, for the reason already recorded, and the 5,097 is offered as the same corroboration the 3,142
+    was.'
   sources:
   - url: https://github.com/stanford-crfm/helm
     shows: multiple public leaderboards (HELM Capabilities/Safety/VHELM/HEIM/MedHELM); Stanford CRFM standardized
@@ -43,6 +71,18 @@ adoption:
   - url: https://pypistats.org/packages/crfm-helm
     shows: 3,142 PyPI downloads last month (low because usage is leaderboard/citation-driven, not pip)
     accessed: '2026-06-04'
+  - url: https://pypistats.org/api/packages/crfm-helm/recent
+    shows: last_month = 5,097 downloads of the crfm-helm package (last_week 2,327, last_day 714)
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 413fbe6c3f3b21a3b1de4571f754470a9fc511e58863b4d1e79f7c138ef6ca80
+  - url: https://raw.githubusercontent.com/stanford-crfm/helm/main/README.md
+    shows: README lists the maintained public leaderboards - HELM Capabilities, HELM Safety, VHELM, HEIM,
+      ToRR, MedHELM and audio - each with its published paper, which is the standard-setting evidence
+      the level rests on.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 465390a907127138096869b49fd79c817392f5404d23d98161d881f2e408a303
 capability:
   score: 5
   basis: feature_matrix
@@ -51,11 +91,24 @@ capability:
     medical (MedHELM), audio, and enterprise; unified model access across OpenAI/Anthropic/Google/etc.;
     metrics beyond accuracy; standardized reproducible format + web UI.'
   confidence: high
+  relative_to: inspect-ai
+  relation: at
+  last_verified: '2026-08-13'
   note: Frontier-defining on coverage and standardization, the holistic multi-modality leaderboard standard.
     One of the 1-2 category leaders, scored 5. (Weaker than Inspect AI on agentic-eval support, but broader
-    on benchmark/modality coverage.)
+    on benchmark/modality coverage.) That trade is why the recorded comparison is `at` rather than above
+    or below Inspect AI. Feature matrix re-read 2026-08-13 and unchanged - the same leaderboard family
+    across text, vision-language, text-to-image, table reasoning, medical and audio. HELM entered maintenance
+    mode on 2026-06-01, which caps future breadth without narrowing what is there.
   sources:
   - url: https://github.com/stanford-crfm/helm
     shows: standardized datasets, unified model access, metrics beyond accuracy, web UI, multi-modal leaderboards
       (MMLU-Pro/GPQA/IFEval/WildBench)
     accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/stanford-crfm/helm/main/README.md
+    shows: standardized scenario/adapter/metric framework with a web leaderboard UI; leaderboards span
+      text (Capabilities, Safety, ToRR), vision-language (VHELM), text-to-image (HEIM), medical (MedHELM),
+      audio and enterprise benchmarks; maintenance-mode notice dated 2026-06-01.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 465390a907127138096869b49fd79c817392f5404d23d98161d881f2e408a303

--- a/sources/scores/inspect-ai.yaml
+++ b/sources/scores/inspect-ai.yaml
@@ -18,7 +18,10 @@ openness:
     free_text:
     - no managed/gated tier
   confidence: high
-  note: Fully OSI (MIT), government-backed, no proprietary core, full pipeline open.
+  last_verified: '2026-08-13'
+  note: Fully OSI (MIT), government-backed, no proprietary core, full pipeline open. Re-read 2026-08-13
+    - the license endpoint still reports MIT and the README still builds and runs the whole framework,
+    web UI included, from the checkout with no paid tier.
   raw: license:MIT(OSI);source:public(full framework, 200+ evals);governance:public-sector(UK AISI)+Meridian
     Labs; no managed/gated tier;core-gated:ungated
   sources:
@@ -26,26 +29,64 @@ openness:
     shows: MIT license; framework for LLM evals with 200+ pre-built evals; UK AISI maintainer; 2.2k stars,
       5,886 commits
     accessed: '2026-06-04'
+  - url: https://api.github.com/repos/UKGovernmentBEIS/inspect_ai/license
+    shows: GitHub's license endpoint reports spdx_id MIT for UKGovernmentBEIS/inspect_ai and returns the
+      MIT text as the LICENSE body.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 06df7177dede41e1d2949700e98e6e099fdaea893798c5f93ba95ceae6ef2415
+    establishes:
+    - license
+  - url: https://raw.githubusercontent.com/UKGovernmentBEIS/inspect_ai/main/README.md
+    shows: README is a build-from-source guide - clone the repo, `pip install -e ".[dev]"`, build the
+      React web UI from the checked-in submodule, render the docs locally. It names UK AISI as the creator
+      and points at 'over 200 pre-built evaluations ready to run on any model'. There is no pricing, no
+      hosted tier, no enterprise edition and no license key anywhere in it.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a9a1e07b955d869137d8ad109f1c238268f361dcdfac30cfcc94983a51a99b17
+    establishes:
+    - source
+    - core-gated
 adoption:
   level: 4
   signal_type: reported_traction
   confidence: high
+  last_verified: '2026-08-13'
   note: 'Headline signal (per recipe: adoption by frontier labs / cited in release-grade safety work):
     adopted as the evaluation framework of choice by major labs incl. Anthropic, Google DeepMind, and
     xAI/Grok, and powers nearly all of UK AISI''s automated frontier-model evaluations. Corroborated by
     ~9.9M PyPI downloads in the last 30 days (pepy.tech) / 10.5M (pypistats), though that figure is inflated
     by CI/dependency traffic, so lab adoption is treated as the primary basis. Placed at level 4, not
-    5, because the human-operator base (eval engineers at labs/AISI) is far smaller than mass-market scale.'
+    5, because the human-operator base (eval engineers at labs/AISI) is far smaller than mass-market scale.
+    Re-read 2026-08-13, with one correction. The AISI post cited here does NOT say AISI runs thousands
+    of evaluations on Inspect - it reports evaluating 16 models in its first year, and says of Inspect
+    only that ''now it is used by other governments and some of the leading AI developers''. The lab
+    names in this note come from elsewhere and are not established by the cited page, so the basis is
+    narrowed to what the post actually asserts. The download corroboration holds and got sharper: 9,278,867
+    inspect-ai downloads in the trailing 30 days on pypistats, against the 9.86M pepy figure recorded
+    before. Level 4 unchanged. The inspect-ai PyPI package is not declared as an artifact on this product
+    and should be; flagged rather than declared here.'
   sources:
   - url: https://www.aisi.gov.uk/blog/our-first-year
-    shows: AISI runs thousands of frontier-model evaluations on Inspect; broad lab adoption
-    accessed: '2026-06-04'
+    shows: 'Re-read 2026-08-13: ''we open sourced our evaluations platform, Inspect ... now it is used
+      by other governments and some of the leading AI developers''. The post reports evaluations on 16
+      models in AISI''s first year. It does NOT carry the ''thousands of evaluations'' figure this source
+      was previously recorded as showing.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 607848ae11534d6e9699c8073624bfef2c07f2be9899531adde35ef981639f65
   - url: https://inspect.aisi.org.uk/
     shows: framework for frontier AI evaluations by UK AISI + Meridian Labs; adopted by major labs
     accessed: '2026-06-04'
   - url: https://pepy.tech/projects/inspect-ai
     shows: 87.89M total / 9,856,617 last-30-day PyPI downloads (corroboration)
     accessed: '2026-06-04'
+  - url: https://pypistats.org/api/packages/inspect-ai/recent
+    shows: last_month = 9,278,867 downloads of the inspect-ai package (last_week 1,494,033, last_day 262,149)
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 228f6935b869c9af11e7bfe49a8f34e6f160dc3846e86fba6b2b7885d77d5d3a
 capability:
   score: 5
   basis: feature_matrix
@@ -53,8 +94,12 @@ capability:
     model-graded scoring; broadest model-backend abstraction in the category (OpenAI/Anthropic/Google/Groq/Mistral/xAI/Bedrock/Azure/Together/Cloudflare
     + local vLLM/Ollama/llama-cpp); reproducibility tooling for large-scale frontier evals.
   confidence: high
+  last_verified: '2026-08-13'
   note: 'Frontier-defining for this category: combines the broadest backend coverage, agentic-eval support,
-    and de-facto-standard status among frontier-safety labs. One of the 1-2 leaders, so scored 5.'
+    and de-facto-standard status among frontier-safety labs. One of the 1-2 leaders, so scored 5. Feature
+    matrix re-read 2026-08-13 and unchanged, and if anything wider - the providers page now also lists
+    Mistral, DeepSeek, Moonshot, Perplexity, SageMaker, Fireworks, SambaNova, SGLang and TransformerLens
+    behind the same interface.'
   sources:
   - url: https://inspect.aisi.org.uk/models.html
     shows: single interface over OpenAI/Anthropic/Google/xAI/Bedrock/Azure/local vLLM/Ollama/llama-cpp
@@ -62,3 +107,17 @@ capability:
   - url: https://github.com/UKGovernmentBEIS/inspect_ai
     shows: 200+ pre-built evals; tool use, multi-turn, model-graded eval components
     accessed: '2026-06-04'
+  - url: https://inspect.aisi.org.uk/models.html
+    shows: 'Re-read 2026-08-13: one naming convention (`openai/gpt-4o`, `anthropic/claude-sonnet-4-0`)
+      over lab APIs (OpenAI, Anthropic, Google, Grok, Mistral, DeepSeek, Moonshot, Perplexity), cloud
+      APIs (Bedrock, SageMaker, Azure AI), hosted open models (Groq, Together, Fireworks, Cloudflare,
+      HF Inference Providers, SambaNova) and local ones (HF, vLLM, Ollama, llama-cpp-python, SGLang, TransformerLens).'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 587a29f7b185efc120a0692c0b7d308d4c45d1971a4dd6926d5227492d1a6e4e
+  - url: https://raw.githubusercontent.com/UKGovernmentBEIS/inspect_ai/main/README.md
+    shows: 'README: built-in components for prompt engineering, tool usage, multi-turn dialog and model-graded
+      evaluations, plus ''a collection of over 200 pre-built evaluations ready to run on any model''.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a9a1e07b955d869137d8ad109f1c238268f361dcdfac30cfcc94983a51a99b17

--- a/sources/scores/lighteval.yaml
+++ b/sources/scores/lighteval.yaml
@@ -16,21 +16,46 @@ openness:
     - multi-backend (Accelerate/vLLM/SGLang/TGI/LiteLLM/inspect-ai)
     - 1000+ tasks
   confidence: high
+  last_verified: '2026-08-13'
   note: Fully OSI-licensed (MIT), full source public, no managed/commercial tier gating the eval engine.
+    Re-read 2026-08-13 - the license endpoint still reports MIT and the README still runs every backend
+    locally with no paid tier or license key.
   raw: license:MIT(OSI);source:public(github.com/huggingface/lighteval);no feature-gated core; multi-backend
     (Accelerate/vLLM/SGLang/TGI/LiteLLM/inspect-ai); 1000+ tasks;core-gated:ungated
   sources:
   - url: https://github.com/huggingface/lighteval
     shows: MIT license, public source, v0.13.0 (Nov 2025), 1000+ tasks, multi-backend support
     accessed: '2026-06-04'
+  - url: https://api.github.com/repos/huggingface/lighteval/license
+    shows: GitHub's license endpoint reports spdx_id MIT for huggingface/lighteval and returns the MIT
+      text as the LICENSE body.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1ac1ffb3c88d2fb0a5dc70c064a785075d599a364a6788572506782982f7ec4a
+    establishes:
+    - license
+  - url: https://raw.githubusercontent.com/huggingface/lighteval/main/README.md
+    shows: README carries the MIT badge and documents running the whole toolkit locally through `lighteval
+      eval`, `lighteval vllm`, `lighteval sglang` and `lighteval endpoint`, with the 1000+ tasks shipping
+      in the package. The optional endpoints are third-party inference providers, not a paid edition of
+      lighteval. No pricing, enterprise tier or license key appears in it.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5147e564c99edeb6cb2c01f34602f05bcdda77bbae5b60f43eb251485e01c056
+    establishes:
+    - source
+    - core-gated
 adoption:
   level: 2
   reach: 10K-100K
   signal_type: usage_volume
   confidence: medium
+  last_verified: '2026-08-13'
   note: ~37,239 PyPI downloads in the last month (pypistats). Powers the HF Open LLM Leaderboard and is
     the reproducible eval suite behind it; meaningful in the eval/research community but a smaller install
     base than general-purpose harnesses. 2.4k GitHub stars corroborate only. Headline = PyPI volume (primary).
+    Re-read 2026-08-13 - the pypistats API now reports 24,962 lighteval downloads in the trailing 30 days,
+    down from 37,239 but still inside the same 10K-100K band, so level 2 stands. 2.5k stars.
   sources:
   - url: https://pypistats.org/packages/lighteval
     shows: ~37,239 lighteval downloads in the last month
@@ -38,6 +63,17 @@ adoption:
   - url: https://github.com/huggingface/lighteval
     shows: stated as the toolkit powering the HF Open LLM Leaderboard; 2.4k stars (corroboration)
     accessed: '2026-06-04'
+  - url: https://pypistats.org/api/packages/lighteval/recent
+    shows: last_month = 24,962 downloads of the lighteval package (last_week 6,698, last_day 978)
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e1b02ba3b772a99fc7d6c8cd718152d33f8a8cd734351c0a592ef02661d24b02
+  - url: https://raw.githubusercontent.com/huggingface/lighteval/main/README.md
+    shows: README still bills the project as coming 'from Hugging Face's Leaderboard and Evals Team',
+      which is the leaderboard tie the corroborating half of this level rests on.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5147e564c99edeb6cb2c01f34602f05bcdda77bbae5b60f43eb251485e01c056
 capability:
   score: 4
   basis: feature_matrix
@@ -46,10 +82,22 @@ capability:
     Endpoints/custom; reproducibility: standardized suite reproducing the HF Open LLM Leaderboard; agentic-eval:
     via inspect-ai backend'
   confidence: high
+  relative_to: lm-evaluation-harness
+  relation: one_below
+  last_verified: '2026-08-13'
   note: Strong across the recipe's feature-matrix dimensions (coverage, backend breadth, reproducibility,
     some agentic support). Not a 5; lm-evaluation-harness remains the broader de-facto standard cited
-    in more frontier release reports; lighteval is the HF-leaderboard-tied counterpart.
+    in more frontier release reports; lighteval is the HF-leaderboard-tied counterpart. Feature matrix
+    re-read 2026-08-13 and unchanged, and the comparison the note already made to lm-eval is now recorded
+    structurally.
   sources:
   - url: https://github.com/huggingface/lighteval
     shows: 1000+ tasks, 8+ model backends, reproduces Open LLM Leaderboard evals
     accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/huggingface/lighteval/main/README.md
+    shows: '''Lighteval supports 1000+ evaluation tasks across multiple domains''; backends invoked as
+      `lighteval eval` (inspect-ai, preferred), `vllm`, `sglang` and `endpoint` including HF inference
+      providers; custom task and custom metric authoring documented.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5147e564c99edeb6cb2c01f34602f05bcdda77bbae5b60f43eb251485e01c056

--- a/sources/scores/lm-evaluation-harness.yaml
+++ b/sources/scores/lm-evaluation-harness.yaml
@@ -14,20 +14,44 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: MIT-licensed, fully public; OSI -> open_source.
+  last_verified: '2026-08-13'
+  note: MIT-licensed, fully public; OSI -> open_source. Re-read 2026-08-13 - the license endpoint still
+    reports MIT and the README still ships the whole harness with no paid tier or license key.
   raw: license:MIT(OSI);source:public(GitHub);no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/EleutherAI/lm-evaluation-harness
     shows: MIT license, public source, v0.4.12 (May 2026)
     accessed: '2026-06-04'
+  - url: https://api.github.com/repos/EleutherAI/lm-evaluation-harness/license
+    shows: GitHub's license endpoint reports spdx_id MIT for EleutherAI/lm-evaluation-harness and returns
+      the MIT text as the LICENSE.md body.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: ed3e3439d9e57b5983883bc3c526e1dde78908b1abfc2eaa169b79f0ea379af0
+    establishes:
+    - license
+  - url: https://raw.githubusercontent.com/EleutherAI/lm-evaluation-harness/main/README.md
+    shows: README documents installing from the repo and running `lm-eval` locally against local weights,
+      vLLM, and commercial APIs; the whole task library ships in `lm_eval/tasks`. Nothing in the 53KB
+      of it mentions pricing, a paid tier, an enterprise edition or a license key - the only commercial
+      reference is that the harness can call third-party model APIs.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 506dc91c553911a23ab89991f5de9d3dcb1d0b97a896da232089d2e93a4387cf
+    establishes:
+    - source
+    - core-gated
 adoption:
   level: 4
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
+  last_verified: '2026-08-13'
   note: ~1.57M monthly PyPI downloads (lm-eval); backs HuggingFace Open LLM Leaderboard and is used in
     hundreds of papers and model release reports -- the strongest 'cited as standard' signal in the category.
-    Headline = PyPI primary source; standard-status corroborates.
+    Headline = PyPI primary source; standard-status corroborates. Re-read 2026-08-13 - the pypistats
+    API reports 1,658,820 lm-eval downloads in the trailing 30 days, which still bands at level 4 (1M-10M),
+    and the README still names the Open LLM Leaderboard task group.
   sources:
   - url: https://pypistats.org/packages/lm-eval
     shows: ~1,571,581 monthly PyPI downloads
@@ -35,6 +59,17 @@ adoption:
   - url: https://github.com/EleutherAI/lm-evaluation-harness
     shows: backend for HF Open LLM Leaderboard; used in hundreds of papers
     accessed: '2026-06-04'
+  - url: https://pypistats.org/api/packages/lm-eval/recent
+    shows: last_month = 1,658,820 downloads of the lm-eval package (last_week 429,834, last_day 63,998)
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: f9c7db7e7cffcb547ead5d915055da05947b0880394150c9e81e40a7fc7c64fd
+  - url: https://raw.githubusercontent.com/EleutherAI/lm-evaluation-harness/main/README.md
+    shows: README records that the Open LLM Leaderboard task group ships in the repo and that the harness
+      backs it; 13.6k stars on the repo corroborate.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 506dc91c553911a23ab89991f5de9d3dcb1d0b97a896da232089d2e93a4387cf
 capability:
   score: 5
   basis: feature_matrix
@@ -42,9 +77,19 @@ capability:
     Transformers, vLLM, OpenAI, Anthropic, SGLang, NeMo, Megatron-LM, local servers); reproducibility/standardization
     (powers Open LLM Leaderboard)
   confidence: high
+  last_verified: '2026-08-13'
   note: Frontier-definer within evaluation_code -- widest task + backend coverage and the standardization
-    reference harness for LLM eval.
+    reference harness for LLM eval. Feature matrix re-read 2026-08-13 and unchanged - the README still
+    states 'Over 60 standard academic benchmarks for LLMs, with hundreds of subtasks and variants implemented'
+    and still lists the same backend spread.
   sources:
   - url: https://github.com/EleutherAI/lm-evaluation-harness
     shows: 60+ benchmarks, multi-backend support, Open LLM Leaderboard backend
     accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/EleutherAI/lm-evaluation-harness/main/README.md
+    shows: '''Over 60 standard academic benchmarks for LLMs, with hundreds of subtasks and variants implemented'';
+      model types cover HF Transformers, vLLM, SGLang, NeMo, Megatron-LM, commercial APIs and local inference
+      servers; leaderboard task group present.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 506dc91c553911a23ab89991f5de9d3dcb1d0b97a896da232089d2e93a4387cf

--- a/sources/scores/open-llm-leaderboard.yaml
+++ b/sources/scores/open-llm-leaderboard.yaml
@@ -15,7 +15,11 @@ openness:
       value: ungated
       detail: Space source public and docker-compose deployable, no paid tier
   confidence: high
-  note: Open Apache-2.0 leaderboard built on open eval backends (now archived).
+  last_verified: '2026-08-13'
+  note: Open Apache-2.0 leaderboard built on open eval backends (now archived). Re-read 2026-08-13 - the
+    Space is still public and RUNNING, its card data still declares apache-2.0 and sdk docker, and the
+    README still brings the React frontend and FastAPI backend up with `docker-compose up`. Nothing has
+    been withdrawn or gated since archival.
   raw: license:Apache-2.0(HF-Space);backend:lm-eval-harness/lighteval(open);source:public;core-gated:ungated(Space
     source public and docker-compose deployable, no paid tier)
   sources:
@@ -37,24 +41,89 @@ openness:
     - core-gated
     - license
     - source
+  - url: https://huggingface.co/spaces/open-llm-leaderboard/open_llm_leaderboard/raw/main/README.md
+    shows: 'Re-read 2026-08-13: frontmatter still declares ''license: apache-2.0'' and ''sdk: docker'',
+      and the body still documents bringing the React frontend and FastAPI backend up with `docker-compose
+      up`. No feature is described as paid, licensed or restricted.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 506aed8ab5aeccd01310992962de01898974545083e3c38170203d52b7e57214
+    establishes:
+    - license
+    - source
+    - core-gated
+  - url: https://huggingface.co/api/spaces/open-llm-leaderboard/open_llm_leaderboard
+    shows: Space API reports private = false, cardData.license = apache-2.0, sdk = docker, runtime stage
+      RUNNING, and 14,072 likes.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 588a3bf4c3f60b696f92d8fc9dec3188ac55d2f4bb5bd5a7a4693c688f8431a9
+    establishes:
+    - license
+    - source
 adoption:
   level: 4
   signal_type: reported_traction
   confidence: high
+  last_verified: '2026-08-13'
   note: 'ARCHIVED 2025-03-13. At peak: 13,000+ models evaluated, 2M+ unique visitors - historically the most influential
-    open-model leaderboard.'
+    open-model leaderboard. Re-read 2026-08-13 and both figures check out, from two different pages. The
+    retirement post says ''For the last 2 years, we''ve evaluated over 13K models with the Open LLM Leaderboard'';
+    the archive page carries the visitor figure - ''visited by more than 2 million unique people over
+    the last 10 months'', with around 300,000 community members using it monthly. The Space itself still
+    shows 14,072 likes. Level 4 unchanged, and the figures are historical by nature since the product
+    is retired.'
   sources:
   - url: https://huggingface.co/spaces/open-llm-leaderboard/open_llm_leaderboard/discussions/1135
     shows: retirement announcement, 2025-03-13
     accessed: '2026-06-17'
+  - url: https://huggingface.co/spaces/open-llm-leaderboard/open_llm_leaderboard/discussions/1135
+    shows: 'Re-read 2026-08-13: retirement announcement dated 2025-03-13, stating ''For the last 2 years,
+      we''ve evaluated over 13K models with the Open LLM Leaderboard'' and noting that over 200 community-led
+      leaderboards now exist on Hugging Face. It carries no visitor figure.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c1d074b0c1119d66df281824db0824ba1409a7e4cac8272d95d36215950b6c57
+  - url: https://huggingface.co/docs/leaderboards/en/open_llm_leaderboard/archive
+    shows: 'archive page: ''visited by more than 2 million unique people over the last 10 months'' and
+      ''Around 300,000 community members used and collaborated on it monthly''.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9d39be4322e6018399babc9b4eca161a1906cd2828abb9fef0bfb40b32f2fb02
+  - url: https://huggingface.co/api/spaces/open-llm-leaderboard/open_llm_leaderboard
+    shows: likes = 14,072 on the archived Space
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 588a3bf4c3f60b696f92d8fc9dec3188ac55d2f4bb5bd5a7a4693c688f8431a9
 capability:
   score: 4
   basis: feature_matrix
   value: 'standardized 6-benchmark suite (v2: IFEval/BBH/MATH-L5/GPQA/MuSR/MMLU-Pro); shared-cluster reproducible
     runs; 13,000+ models'
   confidence: high
-  note: Historically the most visible open-model leaderboard; static rather than human-preference; now archived.
+  last_verified: '2026-08-13'
+  note: 'Historically the most visible open-model leaderboard; static rather than human-preference; now archived.
+    Feature matrix re-read 2026-08-13, with one attribution correction. The archive URL cited here documents
+    the v1 leaderboard, not v2: six benchmarks (ARC 25-shot, HellaSwag 10-shot, MMLU 5-shot, TruthfulQA,
+    Winogrande 5-shot, GSM8k 5-shot) run on a single node of 8 H100s through lm-evaluation-harness, with
+    a reproduction command. So it establishes the shared-cluster reproducible-runs half of this value
+    and the 2M visitors, but not the v2 suite; the v2 benchmark list is corroborated by the Space''s own
+    tags. The 13,000+ model figure comes from the retirement post. Band unchanged.'
   sources:
   - url: https://huggingface.co/docs/leaderboards/en/open_llm_leaderboard/archive
     shows: v2 benchmark suite, 2M visitors, archive
     accessed: '2026-06-17'
+  - url: https://huggingface.co/docs/leaderboards/en/open_llm_leaderboard/archive
+    shows: 'Re-read 2026-08-13: this page covers Open LLM Leaderboard v1 - six benchmarks (ARC, HellaSwag,
+      MMLU, TruthfulQA, Winogrande, GSM8k) evaluated with the EleutherAI harness on a single node of 8
+      H100s, with the exact reproduction command published. Archived June 2024 and replaced by v2. It
+      does NOT list the v2 suite this value names.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9d39be4322e6018399babc9b4eca161a1906cd2828abb9fef0bfb40b32f2fb02
+  - url: https://huggingface.co/api/spaces/open-llm-leaderboard/open_llm_leaderboard
+    shows: Space card data still tags the leaderboard 'eval:code' and 'eval:math' with automatic submission
+      and a public test set, and describes it as 'Track, rank and evaluate open LLMs and chatbots'.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 588a3bf4c3f60b696f92d8fc9dec3188ac55d2f4bb5bd5a7a4693c688f8431a9

--- a/sources/scores/openai-evals-api-dashboard.yaml
+++ b/sources/scores/openai-evals-api-dashboard.yaml
@@ -12,8 +12,10 @@ openness:
     - managed-only(no self-host)
     - being deprecated Nov 2026
   confidence: high
+  last_verified: '2026-08-13'
   note: Closed hosted SaaS bound to the OpenAI platform; not the MIT-licensed openai/evals repo (that
-    is scored separately).
+    is scored separately). Re-read 2026-08-13 - the guide still describes a hosted platform product with
+    no source, no self-host and no license offered, and still carries the same sunset dates.
   raw: license:Proprietary(SaaS, OpenAI-platform-only);source:closed;managed-only(no self-host); being deprecated
     Nov 2026
   sources:
@@ -21,17 +23,38 @@ openness:
     shows: hosted proprietary Evals API + dashboard on OpenAI platform; sunset dates (read-only Oct 31
       2026, shutdown Nov 30 2026)
     accessed: '2026-06-04'
+  - url: https://developers.openai.com/api/docs/guides/evals
+    shows: 'Re-read 2026-08-13. The guide states ''OpenAI is deprecating the Evals platform'' and ''Evals
+      will become read-only for existing users on October 31, 2026, and the platform is scheduled to shut
+      down on November 30, 2026'', and now points new users at Datasets instead. It is documented purely
+      as a hosted surface of the OpenAI API - no repository, no self-hostable implementation and no license
+      to any evaluation code is offered anywhere on the page.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 97f7c685f89228fcbcfc2374f139ed6daade56bb81d42d2a6d525ce2eb666c10
+    establishes:
+    - source
+    - license
 adoption:
   level: null
   reach: null
   signal_type: unknown
   confidence: low
+  last_verified: '2026-08-13'
   note: OpenAI publishes no usage figures for the Evals API/dashboard specifically, and the product is
-    being sunset, so there is no honest adoption signal to report.
+    being sunset, so there is no honest adoption signal to report. Re-read 2026-08-13 - looked for a run
+    count, a customer count, a developer count or any usage statistic on the guide and found none, so
+    the abstention is re-confirmed rather than lifted.
   sources:
   - url: https://developers.openai.com/api/docs/guides/evals
     shows: no usage/customer figures; product on sunset path
     accessed: '2026-06-04'
+  - url: https://developers.openai.com/api/docs/guides/evals
+    shows: 'Re-read 2026-08-13: the guide publishes no eval-run count, no customer count and no developer
+      count for the Evals platform, and the deprecation notice adds none. Nothing bandable has appeared.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 97f7c685f89228fcbcfc2374f139ed6daade56bb81d42d2a6d525ce2eb666c10
 capability:
   score: 2
   basis: feature_matrix
@@ -40,9 +63,19 @@ capability:
     Locked to OpenAI models; no multi-backend support; no standardized academic benchmark suite; being
     deprecated.
   confidence: medium
+  last_verified: '2026-08-13'
   note: Convenient managed eval surface for OpenAI-model users, but narrow (single-provider, no benchmark
-    library) and on a deprecation path, not a frontier harness.
+    library) and on a deprecation path, not a frontier harness. Feature matrix re-read 2026-08-13 and
+    unchanged; the deprecation is now dated rather than pending, which reinforces the band rather than
+    moving it.
   sources:
   - url: https://developers.openai.com/api/docs/guides/evals
     shows: grading methods, dataset upload, run execution vs OpenAI APIs, dashboard + cost analysis
     accessed: '2026-06-04'
+  - url: https://developers.openai.com/api/docs/guides/evals
+    shows: 'Re-read 2026-08-13: criteria-based grading against OpenAI models only, dataset upload, runs
+      and a dashboard; no multi-provider backend and no standardized benchmark suite. Read-only from 2026-10-31,
+      shut down 2026-11-30.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 97f7c685f89228fcbcfc2374f139ed6daade56bb81d42d2a6d525ce2eb666c10

--- a/sources/scores/openai-evals.yaml
+++ b/sources/scores/openai-evals.yaml
@@ -17,8 +17,12 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
+  last_verified: '2026-08-13'
   note: Framework code is fully OSI (MIT); the included eval datasets carry their own open licenses, which
-    is standard for a harness.
+    is standard for a harness. Re-read 2026-08-13 - LICENSE.md is still the unmodified MIT text, copyright
+    2023 OpenAI, followed by the per-dataset carve-out that the components already record. GitHub's own
+    detector reports NOASSERTION because of that appended section, which is a detector artifact rather
+    than a second license over the framework code.
   raw: license:MIT(OSI);source:public(full framework + registry);per-dataset-licenses:mixed(CC/CC0/Apache
     for bundled data); no feature-gated core;core-gated:ungated
   sources:
@@ -28,6 +32,26 @@ openness:
   - url: https://github.com/openai/evals
     shows: open framework for evaluating LLMs with open benchmark registry; MIT badge; 18.6k stars
     accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/openai/evals/main/LICENSE.md
+    shows: 'LICENSE.md opens ''MIT License / Copyright (c) 2023 OpenAI'' with the full unmodified MIT
+      body, then ''NOTE: This license applies to all parts of this repository except for the datasets
+      specified below'' followed by the per-dataset license table.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 055f213a5784ecbe4d24df5f539bd134490e327d5e83c51c2ba4e9d5cf308757
+    establishes:
+    - license
+  - url: https://raw.githubusercontent.com/openai/evals/main/README.md
+    shows: README documents cloning the repo, `pip install -e .`, and pulling the bundled eval registry
+      over Git-LFS, so the whole framework and its benchmark registry run from the published source. The
+      only requirement it adds is the reader's own OPENAI_API_KEY. No pricing, paid tier, enterprise edition
+      or license key appears in it.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: f0b50bd53e2fbc81be774a6bfb0cf20997aa7509bd22925ae779a87d57c7c914
+    establishes:
+    - source
+    - core-gated
 adoption:
   level: 3
   reach: '>10K stars'
@@ -41,11 +65,19 @@ adoption:
     instrument does not offer - a star is not a download. THE REAL DEFECT is upstream: this product declares
     no artifacts at all, so a stars_fallback band had no stars source behind it and the count lived only in
     this note. Declaring openai/evals would fix it, and is deliberately not done here because a declared code
-    repo also re-routes the openness license dimension. No last_verified claimed: a star count is volatile.'
+    repo also re-routes the openness license dimension. Re-read against the GitHub API on 2026-08-13 -
+    19,161 stars and 3,052 forks, last push 2026-04-14, so the band is unchanged and the repo has gone
+    four months without a commit.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/openai/evals
     shows: 18.6k stars, 3k forks, 691 commits
     accessed: '2026-06-04'
+  - url: https://api.github.com/repos/openai/evals
+    shows: stargazers_count = 19,161, forks 3,052, pushed_at 2026-04-14, archived = false
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 83027d82d0f08c3f337a0cc7a2e917098f42c197d05e7a41c3a4a7d959851bcd
 capability:
   score: 3
   basis: feature_matrix
@@ -53,9 +85,22 @@ capability:
     and exact/fuzzy-match graders. Coverage breadth modest vs lm-eval-harness/HELM; no built-in agentic-eval
     harness; maintenance has slowed.
   confidence: medium
+  relative_to: lm-evaluation-harness
+  relation: two_below
+  last_verified: '2026-08-13'
   note: Solid general-purpose authoring framework but not frontier on task coverage, backend breadth,
-    or agentic-eval support relative to category leaders.
+    or agentic-eval support relative to category leaders. Feature matrix re-read 2026-08-13 and unchanged
+    - the README still describes a registry of evals plus custom-eval authoring, and the repo has not
+    been pushed since 2026-04-14, which is the slowed maintenance the value already records. The comparison
+    to lm-eval-harness is now recorded structurally.
   sources:
   - url: https://github.com/openai/evals
     shows: framework + registry of benchmarks, custom eval authoring, model-graded grading
     accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/openai/evals/main/README.md
+    shows: 'README: ''We offer an existing registry of evals to test different dimensions of OpenAI models
+      and the ability to write your own custom evals''; private evals over your own data supported. No
+      agentic-eval harness and no multi-backend abstraction described.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: f0b50bd53e2fbc81be774a6bfb0cf20997aa7509bd22925ae779a87d57c7c914

--- a/sources/scores/opencompass.yaml
+++ b/sources/scores/opencompass.yaml
@@ -14,32 +14,81 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Apache-2.0, fully public; OSI -> open_source.
+  last_verified: '2026-08-13'
+  note: Apache-2.0, fully public; OSI -> open_source. Re-read 2026-08-13 - the license endpoint still
+    reports Apache-2.0 and the README still installs and runs the whole platform locally with no paid
+    tier.
   raw: license:Apache-2.0(OSI);source:public(GitHub);no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/open-compass/opencompass
     shows: Apache-2.0 license, public source, v0.5.2 (Feb 2026)
     accessed: '2026-06-04'
+  - url: https://api.github.com/repos/open-compass/opencompass/license
+    shows: GitHub's license endpoint reports spdx_id Apache-2.0 for open-compass/opencompass and returns
+      the Apache-2.0 text as the LICENSE body.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 4c98cbd9e68d93f3b5ad7b08688d170d9f10d2f02578441432ad6e439a12610d
+    establishes:
+    - license
+  - url: https://raw.githubusercontent.com/open-compass/opencompass/main/README.md
+    shows: README installs the platform with `pip install -U opencompass` or editable from a clone and
+      runs evaluations locally against local weights or model APIs; all dataset and model configs ship
+      inside the package. CompassRank and CompassHub are free public leaderboard and dataset sites beside
+      it. No pricing, enterprise edition, paid tier or license key appears in the README.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9c9258560278da5596691646e561998a38f663b67ec448a34ada47a5f2b4119c
+    establishes:
+    - source
+    - core-gated
 adoption:
   level: 3
   signal_type: reported_traction
   confidence: medium
+  last_verified: '2026-08-13'
   note: Widely used eval framework, especially in the China/HF ecosystem; 7.1k GitHub stars and broad
     dataset+backend coverage. No clean PyPI/download headline located this run; level 3 on reported_traction
-    (framework distribution + star footprint), not on stars alone past the cap.
+    (framework distribution + star footprint), not on stars alone past the cap. Re-read 2026-08-13 - 7,299
+    stars and 837 forks, still actively pushed. A PyPI package `opencompass` does exist and is genuinely
+    this project's, and it is deliberately NOT declared as an artifact - it sees 5,728 downloads a month
+    against a project whose documented path is a git clone and a config tree, so banding on it would drop
+    this record to level 1 on a minority channel. Flagged for a ruling rather than declared here.
   sources:
   - url: https://github.com/open-compass/opencompass
     shows: 7.1k stars; 100+ datasets, multi-backend eval framework
     accessed: '2026-06-04'
+  - url: https://api.github.com/repos/open-compass/opencompass
+    shows: stargazers_count = 7,299, forks 837, pushed_at 2026-08-12, license Apache-2.0
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1f0dfda7086a66d4dd6a83f1c4e1ebefcc6745b61883877e75c76787dc16e6a7
+  - url: https://raw.githubusercontent.com/open-compass/opencompass/main/README.md
+    shows: README still describes 100+ supported datasets and the CompassRank public leaderboards that
+      carry the project's reported traction.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9c9258560278da5596691646e561998a38f663b67ec448a34ada47a5f2b4119c
 capability:
   score: 4
   basis: feature_matrix
   value: 100+ datasets (70+ with ~400k questions); 20+ HF models pre-supported + OpenAI/Gemini/Claude
     API backends; broad multi-task coverage and standardized reporting
   confidence: medium
+  relative_to: lm-evaluation-harness
+  relation: one_below
+  last_verified: '2026-08-13'
   note: Very broad multi-benchmark coverage and backend breadth -- just below lm-eval as the standardization
-    reference; strong but not the single de-facto global standard.
+    reference; strong but not the single de-facto global standard. Feature matrix re-read 2026-08-13 and
+    unchanged - the README still claims 100+ datasets and lists HF, LMDeploy, vLLM and API backends as
+    install extras. The comparison the note already made to lm-eval is now recorded structurally.
   sources:
   - url: https://github.com/open-compass/opencompass
     shows: 100+ datasets, 20+ HF + API model backends
     accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/open-compass/opencompass/main/README.md
+    shows: 100+ supported datasets; model backends offered as install extras (`opencompass[full]`, `[lmdeploy]`,
+      `[vllm]`, `[api]`); subjective and objective scoring modes documented.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9c9258560278da5596691646e561998a38f663b67ec448a34ada47a5f2b4119c

--- a/sources/scores/osworld.yaml
+++ b/sources/scores/osworld.yaml
@@ -16,8 +16,11 @@ openness:
     - execution-based eval harness + 369-task environment public
     - multi-platform (VMware/VirtualBox/Docker/AWS)
   confidence: high
+  last_verified: '2026-08-13'
   note: Apache-2.0, full harness + environment public. Scored as the evaluation harness; the bundled 369-task
-    set is also openly redistributable.
+    set is also openly redistributable. Re-read 2026-08-13 - the license endpoint still reports Apache-2.0
+    and the README still sets the benchmark up to run locally under VMware, VirtualBox or Docker with
+    no paid tier.
   raw: license:Apache-2.0(OSI);source:public(github.com/xlang-ai/OSWorld);execution-based eval harness +
     369-task environment public; multi-platform (VMware/VirtualBox/Docker/AWS);core-gated:ungated(full harness
     runs locally on VMware, VirtualBox or Docker, no paid tier)
@@ -40,6 +43,24 @@ openness:
     content_sha256: 83b8684c2f4ac4f31996b8b4752195fcb6cc5429f89d92398177b9b721d787fc
     establishes:
     - core-gated
+  - url: https://api.github.com/repos/xlang-ai/OSWorld/license
+    shows: GitHub's license endpoint reports spdx_id Apache-2.0 for xlang-ai/OSWorld and returns the Apache-2.0
+      text as the LICENSE body.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: f4949be7c5cc1918f147800213fab6f49ccc872b529fea02daed6c8700824988
+    establishes:
+    - license
+  - url: https://raw.githubusercontent.com/xlang-ai/OSWorld/main/README.md
+    shows: 'Re-read 2026-08-13: unchanged from the 2026-08-11 read - Apache-2.0 badge, full local setup
+      under VMware, VirtualBox or Docker with KVM, AWS and Azure optional for parallel runs, and no paid
+      tier, commercial edition or license key.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 83b8684c2f4ac4f31996b8b4752195fcb6cc5429f89d92398177b9b721d787fc
+    establishes:
+    - source
+    - core-gated
 adoption:
   level: 3
   signal_type: reported_traction
@@ -48,14 +69,31 @@ adoption:
     scores reported in OpenAI (CUA 38.1%, GPT-5.4 75.0%), Anthropic (Claude Sonnet 4.5 61.4%, Sonnet 4.6
     72.5%, Opus 4.6 72.7%) computer-use launches through 2026. Reach band is directional. The harness
     is run by a concentrated set of frontier labs/agent teams rather than a mass install base. 2.9k stars
-    corroborate only.'
+    corroborate only. Re-read 2026-08-13, with two notes. The Anthropic Sonnet 4.6 post still reports
+    OSWorld - ''Across sixteen months, our Sonnet models have made steady gains on OSWorld'' - but carries
+    the figure in a chart rather than in text, so the 72.5% in this note is not quotable from that page.
+    And os-world.github.io now 301-redirects to osworld-v1.xlang.ai, which is where the leaderboard lives;
+    the cited URL still resolves through the redirect. Level 3 unchanged; 3.1k stars.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.anthropic.com/news/claude-sonnet-4-6
-    shows: Claude Sonnet 4.6 OSWorld score reported in official model release (standard-citation signal)
-    accessed: '2026-06-04'
+    shows: 'Re-read 2026-08-13: the Sonnet 4.6 release post reports OSWorld results and charts Sonnet''s
+      progress on it across sixteen months. The benchmark is cited, which is the standard-citation signal;
+      the numeric score is in the chart rather than the prose.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 589bbbfe76178ca13e5400a385164d4bae550ca83abbd587bb13f2533d9a867a
   - url: https://os-world.github.io/
     shows: best-model vs human baselines; ongoing updates with new LLMs/VLMs
     accessed: '2026-06-04'
+  - url: https://osworld-v1.xlang.ai/
+    shows: 'the site os-world.github.io now redirects here; it still publishes the human-vs-model baselines
+      - ''While humans can accomplish over 72.36% of the tasks, the best model achieves only 12.24% success''
+      for the original v1 setting - and still lists the model families evaluated (Operator, GPT, Gemini,
+      Claude, UI-TARS, Agent-S, Qwen, CogAgent).'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: bf37e00ce23e8c5472d485a6eb3b291ffa2de220b44040402516e41cbc48c516
 capability:
   score: 5
   basis: feature_matrix
@@ -64,9 +102,12 @@ capability:
     trajectories; model-backend breadth: any VLM/LLM agent (Operator, GPT, Gemini, Claude, UI-TARS, Agent-S,
     Qwen, CogAgent baselines); reproducibility: multi-platform virtualization (VMware/VirtualBox/Docker/AWS)'
   confidence: high
+  last_verified: '2026-08-13'
   note: Frontier-defining within evaluation_code for the computer-use/agentic axis. Execution-based,
     real-environment agent evaluation is the hardest eval modality and OSWorld is its reference harness.
-    A 5 here is for the category's frontier-definers; OSWorld qualifies for agentic eval.
+    A 5 here is for the category's frontier-definers; OSWorld qualifies for agentic eval. Feature matrix
+    re-read 2026-08-13 and unchanged - 369 tasks (361 excluding the eight Google Drive ones), 134 execution-based
+    evaluation functions, and the same multi-platform virtualization story.
   sources:
   - url: https://os-world.github.io/
     shows: 369 execution-based real-computer tasks, multi-OS, agent-trajectory evaluation
@@ -74,3 +115,15 @@ capability:
   - url: https://github.com/xlang-ai/OSWorld
     shows: harness + baselines for Operator/GPT/Gemini/Claude/UI-TARS/Agent-S
     accessed: '2026-06-04'
+  - url: https://osworld-v1.xlang.ai/
+    shows: 369 tasks with an official note that the 8 Google Drive tasks may be excluded for a 361-task
+      run; 134 execution-based evaluation functions; 'reliable, reproducible setup and evaluation scripts'.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: bf37e00ce23e8c5472d485a6eb3b291ffa2de220b44040402516e41cbc48c516
+  - url: https://raw.githubusercontent.com/xlang-ai/OSWorld/main/README.md
+    shows: harness runs the environment under VMware, VirtualBox, Docker/KVM, AWS or Azure and evaluates
+      full agent trajectories against any VLM/LLM agent.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 83b8684c2f4ac4f31996b8b4752195fcb6cc5429f89d92398177b9b721d787fc

--- a/sources/scores/patronus-evaluation-platform.yaml
+++ b/sources/scores/patronus-evaluation-platform.yaml
@@ -15,12 +15,17 @@ openness:
     free_text:
     - eval engine + proprietary evaluators not self-hostable
   confidence: medium
+  last_verified: '2026-08-13'
   note: The open-source SDK is a thin client to a closed hosted evaluation backend; the core scoring engine
     and the managed Lynx/Glider evaluators are proprietary and not self-hostable. License text is not displayed
     on the SDK repo page. Class corrected from open_core on 2026-07-30. In this ladder open_core means an
     OSI core with functionality withheld for a paid tier, and there is no open core here, only an open periphery.
     A repo that exists while the runtime does not ship is source:partial, which the ladder scores 2/source_available.
-    The score itself was already 2.
+    The score itself was already 2. Re-read 2026-08-13 and unchanged. The SDK README still carries the
+    comment 'This evaluator runs remotely on Patronus infrastructure', the repo still declares no license
+    at all (GitHub's license field is null), it is at 8 stars and has not been pushed since 2026-01-09,
+    and the docs still describe Lynx and Glider as evaluators the hosted platform runs. No self-hostable
+    engine has appeared.
   raw: platform:closed(hosted SaaS; remote Judge/Lynx/Glider evaluators run on Patronus infrastructure);source:partial(patronus-py
     is a client wiring to the hosted API, not the engine);client-SDKs:open(patronus-py public on GitHub,
     v0.1.25, but only 7 stars and wires to the hosted API);eval engine + proprietary evaluators not self-hostable
@@ -33,18 +38,60 @@ openness:
     shows: 'hosted platform: built-in Lynx/Glider evaluators, experiments, production monitoring, SDK
       access to cloud service'
     accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/patronus-ai/patronus-py/main/README.md
+    shows: 'SDK README''s own example carries the comment ''# This evaluator runs remotely on Patronus
+      infrastructure.'' - the published code wires to the hosted engine rather than being it.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 636a0ea4f152a29c35f5b00282d27f714a16239a7d2452e33136f9ba97f5d254
+    establishes:
+    - source
+  - url: https://api.github.com/repos/patronus-ai/patronus-py
+    shows: stargazers_count = 8, pushed_at 2026-01-09, and the repo's `license` field is null - GitHub
+      detects no license file on the SDK at all.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 4d6878b7a74e8c2501ca2c48d3ab4ea05b883f23053bb4b2197f0fd4465e5eff
+    establishes:
+    - source
+  - url: https://docs.patronus.ai/docs
+    shows: 'Re-read 2026-08-13: still an end-to-end hosted system for evaluating, monitoring and improving
+      performance, with Lynx and Glider as in-house evaluators, experiments, real-time production monitoring
+      and Python/TypeScript SDKs into the cloud service. No self-hostable or open-source evaluation engine
+      is offered anywhere in it.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 757070b285359722c692ea3a97d1b9447e0603af24f72cbe73d131587e65e13e
+    establishes:
+    - source
 adoption:
   level: null
   reach: null
   signal_type: unknown
   confidence: low
+  last_verified: '2026-08-13'
   note: No disclosed user/customer counts or usage volume found on the docs/homepage this run; open source
     SDK has only 7 GitHub stars (stars_fallback would cap at hobbyist and is not an honest signal for
-    a hosted platform). Declining to assign a level rather than infer from marketing.
+    a hosted platform). Declining to assign a level rather than infer from marketing. Re-read 2026-08-13
+    - looked on the docs for a customer count, an evaluation-run count or a seat count and found none.
+    The docs name three case studies (Nova AI, Etsy, Weaviate) and attach no figures to them. The SDK
+    is now at 8 stars. The abstention is re-confirmed rather than lifted.
   sources:
   - url: https://github.com/patronus-ai/patronus-py
     shows: 7 stars on the public SDK (no honest usage figure for the hosted platform)
     accessed: '2026-06-04'
+  - url: https://docs.patronus.ai/docs
+    shows: 'Re-read 2026-08-13: no customer count, no usage volume and no seat count published. Three
+      named case studies (Nova AI, Etsy, Weaviate) carry no quantitative adoption data.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 757070b285359722c692ea3a97d1b9447e0603af24f72cbe73d131587e65e13e
+  - url: https://api.github.com/repos/patronus-ai/patronus-py
+    shows: stargazers_count = 8 on the public SDK, which is not an honest usage figure for the hosted
+      platform
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 4d6878b7a74e8c2501ca2c48d3ab4ea05b883f23053bb4b2197f0fd4465e5eff
 capability:
   score: 3
   basis: feature_matrix
@@ -53,10 +100,21 @@ capability:
     proprietary evaluators: Lynx (hallucination), Glider; reproducibility: hosted/standardized but not
     independently reproducible (closed engine)'
   confidence: medium
+  last_verified: '2026-08-13'
   note: Solid, broad commercial eval feature set (evaluators + experiments + monitoring + agent eval)
     but not frontier-defining within the category and the closed backend limits reproducibility. Mid-tier
-    on the feature matrix.
+    on the feature matrix. Feature matrix re-read 2026-08-13 and unchanged. No `relative_to` is recorded
+    because the note names no peer - 'mid-tier' is a position in the category rather than a comparison
+    to a product.
   sources:
   - url: https://docs.patronus.ai/docs
     shows: Lynx/Glider evaluators, RAG/agent/NLP/OWASP metrics, experiments, red-teaming, monitoring
     accessed: '2026-06-04'
+  - url: https://docs.patronus.ai/docs
+    shows: 'Re-read 2026-08-13: Lynx and Glider in-house evaluators plus custom ones, experiments for
+      A/B testing, real-time production monitoring through tracing and alerts, and Python/TypeScript SDKs.
+      Agent evaluation and Percival still present. Nothing independently reproducible, the engine being
+      closed.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 757070b285359722c692ea3a97d1b9447e0603af24f72cbe73d131587e65e13e

--- a/sources/scores/promptfoo.yaml
+++ b/sources/scores/promptfoo.yaml
@@ -14,14 +14,36 @@ openness:
     free_text:
     - no feature-gated core observed (acquired by OpenAI, stated to remain MIT/open source)
   confidence: high
+  last_verified: '2026-08-13'
   note: MIT-licensed, fully public; OSI -> open_source. OpenAI ownership noted but does not change the
-    OSS license at scoring time.
+    OSS license at scoring time. Re-read 2026-08-13 - the license endpoint still reports MIT and the README
+    still says 'Promptfoo remains open source and MIT licensed' under OpenAI, with no paid tier or license
+    key in it.
   raw: license:MIT(OSI);source:public(GitHub);no feature-gated core observed (acquired by OpenAI, stated
     to remain MIT/open source);core-gated:ungated
   sources:
   - url: https://github.com/promptfoo/promptfoo
     shows: MIT license; 'remains open source and MIT licensed' under OpenAI; v0.121.14
     accessed: '2026-06-04'
+  - url: https://api.github.com/repos/promptfoo/promptfoo/license
+    shows: GitHub's license endpoint reports spdx_id MIT for promptfoo/promptfoo and returns the MIT text
+      as the LICENSE body.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9e2e7d4a78cf4660e6591244d49e3b8458188252ac10bacaf68f7ee76b2da8f3
+    establishes:
+    - license
+  - url: https://raw.githubusercontent.com/promptfoo/promptfoo/main/README.md
+    shows: README states 'Promptfoo is now part of OpenAI. Promptfoo remains open source and MIT licensed'
+      and lists 'Open source - MIT licensed, with an active community' among its properties. The CLI installs
+      and runs from npm with no account, and nothing in the README offers a paid tier, an enterprise edition
+      or a license key.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 426270e1b7c45d0bf456b1284cdc1af055218db73869864b9590b1e0bdaab5cb
+    establishes:
+    - source
+    - core-gated
 adoption:
   level: 4
   reach: 1M-10M
@@ -36,14 +58,25 @@ adoption:
     docs/guides/adoption.md - if the declared artifact is not the product''s primary distribution channel,
     banding on it is a substitution rather than a measurement - applied before the mistake rather than after.
     The band stands on the evidence already cited here; what this record needs is a route to its real channel,
-    not a convenient one.'
+    not a convenient one. Re-read 2026-08-13 - the npm registry reports 2,277,977 downloads for the window
+    2026-07-11 to 2026-08-09, still inside the 1M-10M band, and the PyPI package is now at 13,629 a month,
+    unchanged as a minority channel.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://api.npmjs.org/downloads/point/last-month/promptfoo
-    shows: 1,176,340 monthly npm downloads
-    accessed: '2026-06-04'
+    shows: 2,277,977 npm downloads for 2026-07-11 to 2026-08-09 (was 1,176,340 when first read)
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 682df629e9b291c6dfbd63d26d684f0fe2bfe26e605a15614e93877facf46352
   - url: https://github.com/promptfoo/promptfoo
     shows: 21.9k stars; '10M+ users in production' claim
     accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/promptfoo/promptfoo/main/README.md
+    shows: README re-read 2026-08-13; the repo carries 24.2k stars and the README still positions the
+      tool as used by OpenAI and Anthropic. No standalone user count is published beyond that.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 426270e1b7c45d0bf456b1284cdc1af055218db73869864b9590b1e0bdaab5cb
 capability:
   score: 4
   basis: feature_matrix
@@ -51,9 +84,20 @@ capability:
     scanning, CI/CD integration, caching/live-reload; agentic + app eval plus a security dimension peers
     lack'
   confidence: high
+  relative_to: lm-evaluation-harness
+  relation: one_below
+  last_verified: '2026-08-13'
   note: Very broad eval coverage plus a distinctive red-teaming/security axis; top-tier for application
-    eval, below the academic-benchmark standardization references on raw benchmark coverage.
+    eval, below the academic-benchmark standardization references on raw benchmark coverage. Feature matrix
+    re-read 2026-08-13 and unchanged; the comparison to the standardization references is now recorded
+    structurally against lm-evaluation-harness.
   sources:
   - url: https://github.com/promptfoo/promptfoo
     shows: eval + red-teaming + model comparison + CI/CD features
     accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/promptfoo/promptfoo/main/README.md
+    shows: README lists red teaming and vulnerability scanning, side-by-side model comparison across OpenAI/Anthropic/Azure/Bedrock/Ollama,
+      CI/CD automation, and 'live reload and caching' - the same feature set the band was placed on.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 426270e1b7c45d0bf456b1284cdc1af055218db73869864b9590b1e0bdaab5cb

--- a/sources/scores/ragas.yaml
+++ b/sources/scores/ragas.yaml
@@ -14,22 +14,49 @@ openness:
     free_text:
     - core un-gated. (Vendor also offers a hosted app.ragas.io tier; not required for the library.)
   confidence: high
+  last_verified: '2026-08-13'
   note: Core library is fully OSI (Apache-2.0) with no feature-gated functionality; could be argued open_core
     given the hosted cloud product, but the eval library itself is complete and open, so scored open_source.
+    Re-read 2026-08-13 against the repo the product declares, vibrantlabsai/ragas (the cited explodinggradients
+    path now redirects there after the org rename). The license endpoint still reports Apache-2.0 and
+    the README installs and runs the whole metric suite from PyPI or a git checkout with no account, no
+    hosted tier and no license key mentioned anywhere in it.
   raw: license:Apache-2.0(OSI);source:public(full metrics + test-gen library); core un-gated. (Vendor also
     offers a hosted app.ragas.io tier; not required for the library.);core-gated:ungated
   sources:
   - url: https://github.com/explodinggradients/ragas
     shows: Apache-2.0 license; LLM-app eval metrics + test-set generation; v0.4.3 (Jan 2026); 14.2k stars
     accessed: '2026-06-04'
+  - url: https://api.github.com/repos/vibrantlabsai/ragas/license
+    shows: GitHub's license endpoint reports spdx_id Apache-2.0 for vibrantlabsai/ragas and returns the
+      Apache-2.0 text as the LICENSE body.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: ecb1c43652c8f8f20a3c90f2f1303b6725a3caa933fe71671d3df76d85234b96
+    establishes:
+    - license
+  - url: https://raw.githubusercontent.com/vibrantlabsai/ragas/main/README.md
+    shows: README carries the Apache-2.0 badge and installs with `pip install ragas` or straight from
+      the git repo; the metric suite and test-set generation ship in the package. No pricing page, hosted
+      tier, enterprise edition or license key is mentioned - even the app.ragas.io cloud product goes
+      unnamed in it.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: af20b2258507b12bf930e897b63ee5bb87aac4a4696da078ea5a3c29addb6db7
+    establishes:
+    - source
+    - core-gated
 adoption:
   level: 4
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
+  last_verified: '2026-08-13'
   note: ~1.51M PyPI downloads in the last 30 days (pypistats), de facto standard for RAG/LLM-app evaluation,
     widely integrated (LangChain, LlamaIndex, observability platforms). Stars (14.2k) corroborate. Solidly
-    in the 1M-10M monthly band.
+    in the 1M-10M monthly band. Re-read 2026-08-13 - the pypistats API reports 1,587,521 ragas downloads
+    in the trailing 30 days, still inside the same band, and the repo is at 15.3k stars under its new
+    vibrantlabsai org.
   sources:
   - url: https://pypistats.org/packages/ragas
     shows: 1,513,553 downloads in the last month
@@ -37,6 +64,11 @@ adoption:
   - url: https://github.com/explodinggradients/ragas
     shows: 14.2k stars; LangChain/observability integrations
     accessed: '2026-06-04'
+  - url: https://pypistats.org/api/packages/ragas/recent
+    shows: last_month = 1,587,521 downloads of the ragas package (last_week 335,773, last_day 58,054)
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 530ab0ea87e7d7f1e52d33bb53160ad5eeb964cedf0abbe351221999d0283cd0
 capability:
   score: 4
   basis: feature_matrix
@@ -45,10 +77,23 @@ capability:
     framework + observability integrations. Specialized for application/RAG eval rather than academic-benchmark
     model eval (different sub-domain from HELM/lm-eval-harness).
   confidence: medium
+  relative_to: helm
+  relation: one_below
+  last_verified: '2026-08-13'
   note: Frontier within the application/RAG-eval niche (metric breadth + test generation), but not a general
-    academic-benchmark model harness; scored 4 not 5 because coverage is domain-scoped.
+    academic-benchmark model harness; scored 4 not 5 because coverage is domain-scoped. Feature matrix
+    re-read 2026-08-13 and unchanged; the comparison the note draws to the academic-benchmark harnesses
+    is now recorded structurally against HELM.
   sources:
   - url: https://github.com/explodinggradients/ragas
     shows: objective metrics (LLM-based + traditional), Aspect Critique, automatic test-data generation,
       integrations
     accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/vibrantlabsai/ragas/main/README.md
+    shows: 'README still leads on the same three capabilities - ''Objective Metrics: Evaluate your LLM
+      applications with precision using both LLM-based and traditional metrics'', ''Test Data Generation:
+      Automatically create comprehensive test datasets'', and data-driven insights - and demonstrates
+      Aspect Critique through `DiscreteMetric`.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: af20b2258507b12bf930e897b63ee5bb87aac4a4696da078ea5a3c29addb6db7

--- a/sources/scores/scale-evaluation.yaml
+++ b/sources/scores/scale-evaluation.yaml
@@ -19,8 +19,13 @@ openness:
     free_text:
     - human-eval workforce is a proprietary service
   confidence: high
+  last_verified: '2026-08-13'
   note: Proprietary by design; the deliberately-private benchmark datasets and hosted expert-eval workforce
-    are the moat; no open source eval code. Closed.
+    are the moat; no open source eval code. Closed. Re-read 2026-08-13 and unchanged. The platform page
+    still offers only VPC deployment of the proprietary product, with no repository and no license to
+    the evaluation code, and the SEAL post still says the datasets 'will remain private and unpublished'.
+    The page now describes a 'largely open-source technology toolkit' in passing but names no repository
+    and offers nothing downloadable, so it does not move `source` off closed.
   raw: platform:closed(proprietary hosted SaaS); datasets:closed(private, unpublished SEAL benchmarks kept
     private to prevent gaming/training contamination); methodology:partially-disclosed(leaderboard transparency)
     but no open eval code or self-hostable engine; human-eval workforce is a proprietary service;source:closed(proprietary
@@ -43,14 +48,36 @@ openness:
     accessed: '2026-08-11'
     establishes:
     - source
+  - url: https://scale.com/genai-platform
+    shows: 'Re-read 2026-08-13: the platform page still offers ''Deploy securely within your own VPC.
+      Full support for AWS, Azure, and GCP'' and still names SEAL as an in-house frontier benchmarking
+      lab. It refers to a ''largely open-source technology toolkit'' but identifies no repository and
+      offers no downloadable source or license to the evaluation engine.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e8cc5a29bc75e06fbddb1457767e22782cd17820b8254a3b58620d076b1cabad
+    establishes:
+    - source
+  - url: https://scale.com/blog/leaderboard
+    shows: 'Re-read 2026-08-13: ''Scale''s proprietary datasets will remain private and unpublished, ensuring
+      they cannot be exploited'', and the leaderboards use ''curated private datasets that can''t be gamed''.
+      No eval code is published alongside them.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9ee56219a844162417efca29d4caaf8082562185d97f7cd31a8210e25307e038
+    establishes:
+    - source
 adoption:
   level: 3
   signal_type: reported_traction
   confidence: low
+  last_verified: '2026-08-13'
   note: SEAL Leaderboards are widely cited and 'trusted by leading AI labs' as a third-party evaluator;
     SEAL Showdown reports 'millions of real-world conversations' across 100+ countries / 70 languages
     / 200 professional domains. No disclosed paying-customer count for the Scale Evaluation platform specifically.
-    Level 3 reflects reported traction of the eval surface, not a verified user count; directional.
+    Level 3 reflects reported traction of the eval surface, not a verified user count; directional. Re-read
+    2026-08-13 - both cited figures are still on their pages verbatim, and no paying-customer count has
+    appeared.
   sources:
   - url: https://scale.com/blog/showdown
     shows: SEAL Showdown built on millions of real-world conversations, 100+ countries, 70 languages,
@@ -59,6 +86,19 @@ adoption:
   - url: https://scale.com/blog/leaderboard
     shows: third-party evaluator trusted by leading AI labs
     accessed: '2026-06-04'
+  - url: https://scale.com/blog/showdown
+    shows: 'Re-read 2026-08-13: ''SEAL Showdown is based on millions of real-world conversations from
+      Scale''s diverse global contributor network'' spanning ''over 100 countries, 70 languages, and 200
+      professional domains'' - the same figures as recorded.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: bea77274d044a922262f1a4a747a1b1ba8e2650f2926a69e553833100c837554
+  - url: https://scale.com/blog/leaderboard
+    shows: 'Re-read 2026-08-13: Scale is still described as ''a third-party model evaluator trusted by
+      leading AI labs''. No user, customer or run count is published.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9ee56219a844162417efca29d4caaf8082562185d97f7cd31a8210e25307e038
 capability:
   score: 4
   basis: feature_matrix
@@ -67,9 +107,16 @@ capability:
     vulnerability scans + human expert eval + real-preference (Showdown); reproducibility: NOT reproducible
     by design (private datasets); standardization: high (neutral third-party)'
   confidence: medium
+  last_verified: '2026-08-13'
   note: 'Very broad professional eval coverage (multi-domain private benchmarks + expert workforce + adversarial
     red-teaming + real-preference), strong commercial capability. Not a 5: closed/non-reproducible and
-    not a community-standard harness in the open-eval-code sense.'
+    not a community-standard harness in the open-eval-code sense. Re-read 2026-08-13, with one correction
+    to the evidence rather than the band. The SEAL leaderboard post cited here announces four domains
+    - coding, instruction following, math (GSM1k) and multilinguality - and says more will follow; it
+    does not itself establish the reasoning, agentic, multimodal and safety coverage this value lists.
+    The breadth claim now rests on the platform page (auto-generated eval datasets, adversarial vulnerability
+    scans, expert human eval) plus SEAL Showdown''s real-preference stream, which is enough for a 4 and
+    is stated here rather than left implied.'
   sources:
   - url: https://scale.com/blog/leaderboard
     shows: SEAL multi-domain expert-driven leaderboards (coding/IF/math/multilingual/reasoning/agentic/safety)
@@ -78,3 +125,17 @@ capability:
     shows: auto-generated eval datasets + proprietary benchmarks + adversarial vulnerability scans + expert
       human eval
     accessed: '2026-06-04'
+  - url: https://scale.com/blog/leaderboard
+    shows: 'Re-read 2026-08-13: the post names four launch domains - coding, instruction following, math
+      (GSM1k) and multilinguality - with a stated intention to add more. It does NOT list reasoning, agentic
+      or safety leaderboards, which this axis previously recorded it as showing.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9ee56219a844162417efca29d4caaf8082562185d97f7cd31a8210e25307e038
+  - url: https://scale.com/genai-platform
+    shows: 'Re-read 2026-08-13: automated and human feedback in the evaluation loop, SEAL as the in-house
+      frontier benchmarking lab, and a continuous-learning flywheel over customer usage. Nothing externally
+      reproducible, the benchmarks being private by design.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e8cc5a29bc75e06fbddb1457767e22782cd17820b8254a3b58620d076b1cabad

--- a/sources/scores/simple-evals.yaml
+++ b/sources/scores/simple-evals.yaml
@@ -14,12 +14,35 @@ openness:
     free_text:
     - no managed tier
   confidence: high
-  note: Fully OSI (MIT); purely a reference-implementation library, no gated core.
+  last_verified: '2026-08-13'
+  note: Fully OSI (MIT); purely a reference-implementation library, no gated core. Re-read 2026-08-13
+    - the license endpoint still reports MIT and the README is unchanged apart from carrying the same
+    July 2025 deprecation notice. A frozen repo is still a published one, so `source` and `core-gated`
+    are unaffected.
   raw: license:MIT(OSI);source:public(reference eval implementations); no managed tier;core-gated:ungated
   sources:
   - url: https://github.com/openai/simple-evals
     shows: MIT license; lightweight eval library; deprecation notice (July 2025); ~4.5k stars
     accessed: '2026-06-04'
+  - url: https://api.github.com/repos/openai/simple-evals/license
+    shows: GitHub's license endpoint reports spdx_id MIT for openai/simple-evals and returns the MIT text
+      as the LICENSE body.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 42b64dab65f25affe35be4e3c5b7442f1caa0041bcc2a9148313fec222311ee1
+    establishes:
+    - license
+  - url: https://raw.githubusercontent.com/openai/simple-evals/main/README.md
+    shows: 'README opens with a deprecation notice - ''July 2025: simple-evals will no longer be updated
+      for new models or benchmark results. The repo will continue to host reference implementations for
+      HealthBench, BrowseComp, and SimpleQA'' - and the eval scripts are in the repo. No paid tier, managed
+      service or license key is offered anywhere in it.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d9647c4a0e34cd9b2b528ff6986141734aac6f5f2f18a068eeadb2af0b29786f
+    establishes:
+    - source
+    - core-gated
 adoption:
   level: 2
   reach: 1K-10K stars
@@ -31,21 +54,44 @@ adoption:
     rather than as a live harness. Stars read 2026-08-13: 4,598 across the 1 declared repo, which bands at
     1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach ''10K-100K'' was not a
     label this instrument offers - stars have their own vocabulary because a star is not a download. No
-    last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch,
-    and the rest of the axis was not re-read.'
+    Re-read against the GitHub API on 2026-08-13 - 4,598 stars and 503 forks, and the README still leads
+    with the July 2025 deprecation notice, so both halves of the level hold.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/openai/simple-evals
     shows: ~4.5k stars, 490 forks; deprecation notice
     accessed: '2026-06-04'
+  - url: https://api.github.com/repos/openai/simple-evals
+    shows: stargazers_count = 4,598, forks 503, pushed_at 2026-04-22
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 91a1314636db06ee60fa04ca1863ba4ad41c3c983ba78ded50711dc579678a1b
+  - url: https://raw.githubusercontent.com/openai/simple-evals/main/README.md
+    shows: deprecation notice still first in the README; only HealthBench, BrowseComp and SimpleQA reference
+      implementations remain maintained
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d9647c4a0e34cd9b2b528ff6986141734aac6f5f2f18a068eeadb2af0b29786f
 capability:
   score: 2
   basis: feature_matrix
   value: ~9 bundled benchmarks, zero-shot/CoT only; no plugin task system, no agentic-eval support, no
     model-backend abstraction beyond direct API calls; deprecated/frozen.
   confidence: medium
+  last_verified: '2026-08-13'
   note: Deliberately minimal reference harness, now frozen; narrow coverage and feature set vs category
-    leaders (HELM, Inspect AI, lm-eval-harness).
+    leaders (HELM, Inspect AI, lm-eval-harness). Feature matrix re-read 2026-08-13 and unchanged - the
+    README still lists the same nine bundled benchmarks and still says the repo is not actively maintained
+    and takes no new evals. No `relative_to` is recorded because the note's comparison is to three leaders
+    at once, three rungs above, which the relation vocabulary cannot express.
   sources:
   - url: https://github.com/openai/simple-evals
     shows: bundled benchmark list (MMLU/MATH/GPQA/HumanEval/HealthBench/etc.); zero-shot CoT approach
     accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/openai/simple-evals/main/README.md
+    shows: bundled benchmarks MMLU, MATH, GPQA, DROP, MGSM, HumanEval, SimpleQA, BrowseComp and HealthBench,
+      each with its upstream license; 'We will not be actively maintaining this repository ... we're not
+      accepting new evals'.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d9647c4a0e34cd9b2b528ff6986141734aac6f5f2f18a068eeadb2af0b29786f

--- a/sources/scores/simpleaudit.yaml
+++ b/sources/scores/simpleaudit.yaml
@@ -14,7 +14,11 @@ openness:
     free_text:
     - Python
   confidence: high
-  note: Permissive OSI (MIT) license with full public source.
+  last_verified: '2026-08-13'
+  note: Permissive OSI (MIT) license with full public source. Re-read 2026-08-13 - the LICENSE body is
+    still the MIT text with Simula Research Laboratory's copyright, and the README still states 'MIT License'
+    and still describes a local-first framework that ships its scenario packs and needs no account. No
+    paid tier, hosted edition or license key appears in the 39KB of it.
   raw: license:MIT(OSI; verified LICENSE body, copyright Simula);source:public;Python;core-gated:ungated(local
     execution is the default mode, all scenario packs ship in the package)
   sources:
@@ -35,6 +39,25 @@ openness:
     http_status: 200
     content_sha256: 6c851942b0521b6cbf776a4b1b4905d8255fb261eff3cfcb3aa7abf07df09c46
     establishes:
+    - core-gated
+  - url: https://raw.githubusercontent.com/kelkalot/simpleaudit/main/LICENSE
+    shows: 'Re-read 2026-08-13: LICENSE body is still ''MIT License'', copyright Simula Research Laboratory.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6a48f8bb76cd134073d1231f140425f5695b0659cc1fba3ea5596a0a0879fe19
+    establishes:
+    - license
+  - url: https://raw.githubusercontent.com/kelkalot/simpleaudit/main/README.md
+    shows: 'Re-read 2026-08-13: ''SimpleAudit is a simple, extensible, local-first framework for multilingual
+      auditing and red-teaming of AI systems via adversarial probing. It supports open models running
+      locally (no APIs required)'', and it closes ''MIT License - see LICENSE for details''. The scenario
+      packs, rubric, auditor and judge configuration ship in the package; the only external dependency
+      is the reader''s own model API key if they choose to use one.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6c851942b0521b6cbf776a4b1b4905d8255fb261eff3cfcb3aa7abf07df09c46
+    establishes:
+    - source
     - core-gated
 adoption:
   level: 1
@@ -58,8 +81,21 @@ capability:
   value: Multilingual adversarial probing with local/open-model support; scenario packs (safety, RAG,
     healthcare) plus a broken-premise evaluator.
   confidence: high
-  note: Focused but functional red-teaming toolkit with a distinctive broken-premise mode.
+  last_verified: '2026-08-13'
+  note: Focused but functional red-teaming toolkit with a distinctive broken-premise mode. Feature matrix
+    re-read 2026-08-13 and unchanged in kind, though the README has grown a validation section reporting
+    AUROC 0.89-1.00 for safe-versus-unsafe separation and a direct comparison against Petri. Still a single-purpose
+    adversarial-probing tool rather than a general harness, so the band holds. No `relative_to` is recorded
+    because Petri is not a product in this category.
   sources:
   - url: https://github.com/kelkalot/simpleaudit
     shows: 'README: adversarial probing, local-first, scenario packs, broken-premise runner'
     accessed: '2026-06-22'
+  - url: https://raw.githubusercontent.com/kelkalot/simpleaudit/main/README.md
+    shows: multilingual adversarial probing with local open models or optional API-hosted ones; a fixed
+      default scenario pack, rubric, auditor, judge and sampling configuration so reruns are comparable;
+      reported responsiveness of AUROC 0.89-1.00 across judge-auditor cells; results reported as a bundle
+      rather than a leaderboard rank.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6c851942b0521b6cbf776a4b1b4905d8255fb261eff3cfcb3aa7abf07df09c46

--- a/sources/scores/swe-bench.yaml
+++ b/sources/scores/swe-bench.yaml
@@ -15,7 +15,10 @@ openness:
     - harness+inference+eval code public
     - no feature-gated core
   confidence: high
-  note: MIT-licensed harness, full source public; OSI -> open_source.
+  last_verified: '2026-08-13'
+  note: MIT-licensed harness, full source public; OSI -> open_source. Re-read 2026-08-13 against the repo
+    the product declares, SWE-bench/SWE-bench (the cited princeton-nlp path now redirects there). The
+    license endpoint still reports MIT and the README still ships the whole harness with no paid tier.
   raw: license:MIT(OSI);source:public(GitHub);harness+inference+eval code public;no feature-gated core;core-gated:ungated
   sources:
   - url: https://pypi.org/project/swebench/
@@ -24,15 +27,40 @@ openness:
   - url: https://github.com/princeton-nlp/SWE-bench
     shows: MIT license, public harness source
     accessed: '2026-06-04'
+  - url: https://api.github.com/repos/SWE-bench/SWE-bench/license
+    shows: GitHub's license endpoint reports spdx_id MIT for SWE-bench/SWE-bench, and returns the LICENSE.md
+      body as the MIT text.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: ca9d720a1e08b9205f4ed097936eaba48dab795f7e848fe8721c508664289871
+    establishes:
+    - license
+  - url: https://raw.githubusercontent.com/SWE-bench/SWE-bench/main/README.md
+    shows: README carries the MIT badge, closes with 'MIT license. Check LICENSE.md', and documents building
+      the harness from source and running containerized Docker evaluation on the reader's own machine.
+      No pricing, enterprise edition, paid tier or license key appears anywhere in it. The only held-back
+      piece is the SWE-bench Multimodal test split, whose grading runs through the free sb-cli service -
+      a contamination control on one split, not a commercial gate on the harness.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 910cf1bd353b898e9c6299d8e805c1a115d00c1b877e1239753be8d9caa4275f
+    establishes:
+    - source
+    - core-gated
 adoption:
   level: 4
   signal_type: reported_traction
   confidence: medium
+  last_verified: '2026-08-13'
   note: SWE-bench Verified is the de-facto-standard agentic-coding eval cited in essentially every 2025-26
     frontier release report (GPT-5 74.9%, DeepSeek-V4-Pro 80.6%, Qwen3.6, Kimi K2.6) -- the top adoption
     signal for a harness per recipe. pypistats reports ~31.5M swebench downloads/mo but that figure is
     almost certainly CI/benchmark-runner-inflated and not human installs, so used as corroboration only,
-    not the headline; level set on standard-status, capped at 4.
+    not the headline; level set on standard-status, capped at 4. Re-read 2026-08-13 - the pypistats API
+    now reports 45,994,790 swebench downloads in the trailing 30 days, up from the 31.5M cited here. On
+    the software download bands that figure would sit at level 5, and the level is deliberately not moved
+    on it, for the reason already recorded - this package is pulled by benchmark runners rather than
+    installed by people, so the count is not a use count. Flagged for review rather than edited.
   sources:
   - url: https://pypistats.org/packages/swebench
     shows: ~31.5M monthly PyPI downloads (likely CI-inflated; corroboration only)
@@ -40,6 +68,19 @@ adoption:
   - url: https://github.com/princeton-nlp/SWE-bench
     shows: ICLR 2024 oral; harness used across model evaluations
     accessed: '2026-06-04'
+  - url: https://pypistats.org/api/packages/swebench/recent
+    shows: last_month = 45,994,790 downloads of the swebench package (last_week 14,827,831, last_day
+      1,708,049)
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 385cc2f2f27a10a91fe8e9b4cb2a198fced1a36d8ef4d22402d2ad51848cfb46
+  - url: https://raw.githubusercontent.com/SWE-bench/SWE-bench/main/README.md
+    shows: README records the ICLR 2024 oral and ICLR 2025 Multimodal papers and the SWE-bench Verified
+      500-problem split built with OpenAI Preparedness - the standard-status evidence the level rests
+      on.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 910cf1bd353b898e9c6299d8e805c1a115d00c1b877e1239753be8d9caa4275f
 capability:
   score: 5
   basis: feature_matrix
@@ -47,9 +88,19 @@ capability:
     Verified/Lite/Multimodal/Pro splits; broad model-backend support; reference implementation for the
     most-cited coding benchmark'
   confidence: high
+  last_verified: '2026-08-13'
   note: Frontier-definer within evaluation_code for agentic/coding eval -- the reference harness for the
-    benchmark every lab reports against.
+    benchmark every lab reports against. Feature matrix re-read 2026-08-13 and unchanged - patch generation
+    against real GitHub issues, containerized test-based grading, and the Verified/Lite/Multimodal splits
+    all still documented in the repo README.
   sources:
   - url: https://github.com/princeton-nlp/SWE-bench
     shows: harness runs models on real GitHub issues with test-based verification; multimodal split
     accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/SWE-bench/SWE-bench/main/README.md
+    shows: harness generates patches for real GitHub issues and grades them by running the repository's
+      own tests in Docker; SWE-bench Verified, Lite and Multimodal splits documented; Modal cloud execution
+      offered as an alternative backend.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 910cf1bd353b898e9c6299d8e805c1a115d00c1b877e1239753be8d9caa4275f

--- a/sources/scores/vals-ai.yaml
+++ b/sources/scores/vals-ai.yaml
@@ -14,8 +14,15 @@ openness:
     eval-harness:
       value: closed
   confidence: high
-  note: Closed third-party eval platform; benchmarks deliberately held private to prevent dataset leakage,
-    eval infra not open sourced.
+  note: 'Closed third-party eval platform; benchmarks deliberately held private to prevent dataset leakage,
+    eval infra not open sourced. NO last_verified claimed and the axis is ESCALATED, because the re-read
+    on 2026-08-13 contradicts the recorded value. The about page now says Vals has open-sourced ''Valkyrie,
+    a distributed system to run agentic benchmarks, and our model library, a free standard API to call
+    models with'', and both repos are live and actively pushed - vals-ai/valkyrie under AGPL-3.0 and vals-ai/model-library
+    under MIT. That makes ''source:closed(SaaS-only,no public repo)'' and ''eval-harness:closed'' wrong
+    as written. The likely correct record is source:partial, which the software ladder scores 2/source_available:
+    a real harness is published while the Vals Index runtime and its held-out datasets still do not ship.
+    That is a score change, so it is reported rather than made here.'
   raw: license:proprietary;source:closed(SaaS-only,no public repo);benchmarks:proprietary/private-held-out(Vals
     Index on non-public datasets);eval-harness:closed
   sources:
@@ -26,6 +33,15 @@ openness:
   - url: https://www.vals.ai/about
     shows: runs evaluations in-house on private/held-out datasets as neutral third party
     accessed: '2026-06-04'
+  - url: https://www.vals.ai/about
+    shows: 'Re-read 2026-08-13: Vals still describes itself as ''the independent evaluator of artificial
+      intelligence'' running evaluations in-house on ''privately held test sets''. It now ALSO states
+      it has open-sourced Valkyrie, a distributed system for running agentic benchmarks, and a model library
+      offering a free standard API for calling models, both linked to GitHub. This contradicts the recorded
+      source:closed.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: deb010de89092a2071bc5e3e8168d9b85e7bfa3887d7105476aba611c90234fc
 adoption:
   level: 3
   signal_type: reported_traction
@@ -34,12 +50,23 @@ adoption:
     2026-06-04); benchmark figures (e.g. GLM-5.1) are referenced in the project''s own flagship scoring
     sources and across third-party model coverage; partnered with Legaltech Hub for industry studies.
     No standalone user/traffic count published, so reported_traction; level 3 reflects broad referenced
-    use as a benchmark authority rather than a measured usage figure.'
+    use as a benchmark authority rather than a measured usage figure. Re-read 2026-08-13 - the benchmarks
+    page now tracks 43 models across the Vals Index, an RSI Index, the Multimodal Index and legal/finance/healthcare/math/academic/education/coding
+    families, with results dated 2026-08-13, so the leaderboard is broader and current. Still no user,
+    traffic or customer figure of any kind, so the level stays reported_traction at 3.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.vals.ai/benchmarks
     shows: live multi-domain leaderboards (Vals Index, Multimodal Index) tracking 24+ frontier models,
       updated June 2026
     accessed: '2026-06-04'
+  - url: https://www.vals.ai/benchmarks
+    shows: 'Re-read 2026-08-13: 43 models tested; Vals Index, RSI Index and Vals Multimodal Index plus
+      legal, finance, healthcare, math, academic, education, coding, cybersecurity and games benchmarks;
+      several results dated 2026-08-13. No usage, traffic or customer figure is published on the page.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 68b57a0a93207cd98932ef7bb54e1e638db27450bbb70d5e8fb6cae4841d5a6f
 capability:
   score: 4
   basis: feature_matrix
@@ -48,11 +75,25 @@ capability:
     held-out sets (anti-leakage); agentic-eval support (Finance Agent v2). Pointwise scoring + composite
     indices.'
   confidence: medium
+  last_verified: '2026-08-13'
   note: 'Strong feature_matrix: leading independent/blind benchmark suite with deep vertical coverage
     and agentic-eval, but narrower than a general harness (no self-host, fixed proprietary task set).
-    Not a frontier-definer (5) on standardization since methodology is closed; placed at 4.'
+    Not a frontier-definer (5) on standardization since methodology is closed; placed at 4. Feature matrix
+    re-read 2026-08-13 and the vertical coverage holds, with cybersecurity and games benchmarks added
+    since. The ''no self-host'' clause in this note is the part now under review - see the openness axis,
+    where two Vals repos have appeared - but self-hosting the index is still not offered, so the band
+    is unchanged.'
   sources:
   - url: https://www.vals.ai
     shows: Vals Index + Multimodal Index + domain benchmarks (finance/law/healthcare/coding/math/education)
       incl TaxEval, CorpFin, MedCode, LegalBench
     accessed: '2026-06-04'
+  - url: https://www.vals.ai
+    shows: 'Re-read 2026-08-13: Vals Index and Vals Multimodal Index over finance (CorpFin v2, Finance
+      Agent v2, TaxEval v2), legal (LegalBench, Case Law v2, Legal Research Bench), healthcare (MedCode,
+      MedScribe, MedQA), coding (SWE-bench Verified, Terminal-Bench, Vibe Code Bench, IOI, LiveCodeBench),
+      math (ProofBench, AIME, GPQA Diamond) and education (SAGE, MMLU Pro, MMMU). ''We run all of our
+      own evaluations and create many of our benchmarks in-house''.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 303bde67a1b32448cbe8de1ef60414a71472450740363231f8cdda41ef4423db

--- a/sources/scores/vertex-ai-gen-ai-evaluation-service.yaml
+++ b/sources/scores/vertex-ai-gen-ai-evaluation-service.yaml
@@ -14,7 +14,12 @@ openness:
     billing:
       value: GCP managed-service pricing
   confidence: high
+  last_verified: '2026-08-13'
   note: Proprietary Google Cloud managed service; no source, no self-host, runs as Vertex AI eval pipelines.
+    Re-read 2026-08-13 - the overview still documents the service only as a managed part of the Gemini
+    Enterprise Agent Platform, with no source, no self-host and no license offered for the evaluation
+    service itself. The open-model references on the page are about models it can deploy and evaluate,
+    not about the service.
   raw: license:proprietary(GCP managed service);source:closed;deployment:cloud-only(Vertex AI pipelines/AutoSxS);billing:GCP
     managed-service pricing
   sources:
@@ -22,18 +27,38 @@ openness:
     shows: managed GCP eval service (computation-based + autorater + AutoSxS) within Gemini Enterprise
       Agent Platform
     accessed: '2026-06-04'
+  - url: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/evaluation-overview
+    shows: 'Re-read 2026-08-13: the Gen AI evaluation service is documented as part of the Gemini Enterprise
+      Agent Platform, run through computation-based pipelines, model-based metric templates and the AutoSxS
+      pipeline. No self-hosting option and no source for the service is offered; the ''self-deployed open
+      models'' links refer to models under evaluation, not to the evaluator.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 4d1f8992f97637bb096575d3c3f5c45fd47702c427c76e682e34eaf7cfd60641
+    establishes:
+    - source
+    - license
 adoption:
   level: null
   reach: null
   signal_type: unknown
   confidence: low
+  last_verified: '2026-08-13'
   note: Managed GCP feature with no published standalone usage/customer count and no download or stars
     signal (closed cloud service). Unlike Bedrock Evaluations there was no clear GA-scale traction figure
     verifiable this run, so declining to assign a level rather than infer from the parent Vertex surface.
+    Re-read 2026-08-13 - looked for an evaluation-run count, a customer count or any usage statistic on
+    the overview and found none, so the abstention is re-confirmed rather than lifted.
   sources:
   - url: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/evaluation-overview
     shows: managed Vertex AI feature, no usage/adoption figures disclosed
     accessed: '2026-06-04'
+  - url: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/evaluation-overview
+    shows: 'Re-read 2026-08-13: no usage, customer, run-count or adoption figure of any kind is published
+      on the evaluation-service overview.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 4d1f8992f97637bb096575d3c3f5c45fd47702c427c76e682e34eaf7cfd60641
 capability:
   score: 4
   basis: feature_matrix
@@ -41,11 +66,23 @@ capability:
     (managed rubric-based metrics + custom judge models), pointwise + pairwise (AutoSxS side-by-side);
     RAG grounding evaluation; model-backend breadth = Gemini + custom/external models.'
   confidence: medium
+  relative_to: amazon-bedrock-evaluations
+  relation: at
+  last_verified: '2026-08-13'
   note: 'Broad managed eval suite: model/agent/RAG targets, both computation- and autorater-based metrics,
     and pointwise + pairwise (AutoSxS) comparison. Comparable scope to Bedrock Evaluations; a custom-dataset
-    eval product rather than a public standardized leaderboard, so 4 not 5.'
+    eval product rather than a public standardized leaderboard, so 4 not 5. Feature matrix re-read 2026-08-13
+    and unchanged; the comparison to Bedrock Evaluations the note already draws is now recorded structurally,
+    both sitting at 4.'
   sources:
   - url: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/evaluation-overview
     shows: evaluates models/agents/RAG with computation-based + autorater metrics and pointwise/pairwise
       AutoSxS
     accessed: '2026-06-04'
+  - url: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/evaluation-overview
+    shows: 'Re-read 2026-08-13: separate sections for evaluating models, evaluating agents and grounding
+      responses using RAG; computation-based evaluation pipeline, model-based metric templates and the
+      AutoSxS pairwise pipeline all still documented.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 4d1f8992f97637bb096575d3c3f5c45fd47702c427c76e682e34eaf7cfd60641


### PR DESCRIPTION
**103 of 104 axes closed.** No `score`, `level`, `class`, `reach`, `signal_type`, `basis` or `confidence` changed anywhere in the diff — this pass was almost entirely re-reading and re-sourcing.

Every openness axis now cites a license source and a raw README **separately**, so `license`, `source` and `core-gated` each have their own establishing read rather than one URL asserted to settle all three. Rendered `github.com/owner/repo` pages were left as history but never re-dated — the right instinct, since their digests drift forever.

Eleven `relative_to`/`relation` pairs recorded where the note already named a peer in prose. Corpus comparisons now 43.

## One score change, escalated not applied

**`vals-ai` openness.** The about page now says Vals has open-sourced "Valkyrie, a distributed system to run agentic benchmarks, and our model library". Both repos are real and live — `vals-ai/valkyrie` (AGPL-3.0, pushed today) and `vals-ai/model-library` (MIT). The record says `source: closed (SaaS-only, no public repo)`, score 1/closed.

Recommend **2/source_available** with `source: partial`: a harness is published while the Vals Index runtime and its held-out datasets don't ship. Adoption and capability were re-read and dated; only openness is held.

## Cited evidence that had quietly gone wrong

This is the pattern that keeps recurring, and this pass found five more:

- **`inspect-ai`** cited an AISI blog as showing "thousands of frontier-model evaluations on Inspect". It doesn't — it reports **16 models** in the first year, and says only that Inspect "is used by other governments and some of the leading AI developers". The named labs aren't on that page either. `shows` narrowed; level 4 holds on download corroboration.
- **`scale-evaluation`** cited the SEAL post for seven domains. That post announces **four**.
- **`open-llm-leaderboard`** cited an archive page for the **v2** suite; that page documents **v1**. The 2M-visitor figure is there; the 13K-model figure is in the retirement post. Attribution split across both.
- **`osworld`**'s 72.5% Sonnet 4.6 figure now exists only in a chart image, not in text.
- **`alpacaeval`**'s "Data License CC By NC 4.0" badge links to a *sibling* repo; `alpaca_eval` has no `DATA_LICENSE`. Apache-2.0 stands — recorded so nobody re-litigates it.

## Adoption findings for a ruling

**`swe-bench`** pypistats now reads **45,994,790/mo** against a recorded 31.5M. On the download bands that's level 5; the record holds level 4 on `reported_traction` with an explicit "this is CI traffic, not installs" rationale. Level left alone, new figure recorded. Worth deciding whether that cap survives a 46M reading.

**Three undeclared PyPI artifacts**, with the recommendation differing per product — which is the right way to treat them:
- `inspect-ai` 9,278,867/mo → declaring **confirms** the existing 4 and gives the axis a real route. Worth doing.
- `alpacaeval` → `alpaca-eval` 30,340/mo → level stays 2, instrument moves off `stars_fallback`. Worth doing.
- `opencompass` 5,728/mo → declaring would drop it **3 → 1** on a minority channel. **Recommend not declaring** — the `promptfoo` precedent.

## State changes recorded

`bigcodebench` is **archived read-only**; HELM entered **maintenance mode** on 2026-06-01; `openai/evals` unpushed since April; `ragas` moved org; `swe-bench` moved to `SWE-bench/SWE-bench`; `patronus-py` has **no license file at all** (GitHub's `license` field is null).

Nothing was unverifiable — every URL fetched 200, with GitHub API and pypistats rate limits retried to success rather than skipped.

All gates green: `validate` 0 errors, `check_verification` all three OK, `check_capability` OK, `check_adoption --strict` exit 0, 488 tests.