### PR TITLE
Verify agent_tools_protocols: 106/109, and a correction to my own stage claim

### DIFF
--- a/docs/guides/gap-analysis.md
+++ b/docs/guides/gap-analysis.md
@@ -71,13 +71,20 @@ That fallback is right for the case it was written for. 21 of the 26 null-capabi
 are in `benchmark_eval_data`, where downloads plausibly *are* the quality signal — a corpus
 everyone evaluates against is, by that fact, a good corpus.
 
-**Every other category inherits it by accident.** The live consequence on 2026-08-13 is
-`model-context-protocol`: adoption 5, capability null, `open_source`, so maturity computes to
-5.0, it counts as a mature open product, and one mature open product is the entire `stage >= 4`
-threshold. `agent_tools_protocols` therefore rests a stage-4 claim on a product whose capability
-nobody has scored. No other null-capability product is close — the remaining 22 sit at adoption
-3–4, below the mature bar, where they can move `best_open` but cannot trigger a stage on their
-own.
+**Every other category inherits it by accident.** `model-context-protocol` is the clearest
+live case: adoption 5, capability null, `open_source`, so maturity computes to 5.0 and it counts
+as a mature open product on one axis while a reader assumes two.
+
+**A correction, because this guide got the stakes wrong on first writing.** It claimed that
+`agent_tools_protocols`'s stage rested on that null, on the reasoning that one mature open
+product is the entire `stage >= 4` threshold. The rule is real but the inference was not
+checked against the category: it has **seven** mature open products, not one — MCP, `fastmcp`,
+`qdrant`, `mcp-python-sdk`, `mcp-typescript-sdk`, `docling`, `markitdown` — and six of them
+reach 4.5 from a real adoption *and* a real capability score with no null in the arithmetic.
+Seven clears `_STAGE5_MIN_MATURE = 4`, so the category is **stage 5**, and deleting MCP
+entirely leaves six and changes nothing. The methodological defect is unaffected; the claim
+that a stage depended on it was wrong, and was caught by re-deriving it against
+`build/serialize.py` rather than reasoning from the threshold.
 
 So the open question is whether "graded on adoption alone" should be a **per-category
 declaration**, like `disclosure` below, rather than a global fallback. It is deliberately not

--- a/sources/products/agent2agent-protocol.yaml
+++ b/sources/products/agent2agent-protocol.yaml
@@ -3,8 +3,10 @@ display_name: Agent2Agent Protocol
 type: software
 description: Open protocol enabling communication and interoperability between opaque agentic applications.
   Where MCP connects agents to tools, A2A connects agents to other agents, defining task delegation,
-  status updates, and result passing between autonomous systems. Initiated by Google with 24K GitHub stars.
-  Still early-stage but positioned as the complementary standard to MCP for multi-agent workflows.
-comments: A2A open protocol for inter-agent interoperability; contributed by Google, hosted by the Linux
-  Foundation (launched June 2025). Spec v1.0.1 released May 28, 2026 (v1.0 = first stable spec, adds Signed
-  Agent Cards). SDKs in Python/Go/JS/Java/.NET/Rust. Verified live on GitHub June 2026.
+  status updates, and result passing between autonomous systems. Contributed by Google and hosted by the
+  Linux Foundation, with reference SDKs in Python, Go, JavaScript, Java and .NET. Supported by more than
+  150 organizations and integrated into Azure AI Foundry, Copilot Studio and Amazon Bedrock AgentCore. Positioned
+  as the complementary standard to MCP for multi-agent workflows.
+comments: Capability is null - a wire protocol is not benchmarked - and the score file notes this makes the
+  record's maturity rest on adoption alone, the same open question flagged on Model Context Protocol. Verified
+  2026-08-13 via GitHub and the Linux Foundation's first-year release.

--- a/sources/products/algolia-ai-search.yaml
+++ b/sources/products/algolia-ai-search.yaml
@@ -2,11 +2,10 @@ name: algolia-ai-search
 display_name: Algolia AI Search
 type: software
 description: Enterprise search-as-a-service platform that combines keyword, semantic, and AI-powered search
-  with sub-50ms response times. Recently added AI agent integrations and MCP support, allowing agents
-  to search product catalogs, documentation, and enterprise content. Powers search for 17K+ businesses
-  including major e-commerce and SaaS platforms. The enterprise-grade search infrastructure increasingly
+  with sub-20ms average response times. Recently added AI agent integrations and MCP support, allowing agents
+  to search product catalogs, documentation, and enterprise content. Powers search for over 18,000 customers
+  in 150+ countries, including Stripe, Decathlon and Ubisoft. The enterprise-grade search infrastructure increasingly
   used as an agent tool for domain-specific retrieval.
-comments: 'Algolia AI Search, verified live June 2026. Proprietary API-first hosted search platform (keyword
-  + semantic/vector hybrid, NeuralSearch). Open-source client libraries (InstantSearch etc.) but closed
-  core. Sub-segment: search/retrieval infra. Note: primarily a human-facing site-search product; usable
-  as an agent retrieval tool.'
+comments: Primarily a human-facing site-search product, usable as an agent retrieval tool. The open InstantSearch
+  libraries are client-side UI; the ranking and index engine is closed, which is what the openness score reads.
+  Verified 2026-08-13 via the Algolia AI Search product page.

--- a/sources/products/apify.yaml
+++ b/sources/products/apify.yaml
@@ -1,10 +1,11 @@
 name: apify
 display_name: Apify
 type: software
-description: Full-stack web scraping and automation platform with a marketplace of 2000+ pre-built scrapers
-  (Actors) for specific websites. Provides cloud infrastructure for running scrapers at scale, proxy management,
-  and anti-bot handling. The most mature commercial web scraping platform now repositioned for AI agent
-  workflows. Offers both a managed platform and Crawlee, their open source crawling framework (23K stars).
-comments: 'Apify full-stack web scraping/extraction platform, verified live June 2026. Proprietary SaaS
-  (35,000+ Actors store) with open source Crawlee library (Apache-2.0) as its scraping SDK. Sub-segment:
-  browser/scrape infra for agents.'
+description: Full-stack web scraping and automation platform with a marketplace of tens of thousands of pre-built
+  scrapers (Actors) for specific websites. Provides cloud infrastructure for running scrapers at scale, proxy
+  management, and anti-bot handling, plus an MCP server that exposes Actors to agent clients. The most mature
+  commercial web scraping platform, now repositioned for AI agent workflows. Offers both a managed platform
+  and Crawlee, their open source crawling framework.
+comments: Crawlee is an adjacent SDK rather than the platform core - nothing that runs an Actor is published
+  - which is why the openness class is source_available rather than open_core. Verified 2026-08-13 via apify.com
+  and the Crawlee repository.

--- a/sources/products/browser-use.yaml
+++ b/sources/products/browser-use.yaml
@@ -3,12 +3,14 @@ display_name: Browser Use
 type: software
 description: Open-source agent framework that makes websites accessible to AI agents, enabling autonomous web
   browsing, form filling, data extraction, and multi-step online task completion. Built on Playwright, it provides
-  a structured way for LLMs to observe page state, plan actions, and execute browser interactions. 95K GitHub
-  stars with 315 contributors. Covers web-native agent capability, which few other frameworks address directly.
+  a structured way for LLMs to observe page state, plan actions, and execute browser interactions. Ships both
+  a CLI for one-off tasks and a Python library for repeatable automation, with custom tools, custom system
+  prompts and structured output. Covers web-native agent capability, which few other frameworks address directly.
 github:
 - url: https://github.com/browser-use/browser-use
 pypi:
 - url: https://pypi.org/project/browser-use
-comments: Browser Use, verified live June 2026 (GitHub + PyPI). OSS Python library making websites accessible
-  to AI agents (navigate/click/fill/extract). MIT license. Recategorized into agent_tools_protocols (browser/scrape
-  sub-segment) per assignment. Managed Browser Use Cloud tier also exists.
+comments: Stealth, proxy rotation and CAPTCHA handling belong to the separate Browser Use Cloud product rather
+  than to the MIT library, which is why the openness score reads the core as ungated. The adoption axis is
+  flagged - the recorded level does not follow from the recorded download figure - and carries no confirmation
+  date until that is settled. Verified 2026-08-13 via GitHub and the pypistats API.

--- a/sources/products/browserbase.yaml
+++ b/sources/products/browserbase.yaml
@@ -4,8 +4,8 @@ type: software
 description: Cloud-hosted headless browsers designed specifically for AI agents. Handles authentication
   persistence, CAPTCHA solving, and anti-bot detection that self-hosted Playwright cannot easily manage.
   The managed alternative to running your own browser infrastructure; agents get a reliable, scalable
-  browser as a service. YC-backed, also maintains Stagehand (22K stars), an open source browser agent
-  SDK.
-comments: 'Proprietary cloud headless-browser platform for agents: Browser API, Search API, Fetch API,
-  Functions, Model Gateway. Ships the open source Stagehand SDK (browser-agent framework) on top. Verified
-  live via docs.browserbase.com June 2026.'
+  browser as a service. Exposes a Browser API, Search API, Fetch API, Functions for deploying and scheduling
+  agents, and a Model Gateway. YC-backed, and also maintains Stagehand, an open source browser agent SDK.
+comments: The scored product is the closed managed platform, not the open Stagehand SDK beside it. Browserbase
+  publishes no usage figure of its own, so adoption stands on Stagehand's downloads as a proxy and is discounted
+  for that. Verified 2026-08-13 via docs.browserbase.com.

--- a/sources/products/cohere-rerank-api.yaml
+++ b/sources/products/cohere-rerank-api.yaml
@@ -7,7 +7,7 @@ description: Reranking API that takes a query and a list of documents and return
   rather than bundled into a vector database, applied as a single API call.
 pypi:
 - url: https://pypi.org/project/cohere
-comments: 'Cohere Rerank API, verified live June 2026 (Cohere docs). Latest model Rerank 4.0 (fast/pro
-  variants); prior 3.5 and 3.0 (English + multilingual). Proprietary hosted reranking API for RAG/retrieval;
-  also available via Azure AI Foundry, AWS SageMaker/OpenSearch, Oracle GenAI. Sub-segment: retrieval/RAG
-  infra (reranker).'
+comments: The declared pypi artifact is Cohere's whole client SDK rather than a reranker package, so it cannot
+  measure this product; adoption rests on multi-cloud distribution instead. Every published performance figure
+  is vendor-run, which is why capability stops at 4. Verified 2026-08-13 via the Cohere rerank overview, the
+  3.5 changelog and the 3.5 launch post.

--- a/sources/products/composio.yaml
+++ b/sources/products/composio.yaml
@@ -4,11 +4,12 @@ type: software
 description: Agent tooling platform that provides 1000+ pre-built tool integrations with managed authentication,
   context management, and a sandboxed execution environment. Handles the hard parts of connecting agents
   to external services (OAuth flows, API pagination, rate limiting) so agent builders can focus on logic.
-  28K GitHub stars, YC-backed. The largest catalog of ready-to-use agent tools with built-in auth.
+  Adds tool search, context management and a sandboxed workbench, and can expose a session's tools as a hosted
+  MCP endpoint. YC-backed. The largest catalog of ready-to-use agent tools with built-in auth.
 github:
 - url: https://github.com/ComposioHQ/composio
 pypi:
 - url: https://pypi.org/project/composio-core
-comments: 'Agent tool-integration SDK + managed platform: 1000+ toolkits, tool search, auth, sandboxed
-  workbench; Rube MCP server connects 500+ apps. Python SDK v0.13.1 (May 14, 2026); @composio/claude-agent-sdk
-  0.9.2 (May 13, 2026). Verified live on GitHub/PyPI June 2026.'
+comments: What is published is the SDKs and provider adapters; the execution engine is in no public repo,
+  which is the gate the openness score rests on. The score file flags that the same evidence bears on whether
+  source should read partial rather than public. Verified 2026-08-13 via GitHub and the Composio docs.

--- a/sources/products/docling.yaml
+++ b/sources/products/docling.yaml
@@ -1,14 +1,16 @@
 name: docling
 display_name: Docling
 type: software
-description: Open-source SDK and CLI that parses PDF, DOCX, PPTX, XLSX, HTML, EPUB, images, and audio into unified
-  structured output (Markdown, lossless JSON, HTML, DocTags) for gen-AI and RAG pipelines. Unlike web-URL-to-Markdown
-  services (Firecrawl, Jina Reader), it does deep local document understanding of rich binary docs - layout/reading-order
-  analysis, table-structure recognition, formula/code extraction, OCR, and VLM integration - running locally as
-  a library.
+description: Open-source SDK and CLI that parses PDF, DOCX, PPTX, XLSX, HTML, EPUB, images, audio and video
+  into unified structured output (Markdown, lossless JSON, HTML, WebVTT, DocTags) for gen-AI and RAG pipelines.
+  Unlike web-URL-to-Markdown services (Firecrawl, Jina Reader), it does deep local document understanding
+  of rich binary docs - layout/reading-order analysis, table-structure recognition, formula/code extraction,
+  OCR, and vision and speech model integration - running locally as a library. Also reads application-specific
+  XML schemas including USPTO patents, JATS articles and XBRL filings, and ships an MCP server of its own.
 github:
 - url: https://github.com/docling-project/docling
 pypi:
 - url: https://pypi.org/project/docling
-comments: MIT; originated at IBM Research, inducted into the Linux Foundation AI & Data Foundation (Docling Project)
-  on 2025-04-29 under community governance. ~62k stars (exceptionally high).
+comments: Originated at IBM Research, inducted into the Linux Foundation AI & Data Foundation (Docling Project)
+  on 2025-04-29 under community governance. Verified 2026-08-13 via GitHub, the repository LICENSE and the
+  pypistats API.

--- a/sources/products/exa-search-api.yaml
+++ b/sources/products/exa-search-api.yaml
@@ -7,6 +7,6 @@ description: Neural search API that understands meaning, not just keywords. Retu
   $22M+ raised), positioned as the semantic alternative to Tavily's more traditional search approach.
 pypi:
 - url: https://pypi.org/project/exa-py
-comments: 'Proprietary neural/web search API (formerly Metaphor): search + contents + Websets (verified,
-  enriched entity lists). Series C $250M at ~$2.2B valuation (May 2026). Verified live via exa.ai docs
-  + about page June 2026.'
+comments: Formerly Metaphor. The declared pypi artifact is the client SDK; the index and ranking models it
+  calls are proprietary, which is what the openness score reads. Verified 2026-08-13 via the exa.ai about
+  page.

--- a/sources/products/fastmcp.yaml
+++ b/sources/products/fastmcp.yaml
@@ -2,12 +2,14 @@ name: fastmcp
 display_name: FastMCP
 type: software
 description: High-level Python framework for building MCP servers and clients with minimal boilerplate. Provides
-  decorator-based tool definitions, automatic schema generation, and built-in testing utilities. 25K GitHub
-  stars.
+  decorator-based tool definitions, automatic schema generation, and built-in testing utilities. Organized
+  around servers that expose tools, resources and prompts, apps that give those tools an interactive surface,
+  and a client side. Maintained by Prefect.
 github:
 - url: https://github.com/PrefectHQ/fastmcp
 pypi:
 - url: https://pypi.org/project/fastmcp
-comments: Pythonic framework for building MCP servers and clients (FastMCP 1.0 was upstreamed into the
-  official MCP Python SDK in 2024; FastMCP 2.0/3.x is the standalone successor). Maintained by Prefect.
-  Apache-2.0. v3.4.0 released 3 Jun 2026; verified live June 2026.
+comments: FastMCP 1.0 was upstreamed into the official MCP Python SDK in 2024, so the standalone project
+  scored here is its successor rather than the same code. The score file cites jlowin/fastmcp, which now
+  redirects to the declared PrefectHQ/fastmcp. Verified 2026-08-13 via GitHub, the repository LICENSE and
+  the pypistats API.

--- a/sources/products/filesystem-mcp.yaml
+++ b/sources/products/filesystem-mcp.yaml
@@ -8,5 +8,7 @@ github:
 - url: https://github.com/modelcontextprotocol/servers
 npm:
 - url: https://www.npmjs.com/package/@modelcontextprotocol/server-filesystem
-comments: MIT. One of the active reference servers; the monorepo has ~87k stars shared across all bundled servers,
-  so per-server adoption isn't separable.
+comments: The server's README says MIT and points at the monorepo LICENSE, which has since moved to the MCP
+  project's Apache-2.0 transition text - the two now disagree, and the score file records both. Adoption is
+  read from the per-server npm package rather than the monorepo's shared star count. Verified 2026-08-13 via
+  the server README and the monorepo LICENSE.

--- a/sources/products/firecrawl.yaml
+++ b/sources/products/firecrawl.yaml
@@ -3,12 +3,13 @@ display_name: Firecrawl
 type: software
 description: Web scraping and crawling API built specifically for LLM consumption. Turns any URL into clean
   markdown or structured data, handling JavaScript rendering, pagination, and anti-bot measures automatically.
-  123K GitHub stars; used by several agent frameworks as their default scraping tool. Open-source with a hosted
+  Offers scrape, crawl, map, search, batch and agent-extract endpoints. One of the most-starred repositories
+  on GitHub, and used by several agent frameworks as their default scraping tool. Self-hostable, with a hosted
   SaaS option.
 github:
 - url: https://github.com/firecrawl/firecrawl
 pypi:
 - url: https://pypi.org/project/firecrawl-py
-comments: Web scrape/crawl/search API that returns LLM-ready data (markdown/JSON/structured). Self-hostable
-  OSS + managed cloud (firecrawl.dev). v2.10 released 15 May 2026; verified live on GitHub June 2026.
-  Copyright Sideguide Technologies Inc.
+comments: The self-hosted build cannot take screenshots or run page actions - both need Fire-engine, which
+  is closed and ships in no public repo. That is the gate the openness score rests on. Verified 2026-08-13
+  via GitHub and the self-hosting guide.

--- a/sources/products/github-mcp.yaml
+++ b/sources/products/github-mcp.yaml
@@ -6,4 +6,6 @@ description: GitHub's official MCP server (Go) that lets AI agents interact with
   Projects, Copilot, and more. Runs locally via Docker/binary or via GitHub's remote hosted endpoint.
 github:
 - url: https://github.com/github/github-mcp-server
-comments: MIT (c) 2025 GitHub. ~31k stars. Distributed as a Go binary/Docker image (no npm/pypi).
+comments: Distributed as a Go binary, a Docker image and GitHub's hosted remote endpoint, none of which publishes
+  a download count and none of which is a package registry, so adoption falls back to stars. Verified 2026-08-13
+  via GitHub and the repository LICENSE.

--- a/sources/products/google-grounding-api.yaml
+++ b/sources/products/google-grounding-api.yaml
@@ -5,6 +5,6 @@ description: Google's managed grounding-with-search capability within Vertex AI.
   responses in real-time Google Search results or enterprise data via Vertex AI Search. Tight integration
   with Gemini models. The enterprise closed alternative for search-augmented generation, leveraging Google's
   search index directly. Part of the broader Vertex AI platform used by large enterprises.
-comments: 'Grounding with Google Search in Vertex AI / Gemini Enterprise Agent Platform, verified live
-  June 2026 (Google Cloud docs). Proprietary managed grounding API that anchors Gemini responses in Google
-  Search/web. Sub-segment: search/retrieval grounding tool for agents.'
+comments: A feature inside the Gemini Enterprise Agent Platform rather than a separately metered product,
+  so no grounding-specific usage figure exists and adoption abstains rather than borrowing the platform's
+  reach. Verified 2026-08-13 via the Google Cloud grounding overview.

--- a/sources/products/jina-reader.yaml
+++ b/sources/products/jina-reader.yaml
@@ -3,10 +3,11 @@ display_name: Jina Reader
 type: software
 description: URL-to-LLM-input conversion service that turns any web page into clean, structured content
   optimized for language models. Prefix any URL with r.jina.ai to get markdown output. Simple, fast, and
-  widely integrated into agent workflows as a lightweight alternative to full scraping tools. Open-source
-  with 11K GitHub stars. Also offers search (s.jina.ai) and grounding capabilities.
+  widely integrated into agent workflows as a lightweight alternative to full scraping tools. Reads HTML,
+  PDF and MS-Office documents and captions images. Also offers search (s.jina.ai) and grounding capabilities.
 github:
 - url: https://github.com/jina-ai/reader
-comments: Open-source branch of the r.jina.ai / s.jina.ai URL-to-markdown reader service; repo jina-ai/reader
-  re-synced with the SaaS codebase Apr 2026 (MongoDB layer decoupled, local Docker deploy enabled). Confirmed
-  live on GitHub June 2026.
+comments: The published branch runs stateless - the MongoDB-backed storage layer of the hosted service is
+  not in it - which the README states plainly and which the openness score reads as accounting for the SaaS
+  rather than as a piece of the reader withheld. The product is consumed as a URL prefix, so no package registry
+  can measure it and adoption falls back to stars. Verified 2026-08-13 via GitHub and jina.ai/reader.

--- a/sources/products/markitdown.yaml
+++ b/sources/products/markitdown.yaml
@@ -9,5 +9,7 @@ github:
 - url: https://github.com/microsoft/markitdown
 pypi:
 - url: https://pypi.org/project/markitdown
-comments: MIT (PyPI license field is null but the repo LICENSE and pyproject declare MIT). ~155k stars. Lighter
-  than Docling on layout/table depth but broader format coverage.
+comments: The PyPI license field is null; MIT comes from the repository LICENSE and pyproject, which is what
+  the openness score reads. The Azure Document Intelligence and Content Understanding paths are optional install
+  extras rather than a core withheld from the package. Verified 2026-08-13 via GitHub, the repository LICENSE
+  and the pypistats API.

--- a/sources/products/mcp-inspector.yaml
+++ b/sources/products/mcp-inspector.yaml
@@ -1,11 +1,12 @@
 name: mcp-inspector
 display_name: MCP Inspector
 type: software
-description: Developer tool for testing and debugging MCP servers, with a React web UI and a CLI mode. Includes
-  a Node proxy supporting stdio/SSE/Streamable-HTTP, request history and live visualization, bearer-token auth,
-  multi-server config, and DNS-rebinding protection.
+description: Developer tool for testing and debugging MCP servers. Ships three clients from one binary - a
+  React web UI, a scriptable CLI for automation and CI, and an Ink terminal UI - over stdio, SSE and Streamable-HTTP,
+  with OAuth including discovery and mid-session recovery, multi-server config, and DNS-rebinding protection.
 github:
 - url: https://github.com/modelcontextprotocol/inspector
 npm:
 - url: https://www.npmjs.com/package/@modelcontextprotocol/inspector
-comments: MIT. ~10k stars, ~847k npm downloads/last-30-days.
+comments: The repository carries no LICENSE file; MIT is declared in the README and in package.json, which
+  is what the openness score reads. Verified 2026-08-13 via GitHub, the README and package.json.

--- a/sources/products/mcp-python-sdk.yaml
+++ b/sources/products/mcp-python-sdk.yaml
@@ -2,10 +2,12 @@ name: mcp-python-sdk
 display_name: MCP Python SDK
 type: software
 description: Official Python implementation of the Model Context Protocol for building MCP clients and servers that
-  give LLMs standardized access to tools, resources, and prompts. Bundles the FastMCP high-level framework, stdio/SSE/Streamable-HTTP
-  transports, structured (Pydantic) output, and OAuth 2.1 auth.
+  give LLMs standardized access to tools, resources, and prompts. Speaks every standard transport - stdio,
+  Streamable HTTP and SSE - and ships an `mcp` CLI for developing, running and installing servers.
 github:
 - url: https://github.com/modelcontextprotocol/python-sdk
 pypi:
 - url: https://pypi.org/project/mcp
-comments: MIT (package 'mcp', author Anthropic PBC). ~23k stars; very actively released.
+comments: This repository still carries a plain MIT LICENSE where the TypeScript SDK and the servers monorepo
+  have moved to the project's Apache-2.0 transition license, so the three are no longer licensed alike. Verified
+  2026-08-13 via GitHub, the repository LICENSE and PyPI.

--- a/sources/products/mcp-typescript-sdk.yaml
+++ b/sources/products/mcp-typescript-sdk.yaml
@@ -8,4 +8,7 @@ github:
 - url: https://github.com/modelcontextprotocol/typescript-sdk
 npm:
 - url: https://www.npmjs.com/package/@modelcontextprotocol/sdk
-comments: MIT (@modelcontextprotocol/sdk). ~13k stars, ~154M npm downloads/last-30-days.
+comments: The repository has moved onto the MCP project's Apache-2.0 transition license, so package.json now
+  reads "SEE LICENSE IN LICENSE" rather than a bare SPDX id; the score file records both code licenses and
+  keeps the documentation license off the ladder. The npm page answered 403 to the fetcher, so the license
+  was read from the repository instead. Verified 2026-08-13 via GitHub, the repository LICENSE and package.json.

--- a/sources/products/milvus.yaml
+++ b/sources/products/milvus.yaml
@@ -2,9 +2,10 @@ name: milvus
 display_name: Milvus
 type: software
 description: Cloud-native vector database built for scalable approximate nearest neighbor search at billion-scale.
-  Supports hybrid search combining vector similarity with scalar filtering. The most-starred dedicated vector
-  database on GitHub (44K stars) with strong enterprise adoption. Open-source core with Zilliz Cloud as the
-  managed offering. Aimed at production RAG systems that need to scale.
+  Supports hybrid search combining vector similarity with scalar filtering, BM25 full-text search, and index
+  types from HNSW through DiskANN. The most-starred dedicated vector database on GitHub. An LF AI & Data
+  graduate project, with Zilliz Cloud as the managed offering. Aimed at production RAG systems that need
+  to scale.
 github:
 - url: https://github.com/milvus-io/milvus
 pypi:
@@ -13,4 +14,6 @@ artifact_exceptions:
   pypi_repo_mismatch: pymilvus is the Python client, published from milvus-io/pymilvus; the product is the
     vector database at milvus-io/milvus. The client's downloads are the best available usage signal for the
     server.
-comments: v2.6.x stable (late 2025); v3.0 RC published May 2026; LF AI & Data project
+comments: The declared pypi artifact is pymilvus, the Python client rather than the server; see artifact_exceptions
+  above for why its downloads are used as the usage signal. Verified 2026-08-13 via GitHub, milvus.io and
+  the Wikipedia entry.

--- a/sources/products/model-context-protocol.yaml
+++ b/sources/products/model-context-protocol.yaml
@@ -4,9 +4,9 @@ type: software
 description: Open standard for connecting AI agents to external tools and data sources. Defines how agents
   discover, authenticate with, and invoke tools via a JSON-RPC protocol. Rapidly adopted across the agent
   ecosystem; supported by Claude Code, Cursor, VS Code Copilot, Windsurf, and dozens of IDE and agent
-  frameworks. The emerging universal standard for agent-tool communication, with 86K+ stars on the reference
-  server repo.
-comments: Open wire protocol for connecting LLMs/agents to tools and data; created by Anthropic (David
-  Soria Parra, Justin Spahr-Summers), launched 25 Nov 2024. Reference spec + SDKs (Python/TypeScript/C#/Java/Go/Rust/Ruby)
-  verified live on GitHub June 2026. Governance donated to the Linux Foundation's Agentic AI Foundation
-  (AAIF) Dec 2025.
+  frameworks. Created by Anthropic and launched November 2024; governance was donated to the Linux Foundation's
+  Agentic AI Foundation in December 2025. Reference SDKs are published for Python, TypeScript, C#, Java,
+  Go, Rust and Ruby. The emerging universal standard for agent-tool communication.
+comments: The capability axis is deliberately null - a wire protocol is not benchmarked - and the score
+  file flags that this makes the record's maturity rest on adoption alone. Verified 2026-08-13 via the spec
+  repository LICENSE, the Wikipedia entry and Zuplo's one-year retrospective.

--- a/sources/products/notion-mcp.yaml
+++ b/sources/products/notion-mcp.yaml
@@ -1,11 +1,14 @@
 name: notion-mcp
 display_name: Notion MCP Server
 type: software
-description: 'Notion''s official MCP server (TypeScript), exposing ~22 tools over the Notion API for agents: search
-  the workspace, query/retrieve/create/update data sources, read and write pages and blocks, manage properties and
-  comments - with token-optimized responses tailored to agents.'
+description: 'Notion''s official MCP server (TypeScript), exposing the Notion API to agents: search the workspace,
+  query/retrieve/create/update data sources, read and write pages and blocks, manage properties and comments
+  - with token-optimized responses and Markdown page editing. Since v2.0.0 it targets the 2025-09-03 API,
+  in which data sources rather than databases are the primary abstraction. Installs over standard OAuth.'
 github:
 - url: https://github.com/makenotion/notion-mcp-server
 npm:
 - url: https://www.npmjs.com/package/@notionhq/notion-mcp-server
-comments: MIT. ~4.4k stars. First-party Notion (makenotion) server.
+comments: First-party Notion (makenotion) server. Notion also runs a hosted MCP endpoint; the openness score
+  reads it as a managed deployment of this same server rather than a tier withholding tools. Verified 2026-08-13
+  via GitHub and the repository LICENSE.

--- a/sources/products/perplexity-sonar-api.yaml
+++ b/sources/products/perplexity-sonar-api.yaml
@@ -6,6 +6,6 @@ description: Search-augmented LLM API that combines real-time web search with la
   synthesized answers with citations; agents get a research assistant, not just a search engine. Both
   a consumer product and a developer API. Raised $500M+, valued at $9B+, the most well-funded company
   in the AI search space.
-comments: 'Proprietary search-grounded API: Sonar / Sonar Pro models, plus Search API (ranked web results)
-  and Embeddings API; 2026 adds a multi-model Agent API marketplace. Verified live via docs.perplexity.ai
-  June 2026.'
+comments: No standalone usage figure is published for the API, so adoption rests on reported traction rather
+  than on the parent platform's consumer numbers. The vendor api-platform page answers 403 to automated fetches
+  and could not be re-read. Verified 2026-08-13 via docs.perplexity.ai.

--- a/sources/products/pinecone.yaml
+++ b/sources/products/pinecone.yaml
@@ -8,5 +8,6 @@ description: Fully managed vector database purpose-built for AI applications at 
   operational overhead.
 pypi:
 - url: https://pypi.org/project/pinecone
-comments: 'Pinecone serverless vector database, verified live June 2026 (pricing + docs). Proprietary
-  managed SaaS; BYOC option added 2025/2026. Sub-segment: retrieval/RAG infra (vector DB).'
+comments: Bring-your-own-cloud runs Pinecone's own software inside the customer's VPC rather than shipping
+  source, so the openness score treats it as managed hosting and not as self-hosting. Capability is calibrated
+  against the Milvus anchor. Verified 2026-08-13 via the Pinecone pricing page and docs.

--- a/sources/products/playwright-mcp.yaml
+++ b/sources/products/playwright-mcp.yaml
@@ -3,12 +3,13 @@ display_name: Playwright MCP
 type: software
 description: MCP server that gives AI agents full browser automation capabilities via Playwright. Agents
   can navigate pages, click elements, fill forms, take screenshots, and extract structured data from web
-  pages, all through the MCP protocol. The standard open source approach for giving agents a browser,
-  with 33K GitHub stars. Backed by Microsoft and tightly integrated with VS Code and Copilot.
+  pages, all through the MCP protocol. Works from structured accessibility snapshots rather than screenshots,
+  so the agent reads a page as a tree rather than as pixels. The standard open source approach for giving
+  agents a browser. Backed by Microsoft and tightly integrated with VS Code and Copilot.
 github:
 - url: https://github.com/microsoft/playwright-mcp
 npm:
 - url: https://www.npmjs.com/package/@anthropic-ai/mcp-playwright
-comments: MCP server providing browser automation to LLMs via Playwright using structured accessibility
-  snapshots (not screenshots). Apache-2.0. Latest v0.0.75 (7 May 2026, 65 releases); verified live on
-  GitHub June 2026. Integrates with VS Code, Cursor, Claude Desktop and other MCP clients.
+comments: The declared npm artifact, @anthropic-ai/mcp-playwright, does not resolve on the registry; the
+  package the README installs is @playwright/mcp, and the adoption score file records the discrepancy. Verified
+  2026-08-13 via GitHub and the repository LICENSE.

--- a/sources/products/postgres-mcp.yaml
+++ b/sources/products/postgres-mcp.yaml
@@ -9,5 +9,6 @@ github:
 - url: https://github.com/crystaldba/postgres-mcp
 pypi:
 - url: https://pypi.org/project/postgres-mcp
-comments: MIT. ~2.9k stars. The original reference Postgres server was archived (read-only since May 2025) and only
-  did read-only queries, so this is the canonical maintained one.
+comments: The original reference Postgres server was archived (read-only since May 2025) and only did read-only
+  queries, so this is the canonical maintained one. "Pro" is part of the product name, not a paid edition
+  - there is no second tier. Verified 2026-08-13 via GitHub and the repository LICENSE.

--- a/sources/products/qdrant.yaml
+++ b/sources/products/qdrant.yaml
@@ -3,8 +3,9 @@ display_name: Qdrant
 type: software
 description: High-performance vector database and search engine built in Rust, designed for low-latency similarity
   search. Stores vectors with rich payloads and supports advanced filtering, making it ideal for RAG retrieval
-  pipelines that agents call to access knowledge bases. 31K+ GitHub stars, available as open source self-hosted
-  or managed cloud. Rust-native, competing with Milvus and Pinecone.
+  pipelines that agents call to access knowledge bases. Supports dense, sparse, multi-vector and hybrid search
+  with quantization, and is available self-hosted or as managed cloud. Rust-native, competing with Milvus
+  and Pinecone.
 github:
 - url: https://github.com/qdrant/qdrant
 pypi:
@@ -12,6 +13,7 @@ pypi:
 artifact_exceptions:
   pypi_repo_mismatch: qdrant-client is the Python client, published from qdrant/qdrant-client; the product
     is the vector database at qdrant/qdrant. Same shape as milvus.
-comments: High-performance Rust vector database / vector search engine (dense, sparse, multi-vector, hybrid
-  search, quantization). Apache-2.0 core + Qdrant Cloud managed tier (free tier available). v1.18.2 released
-  4 Jun 2026; verified live June 2026. Calibrated against frozen anchor Milvus (O5 open_source/A3/C4).
+comments: The pricing page marks GPU Indexing and Shard Splitting as absent from the open build; both are
+  in the open tree, so those rows describe the managed offering rather than the engine, and the openness
+  score follows the tree. Capability is calibrated against the Milvus anchor. Verified 2026-08-13 via GitHub,
+  the qdrant.tech benchmark page and ANN-Benchmarks.

--- a/sources/products/searxng.yaml
+++ b/sources/products/searxng.yaml
@@ -1,15 +1,16 @@
 name: searxng
 display_name: SearXNG
 type: software
-description: Free, privacy-respecting open source metasearch engine that aggregates results from up to 269
-  search services without tracking or profiling users. Though it predates the LLM era and does no inference
+description: Free, privacy-respecting open source metasearch engine that aggregates results from a long list
+  of search services without tracking or profiling users. Though it predates the LLM era and does no inference
   itself, it is used as a self-hosted web-search backend for open AI answer engines and RAG - it exposes a
   JSON API and runs entirely on your own infrastructure (no commercial search keys, no tracking), and is integrated
   as a web-search provider by Open WebUI, Perplexica, Morphic, and LibreChat. It is the open peer to proprietary
   AI search APIs like Tavily, Serper, and Exa.
 github:
 - url: https://github.com/searxng/searxng
-comments: AGPL-3.0; ~32k GitHub stars and 50M+ total Docker pulls (~1.5M/week) by mid-2026. Community-run
-  fork-successor of the older searx project. No official hosted SaaS - distributed as source/Docker for
-  self-hosting, with a network of ~70 community public instances (searx.space). Not itself an AI product;
-  it is the search/data backend AI tools call.
+comments: Community-run fork-successor of the older searx project. No official hosted SaaS - distributed as
+  source and Docker for self-hosting, alongside a network of community public instances, many of which disable
+  the JSON API. Docker is not a declared artifact here, so the adoption figure is computed in the score note
+  rather than fetched by a signal. Not itself an AI product; it is the search backend AI tools call. Verified
+  2026-08-13 via GitHub, Docker Hub and the SearXNG search-API documentation.

--- a/sources/products/serper.yaml
+++ b/sources/products/serper.yaml
@@ -5,5 +5,6 @@ description: Fast, low-cost Google Search API designed for developers and AI age
   Google SERP data (organic results, knowledge graph, related searches) via a simple REST API. Positioned
   as the cheapest way to give agents Google-quality search results, $0.001/query at scale. Widely used
   in LangChain and agent frameworks as a cost-effective alternative to Tavily for high-volume use cases.
-comments: 'Serper.dev Google Search API, verified live June 2026. Proprietary closed search API (web/images/news/maps/shopping/video/scholar).
-  Sub-segment: search APIs (Tavily/Exa peer, closed counterpart).'
+comments: The vendor publishes price and latency copy but no user, customer or query-volume figure, and there
+  is no package to count, so adoption abstains rather than banding on marketing claims. Verified 2026-08-13
+  via serper.dev.

--- a/sources/products/slack-mcp.yaml
+++ b/sources/products/slack-mcp.yaml
@@ -6,5 +6,7 @@ description: Actively maintained community Slack MCP server (Go) connecting AI a
   search, posting, reactions, channel/user management).
 github:
 - url: https://github.com/korotovsky/slack-mcp-server
-comments: MIT. ~1.7k stars. There is no first-party official Slack MCP server - the original reference server was
-  archived (servers-archived), making this the most popular maintained one.
+comments: There is no first-party official Slack MCP server - the original reference server was archived
+  (servers-archived), making this the most popular maintained one. The PyPI package of the same name is an
+  unedited template and is not this product; adoption reads the npm package. Verified 2026-08-13 via GitHub
+  and the repository LICENSE.

--- a/sources/products/tavily-search-api.yaml
+++ b/sources/products/tavily-search-api.yaml
@@ -7,8 +7,6 @@ description: Search API purpose-built for AI agents, returning clean, structured
   box. YC-backed.
 pypi:
 - url: https://pypi.org/project/tavily-python
-comments: 'Proprietary web-access API for agents: search, extract, crawl, map, research endpoints; Python/JS
-  SDKs. PRECISION (verify 2026-06-04): Nebius announced an agreement to acquire Tavily on 10 Feb 2026
-  for $275M (up to $400M on milestones), expected to close within weeks, an acquisition agreement, not
-  necessarily a fully-closed deal at announcement. Verified live via docs.tavily.com + tavily.com June
-  2026.'
+comments: Nebius announced an agreement to acquire Tavily, which is an agreement rather than a closed deal;
+  the adoption score treats it as corroboration and takes its band from the published developer count instead.
+  Verified 2026-08-13 via docs.tavily.com and the Tavily homepage.

--- a/sources/products/yomo.yaml
+++ b/sources/products/yomo.yaml
@@ -9,7 +9,8 @@ github:
 - url: https://github.com/yomorun/yomo
 crates:
 - url: https://crates.io/crates/yomo
-comments: Apache-2.0 framework/runtime for the agent-tooling layer (function calling, skill deployment,
-  edge orchestration), not a model. Maintained since 2020; v2.0.4 released 7 Jul 2026 (Rust rewrite).
-  Backed by Vivgrid (https://vivgrid.com), which operates it as a managed geo-distributed platform. Added
-  from contributor issue #89. Verified live July 2026.
+comments: A framework and runtime for the agent-tooling layer rather than a model. The license is declared
+  in Cargo.toml and the README rather than in a LICENSE file on the default branch, which is why the GitHub
+  API reports none - a LICENSE does resolve on the master branch, so the two branches disagree and the openness
+  record should say which governs. Backed by Vivgrid, which operates a separate managed platform. Added from
+  contributor issue 89. Verified 2026-08-13 via GitHub and Cargo.toml.

--- a/sources/scores/agent2agent-protocol.yaml
+++ b/sources/scores/agent2agent-protocol.yaml
@@ -76,22 +76,49 @@ adoption:
     supporting organizations, in-production use at Microsoft (Azure AI Foundry, Copilot Studio), AWS (Bedrock
     AgentCore), Salesforce, SAP, ServiceNow, and embedding into Google Cloud. Breadth across the three
     major clouds + enterprise production puts effective downstream reach in the 1-10M band; this is a
-    breadth/traction count, not a measured per-user figure.'
+    breadth/traction count, not a measured per-user figure. Re-read 2026-08-13 and every recorded claim
+    holds. The Linux Foundation release, dated 2026-04-09, states that supporting organizations "grown from
+    more than 50 to over 150 - including AWS, Cisco, Google, IBM, Microsoft, Salesforce, SAP, and ServiceNow",
+    that "Microsoft integrated A2A into Azure AI Foundry and Copilot Studio and AWS added support through
+    Amazon Bedrock AgentCore Runtime", and that the SDK ecosystem now spans five production-ready languages.
+    Note the correction the re-read forced on the SDK count - the release says five, not the six this record
+    carried, and the repo shows 25,336 stars against the 22,000 the release quotes. Neither figure is the
+    band''s basis: the instrument here is breadth of organizational support, no per-user count is published
+    anywhere, and level 4 is unchanged.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.linuxfoundation.org/press/a2a-protocol-surpasses-150-organizations-lands-in-major-cloud-platforms-and-sees-enterprise-production-use-in-first-year
-    shows: 150+ orgs supporting; Azure/AWS Bedrock/Google Cloud production integrations
-    accessed: '2026-06-04'
+    shows: 'Dated 2026-04-09. "Since April 2025, the number of supporting organizations has grown from more
+      than 50 to over 150 - including AWS, Cisco, Google, IBM, Microsoft, Salesforce, SAP, and ServiceNow.
+      The core repository has surpassed 22,000 GitHub stars, and the SDK ecosystem has expanded from a single
+      Python implementation to five production-ready languages." Microsoft in Azure AI Foundry and Copilot
+      Studio, AWS through Amazon Bedrock AgentCore Runtime. No user or request count.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 858f8ee3b7221025bf01f9ada869e41696ff350e96ee16ca8c91389d06dd76ff
   - url: https://github.com/a2aproject/A2A
-    shows: 6-language SDKs, ~24k stars corroborating developer uptake
-    accessed: '2026-06-04'
+    shows: Repo page, 25,336 stargazers, Apache-2.0, spec plus the reference SDK list.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1165fc1e34756203cf564d09b228b277c3efedb7a0a62a30fac58cb0067a6bd1
 capability:
   score: null
   basis: n/a
   value: null
   confidence: high
-  note: A2A is a wire protocol for agent interoperability; per the recipe, capability is not a meaningful
-    axis for a protocol. The signal lives in openness and adoption-breadth.
+  note: 'A2A is a wire protocol for agent interoperability; per the recipe, capability is not a meaningful
+    axis for a protocol. The signal lives in openness and adoption-breadth. Abstention re-confirmed 2026-08-13:
+    the repository still publishes a specification, ADRs, governance documents and reference SDKs, and no
+    benchmark, leaderboard or measured performance number for the protocol appears on it or anywhere the
+    project points. What was looked for and not found is a published score of any kind that ranks A2A against
+    a peer. SEE ALSO the load-bearing-null note on model-context-protocol: a null capability does not abstain
+    the way a null adoption does, so this record also computes its maturity from adoption alone. The same
+    ruling should cover both.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/a2aproject/A2A
-    shows: described as an open protocol/spec, not a benchmarkable runtime
-    accessed: '2026-06-04'
+    shows: Repo page - specification, ADRs, governance and reference SDK links. Described as an open protocol
+      and spec, not a runtime. No benchmark result, leaderboard entry or performance figure published.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1165fc1e34756203cf564d09b228b277c3efedb7a0a62a30fac58cb0067a6bd1

--- a/sources/scores/algolia-ai-search.yaml
+++ b/sources/scores/algolia-ai-search.yaml
@@ -15,13 +15,25 @@ openness:
     managed:
       value: Algolia-Cloud
   confidence: high
-  note: Closed proprietary hosted search engine; only client/UI integration libraries are open. Core ranking/index
-    engine is not OSS or self-hostable.
+  note: 'Closed proprietary hosted search engine; only client/UI integration libraries are open. Core ranking/index
+    engine is not OSS or self-hostable. Re-read 2026-08-13: the product page sells a hosted platform - NeuralSearch,
+    AI ranking, personalization - reached through an API, and offers no self-host, on-premise or source-available
+    build of the engine anywhere on it. The open InstantSearch family remains client-side UI, which cannot
+    reclassify the closed core. source stays closed and the score stays 1.'
   raw: license:proprietary(SaaS, API-first);source:closed(search engine core);oss:client/UI-libraries-only(InstantSearch);managed:Algolia-Cloud
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.algolia.com/products/ai-search/
-    shows: proprietary API-first cloud search platform; OSS limited to client/integration libraries
-    accessed: '2026-06-04'
+    shows: Hosted API-first search platform with NeuralSearch hybrid retrieval, AI ranking and personalization.
+      No self-host, on-premise or source-available option for the engine; the open libraries are client-side
+      UI only.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e8262ce5ec1ddb656d1cf610bb513a9fb37f6e2acb92ef0ca71f95e4b68df350
+    establishes:
+    - license
+    - source
+    - core-gated
 adoption:
   level: 4
   reach: 1M-10M
@@ -29,22 +41,43 @@ adoption:
   confidence: high
   note: 18,000+ customers across 150+ countries; processes over 1 billion queries every 5 seconds at sub-20ms
     average latency. Named users incl. Stripe, Decathlon, Ubisoft. Query volume is enormous; end-user
-    reach (consumers hitting Algolia-powered search) is effectively mass-scale, but as a B2B tool the
-    direct customer base sits in the heavy-trending band; placed at 4 on verified query-volume.
+    reach (consumers hitting Algolia-powered search) is effectively mass-scale, but as a B2B tool the direct
+    customer base sits in the heavy-trending band; placed at 4 on verified query-volume. Re-read 2026-08-13
+    and both headline figures are still on the page as written - "More than 18,000 customers in 150+ countries
+    trust Algolia" and "Algolia processes more than 1 billion queries every 5 seconds, with an average response
+    time under 20 milliseconds" - with Stripe, Decathlon and Ubisoft still named. The customer count is what
+    the band actually rests on and 18,000 is nowhere near the 1M-10M reach label recorded beside it; that
+    label reads as an estimate of downstream end users rather than of anything counted here, and it is worth
+    a ruling on whether this axis should carry a numeric reach at all. Level 4 unchanged.
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.algolia.com/products/ai-search/
-    shows: 18,000+ customers, 1B+ queries/5s, sub-20ms latency, named enterprise users
-    accessed: '2026-06-04'
+    shows: '"More than 18,000 customers in 150+ countries trust Algolia"; "Algolia processes more than 1 billion
+      queries every 5 seconds, with an average response time under 20 milliseconds"; Stripe, Decathlon and
+      Ubisoft named.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e8262ce5ec1ddb656d1cf610bb513a9fb37f6e2acb92ef0ca71f95e4b68df350
 capability:
   score: 4
   basis: feature_matrix
   value: hybrid vector+keyword (NeuralSearch), NLP/typo-tolerance/autocomplete, AI ranking + personalization,
     sub-20ms latency at 1B+ queries/5s, multi-content-type
   confidence: high
-  note: Mature hybrid search feature matrix (semantic + keyword, personalization, AI ranking) at very
-    low latency and massive scale, frontier-adjacent for managed site/retrieval search. Rated 4; closed
-    system so no independent ANN-Benchmarks number, basis is feature_matrix.
+  note: 'Mature hybrid search feature matrix (semantic + keyword, personalization, AI ranking) at very low
+    latency and massive scale, frontier-adjacent for managed site/retrieval search. Rated 4; closed system
+    so no independent ANN-Benchmarks number, basis is feature_matrix. Re-read 2026-08-13: NeuralSearch, AI
+    ranking and personalization are all still on the page, and the latency-at-scale claim is stated as "more
+    than 1 billion queries every 5 seconds, with an average response time under 20 milliseconds". The absence
+    was re-checked too - ann-benchmarks.com was fetched the same day and lists 38 algorithms, none of them
+    Algolia - so the "no independent number" half of this note is a confirmed finding. Band unchanged at
+    4.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.algolia.com/products/ai-search/
-    shows: hybrid vector+keyword NeuralSearch, AI ranking, personalization, sub-20ms at 1B+ queries/5s
-    accessed: '2026-06-04'
+    shows: NeuralSearch hybrid vector-plus-keyword retrieval, AI ranking, personalization; "Algolia processes
+      more than 1 billion queries every 5 seconds, with an average response time under 20 milliseconds".
+      All figures vendor-stated.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e8262ce5ec1ddb656d1cf610bb513a9fb37f6e2acb92ef0ca71f95e4b68df350

--- a/sources/scores/apify.yaml
+++ b/sources/scores/apify.yaml
@@ -21,18 +21,37 @@ openness:
     most value stays behind the managed cloud. Class corrected from open_core on 2026-07-30. In this ladder
     open_core means an OSI core with functionality withheld for a paid tier, and there is no open core here,
     only an open periphery. A repo that exists while the runtime does not ship is source:partial, which
-    the ladder scores 2/source_available. The score itself was already 2.
+    the ladder scores 2/source_available. The score itself was already 2. Re-read 2026-08-13 and the shape
+    holds exactly. apify.com still files Crawlee under a navigation heading literally labelled "Open source"
+    - "Web scraping and crawling library" - beside the closed platform pieces, Actors, Proxy, Anti-blocking,
+    Integrations and the MCP server. Crawlee's own repo confirms Apache-2.0 in both the badge and the GitHub
+    metadata (spdxId Apache-2.0). Nothing that RUNS an Actor is published anywhere, so `source - partial`
+    stands and so does 2/source_available.
   raw: platform:proprietary(Apify-Cloud,Actor-store,managed);source:partial(Crawlee SDK published, the platform
     that runs Actors is not);oss-sdk:Crawlee(Apache-2.0,OSI, JS+Python);license:mixed(platform closed, SDK
     open)
+  last_verified: '2026-08-13'
   sources:
   - url: https://apify.com
-    shows: proprietary full-stack scraping platform with 35,000+ Actors; Crawlee called out as their OSS
-      contribution
-    accessed: '2026-06-04'
+    shows: Proprietary full-stack platform - Apify Store, Actors ("Build and run serverless programs"), Integrations,
+      an MCP server, Anti-blocking and Proxy - with a single "Open source" navigation heading holding Crawlee
+      alone. The store now advertises 59,817 Actors, up from the 35,000+ this record carried. No self-hosted
+      Actor runtime is offered.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a8381edef66756b2b7e4d919e2b66baa313e00b95311d5cd85e015905977c21d
+    establishes:
+    - source
+    - license
   - url: https://github.com/apify/crawlee
-    shows: Crawlee Apache-2.0 license (OSI), Apify's open source scraping library
-    accessed: '2026-06-04'
+    shows: Crawlee repo - Apache-2.0 license badge and repo metadata spdxId Apache-2.0, "Apache License 2.0";
+      LICENSE.md at the root. The library only; it is not the Actor platform.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: ec88f295f5cacae7903e4e3d7884b7d33f1e709f2441d3a0dcfd44e2bf48e9e8
+    establishes:
+    - license
+    - source
 adoption:
   level: 3
   reach: 100K-1M
@@ -41,27 +60,53 @@ adoption:
   note: Crawlee at 23.7k GitHub stars (corroborating, not basis); platform serves named enterprises (T-Mobile,
     Microsoft, Accenture) and a 15,000+ member Discord. 35,000+ published Actors implies a sizable active
     developer base. No precise account/API-call count published; placed at 3 on combined developer/usage
-    signal across platform + OSS SDK.
+    signal across platform + OSS SDK. Re-read 2026-08-13, and the Actor count has moved a long way - the
+    store now says 59,817 Actors against the 35,000+ recorded, and Crawlee is at 25,373 stars against 23.7k.
+    The named enterprises are still on the page. The 15,000+ Discord figure is NOT - the page links to a
+    Discord invite without stating a member count, so that clause has been dropped from the note rather than
+    carried on nothing. None of these is a usage figure in the scale''s sense; Apify still publishes no account,
+    run or API-call count, so the level remains an aggregate judgment and stays at 3.
+  last_verified: '2026-08-13'
   sources:
   - url: https://apify.com
-    shows: 35,000+ Actors, named enterprise users (T-Mobile, Microsoft, Accenture), 15,000+ Discord members
-    accessed: '2026-06-04'
+    shows: '"Browse 59,817 Actors" in the store; T-Mobile and Accenture among named enterprise users; a Discord
+      invite link. NOT on the page: a Discord member count, an account count, a run count or an API-call
+      figure.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a8381edef66756b2b7e4d919e2b66baa313e00b95311d5cd85e015905977c21d
   - url: https://github.com/apify/crawlee
-    shows: 23.7k stars on the OSS Crawlee library (corroborating signal)
-    accessed: '2026-06-04'
+    shows: 25,373 stargazers on the OSS Crawlee library. Corroborating attention signal, not the basis.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: ec88f295f5cacae7903e4e3d7884b7d33f1e709f2441d3a0dcfd44e2bf48e9e8
 capability:
   score: 4
   basis: feature_matrix
-  value: 'coverage: 35,000+ prebuilt Actors; HTTP + headless (Playwright/Puppeteer/Selenium); proxy rotation/session
-    mgmt; structured output; serverless custom Actors; MCP-client integration'
+  value: 'coverage - 59,817 prebuilt Actors in the store; HTTP + headless via Puppeteer, Playwright, Cheerio
+    and JSDOM; proxy rotation and session management; anti-blocking; structured output of tabular data and
+    files; serverless custom Actors; an Apify MCP server for agent clients'
   confidence: high
-  note: Broad scrape/browse feature matrix, multi-engine crawling, proxy/anti-block, structured extraction,
-    serverless deploy, and MCP integration for agents. Among the most complete scrape platforms; rated
-    4 (frontier-adjacent for the browser/scrape sub-segment).
+  note: 'Broad scrape/browse feature matrix, multi-engine crawling, proxy/anti-block, structured extraction,
+    serverless deploy, and MCP integration for agents. Among the most complete scrape platforms; rated 4
+    (frontier-adjacent for the browser/scrape sub-segment). Re-read 2026-08-13. Every dimension holds and
+    two figures were corrected upward - the store now advertises 59,817 Actors, and Crawlee''s own description
+    names Puppeteer, Playwright, Cheerio, JSDOM and raw HTTP rather than the Selenium this record had, in
+    both headful and headless mode with integrated proxy rotation and session management. The Apify MCP server
+    is now a first-class navigation item, "Give your AI access to Actors". Band unchanged at 4.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://apify.com
-    shows: multi-engine crawling, proxy rotation, Actor store, MCP-client integration
-    accessed: '2026-06-04'
+    shows: '"Browse 59,817 Actors"; navigation items for Actors, Integrations, MCP ("Give your AI access to
+      Actors"), Anti-blocking ("Scrape without getting blocked") and Proxy ("Rotate scraper IP addresses");
+      "Configure your Apify MCP server with Actors and tools for seamless integration with MCP clients".'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a8381edef66756b2b7e4d919e2b66baa313e00b95311d5cd85e015905977c21d
   - url: https://github.com/apify/crawlee
-    shows: Crawlee multi-engine (Playwright/Puppeteer/Cheerio/JSDOM), proxy + session management
-    accessed: '2026-06-04'
+    shows: '"Works with Puppeteer, Playwright, Cheerio, JSDOM, and raw HTTP. Both headful and headless mode.
+      With proxy rotation." Feature list adds structured storage of tabular data and files, automatic scaling,
+      "Integrated proxy rotation and session management", hooks and a bootstrap CLI. NOT named: Selenium.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: ec88f295f5cacae7903e4e3d7884b7d33f1e709f2441d3a0dcfd44e2bf48e9e8

--- a/sources/scores/browser-use.yaml
+++ b/sources/scores/browser-use.yaml
@@ -80,27 +80,53 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: ~27M PyPI downloads in the last month (browser-use), strong real install/usage volume, not stars.
-    97.2k GitHub stars corroborate but are not the basis. Solidly in the 1-10M+ monthly-download band;
-    one of the most-used agent browser-automation libraries.
+  note: '~27M PyPI downloads in the last month (browser-use), strong real install/usage volume, not stars.
+    97.2k GitHub stars corroborate but are not the basis. Solidly in the 1-10M+ monthly-download band; one
+    of the most-used agent browser-automation libraries. FLAGGED FOR A HUMAN 2026-08-13 and deliberately
+    NOT applied: the recorded level does not follow from the recorded figure, and did not before this pass
+    either. The pypistats API reports last_month = 53,142,086 downloads for browser-use, and the ~27M already
+    on the record was itself above the >10M level-5 floor - so this axis has been sitting at 4/1M-10M under
+    a figure that bands at 5/>10M by the software scale in sources/rubrics/software.yaml, twice over. Both
+    the level and the reach need correcting; a level change is not this pass''s to make, so the axis carries
+    no last_verified. The repo now shows 109,104 stars, still corroborating rather than the basis.'
   sources:
+  - url: https://pypistats.org/api/packages/browser-use/recent
+    shows: last_month = 53,142,086 downloads for browser-use (last_week 14,575,579, last_day 2,624,999).
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9d86d983650b3dc84598d2efb324087b0f5c04845286f5d6a1fdcb86fc83b23c
   - url: https://pypistats.org/packages/browser-use
-    shows: ~26.96M PyPI downloads last month
-    accessed: '2026-06-04'
+    shows: The rendered pypistats page for browser-use; figures read from its API endpoint above.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: e9d88ad1daef6a77a29d1f5c82064bdb571f67c782878a2427278ba71d73c49a
   - url: https://github.com/browser-use/browser-use
-    shows: 97.2k GitHub stars (corroborating)
-    accessed: '2026-06-04'
+    shows: Repo page, 109,104 stargazers (corroborating).
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: be8cf11dbbe465f67c9957830b2d7adbce0f871d8c2c5663d243251b941da575
 capability:
   score: 4
   basis: feature_matrix
   value: 'agent browser control: navigate/click/fill-forms/extract/multi-step tasks; LLM-driven DOM interaction;
     cloud infra adds proxy rotation, stealth fingerprinting, CAPTCHA solving, 1000+ integrations'
   confidence: medium
-  note: Leading OSS browser-automation-for-agents library with broad action coverage and a production
-    cloud tier; widely adopted as the default agent browsing layer. Rated 4 on feature_matrix (multi-step
-    web tasks, structured extraction, anti-block infra); no standard benchmark applies to a browser-control
-    library.
+  note: 'Leading OSS browser-automation-for-agents library with broad action coverage and a production cloud
+    tier; widely adopted as the default agent browsing layer. Rated 4 on feature_matrix (multi-step web tasks,
+    structured extraction, anti-block infra); no standard benchmark applies to a browser-control library.
+    Re-read 2026-08-13: the README still describes the same surface - a CLI for one-off tasks and a Python
+    library for repeatable automation, "custom tools, custom system prompts, structured output, fine-grained
+    browser control", with a skills/ directory in the tree - and it still places stealth and proxy rotation
+    on the cloud browsers rather than in the library, which is what the recorded value says. No standardized
+    benchmark for browser-control libraries has appeared, so the basis stays feature_matrix and the band
+    stays 4.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/browser-use/browser-use
-    shows: agent browser automation feature set + cloud capabilities (proxies, stealth, CAPTCHA, integrations)
-    accessed: '2026-06-04'
+    shows: 'README - CLI for one-off tasks, Python library for repeatable automation; "Custom tools, custom
+      system prompts, structured output, fine-grained browser control"; skills/ in the root tree. Stealth,
+      proxy rotation and scaling are attributed to the hosted cloud browsers - "We recommend pairing it with
+      our cloud browsers for leading stealth, proxy rotation, and scaling".'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: be8cf11dbbe465f67c9957830b2d7adbce0f871d8c2c5663d243251b941da575

--- a/sources/scores/browserbase.yaml
+++ b/sources/scores/browserbase.yaml
@@ -15,16 +15,30 @@ openness:
       raw: companion Stagehand SDK IS open source (Apache/MIT) but the Browserbase service being scored
         is the closed managed platform
   confidence: high
-  note: The scored product is the managed browser-infrastructure service, which is closed/proprietary;
-    only the separate Stagehand client SDK is open; do not let the open SDK reclassify the closed service.
+  note: 'The scored product is the managed browser-infrastructure service, which is closed/proprietary; only
+    the separate Stagehand client SDK is open; do not let the open SDK reclassify the closed service. Re-read
+    2026-08-13: the docs still document a hosted platform reached with one API key - Browser API, Search
+    API, Fetch API, Functions and Model Gateway - with no self-host, on-premise or source-available option
+    anywhere in them. Stagehand is still called out as "The SDK for browser agents ... Built by Browserbase"
+    and links out to its own docs site, which is exactly the separation this note warns against collapsing.
+    source stays closed and the score stays 1.'
   raw: license:Proprietary(API-only managed browser infra);source:closed(cloud browser fleet/session infra);note:companion
     Stagehand SDK IS open source (Apache/MIT) but the Browserbase service being scored is the closed managed
     platform
+  last_verified: '2026-08-13'
   sources:
   - url: https://docs.browserbase.com/
-    shows: one API key for cloud browsers/search/fetch/runtime, managed proprietary platform; Stagehand
-      SDK noted as the open source client
-    accessed: '2026-06-04'
+    shows: One API key across a hosted Browser API, Search API, Fetch API, Functions and Model Gateway. Stagehand
+      documented as a separate SDK - "The SDK for browser agents. Natural language selectors, self-healing
+      actions, and caching at scale ... Built by Browserbase" - on its own docs site. No self-hosting option
+      for the platform itself.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 7134c34322beae8ecc5e5f7861058d5c37e0c891318a809215edd0ff7e21765b
+    establishes:
+    - license
+    - source
+    - core-gated
 adoption:
   level: 3
   reach: 100K-1M
@@ -33,12 +47,21 @@ adoption:
   note: No primary usage figure for the Browserbase managed service itself was published. Best primary
     proxy is its own SDK, Stagehand, which Browserbase docs cite at 22k GitHub stars and 700k+ weekly
     downloads, a strong open-SDK adoption signal that approximates the platform's developer reach (100K-1M
-    band). The closed service's own user/session count is undisclosed.
+    band). The closed service's own user/session count is undisclosed. Re-read 2026-08-13 and the proxy figures
+    are unchanged - the docs still say of Stagehand "22k GitHub stars, 700k+ weekly downloads. Built by Browserbase"
+    - and the platform still publishes no session, request or customer count of its own, which is what was
+    looked for and not found. 700k weekly is roughly 3M monthly, which would band at 4 if it were the product's
+    own figure; it is not, it is a companion SDK standing in, so the level stays at 3 with the discount that
+    substitution deserves. Level and reach unchanged.
+  last_verified: '2026-08-13'
   sources:
   - url: https://docs.browserbase.com/
-    shows: vendor-stated Stagehand SDK 22k stars, 700k+ weekly downloads (proxy for Browserbase developer
-      reach)
-    accessed: '2026-06-04'
+    shows: '"The SDK for browser agents. Natural language selectors, self-healing actions, and caching at
+      scale. 22k GitHub stars, 700k+ weekly downloads. Built by Browserbase." No session, request, user or
+      customer figure for the Browserbase platform itself appears anywhere in the docs.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 7134c34322beae8ecc5e5f7861058d5c37e0c891318a809215edd0ff7e21765b
 capability:
   score: 4
   basis: feature_matrix
@@ -46,9 +69,17 @@ capability:
     Model Gateway (100+ LLM providers); Stagehand: natural-language selectors, self-healing actions, caching
     at scale'
   confidence: medium
-  note: Broad browser-automation-for-agents feature set (control + search + fetch + deploy + model routing)
-    plus a capable agent SDK; near-frontier among agent browser/scrape platforms.
+  note: 'Broad browser-automation-for-agents feature set (control + search + fetch + deploy + model routing)
+    plus a capable agent SDK; near-frontier among agent browser/scrape platforms. Re-read 2026-08-13: the
+    five components in the recorded value are all still documented - Browser API, Search API, Fetch API,
+    Functions and Model Gateway - as are Stagehand''s natural-language selectors, self-healing actions and
+    caching at scale. No independent benchmark for hosted browser platforms exists, so the basis stays feature_matrix
+    and the band stays 4.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://docs.browserbase.com/
-    shows: '5-component platform: Browser/Search/Fetch/Functions/Model Gateway + Stagehand features'
-    accessed: '2026-06-04'
+    shows: Browser API, Search API, Fetch API, Functions and Model Gateway documented as the platform surface;
+      Stagehand's natural-language selectors, self-healing actions and caching at scale.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 7134c34322beae8ecc5e5f7861058d5c37e0c891318a809215edd0ff7e21765b

--- a/sources/scores/cohere-rerank-api.yaml
+++ b/sources/scores/cohere-rerank-api.yaml
@@ -13,44 +13,97 @@ openness:
     managed:
       value: Cohere+Azure/AWS/Oracle
   confidence: high
-  note: Proprietary closed reranking models served via API and cloud marketplaces; no open weights or
-    source. Marketed as 'open' in search-relevance contexts but is not OSS.
+  note: 'Proprietary closed reranking models served via API and cloud marketplaces; no open weights or source.
+    Marketed as ''open'' in search-relevance contexts but is not OSS. Re-read 2026-08-13: the overview documents
+    rerank-v4.0-pro, rerank-v4.0-fast, rerank-v3.5 and the 3.0 pair as hosted models called through the API
+    and billed in search units. No weights download, no model card on a hub and no self-hosted build is offered
+    for any of them; the only "open" thing on the page is the list of open-source vector stores it integrates
+    with. weights stay not-released and the score stays 1.'
   raw: license:proprietary(hosted-API; also cloud-marketplace deploy);source:closed;weights:not-released;managed:Cohere+Azure/AWS/Oracle
+  last_verified: '2026-08-13'
   sources:
   - url: https://docs.cohere.com/docs/rerank-overview
-    shows: commercial Rerank API; models 4.0/3.5/3.0, no source or weight release
-    accessed: '2026-06-04'
+    shows: 'Model lineup - "Rerank 4.0 (both ''fast'' and ''pro''): A single multilingual model (rerank-v4.0-pro
+      and rerank-v4.0-fast). Rerank 3.5: A single multilingual model (rerank-v3.5). Rerank 3.0: Separate
+      English-only and multilingual models." Calls are billed in search_units. No weights download, hub model
+      card or self-hosted build for any of them.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5b1e58e8c25f9e9eb88003ff18eae6ba717fed6c443354731a282a7a8f88071f
+    establishes:
+    - license
+    - source
+    - weights
   - url: https://docs.cohere.com/changelog/rerank-v3.5
-    shows: Rerank v3.5 announced as a hosted proprietary model
-    accessed: '2026-06-04'
+    shows: Release notes for Rerank 3.5 as a hosted model reached through the API, with a context length of
+      4096. No weights release accompanies it.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: bc5906343e711e89148a704a2e771f0e3e453737f4b433bdc6d55960675960e1
+    establishes:
+    - weights
 adoption:
   level: 3
   signal_type: reported_traction
   confidence: medium
   note: De facto default managed reranker for RAG, distributed across Azure AI Foundry, AWS SageMaker
     JumpStart / OpenSearch, and Oracle GenAI in addition to Cohere's API. No hard call-volume/user count
-    published; placed at 3 on broad multi-cloud distribution (reported_traction).
+    published; placed at 3 on broad multi-cloud distribution (reported_traction). Re-read 2026-08-13. The
+    AWS Big Data blog is still published, co-written with Cohere, on integrating Rerank 3.5 with Amazon OpenSearch
+    Service; the Azure AI Foundry catalog still carries Cohere as a model provider and describes deploying
+    "Command or Rerank side-by-side with Azure AI Search". Neither publishes a call volume, a customer count
+    or a developer count, which is what was looked for and not found, so the instrument stays reported_traction
+    and the level stays 3.
+  last_verified: '2026-08-13'
   sources:
   - url: https://aws.amazon.com/blogs/big-data/enhancing-search-relevancy-with-cohere-rerank-3-5-and-amazon-opensearch-service/
-    shows: Rerank 3.5 integrated/distributed via Amazon OpenSearch Service
-    accessed: '2026-06-04'
+    shows: '"Enhancing Search Relevancy with Cohere Rerank 3.5 and Amazon OpenSearch Service", co-written
+      with Cohere. Establishes distribution through OpenSearch; carries no usage figure.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5da7eec30262747394e823efb3715dbadd6c7f6d43d2174373dbdd376d6768bb
   - url: https://ai.azure.com/catalog/models/Cohere-rerank-v3.5
-    shows: Rerank v3.5 available in Azure AI Foundry model catalog
-    accessed: '2026-06-04'
+    shows: Azure AI Foundry catalog, Cohere provider entry - "Built around large-language-model families such
+      as Command R/R+, Command A, and high-precision Rerank APIs"; "Deploy Command or Rerank side-by-side
+      with Azure AI Search". Establishes availability; carries no usage figure.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 39dc99efde987fcac5f5730366364488971b102379f7b362534ce26b49aab623
 capability:
   score: 4
   basis: feature_matrix
-  value: SOTA on BEIR + multilingual retrieval (nDCG@10), 100+ languages with SOTA on 10 business languages;
-    up to ~25% gain over embedding-only retrieval; multimodal/long-context in newer variants
+  value: vendor-claimed SOTA on BEIR and on multilingual retrieval, plus reasoning capability and a 4096-token
+    context, on the 3.5 release; +26.4% on cross-lingual search against the previous Rerank 3, measured by
+    nDCG@10 over an in-house 18-language suite; trained across 100+ languages, with 4.0 shipping fast and
+    pro variants
   confidence: medium
-  note: Vendor reports SOTA on BEIR and multilingual nDCG@10; widely treated as the reference managed
-    reranker. Concrete nDCG numbers not disclosed on primary pages (claims are vendor-run, not an independent
-    leaderboard), so rated 4 rather than 5. Capability basis is feature_matrix as no standard public reranker
-    leaderboard applies.
+  note: 'Vendor reports SOTA on BEIR and multilingual nDCG@10; widely treated as the reference managed reranker.
+    Concrete nDCG numbers not disclosed on primary pages (claims are vendor-run, not an independent leaderboard),
+    so rated 4 rather than 5. Capability basis is feature_matrix as no standard public reranker leaderboard
+    applies. Re-read 2026-08-13, and the value needed re-attributing and one figure correcting. The BEIR
+    claim is real but lives on the CHANGELOG, not the blog this record cited it to - "Rerank 3.5 has SOTA
+    performance on BEIR and domains such as Finance, E-commerce, Hospitality, Project Management, and Email/Messaging
+    Retrieval tasks" - and the string BEIR appears nowhere on the blog page. The recorded "~25% gain over
+    embedding-only retrieval" is not on either page; what the blog says is "+26.4% improvement on cross-lingual
+    search" against Cohere''s own previous Rerank 3, which is a different comparison against a different baseline,
+    so the value now states it that way. The vendor-run caveat is if anything stronger than recorded - the
+    multilingual suite is Cohere''s own, "external datasets covering 18 different languages" scored by nDCG@10
+    - so the 4 rather than 5 stands.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://cohere.com/blog/rerank-3pt5
-    shows: vendor SOTA claims on BEIR + multilingual retrieval, ~25% gain over embedding search
-    accessed: '2026-06-04'
+    shows: '"Cohere''s multilingual evaluation suite consists of external datasets covering 18 different languages
+      in a variety of monolingual and cross-lingual settings. Multilingual performance is measured by nDCG@10";
+      "When compared to our previous Rerank 3 model, Rerank 3.5 delivers a +26.4% improvement on cross-lingual
+      search". NOT on this page: BEIR, or any comparison against embedding-only retrieval.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: cd2f77a145b96ffb93c20e6778b9c61c240fe787d5bb294013034b3ea460f9b1
   - url: https://docs.cohere.com/changelog/rerank-v3.5
-    shows: multilingual 100+ language reranking, nDCG@10 evaluation
-    accessed: '2026-06-04'
+    shows: '"Rerank 3.5 has a context length of 4096, SOTA performance on Multilingual Retrieval tasks and
+      Reasoning Capabilities. In addition, Rerank 3.5 has SOTA performance on BEIR and domains such as Finance,
+      E-commerce, Hospitality, Project Management, and Email/Messaging Retrieval tasks." No nDCG figure is
+      given here.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: bc5906343e711e89148a704a2e771f0e3e453737f4b433bdc6d55960675960e1

--- a/sources/scores/composio.yaml
+++ b/sources/scores/composio.yaml
@@ -103,13 +103,24 @@ adoption:
 capability:
   score: 4
   basis: feature_matrix
-  value: 1000+ toolkits / 500+ apps (Rube MCP), tool search, managed OAuth/auth, sandboxed workbench,
-    multi-framework SDKs (OpenAI/Anthropic/LangChain/LlamaIndex)
+  value: 1000+ toolkits, tool search, context management, managed OAuth/auth, sandboxed workbench, a per-session
+    hosted MCP endpoint, multi-framework SDKs (OpenAI/Anthropic/LangChain/LlamaIndex)
   confidence: medium
-  note: Broad tool-coverage and auth/sandbox feature set make it one of the most capable agent tool-integration
+  note: 'Broad tool-coverage and auth/sandbox feature set make it one of the most capable agent tool-integration
     layers; strong on the {coverage, structured output, breadth} matrix, just short of a frontier-defining
-    5.
+    5. Re-read 2026-08-13. The repository description still reads "Composio powers 1000+ toolkits, tool search,
+    context management, authentication, and a sandboxed workbench", and the README still offers a hosted
+    MCP endpoint per session - "Pass mcp: true to composio.create()". One recorded clause did not survive:
+    the value named "500+ apps (Rube MCP)" and the string Rube appears nowhere on the page now, so it has
+    been replaced with the per-session MCP endpoint the README does describe and with "context management",
+    which the description adds. The band is unchanged at 4 - the surface is the same size, described differently.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/ComposioHQ/composio
-    shows: 1000+ toolkits, tool search, auth, sandboxed workbench, Rube MCP 500+ apps
-    accessed: '2026-06-04'
+    shows: 'Repo description - "Composio powers 1000+ toolkits, tool search, context management, authentication,
+      and a sandboxed workbench to help you build AI agents that turn intent into action." README - "let
+      the agent take action across 1000+ apps"; a hosted MCP endpoint per session. NOT on the page: any mention
+      of Rube.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 54d3c57c63b6308992d0b715185191a69239c5a0a26743c88eb7a45e69e967f9

--- a/sources/scores/docling.yaml
+++ b/sources/scores/docling.yaml
@@ -16,12 +16,33 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: MIT, local-first document parsing, fully self-hostable with integrated open-weight models.
+  note: 'MIT, local-first document parsing, fully self-hostable with integrated open-weight models. Re-read
+    2026-08-13: the repository LICENSE is the plain MIT License, "Copyright (c) 2024 International Business
+    Machines", and the repo page carries the matching badge. Self-hosting is not merely allowed but the point
+    - the README advertises "Local execution capabilities for sensitive data and air-gapped environments"
+    - and the VLM and ASR models it reaches for are open weights on the Hub (GraniteDocling) rather than
+    a hosted service. docling-serve runs the same code as an API server. Nothing is withheld and nothing
+    is sold beside it.'
   raw: license:MIT(OSI);source:public(github.com/docling-project/docling);self-host:primary;no-feature-gated-core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
+  - url: https://raw.githubusercontent.com/docling-project/docling/main/LICENSE
+    shows: 'Plain MIT License text: "Copyright (c) 2024 International Business Machines".'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9816fb12b11c33c552f4e8621879d0da493be47c0f86be785b53a2cf7f7ae4c6
+    establishes:
+    - license
   - url: https://github.com/docling-project/docling
-    shows: MIT, ~61.8k stars, multi-format document parser
-    accessed: '2026-06-18'
+    shows: Repo page - MIT badge, 64,719 stargazers. "Local execution capabilities for sensitive data and
+      air-gapped environments"; open-weight VLMs such as GraniteDocling driven from the CLI; docling-serve
+      as the self-run API server. No paid tier, license key or enterprise directory.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 23ecab48418cfbc5de53cbb3a01663ec3af4e2e029550cf73306342d7cc2a891
+    establishes:
+    - source
+    - core-gated
 adoption:
   level: 5
   signal_type: usage_volume
@@ -41,11 +62,26 @@ adoption:
 capability:
   score: 5
   basis: feature_matrix
-  value: parses PDF/DOCX/PPTX/XLSX/HTML/EPUB/images/audio -> Markdown/JSON/HTML/DocTags; layout + reading-order;
-    table-structure recognition; formula/code extraction; OCR; VLM integration
+  value: parses PDF/DOCX/PPTX/XLSX/HTML/EPUB/WAV/MP3/WebVTT/email/images/LaTeX and video -> Markdown/HTML/WebVTT/DocLang/DocTags/lossless
+    JSON; layout + reading-order; table-structure recognition; formula/code extraction; image classification;
+    OCR; VLM and ASR models; application-specific XML schemas (DocLang, USPTO patents, JATS, XBRL); MCP server
   confidence: high
-  note: Deepest local document understanding among RAG ingestion tools; web-URL parsers lack rich binary-doc depth.
+  note: 'Deepest local document understanding among RAG ingestion tools; web-URL parsers lack rich binary-doc
+    depth. Re-read 2026-08-13, and the surface has grown rather than merely held, so the value has been restated.
+    Everything recorded is still there - "Advanced PDF understanding incl. page layout, reading order, table
+    structure, code, formulas, image classification", extensive OCR, VLM support - and the README now adds
+    audio with ASR models, video parsing, WebVTT and DocLang export, application-specific XML schemas for
+    USPTO patents, JATS articles and XBRL filings, and an MCP server of its own. The band was already 5 and
+    stays there.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/docling-project/docling
-    shows: 'feature set: multi-format, layout, tables, OCR, VLM'
-    accessed: '2026-06-18'
+    shows: 'Feature list - PDF, DOCX, PPTX, XLSX, HTML, EPUB, WAV, MP3, WebVTT, Box Notes, EML/MSG, images,
+      LaTeX, DocLang and plain text input; "Advanced PDF understanding incl. page layout, reading order, table
+      structure, code, formulas, image classification"; export to Markdown, HTML, WebVTT, DocLang, DocTags
+      and lossless JSON; "Extensive OCR support for scanned PDFs and images"; VLM support; "Audio support
+      with Automatic Speech Recognition (ASR) models"; "Connect to any agent using the MCP server"; video
+      parsing under What''s new.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 23ecab48418cfbc5de53cbb3a01663ec3af4e2e029550cf73306342d7cc2a891

--- a/sources/scores/exa-search-api.yaml
+++ b/sources/scores/exa-search-api.yaml
@@ -14,26 +14,45 @@ openness:
       detail: usage-based pricing
       raw: cloud SaaS with API keys, usage-based pricing
   confidence: high
-  note: Closed neural-search API; no self-hostable core, the index and ranking models are proprietary.
+  note: 'Closed neural-search API; no self-hostable core, the index and ranking models are proprietary. Re-read
+    2026-08-13: the about page still describes Exa as a search engine sold as a service - "Exa: The Search
+    Engine for Developers" - powering search for named customers through an API, with Websets layered on
+    top. It offers no self-host, on-premise or source-available path, and neither the index nor the ranking
+    models are published. source stays closed and the score stays 1.'
   raw: license:Proprietary(API-only);source:closed(neural search models + index proprietary; only client
     SDKs public);managed:cloud SaaS with API keys, usage-based pricing
+  last_verified: '2026-08-13'
   sources:
   - url: https://exa.ai/about
-    shows: search-as-a-service, API dashboard, no self-host/open source option
-    accessed: '2026-06-04'
+    shows: '"Exa: The Search Engine for Developers & Custom AI Search Solution"; "search for Cursor, Cognition,
+      HubSpot, OpenRouter, Monday.com and over 400,000 developers"; Websets described as a product on top.
+      No self-hosting, on-premise or source-available option anywhere on the page.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c8499eb43fde80934b39abebb7c4a8a363a3c29fc163c9359dfa3c8ee8d3bb74
+    establishes:
+    - license
+    - source
+    - core-gated
 adoption:
   level: 3
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
   note: Exa's own about page states it powers search for Cursor, Cognition, HubSpot, OpenRouter, Monday.com
-    and 400,000+ developers. Developer reach in the 100K-1M band; large enterprise/agent customers but
-    below the 1M-developer Tavily tier.
+    and 400,000+ developers. Developer reach in the 100K-1M band; large enterprise/agent customers but below
+    the 1M-developer Tavily tier. Re-read 2026-08-13 and the sentence is still there verbatim - "search for
+    Cursor, Cognition, HubSpot, OpenRouter, Monday.com and over 400,000 developers" - so the figure, the
+    named customers and the 100K-1M band are all unchanged, as is the comparison to Tavily, whose 2M+ developer
+    claim was re-read the same day.
+  last_verified: '2026-08-13'
   sources:
   - url: https://exa.ai/about
-    shows: vendor-stated 400,000+ developers; named customers Cursor, Cognition, HubSpot, OpenRouter,
-      Monday.com
-    accessed: '2026-06-04'
+    shows: '"search for Cursor, Cognition, HubSpot, OpenRouter, Monday.com and over 400,000 developers". No
+      request, query or revenue figure is published.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c8499eb43fde80934b39abebb7c4a8a363a3c29fc163c9359dfa3c8ee8d3bb74
 capability:
   score: 4
   basis: feature_matrix
@@ -41,9 +60,16 @@ capability:
     entity lists); positioned for high-compute complex queries; scaling to hundreds of thousands of searches/sec
     (vendor)
   confidence: medium
-  note: Strong on {coverage, structured output}; Websets' verify-and-enrich pipeline is a differentiated
-    capability beyond plain search; near-frontier among agent search APIs.
+  note: 'Strong on {coverage, structured output}; Websets'' verify-and-enrich pipeline is a differentiated
+    capability beyond plain search; near-frontier among agent search APIs. Re-read 2026-08-13: the about
+    page still positions Exa as a neural search engine for developers with Websets on top, and still frames
+    the roadmap around search volume growing as agents rather than people issue the queries. No independent
+    benchmark for semantic search APIs exists, so the basis stays feature_matrix and the band stays 4.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://exa.ai/about
-    shows: neural search + Websets verify/enrich; high-compute search positioning
-    accessed: '2026-06-04'
+    shows: Neural/semantic search plus contents retrieval; Websets named as the verify-and-enrich product
+      on top; positioning around AI-issued rather than human-issued search volume.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c8499eb43fde80934b39abebb7c4a8a363a3c29fc163c9359dfa3c8ee8d3bb74

--- a/sources/scores/fastmcp.yaml
+++ b/sources/scores/fastmcp.yaml
@@ -14,36 +14,80 @@ openness:
     - no-feature-gated-core
     - maintained-by-Prefect
   confidence: high
-  note: Fully OSI-licensed, no open-core split observed on the repo.
+  note: 'Fully OSI-licensed, no open-core split observed on the repo. Re-read 2026-08-13: the repository
+    LICENSE resolves to the full Apache License 2.0 text and the repo page carries the matching badge. The
+    whole framework - servers, apps and clients - is in the published tree and installs from PyPI with no
+    key; Prefect maintains it rather than selling a tier of it, so there is nothing withheld from the source.'
   raw: license:Apache-2.0(OSI);source:public;no-feature-gated-core;maintained-by-Prefect;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/jlowin/fastmcp
-    shows: Apache-2.0 license, v3.4.0 (3 Jun 2026), maintained by Prefect
-    accessed: '2026-06-04'
+    shows: Repo page - Apache-2.0 badge, 27,203 stargazers, the whole framework in the tree, maintained by
+      Prefect. No enterprise directory, license key or paid tier.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6d6f8c232f68238fe065bd4f1feb7c9ea73fe1d5970402aaa6edc4f3d89ae300
+    establishes:
+    - source
+    - core-gated
+  - url: https://raw.githubusercontent.com/jlowin/fastmcp/main/LICENSE
+    shows: The full Apache License, Version 2.0 text.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 43070e2d4e532684de521b885f385d0841030efa2b1a20bafb76133a5e1379c1
+    establishes:
+    - license
 adoption:
   level: 5
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: fastmcp ~72.7M PyPI downloads in the last month; README reports ~1M downloads/day, used by ~10k
-    dependent projects, and powering ~70% of MCP servers across languages. Mass-market reach for MCP server
-    tooling.
+  note: 'fastmcp ~72.7M PyPI downloads in the last month; README reports ~1M downloads/day and powering
+    ~70% of MCP servers across languages. Mass-market reach for MCP server tooling. Re-derived 2026-08-13
+    from the pypistats API rather than the rendered page: last_month = 94,141,215 downloads for fastmcp,
+    up from the 72.7M recorded and still comfortably above the >10M level-5 floor, so level 5 and reach
+    >10M are unchanged. The README''s own claims re-read the same day and both still stand as written -
+    "downloaded a million times a day, and some version of FastMCP powers 70% of MCP servers across all
+    languages" - and both remain vendor statements, corroborating rather than carrying the band. The
+    "~10k dependent projects" clause was dropped: it appears nowhere on the repo page now.'
+  last_verified: '2026-08-13'
   sources:
+  - url: https://pypistats.org/api/packages/fastmcp/recent
+    shows: last_month = 94,141,215 downloads for fastmcp (last_week 24,037,435, last_day 4,222,355).
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 8659beeba41a5031bc369d200e3d0e32fc36a635160b6cd98cac65737b1d52f9
   - url: https://pypistats.org/packages/fastmcp
-    shows: ~72.7M monthly PyPI downloads
-    accessed: '2026-06-04'
+    shows: The rendered pypistats page for fastmcp; the figures are read from its API endpoint above rather
+      than from the chart.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b2d55be6d54dea465f1a978227cbc9797563c9e0112df98242009dbfedc98d48
   - url: https://github.com/jlowin/fastmcp
-    shows: ~25.5k stars, ~10k dependents, README claims ~1M downloads/day and ~70% of MCP servers
-    accessed: '2026-06-04'
+    shows: '27,203 stargazers; README - "the actively maintained standalone project is downloaded a million
+      times a day, and some version of FastMCP powers 70% of MCP servers across all languages". No dependent-project
+      count is stated on the page.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6d6f8c232f68238fe065bd4f1feb7c9ea73fe1d5970402aaa6edc4f3d89ae300
 capability:
   score: 4
   basis: feature_matrix
   value: auto schema generation/validation, tool/resource/prompt primitives, server+client, auth, deployment,
     protocol lifecycle management; the standard high-level MCP server framework
   confidence: medium
-  note: Most feature-complete framework for authoring the tool-protocol layer (MCP); scored 4 on protocol-tooling
-    feature breadth; a 5 is reserved for the protocol/category-definer (MCP itself).
+  note: 'Most feature-complete framework for authoring the tool-protocol layer (MCP); scored 4 on protocol-tooling
+    feature breadth; a 5 is reserved for the protocol/category-definer (MCP itself). Re-read 2026-08-13:
+    the README now organizes the framework around "three pillars" - Servers exposing tools, resources and
+    prompts; Apps giving those tools an interactive surface; and the client side - which is the same surface
+    the recorded value describes rather than a new one. FastMCP 1.0 remains upstreamed into the official
+    Python SDK, with this the standalone successor. Band unchanged at 4.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/jlowin/fastmcp
-    shows: 'framework feature set: schema gen/validation, server+client, auth, deployment'
-    accessed: '2026-06-04'
+    shows: 'README - "FastMCP is the standard framework for working with MCP. FastMCP 1.0 was incorporated
+      into the official MCP Python SDK in 2024." Three pillars: Servers, Apps, clients. Schema generation
+      and validation, tool/resource/prompt primitives, auth and deployment.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6d6f8c232f68238fe065bd4f1feb7c9ea73fe1d5970402aaa6edc4f3d89ae300

--- a/sources/scores/filesystem-mcp.yaml
+++ b/sources/scores/filesystem-mcp.yaml
@@ -4,8 +4,14 @@ openness:
   class: open_source
   components:
     license:
+    - name: Apache-2.0
+      detail: OSI, new code under the monorepo's transition LICENSE
     - name: MIT
-      detail: OSI
+      detail: OSI, legacy contributions not yet relicensed; also what this server's own README states
+    docs:
+      value: CC-BY-4.0
+      detail: documentation other than the specifications; not read by the openness ladder, which scores the
+        artifact the product ships
     source:
       value: public
     core-gated:
@@ -13,12 +19,51 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: Fully MIT reference server.
-  raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
+  note: 'Fully OSI-licensed reference server, no feature-gated core. LICENSE CORRECTED 2026-08-13, and the
+    two available statements disagree. This record said MIT on the strength of the server''s own README,
+    which still says "This MCP server is licensed under the MIT License ... please see the LICENSE file in
+    the project repository". That LICENSE file is no longer MIT: modelcontextprotocol/servers now carries
+    the MCP project''s transition text, byte-identical to the spec repo''s - Apache-2.0 for new code, CC-BY-4.0
+    for documentation other than specifications, MIT retained only for pre-transition contributions not yet
+    relicensed. So the README points at a file that contradicts it. Both code licenses are recorded, the
+    documentation license sits under a `docs:` key the ladder does not read, and since every part is OSI
+    the tier and the 5/open_source are unchanged. The disagreement is the finding, not a re-scoring.'
+  raw: license:Apache-2.0(OSI, new code under the monorepo's transition LICENSE)+MIT(OSI, legacy contributions
+    not yet relicensed; also what this server's own README states);docs:CC-BY-4.0(documentation other than
+    the specifications; not read by the openness ladder, which scores the artifact the product ships);source:public;no-feature-gated-core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
+  - url: https://raw.githubusercontent.com/modelcontextprotocol/servers/main/LICENSE
+    shows: 'The monorepo LICENSE, digest byte-identical to the MCP spec repo''s: "The MCP project is undergoing
+      a licensing transition from the MIT License to the Apache License, Version 2.0. All new code and specification
+      contributions to the project are licensed under Apache-2.0. Documentation contributions (excluding specifications)
+      are licensed under CC-BY-4.0. Contributions made by authors who originally licensed their work under
+      the MIT License and who have not yet granted explicit permission to relicense remain licensed under
+      the MIT License." Followed by the full Apache-2.0 text.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0382b0057770ca05e9c350a50aa3b1c1fea84da0bc81d723bf00b9aa841be58a
+    establishes:
+    - license
+  - url: https://raw.githubusercontent.com/modelcontextprotocol/servers/main/src/filesystem/README.md
+    shows: 'License section - "This MCP server is licensed under the MIT License. This means you are free
+      to use, modify, and distribute the software, subject to the terms and conditions of the MIT License.
+      For more details, please see the LICENSE file in the project repository." The whole server ships here
+      and installs as @modelcontextprotocol/server-filesystem; nothing is withheld and there is no paid tier.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: df276d57efc04b85fa1e8163fe1aa3d5b11d5b2a7de5ec51ba083e5cb04019cd
+    establishes:
+    - license
+    - source
+    - core-gated
   - url: https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem
-    shows: MIT, reference filesystem server
-    accessed: '2026-06-17'
+    shows: The server's directory in the monorepo, rendering the README above.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 25d203fcb2f09a85d3d04932e4eb5222f66a2b9e02b734e0ddb50952ef89354a
+    establishes:
+    - source
 adoption:
   level: 4
   signal_type: usage_volume
@@ -42,8 +87,25 @@ capability:
   value: granular read/write/edit; directory tree; search; media reads; sandboxed allowed-directory access; Roots
     support
   confidence: high
-  note: Full local-filesystem surface with sandboxed access controls.
+  note: 'Full local-filesystem surface with sandboxed access controls. Re-read 2026-08-13 against the server''s
+    README and every clause of the recorded value holds. The tool table runs read_text_file (with head/tail),
+    read_media_file returning base64 with a MIME type, read_multiple_files, list_directory, list_directory_with_sizes,
+    directory_tree, get_file_info, plus write, edit, create, move, delete and search. Access is confined
+    to Allowed directories set either by command-line argument or, preferred, dynamically by the client through
+    the MCP Roots protocol, and the server refuses to initialize if neither is provided. Band unchanged at
+    4.'
+  last_verified: '2026-08-13'
   sources:
+  - url: https://raw.githubusercontent.com/modelcontextprotocol/servers/main/src/filesystem/README.md
+    shows: 'Features - read/write files, create/list/delete directories, move, search, file metadata, "Dynamic
+      directory access control via Roots". Per-tool table with readOnlyHint and destructiveHint columns; read_media_file
+      streams a file back as a base64 content block with its MIME type. Without command-line arguments and
+      without client Roots support "the server will throw an error during initialization".'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: df276d57efc04b85fa1e8163fe1aa3d5b11d5b2a7de5ec51ba083e5cb04019cd
   - url: https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem
-    shows: tool list
-    accessed: '2026-06-17'
+    shows: The server's directory in the monorepo, rendering the tool list above.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 25d203fcb2f09a85d3d04932e4eb5222f66a2b9e02b734e0ddb50952ef89354a

--- a/sources/scores/firecrawl.yaml
+++ b/sources/scores/firecrawl.yaml
@@ -95,12 +95,19 @@ adoption:
     as an agent scrape tool (LangChain, etc.) but no primary usage figure found this run. Stars read
     2026-08-13: 166,749 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in
     signal_routing.yaml. The previous reach ''100K-1M'' was not a label this instrument offers - stars have
-    their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile,
-    so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.'
+    their own vocabulary because a star is not a download. Re-read in full 2026-08-13: the repo page reports
+    166,863 stargazers, which is the same band, and the repo and the pricing page still publish no download,
+    request-volume or customer count of any kind - a paid API sells credits rather than reporting usage,
+    so there is nothing here to band as usage_volume. The stars fallback and its level-3 cap therefore both
+    stand. The digest below is of a page carrying a live star counter and will not match on a later refetch;
+    that is expected drift on this source rather than a signal about the claim.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/mendableai/firecrawl
-    shows: ~129k GitHub stars, v2.10 (15 May 2026)
-    accessed: '2026-06-04'
+    shows: Repo page, 166,863 stargazers, AGPL-3.0. No download count, request count or customer count published.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: aee41ec84dd7499ff3e46d8b412424b56ae83f73395a9d51a7d294754ec61250
 capability:
   score: 4
   basis: feature_matrix
@@ -108,9 +115,18 @@ capability:
     handling; markdown/JSON/screenshot/structured output; P95 latency 3.4s, claims 96% web coverage
   confidence: medium
   note: 'Broad scrape/browse feature coverage (the recipe''s search/scrape dimensions: coverage, freshness,
-    structured output, rate limits), among the most capable open scrape tools; not a 5 (no benchmark,
-    and frontier reserved for category-definers).'
+    structured output, rate limits), among the most capable open scrape tools; not a 5 (no benchmark, and
+    frontier reserved for category-definers). Re-read 2026-08-13: the README still carries both figures
+    the recorded value quotes, verbatim - "Industry-leading reliability: Covers 96% of the web, including
+    JS-heavy pages" and "Blazingly fast: P95 latency of 3.4s across millions of pages" - and both remain
+    vendor-run rather than independently benchmarked, which is why the basis stays feature_matrix and the
+    band stays 4.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/mendableai/firecrawl
-    shows: 'feature list: search/scrape/crawl/map/agent/batch, LLM-ready output formats'
-    accessed: '2026-06-04'
+    shows: 'README feature list - scrape, crawl, map, search, agent extract and batch, with LLM-ready output
+      formats; "Covers 96% of the web, including JS-heavy pages"; "P95 latency of 3.4s across millions of
+      pages". The coverage figure links to the vendor''s own benchmark post, not to a third party.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: aee41ec84dd7499ff3e46d8b412424b56ae83f73395a9d51a7d294754ec61250

--- a/sources/scores/github-mcp.yaml
+++ b/sources/scores/github-mcp.yaml
@@ -13,12 +13,32 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: Fully MIT, first-party GitHub server.
+  note: 'Fully MIT, first-party GitHub server, no feature-gated core. Re-read 2026-08-13: the repository LICENSE
+    is the plain MIT License, "Copyright (c) 2025 GitHub", and the repo page carries the matching badge.
+    The whole Go server is in the tree with a Dockerfile and a goreleaser config beside it, so the self-hosted
+    build is the published build. GitHub also runs a hosted Remote GitHub MCP Server, and that is a managed
+    endpoint for the same server rather than a tier holding features back - the toolset list is the same
+    one, configured by header instead of by flag - which is the langchain shape the ladder settles as ungated.'
   raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
+  - url: https://raw.githubusercontent.com/github/github-mcp-server/main/LICENSE
+    shows: 'Plain MIT License text: "Copyright (c) 2025 GitHub".'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9e48ecfa18e2b15169746a3c97beda4d1d6c6796097038498ca434ca7e0ccd44
+    establishes:
+    - license
   - url: https://github.com/github/github-mcp-server
-    shows: MIT, ~30.8k stars, official GitHub server
-    accessed: '2026-06-17'
+    shows: Repo page - MIT badge, 32,220 stargazers, root tree carrying LICENSE, Dockerfile, .goreleaser.yaml
+      and the Go source. The Remote GitHub MCP Server section documents GitHub's hosted endpoint for the same
+      server and the same toolsets; no separate license, no license key, no enterprise directory.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 8be6c1224a3de08b51eeb4296ccd3f1bbfabcb637898be33a25ea27f32fa988c
+    establishes:
+    - source
+    - core-gated
 adoption:
   level: 3
   reach: '>10K stars'
@@ -27,19 +47,39 @@ adoption:
   note: '~31k stars; no download metric for Go/Docker distribution - stars_fallback (first-party backing
     implies higher real usage). Stars read 2026-08-13: 32,212 across the 1 declared repo, which bands at >10K
     stars, level 3 on the stars scale in signal_routing.yaml. The record carried no reach label at all before
-    this. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every
-    refetch, and the rest of the axis was not re-read.'
+    this. Re-read in full 2026-08-13: the repo page reports 32,220 stargazers, the same band, and the fallback
+    is still forced rather than chosen - the server is distributed as a Go binary and a Docker image plus
+    GitHub''s own hosted remote endpoint, none of which publishes a count, and there is no npm or PyPI package
+    to read. So the stars instrument and its level-3 cap both stand. The digest below is of a page carrying
+    a live star counter and will not match on a later refetch; that is expected drift on this source rather
+    than a signal about the claim.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/github/github-mcp-server
-    shows: ~30.8k stars
-    accessed: '2026-06-17'
+    shows: Repo page, 32,220 stargazers. Distribution is a Go binary, a Docker image and GitHub's hosted remote
+      endpoint; no package-registry download count exists for any of them.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 8be6c1224a3de08b51eeb4296ccd3f1bbfabcb637898be33a25ea27f32fa988c
 capability:
   score: 5
   basis: feature_matrix
   value: '20+ toolsets: repos, issues, PRs, Actions, code security, Dependabot, Discussions, Projects, Copilot'
   confidence: high
-  note: The most comprehensive GitHub-platform tool surface among MCP servers.
+  note: 'The most comprehensive GitHub-platform tool surface among MCP servers. Re-read 2026-08-13: the toolset
+    table still spans repositories, issues, pull requests, Actions, code security, Dependabot, discussions,
+    projects and Copilot, grouped in the README as repository management, CI/CD intelligence, code analysis
+    and team collaboration, with a default toolset applied when none is named and an Insiders mode for the
+    rest. It runs locally as a binary or Docker image and remotely against GitHub''s hosted endpoint with
+    the same toolsets. Band unchanged at 5.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/github/github-mcp-server
-    shows: toolset list
-    accessed: '2026-06-17'
+    shows: 'Toolset table with per-toolset icons, including dependabot; README groups them as repository management,
+      "CI/CD intelligence: Monitor GitHub Actions workflow runs, analyze build failures, manage releases",
+      "Code Analysis: Examine security findings, review Dependabot alerts" and "Team Collaboration: Access
+      discussions, manage notifications". Default toolsets apply when none is specified; Insiders mode and
+      the remote server documentation cover the rest.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 8be6c1224a3de08b51eeb4296ccd3f1bbfabcb637898be33a25ea27f32fa988c

--- a/sources/scores/google-grounding-api.yaml
+++ b/sources/scores/google-grounding-api.yaml
@@ -11,37 +11,68 @@ openness:
     managed:
       value: Vertex-AI/Gemini-Agent-Platform
   confidence: high
-  note: Fully proprietary Google Cloud managed grounding service; no open source component or self-host.
-    Tied to Gemini + Google Search index.
+  note: 'Fully proprietary Google Cloud managed grounding service; no open source component or self-host.
+    Tied to Gemini + Google Search index. Re-read 2026-08-13: Grounding with Google Search is still one row
+    in a table of managed grounding options inside the Gemini Enterprise Agent Platform, beside Google Maps,
+    Agent Search, RAG, Elasticsearch, Parallel and Exa. It is a platform feature reached through the Gemini
+    API, with no source, no weights and no self-hostable component of any kind. Score stays 1.'
   raw: license:proprietary(GCP-managed API);source:closed;managed:Vertex-AI/Gemini-Agent-Platform
+  last_verified: '2026-08-13'
   sources:
   - url: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/grounding/overview
-    shows: Grounding with Google Search listed as a managed grounding option in the Gemini Enterprise
-      Agent Platform; proprietary GCP feature
-    accessed: '2026-06-04'
+    shows: '"You can ground supported-model output in Gemini Enterprise Agent Platform in the following ways",
+      with Grounding with Google Search - "Connect your model to world knowledge and a wide possible range
+      of topics using results from Google''s search engine" - as one row beside Google Maps, Agent Search,
+      your own search API, RAG, Elasticsearch, Parallel and Exa. No source release, self-host or on-premise
+      option.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6cdb0c2ef2eb8c68310dc37b3cf5e7dbe6e430ef6f2bf224b95c75c40d326cd4
+    establishes:
+    - license
+    - source
+    - core-gated
 adoption:
   level: null
   reach: null
   signal_type: unknown
   confidence: low
-  note: Bundled feature of Vertex AI / Gemini Enterprise Agent Platform with no standalone usage figure
-    disclosed. The broad Vertex AI / Gemini surface is large, but no honest grounding-API-specific adoption
-    signal is verifiable; not scoring on the parent platform's reach.
+  note: 'Bundled feature of Vertex AI / Gemini Enterprise Agent Platform with no standalone usage figure disclosed.
+    The broad Vertex AI / Gemini surface is large, but no honest grounding-API-specific adoption signal is
+    verifiable; not scoring on the parent platform''s reach. Abstention re-confirmed 2026-08-13. What was
+    looked for on the overview page and not found - a request count, a customer count, a developer count
+    or a named-customer list for grounding specifically. What is there is a capability table and a benefits
+    list. Grounding remains a feature inside a platform rather than a product with its own meter, and there
+    is no package or registry artifact to band, so the abstention stands and is now dated.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/grounding/overview
-    shows: feature documented but no usage/customer figures for the grounding API itself
-    accessed: '2026-06-04'
+    shows: Grounding documented as a platform capability with a benefits list (reduces hallucinations, anchors
+      responses to your data sources, provides grounding support links for auditability) and a table of grounding
+      types. No usage, request or customer figure for the grounding API itself.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6cdb0c2ef2eb8c68310dc37b3cf5e7dbe6e430ef6f2bf224b95c75c40d326cd4
 capability:
   score: 4
   basis: feature_matrix
   value: 'coverage: full Google Search index grounding; freshness=live web; structured grounding metadata
     + citations/grounding-support attribution returned to the model'
   confidence: medium
-  note: Grounds LLM output in the full Google Search index with citation/grounding-support metadata,
-    best-in-class web freshness/coverage for agent grounding. Rated 4 on the coverage/freshness/structured-output
-    matrix; capped below 5 as detailed per-feature confirmation came from the overview page only (deeper
-    feature docs not fetched this run).
+  note: 'Grounds LLM output in the full Google Search index with citation/grounding-support metadata, best-in-class
+    web freshness/coverage for agent grounding. Rated 4 on the coverage/freshness/structured-output matrix;
+    capped below 5 as detailed per-feature confirmation came from the overview page only (deeper feature
+    docs not fetched this run). Re-read 2026-08-13 against the same overview page, so the cap''s stated reason
+    still applies exactly. The page confirms the coverage claim - "Connect your model to world knowledge
+    and a wide possible range of topics using results from Google''s search engine" - and the structured-output
+    claim, which it words as "Provides auditability by providing grounding support, which are links to sources".
+    Band unchanged at 4.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/grounding/overview
-    shows: grounds responses in Google Search/web within the agent platform
-    accessed: '2026-06-04'
+    shows: '"Connect your model to world knowledge and a wide possible range of topics using results from
+      Google''s search engine"; "Provides auditability by providing grounding support, which are links to
+      sources"; "Reduces model hallucinations". Overview level only - no per-feature reference on this page.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 6cdb0c2ef2eb8c68310dc37b3cf5e7dbe6e430ef6f2bf224b95c75c40d326cd4

--- a/sources/scores/jina-reader.yaml
+++ b/sources/scores/jina-reader.yaml
@@ -71,23 +71,37 @@ adoption:
     repo plus a widely-used hosted r.jina.ai endpoint; capped at 3 on stars/reported-traction fallback in the
     absence of a measured usage figure. Stars read 2026-08-13: 11,862 across the 1 declared repo, which bands
     at >10K stars, level 3 on the stars scale in signal_routing.yaml. The previous reach ''100K-1M'' was not a
-    label this instrument offers - stars have their own vocabulary because a star is not a download. No
-    last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch,
-    and the rest of the axis was not re-read.'
+    label this instrument offers - stars have their own vocabulary because a star is not a download. Re-read
+    in full 2026-08-13: the repo page reports 11,865 stargazers, the same band, and neither it nor jina.ai/reader
+    publishes a request count, a user count or any downloadable package for the reader itself - the product
+    is consumed as a URL prefix, so there is no registry to band. The stars fallback and its level-3 cap
+    therefore both stand. The digest below is of a page carrying a live star counter and will not match on
+    a later refetch; that is expected drift on this source rather than a signal about the claim.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/jina-ai/reader
-    shows: ~11k stars, active maintenance (550 commits), production SaaS backing
-    accessed: '2026-06-04'
+    shows: Repo page, 11,865 stargazers, Apache-2.0, "Convert any URL to an LLM-friendly input with a simple
+      prefix https://r.jina.ai/". No download, request or user figure.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 2036425188beee6cb596f6ff67b63e907edd64b625384651b3a366463539d515
 capability:
   score: 3
   basis: feature_matrix
   value: URL->LLM-friendly markdown; handles HTML/PDF/MS-Office/images (AI captioning); web search via
     s.jina.ai; stateless + optional caching; self-host or hosted
   confidence: medium
-  note: Solid single-purpose reader/scrape tool with multi-format coverage and a search mode; mid-tier
-    on the {coverage, freshness, structured output, rate limits} feature matrix vs full agentic browse/search
-    platforms.
+  note: 'Solid single-purpose reader/scrape tool with multi-format coverage and a search mode; mid-tier on
+    the {coverage, freshness, structured output, rate limits} feature matrix vs full agentic browse/search
+    platforms. Re-read 2026-08-13: the README still describes the same surface - URL to LLM-friendly markdown
+    via the r.jina.ai prefix, PDF and MS-Office input, image captioning, web search through s.jina.ai, and
+    a stateless mode with optional bucket caching. Nothing has been added that would move it against the
+    agentic browse platforms it is banded below, so the 3 stands.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/jina-ai/reader
-    shows: 'feature list: HTML/PDF/Office/image input, markdown output, search mode, caching'
-    accessed: '2026-06-04'
+    shows: 'Feature list - HTML, PDF and MS-Office input, image captioning, markdown output, search mode via
+      s.jina.ai, stateless operation with optional bucket caching.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 2036425188beee6cb596f6ff67b63e907edd64b625384651b3a366463539d515

--- a/sources/scores/markitdown.yaml
+++ b/sources/scores/markitdown.yaml
@@ -13,12 +13,34 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: Fully MIT; optional Azure/LLM features are pluggable, not gating.
+  note: 'Fully MIT; optional Azure/LLM features are pluggable, not gating. Re-read 2026-08-13, and the pluggable
+    claim was checked rather than assumed. The LICENSE is the plain MIT License, "Copyright (c) Microsoft
+    Corporation", and the repo page carries the matching badge. Azure Document Intelligence and Azure Content
+    Understanding are optional extras - the `[az-doc-intel]` and `[az-content-understanding]` install groups
+    - sitting in a capability table beside the built-in converters, which the README describes as offline
+    and format-specific. So the conversion the product exists to do runs entirely in the published package;
+    the Azure paths are alternatives you may buy, not a core withheld from it. core-gated stays ungated.'
   raw: license:MIT(OSI; repo LICENSE + pyproject, PyPI field null);source:public;no-feature-gated-core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://raw.githubusercontent.com/microsoft/markitdown/main/LICENSE
-    shows: MIT, Copyright Microsoft Corporation
-    accessed: '2026-06-18'
+    shows: 'Plain MIT License text: "Copyright (c) Microsoft Corporation".'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383
+    establishes:
+    - license
+  - url: https://github.com/microsoft/markitdown
+    shows: Repo page - MIT badge, root tree carrying LICENSE, Dockerfile and packages/. A capability table
+      compares "Built-in converters" (offline, format-specific) against Azure Document Intelligence and Azure
+      Content Understanding, both installed as optional extras `[az-doc-intel]` and `[az-content-understanding]`.
+      No license key, second license or enterprise directory.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0d8669638b70573b34edd1d33c32c3120695f1c25466cd087ac848083108d0e9
+    establishes:
+    - source
+    - core-gated
 adoption:
   level: 5
   signal_type: usage_volume
@@ -41,8 +63,20 @@ capability:
   value: converts PDF/DOCX/PPTX/XLSX/images(OCR)/audio/HTML/CSV/JSON/XML/ZIP/EPub/YouTube -> Markdown; CLI + Python
     API + Docker; plugins; optional Azure Doc Intelligence + LLM vision
   confidence: medium
-  note: Broadest format coverage among RAG ingestion tools; lighter on deep layout parsing than Docling.
+  note: 'Broadest format coverage among RAG ingestion tools; lighter on deep layout parsing than Docling.
+    Re-read 2026-08-13 and the recorded value holds clause for clause: the format list still runs PDF, Office
+    documents, images with OCR, audio with speech transcription, HTML, CSV/JSON/XML, ZIP (iterating over
+    contents), YouTube URLs and EPubs, and the optional-extra list still carries `[audio-transcription]`,
+    `[youtube-transcription]`, `[az-doc-intel]` and `[az-content-understanding]` alongside a plugin section
+    and a Dockerfile. Band unchanged at 4 - the depth gap against Docling on layout and table structure is
+    the same one.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/microsoft/markitdown
-    shows: format coverage + interfaces
-    accessed: '2026-06-18'
+    shows: 'Format list - PDF, Office documents, images (OCR), audio (speech transcription), HTML, text-based
+      formats (CSV, JSON, XML), "ZIP files (iterates over contents)", YouTube URLs, EPubs. Optional extras
+      `[audio-transcription]`, `[youtube-transcription]`, `[az-doc-intel]`, `[az-content-understanding]`;
+      a Plugins section; a Dockerfile in the root tree.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0d8669638b70573b34edd1d33c32c3120695f1c25466cd087ac848083108d0e9

--- a/sources/scores/mcp-inspector.yaml
+++ b/sources/scores/mcp-inspector.yaml
@@ -13,12 +13,40 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: Fully MIT.
+  note: 'Fully MIT, no feature-gated core. Re-read 2026-08-13, and the cited evidence had to be replaced:
+    this record said "MIT license file" and there is no LICENSE file in the repository at all - not at LICENSE,
+    not at LICENSE.md, and not in the root listing. MIT is still the right answer and is now sourced where
+    the project actually states it, in the README''s License section ("MIT.") and in package.json ("license":
+    "MIT"). Worth noting alongside the sibling repos: typescript-sdk and servers have both moved to the MCP
+    Apache-2.0 transition license and this one has not, so the org is no longer uniform. The whole tool is
+    in the published tree and runs via `npx @modelcontextprotocol/inspector` with no key or paid tier.'
   raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
+  - url: https://raw.githubusercontent.com/modelcontextprotocol/inspector/main/README.md
+    shows: 'License section reads, in full - "MIT." The repository root carries no LICENSE file; raw.githubusercontent
+      answers 404 for both main/LICENSE and main/LICENSE.md.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 60e4c9ed29f5a27f39d0251d5e8a6457698b43238e50689ad710f9e7e9838315
+    establishes:
+    - license
+  - url: https://raw.githubusercontent.com/modelcontextprotocol/inspector/main/package.json
+    shows: '"license": "MIT" - the machine-readable declaration, agreeing with the README.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 4ac78f0c8f933d02b13ad440fbceca0552a45c83aeac0c97ead664eeb891cbdb
+    establishes:
+    - license
   - url: https://github.com/modelcontextprotocol/inspector
-    shows: MIT license file
-    accessed: '2026-06-17'
+    shows: Repo page, 10,660 stargazers. Web, CLI and TUI clients plus shared core all in the tree, run from
+      one `npx @modelcontextprotocol/inspector` binary. No paid tier, license key or enterprise directory.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: ec7659bf41d4f9d37567c99cc494440d40d669d79edd9167076c65e1f54c87f0
+    establishes:
+    - source
+    - core-gated
 adoption:
   level: 3
   signal_type: usage_volume
@@ -37,10 +65,31 @@ adoption:
 capability:
   score: 4
   basis: feature_matrix
-  value: visual + CLI MCP debugging; all transports; request history/visualization; auth; multi-server config
+  value: three MCP debugging surfaces from one binary - a React web UI, a scriptable CLI for automation and
+    CI, and an Ink terminal UI; all transports including stateless streamable-HTTP; OAuth with discovery and
+    mid-session recovery; multi-server config
   confidence: high
-  note: Best-in-class for its debugging niche; narrower scope than the SDKs by design.
+  note: 'Best-in-class for its debugging niche; narrower scope than the SDKs by design. Re-read 2026-08-13
+    and the surface has GROWN since this value was written, so it has been restated rather than confirmed.
+    The tool is now at v2 and ships three clients from one `mcp-inspector` binary - Web (Vite + React + Mantine),
+    CLI ("a scriptable command-line client for automation, CI, and fast agent feedback loops") and TUI (Ink)
+    - where the record had only "visual + CLI". OAuth has grown into providers, discovery, storage and mid-session
+    recovery, and the connection can negotiate the modern 2026-07-28 protocol era alongside the legacy one.
+    The one clause dropped is "request history/visualization", which the README no longer mentions. The band
+    stays 4: this is still a debugger rather than a runtime, which is what puts it a rung under the SDKs.'
+  last_verified: '2026-08-13'
   sources:
+  - url: https://raw.githubusercontent.com/modelcontextprotocol/inspector/main/README.md
+    shows: '"three ways to inspect a server: Web - a Vite + React + Mantine single-page app with a Node backend.
+      CLI - a scriptable command-line client for automation, CI, and fast agent feedback loops. TUI - an interactive
+      terminal UI built with Ink." core/auth covers "OAuth: providers, discovery, storage, mid-session recovery".
+      A streamable-HTTP server can serve the modern 2026-07-28 protocol era or dual-era. NOT on the page:
+      request history or visualization.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 60e4c9ed29f5a27f39d0251d5e8a6457698b43238e50689ad710f9e7e9838315
   - url: https://github.com/modelcontextprotocol/inspector
-    shows: 'feature set: web UI + CLI debugging, all transports'
-    accessed: '2026-06-17'
+    shows: Repo page for the same README.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: ec7659bf41d4f9d37567c99cc494440d40d669d79edd9167076c65e1f54c87f0

--- a/sources/scores/mcp-python-sdk.yaml
+++ b/sources/scores/mcp-python-sdk.yaml
@@ -13,12 +13,42 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: Fully MIT reference SDK.
+  note: 'Fully MIT reference SDK. Re-read 2026-08-13. The repository LICENSE is still the plain MIT License,
+    "Copyright (c) 2024 Anthropic, PBC" - worth stating because the sibling MCP repos are not: modelcontextprotocol/typescript-sdk
+    and modelcontextprotocol/servers have both moved to the project''s Apache-2.0 transition license, and
+    this one has not. PyPI agrees, classifying `mcp` as "OSI Approved :: MIT License", though its Author
+    field now reads "Model Context Protocol a Series of LF Projects, LLC" where this record had Anthropic
+    PBC. The whole SDK is in the published repo and installs from PyPI with no key or paid tier, so core-gated
+    stays ungated.'
   raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://pypi.org/project/mcp/
-    shows: MIT, package 'mcp', author Anthropic PBC
-    accessed: '2026-06-17'
+    shows: 'Package `mcp`. "License MIT License (MIT)", classifier "OSI Approved :: MIT License", "This project
+      is licensed under the MIT License." Author - Model Context Protocol a Series of LF Projects, LLC; maintainer
+      David Soria Parra. Latest release 2026-07-28.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c0d00a07217e5f2d73c1b99250d1c8643d56fceeb9eef530ac6c15a9c833f5f6
+    establishes:
+    - license
+  - url: https://raw.githubusercontent.com/modelcontextprotocol/python-sdk/main/LICENSE
+    shows: 'Plain MIT License text: "Copyright (c) 2024 Anthropic, PBC". No Apache-2.0 transition preamble,
+      unlike the typescript-sdk and servers repositories.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 5e13dbbc1d120fc2a03cecde7c91424ae2d7de11b63d58ded2f4431e261ee50d
+    establishes:
+    - license
+  - url: https://github.com/modelcontextprotocol/python-sdk
+    shows: Repo page, 24,000 stargazers. The whole SDK is in the tree; install is `uv add "mcp[cli]"` with
+      no key. No enterprise directory, second license or paid tier.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 95eba3f326fa703f49d41a7e7a3a254b7d4545d0fbcd5f5376cea16404ac4cde
+    establishes:
+    - source
+    - core-gated
 adoption:
   level: 5
   signal_type: usage_volume
@@ -39,10 +69,23 @@ adoption:
 capability:
   score: 5
   basis: feature_matrix
-  value: client+server; stdio/SSE/Streamable-HTTP; FastMCP; structured output; OAuth 2.1; elicitation
+  value: client+server; every standard transport - stdio, Streamable HTTP and SSE; tools, resources and prompts;
+    an `mcp` CLI (dev/run/install)
   confidence: high
-  note: Most complete Python MCP toolkit.
+  note: 'Most complete Python MCP toolkit. Re-read 2026-08-13, and the recorded value did not fully survive
+    it. The README has been trimmed to three bullets - build servers exposing "tools, resources, and prompts
+    to any MCP host", build clients, and "Speak every standard transport: stdio, Streamable HTTP, and SSE"
+    - and no longer mentions FastMCP, structured output, OAuth 2.1 or elicitation anywhere on the page. Those
+    clauses are removed rather than restated elsewhere, because a capability value has to be traceable to
+    the source under it and these now are not. The band is left at 5: what the page does show is still the
+    reference implementation of the protocol in Python, carrying every transport the spec defines, and nothing
+    suggests capability was lost - only that the README stopped enumerating it.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/modelcontextprotocol/python-sdk
-    shows: 'feature set: client/server, transports, FastMCP, OAuth'
-    accessed: '2026-06-17'
+    shows: 'README - build MCP servers exposing tools, resources and prompts to any host; build MCP clients;
+      "Speak every standard transport: stdio, Streamable HTTP, and SSE". The `cli` extra adds `mcp dev`,
+      `mcp run` and `mcp install`. NOT on the page: FastMCP, OAuth 2.1, structured output or elicitation.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 95eba3f326fa703f49d41a7e7a3a254b7d4545d0fbcd5f5376cea16404ac4cde

--- a/sources/scores/mcp-typescript-sdk.yaml
+++ b/sources/scores/mcp-typescript-sdk.yaml
@@ -4,8 +4,14 @@ openness:
   class: open_source
   components:
     license:
+    - name: Apache-2.0
+      detail: OSI, new code
     - name: MIT
-      detail: OSI
+      detail: OSI, legacy contributions not yet relicensed
+    docs:
+      value: CC-BY-4.0
+      detail: documentation other than the specifications; not read by the openness ladder, which scores the
+        artifact the product ships
     source:
       value: public
     core-gated:
@@ -13,12 +19,53 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: Fully MIT reference SDK.
-  raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
+  note: 'Fully OSI-licensed reference SDK, no feature-gated core. LICENSE CORRECTED 2026-08-13. This record
+    said MIT; the repository''s LICENSE is now the MCP project''s transition text, identical byte-for-byte
+    to the one on the spec repo - "All new code and specification contributions to the project are licensed
+    under Apache-2.0", documentation other than specifications under CC-BY-4.0, and pre-transition contributions
+    whose authors have not consented remaining MIT. package.json says so too, carrying "license": "SEE LICENSE
+    IN LICENSE" rather than a bare SPDX id. The components now mirror model-context-protocol''s: both code
+    licenses under `license`, the documentation license under a `docs:` key the ladder does not read, because
+    a license covering PROSE must not govern the artifact you run. Both parts are OSI, the tier is unchanged,
+    and the score stays 5/open_source - this is the record catching up with the project, not a re-scoring.'
+  raw: license:Apache-2.0(OSI, new code)+MIT(OSI, legacy contributions not yet relicensed);docs:CC-BY-4.0(documentation
+    other than the specifications; not read by the openness ladder, which scores the artifact the product
+    ships);source:public;no-feature-gated-core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.npmjs.com/package/@modelcontextprotocol/sdk
-    shows: MIT, ~154M downloads/30d
+    shows: The npm package page. Not re-read this pass - the registry answered HTTP 403 to the fetcher on
+      2026-08-13 - so the license was re-derived from the repository LICENSE and package.json instead.
     accessed: '2026-06-17'
+  - url: https://raw.githubusercontent.com/modelcontextprotocol/typescript-sdk/main/LICENSE
+    shows: 'The MCP transition license, whose digest is byte-identical to the spec repo''s: "The MCP project
+      is undergoing a licensing transition from the MIT License to the Apache License, Version 2.0. All new
+      code and specification contributions to the project are licensed under Apache-2.0. Documentation contributions
+      (excluding specifications) are licensed under CC-BY-4.0. Contributions made by authors who originally
+      licensed their work under the MIT License and who have not yet granted explicit permission to relicense
+      remain licensed under the MIT License." Followed by the full Apache-2.0 text.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0382b0057770ca05e9c350a50aa3b1c1fea84da0bc81d723bf00b9aa841be58a
+    establishes:
+    - license
+  - url: https://raw.githubusercontent.com/modelcontextprotocol/typescript-sdk/main/package.json
+    shows: '"license": "SEE LICENSE IN LICENSE" - the package no longer declares a bare SPDX id, which is
+      the machine-readable half of the transition above.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 154e5e4b5dd7800a0d6de39af3e02997635ab3e538ca986eba5b396de3d26a7a
+    establishes:
+    - license
+  - url: https://github.com/modelcontextprotocol/typescript-sdk
+    shows: Repo page, 13,160 stargazers. The whole SDK is in the tree and installs from npm with no key; no
+      enterprise directory, second license or paid tier.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 63924218dd6803902c5f600a97a0fa764c5984f3532e51df5d1ac347af92c305
+    establishes:
+    - source
+    - core-gated
 adoption:
   level: 5
   signal_type: usage_volume
@@ -39,8 +86,16 @@ capability:
   basis: feature_matrix
   value: client+server; Node/Bun/Deno; Streamable-HTTP/stdio; auth + framework middleware
   confidence: high
-  note: Feature parity with the Python SDK; the canonical JS/TS MCP implementation.
+  note: 'Feature parity with the Python SDK; the canonical JS/TS MCP implementation. Re-read 2026-08-13:
+    the repository still publishes the full client and server libraries across the Node/Bun/Deno runtimes
+    with the stdio and Streamable-HTTP transports, and it remains the reference implementation the spec repo
+    points at. The recorded value is unchanged and the 5 stands - the same rung as the Python SDK, which
+    is what parity means here.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/modelcontextprotocol/typescript-sdk
-    shows: 'feature set: client/server, multi-runtime, transports'
-    accessed: '2026-06-17'
+    shows: Repo page - client and server libraries, multi-runtime support, stdio and Streamable-HTTP transports,
+      auth helpers and framework middleware. 13,160 stargazers.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 63924218dd6803902c5f600a97a0fa764c5984f3532e51df5d1ac347af92c305

--- a/sources/scores/milvus.yaml
+++ b/sources/scores/milvus.yaml
@@ -12,45 +12,97 @@ openness:
     free_text:
     - LF-AI&Data-governed(Zilliz-Cloud is managed hosting, not gated core)
   confidence: high
-  note: license:Apache-2.0;source:public;LF-AI&Data-governed(Zilliz-Cloud is managed hosting, not gated
-    core)
+  note: 'license:Apache-2.0;source:public;LF-AI&Data-governed(Zilliz-Cloud is managed hosting, not gated
+    core). Re-read 2026-08-13: the LICENSE file resolves to the full Apache License 2.0 text, the repo
+    page carries an "Apache-2.0 license" badge, docker-compose self-host instructions and Zilliz Cloud
+    named only as the managed offering beside it, and Wikipedia''s infobox records Apache License 2.0 with
+    LF AI & Data graduation in June 2021. Nothing is withheld from the published tree, so source:public
+    and core-gated:ungated both hold.'
   raw: license:Apache-2.0;source:public;LF-AI&Data-governed(Zilliz-Cloud is managed hosting, not gated core);core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/milvus-io/milvus/blob/master/LICENSE
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+    shows: Full Apache License 2.0 text (11,357 bytes), served from raw.githubusercontent for the master
+      branch.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
+    establishes:
+    - license
   - url: https://github.com/milvus-io/milvus
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+    shows: Repo page - "Apache-2.0 license", 45,627 stargazers, docker-compose standalone install in the
+      README, Zilliz Cloud referenced as the managed service rather than as a tier holding functionality
+      back. No enterprise directory or separately licensed tree.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 35f8f51c1fec1c38b1261ac74d373d403a03f7626275874277e2adbfece05d31
+    establishes:
+    - source
+    - core-gated
   - url: https://en.wikipedia.org/wiki/Milvus_(vector_database)
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+    shows: Infobox license Apache License 2.0; joined LF AI & Data January 2020 and "became a graduate in
+      June 2021", citing the foundation's graduation announcement.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: edcc1d107b4e9016ed9e74e0cb31a651afbdb691a1cef1dd408f77bbdd1ec76e
+    establishes:
+    - license
 adoption:
   level: 3
   signal_type: reported_traction
   confidence: high
-  note: Described as the default open source engine for billion-scale semantic search; LF AI & Data graduate.
-    No precise verified deployment/download count, rated 3 on reported traction.
+  note: 'Described as the default open source engine for billion-scale semantic search; LF AI & Data graduate.
+    No precise verified deployment/download count, rated 3 on reported traction. Re-read 2026-08-13: Zilliz''s
+    own page still describes Milvus as an "Open-source vector database built for billion-scale vector similarity
+    search" and publishes no user, deployment or download figure; the repo page publishes only a star count
+    (45,627), which is a different instrument and may not be banded as usage volume. The reported-traction
+    level 3 therefore stands unchanged and the absence of a countable figure is re-confirmed. FLAG FOR A
+    HUMAN, raised in this pass and deliberately not acted on: the product DOES declare a pypi artifact,
+    pymilvus, with an artifact_exception saying in terms that "the client''s downloads are the best available
+    usage signal for the server". pymilvus reported 5,976,463 downloads in the trailing 30 days on 2026-08-13,
+    which bands at level 4 (1M-10M) as usage_volume. Qdrant - the same product shape, the same client-not-server
+    artifact_exception - bands on qdrant-client as usage_volume and scores 5. So milvus is abstaining from
+    a figure the map elsewhere treats as countable, and either milvus should move to usage_volume 4 or qdrant
+    should not be on usage_volume either. That is a ruling about the instrument rather than about this product,
+    so the level was left alone.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/milvus-io/milvus
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+    shows: Repo page, 45,627 stargazers. No download, deployment or customer figure of any kind.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 35f8f51c1fec1c38b1261ac74d373d403a03f7626275874277e2adbfece05d31
   - url: https://zilliz.com/what-is-milvus
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+    shows: '"Open-source vector database built for billion-scale vector similarity search"; LF AI & Data
+      trademark attribution in the footer. No published adoption count.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 3ec5137502914fb4bb8e54a2908950c6e70c9db60441133d3b76f7ffde223338
 capability:
   score: 4
   basis: benchmark
   basis_detail: ANN-Benchmarks
   value: null
   confidence: high
-  note: High-performance cloud-native vector ANN search; covered by independent ANN-Benchmarks and first-party
+  note: 'High-performance cloud-native vector ANN search; covered by independent ANN-Benchmarks and first-party
     VectorDBBench. v2.6 adds Storage Format V2, advanced JSON, BM25 full-text search. Rated on ANN benchmark
-    coverage / scale.
+    coverage / scale. Re-read 2026-08-13: milvus.io now leads with "Announcing Milvus 3.0 - Lake-Native
+    Vector Search, S3-based storage, and a More Powerful Retrieval Engine", so the released line has moved
+    past the v2.6 the note describes; the first-party benchmark harness is still there, now branded VDB
+    Bench ("Setting up a Milvus cluster for performance testing or benchmarking? Refer to VDB Bench"), and
+    the index-selection guidance still spans HNSW / IVF_SQ8 / IVF_PQ / DiskANN up to billion scale. BM25
+    full-text search is still described. The band 4 rests on that benchmark coverage and scale and is unchanged;
+    only the version prose above is now behind the product.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/milvus-io/milvus
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+    shows: Repo page - vector database feature set, standalone and distributed deployment.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 35f8f51c1fec1c38b1261ac74d373d403a03f7626275874277e2adbfece05d31
   - url: https://milvus.io/
-    shows: flagship phase-C verification source
-    accessed: '2026-06-04'
+    shows: Milvus 3.0 announcement headline; VDB Bench named as the benchmarking harness; index guidance
+      from HNSW through DiskANN at billion scale; BM25 full-text search.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b38fa01081763668421a2a358613aeb03435f74478a64a352f9c2771dfd856c6

--- a/sources/scores/model-context-protocol.yaml
+++ b/sources/scores/model-context-protocol.yaml
@@ -78,17 +78,44 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: De facto standard agent tool protocol. ~97M monthly SDK downloads in Mar 2026 (up from ~2M at
-    Nov 2024 launch); adopted natively by OpenAI (ChatGPT), Google DeepMind (Gemini), Microsoft, AWS;
-    >16,000 MCP servers in the wild (Nerq Q1 2026 census indexed 17,468). Native client/agent support
-    breadth is the headline MCP signal per recipe.
+  note: 'De facto standard agent tool protocol, adopted natively by OpenAI (ChatGPT, Agents SDK, Responses
+    API), Google DeepMind (Gemini), Microsoft and AWS, with more than 16,000 MCP servers in the wild. Re-read
+    2026-08-13, and one recorded figure did not survive it: the note claimed "~97M monthly SDK downloads
+    in Mar 2026 (up from ~2M at Nov 2024 launch)" and "4,750% growth since launch" on the strength of the
+    Zuplo retrospective. That page carries neither figure and never could have - it is dated 2025-11-24,
+    four months before the month it was cited for. What it does say is "Over 16,000 MCP servers exist in
+    the wild" and the vendor-adoption list, both of which the note keeps. The download claim has been replaced
+    with a measured one from the two reference SDK registries, read the same day: 335,363,270 PyPI downloads
+    in the trailing 30 days for `mcp` and 198,046,096 npm downloads for @modelcontextprotocol/sdk. Either
+    alone clears the >10M level-5 floor by more than an order of magnitude, so level 5 and reach >10M are
+    unchanged and now rest on a countable figure rather than on an aggregator sentence that was not there.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://en.wikipedia.org/wiki/Model_Context_Protocol
-    shows: adoption by OpenAI/Google DeepMind/Microsoft/AWS; SDKs across 7+ languages
-    accessed: '2026-06-04'
+    shows: Adoption by OpenAI, Google DeepMind, Microsoft and AWS; reference SDKs across seven-plus languages;
+      donation to the Linux Foundation.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 53d1b3c1bf371857fef3867e51fbdda5dc4b0a968746d50382ac9938dda69e1b
   - url: https://zuplo.com/blog/one-year-of-mcp
-    shows: ~97M monthly SDK downloads Mar 2026, 4,750% growth since launch (corroborating aggregator)
-    accessed: '2026-06-04'
+    shows: 'Dated 2025-11-24. "Over 16,000 MCP servers exist in the wild. OpenAI has adopted it across ChatGPT
+      (sort of), their Agents SDK, and their Responses API. Google DeepMind announced MCP support for Gemini.
+      Companies like GitHub, Block, Apollo, Replit, Sourcegraph, Linear, Zapier and many others have integrated
+      it into their platforms." NOT on this page, contrary to what this source previously claimed: any SDK
+      download figure, the number 97M, or a 4,750% growth rate.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: fb54a9906933810c9dfd626a702c5cbd300c0c7fd3e96d1dc55c3637322604cb
+  - url: https://pypistats.org/api/packages/mcp/recent
+    shows: last_month = 335,363,270 downloads for the reference Python SDK package `mcp`.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1a7debd70ebcd757caf055a242507ec284a8172fd0e452e2e0d79999bb79c79f
+  - url: https://api.npmjs.org/downloads/point/last-month/@modelcontextprotocol/sdk
+    shows: 198,046,096 downloads for the window 2026-07-11 to 2026-08-09 for the reference TypeScript SDK.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: a5daab95266dd756f2c613e07ac16b5636554268822c6a8c52e7caebcb051610
 capability:
   score: null
   basis: n/a
@@ -97,16 +124,48 @@ capability:
   note: 'A wire protocol is not benchmarked; capability is not a meaningful axis per recipe. Openness +
     adoption carry the signal.
 
-    LOAD-BEARING NULL, flagged 2026-08-13 and to be settled in the agent_tools_protocols verification
-    pass. A null capability does not abstain the way a null adoption does - build/serialize.py falls
-    through to adoption alone rather than dropping the product - so this record computes maturity 5.0
-    from its adoption 5, counts as a mature open product, and one mature open product IS the entire
-    stage>=4 threshold. This category''s stage-4 claim currently rests on an axis nobody has scored.
+    A NULL WORTH SETTLING, flagged 2026-08-13. A null capability does not abstain the way a
+    null adoption does - build/serialize.py falls through to adoption alone rather than dropping the
+    product - so this record computes maturity 5.0 from its adoption 5 and counts as a mature open
+    product on one axis while a reader assumes two.
 
-    The claim may well be right; a protocol every major vendor implements is not obviously immature.
-    But it is presently unfalsifiable, and the two ways out are different decisions: score capability
-    here on some defensible basis (implementation breadth, say), or declare adoption-only grading as a
-    per-category attribute the way `disclosure` already is, so that a category OPTS IN to it rather
-    than inheriting it from a fallback written for benchmark corpora. See docs/guides/gap-analysis.md,
-    "The two nulls are not symmetric".'
+    CORRECTION, recorded because the first version of this note overstated it: it said the category''s
+    stage rested on this null, on the reasoning that one mature open product is the entire stage>=4
+    threshold. Re-derived against build/serialize.py during the category pass, agent_tools_protocols
+    has SEVEN mature open products, six of which reach 4.5 with no null in the arithmetic. That clears
+    _STAGE5_MIN_MATURE, so the category is stage 5 and deleting this record entirely would leave six
+    and change nothing. The defect is policy hygiene, not a threshold rescue.
+
+    The recommendation from that pass is to DECLARE adoption-only grading for protocols rather than
+    score capability here, because implementation breadth is adoption wearing a capability label -
+    the map already bands this product''s adoption on SDK downloads, so putting breadth in capability
+    makes the blend (adoption + adoption) / 2. agent2agent-protocol has the identical shape. See
+    docs/guides/gap-analysis.md, "The two nulls are not symmetric".
+
+
+    RE-DERIVED 2026-08-13 in the agent_tools_protocols pass, and the premise above is WRONG on the
+    facts, which changes what is at stake rather than whether it matters. The null is not load-bearing
+    for the category. Counting the rule in build/serialize.py against the current corpus, seven fully-open
+    products in this category clear the 4.5 maturity floor - model-context-protocol, fastmcp, qdrant,
+    mcp-python-sdk, mcp-typescript-sdk, docling and markitdown - and six of the seven get there from a
+    real adoption AND a real capability score with no null anywhere in the arithmetic. Seven is at or
+    above _STAGE5_MIN_MATURE, so the category is at stage 5 rather than stage 4, and striking this record
+    out entirely leaves six, still above the threshold. So the claim "this category''s stage-4 claim rests
+    on an axis nobody has scored" was an error; the stage does not move either way.
+
+    What remains true is the methodological defect, and it should still be settled - a record that
+    computes a maturity of 5.0 from one axis, while a reader assumes two, is wrong in a way that will
+    matter in a category with fewer mature products. The recommendation from this pass is the SECOND
+    option, declaring adoption-only grading, and against the first. Every candidate basis for a score
+    fails a different test. Implementation breadth is adoption wearing a capability label: the map already
+    bands MCP''s adoption on SDK downloads and A2A''s on the count of supporting organizations, so putting
+    breadth here would let one instrument vote twice and make the blend (adoption + adoption) / 2. Spec
+    maturity is genuinely independent of uptake, but there is no ladder for it anywhere in the four
+    rubrics, it would be a fifth instrument sharing the `capability` field name with benchmark,
+    feature_matrix and internal-eval - the collision docs/guides/verification.md already names as the
+    reason not to structure this field - and with only two protocols on the map there is nothing to
+    anchor a `relative_to` against. A two-product feature matrix against agent2agent-protocol is the only
+    option the existing machinery could enforce, and it requires un-nulling A2A first, so it is not a
+    smaller change than the declaration. Declaring the exclusion fixes both protocols and every future
+    one in a single move, and it converts a fallback nobody chose into a policy someone can argue with.'
   sources: []

--- a/sources/scores/notion-mcp.yaml
+++ b/sources/scores/notion-mcp.yaml
@@ -13,12 +13,31 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: Fully MIT, first-party Notion server.
+  note: 'Fully MIT, first-party Notion server, no feature-gated core. Re-read 2026-08-13: the repository LICENSE
+    is the MIT permission grant, "Copyright (c) 2025 Notion Labs, Inc.", and the repo page carries the matching
+    badge. The whole server is in the tree and installs from npm with no key. Notion also runs a hosted MCP
+    endpoint documented at developers.notion.com, and that is a managed deployment of this same server rather
+    than a tier withholding tools from it, which the ladder settles as ungated.'
   raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
+  - url: https://raw.githubusercontent.com/makenotion/notion-mcp-server/main/LICENSE
+    shows: 'MIT permission grant: "Copyright (c) 2025 Notion Labs, Inc."'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 2fd3e5272a40483e9cc8140136b4438708a496ea2da2537b98f0f2bbb68148ee
+    establishes:
+    - license
   - url: https://github.com/makenotion/notion-mcp-server
-    shows: MIT, ~4.4k stars, official Notion server
-    accessed: '2026-06-17'
+    shows: Repo page - MIT badge, 4,588 stargazers, the whole server in the tree, installed from npm. The
+      hosted Notion MCP is pointed at as documentation rather than as a paid tier; no license key, second
+      license or enterprise directory.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 2551411540a29e3a7bafa33a61391a5cfb155ad2d0296ae021c2af21e94232f8
+    establishes:
+    - source
+    - core-gated
 adoption:
   level: 3
   signal_type: usage_volume
@@ -39,10 +58,24 @@ adoption:
 capability:
   score: 4
   basis: feature_matrix
-  value: ~22 tools across search, data sources, pages, blocks, comments; agent-optimized output
+  value: tools across search, data sources, pages, blocks and comments, with data sources the primary database
+    abstraction since v2.0.0; OAuth installation; token-optimized responses and Markdown page editing
   confidence: medium
-  note: Comprehensive single-product Notion API coverage.
+  note: 'Comprehensive single-product Notion API coverage. Re-read 2026-08-13: v2.0.0 migrated the server
+    to the Notion API 2025-09-03, "which introduces data sources as the primary abstraction for databases",
+    adding seven tools around query-data-source, retrieve-a-data-source, update-a-data-source and create-a-data-source.
+    The README also now leads on "Easy installation via standard OAuth. No need to fiddle with JSON or API
+    tokens anymore" and on tools "designed with optimized token consumption in mind". The recorded "~22 tools"
+    count is not stated on the page any more, so the value drops the number and keeps the surface; the band
+    is unchanged at 4.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/makenotion/notion-mcp-server
-    shows: 22-tool feature set
-    accessed: '2026-06-17'
+    shows: '"Version 2.0.0 migrates to the Notion API 2025-09-03 which introduces data sources as the primary
+      abstraction for databases", with seven new tools listed. "Easy installation via standard OAuth"; "Powerful
+      tools tailored to AI agents, including editing pages in Markdown. These tools are designed with optimized
+      token consumption in mind." Worked examples call v1/search and v1/comments. NOT on the page: a tool
+      count of 22 or any other number.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 2551411540a29e3a7bafa33a61391a5cfb155ad2d0296ae021c2af21e94232f8

--- a/sources/scores/perplexity-sonar-api.yaml
+++ b/sources/scores/perplexity-sonar-api.yaml
@@ -14,28 +14,49 @@ openness:
       detail: token + per-request pricing
       raw: cloud SaaS, token + per-request pricing
   confidence: high
-  note: Fully closed search-grounded API; no weights, source, or self-host path.
+  note: 'Fully closed search-grounded API; no weights, source, or self-host path. Re-read 2026-08-13: the
+    docs still describe Sonar, the Search API, the Embeddings API and the Agent API as hosted developer surfaces
+    priced per token and per request, and document no weights download, no source release and no self-host
+    or on-premise deployment. source stays closed and the score stays 1.'
   raw: license:Proprietary(API-only);source:closed(Sonar models, search index, ranking all proprietary);managed:cloud
     SaaS, token + per-request pricing
+  last_verified: '2026-08-13'
   sources:
   - url: https://docs.perplexity.ai/
-    shows: Sonar/Search/Embeddings APIs, token + per-request pricing, proprietary hosted service
-    accessed: '2026-06-04'
+    shows: Sonar, Search API, Embeddings API and Agent API documented as hosted endpoints with token and per-request
+      pricing. No weights, source release, self-host or on-premise option documented anywhere.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 19fc95d18eb21a0e33f6b8fed921be1d610daa1f1b0a70fbb08bcc977774d8da
+    establishes:
+    - license
+    - source
+    - core-gated
 adoption:
   level: 4
   signal_type: reported_traction
   confidence: medium
-  note: No standalone Sonar-API request/developer count is published by a primary source; Perplexity docs
+  note: 'No standalone Sonar-API request/developer count is published by a primary source; Perplexity docs
     confirm the API exists and is a core developer surface. Platform-level scale is large (45M+ MAU, ~1B+
     queries/month per 2026 reporting) but that is the consumer app, not the API specifically. Rated 4
     on reported developer-API traction within a clearly mass-scale parent platform; flagged that the headline
-    platform numbers are aggregator-reported and not API-specific.
+    platform numbers are aggregator-reported and not API-specific. Re-read 2026-08-13. The docs still document
+    Sonar, Search, Embeddings and Agent as a full developer surface and still publish no request count, developer
+    count or customer count for the API - which is what was looked for and not found, and why the instrument
+    stays reported_traction rather than moving to a measured one. The vendor api-platform page could not
+    be re-read - perplexity.ai answered HTTP 403 to the fetcher - so that source keeps its June date and the
+    confirmation rests on the docs alone. Level 4 unchanged.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://docs.perplexity.ai/
-    shows: Sonar API is a documented developer surface (Agent/Search/Embeddings)
-    accessed: '2026-06-04'
+    shows: Sonar, Search API, Embeddings API and Agent API documented as first-class developer surfaces. No
+      request, developer or customer figure appears anywhere in the docs.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 19fc95d18eb21a0e33f6b8fed921be1d610daa1f1b0a70fbb08bcc977774d8da
   - url: https://www.perplexity.ai/api-platform
-    shows: vendor API-platform page positioning Sonar for developers
+    shows: Vendor API-platform page positioning Sonar for developers. Not re-read on 2026-08-13 - the host
+      answered HTTP 403 - so this source keeps its earlier access date.
     accessed: '2026-06-04'
 capability:
   score: 4
@@ -44,10 +65,17 @@ capability:
     ranked Search API with filtering; Embeddings API for RAG; Agent API routes to external models (e.g.
     GPT-5.x)
   confidence: medium
-  note: Strong {coverage, freshness, structured output}, grounded answers + raw search + embeddings in
-    one API; near-frontier among agent search/retrieval APIs but a wrapper-plus-search rather than a category-defining
-    5.
+  note: 'Strong {coverage, freshness, structured output}, grounded answers + raw search + embeddings in one
+    API; near-frontier among agent search/retrieval APIs but a wrapper-plus-search rather than a category-defining
+    5. Re-read 2026-08-13: all four surfaces the recorded value names are still documented - the Sonar tiers,
+    the ranked Search API, the Embeddings API for RAG and the Agent API that routes to external models -
+    and nothing in the docs turns the product into something other than retrieval wrapped around a model.
+    Band unchanged at 4.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://docs.perplexity.ai/
-    shows: Sonar/Sonar Pro grounded search, Search API filtering, Embeddings, Agent API model routing
-    accessed: '2026-06-04'
+    shows: Sonar and Sonar Pro grounded search with context-depth pricing, ranked Search API with filtering,
+      Embeddings API, Agent API routing to external models.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 19fc95d18eb21a0e33f6b8fed921be1d610daa1f1b0a70fbb08bcc977774d8da

--- a/sources/scores/pinecone.yaml
+++ b/sources/scores/pinecone.yaml
@@ -14,18 +14,37 @@ openness:
     managed:
       value: Pinecone-Cloud
   confidence: high
-  note: Fully proprietary managed vector DB; no open source core (contrast Milvus/Qdrant which are OSI-licensed).
-    BYOC is still closed-source software run in customer cloud.
+  note: 'Fully proprietary managed vector DB; no open source core (contrast Milvus/Qdrant which are OSI-licensed).
+    BYOC is still closed-source software run in customer cloud. Re-read 2026-08-13, and the BYOC judgment
+    in particular was checked rather than carried forward. The pricing page describes BYOC as "Pinecone in
+    your cloud account and VPC" with "Zero-access operations - no SSH, VPN, or inbound access required" -
+    which is Pinecone''s own software running on your infrastructure, not source you receive, so it does not
+    make the core self-hostable and `self-host: none` holds. The tier list is unchanged at Starter, Builder,
+    Standard and Enterprise, and the words "open source" appear nowhere on the page. Score stays 1.'
   raw: license:proprietary(SaaS);source:closed;self-host:none(BYOC runs Pinecone-managed in customer VPC,
     not OSS);managed:Pinecone-Cloud
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.pinecone.io/pricing/
-    shows: proprietary tiered SaaS pricing (Starter/Builder/Standard/Enterprise/BYOC); no OSS/self-host
-      license
-    accessed: '2026-06-04'
+    shows: 'Tiers Starter, Builder, Standard and Enterprise, plus BYOC: "Bring-your-own-cloud (BYOC) runs
+      Pinecone in your cloud account and VPC. Pinecone does not need SSH, VPN, or inbound network access
+      to operate the system." Enterprise adds a 99.95% uptime SLA, private endpoints and customer-managed
+      keys. The phrase "open source" does not appear on the page.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: d686117aacefb4fe49f4977205748e7233f1b2914b875a897642db44761f46dc
+    establishes:
+    - license
+    - source
+    - self-host
   - url: https://docs.pinecone.io/guides/get-started/overview
-    shows: described as 'fully managed vector database', billions of items searched in ms
-    accessed: '2026-06-04'
+    shows: Pinecone documented as a fully managed vector database reached through an API key; no source release
+      or self-hostable build offered.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0438b9bbff90bd6f1bc61afe2c4e91234944fa4b2426eb94a6073c33329bc9b4
+    establishes:
+    - source
 adoption:
   level: 4
   reach: 1M-10M
@@ -34,14 +53,29 @@ adoption:
   note: Leading managed vector DB; production deployments cited at 1.4B vectors / 5,700 QPS for a single
     e-commerce customer and 135M vectors / 2,200 QPS load-tested for another. Broad enterprise/developer
     base via serverless + AWS Marketplace PAYG. No single hard user count published; placed at 4 on aggregate
-    production usage_volume. (Some churn noted, e.g. Notion left over cost.)
+    production usage_volume. (Some churn noted, e.g. Notion left over cost.) Re-read 2026-08-13 and both cited
+    deployments are still on the page verbatim - "5,700 queries per second with a P50 latency of just 26
+    milliseconds across a database of 1.4 billion vectors" for the e-commerce customer, and 600 QPS at 45ms
+    across 135 million vectors with a load test reaching "2,200 queries per second with a P50 latency of
+    just 60 milliseconds" for the design platform. Still no single published user or customer count, which
+    is what was looked for; the band remains an aggregate judgment over production deployments and stays
+    at 4.
+  last_verified: '2026-08-13'
   sources:
   - url: https://siliconangle.com/2025/12/01/pinecone-scales-vector-database-support-demanding-workloads/
-    shows: billion-scale production workloads, multi-thousand QPS customer deployments
-    accessed: '2026-06-04'
+    shows: 'Two named-shape customer deployments: 600 QPS at 45ms over 135 million vectors, load-tested to
+      "2,200 queries per second with a P50 latency of just 60 milliseconds"; and "5,700 queries per second
+      with a P50 latency of just 26 milliseconds across a database of 1.4 billion vectors". No user or customer
+      count.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 065aca152e1b956651a4e7c6637129f8e68e42f7c3c1a9332564ea6f684c23b2
   - url: https://aws.amazon.com/marketplace/pp/prodview-xhgyscinlz4jk
-    shows: Pinecone PAYG distribution via AWS Marketplace (broad enterprise availability)
-    accessed: '2026-06-04'
+    shows: Pinecone listed on AWS Marketplace with pay-as-you-go availability. Distribution breadth only;
+      no usage figure.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9b7f9b8d0bd8d3b225d0887a5c1749ef139f07c79649e5f0dd8ad706205d8e63
 capability:
   score: 4
   basis: benchmark
@@ -51,13 +85,27 @@ capability:
   value: P50 latency ~26-60ms at 1.4B-vector scale, 5,700 QPS; serverless auto-indexing, dedicated read
     nodes
   confidence: medium
-  note: Top-tier managed ANN search at billion-vector scale with strong latency/QPS. No independent ANN-Benchmarks/VectorDBBench
-    submission found (closed system, vendor-reported figures); rated 4 (peer to Milvus C4), reserving
-    5 for benchmark-proven frontier.
+  note: 'Top-tier managed ANN search at billion-vector scale with strong latency/QPS. No independent ANN-Benchmarks/VectorDBBench
+    submission found (closed system, vendor-reported figures); rated 4 (peer to Milvus C4), reserving 5 for
+    benchmark-proven frontier. Re-read 2026-08-13. The latency and QPS figures in the recorded value are
+    still on the page as written - 26ms P50 at 5,700 QPS over 1.4 billion vectors, 60ms P50 at 2,200 QPS
+    on a load test - and Dedicated Read Nodes are still the mechanism described. Re-checked the absence too:
+    ann-benchmarks.com was fetched the same day and lists 38 algorithms, none of them Pinecone, so the "no
+    independent submission" half of this note is a confirmed finding rather than an assumption. The Milvus
+    anchor was re-read and re-dated the same day and also holds at 4, so `relation: at` remains arithmetically
+    true.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.infoq.com/news/2025/12/pinecone-drn-vector-workloads/
-    shows: dedicated read nodes for predictable vector workloads, serverless scaling
-    accessed: '2026-06-04'
+    shows: Dedicated read nodes for predictable vector workloads; serverless scaling.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 2a84fad84298a7a3621b4a6f9a0de72c2a80f447e146bebca16bd1d161b6dcd7
   - url: https://siliconangle.com/2025/12/01/pinecone-scales-vector-database-support-demanding-workloads/
-    shows: 26-60ms P50 latency, thousands of QPS at billion-vector scale
-    accessed: '2026-06-04'
+    shows: '"5,700 queries per second with a P50 latency of just 26 milliseconds across a database of 1.4
+      billion vectors"; and 600 QPS at 45ms over 135 million vectors, load-tested to "2,200 queries per second
+      with a P50 latency of just 60 milliseconds". Vendor-sourced figures reported by a trade outlet, not
+      an independent harness.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 065aca152e1b956651a4e7c6637129f8e68e42f7c3c1a9332564ea6f684c23b2

--- a/sources/scores/playwright-mcp.yaml
+++ b/sources/scores/playwright-mcp.yaml
@@ -15,12 +15,29 @@ openness:
     - no-feature-gated-core
     - no-managed-tier
   confidence: high
-  note: Fully OSI-licensed Microsoft repo, no open-core split.
+  note: 'Fully OSI-licensed Microsoft repo, no open-core split. Re-read 2026-08-13: the repository LICENSE
+    resolves to the full Apache License 2.0 text and the repo page carries the matching Apache-2.0 badge.
+    The whole server is in the tree and it is installed as a single npm package with no key, no enterprise
+    directory and no hosted tier sold beside it, so nothing is withheld from the published source.'
   raw: license:Apache-2.0(OSI);source:public(Microsoft repo);no-feature-gated-core;no-managed-tier;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/microsoft/playwright-mcp
-    shows: Apache-2.0 license, v0.0.75 (7 May 2026)
-    accessed: '2026-06-04'
+    shows: Repo page - Apache-2.0 license badge, full server source, npm install instructions for the MCP
+      clients. No paid tier, license key or enterprise directory.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 798fec7303430fec1d0b5046dbac0a4da612ae0c8518a72a41c5b70cad0d4478
+    establishes:
+    - source
+    - core-gated
+  - url: https://raw.githubusercontent.com/microsoft/playwright-mcp/main/LICENSE
+    shows: The full Apache License, Version 2.0 text.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 9a7110fc2d2f964038e5dc49128f908f29f47a574c961cba16085914e879cbda
+    establishes:
+    - license
 adoption:
   level: 4
   reach: 1M-10M
@@ -30,20 +47,43 @@ adoption:
     shipped/recommended across major MCP clients (VS Code, Cursor, Claude Desktop). npm download page
     returned HTTP 403 this run so an exact weekly-download figure could not be fetched; level 4 rests
     on broad multi-client native integration plus 33.5k stars (corroborating, not basis). Confidence medium
-    pending a clean download number.'
+    pending a clean download number. FLAGGED FOR A HUMAN 2026-08-13, and deliberately NOT applied: the clean
+    number now exists. api.npmjs.org reports 25,901,643 downloads of @playwright/mcp for the window 2026-07-11
+    to 2026-08-09, which bands at level 5 (>10M) rather than the recorded 4, at high confidence rather than
+    medium. Changing a level is not this pass''s to make, so the axis carries no last_verified either - the
+    recorded value is the one that was NOT re-derived. The product also declares an npm artifact of
+    @anthropic-ai/mcp-playwright, which api.npmjs.org answers 404 for; the real package is @playwright/mcp,
+    and that declaration needs correcting before any fetcher bands this product automatically.'
   sources:
   - url: https://github.com/microsoft/playwright-mcp
-    shows: 33.5k stars, integration list across VS Code/Cursor/Claude Desktop and many MCP clients
-    accessed: '2026-06-04'
+    shows: 36,089 stargazers; integration instructions across VS Code, Cursor, Claude Code and other MCP
+      clients; the package installed is @playwright/mcp.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 798fec7303430fec1d0b5046dbac0a4da612ae0c8518a72a41c5b70cad0d4478
+  - url: https://api.npmjs.org/downloads/point/last-month/@playwright/mcp
+    shows: 25,901,643 downloads for the window 2026-07-11 to 2026-08-09.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b843947758b2887b19551acc31f41829b49cd4de630b81189b79412a6a0539fb
 capability:
   score: 4
   basis: feature_matrix
   value: structured accessibility-snapshot navigation, click/type/fill-form, screenshots, network requests,
     console, tabs, file upload, code-eval; cross-browser via Playwright
   confidence: medium
-  note: Deep, broad browser-control surface (the leading agentic browser tool); scored 4 on the scrape/browse
-    feature matrix, strong coverage but no standardized benchmark and not the single category-definer.
+  note: 'Deep, broad browser-control surface (the leading agentic browser tool); scored 4 on the scrape/browse
+    feature matrix, strong coverage but no standardized benchmark and not the single category-definer. Re-read
+    2026-08-13: the README''s tool list still works from structured accessibility snapshots rather than screenshots
+    and still spans navigation, browser_click / browser_type / browser_fill_form, screenshots, network requests,
+    console messages, tabs, file upload and code evaluation, across the Playwright browser set. The recorded
+    value is unchanged and no standardized benchmark for browser-control servers has appeared, so the basis
+    stays feature_matrix.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/microsoft/playwright-mcp
-    shows: browser automation feature set via structured snapshots
-    accessed: '2026-06-04'
+    shows: Tool list built on accessibility snapshots - navigate, click, type, fill form, screenshot, network
+      requests, console, tabs, file upload, evaluate.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 798fec7303430fec1d0b5046dbac0a4da612ae0c8518a72a41c5b70cad0d4478

--- a/sources/scores/postgres-mcp.yaml
+++ b/sources/scores/postgres-mcp.yaml
@@ -13,12 +13,30 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: Fully MIT.
+  note: 'Fully MIT, no feature-gated core. Re-read 2026-08-13: the repository LICENSE is the plain MIT License,
+    "Copyright (c) 2025, Crystal Corp.", and the repo page carries the matching badge. Despite the "Pro"
+    in the product name there is no paid edition - the whole server, index tuning and health checks included,
+    ships in the tree and runs from PyPI or the crystaldba/postgres-mcp Docker image with only a DATABASE_URI.
+    No license key, second license or enterprise directory.'
   raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
+  - url: https://raw.githubusercontent.com/crystaldba/postgres-mcp/main/LICENSE
+    shows: 'Plain MIT License text: "Copyright (c) 2025, Crystal Corp."'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 013c8daa80c427b5f98cf7ff16c0c79f2adc2a5bd29e05aef7775f43f6c00fdd
+    establishes:
+    - license
   - url: https://github.com/crystaldba/postgres-mcp
-    shows: MIT, ~2.9k stars, Postgres MCP Pro
-    accessed: '2026-06-17'
+    shows: Repo page - MIT badge, 3,188 stargazers, the whole server in the tree. Runs from PyPI or the crystaldba/postgres-mcp
+      Docker image with a DATABASE_URI and an --access-mode flag; nothing is withheld for a paid tier.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0fe59606d32afd588b7354d4e3f694c1c685117ef745f8a5adf3562a0cbefe53
+    establishes:
+    - source
+    - core-gated
 adoption:
   level: 3
   signal_type: usage_volume
@@ -40,8 +58,21 @@ capability:
   value: '9 tools: schema/object inspection, execute_sql w/ access modes, EXPLAIN + hypothetical indexes, slow-query
     analysis, index advising, health checks'
   confidence: medium
-  note: Richest open Postgres MCP surface, well beyond the archived read-only reference server.
+  note: 'Richest open Postgres MCP surface, well beyond the archived read-only reference server. Re-read 2026-08-13
+    and every clause of the recorded value holds. The README''s own subtitle is "A Postgres MCP server with
+    index tuning, explain plans, health checks, and safe sql execution", and the feature list runs Database
+    Health, Index Tuning ("explore thousands of possible indexes ... using industrial-strength algorithms"),
+    Query Plans with hypothetical-index simulation, Schema Intelligence and Safe SQL Execution via the --access-mode
+    flag. The tool table still carries explain_query, get_top_queries and analyze_db_health. Band unchanged
+    at 4.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/crystaldba/postgres-mcp
-    shows: 9-tool feature set
-    accessed: '2026-06-17'
+    shows: '"A Postgres MCP server with index tuning, explain plans, health checks, and safe sql execution."
+      Tool table - explain_query "Can be invoked with hypothetical indexes to simulate the behavior after
+      adding indexes"; get_top_queries "Reports the slowest SQL queries based on total execution time";
+      analyze_db_health "buffer cache hit rates, connection health, constraint validation, index health
+      (duplicate/unused/invalid), sequence limits, and vacuum health". Access modes set by --access-mode.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 0fe59606d32afd588b7354d4e3f694c1c685117ef745f8a5adf3562a0cbefe53

--- a/sources/scores/qdrant.yaml
+++ b/sources/scores/qdrant.yaml
@@ -94,11 +94,18 @@ adoption:
     the reach as 1M-10M). The map''s prevailing usage_volume level-5 floor is
     >10M/mo (cf. pydantic-ai ~31M, langgraph ~58M at level 5); Qdrant''s client
     volume clears it. It remains one above the Milvus anchor (A3) on download
-    volume, a leading open vector DB for RAG/agent retrieval.'
+    volume, a leading open vector DB for RAG/agent retrieval. Re-derived 2026-08-13: last_month = 19,077,155
+    for qdrant-client, down from the 23,061,488 recorded but still well clear of the >10M level-5 floor,
+    so the level and the >10M reach are both unchanged. The figure is the Python client rather than the
+    server, which is what the product''s artifact_exceptions block declares and why it is the usage signal
+    here.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/qdrant-client/recent
-    shows: last_month downloads = 23,061,488
-    accessed: '2026-06-25'
+    shows: last_month = 19,077,155 downloads for qdrant-client (last_week 4,271,948, last_day 681,811).
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1a02e7e2d8e098c2eeace43ebe454d513986d5564f20dea113fb621ca0a4d08b
 capability:
   score: 4
   basis: benchmark
@@ -109,13 +116,29 @@ capability:
     highest RPS and lowest latency in almost all scenarios vs Milvus/Weaviate/Elasticsearch/Redis at matched
     precision; advanced filtered-search query planning.'
   confidence: medium
-  note: Top-tier ANN engine on RPS/latency; tied with the Milvus anchor at C4 (frontier vector-DB capability).
-    Headline comparison is vendor-run (qdrant.tech/benchmarks); ANN-Benchmarks corroborates inclusion
-    but its interactive plots did not yield a clean ranking number this run, hence medium confidence.
+  note: 'Top-tier ANN engine on RPS/latency; tied with the Milvus anchor at C4 (frontier vector-DB capability).
+    Headline comparison is vendor-run (qdrant.tech/benchmarks); ANN-Benchmarks corroborates inclusion but
+    its interactive plots did not yield a clean ranking number this run, hence medium confidence. Re-read
+    2026-08-13, and both halves still hold. ANN-Benchmarks lists 38 algorithms rather than the 37 recorded,
+    with qdrant and Milvus(Knowhere) both among them, and it still publishes only interactive recall-versus-QPS
+    plots, no ranking table - so it corroborates inclusion and nothing more, exactly as the note says. The
+    vendor page still states "Qdrant achieves highest RPS and lowest latencies in almost all the scenarios,
+    no matter the precision threshold and the metric we choose", against Milvus, Weaviate, Elasticsearch
+    and Redis. The Milvus anchor was re-read and re-dated the same day and also holds at 4, so the recorded
+    relation `at` remains arithmetically true.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://ann-benchmarks.com/
-    shows: Qdrant included among 37 benchmarked ANN algorithms
-    accessed: '2026-06-04'
+    shows: Qdrant listed among 38 benchmarked ANN algorithms, alongside Milvus(Knowhere), faiss-ivf, scann,
+      hnswlib and weaviate. Results published as interactive recall-versus-queries-per-second plots per dataset;
+      no ranking table.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 13d5e2d00070ba5ec7dc53d4ce89e86c86cb7c0ef43803a4fe565f397c956861
   - url: https://qdrant.tech/benchmarks/
-    shows: Qdrant highest RPS/lowest latency vs Milvus/Weaviate/Elasticsearch/Redis (vendor benchmark)
-    accessed: '2026-06-04'
+    shows: 'Vendor benchmark, Observations section - "Qdrant achieves highest RPS and lowest latencies in
+      almost all the scenarios, no matter the precision threshold and the metric we choose. It has also shown
+      4x RPS gains on one of the datasets." Compared against Milvus, Weaviate, Elasticsearch and Redis.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: fd5094d6c8c1b0c729e2725a7b28cda8292b6b0979c2cd058d50f998cea21c0e

--- a/sources/scores/searxng.yaml
+++ b/sources/scores/searxng.yaml
@@ -18,14 +18,29 @@ openness:
     - reproducible-Docker-build
     - no-proprietary-backend
   confidence: high
-  note: Fully open source under copyleft AGPL-3.0, complete source public, reproducible official Docker image,
-    no proprietary backend or gated hosted tier - self-hosting (or community public instances) is the only
-    distribution.
+  note: 'Fully open source under copyleft AGPL-3.0, complete source public, reproducible official Docker
+    image, no proprietary backend or gated hosted tier - self-hosting (or community public instances) is
+    the only distribution. Re-read 2026-08-13: the repo page states "This project is licensed under the GNU
+    Affero General Public License (AGPL-3.0)" and GitHub''s own metadata reports spdxId AGPL-3.0. The whole
+    engine is in the tree - searx/, searxng_extra/, client/simple, container/, utils/ - with a container
+    build beside it and no ee/, enterprise/ or second-licensed path. There is nothing to gate with, because
+    the project sells nothing at all.'
   raw: license:AGPL-3.0(OSI);source:public(github.com/searxng/searxng);self-host:only(no official SaaS);reproducible-Docker-build;no-proprietary-backend;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/searxng/searxng
-    shows: AGPL-3.0 license; ~32k stars; privacy metasearch engine, no tracking
-    accessed: '2026-06-17'
+    shows: '"This project is licensed under the GNU Affero General Public License (AGPL-3.0)"; repo metadata
+      spdxId AGPL-3.0, "GNU Affero General Public License v3.0"; 35,415 stargazers. Root tree carries searx/,
+      searxng_extra/, client/simple, container/, docs/, tests/, utils/ and one LICENSE. No paid tier, hosted
+      service or enterprise directory.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c683e257d77e4041db383c7c89ad2537a869f026ce1668825aa8dd93d8c3035c
+    establishes:
+    - license
+    - source
+    - core-gated
+    - self-host
 adoption:
   level: 4
   reach: 1M-10M
@@ -40,22 +55,43 @@ adoption:
     so a lifetime total is not comparable to any other record on the scale. Level unchanged at 4. Recorded AS
     A DECLARED FLOOR, per the rule: a lifetime average understates a growing product, and SearXNG''s pull rate
     is not flat. Docker is not declared as an artifact here, so the figure lives in this note rather than in a
-    signal - the same gap issue #163 tracks. No last_verified claimed: only the figure was re-read.'
+    signal - the same gap issue #163 tracks. Re-derived 2026-08-13 from the Docker Hub repository payload rather
+    than from the rendered counter - pull_count 71,581,974, date_registered 2021-04-22 - which is 63.70 months
+    and an average of 1,123,660 pulls a month. That is the same 1M-10M band and the same level 4, and it still
+    reads as a declared floor for the reason above.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://hub.docker.com/r/searxng/searxng
-    shows: official image, 50M+ total pulls, ~1.5M weekly
-    accessed: '2026-06-17'
+    shows: Official image searxng/searxng. Repository payload gives pull_count 71,581,974, star_count 186, status
+      active, date_registered 2021-04-22.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 7a9d29c4bf78123a855e7869aeeb8331951e5c88c7a2d08734a62ff14f60a387
 capability:
   score: 4
   basis: feature_matrix
-  value: 'engines aggregated: up to 269 search services; API: JSON (also CSV/RSS) via ?format=json, no auth
-    required by default; programmatic access: simple HTTP GET; consumed as a web-search/RAG backend by Open
-    WebUI, Perplexica, Morphic, LibreChat; self-hostable official Docker image'
+  value: 'engines aggregated - a long declared list spanning general web, images, science, code and package
+    registries; API - JSON, CSV and RSS via ?format=json, GET or POST to /search; programmatic access - a
+    simple HTTP call, though many public instances disable the non-HTML formats; consumed as a web-search/RAG
+    backend by Open WebUI, Perplexica, Morphic, LibreChat; self-hostable official Docker image'
   confidence: medium
-  note: The reference open implementation of the search-backend slot - broad source aggregation, clean structured
+  note: 'The reference open implementation of the search-backend slot - broad source aggregation, clean structured
     JSON, fully self-hosted. Below top among AI search APIs because it is raw metasearch without the AI-native
-    extraction/reranking that proprietary peers (Tavily/Exa) layer on.
+    extraction/reranking that proprietary peers (Tavily/Exa) layer on. Re-read 2026-08-13, and one recorded
+    figure did not survive: the value claimed "up to 269 search services" on the strength of the search-API
+    page, and no number appears on that page at all - the engine roster lives in a separate Configured Engines
+    document and is a long unnumbered list. The count has been replaced by a description of what the list
+    covers rather than carried on an unsupported figure. What the page does establish is confirmed: GET and
+    POST /search, `?format=json` with CSV and RSS alternatives, and a caveat this record did not carry -
+    "many public instances have these formats disabled", which matters for anyone treating a public instance
+    as an API. Band unchanged at 4.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://docs.searxng.org/dev/search_api.html
-    shows: '?format=json search API; up to 269 search services aggregated'
-    accessed: '2026-06-17'
+    shows: 'Endpoints GET / , GET /search , POST / , POST /search with `?format=json` and `format=csv` examples.
+      "Be aware that many public instances have these formats disabled" and will return 403. Engine roster
+      is a separate Configured Engines page. NOT on this page: any count of aggregated search services, 269
+      or otherwise. Docs build 2026.8.13.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 217b29dab753375c44193abe49cd66b40e0e7a0e208a08188551fd70a51994f9

--- a/sources/scores/serper.yaml
+++ b/sources/scores/serper.yaml
@@ -12,35 +12,65 @@ openness:
       value: Serper-Cloud
       detail: key-gated
   confidence: high
-  note: Proprietary commercial SERP API; no source or self-host. Closed counterpart to OSS-adjacent search
-    tools, like Tavily/Exa per the recipe.
+  note: 'Proprietary commercial SERP API; no source or self-host. Closed counterpart to OSS-adjacent search
+    tools, like Tavily/Exa per the recipe. Re-read 2026-08-13: serper.dev is still a key-gated hosted API
+    priced per query - "2,500 free queries" then "starting at $0.30 per 1,000 queries" - with no repository,
+    no license, and no self-host or on-premise option offered anywhere on the page. source stays closed and
+    the score stays 1.'
   raw: license:proprietary(API-only);source:closed;managed:Serper-Cloud(key-gated)
+  last_verified: '2026-08-13'
   sources:
   - url: https://serper.dev
-    shows: commercial key-gated Google Search API, JSON output, 2,500 free queries then paid; no OSS license
-    accessed: '2026-06-04'
+    shows: Key-gated hosted Google Search API returning structured JSON. "Get 2,500 free queries"; pricing
+      "starting at $0.30 per 1,000 queries". No license, repository link, self-host or on-premise option.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: cbf8b2324e279fbab25e51bde39a73084618b4d43d17bdc061cb6f5060180ba0
+    establishes:
+    - license
+    - source
+    - core-gated
 adoption:
   level: null
   reach: null
   signal_type: unknown
   confidence: low
-  note: Popular low-cost SERP API widely wired into agent stacks (LangChain/CrewAI tool integrations),
-    but vendor publishes no hard user/query-volume figure and no primary download/API-call count is verifiable.
-    Declining to score adoption rather than rely on marketing 'fastest & cheapest' claims.
+  note: 'Popular low-cost SERP API widely wired into agent stacks (LangChain/CrewAI tool integrations), but
+    vendor publishes no hard user/query-volume figure and no primary download/API-call count is verifiable.
+    Declining to score adoption rather than rely on marketing ''fastest & cheapest'' claims. Abstention re-confirmed
+    2026-08-13. What was looked for on serper.dev and not found - a user count, a customer count, a developer
+    count, a total or monthly query volume, or a named-customer list. What is there is price and speed copy
+    only - "The World''s Fastest and Cheapest Google Search API", "search results in 1-2 seconds, at an unbeatable
+    price starting at $0.30 per 1,000 queries" - and $0.30 per 1,000 queries is a rate card, not a volume.
+    There is no package, repository or registry artifact to band either. So the abstention stands and is
+    now dated rather than merely unfilled.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://serper.dev
-    shows: no published user/query-volume figures, only marketing speed/price claims
-    accessed: '2026-06-04'
+    shows: '"The World''s Fastest and Cheapest Google Search API"; "search results in 1-2 seconds, at an unbeatable
+      price starting at $0.30 per 1,000 queries"; "Get 2,500 free queries". No user, customer, developer
+      or query-volume figure appears anywhere on the page.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: cbf8b2324e279fbab25e51bde39a73084618b4d43d17bdc061cb6f5060180ba0
 capability:
   score: 3
   basis: feature_matrix
   value: 'coverage: web/images/news/maps/shopping/video/scholar/patents/autocomplete; structured JSON
     output; ~1-2s latency; freshness=live Google index'
   confidence: medium
-  note: Broad search-type coverage with structured output and live freshness; solid feature matrix for
-    a search API, but thinner than full agent-search tools (no built-in extraction/answer synthesis like
-    Tavily/Exa). Rated 3 on coverage/freshness/structured-output dimensions.
+  note: 'Broad search-type coverage with structured output and live freshness; solid feature matrix for a
+    search API, but thinner than full agent-search tools (no built-in extraction/answer synthesis like Tavily/Exa).
+    Rated 3 on coverage/freshness/structured-output dimensions. Re-read 2026-08-13 and every element of the
+    recorded value is still on the page, including the latency figure: the vertical tabs still run through
+    Scholar and Patents, output is still structured JSON, and the meta description still promises "search
+    results in 1-2 seconds". Still no extraction or answer-synthesis endpoint, which is what keeps it a rung
+    under Tavily and Exa. Band unchanged at 3.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://serper.dev
-    shows: 9 search verticals, structured JSON, 1-2s latency
-    accessed: '2026-06-04'
+    shows: Vertical tabs including Scholar and Patents with worked structured-JSON responses; "search results
+      in 1-2 seconds". No extraction, crawl or answer-synthesis endpoint offered.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: cbf8b2324e279fbab25e51bde39a73084618b4d43d17bdc061cb6f5060180ba0

--- a/sources/scores/slack-mcp.yaml
+++ b/sources/scores/slack-mcp.yaml
@@ -13,12 +13,29 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: Fully MIT.
+  note: 'Fully MIT, no feature-gated core. Re-read 2026-08-13: the repository LICENSE is the plain MIT License,
+    "Copyright (c) 2025 Dmitrii Korotovskii", and the repo page carries the matching badge. The whole Go
+    server ships in the tree, installs from npm or Docker with no key, and the maintainer sells nothing beside
+    it - there is no hosted tier, enterprise directory or second license.'
   raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
+  last_verified: '2026-08-13'
   sources:
+  - url: https://raw.githubusercontent.com/korotovsky/slack-mcp-server/master/LICENSE
+    shows: 'Plain MIT License text: "Copyright (c) 2025 Dmitrii Korotovskii".'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: c9c83612abe6c352b95a2fc1146638accdd5b348b21cdef333cc78f756e22397
+    establishes:
+    - license
   - url: https://github.com/korotovsky/slack-mcp-server
-    shows: MIT, ~1.7k stars, v1.3.0
-    accessed: '2026-06-17'
+    shows: Repo page - MIT badge, 1,782 stargazers, the whole server in the tree. No paid tier, hosted service,
+      license key or enterprise directory.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: f38b737fc78075988b9677af13bebb862515ad41b6bfe040f4284135f1ae4c5d
+    establishes:
+    - source
+    - core-gated
 adoption:
   level: 3
   signal_type: usage_volume
@@ -42,8 +59,19 @@ capability:
   value: '18 tools: history/replies/search, posting, reactions, channel/user/usergroup management, saved items;
     stealth + OAuth modes'
   confidence: medium
-  note: Broad Slack read/write surface with an unusual no-permission stealth mode.
+  note: 'Broad Slack read/write surface with an unusual no-permission stealth mode. Re-read 2026-08-13: the
+    README still leads on the two access modes - "Run the server without requiring additional permissions
+    or bot installations (stealth mode), or use secure OAuth tokens" - and still lists stdio, SSE and HTTP
+    transports, proxy settings, DMs and group DMs, and Smart History fetch by date or count, alongside the
+    Tools table. Enterprise workspace support is named too, which the recorded value does not mention. Band
+    unchanged at 4.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/korotovsky/slack-mcp-server
-    shows: 18-tool feature set
-    accessed: '2026-06-17'
+    shows: 'README - "supports Stdio, SSE and HTTP transports, proxy settings, DMs, Group DMs, Smart History
+      fetch (by date or count), may work via OAuth or in complete stealth mode with no permissions and scopes
+      in Workspace". Feature list opens with "Stealth and OAuth Modes" and "Enterprise Workspaces Support";
+      a Tools section enumerates the tool set.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: f38b737fc78075988b9677af13bebb862515ad41b6bfe040f4284135f1ae4c5d

--- a/sources/scores/tavily-search-api.yaml
+++ b/sources/scores/tavily-search-api.yaml
@@ -14,14 +14,29 @@ openness:
       detail: credits, rate limits
       raw: cloud SaaS with API keys, credits, rate limits
   confidence: high
-  note: Closed search/scrape API (the recipe's closed counterpart to Milvus/Qdrant); only client SDKs
-    are open, the search service itself is proprietary.
+  note: 'Closed search/scrape API (the recipe''s closed counterpart to Milvus/Qdrant); only client SDKs are
+    open, the search service itself is proprietary. Re-read 2026-08-13: the docs are organized around API
+    credits and rate limits with hosted Search, Extract, Crawl, Map and Research endpoints, and the only
+    Open Source section in the navigation is a gallery of example projects BUILT WITH the API, not the API
+    itself. No self-host, on-premise or source-available option is documented anywhere in it. So source stays
+    closed and the score stays 1.'
   raw: license:Proprietary(API-only);source:closed(no self-hostable core; only thin client SDKs are public);managed:cloud
     SaaS with API keys, credits, rate limits
+  last_verified: '2026-08-13'
   sources:
   - url: https://docs.tavily.com/
-    shows: API keys, credits, rate limits, hosted endpoints, no self-hostable open core
-    accessed: '2026-06-04'
+    shows: 'Hosted Search, Extract, Crawl, Map and Research endpoints behind an API key. Developer Resources
+      lead with "API Credits Overview - Learn how Tavily API credits work" and "Rate Limits - Understand
+      Tavily''s rate limits and policies". The navigation''s Open Source group is "popular open source projects
+      that showcase Tavily''s use cases", i.e. consumers of the API. No self-hosting or source-available option
+      documented.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1bc9cddc56bca559ab891442291b6e2c633258084e35f89f5313586d043f5204
+    establishes:
+    - license
+    - source
+    - core-gated
 adoption:
   level: 4
   reach: 1M-10M
@@ -30,24 +45,43 @@ adoption:
   note: Tavily's own homepage states 2M+ developers and 300M+ monthly requests, billions of pages crawled
     (both figures re-confirmed on the live homepage 2026-06-04); it is the default search provider wired
     into LangChain/CrewAI/LlamaIndex agent stacks. Developer reach solidly in 1-10M band; request volume
-    is far higher. Acquisition by Nebius corroborates enterprise traction.
+    is far higher. Acquisition by Nebius corroborates enterprise traction. Re-read 2026-08-13 and both figures
+    are still on the homepage unchanged - "Trusted by 2M+ developers around the world" and a stats grid reading
+    300M+ "monthly requests handled" and Billions of pages extracted. The band is taken on the developer
+    count, which is what puts it at 1M-10M; the request figure would band higher but requests are not the
+    quantity this scale measures, and it stays in the note as context rather than as the basis. Level 4 unchanged.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.tavily.com/
-    shows: vendor-stated 2M+ developers, 300M+ monthly requests, billions of pages crawled
-    accessed: '2026-06-04'
+    shows: '"Trusted by 2M+ developers around the world"; stats grid - 300M+ "monthly requests handled", Billions
+      of pages "extracted without downtime".'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 987a586cfe2beef1f4c25a7e0cd6876e1898e948b737a62e1061be81d7155236
   - url: https://nebius.com/newsroom/nebius-announces-agreement-to-acquire-tavily-to-add-agentic-search-to-its-ai-cloud-platform
-    shows: Nebius agreement to acquire Tavily (Feb 2026), Tavily serving Fortune 500 / leading AI companies
-    accessed: '2026-06-04'
+    shows: Nebius agreement to acquire Tavily, positioning it as agentic search for the Nebius AI cloud. Corroborating
+      enterprise traction; carries no usage figure of its own.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 75aba5a8ab16b90ffdfbb4e23e31c2839e0688e680e4fec6b9bce1edc47a6f0c
 capability:
   score: 4
   basis: feature_matrix
   value: search + extract + crawl + map + research endpoints; real-time freshness; structured/LLM-ready
     output; SLA + rate limits; default integration across major agent frameworks
   confidence: medium
-  note: Full {coverage, freshness, structured output, rate limits} feature set purpose-built for agents
-    and the de-facto default in agent frameworks; near-frontier among agent search APIs but not the single
-    category-definer.
+  note: 'Full {coverage, freshness, structured output, rate limits} feature set purpose-built for agents and
+    the de-facto default in agent frameworks; near-frontier among agent search APIs but not the single category-definer.
+    Re-read 2026-08-13: the documented endpoint set is unchanged - Search, Extract, Crawl, Map and Research
+    - and the Research API now shows structured JSON-schema output with a citation_format option, which is
+    the structured-output dimension the band rests on. Rate limits and credits are still first-class documented
+    concerns. No independent benchmark for agent search APIs has appeared, so the basis stays feature_matrix
+    and the band stays 4.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://docs.tavily.com/
-    shows: search/extract/crawl/map/research endpoints with rate limits and credits
-    accessed: '2026-06-04'
+    shows: Search, Extract, Crawl, Map and Research endpoints; a Research API example returning a JSON schema
+      with `citation_format - numbered`; Credits and Rate Limits documented as developer resources.
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: 1bc9cddc56bca559ab891442291b6e2c633258084e35f89f5313586d043f5204

--- a/sources/scores/yomo.yaml
+++ b/sources/scores/yomo.yaml
@@ -97,10 +97,22 @@ capability:
     nodes, QUIC transport + TLS 1.3, OpenAI-compatible chat completions API, MCP and A2A integration,
     TypeScript and Go SDKs
   confidence: medium
-  note: Distinctive full agent runtime with an edge/geo-distributed angle and multi-language SDKs. Functional
-    and coherent feature set for the agent-tooling layer but narrower ecosystem and integration surface
-    than the category leaders (MCP itself, FastMCP). Rated 3 on feature breadth from repo/README review.
+  note: 'Distinctive full agent runtime with an edge/geo-distributed angle and multi-language SDKs. Functional
+    and coherent feature set for the agent-tooling layer but narrower ecosystem and integration surface than
+    the category leaders (MCP itself, FastMCP). Rated 3 on feature breadth from repo/README review. Re-read
+    2026-08-13 and the shape of the recorded value holds, with the emphasis shifted. The repo now describes
+    itself as a "Serverless AI Agent Framework with Geo-distributed Edge AI Infra" under a "Focuses on Geo-distributed
+    AI Inference Infra" heading, and its declared topics carry quic, function-calling, managed-skills, skills,
+    mcp, a2a-protocol and openai - so every element of the recorded value is still claimed by the project,
+    though the README states them as topics and headings rather than as the SDK list this record quotes.
+    Nothing found suggests the surface has widened toward the category leaders, so the 3 stands.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/yomorun/yomo
-    shows: 'feature set: function calling/skills, serverless edge deployment, QUIC, OpenAI-compatible API, MCP/A2A'
-    accessed: '2026-07-09'
+    shows: 'Repo page - "Serverless AI Agent Framework with Geo-distributed Edge AI Infra", section "Focuses
+      on Geo-distributed AI Inference Infra", worked example posting to a serverless function at /tool/get-weather.
+      Declared topics: a2a-protocol, agent-framework, distributed-cloud, function-calling, geodistributedsystems,
+      managed-skills, mcp, openai, quic, realtime, serverless, skills. 1,920 stargazers.'
+    accessed: '2026-08-13'
+    http_status: 200
+    content_sha256: b2383bbd1d926f9454c1a9a4feba1245a79938a0057fca8463a934ebfb4bb052

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -768,7 +768,7 @@ def test_real_sources_serialize_without_errors():
         # undeclared-key row, exactly as `autogen`'s CC-BY-4.0 documentation license
         # already did - which is the evidence that MCP was made to match an existing
         # convention rather than given a new one.
-        "agent_tools_protocols": 134, "dataset_processing_tools": 90, "evaluation_code": 107,
+        "agent_tools_protocols": 138, "dataset_processing_tools": 90, "evaluation_code": 107,
         # inference_code 47 -> 64 when the sweep read the category: four stale deferrals came
         # off (a deferred product publishes no openness evidence at all), and several products
         # that had described their gating in prose gained a readable `source:`/`core-gated:`.


### PR DESCRIPTION
**106 of 109 closed.** Three axes left undated as escalations.

## I was wrong, and this pass caught it

This morning I wrote into `gap-analysis.md` and onto `model-context-protocol`'s record that **this category's stage rested on MCP's null capability**, reasoning that one mature open product is the entire `stage >= 4` threshold.

The rule is real. The inference was never checked against the category. Re-derived against `build/serialize.py`:

```
7 mature open products in agent_tools_protocols
  5.0  model-context-protocol   (capability null)
  5.0  mcp-typescript-sdk
  5.0  mcp-python-sdk
  5.0  docling
  4.5  qdrant / markitdown / fastmcp
_STAGE5_MIN_MATURE = 4  =>  stage 5
without MCP: 6 mature open  =>  still stage 5
```

**Six of the seven reach 4.5 with no null in the arithmetic.** Deleting MCP entirely changes nothing. The methodological defect stands — a 5.0 maturity computed from one axis while a reader assumes two — but it's policy hygiene, not a threshold rescue. Both the guide and the record are corrected, with the correction *recorded* rather than quietly swapped.

## And it argued the fix better than I framed it

> *Implementation breadth is adoption wearing a capability label.*

The map already bands MCP's adoption on SDK downloads, so putting breadth in `capability` makes the blend `(adoption + adoption) / 2` — **worse** than the fall-through, because it launders one instrument into two votes while looking independent. Spec maturity is genuinely independent but has no ladder in any rubric and would become a fifth instrument sharing the field name. With two protocols on the map there's nothing to anchor a `relative_to` against.

Recommends declaring adoption-only grading for protocols. `agent2agent-protocol` has the identical shape, so a ruling should cover both.

## Licenses corrected — tier unchanged, but the MCP repos have diverged

`mcp-typescript-sdk` and `filesystem-mcp` both recorded plain MIT. Both repos now carry the MCP project's **transition LICENSE** — byte-identical digest to the spec repo's — Apache-2.0 for new code, CC-BY-4.0 for docs, MIT retained only for unrelicensed pre-transition contributions. **`mcp-python-sdk` is not affected** and still carries plain MIT, so the three MCP org repos are no longer licensed alike.

That's what moves the pinned evidence count `134 → 138` in `tests/test_serialize_rubric.py`. The agent correctly refused to edit `tests/` and reported the one-line fix instead; I made it.

## Escalated, not applied

- **`playwright-mcp` declares an npm artifact that does not exist.** `@anthropic-ai/mcp-playwright` 404s; the real package is `@playwright/mcp`, which reports **25,901,643** downloads → level 5 against a recorded 4.
- **`browser-use` 4 → 5** on 53,142,086 PyPI downloads — and its recorded `~27M` was *already* above the level-5 floor, so this axis has been a band low under its own figure.
- **`milvus` abstains from a figure `qdrant` counts.** Both declare a client rather than the server, both carry the same `artifact_exceptions` reasoning — `pymilvus` reads 5,976,463/30d. Either milvus moves to `usage_volume` or qdrant shouldn't be on it. An instrument ruling, so it was left and the conflict written onto the record.

## Nine cited figures that no longer exist

Each corrected in place with the band kept. The clearest: **`model-context-protocol` adoption cited "~97M monthly SDK downloads Mar 2026, 4,750% growth" to a page dated 2025-11-24** — four months *before* the month cited, and carrying neither figure. Replaced with measured registry reads (`mcp` 335,363,270 PyPI, `@modelcontextprotocol/sdk` 198,046,096 npm), so level 5 is now countable rather than asserted.

Also: `cohere-rerank-api`'s BEIR claim lives on a different cited page than the one it was attributed to; `mcp-inspector` cites an "MIT license file" that does not exist (MIT is real, sourced to the README and `package.json`); `apify`'s store shows 59,817 Actors, not 35,000+.

## Incidental, worth a repo-wide check

**`sources/products/yomo.yaml` had a silently truncated `comments` field** — ` #` inside a plain multi-line scalar starts a YAML comment, so everything after it, including the verification line, was never parsed. Worth grepping for ` #` in plain scalars corpus-wide.

All gates green: `validate` 0 errors, `check_verification` all three OK, `check_capability` OK, `check_adoption --strict` exit 0, `check_rubric` 32/32 reproduced, 488 tests.