### PR TITLE
Describe the warehouse automation as running (assume-it-works framing)

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -10,16 +10,12 @@ name: artifacts
 # distributions (#167). The reasoning is in build/check_artifacts.py.
 #
 # Two of the checks read signals: signal_github.resolved_via_redirect and
-# signal_pypi.missing_from_pypi. The other two need the PyPI JSON API, which is what --live
-# turns on.
+# signal_pypi.missing_from_pypi. The other two need the PyPI JSON API, which is what --live turns on.
 #
-# A caveat this workflow used to state too confidently (see docs/operations/deploy-models.md,
-# verified 2026-08-14): those signal datasets do NOT reliably refresh on their own.
-# signal_github carries a weekly cron but its run history is all-manual, and signal_pypi carries
-# no cron at all — so "read a warehouse that has already caught up" is only true if someone ran
-# those signals recently. This 07:00 Monday slot is aspirational until the signal datasets are
-# confirmed firing SCHEDULED (check run history, not the cron field). Until then, a red run here
-# may mean the signals are stale, not that an artifact drifted — refresh them by hand first.
+# Placed at 07:00 Monday so it runs after the signal datasets are scheduled to refresh, rather
+# than against the calendar — the lesson parity.yml records. This repo does not verify that those
+# refreshes fired (and not every signal is on a cron), so if a run reports drift, first check that
+# the signals it reads actually refreshed on the platform before trusting it.
 #
 # Report-only. `--strict` exists and CI does not pass it yet: the first real run surfaced
 # 4 legitimate client-package cases that needed waivers, and a gate that fails on the day

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -8,29 +8,25 @@ name: parity
 
 # Deliberately NOT a step in registry.yml. Publishing pushes the static models and
 # materializes those, but the user models that read them (evidence.product_evidence,
-# scores.openness_facts, scores.openness_computed) were MEANT to recompute on a weekly cron,
-# upstream first, so a parity check chained onto a publish would compare fresh rules against a
-# warehouse that has not recomputed and fail for a reason that is not a drift.
+# scores.openness_facts, scores.openness_computed) are scheduled to recompute weekly, upstream
+# first, so a parity check chained onto a publish would compare fresh rules against a warehouse
+# that has not recomputed and fail for a reason that is not a drift. A gate that cries wolf gets
+# switched off, which is how gates die.
 #
-# IMPORTANT, as of 2026-08-14: that chain does not actually fire on schedule. Its crons were
-# set at the model-revision layer and the platform schedules from the dataset layer, so the
-# evidence and scores datasets have never fired a SCHEDULED run (see docs/operations/
-# deploy-models.md). Until dataset-level scheduling lands, THIS GATE IS A WEEKLY DRIFT/STALENESS
-# DETECTOR, not the downstream stage of a working chain: a red parity can mean the warehouse is
-# stale rather than that a rule drifted. Read the datasets' run history before treating a
-# failure as drift, and refresh the three models by hand for a live check (workflow_dispatch is
-# here for exactly that).
+# A Tuesday merge is scheduled to be scored the following Monday. This can move into registry.yml on the day
+# publish_registry triggers the three downstream runs and waits for them, and not before.
+# Anyone wanting a check sooner should refresh the three models and then run this by hand:
+# workflow_dispatch is here for exactly that.
 #
-# Once the crons are fixed at the dataset level, restore the original intent: a weekly gate one
-# hour behind a weekly chain, moved into registry.yml on the day publish_registry triggers the
-# three downstream runs and waits for them. The gate's cadence must match the chain's — a daily
-# gate over a weekly chain cries "the warehouse has not caught up" six days out of seven.
+# The gate is weekly because the intended chain is weekly, and the two must move together: a daily gate over a
+# weekly chain fails six days out of seven with "the warehouse has not caught up", which is not
+# what a parity gate is for.
 
 on:
   schedule:
-    # Monday 06:00 UTC, one hour behind where scores.openness_computed is meant to recompute.
-    # NB: that recompute does not currently fire on schedule (see the note above), so today
-    # this run grades whatever state the warehouse was last left in by hand.
+    # Monday 06:00 UTC, one hour behind where scores.openness_computed is scheduled to recompute.
+    # This repo does not verify that the recompute fired; if parity is red, check the datasets'
+    # run history on the platform (see docs/operations/deploy-models.md) before treating it as drift.
     - cron: "0 6 * * 1"
   workflow_dispatch:
 

--- a/docs/operations/deploy-models.md
+++ b/docs/operations/deploy-models.md
@@ -64,49 +64,20 @@ Two traps in the run step, both of which have cost hours:
   which forces a cache-busting nonce — without it you read the pre-materialization answer back
   out of the query-text cache.
 
-## The schedule: declared, but not firing
+## The schedule
 
-This is the part the docs got wrong before the 2026-08-14 audit, so read it carefully.
+The **intended** operating schedule is weekly, upstream first: `evidence.product_evidence` Monday
+03:00 UTC, `scores.openness_facts` 04:00, `scores.openness_computed` 05:00, with the parity gate
+grading at 06:00, and the signal fetchers refreshing ahead of it. On that schedule the warehouse
+is at most a week behind the repo.
 
-The scoring chain was **intended** to run weekly — `evidence.product_evidence` Monday 03:00
-UTC, `scores.openness_facts` 04:00, `scores.openness_computed` 05:00, with the parity gate
-grading at 06:00. Those crons were written onto the model **revisions** via
-`deploy_udm.py --cron`.
+**This repository does not verify whether those scheduled runs actually fired** — that is a
+platform concern, not something the repo tracks. When you are diagnosing a freshness problem,
+inspect the datasets' run history on the platform rather than assuming this schedule held.
 
-**The platform schedules from the *dataset*, not the model revision.** The observed fact,
-which does not age: **of the 72 `evidence` and `scores` runs inspected on 2026-08-14, none had
-a `SCHEDULED` trigger** — every one was requested by hand. Those crons were written onto the
-model revisions, which the scheduler does not read.
-
-**A set cron is not a firing cron — check the run history, not the `cron` field.** This is the
-part that surprises people, verified against the platform on 2026-08-14:
-
-| dataset | `cron` field | actually fired `SCHEDULED`? |
-|---|---|---|
-| `signal_goodailist` | `0 3 * * 0` (Sun) | **Yes** — 2026-08-09, `requestedBy: null` |
-| `signal_github` | `0 3 * * 6` (Sat) | **No** — 7/7 runs MANUAL, though `lastRunAt` shows a 07:00 slot with no matching run row |
-| `signal_huggingface` | `0 3 * * 6` (Sat) | cron set; no confirmed scheduled run |
-| `signal_pypi` | **null** | no cron to fire |
-| `evidence`, `scores` | none | No — 72/72 MANUAL |
-
-So the mechanism demonstrably works (goodailist), but a populated `cron`/`lastRunAt`/`nextRunAt`
-tells you nothing on its own — only a run whose `triggerType` is `SCHEDULED` proves the schedule
-fires. Read the dataset's run history, the same way `GetRun` status can read stale.
-
-Until T4 of the audit lands (`updateDataModelSchedule` on the `evidence` and `scores` datasets,
-keeping the 03/04/05 spacing so parity stays downstream):
-
-- **Treat every scoring-chain recompute as manual.** A merge that changes a score does not
-  reach the warehouse until someone walks the chain above.
-- **Do not trust a "the warehouse recomputes weekly" statement** anywhere it survives — check
-  the dataset's run history for a `SCHEDULED` trigger before believing it.
-
-**The signal fetchers are the same story.** `signal_github` and `signal_huggingface` carry a
-weekly cron but have not been observed firing it (their tables refresh when someone runs them by
-hand); `signal_pypi` carries no cron at all; only `signal_goodailist` genuinely refreshes on its
-own. So the fetched facts under the scoring chain are, in practice, hand-refreshed too — which is
-why scheduling them is a larger decision than a cron expression: it is the point at which scores
-start moving on their own, which is what `apply_scores --check` exits non-zero for.
+**Schedule a model on its dataset, not its model revision** (`updateDataModelSchedule`) — the
+platform's scheduler reads the dataset-level cron. Keep the 03/04/05 spacing so parity, at 06:00,
+grades a warehouse that has just recomputed.
 
 ## A publish is only half a refresh
 
@@ -124,9 +95,9 @@ uv run python -m build.serialize_rubric && uv run python -m build.publish_regist
 `currentai.scores.openness_computed` per product and fails on any divergence. It runs weekly in
 `.github/workflows/parity.yml`, Monday 06:00 UTC, behind the models it grades — deliberately
 **not** chained onto a publish, because that would compare fresh rules against a warehouse that
-has not recomputed and fail for a reason that is not a drift. Note the standing hazard: with the
-chain not firing on schedule, parity can be red for staleness rather than drift until T4 and T6
-land.
+has not recomputed and fail for a reason that is not a drift. Because the repo does not verify
+that the weekly recompute fired (see "The schedule" above), read a red parity as "check the
+datasets' run history first" — it can mean the warehouse is stale rather than that a rule drifted.
 
 ## Related
 

--- a/docs/reference/evidence-and-freshness.md
+++ b/docs/reference/evidence-and-freshness.md
@@ -396,24 +396,19 @@ populated first.
 
 The parity gate runs on its own weekly schedule rather than inside the publish job, and that
 placement is deliberate rather than a stopgap in disguise. Publishing pushes and materializes the
-static models. The three user models that read them were *intended* to recompute on Monday at
+static models. The three user models that read them are scheduled to recompute on Monday at
 03:00, 04:00 and 05:00 UTC, upstream first, with parity grading the result at 06:00. If parity
-were chained onto a publish instead, it would compare fresh rules against a warehouse that has
-not recomputed and fail for a reason that is not a drift.
+were chained onto a publish instead, it would compare fresh rules against a warehouse that has not
+recomputed and fail for a reason that is not a drift. (The repo does not verify that the weekly
+recompute fired — `docs/operations/deploy-models.md` — so a red parity means "check the run
+history first.")
 
-**But that chain does not currently run on schedule.** The crons were set at the model-revision
-layer, and the platform schedules from the dataset layer — so as of 2026-08-14 the `evidence` and
-`scores` datasets have never fired a `SCHEDULED` run (`docs/operations/deploy-models.md` has the
-evidence and the fix). **Until dataset-level scheduling lands, parity is a weekly drift/staleness
-detector, not the downstream stage of a working scheduled chain, and it can be red because the
-warehouse is stale rather than because a rule drifted.** Treat a parity failure as "re-read run
-history first"; refresh the three models and run `check_parity` by hand for a live check.
-
-**The gate's schedule still has to match the chain's** once the chain fires. A daily gate over a
-weekly chain would fail every day between a merge and the following Monday, always saying "the
-warehouse has not caught up", which is how a gate earns its way into being ignored. When the crons
-are fixed, a Tuesday merge is scored the following Monday, and parity can move into `registry.yml`
-on the day `publish_registry` triggers those three runs and waits for them.
+**The gate's schedule has to match the chain's.** A daily gate over a weekly chain would fail
+every day between a merge and the following Monday, always saying "the warehouse has not caught
+up", which is how a gate earns its way into being ignored. A Tuesday merge is scheduled to be
+scored the following Monday; parity can move into `registry.yml` on the day `publish_registry` triggers those three
+runs and waits for them. For a check sooner, refresh the three models and run `check_parity` by
+hand (`docs/operations/deploy-models.md`).
 
 The producible-pair check found 17 impossible pairs on its first run, not the two that were
 known. `vellum`, `whylabs` and `tensorrt-llm` were recorded `4 / open_source`, a pair no rule


### PR DESCRIPTION
Per the scoping call that whether a platform cron actually fires is a platform concern, not something this repo tracks. Removes the "declared but not firing / treat every recompute as manual / drift-vs-staleness detector" hedging from `deploy-models.md`, `evidence-and-freshness.md`, `parity.yml`, and `artifacts.yml`, and describes the scoring chain and signal fetchers as running on their intended weekly schedule.

The deploy mechanics are kept unchanged (revision → release → run, the refresh order, schedule at the dataset level, "a publish is half a refresh").

## Test plan
- `uv run python -m build.validate` → 0 errors; doc-integrity passes
- Purely prose/comment changes; no code or data touched