### PR TITLE
Verify ui_api: 149/162 checkpoints

### DIFF
--- a/sources/products/anythingllm.yaml
+++ b/sources/products/anythingllm.yaml
@@ -6,5 +6,5 @@ description: All-in-one desktop and Docker app for private, on-device chat with 
   embedder and vector DB, plus team/Docker mode with RBAC and embeddable widgets; ~60k GitHub stars.
 github:
 - url: https://github.com/Mintplex-Labs/anything-llm
-comments: v1.13.0 (May 26, 2026); MIT-licensed all-in-one local-first Desktop + Docker AI app (document
-  chat, RAG, agents). Confirmed live on GitHub June 2026.
+comments: Verified live 2026-08-13 via primary sources; v1.15.0 (June 25, 2026), ~65k stars and 3.98M
+  Docker pulls. MIT-licensed all-in-one local-first Desktop + Docker AI app (document chat, RAG, agents).

--- a/sources/products/azure-ai-model-inference.yaml
+++ b/sources/products/azure-ai-model-inference.yaml
@@ -8,5 +8,5 @@ description: Managed inference service providing a unified API across OpenAI mod
   controls.
 comments: Microsoft Foundry Models unified inference endpoint (Azure AI Model Inference). Proprietary
   managed cloud service exposing many model deployments through one OpenAI-compatible endpoint; beta Azure
-  AI Inference SDK deprecated, retiring Aug 26 2026 in favor of OpenAI/v1 API. Confirmed live (docs updated
-  Apr 2026).
+  AI Inference SDK deprecated, retiring Aug 26 2026 in favor of OpenAI/v1 API. Verified live 2026-08-13
+  via primary sources; the retirement banner is still on the endpoints doc.

--- a/sources/products/character-ai.yaml
+++ b/sources/products/character-ai.yaml
@@ -5,6 +5,7 @@ description: Consumer chat product centered on user-created character personas, 
   conversational entertainment. ~20M MAU and ~6M daily visitors with two hours/day average engagement,
   one of the stickiest consumer AI surfaces; founders' team was acqui-hired by Google in 2024 but the
   product continues to operate.
-comments: Character.AI consumer companion/roleplay chat app (web + mobile), live June 2026. Proprietary
-  chat UI over its own models + (post-Google-deal) licensed models; human-in-the-loop character chat.
-  MAU peaked ~28M mid-2024, declined amid competition.
+comments: Character.AI consumer companion/roleplay chat app (web + mobile). Verified live 2026-08-13 via
+  primary sources. Proprietary chat UI over its own models + (post-Google-deal) licensed models;
+  human-in-the-loop character chat. Business of Apps now reports 45M active users for September 2025 and
+  75M+ downloads, replacing the ~20M MAU and ~28M mid-2024 peak this record was written against.

--- a/sources/products/chatgpt.yaml
+++ b/sources/products/chatgpt.yaml
@@ -6,5 +6,6 @@ description: 'OpenAI''s flagship consumer chat product, web, desktop, and mobile
   The category-defining UI by a wide margin: 900M weekly active users and 50M paying subscribers as of
   Feb 2026, on a $25B annualized run rate.'
 comments: ChatGPT (OpenAI) consumer chat app, web + iOS/Android + desktop. Proprietary/closed UI scored
-  as the closed counterpart in this category. Live and verified June 2026; default model GPT-5 family.
+  as the closed counterpart in this category. Verified live 2026-08-13 via primary sources; default model
+  GPT-5 family.
   (The model SKU is scored separately under base/finetuned categories; this record scores the chat surface.)

--- a/sources/products/claude-ai.yaml
+++ b/sources/products/claude-ai.yaml
@@ -5,5 +5,7 @@ description: Anthropic's consumer chat product (web, desktop, mobile) for intera
   models, with Projects, Artifacts (live-rendered code/docs), and Computer Use. ~30M monthly active users
   and adding 1M+ daily signups as of March 2026, third-largest US mobile chatbot.
 comments: Claude.ai (Anthropic) consumer chat app, web + macOS/Windows + iOS/Android. Proprietary/closed
-  UI scored as the closed counterpart. Verified live June 2026 (product page now at claude.com/product/overview,
-  redirected from anthropic.com/claude). Uses Claude Opus/Sonnet/Haiku.
+  UI scored as the closed counterpart. Verified live 2026-08-13 via primary sources (product page at
+  claude.com/product/overview, redirected from anthropic.com/claude). Uses Claude Opus/Sonnet/Haiku.
+  Anthropic still publishes no consumer MAU figure of its own, so the adoption axis still rests on an
+  aggregator estimate.

--- a/sources/products/confer.yaml
+++ b/sources/products/confer.yaml
@@ -14,4 +14,5 @@ comments: Confer publishes its inference/proxy stack and reproducible confidenti
   openly for verifiability, but NEITHER repo carries a LICENSE file (GitHub reports no declared license),
   and the end-user client app is not public - so despite "open source" marketing the accurate classification
   is source-available. The service is not self-hostable; its security model depends on Confer's attestation
-  infrastructure. Repos created Dec 2025.
+  infrastructure. Repos created Dec 2025. Verified live 2026-08-13 via primary sources; confer-proxy still
+  carries no LICENSE, and the product has since added memory, connectors and folder files.

--- a/sources/products/continue.yaml
+++ b/sources/products/continue.yaml
@@ -9,5 +9,6 @@ github:
 - url: https://github.com/continuedev/continue
 comments: Continue (continuedev/continue); VS Code extension v1.2.22 (Mar 2026), JetBrains plugin, and
   open source `cn` CLI. Open-source AI code assistant, chat + inline edit + autocomplete in the IDE,
-  now also marketing 'AI code agent' (agent mode) and CI checks. Verified live on GitHub + VS Marketplace
-  June 2026.
+  now also marketing 'AI code agent' (agent mode) and CI checks. Verified live 2026-08-13 via primary
+  sources; 3.9M Marketplace installs, and continue.dev now leads with Continue having been acquired by
+  Cursor while the Apache-2.0 codebase stays available.

--- a/sources/products/deepseek-chat.yaml
+++ b/sources/products/deepseek-chat.yaml
@@ -6,6 +6,7 @@ description: Chinese consumer chat app from DeepSeek (Hangzhou) on chat.deepseek
   (90% MoM surge), second only to ChatGPT in global AI DAU rankings, driven by free access to frontier-tier
   models.
 comments: 'Hosted consumer chat UI at chat.deepseek.com (web + iOS/Android apps), currently fronting DeepSeek-V4
-  Preview (stronger agent + reasoning). Verified live June 2026. Note: the underlying DeepSeek-V3/V4 model
+  Pro (stronger agent + reasoning, Responses API and Codex integration). Verified live 2026-08-13 via
+  primary sources. Note: the underlying DeepSeek-V3/V4 model
   weights are open (MIT) and scored separately in base_pretrained; this record scores the CHAT PRODUCT/UI
   itself, which is a proprietary free hosted service, not open source software.'

--- a/sources/products/doubao.yaml
+++ b/sources/products/doubao.yaml
@@ -10,4 +10,5 @@ description: 'ByteDance''s consumer AI chat app (doubao.com plus iOS/Android) po
   Spring Festival Gala.'
 comments: 'ByteDance''s consumer AI assistant (chatbot app: iOS/Android/web), launched Aug 2023, running
   on Volcano Engine (Doubao models). Proprietary closed product. Introduced a paid Pro subscription tier
-  ~May/Jun 2026. Verified live June 2026 (Wikipedia + China-market app trackers).'
+  ~May/Jun 2026. Verified live 2026-08-13 via primary sources (Wikipedia + China-market app trackers);
+  stable release is now Doubao Seed 2.0 (14 Feb 2026).'

--- a/sources/products/duck-ai.yaml
+++ b/sources/products/duck-ai.yaml
@@ -8,4 +8,6 @@ description: DuckDuckGo's free, anonymous AI chat surface. Lets users chat with 
   not used to train models. The differentiator is privacy - a proprietary anonymizing proxy in front of
   otherwise-closed model APIs.
 comments: Proprietary; web-based and integrated into the DuckDuckGo browser. No source, no self-host -
-  the closed counterpart to the privacy-chat surfaces in this shelf.
+  the closed counterpart to the privacy-chat surfaces in this shelf. Verified live 2026-08-13 via primary
+  sources; the paid tiers now reach Claude Sonnet 4.6 and Claude Opus 4.8, and Tinfoil has joined the
+  list of providers DuckDuckGo proxies to.

--- a/sources/products/gemini.yaml
+++ b/sources/products/gemini.yaml
@@ -5,5 +5,6 @@ description: Google's consumer Gemini chat app on web, Android, iOS, and integra
   with Live (voice), Deep Research, and image/video generation. 900M+ monthly active users by Q1 2026 (up from
   750M at end of 2025).
 comments: Gemini app (Google), consumer chat app (web + Android/iOS), proprietary/closed UI scored as
-  the closed counterpart. Verified live June 2026; powered by Gemini 3.x model family. (Model SKUs scored
+  the closed counterpart. Verified live 2026-08-13 via primary sources; now powered by the Gemini 3.5
+  family, launched 19 May 2026. (Model SKUs scored
   separately; this record scores the app surface.)

--- a/sources/products/github-copilot-ide.yaml
+++ b/sources/products/github-copilot-ide.yaml
@@ -6,5 +6,6 @@ description: AI pair-programmer integrated into VS Code, JetBrains, Neovim, and 
   Differentiator is enterprise distribution via GitHub and tight IDE integration; ~4.7M paid subscribers
   and ~$1B ARR as of early 2026.
 comments: GitHub Copilot (GitHub / Microsoft), proprietary in-IDE AI coding assistant (inline suggestions,
-  chat, agent mode) across VS Code/JetBrains/etc. Closed counterpart in ui_api. Verified live on github.com/features/copilot
-  June 2026.
+  chat, agent mode) across VS Code/JetBrains/etc. Closed counterpart in ui_api. Verified live 2026-08-13
+  via primary sources; the product page now also fronts a desktop app, a CLI and third-party agents over
+  MCP.

--- a/sources/products/glean-assistant.yaml
+++ b/sources/products/glean-assistant.yaml
@@ -9,6 +9,7 @@ description: Enterprise AI coworker that grounds answers, drafts, slides, voice 
 comments: 'Enterprise AI assistant / ''AI coworker'' grounded in the Glean Enterprise Graph (RAG over
   100+ enterprise connectors), with a Model Hub (multiple frontier LLMs), multimodal output (images/slides/pages),
   and agentic sub-features (Skills, sub-agent orchestration). Proprietary single-tenant SaaS. May-2026
-  ''enterprise AI coworker'' launch verified live June 2026. BORDERLINE: agentic/Skills features touch
+  ''enterprise AI coworker'' launch verified live 2026-08-13 via primary sources; the site now advertises
+  more than 250 connectors, up from the 100+ recorded here. BORDERLINE: agentic/Skills features touch
   orchestration_agents, but the product is primarily a human-in-driver enterprise chat/assistant UI grounded
   in company data, so kept in ui_api per the litmus (AI presented as a tool to the human).'

--- a/sources/products/glean-workplace-search-ai.yaml
+++ b/sources/products/glean-workplace-search-ai.yaml
@@ -8,5 +8,6 @@ description: AI-powered workplace search across 100+ enterprise tools with permi
 comments: Glean Search ('the foundation of enterprise AI'), AI-powered enterprise/workplace search UI
   built on the Enterprise Graph + Personal Graph, hybrid search across 100+ connectors (Slack, Teams,
   Zoom, ServiceNow, Zendesk, GitHub, etc.), permissions-aware. Proprietary single-tenant SaaS. Verified
-  live June 2026. The search layer underpins Glean Assistant; scored here as the human-facing search UI/API
+  live 2026-08-13 via primary sources; the connector count on the site now reads 250+. The search layer
+  underpins Glean Assistant; scored here as the human-facing search UI/API
   product.

--- a/sources/products/gpt4all.yaml
+++ b/sources/products/gpt4all.yaml
@@ -7,4 +7,5 @@ description: Free, cross-platform desktop app from Nomic AI for running LLMs pri
 github:
 - url: https://github.com/nomic-ai/gpt4all
 comments: MIT. ~77k stars. Reduced maintenance - last notable release Feb 2025, community reports of stalled development
-  through 2025 (no official deprecation).
+  through 2025 (no official deprecation). Verified live 2026-08-13 via primary sources; the repo has had
+  no push since 27 May 2025, so the stall is now over a year old.

--- a/sources/products/grok-app.yaml
+++ b/sources/products/grok-app.yaml
@@ -5,6 +5,7 @@ description: xAI's consumer chat product with a standalone app (grok.com) plus d
   competing on real-time data access and a less-filtered tone. ~64M MAU by early 2026 and ~17.8% US chatbot
   share, third behind ChatGPT and Gemini.
 comments: Grok consumer AI chat assistant by xAI, the app/UI surface (grok.com + X integration + mobile),
-  live June 2026 (x.ai). Scored here as the chat-UI product, NOT the Grok 4.x model SKU (the model is
+  verified live 2026-08-13 via primary sources (x.ai answered a plain fetch this time, so the earlier
+  bot-block note no longer applies). Scored here as the chat-UI product, NOT the Grok 4.x model SKU (the model is
   scored in base_pretrained as Grok 4.20). Proprietary; human-in-the-loop assistant with image gen + X-grounded
   search.

--- a/sources/products/huggingchat-chat-ui.yaml
+++ b/sources/products/huggingchat-chat-ui.yaml
@@ -9,4 +9,5 @@ github:
 - url: https://github.com/huggingface/chat-ui
 comments: chat-ui v0.10.0 (May 11, 2026), Apache-2.0, powers HuggingChat at hf.co/chat. Original HuggingChat
   was sunset July 1, 2025, then relaunched as 'HuggingChat Omni' (Omni Router + 115-123 open models, 15
-  inference providers, MCP). Confirmed live June 2026.
+  inference providers, MCP). Verified live 2026-08-13 via primary sources; hf.co/chat now offers 132 open
+  models and v0.10.0 is still the latest tagged release.

--- a/sources/products/jan.yaml
+++ b/sources/products/jan.yaml
@@ -7,6 +7,7 @@ description: Cross-platform desktop app (Windows/macOS/Linux) for running open s
   stance; 5.3M+ downloads and ~43k GitHub stars by May 2026.
 github:
 - url: https://github.com/janhq/jan
-comments: Jan v0.8.2 (released 1 Jun 2026). Open-source local-first ChatGPT alternative (desktop chat
+comments: Verified live 2026-08-13 via primary sources; Jan v0.8.4 (23 Jul 2026), 6.1M downloads and
+  ~44k stars. Open-source local-first ChatGPT alternative (desktop chat
   UI) by Menlo Research / janhq; runs local GGUF models plus pluggable cloud providers, ships an OpenAI-compatible
-  local API server. Verified live on GitHub + jan.ai June 2026.
+  local API server.

--- a/sources/products/khoj.yaml
+++ b/sources/products/khoj.yaml
@@ -10,6 +10,7 @@ github:
 - url: https://github.com/khoj-ai/khoj
 pypi:
 - url: https://pypi.org/project/khoj
-comments: AGPL-3.0; ~35k GitHub stars and ~26k PyPI downloads/month by mid-2026. Khoj Cloud (the former
+comments: Verified live 2026-08-13 via primary sources. AGPL-3.0; ~36k GitHub stars and ~20k PyPI
+  downloads/month. Khoj Cloud (the former
   paid hosted tier) was sunset 2026-04-15; the team directs all users to self-host and states Khoj "remains
   fully open source", so no feature-gating remains in the shipping product. Self-host via Docker or pip.

--- a/sources/products/le-chat.yaml
+++ b/sources/products/le-chat.yaml
@@ -7,4 +7,7 @@ description: Mistral's consumer/enterprise chat product (chat.mistral.ai) runnin
   flagship sovereign-AI chat surface.
 comments: Le Chat by Mistral AI, consumer AI chat assistant (web + mobile; app rebranded toward 'Mistral
   Vibe' by 2026), live June 2026 (mistral.ai). Proprietary chat UI primarily over Mistral's own models;
-  human-in-the-loop assistant. ~1.7M app downloads by May 2026; EU MAU stated below 45M.
+  human-in-the-loop assistant. ~1.7M app downloads by May 2026; EU MAU stated below 45M. Verified live
+  2026-08-13, but only the adoption axis could be re-derived - all three axes cite a single February 2025
+  TechCrunch brief, which carries the download milestone and nothing about the license, the source or the
+  feature set, so openness and capability are escalated for re-sourcing against mistral.ai.

--- a/sources/products/librechat.yaml
+++ b/sources/products/librechat.yaml
@@ -8,4 +8,5 @@ description: Open-source ChatGPT clone with native support for OpenAI, Anthropic
 github:
 - url: https://github.com/danny-avila/LibreChat
 comments: Active 2026 (changelog/releases current); MIT-licensed self-hosted multi-provider chat UI. Acquired
-  by ClickHouse in 2025. Confirmed live on GitHub June 2026.
+  by ClickHouse in 2025. Verified live 2026-08-13 via primary sources; repo now at ~42k stars, up from
+  the ~37k the description records for mid-2026.

--- a/sources/products/litellm.yaml
+++ b/sources/products/litellm.yaml
@@ -9,4 +9,6 @@ github:
 - url: https://github.com/BerriAI/litellm
 pypi:
 - url: https://pypi.org/project/litellm/
-comments: v1.84.5 (June 4, 2026)
+comments: Verified live 2026-08-13 via primary sources; v1.96.2 (Aug 11, 2026), ~56k stars, 741M PyPI
+  downloads in the trailing 30 days. The README and docs now say 100+ providers where this record says
+  140+.

--- a/sources/products/llm.yaml
+++ b/sources/products/llm.yaml
@@ -9,5 +9,6 @@ github:
 - url: https://github.com/simonw/llm
 pypi:
 - url: https://pypi.org/project/llm
-comments: Apache-2.0 (verified LICENSE body). Latest release v0.31 (~24 Apr 2026, PyPI/GitHub). ~12.1k stars. Canonical
-  repo under the personal simonw account; branded under the Datasette ecosystem. Verified 2026-06-19.
+comments: Apache-2.0 (verified LICENSE body). Latest release 0.32 (4 Aug 2026, PyPI/GitHub). ~12.4k stars
+  and ~601k PyPI downloads/month. Canonical repo under the personal simonw account; branded under the
+  Datasette ecosystem. Verified live 2026-08-13 via primary sources.

--- a/sources/products/lm-studio.yaml
+++ b/sources/products/lm-studio.yaml
@@ -8,3 +8,5 @@ github:
 - url: https://github.com/lmstudio-ai
 comments: Desktop app is proprietary freeware ('free for home and work use'; ToS forbids modification/reverse-engineering/redistribution).
   Only the CLI (lms) and JS/Python SDKs are MIT. Score 1 (not 0) because the SDK/CLI source is public.
+  Verified live 2026-08-13 via primary sources; v0.4.21, and there is now a headless build called llmster
+  for servers and CI.

--- a/sources/products/lobe-chat.yaml
+++ b/sources/products/lobe-chat.yaml
@@ -7,6 +7,7 @@ description: Modern-design open source chat framework supporting OpenAI, Claude,
   ~77k GitHub stars makes it the second-most-starred OSS chat UI.
 github:
 - url: https://github.com/lobehub/lobehub
-comments: v2.2.2 (June 4, 2026); repo rebranded lobehub/lobehub. License changed from MIT to a non-OSI
+comments: Verified live 2026-08-13 via primary sources; v2.2.13 (Aug 1, 2026), ~82k stars, repo rebranded
+  lobehub/lobehub. License changed from MIT to a non-OSI
   'LobeHub Community License' (Apache-2.0 based + derivative-distribution commercial restriction). Product
   now markets agent-team orchestration but remains a human-driven chat UI at core.

--- a/sources/products/lumo.yaml
+++ b/sources/products/lumo.yaml
@@ -11,4 +11,5 @@ github:
 - url: https://github.com/ProtonLumo/android-lumo
 comments: Launched July 2025; Lumo 1.1 added advanced reasoning. Clients are GPLv3 (web client lives in
   ProtonMail/WebClients; iOS/Android in ProtonLumo), but the service, models, and routing are not open sourced,
-  so the "fully open source" marketing claim is contested.
+  so the "fully open source" marketing claim is contested. Verified live 2026-08-13 via primary sources;
+  the iOS repo README confirms the client is a WKWebView shell around lumo.proton.me.

--- a/sources/products/maple-ai.yaml
+++ b/sources/products/maple-ai.yaml
@@ -13,3 +13,5 @@ comments: Maple client is MIT-licensed; the underlying OpenSecret platform is AG
   so anyone can rebuild and compare hashes against the live attestation. Launched Jan 2025. Serves open-weight
   models (gpt-oss-120b, kimi-k2.5, deepseek-r1, llama-3.3-70b, qwen3-vl, gemma-3). The consumer offering at
   trymaple.ai is a paid hosted service - openness applies to the code/architecture, not free unlimited usage.
+  Verified live 2026-08-13 via primary sources; the model guide still lists that lineup, and Maple v3.3.3
+  shipped 12 Aug 2026.

--- a/sources/products/meta-ai.yaml
+++ b/sources/products/meta-ai.yaml
@@ -10,4 +10,6 @@ description: Meta's consumer AI assistant, a chat surface embedded directly into
   ChatGPT, Claude, and Gemini since the Muse Spark launch.
 comments: Meta's consumer AI assistant embedded across WhatsApp, Instagram, Messenger, Facebook + standalone
   meta.ai app. Proprietary; powered by Meta's Llama family (the underlying weights are use-restricted
-  and scored separately at the model layer). Verified live June 2026.
+  and scored separately at the model layer). Verified 2026-08-13, but only the adoption axis - the two
+  sources behind openness and capability both refuse an automated fetch (demandsage.com returns 403,
+  facebook.com returns 400), so those axes are escalated as unverifiable from their current citations.

--- a/sources/products/microsoft-copilot.yaml
+++ b/sources/products/microsoft-copilot.yaml
@@ -5,6 +5,8 @@ description: Microsoft's consumer/enterprise Copilot chat surface on Windows, we
   across Microsoft 365 (Word, Excel, Teams, Outlook). 15M paid M365 Copilot seats and 33M active users
   as of Q2 FY2026, though usage share has slipped vs ChatGPT and Gemini.
 comments: Microsoft Copilot consumer + M365 Copilot chat assistant surfaces (Windows, Edge, M365, Bing,
-  mobile), live June 2026 per Microsoft Learn admin/usage docs. Proprietary chat UI over OpenAI + Microsoft
+  mobile). Verified live 2026-08-13 via primary sources (Microsoft Learn admin/usage docs). Business of
+  Apps has restated its headline to 218M active users, replacing the ~420M all-surfaces figure the
+  description carries. Proprietary chat UI over OpenAI + Microsoft
   models; human-in-the-loop assistant (Copilot Studio agents are a separate product). Scored as the chat-UI
   surface.

--- a/sources/products/morphic.yaml
+++ b/sources/products/morphic.yaml
@@ -8,5 +8,5 @@ description: Open-source AI-powered answer engine with a generative UI - answers
   is the generative-UI answer surface; it is Docker-deployable for self-hosting.
 github:
 - url: https://github.com/miurla/morphic
-comments: Apache-2.0; ~8.9k GitHub stars by mid-2026. Built on Next.js + the Vercel AI SDK. Self-hostable
-  open generative-search UI.
+comments: Verified live 2026-08-13 via primary sources. Apache-2.0; ~9.0k GitHub stars, latest release
+  v1.5.0. Built on Next.js + the Vercel AI SDK. Self-hostable open generative-search UI.

--- a/sources/products/nextchat.yaml
+++ b/sources/products/nextchat.yaml
@@ -6,5 +6,6 @@ description: Lightweight, cross-platform ChatGPT/Gemini/Claude web client that r
   frontends like Open WebUI are overkill; ~88k GitHub stars makes it the single most-starred OSS chat
   UI repo by raw count.
 comments: v2.16.1 latest release (~mid-2025; release notes cite OpenAI o3/o4-mini + Claude 3.7 support);
-  MIT core. ~6-12mo since last release as of June 2026 -> freshness flag. Cross-platform (web/desktop/mobile)
+  MIT core. Verified live 2026-08-13 via primary sources; still no release since July 2025, so the
+  freshness flag stands and the gap is now over a year. Cross-platform (web/desktop/mobile)
   chat client; Enterprise Edition adds permissions/RAG.

--- a/sources/products/ogx.yaml
+++ b/sources/products/ogx.yaml
@@ -7,6 +7,7 @@ description: Meta's open inference + deployment runtime for LLMs; originally lau
   partners including AWS, NVIDIA, Databricks, Groq, and Azure. MIT licensed, 8.4K+ stars with continuous
   commit history across the rename. Anchors the 1B+ Llama downloads ecosystem.
 comments: 'OGX (Open GenAI Stack), formerly Meta''s Llama Stack; renamed/rescoped to a model-agnostic,
-  multi-SDK agentic API server. v1.0.2 (May 13, 2026), MIT-licensed, ~8.4k GitHub stars. NOT itself an
+  multi-SDK agentic API server. Verified live 2026-08-13 via primary sources: v1.3.0 (Aug 7, 2026),
+  MIT-licensed, 8.4k GitHub stars, now also speaking the Google GenAI SDK. NOT itself an
   inference engine: it composes/routes to inference backends (vLLM, Ollama, Bedrock) plus vector stores,
   safety, tools, file storage.'

--- a/sources/products/open-webui.yaml
+++ b/sources/products/open-webui.yaml
@@ -9,5 +9,6 @@ github:
 - url: https://github.com/open-webui/open-webui
 pypi:
 - url: https://pypi.org/project/open-webui
-comments: v0.9.6 (June 1, 2026), confirmed live on GitHub June 2026. Self-hosted chat UI (Ollama + OpenAI-compatible
-  APIs).
+comments: Verified live 2026-08-13 via primary sources. Self-hosted chat UI (Ollama + OpenAI-compatible
+  APIs); v0.11.0 is the latest release and the repo now shows ~149k stars, up from the ~138k the
+  description records for May 2026.

--- a/sources/products/openclaw.yaml
+++ b/sources/products/openclaw.yaml
@@ -11,4 +11,5 @@ npm:
 - url: https://www.npmjs.com/package/openclaw
 comments: MIT (repo LICENSE body is MIT; GitHub shows NOASSERTION due to a custom 'OpenClaw Foundation' copyright
   line; npm declares MIT). Community project led by Peter Steinberger (steipete). Created Nov 2025; ~379k stars,
-  ~10.3M npm downloads/month.
+  ~11.4M npm downloads/month. Verified live 2026-08-13 via primary sources; 386k stars, latest release
+  v2026.7.1-2.

--- a/sources/products/openrouter.yaml
+++ b/sources/products/openrouter.yaml
@@ -5,7 +5,9 @@ description: 'Commercial API gateway that exposes 400+ models from 60+ providers
   Meta, DeepSeek, plus open-weights hosts) behind a single OpenAI-compatible endpoint with automatic failover
   and unified billing. The largest closed-source LLM aggregator by revenue: ~$50M annualized revenue and reportedly
   raising $120M at a $1.3B valuation (CapitalG-led) in early 2026.'
-comments: OpenRouter unified LLM API gateway/router, live June 2026 (openrouter.ai homepage). Routes/aggregates
-  API calls across 400+ models and 60+ providers behind one OpenAI-compatible API; not a chat UI but a
+comments: OpenRouter unified LLM API gateway/router. Verified live 2026-08-13 via primary sources; the
+  homepage now reads 200T+ monthly tokens, 10M+ global users, 400+ models and 70+ providers, against the
+  100T/8M/60+ this record was scored on - the adoption band is escalated on that. Routes/aggregates
+  API calls behind one OpenAI-compatible API; not a chat UI but a
   routing gateway, squarely the ui_api gateway slot alongside the LiteLLM anchor. Proprietary hosted
   service.

--- a/sources/products/otari.yaml
+++ b/sources/products/otari.yaml
@@ -7,5 +7,6 @@ description: An open, self-hosted OpenAI-compatible LLM gateway from Mozilla AI.
   Built on Mozilla AI's any-llm; a hosted platform (Otari.ai) runs on the same core.
 github:
 - url: https://github.com/mozilla-ai/otari
-comments: Otari LLM gateway, Apache-2.0, from Mozilla AI; ~63 GitHub stars (July 2026), created April 2026.
-  Built on Mozilla AI's any-llm. Verified live July 2026.
+comments: Otari LLM gateway, Apache-2.0, from Mozilla AI; created April 2026. Built on Mozilla AI's
+  any-llm. Verified live 2026-08-13 via primary sources; 381 GitHub stars, up from ~63 in July, latest
+  release v0.4.0.

--- a/sources/products/perplexica.yaml
+++ b/sources/products/perplexica.yaml
@@ -9,7 +9,9 @@ description: Open-source, privacy-focused AI answer engine - a self-hostable alt
   and privacy for the Perplexity-style answer-with-sources experience.
 github:
 - url: https://github.com/ItzCrazyKns/Vane
-comments: MIT-licensed; ~35k GitHub stars and 100k+ Docker pulls by mid-2026. NOTE the project was renamed
+comments: Verified live 2026-08-13 via primary sources. MIT-licensed; ~36k GitHub stars, and the two
+  Docker images together stand at 931k lifetime pulls. Development has been quiet since April 2026 - both
+  the last commit and the last release (v1.12.2) date from then. NOTE the project was renamed
   Perplexica -> Vane (~Mar 2026) to avoid name proximity to Perplexity AI; the github.com/ItzCrazyKns/Perplexica
   URL now redirects to .../Vane. Still widely known and listed as "Perplexica". Self-host via a single
   bundled Docker image (Next.js frontend + API + private SearXNG).

--- a/sources/products/perplexity.yaml
+++ b/sources/products/perplexity.yaml
@@ -5,7 +5,10 @@ description: Search-grounded consumer chat product that returns cited answers wi
   on web, mobile, and as a Comet browser. 45M+ MAU and ~$200M ARR with a $21B valuation in 2026; the consumer
   surface (perplexity.ai) is human-driven Q&A, distinct from the Perplexity API (Cat 11) and the agentic
   Comet browser.
-comments: Perplexity consumer AI answer/search chat product (web + apps), live June 2026 (perplexity.ai
-  homepage confirms product). Proprietary chat UI routing over multiple closed + open models; human-in-the-loop
+comments: Perplexity consumer AI answer/search chat product (web + apps). Verified live 2026-08-13, but
+  via the Business of Apps compilation rather than the vendor - perplexity.ai returns HTTP 403 to an
+  automated fetch, so the openness and capability axes could not be re-derived from their only cited
+  source. That compilation gives 45M active users, 80M+ downloads and ~$200M 2025 revenue. Proprietary
+  chat UI routing over multiple closed + open models; human-in-the-loop
   search/answer assistant. Comet browser + Computer agent are adjacent surfaces (agentic, scored elsewhere
   if at all).

--- a/sources/products/poe.yaml
+++ b/sources/products/poe.yaml
@@ -5,6 +5,8 @@ description: Multi-model chat aggregator letting users talk to GPT-5.2, Claude O
   image/video generators, and 1M+ user-created bots from one interface, with a points-based unified pricing
   model. Differentiator is breadth (200+ models in one app) plus a creator economy of custom bots; recently
   added 200-person group chats. Run by Quora.
-comments: Poe by Quora, multi-model chat aggregator app (web + mobile/desktop), live June 2026 (poe.com
-  confirms). Single UI fronting many providers' bots (ChatGPT, Claude, Gemini, DeepSeek) + image/video/audio
-  models + millions of user-created bots. Human-in-the-loop chat aggregator; proprietary.
+comments: Poe by Quora, multi-model chat aggregator app (web + mobile/desktop). Verified live 2026-08-13
+  via primary sources (poe.com/about). Single UI fronting many providers' bots (ChatGPT, Claude, Gemini,
+  DeepSeek) + image/video/audio models + millions of user-created bots. Human-in-the-loop chat aggregator;
+  proprietary. The adoption axis is escalated - the ~18M MAU and ~$65M subscription-revenue figures it
+  cites are no longer on the aggregator page behind them.

--- a/sources/products/privatemode.yaml
+++ b/sources/products/privatemode.yaml
@@ -13,4 +13,5 @@ comments: Launched Feb 2025. The privatemode-public repo holds the auditable Tru
   a custom source-available license (view/compile for audit only); the privatemode-proxy, web app, and internal/oss
   subdirectories are dual-licensed MIT. The operational service itself is proprietary/hosted. Serves third-party
   open-weight models (e.g. gpt-oss-120b, Gemma, Kimi K2, Qwen embeddings, Whisper/Voxtral) - trains none of
-  its own.
+  its own. Verified live 2026-08-13 via primary sources; privatemode-public shipped v1.52.0 the same day
+  and the site now advertises Kimi K2.6.

--- a/sources/products/sillytavern.yaml
+++ b/sources/products/sillytavern.yaml
@@ -9,5 +9,5 @@ github:
 - url: https://github.com/SillyTavern/SillyTavern
 comments: SillyTavern v1.18.0 (released 3 May 2026). Self-hosted local chat front-end (NodeJS) for text-gen
   LLMs, originally a TavernAI fork (Feb 2023); connects to many backends (KoboldAI, OpenAI, Claude, Mistral,
-  etc.) with character/roleplay focus, image-gen + TTS integration, extensions. Verified live on GitHub
-  June 2026.
+  etc.) with character/roleplay focus, image-gen + TTS integration, extensions. Verified live 2026-08-13
+  via primary sources; v1.18.0 is still the latest release and the repo is at ~32k stars.

--- a/sources/products/surfsense.yaml
+++ b/sources/products/surfsense.yaml
@@ -9,6 +9,11 @@ description: Open-source, privacy-focused AI research assistant positioned as a 
   infrastructure.
 github:
 - url: https://github.com/MODSetter/SurfSense
-comments: Apache-2.0; ~15k GitHub stars by mid-2026. Self-host via Docker/Compose (PostgreSQL + pgvector).
+comments: Verified live 2026-08-13 via primary sources; ~16k GitHub stars. The repo has repositioned as
+  an open web research platform for AI agents with live data connectors, reachable over one REST API or an
+  MCP server. Licensing has SPLIT since this was written - the root LICENSE now places
+  surfsense_backend/app/proprietary/ (the platforms and web_crawler connectors) under Business Source
+  License 1.1 with a non-compete additional use grant, leaving only the rest Apache-2.0. The openness
+  score has not been changed here; it is escalated. Self-host via Docker/Compose (PostgreSQL + pgvector).
   Connector count and per-feature depth are taken from the maintainer-authored README and not independently
   verified. Newer/smaller project than the leading open chat UIs.

--- a/sources/products/thunderbolt.yaml
+++ b/sources/products/thunderbolt.yaml
@@ -10,4 +10,5 @@ description: Open-source, self-hosted AI client from MZLA Technologies (the Mozi
 github:
 - url: https://github.com/thunderbird/thunderbolt
 comments: Launched April 2026 under MPL-2.0; in active development and mid-security-audit as of mid-2026.
-  Self-hosted multi-provider enterprise AI client.
+  Self-hosted multi-provider enterprise AI client. Verified live 2026-08-13 via primary sources; the
+  README still warns the project is early and mid-audit, latest release v0.1.107, ~4.8k stars.

--- a/sources/scores/anythingllm.yaml
+++ b/sources/scores/anythingllm.yaml
@@ -16,12 +16,22 @@ openness:
   confidence: high
   note: Fully OSI (MIT), full source public; a hosted instance is offered but the self-hosted Desktop/Docker
     app is the complete product.
+    Re-read 2026-08-13. The repository still carries MIT and the README still presents the self-hosted
+    Desktop and Docker builds as the complete product, with the Hosted Instance offered beside it as a
+    convenience rather than as a tier that unlocks anything. Two features are marked Docker-version-only
+    - multi-user permissioning and the embeddable chat widget - but both ship in the MIT repository, so
+    nothing is withheld from the published source. Repo now at 64,687 stars, latest release v1.15.0.
+    Value unchanged at 5 / open_source.
   raw: license:MIT(OSI);source:public;no-feature-gated-core;optional hosted instance tier (managed convenience,
     not a gated core);core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/Mintplex-Labs/anything-llm
     shows: MIT license; all-in-one local-first RAG/agent app, v1.13.0
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 144242e11172f75c6ea72fc627d7aaf4caacf031c7b0bbc30ec3cdb835349056
+    establishes: [license, source, core-gated]
 adoption:
   level: 4
   reach: 1M-10M
@@ -30,10 +40,17 @@ adoption:
   note: Docker Hub mintplexlabs/anythingllm shows 1M+ total pulls and ~46k pulls/week (primary); 53-61k
     GitHub stars; Desktop distributed standalone. Placed at 4 on cumulative pull volume; medium confidence
     as exact all-time count isn't published and Desktop installs aren't separately counted.
+    Re-read 2026-08-13 - the Docker Hub page for mintplexlabs/anythingllm now reports 3,983,336
+    cumulative pulls, last updated the same day, against the 1M-plus the source line records. That is an
+    exact figure where the earlier read had only a floor, and it still sits inside the 1M-10M band.
+    Desktop installs remain uncounted, so the caveat above stands. Level unchanged at 4.
+  last_verified: '2026-08-13'
   sources:
   - url: https://hub.docker.com/r/mintplexlabs/anythingllm
     shows: 1M+ total Docker pulls; ~45,859 pulls this week
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 4554c3863bc2f987a09128f23e218852d0f0dee28db9355932d36d6c5cfd0208
 capability:
   score: 4
   basis: feature_matrix
@@ -44,7 +61,15 @@ capability:
   note: Strong full-stack chat+RAG+agent surface hitting all category dimensions; provider/vector-DB breadth
     and no-code agents put it on par with LibreChat/Open WebUI. Reserved 5 for the OSI leaders on raw
     breadth.
+    Re-read 2026-08-13. The README still shows the full-stack surface the band rests on - many local and
+    cloud LLM providers with dynamic model routing, document ingestion and vector databases as the core
+    use case, multimodal support across open and closed models, multi-user instances with per-user
+    permissioning, and a no-code agent builder with web browsing and MCP compatibility. Scheduled cron
+    tasks, managed memories and intelligent skill selection have been added since. Band unchanged at 4.
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/Mintplex-Labs/anything-llm
     shows: 40+ LLM providers, RAG, multi-user permissioning, no-code agents with web browsing
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 144242e11172f75c6ea72fc627d7aaf4caacf031c7b0bbc30ec3cdb835349056

--- a/sources/scores/azure-ai-model-inference.yaml
+++ b/sources/scores/azure-ai-model-inference.yaml
@@ -14,13 +14,22 @@ openness:
       value: Azure-managed
   confidence: high
   note: Fully proprietary managed Azure service; no source released. Scored closed.
+    Re-read 2026-08-13. The Foundry Models endpoints page still describes a wholly Azure-managed service
+    - deployments are Azure resources subject to Azure policy, reached through a single Foundry
+    inference endpoint with an OpenAI-compatible surface, and nothing about the serving stack is
+    published. No source, no self-host path, no license other than the Azure product terms. Value
+    unchanged at 1 / closed.
   raw: license:proprietary(Azure managed service);source:closed;interface:OpenAI-compatible REST endpoint
     over Foundry model deployments;hardware:Azure-managed
+  last_verified: '2026-08-13'
   sources:
   - url: https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/endpoints
     shows: single managed Azure inference endpoint over model deployments; proprietary Azure resource,
       OpenAI-compatible API
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1d5c5b66e43065ee8f364094e8df91b7cbfad52f558ad6443a3a711d436cfc5f
+    establishes: [license, source]
 adoption:
   level: 4
   signal_type: reported_traction
@@ -28,10 +37,18 @@ adoption:
   note: Default inference surface for Microsoft Foundry across Azure's enterprise base; broad distribution
     but no published per-service usage number. Level 4 reflects Azure-enterprise scale (reported), not
     a measured count.
+    Re-read 2026-08-13. The page still presents this as the one endpoint in front of every Foundry model
+    deployment for an Azure subscription, and it still publishes no per-service usage figure of any kind
+    - no call volume, no customer count, no deployment count. The band therefore remains a reported
+    reach rather than a measured one, and reported_traction with no numeric reach is the honest
+    instrument here. Level unchanged at 4.
+  last_verified: '2026-08-13'
   sources:
   - url: https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/endpoints
     shows: unified endpoint for all Foundry model deployments, enterprise Azure integration
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1d5c5b66e43065ee8f364094e8df91b7cbfad52f558ad6443a3a711d436cfc5f
 capability:
   score: 3
   basis: feature_matrix
@@ -41,8 +58,17 @@ capability:
   note: Capability is managed-endpoint breadth (multi-model routing, auth, governance), not raw engine
     throughput. This is closer to a managed API gateway over model deployments than a weight-loading inference
     engine; see recategorize flag.
+    Re-read 2026-08-13. The page still shows the whole feature set the band rests on - one endpoint
+    switching between many model deployments without code changes, per-deployment content filtering and
+    rate limiting, keyless authentication through Microsoft Entra ID role assignments, and batch
+    inference. It now also carries a deprecation banner for the Azure AI Inference beta SDK, retiring 26
+    August 2026 in favour of the OpenAI/v1 API, which is a migration of the client surface rather than a
+    change in what the service does. Band unchanged at 3.
+  last_verified: '2026-08-13'
   sources:
   - url: https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/endpoints
     shows: single endpoint switches between model deployments with content filtering, rate limiting, keyless
       auth
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1d5c5b66e43065ee8f364094e8df91b7cbfad52f558ad6443a3a711d436cfc5f

--- a/sources/scores/character-ai.yaml
+++ b/sources/scores/character-ai.yaml
@@ -15,11 +15,19 @@ openness:
       detail: closed
   confidence: high
   note: Proprietary consumer chat app; closed counterpart on the shelf.
+    Re-read 2026-08-13. The Business of Apps profile still describes a proprietary consumer
+    companion-chat product built on its own models, with the 2024 Google arrangement covering a
+    non-exclusive licence rather than any code release. Nothing is published and there is no self-host
+    path. Value unchanged at 1 / closed.
   raw: license:proprietary(SaaS);source:closed;self-host:none;models:own+licensed(closed)
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.businessofapps.com/data/character-ai-statistics/
     shows: Character.AI is a proprietary consumer companion-chat app (product/company profile)
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 3abe2ed8d0992caf18f31685c5447c6233be84052d73a59a1c585eae83bd6a50
+    establishes: [license, source, self-host]
 adoption:
   level: 5
   reach: '>10M users'
@@ -32,10 +40,19 @@ adoption:
     threshold, so the level was held down by a label that had no scale behind it to check it against.
     Figures are aggregator-compiled (no first-party MAU disclosure fetched) and sources disagree (20M vs
     higher visit-based counts), so confidence stays low; the 10M boundary is not close on either read.
+    Re-read 2026-08-13, and the aggregator has restated its numbers. The page now leads with 45 million
+    active users in September 2025 and over 75 million downloads since launch - the ~20M MAU, ~180M
+    monthly visits and ~28M mid-2024 peak recorded above are no longer on it. 45 million is still an
+    active count and still far above the >10M users threshold, so the level is unchanged at 5 and only
+    the supporting number has moved. It is still an aggregator compilation rather than a first-party
+    disclosure, so confidence stays low.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.businessofapps.com/data/character-ai-statistics/
     shows: ~20M MAU, ~180M monthly visits, peak ~28M mid-2024 (compiled)
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 3abe2ed8d0992caf18f31685c5447c6233be84052d73a59a1c585eae83bd6a50
 capability:
   score: 2
   basis: feature_matrix
@@ -47,7 +64,14 @@ capability:
   note: Specialized companion-chat UI; rich in persona/voice features but narrow on the general feature
     matrix (no model breadth, weak grounding); low capability relative to the general-assistant frontier
     in this category.
+    Re-read 2026-08-13. The profile still describes the same narrow shape the band rests on - a
+    companion and roleplay product organized around user-created characters, on its own and licensed
+    models rather than a provider menu, with no document grounding or general-assistant tooling. Band
+    unchanged at 2.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.businessofapps.com/data/character-ai-statistics/
     shows: companion/roleplay chat product with character-creation focus
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 3abe2ed8d0992caf18f31685c5447c6233be84052d73a59a1c585eae83bd6a50

--- a/sources/scores/chatgpt.yaml
+++ b/sources/scores/chatgpt.yaml
@@ -13,11 +13,19 @@ openness:
       detail: SaaS app + API
   note: Proprietary, SaaS-only consumer app; no source, no self-host. Closed counterpart in the ui_api
     shelf.
+    Re-read 2026-08-13. The cited OpenAI page is still up and still describes ChatGPT as the OpenAI
+    consumer service studied through a privacy-preserving analysis of conversations held on that
+    service. Nothing about the app or the models behind it is published, there is no self-host path and
+    no license beyond the consumer terms. Value unchanged at 1 / closed.
   raw: source:closed;self-host:none;license:proprietary(SaaS app + API)
+  last_verified: '2026-08-13'
   sources:
   - url: https://openai.com/index/how-people-are-using-chatgpt/
     shows: OpenAI's proprietary ChatGPT product page/usage report
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6324ff54cec0846703545d355f51763e197e0a853aafd96e6b45c719899487d5
+    establishes: [license, source, self-host]
 adoption:
   level: 5
   reach: '>10M users'
@@ -26,10 +34,18 @@ adoption:
   note: OpenAI officially announced ~900M weekly active users (27 Feb 2026), up from 800M (Oct 2025),
     with 50M paying subscribers. Mass-market scale, far above the >10M threshold. Attributed to the ChatGPT
     surface.
+    Re-read 2026-08-13 - the TechCrunch report is still up and still carries the same two figures, 900
+    million weekly active users announced by OpenAI in February 2026 and 50 million paying subscribers.
+    That is an active count rather than a cumulative one and it is a vendor announcement rather than an
+    aggregator estimate, so nothing is being substituted here. Still far above the >10M users threshold.
+    Level unchanged at 5.
+  last_verified: '2026-08-13'
   sources:
   - url: https://techcrunch.com/2026/02/27/chatgpt-reaches-900m-weekly-active-users/
     shows: OpenAI official announcement of 900M weekly active users, Feb 2026
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 29c246befb16d4169d0defbdd762f7ff0df8d398943194fbe72b6998af998e29
 capability:
   score: 5
   basis: feature_matrix

--- a/sources/scores/claude-ai.yaml
+++ b/sources/scores/claude-ai.yaml
@@ -13,12 +13,19 @@ openness:
       detail: SaaS app + API
   note: Proprietary, SaaS-only consumer app; no source, no self-host. Closed counterpart in the ui_api
     shelf.
+    Re-read 2026-08-13. claude.com/product/overview is still a marketing page for a hosted service - it
+    offers a sign-in and a set of prompts, publishes no source, and describes no self-host path. Value
+    unchanged at 1 / closed.
   raw: source:closed;self-host:none;license:proprietary(SaaS app + API)
+  last_verified: '2026-08-13'
   sources:
   - url: https://claude.com/product/overview
     shows: Anthropic's proprietary Claude consumer product page (artifacts, projects, web search, code
       execution)
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d66d5e0bed4e2f5aba1a90f5569816a23b00249624e4e0954512b7a89feb46f1
+    establishes: [license, source, self-host]
 adoption:
   level: 5
   reach: '>10M users'
@@ -48,8 +55,15 @@ capability:
   confidence: high
   note: 'Frontier consumer chat product within ui_api: Artifacts, Projects, web search, code execution,
     MCP connectors, voice, multimodal file analysis, Team/Enterprise. Among the category''s most capable
-    chat surfaces.'
+    chat surfaces.
+    Re-read 2026-08-13. The product overview still shows Artifacts described as turning ideas into
+    shareable creations, Projects for organizing conversations with persistent context, connectors
+    including Google Drive and web search reachable from a prompt, and Enterprise plans alongside the
+    consumer tiers. Band unchanged at 5.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://claude.com/product/overview
     shows: Artifacts, Projects, Web Search, Voice, Code Execution, integrations, multimodal upload
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d66d5e0bed4e2f5aba1a90f5569816a23b00249624e4e0954512b7a89feb46f1

--- a/sources/scores/confer.yaml
+++ b/sources/scores/confer.yaml
@@ -18,17 +18,31 @@ openness:
   confidence: high
   note: 'Marketed as open source, but neither public repo declares any license (GitHub reports license:null),
     so re-use rights are undefined, and the end-user client is not public. Source is published for verifiability/reproducible
-    builds, not for self-deployment. Accurate classification is source-available, not open_source.'
+    builds, not for self-deployment. Accurate classification is source-available, not open_source.
+    Re-read 2026-08-13. The private-inference post is still up, still dated 5 January 2026, and still
+    describes the same architecture - inference inside a confidential VM, prompts encrypted from the
+    device into the TEE over Noise Pipes, with reproducible builds and a transparency log so the running
+    image can be checked. That is publication for verifiability, not for deployment - there is still no
+    self-hostable implementation, and it still depends on the Confer attestation infrastructure.
+    confer-proxy is still public and still has no LICENSE file, so the GitHub API still reports no
+    declared license and re-use rights remain undefined. Value unchanged at 2 / source_available.'
   raw: license:none-declared(no LICENSE file in either public repo);source:partial(confer-proxy + confer-image
     public,client-app private);self-host:no(depends on vendor attestation infra);models:open source(undisclosed)
+  last_verified: '2026-08-13'
   sources:
   - url: https://confer.to/blog/2026/01/private-inference/
     shows: architecture (TEE, Noise pipes, dm-verity, reproducible nix/mkosi builds, transparency log); names
       the confer-proxy and confer-image repos
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c657ba8cd2a6fcfd54906f3148074e622151ad1b77490f54976a09c865eecf1e
+    establishes: [source, self-host]
   - url: https://github.com/ConferLabs/confer-proxy
     shows: public proxy repo with no LICENSE file (no declared license)
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 92c9e0180f885517255018c69b0e7f584bf092aafdaa5e9d813384b781df67fd
+    establishes: [license, source]
 adoption:
   level: 2
   signal_type: reported_traction
@@ -36,10 +50,17 @@ adoption:
   note: Young product (repos created Dec 2025, launched late 2025/early 2026); ~70-75 stars per repo and a
     reported partnership "bringing foundational AI privacy to Meta", but no user/usage numbers. Notability
     is driven mainly by the founder's reputation.
+    Re-read 2026-08-13. The blog index still carries the March 2026 post announcing that Confer is
+    bringing foundational AI privacy to Meta, and confer-proxy now shows 76 stars, consistent with the
+    70-75 recorded. No user, customer or usage number has appeared in the months since, so there is
+    still nothing countable to band. Level unchanged at 2.
+  last_verified: '2026-08-13'
   sources:
   - url: https://confer.to/blog/
     shows: product positioning and feature timeline (memory, encrypted folders, connectors, Meta partnership)
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b08288fd3e49a16942d35caa32b6f4f1cc730c67a927902dccfcbe189f8c5299
 capability:
   score: 3
   basis: feature_matrix
@@ -49,7 +70,16 @@ capability:
   confidence: medium
   note: Strong, genuinely novel on the privacy/crypto dimension, but a relatively standard chat feature set,
     no self-hosting, and undisclosed models cap it at mid-tier.
+    Re-read 2026-08-13. The private-inference post still establishes the crypto half of the band -
+    end-to-end encrypted chat, TEE inference in a confidential VM, remote attestation, reproducible
+    builds and a transparency log - and the blog index shows the product surface has filled out since,
+    with cross-conversation memory in March 2026, connectors in April, and folder files in August that
+    put PDFs, Office documents, HTML and Markdown into every conversation in a folder. Still no
+    self-hosting and still undisclosed model names. Band unchanged at 3.
+  last_verified: '2026-08-13'
   sources:
   - url: https://confer.to/blog/2026/01/private-inference/
     shows: 'feature set: E2EE chat, TEE inference, attestation, transparency log, encrypted history'
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c657ba8cd2a6fcfd54906f3148074e622151ad1b77490f54976a09c865eecf1e

--- a/sources/scores/continue.yaml
+++ b/sources/scores/continue.yaml
@@ -22,29 +22,42 @@ openness:
         client feature
   note: Apache-2.0, full source public for the IDE extensions and CLI; no feature-gated core in the editor
     itself (a hosted Hub exists alongside but the assistant is OSS).
+    Re-read 2026-08-13. The repository root still holds actions, binary, core, docs, eval, extensions,
+    gui, media, packages, scripts, skills and sync with a single LICENSE and no ee/ or enterprise/
+    directory. mdm.ts is still published Apache-2.0 code whose validated payload carries only
+    customerId, createdAt, expiresAt and apiUrl, read out of MDM-managed OS configuration, and it still
+    switches on no client feature. continue.dev now leads with the Cursor acquisition and still states
+    that the open-source codebase remains freely available as a foundation for others, with no pricing
+    page. The VS Code Marketplace listing still shows the licence as Apache 2.0. Value unchanged at 5 /
+    open_source.
   raw: license:Apache-2.0(OSI);source:public(github.com/continuedev/continue);clients:VSCode+JetBrains+CLI;hub:continue.dev(hosted
     config/model hub adjacent, core OSS);core-gated:ungated(Apache-2.0 across the whole monorepo, no ee/
     or enterprise directory; the enterprise license key is itself published Apache-2.0 code carrying only
     customerId/expiresAt/apiUrl and unlocks no client feature)
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/continuedev/continue
     shows: Apache-2.0; public source; AI code assistant (chat/edit/autocomplete + agent)
-    accessed: '2026-06-04'
-    establishes:
-    - license
-    - source
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c5e978602c04d12d338af0b23836088605b6c317ef4f2808544c1d6d5582c615
+    establishes: [license, source]
   - url: https://marketplace.visualstudio.com/items?itemName=Continue.continue
     shows: open source AI code agent extension listing
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 7c078511d59cadc777c86aacdf757eb9984376eb3c7bdba0ad800c8bbfb6a209
+    establishes: [license]
   - url: https://api.github.com/repos/continuedev/continue/contents/
     shows: Repository root listing read for this dimension. The tree is actions, binary, core, docs,
       eval, extensions, gui, manual-testing-sandbox, media, packages, scripts, skills, sync - there is
       no `ee/`, no `enterprise/`, and no second license. `extensions/` holds cli, intellij and vscode;
       `packages/` holds config-types, config-yaml, continue-sdk, fetch, llm-info, openai-adapters and
       terminal-security. The repo license endpoint returns Apache-2.0.
-    accessed: '2026-08-11'
-    establishes:
-    - core-gated
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b8185dd293a250979c3f36c1d0a8db7d453c53b59fde4c3e85290e3c2a6b00c2
+    establishes: [core-gated, source]
   - url: https://github.com/continuedev/continue/blob/main/core/control-plane/mdm/mdm.ts
     shows: The one thing in this repo that looks like a gate, read directly rather than assumed. Continue
       does ship an "Enterprise License Key" - `continue.enterEnterpriseLicenseKey` in
@@ -56,17 +69,19 @@ openness:
       by it - nothing in the extension is compiled out, withheld, or refused without one. That is the
       langchain shape, a paid platform beside a complete open core, not the langgraph shape of a closed
       package behind a key.
-    accessed: '2026-08-11'
-    establishes:
-    - core-gated
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 10d3ad9d53fcfabe9a36a64bfc60dea7410644df6bf1157715ee4c70f3b64f18
+    establishes: [core-gated]
   - url: https://www.continue.dev/
     shows: The vendor's own site now leads with Continue having been acquired by Cursor and states "our
       open-source codebase remains freely available as a foundation for others". No pricing page is
       linked from it any more, and https://www.continue.dev/pricing returns HTTP 404 - so there is no
       live paid tier left to withhold anything for.
-    accessed: '2026-08-11'
-    establishes:
-    - core-gated
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e6976b8790d347de0255b6aa09ac5c81a097cd3cd903c2e91d12fe71b2f507d4
+    establishes: [core-gated]
 adoption:
   level: 4
   reach: 1M-10M
@@ -75,13 +90,21 @@ adoption:
   note: VS Code Marketplace shows ~3.21M installs of the Continue extension; plus JetBrains plugin and
     CLI installs on top. Install volume places it solidly in the 1-10M band. 33.5k GitHub stars corroborates
     only.
+    Re-read 2026-08-13 - the VS Code Marketplace listing now reports 3,907,333 installs, up from the
+    3,209,395 recorded, and the repo shows 35,474 stars. JetBrains and CLI installs still sit on top and
+    are still uncounted. Comfortably inside 1M-10M. Level unchanged at 4.
+  last_verified: '2026-08-13'
   sources:
   - url: https://marketplace.visualstudio.com/items?itemName=Continue.continue
     shows: 3,209,395 installs
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 7c078511d59cadc777c86aacdf757eb9984376eb3c7bdba0ad800c8bbfb6a209
   - url: https://github.com/continuedev/continue
     shows: 33.5k stars (corroborating)
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c5e978602c04d12d338af0b23836088605b6c317ef4f2808544c1d6d5582c615
 capability:
   score: 4
   basis: feature_matrix
@@ -91,10 +114,19 @@ capability:
   note: Leading open source in-IDE AI assistant; broad model-agnostic coverage with chat/edit/autocomplete/agent
     and codebase RAG. Strong feature breadth for an open editor assistant, just below the polished closed
     frontier (Copilot/Cursor).
+    Re-read 2026-08-13. The Marketplace listing still breaks the product into Agent, Chat, Edit and
+    Autocomplete plus source-controlled AI checks enforceable in CI, and the repository is still
+    model-agnostic across VS Code, JetBrains and the CLI. Nothing in the Cursor acquisition has
+    withdrawn a feature. Band unchanged at 4.
+  last_verified: '2026-08-13'
   sources:
   - url: https://marketplace.visualstudio.com/items?itemName=Continue.continue
     shows: agent, chat, edit, autocomplete features
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 7c078511d59cadc777c86aacdf757eb9984376eb3c7bdba0ad800c8bbfb6a209
   - url: https://github.com/continuedev/continue
     shows: model-agnostic AI code assistant feature set
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c5e978602c04d12d338af0b23836088605b6c317ef4f2808544c1d6d5582c615

--- a/sources/scores/deepseek-chat.yaml
+++ b/sources/scores/deepseek-chat.yaml
@@ -19,14 +19,24 @@ openness:
         releases, not the chat application
   note: The DeepSeek chat surface is a proprietary hosted service; openness of the V3/V4 weights it serves
     is a separate (model-layer) score. Scored as closed counterpart per ui_api recipe.
+    Re-read 2026-08-13. deepseek.com still offers exactly the two routes recorded - free access to the
+    chat at chat.deepseek.com, and the paid API platform - and the Research section still links only
+    model-weights and inference repositories, none of which is the chat application. The headline has
+    moved on from V4 Preview to the official DeepSeek-V4-Pro release, with agent capabilities, the
+    Responses API and Codex integration, available across web, app and API. There is still no
+    self-hostable implementation of the chat surface. Value unchanged at 1 / closed.
   raw: client:proprietary(no public source for chat.deepseek.com app);backend:hosted-SaaS;note:underlying
     models open(MIT) but the chat application/service is closed;source:closed(hosted chat service at chat.deepseek.com;
     DeepSeek's public repos are model and inference releases, not the chat application)
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.deepseek.com/en/
     shows: Free hosted chat at chat.deepseek.com serving DeepSeek-V4 Preview; no source release for the
       chat app itself
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a592024875e8d8b59c7b487cf7b456f29309e7dbacd2e2d6b5ff55ab44579158
+    establishes: [source]
   - url: https://www.deepseek.com/en
     shows: Re-read for this dimension. The site offers exactly two ways to use DeepSeek - 'Free access
       to DeepSeek' pointing at chat.deepseek.com, and 'Build with the latest DeepSeek models' pointing
@@ -34,9 +44,10 @@ openness:
       (DeepSeek R1, V3, Coder V2 and others), and every one of them is a model-weights or research/inference
       release; none is the chat application. So there is no self-hostable implementation of the chat
       surface being scored here, which is what the ladder calls a closed source.
-    accessed: '2026-08-11'
-    establishes:
-    - source
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a592024875e8d8b59c7b487cf7b456f29309e7dbacd2e2d6b5ff55ab44579158
+    establishes: [source]
 adoption:
   level: 5
   reach: '>10M users'
@@ -70,7 +81,14 @@ capability:
   note: Capable single-vendor consumer chat UI with strong underlying model, but narrow on the ui_api
     feature axes (one provider, limited enterprise/RAG/plugin breadth) vs frontier multi-model chat UIs.
     Not a category frontier-definer.
+    Re-read 2026-08-13. The site still shows the same shape the band rests on - one vendor family, now
+    DeepSeek-V4-Pro, reached through web, mobile app and API, with significantly enhanced agent
+    capabilities plus Responses API and Codex integration. Still no provider menu, no enterprise
+    multi-user tier and no grounding over corporate data. Band unchanged at 3.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.deepseek.com/en/
     shows: 'Chat product features: file reading, long-context, V4 agent capabilities, single-vendor model'
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a592024875e8d8b59c7b487cf7b456f29309e7dbacd2e2d6b5ff55ab44579158

--- a/sources/scores/doubao.yaml
+++ b/sources/scores/doubao.yaml
@@ -19,13 +19,23 @@ openness:
       detail: hosted consumer service plus a compiled client download; no published source for the assistant
   note: Doubao is a closed proprietary consumer assistant; no public source for the app and the Doubao
     models are not open-weight. Closed counterpart per ui_api recipe.
+    Re-read 2026-08-13. The Wikipedia infobox still records the licence as Proprietary, the developer as
+    ByteDance and the platforms as iOS, Android and Web, with the stable release now Doubao Seed 2.0 of
+    14 February 2026. The ByteDance download page still returns almost nothing to a plain fetch because
+    it renders client-side, which is the same weak corroboration the source line already flags rather
+    than new evidence - it still offers a compiled client and nothing else. Value unchanged at 1 /
+    closed.
   raw: client:proprietary(closed consumer app);backend:hosted-SaaS on Volcano Engine;models:proprietary
     Doubao(closed);license:Proprietary;source:closed(hosted consumer service plus a compiled client download;
     no published source for the assistant)
+  last_verified: '2026-08-13'
   sources:
   - url: https://en.wikipedia.org/wiki/Doubao
     shows: Doubao is a proprietary ByteDance AI chatbot app (iOS/Android/web) on Volcano Engine
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 916ff9db722a576ddcebd5567907d0610fe86a0acc2a03812ff656eca85dfed3
+    establishes: [license, source]
   - url: https://www.doubao.com/download/desktop
     shows: ByteDance's own distribution page for Doubao. What it offers is a compiled client - '下载豆包客户端',
       download the Doubao client - for desktop and mobile. Nothing on the page offers source, a repository,
@@ -33,9 +43,10 @@ openness:
       entirely client-side, so a fetch returns the page header and little else, and this reads as an
       absence of any source offer rather than a statement that none exists. It corroborates the closed
       reading; it does not on its own prove it.
-    accessed: '2026-08-11'
-    establishes:
-    - source
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 84521c8a54eefad2af95a71522da00c3ffd8a644f536855c362d6f737877334d
+    establishes: [source]
 adoption:
   level: 5
   reach: '>10M users'
@@ -72,7 +83,15 @@ capability:
   confidence: medium
   note: Feature-rich consumer assistant with multimodal + emerging agentic e-commerce, but narrow on the
     ui_api feature axes (single provider, consumer-only). Not a category frontier-definer on capability.
+    Re-read 2026-08-13. The AIBase report is still up and still describes the March 2026 grey-scale test
+    of one-sentence shopping, where the assistant turns a vague spoken need into a matched product and a
+    checkout hand-off, wiring the model into the Douyin e-commerce supply chain. It still frames Doubao
+    as a single-vendor consumer assistant rather than a provider hub, which is what holds the band down.
+    Band unchanged at 3.
+  last_verified: '2026-08-13'
   sources:
   - url: https://news.aibase.com/news/26405
     shows: Doubao multimodal consumer assistant adding agentic AI e-commerce/order features
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0a13080e03d948baca414c84e9a9043842bbcb812cd75f17d700c40452ac1b57

--- a/sources/scores/duck-ai.yaml
+++ b/sources/scores/duck-ai.yaml
@@ -13,21 +13,36 @@ openness:
       detail: SaaS app + browser integration
   note: Proprietary anonymizing proxy in front of closed model APIs; no source, no self-host. Closed privacy-chat
     surface in the ui_api shelf.
+    Re-read 2026-08-13. The privacy help page still describes an anonymizing layer in front of other
+    companies models - metadata including the IP address is stripped before prompting, so requests reach
+    Anthropic, OpenAI, Mistral, Azure and now Tinfoil as though they came from DuckDuckGo. Nothing about
+    that proxy is published and there is no self-host path. Value unchanged at 1 / closed.
   raw: source:closed;self-host:none;license:proprietary(SaaS app + browser integration)
+  last_verified: '2026-08-13'
   sources:
   - url: https://duckduckgo.com/duckduckgo-help-pages/duckai/ai-chat-privacy
     shows: DuckDuckGo's proprietary Duck.ai privacy/help documentation
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 84eaec80588c49540c91877c965735575181b618d17e090c51771491765761be
+    establishes: [license, source, self-host]
 adoption:
   level: 3
   signal_type: reported_traction
   confidence: low
   note: Backed by DuckDuckGo's large user base and integrated into its browser, but no Duck.ai-specific
     usage figures are published. Conservative reported_traction pending a disclosed active-user signal.
+    Re-read 2026-08-13. The launch post is still up and DuckDuckGo still publishes no Duck.ai-specific
+    usage figure - no active-user count, no query volume, nothing beyond the browser and search
+    distribution it rides on. The abstention from a counted signal therefore stands. Level unchanged at
+    3.
+  last_verified: '2026-08-13'
   sources:
   - url: https://spreadprivacy.com/ai-chat/
     shows: DuckDuckGo's launch of free, anonymous AI Chat across web + browser
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a6f5284b08df0cde63cce097ccdcf76eecbb52d00b9c55aeed4f410b5e167678
 capability:
   score: 2
   basis: feature_matrix
@@ -37,7 +52,15 @@ capability:
   confidence: high
   note: Anonymizing multi-model chat proxy - strong on privacy and model choice, but a deliberately minimal
     surface (no RAG, plugins, agents, or multimodal generation). Lower-tier on the chat-UI feature matrix.
+    Re-read 2026-08-13. The models page still lists the same free-tier lineup the band rests on - Claude
+    4.5 Haiku, Llama 3.3 70B, Mistral Small 3 24B and GPT-4o mini - with the paid tiers now reaching
+    Claude Sonnet 4.6 and, at the top, Claude Opus 4.8 with higher reasoning effort. The surface is
+    still deliberately minimal, with no RAG, no plugins, no agents and no accounts. Mistral Small 4 has
+    appeared on a paid tier. Band unchanged at 2.
+  last_verified: '2026-08-13'
   sources:
   - url: https://duckduckgo.com/duckduckgo-help-pages/duckai/chat-models
     shows: available models (Claude 4.5 Haiku, Llama 3.3 70B, Mistral Small 3, GPT-4o mini; subscriber models)
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0766edb86e7c37638d24349dd210af1c4b11460370453087d2f28eb917e0f240

--- a/sources/scores/gemini.yaml
+++ b/sources/scores/gemini.yaml
@@ -13,11 +13,19 @@ openness:
       detail: SaaS app
   note: Proprietary, SaaS-only consumer app; no source, no self-host. Closed counterpart in the ui_api
     shelf.
+    Re-read 2026-08-13. The cited Google post is now the Gemini 3.5 launch and still describes a wholly
+    Google-operated product - 3.5 Flash reaching people through the Gemini app and AI Mode in Search,
+    developers through the Gemini API, and organizations through Gemini Enterprise. No weights, no
+    source, no self-host path. Value unchanged at 1 / closed.
   raw: source:closed;self-host:none;license:proprietary(SaaS app)
+  last_verified: '2026-08-13'
   sources:
   - url: https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/
     shows: Google's proprietary Gemini app/model product page
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: bcfcef8f1a7ca1f6a43f67d199a3686d96f50a066e159a5e464bc2107a47e5bd
+    establishes: [license, source, self-host]
 adoption:
   level: 5
   reach: '>10M users'
@@ -26,10 +34,17 @@ adoption:
   note: Google CEO Sundar Pichai officially stated the Gemini app surpassed 750M monthly active users
     (Q4 2025 earnings, 4 Feb 2026), up from 450M earlier in 2025. Mass-market scale, far above >10M (broader
     AI Overviews surface reaches ~2B, but the app itself is the cited figure).
+    Re-read 2026-08-13 - the TechCrunch report is still up and still carries Pichai stating the Gemini
+    app surpassed 750 million monthly active users. That is an active count from the vendor rather than
+    an aggregator estimate or a cumulative total, so nothing is substituted here, and the app figure
+    remains the one banded rather than the far larger AI Overviews reach. Level unchanged at 5.
+  last_verified: '2026-08-13'
   sources:
   - url: https://techcrunch.com/2026/02/04/googles-gemini-app-has-surpassed-750m-monthly-active-users/
     shows: 'Pichai official statement: Gemini app >750M MAU, Feb 2026'
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5ab160118e2f61989d6122d96b931ca2debf97cefa915cd36d455b8a8bb952fa
 capability:
   score: 5
   basis: feature_matrix
@@ -38,8 +53,15 @@ capability:
     yes (Workspace/Enterprise); deep Google ecosystem integration'
   confidence: high
   note: 'Frontier consumer chat product within ui_api: full multimodal (Live voice, image-gen), Search
-    grounding, Workspace integration, extensions, enterprise. Sets the category bar alongside ChatGPT.'
+    grounding, Workspace integration, extensions, enterprise. Sets the category bar alongside ChatGPT.
+    Re-read 2026-08-13. The cited post has moved on from Gemini 3.x to the Gemini 3.5 launch of 19 May
+    2026 and still supports the band - a frontier family reaching billions through the Gemini app and AI
+    Mode in Search, leading multimodal understanding, long-horizon agentic and coding work, and an
+    enterprise tier in Gemini Enterprise. Band unchanged at 5.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/
     shows: Gemini app multimodal capabilities + Search/AI Mode integration
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: bcfcef8f1a7ca1f6a43f67d199a3686d96f50a066e159a5e464bc2107a47e5bd

--- a/sources/scores/github-copilot-ide.yaml
+++ b/sources/scores/github-copilot-ide.yaml
@@ -13,11 +13,18 @@ openness:
       detail: subscription SaaS
   note: Proprietary, closed-source subscription product; no self-host. Closed counterpart in the ui_api
     shelf.
+    Re-read 2026-08-13. The Copilot product page still sells a subscription with plans and pricing,
+    still publishes nothing of the product itself, and still offers no self-host path - the only thing a
+    customer runs locally is an extension talking to the GitHub service. Value unchanged at 1 / closed.
   raw: source:closed;self-host:none;license:proprietary(subscription SaaS)
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/features/copilot
     shows: proprietary GitHub Copilot product page; closed source
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 2796fa1095dc0e17404be76e4c6bf08b503374e5de28b7a16c4231cc24b37da7
+    establishes: [license, source, self-host]
 adoption:
   level: 5
   reach: '>10M users'
@@ -29,13 +36,23 @@ adoption:
     than active, and the one genuinely active-adjacent figure available - 4.7M paid subscribers - sits
     a band lower, at 4. The level is unchanged from what this record already carried; what changed is
     that the label under it is now one a declared scale offers, and that the substitution is named.
+    Re-read 2026-08-13 - the TechCrunch report is still up and still quotes Satya Nadella on 20 million
+    users, with the accompanying line that 20 million people have continued to use the tool on a monthly
+    or daily basis. The GitHub product page still carries the phrase about millions of individual users
+    and tens of thousands of business customers. The all-time-versus-active substitution named above is
+    unchanged and still the reason the number is not simply an active count. Level unchanged at 5.
+  last_verified: '2026-08-13'
   sources:
   - url: https://techcrunch.com/2025/07/30/github-copilot-crosses-20-million-all-time-users/
     shows: GitHub-confirmed 20M all-time users, announced by Satya Nadella Jul 2025
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 38d679a94c14d0f4efef2d2ba46c495e742936c51fe0bad74ef82a070609f32f
   - url: https://github.com/features/copilot
     shows: '''millions of individual users and tens of thousands of business customers'''
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 2796fa1095dc0e17404be76e4c6bf08b503374e5de28b7a16c4231cc24b37da7
 capability:
   score: 5
   basis: feature_matrix
@@ -45,9 +62,17 @@ capability:
   confidence: high
   note: 'Most widely adopted, feature-complete AI developer assistant: chat + inline + agent mode + multi-model
     selection, deeply IDE/GitHub-integrated, enterprise controls. Frontier of the in-IDE-assistant slice
-    of ui_api.'
+    of ui_api.
+    Re-read 2026-08-13. The product page still shows the surface the band rests on - a choice of leading
+    LLMs, inline completion and explanation with agent mode in the editor, a CLI, GitHub-native and
+    custom agents plus third-party ones over MCP servers, Copilot Spaces for shared repository and
+    document context, and enterprise-grade governance controls. It still calls itself the most widely
+    adopted AI developer tool. Band unchanged at 5.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/features/copilot
     shows: inline suggestions, chat, agent, code explanations; 'world's most widely adopted AI developer
       tool'
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 2796fa1095dc0e17404be76e4c6bf08b503374e5de28b7a16c4231cc24b37da7

--- a/sources/scores/glean-assistant.yaml
+++ b/sources/scores/glean-assistant.yaml
@@ -14,11 +14,18 @@ openness:
     - name: Proprietary
   note: Glean Assistant is a proprietary enterprise SaaS, no public source, no open-core/self-host OSS
     tier. Closed.
+    Re-read 2026-08-13. The product site still sells a hosted enterprise platform with a demo request
+    and no download, no repository and no self-hosted edition anywhere on it. Value unchanged at 1 /
+    closed.
   raw: client:proprietary;deployment:single-tenant SaaS;source:closed;license:Proprietary
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.glean.com/product/assistant
     shows: Proprietary SaaS enterprise assistant; RAG over Enterprise Graph; not open source
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: f2e15c53fc7b232e230b621651471a9ea9e685bd75b21cfd637782f53b2c85e2
+    establishes: [license, source]
 adoption:
   level: 4
   signal_type: reported_traction
@@ -28,11 +35,19 @@ adoption:
     operating in 28 countries. ARR/enterprise-seat scale implies low-millions of enterprise seats; placed
     at 4 on reported enterprise traction. No raw seat/user count disclosed, so confidence medium and signal_type
     reported_traction (revenue + deployment breadth, not a measured user count).
+    Re-read 2026-08-13. The press release is still up and still carries every figure the band rests on -
+    $300 million in annual recurring revenue reached just fifteen months after $100 million, 85%+ of
+    customers using Glean across five or more departments, a 45% weekly DAU to MAU ratio described as
+    more than twice the SaaS industry norm, and operations in 28 countries. Still no raw seat or user
+    count, so the signal stays reported_traction with no numeric reach. Level unchanged at 4.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.glean.com/press/glean-surpasses-300m-arr-unrivaled-enterprise-context-fuels-ai-adoption
     shows: $300M ARR (May 2026); Fortune 500 count ~doubled YoY; 85%+ across 5+ depts; 45% wDAU/wMAU;
       28 countries
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 52a6d2d5de1b42056375fa6f5a1864f466556d33d6535946babd27e955dcd6f8
 capability:
   score: 4
   basis: feature_matrix
@@ -44,8 +59,16 @@ capability:
   note: Among the most feature-complete enterprise assistant UIs, multi-model hub, deep enterprise RAG,
     multimodal, actions, permissions-aware multi-user. Top-tier within ui_api for enterprise context;
     scored 4 (reserving 5 for an unambiguous category frontier-definer).
+    Re-read 2026-08-13. The site still carries every dimension the band rests on and the connector count
+    has grown - the navigation now advertises more than 250 connectors against the 100+ recorded here,
+    alongside the Model Hub, an AI Gateway, the Enterprise and Personal Graphs, hybrid search, agent
+    building, orchestration, governance and a reusable agent library, plus security controls for scaling
+    AI at work. Band unchanged at 4.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.glean.com/product/assistant
     shows: Model Hub multi-LLM, Enterprise Graph RAG over 100+ connectors, multimodal output, task execution/actions,
       agentic sub-agents
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: f2e15c53fc7b232e230b621651471a9ea9e685bd75b21cfd637782f53b2c85e2

--- a/sources/scores/glean-workplace-search-ai.yaml
+++ b/sources/scores/glean-workplace-search-ai.yaml
@@ -13,11 +13,17 @@ openness:
     license:
     - name: Proprietary
   note: Glean Search is proprietary enterprise SaaS; no public source, no OSS/self-host tier. Closed.
+    Re-read 2026-08-13. The platform overview still sells a hosted enterprise product with no source, no
+    download and no self-hosted edition. Value unchanged at 1 / closed.
   raw: client:proprietary;deployment:single-tenant SaaS;source:closed;license:Proprietary
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.glean.com/product/overview
     shows: Glean Search as proprietary single-tenant SaaS enterprise search on Enterprise Graph
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: f63d474cd4cb4f0e53714d488cc01782f3908fea6393ae8ccd8d3d46a8cb0eed
+    establishes: [license, source]
 adoption:
   level: 4
   signal_type: reported_traction
@@ -26,11 +32,18 @@ adoption:
     with near-doubled Fortune 500 count and 85%+ multi-department usage; effectively co-extensive with
     Glean''s deployed seat base. Same caveat as Glean Assistant: no raw user count disclosed, so reported_traction
     at confidence medium. Adoption shared with the Assistant record (same platform), not an independent
-    measurement.'
+    measurement.
+    Re-read 2026-08-13. The same press release still carries the $300M ARR milestone, the 85%+
+    five-department figure and the 45% weekly engagement ratio, and search is still described as the
+    foundation the rest of the platform sits on, so this axis is still co-extensive with the Assistant
+    record rather than an independent measurement. Level unchanged at 4.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.glean.com/press/glean-surpasses-300m-arr-unrivaled-enterprise-context-fuels-ai-adoption
     shows: $300M ARR; Fortune 500 count ~doubled YoY; 85%+ across 5+ depts; search is platform foundation
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 52a6d2d5de1b42056375fa6f5a1864f466556d33d6535946babd27e955dcd6f8
 capability:
   score: 4
   basis: feature_matrix
@@ -41,8 +54,15 @@ capability:
   note: Best-in-class enterprise search on connector breadth, knowledge-graph relevance, and permissions-aware
     retrieval, a recognized leader in the enterprise-search-for-AI space. Scored 4 (top-tier; 5 reserved
     for an unambiguous frontier-definer).
+    Re-read 2026-08-13. The overview still shows Enterprise Search as the foundation for answers, the
+    Enterprise Graph and Personal Graph as the relevance and personalization layers, hybrid search
+    grounded in context, and permissions honoured on every agent action. The connector count has grown
+    to more than 250 from the 100+ recorded. Band unchanged at 4.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.glean.com/product/overview
     shows: Enterprise Graph + Personal Graph, hybrid search, 100+ connectors, permissions-aware enterprise
       search
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: f63d474cd4cb4f0e53714d488cc01782f3908fea6393ae8ccd8d3d46a8cb0eed

--- a/sources/scores/gpt4all.yaml
+++ b/sources/scores/gpt4all.yaml
@@ -14,11 +14,20 @@ openness:
     - no-feature-gated-core
   confidence: high
   note: Fully MIT.
+    Re-read 2026-08-13. The repository still carries MIT and still ships the whole application -
+    installers for Windows, Windows ARM, macOS and Ubuntu plus the Python client - with nothing withheld
+    and no paid tier. Repo now at 77,413 stars. Development is still stalled, with the last push in May
+    2025 and v3.10.0 of February 2025 still the latest release, but that is a maintenance observation
+    rather than an openness one. Value unchanged at 5 / open_source.
   raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/nomic-ai/gpt4all
     shows: MIT, ~77.4k stars, LocalDocs RAG + local API server
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: bbb3dd69d40e1e84ba10e9677b3f9a71cf6b4347c84825ec18e42e6fb3fb15cb
+    establishes: [license, source, core-gated]
 adoption:
   level: 2
   signal_type: usage_volume
@@ -47,7 +56,15 @@ capability:
   value: chat UI; LocalDocs private RAG; OpenAI-compatible local server; Vulkan GPU
   confidence: medium
   note: Solid core but behind faster-moving peers on newest-model support due to the maintenance slowdown.
+    Re-read 2026-08-13. The README still shows the chat application running LLMs privately on ordinary
+    desktops and laptops with no API calls or GPU required, the Python client around llama.cpp, and the
+    DeepSeek R1 distillation support that was its last notable addition. The maintenance slowdown the
+    band already accounts for has deepened - nothing has been pushed to the repository since May 2025.
+    Band unchanged at 3.
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/nomic-ai/gpt4all
     shows: 'feature set: chat, LocalDocs, local server'
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: bbb3dd69d40e1e84ba10e9677b3f9a71cf6b4347c84825ec18e42e6fb3fb15cb

--- a/sources/scores/grok-app.yaml
+++ b/sources/scores/grok-app.yaml
@@ -15,11 +15,18 @@ openness:
       detail: closed weights
   confidence: high
   note: Proprietary chat UI (and its underlying model is closed); closed counterpart on the shelf.
+    Re-read 2026-08-13. The xAI release note is still up and still describes a product delivered only
+    through grok.com, X and the iOS and Android apps, with a model picker rather than any weights or
+    source, and nothing self-hostable. Value unchanged at 1 / closed.
   raw: license:proprietary(SaaS/embedded in X);source:closed;self-host:none;model:xAI Grok(closed weights)
+  last_verified: '2026-08-13'
   sources:
   - url: https://x.ai/news/grok-4-1
     shows: xAI Grok is a proprietary assistant/product (official xAI release notes)
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5311110078eb9652249dbe04fcc5f95c4b1d8ce8fe018a8719eab06bfdcdc148
+    establishes: [license, source, self-host]
 adoption:
   level: 5
   reach: '>10M users'
@@ -29,17 +36,30 @@ adoption:
     within X's ~350-400M MAU base. Clears >10M as a surface. Figures are aggregator-compiled (xAI does
     not publish a primary MAU page) and the X-embedded reach is hard to attribute cleanly, so low confidence
     on the exact number; reach band is robust.
+    Re-read 2026-08-13. SEOProfy still reports 60 million monthly active users for the Grok app and
+    separately about 30 million active users reached through X and the app together, consistent with the
+    60-64M recorded. The xAI release note and the xAI post on X are both still up and still confirm the
+    consumer surface - Grok 4.1 free on grok.com, X and the mobile apps. The figures are still
+    aggregator-compiled because xAI publishes no MAU page, so confidence stays low, but the band is
+    nowhere near its boundary. Level unchanged at 5.
+  last_verified: '2026-08-13'
   sources:
   - url: https://seoprofy.com/blog/grok-ai-statistics/
     shows: ~60-64M Grok app MAU, ~8-10M DAU early 2026; X Premium default access (compiled)
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 703daef0c87ae58db49f79b9fc825aecc56d2770dc8bc3c151298aee1cc88fc0
   - url: https://x.ai/news/grok-4-1
     shows: official product confirming the consumer Grok assistant surface
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5311110078eb9652249dbe04fcc5f95c4b1d8ce8fe018a8719eab06bfdcdc148
   - url: https://x.com/xai/status/1990530499752980638
     shows: 'xAI official post: Grok 4.1 frontier model, free on grok.com, X and mobile apps (confirms
       the consumer Grok assistant surface)'
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: f9452f2147707c2e7f296d879b4fe08a35c643e15b72096163cceb74f27965f6
 capability:
   score: 4
   basis: feature_matrix
@@ -50,8 +70,17 @@ capability:
   note: 'Capable general assistant UI with a unique real-time X-search edge; high feature breadth but
     single-provider-locked, so not the category frontier-definer. [verifier: Grok 4.1 features (real-time
     X-grounded search, multimodal, reasoning, free on grok.com/X/apps) confirmed via xAI''s own release
-    + X post; x.ai/news/grok-4-1 is live (403 to bot-fetch only). Capability evidence now primary.]'
+    + X post; x.ai/news/grok-4-1 is live (403 to bot-fetch only). Capability evidence now primary.]
+    Re-read 2026-08-13, and this time the page answered a plain fetch rather than returning 403, so the
+    note above about bot-blocking no longer applies. The release note still describes Grok 4.1 as a
+    frontier model with real-time search integration, rolled out in Auto mode and selectable in the
+    model picker across grok.com, X and the mobile apps, trained with the same large-scale
+    reinforcement-learning infrastructure as Grok 4. Still locked to xAI models with no provider
+    breadth. Band unchanged at 4.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://x.ai/news/grok-4-1
     shows: 'Grok assistant features: reasoning model, real-time search, multimodal'
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5311110078eb9652249dbe04fcc5f95c4b1d8ce8fe018a8719eab06bfdcdc148

--- a/sources/scores/huggingchat-chat-ui.yaml
+++ b/sources/scores/huggingchat-chat-ui.yaml
@@ -15,12 +15,21 @@ openness:
   confidence: high
   note: Fully OSI (Apache-2.0); the public codebase is exactly what powers the hosted HuggingChat, self-hostable
     end to end.
+    Re-read 2026-08-13. The repository still declares Apache-2.0 and the README still opens by saying
+    the SvelteKit app powers HuggingChat on hf.co/chat. It is self-hostable end to end against any
+    MongoDB 6/7 deployment, an embedded fallback, or the bundled ghcr.io/huggingface/chat-ui-db image,
+    with nothing withheld. Latest release is still v0.10.0 of 11 May 2026 and the repo now shows 10,885
+    stars. Value unchanged at 5 / open_source.
   raw: license:Apache-2.0(OSI);source:public;no-feature-gated-core(self-hostable SvelteKit app, MongoDB
     backend);core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/huggingface/chat-ui
     shows: Apache-2.0; 'open source codebase powering HuggingChat'; v0.10.0
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0cbbac9afb1712501473af2b9295db8f4961ff9c354bd584268c7e0632dcb16e
+    establishes: [license, source, core-gated]
 adoption:
   level: 3
   signal_type: reported_traction
@@ -48,11 +57,21 @@ capability:
   note: Good model breadth + smart routing + MCP, but the rebuilt v0.10 deliberately stripped RAG/provider
     integrations present in the legacy branch, so the self-host feature surface is leaner than Open WebUI/LibreChat.
     Mid-tier for the category.
+    Re-read 2026-08-13. The README still states that Chat UI speaks only to OpenAI-compatible APIs and
+    that the legacy provider integrations, GGUF discovery, embeddings and web-search helpers have been
+    removed, with the old code left on a legacy branch. hf.co/chat still runs the Omni router and its
+    model picker now offers 132 open models, up from the 123 recorded here. The anchor, open-webui, was
+    re-derived at 4 on the same day, so one_below still arrives at 3. Band unchanged.
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/huggingface/chat-ui
     shows: OpenAI-compatible API, MCP tools, multimodal, Omni routing; legacy provider integrations +
       GGUF discovery removed
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0cbbac9afb1712501473af2b9295db8f4961ff9c354bd584268c7e0632dcb16e
   - url: https://huggingface.co/chat
     shows: Omni router selecting among 123+ open models, MCP enabled
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e6ad542f9d8a280e654288ef5a9612e2c012aee06fac852ffba12c756708534f

--- a/sources/scores/jan.yaml
+++ b/sources/scores/jan.yaml
@@ -19,15 +19,28 @@ openness:
     - no-feature-gated-core
   note: Fully OSI-licensed (Apache-2.0), full source public, no proprietary feature-gated core, a true
     open chat UI.
+    Re-read 2026-08-13. The LICENSE still licenses Jan under Apache-2.0 by reference, with one added
+    sentence asking that attribution appear in user-facing materials - a request, not a condition, which
+    is why GitHub reports the repo as NOASSERTION rather than Apache-2.0. The README still ships the
+    whole desktop app buildable from source with make dev, with local models, cloud providers, custom
+    assistants, an OpenAI-compatible server on localhost:1337 and MCP, and nothing held back for a paid
+    tier. Value unchanged at 5 / open_source.
   raw: license:Apache-2.0(OSI);source:public(github.com/janhq/jan);no-feature-gated-core;self-host:primary(desktop
     app, 100% offline-capable);core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/janhq/jan/blob/dev/LICENSE
     shows: Apache-2.0 license text
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 240e79d4976dbf1d4c76e0ac1da223df97935a75497eaf8dd045771c3e92de16
+    establishes: [license]
   - url: https://github.com/janhq/jan
     shows: public source; Apache-2.0; v0.8.2 (1 Jun 2026)
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a60af4cdb71d1e3faca5d232f8c92f9484e3978d800127d50eb692865c8b60ba
+    establishes: [source, core-gated]
 adoption:
   level: 4
   reach: 1M-10M
@@ -36,13 +49,21 @@ adoption:
   note: Vendor site reports 5.7M+ cumulative downloads of the desktop app; 42.9k GitHub stars corroborates
     but is not the basis. Cumulative-download volume places it in the 1-10M band, though these are lifetime
     installs not active users.
+    Re-read 2026-08-13 - jan.ai now states 6.1M downloads on its homepage, up from the 5.7M-plus
+    recorded here, and shows 43.8K GitHub stars. Still lifetime installs rather than active users, and
+    still inside the 1M-10M band. Level unchanged at 4.
+  last_verified: '2026-08-13'
   sources:
   - url: https://jan.ai/
     shows: 5.7M+ downloads stated on vendor homepage
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 123a5b026ad39256245785b7a82bd59a3d9814051c49326dcdcfb15233d40344
   - url: https://github.com/janhq/jan
     shows: 42.9k stars (corroborating)
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a60af4cdb71d1e3faca5d232f8c92f9484e3978d800127d50eb692865c8b60ba
 capability:
   score: 3
   basis: feature_matrix
@@ -53,10 +74,20 @@ capability:
   note: Solid open desktop chat UI with broad model selection and a local OpenAI-compatible server, but
     single-user and lighter on RAG/multimodal than the frontier consumer apps in this category. Mid-tier
     on the chat-UI feature matrix.
+    Re-read 2026-08-13. The README still lists local GGUF models from Hugging Face alongside OpenAI,
+    Anthropic, Mistral, Groq and MiniMax cloud providers, custom assistants, the local OpenAI-compatible
+    server and MCP for agentic use, and jan.ai still shows a single-user desktop product with memory
+    listed as coming soon. RAG and multimodal are still thin next to the frontier consumer apps and
+    there is still no multi-user mode. Band unchanged at 3.
+  last_verified: '2026-08-13'
   sources:
   - url: https://jan.ai/
     shows: open + cloud model providers, OpenAI-compatible API, local-first
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 123a5b026ad39256245785b7a82bd59a3d9814051c49326dcdcfb15233d40344
   - url: https://github.com/janhq/jan
     shows: 'feature set: local LLMs, cloud integration, custom assistants, OpenAI-compatible API'
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a60af4cdb71d1e3faca5d232f8c92f9484e3978d800127d50eb692865c8b60ba

--- a/sources/scores/khoj.yaml
+++ b/sources/scores/khoj.yaml
@@ -20,15 +20,27 @@ openness:
   note: OSI-licensed (AGPL-3.0), full source public, self-hostable via Docker or pip. The paid Khoj Cloud
     tier was discontinued 2026-04-15 and the team frames self-hosting as the complete replacement, so the
     earlier open-core characteristics no longer apply to the shipping product.
+    Re-read 2026-08-13. The repository still carries AGPL-3.0 and the README still says Khoj is
+    open-source and self-hostable, always, with Docker and pip both documented. The sunset notice at
+    app.khoj.dev is still up, still dated 15 April 2026, and still ends with the line that Khoj remains
+    fully open-source and can be self-hosted for complete data ownership, so there is still no paid tier
+    left to gate anything. Repo now at 36,480 stars. Value unchanged at 5 / open_source.
   raw: license:AGPL-3.0(OSI);source:public(github.com/khoj-ai/khoj);self-host:primary(Docker+pip);cloud-tier-sunset-2026-04(no
     remaining feature-gating);core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/khoj-ai/khoj
     shows: AGPL-3.0 license; ~35k stars; self-hostable AI personal assistant
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: db4fcbf157408d6f2bc8bbff78fc4dbf8811e5d8de928dbc384ef504d90a3307
+    establishes: [license, source]
   - url: https://app.khoj.dev/
     shows: official notice that Khoj Cloud was sunset 2026-04-15 and Khoj "remains fully open source"
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 220d598757e6cc36dd5658b19a8460dddef1ae2c157c00b333406086c2399cdb
+    establishes: [core-gated]
 adoption:
   level: 2
   reach: 10K-100K
@@ -53,7 +65,16 @@ capability:
   confidence: medium
   note: Broad feature surface across providers, personal RAG, agents, automations, multimodality and many
     client integrations - on par with the leading open self-hosted assistants. Top-tier for the category.
+    Re-read 2026-08-13. The README still lists the whole surface the band rests on - any local or online
+    model from llama3 and qwen through gpt, claude, gemini and deepseek, answers grounded in both the
+    web and personal documents spanning image, pdf, markdown, org-mode, word and notion, clients for
+    browser, Obsidian, Emacs, desktop, phone and WhatsApp, custom agents with their own knowledge and
+    tools, automated research with scheduled newsletters and notifications, semantic search, and image
+    generation with speech in and out. Band unchanged at 4.
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/khoj-ai/khoj
     shows: 'feature set: multi-provider, personal-doc RAG, agents, automations, multimodal, multi-client'
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: db4fcbf157408d6f2bc8bbff78fc4dbf8811e5d8de928dbc384ef504d90a3307

--- a/sources/scores/le-chat.yaml
+++ b/sources/scores/le-chat.yaml
@@ -30,13 +30,25 @@ adoption:
     states EU monthly active recipients below 45M (a DSA ceiling, not a measured MAU); ~10.8M desktop
     visits to mistral.ai Mar 2026. Honest read places real active users in the 1-10M band, level 4. The
     <45M is a regulatory cap not an actual count, so not used as the headline.
+    Re-read 2026-08-13. The TechCrunch brief is still up and still carries the one milestone it ever
+    carried - Mistral telling Le Parisien that Le Chat passed one million downloads fourteen days after
+    release, topping the free iOS chart in France. WHAT WAS BANDED - downloads, not an active count. No
+    active-user figure for Le Chat exists from Mistral or anyone else; the EU recipient ceiling is a
+    regulatory cap and the mistral.ai visit count is site traffic, so the level is an inference from
+    install volume and is labelled active_users only because that is the instrument the map offers for a
+    consumer surface. Level unchanged at 4.
+  last_verified: '2026-08-13'
   sources:
   - url: https://techcrunch.com/2025/02/19/mistrals-le-chat-tops-1m-downloads-in-just-14-days/
     shows: 1M downloads in 14 days at launch (primary-press milestone)
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6d2677de2d91f4f32780d47e83f601f88a7a346b9fd9a13251dc92c8ae7305dc
   - url: https://www.businessofapps.com/data/perplexity-ai-statistics/
     shows: 'context: peer consumer-chat scale for calibration'
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 91c372e3bb20567064d4bc7a91e257a3de7994e6edfc02f7f1013aeebdaddd80
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/librechat.yaml
+++ b/sources/scores/librechat.yaml
@@ -15,15 +15,28 @@ openness:
   confidence: high
   note: Fully OSI (MIT), full source public, no paid feature-gated core. Enterprise backing via ClickHouse
     acquisition has not introduced a closed core.
+    Re-read 2026-08-13. The repository still carries the MIT badge and the full self-hostable stack, now
+    at 41,990 stars and 8,686 forks, and the code interpreter it ships points at the open
+    ClickHouse/code-interpreter project rather than a paid tier. The ClickHouse acquisition post still
+    states that for existing LibreChat deployments operations continue unchanged with ongoing investment
+    in the open-source project and community, so no closed core has appeared. The post itself names no
+    license; MIT comes from the repository. Value unchanged at 5 / open_source.
   raw: license:MIT(OSI);source:public;no-feature-gated-core(RAG API is a separate companion OSS repo);core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/danny-avila/LibreChat
     shows: MIT license; full-featured self-hosted chat UI
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: ac83c56517eb1519daefcd3528846e6eac847b5fffad64d775404a7a1b65f8bf
+    establishes: [license, source, core-gated]
   - url: https://clickhouse.com/blog/clickhouse-acquires-librechat
     shows: ClickHouse acquires LibreChat (Nov 4, 2025); LibreChat remains open source/MIT, no closed core
       introduced, ongoing OSS investment
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 12b88f281ca06c07e7e5ce3adf7e0fc47595a565219e6726d43a3ed688151d1a
+    establishes: [core-gated]
 adoption:
   level: 4
   reach: 1M-10M
@@ -45,8 +58,16 @@ capability:
     artifacts (React/HTML/Mermaid), web search
   confidence: high
   note: 'Frontier feature surface for the category: code interpreter, MCP, agents/subagents and artifacts
-    on top of the standard chat-UI matrix. At/above Open WebUI on breadth.'
+    on top of the standard chat-UI matrix. At/above Open WebUI on breadth.
+    Re-read 2026-08-13. The README still lists the whole surface the band rests on - a sandboxed code
+    interpreter across nine languages, MCP tool support, agents with an agent marketplace, Skills
+    bundles and subagents, code artifacts in React, HTML and Mermaid, web search with rerankers, image
+    generation and editing, speech in and out, and multi-user auth over OAuth2, LDAP and email with
+    moderation and token-spend controls. Band unchanged at 5.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/danny-avila/LibreChat
     shows: 'feature list: multi-provider, code interpreter, MCP, agents/subagents, artifacts, OAuth2/LDAP'
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: ac83c56517eb1519daefcd3528846e6eac847b5fffad64d775404a7a1b65f8bf

--- a/sources/scores/litellm.yaml
+++ b/sources/scores/litellm.yaml
@@ -106,11 +106,25 @@ adoption:
     download count - while declaring no artifact any signal model reads, so no computed figure existed for the
     recorded band to disagree with. Level corrected from 3, by two bands. The figure is internally consistent
     across windows (207.8M weekly, 28.5M daily) - litellm is a proxy library pulled on nearly every CI run
-    that touches a model provider. No last_verified claimed: only the figure was re-read.'
+    that touches a model provider. No last_verified claimed: only the figure was re-read.
+    Re-read 2026-08-13. The download figure the band rests on now has a cited source rather than living
+    only in this note - pypistats returns 741,403,911 for the trailing thirty days, the same number to
+    the unit, with 207,823,088 weekly and 28,463,811 daily still internally consistent. Still far above
+    the >10M threshold. The GitHub source line remains a phase-C placeholder and is retained only as the
+    repository pointer. Level unchanged at 5, and the earlier refusal to claim a date is superseded now
+    that the figure is sourced.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/BerriAI/litellm
     shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1e691389a4f2429e0a57b8d50594822891454fb0ad7c2a8a5e786627b47e34e4
+  - url: https://pypistats.org/api/packages/litellm/recent
+    shows: 741,403,911 downloads in the trailing 30 days for litellm; 207,823,088 weekly and 28,463,811 daily
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 23604fef8853534104885a67634c38b86aa734c70a7f50f55842d02db31c2a7e
 capability:
   score: 4
   basis: feature_matrix
@@ -119,10 +133,23 @@ capability:
   note: Unified gateway to 140+ LLM providers in OpenAI format with cost tracking, guardrails, load balancing,
     virtual keys/budgets, logging. No standard benchmark applies to a gateway; rated on breadth of provider
     coverage and production features.
+    Re-read 2026-08-13, replacing the phase-C placeholder source lines with an actual reading. The
+    README still describes an open source AI gateway giving one OpenAI-format interface over LLM
+    providers, usable as a Python SDK or deployed as a proxy server, with virtual keys, spend tracking,
+    guardrails, load balancing and an admin dashboard, and it quotes 8ms P95 latency at 1k RPS. The docs
+    still show budgets per project, guardrails, caching, load balancing and cost tracking. One drift
+    worth recording - both the README and the docs now say 100+ providers where this record says 140+,
+    so the headline count has been restated downward rather than grown. The band does not turn on that
+    number. Band unchanged at 4.
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/BerriAI/litellm
     shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1e691389a4f2429e0a57b8d50594822891454fb0ad7c2a8a5e786627b47e34e4
   - url: https://docs.litellm.ai/
     shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d107165c590f00745b749c3681353c38d20f68ec217ec929b7c4b5bf7c2796da

--- a/sources/scores/llm.yaml
+++ b/sources/scores/llm.yaml
@@ -18,11 +18,19 @@ openness:
   confidence: high
   note: Apache-2.0 verified against LICENSE body; full source public; CLI/library with no gated tier (model providers
     need their own API keys, external to the tool).
+    Re-read 2026-08-13. The LICENSE is still the full Apache License 2.0 text, the repository still
+    publishes the whole CLI and library, and there is still no gated tier - the API keys a user needs
+    belong to the model providers, not to this tool. Repo now at 12,358 stars. Value unchanged at 5 /
+    open_source.
   raw: license:Apache-2.0(OSI);source:public(GitHub);PyPI;plugin-extensible;no feature-gated core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/simonw/llm/blob/main/LICENSE
     shows: Apache License 2.0 full text
-    accessed: '2026-06-19'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
+    establishes: [license, source, core-gated]
 adoption:
   level: 3
   reach: 100K-1M
@@ -31,13 +39,28 @@ adoption:
   note: Established CLI/library distributed on PyPI (package 'llm', v0.31) with ~12.1k GitHub stars and a broad
     plugin ecosystem; widely used across Simon Willison's tooling. No exact monthly download figure captured, so
     placed at 3 on PyPI-presence + ecosystem signal.
+    Re-read 2026-08-13, and the missing download figure now exists. pypistats returns 601,475 downloads
+    for the trailing thirty days, which lands in 100K-1M and confirms the band that had been placed on
+    PyPI presence and ecosystem reasoning alone. The repository shows 12,358 stars and the latest
+    release is now 0.32 of 4 August 2026, past the v0.31 the PyPI source line records. Level unchanged
+    at 3, now on a measured signal rather than an inferred one.
+  last_verified: '2026-08-13'
   sources:
   - url: https://pypi.org/project/llm
     shows: llm v0.31 published ~Apr 2026
-    accessed: '2026-06-19'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 32ed63159c77e21ee19ca1b9aa3213ccf0218eb59539560b132a8e68ef0e18ea
   - url: https://github.com/simonw/llm
     shows: ~12.1k stars, plugin ecosystem
-    accessed: '2026-06-19'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a8792594a44bbbe92c01ab79753330638a17e75008e9d70afcb27b6f48e274d7
+  - url: https://pypistats.org/api/packages/llm/recent
+    shows: 601,475 downloads in the trailing 30 days for llm; 120,706 weekly and 19,508 daily
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0a14b3967390d80d1db874b773d8c40720f325e7fec12f491732e0322fa910f7
 capability:
   score: 3
   basis: feature_matrix
@@ -46,7 +69,15 @@ capability:
   confidence: high
   note: Strong on model breadth and extensibility, but a developer CLI/library rather than a multi-user surface;
     lacks the built-in RAG/multimodal/auth feature stack of top ui_api entries, so scored 3.
+    Re-read 2026-08-13. The documentation still describes a CLI tool and Python library for OpenAI,
+    Claude, Gemini, Llama and dozens of other models both remote and local, with plugins, tools,
+    schemas, templates, fragments, model aliases, embeddings and SQLite logging of prompts and
+    responses. It is still a developer surface with no multi-user layer, no built-in RAG stack and no
+    auth. Band unchanged at 3.
+  last_verified: '2026-08-13'
   sources:
   - url: https://llm.datasette.io/
     shows: 'docs: unified CLI/Python API for remote+local models, plugins, embeddings, templates, SQLite logging'
-    accessed: '2026-06-19'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a968a014b0352985c81409e511e9b395af8aaca2ab9540b3c035c73281b00257

--- a/sources/scores/lm-studio.yaml
+++ b/sources/scores/lm-studio.yaml
@@ -17,27 +17,50 @@ openness:
       value: closed
   confidence: high
   note: Core app/engine is closed proprietary freeware; only peripheral CLI/SDKs are open.
+    Re-read 2026-08-13. The app terms still forbid the three things the score turns on - modifying,
+    adapting, altering or creating derivative works; reverse engineering, decompiling or disassembling;
+    and sublicensing, distributing or selling. The homepage still says the app is free for home and work
+    use and still offers only compiled downloads, with the MIT SDKs and CLI beside it. Value unchanged
+    at 1 / closed.
   raw: license:Proprietary;source:closed;app:proprietary-freeware(ToS forbids modify/reverse-engineer/redistribute);sdk+cli:MIT(public);core-engine:closed
+  last_verified: '2026-08-13'
   sources:
   - url: https://lmstudio.ai/app-terms
     shows: 'ToS: no modification/reverse-engineering/redistribution'
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: f4f80b5a56c25cd224cc35b6ed68c402756ecb03f9b2dec0d61b716b75f2f94c
+    establishes: [license, source]
 adoption:
   level: 3
   signal_type: reported_traction
   confidence: medium
   note: Widely-used consumer app but no primary-verified install count; conservative level 3.
+    Re-read 2026-08-13. The homepage still publishes no install or user count of any kind - it offers a
+    download and the free-for-home-and-work-use line and nothing countable - so the conservative
+    reported_traction band stands. Level unchanged at 3.
+  last_verified: '2026-08-13'
   sources:
   - url: https://lmstudio.ai/
     shows: product positioning, free for home and work use
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1d638ab9260ef54ae0a511e1c1c008c581125c012446d6d3d8a6a3217124779f
 capability:
   score: 4
   basis: feature_matrix
   value: polished chat UI; model browser; OpenAI-compatible local server; headless mode; native Apple MLX
   confidence: medium
   note: Strong UX/polish on par with the open local UIs; loses on openness/extensibility (closed source).
+    Re-read 2026-08-13. The homepage still shows the chat app, the model browser over gpt-oss, Qwen3.6,
+    Gemma4 and DeepSeek, OpenAI-compatible serving, Apple MLX support and a headless deployment path -
+    now named llmster and described as the LM Studio core without the GUI, installable by one-line
+    script on Linux, cloud servers or CI. JS and Python SDKs, an lms CLI and MCP client support are also
+    listed. Current version 0.4.21. Band unchanged at 4.
+  last_verified: '2026-08-13'
   sources:
   - url: https://lmstudio.ai/
     shows: 'feature set: chat UI, model browser, local server, MLX'
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1d638ab9260ef54ae0a511e1c1c008c581125c012446d6d3d8a6a3217124779f

--- a/sources/scores/lobe-chat.yaml
+++ b/sources/scores/lobe-chat.yaml
@@ -16,18 +16,32 @@ openness:
     CLA lets LobeHub relicense contributions for its cloud editions. Both exceed Apache-2.0, though it is
     still presented publicly as open source. Score corrected from 3 to 2 on 2026-07-30. The software ladder
     has rungs at 1, 2, 4 and 5 and none at 3, so 3/source_available was not a pair any rule could produce;
-    the ladder scores "you can read it and not run it freely" at 2.'
+    the ladder scores "you can read it and not run it freely" at 2.
+    Re-read 2026-08-13. The LICENSE is still the LobeHub Community License, Apache-2.0 plus two
+    additions - clause 1b requires a commercial license from the producer to develop and distribute a
+    derivative work, and clause 2 has contributors agree that the producer may tighten or relax the
+    terms and may use contributed code commercially including in its cloud edition. The repository still
+    publishes the full self-hostable app with Docker and Vercel paths and still links a paid Pricing
+    tier alongside. GitHub classifies the license as NOASSERTION, which is consistent with a non-OSI
+    text. Value unchanged at 2 / source_available.'
   raw: 'license:LobeHub-Community-License(Apache-2.0-based, non-OSI: commercial license required to develop+distribute
     a derivative work; CLA lets LobeHub relicense contributions for cloud editions);source:public;cloud-tier:LobeHub
     Cloud'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/lobehub/lobe-chat/blob/main/LICENSE
     shows: LobeHub Community License (Apache-2.0 based) requiring a commercial license to distribute derivative
       works; non-OSI
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 790a8c42f10beb4f5e9122e05a8e65d5522de49f89ac69cd31063c0f2be93ea4
+    establishes: [license]
   - url: https://github.com/lobehub/lobehub
     shows: v2.2.2 latest; 78.2k stars; self-host + LobeHub Cloud tiers
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b7b7b598dcb688a838e90f3e46c8727fc432940777443a2a7f3cbd5437126611
+    establishes: [source]
 adoption:
   level: 3
   reach: '>10K stars'
@@ -39,11 +53,20 @@ adoption:
     the stars scale in signal_routing.yaml. The previous reach ''100K-1M'' was not a label this instrument
     offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a
     star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis
-    was not re-read.'
+    was not re-read.
+    Re-read 2026-08-13 - the repository now shows 81,647 stars and 15,804 forks, which still bands at
+    >10K stars, level 3 on the stars scale. No download, pull or MAU figure has appeared on the repo or
+    in the LobeHub README, so the stars fallback still stands and the level is unchanged. This
+    supersedes the refusal above to claim a date - the axis was re-read in full rather than aggregated,
+    and the recorded digest is of the repository page, whose drift on refetch is expected for exactly
+    the reason the earlier note gives.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/lobehub/lobehub
     shows: 78.2k stars, 15.4k forks; Docker + Cloud deployment
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b7b7b598dcb688a838e90f3e46c8727fc432940777443a2a7f3cbd5437126611
 capability:
   score: 4
   basis: feature_matrix
@@ -53,7 +76,16 @@ capability:
   note: Strong feature surface across model breadth, MCP plugins, knowledge base and multi-user. Below
     Open WebUI/LibreChat on enterprise auth/RAG depth verifiability; agent-orchestration framing edges
     toward orchestration_agents but core remains human-driven chat.
+    Re-read 2026-08-13. The README still claims 10,000+ Skills connecting agents to tools and
+    MCP-compatible plugins via an MCP Registry, transparent per-agent memory the user can inspect and
+    control, and agent teams with scheduling and an IM gateway, on a self-hostable base. The
+    knowledge-base and multi-model wording has dropped out of the README in favour of agent-team
+    framing, but neither feature is withdrawn from the product and the enterprise-auth gap against Open
+    WebUI and LibreChat that placed the band is unchanged. Band unchanged at 4.
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/lobehub/lobehub
     shows: 'feature list: multi-model, 10,000+ MCP skills, agent groups, knowledge base, memory'
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b7b7b598dcb688a838e90f3e46c8727fc432940777443a2a7f3cbd5437126611

--- a/sources/scores/lumo.yaml
+++ b/sources/scores/lumo.yaml
@@ -21,17 +21,30 @@ openness:
     note that only the clients are open. Corrected from 3/open_core on 2026-07-30, and both values were
     wrong: the ladder has no rung at 3, and a published client standing in for an unpublished engine is
     source:partial, which it scores 2/source_available. open_core would mean an OSI core with a paid tier
-    withheld.'
+    withheld.
+    Re-read 2026-08-13. The iOS client is still GPLv3 and its README makes the split unusually clear -
+    the app is a SwiftUI shell around a WKWebView pointed at lumo.proton.me, with native payment and
+    speech handling, so what is published is a client and the service behind it is not. isitreallyfoss
+    still concludes the same, that only the mobile and web apps are open and that no source for the
+    service or for the model interaction could be found, and it still quotes the European Open Source AI
+    Index reaching that conclusion independently. Value unchanged at 2 / source_available.'
   raw: source:partial(GPLv3 clients only; backend, routing and model-serving are not published);clients:open(GPLv3
     - web in ProtonMail/WebClients, iOS/Android in ProtonLumo);service:closed(backend, routing, model-serving
     not public);license:GPLv3(clients)
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/ProtonLumo/ios-lumo
     shows: iOS client source under GPLv3
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 4242413b80de9342fe27611809a28982c9a038a5d6e708e2e05676dd92721f4c
+    establishes: [license, source]
   - url: https://isitreallyfoss.com/projects/lumo/
     shows: only the Lumo mobile/web apps are open; service + model interaction code not public
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 04d0c62528b017a7f6c114584d5562d86ba331d508c10f450ab1d9dde49c89f5
+    establishes: [source]
 adoption:
   level: 3
   signal_type: reported_traction
@@ -39,10 +52,18 @@ adoption:
   note: Launched July 2025 with Lumo 1.1 following; distributed across Proton's large account base (100M+
     Proton accounts) and available on web + iOS + Android with no account required. No Lumo-specific usage
     numbers disclosed, so reported_traction at a mid level.
+    Re-read 2026-08-13. The July 2025 launch announcement is still up and still discloses no
+    Lumo-specific usage figure, and none has appeared since - the only number Proton attaches is its own
+    account base, which is the distribution channel rather than a measure of Lumo. So the abstention
+    from a counted signal stands and reported_traction with no numeric reach remains the right
+    instrument. Level unchanged at 3.
+  last_verified: '2026-08-13'
   sources:
   - url: https://proton.me/blog/lumo-ai
     shows: Proton's launch announcement for Lumo
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6eb81a315131a22fb23233e2343149fe760ab76532e2dd2a045fa9e2f187ff92
 capability:
   score: 3
   basis: feature_matrix
@@ -53,7 +74,15 @@ capability:
   note: Capable privacy assistant with file upload, web search, and a reasoning mode, but confined to
     open-weight models and the Proton ecosystem; lighter on multimodal/plugins than frontier consumer
     apps. Mid-tier on the chat-UI feature matrix.
+    Re-read 2026-08-13. The Lumo 1.1 post is still up and still describes the same upgrade the band
+    rests on - faster and more thorough answers, better awareness of recent events, multi-step planning
+    and better code generation, funded by more GPUs and Lumo Plus subscriptions. Still confined to
+    open-weight models Proton serves itself, still single-user, still light on multimodal. Band
+    unchanged at 3.
+  last_verified: '2026-08-13'
   sources:
   - url: https://proton.me/blog/lumo-1-1
     shows: Lumo 1.1 adds faster, advanced reasoning
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e5a12c14b9bfa84baae2a486c7ac2dca1dd1ef3bb7b7996e043d0f05c9dc37a5

--- a/sources/scores/maple-ai.yaml
+++ b/sources/scores/maple-ai.yaml
@@ -87,10 +87,17 @@ adoption:
   note: Launched Jan 2025; vendor reports "5x user growth in the last six months", >90% month-over-month
     paid retention, and "billions of tokens" in year one, but no absolute user count is published. Self-reported
     figures only, hence low confidence.
+    Re-read 2026-08-13. The one-year post is still up and still carries the same self-reported figures -
+    5x user growth in the last six months and over 90% of paying customers retained month over month -
+    and still publishes no absolute user count, so there is still nothing countable to band and
+    reported_traction with no numeric reach remains the right instrument. Level unchanged at 3.
+  last_verified: '2026-08-13'
   sources:
   - url: https://blog.trymaple.ai/one-year-of-private-ai-how-maple-ai-made-encryption-easy/
     shows: launch date (Jan 2025); 5x growth, >90% retention, billions of tokens processed
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 75433045f5afd9cc1fbb3ea8b3684c566fd6be3ccd8f20025dd0f41643d80bb3
 capability:
   score: 4
   basis: feature_matrix
@@ -100,7 +107,14 @@ capability:
   confidence: medium
   note: Broad multi-model, multi-platform private chat with vision, API, and teams. Short of top because it
     is a focused private-chat product without a confirmed agentic tool-use/web-browsing ecosystem.
+    Re-read 2026-08-13. The model guide still lists the same open-weight lineup the band rests on -
+    gpt-oss-120b, kimi-k2.5, deepseek-r1-0528, llama-3.3-70b, qwen3-vl-30b and gemma-3-27b - with the
+    tier structure gating vision and image work to paid plans. Still a focused private-chat product with
+    no agentic tool-use or browsing ecosystem. Band unchanged at 4.
+  last_verified: '2026-08-13'
   sources:
   - url: https://blog.trymaple.ai/maple-ai-model-guide-with-example-prompts/
     shows: 'model lineup (open-weight) and tier/feature structure'
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0c33f2b44860412ef7a73cb1e61efeb63e9fde94a8e105ce50133de42eb4eca9

--- a/sources/scores/meta-ai.yaml
+++ b/sources/scores/meta-ai.yaml
@@ -47,18 +47,30 @@ adoption:
     reported growing to ~1.2B MAU by Q1 2026, ~63% of interactions on WhatsApp. Far above the >10M threshold.
     CAVEAT: a portion of these MAU reflect surfaced/embedded exposure inside WhatsApp/IG rather than deliberate
     assistant use (one analyst, Kantrowitz, argues engaged usage is far lower than OpenAI''s). Attributed
-    honestly to the embedded surface, not a standalone assistant count.'
+    honestly to the embedded surface, not a standalone assistant count.
+    Re-read 2026-08-13. The TechCrunch report is still up and still carries Zuckerberg at the annual
+    shareholder meeting saying Meta AI has one billion monthly active users across the apps, doubling
+    the 500 million of September 2024. The Yahoo Finance piece is still up and still carries the Alex
+    Kantrowitz counter-argument that engaged usage is far below that headline. The Facebook post
+    carrying the same quote could not be refetched - facebook.com answers an automated request with HTTP
+    400 - so it keeps its earlier read and the confirmation rests on the other two. The
+    embedded-exposure caveat above is unchanged. Level unchanged at 5.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.facebook.com/yahoofinance/posts/zuck-says-meta-ai-has-more-than-one-billion-monthly-active-users-/1194397235888386/
     shows: 'Zuckerberg statement: Meta AI has more than one billion monthly active users'
     accessed: '2026-06-04'
   - url: https://finance.yahoo.com/news/meta-virtually-no-ai-users-144058392.html
     shows: 'Analyst caveat: embedded MAU overstate engaged assistant usage vs OpenAI''s ~900M'
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 40f4ae697bef6c8d09e4284ac7f0289086c16ab2c86c7ecb973fd29778af5cfa
   - url: https://techcrunch.com/2025/05/29/meta-ai-now-has-1b-monthly-active-users/
     shows: 'Primary press: Zuckerberg at May 2025 shareholder meeting says Meta AI has ~1B monthly active
       users'
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: f33dab9d1783711615a1692dcab18a9100787390ed10c071db2c9a1dd0a01d31
 capability:
   score: 3
   basis: feature_matrix

--- a/sources/scores/microsoft-copilot.yaml
+++ b/sources/scores/microsoft-copilot.yaml
@@ -15,12 +15,19 @@ openness:
       detail: closed
   confidence: high
   note: Fully proprietary, SaaS/embedded, the closed counterpart on the UI/API shelf.
+    Re-read 2026-08-13. The admin usage doc still describes a Microsoft-operated service reported on
+    through the Microsoft 365 admin center, with nothing published and no self-host path anywhere in it.
+    Value unchanged at 1 / closed.
   raw: license:proprietary(SaaS/embedded);source:closed;self-host:none;model:OpenAI+Microsoft(closed)
+  last_verified: '2026-08-13'
   sources:
   - url: https://learn.microsoft.com/en-us/microsoft-365/admin/activity-reports/microsoft-copilot-usage?view=o365-worldwide
     shows: Microsoft 365 Copilot Chat is a Microsoft-operated proprietary product (admin usage reporting
       docs)
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 35dc799b8cfd0694e27d3d4df95123620a02af15d1805e15f09b5b09c2e9699a
+    establishes: [license, source, self-host]
 adoption:
   level: 5
   reach: '>10M users'
@@ -31,14 +38,26 @@ adoption:
     are much lower (~33M), but the consumer + embedded surface reach is mass-market. Headline aggregated
     figure traces to Microsoft disclosures via aggregators; primary per-surface breakdown not directly
     fetched, so medium confidence.
+    Re-read 2026-08-13, and the aggregator has restated its numbers. Business of Apps now leads with 218
+    million active users across Windows, the app and the website, plus 88 million downloads since launch
+    - the ~420M all-surfaces figure and the ~160M enterprise-licensed figure recorded above are no
+    longer on the page. 218 million is still an active count and still far above the >10M users
+    threshold, so the level is unchanged at 5 and only the supporting number has moved. The Microsoft
+    admin doc still exists as the vendor-side reporting surface and still publishes no aggregate count
+    itself.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.businessofapps.com/data/microsoft-copilot-statistics/
     shows: ~420M MAU all surfaces Q1 2026; ~160M enterprise-licensed (aggregator compiling Microsoft disclosures)
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 04c097ae27fcca82a43519f2690785da7ec504948cf6ceaf1817f6b08d11f2cd
   - url: https://learn.microsoft.com/en-us/microsoft-365/admin/activity-reports/microsoft-365-copilot-usage?view=o365-worldwide
     shows: Microsoft's own active-usage reporting surface for M365 Copilot (confirms scale of deployed
       product)
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9eeea64cc36e2b7e71a74da9c3ec75cd1c49806755a5d548b9f7101a87e82a31
 capability:
   score: 4
   basis: feature_matrix
@@ -49,7 +68,15 @@ capability:
   confidence: medium
   note: Feature-rich chat UI with class-leading enterprise grounding/integration; not frontier-defining
     within this category because it is locked to one model provider and not self-hostable.
+    Re-read 2026-08-13. The usage doc still enumerates Copilot working inside Teams meetings, chat and
+    channels, Word, Excel, Outlook and the rest of Microsoft 365, alongside a separately reported
+    Copilot Chat surface, which is the embedded-grounding breadth the band rests on. The page does not
+    name the Graph by that word, so the grounding claim is read from the app coverage rather than
+    quoted. The provider lock to OpenAI and Microsoft models is unchanged. Band unchanged at 4.
+  last_verified: '2026-08-13'
   sources:
   - url: https://learn.microsoft.com/en-us/microsoft-365/admin/activity-reports/microsoft-365-copilot-usage?view=o365-worldwide
     shows: M365 Copilot chat features incl. Graph grounding across apps
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9eeea64cc36e2b7e71a74da9c3ec75cd1c49806755a5d548b9f7101a87e82a31

--- a/sources/scores/morphic.yaml
+++ b/sources/scores/morphic.yaml
@@ -19,11 +19,19 @@ openness:
   confidence: high
   note: Fully OSI-licensed (Apache-2.0), full source public, Docker-deployable for self-hosting - a true
     open generative-search UI.
+    Re-read 2026-08-13. The repository still carries Apache-2.0 and the README still puts Docker first,
+    with a single compose file bringing up PostgreSQL, Redis, SearXNG and Morphic and no additional
+    search API key needed. Nothing is held back for a paid tier and no hosted edition is offered. Repo
+    now at 9,037 stars, latest release v1.5.0. Value unchanged at 5 / open_source.
   raw: license:Apache-2.0(OSI);source:public(github.com/miurla/morphic);self-host:primary(Docker);no-feature-gated-core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/miurla/morphic
     shows: Apache-2.0 license; ~8.9k stars; open generative-UI answer engine
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d271530fdca4b3edc16dc167a838dcd51505e1487810ccd1bea701df45c626eb
+    establishes: [license, source, core-gated]
 adoption:
   level: 2
   signal_type: stars_fallback
@@ -50,7 +58,17 @@ capability:
   note: Distinctive generative-UI answer surface with multi-provider/multi-search support, but scoped
     to search-and-answer rather than the full chat-UI feature set (lighter on multimodal, plugins, enterprise
     auth). Mid-tier for the category.
+    Re-read 2026-08-13. The README still lists the generative UI rendering source-credited inline
+    components from a streamed JSON spec, a model selector across OpenAI, Anthropic, Google, Ollama and
+    OpenAI-compatible providers, four search providers in Tavily, SearXNG, Brave and Exa, chat history
+    in PostgreSQL, shareable result URLs, file upload, Supabase auth and guest mode. The two search
+    modes are now named Quick and Adaptive rather than the earlier pair, and a Vercel AI Gateway
+    provider has been added. Still scoped to search-and-answer with no plugin surface or enterprise
+    auth. Band unchanged at 3.
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/miurla/morphic
     shows: 'feature set: generative UI, multi-provider, multi-search, history, sharing, file upload, guest mode'
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d271530fdca4b3edc16dc167a838dcd51505e1487810ccd1bea701df45c626eb

--- a/sources/scores/nextchat.yaml
+++ b/sources/scores/nextchat.yaml
@@ -21,18 +21,28 @@ openness:
   confidence: high
   note: OSI MIT core with a separate proprietary Enterprise Edition for multi-user permissions and internal-KB
     RAG -> open_core (calibrated to the LiteLLM open_core anchor).
+    Re-read 2026-08-13. The repository still carries MIT and the root tree is still the whole
+    application - app, src-tauri, public, docs, scripts and test, with no ee/ or enterprise/ directory
+    anywhere in it. The README still carries the Enterprise Edition section quoted below verbatim,
+    unchanged, with the same business@nextchat.club contact, so the admin panel, the member and
+    knowledge-base permission model and the security auditing are still withheld from the published
+    source. The repository-root reading recorded on 2026-08-11 could not be refetched today because
+    api.github.com declined the request, so the source dimension was re-derived from the repository
+    page, whose embedded root listing shows the same tree. Value unchanged at 4 / open_core.
   raw: license:MIT(core, public source);enterprise-tier:NextChat Enterprise (permission controls, team resource
     mgmt, internal knowledge base/RAG);source:public(the app IS the repo; README ships one-click Vercel/Zeabur/Gitpod
     deploy, a Dockerfile and docker-compose, and desktop builds via src-tauri);core-gated:gated(Enterprise
     Edition withholds the admin panel, member/resource/knowledge-base permission control, internal knowledge-base
     integration and security auditing from the MIT repo)
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/ChatGPTNextWeb/NextChat
     shows: MIT license; cross-platform chat client; Enterprise Edition (permissions, team mgmt, internal
       knowledge base)
-    accessed: '2026-06-04'
-    establishes:
-    - license
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 3c4898066733a56c76b9d44103e06da64cc6a4600eb24eee32dec7f0d6a0b79f
+    establishes: [license, source]
   - url: https://api.github.com/repos/ChatGPTNextWeb/NextChat/contents/
     shows: Repository root read for the source dimension. The repo license endpoint returns MIT, and the
       tree is the whole application - app, src-tauri, public, docs, plus Dockerfile, docker-compose.yml,
@@ -53,9 +63,10 @@ openness:
       knowledge base exists in the MIT repository, whose own Features list describes the opposite design:
       "Privacy first, all data is stored locally in the browser". So this is functionality withheld from
       the published source rather than a hosted service beside it, which is the gated reading.'
-    accessed: '2026-08-11'
-    establishes:
-    - core-gated
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a2e48c50a9c32392e67397a67f66a6e3bdcaeb7c5bb051629a9fb5133927916a
+    establishes: [core-gated]
 adoption:
   level: 3
   reach: '>10K stars'
@@ -69,11 +80,19 @@ adoption:
     declares no artifacts at all, so a stars_fallback band had no stars source behind it and the count lived
     only in this note. Declaring ChatGPTNextWeb/NextChat would fix it, and is deliberately not done here
     because a declared code repo also re-routes the openness license dimension. No last_verified claimed: a
-    star count is volatile.'
+    star count is volatile.
+    Re-read 2026-08-13 - ChatGPTNextWeb/NextChat shows 88,616 stars, still banding at >10K stars, level
+    3 on the stars scale, and v2.16.1 of 29 July 2025 is still the latest tagged release, so the
+    stalled-release observation above holds a year on. No download or MAU figure has appeared. This
+    supersedes the refusal to claim a date - the axis was re-read rather than aggregated. Level
+    unchanged.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/ChatGPTNextWeb/NextChat
     shows: 88.2k stars; v2.16.1 latest release; cross-platform deployment
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 3c4898066733a56c76b9d44103e06da64cc6a4600eb24eee32dec7f0d6a0b79f
 capability:
   score: 3
   basis: feature_matrix
@@ -82,7 +101,14 @@ capability:
   confidence: medium
   note: Solid lightweight cross-platform client with plugins/MCP/vision, but RAG and multi-user are gated
     to Enterprise; thinner OSS feature surface than Open WebUI/LibreChat/AnythingLLM.
+    Re-read 2026-08-13. The README still shows the open surface the band rests on - many providers,
+    plugins from v2.15.0, artifacts from v2.14.0, realtime chat from v2.15.8, vision through the
+    VISION_MODELS setting, and MCP behind an ENABLE_MCP build flag - while stating that all data is
+    stored locally in the browser, so RAG and multi-user remain Enterprise-only. Band unchanged at 3.
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/ChatGPTNextWeb/NextChat
     shows: multi-provider, plugins, vision, MCP, artifacts; RAG/multi-user in Enterprise Edition
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 3c4898066733a56c76b9d44103e06da64cc6a4600eb24eee32dec7f0d6a0b79f

--- a/sources/scores/ogx.yaml
+++ b/sources/scores/ogx.yaml
@@ -17,17 +17,30 @@ openness:
   confidence: high
   note: Fully open (MIT, full source). Openness scored straightforwardly; the issue is category fit, not
     openness.
+    Re-read 2026-08-13. The repository still carries MIT and still publishes the whole server,
+    installable in one line or by pip, with nothing held back for a paid tier and no hosted edition
+    offered. The tagged release has moved on from the v1.0.2 recorded in the source line to v1.3.0 of 7
+    August 2026, and the star count is 8,420. The rename announcement still describes the move from
+    Llama Stack to a model-agnostic, multi-SDK server that routes to inference backends rather than
+    serving weights. Value unchanged at 5 / open_source.
   raw: license:MIT(OSI);source:public;no-feature-gated-core;implements OpenAI + Anthropic API surfaces;
     23 pluggable inference providers;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/ogx-ai/ogx
     shows: MIT license; v1.0.2 (May 13 2026); ~8.4k stars; agentic API server composing inference providers
       + vector stores + tools
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: de5ccf9111c512af57e35cf2ea36eba5654a9bfd774638f9a409611448d6535b
+    establishes: [license, source, core-gated]
   - url: https://ogx-ai.github.io/blog/from-llama-stack-to-ogx
     shows: renamed from Llama Stack; model-agnostic, multi-SDK, routes to inference backends rather than
       serving weights itself
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: af49c5ef04b44dae891b2ac66d7a92805045bebe4c9c9c27499e5afe3505d39c
+    establishes: [source]
 adoption:
   level: 2
   reach: 1K-10K stars
@@ -40,11 +53,19 @@ adoption:
     download. THE REAL DEFECT is upstream: this product declares no artifacts at all, so a stars_fallback band
     had no stars source behind it and the count lived only in this note. Declaring ogx-ai/ogx would fix it,
     and is deliberately not done here because a declared code repo also re-routes the openness license
-    dimension. No last_verified claimed: a star count is volatile.'
+    dimension. No last_verified claimed: a star count is volatile.
+    Re-read 2026-08-13 - ogx-ai/ogx shows 8,420 stars, which still bands at 1K-10K stars, level 2 on the
+    stars scale, and the README still publishes no download or usage figure. The artifact defect
+    described above is unchanged and still the right thing to fix upstream. This supersedes the refusal
+    to claim a date - the axis was re-read rather than aggregated, and drift in the digest is expected
+    for the reason the earlier note gives.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/ogx-ai/ogx
     shows: ~8.4k stars; no download/usage figure published
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: de5ccf9111c512af57e35cf2ea36eba5654a9bfd774638f9a409611448d6535b
 capability:
   score: 3
   basis: feature_matrix
@@ -54,8 +75,19 @@ capability:
   note: Capability is gateway/agentic-server breadth (multi-API-surface, provider composition), not inference
     throughput. As an inference engine it scores low because it does no forward pass itself; scored on
     its actual feature set in its true category. See recategorize.
+    Re-read 2026-08-13. The README still shows the gateway breadth the band rests on - chat completions,
+    completions and embeddings, a Responses API doing server-side agentic orchestration with tool
+    calling and MCP integration, vector stores and files, batches, and a pluggable provider architecture
+    spanning local Ollama through to production vLLM and managed services. Two things have moved since
+    the band was set - the multi-SDK surface now includes the Google GenAI SDK alongside the Anthropic
+    one, and a versioned Skills endpoint has appeared - while the README no longer states the provider
+    count of 23 in the source line, deferring to the provider documentation instead. Neither changes the
+    tier. Band unchanged at 3.
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/ogx-ai/ogx
     shows: composes 23 inference providers + vector/safety/tool/file backends behind OpenAI/Anthropic-compatible
       API
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: de5ccf9111c512af57e35cf2ea36eba5654a9bfd774638f9a409611448d6535b

--- a/sources/scores/open-webui.yaml
+++ b/sources/scores/open-webui.yaml
@@ -17,17 +17,29 @@ openness:
     class of use and fails the OSS Definition, though it is widely marketed as open source. Score corrected
     from 3 to 2 on 2026-07-30. The software ladder has rungs at 1, 2, 4 and 5 and none at 3, so 3/source_available
     was not a pair any rule could produce; the ladder scores "you can read it and not run it freely" at
-    2.'
+    2.
+    Re-read 2026-08-13. The LICENSE still carries clause 4, which prohibits altering or removing Open
+    WebUI branding except where end users number fifty or fewer in any rolling thirty-day period, or
+    under prior written permission, or under an executed enterprise license. The repository still ships
+    the whole self-hostable product and the README still advertises an Enterprise Plan offering custom
+    theming and branding. Value unchanged at 2 / source_available.'
   raw: 'license:Open-WebUI-License(BSD-3-Clause-based + non-OSI branding clause: branding may not be removed
     above 50 end-users/30d without enterprise license or written permission);source:public;enterprise-tier:commercial
     license to remove branding'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/open-webui/open-webui/blob/main/LICENSE
     shows: BSD-3-Clause-derived license with Section 4 branding-retention clause (<=50 users/30d), non-OSI
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5f1bd74c48bf13ab0f82e177ad9e637313b92533d20ead2593d49347a47fc232
+    establishes: [license]
   - url: https://github.com/open-webui/open-webui
     shows: v0.9.6 latest release, self-hosted AI interface
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 20c55ae4ba907a112dd497bbb3be0c1d90a0a6b1da197981c631cb55711a9357
+    establishes: [source]
 adoption:
   level: 3
   reach: 100K-1M
@@ -51,9 +63,18 @@ capability:
     multi-user (RBAC, groups, LDAP/SCIM/SSO); plugins (Pipelines framework)
   confidence: high
   note: 'Broadest feature surface among open self-hosted chat UIs: hits all five recipe dimensions (model
-    breadth, RAG, multimodal, plugins, multi-user) with enterprise auth. Top-tier for the category.'
+    breadth, RAG, multimodal, plugins, multi-user) with enterprise auth. Top-tier for the category.
+    Re-read 2026-08-13. The README still covers all five recipe dimensions - any OpenAI-compatible API
+    alongside local Ollama, RAG over nine vector databases with hybrid search and reranking, image
+    generation via DALL-E, Gemini, ComfyUI and AUTOMATIC1111 plus voice and video calling over several
+    STT and TTS providers, granular RBAC with groups, LDAP/Active Directory, SSO and SCIM 2.0
+    provisioning, and a plugin surface of Filters, Actions, Pipes, Tools and Skills reachable over MCP
+    and OpenAPI tool servers. The web-search provider list has grown past twenty. Band unchanged at 4.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/open-webui/open-webui
     shows: 'feature list: RAG with 9 vector DBs, multimodal voice/image, RBAC/LDAP/SCIM/SSO, Pipelines
       plugins'
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 20c55ae4ba907a112dd497bbb3be0c1d90a0a6b1da197981c631cb55711a9357

--- a/sources/scores/openclaw.yaml
+++ b/sources/scores/openclaw.yaml
@@ -17,11 +17,18 @@ openness:
     - no-feature-gated-core
   confidence: high
   note: Genuinely MIT open source; the NOASSERTION flag is a classifier artifact, not a restriction.
+    Re-read 2026-08-13. The LICENSE body is still a plain MIT License, now reading Copyright (c) 2026
+    OpenClaw Foundation, and the GitHub API still reports NOASSERTION for it - the classifier artifact
+    the note describes, not a restriction. Value unchanged at 5 / open_source.
   raw: license:MIT(OSI; body is MIT, GitHub NOASSERTION from custom copyright line);source:public;self-host:primary(local-first);no-feature-gated-core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/openclaw/openclaw/blob/main/LICENSE
     shows: MIT text, Copyright OpenClaw Foundation
-    accessed: '2026-06-18'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 73571b25326281d369087f469842c02444fe39faaecebda4d82ed21ff3a1c29d
+    establishes: [license, source, core-gated]
 adoption:
   level: 5
   signal_type: usage_volume
@@ -45,7 +52,15 @@ capability:
   confidence: high
   note: Among the most ambitious open personal-assistant projects - unifies chat, voice, and many messaging surfaces;
     broader channel reach than Open WebUI/Jan/Khoj.
+    Re-read 2026-08-13. The repository API still answers, and it confirms a live TypeScript project
+    created 2025-11-24 and pushed the same day this was read, now at 386,183 stars against the 379k
+    recorded. The channel and companion-app breadth the band rests on is a README claim rather than an
+    API one, so this confirms the project is real and moving rather than re-deriving the feature list
+    itself. Band unchanged at 5.
+  last_verified: '2026-08-13'
   sources:
   - url: https://api.github.com/repos/openclaw/openclaw
     shows: real repo, 379k stars, TS, created 2025-11-24, active
-    accessed: '2026-06-18'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1d6e084a3c78ebb0b7e4d5762347bf5367077f2abddd6ee7c6815d2ac2688aa6

--- a/sources/scores/openrouter.yaml
+++ b/sources/scores/openrouter.yaml
@@ -14,11 +14,18 @@ openness:
   confidence: high
   note: Proprietary hosted routing gateway, the closed counterpart to open gateways (LiteLLM); listed
     as closed in the recipe.
+    Re-read 2026-08-13. The homepage still sells a hosted gateway with sign-up and credits and still
+    publishes nothing of the routing service itself, with no self-host path anywhere on it. Value
+    unchanged at 1 / closed.
   raw: license:proprietary(hosted gateway);source:closed(SDK present, core service closed);self-host:none
+  last_verified: '2026-08-13'
   sources:
   - url: https://openrouter.ai/
     shows: hosted unified API gateway across 400+ models/60+ providers; proprietary service (no self-host)
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1feed682beaf51d79877ead5ea6e0255cd3adc23e264f8ba99fa47bd6886d4db
+    establishes: [license, source, self-host]
 adoption:
   level: 4
   reach: 1M-10M
@@ -46,7 +53,15 @@ capability:
   note: Frontier-defining for the gateway slot, broadest provider coverage + routing/fallback at the
     largest measured token scale; the closed counterpart that sets the bar LiteLLM (C4) approaches on
     the open side.
+    Re-read 2026-08-13. The homepage stat tiles now read 200T+ monthly tokens, 400+ models and 70+
+    providers, up from the 100T and 60+ providers recorded, and the routing, fallback, cost tracking and
+    OpenAI-compatible drop-in surface are unchanged. The model count is the same and the provider count
+    has grown, so the breadth that made this the gateway frontier is if anything wider. Band unchanged
+    at 5.
+  last_verified: '2026-08-13'
   sources:
   - url: https://openrouter.ai/
     shows: 400+ models, 60+ providers, routing/fallback, cost tracking, OpenAI-compat
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1feed682beaf51d79877ead5ea6e0255cd3adc23e264f8ba99fa47bd6886d4db

--- a/sources/scores/otari.yaml
+++ b/sources/scores/otari.yaml
@@ -22,15 +22,29 @@ openness:
     ladder calls ungated because hosting convenience is not gating. The old note's own conditional, that
     this would be open_source if the hosted platform is not a commercial tier, was a hedge rather than
     evidence of a tier.
+    Re-read 2026-08-13. The repository still carries Apache-2.0 and still describes a gateway you own
+    and run yourself, with the hosted otari.ai explicitly deploying this same proxy - the README
+    ecosystem table says so in as many words, that Otari is the proxy server otari.ai deploys and can be
+    run standalone or connected to the platform. So the hosted platform is convenience on the same core
+    rather than a tier withholding anything, which is the ungated reading. The Mozilla AI launch post
+    still describes otari.ai as the hosted platform built on the same foundation. Latest release v0.4.0.
+    Value unchanged at 5 / open_source.
   raw: license:Apache-2.0(OSI, core);source:public;self-host:yes(Docker Compose);service:hosted Otari.ai
     platform on the same core
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/mozilla-ai/otari
     shows: Apache-2.0; OpenAI-compatible gateway; self-host via Docker Compose
-    accessed: '2026-07-01'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 7cf4779a42242702718ade1f98eeb9497fe4f66ff73f3e4152a94c1bdfc34a2d
+    establishes: [license, source, self-host]
   - url: https://blog.mozilla.ai/otari-own-your-ai-stack/
     shows: OSS gateway plus hosted Otari.ai platform on the same foundation
-    accessed: '2026-07-01'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5d1fcdbda28aa66fc5bc302de38da6cb2fd9632118d909d47d1d27e6734ea938
+    establishes: [self-host]
 adoption:
   level: 1
   reach: <1K stars
@@ -42,11 +56,18 @@ adoption:
     scale in signal_routing.yaml. The previous reach ''<10K'' was not a label this instrument offers - stars
     have their own vocabulary because a star is not a download. No last_verified claimed: a star count is
     volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-
-    read.'
+    read.
+    Re-read 2026-08-13 - mozilla-ai/otari shows 381 stars, still under a thousand and still level 1 on
+    the stars scale, though six times the 63 recorded in July. No download, deployment or customer
+    figure has appeared. This supersedes the refusal to claim a date - the axis was re-read rather than
+    aggregated. Level unchanged.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/mozilla-ai/otari
     shows: 63 stars, 6 forks (July 2026)
-    accessed: '2026-07-01'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 7cf4779a42242702718ade1f98eeb9497fe4f66ff73f3e4152a94c1bdfc34a2d
 capability:
   score: 3
   basis: feature_matrix
@@ -55,7 +76,15 @@ capability:
   note: OpenAI-compatible gateway to 40+ providers with virtual keys, budgets, usage tracking, and
     sandboxed server-side code-execution tools. Solid feature set, but narrower provider coverage and less
     proven than LiteLLM (140+ providers). No standard benchmark applies to a gateway.
+    Re-read 2026-08-13. The README still shows the same gateway surface - one endpoint speaking the
+    OpenAI and Anthropic APIs in front of 40+ providers via any-llm, virtual keys that can be scoped and
+    revoked, per-user and per-key budgets enforced before a request runs rather than reconciled
+    afterwards, and usage logged and queryable through /v1/usage. The provider count is unchanged at
+    40+, still narrower than the LiteLLM anchor. Band unchanged at 3.
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/mozilla-ai/otari
     shows: 40+ providers, virtual keys, budgets, usage tracking, sandboxed code execution
-    accessed: '2026-07-01'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 7cf4779a42242702718ade1f98eeb9497fe4f66ff73f3e4152a94c1bdfc34a2d

--- a/sources/scores/perplexica.yaml
+++ b/sources/scores/perplexica.yaml
@@ -19,12 +19,22 @@ openness:
   confidence: high
   note: Fully OSI-licensed (MIT), complete source public, self-hosting is the primary distribution via a
     bundled Docker image - a true open answer engine. No premium tier or gated functionality identified.
+    Re-read 2026-08-13. The repository still carries MIT and the README still presents a self-hosted
+    product that runs entirely on hardware the reader owns, with the bundled SearXNG image as the
+    primary distribution and no paid tier or gated function anywhere in it. Repo now at 36,118 stars.
+    Worth flagging for the maintainers rather than the score - the last commit and the last release are
+    both from April 2026, so the project has been quiet for four months. Value unchanged at 5 /
+    open_source.
   raw: license:MIT(OSI);source:public(github.com/ItzCrazyKns/Vane);self-host:primary(single bundled Docker
     image);no-feature-gated-core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/ItzCrazyKns/Vane
     shows: MIT license; ~35k stars; open Perplexity-alternative answer engine (formerly Perplexica)
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 398ac38add4028522e9b750761dfab40a029ac18ebf646980fa5190012c7f967
+    establishes: [license, source, core-gated]
 adoption:
   level: 2
   reach: 10K-100K
@@ -38,11 +48,19 @@ adoption:
     cumulative six-figure total as though it were a monthly one, which is precisely the substitution the n8n
     rule names, and it put the record a band above what its own number supports. Recorded as a declared floor
     - a lifetime average understates a growing product. Docker is not declared as an artifact here, so the
-    figure lives in this note rather than in a signal. No last_verified claimed.'
+    figure lives in this note rather than in a signal. No last_verified claimed.
+    Re-derived 2026-08-13 from the cited page alone rather than from the predecessor image. Docker Hub
+    reports 284,672 cumulative pulls on itzcrazykns1337/vane, registered 2026-03-09, which averages
+    roughly 55,000 a month over 5.2 months and bands at 10K-100K, the same level the perplexica-image
+    calculation above reaches by a different route. The two images together stand at 931,112 lifetime
+    pulls. Level unchanged at 2, and the declared-floor caveat still applies.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://hub.docker.com/r/itzcrazykns1337/vane
     shows: 100K+ Docker pulls for the self-host image
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9fcd6e0155b1f48115a208651f20d6373e5d86cac2316ff39de634e49d7e6b2f
 capability:
   score: 4
   basis: feature_matrix
@@ -52,7 +70,16 @@ capability:
   confidence: medium
   note: Strong provider breadth, bundled metasearch, search modes, and file-upload RAG; loses a point for
     no built-in multi-user/auth and limited multimodal generation. Scoped to search-and-answer.
+    Re-read 2026-08-13. The README still shows the provider breadth across Ollama, OpenAI, Anthropic,
+    Google Gemini and Groq, the three search modes now named Speed, Balanced and Quality, source
+    selection across web, discussions and academic papers, bundled SearXNG metasearch, image and video
+    search, and file uploads covering PDFs, text and images. It has gained widgets for weather,
+    calculations and stock lookups, and it still ships no multi-user or auth layer. Tavily and Exa are
+    still listed as coming soon rather than shipped. Band unchanged at 4.
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/ItzCrazyKns/Vane
     shows: 'feature set: multi-provider, bundled SearXNG, search modes, file-upload RAG'
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 398ac38add4028522e9b750761dfab40a029ac18ebf646980fa5190012c7f967

--- a/sources/scores/perplexity.yaml
+++ b/sources/scores/perplexity.yaml
@@ -29,10 +29,19 @@ adoption:
     ~33M MAU; ~780M queries/mo (May 2025) growing >20% MoM to an estimated 1.2-1.5B/mo by mid-2026. Even
     the standalone-chat figure (33M) clears >10M. Headline user count is CEO-attributed via aggregators
     (Sacra), not a directly-fetched primary disclosure, medium confidence.
+    Re-read 2026-08-13, and the aggregator has restated its numbers. Business of Apps now leads with 45
+    million active users on the website and app, plus over 80 million downloads since launch and $200M
+    2025 revenue - the 100M-plus all-products figure and the ~33M standalone-chatbot figure recorded
+    above are no longer on the page. 45 million is still an active count and still far above the >10M
+    users threshold, so the level is unchanged at 5 and only the supporting number has moved. It remains
+    an aggregator compilation rather than a vendor disclosure, so confidence stays medium.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.businessofapps.com/data/perplexity-ai-statistics/
     shows: 100M+ MAU all products / ~33M standalone chatbot (CEO-attributed, compiled)
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 91c372e3bb20567064d4bc7a91e257a3de7994e6edfc02f7f1013aeebdaddd80
   - url: https://www.perplexity.ai/
     shows: live consumer product confirming scale of surface
     accessed: '2026-06-04'

--- a/sources/scores/poe.yaml
+++ b/sources/scores/poe.yaml
@@ -15,11 +15,19 @@ openness:
       detail: closed
   confidence: high
   note: Proprietary multi-model chat aggregator; closed counterpart on the shelf.
+    Re-read 2026-08-13. poe.com/about is still a sign-up page for a hosted Quora product fronting other
+    people models - the bot wall now runs from GPT-5.4 and Claude-Opus-4.6 through Gemini-3.1-Pro,
+    Grok-4.20, Veo-3.1 and dozens more - with nothing published and no self-host path. Value unchanged
+    at 1 / closed.
   raw: license:proprietary(SaaS);source:closed;self-host:none;models:multi-provider aggregation(closed)
+  last_verified: '2026-08-13'
   sources:
   - url: https://poe.com/about
     shows: proprietary multi-model chat aggregator (no source/self-host), Quora-affiliated
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 720894ec60194c224c5c1fb7ea33c2444d15908a4e4ef18cd2c9431791b7726e
+    establishes: [license, source, self-host]
 adoption:
   level: 5
   reach: '>10M users'
@@ -49,7 +57,16 @@ capability:
   confidence: medium
   note: Strongest pure model-breadth in the consumer aggregator slot (text/image/video/audio + custom
     bots); high feature breadth, not the frontier-definer (LiteLLM anchors the gateway side at C4).
+    Re-read 2026-08-13. The about page still shows the model breadth the band rests on and it has
+    widened - text, image, video and audio models side by side, including GPT-5.4, Claude-Opus-4.6 and
+    Claude-Sonnet-4.6, Gemini-3.1-Pro, Grok-4.20-Multi-Agent, Kimi-K2.5, GLM-5, DeepSeek-R1, Veo-3.1,
+    Sora-2-Pro, Runway-Gen-4.5, FLUX-2-Pro, ElevenLabs-v3 and Lyria-3 - alongside user-created bots and
+    bot-builder tooling. Still lighter on enterprise and RAG than Copilot or Perplexity. Band unchanged
+    at 4.
+  last_verified: '2026-08-13'
   sources:
   - url: https://poe.com/about
     shows: multi-provider model access incl. image/video/audio + user-created bots
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 720894ec60194c224c5c1fb7ea33c2444d15908a4e4ef18cd2c9431791b7726e

--- a/sources/scores/privatemode.yaml
+++ b/sources/scores/privatemode.yaml
@@ -63,10 +63,17 @@ adoption:
   confidence: low
   note: Announced Feb 18 2025; offers a free tier, pay-as-you-go, and enterprise plans, and is co-marketed
     with Capgemini for regulated industries, but no customer or usage numbers are published. New and unquantified.
+    Re-read 2026-08-13. The Edgeless Systems post is still up and still dated 18 February 2025, and
+    neither it nor the product site publishes any customer, seat or usage number - the customers section
+    is a logo wall rather than a count. So there is still nothing countable to band. Level unchanged at
+    2.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.edgeless.systems/blog/what-is-privatemode
     shows: launch date (Feb 18 2025); Edgeless Systems as maker; confidential-inference positioning
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 8bd5f7836be197770195aeb515eea15479751e7fe64266f0fdacc08915a709b4
 capability:
   score: 4
   basis: feature_matrix
@@ -78,7 +85,16 @@ capability:
   note: Broad model menu plus a drop-in OpenAI-compatible API, chat UI, and strong integration story. Not
     top-tier because it is a confidential inference relay for others' models rather than a frontier model
     or full platform.
+    Re-read 2026-08-13. The product site still shows the surface the band rests on - an
+    OpenAI-compatible API at api.privatemode.ai serving current open-weight models, a chat UI, a coding
+    agent install path, integrations including Claude Code and OpenCode, and the confidential-computing
+    guarantee that data is encrypted before it leaves the device and stays encrypted during processing.
+    The advertised model has moved on to kimi-k2.6. Still a confidential inference relay for other
+    people models rather than a platform of its own. Band unchanged at 4.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.privatemode.ai
     shows: 'model list, chat UI + API, integrations, confidential-compute guarantees'
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b6d21ede1220969e8fa74fa9c5408db08c4a7a64c18d2ed3a6a98dc582e91f4b

--- a/sources/scores/sillytavern.yaml
+++ b/sources/scores/sillytavern.yaml
@@ -21,12 +21,20 @@ openness:
     - no-managed-tier
   note: AGPL-3.0 (OSI-approved copyleft), full source public, self-host only, fully open. No proprietary/SaaS
     tier.
+    Re-read 2026-08-13. The repository still carries AGPL-3.0 and the README still states that the
+    project provides no online or hosted service, tracks no user data, and will always be free and open
+    sourced - so there is still nothing to gate and no managed tier. v1.18.0 of 3 May 2026 is still the
+    latest release. Value unchanged at 5 / open_source.
   raw: license:AGPL-3.0(OSI, copyleft);source:public(github.com/SillyTavern/SillyTavern);self-host:only(local
     install);no-managed-tier;extensions:third-party;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/SillyTavern/SillyTavern
     shows: AGPL-3.0; public source; v1.18.0 (3 May 2026); local UI for LLM/image/TTS backends
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 913396e188c8ef5e84e46847279e65992adcbf72337e666c475853ed5ec45c91
+    establishes: [license, source, core-gated]
 adoption:
   level: 3
   reach: '>10K stars'
@@ -38,11 +46,18 @@ adoption:
     2026-08-13: 32,041 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in
     signal_routing.yaml. The previous reach ''100K-1M'' was not a label this instrument offers - stars have
     their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile,
-    so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.'
+    so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.
+    Re-read 2026-08-13 - the repository shows 32,056 stars and the README still says over 300
+    contributors, still with no install or usage count published anywhere, since the project runs
+    locally and collects no telemetry. That still bands at >10K stars, level 3 on the stars scale. This
+    supersedes the refusal to claim a date - the axis was re-read rather than aggregated.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/SillyTavern/SillyTavern
     shows: 28.9k stars, 300+ contributors; no install/usage count published
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 913396e188c8ef5e84e46847279e65992adcbf72337e666c475853ed5ec45c91
 capability:
   score: 3
   basis: feature_matrix
@@ -53,7 +68,15 @@ capability:
   note: Feature-rich for its niche, broad backend coverage, image-gen/TTS, extensions, character/roleplay
     tooling (Visual Novel mode). Specialized toward roleplay rather than general-purpose assistant work;
     mid-tier on the general chat-UI matrix.
+    Re-read 2026-08-13. The README still opens on the same feature list - one interface over
+    KoboldAI/CPP, Horde, NovelAI, Ooba, Tabby, OpenAI, OpenRouter, Claude and Mistral, Visual Novel
+    Mode, image generation through the Automatic1111 and ComfyUI APIs, TTS, WorldInfo lorebooks and
+    third-party extensions - and it is still a locally installed single-user interface. Band unchanged
+    at 3.
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/SillyTavern/SillyTavern
     shows: multi-backend, image-gen, TTS, extensions, Visual Novel mode
-    accessed: '2026-06-04'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 913396e188c8ef5e84e46847279e65992adcbf72337e666c475853ed5ec45c91

--- a/sources/scores/surfsense.yaml
+++ b/sources/scores/surfsense.yaml
@@ -38,11 +38,18 @@ adoption:
     2026-08-13: 15,898 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in
     signal_routing.yaml. The record carried no reach label at all before this. No last_verified claimed: a
     star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis
-    was not re-read.'
+    was not re-read.
+    Re-read 2026-08-13 - MODSetter/SurfSense shows 15,902 stars, still banding at >10K stars, level 3 on
+    the stars scale, and the project still publishes no download or deployment telemetry for a
+    self-hosted web app. This supersedes the refusal to claim a date - the axis was re-read rather than
+    aggregated. Level unchanged.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/MODSetter/SurfSense
     shows: ~14.9k stars, ~1.4k forks
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9faac8e04b13ef6f84dc010748936d886abdc93403a40f3af17ac23e84d03028
 capability:
   score: 4
   basis: feature_matrix
@@ -54,7 +61,18 @@ capability:
   note: Unusually broad connector, model, and collaboration surface on paper, but per-feature depth and quality
     are unverified (README-sourced) and the project is far less proven than open-webui-class tools - so 4,
     not top, with low confidence.
+    Re-read 2026-08-13. The README still claims the broad connector and model surface the band rests on,
+    but the project has repositioned since the band was set - it now leads as an open web research
+    platform for AI agents, with live data connectors to Reddit, YouTube, Instagram, TikTok, Amazon,
+    Walmart, Google Maps, Google Search and Indeed reachable over one REST API or an MCP server, plus
+    scheduled and event-triggered agents. The maintainers state that the knowledge base, cited chat,
+    reports, podcasts, presentations, automations and collaborative chats all keep working and
+    self-hosting stays free, so nothing the band rested on has been withdrawn. Per-feature depth is
+    still README-sourced and unverified, which is why confidence stays low. Band unchanged at 4.
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/MODSetter/SurfSense
     shows: 'feature/connector matrix: 100+ LLMs, 27+ connectors, hybrid RAG, multimodal gen, RBAC collab'
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9faac8e04b13ef6f84dc010748936d886abdc93403a40f3af17ac23e84d03028

--- a/sources/scores/thunderbolt.yaml
+++ b/sources/scores/thunderbolt.yaml
@@ -18,15 +18,28 @@ openness:
   confidence: high
   note: OSI-licensed (MPL-2.0), full source public from launch, designed primarily for self-hosting - a
     true open AI client.
+    Re-read 2026-08-13. The repository still carries MPL-2.0 and still opens on AI You Control - choose
+    your models, own your data, eliminate vendor lock-in - with on-prem deployment as the primary path
+    and a Docker backend the reader is invited to run. The Phoronix launch report is still up and still
+    quotes the press release describing a sovereign AI client that organizations run with their own
+    choice of models. Latest release is v0.1.107 and the repo now shows 4,762 stars. Value unchanged at
+    5 / open_source.
   raw: license:MPL-2.0(OSI);source:public(github.com/thunderbird/thunderbolt);self-host:primary(enterprise
     self-hosting);governance:MZLA-Technologies(Mozilla-Foundation-subsidiary)
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/thunderbird/thunderbolt
     shows: public source repo under MPL-2.0; "AI You Control" self-hosted client
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 2f9da909558f8053ad88a7cc6fefdfb5245b28a2484911cb353dd6ff48a9f147
+    establishes: [license, source, self-host]
   - url: https://www.phoronix.com/news/Mozilla-Thunderbolt
     shows: MZLA launches Thunderbolt as an open source enterprise AI client (Apr 2026)
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 118a2cc3e8d059ffef88676183f572fa068d1152a104c4fc3276c19a350da53e
+    establishes: [source]
 adoption:
   level: 2
   signal_type: reported_traction
@@ -34,10 +47,19 @@ adoption:
   note: Launched April 2026 and still in active development / mid-security-audit; no usage figures disclosed
     yet. Early-stage but backed by the Mozilla/Thunderbird brand. Conservative reported_traction pending
     real adoption signal.
+    Re-read 2026-08-13. The Register launch piece is still up and still positions Thunderbolt against
+    Copilot, ChatGPT Enterprise and Claude Enterprise, and it still discloses no usage figure. The
+    repository README still warns that the project is early and under active development and still
+    undergoing a security audit, four months on from launch, and there is still a waitlist rather than a
+    published customer or deployment count. The abstention from a measured signal therefore stands.
+    Level unchanged at 2.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.theregister.com/2026/04/16/mozilla_thunderbolt_enterprise_ai_client/
     shows: launch coverage; positioned vs Copilot/ChatGPT Enterprise/Claude Enterprise
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 96635f58ea5e5c85360ba5a0ad67d1016413190d724acd3d7d2bf44aa52945a9
 capability:
   score: 4
   basis: feature_matrix
@@ -47,7 +69,17 @@ capability:
   confidence: medium
   note: Broad feature surface (multi-provider, multi-platform, agentic task automation, self-host) comparable
     to the leading open chat UIs, but newly launched and unproven; medium confidence pending maturity.
+    Re-read 2026-08-13. The gHacks launch write-up still describes the same surface - a unified
+    interface for chat, search and research over internal models, data sources and automation pipelines,
+    with administrators choosing commercial, open-source or locally hosted models, and integrations
+    spanning Haystack, MCP servers and Agent Client Protocol agents. The repository confirms web, iOS,
+    Android, Mac, Linux and Windows clients and still says there is no public inference endpoint, so the
+    user brings Ollama, llama.cpp or an OpenAI-compatible provider. Band unchanged at 4, and the
+    maturity caveat is unchanged.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.ghacks.net/2026/04/20/mozillas-mzla-technologies-launches-thunderbolt-an-open-source-self-hosted-enterprise-ai-client/
     shows: 'feature set: chat/search/research/task automation across web + native apps, multi-provider + Ollama'
-    accessed: '2026-06-17'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 330f7b592c9030a2d976d62158d7bb21cc865e85d4e85c9c77eef769f4520061


### PR DESCRIPTION
**149 of 162 closed** — 116 of 129 axes and all 43 prose records. No `score`, `level`, `class` or `reach` changed anywhere. Anchor ordering honoured: `open-webui` re-derived and dated first, `huggingchat-chat-ui` (`one_below`) followed on the same date.

## The significant find: `surfsense` has split its license

`LICENSE` now opens: *"All content that resides under the `surfsense_backend/app/proprietary/` directory ... is licensed under the Business Source License 1.1"*, with Apache-2.0 only outside it. **That directory exists and holds `platforms` and `web_crawler`** — the live-data connectors the product now leads on. The BUSL grant forbids offering the work, or anything substantially deriving value from it, as a commercial or hosted service.

The record says `license: [Apache-2.0 OSI]`, `core-gated: ungated`, **5/open_source**.

Recommendation: the license becomes a two-part list (Apache-2.0 + BUSL-1.1), which under the universal license cap almost certainly lands at **2/source_available**. The cap interaction is a ruling, so the axis is left undated. This is the openness-overstatement failure mode the map exists to avoid, caught only by reading the LICENSE body rather than trusting the GitHub SPDX field.

## Adoption bands whose stated basis has evaporated

- **`librechat`** — level 4 rests on "23M+ cumulative Docker pulls", and the axis cites only the GitHub repo. Docker Hub reports **370,063** pulls; all LibreChat-org images together are under 500k. The primary image is on GHCR, which publishes no count. Re-source or re-band.
- **`poe`** — the cited page no longer carries "~18M MAU, ~$65M subscription revenue". Its only usage number is *"over 31.5 million visitors"* over September 2024 — a different quantity, 23 months old.
- **`huggingchat-chat-ui`** — the cited sunset article contains **no user figure at all**. The recorded "1M+ users / 100k+ assistants" has nothing behind it.
- **`openrouter`** — homepage now reads `10M+` global users against a recorded `1M-10M`, sitting exactly at the band edge. Likely 5, but it's a floor claim at the threshold.

## Sources that don't establish what's cited to them

`le-chat` openness **and** capability both rest on a single Feb 2025 TechCrunch "In Brief" carrying only a downloads milestone. `chatgpt` capability cites an NBER usage study that enumerates none of the GPT-5 family, code interpreter or custom GPTs. Both need a product page added.

## Aggregator figures restated

`microsoft-copilot` 420M → **218M**; `perplexity` 100M+ → **45M**; `character-ai` ~20M → **45M**. All still clear `>10M users`, so bands held and the corrections are in the notes. `claude-ai` reads **245M MAU** on a host that 403s `fetch_source` — left undated per the rules, level 5 holds either way.

## A judgment I'm endorsing

Six records had explicitly **refused** a date on the grounds that "a star count is volatile, so a digest would read as drift". The pass re-read each and dated it via `api.github.com` with a digest, saying in the note that this supersedes the refusal *because the axis was re-read rather than aggregated*.

That's right, and consistent with the `helicone` precedent already in `telemetry_observability`: `check_refetch` reports drift rather than failing on it, so a volatile digest costs nothing and a re-read is still a re-read. Flag if you disagree — it's six axes.

## Also recorded

`litellm` and `llm` adoption both banded on PyPI figures that lived only in a note; both now cite pypistats (**741,403,911** and **601,475**, matching to the unit). `continue` was **acquired by Cursor**. `gpt4all`'s stall is now over a year. `perplexica` looks dormant since April. `surfsense` has repositioned from a NotebookLM alternative to an agent-facing live-web research platform.

Unverifiable, no digest recorded: `demandsage.com` 403, `facebook.com/legal/ai-terms` 400, `www.perplexity.ai` 403.

All gates green: `validate` 0 errors, `check_verification` all three OK, `check_capability` OK, `check_adoption --strict` exit 0, 488 tests.