### PR TITLE
Turn on the 30-day freshness gate, and fold the category-pass SOP into the runbook

### DIFF
--- a/.github/workflows/freshness.yml
+++ b/.github/workflows/freshness.yml
@@ -1,0 +1,56 @@
+name: freshness
+
+# The age gate: no category's oldest axis may be more than 30 days old.
+#
+# The window is 30 days, decided 2026-08-09. docs/guides/verification.md step 5 owns the number
+# and the reasoning; it is a judgment about how much re-reading the map is worth rather than
+# something derivable, and it is not re-argued per category.
+#
+# Deliberately NOT a step in validate.yml, and this is the difference that decides it: every
+# other gate in this repo fails on something in the diff in front of you. This one fails on the
+# passage of time. Per pull request it would block work unrelated to the stale category, and the
+# person looking at the red check could not clear it from inside their own PR either — the remedy
+# is to re-read a category against its sources, which is a research pass ending in a PR of its
+# own. An outside contributor adding one product would get a failure for a category they have
+# never touched. That is the failure mode parity.yml is written to avoid: a gate that fails for a
+# reason the person in front of it cannot act on gets switched off, which is how gates die.
+#
+# Weekly rather than daily for the same reason parity is weekly — the cadence has to match the
+# work it polices. A category is re-read in one run, so all of its axes carry one date and all of
+# them age out together; sixteen categories on a 30-day window is about four crossing the line
+# per week. A daily gate would re-report the same cliff every day until the re-read landed, which
+# is nagging rather than information.
+#
+# validate.yml runs the same report with no threshold, so it prints and cannot fail. That is
+# where a re-read PR sees whether the category it refreshed came back inside the window.
+
+on:
+  schedule:
+    # Monday 08:00 UTC. This needs no warehouse, so unlike parity.yml it is not tied to the
+    # Monday recompute chain; it sits after it so the week's queue of categories to re-read
+    # appears in one place at the start of the week.
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+    inputs:
+      max-age-days:
+        description: "Window in days. Leave at 30 unless testing what a different one would say."
+        default: "30"
+
+jobs:
+  freshness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history, for the same reason validate.yml needs it: an axis with no
+          # last_verified is dated from the last commit that changed what its score file
+          # claims, and a shallow clone collapses every one of those onto the tip commit —
+          # which reads as freshly verified and would turn this gate green on nothing.
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Install dependencies
+        run: uv sync --locked
+      - name: Age gate (no category's oldest axis over the window)
+        run: uv run python -m build.check_freshness --max-age-days "${{ inputs.max-age-days || 30 }}"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -93,6 +93,16 @@ jobs:
       # sitting in prose, which is the argument for counting it here instead.
       - name: Instrument gate (every signal_type claim has what it needs to be falsifiable)
         run: uv run python -m build.check_instrument
+      # How stale is every axis, per category. Informational on purpose: no --max-age-days, so
+      # it prints and cannot fail. The gate at 30 days is `.github/workflows/freshness.yml`,
+      # weekly, and it is the one gate here that must not run per PR — it fails on the passage
+      # of time, so it would block work unrelated to the stale category and nobody could clear
+      # it from inside their own PR. What this step is for is the other half: a re-read PR
+      # seeing, in its own log, whether the category it just refreshed came back inside the
+      # window. See docs/guides/freshness.md.
+      - name: Freshness report (informational, does not gate)
+        run: uv run python -m build.check_freshness
+
       - name: Serialize dry-run
         run: uv run python -m build.serialize --date ci-dry-run
 

--- a/build/check_freshness.py
+++ b/build/check_freshness.py
@@ -1,7 +1,7 @@
 """Report how stale the map's scores are.
 
-The map's value depends on its numbers being current, and until now there was no
-way to check that without reading 501 files. A score last touched in June looks
+The map's value depends on its numbers being current, and until this existed there was no
+way to check that without reading 472 files. A score last touched in June looks
 exactly like one touched yesterday.
 
 **`docs/guides/freshness.md` is the normative definition.** The rule is one sentence:
@@ -13,8 +13,9 @@ when the two disagree the guide wins.
 
   * **`last_verified`** — the most recent date on which everything in the score was
     confirmed still correct. Written when an axis is re-checked against its sources,
-    whether or not the value changed. 137 of 1,370 axes carry one, up from zero when
-    the field landed, and watching that fill in is how we measure the automation.
+    whether or not the value changed. All 1,416 axes carry one as of 2026-08-14, up from
+    zero when the field landed and 137 when this module did, and watching that fill in is
+    how the automation was measured.
   * **The score file's last commit date** — the fallback. Somebody committed this
     file on that date and left the score standing, which git records and nobody can
     inflate. Weaker than a re-check and *not* presented as one. Read `commit_dates` for
@@ -35,9 +36,25 @@ the commit date dates the import, which still answers "has anyone revisited this
 This report labels which signal each number came from, and never lets the weaker one
 be read as the stronger.
 
-Exit status is 0 unless `--max-age-days` is given, so it is safe to run for
-information. Pass a threshold to turn it into a CI gate once layer-2 is keeping
-scores fresh; gating today would only fail on the pre-automation backlog.
+Exit status is 0 unless `--max-age-days` is given, so it is safe to run for information.
+With a threshold it is a gate, and it fails if any category's oldest axis is over the
+window, or if any axis has no date at all for the window to be measured against.
+
+## Where the gate runs
+
+`.github/workflows/freshness.yml`, weekly, at 30 days — the window decided 2026-08-09 and
+owned by `docs/guides/verification.md` step 5. Not in `validate.yml`, and that is the one
+design decision in this file worth knowing about.
+
+Every other gate in this repo fails on something in a diff. This one fails on the passage of
+time, so per pull request it would block work unrelated to the stale category, and nobody
+could clear it from inside that pull request either: the remedy is to re-read a category
+against its sources, which is a research pass ending in a pull request of its own. Weekly
+rather than daily because a category is re-read in a single run, so its axes all age out
+together and roughly four categories cross the line per week; a daily gate would re-report
+the same cliff every day until the re-read finished. `validate.yml` runs the report without
+a threshold, so a re-read pull request can see its own effect without anything being able to
+fail on the clock.
 
 Usage:
     uv run python -m build.check_freshness
@@ -278,20 +295,27 @@ def commit_dates(root: Path | None = None) -> dict[str, date]:
     return {slug: when for slug, when in dates.items() if when is not None}
 
 
-def collect() -> tuple[dict[str, list[tuple[str, str, date, bool]]], list[str]]:
+def collect(
+    root: Path | None = None,
+) -> tuple[dict[str, list[tuple[str, str, date, bool]]], list[str]]:
     """Return (category -> [(product, axis, when, is_verified)], axes with no date).
 
     `is_verified` separates a real `last_verified` from a commit-date fallback, so
     the report can never present the weaker signal as the stronger one.
+
+    `root` defaults to this module's own repository, which is what the command line wants.
+    The tests pass a fixture checkout, so the gate's behavior can be asserted against dates
+    they construct rather than against whatever the corpus happens to say today.
     """
-    committed = commit_dates()
+    root = root or ROOT
+    committed = commit_dates(root)
     by_category: dict[str, list[tuple[str, str, date, bool]]] = defaultdict(list)
     undated: list[str] = []
 
-    for path in sorted((ROOT / "sources" / "categories").glob("*.yaml")):
+    for path in sorted((root / "sources" / "categories").glob("*.yaml")):
         category = yaml.safe_load(path.read_text())
         for product in category.get("products") or []:
-            score_path = ROOT / "sources" / "scores" / f"{product}.yaml"
+            score_path = root / "sources" / "scores" / f"{product}.yaml"
             if not score_path.exists():
                 continue
             scores = yaml.safe_load(score_path.read_text()) or {}
@@ -315,7 +339,7 @@ def collect() -> tuple[dict[str, list[tuple[str, str, date, bool]]], list[str]]:
     return by_category, undated
 
 
-def main() -> int:
+def main(argv: list[str] | None = None, root: Path | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--category", help="limit to one category slug")
     parser.add_argument(
@@ -324,10 +348,12 @@ def main() -> int:
         help="exit 1 if any category's oldest axis exceeds this. Omit to report only.",
     )
     parser.add_argument("--today", help="override today's date, YYYY-MM-DD, for testing")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
+    if args.max_age_days is not None and args.max_age_days < 1:
+        parser.error("--max-age-days must be at least 1; a window of zero days fails everything")
 
     today = parse_date(args.today) or date.today()
-    by_category, undated = collect()
+    by_category, undated = collect(root)
     if args.category:
         by_category = {k: v for k, v in by_category.items() if k == args.category}
 
@@ -353,13 +379,19 @@ def main() -> int:
     )
 
     verified_n = sum(1 for _, _, _, is_verified in rows if is_verified)
-    print(
-        f"\n{verified_n} of {len(rows)} axes carry a real last_verified. "
-        f"The other {len(rows) - verified_n} fall back to the score file's last commit "
-        "date, which dates the last time somebody committed the file and left the score "
-        "standing. For a file untouched since it was added that dates the import, not a "
-        "review, so read those ages as 'nobody has revisited this'."
-    )
+    if verified_n == len(rows):
+        print(
+            f"\nall {len(rows)} axes carry a real last_verified, so no age above rests on "
+            "the commit-date fallback."
+        )
+    else:
+        print(
+            f"\n{verified_n} of {len(rows)} axes carry a real last_verified. "
+            f"The other {len(rows) - verified_n} fall back to the score file's last commit "
+            "date, which dates the last time somebody committed the file and left the score "
+            "standing. For a file untouched since it was added that dates the import, not a "
+            "review, so read those ages as 'nobody has revisited this'."
+        )
     if undated:
         print(
             f"{len(undated)} axes have no date at all: {', '.join(undated[:6])}"
@@ -368,13 +400,35 @@ def main() -> int:
 
     if args.max_age_days is None:
         return 0
+
     over = [(age, cat, what) for age, cat, what in stalest if age > args.max_age_days]
-    if over:
-        print(f"\n{len(over)} categor(ies) exceed {args.max_age_days}d:")
-        for age, cat, what in sorted(over, reverse=True):
-            print(f"  ! {cat:<28} {age}d  ({what})")
+    if over or undated:
+        if over:
+            print(f"\n{len(over)} of {len(by_category)} categories are over {args.max_age_days}d:")
+            for age, cat, what in sorted(over, reverse=True):
+                print(f"  ! {cat:<28} {age}d  ({what})")
+        # An undated axis is unmeasurable, so the gate cannot vouch for it either way. This
+        # list is repo-wide even under --category, because a missing date is not a fact about
+        # the category you asked about. In CI it should be empty: it is only reachable for a
+        # file git has never seen.
+        if undated:
+            print(
+                f"\n{len(undated)} axes have no date for the window to measure: "
+                f"{', '.join(undated)}"
+            )
+        print(
+            "\nRe-read each category named above against its sources and stamp a fresh\n"
+            "last_verified per axis: `skills/refresh-category` drives that, one category per\n"
+            "PR. Editing a date without re-reading is the failure this gate exists to catch;\n"
+            "docs/guides/verification.md says what a confirmation has to consist of.\n"
+            "\n"
+            "Several categories aging out at once is expected rather than a backlog. A category\n"
+            "is re-read in one run, so all of its axes carry one date and all of them cross the\n"
+            f"line together. {len(by_category)} categories on a {args.max_age_days}d window is "
+            f"about {round(len(by_category) * 7 / args.max_age_days)} a week."
+        )
         return 1
-    print(f"\nall categories within {args.max_age_days}d")
+    print(f"\nall {len(by_category)} categories within {args.max_age_days}d")
     return 0
 
 

--- a/docs/guides/adoption.md
+++ b/docs/guides/adoption.md
@@ -281,8 +281,31 @@ it says something the level does not, which is usually the *shape* of the tracti
 its size: `osprey` at 446 GitHub stars but running in production at Discord is `niche` in a way
 that matters. The words are hardware's, which has used exactly these since before this route
 existed; sharing them beats minting a parallel set.
-- A `stars_fallback` band means no download signal existed when it was set. If one exists now,
-  re-band on it.
+
+### When a re-read may re-band, and when it may not
+
+Settled 2026-08-14, at the end of the verification sweep, because the same five questions
+arrived once per category and got answered from scratch each time. These are curation rules and
+no gate enforces them; `docs/runbooks/verification-pass.md` is where a pass applies them.
+
+- **A measured signal on an already-declared artifact beats a hand-set band.** The artifact was
+  declared, so the count is the instrument the record already claims to have been read with, and
+  the band follows the count. Re-band, and put the figure in the note.
+- **A `stars_fallback` band means no download signal existed when it was set.** If one exists
+  now, re-band on it.
+- **A `usage_volume` record over a page publishing no count at all is on the wrong instrument.**
+  Move it to `reported_traction`, drop the numeric `reach`, and **leave the level alone.** What
+  was wrong is the claim to have counted something, not the reading of the product's standing.
+  Re-deriving the level is a separate judgment and needs its own evidence.
+- **Declaring a NEW artifact requires it to be provably the product's own AND its primary
+  channel.** Both, not either. Refused on 2026-08-14 for `gvisor`, `ollama`, `promptfoo` and
+  `opencompass`: each has a findable package, and banding on it would have moved a level on a
+  minority channel. That is the under-coverage error below, met from the other direction.
+- **An SDK's downloads band the hosted platform it talks to**, with two exceptions. A package
+  that is a transitive dependency of a *different* product measures that product's reach —
+  `langsmith` is pulled in by `langchain-core`. And one SDK spanning N products may not be
+  attributed to one of them, which is `cohere-rerank-api` banded on the whole `cohere` package.
+  In both the count is real and is counting something other than the product.
 
 Measured 2026-08-10, 49 of the 60 products whose recorded band exceeded the computed one
 declared `usage_volume` while their own notes cited figures that matched the warehouse almost
@@ -351,7 +374,8 @@ it does not make the claim automatic, it makes it falsifiable.
   API integration, and the trap is attribution. `cohere-rerank-api` is currently banded on
   37.9M downloads of the `cohere` package, which is the SDK for Cohere's entire API surface
   rather than the rerank product. **An SDK covering N products may not be attributed wholly to
-  one**, and no such rule exists yet.
+  one** — the rule is in "When a re-read may re-band" above, along with the
+  transitive-dependency case it did not originally anticipate.
 - **OpenRouter rankings** — the only true API-channel signal, via
   `/api/v1/datasets/rankings-daily`. Two limits: it returns the top 50 models per day, and its
   `hugging_face_id` bridge is empty for exactly the closed and API-first models that need it

--- a/docs/guides/freshness.md
+++ b/docs/guides/freshness.md
@@ -46,12 +46,17 @@ staleness of 55 days when the files had in fact been revised a median of 35 days
 
 ## The fallback: the score file's last commit date
 
-Most axes carry no `last_verified` yet. For those, freshness falls back to **the date of
-the last commit that changed what `sources/scores/<slug>.yaml` claims**.
+Where an axis carries no `last_verified`, freshness falls back to **the date of the last
+commit that changed what `sources/scores/<slug>.yaml` claims**.
 
 Somebody committed that file on that date and left the score standing, which is a
 review rather than a reading. Git records it, and nobody can inflate it. As #102 put
 it, the git history of a score file *is* its verification record.
+
+As of 2026-08-14 every one of the 1,416 axes carries a real `last_verified`, so nothing on
+the map is currently read through the fallback. It remains the rule rather than history: a
+product added tomorrow has no date until somebody confirms it, and the age gate below reads
+whichever signal an axis has.
 
 **Changed what it claims, not merely touched.** Some commits move a file without
 reviewing it. The Phase 1a migration reshapes `openness.components` from a string into a
@@ -104,10 +109,44 @@ can never be conflated.
 ## What it is for
 
 Triage. A category whose oldest axis is 50 days old is a category to go and look at.
-`build/check_freshness.py` reports per-category median and oldest, names the stalest
-product, and takes `--max-age-days` to become a CI gate once enough axes carry a real
-`last_verified` that gating would fail on genuine staleness rather than on the
-pre-automation backlog.
+`build/check_freshness.py` reports per-category median and oldest and names the stalest
+product. `--max-age-days N` turns that report into a gate: it exits non-zero if any
+category's oldest axis is older than N days.
+
+**The window is 30 days**, decided 2026-08-09; `docs/guides/verification.md` step 5 holds the
+reasoning and owns the number.
+
+### Where the gate runs, and why not in `validate.yml`
+
+**`.github/workflows/freshness.yml`, weekly, and nowhere else.** It is the only gate here that
+fails on the passage of time rather than on something in a diff, and that difference decides
+where it belongs.
+
+Per-pull-request it would block work that has nothing to do with the stale category. Nobody can
+clear it from within the offending pull request either: the remedy is to re-read a category
+against its sources, which is a research pass (`skills/refresh-category`) ending in a pull
+request of its own. An outside contributor adding one product would be handed a red check for a
+category they have never touched and no way to turn it green. That is the failure mode
+`parity.yml` is written to avoid — a gate that fails for a reason the person in front of it
+cannot act on gets switched off.
+
+Weekly rather than daily for the same reason parity is weekly: the cadence has to match the work
+it polices. A category is re-read in one run, so all of its axes carry one date and all of them
+age out together, and about four categories cross a 30-day line per week. A daily gate would
+re-report the same cliff for as many days as the re-read takes, which is nagging rather than
+information.
+
+`validate.yml` runs the same report per pull request **without** `--max-age-days`, so it prints
+and cannot fail. That is what makes a re-read pull request show, in its own check log, whether
+the category it refreshed came back inside the window.
+
+### What the fallback means under a gate
+
+An axis with no `last_verified` is measured by its commit date, so a product added last week
+passes the age gate without anybody having confirmed it. That is not the gate leaking: age and
+confirmation are different questions, and "never confirmed" is `build/sweep_status.py`'s and
+`build/check_verification.py`'s. The report prints how many of its ages rest on the fallback so
+a pass can never quietly be resting on the weaker signal.
 
 ## Who may write `last_verified`
 

--- a/docs/guides/verification.md
+++ b/docs/guides/verification.md
@@ -139,6 +139,13 @@ cites it. Neither is a hard failure on its own — pages legitimately change —
 reasons to re-check, and a *missing* digest on a newly claimed confirmation is a hard
 failure, because it means the tool did not fetch anything.
 
+**A digest is only ever the output of a fetch, and there is no other way to obtain one.** A
+fabricated digest is worse than an absent one: an absent one fails the gate, while a fabricated
+one passes it and then defeats the sampled re-fetch, which is the only thing that ever goes back
+and checks whether a cited page says what it was recorded as saying. Three were fabricated on
+2026-08-13 by padding truncated prefixes out to 64 characters, which is why this is stated here
+rather than assumed. `docs/runbooks/verification-pass.md` carries the command that produces one.
+
 ## The gates, and why they ratchet
 
 Every failure mode this project has actually hit gets a mechanism, not a note. Cheap ones
@@ -152,14 +159,26 @@ gate every PR. The ones needing the network run periodically.
 | refetch | fabricated or rotted sources | sampled re-fetch, digest and `shows` token match | network, weekly |
 | parity | repo and warehouse drifting apart | `build/check_parity.py`, a per-product differential | network, weekly |
 | capability-anchors | a recorded peer comparison that does not hold | `relation` must agree with both scores, and a dated band's peer must be confirmed at least as recently | free |
+| age | a corpus that was confirmed once and then quietly aged | `build/check_freshness.py --max-age-days 30`, scheduled weekly | free, weekly |
 
 These were numbered G1-G6 until 2026-08-08. Older PRs and commit messages use the numbers.
 
+The age gate is the last one on this table to arrive (2026-08-14) and the only one that fails on
+the passage of time rather than on something in a diff. That is why it is scheduled rather than
+per-pull-request: a contributor adding one product cannot re-read a category to turn it green, and
+a gate nobody in front of it can act on is a gate that gets ignored. Step 5 below has the window
+and its owner; `docs/guides/freshness.md` has the shape.
+
 **They ratchet rather than switch on.** The invariant and the digest requirement apply only to
-axes that carry a `last_verified`, which is 137 today and grows as the re-read pass proceeds. So
-they cover exactly what has been done, never block progress, and never permit a regression on
-ground already taken. A big-bang gate over all 1370 axes would fail on day one and get switched
-off, which is how gates die.
+axes that carry a `last_verified`. So they cover exactly what has been done, never block progress,
+and never permit a regression on ground already taken. A big-bang gate over every axis at once
+would have failed on day one and been switched off, which is how gates die.
+
+**The ratchet has now closed.** That count was 137 when this section was written and is **1,416 as
+of 2026-08-14 — every axis in the corpus.** So the invariant and the digest requirement now apply
+everywhere, and the age gate above became possible only because of it: gating on age while most
+axes carried no date at all would have measured the backlog rather than staleness. Read the count
+from `check_freshness` rather than from this paragraph, which will drift again.
 
 The producible-pair check and the parity gate apply in full immediately — nothing has to be
 populated first.
@@ -526,10 +545,12 @@ score for this reason.
 
 ### 5. Turn on the age gate
 
-`build/check_freshness.py --max-age-days 30` becomes a CI gate. This is the entire point of
-having the field: a category whose oldest axis is 50 days old is a category to go and look
-at. Gating earlier would only fail on the pre-automation backlog rather than on genuine
-staleness.
+**Done 2026-08-14.** `build/check_freshness.py --max-age-days 30` gates in
+`.github/workflows/freshness.yml`, weekly. This is the entire point of having the field: a
+category whose oldest axis is 50 days old is a category to go and look at. Gating earlier would
+only have failed on the pre-automation backlog rather than on genuine staleness; step 4 closed
+that, and on the day the gate landed all 1,416 axes carried a real `last_verified` and the
+oldest category read 6 days.
 
 **The window is 30 days, decided 2026-08-09.** It is a judgment about how much re-reading the
 map is worth rather than anything derivable, so it is recorded here with its date and its owner
@@ -543,6 +564,9 @@ than drifting past the line one product at a time — that is the shape of the w
 backlog. And the sampled re-fetch will keep reporting drift on pages that change daily;
 at this window that drift is noise, and a digest that *matches* remains the only thing it
 positively proves.
+
+The cliff is also why the gate is scheduled rather than per-pull-request, and weekly rather than
+daily. `docs/guides/freshness.md` has that argument and the shape of the workflow.
 
 ## Related
 

--- a/docs/runbooks/verification-pass.md
+++ b/docs/runbooks/verification-pass.md
@@ -290,7 +290,9 @@ The unit of work is therefore per product, not per axis:
    `http_status`, `license_*`, `is_archived`, `is_gated`, `downloads_30d` and `fetched_at`.
 2. Fetch each cited URL a signal does not already cover; record `http_status`,
    `content_sha256`, and a `shows` extract that actually appears in the body. A cited URL that
-   404s is a finding, not something to paper over.
+   404s is a finding, not something to paper over — and so is a cited figure that no longer
+   appears in a page which still resolves. One product in the 2026-08 sweep cited a leaderboard
+   position that had ceased to exist at all, on a URL returning 200.
 3. Re-derive each recorded dimension and attribute it: `establishes: [...]`.
    On capability, that means the peer comparison: if the band was placed against another
    product, record it as `relative_to` + `relation` rather than leaving it in the note, and
@@ -304,11 +306,39 @@ The unit of work is therefore per product, not per axis:
 6. Stamp `last_verified` only once every recorded dimension has an establishing source.
    Otherwise `deferred` with a real reason. Never both, and never silently absent.
 
+**Order the batch anchors first, which is not optional.** `check_capability` enforces transitive
+freshness: a band recording `relative_to: X` may not claim a `last_verified` more recent than
+X's, so an anchor confirmed yesterday fails a band dated today. Find the anchors inside the batch
+with `grep -l relative_to sources/scores/*.yaml` intersected with the roster, and date them in the
+same run.
+
+**Four rules a pass may not bend.** Each of these is a defect this project shipped rather than a
+precaution against one.
+
+1. **Never invent a digest.** The only thing that produces a `content_sha256` is
+   `uv run python -m build.fetch_source <url>`, and what it prints is the full 64 characters.
+   Three were fabricated on 2026-08-13 by padding truncated prefixes out to full length. If a URL
+   cannot be fetched, record no digest for it and leave the axis undated.
+2. **`accessed`, `http_status` and `content_sha256` travel together** on the same source. A fresh
+   `accessed` with nothing under it fails `check_verification`, so re-dating a source and
+   digesting it are one edit rather than two.
+3. **An unreachable host says nothing about whether the fact is true.** A 403, a 429 or a dead URL
+   means the axis stays undated and the host gets reported. It never means the value is wrong.
+4. **A plain YAML scalar cannot contain `": "`.** Write ` - ` instead, or single-quote the whole
+   scalar. This cost four separate parse failures in one day.
+
+**A null axis is a finding, and it earns a date too.** `level: null` over a note saying no figure
+is published is a deliberate abstention rather than missing work. Re-read the page, confirm
+nothing has appeared, and date it — citing the page that publishes nothing and saying in the note
+what was looked for. `verification.md`, "A null axis can earn a `last_verified`", is the rule
+(#236).
+
 Batch by category so `check_rubric` gives a clean signal per batch, and run
-`check_verification` after each batch rather than at the end. One PR per category, prose and
-scores together, with every moved score itemized against its evidence. Categories go in order
-of **worst signal coverage first**, so no manual reading duplicates what Phase 3's write-back
-would have earned for free.
+`check_verification` after each batch rather than at the end. The full gate list for a batch is
+step 6 of `skills/refresh-category/SKILL.md`, and that is the only copy of it. One PR per
+category, prose and scores together, with every moved score itemized against its evidence.
+Categories go in order of **worst signal coverage first**, so no manual reading duplicates what
+Phase 3's write-back would have earned for free.
 
 **On agent execution.** This is 1106 fetches and it is the step most exposed to
 rubber-stamping — an agent that "confirms" without reading would reproduce #108's failure at
@@ -316,6 +346,40 @@ fifty times the scale while looking legitimate. Three things make that not work:
 requires the `accessed` bump on every dimension, the digest requirement requires a digest that
 only fetching produces, and the sampled re-fetch goes back to the network for a sample and
 compares. Do not relax any of the three to make a batch finish.
+
+### Running the pass in parallel
+
+One agent per category, several categories at once, is what closed all 472 products between
+2026-08-13 and 2026-08-14. `skills/refresh-category/SKILL.md` is the orchestration — the batch
+shape, the concurrency cap, the research / audit / apply split, and the reading list each agent
+gets. Four things belong to the agent rather than the orchestrator, and each is a defect the sweep
+actually hit:
+
+- **Namespace scratch files per agent.** The session scratchpad is shared. Two passes had a fetch
+  log and a helper script overwritten mid-run by a sibling agent using the same filenames, and had
+  to re-fetch everything to be sure the digests they were about to record were their own. Write
+  only under a private subdirectory named for the category.
+- **Touch only your own category's files** — `sources/scores/<member>.yaml` and
+  `sources/products/<member>.yaml` for members of that category. Never `docs/`, `tests/`,
+  `.github/`, `build/notebook_data.json`, `notebooks/`, or another category's products.
+- **Escalate anything that moves a level.** Step 5 above says a moved value is the valuable
+  output, and it is, but the agent that finds one is not the one who applies it. Escalate any
+  change to a `score`, `level`, `class` or `reach`, declaring a new artifact, refusing an artifact
+  that exists, an axis whose evidence is gone and needs new sources found, and anything you are
+  guessing at. Then carry on: escalating one product does not block the other twenty.
+- **Where the entity moved rather than the evidence, it is a curation call.** A product that
+  merged, split into tiers or was renamed is `docs/guides/identity.md` work, not a re-read. Record
+  the finding and leave the slug alone.
+
+**The escalations are where the pass earns its money.** Agents refusing to date
+`fireworks-inference`, `math`, `muse-spark`, `grok` and `doubao-seed` is how the sweep found
+evidence that had quietly vanished. A batch escalating nothing is more suspicious than one
+escalating five things.
+
+When the escalation is an adoption re-band, `docs/guides/adoption.md`, "When a re-read may
+re-band", carries the standing answers: measured signal against a hand-set band, `stars_fallback`,
+relabelling to `reported_traction`, declaring a new artifact, and SDK attribution. Rule from there
+rather than deciding it again per category.
 
 **Expect scores to move.** The RWKV correction in #105 came out of a pass like this. Movement
 is the return on the work, not a problem with it — `apply_scores --check` exits non-zero on a
@@ -330,7 +394,7 @@ moved score deliberately.
 ## Phase 5 — Close the ratchet
 
 ```bash
-uv run python -m build.check_freshness --max-age-days 90     # tune, then gate
+uv run python -m build.check_freshness --max-age-days 30     # the gate, run by hand
 ```
 
 **The sampled re-fetch landed early**, in #148, because Phase 4 is the step it exists to police
@@ -340,8 +404,11 @@ and running that without it would be the rubber-stamp risk with nothing undernea
 legitimately change. A digest that **matches** is the proof — one that differs proves nothing on
 its own.
 
-What remains here: turn `--max-age-days` into a CI gate once coverage makes it fail on genuine
-staleness rather than on backlog, and drop the digest requirement's exemption list.
+**The age gate is on** as of 2026-08-14, at 30 days, weekly in
+`.github/workflows/freshness.yml` rather than per-pull-request — it fails on the passage of time,
+so nobody can clear it from inside an unrelated PR. `docs/guides/freshness.md` has the argument.
+
+What remains here: drop the digest requirement's exemption list.
 
 **Exit criteria:** the five definition-of-done conditions hold, and each is enforced by
 something that runs without being remembered.
@@ -355,6 +422,13 @@ Every one of these has happened. They are not hypotheticals.
 | hazard | tell | guard |
 |---|---|---|
 | Derived date sold as a confirmation | any aggregate of `accessed` reaching `last_verified` | `tests/test_apply_scores.py`; the invariant validates, never derives |
+| Fabricated digest | a full-length `content_sha256` on a source nobody could fetch | only `build.fetch_source` produces one; the sampled re-fetch compares it |
+| A re-dated source with nothing under it | a fresh `accessed`, no `http_status` or `content_sha256` | `check_verification`'s digest requirement |
+| A parse failure from a `": "` in a scalar | `validate` cannot read a file the pass just wrote | write ` - `, or single-quote the whole scalar |
+| Parallel agents sharing a scratch directory | a fetch log or helper script rewritten mid-run | one private subdirectory per category |
+| A 404 read as a product being gone | a retirement resting on one dead URL | check the URL first: `arduino/app-lab` 404s, `arduino/arduino-app-lab` is public, GPL-3.0 and actively pushed |
+| A marketing reorganization read as a withdrawal | the vendor site stops listing it; the docs still ship it | `snorkel-flow` was nearly retired off its marketing site while `docs.snorkel.ai` had it at v26.1 with an install guide |
+| A test whose setup depends on the bug | the test dies when the bug is fixed | build the fixture; never borrow a live failing record, as `test_relabelling_to_reported_traction_does_not_buy_a_pass` did |
 | Stale warehouse read | identical query text returning a pre-materialization answer | the nonce helper (0.4) |
 | Unreleased revision | "my SQL change had no effect", no error | the release assertion (0.5) |
 | Repo/warehouse drift | local reproduces, warehouse abstains | the parity gate (Phase 2) |
@@ -367,5 +441,8 @@ Every one of these has happened. They are not hypotheticals.
 
 - `docs/guides/verification.md` — normative: the invariant, the gates, who may write a date
 - `docs/guides/freshness.md` — normative: what `last_verified` means
+- `docs/guides/adoption.md` — normative: the bands, the instrument vocabulary, and when a re-read
+  may re-band
 - `docs/runbooks/deploy-udms.md` — revision → release → run
+- `skills/refresh-category/SKILL.md` — the orchestration for one category of Phase 4
 - `AGENTS.md` — the layer-2 loop and the evidence grading rule

--- a/skills/refresh-category/SKILL.md
+++ b/skills/refresh-category/SKILL.md
@@ -143,7 +143,12 @@ curl and never WebFetch, so the digest recorded is one the weekly sampled re-fet
 
 Give every agent these. Each is a defect the pilot actually produced:
 
-- **A transient status is not an absence.** `fetch_source` retries and returns
+- **The four rules a pass may not bend** — `docs/runbooks/verification-pass.md`, Phase 4: digests,
+  the three fetch fields traveling together, unreachable hosts, and `": "` in a plain scalar.
+  Point the agent at that section rather than restating them here, or there are two copies to
+  keep true.
+- **A transient status is not an absence**, which is that section's third rule in
+  `fetch_source`'s own terms. `fetch_source` retries and returns
   `"transient": true` with no digest when one survives. That means retry or defer. It never
   means the fact is missing. One un-retried 429 was promoted into the ground for a confirmation;
   the figure was there.
@@ -227,10 +232,16 @@ uv run python -m build.validate
 uv run python -m build.check_verification --verbose
 uv run python -m build.check_capability
 uv run python -m build.check_recipe
+uv run python -m build.check_adoption --strict
 uv run python -m build.check_refetch --product <one you just wrote>
 uv run python -m build.check_freshness --category <slug>
 uv run python -m pytest tests/ -q
 ```
+
+This is the canonical list for a category batch; the runbook's Phase 4 points at it rather than
+carrying a second copy. `validate` must print `0 error(s)`, `check_verification` must report all
+three gates OK, and `check_adoption --strict` must exit 0. **Do not commit while a gate is
+failing** — report the failure instead.
 
 Expect gates to **fail first and tell you something**. On the pilot, `validate` rejected an
 `establishes` naming a components key no ladder reads, and `check_recipe` demanded a stale

--- a/tests/test_freshness_gate.py
+++ b/tests/test_freshness_gate.py
@@ -1,0 +1,150 @@
+"""The age gate's exit status.
+
+`--max-age-days N` exits non-zero when a category's oldest axis is over N days old, and zero
+when nothing is. `docs/guides/freshness.md` owns the rule and `docs/guides/verification.md`
+step 5 owns the window.
+
+Every fixture here is built from dates these tests choose, and `--today` pins the clock. That
+is deliberate: a test that borrowed a currently-stale record from `sources/` would pass only
+until somebody re-read that category, which is exactly how
+`test_relabelling_to_reported_traction_does_not_buy_a_pass` expired once already. Nothing here
+reads the corpus.
+
+The fixture is a real git repository with one commit, because `collect` dates a fallback axis
+from git history. Every axis below carries a `last_verified`, so no test depends on what that
+history says — the repository exists so the walk has something to open.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import yaml
+
+from build.check_freshness import main
+
+TODAY = "2026-08-14"
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "T",
+            "GIT_AUTHOR_EMAIL": "t@example.com",
+            "GIT_COMMITTER_NAME": "T",
+            "GIT_COMMITTER_EMAIL": "t@example.com",
+        },
+    )
+
+
+def _corpus(tmp_path: Path, categories: dict[str, dict[str, str | None]]) -> Path:
+    """Build a checkout from {category: {product: last_verified or None}}.
+
+    A `None` date writes a score block with no `last_verified`, which is the fallback case.
+    """
+    (tmp_path / "sources" / "categories").mkdir(parents=True)
+    (tmp_path / "sources" / "scores").mkdir(parents=True)
+
+    for category, products in categories.items():
+        (tmp_path / "sources" / "categories" / f"{category}.yaml").write_text(
+            yaml.safe_dump({"name": category, "products": sorted(products)}, sort_keys=False)
+        )
+        for product, verified in products.items():
+            axes = {}
+            for axis, value in (("openness", {"score": 5}), ("adoption", {"level": 3}),
+                                ("capability", {"score": 4})):
+                axes[axis] = dict(value)
+                if verified is not None:
+                    axes[axis]["last_verified"] = verified
+            (tmp_path / "sources" / "scores" / f"{product}.yaml").write_text(
+                yaml.safe_dump({"product": product, **axes}, sort_keys=False)
+            )
+
+    _git(tmp_path, "init", "-q", "-b", "main", str(tmp_path))
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-q", "-m", "corpus")
+    return tmp_path
+
+
+def _run(root: Path, *args: str) -> int:
+    return main([*args, "--today", TODAY], root=root)
+
+
+def test_everything_inside_the_window_passes(tmp_path):
+    root = _corpus(tmp_path, {"widgets": {"a": "2026-08-13", "b": "2026-07-20"}})
+
+    assert _run(root, "--max-age-days", "30") == 0
+
+
+def test_an_axis_over_the_window_fails(tmp_path):
+    """25 days is inside, 31 is not, and one axis over the line is enough."""
+    root = _corpus(tmp_path, {"widgets": {"a": "2026-07-20", "b": "2026-07-14"}})
+
+    assert _run(root, "--max-age-days", "30") == 1
+
+
+def test_the_boundary_is_older_than_rather_than_at(tmp_path):
+    """Exactly N days old is inside the window; N + 1 is not."""
+    at_the_line = _corpus(tmp_path / "at", {"widgets": {"a": "2026-07-15"}})
+    a_day_past = _corpus(tmp_path / "past", {"widgets": {"a": "2026-07-14"}})
+
+    assert _run(at_the_line, "--max-age-days", "30") == 0
+    assert _run(a_day_past, "--max-age-days", "30") == 1
+
+
+def test_a_stale_category_does_not_fail_a_fresh_one_when_scoped(tmp_path):
+    """--category limits the gate, which is what makes it usable while re-reading one."""
+    root = _corpus(tmp_path, {"fresh": {"a": "2026-08-13"}, "stale": {"b": "2026-06-01"}})
+
+    assert _run(root, "--max-age-days", "30") == 1
+    assert _run(root, "--category", "fresh", "--max-age-days", "30") == 0
+    assert _run(root, "--category", "stale", "--max-age-days", "30") == 1
+
+
+def test_without_the_flag_a_stale_corpus_still_exits_zero(tmp_path):
+    """The report stays safe to run for information. validate.yml depends on this."""
+    root = _corpus(tmp_path, {"widgets": {"a": "2026-01-01"}})
+
+    assert _run(root) == 0
+
+
+def test_the_failure_names_the_category_and_what_to_do(tmp_path, capsys):
+    """A gate whose output does not say what to go and do gets ignored."""
+    root = _corpus(tmp_path, {"stale": {"b": "2026-06-01"}})
+
+    assert _run(root, "--max-age-days", "30") == 1
+    out = capsys.readouterr().out
+    assert "stale" in out
+    assert "refresh-category" in out
+    assert "verification.md" in out
+
+
+def test_a_fallback_age_is_labeled_rather_than_counted_as_confirmed(tmp_path, capsys):
+    """An axis with no last_verified is dated from git, and the report has to say so."""
+    root = _corpus(tmp_path, {"widgets": {"dated": "2026-08-13", "undated": None}})
+
+    assert _run(root, "--max-age-days", "30") == 0
+    out = capsys.readouterr().out
+    assert "3 of 6 axes carry a real last_verified" in out
+
+
+def test_an_axis_with_no_date_at_all_fails_the_gate(tmp_path, capsys):
+    """The commit-date fallback is unavailable for a file git has never seen, so the window
+    has nothing to measure. Unmeasurable is a failure, not a pass."""
+    root = _corpus(tmp_path, {"widgets": {"a": "2026-08-13"}})
+    (root / "sources" / "categories" / "widgets.yaml").write_text(
+        yaml.safe_dump({"name": "widgets", "products": ["a", "uncommitted"]}, sort_keys=False)
+    )
+    (root / "sources" / "scores" / "uncommitted.yaml").write_text(
+        yaml.safe_dump({"product": "uncommitted", "openness": {"score": 5}}, sort_keys=False)
+    )
+
+    assert _run(root, "--max-age-days", "30") == 1
+    assert "no date for the window to measure" in capsys.readouterr().out


### PR DESCRIPTION
Two changes that both close the same gap, so they land together: the 2026-08 verification sweep proved the corpus is current, and nothing yet kept it that way or wrote down how the sweep was actually run.

## 1. The age gate is on

`build/check_freshness.py --max-age-days 30` becomes a real gate. This was step 5 of the plan in `verification.md` and it was blocked only by coverage — gating while most axes carried no date would have measured the backlog rather than staleness. Step 4 closed that.

**The window was already decided:** 30 days, 2026-08-09, recorded in the guide with its owner and explicitly not to be re-argued per category. Nothing here re-opens it.

Measured on the day it landed:

```
1416 axes | median 1d | oldest 6d (trl.openness) | newest 0d
all 1416 carry a real last_verified — no age rests on the commit-date fallback
all 16 categories within 30d
```

**Weekly in `.github/workflows/freshness.yml`, not per-pull-request.** It is the only gate in this repo that fails on the passage of time rather than on something in a diff, so per-PR it would go red for a category the PR never touched, and an outside contributor could not turn it green — the remedy is a research pass ending in its own PR. That is the argument `parity.yml` already makes for itself. `validate.yml` gains a `check_freshness` step with **no threshold**, so a `refresh-category` PR can read its own result in its own log without being able to block anything.

Weekly rather than daily because a category is re-read in one run, so its axes carry one date and expire together — roughly four categories cross the line per week. A daily gate would re-report the same cliff every day until the re-read landed.

Not issue-opening: no workflow here does that, and `parity.yml` is the existing precedent for a hard-failing scheduled gate. Followed it rather than inventing machinery.

**Two things worth more than the flag flip:**

- `fetch-depth: 0`, with a comment. Without it a shallow clone collapses every commit date onto the tip, which reads as freshly verified — a false green. Latent today at zero fallback axes, live the moment a product is added.
- **An axis with no date at all now fails** under a threshold rather than being skipped. The window has nothing to measure and unmeasurable is not a pass.

Also: `--max-age-days 0` is rejected rather than failing everything, and the report stops printing the commit-date-fallback explanation when nothing used it.

The failure message names the category, the oldest axis, and `skills/refresh-category` as the thing to run — and says outright that editing a date without re-reading is the failure the gate exists to catch, because that is the obvious way to make it green.

## 2. The category-pass SOP moves into the repo

The procedure that closed 472 products existed only in a session scratchpad, which is exactly the "written in prose, therefore lost" failure the sweep kept finding.

It is **merged into `docs/runbooks/verification-pass.md` rather than added beside it.** The runbook already existed at 371 lines with the gate order and a hazards table; a second procedure would have recreated the problem in a new form. Split along the line the repo already draws — a rule about what a value *means* is normative and goes in a guide, a rule about what to *run* and what will bite you goes in the runbook:

- **`docs/guides/adoption.md`** — the five re-banding rulings, under "When a re-read may re-band, and when it may not". They answer which instrument a record is on, which is a meaning question. One (`stars_fallback` re-bands) was already there as a dangling bullet and got absorbed rather than duplicated; the SDK-attribution note saying "no such rule exists yet" is now false and was removed.
- **`docs/guides/verification.md`** — one sentence: a digest is only ever the output of a fetch, and a fabricated one is worse than an absent one because it passes the gate *and* defeats the sampled re-fetch.
- **`docs/runbooks/verification-pass.md`** — the mechanics, in Phase 4 where the re-read already lives, plus a new "Running the pass in parallel" section and **seven new hazard rows**.
- **`skills/refresh-category/SKILL.md`** — a pointer, not a copy.

**What was dropped as already-covered:** eight items the guides state better, each cross-referenced instead. Notably the gate command block — `refresh-category` step 6 already had a longer version, so it got the one command it was missing (`check_adoption --strict`) plus exit conditions and is now labelled the only copy, rather than becoming a second list that drifts.

**A contradiction resolved rather than papered over.** The SOP said *escalate* anything that moves a level; the runbook's Phase 4 said a moved value is the valuable output, so *fix the score*. Both are right for different actors, and that is now explicit: the pass fixes, an agent inside a parallel batch escalates, because it is not the one applying. `refresh-category` already enforces that shape.

Worth recording for whoever plans the next sweep: **`refresh-category/SKILL.md` was already a more developed version of this SOP** — 273 lines of orchestration that says "every rule about how to verify lives in the guides." The procedure was never missing from the repo. Only the hazards and the rulings were.

## 3. Finalizing against the existing docs

Reviewing the merged result, not just the textual merge:

- **The gates table in `verification.md` gained an `age` row.** It is the canonical inventory and every other gate is in it; the new one being absent would have been the same invisibility problem one level up.
- **"which is 137 today" was flatly false** — that count is now 1,416, every axis in the corpus. Corrected, with the ratchet argument kept and a note to read the number from `check_freshness` rather than from the paragraph, since it will drift again.
- Left alone deliberately: the `1370` figures elsewhere in `verification.md` and the runbook's exit criteria. That is a **different denominator** — real claims, versus `check_freshness`'s count of every axis block including deliberately-null ones — and they are dated measurements. Same for `score.schema.json`'s "137 distinct keys", which is component keys and a coincidence.
- All four new cross-references were checked to resolve: adoption.md's "When a re-read may re-band" (line 285), verification.md's "A null axis can earn a `last_verified`" (line 318), and `refresh-category` step 6's gate list.

## Test plan

```
uv run pytest -q                           → 496 passed
build.validate                             → 0 error(s)
check_verification --verbose               → invariant [OK] digests [OK] producible-pairs [OK]
check_capability                           → [OK]
check_recipe --verbose                     → [OK] 0 failure(s)
check_components                           → [OK]
check_rubric                               → reproduced
check_adoption --strict                    → 452 products [OK]
check_instrument                           → 452 adoption records [OK]
check_freshness                            → EXIT 0 (informational, no threshold)
check_freshness --max-age-days 30          → EXIT 0 (the gate, passes today)
serialize + check_payload                  → 472 products, 257 organizations, ok
serialize_rubric --check                   → nothing written
all 8 workflow YAMLs parse
```

`tests/test_freshness_gate.py` is 8 new tests that build their own corpus and git repo and pin the clock with `--today`, so nothing depends on a condition that gets fixed — the failure mode `test_relabelling_to_reported_traction_does_not_buy_a_pass` already hit once. Covers both sides of the boundary (30d in, 31d out), `--category` scoping, that no flag exits 0 even on a stale corpus (which `validate.yml` depends on), and that a date-less axis fails.

Generated files were reverted after the dry runs; nothing bot-owned is in either commit.

## Known limits, stated rather than hidden

- The gate reads a commit-date fallback as satisfying the window, so a product added today passes without ever having been confirmed. Age and confirmation are different questions — `check_verification` owns the second — and the report prints the fallback count so it cannot hide.
- The `undated` list stays repo-wide even under `--category`, because a missing date is not a fact about the category you asked about.
- Whether a red weekly run is loud enough is unresolved. A `push` trigger is the wrong fix, since a merge cannot make anything older.

Related: #236, #108, #115.
