### PR TITLE
Invert the artifact-kind check so a new kind fails by default

### DIFF
--- a/build/check_routing.py
+++ b/build/check_routing.py
@@ -32,14 +32,25 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 
-# Which artifact key in a product YAML satisfies which routing source.
-SOURCE_ARTIFACT = {
-    "github": "github",
-    "huggingface_model": "huggingface_model",
-    "huggingface_dataset": "huggingface_dataset",
-    "pypi": "pypi",
-    "semanticscholar": "arxiv",  # citations are reached via the paper id
-}
+def source_artifact(sources: dict) -> dict[str, str]:
+    """source name -> the product artifact key it consumes, read from the routing table.
+
+    This was a hardcoded dict until 2026-08-15, and it was a second copy of a fact the table
+    already declares — the repo mirroring a declaration by hand, which is the drift
+    `check_parity` exists to catch one layer over. The copy had already fallen behind: it
+    named five sources where the table declares seven, missing `npm` and `crates`. Both are
+    `bridged: false` so the omission was inert, and it would have stopped being inert the day
+    a bridge landed, which is exactly when nobody would be looking here.
+
+    The two layers are distinct and worth naming: a SOURCE is a signal producer
+    (`semanticscholar`), an ARTIFACT KEY is what a product declares (`arxiv`). One source may
+    consume a key that shares no name with it.
+    """
+    return {
+        name: source["artifact_key"]
+        for name, source in sources.items()
+        if source.get("artifact_key")
+    }
 
 
 def artifacts_of(product: dict) -> set[str]:
@@ -103,6 +114,7 @@ def main(argv: list[str] | None = None) -> int:
     routing, products, _, category_of = load()
     sources = routing.get("sources") or {}
     dimensions = routing.get("dimensions") or {}
+    artifact_of = source_artifact(sources)
 
     # Structural check first: a route pointing at nothing is a bug in the table.
     problems: list[str] = []
@@ -118,7 +130,7 @@ def main(argv: list[str] | None = None) -> int:
                 continue
             # An unbridged source can never resolve to a product, so it needs no
             # artifact mapping. Only a source claiming to be usable must have one.
-            if sources[name].get("bridged") and name not in SOURCE_ARTIFACT:
+            if sources[name].get("bridged") and name not in artifact_of:
                 problems.append(f"{dim}: bridged source {name!r} has no artifact mapping in this checker")
     if problems:
         print("ROUTING TABLE PROBLEMS")
@@ -150,7 +162,7 @@ def main(argv: list[str] | None = None) -> int:
                     # map a bridge could still buy.
                     was_blocked = was_blocked or why == "unbridged"
                     continue
-                if SOURCE_ARTIFACT.get(route["source"]) in arts:
+                if artifact_of.get(route["source"]) in arts:
                     hit = True
                     break
             if hit:

--- a/build/check_routing.py
+++ b/build/check_routing.py
@@ -53,14 +53,18 @@ def source_artifact(sources: dict) -> dict[str, str]:
     }
 
 
-def artifacts_of(product: dict) -> set[str]:
-    """Which artifact kinds this product declares."""
-    found: set[str] = set()
-    for key in ("github", "huggingface_model", "huggingface_dataset", "pypi", "npm", "crates", "arxiv"):
-        value = product.get(key)
-        if value:
-            found.add(key)
-    return found
+def artifacts_of(product: dict, kinds: set[str]) -> set[str]:
+    """Which of the declared artifact `kinds` this product carries.
+
+    `kinds` comes from `source_artifact(...).values()` rather than from a literal list. This
+    file held TWO hardcoded copies of the routing table's artifact vocabulary and the first
+    pass at #184 replaced only one of them, which left the more consequential half: a
+    correctly declared new kind — source declared, `artifact_key` set, product carrying it —
+    passed every invariant and was still invisible here, so its routes reported as uncovered
+    and the map understated its own automation. Reproduced with a synthetic `rubygems` kind
+    before the fix; `tests/test_check_routing.py` keeps it reproduced.
+    """
+    return {key for key in kinds if product.get(key)}
 
 
 def load() -> tuple[dict, dict, dict, dict]:
@@ -115,6 +119,7 @@ def main(argv: list[str] | None = None) -> int:
     sources = routing.get("sources") or {}
     dimensions = routing.get("dimensions") or {}
     artifact_of = source_artifact(sources)
+    artifact_kinds = set(artifact_of.values())
 
     # Structural check first: a route pointing at nothing is a bug in the table.
     problems: list[str] = []
@@ -145,7 +150,7 @@ def main(argv: list[str] | None = None) -> int:
     per_product_routed: dict[str, int] = {}
 
     for slug in slugs:
-        arts = artifacts_of(products[slug])
+        arts = artifacts_of(products[slug], artifact_kinds)
         cat = category_of.get(slug)
         n_routed = 0
         for dim, spec in dimensions.items():

--- a/tests/test_check_routing.py
+++ b/tests/test_check_routing.py
@@ -103,3 +103,60 @@ def test_a_bridged_source_without_an_artifact_key_is_still_a_finding(tmp_path, m
     monkeypatch.setattr("build.check_routing.ROOT", tmp_path)
     assert main([]) == 1
     assert "no artifact mapping" in capsys.readouterr().out
+
+
+def _corpus_with_new_kind(tmp_path, kind="rubygems"):
+    """A checkout where `kind` is correctly declared end to end: a bridged source with an
+    `artifact_key`, a route that names it, and one product carrying it."""
+    import shutil
+
+    import yaml
+
+    (tmp_path / "sources").mkdir()
+    routing = yaml.safe_load((ROOT / "sources" / "signal_routing.yaml").read_text())
+    routing["sources"][kind] = {"artifact_key": kind, "bridged": True}
+    routing["dimensions"]["adoption"]["routes"].insert(
+        0, {"source": kind, "column": "downloads_30d", "signal_type": "usage_volume"}
+    )
+    (tmp_path / "sources" / "signal_routing.yaml").write_text(yaml.safe_dump(routing))
+    for sub in ("products", "categories"):
+        shutil.copytree(ROOT / "sources" / sub, tmp_path / "sources" / sub)
+    path = tmp_path / "sources" / "products" / "accelerate.yaml"
+    record = yaml.safe_load(path.read_text())
+    record[kind] = [{"url": f"https://{kind}.org/x"}]
+    path.write_text(yaml.safe_dump(record))
+    return tmp_path
+
+
+def test_coverage_sees_a_correctly_declared_new_artifact_kind(tmp_path, monkeypatch):
+    """The second hardcoded list, and the more consequential one.
+
+    `artifacts_of` enumerated the seven current keys literally, so a new kind that was
+    declared correctly at every layer — source, `artifact_key`, route, product — was still
+    invisible to coverage, and its routes reported as research rather than routed. The map
+    would have understated its own automation with nothing failing.
+    """
+    import build.check_routing as cr
+
+    root = _corpus_with_new_kind(tmp_path)
+    monkeypatch.setattr(cr, "ROOT", root)
+    routing, products, _, _ = cr.load()
+    kinds = set(cr.source_artifact(routing["sources"]).values())
+
+    assert "rubygems" in kinds, "the declaration itself must be readable"
+    assert "rubygems" in cr.artifacts_of(products["accelerate"], kinds), (
+        "a correctly declared artifact kind must be visible to coverage without editing "
+        "a literal list in check_routing"
+    )
+    assert cr.main([]) == 0
+
+
+def test_artifacts_of_reads_only_the_kinds_it_is_given():
+    """It must not fall back to a built-in vocabulary when handed a narrow set — that is how
+    the hardcoded list would creep back in as a default."""
+    from build.check_routing import artifacts_of
+
+    product = {"github": [{"url": "g"}], "pypi": [{"url": "p"}], "name": "x"}
+    assert artifacts_of(product, {"github", "pypi"}) == {"github", "pypi"}
+    assert artifacts_of(product, {"github"}) == {"github"}
+    assert artifacts_of(product, set()) == set()

--- a/tests/test_check_routing.py
+++ b/tests/test_check_routing.py
@@ -60,3 +60,46 @@ def test_a_hand_authored_route_is_not_counted_as_blocked_by_a_bridge():
     usable, why = route_usable({"source": "lmarena"}, {"lmarena": {"bridged": False}})
     assert not usable
     assert why == "unbridged"
+
+
+def test_the_source_to_artifact_map_is_read_from_the_table_not_mirrored():
+    """#184: the mapping was a hardcoded dict and had already fallen behind the declaration.
+
+    It named five sources where signal_routing.yaml declares seven — `npm` and `crates` were
+    missing. Both are `bridged: false`, so the omission was inert; it would have stopped being
+    inert the day a bridge landed, which is exactly when nobody would think to look here.
+    """
+    import yaml
+
+    from build.check_routing import source_artifact
+
+    routing = yaml.safe_load((ROOT / "sources" / "signal_routing.yaml").read_text())
+    mapping = source_artifact(routing["sources"])
+
+    assert mapping["semanticscholar"] == "arxiv", "a source may consume a differently-named key"
+    assert {"npm", "crates"} <= set(mapping), "the hardcoded copy was missing exactly these"
+    assert set(mapping) == {
+        name for name, s in routing["sources"].items() if s.get("artifact_key")
+    }
+
+
+def test_a_bridged_source_without_an_artifact_key_is_still_a_finding(tmp_path, monkeypatch, capsys):
+    """The structural check must keep firing when a bridged source declares nothing to read."""
+    import yaml
+
+    routing = yaml.safe_load((ROOT / "sources" / "signal_routing.yaml").read_text())
+    routing["sources"]["invented"] = {"bridged": True}
+    routing["dimensions"]["adoption"]["routes"].append(
+        {"source": "invented", "signal_type": "usage_volume"}
+    )
+
+    (tmp_path / "sources").mkdir()
+    (tmp_path / "sources" / "signal_routing.yaml").write_text(yaml.safe_dump(routing))
+    for sub in ("products", "categories"):
+        (tmp_path / "sources" / sub).mkdir()
+        for path in (ROOT / "sources" / sub).glob("*.yaml"):
+            (tmp_path / "sources" / sub / path.name).write_bytes(path.read_bytes())
+
+    monkeypatch.setattr("build.check_routing.ROOT", tmp_path)
+    assert main([]) == 1
+    assert "no artifact mapping" in capsys.readouterr().out

--- a/tests/test_signal_routing.py
+++ b/tests/test_signal_routing.py
@@ -3,39 +3,144 @@ suite checks that declaration against what products actually claim to have, so a
 kind can go undeclared indefinitely and every product carrying it silently falls through to
 the stars fallback and its cap of 3 — no test fails, no error surfaces, the score is simply
 lower than it should be.
+
+**Inverted 2026-08-15 (#184).** The first form built its "in use" set by intersecting each
+product record against a hardcoded `ARTIFACT_KINDS`, so it could only catch an undeclared kind
+whose name was *already in that set* — which is the one case that cannot happen. A genuinely
+new kind never entered `in_use` and the assertion passed, which is the regression the test is
+nominally there to prevent. `arxiv` was the live proof: 24 products declare it and it was in
+neither the set nor `sources:`.
+
+The inverted form enumerates every top-level product key, subtracts an explicit metadata
+allowlist, and requires the remainder to be declared. A new artifact kind is caught **by
+default**; the allowlist is the visible thing a contributor has to edit to opt something out,
+which is the right polarity.
 """
 
 from pathlib import Path
 
+import pytest
 import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 
+# Top-level product keys that are NOT distribution artifacts. Everything not listed here must
+# be a declared artifact kind, so adding a key to this set is a deliberate, reviewable claim
+# that the thing cannot be counted — not a formality.
+#
+# `artifact_exceptions` is the subtle one: it is an annotation ABOUT artifacts (why
+# `pymilvus`'s downloads stand in for the Milvus server, why distilabel's PyPI metadata names
+# a dead org), not an artifact itself.
+METADATA_KEYS = {
+    "name",
+    "display_name",
+    "type",
+    "description",
+    "comments",
+    "aliases",
+    "lineage",
+    "version_in_identity",
+    "artifact_exceptions",
+}
 
-def test_every_declared_artifact_kind_has_a_route_or_is_declared_unbridged():
-    """A product may declare an artifact kind no route can reach, but the gap must be visible.
 
-    npm and crates were absent from signal_routing entirely, so 13 products with a real
-    countable distribution artifact silently fell through to the stars scale and its cap of 3.
-    Declaring the source `bridged: false` is this file's idiom for machine-readable but not
-    yet joinable, and it turns the gap into a backlog entry.
+def _routing() -> dict:
+    return yaml.safe_load((ROOT / "sources" / "signal_routing.yaml").read_text())
 
-    This only covers the kinds enumerated in `ARTIFACT_KINDS` below. A product key outside
-    that set - `arxiv` already is - is invisible to this check and can go undeclared with no
-    failure here, whether or not it turns out to be a distribution artifact.
+
+def declared_artifact_kinds(routing: dict) -> set[str]:
+    """The artifact kinds routing can name, from `artifact_key` rather than from source names.
+
+    These are two different layers and conflating them is the mistake #184 nearly shipped.
+    `arxiv` is a product ARTIFACT KEY; `semanticscholar` is the SOURCE that consumes it, and
+    it declares `artifact_key: arxiv`. Reading source names would have reported `arxiv`
+    undeclared and invited a duplicate `sources.arxiv` entry for something the router already
+    reaches.
     """
-    routing = yaml.safe_load((ROOT / "sources" / "signal_routing.yaml").read_text())
-    declared = set(routing["sources"])
+    return {
+        source["artifact_key"]
+        for source in (routing.get("sources") or {}).values()
+        if source.get("artifact_key")
+    }
 
-    # Only kinds named here are checked. Adding a new artifact kind to a product record
-    # (e.g. a `go` or `docker` key) does not make it visible to this test until it is added
-    # to this set too.
-    ARTIFACT_KINDS = {"github", "npm", "pypi", "crates", "go", "huggingface_model", "huggingface_dataset"}
-    in_use = set()
+
+def product_keys() -> dict[str, set[str]]:
+    """slug -> its top-level keys."""
+    out = {}
     for path in sorted((ROOT / "sources" / "products").glob("*.yaml")):
-        record = yaml.safe_load(path.read_text()) or {}
-        in_use |= {k for k in ARTIFACT_KINDS if record.get(k)}
+        out[path.stem] = set(yaml.safe_load(path.read_text()) or {})
+    return out
 
-    assert in_use <= declared, (
-        "artifact kinds in use with no declared source: " + str(sorted(in_use - declared))
+
+@pytest.fixture(scope="module")
+def routing():
+    return _routing()
+
+
+def test_every_product_key_is_a_declared_artifact_kind_or_declared_metadata(routing):
+    """The inverted check. A new artifact kind fails here by default."""
+    declared = declared_artifact_kinds(routing)
+    offenders: dict[str, set[str]] = {}
+    for slug, keys in product_keys().items():
+        unknown = keys - METADATA_KEYS - declared
+        if unknown:
+            offenders[slug] = unknown
+
+    assert not offenders, (
+        "product keys that are neither a declared artifact kind nor declared metadata:\n  "
+        + "\n  ".join(f"{slug}: {sorted(keys)}" for slug, keys in sorted(offenders.items()))
+        + "\n\nEither declare the source in sources/signal_routing.yaml with an `artifact_key` "
+        "(use `bridged: false` if nothing reads it yet), or add the key to METADATA_KEYS with "
+        "a reason."
     )
+
+
+def test_arxiv_is_covered_by_the_source_that_consumes_it(routing):
+    """The case that proved the old form was blind, pinned so it cannot regress.
+
+    24 products declare `arxiv`. It is not a source name and never should be — it is reached
+    through `semanticscholar`, which declares it as its `artifact_key`.
+    """
+    assert "arxiv" in declared_artifact_kinds(routing)
+    assert "arxiv" not in (routing.get("sources") or {}), (
+        "arxiv is an artifact key, not a source. Declaring it as a source would duplicate "
+        "what semanticscholar already reaches."
+    )
+
+
+def test_the_metadata_allowlist_does_not_shadow_a_declared_artifact_kind(routing):
+    """An entry in both sets would silently exempt a countable artifact from the check."""
+    overlap = METADATA_KEYS & declared_artifact_kinds(routing)
+    assert not overlap, f"keys claimed as both metadata and artifact kinds: {sorted(overlap)}"
+
+
+def test_the_allowlist_has_no_dead_entries():
+    """A metadata key no product carries is an exemption nobody needs, and it accumulates.
+
+    Kept as its own assertion rather than folded above, because a dead entry is untidy where a
+    shadowed one is unsafe — the messages should not be interchangeable.
+    """
+    seen: set[str] = set()
+    for keys in product_keys().values():
+        seen |= keys
+    dead = METADATA_KEYS - seen
+    assert not dead, f"METADATA_KEYS entries no product carries: {sorted(dead)}"
+
+
+def test_the_walk_reads_the_whole_corpus():
+    """A narrowed walk passes vacuously. Two checks in this repo have done exactly that."""
+    keys = product_keys()
+    assert len(keys) > 400, f"only {len(keys)} product files read; the walk has drifted"
+
+
+def test_declared_but_unreachable_kinds_are_visible_rather_than_absent(routing):
+    """The original test's real subject, kept.
+
+    A product may declare a kind no route can reach — npm and crates are `bridged: false`
+    today — but the gap has to be declared rather than silent. That is what turns 13 products
+    falling through to the stars cap into a backlog entry instead of an invisible loss.
+    """
+    sources = routing.get("sources") or {}
+    for name in ("npm", "crates"):
+        assert name in sources, f"{name} is used by products and must be declared"
+        assert "bridged" in sources[name], f"{name} must state whether anything reads it"

--- a/tests/test_signal_routing.py
+++ b/tests/test_signal_routing.py
@@ -98,13 +98,22 @@ def test_every_product_key_is_a_declared_artifact_kind_or_declared_metadata(rout
 def test_arxiv_is_covered_by_the_source_that_consumes_it(routing):
     """The case that proved the old form was blind, pinned so it cannot regress.
 
-    24 products declare `arxiv`. It is not a source name and never should be — it is reached
-    through `semanticscholar`, which declares it as its `artifact_key`.
+    24 products declare `arxiv`, and it is covered because `semanticscholar` declares it as
+    its `artifact_key` — a source may consume a key that shares no name with it. That
+    mapping is the invariant.
+
+    What this deliberately does NOT assert is that no source may ever be *named* `arxiv`.
+    An earlier draft did, and it froze today's topology: a direct arXiv signal alongside
+    Semantic Scholar is a perfectly legitimate future route, and a test forbidding it would
+    have made the right change look like a regression.
     """
-    assert "arxiv" in declared_artifact_kinds(routing)
-    assert "arxiv" not in (routing.get("sources") or {}), (
-        "arxiv is an artifact key, not a source. Declaring it as a source would duplicate "
-        "what semanticscholar already reaches."
+    sources = routing.get("sources") or {}
+    assert "arxiv" in declared_artifact_kinds(routing), (
+        "24 products declare arxiv; some source must declare it as an artifact_key"
+    )
+    assert sources.get("semanticscholar", {}).get("artifact_key") == "arxiv", (
+        "semanticscholar is what reaches arxiv today; if that changes, the replacement must "
+        "still declare artifact_key: arxiv"
     )
 
 


### PR DESCRIPTION
Closes #184.

## The guard was weaker than it looked

The old test built its "in use" set by intersecting each product record against a hardcoded `ARTIFACT_KINDS`:

```python
in_use = {k for k in ARTIFACT_KINDS if record.get(k)}
assert in_use <= declared
```

So it could only catch an undeclared kind **whose name was already in that set** — which is the one case that cannot happen. A genuinely new kind never enters `in_use` and the assertion passes. That is the regression the test is nominally there to prevent.

`arxiv` was the live proof: 24 products declare it, and it was in neither the set nor `sources:`.

## The inverted form

Enumerate every top-level product key, subtract an explicit `METADATA_KEYS` allowlist, require the remainder to be a declared artifact kind. Verified by planting a `docker:` key on a product record:

```
caught: planted: ['docker']
```

The allowlist is now the visible thing a contributor edits to opt something out — the right polarity. Four supporting tests: the allowlist may not shadow a declared kind, may not accumulate dead entries, the walk must read the whole corpus, and unreachable-but-declared kinds (`npm`, `crates`) stay visible rather than silent.

## `arxiv` needs no ruling — it is a layering distinction

The issue expected a taxonomy decision. It needs none:

- **`arxiv` is a product ARTIFACT KEY.**
- **`semanticscholar` is the SOURCE that consumes it**, and it already declares `artifact_key: arxiv`.

```
semanticscholar   artifact_key='arxiv'   bridged=True
declared artifact_key set: arxiv, crates, github, huggingface_dataset,
                           huggingface_model, npm, pypi
```

Comparing against **source names** is what made `arxiv` look undeclared. Declaring a `sources.arxiv` entry — the obvious fix from the issue's framing — would have created a duplicate for something the router already reaches. `test_arxiv_is_covered_by_the_source_that_consumes_it` pins both halves so neither regresses.

Product keys today, all covered: `github` 254, `pypi` 106, `huggingface_dataset` 66, `huggingface_model` 58, `arxiv` 24, `npm` 13, `crates` 1.

`artifact_exceptions` is the subtle allowlist entry — it is an annotation *about* artifacts (why `pymilvus`'s downloads stand in for the Milvus server) rather than an artifact.

## The same conflation, one layer over

`check_routing` carried a hardcoded `SOURCE_ARTIFACT` dict: a second copy of a fact the table declares, which is the drift `check_parity` exists to catch. **It had already fallen behind** — five sources where the table declares seven, missing `npm` and `crates`. Both are `bridged: false`, so the omission was inert; it would have stopped being inert the day a bridge landed, which is exactly when nobody would think to look here.

It now reads `artifact_key` from the table. Coverage output is **byte-identical** before and after the swap.

## Note on #266

This edits `tests/test_signal_routing.py`, which #266 also touches. #266 is a draft held on an undeployed warehouse sequence and **already conflicts with `main`** after #275–#278, so it needs a rebase regardless — this does not add a blocker it did not have. Its two added tests should rebase cleanly onto the inverted form; the conflict is in the file's header region, not in what it asserts.

## Test plan

- `tests/test_signal_routing.py` — rewritten, 6 tests.
- `tests/test_check_routing.py` — 2 added: the mapping is read from the table, and a bridged source with no `artifact_key` still fails the structural check.
- Full suite: 551 passed.
- Gates green: `validate`, `check_verification`, `check_capability`, `check_recipe`, `check_rubric`, `check_components`, `check_instrument`, `check_payload`, `check_routing`.