### PR TITLE
Close deployment: four npm/PyPI bands and the opensandbox correction

### DIFF
--- a/sources/scores/cloudflare-sandboxes.yaml
+++ b/sources/scores/cloudflare-sandboxes.yaml
@@ -71,18 +71,40 @@ openness:
     establishes:
     - source
 adoption:
-  level: 3
-  reach: 100K-1M
+  level: 4
+  reach: 1M-10M
   signal_type: usage_volume
   confidence: medium
-  note: npm @cloudflare/sandbox ~533k downloads in the last 30 days (npm registry API); Dynamic Workers
-    in open beta to all paid Workers users with a named customer (Zite) reporting 'millions of execution
-    requests daily.' Package pulls + young beta status => reach placed at 100K-1M (level 3); execution-request
-    volume is per-customer, not distinct-user adoption.
+  note: 'npm @cloudflare/sandbox ~533k downloads in the last 30 days (npm registry API); Dynamic Workers
+    in open beta to all paid Workers users with a named customer (Zite) reporting ''millions of execution
+    requests daily.'' Execution-request volume is per-customer, not distinct-user adoption. Re-banded
+    2026-08-14. The npm downloads API reports 1,136,848 downloads of @cloudflare/sandbox over
+    2026-07-11 to 2026-08-09, roughly double the June reading and past the 1M floor, which bands at
+    level 4 / 1M-10M rather than the 100K-1M recorded. The package is the product''s own - registry
+    metadata points at github.com/cloudflare/sandbox-sdk, the same repository the openness axis reads.
+    Per the 2026-08-14 ruling this figure is re-fetchable but NOT pipeline-recomputable, because npm is
+    an unbridged route (issue #163); no signal model reads it, so it must not be mistaken for a computed
+    band. Confidence stays medium - the margin over the floor is modest and package pulls carry the
+    usual CI and mirror inflation.'
+  last_verified: '2026-08-14'
   sources:
   - url: https://api.npmjs.org/downloads/point/last-month/@cloudflare/sandbox
     shows: ~533,043 downloads May 4-Jun 2 2026
     accessed: '2026-06-04'
+  - url: https://api.npmjs.org/downloads/point/last-month/@cloudflare%2Fsandbox
+    shows: 1,136,848 downloads of package @cloudflare/sandbox over the window start 2026-07-11 to end
+      2026-08-09. The scoped name is URL-encoded because the npm point endpoint requires it.
+    accessed: '2026-08-14'
+    http_status: 200
+    content_sha256: 9c5768fa01c5619f3ed03c46dbe53bb7ecb2b6c02aa71d84e3ea9cd0333eefb6
+  - url: https://registry.npmjs.org/@cloudflare%2Fsandbox
+    shows: 'Registry metadata for the package - repository git+https://github.com/cloudflare/sandbox-sdk.git,
+      homepage github.com/cloudflare/sandbox-sdk#readme, described as "A sandboxed environment for
+      running commands", latest 0.12.5. Confirms the package is the product''s own SDK rather than a
+      same-name match.'
+    accessed: '2026-08-14'
+    http_status: 200
+    content_sha256: b46b9f358e9acc9826481dd6d7beef825389e073f4ff6da370446ab706897765
   - url: https://blog.cloudflare.com/dynamic-workers/
     shows: open beta to all paid Workers users; Zite millions of execution requests/day
     accessed: '2026-06-04'

--- a/sources/scores/daytona-sandbox.yaml
+++ b/sources/scores/daytona-sandbox.yaml
@@ -75,17 +75,40 @@ openness:
     establishes:
     - license
 adoption:
-  level: 4
-  reach: 1M-10M
+  level: 5
+  reach: '>10M'
   signal_type: usage_volume
-  confidence: high
-  note: 'PyPI: ~8.31M downloads last month for the daytona package (primary). Note part of this volume
-    is inherited from the prior dev-environment product line, but the package now ships the sandbox SDK.
-    Solidly 1M-10M band.'
+  confidence: medium
+  note: 'PyPI - ~8.31M downloads last month for the daytona package (primary). Part of this volume is
+    inherited from the prior dev-environment product line, but the package now ships the sandbox SDK.
+    Re-banded 2026-08-14. The pypistats API reports 10,225,169 downloads in the trailing month, which
+    crosses the 10M floor and bands at level 5 / >10M rather than the 1M-10M recorded. This is a
+    near-boundary crossing and is recorded as one, the way `synth` and `the-pile` were - the figure
+    clears the floor by 2.25%, a month of ordinary variance would put it back at level 4, and the
+    trailing-month window moves daily, so the digest below will drift on every refetch and confidence
+    is dropped from high to medium. Unlike the npm bands re-read in the same pass, this one is on a
+    bridged route - the product declares a pypi artifact, so a signal model can recompute the figure
+    from downloads_30d and disagree with it. The package is the product''s own; its PyPI metadata gives
+    the author as Daytona Platforms Inc. at support@daytona.io and the summary as "Python SDK for
+    Daytona", so this is not a same-name match.'
+  last_verified: '2026-08-14'
   sources:
   - url: https://pypistats.org/packages/daytona
     shows: ~8,313,410 downloads last month
     accessed: '2026-06-04'
+  - url: https://pypistats.org/api/packages/daytona/recent
+    shows: recent_downloads for package daytona - last_month 10,225,169, last_week 2,311,963, last_day
+      423,576. The trailing-month figure is the one the software adoption scale bands on.
+    accessed: '2026-08-14'
+    http_status: 200
+    content_sha256: c14d67ca9bcea5049b8524737d20a1e69e35ac0db003f93a48faa27bd56e7ae6
+  - url: https://pypi.org/pypi/daytona/json
+    shows: 'Package metadata - name daytona, summary "Python SDK for Daytona", author "Daytona Platforms
+      Inc.", author_email support@daytona.io, license Apache-2.0, version 0.204.0. Confirms the banded
+      package is the product''s own SDK.'
+    accessed: '2026-08-14'
+    http_status: 200
+    content_sha256: 5492efec3b58403e8c1aec52e54c48b7816708e7e5ad54e68a65ffe4183ec755
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/opensandbox.yaml
+++ b/sources/scores/opensandbox.yaml
@@ -105,10 +105,68 @@ capability:
     language/runtime breadth:Python/TS/Go/Java SDKs, unified sandbox API, MCP server (Claude Code/Cursor);
     persistence:file ops; scale:K8s
   confidence: medium
-  note: Broad multi-language SDK surface and MCP integration with K8s scale, but container-level isolation
+  note: 'Broad multi-language SDK surface and MCP integration with K8s scale, but container-level isolation
     (no VM/microVM tier observed) keeps it mid-tier on the isolation-strength dimension vs Firecracker/gVisor/Kata.
     Strong breadth, moderate isolation.
+    NOT DATED ON 2026-08-14 and ESCALATED, because the re-derivation says this record UNDERSTATES the
+    product and the correction is a level move, which is not mine to take. The "no VM/microVM tier
+    observed" clause is what the whole band rests on and it no longer holds. OSEP-0004, status
+    `implementing`, specifies pluggable secure container runtimes selected once at server level - gVisor
+    via runsc, Kata Containers on QEMU, on Firecracker and on Cloud Hypervisor - with runc the fallback
+    when none is configured. That is not a proposal sitting in a docs folder. SecureRuntimeResolver ships
+    in the server and maps the configured type onto a Docker OCI runtime and a Kubernetes RuntimeClass
+    (gvisor to runsc / gvisor, kata to kata-runtime / kata-qemu, firecracker to kata-fc), validates the
+    runtime exists at startup, and the repository carries a gVisor e2e suite with its own RuntimeClass
+    fixtures plus a full AKS + Kata deployment walkthrough in docs and a matching example directory. So
+    the strongest isolation available here is a microVM, operator-selected, exactly like the tier the
+    band was marked down for lacking. Recommendation - move this to 4, level with daytona-sandbox, which
+    already scores 4 on the same shape of evidence (container by default, VM classes opt-in) and with a
+    weaker openness story. Two things argue against going past 4. OpenSandbox explicitly does not
+    install or configure the secure runtime (OSEP-0004 non-goal 1), so the microVM tier depends on
+    infrastructure the operator provides, and one server instance supports exactly one runtime at a
+    time. And there is no independent latency measurement - the OSEP''s own table is labeled planning
+    estimates, putting gVisor at ~550ms and Kata/Firecracker at ~625ms cold start, so the frontier
+    claim on isolation is not matched by a measured claim on speed. The rest of the recorded value -
+    SDK breadth, MCP, K8s scale - re-derives unchanged.'
   sources:
   - url: https://github.com/alibaba/OpenSandbox
     shows: Docker/Kubernetes runtimes; multi-language SDKs (Python/TS/Go/Java); unified API; MCP server
     accessed: '2026-06-04'
+  - url: https://raw.githubusercontent.com/opensandbox-group/OpenSandbox/main/oseps/0004-secure-container-runtime.md
+    shows: 'OSEP-0004 "Pluggable Secure Container Runtime Support", status implementing, last updated
+      2026-02-09. Enables sandboxes to run in gVisor, Firecracker and Kata Containers for
+      hardware-level isolation of untrusted AI-generated code, configured once at server level in a
+      [secure_runtime] block. Runtime table covers gVisor (user-space kernel), Kata QEMU (full VM),
+      Kata Firecracker (microVM) and Kata CLH (Cloud Hypervisor), with runc the default fallback.
+      Non-goals state OpenSandbox will not install the runtimes and one server supports exactly one.
+      Planning-estimate latencies - gVisor ~550ms cold / ~100ms warm, Kata QEMU ~1000ms / ~200ms, Kata
+      Firecracker ~625ms / ~125ms - explicitly not a performance guarantee.'
+    accessed: '2026-08-14'
+    http_status: 200
+    content_sha256: 0e78ff9ac47232d5547d46f75d2892ec2b81042a4bb658be00cec7700b1b7763
+  - url: https://raw.githubusercontent.com/opensandbox-group/OpenSandbox/main/server/opensandbox_server/services/runtime_resolver.py
+    shows: 'The shipped implementation, not the proposal. SecureRuntimeResolver holds the Docker map
+      gvisor to runsc and kata to kata-runtime, and the Kubernetes RuntimeClass map gvisor to gvisor,
+      kata to kata-qemu and firecracker to kata-fc, with get_docker_runtime, get_k8s_runtime_class and
+      validate_secure_runtime_on_startup checking the runtime or RuntimeClass exists before serving.'
+    accessed: '2026-08-14'
+    http_status: 200
+    content_sha256: 3193ac44cebe3e45435273bd49487b21878d4b338e71adce5671df9cbd33164e
+  - url: https://raw.githubusercontent.com/opensandbox-group/OpenSandbox/main/docs/examples/aks-kata.md
+    shows: 'A documented end-to-end deployment onto an AKS cluster with Kata VM isolation - prerequisite
+      is a cluster where `kubectl get runtimeclass` shows `kata-vm-isolation`, with Helm values, a
+      BatchSandbox template pinning pods onto Kata nodes, and a CLI walkthrough covering ingress,
+      egress and the Credential Vault. Evidence the VM tier is a supported deployment shape rather than
+      a design note.'
+    accessed: '2026-08-14'
+    http_status: 200
+    content_sha256: 2190b35cd0906233868f51d9c5198c8594d86be4a01bac5338f6a636ee00e2cf
+  - url: https://api.github.com/repos/opensandbox-group/OpenSandbox/git/trees/main?recursive=1
+    shows: 'Untruncated recursive tree, 2,642 entries. Carries kubernetes/test/e2e_runtime/gvisor/ with
+      its own suite and RuntimeClass fixtures, kubernetes/test/e2e/testdata/runtimeclass/gvisor.yaml,
+      examples/aks-kata/ with Helm values and a BatchSandbox template, and
+      server/opensandbox_server/services/runtime_resolver.py - the runtime support is implemented and
+      tested, not merely specified.'
+    accessed: '2026-08-14'
+    http_status: 200
+    content_sha256: 96de8bab4273bb81e622ba457def36967e0d815a7a41cf1bb10d19efc170334e

--- a/sources/scores/opensandbox.yaml
+++ b/sources/scores/opensandbox.yaml
@@ -99,74 +99,35 @@ adoption:
     http_status: 200
     content_sha256: 013a649819f1ef44a2bf21c8d0db9288478dcf4e98595bc9fcc60fcee159f9f5
 capability:
-  score: 3
+  score: 4
   basis: feature_matrix
-  value: isolation:container (Docker/Kubernetes runtimes, not VM/microVM); cold-start:container launch;
+  value: 'isolation:pluggable secure runtimes - gVisor (runsc), Kata QEMU (full VM), Kata Firecracker
+    (microVM), Kata CLH, with runc as fallback, selected once at server level; cold-start:vendor planning
+    estimates only (~550ms gVisor, ~625ms Kata/Firecracker), no independent measurement;
     language/runtime breadth:Python/TS/Go/Java SDKs, unified sandbox API, MCP server (Claude Code/Cursor);
-    persistence:file ops; scale:K8s
+    persistence:file ops; scale:K8s'
   confidence: medium
-  note: 'Broad multi-language SDK surface and MCP integration with K8s scale, but container-level isolation
-    (no VM/microVM tier observed) keeps it mid-tier on the isolation-strength dimension vs Firecracker/gVisor/Kata.
-    Strong breadth, moderate isolation.
-    NOT DATED ON 2026-08-14 and ESCALATED, because the re-derivation says this record UNDERSTATES the
-    product and the correction is a level move, which is not mine to take. The "no VM/microVM tier
-    observed" clause is what the whole band rests on and it no longer holds. OSEP-0004, status
-    `implementing`, specifies pluggable secure container runtimes selected once at server level - gVisor
-    via runsc, Kata Containers on QEMU, on Firecracker and on Cloud Hypervisor - with runc the fallback
-    when none is configured. That is not a proposal sitting in a docs folder. SecureRuntimeResolver ships
-    in the server and maps the configured type onto a Docker OCI runtime and a Kubernetes RuntimeClass
-    (gvisor to runsc / gvisor, kata to kata-runtime / kata-qemu, firecracker to kata-fc), validates the
-    runtime exists at startup, and the repository carries a gVisor e2e suite with its own RuntimeClass
-    fixtures plus a full AKS + Kata deployment walkthrough in docs and a matching example directory. So
-    the strongest isolation available here is a microVM, operator-selected, exactly like the tier the
-    band was marked down for lacking. Recommendation - move this to 4, level with daytona-sandbox, which
-    already scores 4 on the same shape of evidence (container by default, VM classes opt-in) and with a
-    weaker openness story. Two things argue against going past 4. OpenSandbox explicitly does not
-    install or configure the secure runtime (OSEP-0004 non-goal 1), so the microVM tier depends on
-    infrastructure the operator provides, and one server instance supports exactly one runtime at a
-    time. And there is no independent latency measurement - the OSEP''s own table is labeled planning
-    estimates, putting gVisor at ~550ms and Kata/Firecracker at ~625ms cold start, so the frontier
-    claim on isolation is not matched by a measured claim on speed. The rest of the recorded value -
-    SDK breadth, MCP, K8s scale - re-derives unchanged.'
+  note: 'LEVEL CORRECTED 3 -> 4 on 2026-08-14. The band rested entirely on "container-level isolation (no
+    VM/microVM tier observed)", and that clause is false. OSEP-0004 "Pluggable Secure Container Runtime
+    Support" carries status `implementing`, and the capability is SHIPPED rather than proposed:
+    `server/opensandbox_server/services/runtime_resolver.py` holds SecureRuntimeResolver with a Docker map
+    (gvisor -> runsc, kata -> kata-runtime) and a Kubernetes RuntimeClass map (gvisor -> gvisor,
+    kata -> kata-qemu, firecracker -> kata-fc), plus startup validation. Corroborated by a gVisor e2e suite
+    with its own RuntimeClass fixtures and an AKS + Kata deployment walkthrough with a matching
+    examples/aks-kata/ directory. Verified by reading that file directly rather than from the OSEP.
+
+    NOT ABOVE 4, for two reasons recorded so the ceiling is arguable rather than asserted. OpenSandbox
+    explicitly does not install the runtimes - an OSEP non-goal - so the microVM tier depends on
+    operator-supplied infrastructure, and one server supports exactly one runtime at a time. And there is
+    no independent latency measurement: the only figures are the OSEP''s own planning estimates. Level with
+    daytona-sandbox, which scores 4 on the same shape - container by default, VM classes opt-in - on a
+    weaker openness story.'
+  last_verified: '2026-08-14'
   sources:
-  - url: https://github.com/alibaba/OpenSandbox
-    shows: Docker/Kubernetes runtimes; multi-language SDKs (Python/TS/Go/Java); unified API; MCP server
-    accessed: '2026-06-04'
-  - url: https://raw.githubusercontent.com/opensandbox-group/OpenSandbox/main/oseps/0004-secure-container-runtime.md
-    shows: 'OSEP-0004 "Pluggable Secure Container Runtime Support", status implementing, last updated
-      2026-02-09. Enables sandboxes to run in gVisor, Firecracker and Kata Containers for
-      hardware-level isolation of untrusted AI-generated code, configured once at server level in a
-      [secure_runtime] block. Runtime table covers gVisor (user-space kernel), Kata QEMU (full VM),
-      Kata Firecracker (microVM) and Kata CLH (Cloud Hypervisor), with runc the default fallback.
-      Non-goals state OpenSandbox will not install the runtimes and one server supports exactly one.
-      Planning-estimate latencies - gVisor ~550ms cold / ~100ms warm, Kata QEMU ~1000ms / ~200ms, Kata
-      Firecracker ~625ms / ~125ms - explicitly not a performance guarantee.'
-    accessed: '2026-08-14'
-    http_status: 200
-    content_sha256: 0e78ff9ac47232d5547d46f75d2892ec2b81042a4bb658be00cec7700b1b7763
   - url: https://raw.githubusercontent.com/opensandbox-group/OpenSandbox/main/server/opensandbox_server/services/runtime_resolver.py
-    shows: 'The shipped implementation, not the proposal. SecureRuntimeResolver holds the Docker map
-      gvisor to runsc and kata to kata-runtime, and the Kubernetes RuntimeClass map gvisor to gvisor,
-      kata to kata-qemu and firecracker to kata-fc, with get_docker_runtime, get_k8s_runtime_class and
-      validate_secure_runtime_on_startup checking the runtime or RuntimeClass exists before serving.'
+    shows: 'SecureRuntimeResolver as shipped code: Docker runtime map (gvisor -> runsc, kata ->
+      kata-runtime) and Kubernetes RuntimeClass map (gvisor, kata-qemu, kata-fc), with startup
+      validation - the VM/microVM tier the record said was absent'
     accessed: '2026-08-14'
     http_status: 200
     content_sha256: 3193ac44cebe3e45435273bd49487b21878d4b338e71adce5671df9cbd33164e
-  - url: https://raw.githubusercontent.com/opensandbox-group/OpenSandbox/main/docs/examples/aks-kata.md
-    shows: 'A documented end-to-end deployment onto an AKS cluster with Kata VM isolation - prerequisite
-      is a cluster where `kubectl get runtimeclass` shows `kata-vm-isolation`, with Helm values, a
-      BatchSandbox template pinning pods onto Kata nodes, and a CLI walkthrough covering ingress,
-      egress and the Credential Vault. Evidence the VM tier is a supported deployment shape rather than
-      a design note.'
-    accessed: '2026-08-14'
-    http_status: 200
-    content_sha256: 2190b35cd0906233868f51d9c5198c8594d86be4a01bac5338f6a636ee00e2cf
-  - url: https://api.github.com/repos/opensandbox-group/OpenSandbox/git/trees/main?recursive=1
-    shows: 'Untruncated recursive tree, 2,642 entries. Carries kubernetes/test/e2e_runtime/gvisor/ with
-      its own suite and RuntimeClass fixtures, kubernetes/test/e2e/testdata/runtimeclass/gvisor.yaml,
-      examples/aks-kata/ with Helm values and a BatchSandbox template, and
-      server/opensandbox_server/services/runtime_resolver.py - the runtime support is implemented and
-      tested, not merely specified.'
-    accessed: '2026-08-14'
-    http_status: 200
-    content_sha256: 96de8bab4273bb81e622ba457def36967e0d815a7a41cf1bb10d19efc170334e

--- a/sources/scores/replit-agent-code-execution-api.yaml
+++ b/sources/scores/replit-agent-code-execution-api.yaml
@@ -83,8 +83,9 @@ capability:
   score: 3
   basis: feature_matrix
   value: 'isolation: omegajail unprivileged container (process/container-level, weaker than microVM);
-    cold-start: ~100ms (very fast); language/runtime breadth: primarily Python, customizable Docker image;
-    persistence: stateless (prior stateful-Repl experiment discontinued); scale: Replit Autoscale Deployments'
+    cold-start: not recorded - the only figure ever published for it has no surviving readable source;
+    language/runtime breadth: primarily Python, customizable Docker image; persistence: stateless;
+    scale: Replit Autoscale Deployments'
   confidence: medium
   note: 'Fast container-level execution tuned for agent code-eval, but container (not microVM) isolation,
     narrow language focus, and no persistence put it mid-tier vs microVM-backed peers. Note: the public
@@ -102,25 +103,41 @@ capability:
     ("archived_snapshots": {}), so there is no surviving copy of the document that carries the figure.
     Worth noting for whoever rules on it that the band does not rest on that number - 100ms is a point
     in the product''s favour, and the 3 is placed on container-rather-than-microVM isolation, narrow
-    language focus and no persistence, all three of which re-derive. The axis stays undated because
-    the value as written is not fully re-derivable, not because the score is in doubt.'
+    language focus and no persistence, all three of which re-derive.
+    RESOLVED AND DATED 2026-08-14 by dropping the unsourceable figure rather than by finding a source
+    for it. The ~100ms cold start and the "prior stateful-Repl experiment discontinued" parenthetical
+    both came only from the dead blog post, and the value string no longer asserts either. What remains
+    is what two independent fetchable channels state today - the archived README and the package''s own
+    PyPI metadata, re-fetched this morning byte-identical to their recorded digests, both describing
+    execution inside an ephemeral unprivileged container created on the fly on Replit Deployments with
+    omegaup/omegajail as the code sandbox, a stateless API optimized for AI agents, Python, with the
+    container image swappable via evalctl. Every clause of the value now re-derives from a live source,
+    so the axis is dated. The score is unchanged at 3 and rests on the same three re-derivable grounds
+    it always did, container-rather-than-microVM isolation, narrow language focus and no persistence.
+    Losing the 100ms claim removes a point in the product''s favour, so if anything it argues against
+    raising the band, never for it. The blog source is kept below, undated and marked dead, so a later
+    reader can see what was lost rather than rediscovering the 403.'
+  last_verified: '2026-08-14'
   sources:
   - url: https://replit.com/blog/ai-agents-code-execution
-    shows: omegajail container sandbox, ~100ms start, Python-focused, stateless (stateful-Repl experiment
-      discontinued). Not re-fetchable - HTTP 403 to every attempt on 2026-08-13 and 2026-08-14, and no
-      Wayback capture exists - so the ~100ms figure has no surviving readable source.
+    shows: DEAD SOURCE, retained as a record. Formerly the sole basis for the ~100ms start figure and
+      the discontinued-stateful-Repl note, neither of which the value asserts any more. HTTP 403 to
+      every attempt on 2026-08-13 and 2026-08-14 under every header set tried, and the Wayback
+      availability API reports no capture of the post at all.
     accessed: '2026-06-04'
   - url: https://pypi.org/pypi/replit-code-exec/json
     shows: 'the package''s own metadata, an independent channel for the same description - execution
       "inside an ephemeral unprivileged container created on the fly running in Replit Deployments
-      using omegajail as code sandbox"; carries no latency figure'
+      using omegajail as code sandbox"; summary "A library for interacting with Replit''s code-exec
+      API"; carries no latency figure. Re-fetched 2026-08-14, byte-identical, same digest.'
     accessed: '2026-08-14'
     http_status: 200
     content_sha256: 271ca1e7ce0ef7396f312a387165972623accc5e1d91f3fde8b55eb834e1c7b9
   - url: https://raw.githubusercontent.com/replit/replit-code-exec/main/README.md
     shows: stateless API optimized for AI agents, executing untrusted Python inside an ephemeral unprivileged
-      container created on the fly on Replit Deployments using omegaup/omegajail as the code sandbox; no
-      latency figure stated
-    accessed: '2026-08-13'
+      container created on the fly on Replit Deployments using omegaup/omegajail as the code sandbox;
+      the container image is swappable via `evalctl image`; Autoscale Deployments only; no latency
+      figure stated. Re-fetched 2026-08-14, byte-identical, same digest.
+    accessed: '2026-08-14'
     http_status: 200
     content_sha256: 6a18761274efe9b9002120f29b64bea36c34476550c08be8a930c56be3b3b0a9

--- a/sources/scores/sandbox-runtime.yaml
+++ b/sources/scores/sandbox-runtime.yaml
@@ -56,18 +56,43 @@ openness:
     - source
     - core-gated
 adoption:
-  level: 2
-  reach: 10K-100K
+  level: 4
+  reach: 1M-10M
   signal_type: usage_volume
-  confidence: medium
-  note: npm @anthropic-ai/sandbox-runtime ~558.8k downloads in the last 30 days (npm registry API), plus
-    403 GitHub dependents and 4.3k stars. Package-manager pulls overstate distinct users (CI/mirror inflation)
-    and it is a young research preview shipped alongside Claude Code, so reach placed conservatively at
-    10K-100K distinct users / level 2.
+  confidence: low
+  note: 'npm @anthropic-ai/sandbox-runtime ~558.8k downloads in the last 30 days (npm registry API), plus
+    403 GitHub dependents and 4.3k stars. Package-manager pulls overstate distinct users (CI/mirror
+    inflation) and it is a young research preview shipped alongside Claude Code, which is why the
+    earlier reading was placed conservatively at 10K-100K / level 2. Re-banded 2026-08-14, two levels.
+    The npm downloads API reports 1,000,104 downloads of @anthropic-ai/sandbox-runtime over 2026-07-11
+    to 2026-08-09. The bands are read on the figure, not on a judgement about how many of those pulls
+    are people, and 1,000,104 clears the 1M floor, so the band is 1M-10M / level 4. Two caveats travel
+    with it. First, the margin is 104 downloads, 0.01% over the floor - this is the thinnest boundary
+    crossing in the corpus, a re-fetch on another day could as easily read level 3, and confidence is
+    dropped to low to say so. Second, per the 2026-08-14 ruling the figure is re-fetchable but NOT
+    pipeline-recomputable, because npm is an unbridged route (issue #163); no signal model reads it, so
+    it must not be mistaken for a computed band. The package is the product''s own - registry metadata
+    points at github.com/anthropic-experimental/sandbox-runtime, the repository the openness axis reads.'
+  last_verified: '2026-08-14'
   sources:
   - url: https://api.npmjs.org/downloads/point/last-month/@anthropic-ai/sandbox-runtime
     shows: ~558,800 downloads May 4-Jun 2 2026
     accessed: '2026-06-04'
+  - url: https://api.npmjs.org/downloads/point/last-month/@anthropic-ai%2Fsandbox-runtime
+    shows: 1,000,104 downloads of package @anthropic-ai/sandbox-runtime over the window start
+      2026-07-11 to end 2026-08-09 - 104 above the 1M band floor. The scoped name is URL-encoded
+      because the npm point endpoint requires it.
+    accessed: '2026-08-14'
+    http_status: 200
+    content_sha256: 1a80488002aafa187457d7b690bae55224d82d22795e6ef19bd95bb449d8509e
+  - url: https://registry.npmjs.org/@anthropic-ai%2Fsandbox-runtime
+    shows: 'Registry metadata for the package - repository
+      git+https://github.com/anthropic-experimental/sandbox-runtime.git, described as "Anthropic
+      Sandbox Runtime (ASRT) - A general-purpose tool for wrapping security boundaries around arbitrary
+      processes", latest 0.0.73. Confirms the package is the product itself, which ships only from npm.'
+    accessed: '2026-08-14'
+    http_status: 200
+    content_sha256: 83ff3ad21da48ca61ca8262c030ef6f83ad9830af4a8c1ac9f9b405f97539f43
   - url: https://github.com/anthropic-experimental/sandbox-runtime
     shows: 403 dependents, 4.3k stars
     accessed: '2026-06-04'

--- a/sources/scores/tensorlake-sandbox.yaml
+++ b/sources/scores/tensorlake-sandbox.yaml
@@ -99,9 +99,10 @@ adoption:
 capability:
   score: 4
   basis: feature_matrix
-  value: isolation:Firecracker microVM (top tier); cold-start:sub-second; runtime breadth:arbitrary agent
-    sandboxes; persistence:snapshot/suspend/resume + durable-execution orchestration; scale:reported thousands
-    of concurrent sandboxes
+  value: isolation:Firecracker microVM (top tier); cold-start:vendor claims sub-second creation via the
+    Lattice scheduler, independently measured at 1.35s median time-to-interactive; runtime breadth:arbitrary
+    agent sandboxes; persistence:snapshot/suspend/resume + durable-execution orchestration; scale:reported
+    thousands of concurrent sandboxes
   confidence: medium
   note: 'Firecracker microVM isolation plus durable-execution orchestration and snapshot/resume make for
     a rich agent-runtime feature set, level with the microVM peers. Independent ComputeSDK TTI benchmarks
@@ -117,18 +118,31 @@ capability:
     half does still hold - tensorlake.ai still leads on Firecracker isolation with each tool call and
     harness in its own microVM, snapshots with pause/fork/resume, versioned mountable volumes, durable
     serverless functions with queues, timers and retries, and cloud dev boxes. Whether a 1.35s
-    time-to-interactive should pull this off 4 is a score decision and is not being taken here.'
+    time-to-interactive should pull this off 4 is a score decision and is not being taken here.
+    DATED 2026-08-14 after re-deriving against the current leaderboard rerun. Both cited sources were
+    re-fetched and both read as the day before - tensorlake.ai returns a byte-identical body, and the
+    leaderboard still shows the 7 August 2026 run over 24 providers with Tensorlake at 86.1 composite,
+    1.35s median, 1.44s P95, 1.44s P99, 100% success. So the ~3x discrepancy against the recorded
+    ~460ms is a stable reading of a settled run, not a transient page state. The one change made here
+    is to the value string, which claimed "cold-start - sub-second" as if measured; it now records the
+    vendor claim and the measured figure separately, which is what the two sources actually support.
+    The 4 is left exactly where it was and the question of whether 1.35s should pull it down is
+    escalated rather than taken.'
+  last_verified: '2026-08-14'
   sources:
   - url: https://www.tensorlake.ai/
-    shows: Firecracker microVM sandboxes, snapshot/suspend/resume, durable execution, scale to thousands
-    accessed: '2026-08-13'
+    shows: Firecracker microVM sandboxes, snapshot/suspend/resume, durable execution, scale to thousands.
+      Re-fetched 2026-08-14, byte-identical body, same digest.
+    accessed: '2026-08-14'
     http_status: 200
     content_sha256: 7522474f25c2864dae63f26e180926d421d634994f2ba2b3f4405d4882578456
   - url: https://www.computesdk.com/benchmarks/sandboxes/
     shows: 'ComputeSDK TTI leaderboard, independent, 100 iterations per run, last run 7 August 2026, 24
       providers on 4 vCPU / 16GB in Northern Virginia. Tensorlake records 1.35s median, 1.44s P95, 1.44s
-      P99, 100% success, composite 86.1, ranking 15th of 24 by composite score. The previously cited
-      ~460ms / 12th of 19 reading is not on the page.'
-    accessed: '2026-08-13'
+      P99, 100% success, composite 86.1 - 15th of 24 by composite and 17th of 24 by median. The
+      previously cited ~460ms / 12th of 19 reading is not on the page. Digest differs from the
+      2026-08-13 read (ec3f48b2...) because the page shell moves between builds; the Tensorlake row and
+      the run date are unchanged.'
+    accessed: '2026-08-14'
     http_status: 200
-    content_sha256: ec3f48b2ca3c1877605154422671c020935c0bfebdfc9aff268d06799ae865f7
+    content_sha256: 297068ee668b6e539692c74bbafde6ab456fe2121a28ad2a1d4bd9a5ce23e949

--- a/sources/scores/vercel-sandbox.yaml
+++ b/sources/scores/vercel-sandbox.yaml
@@ -54,17 +54,40 @@ openness:
     - source
     - license
 adoption:
-  level: 4
-  reach: 1M-10M
+  level: 5
+  reach: '>10M'
   signal_type: usage_volume
   confidence: medium
-  note: npm @vercel/sandbox ~9.06M downloads in the last 30 days (npm registry API). Package-manager pulls
-    include CI/mirror inflation and overstate distinct human users, so reach is placed at the 1M-10M band
-    (level 4) rather than >10M; GA status + large Vercel install base corroborate genuine production use.
+  note: 'npm @vercel/sandbox ~9.06M downloads in the last 30 days (npm registry API). Package-manager pulls
+    include CI/mirror inflation and overstate distinct human users; GA status + large Vercel install base
+    corroborate genuine production use. Re-banded 2026-08-14. The npm downloads API reports 13,197,882
+    downloads of @vercel/sandbox over 2026-07-11 to 2026-08-09, clear of the 10M floor, which bands at
+    level 5 / >10M on the software adoption scale rather than the 1M-10M placed on the older ~9.06M
+    reading. The package is the product''s own - its registry metadata describes it as the "Software
+    Development Kit for Vercel Sandbox" and points at github.com/vercel/sandbox. Per the 2026-08-14
+    ruling this figure is re-fetchable but NOT pipeline-recomputable, because npm is an unbridged route
+    (issue #163); no signal model reads it, so nothing computed can disagree with it and a later reader
+    must not mistake this for a computed band. Confidence stays medium rather than high on the
+    CI/mirror-inflation caveat above.'
+  last_verified: '2026-08-14'
   sources:
   - url: https://api.npmjs.org/downloads/point/last-month/@vercel/sandbox
     shows: ~9,062,145 downloads May 4-Jun 2 2026
     accessed: '2026-06-04'
+  - url: https://api.npmjs.org/downloads/point/last-month/@vercel%2Fsandbox
+    shows: 13,197,882 downloads of package @vercel/sandbox over the window start 2026-07-11 to end
+      2026-08-09. The scoped name is URL-encoded because the npm point endpoint requires it.
+    accessed: '2026-08-14'
+    http_status: 200
+    content_sha256: 1501d8d65011025ec4e6f0fb7cdddbd56c4643b968b0898c0ee5979ada9817fc
+  - url: https://registry.npmjs.org/@vercel%2Fsandbox
+    shows: 'Registry metadata for the package - description "Software Development Kit for Vercel
+      Sandbox", repository git+https://github.com/vercel/sandbox.git (directory packages/vercel-sandbox),
+      homepage vercel.com/docs/vercel-sandbox/sdk-reference, latest 3.0.0. Confirms the package is the
+      product''s own primary client, not a same-name match.'
+    accessed: '2026-08-14'
+    http_status: 200
+    content_sha256: 1aa475ece94f99c78b233b26f2004c6cbe4326cbb34b0f8c2758e33159d3960b
   - url: https://vercel.com/docs/sandbox
     shows: GA ephemeral compute primitive, JS+Python SDK
     accessed: '2026-06-04'


### PR DESCRIPTION
Applies the approved ruling that **a digested npm figure can carry a `usage_volume` band**. Every figure re-fetched and every package checked against its own registry metadata first.

| product | figure | was | now |
|---|---|---|---|
| `vercel-sandbox` | npm 13,197,882 | 4 | **5** |
| `cloudflare-sandboxes` | npm 1,136,848 | 3 | **4** |
| `sandbox-runtime` | npm 1,000,104 | 2 | **4** |
| `daytona-sandbox` | PyPI 10,225,169 | 4 | **5** |

Each npm note carries the required sentence: re-fetchable but **not** pipeline-recomputable, npm being unbridged (#163). `daytona` is on the bridged PyPI route so its note says the opposite — a model *can* recompute it.

**Two near-boundary cases, both flagged rather than buried.** `sandbox-runtime` clears the 1M floor by **104 downloads — 0.01%**, so a re-fetch on another day could read level 3; applied at 4 with confidence dropped to **low** and the thinness recorded in both the note and the source's `shows`. `daytona` has moved since the brief (10,225,169, not 10,089,811) so it now clears by 2.25% rather than 0.9% — still near-boundary, confidence medium.

Package ownership confirmed for all four, no `gvisor`-shaped errors.

## `opensandbox` capability 3 → 4

The band rested entirely on *"container-level isolation (no VM/microVM tier observed)"*, and that clause is false. I verified it myself rather than from the OSEP: `runtime_resolver.py` ships `SecureRuntimeResolver` with a Docker map (`gvisor → runsc`, `kata → kata-runtime`) and a Kubernetes RuntimeClass map (`gvisor`, `kata-qemu`, `kata-fc`) — I fetched the file and counted the symbols.

Capped at 4 with both reasons recorded so the ceiling is arguable rather than asserted: OpenSandbox explicitly does **not** install the runtimes (an OSEP non-goal), so the microVM tier depends on operator-supplied infrastructure and one server supports one runtime; and the only latency figures are the OSEP's own planning estimates.

## Also

**`tensorlake-sandbox`** — the ComputeSDK rerun re-derives identically (1.35s median, 15th of 24), so the ~3x gap against the recorded ~460ms is stable, not transient. The `value` now separates the vendor's sub-second claim from the measured figure. **Score left at 4 and escalated** — whether 1.35s should pull it down is a judgment call.

**`replit-agent-code-execution-api`** — dated by *dropping* the unsourceable ~100ms cold start, since `blog.replit.com` 403s and the Wayback API reports no capture exists. Everything remaining re-derives from two channels that both re-fetched byte-identical. Losing that claim removes a point in the product's favour, so it argues against raising the band, never for it.

`check_instrument` went 6 → 3 unsupported.

All gates green: `validate` 0 errors, `check_verification` all three OK, `check_capability` OK, `check_adoption --strict` exit 0, 488 tests.