### PR TITLE
snorkel-flow was renamed, not retired — closes dataset_processing_tools at 21/21

### DIFF
--- a/sources/products/snorkel-flow.yaml
+++ b/sources/products/snorkel-flow.yaml
@@ -1,9 +1,16 @@
 name: snorkel-flow
-display_name: Snorkel Flow
+display_name: Snorkel AI Data Development Platform
 type: software
-description: 'Snorkel AI''s commercial data-development platform: programmatic labeling and weak supervision
-  (heuristic and LLM-generated labeling functions), plus curation, slicing, filtering, and fine-tuning/evaluation
-  data workflows.'
-comments: 'Snorkel Flow, proprietary enterprise platform (distinct from the Apache-2.0 snorkel-team/snorkel
-  OSS library, which is stale: last release 0.10.0, Feb 2024). Confirmed 2026-07-21. ~$237M raised, ~$1.3B
-  valuation (Series D, May 2025); enterprise/government rather than frontier-lab customers.'
+description: 'Snorkel AI''s commercial data-development platform, shipping as version 26.1: programmatic
+  labeling and weak supervision (heuristic and LLM-generated labeling functions), plus curation, slicing,
+  filtering, and fine-tuning/evaluation data workflows. Deployed by the customer rather than consumed as
+  a service - the documentation carries an administrator guide covering installation, users, roles and
+  permissions.'
+comments: 'Verified live 2026-08-14 via docs.snorkel.ai. RENAMED, NOT RETIRED: the product ships today as
+  the "Snorkel AI Data Development Platform" (v26.1); "Snorkel Flow" is the former name and still labels the
+  archived doc versions. The slug stays `snorkel-flow` because slugs are immutable identities rather than
+  labels - see docs/guides/identity.md - and the rename is carried by display_name and here. A 2026-08-13
+  pass read only the marketing site, where /snorkel-flow/ now 301s to /data-development/ and the copy sells
+  data services, and concluded the platform was gone; the documentation site shows it is not. A vendor
+  reorganising its marketing is not evidence a product has been withdrawn. Distinct from the Apache-2.0
+  snorkel-team/snorkel OSS library, which is stale (last release 0.10.0, Feb 2024) and is not this entry.'

--- a/sources/scores/snorkel-flow.yaml
+++ b/sources/scores/snorkel-flow.yaml
@@ -3,42 +3,83 @@ openness:
   score: 1
   class: closed
   components:
-    license:
-    - name: Proprietary
     source:
       value: closed
-    free_text:
-    - proprietary enterprise SaaS
-    - the original 'snorkel' weak-supervision library is a separate Apache-2.0 OSS repo (stale), not the
-      shipped product
+      detail: no published source; the platform is installed from a licensed enterprise distribution
+    license:
+    - name: Proprietary
+    self-host:
+      value: 'yes'
+      detail: customer-deployed, but from a proprietary distribution rather than published source
   confidence: high
-  note: The commercial Snorkel Flow product is closed; the open snorkel library is separate and effectively
-    in maintenance/wind-down.
-  raw: license:Proprietary;source:closed;proprietary enterprise SaaS; the original 'snorkel' weak-supervision
-    library is a separate Apache-2.0 OSS repo (stale), not the shipped product
+  note: 'Re-read 2026-08-14 against docs.snorkel.ai, which is the source the record should have cited all
+    along. The documentation carries an administrator guide - "Find out how to install the Snorkel AI Data
+    Development Platform and manage users, roles, and permissions" - so the product IS customer-deployed,
+    which the previous record did not capture. That does not make it open: nothing on the documentation
+    site offers source, a repository or a license grant, and the footer carries Terms of Use, SOC and HIPAA
+    compliance badges rather than any OSI license. Self-hostable and closed-source are not in tension; the
+    software ladder settles on `source` regardless of deployment model. Score unchanged at 1/closed.'
+  last_verified: '2026-08-14'
+  raw: source:closed(no published source; the platform is installed from a licensed enterprise distribution);license:Proprietary;self-host:yes(customer-deployed,
+    but from a proprietary distribution rather than published source)
   sources:
-  - url: https://snorkel.ai
-    shows: Commercial enterprise data-development platform; separate OSS snorkel library is stale
-    accessed: '2026-07-21'
+  - url: https://docs.snorkel.ai/docs/26.1/administration/installation/prior-to-installing/installation-overview-and-conventions
+    shows: installation guide for the platform - establishes a customer-deployed product, and offers no
+      source, repository or license grant anywhere
+    accessed: '2026-08-14'
+    establishes:
+    - source
+    - license
+    - self-host
+    http_status: 200
+    content_sha256: cf25e5cf908549825c3f57d97ddb9e625b0754fdf2820896ea81422e900b14a0
+  - url: https://docs.snorkel.ai/
+    shows: 'product documented as "Snorkel AI Data Development Platform" v26.1, with User Guide, Admin
+      Guide and SDK sections; no open-source statement anywhere, footer carries Terms of Use plus AICPA
+      SOC and HIPAA badges'
+    accessed: '2026-08-14'
+    http_status: 200
+    content_sha256: 7d4603438e0f609f1f3559eb10a5d8209046008b88e29c744d9436ae4ae03774
 adoption:
   level: 3
   reach: niche
   signal_type: reported_traction
-  confidence: medium
-  note: ~$237M raised at a ~$1.3B valuation (Series D, May 2025); established enterprise/government adoption
-    rather than frontier-lab pretraining use. Directional.
+  confidence: low
+  note: 'Re-read 2026-08-14. Snorkel publishes no usage figure of any kind - no customer count, no
+    deployment count, no download count - so reported_traction with a qualitative reach is the correct
+    instrument and there is nothing to band on. Held at 3 on established enterprise/government traction.
+    THE PREVIOUS BASIS IS WITHDRAWN: the band cited a ~$1.3B Series D valuation that is not on any page
+    the record cites, and funding is not adoption in any case. What the live documentation does establish
+    is that the product is actively maintained and shipping - v26.1, with dated release notes - which is
+    what a level-3 reported_traction band rests on here.'
+  last_verified: '2026-08-14'
   sources:
-  - url: https://snorkel.ai
-    shows: Enterprise data-development platform; ~$1.3B valuation (Series D, 2025)
-    accessed: '2026-07-21'
+  - url: https://docs.snorkel.ai/
+    shows: 'actively maintained commercial platform at v26.1 with release notes; no customer count,
+      deployment count or usage figure appears anywhere on the documentation site'
+    accessed: '2026-08-14'
+    http_status: 200
+    content_sha256: 7d4603438e0f609f1f3559eb10a5d8209046008b88e29c744d9436ae4ae03774
 capability:
   score: 4
   basis: feature_matrix
-  value: Programmatic labeling / weak supervision at scale plus curation, slicing, filtering, and fine-tuning/eval
-    data workflows.
+  value: Programmatic labeling and weak supervision via heuristic and LLM-generated labeling functions,
+    with curation, slicing and filtering; a documented Python SDK; and role-based multi-user administration
+    over a customer-installed deployment. Documented at v26.1 with a separate legacy Predictive ML line
+    ending at v25.4.
   confidence: medium
-  note: Broad enterprise data-development coverage; less oriented to frontier-scale pretraining corpora.
+  note: 'Re-derived 2026-08-14 from the live documentation rather than the marketing site. The feature
+    surface the score rests on - programmatic labeling, curation, an SDK, multi-user administration - is
+    all documented and current at v26.1. Score unchanged at 4: a mature, well-documented commercial data
+    development platform, below the open frontier tooling this category scores 5 on breadth of published
+    method rather than on product polish.'
+  last_verified: '2026-08-14'
+  basis_detail: Documentation sections for User Guide, Admin Guide and SDK at v26.1, plus a legacy
+    Predictive ML line ending at v25.4.
   sources:
-  - url: https://snorkel.ai
-    shows: Snorkel Flow product/feature description
-    accessed: '2026-07-21'
+  - url: https://docs.snorkel.ai/
+    shows: 'User Guide, Admin Guide and SDK Overview sections at v26.1; legacy "Predictive ML" line
+      documented through v25.4'
+    accessed: '2026-08-14'
+    http_status: 200
+    content_sha256: 7d4603438e0f609f1f3559eb10a5d8209046008b88e29c744d9436ae4ae03774

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -768,7 +768,7 @@ def test_real_sources_serialize_without_errors():
         # undeclared-key row, exactly as `autogen`'s CC-BY-4.0 documentation license
         # already did - which is the evidence that MCP was made to match an existing
         # convention rather than given a new one.
-        "agent_tools_protocols": 138, "dataset_processing_tools": 90, "evaluation_code": 107,
+        "agent_tools_protocols": 138, "dataset_processing_tools": 92, "evaluation_code": 107,
         # inference_code 47 -> 64 when the sweep read the category: four stale deferrals came
         # off (a deferred product publishes no openness evidence at all), and several products
         # that had described their gating in prose gained a readable `source:`/`core-gated:`.


### PR DESCRIPTION
I recommended retiring this product yesterday. **That was wrong**, and how it was wrong is the useful part.

The `dataset_processing_tools` pass found `snorkel.ai/snorkel-flow/` 301-redirecting to `/data-development/`, the marketing copy selling data *services* rather than software, and the `$1.3B` valuation gone from the page. It correctly refused to date any axis and escalated. I read the same marketing site, agreed, and recommended retirement.

**Neither of us opened `docs.snorkel.ai`.** The product ships today as the **"Snorkel AI Data Development Platform" v26.1**, with a User Guide, an SDK reference, dated release notes, and an administrator guide that begins *"Find out how to install the Snorkel AI Data Development Platform and manage users, roles, and permissions."*

It's a rename, and it's still a product a customer deploys.

> A vendor reorganising its marketing is not evidence a product has been withdrawn.

The verification rule is to re-read *the cited source* — and the cited source here was the marketing homepage, which was the actual defect. An entry for an installable enterprise platform should have cited its documentation all along.

The slug stays `snorkel-flow`: slugs are immutable identities rather than labels, per `identity.md`. The rename is carried by `display_name` and `comments`.

## All three axes re-scored against the docs

- **openness 1/closed — unchanged but better evidenced**, and now records `self-host: yes`. The product *is* customer-deployed, which the old record missed entirely, but nothing on the docs site offers source, a repository or a license grant, and the footer carries Terms of Use with SOC and HIPAA badges. **Self-hostable and closed-source are not in tension** — the software ladder settles on `source` regardless of deployment model.
- **adoption 3, held, previous basis withdrawn.** It cited a Series D valuation that appears on no page the record cites — and funding is not adoption in any case. What the docs *do* establish is an actively shipping product at v26.1.
- **capability 4, re-derived** from the documented feature surface rather than marketing copy.

**`dataset_processing_tools` closes at 21/21.** Issue #240 can be closed.

488 tests, all gates green.