### PR TITLE
Add a read-only mirror of the gap-map UDM logic (with provenance)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,10 @@ sources/rubrics/       Shared scoring ladders. A category inherits one with
                        is the example). build/rubrics.py resolves either form.
                        license-to-tier lives here, because whether AGPL is `osi` is
                        a fact about AGPL, not about one category.
-warehouse/models/      UDM SQL (entities, events, metrics, scores)
+warehouse/platform-mirror/  Read-only COPY of the models that run on the OSO platform to
+                       build the gap map's data (evidence, openness scores, signals), with a
+                       provenance manifest. Source of truth is the platform; nothing deploys from here.
+warehouse/models/      SQL for the legacy entities/events/metrics/scores layer (in-repo)
 warehouse/ingest/      Python fetchers that write CSVs to warehouse/catalog/
 warehouse/catalog/     Raw external CSVs (HF benchmarks, incidents, GitHub orgs)
 warehouse/sources.yaml Manifest: each external source declares EITHER a fetcher

--- a/docs/operations/deploy-models.md
+++ b/docs/operations/deploy-models.md
@@ -9,11 +9,11 @@ different places.
 | Family | Models | Where the SQL lives |
 |---|---|---|
 | Legacy warehouse | `entities`, `events`, `metrics`, and the legacy `scores` stack-map models | `warehouse/models/` — **in this repo** |
-| Scoring chain | `evidence.product_evidence` → `scores.openness_facts` → `scores.openness_computed`, plus the `signal_*` fetchers | On the OSO platform only. The deploy script and `.sql` sit one level up in `currentai-org/{tools,udms}/`, **which is not under version control at all.** |
+| Scoring chain | `evidence.product_evidence` → `scores.openness_facts` → `scores.openness_computed`, plus the `signal_*` fetchers | On the OSO platform. The models are copied **read-only** into `warehouse/platform-mirror/` (with a provenance manifest) so they are legible from the repo; the deploy script and the working copies you push from sit one level up in `currentai-org/{tools,udms}/`, outside version control. **Nothing deploys from `warehouse/platform-mirror/`.** |
 
-Mirroring the scoring-chain SQL into `warehouse/udms/` is tracked as T1 of the 2026-08-14
-audit. Until it lands, treat the copy in `../udms/` as the only copy that exists, and run the
-deploy from that directory.
+The `warehouse/platform-mirror/` copy (T1 of the 2026-08-14 audit) makes the scoring models
+readable without platform access. It is a snapshot, not the source of truth — see
+`warehouse/platform-mirror/README.md` and its `manifest.yaml` for the deployed revision each file reflects.
 
 ## The deploy mechanic: revision → RELEASE → run
 

--- a/tests/test_platform_mirror.py
+++ b/tests/test_platform_mirror.py
@@ -1,0 +1,65 @@
+"""Integrity of the read-only platform mirror in warehouse/platform-mirror/.
+
+The mirror is a committed copy of the models that run on the OSO platform; manifest.yaml is
+its provenance record. This test keeps the two honest without needing platform credentials:
+
+- every mirrored artifact is represented in the manifest, and vice versa;
+- the manifest's local_sha256 binds the actual checked-in bytes (so a silent edit to a mirror
+  file, or a stale manifest, fails here);
+- every deployed (non-staged) entry carries model_id + revision + platform hash provenance.
+
+The credentialed drift check (manifest revision vs the live platform) is a separate follow-up;
+this is the offline half.
+"""
+
+import hashlib
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+MIRROR = REPO / "warehouse" / "platform-mirror"
+NON_ARTIFACTS = {"README.md", "manifest.yaml"}
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _manifest() -> dict:
+    return yaml.safe_load((MIRROR / "manifest.yaml").read_text())
+
+
+def test_every_mirror_file_is_in_the_manifest():
+    on_disk = {p.name for p in MIRROR.iterdir() if p.is_file() and p.name not in NON_ARTIFACTS}
+    listed = set()
+    for m in _manifest()["models"]:
+        listed.add(m["file"])
+        if "schema_file" in m:
+            listed.add(m["schema_file"])
+    missing = on_disk - listed
+    unknown = listed - on_disk
+    assert not missing, f"mirror files absent from manifest.yaml: {sorted(missing)}"
+    assert not unknown, f"manifest.yaml references files not on disk: {sorted(unknown)}"
+
+
+def test_local_hashes_bind_the_checked_in_bytes():
+    problems = []
+    for m in _manifest()["models"]:
+        f = MIRROR / m["file"]
+        if m.get("local_sha256") != _sha256(f):
+            problems.append(f"{m['file']}: local_sha256 does not match its bytes")
+        if "schema_file" in m and m.get("schema_local_sha256") != _sha256(MIRROR / m["schema_file"]):
+            problems.append(f"{m['schema_file']}: schema_local_sha256 does not match its bytes")
+    assert not problems, "manifest hashes are stale:\n" + "\n".join(problems)
+
+
+def test_deployed_entries_have_revision_provenance():
+    problems = []
+    for m in _manifest()["models"]:
+        if m.get("status") == "staged":
+            continue
+        for field in ("model_id", "revision", "hash"):
+            if not m.get(field):
+                problems.append(f"{m['file']} -> {m.get('table')}: missing {field}")
+    assert not problems, "deployed mirror entries lack provenance:\n" + "\n".join(problems)

--- a/warehouse/platform-mirror/README.md
+++ b/warehouse/platform-mirror/README.md
@@ -1,0 +1,38 @@
+# warehouse/platform-mirror — read-only copy of the platform models
+
+These files are a **committed copy of the models that run on the OSO platform to build the gap
+map's data** (the openness scores, the evidence behind them, and the adoption/capability
+signals). They live here so anyone reading the repo can see how the data is produced, without
+needing platform access.
+
+**The platform is the source of truth, not this folder.** Do not edit these files to change how
+anything is computed — nothing here is deployed. The real editing/deploy happens on the platform
+(the working copies you push from live in `currentai-org/{tools,udms}/`, outside this repo). A
+copy can only drift from what's live, so treat any mismatch as "this copy is stale" and re-sync.
+
+**Provenance is in [`manifest.yaml`](manifest.yaml)** — for each file, the deployed model it
+mirrors, the revision it reflects, and a hash of the checked-in bytes, plus the sync date. That's
+what makes this a checkable snapshot rather than just a copy. `tests/test_platform_mirror.py`
+keeps the manifest and the files in step; a credentialed job that compares against the live
+platform to catch drift is a planned follow-up.
+
+## What each file is
+
+| File | Platform table |
+|---|---|
+| `evidence_product_evidence.sql` | `currentai.evidence.product_evidence` — the evidence behind each scoring dimension |
+| `scores_openness_facts.sql` | `currentai.scores.openness_facts` — resolves each dimension per product |
+| `scores_openness_computed.sql` | `currentai.scores.openness_computed` — walks each openness ladder in SQL |
+| `github_repo_state.py` | `currentai.signal_github.repo_state` |
+| `huggingface_hub_state.py` | `currentai.signal_huggingface.hub_state` |
+| `pypi_package_downloads.sql` | `currentai.signal_pypi.package_downloads` |
+| `artificialanalysis_models.py` | `currentai.signal_artificialanalysis.model_evaluations` |
+| `lmarena_leaderboard.py` | `currentai.signal_lmarena.text_leaderboard` |
+| `semanticscholar_paper_citations.py` | `currentai.signal_semanticscholar.paper_citations` |
+| `goodailist_repos.py` | `currentai.signal_goodailist.repo_catalog` |
+| `packages_*.{sql,py}` | `currentai.signal_packages.*` — package-adoption successor (staged) |
+| `*.schema.json` | the output columns each model declares |
+
+The `check_parity` gate is what actually enforces that `scores_openness_computed.sql` and
+`build/check_rubric.py` agree — this copy is for reading, that gate is for correctness. See
+`docs/operations/deploy-models.md`.

--- a/warehouse/platform-mirror/artificialanalysis_models.py
+++ b/warehouse/platform-mirror/artificialanalysis_models.py
@@ -1,0 +1,197 @@
+# ────── PLATFORM MIRROR (read-only) ──────
+# A snapshot of a model that runs on the OSO platform to build one of the gap map's
+# tables. The platform is the source of truth; nothing deploys from this copy, and
+# editing it here changes nothing. See README.md and manifest.yaml in this folder.
+
+"""Artificial Analysis model evaluations — the capability aggregator.
+
+One authenticated request returns every model AA tracks with its full evaluation
+block. This matters because most benchmark leaderboards publish HTML or keep
+results behind a dashboard app rather than as files: AILuminate's repo carries only
+prompt sets, Terminal-Bench's results sit in a database, and SWE-bench has no
+aggregate. AA has already done that aggregation and exposes it as JSON, so this one
+source reaches Terminal-Bench, tau2, LiveCodeBench, GPQA, MMLU-Pro, AIME and HLE.
+
+Deliberately NOT joined to the map's products. AA names point releases
+("Claude Sonnet 4.6 (Non-reasoning, High Effort)") while the map keeps generic
+version buckets, and normalized-name matching mis-mapped Claude Sonnet 4 onto
+Sonnet 4.6 in testing. This lands AA's own rows keyed on AA's own slug; the
+product bridge is a separate, curated piece of work.
+
+Every numeric field arrives as int OR float depending on the record — the
+intelligence index alone is 496 floats and 77 ints across the corpus — so numbers
+are read as float. Reading them as int would silently turn a score of 60.7 into 60.
+
+Thirteen models carry no intelligence index at all, and they are the newest
+frontier releases (the Claude Sonnet 5 variants, GPT-5.5 Pro). AA has not scored
+them yet, so a null score means unmeasured, not incapable.
+
+Coverage caveat worth carrying: AA matched 57 of the map's 106 model products on
+name in a manual check, and the misses skew toward small open models, safety
+models, and the map's deliberate version buckets. AA is a frontier-model source,
+not a whole-map one.
+"""
+
+from datetime import date, datetime, timezone
+
+import oso
+import polars as pl
+
+AA_URL = "https://artificialanalysis.ai/api/v2/data/llms/models"
+
+EVAL_FIELDS = [
+    "artificial_analysis_intelligence_index",
+    "artificial_analysis_coding_index",
+    "artificial_analysis_math_index",
+    "mmlu_pro",
+    "gpqa",
+    "hle",
+    "livecodebench",
+    "scicode",
+    "math_500",
+    "aime",
+    "aime_25",
+    "ifbench",
+    "lcr",
+    "terminalbench_hard",
+    "terminalbench_v2_1",
+    "tau2",
+    "tau_banking",
+]
+PRICE_FIELDS = ["price_1m_blended_3_to_1", "price_1m_input_tokens", "price_1m_output_tokens"]
+SPEED_FIELDS = [
+    "median_output_tokens_per_second",
+    "median_time_to_first_token_seconds",
+    "median_time_to_first_answer_token",
+]
+
+
+def _records(payload: object) -> list[dict]:
+    """Rows live under `data`; narrow rather than assume."""
+    if not isinstance(payload, dict):
+        return []
+    rows = payload.get("data")
+    if not isinstance(rows, list):
+        return []
+    return [row for row in rows if isinstance(row, dict)]
+
+
+def _text(payload: object, key: str) -> str | None:
+    if isinstance(payload, dict):
+        value = payload.get(key)
+        if isinstance(value, str):
+            return value
+    return None
+
+
+def _float(payload: object, key: str) -> float | None:
+    """Scores arrive as int or float per record. Always read as float."""
+    if not isinstance(payload, dict):
+        return None
+    value = payload.get(key)
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _nested(payload: object, block: str, key: str) -> str | None:
+    if isinstance(payload, dict):
+        inner = payload.get(block)
+        if isinstance(inner, dict):
+            value = inner.get(key)
+            if isinstance(value, str):
+                return value
+    return None
+
+
+def _nested_float(payload: object, block: str, key: str) -> float | None:
+    if isinstance(payload, dict):
+        inner = payload.get(block)
+        if isinstance(inner, dict):
+            return _float(inner, key)
+    return None
+
+
+def _price(payload: object, key: str) -> float | None:
+    """AA encodes "no hosted pricing" as 0.0, never as null.
+
+    211 of 586 models carry 0.0 — open-weights families with no hosted endpoint,
+    plus unreleased frontier models. A hosted model does not cost exactly zero, so
+    0.0 is missing data and is returned as null. Otherwise every downstream reader
+    would see a third of the corpus as free.
+    """
+    value = _nested_float(payload, "pricing", key)
+    if value is None or value == 0.0:
+        return None
+    return value
+
+
+def _has_hosted_pricing(payload: object) -> bool:
+    """True when AA reports any non-zero price, i.e. the model is served somewhere."""
+    return any(
+        (_nested_float(payload, "pricing", field) or 0.0) > 0.0 for field in PRICE_FIELDS
+    )
+
+
+def _release_date(payload: object) -> date | None:
+    raw = _text(payload, "release_date")
+    if raw is None:
+        return None
+    try:
+        return date.fromisoformat(raw[:10])
+    except ValueError:
+        return None
+
+
+@oso.model(
+    secrets=["ARTIFICIAL_ANALYSIS_TOKEN"],
+    environment_name="Default",
+    external_origins=["https://artificialanalysis.ai"],
+)
+def model_evaluations(context: oso.Context) -> oso.DataFrame:
+    token: str = context.secret("ARTIFICIAL_ANALYSIS_TOKEN")
+    response = context.fetch(AA_URL, headers={"X-API-Key": token})
+    if response.status != 200:
+        raise RuntimeError(f"Artificial Analysis returned {response.status}")
+
+    records = _records(response.json())
+    if not records:
+        raise RuntimeError("Artificial Analysis returned no models")
+
+    fetched = datetime.now(timezone.utc).replace(tzinfo=None, microsecond=0)
+
+    rows: list[dict] = []
+    for record in records:
+        row: dict = {
+            "aa_id": _text(record, "id"),
+            "aa_slug": _text(record, "slug"),
+            "name": _text(record, "name"),
+            "release_date": _release_date(record),
+            "creator_name": _nested(record, "model_creator", "name"),
+            "creator_slug": _nested(record, "model_creator", "slug"),
+            "fetched_at": fetched,
+        }
+        for field in EVAL_FIELDS:
+            row[field] = _nested_float(record, "evaluations", field)
+        for field in PRICE_FIELDS:
+            row[field] = _price(record, field)
+        row["has_hosted_pricing"] = _has_hosted_pricing(record)
+        for field in SPEED_FIELDS:
+            row[field] = _float(record, field)
+        rows.append(row)
+
+    schema: dict = {
+        "aa_id": pl.Utf8,
+        "aa_slug": pl.Utf8,
+        "name": pl.Utf8,
+        "release_date": pl.Date,
+        "creator_name": pl.Utf8,
+        "creator_slug": pl.Utf8,
+        "has_hosted_pricing": pl.Boolean,
+        "fetched_at": pl.Datetime("us"),
+    }
+    for field in EVAL_FIELDS + PRICE_FIELDS + SPEED_FIELDS:
+        schema[field] = pl.Float64
+    return pl.DataFrame(rows, schema=schema)

--- a/warehouse/platform-mirror/evidence_product_evidence.schema.json
+++ b/warehouse/platform-mirror/evidence_product_evidence.schema.json
@@ -1,0 +1,87 @@
+[
+  {
+    "name": "product_slug",
+    "type": "VARCHAR",
+    "description": "Joins registry.products."
+  },
+  {
+    "name": "category_slug",
+    "type": "VARCHAR",
+    "description": "Which category's rubric asked. The same product can be asked different questions by different categories."
+  },
+  {
+    "name": "dimension",
+    "type": "VARCHAR",
+    "description": "weights, data, code, license, checkpoints. Undeclared dimensions pass through and are reported by the serializer."
+  },
+  {
+    "name": "part_index",
+    "type": "BIGINT",
+    "description": "Position of this part within a multi-part recorded value; 0 for every single-valued dimension."
+  },
+  {
+    "name": "value",
+    "type": "VARCHAR",
+    "description": "The answer, in the rubric's vocabulary where one applies. Null when the source abstains."
+  },
+  {
+    "name": "value_detail",
+    "type": "VARCHAR",
+    "description": "Detail the formula ignores but a reviewer needs: gating mode, storage size, the raw hub slug."
+  },
+  {
+    "name": "grade",
+    "type": "VARCHAR",
+    "description": "dataset = a named field in a machine-readable source, re-derived by running a query. document = a URL whose content asserts it, re-derived by reading it. Not an author field: the first pass of sources/scores was itself agent-authored."
+  },
+  {
+    "name": "attribution",
+    "type": "VARCHAR",
+    "description": "artifact = the row names the SKU or repo it came from. axis = sources/scores records sources per axis rather than per dimension, so no single URL can honestly be named."
+  },
+  {
+    "name": "artifact_id",
+    "type": "VARCHAR",
+    "description": "The SKU or repo. Null for document rows. A family ships several and they routinely disagree, which is why stage 2 needs a family-level rule."
+  },
+  {
+    "name": "source_url",
+    "type": "VARCHAR",
+    "description": "Where the observation can be re-derived from."
+  },
+  {
+    "name": "source_table",
+    "type": "VARCHAR",
+    "description": "Dataset grade only: the table the value was read from."
+  },
+  {
+    "name": "source_column",
+    "type": "VARCHAR",
+    "description": "Dataset grade only: the column(s) the value was derived from."
+  },
+  {
+    "name": "source_accessed",
+    "type": "DATE",
+    "description": "When the source was actually read, NOT when this model ran, so a recompute cannot make stale evidence look freshly checked."
+  },
+  {
+    "name": "admitted",
+    "type": "BOOLEAN",
+    "description": "False when the source gives no usable answer. The row is still emitted so the gap is queryable rather than invisible."
+  },
+  {
+    "name": "source_reachable",
+    "type": "BOOLEAN",
+    "description": "Whether the artifact responded at all, held apart from admitted because 'it responded' and 'it answered the question' are different facts. Null for document rows, which are never fetched."
+  },
+  {
+    "name": "reject_reason",
+    "type": "VARCHAR",
+    "description": "Why an observation was not admitted."
+  },
+  {
+    "name": "settles_dimension",
+    "type": "BOOLEAN",
+    "description": "False for the GitHub code route, which shows code exists and is alive but not that it is a full training pipeline."
+  }
+]

--- a/warehouse/platform-mirror/evidence_product_evidence.sql
+++ b/warehouse/platform-mirror/evidence_product_evidence.sql
@@ -1,0 +1,312 @@
+-- ────── PLATFORM MIRROR (read-only) ──────
+-- A snapshot of a model that runs on the OSO platform to build one of the gap map's
+-- tables. The platform is the source of truth; nothing deploys from this copy, and
+-- editing it here changes nothing. See README.md and manifest.yaml in this folder.
+
+-- currentai.evidence.product_evidence
+-- Graded, traceable evidence behind each openness dimension, per product.
+--
+-- Sits between the two layer-2 stages: research writes evidence, scoring reads it
+-- and applies the category's rules. Every row records how the value can be arrived
+-- at again, because re-derivability - not authorship - is what makes it checkable.
+-- The first pass of sources/scores was itself agent-authored, so a column saying
+-- whether a human or a model wrote it would grade the wrong thing.
+--
+--   grade = 'dataset'   a named field in a machine-readable source. Re-derived by
+--                       running a query. Carries source_table and source_column.
+--   grade = 'document'  a URL whose content asserts the value. Re-derived by
+--                       reading it. Carries when it was read.
+--
+-- `dataset` is preferred wherever it can answer, because a document is an
+-- interpretation of prose and a dataset field is a lookup. RWKV is why: its
+-- data-openness 5 rested on a paper's claim of a 3.1T open corpus, and what
+-- corrected it to 4 was the Hub showing the published repos hold a component index
+-- and previews. Choosing between the two is stage 2's job, not this model's - this
+-- one records what each source says and whether it says anything usable.
+--
+-- Grain: one row per (product_slug, category_slug, dimension, grade, artifact_id,
+-- part_index). artifact_id is null for document rows and names the SKU for dataset rows,
+-- because a family ships several SKUs and they routinely disagree. That disagreement is
+-- the whole reason stage 2 needs a family-level rule rather than a per-row one.
+--
+-- `part_index` is the same observation one level down, on the document side. A recorded
+-- license can be SEVERAL licenses - `zed` ships an editor, a collab server and a UI
+-- framework under three - and build/serialize_rubric.py publishes one row per part, in the
+-- order the record writes them. Every other dimension answers once and pins the index at 0.
+--
+-- It is a grain column, not a payload one, and it exists because the alternative was
+-- splitting a string in Trino. The repo owns how a recorded value is parsed; when the
+-- warehouse re-derived the parts from punctuation the two disagreed, and three products
+-- scored differently on either side of the bridge for it.
+--
+-- Four limits, surfaced as columns rather than buried:
+--
+--   * `attribution` - document sources are recorded per AXIS in sources/scores,
+--     never per dimension, so a document row cannot name the single URL behind it.
+--     Picking one would invent an attribution the files do not contain. The
+--     evidence-store design wants per-dimension sources; today's files lack them.
+--   * `admitted` - a row citing nothing specific is still emitted, carrying its
+--     reason, so unsourced assertions become a queryable work list instead of
+--     passing for provenance. 111 of the 253 source rows behind the base models say
+--     only 'flagship phase-C verification source'.
+--   * `source_reachable` is held apart from `admitted` deliberately. "The artifact
+--     responded" and "the artifact answered the question" are different facts, and
+--     stage 2's family rule needs the first: it must know how many SKUs it should
+--     have heard from before deciding whether partial coverage is safe to act on.
+--     Null for document rows, which are never fetched.
+--   * `settles_dimension` - the GitHub route establishes that code exists and is
+--     alive, not that it is a full training pipeline. It informs `code` and must not
+--     decide it, per signal_routing.yaml. Its values are deliberately outside the
+--     rubric's code enum so they cannot be mistaken for an answer.
+--   * Abstention values come from currentai.registry.evidence_abstentions rather
+--     than being written here, so sources/signal_routing.yaml stays the single
+--     declaration. A rule implemented in two places drifts.
+--
+-- Openness only. Adoption bands and the capability anchor route differently, and
+-- the capability anchor is still unbridged, so neither is part of this pilot.
+WITH abstain AS (
+  SELECT source, column_name, LOWER(abstain_value) AS abstain_value
+  FROM currentai.registry.evidence_abstentions
+),
+
+-- Only categories with a machine-readable rubric can be scored, so only their
+-- products need evidence. Today that is base_pretrained alone.
+roster AS (
+  SELECT DISTINCT pc.product_slug, pc.category_slug
+  FROM currentai.registry.product_categories pc
+  JOIN (
+    SELECT DISTINCT category_slug FROM currentai.registry.category_scoring_rules
+  ) scored ON scored.category_slug = pc.category_slug
+),
+
+-- Document grade -------------------------------------------------------------
+-- Values parsed from the `components` string by build/serialize_rubric.py. Parsing
+-- stays in the repo because build/check_rubric.py already owns and tests it, and a
+-- second copy here would drift from the first.
+axis_sources AS (
+  SELECT
+    product_slug,
+    category_slug,
+    axis,
+    COUNT(*) AS sources_total,
+    COUNT_IF(admitted) AS sources_admitted,
+    MAX(CASE WHEN admitted THEN NULLIF(source_accessed, '') END) AS last_admitted
+  FROM currentai.registry.product_score_sources
+  GROUP BY product_slug, category_slug, axis
+),
+document AS (
+  SELECT
+    e.product_slug,
+    e.category_slug,
+    e.dimension,
+    CAST(e.part_index AS BIGINT) AS part_index,
+    e.value,
+    NULLIF(e.value_detail, '') AS value_detail,
+    'document' AS grade,
+    'axis' AS attribution,
+    CAST(NULL AS VARCHAR) AS artifact_id,
+    CAST(NULL AS VARCHAR) AS source_url,
+    CAST(NULL AS VARCHAR) AS source_table,
+    CAST(NULL AS VARCHAR) AS source_column,
+    TRY_CAST(s.last_admitted AS DATE) AS source_accessed,
+    COALESCE(s.sources_admitted, 0) > 0 AS admitted,
+    -- Never fetched, so reachability does not apply. Not `false`, which would read
+    -- as "we tried and it was down".
+    CAST(NULL AS BOOLEAN) AS source_reachable,
+    CASE
+      WHEN COALESCE(s.sources_admitted, 0) > 0 THEN CAST(NULL AS VARCHAR)
+      ELSE 'openness axis cites nothing specific: '
+           || CAST(COALESCE(s.sources_total, 0) AS VARCHAR)
+           || ' source(s) recorded, 0 admissible'
+    END AS reject_reason,
+    true AS settles_dimension
+  FROM currentai.registry.product_openness_evidence e
+  LEFT JOIN axis_sources s
+    ON s.product_slug = e.product_slug
+   AND s.category_slug = e.category_slug
+   AND s.axis = 'openness'
+),
+
+-- Dataset grade: Hugging Face ------------------------------------------------
+hub AS (
+  SELECT
+    r.product_slug,
+    r.category_slug,
+    h.artifact_id,
+    h.license,
+    h.is_gated,
+    h.gated_mode,
+    h.is_private,
+    h.is_disabled,
+    h.used_storage_bytes,
+    h.http_status,
+    CAST(h.fetched_at AS DATE) AS fetched_on
+  FROM currentai.signal_huggingface.hub_state h
+  JOIN roster r ON r.product_slug = h.product_slug
+  WHERE h.artifact_kind = 'huggingface_model'
+),
+hub_license AS (
+  SELECT
+    b.product_slug,
+    b.category_slug,
+    'license' AS dimension,
+    -- A hub SKU reports one license, so the part index is 0 by construction. It is not
+    -- null: a null would read as "this row has no position" and the abstain COUNT on the
+    -- document side turns on rows being countable.
+    CAST(0 AS BIGINT) AS part_index,
+    -- The alias is load-bearing. The Hub publishes a slug (`gemma`, `llama3.1`)
+    -- and the rubric's tier examples use license names, so without the map a
+    -- present, use-restricting license reads as absent - which is the direction
+    -- that overstates openness.
+    a.license_name AS value,
+    'hub slug: ' || COALESCE(b.license, '<null>') AS value_detail,
+    'dataset' AS grade,
+    'artifact' AS attribution,
+    b.artifact_id,
+    'https://huggingface.co/' || b.artifact_id AS source_url,
+    'currentai.signal_huggingface.hub_state' AS source_table,
+    'license' AS source_column,
+    b.fetched_on AS source_accessed,
+    (
+      b.http_status = 200
+      AND b.license IS NOT NULL
+      AND ab.abstain_value IS NULL
+      AND a.license_name IS NOT NULL
+    ) AS admitted,
+    (b.http_status = 200) AS source_reachable,
+    CASE
+      WHEN b.http_status <> 200
+        THEN 'declared artifact does not resolve (HTTP ' || CAST(b.http_status AS VARCHAR) || ')'
+      WHEN b.license IS NULL THEN 'hub records no license for this SKU'
+      WHEN ab.abstain_value IS NOT NULL
+        THEN 'hub license ' || b.license || ' is an escape hatch, not a license'
+      WHEN a.license_name IS NULL
+        THEN 'no alias declared for hub license slug ' || b.license
+      ELSE CAST(NULL AS VARCHAR)
+    END AS reject_reason,
+    true AS settles_dimension
+  FROM hub b
+  LEFT JOIN currentai.registry.license_aliases a
+    ON a.source = 'huggingface'
+   AND LOWER(a.license_slug) = LOWER(b.license)
+  -- Joined on the ROUTE's source name rather than a bare 'huggingface', so an
+  -- abstention declared for model licenses cannot be read as applying to dataset
+  -- licenses. Both are declared in signal_routing.yaml, on their own routes.
+  LEFT JOIN abstain ab
+    ON ab.source = 'huggingface_model'
+   AND ab.column_name = 'license'
+   AND ab.abstain_value = LOWER(b.license)
+),
+hub_weights AS (
+  SELECT
+    b.product_slug,
+    b.category_slug,
+    'weights' AS dimension,
+    CAST(0 AS BIGINT) AS part_index,
+    -- Only ever 'open' or nothing. A private or disabled repo is NOT evidence the
+    -- weights are closed: the model may be distributed off the Hub entirely, which
+    -- signal_routing.yaml calls out as unroutable and leaves to research.
+    CASE
+      WHEN b.http_status = 200
+       AND NOT COALESCE(b.is_private, false)
+       AND NOT COALESCE(b.is_disabled, false)
+       AND COALESCE(b.used_storage_bytes, 0) > 0
+      THEN 'open'
+      ELSE CAST(NULL AS VARCHAR)
+    END AS value,
+    -- Gating is recorded here rather than closing the dimension. A click-through
+    -- gate is not the same thing as withheld weights.
+    CONCAT(
+      CASE WHEN COALESCE(b.is_gated, false)
+        THEN 'gated (' || COALESCE(b.gated_mode, 'unspecified') || ')' ELSE 'ungated' END,
+      ', ',
+      CAST(ROUND(COALESCE(b.used_storage_bytes, 0) / 1e9, 1) AS VARCHAR), ' GB on the Hub'
+    ) AS value_detail,
+    'dataset' AS grade,
+    'artifact' AS attribution,
+    b.artifact_id,
+    'https://huggingface.co/' || b.artifact_id AS source_url,
+    'currentai.signal_huggingface.hub_state' AS source_table,
+    'is_private, is_disabled, used_storage_bytes' AS source_column,
+    b.fetched_on AS source_accessed,
+    (
+      b.http_status = 200
+      AND NOT COALESCE(b.is_private, false)
+      AND NOT COALESCE(b.is_disabled, false)
+      AND COALESCE(b.used_storage_bytes, 0) > 0
+    ) AS admitted,
+    (b.http_status = 200) AS source_reachable,
+    CASE
+      WHEN b.http_status <> 200
+        THEN 'declared artifact does not resolve (HTTP ' || CAST(b.http_status AS VARCHAR) || ')'
+      WHEN COALESCE(b.is_private, false) THEN 'hub repo is private'
+      WHEN COALESCE(b.is_disabled, false) THEN 'hub repo is disabled'
+      WHEN COALESCE(b.used_storage_bytes, 0) = 0 THEN 'hub repo carries no files'
+      ELSE CAST(NULL AS VARCHAR)
+    END AS reject_reason,
+    true AS settles_dimension
+  FROM hub b
+),
+
+-- Dataset grade: GitHub ------------------------------------------------------
+-- Presence and liveness only. Whether the code is a full pretraining pipeline or
+-- inference utilities is a judgment no API makes, so this route informs `code`
+-- without settling it. The values are deliberately NOT in the rubric's code enum
+-- (open / partial / closed) so they cannot be read as an answer by mistake.
+repo_code AS (
+  SELECT
+    r.product_slug,
+    r.category_slug,
+    'code' AS dimension,
+    CAST(0 AS BIGINT) AS part_index,
+    CASE
+      WHEN g.http_status <> 200 THEN CAST(NULL AS VARCHAR)
+      WHEN COALESCE(g.is_archived, false) THEN 'repo-archived'
+      ELSE 'repo-present'
+    END AS value,
+    'last pushed ' || COALESCE(CAST(CAST(g.pushed_at AS DATE) AS VARCHAR), 'unknown') AS value_detail,
+    'dataset' AS grade,
+    'artifact' AS attribution,
+    g.repo AS artifact_id,
+    g.html_url AS source_url,
+    'currentai.signal_github.repo_state' AS source_table,
+    'is_archived, pushed_at' AS source_column,
+    CAST(g.fetched_at AS DATE) AS source_accessed,
+    (g.http_status = 200) AS admitted,
+    (g.http_status = 200) AS source_reachable,
+    CASE
+      WHEN g.http_status <> 200
+        THEN 'declared repo does not resolve (HTTP ' || CAST(g.http_status AS VARCHAR) || ')'
+      ELSE CAST(NULL AS VARCHAR)
+    END AS reject_reason,
+    -- The load-bearing false. Everything else about this row is corroboration.
+    false AS settles_dimension
+  FROM currentai.signal_github.repo_state g
+  JOIN roster r ON r.product_slug = g.product_slug
+)
+
+SELECT
+  product_slug,
+  category_slug,
+  dimension,
+  part_index,
+  value,
+  value_detail,
+  grade,
+  attribution,
+  artifact_id,
+  source_url,
+  source_table,
+  source_column,
+  source_accessed,
+  admitted,
+  source_reachable,
+  reject_reason,
+  settles_dimension
+FROM (
+  SELECT * FROM document
+  UNION ALL SELECT * FROM hub_license
+  UNION ALL SELECT * FROM hub_weights
+  UNION ALL SELECT * FROM repo_code
+)
+ORDER BY product_slug, dimension, grade, artifact_id, part_index

--- a/warehouse/platform-mirror/github_repo_state.py
+++ b/warehouse/platform-mirror/github_repo_state.py
@@ -1,0 +1,321 @@
+# ────── PLATFORM MIRROR (read-only) ──────
+# A snapshot of a model that runs on the OSO platform to build one of the gap map's
+# tables. The platform is the source of truth; nothing deploys from this copy, and
+# editing it here changes nothing. See README.md and manifest.yaml in this folder.
+
+"""Live GitHub repo state for the declared gap-map roster.
+
+Roster comes from `currentai.registry.product_artifacts`, filtered to the github
+kind — the repo's own declaration, pushed out by CI, so coverage tracks the map
+rather than a hand-uploaded snapshot. Grain is one row per (product, repo) pair,
+since a few products declare more than one repo.
+
+Deliberately narrow. It does NOT compute contributor counts or commit activity —
+`currentai.events` / `currentai.metrics` carry GitHub Archive activity and
+`currentai.scores.stack_contributors` carries contributors. This model covers
+what nothing else does: first-party repo state for adoption, liveness, and the
+license component of openness.
+
+Three design rules:
+  * Partial failure is data, not an exception. A per-repo `http_status` is
+    recorded rather than raised, so one dead repo cannot kill the whole run. A
+    404 is itself a signal that a product may have gone private or been deleted.
+  * A 301 is free rename detection. `context.fetch` does not follow redirects,
+    so the Location header tells us a repo moved. Renames are the same class of
+    breakage that took down the roadmap label match in CUR-131.
+  * GitHub reports NOASSERTION for genuinely-licensed repos that carry a custom
+    copyright line. For those only, make a second call and keep the first line of
+    the LICENSE so the false negative is visible downstream.
+"""
+
+import asyncio
+import base64
+from datetime import datetime, timezone
+
+import oso
+import polars as pl
+
+GITHUB_API = "https://api.github.com"
+ROSTER_SQL = (
+    "SELECT product_slug, artifact_id "
+    'FROM "currentai"."registry"."product_artifacts" '
+    "WHERE artifact_kind = 'github'"
+)
+NOASSERTION = "NOASSERTION"
+
+
+def _header(headers: object, name: str) -> str | None:
+    """Case-insensitive lookup over an untyped headers mapping."""
+    if not isinstance(headers, dict):
+        return None
+    target = name.lower()
+    for key, value in headers.items():
+        if isinstance(key, str) and key.lower() == target and isinstance(value, str):
+            return value
+    return None
+
+
+def _text(payload: object, key: str) -> str | None:
+    if isinstance(payload, dict):
+        value = payload.get(key)
+        if isinstance(value, str):
+            return value
+    return None
+
+
+def _number(payload: object, key: str) -> int | None:
+    if isinstance(payload, dict):
+        value = payload.get(key)
+        if isinstance(value, bool):
+            return None
+        if isinstance(value, int):
+            return value
+        if isinstance(value, float):
+            return int(value)
+    return None
+
+
+def _flag(payload: object, key: str) -> bool | None:
+    if isinstance(payload, dict):
+        value = payload.get(key)
+        if isinstance(value, bool):
+            return value
+    return None
+
+
+def _stamp(payload: object, key: str) -> datetime | None:
+    raw = _text(payload, key)
+    if raw is None:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed.replace(tzinfo=None, microsecond=0)
+
+
+def _license_field(payload: object, key: str) -> str | None:
+    if isinstance(payload, dict):
+        block = payload.get("license")
+        if isinstance(block, dict):
+            value = block.get(key)
+            if isinstance(value, str):
+                return value
+    return None
+
+
+def _topics(payload: object) -> str | None:
+    if isinstance(payload, dict):
+        value = payload.get("topics")
+        if isinstance(value, list):
+            names = [item for item in value if isinstance(item, str)]
+            if names:
+                return ",".join(names)
+    return None
+
+
+def _license_first_line(payload: object) -> str | None:
+    """Decode the base64 LICENSE body and return its first meaningful line."""
+    if not isinstance(payload, dict):
+        return None
+    content = payload.get("content")
+    if not isinstance(content, str):
+        return None
+    try:
+        decoded = base64.b64decode(content).decode("utf-8", errors="replace")
+    except (ValueError, TypeError):
+        return None
+    for line in decoded.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped[:200]
+    return None
+
+
+def _needs_license_probe(has_payload: bool, spdx: str | None) -> bool:
+    """GitHub's NOASSERTION is a known false negative worth a second look."""
+    return has_payload and (spdx is None or spdx == NOASSERTION)
+
+
+def _is_api_repo_url(url: str | None) -> bool:
+    """Guard the redirect hop to the GitHub API origin we already declared."""
+    return url is not None and url.startswith(f"{GITHUB_API}/repositories/")
+
+
+@oso.model(
+    secrets=["GITHUB_TOKEN"],
+    environment_name="Default",
+    depends_on=["currentai.registry.product_artifacts"],
+    external_origins=["https://api.github.com"],
+)
+async def repo_state(context: oso.AsyncContext) -> oso.DataFrame:
+    token: str = await context.secret("GITHUB_TOKEN")
+    headers: dict[str, str] = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    result = await context.query(ROSTER_SQL)
+    roster = await result.as_pl()
+    slugs: list[str] = []
+    repos: list[str] = []
+    for row in roster.iter_rows(named=True):
+        slug = row.get("product_slug")
+        repo = row.get("artifact_id")
+        if isinstance(slug, str) and isinstance(repo, str) and "/" in repo:
+            slugs.append(slug)
+            repos.append(repo)
+    if not repos:
+        raise RuntimeError("roster query returned no usable repos")
+
+    responses = await asyncio.gather(
+        *(context.fetch(f"{GITHUB_API}/repos/{repo}", headers=headers) for repo in repos)
+    )
+
+    payloads: list[object] = []
+    statuses: list[int] = []
+    locations: list[str | None] = []
+    remaining: int | None = None
+    ok_count = 0
+
+    for response in responses:
+        statuses.append(response.status)
+        locations.append(_header(response.headers, "location"))
+        seen = _header(response.headers, "x-ratelimit-remaining")
+        if seen is not None and seen.isdigit():
+            remaining = int(seen)
+        if response.status == 200:
+            ok_count += 1
+            payloads.append(response.json())
+        else:
+            payloads.append(None)
+
+    if ok_count == 0:
+        raise RuntimeError(
+            f"every one of {len(repos)} GitHub calls failed; first status {statuses[0]}"
+        )
+
+    # Resolve the 301s. Most are case mismatches in the declared roster rather
+    # than real renames (GitHub redirects when casing differs), and the Location
+    # header points at /repositories/{id}, which returns the full payload under
+    # its canonical name. Without this hop those rows carry no data at all.
+    redirected = [
+        index
+        for index, status in enumerate(statuses)
+        if status == 301 and _is_api_repo_url(locations[index])
+    ]
+    resolved_flags: list[bool] = [False] * len(repos)
+    if redirected:
+        followed = await asyncio.gather(
+            *(
+                context.fetch(str(locations[index]), headers=headers)
+                for index in redirected
+            )
+        )
+        for index, response in zip(redirected, followed):
+            if response.status == 200:
+                payloads[index] = response.json()
+                resolved_flags[index] = True
+
+    # Second pass, only for the ambiguous-license repos. Keyed on having a
+    # payload, so redirect-resolved repos get probed too.
+    probe_index = [
+        index
+        for index in range(len(repos))
+        if _needs_license_probe(
+            payloads[index] is not None, _license_field(payloads[index], "spdx_id")
+        )
+    ]
+    first_lines: list[str | None] = [None] * len(repos)
+    if probe_index:
+        probe_responses = await asyncio.gather(
+            *(
+                context.fetch(f"{GITHUB_API}/repos/{repos[index]}/license", headers=headers)
+                for index in probe_index
+            )
+        )
+        for index, response in zip(probe_index, probe_responses):
+            if response.status == 200:
+                first_lines[index] = _license_first_line(response.json())
+
+    fetched = datetime.now(timezone.utc).replace(tzinfo=None, microsecond=0)
+
+    rows: list[dict] = []
+    for index, repo in enumerate(repos):
+        payload = payloads[index]
+        spdx = _license_field(payload, "spdx_id")
+        rows.append(
+            {
+                "product_slug": slugs[index],
+                "repo": repo,
+                "resolved_repo": _text(payload, "full_name"),
+                "github_id": _number(payload, "id"),
+                "node_id": _text(payload, "node_id"),
+                "html_url": _text(payload, "html_url"),
+                "homepage": _text(payload, "homepage"),
+                "description": _text(payload, "description"),
+                "stargazers_count": _number(payload, "stargazers_count"),
+                "forks_count": _number(payload, "forks_count"),
+                "subscribers_count": _number(payload, "subscribers_count"),
+                "open_issues_count": _number(payload, "open_issues_count"),
+                "created_at": _stamp(payload, "created_at"),
+                "updated_at": _stamp(payload, "updated_at"),
+                "pushed_at": _stamp(payload, "pushed_at"),
+                "is_archived": _flag(payload, "archived"),
+                "is_disabled": _flag(payload, "disabled"),
+                "is_fork": _flag(payload, "fork"),
+                "primary_language": _text(payload, "language"),
+                "topics": _topics(payload),
+                "size_kb": _number(payload, "size"),
+                "default_branch": _text(payload, "default_branch"),
+                "license_spdx_id": spdx,
+                "license_key": _license_field(payload, "key"),
+                "license_name": _license_field(payload, "name"),
+                "license_is_noassertion": spdx == NOASSERTION,
+                "license_first_line": first_lines[index],
+                "http_status": statuses[index],
+                "redirect_location": locations[index],
+                "resolved_via_redirect": resolved_flags[index],
+                "rate_limit_remaining": remaining,
+                "fetched_at": fetched,
+            }
+        )
+
+    return pl.DataFrame(
+        rows,
+        schema={
+            "product_slug": pl.Utf8,
+            "repo": pl.Utf8,
+            "resolved_repo": pl.Utf8,
+            "github_id": pl.Int64,
+            "node_id": pl.Utf8,
+            "html_url": pl.Utf8,
+            "homepage": pl.Utf8,
+            "description": pl.Utf8,
+            "stargazers_count": pl.Int64,
+            "forks_count": pl.Int64,
+            "subscribers_count": pl.Int64,
+            "open_issues_count": pl.Int64,
+            "created_at": pl.Datetime("us"),
+            "updated_at": pl.Datetime("us"),
+            "pushed_at": pl.Datetime("us"),
+            "is_archived": pl.Boolean,
+            "is_disabled": pl.Boolean,
+            "is_fork": pl.Boolean,
+            "primary_language": pl.Utf8,
+            "topics": pl.Utf8,
+            "size_kb": pl.Int64,
+            "default_branch": pl.Utf8,
+            "license_spdx_id": pl.Utf8,
+            "license_key": pl.Utf8,
+            "license_name": pl.Utf8,
+            "license_is_noassertion": pl.Boolean,
+            "license_first_line": pl.Utf8,
+            "http_status": pl.Int64,
+            "redirect_location": pl.Utf8,
+            "resolved_via_redirect": pl.Boolean,
+            "rate_limit_remaining": pl.Int64,
+            "fetched_at": pl.Datetime("us"),
+        },
+    )

--- a/warehouse/platform-mirror/goodailist_repos.py
+++ b/warehouse/platform-mirror/goodailist_repos.py
@@ -1,0 +1,265 @@
+# ────── PLATFORM MIRROR (read-only) ──────
+# A snapshot of a model that runs on the OSO platform to build one of the gap map's
+# tables. The platform is the source of truth; nothing deploys from this copy, and
+# editing it here changes nothing. See README.md and manifest.yaml in this folder.
+
+"""GoodAI List repo catalog, read live from goodailist.com's public API.
+
+Replaces the hand-uploaded `catalog.goodailist_repos` static model. No auth
+required. The upstream refreshes daily, so this runs daily.
+
+Two things this adds over the static table:
+  * `first_seen` and `is_new` — the discovery signal for new entrants.
+  * `source_updated_at` — upstream freshness, distinct from our run time, so a
+    stale upstream is visible rather than silently presented as current.
+
+~17k repos across 18 pages at 1000/page. Page count stays under the sandbox's
+25-in-flight cap, so the fan-out is a single wave with no queueing.
+
+Builds a pyarrow Table directly and does NOT use polars. The sandbox is pyodide,
+which is wasm32, and polars' `to_arrow()` allocates through Rust with 32-bit
+capacity — at this row count it panics with `pyo3_runtime.PanicException:
+capacity overflow` during Arrow IPC serialization, after the model's own code has
+finished successfully. Chunking the frame does not avoid it and neither does
+rechunk(); the panic is in the polars->Arrow conversion itself. Returning a
+pyarrow Table skips that conversion, since the runner uses the table as-is.
+
+Keep this model polars-free. Any transformation added here must be expressed in
+plain Python or pyarrow.
+"""
+
+import asyncio
+from collections.abc import AsyncIterator
+from datetime import date, datetime, timezone
+from urllib.parse import urlencode
+
+import oso
+import pyarrow as pa
+
+BASE = "https://goodailist.com"
+SUMMARY_PATH = "/api/summary"
+REPOS_PATH = "/api/repos"
+PAGE_SIZE = 1000
+
+# Two distinct limits bite here, and both fixes are needed.
+#   1. Returning polars panics in Arrow serialization (see the module docstring).
+#      Fixed by building a pyarrow Table.
+#   2. Shipping the whole ~5.5MB table in one response kills the host with
+#      "UDM host /chunks request failed: Server disconnected without sending a
+#      response". Fixed by yielding it in slices.
+# At ~325 bytes/row this is roughly 1.3MB per chunk.
+CHUNK_ROWS = 4000
+
+TEXT_COLUMNS = [
+    "repo",
+    "description",
+    "category",
+    "subcat",
+    "keywords",
+    "country",
+    "top_devs",
+    "language",
+]
+INT_COLUMNS = ["stars", "forks", "contributors", "star_1d", "star_7d"]
+FLOAT_COLUMNS = ["star_1d_pct", "star_7d_pct"]
+DATE_COLUMNS = ["created_at", "updated_at", "first_seen"]
+BOOL_COLUMNS = ["is_new", "archived"]
+
+
+def _repos_url(page: int) -> str:
+    """Build a /api/repos URL for one page."""
+    query = urlencode(
+        {
+            "page": page,
+            "limit": PAGE_SIZE,
+            "sort_by": "stars",
+            "sort_order": "desc",
+        }
+    )
+    return f"{BASE}{REPOS_PATH}?{query}"
+
+
+def _records(payload: object) -> list[dict]:
+    """Pull the `repos` array out of an untyped payload."""
+    if not isinstance(payload, dict):
+        return []
+    entries = payload.get("repos")
+    if not isinstance(entries, list):
+        return []
+    return [entry for entry in entries if isinstance(entry, dict)]
+
+
+def _page_count(payload: object) -> int:
+    """Read `pages` out of an untyped payload."""
+    if isinstance(payload, dict):
+        value = payload.get("pages")
+        if isinstance(value, bool):
+            return 0
+        if isinstance(value, int):
+            return value
+    return 0
+
+
+def _upstream_stamp(payload: object) -> datetime | None:
+    """Parse `updated_at` from /api/summary, which reports upstream freshness."""
+    if not isinstance(payload, dict):
+        return None
+    value = payload.get("updated_at")
+    if not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value).replace(tzinfo=None, microsecond=0)
+    except ValueError:
+        return None
+
+
+def _as_text(value: object) -> str | None:
+    if value is None:
+        return None
+    return value if isinstance(value, str) else str(value)
+
+
+def _as_int(value: object) -> int | None:
+    """bool is a subclass of int, so reject it explicitly rather than store 0/1."""
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(float(value))
+        except ValueError:
+            return None
+    return None
+
+
+def _as_float(value: object) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _as_date(value: object) -> date | None:
+    """Upstream sends YYYY-MM-DD, sometimes with a time component appended."""
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return date.fromisoformat(value[:10])
+    except ValueError:
+        return None
+
+
+def _as_bool(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in ("true", "t", "1", "yes"):
+            return True
+        if lowered in ("false", "f", "0", "no"):
+            return False
+    return None
+
+
+def _dedupe(records: list[dict]) -> list[dict]:
+    """Keep the first occurrence of each repo.
+
+    Upstream returns a handful of exact duplicates (4 of ~17k on the first run),
+    all with identical stars and category, most likely because paging a
+    live-sorted list can show the same row twice. Results are sorted by stars
+    descending, so the first occurrence is the higher-star copy.
+    """
+    seen: set[str] = set()
+    out: list[dict] = []
+    for record in records:
+        repo = _as_text(record.get("repo"))
+        if repo is None or repo in seen:
+            continue
+        seen.add(repo)
+        out.append(record)
+    return out
+
+
+def _build_table(
+    records: list[dict], upstream: datetime | None, stamp: datetime
+) -> pa.Table:
+    """Assemble the Arrow table column by column, with types pinned explicitly.
+
+    The schema is declared rather than inferred so an all-null column still lands
+    with the right type instead of arriving as null and breaking the table
+    contract.
+    """
+    columns: dict[str, pa.Array] = {}
+    for name in TEXT_COLUMNS:
+        columns[name] = pa.array([_as_text(r.get(name)) for r in records], type=pa.string())
+    for name in INT_COLUMNS:
+        columns[name] = pa.array([_as_int(r.get(name)) for r in records], type=pa.int64())
+    for name in FLOAT_COLUMNS:
+        columns[name] = pa.array([_as_float(r.get(name)) for r in records], type=pa.float64())
+    for name in DATE_COLUMNS:
+        columns[name] = pa.array([_as_date(r.get(name)) for r in records], type=pa.date32())
+    for name in BOOL_COLUMNS:
+        columns[name] = pa.array([_as_bool(r.get(name)) for r in records], type=pa.bool_())
+
+    timestamp = pa.timestamp("us")
+    columns["source_updated_at"] = pa.array([upstream] * len(records), type=timestamp)
+    columns["ingested_at"] = pa.array([stamp] * len(records), type=timestamp)
+
+    ordered = (
+        TEXT_COLUMNS
+        + INT_COLUMNS
+        + FLOAT_COLUMNS
+        + DATE_COLUMNS
+        + BOOL_COLUMNS
+        + ["source_updated_at", "ingested_at"]
+    )
+    return pa.table({name: columns[name] for name in ordered})
+
+
+@oso.model(external_origins=["https://goodailist.com"])
+async def repo_catalog(context: oso.AsyncContext) -> AsyncIterator[oso.DataFrame]:
+    summary_response = await context.fetch(f"{BASE}{SUMMARY_PATH}")
+    if summary_response.status != 200:
+        raise RuntimeError(f"goodailist /api/summary returned {summary_response.status}")
+    upstream = _upstream_stamp(summary_response.json())
+
+    first = await context.fetch(_repos_url(1))
+    if first.status != 200:
+        raise RuntimeError(f"goodailist /api/repos returned {first.status} on page 1")
+
+    payload = first.json()
+    pages = _page_count(payload)
+    records: list[dict] = _records(payload)
+
+    if pages > 1:
+        rest = list(range(2, pages + 1))
+        responses = await asyncio.gather(
+            *(context.fetch(_repos_url(page)) for page in rest)
+        )
+        for page, response in zip(rest, responses):
+            if response.status != 200:
+                raise RuntimeError(
+                    f"goodailist /api/repos returned {response.status} on page {page}"
+                )
+            records.extend(_records(response.json()))
+
+    if not records:
+        raise RuntimeError("goodailist returned no repos")
+
+    stamp = datetime.now(timezone.utc).replace(tzinfo=None, microsecond=0)
+    table = _build_table(_dedupe(records), upstream, stamp)
+
+    # combine_chunks() materializes each slice into its own buffers. A bare
+    # pa.Table.slice() is a zero-copy view over the parent, so the IPC writer can
+    # still walk the full-size buffers behind it and defeat the point of chunking.
+    for start in range(0, table.num_rows, CHUNK_ROWS):
+        yield table.slice(start, CHUNK_ROWS).combine_chunks()

--- a/warehouse/platform-mirror/huggingface_hub_state.py
+++ b/warehouse/platform-mirror/huggingface_hub_state.py
@@ -1,0 +1,229 @@
+# ────── PLATFORM MIRROR (read-only) ──────
+# A snapshot of a model that runs on the OSO platform to build one of the gap map's
+# tables. The platform is the source of truth; nothing deploys from this copy, and
+# editing it here changes nothing. See README.md and manifest.yaml in this folder.
+
+"""Hugging Face Hub state for the map's model and dataset artifacts.
+
+Roster comes from `currentai.registry.product_artifacts`, filtered to the two HF
+artifact kinds — the repo's own declaration, pushed out by CI. This is the only adoption source for most of the map's models and
+datasets: just 15 of 106 model products carry a GitHub artifact, while 61 carry a
+`huggingface_model`, and 60 of 65 dataset products live on `huggingface_dataset`.
+
+`downloads` is the Hub's rolling 30-day figure, which is what the adoption bands
+are expressed in, so it is used as-is with no derivation.
+
+Two shape traps in the Hub API, both handled:
+  * `cardData.license` is a plain string for models but a LIST for datasets.
+  * `gated` is either a bool or a mode string ("auto" / "manual"), so gating is
+    recorded as both a flag and the mode.
+
+Partial failure is data, not an exception: a per-artifact `http_status` is
+recorded rather than raised, so one deleted or renamed repo cannot void the run.
+"""
+
+import asyncio
+from datetime import datetime, timezone
+
+import oso
+import polars as pl
+
+HF_API = "https://huggingface.co"
+ROSTER_SQL = (
+    "SELECT product_slug, artifact_kind, artifact_id "
+    'FROM "currentai"."registry"."product_artifacts" '
+    "WHERE artifact_kind IN ('huggingface_model', 'huggingface_dataset')"
+)
+MODEL_KIND = "huggingface_model"
+
+
+def _endpoint(kind: str, artifact_id: str) -> str:
+    """Models and datasets share a shape but not a path."""
+    segment = "models" if kind == MODEL_KIND else "datasets"
+    return f"{HF_API}/api/{segment}/{artifact_id}"
+
+
+def _text(payload: object, key: str) -> str | None:
+    if isinstance(payload, dict):
+        value = payload.get(key)
+        if isinstance(value, str):
+            return value
+    return None
+
+
+def _number(payload: object, key: str) -> int | None:
+    if isinstance(payload, dict):
+        value = payload.get(key)
+        if isinstance(value, bool):
+            return None
+        if isinstance(value, int):
+            return value
+        if isinstance(value, float):
+            return int(value)
+    return None
+
+
+def _flag(payload: object, key: str) -> bool | None:
+    if isinstance(payload, dict):
+        value = payload.get(key)
+        if isinstance(value, bool):
+            return value
+    return None
+
+
+def _stamp(payload: object, key: str) -> datetime | None:
+    raw = _text(payload, key)
+    if raw is None:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed.replace(tzinfo=None, microsecond=0)
+
+
+def _tag_count(payload: object) -> int | None:
+    if isinstance(payload, dict):
+        value = payload.get("tags")
+        if isinstance(value, list):
+            return len(value)
+    return None
+
+
+def _license(payload: object) -> str | None:
+    """`cardData.license` is a string for models and a list for datasets."""
+    if not isinstance(payload, dict):
+        return None
+    card = payload.get("cardData")
+    if not isinstance(card, dict):
+        return None
+    value = card.get("license")
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        names = [item for item in value if isinstance(item, str)]
+        if names:
+            return ",".join(names)
+    return None
+
+
+def _gated(payload: object) -> bool | None:
+    """`gated` is False, or True, or a mode string like "auto" / "manual"."""
+    if not isinstance(payload, dict):
+        return None
+    value = payload.get("gated")
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return True
+    return None
+
+
+def _gated_mode(payload: object) -> str | None:
+    if isinstance(payload, dict):
+        value = payload.get("gated")
+        if isinstance(value, str):
+            return value
+    return None
+
+
+@oso.model(
+    secrets=["HUGGING_FACE_TOKEN"],
+    environment_name="Default",
+    depends_on=["currentai.registry.product_artifacts"],
+    external_origins=["https://huggingface.co"],
+)
+async def hub_state(context: oso.AsyncContext) -> oso.DataFrame:
+    token: str = await context.secret("HUGGING_FACE_TOKEN")
+    headers: dict[str, str] = {"Authorization": f"Bearer {token}"}
+
+    result = await context.query(ROSTER_SQL)
+    roster = await result.as_pl()
+    targets: list[dict] = []
+    for row in roster.iter_rows(named=True):
+        kind = row.get("artifact_kind")
+        artifact_id = row.get("artifact_id")
+        slug = row.get("product_slug")
+        if isinstance(kind, str) and isinstance(artifact_id, str) and isinstance(slug, str):
+            targets.append(
+                {"product_slug": slug, "artifact_kind": kind, "artifact_id": artifact_id}
+            )
+    if not targets:
+        raise RuntimeError("roster query returned no HF artifacts")
+
+    responses = await asyncio.gather(
+        *(
+            context.fetch(_endpoint(t["artifact_kind"], t["artifact_id"]), headers=headers)
+            for t in targets
+        )
+    )
+
+    payloads: list[object] = []
+    statuses: list[int] = []
+    ok_count = 0
+    for response in responses:
+        statuses.append(response.status)
+        if response.status == 200:
+            ok_count += 1
+            payloads.append(response.json())
+        else:
+            payloads.append(None)
+
+    if ok_count == 0:
+        raise RuntimeError(
+            f"every one of {len(targets)} Hub calls failed; first status {statuses[0]}"
+        )
+
+    fetched = datetime.now(timezone.utc).replace(tzinfo=None, microsecond=0)
+
+    rows: list[dict] = []
+    for index, target in enumerate(targets):
+        payload = payloads[index]
+        rows.append(
+            {
+                "product_slug": target["product_slug"],
+                "artifact_kind": target["artifact_kind"],
+                "artifact_id": target["artifact_id"],
+                "resolved_id": _text(payload, "id"),
+                "downloads_30d": _number(payload, "downloads"),
+                "likes": _number(payload, "likes"),
+                "license": _license(payload),
+                "is_gated": _gated(payload),
+                "gated_mode": _gated_mode(payload),
+                "is_private": _flag(payload, "private"),
+                "is_disabled": _flag(payload, "disabled"),
+                "pipeline_tag": _text(payload, "pipeline_tag"),
+                "library_name": _text(payload, "library_name"),
+                "tag_count": _tag_count(payload),
+                "used_storage_bytes": _number(payload, "usedStorage"),
+                "created_at": _stamp(payload, "createdAt"),
+                "last_modified": _stamp(payload, "lastModified"),
+                "http_status": statuses[index],
+                "fetched_at": fetched,
+            }
+        )
+
+    return pl.DataFrame(
+        rows,
+        schema={
+            "product_slug": pl.Utf8,
+            "artifact_kind": pl.Utf8,
+            "artifact_id": pl.Utf8,
+            "resolved_id": pl.Utf8,
+            "downloads_30d": pl.Int64,
+            "likes": pl.Int64,
+            "license": pl.Utf8,
+            "is_gated": pl.Boolean,
+            "gated_mode": pl.Utf8,
+            "is_private": pl.Boolean,
+            "is_disabled": pl.Boolean,
+            "pipeline_tag": pl.Utf8,
+            "library_name": pl.Utf8,
+            "tag_count": pl.Int64,
+            "used_storage_bytes": pl.Int64,
+            "created_at": pl.Datetime("us"),
+            "last_modified": pl.Datetime("us"),
+            "http_status": pl.Int64,
+            "fetched_at": pl.Datetime("us"),
+        },
+    )

--- a/warehouse/platform-mirror/lmarena_leaderboard.py
+++ b/warehouse/platform-mirror/lmarena_leaderboard.py
@@ -1,0 +1,238 @@
+# ────── PLATFORM MIRROR (read-only) ──────
+# A snapshot of a model that runs on the OSO platform to build one of the gap map's
+# tables. The platform is the source of truth; nothing deploys from this copy, and
+# editing it here changes nothing. See README.md and manifest.yaml in this folder.
+
+"""LMArena text leaderboard, style-control config, from Hugging Face.
+
+Reads the `text_style_control` config, NOT `text`. That is the whole reason this
+model works.
+
+The `text` config is unusable: 30% of its (model, category) pairs carry between 2
+and 6 different ratings and ranks on the same publish date, with no column
+distinguishing them — gpt-5.4/overall appears six times at ranks 1, 1, 2, 10, 30
+and 32. Filtering the `full` split to a single date reproduces it exactly, so it
+is the source, not the split. `text_style_control` covers the same 378 models and
+29 categories and is exactly one row per pair, 9,956 of 9,956.
+
+Style control is also the better number on merit rather than a workaround: it
+adjusts for response length and formatting, the known confound where a model
+wins on verbosity and markdown rather than substance.
+
+Transport: the parquet file is one request of ~550KB against 100 paged calls, and
+paging this dataset is what produced HTTP 429 before. Hugging Face 302s the
+parquet URL to a signed CDN host and `context.fetch` does not follow redirects,
+so the redirect is walked by hand. If any of that fails the model falls back to
+the paged rows API, which is slower and rate-limit prone but known to work.
+"""
+
+import asyncio
+import io
+from datetime import datetime, timezone
+from urllib.parse import urlencode
+
+import oso
+import polars as pl
+import pyarrow.parquet as pq
+
+HF_HOST = "https://huggingface.co"
+CDN_HOST = "https://us.aws.cdn.hf.co"
+ROWS_URL = "https://datasets-server.huggingface.co/rows"
+
+DATASET = "lmarena-ai/leaderboard-dataset"
+CONFIG = "text_style_control"
+SPLIT = "latest"
+PARQUET_PATH = (
+    "/datasets/lmarena-ai/leaderboard-dataset/resolve/refs%2Fconvert%2Fparquet"
+    "/text_style_control/latest/0000.parquet"
+)
+
+PAGE_SIZE = 100
+TRANSIENT_STATUSES = [429, 500, 502, 503, 504]
+MAX_ATTEMPTS = 4
+
+TEXT_COLUMNS = ["model_name", "organization", "license", "category", "leaderboard_publish_date"]
+FLOAT_COLUMNS = ["rating", "rating_lower", "rating_upper", "variance"]
+INT_COLUMNS = ["vote_count", "rank"]
+# Spelled out rather than concatenated: top-level assignments must be literals.
+ALL_COLUMNS = [
+    "model_name",
+    "organization",
+    "license",
+    "category",
+    "leaderboard_publish_date",
+    "rating",
+    "rating_lower",
+    "rating_upper",
+    "variance",
+    "vote_count",
+    "rank",
+]
+
+
+def _header(headers: object, name: str) -> str | None:
+    """Case-insensitive lookup over an untyped headers mapping."""
+    if not isinstance(headers, dict):
+        return None
+    target = name.lower()
+    for key, value in headers.items():
+        if isinstance(key, str) and key.lower() == target and isinstance(value, str):
+            return value
+    return None
+
+
+def _rows(payload: object) -> list[dict]:
+    """datasets-server nests each record under a `row` key."""
+    if not isinstance(payload, dict):
+        return []
+    entries = payload.get("rows")
+    if not isinstance(entries, list):
+        return []
+    records: list[dict] = []
+    for entry in entries:
+        if isinstance(entry, dict):
+            row = entry.get("row")
+            if isinstance(row, dict):
+                records.append(row)
+    return records
+
+
+def _total_rows(payload: object) -> int:
+    if isinstance(payload, dict):
+        value = payload.get("num_rows_total")
+        if isinstance(value, bool):
+            return 0
+        if isinstance(value, int):
+            return value
+        if isinstance(value, float):
+            return int(value)
+    return 0
+
+
+def _page_url(offset: int) -> str:
+    query = urlencode(
+        {
+            "dataset": DATASET,
+            "config": CONFIG,
+            "split": SPLIT,
+            "offset": offset,
+            "length": PAGE_SIZE,
+        }
+    )
+    return f"{ROWS_URL}?{query}"
+
+
+async def _fetch_page(
+    context: oso.AsyncContext, offset: int, headers: dict[str, str]
+) -> object:
+    """One page, retrying transient upstream failures with backoff."""
+    delay = 1.0
+    for attempt in range(MAX_ATTEMPTS):
+        response = await context.fetch(_page_url(offset), headers=headers)
+        if response.status == 200:
+            return response.json()
+        if response.status not in TRANSIENT_STATUSES or attempt == MAX_ATTEMPTS - 1:
+            raise RuntimeError(
+                f"rows api returned {response.status} at offset {offset}"
+                f" after {attempt + 1} attempt(s)"
+            )
+        await asyncio.sleep(delay)
+        delay *= 2
+    raise RuntimeError(f"exhausted retries at offset {offset}")
+
+
+async def _via_parquet(context: oso.AsyncContext, headers: dict[str, str]) -> pl.DataFrame | None:
+    """One request plus one redirect hop. Returns None so the caller can fall back."""
+    first = await context.fetch(f"{HF_HOST}{PARQUET_PATH}", headers=headers)
+    body: object = None
+    if first.status == 200:
+        body = first.body
+    elif first.status in (301, 302, 303, 307, 308):
+        location = _header(first.headers, "location")
+        if not isinstance(location, str) or not location.startswith(CDN_HOST):
+            return None
+        followed = await context.fetch(location)
+        if followed.status != 200:
+            return None
+        body = followed.body
+    else:
+        return None
+    if not isinstance(body, (bytes, bytearray)):
+        return None
+    table = pq.read_table(io.BytesIO(bytes(body)))
+    # pl.from_arrow is typed DataFrame | Series; a Table always yields a frame,
+    # but narrow it so the type checker agrees and a surprise falls back instead.
+    frame = pl.from_arrow(table)
+    if not isinstance(frame, pl.DataFrame):
+        return None
+    return frame
+
+
+async def _via_rows(context: oso.AsyncContext, headers: dict[str, str]) -> pl.DataFrame:
+    """Paged fallback. Slower and rate-limit prone, but known to work."""
+    payload = await _fetch_page(context, 0, headers)
+    total = _total_rows(payload)
+    records: list[dict] = _rows(payload)
+    offsets = list(range(PAGE_SIZE, total, PAGE_SIZE))
+    if offsets:
+        pages = await asyncio.gather(
+            *(_fetch_page(context, offset, headers) for offset in offsets)
+        )
+        for page in pages:
+            records.extend(_rows(page))
+    if not records:
+        raise RuntimeError("rows api returned no records")
+    return pl.DataFrame(records)
+
+
+@oso.model(
+    secrets=["HUGGING_FACE_TOKEN"],
+    environment_name="Default",
+    external_origins=[
+        "https://huggingface.co",
+        "https://us.aws.cdn.hf.co",
+        "https://datasets-server.huggingface.co",
+    ],
+)
+async def text_leaderboard(context: oso.AsyncContext) -> oso.DataFrame:
+    token: str = await context.secret("HUGGING_FACE_TOKEN")
+    headers: dict[str, str] = {"Authorization": f"Bearer {token}"}
+
+    frame: pl.DataFrame | None = None
+    via = "parquet"
+    try:
+        frame = await _via_parquet(context, headers)
+    except Exception:  # noqa: BLE001 - any parquet failure is a fallback signal
+        frame = None
+    if frame is None:
+        via = "rows"
+        frame = await _via_rows(context, headers)
+
+    missing = [c for c in ALL_COLUMNS if c not in frame.columns]
+    if missing:
+        raise RuntimeError(f"{via} route returned unexpected columns, missing {missing}")
+
+    # The whole point of this config: one row per model per category. Assert it
+    # rather than trust it, so a change upstream fails loudly instead of silently
+    # double-counting every downstream aggregate.
+    pairs = frame.select("model_name", "category").n_unique()
+    if pairs != frame.height:
+        raise RuntimeError(
+            f"{CONFIG} returned {frame.height} rows for {pairs} (model, category) pairs; "
+            "expected exactly one row each. The `text` config has this defect — check "
+            "whether it has spread to this one before trusting the numbers."
+        )
+
+    stamp = datetime.now(timezone.utc).replace(tzinfo=None, microsecond=0)
+    return (
+        frame.select(
+            *[pl.col(name).cast(pl.Utf8) for name in TEXT_COLUMNS],
+            *[pl.col(name).cast(pl.Float64) for name in FLOAT_COLUMNS],
+            *[pl.col(name).cast(pl.Int64) for name in INT_COLUMNS],
+        )
+        .with_columns(
+            arena_config=pl.lit(CONFIG),
+            fetched_via=pl.lit(via),
+            ingested_at=pl.lit(stamp, dtype=pl.Datetime("us")),
+        )
+    )

--- a/warehouse/platform-mirror/manifest.yaml
+++ b/warehouse/platform-mirror/manifest.yaml
@@ -1,0 +1,105 @@
+# Provenance for the platform mirror in this folder.
+#
+# Each entry says which deployed platform model revision a mirrored file reflects.
+#  - hash:         the platform revision's content hash (an id for the deployed revision,
+#                  compared by a future drift check).
+#  - local_sha256: sha256 of the checked-in bytes, so this manifest binds the actual file.
+# The platform is the source of truth. To re-sync: refetch each model's latest revision,
+# overwrite the file, and update revision/hash/local_sha256/synced_at below.
+org: currentai            # ad7f4c1c-dd2f-430e-a831-e7f1f16e6d9e
+synced_at: '2026-08-15'
+
+models:
+  - file: evidence_product_evidence.sql
+    table: currentai.evidence.product_evidence
+    model_id: 769c20b5-d9c0-4163-bced-81e3a62fbc47
+    revision: 8
+    hash: 0b82978b734971a41ce94a97d9a0c5cb8898733677049057a95675e16595ebdc
+    local_sha256: 4cd20993f6f839e7bc8c2eae7e8b85a9e61b62d5f004462df99d5f203dee403b
+    schema_file: evidence_product_evidence.schema.json
+    schema_local_sha256: 625b9bb254aef512dd92151b8ef1055e8aab3566ec3326c2a4b806ea8feef46c
+  - file: scores_openness_facts.sql
+    table: currentai.scores.openness_facts
+    model_id: 68d9e34c-b0b6-460b-b4ae-21b7016eb1f8
+    revision: 7
+    hash: 7ce706d47d74cc433b6eb02b7b8558d26af21f6689d83426296d2457fa3ad26c
+    local_sha256: 1952f4b3939ade83f4ec239795ad234fa3ec8464c1789edb4d66374f072e4e39
+    schema_file: scores_openness_facts.schema.json
+    schema_local_sha256: e0af61b46f8e470354b9c0c5e1efe8fc419cd37bbbfccc3bdbf44991ecddebf9
+  - file: scores_openness_computed.sql
+    table: currentai.scores.openness_computed
+    model_id: 6aef560b-cc85-4a9d-afa8-8f4798208e74
+    revision: 15
+    hash: 5606414402e540d23105552aa2320e4d62cdc71540e84e1d1a8db842df429ca1
+    local_sha256: afc40feea6966d0ad946b0f2ae1d00b8ad4f5a9a6e2fb74dea8383ec5d88b464
+    schema_file: scores_openness_computed.schema.json
+    schema_local_sha256: 0802e69dd10acc0575ba95e845514f59ec818b6b51e5a69551ceaa2fec910a8e
+  - file: github_repo_state.py
+    table: currentai.signal_github.repo_state
+    model_id: a50ce375-4b91-43c6-b1ce-1fc60911b513
+    revision: 4
+    hash: efbd5ce1104d2f028c123f5f490fa9e5439be14489e8e069be50e0ecf545e4fd
+    local_sha256: a11300a0a4c1a697a217202a43c230af3e00dc9595000c2f73cae74e615b9c66
+  - file: huggingface_hub_state.py
+    table: currentai.signal_huggingface.hub_state
+    model_id: 014a0641-605f-4e57-831b-d24a1304437f
+    revision: 3
+    hash: d7b62c33cb51b13235dcb9d7e8b7f57fd7a8c76ec3bf2f8d912c32c145fc41f5
+    local_sha256: d2c0ef261ee4af9beda119d14965301fd9f99411d9eddd978ed9aeeb49781b21
+  - file: pypi_package_downloads.sql
+    table: currentai.signal_pypi.package_downloads
+    model_id: a88bff56-0a00-49d1-8667-809a79b4d7c0
+    revision: 3
+    hash: d5311e2d3feb3b5f0190134b70c143586bcda911ed530ca52545c53325b7bbd0
+    local_sha256: 21fe2106888e7cf8aecc12d3a57b449a8a064537608eb4ac54ac32bb5d180499
+  - file: artificialanalysis_models.py
+    table: currentai.signal_artificialanalysis.model_evaluations
+    model_id: dbce2dc6-9586-477d-8fe8-1c3ef8a7760c
+    revision: 2
+    hash: 044310c3f02b3bf5d52009095b737a3e9dcf995609641bf646b188e0886db451
+    local_sha256: 1491f28b90e1f730b4de1035c7e2c49327d4baf9055fb359a0625095cce4bb8f
+  - file: lmarena_leaderboard.py
+    table: currentai.signal_lmarena.text_leaderboard
+    model_id: efb89f86-7aff-48df-a78e-ce01234672db
+    revision: 7
+    hash: c4715ace092f807464fafbeeb5a207f3fa54dc4e69ee0e5ba442f089ede07ca4
+    local_sha256: 1844f16f6a0d38d6e756f1f93b6d84242424eca813d9b3e2943c009351d165f9
+  - file: semanticscholar_paper_citations.py
+    table: currentai.signal_semanticscholar.paper_citations
+    model_id: cc73d808-5833-4a91-a47b-35bb0414b6f0
+    revision: 3
+    hash: 369e2abc26bd6e5dd756c200ecac03201f8940420b7b33e5f829db5d1c9027b3
+    local_sha256: 1945bc8dad621c1015e897e2620e445d5a5224bb8fe4a7bc014a5ba7547fb558
+  - file: goodailist_repos.py
+    table: currentai.signal_goodailist.repo_catalog
+    model_id: c7d3a3d9-578c-4c54-8ccf-71879bdd43d2
+    revision: 3
+    hash: 27b7de7c1271500612ae0e29163d7661451db4b16352d7ce1b0dd12df1d466a7
+    local_sha256: eaee5981530529fc1cbd6c21d2d18b7019b0ed2c15751f43b2d84f4f4bb0ae00
+  - file: packages_product_adoption.sql
+    table: currentai.signal_github.product_adoption
+    model_id: 25538fa7-f956-481c-ac14-474ab1661ac3
+    revision: 2
+    hash: 15e77142a74d89e267b2e341c566f6da0e025bd7bda289183bb376cf5332f1eb
+    local_sha256: 554a229cf3608616c8a1c550b32c89b1d44d76633fa8e2ab956619e94f4c390e
+  - file: packages_product_adoption.sql
+    table: currentai.signal_huggingface.product_adoption
+    model_id: abcf0044-dd9d-4942-a2a1-e047dab8e8b1
+    revision: 2
+    hash: bdc8c2b8231bacd62c6404276a11190b5ab3139a81c9b1bcaededafe23ff24ef
+    local_sha256: 554a229cf3608616c8a1c550b32c89b1d44d76633fa8e2ab956619e94f4c390e
+
+  # Staged signal_packages successor (PR #266), not yet a single deployed dataset.
+  # Confirm the exact file->revision mapping on the next re-sync before trusting.
+  - file: packages_package_downloads.sql
+    table: currentai.signal_packages.package_downloads
+    status: staged
+    local_sha256: 97ccc0f2d6150eaedee5ea2d2e82cff5bb7eb47ff700353719fc63cb75f72202
+  - file: packages_package_downloads_daily.py
+    table: currentai.signal_packages.package_downloads_daily
+    status: staged
+    local_sha256: a513593cf14985b9f819e4a64ad60de63ed6d06777b5f492e427c6adea9725ab
+
+# TODO (follow-up): a credentialed check job that refetches each model_id's latest
+# revision and compares `hash` to catch platform drift. tests/test_platform_mirror.py
+# already checks that every mirrored file is listed here and its local hash matches.

--- a/warehouse/platform-mirror/packages_package_downloads.sql
+++ b/warehouse/platform-mirror/packages_package_downloads.sql
@@ -1,0 +1,150 @@
+-- ────── PLATFORM MIRROR (read-only) ──────
+-- A snapshot of a model that runs on the OSO platform to build one of the gap map's
+-- tables. The platform is the source of truth; nothing deploys from this copy, and
+-- editing it here changes nothing. See README.md and manifest.yaml in this folder.
+
+-- currentai.signal_packages.package_downloads
+-- Windowed download volume for every package artifact the map declares, across all three
+-- registries. Grain: one row per (product_slug, artifact_kind, package).
+--
+-- Registry-neutral successor to currentai.signal_pypi.package_downloads. Same column names
+-- wherever the meaning is the same, so a reader comparing the two does not have to translate,
+-- with two differences that the neutrality forces:
+--
+--   * `artifact_kind` is new, carrying the registry's own vocabulary (pypi / npm / crates).
+--     It is the discriminator sources/signal_routing.yaml filters each route on, exactly as
+--     it already filters currentai.signal_huggingface.hub_state into its model and dataset
+--     routes.
+--   * `missing_from_pypi` becomes `missing_from_registry`, because in a neutral table the old
+--     name would be false for two thirds of the rows. It means the same thing: the artifact
+--     was looked for and not found, which is not the same as not looked for yet.
+--
+-- `adoption_level` is deliberately NOT here, and that is the substantive change rather than a
+-- rename. signal_pypi banded per package, and the software / usage_volume unit in
+-- sources/rubrics/software.yaml is "package downloads in the trailing 30 days, summed across
+-- declared artifacts" — so a band on one artifact of a product that ships several is a band on
+-- part of the product. The band moves one grain up, to
+-- currentai.signal_packages.product_adoption.
+--
+-- Where each leg's history comes from:
+--   * pypi   — oso.pypi_downloads.daily_downloads_by_package, the marketplace dataset holding
+--              every package on PyPI at day grain. Nothing to fetch.
+--   * npm    — currentai.signal_packages.package_downloads_daily, which fetches 18 months of
+--              daily history per package, because no global npm dataset exists.
+--   * crates — the same daily table. crates.io serves 90 days and will not page further back.
+--
+-- The 30-day window is anchored per registry on that registry's own latest day, not on
+-- CURRENT_DATE and not on the package's own latest day. Per registry, because PyPI's feed lags
+-- about six days behind npm's and a shared anchor would silently drop days from the slower
+-- leg. Never per package, because then an abandoned package would anchor its window on its own
+-- last day of life and read as healthy.
+--
+-- Counts are raw installer requests everywhere: CI jobs, mirrors and container builds
+-- included. Volume, not unique users.
+
+WITH roster AS (
+  SELECT DISTINCT
+    product_slug,
+    product_type,
+    artifact_kind,
+    artifact_id AS package,
+    -- Why this artifact is not how the product ships, declared per artifact in
+    -- sources/products/*.yaml. Kept as the reason rather than reduced to a flag, because the
+    -- reason is what makes the exclusion reviewable. The download figure is still computed and
+    -- still published here; product_adoption is what leaves it out of the banded sum.
+    NULLIF(not_primary_channel, '') AS not_primary_channel
+  FROM currentai.registry.product_artifacts
+  WHERE artifact_kind IN ('pypi', 'npm', 'crates')
+),
+
+-- Every day of history the three registries can offer, in one shape.
+history AS (
+  SELECT
+    'pypi' AS artifact_kind,
+    package,
+    day,
+    downloads,
+    country_count
+  FROM oso.pypi_downloads.daily_downloads_by_package
+
+  UNION ALL
+
+  SELECT
+    artifact_kind,
+    package,
+    day,
+    downloads,
+    CAST(NULL AS BIGINT) AS country_count
+  FROM currentai.signal_packages.package_downloads_daily
+  WHERE day IS NOT NULL
+    AND downloads IS NOT NULL
+),
+
+anchors AS (
+  SELECT
+    artifact_kind,
+    MAX(day) AS last_day
+  FROM history
+  GROUP BY artifact_kind
+),
+
+windowed AS (
+  SELECT
+    h.artifact_kind,
+    h.package,
+    SUM(CASE WHEN h.day > a.last_day - INTERVAL '30' DAY THEN h.downloads ELSE 0 END) AS downloads_30d,
+    SUM(CASE WHEN h.day > a.last_day - INTERVAL '7' DAY THEN h.downloads ELSE 0 END) AS downloads_7d,
+    -- The 30 days before the current window. This is what tells a step change that has held
+    -- for months from a collapse that happened this week, which two point reads cannot: it is
+    -- the lmdeploy case in issue #163, where 165K -> 50K turned out to be one step in May.
+    SUM(CASE
+      WHEN h.day > a.last_day - INTERVAL '60' DAY AND h.day <= a.last_day - INTERVAL '30' DAY
+      THEN h.downloads ELSE 0 END) AS downloads_prev_30d,
+    COUNT(DISTINCT CASE WHEN h.day > a.last_day - INTERVAL '30' DAY THEN h.day END) AS days_observed,
+    COUNT(DISTINCT h.day) AS days_of_history,
+    MAX(h.country_count) AS max_country_count,
+    MIN(h.day) AS first_day_seen,
+    MAX(h.day) AS last_day_seen
+  FROM history h
+  JOIN anchors a ON a.artifact_kind = h.artifact_kind
+  GROUP BY h.artifact_kind, h.package
+),
+
+-- What the fetch itself reported, per artifact. A 404 is a row in the daily table carrying a
+-- null day, so it survives to here and becomes missing_from_registry below.
+fetch_status AS (
+  SELECT
+    artifact_kind,
+    package,
+    MAX(http_status) AS http_status
+  FROM currentai.signal_packages.package_downloads_daily
+  GROUP BY artifact_kind, package
+)
+
+SELECT
+  r.product_slug,
+  r.product_type,
+  r.artifact_kind,
+  r.package,
+  w.downloads_30d,
+  w.downloads_7d,
+  w.downloads_prev_30d,
+  w.days_observed,
+  w.days_of_history,
+  w.max_country_count AS countries_seen,
+  w.first_day_seen,
+  w.last_day_seen,
+  CAST(a.last_day - INTERVAL '30' DAY AS DATE) AS window_start,
+  -- Looked for and not found. A declared artifact the fetch has not reached yet has no status
+  -- and no window either, so it reads as unmeasured rather than as gone.
+  w.package IS NULL AND (r.artifact_kind = 'pypi' OR s.http_status IS NOT NULL) AS missing_from_registry,
+  s.http_status,
+  r.not_primary_channel
+FROM roster r
+LEFT JOIN anchors a ON a.artifact_kind = r.artifact_kind
+LEFT JOIN windowed w
+  ON w.artifact_kind = r.artifact_kind
+  AND LOWER(w.package) = LOWER(r.package)
+LEFT JOIN fetch_status s
+  ON s.artifact_kind = r.artifact_kind
+  AND s.package = r.package

--- a/warehouse/platform-mirror/packages_package_downloads_daily.py
+++ b/warehouse/platform-mirror/packages_package_downloads_daily.py
@@ -1,0 +1,332 @@
+# ────── PLATFORM MIRROR (read-only) ──────
+# A snapshot of a model that runs on the OSO platform to build one of the gap map's
+# tables. The platform is the source of truth; nothing deploys from this copy, and
+# editing it here changes nothing. See README.md and manifest.yaml in this folder.
+
+"""Daily download history from the package registries this map has to fetch.
+
+Covers npm and crates.io. PyPI is deliberately absent: `oso.pypi_downloads` already
+holds every package on PyPI at day grain, so the PyPI leg of
+`signal_packages.package_downloads` windows a table the warehouse has, and there is
+nothing to fetch. There is no equivalent global dataset for npm or crates, which is
+the whole reason this model exists.
+
+Roster comes from `currentai.registry.product_artifacts`, filtered to those two
+kinds — the repo's own declaration, pushed out by CI, so coverage tracks the map
+rather than a hand-maintained package list. 14 artifacts across 13 products on
+2026-08-14: 13 npm (`mastra` declares both `@mastra/core` and `mastra`) and one
+crate (`yomo`). One request per artifact.
+
+Grain: one row per (product, artifact_kind, package, day). `artifact_kind` uses the
+registry's own vocabulary and is the discriminator `sources/signal_routing.yaml`
+filters each route on, the way it already filters `signal_huggingface.hub_state`
+into its model and dataset routes.
+
+## Why a series and not a trailing total
+
+A point read cannot tell a collapse from a step change that happened months ago,
+and that defect is already filed as issue #163 against the PyPI side. `lmdeploy`
+is the case: two point reads looked like a 165K -> 50K collapse, and the daily
+series showed 171,750 in May, then 57,776, 54,993 and 50,402 — one step change
+that had held for three months, with the earlier trailing window having simply been
+measuring May. The two reads never disagreed. `llama-factory` is still in
+`sources/verification_queue.yaml` for the same reason: "settling it needs the
+download history rather than two point reads."
+
+## What the two APIs actually do, measured 2026-08-14
+
+npm, `https://api.npmjs.org/downloads/range/<start>:<end>/<package>`:
+
+  * Serves at most 18 months and **silently clips a longer request rather than
+    erroring**. Asking 2024-08-14 to 2026-08-13 returned 547 days beginning
+    2025-02-13. So a requested window is not evidence of a served window, and every
+    date here comes from the response.
+  * A scoped name goes through unencoded: `range/.../@mastra/core` answers, and
+    percent-encoding the slash returns 404.
+  * The `last-month` and `last-year` aliases lag about five days behind today and an
+    explicit end date does not. `last-year` ended 2026-08-09 while an explicit range
+    returned full days through 2026-08-13. That is the second reason to ask for a
+    range: it is fresher, not only longer.
+  * Zero is a value npm reports for a day it has no data for, and those zeros are
+    inside the totals it publishes: `n8n` has two in a 30-day window, both Sundays.
+    They are kept as rows, so a total depressed by a gap can be told from a total
+    depressed by a fall in installs.
+
+crates.io, `https://crates.io/api/v1/crates/<crate>/downloads`:
+
+  * Serves **90 days and no more**. `before_date` does not page further back — asked
+    for 2026-05-01 it returned the same trailing 90 days. So crates history is three
+    months, full stop, and a trend over a longer window is not available at any
+    price.
+  * Downloads arrive per version, plus a `meta.extra_downloads` roll-up for versions
+    the response does not enumerate. Both are summed; reading only
+    `version_downloads` undercounts any crate old enough to have retired a version.
+  * Days with no downloads are omitted rather than reported as zero, which is the
+    opposite of npm's habit. A missing day here is a real zero.
+  * `/api/v1/crates/<crate>` is NOT fetched. Its `recent_downloads` covers 90 days
+    while looking like a monthly figure — `yomo` reports 347 there, and its series
+    sums to exactly 347 across 90 days against 96 in the trailing 30 — so banding it
+    monthly would overstate the crate by 3.6x. The series answers the same question
+    without the trap, and `signal_routing.yaml` records the rule.
+
+Both APIs are unauthenticated. crates.io asks for a descriptive User-Agent and gets
+one; npm asks for nothing.
+
+## Failure is a row, not an absence
+
+Taken from `signal_github.repo_state`: an artifact that could not be read
+contributes one row with a null `day` and its own `http_status`, so a 404 is visible
+rather than missing. Both registries answer 404 with a JSON body for an unknown
+name.
+
+That distinction is load-bearing because the roster runs ahead of the signal between
+runs — the registry declared 106 PyPI artifacts while `signal_pypi` held 98 — so
+"declared, not fetched yet" must not read the same as "fetched and gone". The
+`playwright-mcp` record carried `@anthropic-ai/mcp-playwright` for weeks, which
+api.npmjs.org answers 404 for, and nothing in the pipeline could say so.
+
+Counts are raw registry requests: CI jobs, mirrors and container builds included.
+Volume, not unique users. No band here — bands are declared in the repo and applied
+in `signal_packages.product_adoption`.
+"""
+
+import asyncio
+from datetime import date, datetime, timedelta, timezone
+
+import oso
+import polars as pl
+
+NPM_API = "https://api.npmjs.org"
+CRATES_API = "https://crates.io/api/v1/crates"
+USER_AGENT = "os-ai-map-signal-packages/1.0 (https://github.com/currentai-org/os-ai-map)"
+ROSTER_SQL = (
+    "SELECT product_slug, product_type, artifact_kind, artifact_id "
+    'FROM "currentai"."registry"."product_artifacts" '
+    "WHERE artifact_kind IN ('npm', 'crates')"
+)
+# 18 months is npm's own ceiling, and it clips rather than erroring, so asking for
+# exactly the ceiling is how to learn where the data really starts.
+NPM_HISTORY_DAYS = 547
+
+
+def _text(payload: object, key: str) -> str | None:
+    if isinstance(payload, dict):
+        value = payload.get(key)
+        if isinstance(value, str):
+            return value
+    return None
+
+
+def _number(payload: object, key: str) -> int | None:
+    if isinstance(payload, dict):
+        value = payload.get(key)
+        if isinstance(value, bool):
+            return None
+        if isinstance(value, int):
+            return value
+        if isinstance(value, float):
+            return int(value)
+    return None
+
+
+def _day(value: object) -> date | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _npm_series(payload: object) -> list[tuple[date, int]]:
+    """npm serves one object per day, zeros included."""
+    if not isinstance(payload, dict):
+        return []
+    rows = payload.get("downloads")
+    if not isinstance(rows, list):
+        return []
+    out: list[tuple[date, int]] = []
+    for row in rows:
+        day = _day(_text(row, "day"))
+        count = _number(row, "downloads")
+        if day is not None and count is not None:
+            out.append((day, count))
+    return out
+
+
+def _crates_series(payload: object) -> list[tuple[date, int]]:
+    """crates.io serves per-version rows plus a roll-up, and omits empty days."""
+    if not isinstance(payload, dict):
+        return []
+    blocks: list[object] = [payload.get("version_downloads")]
+    meta = payload.get("meta")
+    if isinstance(meta, dict):
+        blocks.append(meta.get("extra_downloads"))
+
+    totals: dict[date, int] = {}
+    for block in blocks:
+        if not isinstance(block, list):
+            continue
+        for row in block:
+            day = _day(_text(row, "date"))
+            count = _number(row, "downloads")
+            if day is None or count is None:
+                continue
+            totals[day] = totals.get(day, 0) + count
+    return sorted(totals.items())
+
+
+def series_for(artifact_kind: str, payload: object) -> list[tuple[date, int]]:
+    """Route the payload to its registry's parser. An unknown kind yields nothing."""
+    if artifact_kind == "npm":
+        return _npm_series(payload)
+    if artifact_kind == "crates":
+        return _crates_series(payload)
+    return []
+
+
+def request_url(artifact_kind: str, package: str, period: str) -> str | None:
+    """The one call this artifact needs, or None if the kind is not one of ours."""
+    if artifact_kind == "npm":
+        return f"{NPM_API}/downloads/range/{period}/{package}"
+    if artifact_kind == "crates":
+        return f"{CRATES_API}/{package}/downloads"
+    return None
+
+
+def npm_period(today: date) -> str:
+    """18 months ending yesterday: today is still accumulating."""
+    end = today - timedelta(days=1)
+    start = end - timedelta(days=NPM_HISTORY_DAYS - 1)
+    return f"{start.isoformat()}:{end.isoformat()}"
+
+
+def rows_for(
+    product_slug: str,
+    product_type: str,
+    artifact_kind: str,
+    package: str,
+    payload: object,
+    http_status: int,
+    fetched_at: datetime,
+) -> list[dict]:
+    """The rows one artifact contributes: its served days, or one failure row."""
+    series = series_for(artifact_kind, payload)
+    if not series:
+        return [
+            {
+                "product_slug": product_slug,
+                "product_type": product_type,
+                "artifact_kind": artifact_kind,
+                "package": package,
+                "day": None,
+                "downloads": None,
+                "http_status": http_status,
+                "fetched_at": fetched_at,
+            }
+        ]
+    return [
+        {
+            "product_slug": product_slug,
+            "product_type": product_type,
+            "artifact_kind": artifact_kind,
+            "package": package,
+            "day": day,
+            "downloads": downloads,
+            "http_status": http_status,
+            "fetched_at": fetched_at,
+        }
+        for day, downloads in series
+    ]
+
+
+@oso.model(
+    environment_name="Default",
+    depends_on=["currentai.registry.product_artifacts"],
+    external_origins=["https://api.npmjs.org", "https://crates.io"],
+)
+async def package_downloads_daily(context: oso.AsyncContext) -> oso.DataFrame:
+    headers: dict[str, str] = {"User-Agent": USER_AGENT, "Accept": "application/json"}
+
+    result = await context.query(ROSTER_SQL)
+    roster = await result.as_pl()
+
+    artifacts: list[tuple[str, str, str, str]] = []
+    for row in roster.iter_rows(named=True):
+        slug = row.get("product_slug")
+        product_type = row.get("product_type")
+        artifact_kind = row.get("artifact_kind")
+        package = row.get("artifact_id")
+        if not isinstance(slug, str) or not isinstance(package, str) or not package:
+            continue
+        if not isinstance(artifact_kind, str):
+            continue
+        artifacts.append(
+            (
+                slug,
+                product_type if isinstance(product_type, str) else "",
+                artifact_kind,
+                package,
+            )
+        )
+    if not artifacts:
+        raise RuntimeError("roster query returned no npm or crates artifacts")
+
+    fetched_at = datetime.now(timezone.utc).replace(tzinfo=None, microsecond=0)
+    period = npm_period(fetched_at.date())
+
+    urls = [
+        request_url(artifact_kind, package, period)
+        for _, _, artifact_kind, package in artifacts
+    ]
+    unroutable = [url is None for url in urls]
+    if all(unroutable):
+        raise RuntimeError("no declared artifact belongs to a registry this model reads")
+
+    responses = await asyncio.gather(
+        *(
+            context.fetch(url, headers=headers)
+            for url in urls
+            if url is not None
+        )
+    )
+    # Put the responses back beside their artifacts, so an unroutable kind still
+    # produces a row rather than shifting every row after it onto the wrong package.
+    answered: list[object] = []
+    cursor = 0
+    for url in urls:
+        if url is None:
+            answered.append(None)
+        else:
+            answered.append(responses[cursor])
+            cursor += 1
+
+    if not any(
+        response is not None and response.status == 200 for response in answered
+    ):
+        raise RuntimeError(f"every one of {len(artifacts)} registry calls failed")
+
+    rows: list[dict] = []
+    for index, (slug, product_type, artifact_kind, package) in enumerate(artifacts):
+        response = answered[index]
+        status = response.status if response is not None else 0
+        payload = response.json() if response is not None and status == 200 else None
+        rows.extend(
+            rows_for(
+                slug, product_type, artifact_kind, package, payload, status, fetched_at
+            )
+        )
+
+    return pl.DataFrame(
+        rows,
+        schema={
+            "product_slug": pl.Utf8,
+            "product_type": pl.Utf8,
+            "artifact_kind": pl.Utf8,
+            "package": pl.Utf8,
+            "day": pl.Date,
+            "downloads": pl.Int64,
+            "http_status": pl.Int64,
+            "fetched_at": pl.Datetime("us"),
+        },
+    )

--- a/warehouse/platform-mirror/packages_product_adoption.sql
+++ b/warehouse/platform-mirror/packages_product_adoption.sql
@@ -1,0 +1,186 @@
+-- ────── PLATFORM MIRROR (read-only) ──────
+-- A snapshot of a model that runs on the OSO platform to build one of the gap map's
+-- tables. The platform is the source of truth; nothing deploys from this copy, and
+-- editing it here changes nothing. See README.md and manifest.yaml in this folder.
+
+-- currentai.signal_packages.product_adoption
+-- One usage_volume band per product, summed across every package registry it ships through.
+-- Grain: one row per product declaring at least one package artifact.
+--
+-- The unit forces the summation. sources/rubrics/software.yaml declares the software /
+-- usage_volume unit as "package downloads in the trailing 30 days, summed across declared
+-- artifacts", and npm, PyPI and crates.io all publish that same quantity on that same window.
+-- So a product's band is one number over all of its package artifacts. `beeai` is the live
+-- case: it declares an npm package and a PyPI package, and a per-registry band would give one
+-- product two levels over two partial figures with nothing to say which one the map means.
+--
+-- `artifact_kind` cannot be a column here, for the same reason: one row may be built from two
+-- registries. What replaces it is `kinds_counted`, a comma-joined list of the kinds that
+-- actually contributed, so a level 5 built from npm plus PyPI is distinguishable from one built
+-- on PyPI alone without re-deriving it. Comma-joined rather than an array because every other
+-- multi-value column this repo publishes is (signal_github.repo_state.topics), and a VARCHAR
+-- survives a CSV round trip into a notebook unchanged.
+--
+-- Scope: the PACKAGE channel of usage_volume only. currentai.signal_huggingface.product_adoption
+-- bands Hub downloads and currentai.signal_github.product_adoption bands stars. Unifying all
+-- three into a single adoption authority is issue #169's question, not this model's.
+--
+-- Two rules it exists to enforce:
+--
+--   * The thresholds are READ, never written here. They are declared per product type in
+--     sources/rubrics/<type>.yaml, published to currentai.registry.adoption_bands, and joined
+--     below on (product_type, signal_type). Issue #173 records what the alternative cost:
+--     signal_pypi carried them as a hardcoded CASE applying the software scale to every type,
+--     under which level 5 is unreachable for a dataset entirely, and nothing in the repo could
+--     see it. A type with no declared band gets adoption_level NULL rather than another type's
+--     scale, which is what hardware's empty band list is for.
+--     The join also filters signal_type, which signal_pypi's does not: adoption_bands holds
+--     three instruments' scales and only usage_volume belongs to a download count.
+--   * Partial coverage abstains. If a declared package artifact produced no figure -- it 404s,
+--     or the fetch has not reached it yet -- the sum is short by an unknown amount, so the band
+--     is NULL and abstain_reason says which. A sum over some of a product's channels is the
+--     under-coverage error in docs/guides/adoption.md, and it is worse than no number because
+--     it carries a level.
+--   * A non-primary artifact is excluded from the sum, never from the table. Where a declared
+--     package is not how the product ships, sources/products/*.yaml says so per artifact with
+--     `not_primary_channel` and a reason, and this model leaves it out of the figure it bands.
+--     `hexabot`'s npm entry is an embeddable widget rather than the self-hosted platform, and
+--     `yomo`'s crate is a Rust SDK for a Go binary; both products then have no primary package
+--     channel at all and fall through to the stars instrument legitimately, rather than being
+--     held at a hand-set level nothing could check. Their downloads are still computed and
+--     still visible in signal_packages.package_downloads. This is the mechanism behind the
+--     minority-channel ruling that also covers gvisor, ollama, promptfoo and opencompass.
+--
+-- A computed band is an observation, never a score. Nothing here writes back into sources/.
+
+WITH measured AS (
+  SELECT
+    product_slug,
+    product_type,
+    artifact_kind,
+    package,
+    downloads_30d,
+    downloads_prev_30d,
+    days_observed,
+    window_start,
+    last_day_seen,
+    missing_from_registry,
+    not_primary_channel,
+    -- An artifact is eligible for the summed figure only if it is how the product ships. The
+    -- artifact stays declared and its downloads stay published per artifact; this is the one
+    -- place the exclusion applies.
+    not_primary_channel IS NULL AS is_primary
+  FROM currentai.signal_packages.package_downloads
+),
+
+rolled AS (
+  SELECT
+    product_slug,
+    product_type,
+    COUNT(*) AS artifacts_declared,
+    COUNT_IF(is_primary) AS artifacts_primary,
+    COUNT_IF(NOT is_primary) AS artifacts_excluded,
+    COUNT(CASE WHEN is_primary THEN downloads_30d END) AS artifacts_counted,
+    COUNT_IF(is_primary AND missing_from_registry) AS artifacts_missing,
+    ARRAY_JOIN(
+      ARRAY_AGG(DISTINCT CASE WHEN is_primary AND downloads_30d IS NOT NULL THEN artifact_kind END
+                ORDER BY CASE WHEN is_primary AND downloads_30d IS NOT NULL THEN artifact_kind END),
+      ','
+    ) AS kinds_counted,
+    ARRAY_JOIN(
+      ARRAY_AGG(DISTINCT CASE WHEN NOT is_primary THEN artifact_kind END
+                ORDER BY CASE WHEN NOT is_primary THEN artifact_kind END),
+      ','
+    ) AS kinds_excluded,
+    SUM(CASE WHEN is_primary THEN downloads_30d END) AS downloads_30d,
+    SUM(CASE WHEN is_primary THEN downloads_prev_30d END) AS downloads_prev_30d,
+    MIN(CASE WHEN is_primary THEN days_observed END) AS days_observed,
+    -- The oldest window bounds what the sum is a sum of. Taking the newest would date the
+    -- claim later than the data supports, and the legs are anchored per registry.
+    MIN(CASE WHEN is_primary THEN window_start END) AS window_start,
+    MIN(CASE WHEN is_primary THEN last_day_seen END) AS last_day_seen
+  FROM measured
+  GROUP BY product_slug, product_type
+),
+
+complete AS (
+  SELECT
+    product_slug,
+    product_type,
+    artifacts_declared,
+    artifacts_primary,
+    artifacts_excluded,
+    artifacts_counted,
+    artifacts_missing,
+    kinds_counted,
+    kinds_excluded,
+    downloads_30d,
+    downloads_prev_30d,
+    days_observed,
+    window_start,
+    last_day_seen,
+    -- Completeness is measured against the PRIMARY artifacts, not against everything declared.
+    -- A product whose only package artifact is a non-primary channel has zero countable
+    -- artifacts, which is a different state from having one that 404s and from having one
+    -- nothing has fetched yet; all three are false here and abstain_reason below says which.
+    artifacts_counted = artifacts_primary AND artifacts_primary > 0 AS is_complete
+  FROM rolled
+),
+
+-- Every band the summed figure clears, then the highest of them. The completeness test rides on
+-- the join, so an incomplete product matches no band rather than banding on a short sum.
+banded AS (
+  SELECT
+    c.product_slug,
+    CAST(MAX(b.level) AS INTEGER) AS adoption_level,
+    MAX_BY(b.reach, b.level) AS reach,
+    MAX_BY(b.unit, b.level) AS unit
+  FROM complete c
+  JOIN currentai.registry.adoption_bands b
+    ON b.product_type = c.product_type
+    AND b.signal_type = 'usage_volume'
+    AND c.downloads_30d > b.above
+  WHERE c.is_complete
+  GROUP BY c.product_slug
+)
+
+SELECT
+  c.product_slug,
+  c.product_type,
+  c.kinds_counted,
+  c.kinds_excluded,
+  c.artifacts_declared,
+  c.artifacts_primary,
+  c.artifacts_excluded,
+  c.artifacts_counted,
+  c.artifacts_missing,
+  CASE WHEN c.is_complete THEN c.downloads_30d END AS downloads_30d,
+  CASE WHEN c.is_complete THEN c.downloads_prev_30d END AS downloads_prev_30d,
+  c.days_observed,
+  c.window_start,
+  c.last_day_seen,
+  b.adoption_level,
+  b.reach,
+  b.unit,
+  c.is_complete,
+  -- Ordered most specific first, and the first two arms are the distinction that matters: an
+  -- artifact excluded as a minority channel is a curator's declared judgment, an artifact that
+  -- 404s is a broken declaration, and reading either as the other loses the finding.
+  CASE
+    WHEN c.artifacts_primary = 0
+      THEN 'no primary package channel: all ' || CAST(c.artifacts_excluded AS VARCHAR)
+        || ' declared package artifacts (' || c.kinds_excluded
+        || ') are marked not_primary_channel, so the product ships another way'
+    WHEN c.artifacts_counted = 0 AND c.artifacts_missing > 0
+      THEN 'every primary package artifact was looked for and not found'
+    WHEN c.artifacts_counted = 0
+      THEN 'no signal row yet for any primary package artifact'
+    WHEN NOT c.is_complete
+      THEN 'partial coverage: ' || CAST(c.artifacts_counted AS VARCHAR) || ' of '
+        || CAST(c.artifacts_primary AS VARCHAR) || ' primary package artifacts counted'
+    WHEN b.adoption_level IS NULL
+      THEN 'no usage_volume band declared for product type ' || c.product_type
+  END AS abstain_reason,
+  CURRENT_TIMESTAMP AS computed_at
+FROM complete c
+LEFT JOIN banded b ON b.product_slug = c.product_slug

--- a/warehouse/platform-mirror/pypi_package_downloads.sql
+++ b/warehouse/platform-mirror/pypi_package_downloads.sql
@@ -1,0 +1,73 @@
+-- ────── PLATFORM MIRROR (read-only) ──────
+-- A snapshot of a model that runs on the OSO platform to build one of the gap map's
+-- tables. The platform is the source of truth; nothing deploys from this copy, and
+-- editing it here changes nothing. See README.md and manifest.yaml in this folder.
+
+-- currentai.signal_pypi.package_downloads
+-- Monthly PyPI download volume for the map's declared pypi artifacts.
+--
+-- Roster from currentai.registry.product_artifacts (the CI-pushed declaration),
+-- joined to the oso.pypi_downloads marketplace dataset. SQL rather than Python:
+-- there is no fetch and no secret here, so this needs neither the Python sandbox
+-- nor the flaky UDM host.
+--
+-- Grain: one row per (product_slug, package).
+--
+-- Two honest limits, both inherited from the source and surfaced as columns
+-- rather than buried:
+--   * Counts are raw installer requests. They include CI jobs, mirrors and other
+--     automated traffic, so they are volume, not unique users. `downloads_30d` is
+--     the adoption input; it is not a user count.
+--   * History is short. `days_observed` and `window_start` make the window
+--     explicit so a partial window is visible instead of reading as a decline.
+WITH bounds AS (
+  SELECT MAX(day) AS last_day FROM oso.pypi_downloads.daily_downloads_by_package
+),
+roster AS (
+  SELECT DISTINCT
+    product_slug,
+    product_type,
+    artifact_id AS package
+  FROM currentai.registry.product_artifacts
+  WHERE artifact_kind = 'pypi'
+),
+windowed AS (
+  SELECT
+    d.package,
+    SUM(CASE WHEN d.day > b.last_day - INTERVAL '30' DAY THEN d.downloads ELSE 0 END) AS downloads_30d,
+    SUM(CASE WHEN d.day > b.last_day - INTERVAL '7' DAY THEN d.downloads ELSE 0 END) AS downloads_7d,
+    COUNT(DISTINCT CASE WHEN d.day > b.last_day - INTERVAL '30' DAY THEN d.day END) AS days_observed,
+    MAX(d.country_count) AS max_country_count,
+    MIN(d.day) AS first_day_seen,
+    MAX(d.day) AS last_day_seen
+  FROM oso.pypi_downloads.daily_downloads_by_package d
+  CROSS JOIN bounds b
+  GROUP BY d.package
+)
+SELECT
+  r.product_slug,
+  r.product_type,
+  r.package,
+  w.downloads_30d,
+  w.downloads_7d,
+  w.days_observed,
+  w.max_country_count AS countries_seen,
+  w.first_day_seen,
+  w.last_day_seen,
+  CAST(b.last_day - INTERVAL '30' DAY AS DATE) AS window_start,
+  -- Adoption band on the map's own scale, so the level is derived here rather
+  -- than re-derived by every consumer. The level-5 floor is >10M monthly.
+  CASE
+    WHEN w.downloads_30d IS NULL THEN NULL
+    WHEN w.downloads_30d > 10000000 THEN 5
+    WHEN w.downloads_30d > 1000000 THEN 4
+    WHEN w.downloads_30d > 100000 THEN 3
+    WHEN w.downloads_30d > 10000 THEN 2
+    ELSE 1
+  END AS adoption_level,
+  -- A roster package absent from PyPI entirely is a data-quality signal, not a zero.
+  w.package IS NULL AS missing_from_pypi
+FROM roster r
+CROSS JOIN bounds b
+LEFT JOIN windowed w
+  ON LOWER(r.package) = LOWER(w.package)

--- a/warehouse/platform-mirror/scores_openness_computed.schema.json
+++ b/warehouse/platform-mirror/scores_openness_computed.schema.json
@@ -1,0 +1,107 @@
+[
+  {
+    "name": "product_slug",
+    "type": "VARCHAR",
+    "description": "Joins registry.products."
+  },
+  {
+    "name": "category_slug",
+    "type": "VARCHAR",
+    "description": "Which category's rubric produced this score."
+  },
+  {
+    "name": "product_type",
+    "type": "VARCHAR",
+    "description": "The product's own declared type, from registry.products."
+  },
+  {
+    "name": "ladder_product_type",
+    "type": "VARCHAR",
+    "description": "Which ladder variant governed. '*' where one ladder covers the whole category, the product's own type where a category mixes them (safeguards holds guardrail models and guardrail software), null where no ladder covers this type - which suppresses the score and says so in scoring_note."
+  },
+  {
+    "name": "is_deferred",
+    "type": "BOOLEAN",
+    "description": "Whether the category's scoring_recipe declares that its ladder does not decide this product. The rule walk does not run for these, so score, class and winning_rule_index are all null and scoring_note carries the recorded reason. 86 of 470 today."
+  },
+  {
+    "name": "openness_score",
+    "type": "BIGINT",
+    "description": "1-5 from the category's formula. Null in four cases, each with a reason in scoring_note: the category defers the product, no ladder covers the product's type, no rule matched and the ladder declares no otherwise, or the license maps to no declared tier. The last matches check_rubric's behavior of reporting rather than scoring, and applies only to ladders that declare a tier vocabulary - the hardware ladder scores design and toolchain and turns on no license at all."
+  },
+  {
+    "name": "openness_class",
+    "type": "VARCHAR",
+    "description": "closed, restricted, source_available, open_core, open_weights, open_source. Null alongside a null score."
+  },
+  {
+    "name": "dimension_values",
+    "type": "VARCHAR",
+    "description": "Every fact the formula could read, as 'key=value; key=value' sorted by key, with '?' where a dimension is declared but unrecorded. Replaces the former weights / data / code columns: the dimension vocabulary is per-ladder, so a column apiece meant reshaping this model every time a category landed."
+  },
+  {
+    "name": "license_tier",
+    "type": "VARCHAR",
+    "description": "Resolved tier the formula consumed, for ladders that declare tiers. Null means no declared tier matched, which suppresses the score; null on a tier-free ladder means the question was never asked."
+  },
+  {
+    "name": "license_tier_grade",
+    "type": "VARCHAR",
+    "description": "dataset when every reachable SKU mapped to one tier, so most-restrictive was computable; document otherwise."
+  },
+  {
+    "name": "winning_rule_index",
+    "type": "BIGINT",
+    "description": "Which rule of the ordered formula fired, within the governing ladder variant - rule_index is unique only per (category, product_type). Makes a score explainable by pointing at the rule rather than restating it. Null when the ladder abstained."
+  },
+  {
+    "name": "dims_relied_on",
+    "type": "BIGINT",
+    "description": "How many facts the winning rule depends on. A conditional rule depends on its own conditions; `otherwise` depends on all of them, because reaching it means every earlier rule was tested and failed. This is the wrong denominator for a freshness claim - see dims_recorded."
+  },
+  {
+    "name": "dims_sourced",
+    "type": "BIGINT",
+    "description": "How many of those facts cite something specific."
+  },
+  {
+    "name": "dims_from_dataset",
+    "type": "BIGINT",
+    "description": "How many of those came from a machine-readable field rather than a document."
+  },
+  {
+    "name": "dims_recorded",
+    "type": "BIGINT",
+    "description": "How many of the ladder's declared dimensions this product actually records a value for, whether or not the winning rule read them. Mirrors build/check_verification.py:recorded_dimensions, which is the set docs/guides/freshness.md means by 'everything in the score'."
+  },
+  {
+    "name": "dims_recorded_from_dataset",
+    "type": "BIGINT",
+    "description": "How many recorded dimensions rest on a machine-readable field."
+  },
+  {
+    "name": "dims_declared",
+    "type": "BIGINT",
+    "description": "How many dimensions the governing ladder declares, plus the license where it declares tiers. The gap to dims_recorded is the product's unanswered questions, which is a curation work list rather than an error."
+  },
+  {
+    "name": "all_recorded_dims_from_dataset",
+    "type": "BOOLEAN",
+    "description": "Whether EVERY dimension this score records is dataset-grade. The precondition docs/guides/verification.md step 2 requires before any tool may write last_verified: a document is someone's reading of prose, and re-reading the repo confirms nothing. Expected false across nearly all of openness, because signal_routing.yaml declares `data` research-only and the GitHub code route does not settle `code`. That is the honest answer, not a coverage gap."
+  },
+  {
+    "name": "unsourced_dimensions",
+    "type": "VARCHAR",
+    "description": "The relied-on facts backed by nothing specific. This is the work list."
+  },
+  {
+    "name": "last_checked",
+    "type": "DATE",
+    "description": "CHECK EVENT: the most recent date on which any admitted evidence behind this score was actually read - a document source's accessed date, or a signal's fetch. Diagnostic only. It is NOT freshness and must never be written into sources/scores as last_verified: that field is a person's confirmation that everything in the score is still correct, and no aggregate of access dates produces it. Normative rule in docs/guides/freshness.md."
+  },
+  {
+    "name": "scoring_note",
+    "type": "VARCHAR",
+    "description": "Why a score is null, or why a dataset route declined in favor of the recorded components. Deferred products carry no row at all - registry.category_deferrals holds their reasons."
+  }
+]

--- a/warehouse/platform-mirror/scores_openness_computed.sql
+++ b/warehouse/platform-mirror/scores_openness_computed.sql
@@ -1,0 +1,424 @@
+-- ────── PLATFORM MIRROR (read-only) ──────
+-- A snapshot of a model that runs on the OSO platform to build one of the gap map's
+-- tables. The platform is the source of truth; nothing deploys from this copy, and
+-- editing it here changes nothing. See README.md and manifest.yaml in this folder.
+
+-- currentai.scores.openness_computed
+-- Layer-2 stage 2b: walk the ordered rules over the resolved facts.
+--
+-- This is build/check_rubric.py:apply_formula ported onto the warehouse. The rules
+-- are NOT written here. They arrive from currentai.registry.category_scoring_rules,
+-- which CI pushes from each category's `scoring_recipe`, so editing a threshold in
+-- the repo re-scores without touching this model. That is the whole point of the
+-- split: the repo declares, OSO computes.
+--
+-- Grain: one row per (product_slug, category_slug).
+--
+-- Reads currentai.scores.openness_facts and the rule tables, never the evidence store or the
+-- raw signals. Resolution - which grade wins, how a license becomes a tier - lives in the
+-- facts model, and the isolation is enforced by the dependency graph rather than by
+-- convention, so this model cannot quietly reach past it.
+--
+-- ## No dimension is named in this file
+--
+-- It used to resolve `weights`, `data`, `code` and `license` in hardcoded UNION branches.
+-- That was written when two model categories had a rubric, and it meant the ten software
+-- categories, the two dataset categories and the hardware category produced no rows at all:
+-- their rules test `source`, `core_gated`, `availability`, `answers`, `documentation`,
+-- `schematics` and `toolchain`, no branch built those facts, so nothing matched and - with no
+-- `otherwise` rung in those ladders - every product fell out of the join. 74 of 470 rows, and
+-- the repo a week ahead of the warehouse.
+--
+-- Facts now arrive keyed by whatever the ladder declares, and a rule's `condition_key` joins
+-- straight onto `fact_key`. A seventeenth category scores here the day its recipe lands.
+--
+-- ## The rule walk is per ladder VARIANT, not per category
+--
+-- `rule_index` is unique only within (category_slug, product_type), because a category whose
+-- products do not all climb the same ladder emits one rule set per type - `safeguards` holds
+-- guardrail models and guardrail software. Every join to the rule tables therefore carries
+-- the governing variant, which each facts row names. Joining on the category alone
+-- interleaves two ladders' numbering, and MIN(rule_index) then picks a rung from whichever
+-- ladder happened to number it lowest.
+--
+-- ## What reproducing the hand-authored scores does and does not prove
+--
+-- It proves the rubric faithfully describes how the category was scored. It does
+-- NOT show the scores are right: the document-grade evidence it reads was parsed
+-- out of the same files the scores live in, so agreement is a fidelity check on the
+-- formula, not a validation of the facts.
+--
+-- ## An unmapped license tier does not fall through, but it only stops the rungs that ask
+--
+-- check_rubric REPORTS an unmapped license rather than scoring it, and so does this:
+-- the score comes out null with a reason. Letting it reach the `otherwise` rule
+-- would silently record every unrecognized license as 3/open_weights.
+--
+-- The guard fires only for ladders that ASK about a license, which is the allowance
+-- check_rubric gained for hardware. `sources/rubrics/hardware.yaml` scores design, toolchain
+-- and availability and declares no `license_tier`; none of the 20 edge products records a
+-- license. Applied unconditionally the guard nulls all 20 scores, and the repo would report
+-- the category fully reproduced while the warehouse published nothing. The facts model emits
+-- a `license_tier` row only where there is a tier vocabulary, so the presence of that fact
+-- key is the test - no second lookup, and no way for the two to disagree.
+--
+-- That allowance was still too coarse, and it was the last shape of parity drift on this
+-- axis (10 of the 13 divergences standing on 2026-08-12). `asks_license` is true whenever the
+-- LADDER declares a tier vocabulary anywhere, so a product the ladder settles on a
+-- source-only rung was nulled because some OTHER rung, further down and never reached, turns
+-- on a license. `apify` records `source:partial` and a license of `mixed`; the software
+-- ladder decides `source:partial` at 2/source_available on the source dimension alone, and
+-- the license it could not map was never going to be consulted. Same for `deepseek-chat` and
+-- `meta-ai` on `source:closed`, and seven more across three categories.
+--
+-- check_rubric fixed this in `walk_formula` (PR #203): resolve a tier only where a rung
+-- actually tests one. The mirror is the `blocked` CTE below, and it is deliberately a
+-- POSITION comparison rather than a condition on the winner. In Python the walk returns at
+-- the first rung it can neither evaluate nor skip - a rung whose non-license conditions all
+-- match, that tests `license_tier`, with no tier resolved - and that return happens BEFORE
+-- any later rung, `otherwise` included, is ever seen. So the test here is whether such a
+-- rung sits at a lower `rule_index` than the winning one.
+--
+-- ## Why an `otherwise` winner is not itself tier-checked
+--
+-- Because `walk_formula` does not check one either: it returns an `otherwise` result the
+-- moment it reaches that rule, consulting no tier. The protection the old guard provided -
+-- an unmapped license must not silently score 3/open_weights through `otherwise` - survives
+-- intact, but it now lives one step earlier. To REACH `otherwise` in a ladder that turns on
+-- a license, the walk must first pass every license rung above it, and any such rung whose
+-- other conditions match is exactly what `blocked` catches. `dify` is the worked example:
+-- it records `source:public`, which reaches the `competition_restricted` rung, so its
+-- unmapped vendor license blocks there and it stays deferred rather than falling through.
+--
+-- Tier-checking the `otherwise` winner directly would be the stricter-looking choice and the
+-- wrong one. It re-nulls every product whose ladder has a license rung it never reached,
+-- which is the bug above wearing a narrower hat.
+--
+-- Note that `deps` below still expands an `otherwise` win to ALL condition keys. That is a
+-- separate and still-correct claim - about which facts the score RESTS on for the
+-- verification counts - and it is not the guard. The two were never the same question.
+--
+-- ## An abstention is a row, not an absence
+--
+-- Every non-deferred product reaching the facts model gets a row here, even when no rule
+-- fires. A ladder with no `otherwise` is saying it does not decide some products - the
+-- software ladders do this on purpose, because whether the published source is the whole
+-- product is recorded for about two thirds of products and an `otherwise` would score the
+-- rest on an absence. Those products used to vanish from this model, which reads as "not in
+-- the map" rather than "the rubric abstained". Now the score is null and `scoring_note` says
+-- which of the two happened.
+--
+-- ## A deferral is the repo refusing, and it is not the same as an abstention
+--
+-- `scoring_recipe.deferred` names products a category has declared its ladder does not decide.
+-- Those products get a row here with a null score and the recorded reason, and the rule walk
+-- never runs for them - `winning_rule_index` is null too, because a rung this model was told
+-- not to apply is not an explanation of anything. All 470 products are therefore present, and
+-- the 86 unscored ones say why in `scoring_note` rather than by being absent.
+--
+-- Keeping them out of the walk is a correctness fix, not tidiness. `sources/rubrics/model.yaml`
+-- ends in `otherwise: {score: 3, class: open_weights}`, so before the flag existed `safeguards`
+-- published a computed score for nine guardrail models the repo had explicitly declined to
+-- stand behind, and seven of the nine disagreed with the recorded value.
+--
+-- The two causes stay distinguishable in `scoring_note`, which matters: a deferral is a
+-- curation decision with an owner and a reason, while an abstention is the ladder reporting
+-- that this product's recorded evidence does not reach any rung.
+--
+-- ## This model computes no freshness date, on purpose
+--
+-- It used to emit `freshness_floor`, the MIN accessed date across the evidence the winning
+-- rule depends on. That column is gone. It was an aggregate of access dates, which is the one
+-- thing docs/guides/freshness.md rules out as a freshness measure: opening a URL is a weaker
+-- claim than confirming a conclusion, and no aggregation upgrades it. Having the column
+-- invited exactly one use - writing it back into sources/scores as last_verified - and that
+-- is what #108 did.
+--
+-- `last_checked` stays. It is the MAX accessed over admitted evidence and it answers a real
+-- question: when did this pipeline last see any of this. It is a diagnostic, never written to
+-- a file, and build/apply_scores.py no longer writes any date at all.
+--
+-- Nothing here stamps CURRENT_DATE either: a recompute must never make stale evidence look
+-- freshly checked.
+--
+-- What IS new is the denominator a freshness claim would need. `dims_relied_on` counts the
+-- facts the winning RULE reads, and a rule can win on the license alone while `data` and
+-- `code` sit unconfirmed, so it can never support a whole-axis claim. `dims_recorded` counts
+-- every declared dimension this product actually records, and
+-- `all_recorded_dims_from_dataset` is the test docs/guides/verification.md step 2 asks for.
+-- For openness it is expected to be false almost everywhere - `data` has no dataset route at
+-- all - and that is the honest answer rather than a gap.
+--
+-- Operational note for whoever revises this next: a run materializes the latest RELEASED
+-- revision, not the latest revision. Creating a revision changes nothing until
+-- createDataModelRelease points at it. Three runs were spent concluding that dropping a
+-- column had broken materialization, when the runs were still executing the previous release
+-- and the new SQL had never executed at all.
+WITH facts AS (
+  SELECT * FROM currentai.scores.openness_facts
+),
+rules AS (
+  SELECT category_slug, product_type, rule_index, is_otherwise, condition_key, condition_value,
+         then_score, then_class
+  FROM currentai.registry.category_scoring_rules
+),
+
+-- The roster and the wide fact view, in one aggregation ----------------------
+-- Both come off the same grain, and computing them separately would mean two scans of the
+-- facts table. This query is the second half of a model that had to be split at Trino's
+-- 150-stage ceiling, so the same discipline applies here.
+axis AS (
+  SELECT
+    product_slug,
+    category_slug,
+    MAX(product_type) AS product_type,
+    MAX(ladder_product_type) AS ladder_type,
+    BOOL_OR(is_deferred) AS is_deferred,
+    MAX(deferral_reason) AS deferral_reason,
+    ARRAY_JOIN(
+      ARRAY_AGG(fact_key || '=' || COALESCE(NULLIF(fact_value, ''), '?') ORDER BY fact_key)
+        FILTER (WHERE fact_key IS NOT NULL),
+      '; '
+    ) AS dimension_values,
+    MAX(CASE WHEN fact_key = 'license_tier' THEN fact_value END) AS license_tier,
+    MAX(CASE WHEN fact_key = 'license_tier' THEN fact_grade END) AS license_tier_grade,
+    MAX(CASE WHEN fact_key = 'license_tier' THEN fact_input END) AS license_name,
+    -- Whether this ladder asks about a license at all. The facts model emits the key only
+    -- where a tier vocabulary exists, so this is the tier-free allowance, read rather than
+    -- re-derived.
+    BOOL_OR(fact_key = 'license_tier') AS asks_license,
+    ARRAY_JOIN(ARRAY_AGG(fact_note ORDER BY fact_key) FILTER (WHERE fact_note IS NOT NULL), ' ')
+      AS abstention_notes,
+    COUNT(fact_key) AS dims_declared,
+    COUNT_IF(is_recorded) AS dims_recorded,
+    COUNT_IF(is_recorded AND fact_grade = 'dataset') AS dims_recorded_from_dataset
+  FROM facts
+  GROUP BY product_slug, category_slug
+),
+
+-- Walk the ordered rules, first match wins ----------------------------------
+rule_size AS (
+  SELECT category_slug, product_type, rule_index, COUNT(*) AS conditions_required
+  FROM rules WHERE NOT is_otherwise
+  GROUP BY category_slug, product_type, rule_index
+),
+rule_hits AS (
+  SELECT
+    f.product_slug,
+    f.category_slug,
+    f.ladder_product_type AS ladder_type,
+    r.rule_index,
+    COUNT(*) AS conditions_met
+  FROM facts f
+  JOIN rules r
+    ON r.category_slug = f.category_slug
+   AND r.product_type = f.ladder_product_type
+   AND r.condition_key = f.fact_key
+   AND r.condition_value = f.fact_value
+  WHERE NOT r.is_otherwise
+    AND NOT f.is_deferred
+  GROUP BY f.product_slug, f.category_slug, f.ladder_product_type, r.rule_index
+),
+otherwise_rule AS (
+  SELECT category_slug, product_type, MIN(rule_index) AS rule_index
+  FROM rules WHERE is_otherwise
+  GROUP BY category_slug, product_type
+),
+candidates AS (
+  SELECT h.product_slug, h.category_slug, h.ladder_type, h.rule_index
+  FROM rule_hits h
+  JOIN rule_size s
+    ON s.category_slug = h.category_slug
+   AND s.product_type = h.ladder_type
+   AND s.rule_index = h.rule_index
+  WHERE h.conditions_met = s.conditions_required
+  UNION ALL
+  -- `otherwise` is a candidate for every product, and MIN below decides. Taking the
+  -- minimum over conditional matches AND the otherwise index is what makes this
+  -- faithful to apply_formula's ordered walk, in which any rule declared after an
+  -- `otherwise` is unreachable.
+  SELECT a.product_slug, a.category_slug, a.ladder_type, o.rule_index
+  FROM axis a
+  JOIN otherwise_rule o
+    ON o.category_slug = a.category_slug
+   AND o.product_type = a.ladder_type
+  WHERE NOT a.is_deferred
+),
+winner AS (
+  SELECT product_slug, category_slug, ladder_type, MIN(rule_index) AS rule_index
+  FROM candidates
+  GROUP BY product_slug, category_slug, ladder_type
+),
+
+-- The rungs a missing license tier actually stops --------------------------
+-- `walk_formula`'s `blocked` return, ported. A rung blocks when it tests `license_tier`,
+-- no tier resolved, and every OTHER condition it carries matches - meaning the walk has
+-- arrived at a rung it can neither satisfy nor rule out, and first-match-wins forbids
+-- stepping over it.
+--
+-- `other_conditions` counts a rung's non-license conditions; `conditions_met` from
+-- `rule_hits` counts what this product matched. Those two can be compared directly here
+-- because the license condition cannot contribute to `conditions_met` when no tier
+-- resolved: the facts row carries a null `fact_value` and the equality join in `rule_hits`
+-- drops it. A rung testing the license and nothing else has `other_conditions = 0` and
+-- blocks unconditionally, which is right - there is nothing about it left to evaluate.
+license_rules AS (
+  SELECT category_slug, product_type, rule_index,
+         COUNT_IF(condition_key <> 'license_tier') AS other_conditions
+  FROM rules
+  WHERE NOT is_otherwise
+  GROUP BY category_slug, product_type, rule_index
+  HAVING COUNT_IF(condition_key = 'license_tier') > 0
+),
+blocked AS (
+  SELECT a.product_slug, a.category_slug, MIN(lr.rule_index) AS rule_index
+  FROM axis a
+  JOIN license_rules lr
+    ON lr.category_slug = a.category_slug
+   AND lr.product_type = a.ladder_type
+  LEFT JOIN rule_hits h
+    ON h.product_slug = a.product_slug
+   AND h.category_slug = a.category_slug
+   AND h.ladder_type = a.ladder_type
+   AND h.rule_index = lr.rule_index
+  WHERE NOT a.is_deferred
+    AND a.asks_license
+    AND COALESCE(NULLIF(a.license_tier, ''), NULL) IS NULL
+    AND COALESCE(h.conditions_met, 0) = lr.other_conditions
+  GROUP BY a.product_slug, a.category_slug
+),
+outcome AS (
+  -- Every condition row of a rule carries the same then_score / then_class, so any
+  -- aggregate picks it out.
+  SELECT category_slug, product_type, rule_index,
+         MAX(then_score) AS score, MAX(then_class) AS class
+  FROM rules
+  GROUP BY category_slug, product_type, rule_index
+),
+
+-- Which facts the winning rule actually rests on -----------------------------
+deps AS (
+  SELECT w.product_slug, w.category_slug, r.condition_key AS fact_key
+  FROM winner w
+  JOIN rules r
+    ON r.category_slug = w.category_slug
+   AND r.product_type = w.ladder_type
+   AND r.rule_index = w.rule_index
+  WHERE NOT r.is_otherwise
+  UNION
+  -- Reaching `otherwise` means every earlier rule was tested and failed, so the
+  -- score rests on all of the facts, not on none of them.
+  SELECT w.product_slug, w.category_slug, k.condition_key
+  FROM winner w
+  JOIN rules ro
+    ON ro.category_slug = w.category_slug
+   AND ro.product_type = w.ladder_type
+   AND ro.rule_index = w.rule_index
+   AND ro.is_otherwise
+  JOIN (
+    SELECT DISTINCT category_slug, product_type, condition_key
+    FROM rules WHERE NOT is_otherwise
+  ) k
+    ON k.category_slug = w.category_slug
+   AND k.product_type = w.ladder_type
+),
+verification AS (
+  SELECT
+    d.product_slug,
+    d.category_slug,
+    COUNT(*) AS dims_relied_on,
+    COUNT_IF(f.fact_admitted) AS dims_sourced,
+    COUNT_IF(f.fact_grade = 'dataset') AS dims_from_dataset,
+    -- A CHECK EVENT: the last time this pipeline read any admitted evidence. Diagnostic
+    -- only. The matching MIN used to be emitted as `freshness_floor` and is gone; see the
+    -- header. Two dates that differ only in aggregate invite being mistaken for each
+    -- other, and one of them has no legitimate consumer.
+    MAX(CASE WHEN f.fact_admitted THEN f.fact_accessed END) AS newest_admitted_accessed,
+    ARRAY_JOIN(
+      ARRAY_AGG(d.fact_key ORDER BY d.fact_key) FILTER (WHERE NOT f.fact_admitted), ', '
+    ) AS unsourced_dimensions
+  FROM deps d
+  JOIN facts f
+    ON f.product_slug = d.product_slug
+   AND f.category_slug = d.category_slug
+   AND f.fact_key = d.fact_key
+  GROUP BY d.product_slug, d.category_slug
+)
+
+SELECT
+  a.product_slug,
+  a.category_slug,
+  a.product_type,
+  -- Which ladder variant governed. '*' for the fifteen uniform categories, the product's own
+  -- type where a category mixes them, null where none covers it.
+  a.ladder_type AS ladder_product_type,
+  a.is_deferred,
+  CASE
+    WHEN a.is_deferred OR a.ladder_type IS NULL THEN CAST(NULL AS BIGINT)
+    -- The blocked rung is checked before the winner, and against its POSITION: a rung the
+    -- walk could not evaluate only counts if the walk would have reached it first.
+    WHEN b.rule_index IS NOT NULL AND (w.rule_index IS NULL OR b.rule_index < w.rule_index)
+      THEN CAST(NULL AS BIGINT)
+    WHEN w.rule_index IS NULL THEN CAST(NULL AS BIGINT)
+    ELSE o.score
+  END AS openness_score,
+  CASE
+    WHEN a.is_deferred OR a.ladder_type IS NULL THEN CAST(NULL AS VARCHAR)
+    WHEN b.rule_index IS NOT NULL AND (w.rule_index IS NULL OR b.rule_index < w.rule_index)
+      THEN CAST(NULL AS VARCHAR)
+    WHEN w.rule_index IS NULL THEN CAST(NULL AS VARCHAR)
+    ELSE o.class
+  END AS openness_class,
+  a.dimension_values,
+  a.license_tier,
+  a.license_tier_grade,
+  w.rule_index AS winning_rule_index,
+  v.dims_relied_on,
+  v.dims_sourced,
+  v.dims_from_dataset,
+  a.dims_recorded,
+  a.dims_recorded_from_dataset,
+  a.dims_declared,
+  -- The precondition for any tool that wants to write a date. False whenever a single
+  -- recorded dimension rests on someone's reading of prose, which for openness is nearly
+  -- always: `data` has no dataset route by declaration, not by omission.
+  a.dims_recorded > 0 AND a.dims_recorded_from_dataset = a.dims_recorded
+    AS all_recorded_dims_from_dataset,
+  v.unsourced_dimensions,
+  -- The CHECK EVENT, and the only date that belongs in sources/scores. The most recent
+  -- date on which any admitted evidence behind this score was actually read - a document
+  -- source's `accessed`, or a signal's fetch. Traceable by construction, because every
+  -- contributing row carries its own source_url and date in the evidence store.
+  v.newest_admitted_accessed AS last_checked,
+  CASE
+    WHEN a.is_deferred
+      THEN 'the category defers this product: '
+           || COALESCE(NULLIF(a.deferral_reason, ''), 'no reason recorded')
+    WHEN a.ladder_type IS NULL
+      THEN 'no ladder in this category covers product type '
+           || COALESCE(NULLIF(a.product_type, ''), '<unrecorded>')
+    -- Blocked outranks "no rule matched", mirroring check_rubric's `check_category`, which
+    -- tests `blocked_on_tier` before it tests an empty result. The two are different
+    -- findings with different owners: an unreadable license is a curation prompt, while an
+    -- unmatched ladder is a rubric gap.
+    WHEN b.rule_index IS NOT NULL AND (w.rule_index IS NULL OR b.rule_index < w.rule_index)
+      THEN 'license ' || COALESCE('''' || a.license_name || '''', '<unrecorded>')
+           || ' maps to no declared tier, and rule ' || CAST(b.rule_index AS VARCHAR)
+           || ' - which the ladder reaches - tests one, so the rubric cannot score it'
+    WHEN w.rule_index IS NULL
+      THEN 'the recipe does not decide this product: no rule matched and it declares no '
+           || 'otherwise [' || COALESCE(a.dimension_values, 'no evidence recorded') || ']'
+    ELSE NULLIF(a.abstention_notes, '')
+  END AS scoring_note
+FROM axis a
+LEFT JOIN winner w
+  ON w.product_slug = a.product_slug AND w.category_slug = a.category_slug
+LEFT JOIN blocked b
+  ON b.product_slug = a.product_slug AND b.category_slug = a.category_slug
+LEFT JOIN outcome o
+  ON o.category_slug = w.category_slug
+ AND o.product_type = w.ladder_type
+ AND o.rule_index = w.rule_index
+LEFT JOIN verification v
+  ON v.product_slug = a.product_slug AND v.category_slug = a.category_slug
+ORDER BY a.product_slug

--- a/warehouse/platform-mirror/scores_openness_facts.schema.json
+++ b/warehouse/platform-mirror/scores_openness_facts.schema.json
@@ -1,0 +1,72 @@
+[
+  {
+    "name": "product_slug",
+    "type": "VARCHAR",
+    "description": "Joins registry.products."
+  },
+  {
+    "name": "category_slug",
+    "type": "VARCHAR",
+    "description": "Which category's ladder asked this question."
+  },
+  {
+    "name": "product_type",
+    "type": "VARCHAR",
+    "description": "The product's own declared type, from registry.products."
+  },
+  {
+    "name": "ladder_product_type",
+    "type": "VARCHAR",
+    "description": "Which ladder variant governs. '*' where one ladder covers the whole category, the product's own type where a category mixes them, null where none covers it - in which case the product carries a single row with a null fact_key rather than vanishing."
+  },
+  {
+    "name": "is_deferred",
+    "type": "BOOLEAN",
+    "description": "Whether the category's scoring_recipe declares that its ladder does not decide this product. 86 of 470 today. The facts are still resolved and published - the refusal is data, and 'why is this one unscored' should be answerable from the table - but openness_computed will not walk the rules for it."
+  },
+  {
+    "name": "deferral_reason",
+    "type": "VARCHAR",
+    "description": "The `because` the repo recorded for a deferral. Null for everything else."
+  },
+  {
+    "name": "fact_key",
+    "type": "VARCHAR",
+    "description": "A dimension the ladder declares, or 'license_tier' for the derived one. Null only on a product no ladder variant covers."
+  },
+  {
+    "name": "fact_value",
+    "type": "VARCHAR",
+    "description": "The value a rule reads. Null means this ladder asked and the product records no answer, which is a curation work list rather than an error - and is deliberately distinguishable from the dimension not being asked about, which produces no row."
+  },
+  {
+    "name": "fact_grade",
+    "type": "VARCHAR",
+    "description": "dataset when a machine-readable route settled it, document when it rests on someone's reading of prose. Null when nothing was recorded."
+  },
+  {
+    "name": "fact_admitted",
+    "type": "BOOLEAN",
+    "description": "Whether the evidence behind the value cites something specific. A document row whose axis cites only 'flagship phase-C verification source' is not admitted."
+  },
+  {
+    "name": "fact_accessed",
+    "type": "DATE",
+    "description": "When the evidence behind this fact was read or fetched. An access date, never a confirmation: see docs/guides/freshness.md."
+  },
+  {
+    "name": "fact_input",
+    "type": "VARCHAR",
+    "description": "For license_tier, the canonical license name the tier lookup consumed, after normalization and aliasing. Lets an unmapped license be read off this table rather than reconstructed. Null for every other fact key."
+  },
+  {
+    "name": "fact_note",
+    "type": "VARCHAR",
+    "description": "Why a dataset-grade route declined in favor of the recorded components: SKUs that disagree, or partial coverage of a most-restrictive aggregate."
+  },
+  {
+    "name": "is_recorded",
+    "type": "BOOLEAN",
+    "description": "Whether this product answers the question at all. Summed downstream into dims_recorded, which is the denominator docs/guides/freshness.md requires for a whole-axis freshness claim."
+  }
+]

--- a/warehouse/platform-mirror/scores_openness_facts.sql
+++ b/warehouse/platform-mirror/scores_openness_facts.sql
@@ -1,0 +1,494 @@
+-- ────── PLATFORM MIRROR (read-only) ──────
+-- A snapshot of a model that runs on the OSO platform to build one of the gap map's
+-- tables. The platform is the source of truth; nothing deploys from this copy, and
+-- editing it here changes nothing. See README.md and manifest.yaml in this folder.
+
+-- currentai.scores.openness_facts
+-- Layer-2 stage 2a: one authoritative fact per dimension a ladder declares.
+--
+-- Grain: one row per (product_slug, category_slug, fact_key), including declared dimensions
+-- the product records NOTHING for - those carry a null value, which is the point. A missing
+-- row would be indistinguishable from a dimension nobody asked about, and the difference
+-- between "unanswered" and "not asked" is what a freshness claim turns on.
+--
+-- ## Why this is its own model
+--
+-- It was one query with `openness_computed` until 2026-08-05. Generalizing off the
+-- hardcoded model dimensions took it to 174 Trino stages against a ceiling of 150, because
+-- the resolution CTEs are referenced several times each by the rule walk and Trino replans
+-- the subtree per reference. Splitting materializes the facts once.
+--
+-- The split earns its keep beyond the stage count. docs/guides/verification.md describes the
+-- audit chain as score <- rule <- dimension values <- evidence <- source, and the third link
+-- had no table: `openness_computed` resolved dimensions inside itself and published only the
+-- score. This is that link, queryable, so "which fact did this score rest on, at what grade"
+-- is a select rather than a re-derivation.
+--
+-- ## What resolution means here
+--
+-- Two grades arrive from the evidence store and one has to win.
+--
+--   * A dataset-grade route reports per SKU and a family of SKUs can disagree, so those rows
+--     are aggregated before they become a fact. Where the admitted SKUs agree, dataset wins:
+--     a field lookup beats someone's reading of prose. Where they disagree, this abstains and
+--     the recorded components decide, with the reason in `fact_note`.
+--   * `license_tier` is the one derived fact. A license is recorded as one or more NAMES and
+--     a rule tests a tier, so each name is normalized and mapped through the ladder's own
+--     examples before anything can read it, and the most restrictive of them governs. Every
+--     part must map or the whole value abstains - see `license_fact`. Ladders that turn on no
+--     license at all - hardware scores design, toolchain and availability - get no
+--     `license_tier` row, and that absence is how `openness_computed` knows not to demand one.
+--
+-- Nothing in this file names a dimension. The vocabulary comes from
+-- currentai.registry.category_dimensions, which is the ladder's own declaration, so a
+-- seventeenth category resolves here the day its recipe lands.
+--
+-- ## Deferrals are marked, not dropped
+--
+-- `scoring_recipe.deferred` names products a category has declared its ladder does not
+-- decide - 86 of the 470 today. They stay in this table carrying `is_deferred` and the
+-- recorded reason, because dropping them would make the openness tables cover 384 products
+-- and answer "why not this one" with silence. The refusal is data.
+--
+-- What must not happen is a score. `openness_computed` refuses to walk the rules for a
+-- deferred product, and the flag has to travel with the facts for it to be able to:
+-- suppressing a product's document rows in the repo does not suppress the hub rows the signal
+-- route writes for the same product, so the evidence store has two inlets and a deferred
+-- product arrives here regardless. Until the flag existed, `safeguards` published a computed
+-- score for nine guardrail models the repo had explicitly declined to stand behind - the
+-- model ladder ends in `otherwise: {score: 3}` - and seven of the nine disagreed with the
+-- recorded value.
+WITH dims AS (
+  SELECT category_slug, product_type, dimension
+  FROM currentai.registry.category_dimensions
+),
+variants AS (
+  SELECT DISTINCT category_slug, product_type FROM dims
+),
+-- One row per (category, ladder variant, example license), which the registry table itself
+-- does not guarantee. `proprietary` is both a declared example and one of the definitional
+-- tokens, and the two dataset ladders each list apache-2.0, mit and odc-by twice: 17 example
+-- licenses across 13 ladders arrive as two or three rows.
+--
+-- It never mattered while the license was one row per product, because every aggregate
+-- downstream absorbed the duplicate. It matters now that the document side COUNTS parts to
+-- decide whether they all mapped - one part matching two rows would read as two parts, and
+-- the count would go into `fact_note` and into the reassembled name.
+--
+-- Least restrictive wins a genuine disagreement, because that is what
+-- `check_rubric._tier_of` does: it returns the FIRST tier whose examples contain the name,
+-- and declaration order is restrictiveness ascending. No duplicate pair disagrees today -
+-- all 17 resolve to a single tier - so this collapses rows without changing an answer. The
+-- rule is written down anyway, because the day one pair does disagree is the day the two
+-- implementations would silently answer differently.
+tiers AS (
+  SELECT
+    category_slug,
+    product_type,
+    example_license,
+    MIN_BY(tier, tier_rank) AS tier,
+    MIN(tier_rank) AS tier_rank
+  FROM (
+    SELECT category_slug, product_type, tier, tier_rank,
+           LOWER(TRIM(example_license)) AS example_license
+    FROM currentai.registry.category_license_tiers
+  )
+  GROUP BY category_slug, product_type, example_license
+),
+ladder_tiers AS (
+  SELECT category_slug, product_type, COUNT(*) AS tier_rows
+  FROM tiers
+  GROUP BY category_slug, product_type
+),
+ev AS (
+  SELECT * FROM currentai.evidence.product_evidence
+),
+
+-- Roster, and which ladder governs each product ------------------------------
+-- `product_type` on the registry tables is '*' when one ladder covers every type and the
+-- product's own type when a category mixes them, mirroring build/rubrics.py:recipe_for. It
+-- has to be resolved here rather than downstream, because `rule_index` is unique only within
+-- (category_slug, product_type) and the tier examples are per variant too: `safeguards`
+-- holds guardrail models on a five-tier ladder and guardrail software on a three-tier one.
+--
+-- The roster is the registry's, not the evidence store's. It used to be
+-- `SELECT DISTINCT product_slug, category_slug FROM product_evidence`, which silently made
+-- coverage conditional on evidence existing: serialize_rubric emits no document rows for a
+-- deferred product, so 36 of the 86 deferrals - the ones with no Hub or GitHub artifact to
+-- generate a dataset row either - were absent rather than unscored. Every product a scored
+-- category claims belongs here, whether or not anything is known about it.
+roster AS (
+  SELECT
+    pc.product_slug,
+    pc.category_slug,
+    COALESCE(p.type, '') AS product_type,
+    d.product_slug IS NOT NULL AS is_deferred,
+    d.because AS deferral_reason
+  FROM currentai.registry.product_categories pc
+  JOIN (
+    SELECT DISTINCT category_slug FROM currentai.registry.category_scoring_rules
+  ) scored
+    ON scored.category_slug = pc.category_slug
+  LEFT JOIN currentai.registry.products p
+    ON p.slug = pc.product_slug
+  LEFT JOIN currentai.registry.category_deferrals d
+    ON d.product_slug = pc.product_slug
+   AND d.category_slug = pc.category_slug
+),
+governing AS (
+  SELECT
+    r.product_slug,
+    r.category_slug,
+    r.product_type,
+    r.is_deferred,
+    r.deferral_reason,
+    -- A '*' variant wins outright; otherwise the one matching this product's type. Null
+    -- means no ladder in the category covers this type, which check_rubric reports as a
+    -- problem. Here it produces a single row with a null fact_key, so the product stays
+    -- visible downstream instead of disappearing.
+    COALESCE(
+      MAX(CASE WHEN v.product_type = '*' THEN '*' END),
+      MAX(CASE WHEN v.product_type = r.product_type THEN v.product_type END)
+    ) AS ladder_type
+  FROM roster r
+  LEFT JOIN variants v
+    ON v.category_slug = r.category_slug
+  GROUP BY r.product_slug, r.category_slug, r.product_type, r.is_deferred, r.deferral_reason
+),
+
+-- Every fact key the governing ladder asks about -----------------------------
+declared AS (
+  SELECT category_slug, product_type, dimension AS fact_key FROM dims
+  UNION ALL
+  -- The derived one, present only where there is a tier vocabulary to derive against.
+  SELECT category_slug, product_type, 'license_tier' FROM ladder_tiers
+),
+
+-- One pass over the evidence store, per declared dimension -------------------
+-- Both grades resolved in a single aggregation rather than two CTEs and a full outer join,
+-- which is again the stage count.
+--
+-- The join to `dims` is what keeps traceability rows out. serialize_rubric emits the
+-- resolved value under the DIMENSION name and every other recorded key under its own name,
+-- so `finetuned_chat`'s data answer arrives as `data` while the raw `post-training-data` row
+-- rides along for provenance. Both are document grade and only one is a fact.
+--
+-- `settles_dimension` on the dataset side replaces a hardcoded exclusion of `code`. The
+-- GitHub route reports that a repo exists and is alive, which informs the code dimension
+-- without answering it, and signal_routing.yaml is where that is declared. Reading the flag
+-- rather than naming the dimension means a future corroborating route is handled correctly
+-- on the day it lands instead of quietly outvoting a document.
+dim_facts AS (
+  SELECT
+    g.product_slug,
+    g.category_slug,
+    e.dimension AS fact_key,
+    -- One document row per grain by construction. The aggregate is defensive: a second row
+    -- would otherwise multiply this product through every downstream join.
+    MAX(CASE WHEN e.grade = 'document' THEN e.value END) AS doc_value,
+    BOOL_OR(e.grade = 'document' AND e.admitted) AS doc_admitted,
+    MAX(CASE WHEN e.grade = 'document' THEN e.source_accessed END) AS doc_accessed,
+    COUNT_IF(e.grade = 'dataset' AND e.settles_dimension AND e.admitted) AS skus_admitted,
+    COUNT(DISTINCT CASE
+      WHEN e.grade = 'dataset' AND e.settles_dimension AND e.admitted THEN e.value END
+    ) AS values_seen,
+    MAX(CASE
+      WHEN e.grade = 'dataset' AND e.settles_dimension AND e.admitted THEN e.value END
+    ) AS ds_value,
+    MIN(CASE
+      WHEN e.grade = 'dataset' AND e.settles_dimension AND e.admitted THEN e.source_accessed END
+    ) AS ds_accessed
+  FROM ev e
+  JOIN governing g
+    ON g.product_slug = e.product_slug
+   AND g.category_slug = e.category_slug
+  JOIN dims d
+    ON d.category_slug = e.category_slug
+   AND d.product_type = g.ladder_type
+   AND d.dimension = e.dimension
+  GROUP BY g.product_slug, g.category_slug, e.dimension
+),
+
+-- The license, which is an input rather than a dimension ---------------------
+-- One row per recorded PART. A license can be several licenses - `zed` ships an editor
+-- under GPL-3.0-or-later, a collab server under AGPL-3.0 and GPUI under Apache-2.0 - and
+-- the tier is the most restrictive of them. The parts arrive already separated, one
+-- evidence row each carrying its `part_index`, so nothing here splits a string.
+--
+-- That is a change of principle rather than of technique. This model used to receive the
+-- whole clause and cut the last `+`-segment out of it when the word 'model' appeared,
+-- while build/serialize_rubric.py published a value already truncated at the first `(`.
+-- Between them, `zed`'s three licenses reached the warehouse as one and
+-- `redpajama-data-v2`'s two arrived joined into a name no tier declares. Both sides were
+-- inferring the count of licenses from punctuation, and they inferred differently: three
+-- of the last standing parity divergences were exactly that.
+--
+-- The curator records the count. `culturax` writes `follows mC4 + OSCAR-2301 terms` as ONE
+-- part, because neither operand is a license, and no rule here could have told that from a
+-- genuine compound. That is why the pre-check this replaces had to exist, and why it does
+-- not need to any more.
+license_rows AS (
+  SELECT
+    g.product_slug,
+    g.category_slug,
+    g.ladder_type,
+    e.grade,
+    e.admitted,
+    e.source_reachable,
+    e.source_accessed,
+    e.part_index,
+    CASE
+      -- Mirrors build/check_rubric.py:normalize_license, and both forms are named in
+      -- the recipe's `normalization` list. A `code ` or `model ` prefix says which
+      -- artifact the license covers, not which license it is; the 'assumed-' prefix marks
+      -- confidence, not a different license. Dataset rows arrive from the hub route
+      -- already resolved to a canonical name, so they skip this.
+      --
+      -- The 'code MIT + model X' rule the old CASE implemented - keep the last segment,
+      -- the model license governs - is gone, and is now a consequence rather than a
+      -- special case: both parts resolve and the most restrictive wins. In every recorded
+      -- instance the weights license IS the restrictive half, and where it would not be,
+      -- the old rule was wrong anyway. A permissive weights license does not buy back a
+      -- restrictive code license.
+      WHEN e.grade = 'document' THEN TRIM(REGEXP_REPLACE(
+        REGEXP_REPLACE(e.value, '(?i)^\s*(code|model)\s+', ''),
+        '(?i)^assumed-', ''))
+      ELSE TRIM(e.value)
+    END AS license_clean
+  FROM ev e
+  JOIN governing g
+    ON g.product_slug = e.product_slug
+   AND g.category_slug = e.category_slug
+  WHERE e.dimension = 'license'
+),
+-- Then the recorded-name alias, which is the third step of normalize_license and
+-- the one that cannot be expressed as a regex. The hub path already joins
+-- license_aliases for the slug a source publishes; this is the same table for the
+-- name a human typed, under source = 'recorded'.
+--
+-- Applied AFTER the regex steps, matching the order in check_rubric, so the alias
+-- table does not have to enumerate an `assumed-` variant of every license.
+--
+-- Left out, `glm-4` and `NVIDIA-Nemotron-Open-Model-License` map to no tier and the
+-- score comes out null, while check_rubric resolves both and reports the category fully
+-- reproduced. The two disagreeing is worse than either being wrong, because the local
+-- checker is what CI gates on and the warehouse is what anyone querying the map sees.
+license_named AS (
+  SELECT
+    l.product_slug,
+    l.category_slug,
+    l.ladder_type,
+    l.grade,
+    l.admitted,
+    l.source_reachable,
+    l.source_accessed,
+    l.part_index,
+    COALESCE(a.license_name, l.license_clean) AS license_name
+  FROM license_rows l
+  LEFT JOIN currentai.registry.license_aliases a
+    ON a.source = 'recorded'
+   AND l.grade = 'document'
+   AND LOWER(a.license_slug) = LOWER(l.license_clean)
+),
+license_tiered AS (
+  SELECT
+    n.product_slug,
+    n.category_slug,
+    n.grade,
+    n.admitted,
+    n.source_reachable,
+    n.source_accessed,
+    n.part_index,
+    n.license_name,
+    t.tier,
+    t.tier_rank
+  FROM license_named n
+  LEFT JOIN tiers t
+    ON t.category_slug = n.category_slug
+   AND t.product_type = n.ladder_type
+   AND t.example_license = LOWER(n.license_name)
+),
+
+-- Grade precedence, and why partial coverage cannot be trusted ---------------
+-- Dataset grade governs a family-level aggregate ONLY when every reachable SKU yielded a
+-- mapped tier.
+--
+-- Measured on qwen-2-5: Qwen2.5-72B reports its license as `other` and Qwen2.5-7B as
+-- apache-2.0. Taking the max over only the SKUs that answered resolves the family to `osi`
+-- and moves it from 2/restricted to 3/open_weights, on the strength of the SKU that is not
+-- the restrictive one. max(restrictiveness) over a subset can only fall, so partial coverage
+-- always biases toward permissive. It overstates openness, which is the worst direction for
+-- this map to be wrong in.
+--
+-- A second way partial trust fails, found 2026-07-29 when release-level products were
+-- collapsed into vendor tiers. A tier declares every release's repos, so `gemma` carries
+-- Gemma 2, 3 and 4: four SKUs report the Gemma License and two report Apache-2.0, and
+-- most-restrictive across all six published the family as `restricted` when Gemma 4 had
+-- relicensed. Same for `hermes`, whose Llama-based and Apache-based builds substitute for
+-- each other. Most-restrictive is only sound across SKUs a user cannot substitute away from;
+-- across releases and interchangeable bases it erases relicensing. So when the mapped SKUs
+-- disagree, the dataset route abstains and the recorded components decide.
+--
+-- Every other dataset route is held to agreement but not to coverage, and the difference is
+-- not an oversight. `license_tier` is an aggregate over SKUs - most restrictive wins - so a
+-- SKU we failed to reach can change the answer. The weights route is a claim about
+-- existence: one downloadable SKU makes the family's weights downloadable, and a SKU we
+-- missed could only have added openness. An unreachable SKU is fatal to the first and
+-- harmless to the second; disagreement among SKUs that DID answer is fatal to both.
+--
+-- ## The document side is now an aggregate too, over PARTS rather than SKUs
+--
+-- Same shape, same reason, one level down. A recorded license has one or more parts and
+-- `check_rubric.license_tier` resolves every one of them: if any part maps to no tier the
+-- whole value abstains, and otherwise the most restrictive governs. Skipping a part it
+-- could not map would be the partial-coverage error again - an unmapped part can only ever
+-- be MORE restrictive than the tier the mapped parts reached, so ignoring it overstates
+-- openness. `doc_parts` and `doc_parts_mapped` are that test; `doc_most_restrictive` is the
+-- MAX over tier rank, which is the ladder's own declaration order ascending.
+license_fact AS (
+  SELECT
+    product_slug,
+    category_slug,
+    COUNT_IF(grade = 'dataset' AND source_reachable) AS skus_reachable,
+    COUNT_IF(grade = 'dataset' AND source_reachable AND admitted AND tier IS NOT NULL)
+      AS skus_mapped,
+    COUNT(DISTINCT CASE
+      WHEN grade = 'dataset' AND admitted AND tier IS NOT NULL THEN tier END
+    ) AS tiers_seen,
+    -- COALESCE to -1 stops an unmapped SKU winning the max, and -2 keeps document rows out
+    -- of the family aggregate entirely. If nothing mapped, the winning value is null anyway
+    -- and the coverage test below rejects the family.
+    MAX_BY(
+      CASE WHEN grade = 'dataset' THEN tier END,
+      CASE WHEN grade = 'dataset' THEN COALESCE(tier_rank, -1) ELSE -2 END
+    ) AS most_restrictive_tier,
+    MIN(CASE
+      WHEN grade = 'dataset' AND admitted AND tier IS NOT NULL THEN source_accessed END
+    ) AS ds_accessed,
+    COUNT_IF(grade = 'document') AS doc_parts,
+    COUNT_IF(grade = 'document' AND tier IS NOT NULL) AS doc_parts_mapped,
+    -- Same -1 / -2 convention as the SKU aggregate above: an unmapped part cannot win the
+    -- max, and dataset rows are kept out of the document one entirely.
+    MAX_BY(
+      CASE WHEN grade = 'document' THEN tier END,
+      CASE WHEN grade = 'document' THEN COALESCE(tier_rank, -1) ELSE -2 END
+    ) AS doc_most_restrictive,
+    -- The recorded license reassembled in the order it was written, which is what
+    -- `part_index` is carried this far for. It is what gets printed when no tier resolves,
+    -- and reading 'GPL-3.0-or-later + AGPL-3.0 + Apache-2.0' is how someone sees which of
+    -- the three the ladder has not been told about.
+    ARRAY_JOIN(
+      ARRAY_AGG(license_name ORDER BY part_index) FILTER (WHERE grade = 'document'), ' + '
+    ) AS doc_license_name,
+    BOOL_OR(grade = 'document' AND admitted) AS doc_admitted,
+    MAX(CASE WHEN grade = 'document' THEN source_accessed END) AS doc_accessed
+  FROM license_tiered
+  GROUP BY product_slug, category_slug
+),
+-- The two verdicts, named once rather than spelled out at each of the five places that
+-- used to repeat the coverage test.
+license_resolved AS (
+  SELECT
+    *,
+    (skus_reachable > 0 AND skus_mapped = skus_reachable AND tiers_seen <= 1)
+      AS dataset_governs,
+    CASE WHEN doc_parts > 0 AND doc_parts_mapped = doc_parts THEN doc_most_restrictive END
+      AS doc_tier
+  FROM license_fact
+),
+
+-- One authoritative fact per key ---------------------------------------------
+resolved AS (
+  SELECT
+    g.product_slug,
+    g.category_slug,
+    'license_tier' AS fact_key,
+    CASE WHEN f.dataset_governs THEN f.most_restrictive_tier ELSE f.doc_tier END AS fact_value,
+    CASE WHEN f.dataset_governs THEN 'dataset' ELSE 'document' END AS fact_grade,
+    CASE WHEN f.dataset_governs THEN true ELSE COALESCE(f.doc_admitted, false) END
+      AS fact_admitted,
+    CASE WHEN f.dataset_governs THEN f.ds_accessed ELSE f.doc_accessed END AS fact_accessed,
+    -- The license as it was named before the tier lookup, so an unmapped one can be read off
+    -- this table instead of reconstructed. check_rubric prints exactly this in its finding.
+    -- All of it, for a compound: the part that failed to map is the one worth seeing, and it
+    -- is not always the first.
+    f.doc_license_name AS fact_input,
+    CASE
+      WHEN f.dataset_governs THEN CAST(NULL AS VARCHAR)
+      WHEN f.tiers_seen > 1
+        THEN 'dataset abstained on the family: its ' || CAST(f.skus_mapped AS VARCHAR)
+             || ' mapped SKUs span ' || CAST(f.tiers_seen AS VARCHAR)
+             || ' license tiers, so most-restrictive is a judgment about which releases '
+             || 'substitute for each other rather than a lookup. Deferred to the recorded '
+             || 'components.'
+      WHEN f.skus_reachable > 0 AND f.skus_mapped < f.skus_reachable
+        THEN 'dataset abstained on the family: ' || CAST(f.skus_mapped AS VARCHAR) || ' of '
+             || CAST(f.skus_reachable AS VARCHAR)
+             || ' reachable SKUs mapped to a tier, so most-restrictive is not computable'
+      -- A partly-mapped recorded license. Distinct from mapping nothing, which is a plain
+      -- "the rubric has not been told about this license" and is reported downstream by
+      -- `openness_computed` off `fact_input`. This one names a rubric gap that a glance at
+      -- the reassembled license would not: two of three parts resolved.
+      WHEN f.doc_parts > f.doc_parts_mapped AND f.doc_parts_mapped > 0
+        THEN 'the recorded license abstained: ' || CAST(f.doc_parts_mapped AS VARCHAR)
+             || ' of its ' || CAST(f.doc_parts AS VARCHAR)
+             || ' parts map to a tier, and an unmapped part can only be more restrictive '
+             || 'than the ones that did, so most-restrictive would overstate openness.'
+      ELSE CAST(NULL AS VARCHAR)
+    END AS fact_note
+  FROM governing g
+  JOIN ladder_tiers lt
+    ON lt.category_slug = g.category_slug
+   AND lt.product_type = g.ladder_type
+  LEFT JOIN license_resolved f
+    ON f.product_slug = g.product_slug AND f.category_slug = g.category_slug
+
+  UNION ALL
+
+  SELECT
+    product_slug,
+    category_slug,
+    fact_key,
+    CASE WHEN values_seen = 1 THEN ds_value ELSE doc_value END,
+    CASE WHEN values_seen = 1 THEN 'dataset' ELSE 'document' END,
+    CASE WHEN values_seen = 1 THEN true ELSE COALESCE(doc_admitted, false) END,
+    CASE WHEN values_seen = 1 THEN ds_accessed ELSE doc_accessed END,
+    CAST(NULL AS VARCHAR),
+    CASE
+      WHEN values_seen > 1
+        THEN 'dataset abstained on ' || fact_key || ': its '
+             || CAST(skus_admitted AS VARCHAR) || ' admitted SKUs report '
+             || CAST(values_seen AS VARCHAR)
+             || ' different values, so the family has no single machine-readable answer. '
+             || 'Deferred to the recorded components.'
+      ELSE CAST(NULL AS VARCHAR)
+    END
+  FROM dim_facts
+)
+
+SELECT
+  g.product_slug,
+  g.category_slug,
+  g.product_type,
+  g.ladder_type AS ladder_product_type,
+  g.is_deferred,
+  g.deferral_reason,
+  d.fact_key,
+  r.fact_value,
+  r.fact_grade,
+  r.fact_admitted,
+  r.fact_accessed,
+  r.fact_input,
+  r.fact_note,
+  -- The distinction the null value cannot carry on its own: this ladder asked, and this
+  -- product has an answer. `dims_recorded` downstream is a sum over this column.
+  r.fact_value IS NOT NULL AND r.fact_value <> '' AS is_recorded
+FROM governing g
+LEFT JOIN declared d
+  ON d.category_slug = g.category_slug
+ AND d.product_type = g.ladder_type
+LEFT JOIN resolved r
+  ON r.product_slug = g.product_slug
+ AND r.category_slug = g.category_slug
+ AND r.fact_key = d.fact_key
+ORDER BY g.product_slug, g.category_slug, d.fact_key

--- a/warehouse/platform-mirror/semanticscholar_paper_citations.py
+++ b/warehouse/platform-mirror/semanticscholar_paper_citations.py
@@ -1,0 +1,195 @@
+# ────── PLATFORM MIRROR (read-only) ──────
+# A snapshot of a model that runs on the OSO platform to build one of the gap map's
+# tables. The platform is the source of truth; nothing deploys from this copy, and
+# editing it here changes nothing. See README.md and manifest.yaml in this folder.
+
+"""Citation counts for products that have a paper, via Semantic Scholar.
+
+Roster comes from `currentai.registry.product_artifacts` where `artifact_kind =
+'arxiv'`, so the repo decides which products have a canonical paper and this model
+only measures them. As of 2026-07-28 that is 23 products, all benchmarks.
+
+Why citations, for benchmarks specifically. Downloads measure a benchmark badly —
+its reach is how many papers evaluate against it, not how many people pulled the
+files. Citations are the closest available proxy, and for this category they are
+arguably a better adoption signal than anything else we collect.
+
+## Why Semantic Scholar and not OpenAlex
+
+OpenAlex was tried first and rejected on evidence, 2026-07-28. Two disqualifying
+problems, both silent:
+
+  1. **Wrong papers.** OpenAlex resolves `10.48550/arXiv.<id>` to the wrong work
+     for some ids. `2105.09938` (APPS) returned "GPT-Neo", `2310.06770`
+     (SWE-bench) returned a 2025 coding-agents paper, `2406.19314` (LiveBench)
+     returned "AI Benchmark Half-Life". 3 of 23 wrong, 1 missing, and every wrong
+     answer looked entirely plausible in a table.
+  2. **Preprint-only counts.** OpenAlex keeps the arXiv preprint and the published
+     version as separate works with no linking field, so a DOI lookup returns
+     preprint citations only. GSM8K came back as 23 against a real ~9,800. The
+     shortfall is not a constant factor, so it inverts the ranking too: OpenAlex
+     put HumanEval above MMLU when the truth is the reverse. That kills even
+     within-set comparison, which was the one defensible use.
+
+Semantic Scholar merges versions, accepts an arXiv id directly, and returned all
+23 correctly in a single batch request.
+
+## What the numbers are
+
+`citation_count` is the merged all-versions total, comparable to a figure quoted
+anywhere else. `influential_citation_count` is Semantic Scholar's subset for
+citations that actually build on the work rather than mention it in passing —
+useful because a benchmark accumulates a long tail of one-line mentions.
+
+`paper_title` is returned so identity stays auditable in SQL. If it ever drifts
+from the product's expected paper, that is the OpenAlex failure recurring here and
+the row should not be trusted.
+
+The batch endpoint takes up to 500 ids per POST, so the whole roster is one
+request. That keeps this inside the anonymous rate limit; per-paper GETs 429 after
+about two calls.
+"""
+
+import json
+from datetime import datetime, timezone
+
+import oso
+import pyarrow as pa
+
+BATCH_URL = "https://api.semanticscholar.org/graph/v1/paper/batch"
+FIELDS = "title,citationCount,influentialCitationCount,year,externalIds,publicationTypes"
+BATCH_SIZE = 400
+
+ROSTER_QUERY = """
+SELECT product_slug, artifact_id
+FROM "currentai"."registry"."product_artifacts"
+WHERE artifact_kind = 'arxiv'
+"""
+
+
+def _entries(payload: object) -> list[object]:
+    """The batch endpoint returns a bare list, positionally aligned to the input,
+    with null where a paper was not found.
+
+    Appended element by element rather than returned directly: narrowing `object`
+    with isinstance gives `list[Unknown]`, which the release type check rejects
+    against a `list[object]` annotation.
+    """
+    out: list[object] = []
+    if isinstance(payload, list):
+        for entry in payload:
+            out.append(entry)
+    return out
+
+
+def _int(value: object) -> int | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    return None
+
+
+def _text(value: object) -> str | None:
+    if value is None:
+        return None
+    return value if isinstance(value, str) else str(value)
+
+
+def _external_id(entry: dict, key: str) -> str | None:
+    external = entry.get("externalIds")
+    if not isinstance(external, dict):
+        return None
+    return _text(external.get(key))
+
+
+def _build_table(rows: list[dict], stamp: datetime) -> pa.Table:
+    def col(name: str, kind: pa.DataType) -> pa.Array:
+        return pa.array([r.get(name) for r in rows], type=kind)
+
+    return pa.table(
+        {
+            "product_slug": col("product_slug", pa.string()),
+            "arxiv_id": col("arxiv_id", pa.string()),
+            "paper_id": col("paper_id", pa.string()),
+            "doi": col("doi", pa.string()),
+            "paper_title": col("paper_title", pa.string()),
+            "publication_year": col("publication_year", pa.int64()),
+            "citation_count": col("citation_count", pa.int64()),
+            "influential_citation_count": col("influential_citation_count", pa.int64()),
+            "found": col("found", pa.bool_()),
+            "fetched_at": pa.array([stamp] * len(rows), type=pa.timestamp("us")),
+        }
+    )
+
+
+@oso.model(
+    depends_on=["currentai.registry.product_artifacts"],
+    external_origins=["https://api.semanticscholar.org"],
+)
+async def paper_citations(context: oso.AsyncContext) -> oso.DataFrame:
+    roster_result = await context.query(ROSTER_QUERY)
+    roster = await roster_result.as_pl()
+    pairs = [
+        (str(slug), str(arxiv))
+        for slug, arxiv in zip(roster["product_slug"], roster["artifact_id"])
+        if slug is not None and arxiv is not None
+    ]
+    if not pairs:
+        raise RuntimeError(
+            "no arxiv artifacts in currentai.registry.product_artifacts; "
+            "the registry publish step may not have run"
+        )
+
+    rows: list[dict] = []
+    for start in range(0, len(pairs), BATCH_SIZE):
+        batch = pairs[start : start + BATCH_SIZE]
+        body = json.dumps({"ids": [f"arXiv:{arxiv}" for _, arxiv in batch]})
+        response = await context.fetch(
+            f"{BATCH_URL}?fields={FIELDS}",
+            method="POST",
+            headers={"Content-Type": "application/json"},
+            body=body,
+        )
+        if response.status != 200:
+            raise RuntimeError(
+                f"semantic scholar batch returned {response.status} "
+                f"for {len(batch)} ids"
+            )
+
+        entries = _entries(response.json())
+        if len(entries) != len(batch):
+            raise RuntimeError(
+                f"semantic scholar returned {len(entries)} entries for {len(batch)} "
+                "ids; the batch endpoint is positional, so a length mismatch means "
+                "results cannot be safely rejoined to products"
+            )
+
+        # Positional alignment is the batch endpoint's contract, and the length
+        # check above is what makes relying on it safe. Every product gets a row,
+        # found or not, so coverage is visible in SQL rather than needing a diff
+        # against the registry.
+        for (slug, arxiv), entry in zip(batch, entries):
+            if not isinstance(entry, dict):
+                rows.append({"product_slug": slug, "arxiv_id": arxiv, "found": False})
+                continue
+            rows.append(
+                {
+                    "product_slug": slug,
+                    "arxiv_id": arxiv,
+                    "paper_id": _text(entry.get("paperId")),
+                    "doi": _external_id(entry, "DOI"),
+                    "paper_title": _text(entry.get("title")),
+                    "publication_year": _int(entry.get("year")),
+                    "citation_count": _int(entry.get("citationCount")),
+                    "influential_citation_count": _int(
+                        entry.get("influentialCitationCount")
+                    ),
+                    "found": True,
+                }
+            )
+
+    stamp = datetime.now(timezone.utc).replace(tzinfo=None, microsecond=0)
+    return _build_table(rows, stamp)


### PR DESCRIPTION
Adds `warehouse/udms/` — a committed snapshot of the gap-map UDM logic deployed on the OSO platform (evidence, `openness_facts`/`openness_computed`, the six signal fetchers, package-adoption models, schemas), so the scoring pipeline is legible from the repo. Each file is headed as a mirror; the platform stays the source of truth and nothing deploys from these copies.

**Provenance:** `warehouse/udms/manifest.yaml` records the deployed model id, revision number and revision hash each file reflects, plus the sync date (2026-08-15) — so the snapshot is checkable, not just a copy. A credentialed drift-check job that compares those revisions against the platform is left as a follow-up.

## Scope correction (from review)
The first version of this PR also archived the "legacy" `entities`/`events`/`metrics`/interpretive-`scores` layer. **That was wrong** — the reviewer caught that `oss-ai-trends` and `long-tail-explorer` (both tracked notebooks) still query `metrics.daily`, `scores.repos_summary`, `entities.models`, `entities.packages`, and that nothing queries `scores.stack_contributors` (which I'd kept). So this PR is now **purely additive** — no models, ingest pathways, or workflows are removed. Retiring the legacy chain is deferred to a separate PR that migrates those notebooks onto replacement signals first.

## Test plan
- `uv run python -m build.validate` → 0 errors; doc-integrity passes
- `manifest.yaml` parses; 15 model entries with deployed revision provenance
- No platform changes; no repo deletions