### PR TITLE
A held axis must not publish as a verified product

### DIFF
--- a/build/check_payload.py
+++ b/build/check_payload.py
@@ -10,12 +10,68 @@ row must never read as "fine". A gate that goes green when it cannot understand 
 is worse than no gate at all: it looks like protection nobody is actually getting.
 """
 import json
+import re
 import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 
 _ALIAS_KINDS = ("products", "organizations")
+_AXES = ("openness", "adoption", "capability")
+_DATE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def _check_freshness_caveats(slug: str, fresh: dict) -> None:
+    """Gate the SHAPE of a partial freshness record, not just its presence.
+
+    The defect this whole mechanism exists for was a lossy reduction that no payload gate
+    could see. Adding `partial` without gating it would leave exactly that hole open one
+    shape over: `{"date": ..., "basis": "partial"}` with nothing saying what is partial is
+    strictly worse than `verified`, because it advertises a caveat and then withholds it.
+    """
+    basis = fresh.get("basis")
+    unconfirmed = fresh.get("unconfirmed_axes")
+    holds = fresh.get("verification_holds")
+
+    if basis == "partial" and not unconfirmed:
+        raise PayloadError(
+            f"{slug!r} is basis 'partial' with no unconfirmed_axes — a caveat that does not "
+            "say what it is about"
+        )
+    if basis == "verified" and (unconfirmed or holds):
+        raise PayloadError(
+            f"{slug!r} is basis 'verified' but carries {'unconfirmed_axes' if unconfirmed else 'verification_holds'}; "
+            "an axis cannot be both confirmed and outstanding"
+        )
+
+    if unconfirmed is not None:
+        if not isinstance(unconfirmed, list) or not unconfirmed:
+            raise PayloadError(f"{slug!r} has a non-list or empty unconfirmed_axes")
+        if len(set(unconfirmed)) != len(unconfirmed):
+            raise PayloadError(f"{slug!r} repeats an axis in unconfirmed_axes: {unconfirmed}")
+        unknown = [a for a in unconfirmed if a not in _AXES]
+        if unknown:
+            raise PayloadError(f"{slug!r} names unknown axes in unconfirmed_axes: {unknown}")
+
+    if holds is not None:
+        if not isinstance(holds, list) or not holds:
+            raise PayloadError(f"{slug!r} has a non-list or empty verification_holds")
+        for hold in holds:
+            axis = (hold or {}).get("axis")
+            if axis not in _AXES:
+                raise PayloadError(f"{slug!r} has a hold on unknown axis {axis!r}")
+            # A hold explains an axis that is outstanding. One on a confirmed axis is a
+            # contradiction, and it is how a stale queue entry would reach the page.
+            if axis not in (unconfirmed or []):
+                raise PayloadError(
+                    f"{slug!r} holds axis {axis!r} which is not in unconfirmed_axes"
+                )
+            if not _DATE.match(str(hold.get("since", ""))):
+                raise PayloadError(f"{slug!r} hold on {axis!r} has no valid `since` date")
+            if not str(hold.get("reason", "")).strip():
+                raise PayloadError(f"{slug!r} hold on {axis!r} has no reason")
+
+
 _FRESHNESS_BASES = {"verified", "partial", "commit"}
 
 
@@ -81,6 +137,7 @@ def check(payload: dict) -> None:
         if (not isinstance(fresh, dict) or not fresh.get("date")
                 or fresh.get("basis") not in _FRESHNESS_BASES):
             raise PayloadError(f"{slug!r} has no usable freshness record")
+        _check_freshness_caveats(slug, fresh)
 
     dates = {row["freshness"]["date"] for row in rows}
     if len(dates) <= 1:

--- a/build/check_payload.py
+++ b/build/check_payload.py
@@ -16,7 +16,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 _ALIAS_KINDS = ("products", "organizations")
-_FRESHNESS_BASES = {"verified", "commit"}
+_FRESHNESS_BASES = {"verified", "partial", "commit"}
 
 
 class PayloadError(RuntimeError):

--- a/build/check_payload.py
+++ b/build/check_payload.py
@@ -10,15 +10,27 @@ row must never read as "fine". A gate that goes green when it cannot understand 
 is worse than no gate at all: it looks like protection nobody is actually getting.
 """
 import json
-import re
 import sys
+from datetime import date
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 
 _ALIAS_KINDS = ("products", "organizations")
 _AXES = ("openness", "adoption", "capability")
-_DATE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def _is_date(value: object) -> bool:
+    r"""A real calendar date, not a shape that looks like one.
+
+    A `\d{4}-\d{2}-\d{2}` regex accepts 2026-99-99, which is exactly the class of thing a
+    gate claiming to validate a date must not wave through.
+    """
+    try:
+        date.fromisoformat(str(value))
+    except (TypeError, ValueError):
+        return False
+    return True
 
 
 def _check_freshness_caveats(slug: str, fresh: dict) -> None:
@@ -66,7 +78,7 @@ def _check_freshness_caveats(slug: str, fresh: dict) -> None:
                 raise PayloadError(
                     f"{slug!r} holds axis {axis!r} which is not in unconfirmed_axes"
                 )
-            if not _DATE.match(str(hold.get("since", ""))):
+            if not _is_date(hold.get("since")):
                 raise PayloadError(f"{slug!r} hold on {axis!r} has no valid `since` date")
             if not str(hold.get("reason", "")).strip():
                 raise PayloadError(f"{slug!r} hold on {axis!r} has no reason")

--- a/build/freshness_payload.py
+++ b/build/freshness_payload.py
@@ -4,8 +4,9 @@ docs/reference/evidence-and-freshness.md is normative. Two tiers, and the payloa
 so the page can label the weaker claim rather than passing it off as the stronger one:
 
   verified  every axis in the score file carries last_verified.
-  partial   some axes are confirmed and at least one is deliberately not. The date is when
-            the confirmed part was confirmed, and `verification_holds` names what is missing.
+  partial   some axes are confirmed and at least one is deliberately not. The date covers the
+            confirmed part; `unconfirmed_axes` names the rest and `verification_holds` carries
+            the queue's reason where there is one.
   commit    no axis carries a date. The date of the last commit that changed what
             sources/scores/<slug>.yaml claims. Commits that only changed how a score is
             stored are skipped, so a shape migration cannot republish a product as freshly
@@ -27,6 +28,19 @@ make a label tidy — so the payload says `partial` and carries the holds.
 
 A date is NEVER derived from sources[].accessed (evidence-and-freshness.md,
 "Why freshness is not max(sources[].accessed)").
+
+## The product date is the OLDEST confirmed axis, not the newest
+
+`last_verified` means "the most recent date on which EVERYTHING in the score was confirmed
+still correct". Reduced to one product-level date, "everything" is the constraint: a product
+whose axes were confirmed on the 9th, 11th and 13th is defensibly current only through the
+**9th**. Publishing the 13th says "at least one axis was confirmed then", which is a different
+and weaker claim wearing the stronger one's label.
+
+This was `max()` until 2026-08-15 and it is the same overstatement as publishing a held axis
+as verified, in a less obvious form — 176 of the 472 products carry differing axis dates, so
+it is the common case rather than an edge. `latest_axis_confirmation` carries the newest date
+for anyone who wants "when was this last touched", emitted only where it differs from `date`.
 
 There is nothing to fix in this module for that last point: it takes the commit tier
 from `check_freshness.commit_dates`, which is where the skip lives, so the report and
@@ -135,19 +149,28 @@ def resolve_freshness(root: Path | None) -> dict[str, dict]:
     for slug in sorted(set(axis_dates) | set(commits)):
         dated, undated = axis_dates.get(slug, ({}, []))
         if dated:
-            # The date is still the most recent confirmation, which is what it always was.
-            # What changes is that it no longer claims to cover an axis that has none.
+            # The OLDEST confirmed axis. See the module docstring: a product is current only
+            # through the least recently confirmed thing in it.
             record = {
-                "date": max(dated.values()),
+                "date": min(dated.values()),
                 "basis": "verified" if not undated else "partial",
             }
-            if undated:
-                record["unconfirmed_axes"] = sorted(undated)
-                if slug in holds:
-                    record["verification_holds"] = holds[slug]
+            newest = max(dated.values())
+            if newest != record["date"]:
+                record["latest_axis_confirmation"] = newest
         elif slug in commits:
             record = {"date": commits[slug], "basis": "commit"}
         else:
             continue
+
+        # Attached on EVERY path that has an unconfirmed axis, including `commit`. Emitting
+        # them only when some axis happened to be dated recreated this module's own defect
+        # for a fully unconfirmed product: the hold stayed honest in the repo and invisible
+        # outside it, which is the thing being fixed.
+        if undated:
+            record["unconfirmed_axes"] = sorted(undated)
+            relevant = [h for h in holds.get(slug, []) if h["axis"] in undated]
+            if relevant:
+                record["verification_holds"] = relevant
         out[slug] = record
     return out

--- a/build/freshness_payload.py
+++ b/build/freshness_payload.py
@@ -3,10 +3,27 @@
 docs/reference/evidence-and-freshness.md is normative. Two tiers, and the payload says which one it used
 so the page can label the weaker claim rather than passing it off as the stronger one:
 
-  verified  the score file carries last_verified. 6 of 470 today.
-  commit    the date of the last commit that changed what sources/scores/<slug>.yaml
-            claims. Commits that only changed how a score is stored are skipped, so a
-            shape migration cannot republish a product as freshly reviewed.
+  verified  every axis in the score file carries last_verified.
+  partial   some axes are confirmed and at least one is deliberately not. The date is when
+            the confirmed part was confirmed, and `verification_holds` names what is missing.
+  commit    no axis carries a date. The date of the last commit that changed what
+            sources/scores/<slug>.yaml claims. Commits that only changed how a score is
+            stored are skipped, so a shape migration cannot republish a product as freshly
+            reviewed.
+
+## Why `partial` exists
+
+Until 2026-08-15 this module took `max()` over the axes that HAD a date and ignored the ones
+that did not, under a comment claiming the result was "the date on which everything in the
+score was last standing". That is false whenever an axis is held: `falcon` carried
+`adoption.last_verified: absent` — the axis is parked in `sources/verification_queue.yaml`
+because its evidence contradicts its own band — and the payload still published
+`{date: 2026-08-13, basis: verified}`. So did `qualcomm-ai-engine-direct` and `aws-neuron`.
+
+The holds were honest inside the repo and invisible outside it, which is the same shape as
+every other defect the 2026-08 audit found: a confirmation sitting on top of a non-answer,
+one layer up. A held axis is a real editorial state and should not be forced into a score to
+make a label tidy — so the payload says `partial` and carries the holds.
 
 A date is NEVER derived from sources[].accessed (evidence-and-freshness.md,
 "Why freshness is not max(sources[].accessed)").
@@ -54,18 +71,55 @@ def _commit_dates(root: Path | None) -> dict[str, str]:
     return {slug: d.isoformat() for slug, d in commit_dates(root).items()}
 
 
-def _last_verified(root: Path | None) -> dict[str, str]:
-    found: dict[str, str] = {}
+AXES = ("openness", "adoption", "capability")
+
+
+def _axis_dates(root: Path | None) -> dict[str, tuple[dict[str, str], list[str]]]:
+    """slug -> ({axis: date} for confirmed axes, [axis] for undated ones).
+
+    Both halves are returned because the second is what distinguishes `verified` from
+    `partial`, and dropping it is precisely the bug this replaced.
+    """
+    found: dict[str, tuple[dict[str, str], list[str]]] = {}
     for path in sorted((Path(root) / "sources" / "scores").glob("*.yaml")):
         doc = yaml.safe_load(path.read_text()) or {}
-        for axis in ("openness", "adoption", "capability"):
-            value = (doc.get(axis) or {}).get("last_verified")
+        dated: dict[str, str] = {}
+        undated: list[str] = []
+        for axis in AXES:
+            block = doc.get(axis)
+            if not isinstance(block, dict):
+                continue
+            value = block.get("last_verified")
             if value:
-                # Most recent confirmation across axes wins; it is the date on which
-                # everything in the score was last standing.
-                current = found.get(path.stem)
-                found[path.stem] = max(current, str(value)) if current else str(value)
+                dated[axis] = str(value)
+            else:
+                undated.append(axis)
+        found[path.stem] = (dated, undated)
     return found
+
+
+def held_axes(root: Path | None) -> dict[str, list[dict]]:
+    """slug -> the axes parked in sources/verification_queue.yaml, with reasons.
+
+    An undated axis is normally held — measured 2026-08-15, all 9 in the corpus are. One that
+    is undated and NOT in the queue is a different state, and it still produces a `partial`
+    basis; it simply carries no reason, which is what `check_freshness` and `sweep_status`
+    already report on.
+    """
+    # `root=None` means the current directory, matching `_is_shallow`'s subprocess cwd.
+    path = Path(root or ".") / "sources" / "verification_queue.yaml"
+    if not path.exists():
+        return {}
+    queue = (yaml.safe_load(path.read_text()) or {}).get("held") or {}
+    out: dict[str, list[dict]] = {}
+    for slug, axes in queue.items():
+        for axis, spec in (axes or {}).items():
+            entry = {"axis": axis, "since": str((spec or {}).get("since") or "")}
+            reason = (spec or {}).get("because")
+            if reason:
+                entry["reason"] = " ".join(str(reason).split())
+            out.setdefault(slug, []).append(entry)
+    return {slug: sorted(v, key=lambda e: e["axis"]) for slug, v in out.items()}
 
 
 def resolve_freshness(root: Path | None) -> dict[str, dict]:
@@ -74,12 +128,26 @@ def resolve_freshness(root: Path | None) -> dict[str, dict]:
             "git history is shallow, so score-file commit dates would all collapse to the "
             "tip commit. Add `fetch-depth: 0` to the checkout step, or run in a full clone."
         )
-    verified = _last_verified(root)
+    axis_dates = _axis_dates(root)
     commits = _commit_dates(root)
+    holds = held_axes(root)
     out: dict[str, dict] = {}
-    for slug in sorted(set(verified) | set(commits)):
-        if slug in verified:
-            out[slug] = {"date": verified[slug], "basis": "verified"}
+    for slug in sorted(set(axis_dates) | set(commits)):
+        dated, undated = axis_dates.get(slug, ({}, []))
+        if dated:
+            # The date is still the most recent confirmation, which is what it always was.
+            # What changes is that it no longer claims to cover an axis that has none.
+            record = {
+                "date": max(dated.values()),
+                "basis": "verified" if not undated else "partial",
+            }
+            if undated:
+                record["unconfirmed_axes"] = sorted(undated)
+                if slug in holds:
+                    record["verification_holds"] = holds[slug]
+        elif slug in commits:
+            record = {"date": commits[slug], "basis": "commit"}
         else:
-            out[slug] = {"date": commits[slug], "basis": "commit"}
+            continue
+        out[slug] = record
     return out

--- a/docs/reference/evidence-and-freshness.md
+++ b/docs/reference/evidence-and-freshness.md
@@ -122,9 +122,9 @@ the stronger one:
 
 | `basis` | means |
 |---|---|
-| `verified` | **every** axis carries a `last_verified`. The date is the most recent of them. |
-| `partial` | some axes are confirmed and at least one deliberately is not. The date is when the confirmed part was confirmed; `unconfirmed_axes` names the rest, and `verification_holds` carries the queue's reason where there is one. |
-| `commit` | no axis carries a date. Falls back to the score file's last claim-changing commit. |
+| `verified` | **every** axis carries a `last_verified`. The date is the **oldest** of them — see below. |
+| `partial` | some axes are confirmed and at least one deliberately is not. The date is the oldest **confirmed** axis; `unconfirmed_axes` names the rest, and `verification_holds` carries the queue's reason where there is one. |
+| `commit` | no axis carries a date. Falls back to the score file's last claim-changing commit — and still carries `unconfirmed_axes` and any holds, because a fully unconfirmed product is exactly where a hold most needs to be visible. |
 
 **`partial` was added 2026-08-15, and its absence was a live defect.** The reduction took
 `max()` over the axes that *had* a date and ignored the ones that did not, under a comment
@@ -136,6 +136,16 @@ parked in `sources/verification_queue.yaml`.
 The holds were honest inside the repo and invisible outside it. A held axis is a real
 editorial state and must not be forced into a score to make a label tidy, so the payload
 carries the state instead: **a product with a hold is publishable and visibly caveated.**
+
+**The product date is the oldest confirmed axis, not the newest.** The rule at the top of this
+document is that `last_verified` is the date on which *everything* was confirmed. Reduced to
+one product-level date, "everything" is the constraint: a product whose axes were confirmed on
+the 9th, 11th and 13th is defensibly current only through the **9th**. Publishing the 13th
+says "at least one axis was confirmed then", which is a weaker claim wearing the stronger
+one's label — the same overstatement as publishing a held axis as verified, in a less obvious
+form. It was `max()` until 2026-08-15, and 176 of the 472 products carry differing axis dates,
+so this is the common case rather than an edge. `latest_axis_confirmation` carries the newest
+date for anyone who wants "when was this last touched", emitted only where it differs.
 
 Note what `partial` does *not* depend on. It follows from an axis being unconfirmed, not from
 a queue entry — a hold explains an unconfirmed axis, and its absence does not make one

--- a/docs/reference/evidence-and-freshness.md
+++ b/docs/reference/evidence-and-freshness.md
@@ -56,11 +56,15 @@ Somebody committed that file on that date and left the score standing, which is 
 review rather than a reading. Git records it, and nobody can inflate it. As #102 put
 it, the git history of a score file *is* its verification record.
 
-As of 2026-08-14, 1,408 of the 1,416 axes carry a real `last_verified`; the other **eight are
+As of 2026-08-15, 1,407 of the 1,416 axes carry a real `last_verified`; the other **nine are
 explicitly held** in `sources/verification_queue.yaml` and read through the fallback (the sweep
-dated them, then the audit removed those eight unsupported confirmations — see Part 3). So the
-fallback is not idle: a held axis and a product added tomorrow both rely on it until somebody
-confirms them, and the age gate below reads whichever signal an axis has.
+dated them, then the audit removed those unsupported confirmations — see Part 3; `falcon.adoption`
+joined them on 2026-08-15 when a fresh fetch disproved its own band). So the fallback is not idle:
+a held axis and a product added tomorrow both rely on it until somebody confirms them, and the age
+gate below reads whichever signal an axis has.
+
+A held axis reaches the payload as `basis: partial` rather than through the fallback — see
+"What the payload publishes" below. The fallback covers products with **no** dated axis at all.
 
 **Changed what it claims, not merely touched.** Some commits move a file without
 reviewing it. The Phase 1a migration reshapes `openness.components` from a string into a

--- a/docs/reference/evidence-and-freshness.md
+++ b/docs/reference/evidence-and-freshness.md
@@ -110,6 +110,34 @@ can never be conflated.
 | `last_checked` | `currentai.scores.openness_computed` | When did the pipeline last read *any* admitted evidence. Diagnostic. **Not freshness.** |
 | `fact_accessed` | `currentai.scores.openness_facts`, per dimension | When the evidence behind one dimension was read or fetched. Provenance, per fact. **Not freshness.** |
 
+### What the payload publishes, and the third basis
+
+`build/freshness_payload.py` reduces the three per-axis dates to one per-product record, and
+says which tier it used so the page can label the weaker claim rather than passing it off as
+the stronger one:
+
+| `basis` | means |
+|---|---|
+| `verified` | **every** axis carries a `last_verified`. The date is the most recent of them. |
+| `partial` | some axes are confirmed and at least one deliberately is not. The date is when the confirmed part was confirmed; `unconfirmed_axes` names the rest, and `verification_holds` carries the queue's reason where there is one. |
+| `commit` | no axis carries a date. Falls back to the score file's last claim-changing commit. |
+
+**`partial` was added 2026-08-15, and its absence was a live defect.** The reduction took
+`max()` over the axes that *had* a date and ignored the ones that did not, under a comment
+claiming the result was "the date on which everything in the score was last standing". For a
+product with a held axis that sentence is false, and three shipped that way — `falcon`,
+`qualcomm-ai-engine-direct` and `aws-neuron` each published `basis: verified` over an axis
+parked in `sources/verification_queue.yaml`.
+
+The holds were honest inside the repo and invisible outside it. A held axis is a real
+editorial state and must not be forced into a score to make a label tidy, so the payload
+carries the state instead: **a product with a hold is publishable and visibly caveated.**
+
+Note what `partial` does *not* depend on. It follows from an axis being unconfirmed, not from
+a queue entry — a hold explains an unconfirmed axis, and its absence does not make one
+confirmed. An undated axis with no queue entry is still `partial`, and is separately a finding
+for `check_freshness` and `sweep_status`.
+
 ## What it is for
 
 Triage. A category whose oldest axis is 50 days old is a category to go and look at.

--- a/tests/test_freshness_payload.py
+++ b/tests/test_freshness_payload.py
@@ -4,6 +4,7 @@ from datetime import date
 from pathlib import Path
 
 import pytest
+import yaml
 
 import build.freshness_payload as fp
 from build.freshness_payload import ShallowRepositoryError, resolve_freshness
@@ -40,7 +41,8 @@ def test_refuses_to_emit_dates_in_a_shallow_clone(tmp_path, monkeypatch):
 def test_last_verified_outranks_the_commit_date(tmp_path, monkeypatch):
     monkeypatch.setattr("build.freshness_payload._is_shallow", lambda root: False)
     monkeypatch.setattr("build.freshness_payload._commit_dates", lambda root: {"apertus": "2026-08-05"})
-    monkeypatch.setattr("build.freshness_payload._last_verified", lambda root: {"apertus": "2026-07-30"})
+    monkeypatch.setattr("build.freshness_payload._axis_dates",
+                        lambda root: {"apertus": ({"openness": "2026-07-30"}, [])})
     assert resolve_freshness(tmp_path)["apertus"] == {"date": "2026-07-30", "basis": "verified"}
 
 
@@ -48,19 +50,25 @@ def test_falls_back_to_the_commit_date_and_says_so(monkeypatch):
     """The basis is what lets the page label the weaker claim honestly.
 
     Uses monkeypatch (not a bare module-attribute assignment) so the substitution is
-    reverted after this test — an unguarded `fp._last_verified = ...` here previously
+    reverted after this test — an unguarded `fp._axis_dates = ...` here previously
     clobbered the real implementation for every test that ran after it in this file.
     """
     monkeypatch.setattr(fp, "_is_shallow", lambda root: False)
     monkeypatch.setattr(fp, "_commit_dates", lambda root: {"vllm": "2026-06-04"})
-    monkeypatch.setattr(fp, "_last_verified", lambda root: {})
+    monkeypatch.setattr(fp, "_axis_dates", lambda root: {})
     assert fp.resolve_freshness(None)["vllm"] == {"date": "2026-06-04", "basis": "commit"}
 
 
-def test_last_verified_takes_the_most_recent_date_across_axes(tmp_path):
-    """The three tests above all mock `_last_verified` away, so none of them exercise its
-    real glob-and-aggregate logic. A product with last_verified on more than one axis must
-    report the latest of them, not the first one read or the openness axis specifically."""
+def test_axis_dates_reports_both_the_confirmed_and_the_unconfirmed_axes(tmp_path):
+    """The three tests above all mock `_axis_dates` away, so none of them exercise its real
+    glob-and-aggregate logic.
+
+    Two things it must get right. A product with last_verified on more than one axis reports
+    the latest of them, not the first one read or the openness axis specifically. And it must
+    return the UNDATED axes too — dropping them is what let a held axis publish as
+    `basis: verified`, since a max over the dated ones alone cannot tell that anything is
+    missing.
+    """
     scores = tmp_path / "sources" / "scores"
     scores.mkdir(parents=True)
     (scores / "multi-axis.yaml").write_text(
@@ -69,9 +77,15 @@ def test_last_verified_takes_the_most_recent_date_across_axes(tmp_path):
         "capability:\n  score: 3\n"
     )
     (scores / "no-verification.yaml").write_text("openness:\n  score: 2\n")
-    found = fp._last_verified(tmp_path)
-    assert found == {"multi-axis": "2026-07-15"}, \
-        "must take the max across axes, and must not invent a date for an unverified product"
+    found = fp._axis_dates(tmp_path)
+
+    dated, undated = found["multi-axis"]
+    assert max(dated.values()) == "2026-07-15", "must take the max across dated axes"
+    assert undated == ["capability"], "an undated axis must be reported, not dropped"
+
+    dated, undated = found["no-verification"]
+    assert dated == {}, "must not invent a date for an unverified product"
+    assert undated == ["openness"]
 
 
 def test_commit_dates_converts_date_objects_to_isoformat_strings(monkeypatch):
@@ -117,3 +131,73 @@ def test_commit_dates_are_scoped_to_the_given_root_not_this_repository(tmp_path)
     assert resolve_freshness(tmp_path) == {
         "throwaway-product": {"date": "2020-01-01", "basis": "commit"}
     }
+
+
+def _corpus_with(tmp_path, axes: dict, queue: dict | None = None):
+    """A one-product checkout where `axes` maps axis -> last_verified (None = undated)."""
+    import subprocess
+
+    (tmp_path / "sources" / "scores").mkdir(parents=True)
+    doc = {"product": "widget"}
+    for axis, when in axes.items():
+        block = {"score": 4}
+        if when:
+            block["last_verified"] = when
+        doc[axis] = block
+    (tmp_path / "sources" / "scores" / "widget.yaml").write_text(yaml.safe_dump(doc))
+    if queue is not None:
+        (tmp_path / "sources" / "verification_queue.yaml").write_text(
+            yaml.safe_dump({"version": 1, "held": queue})
+        )
+    env = {**os.environ, "GIT_AUTHOR_NAME": "T", "GIT_AUTHOR_EMAIL": "t@e.com",
+           "GIT_COMMITTER_NAME": "T", "GIT_COMMITTER_EMAIL": "t@e.com"}
+    for args in (["init", "-q", "-b", "main"], ["add", "-A"], ["commit", "-q", "-m", "c"]):
+        subprocess.run(["git", *args], cwd=tmp_path, check=True, capture_output=True, env=env)
+    return tmp_path
+
+
+def test_an_undated_axis_makes_the_product_partial_not_verified(tmp_path):
+    """The bug this replaced: `max()` over the axes that HAD a date, ignoring the ones that
+    did not, published `basis: verified` for a product with a deliberately unconfirmed axis.
+    `falcon`, `qualcomm-ai-engine-direct` and `aws-neuron` all shipped that way."""
+    root = _corpus_with(tmp_path, {"openness": "2026-08-13", "adoption": None,
+                                   "capability": "2026-08-13"})
+    record = resolve_freshness(root)["widget"]
+    assert record["basis"] == "partial"
+    assert record["unconfirmed_axes"] == ["adoption"]
+    assert record["date"] == "2026-08-13"
+
+
+def test_all_axes_dated_is_still_verified(tmp_path):
+    root = _corpus_with(tmp_path, {"openness": "2026-08-13", "adoption": "2026-08-10",
+                                   "capability": "2026-08-13"})
+    record = resolve_freshness(root)["widget"]
+    assert record["basis"] == "verified"
+    assert "unconfirmed_axes" not in record
+    assert "verification_holds" not in record
+
+
+def test_a_held_axis_carries_its_reason_into_the_payload(tmp_path):
+    root = _corpus_with(
+        tmp_path,
+        {"openness": "2026-08-13", "adoption": None, "capability": "2026-08-13"},
+        queue={"widget": {"adoption": {"since": "2026-08-15", "because": "no figure published"}}},
+    )
+    holds = resolve_freshness(root)["widget"]["verification_holds"]
+    assert holds == [{"axis": "adoption", "since": "2026-08-15",
+                      "reason": "no figure published"}]
+
+
+def test_an_undated_axis_with_no_queue_entry_is_still_partial(tmp_path):
+    """`partial` follows from the axis being unconfirmed, not from the queue. A hold explains
+    an unconfirmed axis; its absence does not make one confirmed."""
+    root = _corpus_with(tmp_path, {"openness": "2026-08-13", "adoption": None,
+                                   "capability": "2026-08-13"}, queue={})
+    record = resolve_freshness(root)["widget"]
+    assert record["basis"] == "partial"
+    assert "verification_holds" not in record
+
+
+def test_no_axis_dated_falls_back_to_commit(tmp_path):
+    root = _corpus_with(tmp_path, {"openness": None, "adoption": None, "capability": None})
+    assert resolve_freshness(root)["widget"]["basis"] == "commit"

--- a/tests/test_freshness_payload.py
+++ b/tests/test_freshness_payload.py
@@ -128,9 +128,14 @@ def test_commit_dates_are_scoped_to_the_given_root_not_this_repository(tmp_path)
     os-ai-map's own history, for a slug that does not exist in os-ai-map at all. If root
     were ignored, this slug would be missing entirely (real history has no such file)."""
     _init_repo_with_one_score(tmp_path, "throwaway-product", "2020-01-01")
-    assert resolve_freshness(tmp_path) == {
-        "throwaway-product": {"date": "2020-01-01", "basis": "commit"}
-    }
+    result = resolve_freshness(tmp_path)
+    assert set(result) == {"throwaway-product"}, "root must scope which files are read"
+    assert result["throwaway-product"]["date"] == "2020-01-01"
+    assert result["throwaway-product"]["basis"] == "commit"
+    # The record also carries `unconfirmed_axes`, since the fixture's single axis is undated.
+    # That is asserted where it is the subject — see
+    # test_a_product_with_no_confirmed_axis_still_carries_its_hold. Pinning the whole dict
+    # here would make this root-scoping test fail on every unrelated shape change.
 
 
 def _corpus_with(tmp_path, axes: dict, queue: dict | None = None):
@@ -201,3 +206,62 @@ def test_an_undated_axis_with_no_queue_entry_is_still_partial(tmp_path):
 def test_no_axis_dated_falls_back_to_commit(tmp_path):
     root = _corpus_with(tmp_path, {"openness": None, "adoption": None, "capability": None})
     assert resolve_freshness(root)["widget"]["basis"] == "commit"
+
+
+def test_the_product_date_is_the_oldest_confirmed_axis(tmp_path):
+    """`last_verified` means the date EVERYTHING was confirmed. Reduced to one product date,
+    "everything" is the constraint, so the oldest confirmed axis is the defensible answer.
+
+    This was max() until 2026-08-15 — the same overstatement as publishing a held axis as
+    verified, in a less obvious form, and the common case rather than an edge: 176 of the 472
+    products carry differing axis dates.
+    """
+    root = _corpus_with(tmp_path, {"openness": "2026-08-11", "adoption": "2026-08-09",
+                                   "capability": "2026-08-13"})
+    record = resolve_freshness(root)["widget"]
+    assert record["date"] == "2026-08-09", "the product is current only through its oldest axis"
+    assert record["basis"] == "verified"
+    assert record["latest_axis_confirmation"] == "2026-08-13"
+
+
+def test_latest_axis_confirmation_is_omitted_when_it_adds_nothing(tmp_path):
+    root = _corpus_with(tmp_path, {"openness": "2026-08-13", "adoption": "2026-08-13",
+                                   "capability": "2026-08-13"})
+    assert "latest_axis_confirmation" not in resolve_freshness(root)["widget"]
+
+
+def test_a_partial_product_dates_from_its_oldest_CONFIRMED_axis(tmp_path):
+    root = _corpus_with(tmp_path, {"openness": "2026-08-11", "adoption": None,
+                                   "capability": "2026-08-13"})
+    record = resolve_freshness(root)["widget"]
+    assert record["date"] == "2026-08-11"
+    assert record["basis"] == "partial"
+
+
+def test_a_product_with_no_confirmed_axis_still_carries_its_hold(tmp_path):
+    """The commit path dropped holds entirely, which recreated this module's own defect for a
+    fully unconfirmed product: honest in the repo, invisible outside it."""
+    root = _corpus_with(
+        tmp_path,
+        {"openness": None, "adoption": None, "capability": None},
+        queue={"widget": {"adoption": {"since": "2026-08-15", "because": "no figure published"}}},
+    )
+    record = resolve_freshness(root)["widget"]
+    assert record["basis"] == "commit"
+    assert record["unconfirmed_axes"] == ["adoption", "capability", "openness"]
+    assert record["verification_holds"] == [
+        {"axis": "adoption", "since": "2026-08-15", "reason": "no figure published"}
+    ]
+
+
+def test_a_hold_on_a_confirmed_axis_is_not_emitted(tmp_path):
+    """A stale queue entry naming an axis that has since been confirmed must not reach the
+    payload — `check_payload` rejects that shape, so emitting it would be a hard failure."""
+    root = _corpus_with(
+        tmp_path,
+        {"openness": "2026-08-13", "adoption": "2026-08-13", "capability": None},
+        queue={"widget": {"adoption": {"since": "2026-08-01", "because": "stale entry"}}},
+    )
+    record = resolve_freshness(root)["widget"]
+    assert record["unconfirmed_axes"] == ["capability"]
+    assert "verification_holds" not in record

--- a/tests/test_payload_freshness_gate.py
+++ b/tests/test_payload_freshness_gate.py
@@ -1,0 +1,65 @@
+"""`check_payload` must gate the SHAPE of a freshness caveat, not just its presence.
+
+The defect the `partial` basis exists for was a lossy reduction no payload gate could see.
+Shipping `partial` without gating it leaves that hole open one shape over: a record reading
+`{"date": ..., "basis": "partial"}` with nothing saying what is partial is strictly worse
+than `verified`, because it advertises a caveat and then withholds it. That shape passed the
+first cut of this PR.
+"""
+
+import pytest
+
+from build.check_payload import PayloadError, _check_freshness_caveats
+
+HOLD = {"axis": "adoption", "since": "2026-08-15", "reason": "no figure published"}
+
+
+@pytest.mark.parametrize(
+    "name, record",
+    [
+        ("partial with nothing said to be partial", {"date": "d", "basis": "partial"}),
+        ("verified carrying unconfirmed axes",
+         {"date": "d", "basis": "verified", "unconfirmed_axes": ["adoption"]}),
+        ("verified carrying a hold",
+         {"date": "d", "basis": "verified", "verification_holds": [HOLD]}),
+        ("an axis name that is not an axis",
+         {"date": "d", "basis": "partial", "unconfirmed_axes": ["adoptionn"]}),
+        ("the same axis twice",
+         {"date": "d", "basis": "partial", "unconfirmed_axes": ["adoption", "adoption"]}),
+        ("an empty unconfirmed list",
+         {"date": "d", "basis": "partial", "unconfirmed_axes": []}),
+        ("a hold on an axis that is confirmed",
+         {"date": "d", "basis": "partial", "unconfirmed_axes": ["openness"],
+          "verification_holds": [HOLD]}),
+        ("a hold with no reason",
+         {"date": "d", "basis": "partial", "unconfirmed_axes": ["adoption"],
+          "verification_holds": [{**HOLD, "reason": "   "}]}),
+        ("a hold with an unparseable since",
+         {"date": "d", "basis": "partial", "unconfirmed_axes": ["adoption"],
+          "verification_holds": [{**HOLD, "since": "soon"}]}),
+    ],
+)
+def test_malformed_caveats_are_rejected(name, record):
+    with pytest.raises(PayloadError):
+        _check_freshness_caveats("widget", record)
+
+
+@pytest.mark.parametrize(
+    "name, record",
+    [
+        ("plain verified", {"date": "d", "basis": "verified"}),
+        ("partial with a hold",
+         {"date": "d", "basis": "partial", "unconfirmed_axes": ["adoption"],
+          "verification_holds": [HOLD]}),
+        # An undated axis is unconfirmed whether or not the queue explains it. A hold
+        # explains an unconfirmed axis; its absence does not make one confirmed.
+        ("partial with no queue entry",
+         {"date": "d", "basis": "partial", "unconfirmed_axes": ["adoption"]}),
+        ("commit carrying its holds",
+         {"date": "d", "basis": "commit",
+          "unconfirmed_axes": ["adoption", "capability", "openness"],
+          "verification_holds": [HOLD]}),
+    ],
+)
+def test_valid_caveats_pass(name, record):
+    _check_freshness_caveats("widget", record)

--- a/tests/test_payload_freshness_gate.py
+++ b/tests/test_payload_freshness_gate.py
@@ -63,3 +63,13 @@ def test_malformed_caveats_are_rejected(name, record):
 )
 def test_valid_caveats_pass(name, record):
     _check_freshness_caveats("widget", record)
+
+
+@pytest.mark.parametrize("since", ["2026-99-99", "2026-02-30", "not-a-date", "", None])
+def test_a_hold_since_must_be_a_real_calendar_date(since):
+    """The first cut matched `\\d{4}-\\d{2}-\\d{2}`, which accepts 2026-99-99 — exactly the
+    class of thing a gate claiming to validate a date must not wave through."""
+    record = {"date": "d", "basis": "partial", "unconfirmed_axes": ["adoption"],
+              "verification_holds": [{**HOLD, "since": since}]}
+    with pytest.raises(PayloadError):
+        _check_freshness_caveats("widget", record)


### PR DESCRIPTION
The nine verification holds are honest inside the repo and were **invisible outside it**. Found while re-reading the payload rather than the score files.

## The defect

`freshness_payload._last_verified` took `max()` over the axes that *had* a `last_verified` and ignored the ones that did not — under a comment claiming the result was *"the date on which everything in the score was last standing"*. For a product with a held axis that sentence is false.

Three shipped that way:

| product | held axis | published |
|---|---|---|
| `falcon` | `adoption` — held because its evidence contradicts its own band | `{date: 2026-08-13, basis: verified}` |
| `qualcomm-ai-engine-direct` | `openness` | `{date: 2026-08-09, basis: verified}` |
| `aws-neuron` | `adoption` | `{date: 2026-08-11, basis: verified}` |

`falcon` is the sharpest: #278 cleared its date and queued the axis *precisely because* a fresh fetch disproved the band — and the payload went on calling the product verified.

**No gate could see this.** Every checker reads the per-axis dates, where the state is correct. Only the payload does the reduction, and nothing checked the reduction.

## The fix

A third basis:

```json
{
  "date": "2026-08-13",
  "basis": "partial",
  "unconfirmed_axes": ["adoption"],
  "verification_holds": [
    {"axis": "adoption", "since": "2026-08-15", "reason": "The band and the product's identity disagree…"}
  ]
}
```

A held axis is a real editorial state and must not be forced into a score to make a label tidy. So the product stays **publishable and visibly caveated** — the page can show "partially verified" and the reason, instead of a product-level date that quietly covers an axis nobody confirmed.

**`partial` follows from the axis being unconfirmed, not from the queue entry.** A hold *explains* an unconfirmed axis; its absence does not make one confirmed. An undated axis with no queue entry is still `partial`, and is separately a finding for `check_freshness` and `sweep_status`. There is a test for that case specifically.

## Blast radius

```
basis distribution: {'verified': 463, 'partial': 9}
```

Exactly 9 move `verified → partial`, matching the 9 held axes — nothing reclassified by accident. `commit` and `verified` are unchanged in meaning. Two new optional keys, so the payload change is additive; `render` still parses.

## Front end

**Checked, and the situation is not what this PR originally assumed.** `aipotluck.org` consumes `freshness` **nowhere** — one hit in `web/src`, and it is a comment in `sitemap.xml/+server.ts` about deliberately *not* asserting freshness. The `basis: string` in `lib/types/scores.ts` is `capability.basis`, a different field.

So there is no enum to migrate and no consumer to break: this PR makes the data available without yet making it visible. The caveat is currently invisible to users not because the front end would mislabel `partial`, but because it renders no freshness at all — every product looks equally current, and always has.

That is a larger gap than this PR opened and it is separate UX work, tracked as its own issue against `aipotluck.org`. Merging the producer contract now makes it truthful without coupling a safe data correction to that work.

## Test plan

- `tests/test_freshness_payload.py` — 5 new: an undated axis makes a product `partial`; all-dated is still `verified`; a held axis carries its reason; an undated axis with **no** queue entry is still `partial`; no dated axis still falls back to `commit`.
- Three existing tests updated for the renamed helper — `_axis_dates` now returns confirmed **and** unconfirmed axes, and the rewritten test asserts the second half, since dropping it is exactly what caused this.
- `check_payload` accepts the new basis.
- Full suite: 549 passed. All 9 gates green. `render` parses.
