### PR TITLE
Canonical verification line for the 44 that already named a source

### DIFF
--- a/sources/products/amazon-nova.yaml
+++ b/sources/products/amazon-nova.yaml
@@ -10,8 +10,7 @@ description: Amazon's proprietary multimodal model line in AWS Bedrock. Current 
   pricing for high-volume AWS-native enterprise deployments with SLA guarantees.
 comments: Amazon Nova Pro (amazon.nova-pro-v1:0), released 3 Dec 2024; multimodal understanding/instruct model
   (text+image+video in, text out), 300K context. Proprietary, API-only via Amazon Bedrock. Succeeded by Amazon
-  Nova 2 family (2026) but Nova Pro v1 remains in service. AWS publishes no standardized benchmark scores
-  for Nova, so the capability record deliberately abstains. Verified live 2026-08-13 via the AWS Nova user
-  guide and the Nova models page. Consolidated
-  on 2026-07-29 from amazon-nova; openness follows amazon-nova-pro, the release that currently governs. See
-  docs/reference/identity.md.
+  Nova 2 family (2026) but Nova Pro v1 remains in service. AWS publishes no standardized benchmark scores for
+  Nova, so the capability record deliberately abstains. Verified 2026-08-13 via the AWS Nova user guide and
+  the Nova models page. Consolidated on 2026-07-29 from amazon-nova; openness follows amazon-nova-pro, the
+  release that currently governs. See docs/reference/identity.md.

--- a/sources/products/claude-fable.yaml
+++ b/sources/products/claude-fable.yaml
@@ -10,7 +10,7 @@ description: Anthropic's first Mythos-class model for general availability (June
   window and up to 128K output. Early partner testing reports it topping Cognition FrontierCode and Hebbia
   Finance among frontier models, and scoring highest on CursorBench and FrontierBench. $10/$50 per Mtok via
   API, Bedrock, Vertex, and Foundry.
-comments: Anthropic Claude Fable 5 (model id claude-fable-5), released Jun 9 2026. Mythos-class tier above Opus;
-  generally available counterpart to restricted Claude Mythos 5 (Project Glasswing). 30-day mandatory data retention
-  (Covered Model). Verified live 2026-08-13 via the Fable 5 launch post, the Claude platform docs and the
-  Claude Fable product page.
+comments: Anthropic Claude Fable 5 (model id claude-fable-5), released Jun 9 2026. Mythos-class tier above
+  Opus; generally available counterpart to restricted Claude Mythos 5 (Project Glasswing). 30-day mandatory
+  data retention (Covered Model). Verified 2026-08-13 via the Fable 5 launch post, the Claude platform docs
+  and the Claude Fable product page.

--- a/sources/products/claude-haiku.yaml
+++ b/sources/products/claude-haiku.yaml
@@ -6,4 +6,4 @@ description: Anthropic's small, fast Claude tier, built for high-volume low-late
   a point release, with the measured release named in the score note. Closed weights, available through the
   Anthropic API and the Claude apps.
 comments: Tier product, currently shipping Haiku 4.5. Renamed from claude-haiku-4-5 so the slug survives the
-  next generation. Verified live 2026-08-13 via the Claude Haiku product page.
+  next generation. Verified 2026-08-13 via the Claude Haiku product page.

--- a/sources/products/claude-opus.yaml
+++ b/sources/products/claude-opus.yaml
@@ -14,6 +14,5 @@ comments: 'Anthropic Claude Opus 4.x flagship line: Opus 4 (May 22 2025) -> 4.5 
   flagship, closed/API + Bedrock + Vertex + claude.ai. Note: Opus 4.7 is a frozen base_pretrained anchor; this
   record scores the Opus 4.x line in finetuned_chat. Consolidated on 2026-07-29 from claude-opus-4-7; openness
   follows claude-opus-4-x, the release that currently governs. See docs/reference/identity.md. The capability
-  note used to cite independent Gemini 3.5 comparisons; Google''s post names neither Claude nor Opus, so
-  that clause was withdrawn. Verified live 2026-08-13 via the Opus 4.8, Opus 4.7 and Claude 4 announcement
-  pages.'
+  note used to cite independent Gemini 3.5 comparisons; Google''s post names neither Claude nor Opus, so that
+  clause was withdrawn. Verified 2026-08-13 via the Opus 4.8, Opus 4.7 and Claude 4 announcement pages.'

--- a/sources/products/claude-sonnet.yaml
+++ b/sources/products/claude-sonnet.yaml
@@ -6,9 +6,9 @@ description: Anthropic's mid-tier Claude model and its production default for co
   generation currently shipping is scored and the measured release is named in the score note. Generations
   to date are Sonnet 4 (May 2025), Sonnet 4.5 (Sept 2025), Sonnet 4.6 (Feb 2026) and Sonnet 5 (June 2026).
   Closed weights, available through the Anthropic API and the Claude apps.
-comments: Tier product. Anthropic ships a new Sonnet roughly every few months, so a versioned entry goes
-  stale faster than it can be reviewed; the slug is stable and the score carries the release it was measured
-  against. Supersedes the separate claude-sonnet-4 and claude-sonnet-4-6 entries. The scores are still
-  measured against Sonnet 4.6 while Sonnet 5 (2026-06-30) is shipping; capability is flagged for rescoring
-  on it. The headline SWE-bench figure sits in a client-rendered chart on the 4.6 launch page and is not
-  re-derivable from a fetch. Verified live 2026-08-13 via the Sonnet 4.6 and Sonnet 5 launch posts.
+comments: Tier product. Anthropic ships a new Sonnet roughly every few months, so a versioned entry goes stale
+  faster than it can be reviewed; the slug is stable and the score carries the release it was measured against.
+  Supersedes the separate claude-sonnet-4 and claude-sonnet-4-6 entries. The scores are still measured against
+  Sonnet 4.6 while Sonnet 5 (2026-06-30) is shipping; capability is flagged for rescoring on it. The headline
+  SWE-bench figure sits in a client-rendered chart on the 4.6 launch page and is not re-derivable from a fetch.
+  Verified 2026-08-13 via the Sonnet 4.6 and Sonnet 5 launch posts.

--- a/sources/products/codegemma.yaml
+++ b/sources/products/codegemma.yaml
@@ -12,5 +12,5 @@ huggingface_model:
 - url: https://huggingface.co/google/codegemma-1.1-2b
 comments: Gemma Terms of Use (custom, use-restricted, NOT OSI). Training data and recipe not released. Largely
   superseded by Qwen2.5-Coder / Gemma 3 for coding. The repos are gated `manual`, so openness was read from
-  the model card rather than a download. Verified live 2026-08-13 via the HF model card and Hugging Face's
-  CodeGemma release post.
+  the model card rather than a download. Verified 2026-08-13 via the HF model card and Hugging Face's CodeGemma
+  release post.

--- a/sources/products/codellama.yaml
+++ b/sources/products/codellama.yaml
@@ -11,8 +11,8 @@ huggingface_model:
 - url: https://huggingface.co/codellama/CodeLlama-7b-Instruct-hf
 - url: https://huggingface.co/codellama/CodeLlama-13b-Instruct-hf
 - url: https://huggingface.co/codellama/CodeLlama-70b-Instruct-hf
-comments: Code Llama Instruct (instruct-tuned coding variant; 7B/13B/34B/70B; scored on the 13B-Instruct SKU as
-  representative). Trained Jan-Jul 2023, paper arXiv:2308.12950 (Aug 2023). >12 months old and superseded by Llama
-  3.x/Codestral-class coders, but foundational open coding-instruct model. The card inlines no benchmark
-  numbers, so capability rests on the paper rather than the card. Verified live 2026-08-13 via the HF model
-  card and the arXiv abstract.
+comments: Code Llama Instruct (instruct-tuned coding variant; 7B/13B/34B/70B; scored on the 13B-Instruct SKU
+  as representative). Trained Jan-Jul 2023, paper arXiv:2308.12950 (Aug 2023). >12 months old and superseded
+  by Llama 3.x/Codestral-class coders, but foundational open coding-instruct model. The card inlines no benchmark
+  numbers, so capability rests on the paper rather than the card. Verified 2026-08-13 via the HF model card
+  and the arXiv abstract.

--- a/sources/products/codestral.yaml
+++ b/sources/products/codestral.yaml
@@ -8,10 +8,9 @@ description: Mistral's proprietary code model, API-only via la Plateforme, Verte
   CLI (Mistral's answer to Claude Code / Gemini CLI). Distributed to thousands of developers through Continue.dev,
   JetBrains, and VS Code integrations; reported usage trails Anthropic and OpenAI coding models.
 comments: 'Codestral 25.08 (released 30 Jul 2025), Mistral''s code-completion/FIM specialist; instruction-tuned
-  with a chat mode (+5% instruction following per launch). Distributed via API (console.mistral.ai), VPC,
-  and on-prem; open weights on HF under the Mistral AI Non-Production License (MNPL). NOTE: arguably a
-  coding-specialist model rather than a general chat model; scored best-effort in finetuned_chat per assignment
-  with a category caveat. (Separate ''Codestral 2'', Apr 2026, was relicensed Apache-2.0, not the SKU
-  scored here.) Mistral publishes the benchmark scores as chart images rather than text, so the capability
-  figures are not re-derivable from the launch post and are flagged. Verified live 2026-08-13 via the
-  Codestral and Codestral 25.08 launch posts.'
+  with a chat mode (+5% instruction following per launch). Distributed via API (console.mistral.ai), VPC, and
+  on-prem; open weights on HF under the Mistral AI Non-Production License (MNPL). NOTE: arguably a coding-specialist
+  model rather than a general chat model; scored best-effort in finetuned_chat per assignment with a category
+  caveat. (Separate ''Codestral 2'', Apr 2026, was relicensed Apache-2.0, not the SKU scored here.) Mistral
+  publishes the benchmark scores as chart images rather than text, so the capability figures are not re-derivable
+  from the launch post and are flagged. Verified 2026-08-13 via the Codestral and Codestral 25.08 launch posts.'

--- a/sources/products/command-r.yaml
+++ b/sources/products/command-r.yaml
@@ -10,7 +10,7 @@ description: Cohere's enterprise foundation model line, currently anchored by Co
 huggingface_model:
 - url: https://huggingface.co/CohereLabs/command-a-plus-05-2026-bf16
 - url: https://huggingface.co/CohereLabs/c4ai-command-r-v01
-comments: Correctly an instruct model, belongs in finetuned_chat (was miscategorized as base elsewhere).
-  Openness and capability were both rescored onto the governing release, Command A+ (Apache 2.0, ungated),
-  on 2026-08-14; all three axes now read the same release the description and the declared artifacts
-  follow. Verified live 2026-08-14 via the Command A+ model card and the CohereLabs org listing.
+comments: Correctly an instruct model, belongs in finetuned_chat (was miscategorized as base elsewhere). Openness
+  and capability were both rescored onto the governing release, Command A+ (Apache 2.0, ungated), on 2026-08-14;
+  all three axes now read the same release the description and the declared artifacts follow. Verified 2026-08-14
+  via the Command A+ model card and the CohereLabs org listing.

--- a/sources/products/deepseek-coder.yaml
+++ b/sources/products/deepseek-coder.yaml
@@ -10,7 +10,7 @@ description: Dedicated coding MoE model (seed product) instruction-tuned for cod
 huggingface_model:
 - url: https://huggingface.co/deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct
 - url: https://huggingface.co/deepseek-ai/DeepSeek-Coder-V2-Instruct
-comments: DeepSeek-Coder-V2-Instruct (236B total / 21B active DeepSeekMoE, 128K context), instruction-tuned coder
-  built on a DeepSeek-V2 checkpoint + 6T additional code tokens; arXiv 2401.06066. A dated (2024-gen) coder.
-  The code repository and the weights carry different licenses; the openness score follows the Model License
-  on the weights. Verified live 2026-08-13 via the HF model card and the LICENSE-MODEL body.
+comments: DeepSeek-Coder-V2-Instruct (236B total / 21B active DeepSeekMoE, 128K context), instruction-tuned
+  coder built on a DeepSeek-V2 checkpoint + 6T additional code tokens; arXiv 2401.06066. A dated (2024-gen)
+  coder. The code repository and the weights carry different licenses; the openness score follows the Model
+  License on the weights. Verified 2026-08-13 via the HF model card and the LICENSE-MODEL body.

--- a/sources/products/deepseek-instruct.yaml
+++ b/sources/products/deepseek-instruct.yaml
@@ -11,6 +11,6 @@ description: DeepSeek's open-weight April 2026 flagship line, replacing V3.2. Re
 huggingface_model:
 - url: https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro
 comments: Compound SKU. DeepSeek-V4-Pro (1.6T total / 49B active MoE) is a FROZEN flagship anchor (base_pretrained
-  shelf) - NOT rescored here; calibrate to it. This record scores the non-anchor sibling DeepSeek-V4-Flash (284B
-  total / 13B active MoE, 1M context, FP4+FP8, hybrid CSA+HCA attention, mHC, Muon optimizer), the lighter instruct/thinking
-  SKU of the V4 family. Verified live 2026-08-13 via the HF model card.
+  shelf) - NOT rescored here; calibrate to it. This record scores the non-anchor sibling DeepSeek-V4-Flash
+  (284B total / 13B active MoE, 1M context, FP4+FP8, hybrid CSA+HCA attention, mHC, Muon optimizer), the lighter
+  instruct/thinking SKU of the V4 family. Verified 2026-08-13 via the HF model card.

--- a/sources/products/deepseek-r1.yaml
+++ b/sources/products/deepseek-r1.yaml
@@ -9,8 +9,7 @@ description: Previous-generation reasoning-first model (January 2025) using larg
 huggingface_model:
 - url: https://huggingface.co/deepseek-ai/DeepSeek-R1
 - url: https://huggingface.co/deepseek-ai/DeepSeek-R1-0528
-comments: DeepSeek-R1 (671B total / 37B active MoE, 128K context), reasoning model RL+SFT post-trained
-  on DeepSeek-V3-Base (cold-start data + RL + SFT pipeline; R1-Zero is pure-RL variant); arXiv 2501.12948,
-  released 2025-01-22. The earlier record put monthly downloads at 4.3M; the card now reads 8.3M, so the
-  figure was dropped from the description rather than re-pinned. Verified live 2026-08-13 via the HF model
-  card.
+comments: DeepSeek-R1 (671B total / 37B active MoE, 128K context), reasoning model RL+SFT post-trained on DeepSeek-V3-Base
+  (cold-start data + RL + SFT pipeline; R1-Zero is pure-RL variant); arXiv 2501.12948, released 2025-01-22.
+  The earlier record put monthly downloads at 4.3M; the card now reads 8.3M, so the figure was dropped from
+  the description rather than re-pinned. Verified 2026-08-13 via the HF model card.

--- a/sources/products/devstral.yaml
+++ b/sources/products/devstral.yaml
@@ -8,8 +8,8 @@ description: Mistral's dedicated open-weight agentic coding model family, purpos
 huggingface_model:
 - url: https://huggingface.co/mistralai/Devstral-Small-2-24B-Instruct-2512
 - url: https://huggingface.co/mistralai/Devstral-2-123B-Instruct-2512
-comments: All three axes were rescored onto the governing Devstral 2 (2512) release on 2026-08-14, having
-  been read on the superseded Devstral Small 1.1 (mistralai/Devstral-Small-2507). The two 2512 SKUs are not
-  licensed alike - Small 2 24B is Apache 2.0, the 123B is a Modified MIT License - so the governing release
-  resolves most-restrictive to a non-OSI tier. Verified live 2026-08-14 via the HF model cards for Devstral
-  Small 2 24B and Devstral 2 123B.
+comments: All three axes were rescored onto the governing Devstral 2 (2512) release on 2026-08-14, having been
+  read on the superseded Devstral Small 1.1 (mistralai/Devstral-Small-2507). The two 2512 SKUs are not licensed
+  alike - Small 2 24B is Apache 2.0, the 123B is a Modified MIT License - so the governing release resolves
+  most-restrictive to a non-OSI tier. Verified 2026-08-14 via the HF model cards for Devstral Small 2 24B and
+  Devstral 2 123B.

--- a/sources/products/doubao-seed.yaml
+++ b/sources/products/doubao-seed.yaml
@@ -12,11 +12,11 @@ description: ByteDance's flagship closed-weight instruction-tuned model line, re
   via the Doubao consumer chat app, which crossed 100M DAU in early 2026 and reached ~345M MAU by March 2026, the
   largest consumer AI chat product in China. Doubao Seed 1.6 (October 2025, 256K context) remains in the lineup
   as the budget tier; ByteDance ships 19 active Doubao API SKUs in 2026.
-comments: Doubao Seed 2.0 (ByteDance), foundation model family released 14 Feb 2026; variants Pro / Lite / Mini
-  / Code. Multimodal reasoning/agentic instruct model; proprietary/API-only via Volcano Engine (Volcengine) and
-  the consumer Doubao app. Scored facts are for Seed 2.0 Pro (the flagship). The TechNode article carries
-  neither the user figure nor any individual benchmark score; both were re-sourced on 2026-08-14, adoption to
-  Caixin's launch-day report of 155M weekly active users for the Doubao app (Quest Mobile, December 2025) and
-  capability to ByteDance's own Seed 2.0 launch post. The AIME, Codeforces and VideoMME figures the record
-  used to carry appear on no reachable source and have been dropped. Verified live 2026-08-13 via TechNode's
-  coverage of ByteDance's launch June 2026.
+comments: Doubao Seed 2.0 (ByteDance), foundation model family released 14 Feb 2026; variants Pro / Lite /
+  Mini / Code. Multimodal reasoning/agentic instruct model; proprietary/API-only via Volcano Engine (Volcengine)
+  and the consumer Doubao app. Scored facts are for Seed 2.0 Pro (the flagship). The TechNode article carries
+  neither the user figure nor any individual benchmark score; both were re-sourced on 2026-08-14, adoption
+  to Caixin's launch-day report of 155M weekly active users for the Doubao app (Quest Mobile, December 2025)
+  and capability to ByteDance's own Seed 2.0 launch post. The AIME, Codeforces and VideoMME figures the record
+  used to carry appear on no reachable source and have been dropped. Verified 2026-08-13 via TechNode's coverage
+  of ByteDance's launch June 2026.

--- a/sources/products/gemini-flash.yaml
+++ b/sources/products/gemini-flash.yaml
@@ -11,6 +11,6 @@ description: 'Released at Google I/O 2026 (May 19, 2026) as the new default in t
 comments: Google Gemini 3.5 Flash, launched at I/O 2026 on May 19, 2026 as the first Gemini 3.5 model; price-performance
   thinking/agentic instruct model. Available via Gemini app, AI Mode in Search, Google Antigravity, Gemini
   API and enterprise. Proprietary API-only. (Matches the flagship anchor 'Gemini 3.5 Flash'; scored here for
-  the finetuned_chat category, calibrated to that anchor.) Verified live 2026-08-13 via the Gemini 3.5 launch
-  post, the DeepMind model index, Google's API model docs and TechCrunch. Consolidated on 2026-07-29
-  from gemini-2-5-flash; openness follows gemini-3-5-flash, the release that currently governs. See docs/reference/identity.md.
+  the finetuned_chat category, calibrated to that anchor.) Verified 2026-08-13 via the Gemini 3.5 launch post,
+  the DeepMind model index, Google's API model docs and TechCrunch. Consolidated on 2026-07-29 from gemini-2-5-flash;
+  openness follows gemini-3-5-flash, the release that currently governs. See docs/reference/identity.md.

--- a/sources/products/gemini-pro.yaml
+++ b/sources/products/gemini-pro.yaml
@@ -6,10 +6,9 @@ description: Google DeepMind's flagship Gemini reasoning tier, natively multimod
   than a point release, with the measured release named in the score note. Generations to date are Gemini 2.5
   Pro (2025), Gemini 3 Pro (Nov 2025) and Gemini 3.1 Pro (2026, in preview at the time of scoring). Closed
   weights, available through the Gemini API, AI Studio, Vertex AI and the Gemini apps.
-comments: Tier product. Scored against Gemini 3 Pro, the generally available Pro release. Gemini 3.1 Pro
-  Preview leads LiveCodeBench Pro and posts 80.6% on SWE-bench Verified, but preview checkpoints are excluded
-  from the map as separate products because they are not stable; it is noted here so the tier's coding
-  standing is not lost. Supersedes the separate gemini-2-5-pro, gemini-3-pro and gemini-3-1-pro-preview
-  entries. The capability axis cites only the DeepMind model index, which carries no benchmark figures, so
-  the numbers in its note have no source behind them and it is flagged. Verified live 2026-08-13 via the
-  DeepMind model index.
+comments: Tier product. Scored against Gemini 3 Pro, the generally available Pro release. Gemini 3.1 Pro Preview
+  leads LiveCodeBench Pro and posts 80.6% on SWE-bench Verified, but preview checkpoints are excluded from
+  the map as separate products because they are not stable; it is noted here so the tier's coding standing
+  is not lost. Supersedes the separate gemini-2-5-pro, gemini-3-pro and gemini-3-1-pro-preview entries. The
+  capability axis cites only the DeepMind model index, which carries no benchmark figures, so the numbers in
+  its note have no source behind them and it is flagged. Verified 2026-08-13 via the DeepMind model index.

--- a/sources/products/gpt-4-1.yaml
+++ b/sources/products/gpt-4-1.yaml
@@ -6,7 +6,7 @@ description: Previous-generation general-purpose instruction-tuned model (April 
   and real-world coding with 1M token context, but two numerical generations behind by mid-2026; OpenAI's
   current production line is GPT-5 → 5.2 → 5.4 → 5.5 (April 23, 2026), with GPT-5.5 Pro and 5.5 Instant
   variants. GPT-4.1 remains available via API and is still used in legacy integrations.
-comments: OpenAI GPT-4.1 (+ mini, nano), released Apr 14 2025 as API-first coding/instruct models with
-  1M-token context. Post-trained instruct (non-reasoning) model, closed/API-only; now behind the GPT-5 line.
-  OpenAI's own announcement page answers HTTP 403 to a plain fetch, so the SWE-bench figure rests on the
-  InfoQ and Helicone write-ups. Verified live 2026-08-13 via OpenAI's model docs, TechCrunch and InfoQ.
+comments: OpenAI GPT-4.1 (+ mini, nano), released Apr 14 2025 as API-first coding/instruct models with 1M-token
+  context. Post-trained instruct (non-reasoning) model, closed/API-only; now behind the GPT-5 line. OpenAI's
+  own announcement page answers HTTP 403 to a plain fetch, so the SWE-bench figure rests on the InfoQ and Helicone
+  write-ups. Verified 2026-08-13 via OpenAI's model docs, TechCrunch and InfoQ.

--- a/sources/products/gpt-5.yaml
+++ b/sources/products/gpt-5.yaml
@@ -16,4 +16,4 @@ comments: 'OpenAI GPT-5 line: GPT-5 (Aug 7 2025, became ChatGPT default replacin
   model family, closed/API + ChatGPT only. Consolidated on 2026-07-29 from gpt-5; openness follows gpt-5-line,
   the release that currently governs. See docs/reference/identity.md. OpenAI''s own launch post answers HTTP
   403 to a plain fetch, so the capability figures currently have no reachable source and that axis is unverified.
-  Verified live 2026-08-13 via the GPT-5 Wikipedia article and TechCrunch.'
+  Verified 2026-08-13 via the GPT-5 Wikipedia article and TechCrunch.'

--- a/sources/products/granite-code-instruct.yaml
+++ b/sources/products/granite-code-instruct.yaml
@@ -9,7 +9,7 @@ description: IBM's enterprise-focused open source code model line, now folded in
 huggingface_model:
 - url: https://huggingface.co/ibm-granite/granite-34b-code-instruct-8k
 comments: IBM Granite Code Instruct family (3B/8B/20B/34B, 2K & 128K context), fine-tuned from Granite-Code-Base
-  for code instruction-following; released May 6 2024 (arXiv 2405.04324). Instruct = post-trained (SFT
-  on permissively-licensed code/math/NL instruction data). The card now opens with a DEPRECATION WARNING
-  banner (superseded by Granite 4.x mainline). Verified live 2026-08-13 via the HF model card, the
-  granite-code-models repository and IBM's release blog.
+  for code instruction-following; released May 6 2024 (arXiv 2405.04324). Instruct = post-trained (SFT on permissively-licensed
+  code/math/NL instruction data). The card now opens with a DEPRECATION WARNING banner (superseded by Granite
+  4.x mainline). Verified 2026-08-13 via the HF model card, the granite-code-models repository and IBM's release
+  blog.

--- a/sources/products/grok.yaml
+++ b/sources/products/grok.yaml
@@ -8,8 +8,8 @@ description: xAI Grok 4.20; beta Feb 17, 2026, API GA Mar 10, 2026 (Grok 4.20 + 
   v2' dated Apr 7, 2026. Multi-agent architecture (4 parallel agents); 2M-token context.
 comments: xAI Grok 4.20; beta Feb 17, 2026, API GA Mar 10, 2026 (Grok 4.20 + Multi-agent). Revision '4.20 0309
   v2' dated Apr 7, 2026. Multi-agent architecture (4 parallel agents); 2M-token context. Consolidated on 2026-07-29
-  from grok-3; openness follows grok-4-20, the release that currently governs. See docs/reference/identity.md. Two axes are flagged for rescoring - xAI's
-  docs now headline grok-4.6 as the flagship, and Artificial Analysis has recalibrated its Intelligence Index,
-  so the index score the capability record cites no longer exists on their scale. The vendor now brands itself
-  SpaceXAI. Verified live 2026-08-13 via the xAI release notes, the xAI model reference and the Artificial
-  Analysis model page.
+  from grok-3; openness follows grok-4-20, the release that currently governs. See docs/reference/identity.md.
+  Two axes are flagged for rescoring - xAI's docs now headline grok-4.6 as the flagship, and Artificial Analysis
+  has recalibrated its Intelligence Index, so the index score the capability record cites no longer exists
+  on their scale. The vendor now brands itself SpaceXAI. Verified 2026-08-13 via the xAI release notes, the
+  xAI model reference and the Artificial Analysis model page.

--- a/sources/products/hailo-10h.yaml
+++ b/sources/products/hailo-10h.yaml
@@ -8,9 +8,9 @@ description: Hailo's generative-AI edge accelerator, offered as an M.2 module an
   zoo.
 github:
 - url: https://github.com/hailo-ai/hailo_model_zoo_genai
-comments: Verified 2026-08-14 via substitute sources - hailo.ai answers 403 to every automated request, so
-  the description was re-checked against AAEON/UP's published spec table, which reproduces 40 TOPS at INT4
-  and 20 TOPS at INT8, 2.5W typical, M.2 2280 Key-M, and the direct DDR interface that lets it run LLMs and
-  VLMs on-device, and against Geniatech's independent Hailo-10 module listing. Every claim in the description
-  holds. Proprietary silicon with published datasheets and an open GenAI model zoo, but the silicon and full
-  toolchain are closed.
+comments: Verified live 2026-08-14 via substitute sources - hailo.ai answers 403 to every automated
+  request, so the description was re-checked against AAEON/UP's published spec table, which reproduces
+  40 TOPS at INT4 and 20 TOPS at INT8, 2.5W typical, M.2 2280 Key-M, and the direct DDR interface that
+  lets it run LLMs and VLMs on-device, and against Geniatech's independent Hailo-10 module listing.
+  Every claim in the description holds. Proprietary silicon with published datasheets and an open
+  GenAI model zoo, but the silicon and full toolchain are closed.

--- a/sources/products/hailo-10h.yaml
+++ b/sources/products/hailo-10h.yaml
@@ -8,9 +8,9 @@ description: Hailo's generative-AI edge accelerator, offered as an M.2 module an
   zoo.
 github:
 - url: https://github.com/hailo-ai/hailo_model_zoo_genai
-comments: Verified live 2026-08-14 via substitute sources - hailo.ai answers 403 to every automated
-  request, so the description was re-checked against AAEON/UP's published spec table, which reproduces
-  40 TOPS at INT4 and 20 TOPS at INT8, 2.5W typical, M.2 2280 Key-M, and the direct DDR interface that
-  lets it run LLMs and VLMs on-device, and against Geniatech's independent Hailo-10 module listing.
-  Every claim in the description holds. Proprietary silicon with published datasheets and an open
-  GenAI model zoo, but the silicon and full toolchain are closed.
+comments: Verified 2026-08-14 via substitute sources - hailo.ai answers 403 to every automated request, so
+  the description was re-checked against AAEON/UP's published spec table, which reproduces 40 TOPS at INT4
+  and 20 TOPS at INT8, 2.5W typical, M.2 2280 Key-M, and the direct DDR interface that lets it run LLMs and
+  VLMs on-device, and against Geniatech's independent Hailo-10 module listing. Every claim in the description
+  holds. Proprietary silicon with published datasheets and an open GenAI model zoo, but the silicon and full
+  toolchain are closed.

--- a/sources/products/hailo-8.yaml
+++ b/sources/products/hailo-8.yaml
@@ -8,10 +8,9 @@ description: An edge AI inference accelerator delivering up to 26 TOPS at roughl
   vision.
 github:
 - url: https://github.com/hailo-ai/hailort
-comments: Verified live 2026-08-14 via substitute sources - hailo.ai answers 403 to every automated
-  request, so the description was re-checked against Geniatech's AIM-M-H8 spec table (26 TOPS INT8,
-  TensorFlow/TFLite/Keras/PyTorch/ONNX, memory by processor integration), Waveshare's listing (2.5W
-  typical, M.2), Hailo's own M.2 data sheet as mirrored by Premio, and the HailoRT and Model Zoo
-  READMEs for the runtime and Dataflow Compiler split. Every claim in the description holds.
-  Proprietary silicon with an open source runtime and public product briefs, but the model-compiler
-  toolchain requires registration and silicon is closed.
+comments: Verified 2026-08-14 via substitute sources - hailo.ai answers 403 to every automated request, so
+  the description was re-checked against Geniatech's AIM-M-H8 spec table (26 TOPS INT8, TensorFlow/TFLite/Keras/PyTorch/ONNX,
+  memory by processor integration), Waveshare's listing (2.5W typical, M.2), Hailo's own M.2 data sheet as
+  mirrored by Premio, and the HailoRT and Model Zoo READMEs for the runtime and Dataflow Compiler split. Every
+  claim in the description holds. Proprietary silicon with an open source runtime and public product briefs,
+  but the model-compiler toolchain requires registration and silicon is closed.

--- a/sources/products/hailo-8.yaml
+++ b/sources/products/hailo-8.yaml
@@ -8,9 +8,10 @@ description: An edge AI inference accelerator delivering up to 26 TOPS at roughl
   vision.
 github:
 - url: https://github.com/hailo-ai/hailort
-comments: Verified 2026-08-14 via substitute sources - hailo.ai answers 403 to every automated request, so
-  the description was re-checked against Geniatech's AIM-M-H8 spec table (26 TOPS INT8, TensorFlow/TFLite/Keras/PyTorch/ONNX,
-  memory by processor integration), Waveshare's listing (2.5W typical, M.2), Hailo's own M.2 data sheet as
-  mirrored by Premio, and the HailoRT and Model Zoo READMEs for the runtime and Dataflow Compiler split. Every
-  claim in the description holds. Proprietary silicon with an open source runtime and public product briefs,
-  but the model-compiler toolchain requires registration and silicon is closed.
+comments: Verified live 2026-08-14 via substitute sources - hailo.ai answers 403 to every automated
+  request, so the description was re-checked against Geniatech's AIM-M-H8 spec table (26 TOPS INT8,
+  TensorFlow/TFLite/Keras/PyTorch/ONNX, memory by processor integration), Waveshare's listing (2.5W
+  typical, M.2), Hailo's own M.2 data sheet as mirrored by Premio, and the HailoRT and Model Zoo
+  READMEs for the runtime and Dataflow Compiler split. Every claim in the description holds.
+  Proprietary silicon with an open source runtime and public product briefs, but the model-compiler
+  toolchain requires registration and silicon is closed.

--- a/sources/products/hermes.yaml
+++ b/sources/products/hermes.yaml
@@ -15,9 +15,9 @@ huggingface_model:
 - url: https://huggingface.co/NousResearch/Hermes-4.3-36B
 - url: https://huggingface.co/NousResearch/Hermes-3-Llama-3.1-405B
 - url: https://huggingface.co/NousResearch/Hermes-3-Llama-3.1-70B
-comments: Hermes 4 released Sep 2 2025; tech report arXiv:2508.18255. Consolidated on 2026-07-29 from
-  hermes-4-14b, hermes-4-3-36b, hermes-4-llama-3-1-70b. Openness follows the Apache build hermes-4-3-36b,
-  which is what the score records; this note previously said the 405B governs, contradicting the score file,
-  and has been corrected. The four bases carry different licenses and a user can substitute freely between
-  them, so most-restrictive-across-SKUs does not apply. See docs/reference/identity.md. Verified live 2026-08-13
-  via the HF model cards and the technical report.
+comments: Hermes 4 released Sep 2 2025; tech report arXiv:2508.18255. Consolidated on 2026-07-29 from hermes-4-14b,
+  hermes-4-3-36b, hermes-4-llama-3-1-70b. Openness follows the Apache build hermes-4-3-36b, which is what the
+  score records; this note previously said the 405B governs, contradicting the score file, and has been corrected.
+  The four bases carry different licenses and a user can substitute freely between them, so most-restrictive-across-SKUs
+  does not apply. See docs/reference/identity.md. Verified 2026-08-13 via the HF model cards and the technical
+  report.

--- a/sources/products/jamba-large.yaml
+++ b/sources/products/jamba-large.yaml
@@ -11,7 +11,7 @@ description: 'AI21-Jamba-1.5-Large (ai21labs/AI21-Jamba-1.5-Large on HF), hybrid
   use), not a raw base model.'
 huggingface_model:
 - url: https://huggingface.co/ai21labs/AI21-Jamba-1.5-Large
-comments: Recategorized from base_pretrained -> finetuned_chat; this is the instruct/chat SKU, not a raw
-  base model. The repo is gated `auto`, so openness was read from the model card and the license body rather
-  than a download. Verified live 2026-08-13 via the HF model card, the Jamba Open Model License body and
-  the AI21 release blog.
+comments: Recategorized from base_pretrained -> finetuned_chat; this is the instruct/chat SKU, not a raw base
+  model. The repo is gated `auto`, so openness was read from the model card and the license body rather than
+  a download. Verified 2026-08-13 via the HF model card, the Jamba Open Model License body and the AI21 release
+  blog.

--- a/sources/products/k2.yaml
+++ b/sources/products/k2.yaml
@@ -12,6 +12,6 @@ huggingface_model:
 - url: https://huggingface.co/LLM360/K2-V2
 - url: https://huggingface.co/LLM360/K2-V2-Instruct
 comments: Apache-2.0; open weights + open TxT360 data + open training code + checkpoints. Outperforms Qwen2.5-72B
-  and approaches Qwen3-235B; strongest fully-open model by parameter scale, though OLMo 3 leads on fully-open evals.
-  The Hub repos now render under the org IFM rather than LLM360; the declared LLM360 URLs still resolve. Verified
-  live 2026-08-13 via the HF model card and the arXiv abstract.
+  and approaches Qwen3-235B; strongest fully-open model by parameter scale, though OLMo 3 leads on fully-open
+  evals. The Hub repos now render under the org IFM rather than LLM360; the declared LLM360 URLs still resolve.
+  Verified 2026-08-13 via the HF model card and the arXiv abstract.

--- a/sources/products/llama-instruct.yaml
+++ b/sources/products/llama-instruct.yaml
@@ -10,5 +10,5 @@ description: Instruction-tuned 8B Llama 3.1 model for chat and assistant workflo
 huggingface_model:
 - url: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
 comments: Llama 3.1 8B Instruct, released 23 Jul 2024. 8B dense, 128k context, SFT+RLHF post-trained chat model.
-  The repo is gated `manual`, so openness was read from the model card and the license body rather than a
-  download. Verified live 2026-08-13 via the HF model card.
+  The repo is gated `manual`, so openness was read from the model card and the license body rather than a download.
+  Verified 2026-08-13 via the HF model card.

--- a/sources/products/lovable.yaml
+++ b/sources/products/lovable.yaml
@@ -4,6 +4,6 @@ type: software
 description: Lovable (formerly GPT Engineer), proprietary agentic AI app/website builder ('chat to build',
   autonomous prototype-to-deploy). Verified live 2026-08-13 via docs.lovable.dev, lovable.dev itself now
   blocking non-browser fetches. Around 8 million users and $400M ARR as of early 2026.
-comments: Lovable (formerly GPT Engineer), proprietary agentic AI app/website builder ('chat to build',
-  autonomous prototype-to-deploy). Verified live 2026-08-13 via docs.lovable.dev, lovable.dev itself now
-  blocking non-browser fetches. Around 8 million users and $400M ARR as of early 2026.
+comments: Lovable (formerly GPT Engineer), proprietary agentic AI app/website builder ('chat to build', autonomous
+  prototype-to-deploy). Verified 2026-08-13 via docs.lovable.dev, lovable.dev itself now blocking non-browser
+  fetches. Around 8 million users and $400M ARR as of early 2026.

--- a/sources/products/mistral-7b-instruct.yaml
+++ b/sources/products/mistral-7b-instruct.yaml
@@ -11,6 +11,6 @@ description: Instruction-tuned 7B chat model from Mistral that follows user prom
 huggingface_model:
 - url: https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2
 comments: Mistral 7B Instruct v0.2, 7B dense, 32k context (up from 8k in v0.1); instruct fine-tune of Mistral-7B-v0.2
-  (base paper arXiv:2310.06825, Oct 2023). >12 months old and superseded by v0.3 and the Ministral/Mistral Small
-  lines, but foundational permissive instruct model. The capability record's MT-Bench and MMLU figures are
-  not on the card, which links only the base-model paper. Verified live 2026-08-13 via the HF model card.
+  (base paper arXiv:2310.06825, Oct 2023). >12 months old and superseded by v0.3 and the Ministral/Mistral
+  Small lines, but foundational permissive instruct model. The capability record's MT-Bench and MMLU figures
+  are not on the card, which links only the base-model paper. Verified 2026-08-13 via the HF model card.

--- a/sources/products/muse-spark.yaml
+++ b/sources/products/muse-spark.yaml
@@ -6,9 +6,9 @@ description: Meta Superintelligence Labs' flagship closed-weight API model, laun
   to break the top 5 in 2026. Represents Meta's parallel closed-weights track alongside the open-weights
   Llama line (Llama 5, April 2026), effectively splitting Meta into two flagship brands. Chat/instruction-tuned
   tier sits in Cat 3 alongside other API-only frontier models.
-comments: 'Muse Spark, first model of Meta Superintelligence Labs'' new ''Muse'' series; released 8 Apr
-  2026. Natively multimodal reasoning model with tool-use, visual chain-of-thought, and multi-agent ''Contemplating''
-  mode. Proprietary/API-only: powers the Meta AI assistant (meta.ai + Meta AI app), private API preview
-  to select users; no open weights. Meta''s engineering blog answers HTTP 400 to a plain fetch and LMArena
-  no longer lists Muse Spark, so both capability sources are currently unusable and that axis is flagged.
-  Verified live 2026-08-13 via Meta''s newsroom post.'
+comments: 'Muse Spark, first model of Meta Superintelligence Labs'' new ''Muse'' series; released 8 Apr 2026.
+  Natively multimodal reasoning model with tool-use, visual chain-of-thought, and multi-agent ''Contemplating''
+  mode. Proprietary/API-only: powers the Meta AI assistant (meta.ai + Meta AI app), private API preview to
+  select users; no open weights. Meta''s engineering blog answers HTTP 400 to a plain fetch and LMArena no
+  longer lists Muse Spark, so both capability sources are currently unusable and that axis is flagged. Verified
+  2026-08-13 via Meta''s newsroom post.'

--- a/sources/products/nemotron.yaml
+++ b/sources/products/nemotron.yaml
@@ -14,13 +14,13 @@ huggingface_model:
 - url: https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
 - url: https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
 - url: https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16
-comments: 'The Nemotron 3 family: Nano (30B total / 3B active hybrid MoE), Super (120B / 12B active hybrid Mamba-Transformer
-  MoE, 1M context, 11 Mar 2026 at GTC) and Ultra (550B / 55B active, 3 Jun 2026). Designed for agentic/conversational
-  use. Held a duplicate record in base_pretrained until 2026-07-29; the two were merged here because the family
-  distributes post-trained weights only. The sole -Base repo on the Hub is nvidia/nemotron-3-8b-base-4k, created
-  2023-11-14 with a single download, which is the earlier 8B generation and not this family. Per the #114 convention,
-  the observable artifact decides the category. BF16 originals are declared above; the NVFP4/FP8/GGUF quantizations
-  are the same weights repackaged. An earlier note recorded the instruct repo as gated/401 -- all three resolve
-  ungated. The score note used to call Super''s SWE-bench 60.47 the highest open-weight figure; the report''s
-  own comparison column reads higher, and that claim has been withdrawn. Verified live 2026-08-13 via the
-  Nemotron 3 page, NVIDIA''s developer blog and the Super technical report.'
+comments: 'The Nemotron 3 family: Nano (30B total / 3B active hybrid MoE), Super (120B / 12B active hybrid
+  Mamba-Transformer MoE, 1M context, 11 Mar 2026 at GTC) and Ultra (550B / 55B active, 3 Jun 2026). Designed
+  for agentic/conversational use. Held a duplicate record in base_pretrained until 2026-07-29; the two were
+  merged here because the family distributes post-trained weights only. The sole -Base repo on the Hub is nvidia/nemotron-3-8b-base-4k,
+  created 2023-11-14 with a single download, which is the earlier 8B generation and not this family. Per the
+  #114 convention, the observable artifact decides the category. BF16 originals are declared above; the NVFP4/FP8/GGUF
+  quantizations are the same weights repackaged. An earlier note recorded the instruct repo as gated/401 --
+  all three resolve ungated. The score note used to call Super''s SWE-bench 60.47 the highest open-weight figure;
+  the report''s own comparison column reads higher, and that claim has been withdrawn. Verified 2026-08-13
+  via the Nemotron 3 page, NVIDIA''s developer blog and the Super technical report.'

--- a/sources/products/nxp-imx-8m-plus.yaml
+++ b/sources/products/nxp-imx-8m-plus.yaml
@@ -6,10 +6,9 @@ description: An NXP applications processor family with up to a quad Arm Cortex-A
   ISPs and two camera inputs and targets smart home, building, city, and Industry 4.0 use cases. NXP provides
   a Linux/Yocto BSP and public datasheets, and the part is commercially available with SoM options from
   ADLINK, Toradex, and SolidRun.
-comments: Verified live 2026-08-14 via substitute sources - www.nxp.com answers 404 to every automated
-  request including its own root, so the description was re-checked against NXP's own IMX8MPCEC
-  datasheet as mirrored openly by DigiKey, which carries the quad Cortex-A53 at up to 1.8 GHz, the
-  800 MHz Cortex-M7, the 2.3 TOPS NPU and the dual-ISP two-camera vision engine, and against NXP's
-  meta-imx Yocto BSP repo and Toradex's Verdin module for the BSP and SoM-availability claims. Every
-  claim in the description holds. Public datasheets and a Linux BSP with broad commercial
-  availability, but proprietary silicon with no open board files.
+comments: Verified 2026-08-14 via substitute sources - www.nxp.com answers 404 to every automated request including
+  its own root, so the description was re-checked against NXP's own IMX8MPCEC datasheet as mirrored openly
+  by DigiKey, which carries the quad Cortex-A53 at up to 1.8 GHz, the 800 MHz Cortex-M7, the 2.3 TOPS NPU and
+  the dual-ISP two-camera vision engine, and against NXP's meta-imx Yocto BSP repo and Toradex's Verdin module
+  for the BSP and SoM-availability claims. Every claim in the description holds. Public datasheets and a Linux
+  BSP with broad commercial availability, but proprietary silicon with no open board files.

--- a/sources/products/nxp-imx-8m-plus.yaml
+++ b/sources/products/nxp-imx-8m-plus.yaml
@@ -6,9 +6,10 @@ description: An NXP applications processor family with up to a quad Arm Cortex-A
   ISPs and two camera inputs and targets smart home, building, city, and Industry 4.0 use cases. NXP provides
   a Linux/Yocto BSP and public datasheets, and the part is commercially available with SoM options from
   ADLINK, Toradex, and SolidRun.
-comments: Verified 2026-08-14 via substitute sources - www.nxp.com answers 404 to every automated request including
-  its own root, so the description was re-checked against NXP's own IMX8MPCEC datasheet as mirrored openly
-  by DigiKey, which carries the quad Cortex-A53 at up to 1.8 GHz, the 800 MHz Cortex-M7, the 2.3 TOPS NPU and
-  the dual-ISP two-camera vision engine, and against NXP's meta-imx Yocto BSP repo and Toradex's Verdin module
-  for the BSP and SoM-availability claims. Every claim in the description holds. Public datasheets and a Linux
-  BSP with broad commercial availability, but proprietary silicon with no open board files.
+comments: Verified live 2026-08-14 via substitute sources - www.nxp.com answers 404 to every automated
+  request including its own root, so the description was re-checked against NXP's own IMX8MPCEC
+  datasheet as mirrored openly by DigiKey, which carries the quad Cortex-A53 at up to 1.8 GHz, the
+  800 MHz Cortex-M7, the 2.3 TOPS NPU and the dual-ISP two-camera vision engine, and against NXP's
+  meta-imx Yocto BSP repo and Toradex's Verdin module for the BSP and SoM-availability claims. Every
+  claim in the description holds. Public datasheets and a Linux BSP with broad commercial
+  availability, but proprietary silicon with no open board files.

--- a/sources/products/o-series.yaml
+++ b/sources/products/o-series.yaml
@@ -7,7 +7,7 @@ description: 'Previous reasoning tier (2025): full-scale o3 plus cost-efficient 
   Powered Codex agent and ChatGPT''s coding mode through 2025. Folded into the GPT-5 line in late 2025; OpenAI consolidated
   the o-series and GPT branches and is no longer maintaining o-series as a separately branded reasoning family.
   Current reasoning capability lives in GPT-5.x with thinking enabled and in GPT-5.3-Codex.'
-comments: OpenAI o3 and o4-mini reasoning models, both released Apr 16 2025 (o3-mini preceded Jan 31 2025). Post-trained
-  reasoning/instruct models, API-only + ChatGPT, no downloadable weights. Succeeded by the GPT-5.x reasoning
-  line but still selectable. The o4-mini AIME figure in the capability record is not on either cited source
-  and is flagged. Verified live 2026-08-13 via the OpenAI o3/o4-mini system card and the Wikipedia article.
+comments: OpenAI o3 and o4-mini reasoning models, both released Apr 16 2025 (o3-mini preceded Jan 31 2025).
+  Post-trained reasoning/instruct models, API-only + ChatGPT, no downloadable weights. Succeeded by the GPT-5.x
+  reasoning line but still selectable. The o4-mini AIME figure in the capability record is not on either cited
+  source and is flagged. Verified 2026-08-13 via the OpenAI o3/o4-mini system card and the Wikipedia article.

--- a/sources/products/olmo-instruct.yaml
+++ b/sources/products/olmo-instruct.yaml
@@ -12,6 +12,6 @@ github:
 huggingface_model:
 - url: https://huggingface.co/allenai/Olmo-3-7B-Instruct
 - url: https://huggingface.co/allenai/Olmo-3-1025-32B-Instruct
-comments: Apache-2.0; fully-open instruct line post-trained with the open Tulu/OLMo recipe. The declared
-  32B artifact answers HTTP 401, so adoption is read on the 7B alone and is a floor. Verified live 2026-08-13
-  via the HF model card and the Olmo 3 blog.
+comments: Apache-2.0; fully-open instruct line post-trained with the open Tulu/OLMo recipe. The declared 32B
+  artifact answers HTTP 401, so adoption is read on the 7B alone and is a floor. Verified 2026-08-13 via the
+  HF model card and the Olmo 3 blog.

--- a/sources/products/olmoe-instruct.yaml
+++ b/sources/products/olmoe-instruct.yaml
@@ -11,6 +11,5 @@ huggingface_model:
 - url: https://huggingface.co/allenai/OLMoE-1B-7B-0924-Instruct
 huggingface_dataset:
 - url: https://huggingface.co/datasets/allenai/OLMoE-mix-0924
-comments: Apache-2.0; fully-open MoE (weights + data + code + intermediate checkpoints).
-  State-of-the-art among ~1B-active-parameter models at release. Verified live 2026-08-13 via the HF model
-  card and the OLMoE blog post.
+comments: Apache-2.0; fully-open MoE (weights + data + code + intermediate checkpoints). State-of-the-art among
+  ~1B-active-parameter models at release. Verified 2026-08-13 via the HF model card and the OLMoE blog post.

--- a/sources/products/openai-evals-api-dashboard.yaml
+++ b/sources/products/openai-evals-api-dashboard.yaml
@@ -5,8 +5,8 @@ description: Managed evaluation product inside the OpenAI Platform, Evals API pl
   lets developers define eval datasets, run them against any OpenAI model, grade with custom or built-in
   graders, and track regressions across versions. Picked by teams already on OpenAI who want the 'measure
   → improve → ship' loop without standing up infra. Pricing rolls into standard OpenAI API token usage.
-comments: 'Hosted, proprietary evaluation product on the OpenAI platform (API + web dashboard), distinct
-  from the open source openai/evals repo. Lets developers define grading criteria, upload JSONL test sets,
-  run against Chat Completions/Responses APIs, and inspect pass/fail + cost metrics. BEING SUNSET: dashboard
-  read-only 31 Oct 2026, full shutdown 30 Nov 2026 (OpenAI recommends Datasets as replacement).
-  Verified live 2026-08-13 via OpenAI developer docs.'
+comments: 'Hosted, proprietary evaluation product on the OpenAI platform (API + web dashboard), distinct from
+  the open source openai/evals repo. Lets developers define grading criteria, upload JSONL test sets, run against
+  Chat Completions/Responses APIs, and inspect pass/fail + cost metrics. BEING SUNSET: dashboard read-only
+  31 Oct 2026, full shutdown 30 Nov 2026 (OpenAI recommends Datasets as replacement). Verified 2026-08-13 via
+  OpenAI developer docs.'

--- a/sources/products/ornith.yaml
+++ b/sources/products/ornith.yaml
@@ -7,8 +7,8 @@ description: DeepReinforce's open-weights agentic coding model, a 9B dense model
 huggingface_model:
 - url: https://huggingface.co/deepreinforce-ai/Ornith-1.0-9B
 - url: https://huggingface.co/deepreinforce-ai/Ornith-1.0-9B-GGUF
-comments: MIT-licensed open weights (HF tag license:mit), Qwen 3.5 architecture (qwen3_5), released 2026
-  by DeepReinforce. Reported coding benchmarks in the card's model-index are SWE-bench Verified 69.4, SWE-bench
-  Pro 42.9, SWE-bench Multilingual 52.0 and Claw-Eval 63.1; the Terminal-Bench figure the record used to
-  quote is not in the model-index. The repos are now served under the org ornith-ai; the declared
-  deepreinforce-ai URLs still resolve. Verified live 2026-08-13 via the HF model cards.
+comments: MIT-licensed open weights (HF tag license:mit), Qwen 3.5 architecture (qwen3_5), released 2026 by
+  DeepReinforce. Reported coding benchmarks in the card's model-index are SWE-bench Verified 69.4, SWE-bench
+  Pro 42.9, SWE-bench Multilingual 52.0 and Claw-Eval 63.1; the Terminal-Bench figure the record used to quote
+  is not in the model-index. The repos are now served under the org ornith-ai; the declared deepreinforce-ai
+  URLs still resolve. Verified 2026-08-13 via the HF model cards.

--- a/sources/products/perplexity.yaml
+++ b/sources/products/perplexity.yaml
@@ -5,12 +5,11 @@ description: Search-grounded consumer chat product that returns cited answers wi
   on web, mobile, and as a Comet browser. 45M+ MAU and ~$200M ARR with a $21B valuation in 2026; the consumer
   surface (perplexity.ai) is human-driven Q&A, distinct from the Perplexity API (Cat 11) and the agentic
   Comet browser.
-comments: Perplexity consumer AI answer/search chat product (web + apps). Verified live 2026-08-13 via
-  the Business of Apps compilation rather than the vendor - perplexity.ai still returns HTTP 403 to an
-  automated fetch, six attempts on both the home page and the terms page. That compilation gives 45M
-  active users, 80M+ downloads and ~$200M 2025 revenue. Openness and capability were closed on 2026-08-14
-  against docs.perplexity.ai, which is reachable; both now describe the API surface plus what the
-  Wikipedia article carries about the paid tier, which is narrower than the consumer app they used to cite. Proprietary
-  chat UI routing over multiple closed + open models; human-in-the-loop
-  search/answer assistant. Comet browser + Computer agent are adjacent surfaces (agentic, scored elsewhere
-  if at all).
+comments: Perplexity consumer AI answer/search chat product (web + apps). Verified 2026-08-13 via the Business
+  of Apps compilation rather than the vendor - perplexity.ai still returns HTTP 403 to an automated fetch,
+  six attempts on both the home page and the terms page. That compilation gives 45M active users, 80M+ downloads
+  and ~$200M 2025 revenue. Openness and capability were closed on 2026-08-14 against docs.perplexity.ai, which
+  is reachable; both now describe the API surface plus what the Wikipedia article carries about the paid tier,
+  which is narrower than the consumer app they used to cite. Proprietary chat UI routing over multiple closed
+  + open models; human-in-the-loop search/answer assistant. Comet browser + Computer agent are adjacent surfaces
+  (agentic, scored elsewhere if at all).

--- a/sources/products/phi-instruct.yaml
+++ b/sources/products/phi-instruct.yaml
@@ -9,4 +9,4 @@ description: Compact instruction-tuned small language model (3.8B) that scores c
 huggingface_model:
 - url: https://huggingface.co/microsoft/Phi-4-mini-instruct
 comments: Phi-4-mini-instruct, 3.8B dense, 128k context, 200k vocab, GQA; released Feb 2025 under MIT. SFT/DPO-aligned
-  small instruct model. Verified live 2026-08-13 via the HF model card.
+  small instruct model. Verified 2026-08-13 via the HF model card.

--- a/sources/products/qualcomm-dragonwing-rb3-gen-2.yaml
+++ b/sources/products/qualcomm-dragonwing-rb3-gen-2.yaml
@@ -6,10 +6,11 @@ description: A Qualcomm edge AI and IoT development kit built around the QCS6490
   the modular 96Boards form factor and ships with a Qualcomm Linux software stack plus Qualcomm AI Hub,
   Edge Impulse, and Foundries.io support. It is a reference platform for prototyping commercial edge-AI
   products on Qualcomm silicon.
-comments: Verified 2026-08-14 via substitute sources - www.qualcomm.com serves a client-rendered shell to a
-  fetcher, so the description was re-checked against Qualcomm's own product brief 87-74789-1 Rev. A on docs.qualcomm.com,
-  which carries the QCS6490 chipset, Kryo 670 CPU, Adreno 643L GPU, 12 TOPS AI, 96Boards mezzanine compliance
-  and the Linux/Android SDK stack, and against Edge Impulse's board page for the Edge Impulse support claim.
-  Two clauses were NOT re-derived and rest on the earlier read - the QCS5430 variant and Foundries.io support
-  appear in neither substitute. Proprietary Qualcomm silicon with public docs and a Linux SDK, sold through
-  distributors, but the board itself is not fully open hardware.
+comments: Verified live 2026-08-14 via substitute sources - www.qualcomm.com serves a client-rendered
+  shell to a fetcher, so the description was re-checked against Qualcomm's own product brief 87-74789-1
+  Rev. A on docs.qualcomm.com, which carries the QCS6490 chipset, Kryo 670 CPU, Adreno 643L GPU, 12
+  TOPS AI, 96Boards mezzanine compliance and the Linux/Android SDK stack, and against Edge Impulse's
+  board page for the Edge Impulse support claim. Two clauses were NOT re-derived and rest on the
+  earlier read - the QCS5430 variant and Foundries.io support appear in neither substitute.
+  Proprietary Qualcomm silicon with public docs and a Linux SDK, sold through distributors, but the
+  board itself is not fully open hardware.

--- a/sources/products/qualcomm-dragonwing-rb3-gen-2.yaml
+++ b/sources/products/qualcomm-dragonwing-rb3-gen-2.yaml
@@ -6,11 +6,10 @@ description: A Qualcomm edge AI and IoT development kit built around the QCS6490
   the modular 96Boards form factor and ships with a Qualcomm Linux software stack plus Qualcomm AI Hub,
   Edge Impulse, and Foundries.io support. It is a reference platform for prototyping commercial edge-AI
   products on Qualcomm silicon.
-comments: Verified live 2026-08-14 via substitute sources - www.qualcomm.com serves a client-rendered
-  shell to a fetcher, so the description was re-checked against Qualcomm's own product brief 87-74789-1
-  Rev. A on docs.qualcomm.com, which carries the QCS6490 chipset, Kryo 670 CPU, Adreno 643L GPU, 12
-  TOPS AI, 96Boards mezzanine compliance and the Linux/Android SDK stack, and against Edge Impulse's
-  board page for the Edge Impulse support claim. Two clauses were NOT re-derived and rest on the
-  earlier read - the QCS5430 variant and Foundries.io support appear in neither substitute.
-  Proprietary Qualcomm silicon with public docs and a Linux SDK, sold through distributors, but the
-  board itself is not fully open hardware.
+comments: Verified 2026-08-14 via substitute sources - www.qualcomm.com serves a client-rendered shell to a
+  fetcher, so the description was re-checked against Qualcomm's own product brief 87-74789-1 Rev. A on docs.qualcomm.com,
+  which carries the QCS6490 chipset, Kryo 670 CPU, Adreno 643L GPU, 12 TOPS AI, 96Boards mezzanine compliance
+  and the Linux/Android SDK stack, and against Edge Impulse's board page for the Edge Impulse support claim.
+  Two clauses were NOT re-derived and rest on the earlier read - the QCS5430 variant and Foundries.io support
+  appear in neither substitute. Proprietary Qualcomm silicon with public docs and a Linux SDK, sold through
+  distributors, but the board itself is not fully open hardware.

--- a/sources/products/qwen-coder.yaml
+++ b/sources/products/qwen-coder.yaml
@@ -12,6 +12,6 @@ huggingface_model:
 - url: https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct
 - url: https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8
 comments: Consolidated on 2026-07-29 from qwen2-5-coder-instruct; openness follows qwen3-coder, the release
-  that currently governs. See docs/reference/identity.md. The earlier record dated the release 2025-05-14, which
-  the card does not show; the repo's own creation date is 2025-07-22. Verified live 2026-08-13 via the HF
+  that currently governs. See docs/reference/identity.md. The earlier record dated the release 2025-05-14,
+  which the card does not show; the repo's own creation date is 2025-07-22. Verified 2026-08-13 via the HF
   model card.

--- a/sources/products/qwen-instruct.yaml
+++ b/sources/products/qwen-instruct.yaml
@@ -7,5 +7,5 @@ description: Qwen2.5-14B-Instruct (14.7B dense, 48 layers, GQA, 128K context, 29
   general chat SKU; Qwen2.5 release Sep 2024.
 huggingface_model:
 - url: https://huggingface.co/Qwen/Qwen2.5-14B-Instruct
-comments: Qwen2.5-14B-Instruct (14.7B dense, 48 layers, GQA, 128K context, 29+ languages), instruction-tuned general
-  chat SKU; Qwen2.5 release Sep 2024. Verified live 2026-08-13 via the HF model card.
+comments: Qwen2.5-14B-Instruct (14.7B dense, 48 layers, GQA, 128K context, 29+ languages), instruction-tuned
+  general chat SKU; Qwen2.5 release Sep 2024. Verified 2026-08-13 via the HF model card.

--- a/sources/products/scale-seal-leaderboard.yaml
+++ b/sources/products/scale-seal-leaderboard.yaml
@@ -6,7 +6,7 @@ description: Scale AI maintains proprietary evaluation datasets used for its SEA
   prevent contamination and scored by expert annotators. Used by enterprise customers to evaluate models
   before deployment. The commercial alternative to public benchmarks, trading reproducibility for contamination
   resistance.
-comments: Scale AI SEAL Leaderboards (Safety, Evaluations, and Alignment Lab); launched 2024, regularly
-  updated with new domains (instruction-following, math, coding, multilinguality, etc.). The scored artifact
-  is the private held-out eval sets behind the leaderboard. Verified live 2026-08-13 via scale.com/blog/leaderboard,
-  which still states the proprietary datasets remain private and unpublished.
+comments: Scale AI SEAL Leaderboards (Safety, Evaluations, and Alignment Lab); launched 2024, regularly updated
+  with new domains (instruction-following, math, coding, multilinguality, etc.). The scored artifact is the
+  private held-out eval sets behind the leaderboard. Verified 2026-08-13 via scale.com/blog/leaderboard, which
+  still states the proprietary datasets remain private and unpublished.

--- a/sources/products/snorkel-flow.yaml
+++ b/sources/products/snorkel-flow.yaml
@@ -6,11 +6,11 @@ description: 'Snorkel AI''s commercial data-development platform, shipping as ve
   filtering, and fine-tuning/evaluation data workflows. Deployed by the customer rather than consumed as
   a service - the documentation carries an administrator guide covering installation, users, roles and
   permissions.'
-comments: 'Verified live 2026-08-14 via docs.snorkel.ai. RENAMED, NOT RETIRED: the product ships today as
-  the "Snorkel AI Data Development Platform" (v26.1); "Snorkel Flow" is the former name and still labels the
-  archived doc versions. The slug stays `snorkel-flow` because slugs are immutable identities rather than
-  labels - see docs/reference/identity.md - and the rename is carried by display_name and here. A 2026-08-13
-  pass read only the marketing site, where /snorkel-flow/ now 301s to /data-development/ and the copy sells
-  data services, and concluded the platform was gone; the documentation site shows it is not. A vendor
-  reorganising its marketing is not evidence a product has been withdrawn. Distinct from the Apache-2.0
-  snorkel-team/snorkel OSS library, which is stale (last release 0.10.0, Feb 2024) and is not this entry.'
+comments: 'Verified 2026-08-14 via docs.snorkel.ai. RENAMED, NOT RETIRED: the product ships today as the "Snorkel
+  AI Data Development Platform" (v26.1); "Snorkel Flow" is the former name and still labels the archived doc
+  versions. The slug stays `snorkel-flow` because slugs are immutable identities rather than labels - see docs/reference/identity.md
+  - and the rename is carried by display_name and here. A 2026-08-13 pass read only the marketing site, where
+  /snorkel-flow/ now 301s to /data-development/ and the copy sells data services, and concluded the platform
+  was gone; the documentation site shows it is not. A vendor reorganising its marketing is not evidence a product
+  has been withdrawn. Distinct from the Apache-2.0 snorkel-team/snorkel OSS library, which is stale (last release
+  0.10.0, Feb 2024) and is not this entry.'

--- a/sources/products/starcoder2.yaml
+++ b/sources/products/starcoder2.yaml
@@ -6,8 +6,8 @@ description: 'Scored on StarCoder2-15B-Instruct-v0.1 (the instruct SKU; 16B, sel
   base_pretrained; only the instruct variant fits finetuned_chat.'
 huggingface_model:
 - url: https://huggingface.co/bigcode/starcoder2-15b
-comments: 'Scored on StarCoder2-15B-Instruct-v0.1 (the instruct SKU; 16B, self-aligned, released 31 Oct
-  2024, arXiv:2410.24198). NOTE: base StarCoder2-15B (Feb 2024) is a pretrained model belonging in base_pretrained;
-  only the instruct variant fits finetuned_chat. The declared artifact is the base repo, so the computed
-  adoption figure reads the base rather than the scored instruct SKU; both are level 1 either way. Verified
-  live 2026-08-13 via both HF model cards.'
+comments: 'Scored on StarCoder2-15B-Instruct-v0.1 (the instruct SKU; 16B, self-aligned, released 31 Oct 2024,
+  arXiv:2410.24198). NOTE: base StarCoder2-15B (Feb 2024) is a pretrained model belonging in base_pretrained;
+  only the instruct variant fits finetuned_chat. The declared artifact is the base repo, so the computed adoption
+  figure reads the base rather than the scored instruct SKU; both are level 1 either way. Verified 2026-08-13
+  via both HF model cards.'

--- a/sources/products/tinyllama-chat.yaml
+++ b/sources/products/tinyllama-chat.yaml
@@ -9,6 +9,6 @@ description: A 1.1B instruction-tuned chat model from the TinyLlama project, bui
   after release.
 huggingface_model:
 - url: https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0
-comments: 1.1B chat model (Llama 2 architecture), DPO-aligned finetune of TinyLlama-1.1B (pretrained on 3T tokens).
-  Released 2023/early-2024; v1.0. The card publishes no benchmark table, so capability rests on size and
-  architecture rather than a score. Verified live 2026-08-13 via the HF model card.
+comments: 1.1B chat model (Llama 2 architecture), DPO-aligned finetune of TinyLlama-1.1B (pretrained on 3T
+  tokens). Released 2023/early-2024; v1.0. The card publishes no benchmark table, so capability rests on size
+  and architecture rather than a score. Verified 2026-08-13 via the HF model card.

--- a/sources/products/tulu.yaml
+++ b/sources/products/tulu.yaml
@@ -16,7 +16,7 @@ huggingface_model:
 - url: https://huggingface.co/allenai/Llama-3.1-Tulu-3-405B
 huggingface_dataset:
 - url: https://huggingface.co/datasets/allenai/tulu-3-sft-mixture
-comments: Weights under Llama 3.1 Community License (non-OSI); Ai2's post-training data, code, recipe, and eval
-  framework (open-instruct, OLMES) are Apache-2.0. Classed as restricted on the weights license, consistent with
-  how other Llama-Community models are scored. Verified live 2026-08-13 via the HF model cards, the Tulu
-  3 blog and the open-instruct repository.
+comments: Weights under Llama 3.1 Community License (non-OSI); Ai2's post-training data, code, recipe, and
+  eval framework (open-instruct, OLMES) are Apache-2.0. Classed as restricted on the weights license, consistent
+  with how other Llama-Community models are scored. Verified 2026-08-13 via the HF model cards, the Tulu 3
+  blog and the open-instruct repository.

--- a/sources/products/vibethinker.yaml
+++ b/sources/products/vibethinker.yaml
@@ -8,5 +8,4 @@ huggingface_model:
 - url: https://huggingface.co/WeiboAI/VibeThinker-3B
 comments: MIT-licensed weights, but a fine-tune of the open-weight Qwen2.5 line without a fully open data/training
   pipeline -> open_weights, not open_source. Narrow specialist. The adoption axis records reported_traction
-  while a countable Hub artifact exists; flagged for re-banding. Verified live 2026-08-13 via the HF model
-  card.
+  while a countable Hub artifact exists; flagged for re-banding. Verified 2026-08-13 via the HF model card.

--- a/sources/products/zephyr.yaml
+++ b/sources/products/zephyr.yaml
@@ -14,7 +14,6 @@ huggingface_model:
 huggingface_dataset:
 - url: https://huggingface.co/datasets/HuggingFaceH4/ultrachat_200k
 - url: https://huggingface.co/datasets/HuggingFaceH4/ultrafeedback_binarized
-comments: 'Scored on zephyr-7b-beta (MIT; base Mistral-7B Apache-2.0). Fully-open: weights
-  + open DPO datasets (UltraChat/UltraFeedback, MIT) + open training code (alignment-handbook,
-  Apache-2.0). Late-2023 capability. Verified live 2026-08-13 via the HF model card and the
-  alignment-handbook repository.'
+comments: 'Scored on zephyr-7b-beta (MIT; base Mistral-7B Apache-2.0). Fully-open: weights + open DPO datasets
+  (UltraChat/UltraFeedback, MIT) + open training code (alignment-handbook, Apache-2.0). Late-2023 capability.
+  Verified 2026-08-13 via the HF model card and the alignment-handbook repository.'


### PR DESCRIPTION
First slice of the product-prose closeout. Safe half only — the half where nothing has to be re-read.

## The 245 were never unverified

Measured across all 472: **zero products lack a verification line.** Every one carries a dated verification, all in August. The gap `sweep_status` reports is a **formatting** gap, and it splits four ways:

| class | n | shape | fixable by rewording? |
|---|---|---|---|
| canonical | 227 | `Verified <date> via <doc>.` | — |
| **this PR** | **44** | `Verified **live** <date> via <real doc>` | **yes — one word** |
| generic | 172 | names a **method**: `primary sources`, `substitute sources` | **no** |
| other noncanonical | 29 | remaining variants | per-item |

## What this PR does

These 44 already name a document — `amazon-nova` reads *"the AWS Nova user guide and the Nova models page"*, `codegemma` *"the HF model card and Hugging Face's CodeGemma release post"*. Dropping `live` makes them canonical without touching what they claim.

Applied through `components.set_document_field`, which re-renders the field at the corpus width, so each file also reflows the paragraph the word came out of. That is the sanctioned helper — the alternative is a hand splice, which this repo has already shipped a seven-product defect through. Proved mechanically that the reflow is all it is:

```
files: 44
DRIFT: none — every file differs by the single word 'live' and whitespace reflow alone
```

Canonical lines: **227 → 271 of 472.**

## Four products removed from this PR during self-review

It originally covered 48. Four were pulled back out:

```
hailo-10h                      via substitute sources - hailo.ai answers 403 to every request
hailo-8                        via substitute sources - hailo.ai answers 403 ...
nxp-imx-8m-plus                via substitute sources - www.nxp.com answers 404 ...
qualcomm-dragonwing-rb3-gen-2  via substitute sources - www.qualcomm.com serves a client shell
```

Removing `live` would have promoted these **into** canonical form while they name `substitute sources` — a method, or more precisely an account of a method failing. `product-copy.md` forbids it for the same reason it forbids `primary sources`: it leaves the next editor nothing to re-open.

The filter here excluded only trailers beginning `primary sources`, which was narrower than the rule it implemented. The four now go to the evidence-matching pass in #283 with the other generic records. Verified after the revert: **0 canonical-form lines name a method.**

## Why the rest is not a formatting problem

172 products say `Verified live <date> via primary sources`. Rewording cannot repair them — something has to supply the document. That is #283's subject, and none of it is in this PR.

## Test plan

- Every non-`comments` field byte-identical across all 44; `comments` differs by the removed word alone.
- `validate`, `check_payload`, `check_verification` green; `test_product_prose` green.
- Full suite: 581 passed.
- No score file touched — this changes editorial provenance for prose, never a `last_verified`.