### PR TITLE
Verify refresh-data's credentials authenticate, not just that they exist

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -31,6 +31,16 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_FETCH_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+      # Two checks, and the second is the one that was missing. Presence proves a secret is
+      # SET; it does not prove it still WORKS, and a PAT expires. This workflow failed on
+      # every scheduled run from 2026-06-22 to 2026-08-10 with `401 - Bad credentials`,
+      # roughly 3.5 hours into each attempt — about 28 hours of runner time spent fetching
+      # data that was then discarded when the job failed, and eight weeks in which
+      # `warehouse/catalog/` silently stopped being refreshed while the workflow still
+      # appeared scheduled and live.
+      #
+      # Both probes are single authenticated GETs and answer in well under a second, so a
+      # dead credential now costs seconds instead of an afternoon.
       - name: Require secrets (fetchers degrade silently without them)
         run: |
           missing=""
@@ -41,6 +51,32 @@ jobs:
             echo "::error::Missing repo secrets:$missing. Without tokens the HF link scan silently drops from ~742 links to ~7; refusing to run."
             exit 1
           fi
+
+      - name: Verify the credentials actually authenticate
+        run: |
+          fail=0
+
+          gh_code=$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/user)
+          if [ "$gh_code" != "200" ]; then
+            echo "::error::GH_FETCH_TOKEN did not authenticate (HTTP $gh_code from api.github.com/user). It is a PAT and PATs expire — mint a new one and update the repo secret. This is what failed every run from 2026-06-22."
+            fail=1
+          fi
+
+          hf_code=$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer $HF_TOKEN" \
+            https://huggingface.co/api/whoami-v2)
+          if [ "$hf_code" != "200" ]; then
+            echo "::error::HF_TOKEN did not authenticate (HTTP $hf_code from huggingface.co/api/whoami-v2)."
+            fail=1
+          fi
+
+          # OSO_API_KEY stays presence-only: every probe for it is a warehouse round trip
+          # against a live model, which is a heavier and less predictable precondition than
+          # this step should carry. The fetchers surface an OSO failure themselves.
+          exit $fail
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true


### PR DESCRIPTION
Found while working #173's disposition manifest: I went to check whether `warehouse/catalog/` was live, and it is not.

## `refresh-data` has been failing for eight weeks

Every scheduled run from **2026-06-22 to 2026-08-10** — the full history I can see:

```
2026-08-10  failure  221 min
2026-08-03  failure  226 min
2026-07-27  failure  203 min
2026-07-20  failure  204 min
2026-07-13  failure  206 min
2026-07-06  failure  210 min
```

The error, ~3.5 hours in: **`Error: 401 - Bad credentials`**. `GH_FETCH_TOKEN` is a PAT set 2026-06-11, and PATs expire.

Consequences, none of which surfaced anywhere:

- `warehouse/catalog/` has not been refreshed since **2026-07-28**. It looks maintained; it is frozen.
- Roughly **28 hours of runner time** spent fetching data that was then discarded, because the job dies before the "Open refresh PR" step.
- The workflow still reads as scheduled and live. Nothing gates on it, so nobody was told.

## The gap, which is the familiar one

The guard checks that three secrets are **set**. It does not check that any of them still **works**:

```bash
[ -n "$OSO_API_KEY" ] || missing="$missing OSO_API_KEY"
```

Presence is not validity. That is the same shape as the other defects this audit has turned up — a check that grades on less than it reports — applied to a credential.

## The fix

One authenticated GET per credential, before the fetchers run. Measured against known-bad tokens:

```
GH_FETCH_TOKEN did not authenticate (HTTP 401)
HF_TOKEN did not authenticate (HTTP 401)
elapsed: 411ms   exit=1
```

**411ms instead of 3.5 hours**, and the error names the likely cause instead of leaving a bare 401 four hours deep in a log.

`OSO_API_KEY` stays presence-only, deliberately: every probe for it is a warehouse round trip against a live model, which is a heavier and less predictable precondition than a preflight should carry, and the fetchers surface an OSO failure themselves. Flagging that asymmetry rather than inventing a probe I could not test.

## What this does **not** do

**It does not fix the expired token.** That needs a new PAT in the `GH_FETCH_TOKEN` repo secret, which is a maintainer action — I have no way to mint or set one. Until that happens this workflow will still fail, just in seconds rather than hours, and with an error that says what to do.

## Test plan

- Workflow YAML parses; step order verified.
- Probe script executed against known-bad tokens: both 401, `exit 1`, 411ms.
- Probe endpoints confirmed to answer 401 quickly for missing and invalid tokens alike (`api.github.com/user`, `huggingface.co/api/whoami-v2`).
- No repo code touched; `test_docs_integrity` green.