### PR TITLE
Complete the doc-integrity contract; add a machine-readable skill registry

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -42,10 +42,14 @@ When in doubt about which door, start there.
 | [`reference/queries.md`](reference/queries.md) | Query conventions for the warehouse |
 | [`reference/notebook-design.md`](reference/notebook-design.md) | The published map's visual style |
 
-## Advanced / internal skills
+## Skills off the primary path
 
-Off the primary path, for maintainers and the automation loop: `build-rubric` (derive a
-category's scoring ladder), `add-data-source` (register a fetcher), `refresh-all-categories`
-(drive the whole-corpus sweep), `pyoso-analyst` (read-only warehouse analysis).
+Every skill is classified in `skills/registry.yaml` (validated in CI). Beyond the five primary
+doors above:
+
+- **Advanced** — deep editorial skills for maintainers: `build-rubric` (derive a category's
+  scoring ladder) and `refresh-all-categories` (drive the whole-corpus sweep).
+- **Internal** — infrastructure and analysis, not map-editing: `add-data-source` (register a
+  fetcher) and `pyoso-analyst` (read-only warehouse analysis).
 
 For the repo map, build pipeline, and data model, see `AGENTS.md`.

--- a/docs/workflows/update-product.md
+++ b/docs/workflows/update-product.md
@@ -75,6 +75,18 @@ it only sees the removal once you have re-serialized. CI does this for you (the 
 in `validate.yml` runs after its serialize step), but run it locally to catch a missing alias
 before you push.
 
+## Validation
+Run the checks named by the route you took (above), plus the baseline that applies to every
+change:
+```bash
+uv run python -m build.validate            # always — 0 error(s)
+# then, per route:
+uv run python -m build.check_artifacts     # identity / artifacts changed
+uv run python -m build.check_retirement    # a retirement alias was recorded
+uv run python -m build.check_verification  # an axis was re-dated
+```
+Never commit `build/notebook_data.json` or `notebooks/` (bot-owned).
+
 ## Files this changes
 Whichever the route above names — never the generated `build/notebook_data.json` or `notebooks/`.
 

--- a/skills/registry.yaml
+++ b/skills/registry.yaml
@@ -1,0 +1,27 @@
+# Machine-readable skill classification. tests/test_docs_integrity.py validates this against
+# what is actually in skills/: every skill directory must appear here exactly once, and each
+# primary skill must map to an existing workflow doc that no other primary skill claims.
+#
+# - primary:  the five contributor front doors, one per task, each backed by a workflow.
+# - advanced: deep editorial skills, off the primary path (a ladder, the whole-corpus sweep).
+# - internal: infrastructure / read-only analysis, not editorial map-editing.
+
+primary:
+  - skill: add-product
+    workflow: docs/workflows/add-product.md
+  - skill: update-product
+    workflow: docs/workflows/update-product.md
+  - skill: edit-category
+    workflow: docs/workflows/edit-category.md
+  - skill: refresh-category
+    workflow: docs/workflows/refresh-category.md
+  - skill: migrate-axis
+    workflow: docs/workflows/migrate-axis.md
+
+advanced:
+  - build-rubric
+  - refresh-all-categories
+
+internal:
+  - add-data-source
+  - pyoso-analyst

--- a/tests/test_docs_integrity.py
+++ b/tests/test_docs_integrity.py
@@ -10,7 +10,10 @@ procedure. This test is that enforcement, and it runs in `validate.yml` on every
 import re
 from pathlib import Path
 
+import yaml
+
 REPO = Path(__file__).resolve().parent.parent
+WORKFLOWS = REPO / "docs" / "workflows"
 
 # The hand-maintained documentation surface. Generated files (notebook_data.json,
 # notebooks/*.py) and the gitignored session workspace are not part of it.
@@ -120,3 +123,76 @@ def test_readme_router_lists_every_primary_skill():
     readme = (REPO / "docs" / "README.md").read_text(encoding="utf-8")
     for s in PRIMARY_SKILLS:
         assert f"workflows/{s}.md" in readme, f"docs/README.md router omits {s}"
+
+
+# ── The integrity contract for workflows and the skill registry ──────────────────────────
+
+def _registry() -> dict:
+    return yaml.safe_load((REPO / "skills" / "registry.yaml").read_text())
+
+
+def _validation_section(workflow_md: Path) -> str:
+    """The text of the workflow's `## Validation` section, or '' if absent."""
+    m = re.search(r"^## Validation\s*$(.*?)(?=^## |\Z)", workflow_md.read_text(), re.M | re.S)
+    return m.group(1) if m else ""
+
+
+def test_every_workflow_has_a_validation_section():
+    missing = [
+        s for s in PRIMARY_SKILLS
+        if not re.search(r"^## Validation\s*$", (WORKFLOWS / f"{s}.md").read_text(), re.M)
+    ]
+    assert not missing, f"workflow docs missing a `## Validation` section: {missing}"
+
+
+def test_validation_sections_reference_real_modules():
+    """Any `build.<module>` a Validation section tells a contributor to run must exist."""
+    problems = []
+    for s in PRIMARY_SKILLS:
+        section = _validation_section(WORKFLOWS / f"{s}.md")
+        for mod in re.findall(r"build\.([a-z_]+)", section):
+            if not (REPO / "build" / f"{mod}.py").exists():
+                problems.append(f"{s}.md Validation -> build.{mod} (no build/{mod}.py)")
+    assert not problems, "Validation sections cite nonexistent modules:\n" + "\n".join(problems)
+
+
+def test_registry_classifies_every_skill_exactly_once():
+    reg = _registry()
+    classified = (
+        [e["skill"] for e in reg.get("primary", [])]
+        + list(reg.get("advanced", []))
+        + list(reg.get("internal", []))
+    )
+    on_disk = {p.name for p in (REPO / "skills").iterdir() if (p / "SKILL.md").exists()}
+    dupes = {s for s in classified if classified.count(s) > 1}
+    assert not dupes, f"skills classified more than once in registry.yaml: {sorted(dupes)}"
+    assert set(classified) == on_disk, (
+        f"registry.yaml out of step with skills/: "
+        f"only-in-registry={sorted(set(classified) - on_disk)}, "
+        f"only-on-disk={sorted(on_disk - set(classified))}"
+    )
+
+
+def test_primary_skills_map_one_to_one_to_workflows():
+    """No two primary skills claim the same task, and each names a real, existing workflow."""
+    primary = _registry().get("primary", [])
+    assert {e["skill"] for e in primary} == set(PRIMARY_SKILLS), (
+        "registry.yaml primary set disagrees with PRIMARY_SKILLS"
+    )
+    workflows = [e["workflow"] for e in primary]
+    dupes = {w for w in workflows if workflows.count(w) > 1}
+    assert not dupes, f"two primary skills claim the same workflow: {sorted(dupes)}"
+    missing = [w for w in workflows if not (REPO / w).exists()]
+    assert not missing, f"registry.yaml points at nonexistent workflows: {missing}"
+
+
+def test_every_workflow_file_is_registered():
+    """Discovery-based: a new docs/workflows/*.md must be a registered primary workflow, so an
+    unregistered sixth workflow fails CI rather than sitting orphaned (the other tests iterate the
+    known five, which would not notice a new file)."""
+    on_disk = {p.name for p in WORKFLOWS.glob("*.md")}
+    registered = {Path(e["workflow"]).name for e in _registry().get("primary", [])}
+    orphan = on_disk - registered
+    missing_file = registered - on_disk
+    assert not orphan, f"workflow docs not registered in skills/registry.yaml: {sorted(orphan)}"
+    assert not missing_file, f"registry names workflows with no file: {sorted(missing_file)}"


### PR DESCRIPTION
Hardening pass from the PR1 (docs reorg) review. The integrity gate now enforces the parts of its promised contract that were unimplemented, and the skill classification becomes machine-readable.

- **`update-product.md` gains a `## Validation` section** — it was the only workflow without one. It's an aggregate: run the route-specific checks (named per route) plus the baseline `build.validate`.
- **`tests/test_docs_integrity.py` now also asserts:**
  - every workflow doc has a `## Validation` section;
  - every `build.<module>` a Validation section cites actually exists;
  - every skill is classified exactly once as primary / advanced / internal;
  - no two primary skills claim the same workflow.
- **`skills/registry.yaml`** is the machine-readable classification the test validates against; `docs/README.md`'s combined "advanced / internal" section is split to match (advanced = `build-rubric`, `refresh-all-categories`; internal = `add-data-source`, `pyoso-analyst`).

Not done (per the reviewer, both genuinely optional): the `edit-category` → `define-category` rename is a product-language choice left to you, and the CLI (`map check`, scaffolding) is the deferred PR2.

## Test plan
- `uv run python -m build.validate` → 0 errors
- `tests/test_docs_integrity.py` → 12 pass (8 prior + 4 new contract assertions)