### PR TITLE
Report a declared state as declared, not as a defect

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -93,6 +93,16 @@ jobs:
       # sitting in prose, which is the argument for counting it here instead.
       - name: Instrument gate (every signal_type claim has what it needs to be falsifiable)
         run: uv run python -m build.check_instrument
+
+      # Structural check on sources/signal_routing.yaml: a route pointing at a source the
+      # table does not declare is a bug, and should fail here rather than halfway through a
+      # research run. Added to CI 2026-08-15. It had never run anywhere, and it had been
+      # exiting 1 on every invocation since the hand-authored adoption routes were declared
+      # on 2026-08-13 — it read their deliberate `source: null` as an unknown source. Both
+      # halves of that mattered: an unrun gate cannot catch anything, and a permanently red
+      # one teaches everybody to ignore it.
+      - name: Routing table structure
+        run: uv run python -m build.check_routing
       # How stale is every axis, per category. Informational on purpose: no --max-age-days, so
       # it prints and cannot fail. The gate at 30 days is `.github/workflows/freshness.yml`,
       # weekly, and it is the one gate here that must not run per PR — it fails on the passage

--- a/build/check_freshness.py
+++ b/build/check_freshness.py
@@ -295,13 +295,38 @@ def commit_dates(root: Path | None = None) -> dict[str, date]:
     return {slug: when for slug, when in dates.items() if when is not None}
 
 
+def held_axes(root: Path | None = None) -> dict[tuple[str, str], str]:
+    """(product, axis) -> the date it was put on hold, from `sources/verification_queue.yaml`.
+
+    A held axis is one a re-read opened, worked, and honestly could not settle, parked with
+    the condition that would close it. It carries no `last_verified` by design, and
+    `tests/test_verification_queue_consistency.py` enforces that it never carries one.
+
+    Without this, the report could only see the absence, so it dated the axis from its last
+    commit and filed it under "nobody has revisited this" — the one thing that is untrue of
+    a product somebody worked and queued. Measured 2026-08-15, every one of the 8 undated
+    axes in the corpus is held, so this was the whole of that line's population.
+    """
+    path = (root or ROOT) / "sources" / "verification_queue.yaml"
+    if not path.exists():
+        return {}
+    queue = yaml.safe_load(path.read_text()) or {}
+    return {
+        (slug, axis): str((spec or {}).get("since") or "?")
+        for slug, axes in (queue.get("held") or {}).items()
+        for axis, spec in (axes or {}).items()
+    }
+
+
 def collect(
     root: Path | None = None,
-) -> tuple[dict[str, list[tuple[str, str, date, bool]]], list[str]]:
-    """Return (category -> [(product, axis, when, is_verified)], axes with no date).
+) -> tuple[dict[str, list[tuple[str, str, date, bool, str | None]]], list[str]]:
+    """Return (category -> [(product, axis, when, is_verified, held_since)], axes with no date).
 
     `is_verified` separates a real `last_verified` from a commit-date fallback, so
-    the report can never present the weaker signal as the stronger one.
+    the report can never present the weaker signal as the stronger one. `held_since` is
+    non-None where the axis is parked in the verification queue, which is a third state:
+    not confirmed, but not unexamined either.
 
     `root` defaults to this module's own repository, which is what the command line wants.
     The tests pass a fixture checkout, so the gate's behavior can be asserted against dates
@@ -309,7 +334,8 @@ def collect(
     """
     root = root or ROOT
     committed = commit_dates(root)
-    by_category: dict[str, list[tuple[str, str, date, bool]]] = defaultdict(list)
+    held = held_axes(root)
+    by_category: dict[str, list[tuple[str, str, date, bool, str | None]]] = defaultdict(list)
     undated: list[str] = []
 
     for path in sorted((root / "sources" / "categories").glob("*.yaml")):
@@ -326,12 +352,13 @@ def collect(
 
                 verified = parse_date(block.get("last_verified"))
                 if verified is not None:
-                    by_category[category["name"]].append((product, axis, verified, True))
+                    by_category[category["name"]].append((product, axis, verified, True, None))
                     continue
 
                 when = committed.get(product)
                 if when is not None:
-                    by_category[category["name"]].append((product, axis, when, False))
+                    since = held.get((product, axis))
+                    by_category[category["name"]].append((product, axis, when, False, since))
                 else:
                     # Only reachable for a file git has never seen, so in practice an
                     # uncommitted local addition rather than a data problem.
@@ -366,32 +393,46 @@ def main(argv: list[str] | None = None, root: Path | None = None) -> int:
     stalest: list[tuple[int, str, str]] = []
     for name in sorted(by_category):
         entries = by_category[name]
-        ages = sorted((today - when).days for _, _, when, _ in entries)
+        ages = sorted((today - when).days for _, _, when, _, _ in entries)
         median = ages[len(ages) // 2]
-        product, axis, _, _ = max(entries, key=lambda e: (today - e[2]).days)
+        product, axis, _, _, _ = max(entries, key=lambda e: (today - e[2]).days)
         print(f"{name:<30}{len(entries):>6}{median:>8}d{ages[-1]:>8}d  {product}.{axis}")
         stalest.append((ages[-1], name, f"{product}.{axis}"))
 
-    all_ages = sorted((today - when).days for _, _, when, _ in rows)
+    all_ages = sorted((today - when).days for _, _, when, _, _ in rows)
     print(
         f"\n{len(rows)} axes | median {all_ages[len(all_ages) // 2]}d "
         f"| oldest {all_ages[-1]}d | newest {all_ages[0]}d"
     )
 
-    verified_n = sum(1 for _, _, _, is_verified in rows if is_verified)
+    verified_n = sum(1 for _, _, _, is_verified, _ in rows if is_verified)
+    held_rows = [(p, a, since) for p, a, _, is_verified, since in rows if not is_verified and since]
+    fallback_n = len(rows) - verified_n - len(held_rows)
     if verified_n == len(rows):
         print(
             f"\nall {len(rows)} axes carry a real last_verified, so no age above rests on "
             "the commit-date fallback."
         )
     else:
-        print(
-            f"\n{verified_n} of {len(rows)} axes carry a real last_verified. "
-            f"The other {len(rows) - verified_n} fall back to the score file's last commit "
-            "date, which dates the last time somebody committed the file and left the score "
-            "standing. For a file untouched since it was added that dates the import, not a "
-            "review, so read those ages as 'nobody has revisited this'."
-        )
+        print(f"\n{verified_n} of {len(rows)} axes carry a real last_verified.")
+        if fallback_n:
+            print(
+                f"{fallback_n} fall back to the score file's last commit date, which dates "
+                "the last time somebody committed the file and left the score standing. For a "
+                "file untouched since it was added that dates the import, not a review, so "
+                "read those ages as 'nobody has revisited this'."
+            )
+        if held_rows:
+            # These are the opposite of unexamined: somebody worked the axis, could not
+            # settle it, and parked it with the condition that would close it. Reporting
+            # them beside the never-touched ones was the misreading this separates out.
+            print(
+                f"{len(held_rows)} are HELD in sources/verification_queue.yaml — worked, "
+                "unsettled, and deliberately carrying no date. Their age is the commit "
+                "fallback and says nothing about the hold:"
+            )
+            for product, axis, since in sorted(held_rows):
+                print(f"  · {f'{product}.{axis}':<52} held since {since}")
     if undated:
         print(
             f"{len(undated)} axes have no date at all: {', '.join(undated[:6])}"

--- a/build/check_routing.py
+++ b/build/check_routing.py
@@ -69,8 +69,23 @@ def load() -> tuple[dict, dict, dict, dict]:
     return routing, products, categories, category_of
 
 
+def hand_authored(route: dict) -> bool:
+    """Does this route declare that no machine source produces it?
+
+    `source: null` is a DECLARATION, not an omission. Two adoption routes carry it:
+    `reported_traction`, the instrument defined by having no count behind it, and
+    `active_users`, a vendor-disclosed figure no endpoint serves. Both set
+    `hand_authored: true` beside the null, which is what tells a reader the absence was
+    chosen. Reading them as "unknown source" made this checker exit 1 on every run, so
+    the two routes the table is most careful about were the two it called broken.
+    """
+    return route.get("source") is None and route.get("hand_authored") is True
+
+
 def route_usable(route: dict, sources: dict) -> tuple[bool, str]:
     """Is this route executable at all, before considering any product?"""
+    if hand_authored(route):
+        return False, "hand-authored"
     source = sources.get(route.get("source")) or {}
     if route.get("blocked_by") == "bridge" or source.get("bridged") is False:
         return False, "unbridged"
@@ -79,11 +94,11 @@ def route_usable(route: dict, sources: dict) -> tuple[bool, str]:
     return True, ""
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--category", help="limit to one category slug")
     parser.add_argument("--unrouted", action="store_true", help="list products with no route")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     routing, products, _, category_of = load()
     sources = routing.get("sources") or {}
@@ -91,9 +106,13 @@ def main() -> int:
 
     # Structural check first: a route pointing at nothing is a bug in the table.
     problems: list[str] = []
+    hand_authored_routes: dict[str, list[str]] = defaultdict(list)
     for dim, spec in dimensions.items():
         for route in spec.get("routes") or []:
             name = route.get("source")
+            if hand_authored(route):
+                hand_authored_routes[dim].append(route.get("signal_type") or "unnamed")
+                continue
             if name not in sources:
                 problems.append(f"{dim}: route names unknown source {name!r}")
                 continue
@@ -124,9 +143,12 @@ def main() -> int:
                 only = route.get("applies_to_categories")
                 if only and cat not in only:
                     continue
-                usable, _ = route_usable(route, sources)
+                usable, why = route_usable(route, sources)
                 if not usable:
-                    was_blocked = True
+                    # A hand-authored route is not "blocked": nothing is waiting on a
+                    # bridge, and counting it as blocked would overstate how much of the
+                    # map a bridge could still buy.
+                    was_blocked = was_blocked or why == "unbridged"
                     continue
                 if SOURCE_ARTIFACT.get(route["source"]) in arts:
                     hit = True
@@ -145,6 +167,14 @@ def main() -> int:
         c = covered[dim]
         b = blocked[dim]
         print(f"{dim:<14}{c:>8}{'':>3}{b:>19}{'':>3}{total - c:>10}")
+
+    if hand_authored_routes:
+        print()
+        for dim, kinds in sorted(hand_authored_routes.items()):
+            print(
+                f"{dim}: {len(kinds)} hand-authored route(s) by declaration "
+                f"({', '.join(sorted(kinds))}) — no machine source, so no coverage to count"
+            )
 
     research_only = routing.get("research_only") or {}
     if research_only:

--- a/tests/test_check_routing.py
+++ b/tests/test_check_routing.py
@@ -1,0 +1,62 @@
+"""`source: null` in the routing table is a declaration, not a broken route.
+
+Two adoption routes carry no machine source on purpose: `reported_traction`, the instrument
+defined by having no count behind it, and `active_users`, a vendor-disclosed figure that no
+endpoint serves. Both mark it with `hand_authored: true`.
+
+Until 2026-08-15 `check_routing` read those nulls as "route names unknown source None" and
+exited 1 on every invocation, so the two routes the table documents most carefully were the
+two it called broken. It was also wired into none of the eight CI workflows, so nothing was
+reading the failure — a gate that is both wrong and unrun cannot catch a real one.
+"""
+
+from __future__ import annotations
+
+import yaml
+
+from build.check_routing import ROOT, hand_authored, main, route_usable
+
+
+def test_the_live_routing_table_is_structurally_clean():
+    """The corpus's own table exits 0. This is the regression the fix was for."""
+    assert main([]) == 0
+
+
+def test_a_declared_null_source_is_hand_authored():
+    assert hand_authored({"source": None, "hand_authored": True, "signal_type": "reported_traction"})
+
+
+def test_a_bare_null_source_is_not_a_declaration():
+    """`hand_authored: true` is what makes the absence deliberate. A null on its own is
+    still a defect, and must keep failing — otherwise a typo that drops a source name
+    reads as an intentional research route."""
+    assert not hand_authored({"source": None})
+    assert not hand_authored({"source": None, "hand_authored": False})
+
+
+def test_a_bare_null_source_still_fails_the_structural_check(tmp_path, monkeypatch, capsys):
+    routing = yaml.safe_load((ROOT / "sources" / "signal_routing.yaml").read_text())
+    routing["dimensions"]["adoption"]["routes"].append({"source": None, "signal_type": "invented"})
+
+    (tmp_path / "sources").mkdir()
+    (tmp_path / "sources" / "signal_routing.yaml").write_text(yaml.safe_dump(routing))
+    for sub in ("products", "categories"):
+        (tmp_path / "sources" / sub).mkdir()
+        for path in (ROOT / "sources" / sub).glob("*.yaml"):
+            (tmp_path / "sources" / sub / path.name).write_bytes(path.read_bytes())
+
+    monkeypatch.setattr("build.check_routing.ROOT", tmp_path)
+    assert main([]) == 1
+    assert "unknown source" in capsys.readouterr().out
+
+
+def test_a_hand_authored_route_is_not_counted_as_blocked_by_a_bridge():
+    """`blocked` means "a bridge would unblock this". Nothing is waiting on a bridge for an
+    instrument that claims no count, so counting it there would overstate what bridging buys."""
+    usable, why = route_usable({"source": None, "hand_authored": True}, {})
+    assert not usable
+    assert why == "hand-authored"
+
+    usable, why = route_usable({"source": "lmarena"}, {"lmarena": {"bridged": False}})
+    assert not usable
+    assert why == "unbridged"

--- a/tests/test_freshness_gate.py
+++ b/tests/test_freshness_gate.py
@@ -135,6 +135,52 @@ def test_a_fallback_age_is_labeled_rather_than_counted_as_confirmed(tmp_path, ca
     assert "3 of 6 axes carry a real last_verified" in out
 
 
+def test_a_held_axis_is_reported_as_held_not_as_never_revisited(tmp_path, capsys):
+    """A queued axis is worked-and-unsettled, which is the opposite of untouched.
+
+    Before 2026-08-15 the report had two buckets, confirmed and fallback, and said of the
+    fallback bucket to "read those ages as 'nobody has revisited this'". Every undated axis
+    in the corpus was in fact held in the verification queue, so that sentence was wrong
+    about all eight of them.
+    """
+    root = _corpus(tmp_path, {"widgets": {"dated": "2026-08-13", "parked": None}})
+    (root / "sources" / "verification_queue.yaml").write_text(
+        yaml.safe_dump(
+            {"version": 1, "held": {"parked": {"adoption": {"since": "2026-08-09",
+                                                            "because": "no figure published"}}}},
+            sort_keys=False,
+        )
+    )
+
+    assert _run(root, "--max-age-days", "30") == 0
+    out = capsys.readouterr().out
+    assert "1 are HELD in sources/verification_queue.yaml" in out
+    assert "parked.adoption" in out
+    assert "held since 2026-08-09" in out
+    # The other two axes on `parked` are undated but NOT queued, so the fallback wording
+    # still applies to them and must survive.
+    assert "nobody has revisited this" in out
+
+
+def test_a_held_axis_does_not_exempt_itself_from_the_window(tmp_path):
+    """A hold explains why an axis is undated; it does not stop the clock.
+
+    Exempting held axes would let a hold hide staleness forever, which is the failure mode
+    the queue's own "it is a queue, not an archive" line warns about.
+    """
+    root = _corpus(tmp_path, {"widgets": {"parked": None}})
+    (root / "sources" / "verification_queue.yaml").write_text(
+        yaml.safe_dump(
+            {"version": 1, "held": {"parked": {"openness": {"since": "2020-01-01",
+                                                            "because": "unreachable primary"}}}},
+            sort_keys=False,
+        )
+    )
+
+    # A clock far enough ahead that the commit-date fallback is unambiguously stale.
+    assert main(["--max-age-days", "30", "--today", "2027-01-01"], root=root) == 1
+
+
 def test_an_axis_with_no_date_at_all_fails_the_gate(tmp_path, capsys):
     """The commit-date fallback is unavailable for a file git has never seen, so the window
     has nothing to measure. Unmeasurable is a failure, not a pass."""


### PR DESCRIPTION
Two checkers read a deliberate declaration as a problem or as silence. Found while auditing a random sample of 20 products.

## `check_routing` — permanently red, and unrun

It exited 1 on **every** invocation, reporting `adoption: route names unknown source None` twice. Both are the routes `signal_routing.yaml` declares with `source: null` and `hand_authored: true`: `reported_traction`, the instrument defined by having no count behind it, and `active_users`, a vendor-disclosed figure no endpoint serves. The two routes the table is most careful about were the two the checker called broken.

- A null source paired with `hand_authored: true` is a declaration. A **bare** null still fails, so a typo that drops a source name does not read as an intentional research route.
- A hand-authored route no longer counts toward `blocked by bridge` — nothing is waiting on a bridge for an instrument that claims no count, and counting it there overstated what bridging would buy.
- It now runs in `validate.yml`. It had been in none of the eight workflows, so nothing was reading the failure. A gate that is both wrong and unrun cannot catch a real one.

## `check_freshness` — held axes printed as never-revisited

The report had two buckets, confirmed and commit-date fallback, and said of the fallback bucket to read those ages as *"nobody has revisited this"*. Every undated axis in the corpus is held in `sources/verification_queue.yaml` — worked, unsettled, and deliberately carrying no date per the "never both" rule. All 8, so the sentence was wrong about the entire bucket.

Held axes now print as held with the date they were parked. A hold explains why an axis is undated; it does not stop the clock, so they still count toward `--max-age-days` — exempting them would let a hold hide staleness forever, which the queue's own "it is a queue, not an archive" line warns about.

```
1408 of 1416 axes carry a real last_verified.
8 are HELD in sources/verification_queue.yaml — worked, unsettled, and deliberately
carrying no date. Their age is the commit fallback and says nothing about the hold:
  · aws-neuron.adoption                    held since 2026-08-09
  · qualcomm-ai-engine-direct.openness     held since 2026-08-09
  ...
```

## Test plan

- `tests/test_check_routing.py` (new) — the live table exits 0; a bare null still fails; a hand-authored route is not counted as bridge-blocked.
- `tests/test_freshness_gate.py` — a held axis reports as held; a held axis does not exempt itself from the window; the existing fallback wording still applies to undated-and-unqueued axes.
- Full suite: 520 passed.
- Gates: `validate`, `check_verification`, `check_capability`, `check_recipe`, `check_adoption --strict`, `check_instrument`, `check_payload`, `check_routing` all green.