### PR TITLE
One owner per vocabulary, and a ratchet against the sibling copy

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Fail on an unrouted retirement
         run: uv run python -m build.check_retirement
       - name: Render notebook
-        run: uv run python build/render.py
+        run: uv run python -m build.render
       - name: Sync README stat badges
         run: uv run python -m build.update_readme
       - name: Notebook structure check

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -138,7 +138,7 @@ jobs:
       # serialized without ever rendering.
       - name: Render notebook and check it parses
         run: |
-          uv run python build/render.py
+          uv run python -m build.render
           uv run python -c "import ast, pathlib; ast.parse(pathlib.Path('notebooks/ai-stack-map.py').read_text()); print('generated notebook parses')"
           uv run marimo check notebooks/ai-stack-map.py
           git checkout -- notebooks/ai-stack-map.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,7 +148,7 @@ hyphenated kebab-case (`llama-3-1`).
 ```bash
 uv run python -m build.validate        # validate sources/ (must print "0 error(s)")
 uv run python -m build.serialize       # sources/ -> build/notebook_data.json
-uv run python build/render.py          # -> notebooks/ai-stack-map.py
+uv run python -m build.render          # -> notebooks/ai-stack-map.py
 uv run marimo export html notebooks/ai-stack-map.py -o /tmp/preview.html
 ```
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ To preview the generated map locally (the output is for preview only — don't c
 
 ```bash
 uv run python -m build.serialize                                          # sources/ → build/notebook_data.json
-uv run python build/render.py                                             # → notebooks/ai-stack-map.py
+uv run python -m build.render                                             # → notebooks/ai-stack-map.py
 uv run marimo export html notebooks/ai-stack-map.py -o /tmp/preview.html
 ```
 

--- a/build/check_freshness.py
+++ b/build/check_freshness.py
@@ -73,10 +73,11 @@ from pathlib import Path
 
 import yaml
 
+from build.vocabulary import axes
 from build.check_rubric import FREE_TEXT, _clauses, components_of
 
 ROOT = Path(__file__).resolve().parents[1]
-AXES = ("openness", "adoption", "capability")
+AXES = axes()  # build/vocabulary.py owns this; the score schema declares it
 
 # `git log --raw` writes this in the old- or new-blob column for an add or a delete.
 NULL_SHA = "0" * 40

--- a/build/check_payload.py
+++ b/build/check_payload.py
@@ -28,8 +28,15 @@ def _is_date(value: object) -> bool:
     A `\d{4}-\d{2}-\d{2}` regex accepts 2026-99-99, which is exactly the class of thing a
     gate claiming to validate a date must not wave through.
     """
+    text = str(value)
+    # Both halves are needed. Shape alone was the original defect — it accepted 2026-99-99.
+    # Parsing alone is also too loose: `date.fromisoformat` takes the compact `20260815` from
+    # Python 3.11, so a second spelling could enter a corpus whose convention, and whose
+    # schema `format: date`, is hyphenated throughout.
+    if len(text) != 10 or text[4] != "-" or text[7] != "-":
+        return False
     try:
-        date.fromisoformat(str(value))
+        date.fromisoformat(text)
     except (TypeError, ValueError):
         return False
     return True

--- a/build/check_payload.py
+++ b/build/check_payload.py
@@ -14,10 +14,12 @@ import sys
 from datetime import date
 from pathlib import Path
 
+from build.vocabulary import axes
+
 ROOT = Path(__file__).resolve().parents[1]
 
 _ALIAS_KINDS = ("products", "organizations")
-_AXES = ("openness", "adoption", "capability")
+_AXES = axes()  # build/vocabulary.py owns this; the score schema declares it
 
 
 def _is_date(value: object) -> bool:

--- a/build/check_refetch.py
+++ b/build/check_refetch.py
@@ -79,8 +79,10 @@ from pathlib import Path
 import requests
 import yaml
 
+from build.vocabulary import axes
+
 ROOT = Path(__file__).resolve().parents[1]
-AXES = ("openness", "adoption", "capability")
+AXES = axes()  # build/vocabulary.py owns this; the score schema declares it
 
 # A real browser-ish UA. Several vendor docs sites answer 403 to the default python-requests
 # string, which would otherwise read as a dead source on every run.

--- a/build/check_verification.py
+++ b/build/check_verification.py
@@ -65,11 +65,12 @@ from pathlib import Path
 
 import yaml
 
+from build.vocabulary import axes
 from build.check_rubric import components_of, license_read_keys, resolve_dimension
 from build.rubrics import load_product_types, load_shared, recipe_for, resolve_recipe_variants
 
 ROOT = Path(__file__).resolve().parents[1]
-AXES = ("openness", "adoption", "capability")
+AXES = axes()  # build/vocabulary.py owns this; the score schema declares it
 
 # Axes exempt from the digest requirement because a digest could not have been recorded when
 # their sources were read. A visible list that shrinks, rather than a date comparison that

--- a/build/freshness_payload.py
+++ b/build/freshness_payload.py
@@ -51,6 +51,7 @@ from pathlib import Path
 
 import yaml
 
+from build.vocabulary import axes
 from build.check_freshness import commit_dates
 
 
@@ -85,7 +86,7 @@ def _commit_dates(root: Path | None) -> dict[str, str]:
     return {slug: d.isoformat() for slug, d in commit_dates(root).items()}
 
 
-AXES = ("openness", "adoption", "capability")
+AXES = axes()  # build/vocabulary.py owns this; the score schema declares it
 
 
 def _axis_dates(root: Path | None) -> dict[str, tuple[dict[str, str], list[str]]]:

--- a/build/propose_artifacts.py
+++ b/build/propose_artifacts.py
@@ -55,10 +55,19 @@ from pathlib import Path
 
 import yaml
 
+from build.vocabulary import artifact_kinds
+
 ROOT = Path(__file__).resolve().parents[1]
 USER_AGENT = "os-ai-map-artifact-proposer/1.0"
 
-VERIFIABLE_KINDS = ("github", "huggingface_model", "huggingface_dataset", "pypi", "npm", "crates")
+# Derived from the routing table rather than restated. `arxiv` IS declared there (via
+# `semanticscholar`, whose `artifact_key` is `arxiv`) and is deliberately excluded here: this
+# constant answers "does the product already carry an artifact a proposal would target", and a
+# paper id is not a distribution artifact. Whether it should count is a curation question
+# rather than a sweep one, raised as its own issue. Writing the exclusion down keeps it a
+# decision instead of the silent drift it previously looked like.
+NOT_A_DISTRIBUTION_ARTIFACT = frozenset({"arxiv"})
+VERIFIABLE_KINDS = tuple(sorted(artifact_kinds() - NOT_A_DISTRIBUTION_ARTIFACT))
 
 # Hugging Face path segments that are not a model id. Without these, a docs or blog
 # link becomes a confident-looking candidate.

--- a/build/propose_artifacts.py
+++ b/build/propose_artifacts.py
@@ -60,14 +60,25 @@ from build.vocabulary import artifact_kinds
 ROOT = Path(__file__).resolve().parents[1]
 USER_AGENT = "os-ai-map-artifact-proposer/1.0"
 
-# Derived from the routing table rather than restated. `arxiv` IS declared there (via
-# `semanticscholar`, whose `artifact_key` is `arxiv`) and is deliberately excluded here: this
-# constant answers "does the product already carry an artifact a proposal would target", and a
-# paper id is not a distribution artifact. Whether it should count is a curation question
-# rather than a sweep one, raised as its own issue. Writing the exclusion down keeps it a
-# decision instead of the silent drift it previously looked like.
+# What this proposer can actually handle, defined by the three behaviors a kind needs to be
+# proposed at all: a URL pattern to mine it out of prose, a live existence check, and a public
+# URL to render. Derived from those handlers rather than from the routing table.
+#
+# The distinction matters and the first cut got it wrong. Deriving from
+# `signal_routing.yaml` made a NEW `artifact_key` an accepted `--kind` the moment somebody
+# declared a source — with no pattern, no verifier and no renderer behind it, so the proposer
+# would accept a flag it cannot service. The two sets are equal today, which is exactly what
+# made the coincidence look like a definition.
+def _supported_kinds() -> tuple[str, ...]:
+    patterned = {kind for kind, _ in PATTERNS}
+    renderable = set(_PUBLIC_URL)
+    return tuple(sorted(patterned & renderable & _VERIFIABLE))
+
+
+# `arxiv` is routed (via `semanticscholar`) and deliberately unsupported here: this tool
+# proposes DISTRIBUTION artifacts, and a paper id is not one. Kept as a named exclusion so the
+# subset check below stays meaningful rather than vacuous.
 NOT_A_DISTRIBUTION_ARTIFACT = frozenset({"arxiv"})
-VERIFIABLE_KINDS = tuple(sorted(artifact_kinds() - NOT_A_DISTRIBUTION_ARTIFACT))
 
 # Hugging Face path segments that are not a model id. Without these, a docs or blog
 # link becomes a confident-looking candidate.
@@ -243,6 +254,12 @@ def check_token(gh_token: str | None) -> str | None:
     return None
 
 
+# The kinds `verify` implements a live existence check for. Named rather than inferred, so a
+# new branch there has to be declared here to count as supported.
+_VERIFIABLE = frozenset({"github", "huggingface_model", "huggingface_dataset",
+                         "pypi", "npm", "crates"})
+
+
 def verify(kind: str, ident: str, gh_token: str | None, hf_token: str | None) -> int:
     """Live existence check. Returns the HTTP status, 0 on transport failure."""
     if kind == "github":
@@ -260,15 +277,18 @@ def verify(kind: str, ident: str, gh_token: str | None, hf_token: str | None) ->
     return 0
 
 
+_PUBLIC_URL = {
+    "github": "https://github.com/{ident}",
+    "huggingface_model": "https://huggingface.co/{ident}",
+    "huggingface_dataset": "https://huggingface.co/datasets/{ident}",
+    "pypi": "https://pypi.org/project/{ident}",
+    "npm": "https://www.npmjs.com/package/{ident}",
+    "crates": "https://crates.io/crates/{ident}",
+}
+
+
 def public_url(kind: str, ident: str) -> str:
-    return {
-        "github": f"https://github.com/{ident}",
-        "huggingface_model": f"https://huggingface.co/{ident}",
-        "huggingface_dataset": f"https://huggingface.co/datasets/{ident}",
-        "pypi": f"https://pypi.org/project/{ident}",
-        "npm": f"https://www.npmjs.com/package/{ident}",
-        "crates": f"https://crates.io/crates/{ident}",
-    }[kind]
+    return _PUBLIC_URL[kind].format(ident=ident)
 
 
 def load_env() -> tuple[str | None, str | None]:
@@ -288,6 +308,9 @@ def load_env() -> tuple[str | None, str | None]:
             if key in ("HF_TOKEN", "HUGGING_FACE_TOKEN") and not hf:
                 hf = value
     return gh, hf
+
+
+VERIFIABLE_KINDS = _supported_kinds()
 
 
 def main() -> int:

--- a/build/prose_provenance.py
+++ b/build/prose_provenance.py
@@ -58,8 +58,10 @@ from pathlib import Path
 
 import yaml
 
+from build.vocabulary import axes
+
 ROOT = Path(__file__).resolve().parents[1]
-AXES = ("openness", "adoption", "capability")
+AXES = axes()  # build/vocabulary.py owns this; the score schema declares it
 
 CANONICAL = re.compile(r"Verified (\d{4}-\d{2}-\d{2}) via ")
 # Any dated verification, however it is worded. The corpus carries `Verified live <date> via`,

--- a/build/render.py
+++ b/build/render.py
@@ -7,7 +7,6 @@ import markdown
 import re
 import yaml
 
-from build.vocabulary import axes
 from pathlib import Path
 
 # Repo root is the parent of build/. Read the serialized payload from
@@ -70,7 +69,13 @@ def _methodology_numbers(d):
     _urls = [
         s.get("url")
         for p in _prods
-        for _axis in axes()
+        # NOT build.vocabulary.axes(). render.py is the one build module invoked as a
+        # SCRIPT (`uv run python build/render.py`, in validate.yml, regenerate.yml and
+        # docs/operations/publish-map.md), which puts build/ on sys.path instead of the repo
+        # root, so it cannot import from the package. Switching the invocation to `-m` is the
+        # real fix and is its own change — it touches the publish runbook. Exempted
+        # explicitly in tests/test_vocabulary_siblings.py so this stays a decision.
+        for _axis in ("openness", "adoption", "capability")
         for s in ((p.get(_axis) or {}).get("sources") or [])
         if s.get("url")
     ]

--- a/build/render.py
+++ b/build/render.py
@@ -6,6 +6,8 @@ import json
 import markdown
 import re
 import yaml
+
+from build.vocabulary import axes
 from pathlib import Path
 
 # Repo root is the parent of build/. Read the serialized payload from
@@ -68,7 +70,7 @@ def _methodology_numbers(d):
     _urls = [
         s.get("url")
         for p in _prods
-        for _axis in ("openness", "adoption", "capability")
+        for _axis in axes()
         for s in ((p.get(_axis) or {}).get("sources") or [])
         if s.get("url")
     ]

--- a/build/render.py
+++ b/build/render.py
@@ -7,6 +7,8 @@ import markdown
 import re
 import yaml
 
+from build.vocabulary import axes
+
 from pathlib import Path
 
 # Repo root is the parent of build/. Read the serialized payload from
@@ -69,13 +71,7 @@ def _methodology_numbers(d):
     _urls = [
         s.get("url")
         for p in _prods
-        # NOT build.vocabulary.axes(). render.py is the one build module invoked as a
-        # SCRIPT (`uv run python build/render.py`, in validate.yml, regenerate.yml and
-        # docs/operations/publish-map.md), which puts build/ on sys.path instead of the repo
-        # root, so it cannot import from the package. Switching the invocation to `-m` is the
-        # real fix and is its own change — it touches the publish runbook. Exempted
-        # explicitly in tests/test_vocabulary_siblings.py so this stays a decision.
-        for _axis in ("openness", "adoption", "capability")
+        for _axis in axes()
         for s in ((p.get(_axis) or {}).get("sources") or [])
         if s.get("url")
     ]

--- a/build/repair_placeholder_shows.py
+++ b/build/repair_placeholder_shows.py
@@ -43,6 +43,8 @@ from pathlib import Path
 
 import yaml
 
+from build.vocabulary import axes
+
 from build.components import set_source
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -242,7 +244,7 @@ def remaining() -> list[tuple[str, str, str]]:
     out = []
     for path in sorted((ROOT / "sources" / "scores").glob("*.yaml")):
         score = yaml.safe_load(path.read_text()) or {}
-        for axis in ("openness", "adoption", "capability"):
+        for axis in axes():
             for source in ((score.get(axis) or {}).get("sources") or []):
                 if source.get("shows") == PLACEHOLDER:
                     out.append((path.stem, axis, source.get("url", "?")))

--- a/build/serialize_rubric.py
+++ b/build/serialize_rubric.py
@@ -66,6 +66,7 @@ from pathlib import Path
 
 import yaml
 
+from build.vocabulary import axes
 from build.check_rubric import (
     components_of,
     dimension_read_map,
@@ -83,7 +84,7 @@ from build.validate import load_sources
 ROOT = Path(__file__).resolve().parents[1]
 OUT_DIR = ROOT / "build" / "registry"
 
-AXES = ("openness", "adoption", "capability")
+AXES = axes()  # build/vocabulary.py owns this; the score schema declares it
 
 # `license_tier()` in check_rubric defines the proprietary tier by MEANING rather
 # than by an example list, because no vendor publishes a license called

--- a/build/sweep_status.py
+++ b/build/sweep_status.py
@@ -59,8 +59,10 @@ from pathlib import Path
 
 import yaml
 
+from build.vocabulary import axes
+
 ROOT = Path(__file__).resolve().parents[1]
-AXES = ("openness", "adoption", "capability")
+AXES = axes()  # build/vocabulary.py owns this; the score schema declares it
 VALUE_KEY = {"openness": "score", "adoption": "level", "capability": "score"}
 ARTIFACTS = ("github", "pypi", "npm", "crates", "huggingface_model", "huggingface_dataset")
 VERIFIED_LINE = re.compile(r"Verified (\d{4}-\d{2}-\d{2}) via ")

--- a/build/validate.py
+++ b/build/validate.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import jsonschema
 import yaml
 
+from build.vocabulary import axes
+
 from build.rubrics import dimension_vocabulary
 
 # Maps each sources/ subdir to its docs/schemas/<name>.schema.json basename.
@@ -222,7 +224,7 @@ def validate_sources(data: dict) -> list[str]:
     vocabulary = dimension_vocabulary(cats, data.get("rubrics") or {})
     if vocabulary:
         for slug, score in sorted(scores.items()):
-            for axis in ("openness", "adoption", "capability"):
+            for axis in axes():
                 for source in (score.get(axis) or {}).get("sources") or []:
                     if not isinstance(source, dict):
                         continue
@@ -245,7 +247,7 @@ def validate_sources(data: dict) -> list[str]:
     # the very guard meant to preserve real checks.
     today = date.today()
     for slug, score in sorted(scores.items()):
-        for axis in ("openness", "adoption", "capability"):
+        for axis in axes():
             block = score.get(axis) or {}
             candidates = [("last_verified", block.get("last_verified"))]
             for source in block.get("sources") or []:

--- a/build/vocabulary.py
+++ b/build/vocabulary.py
@@ -1,0 +1,72 @@
+"""The one owner for vocabularies more than one module needs.
+
+Every entry here was a literal repeated across `build/`, and this repo has now shipped four
+defects of exactly that shape in a fortnight — a sibling copy that had quietly fallen behind
+the thing it mirrored:
+
+  * `check_routing.SOURCE_ARTIFACT` named five sources where the routing table declared
+    seven, so a bridged `npm`/`crates` route would have read as uncovered;
+  * `check_routing.artifacts_of` enumerated the same vocabulary a second time in the same
+    file, so a correctly declared new kind was invisible to coverage;
+  * `apply_provenance` reimplemented `prose_provenance.METHOD_WORDS` more narrowly, so
+    `substitute sources` passed as a document name;
+  * `check_payload` and `apply_provenance` each validated a date by shape, accepting
+    `2026-99-99`.
+
+None of them failed loudly. Each reported success over a narrower question than the one it
+claimed to answer, which is the failure mode this module exists to stop repeating.
+
+**The rule: a vocabulary that already has a declarative owner is derived from it, not
+copied.** The score schema declares the axes; `sources/signal_routing.yaml` declares the
+artifact kinds. Where a literal genuinely differs from its declarative source, the difference
+is written down and tested, so it is a decision rather than drift.
+
+## What is deliberately NOT here
+
+`docs/openness-class-map.json` and its two in-code copies stay where they are. They are
+already gated by `tests/test_openness_buckets.py`, which asserts all three agree — that is the
+same protection this module provides, arrived at differently, and moving them would churn a
+working invariant for symmetry.
+
+`check_adoption._DOWNLOAD_INSTRUMENTS` also stays. It is not a copy of the `signal_type` enum;
+it names the subset measured on a download scale, and its module explains why `unknown` is
+excluded. A narrower vocabulary with a written reason is a decision, not a duplicate.
+"""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@lru_cache(maxsize=1)
+def axes() -> tuple[str, ...]:
+    """The three scored axes, from `docs/schemas/score.schema.json`.
+
+    The schema is the declarative owner: it lists them as properties and requires all three.
+    Seven modules held this triple as a literal. None had drifted — a fourth axis has never
+    been added — but a fourth axis is exactly the change that would silently narrow seven
+    denominators at once, and a walk that quietly skips an axis passes green.
+    """
+    schema = json.loads((ROOT / "docs" / "schemas" / "score.schema.json").read_text())
+    return tuple(k for k in schema["properties"] if k != "product")
+
+
+@lru_cache(maxsize=1)
+def artifact_kinds() -> frozenset[str]:
+    """Product artifact keys any routing source declares it consumes, via `artifact_key`.
+
+    A SOURCE (`semanticscholar`) and an ARTIFACT KEY (`arxiv`) are different layers, and
+    conflating them is what made `arxiv` look undeclared while the router already reached it.
+    """
+    routing = yaml.safe_load((ROOT / "sources" / "signal_routing.yaml").read_text())
+    return frozenset(
+        source["artifact_key"]
+        for source in (routing.get("sources") or {}).values()
+        if source.get("artifact_key")
+    )

--- a/build/vocabulary.py
+++ b/build/vocabulary.py
@@ -49,8 +49,9 @@ def axes() -> tuple[str, ...]:
     """The three scored axes, from `docs/schemas/score.schema.json`.
 
     The schema is the declarative owner: it lists them as properties and requires all three.
-    Seven modules held this triple as a literal. None had drifted — a fourth axis has never
-    been added — but a fourth axis is exactly the change that would silently narrow seven
+    Ten modules held this triple as a literal — seven as a named constant and three inline,
+    including `validate.py`, the schema gate itself. None had drifted, because no fourth axis
+    has ever been added; a fourth axis is also exactly the change that would narrow ten
     denominators at once, and a walk that quietly skips an axis passes green.
     """
     schema = json.loads((ROOT / "docs" / "schemas" / "score.schema.json").read_text())

--- a/docs/operations/publish-map.md
+++ b/docs/operations/publish-map.md
@@ -3,7 +3,7 @@
 1. On `main`, the regenerate workflow has already rebuilt `build/notebook_data.json`
    and `notebooks/ai-stack-map.py` as a bot commit; `git pull` and publish those.
    Rebuild locally only to verify (`uv run python -m build.serialize --date <bot date>
-   && uv run python build/render.py` must produce no diff).
+   && uv run python -m build.render` must produce no diff).
 2. Validate: `uv run python -m build.validate` (must be clean) and
    `uv run marimo check notebooks/ai-stack-map.py`.
 3. Visual sign-off on the exported HTML before publishing (no browser in-container —

--- a/docs/reference/sibling-invariants.md
+++ b/docs/reference/sibling-invariants.md
@@ -38,28 +38,19 @@ and tested, so it stays a decision instead of becoming drift.
     - build/check_payload.py
     - build/validate.py          # inline, in the schema gate itself
     - build/repair_placeholder_shows.py  # inline
+    - build/render.py            # inline
   risk: >-
     A fourth axis narrows ten denominators at once, and a walk that quietly skips an axis
     passes green. None had drifted — no axis has ever been added — so this is the one entry
     fixed before it failed rather than after.
+
+    render.py was briefly EXEMPTED here because it was the only build module invoked as a
+    script, so it could not import from the package. That exemption was unsound: a fourth
+    axis would have left the rendered methodology silently omitting its sources while every
+    other test passed, which is the very defect this entry is about. The invocation moved to
+    `-m` instead — two workflows and three docs — and the exemption is gone.
   disposition: fixed
   regression_test: test_no_module_holds_a_private_copy_of_the_axes
-
-- construct: vocabulary — the three scored axes, in the one script-invoked module
-  canonical_owner: docs/schemas/score.schema.json (via build/vocabulary.axes)
-  duplicates:
-    - build/render.py            # inline, EXEMPT
-  risk: >-
-    render.py is the only build module run as `uv run python build/render.py` rather than
-    with `-m` — in validate.yml, regenerate.yml and docs/operations/publish-map.md — which
-    puts build/ on sys.path instead of the repo root, so it cannot import from the package.
-    Deriving it here broke CI with `ModuleNotFoundError: No module named 'build'`, which is
-    how the exemption was found. Switching the invocation to `-m` is the real fix and is its
-    own change, because it touches the publish runbook.
-  disposition: intentionally_distinct
-  regression_test: >-
-    test_the_only_exemption_is_the_script_invoked_module — asserts render.py is still
-    script-invoked, so the exemption expires automatically if that changes.
 
 - construct: vocabulary — product artifact kinds
   canonical_owner: sources/signal_routing.yaml `artifact_key` (via build/vocabulary.artifact_kinds)
@@ -67,11 +58,15 @@ and tested, so it stays a decision instead of becoming drift.
     - build/propose_artifacts.py  # VERIFIABLE_KINDS, already missing arxiv
   risk: >-
     Already divergent. The same construct as the two check_routing defects, in a third module.
-    Deriving it changes no behavior: `arxiv` is excluded explicitly, because this constant
-    asks "does the product carry an artifact a proposal would target" and a paper id is not a
-    distribution artifact. Whether it should count is a curation question, raised separately.
+
+    The first fix derived it FROM the routing table, which was wrong in the other direction:
+    a newly declared `artifact_key` would have become an accepted `--kind` with no URL
+    pattern, no live check and no renderer behind it. Routed and proposable are different
+    questions, and the two sets being equal today is what made the coincidence look like a
+    definition. Support is now defined by the three handlers a kind needs, and asserted to be
+    an intentional subset of routed kinds with `arxiv` the named gap.
   disposition: fixed
-  regression_test: test_verifiable_kinds_are_derived_with_an_explicit_exclusion
+  regression_test: test_proposer_support_is_defined_by_handlers_not_by_routing
 
 - construct: vocabulary — capability `relation`
   canonical_owner: docs/schemas/score.schema.json
@@ -105,7 +100,13 @@ and tested, so it stays a decision instead of becoming drift.
     on that field is validating a date. The same defect appeared in two modules three days
     apart, the second written after the first was fixed.
   disposition: fixed
-  regression_test: test_dates_are_parsed_not_shape_matched
+  regression_test: >-
+    test_check_payload_rejects_impossible_dates and
+    test_apply_provenance_rejects_impossible_dates — behavioral, calling the validator rather
+    than grepping for `fromisoformat`. The check now requires BOTH the hyphenated shape and a
+    successful parse: shape alone accepted 2026-99-99, and parse alone accepts the compact
+    `20260815` from Python 3.11, which would put a second date spelling into a corpus whose
+    schema declares `format: date`.
 
 - construct: openness class → bucket map
   canonical_owner: docs/openness-class-map.json

--- a/docs/reference/sibling-invariants.md
+++ b/docs/reference/sibling-invariants.md
@@ -37,7 +37,6 @@ and tested, so it stays a decision instead of becoming drift.
     - build/sweep_status.py
     - build/check_payload.py
     - build/validate.py          # inline, in the schema gate itself
-    - build/render.py            # inline
     - build/repair_placeholder_shows.py  # inline
   risk: >-
     A fourth axis narrows ten denominators at once, and a walk that quietly skips an axis
@@ -45,6 +44,22 @@ and tested, so it stays a decision instead of becoming drift.
     fixed before it failed rather than after.
   disposition: fixed
   regression_test: test_no_module_holds_a_private_copy_of_the_axes
+
+- construct: vocabulary — the three scored axes, in the one script-invoked module
+  canonical_owner: docs/schemas/score.schema.json (via build/vocabulary.axes)
+  duplicates:
+    - build/render.py            # inline, EXEMPT
+  risk: >-
+    render.py is the only build module run as `uv run python build/render.py` rather than
+    with `-m` — in validate.yml, regenerate.yml and docs/operations/publish-map.md — which
+    puts build/ on sys.path instead of the repo root, so it cannot import from the package.
+    Deriving it here broke CI with `ModuleNotFoundError: No module named 'build'`, which is
+    how the exemption was found. Switching the invocation to `-m` is the real fix and is its
+    own change, because it touches the publish runbook.
+  disposition: intentionally_distinct
+  regression_test: >-
+    test_the_only_exemption_is_the_script_invoked_module — asserts render.py is still
+    script-invoked, so the exemption expires automatically if that changes.
 
 - construct: vocabulary — product artifact kinds
   canonical_owner: sources/signal_routing.yaml `artifact_key` (via build/vocabulary.artifact_kinds)

--- a/docs/reference/sibling-invariants.md
+++ b/docs/reference/sibling-invariants.md
@@ -1,0 +1,146 @@
+# Sibling invariants
+
+A record of every place in `build/` where the same fact was stated twice, and what was done
+about each. Written 2026-08-15 after four defects of that exact shape shipped in a fortnight.
+
+## Why this exists
+
+None of the four failed loudly. Each reported success over a **narrower question than the one
+it claimed to answer**:
+
+| defect | the narrower question it actually answered |
+|---|---|
+| `check_routing.SOURCE_ARTIFACT` named five sources; the table declared seven | "is this one of the five sources I know about?" |
+| `check_routing.artifacts_of` enumerated the same vocabulary again, in the same file | "does the product declare one of seven hardcoded keys?" |
+| `apply_provenance` reimplemented `METHOD_WORDS` more narrowly | "is this document name one of three forbidden phrases?" |
+| `check_payload` and `apply_provenance` each validated a date by shape | "does this string look like a date?" |
+
+Three were found by review rather than by any gate, and the fourth was found only because the
+third was. The pattern is not carelessness about a particular constant — it is that a fix gets
+applied to the instance in front of the author and the sibling is never searched for.
+
+**The rule this settles on: a vocabulary with a declarative owner is derived from it, never
+copied.** Where a literal genuinely differs from its source, the difference is written down
+and tested, so it stays a decision instead of becoming drift.
+
+## Inventory
+
+```yaml
+- construct: vocabulary — the three scored axes
+  canonical_owner: docs/schemas/score.schema.json (via build/vocabulary.axes)
+  duplicates:
+    - build/check_freshness.py
+    - build/check_refetch.py
+    - build/check_verification.py
+    - build/freshness_payload.py
+    - build/serialize_rubric.py
+    - build/sweep_status.py
+    - build/check_payload.py
+    - build/validate.py          # inline, in the schema gate itself
+    - build/render.py            # inline
+    - build/repair_placeholder_shows.py  # inline
+  risk: >-
+    A fourth axis narrows ten denominators at once, and a walk that quietly skips an axis
+    passes green. None had drifted — no axis has ever been added — so this is the one entry
+    fixed before it failed rather than after.
+  disposition: fixed
+  regression_test: test_no_module_holds_a_private_copy_of_the_axes
+
+- construct: vocabulary — product artifact kinds
+  canonical_owner: sources/signal_routing.yaml `artifact_key` (via build/vocabulary.artifact_kinds)
+  duplicates:
+    - build/propose_artifacts.py  # VERIFIABLE_KINDS, already missing arxiv
+  risk: >-
+    Already divergent. The same construct as the two check_routing defects, in a third module.
+    Deriving it changes no behavior: `arxiv` is excluded explicitly, because this constant
+    asks "does the product carry an artifact a proposal would target" and a paper id is not a
+    distribution artifact. Whether it should count is a curation question, raised separately.
+  disposition: fixed
+  regression_test: test_verifiable_kinds_are_derived_with_an_explicit_exclusion
+
+- construct: vocabulary — capability `relation`
+  canonical_owner: docs/schemas/score.schema.json
+  duplicates:
+    - build/check_capability.py   # DELTA
+  risk: >-
+    DELTA maps each relation to an integer offset, which the schema cannot express, so the
+    dict stays. What it must not do is disagree about which relations EXIST: a relation in the
+    schema but missing from DELTA is accepted by validate and raises in the gate.
+  disposition: intentionally_distinct
+  regression_test: test_capability_relation_deltas_match_the_schema_enum
+
+- construct: vocabulary — the method words a provenance line may not name
+  canonical_owner: build/prose_provenance.py METHOD_WORDS
+  duplicates:
+    - build/apply_provenance.py   # fixed in #283
+  risk: >-
+    The sibling was narrower and let `substitute sources` through as a document name — the
+    exact phrase behind four hardware records that a rewording pass nearly promoted into
+    canonical form.
+  disposition: fixed
+  regression_test: test_the_method_vocabulary_has_exactly_one_definition
+
+- construct: date validation
+  canonical_owner: datetime.date.fromisoformat
+  duplicates:
+    - build/check_payload.py      # fixed
+    - build/apply_provenance.py   # fixed in #283
+  risk: >-
+    A `\d{4}-\d{2}-\d{2}` regex accepts 2026-99-99 and 2026-02-30 in a check whose stated job
+    on that field is validating a date. The same defect appeared in two modules three days
+    apart, the second written after the first was fixed.
+  disposition: fixed
+  regression_test: test_dates_are_parsed_not_shape_matched
+
+- construct: openness class → bucket map
+  canonical_owner: docs/openness-class-map.json
+  duplicates:
+    - build/serialize.py          # _GAP_OPEN / _GAP_OPENISH
+    - build/render.py             # _OPEN
+  risk: >-
+    A divergence would make the gap stage disagree with the published bucket, silently.
+  disposition: intentionally_distinct
+  regression_test: >-
+    tests/test_openness_buckets.py already asserts all three copies agree. That is the same
+    protection this sweep adds elsewhere, arrived at first; moving the constants would churn a
+    working invariant for symmetry.
+
+- construct: adoption instrument subset
+  canonical_owner: none — not a copy
+  duplicates:
+    - build/check_adoption.py     # _DOWNLOAD_INSTRUMENTS
+  risk: none
+  disposition: intentionally_distinct
+  regression_test: >-
+    Not a mirror of the signal_type enum. It names the subset measured on a download scale,
+    and the module states why `unknown` is excluded. A narrower vocabulary with a written
+    reason is a decision, not a duplicate.
+
+- construct: status/exit derived from fewer conditions than the printed report
+  canonical_owner: n/a
+  duplicates:
+    - build/check_instrument.py   # fixed in #276
+  risk: >-
+    `--strict` printed an unattributed-figure violation, followed it with `[OK]`, and exited
+    0. Every other checker was read: `check_verification` iterates all gates so its exit
+    covers everything it prints, and `check_rubric`'s non-gating lines are marked `~` with a
+    written reason. No further instances.
+  disposition: fixed
+  regression_test: test_strict_exits_nonzero_on_an_unattributed_figure
+
+- construct: malformed or unknown input becoming a pass
+  canonical_owner: n/a
+  duplicates: []
+  risk: >-
+    Swept and clean. The three `except` paths in build/ each record the failure — `False`, an
+    `unreachable` list, or an error — rather than falling through to success.
+  disposition: intentionally_distinct
+  regression_test: none needed
+```
+
+## What was deliberately not done
+
+No new abstraction for the sake of deduplication. `build/vocabulary.py` holds two functions,
+both deriving from a file that already owns the fact. Constants that are genuinely local, or
+that already have a working gate, were left where they are — noted above with the reason, so
+the next sweep does not rediscover them as findings.

--- a/tests/test_vocabulary_siblings.py
+++ b/tests/test_vocabulary_siblings.py
@@ -38,15 +38,30 @@ def test_axes_come_from_the_schema():
 def test_no_module_holds_a_private_copy_of_the_axes():
     """Seven modules did. A fourth axis would have silently narrowed seven denominators at
     once, and a walk that quietly skips an axis passes green."""
+    # render.py is the one build module invoked as a SCRIPT rather than with `-m`, so it
+    # cannot import from the package. The exemption is asserted below rather than merely
+    # allowed, so adding a second one is a visible decision.
+    exempt = {"vocabulary.py", "render.py"}
     offenders = []
     for path in sorted((ROOT / "build").glob("*.py")):
-        if path.name == "vocabulary.py":
+        if path.name in exempt:
             continue
         if AXES_LITERAL.search(path.read_text()):
             offenders.append(path.name)
     assert not offenders, (
         "these define the axis triple as a literal instead of importing "
         f"build.vocabulary.axes(): {offenders}"
+    )
+
+
+def test_the_only_exemption_is_the_script_invoked_module():
+    """If render.py ever moves to `-m`, this fails and the exemption comes out."""
+    workflows = " ".join(
+        p.read_text() for p in (ROOT / ".github" / "workflows").glob("*.yml")
+    )
+    assert "python build/render.py" in workflows, (
+        "render.py no longer appears to be script-invoked; drop its exemption in "
+        "test_no_module_holds_a_private_copy_of_the_axes and import axes() there"
     )
 
 

--- a/tests/test_vocabulary_siblings.py
+++ b/tests/test_vocabulary_siblings.py
@@ -10,14 +10,17 @@ each reported success over a narrower question than the one it claimed to answer
     passed as a document name;
   * `check_payload` and `apply_provenance` each validated a date by shape.
 
-These tests are the ratchet. They do not stop a module defining a constant; they stop one
-defining a constant that silently disagrees with the source of truth.
+**These tests inspect the AST and call the code, not the source text.** The first cut matched
+strings — a double-quoted tuple in one exact order, a bare `NAME =` assignment, the substring
+`fromisoformat` anywhere in a file — which reproduced the governing defect one level up: a
+check reporting a semantic guarantee while testing a textual convention. A single-quoted list,
+an annotated assignment, or a reordering would all have passed.
 """
 
 from __future__ import annotations
 
+import ast
 import json
-import re
 from pathlib import Path
 
 import pytest
@@ -25,7 +28,41 @@ import yaml
 
 from build.vocabulary import ROOT, artifact_kinds, axes
 
-AXES_LITERAL = re.compile(r'\(\s*"openness"\s*,\s*"adoption"\s*,\s*"capability"\s*\)')
+BUILD = ROOT / "build"
+
+
+def _module_sources() -> dict[str, str]:
+    return {p.name: p.read_text() for p in sorted(BUILD.glob("*.py"))}
+
+
+def _string_collections(tree: ast.AST) -> list[tuple[int, frozenset[str]]]:
+    """Every literal tuple/list/set of plain strings, as (lineno, frozenset).
+
+    Structure rather than spelling: quote style, ordering and container type all normalize
+    away, which is what makes this a check on the vocabulary rather than on its formatting.
+    """
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Tuple, ast.List, ast.Set)):
+            continue
+        values = [
+            e.value for e in node.elts
+            if isinstance(e, ast.Constant) and isinstance(e.value, str)
+        ]
+        if values and len(values) == len(node.elts):
+            found.append((getattr(node, "lineno", 0), frozenset(values)))
+    return found
+
+
+def _assigned_names(tree: ast.AST) -> set[str]:
+    """Module-level names bound by assignment, including annotated ones."""
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            names.update(t.id for t in node.targets if isinstance(t, ast.Name))
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            names.add(node.target.id)
+    return names
 
 
 def test_axes_come_from_the_schema():
@@ -36,40 +73,43 @@ def test_axes_come_from_the_schema():
 
 
 def test_no_module_holds_a_private_copy_of_the_axes():
-    """Seven modules did. A fourth axis would have silently narrowed seven denominators at
-    once, and a walk that quietly skips an axis passes green."""
-    # render.py is the one build module invoked as a SCRIPT rather than with `-m`, so it
-    # cannot import from the package. The exemption is asserted below rather than merely
-    # allowed, so adding a second one is a visible decision.
-    exempt = {"vocabulary.py", "render.py"}
+    """Ten modules did, seven as constants and three inline — including `validate.py`.
+
+    Matched on the SET of strings, so a reordered tuple, a list, a set, or single quotes are
+    all caught. The earlier regex required one exact spelling and would have missed every one
+    of those.
+    """
+    wanted = frozenset(axes())
     offenders = []
-    for path in sorted((ROOT / "build").glob("*.py")):
-        if path.name in exempt:
+    for name, source in _module_sources().items():
+        if name == "vocabulary.py":
             continue
-        if AXES_LITERAL.search(path.read_text()):
-            offenders.append(path.name)
+        for lineno, values in _string_collections(ast.parse(source)):
+            if values == wanted:
+                offenders.append(f"{name}:{lineno}")
     assert not offenders, (
-        "these define the axis triple as a literal instead of importing "
+        "these state the axis vocabulary literally instead of calling "
         f"build.vocabulary.axes(): {offenders}"
     )
 
 
-def test_the_only_exemption_is_the_script_invoked_module():
-    """If render.py ever moves to `-m`, this fails and the exemption comes out."""
-    workflows = " ".join(
-        p.read_text() for p in (ROOT / ".github" / "workflows").glob("*.yml")
+def test_render_is_importable_so_it_needs_no_exemption():
+    """render.py was exempted while it was script-invoked, and the exemption was unsound: a
+    fourth axis would have left the rendered methodology silently omitting its sources while
+    every other test passed. The invocation moved to `-m` instead of the exemption staying."""
+    workflows = " ".join(p.read_text() for p in (ROOT / ".github" / "workflows").glob("*.yml"))
+    docs = " ".join(
+        (ROOT / f).read_text() for f in ("AGENTS.md", "README.md", "docs/operations/publish-map.md")
     )
-    assert "python build/render.py" in workflows, (
-        "render.py no longer appears to be script-invoked; drop its exemption in "
-        "test_no_module_holds_a_private_copy_of_the_axes and import axes() there"
+    assert "python build/render.py" not in workflows + docs, (
+        "render.py is script-invoked again, so it cannot import build.vocabulary and the "
+        "axis vocabulary will silently fork"
     )
 
 
 def test_artifact_kinds_come_from_the_routing_table():
     routing = yaml.safe_load((ROOT / "sources" / "signal_routing.yaml").read_text())
-    declared = {
-        s["artifact_key"] for s in routing["sources"].values() if s.get("artifact_key")
-    }
+    declared = {s["artifact_key"] for s in routing["sources"].values() if s.get("artifact_key")}
     assert artifact_kinds() == declared
     # The layering the first cut of #184 got wrong: a source and an artifact key are
     # different things, and one source may consume a key that shares no name with it.
@@ -77,13 +117,30 @@ def test_artifact_kinds_come_from_the_routing_table():
     assert "arxiv" not in routing["sources"]
 
 
-def test_verifiable_kinds_are_derived_with_an_explicit_exclusion():
-    """`arxiv` is excluded on purpose. The test exists so the exclusion cannot silently widen
-    into the drift it used to look like — if another kind is dropped, this fails."""
-    from build.propose_artifacts import NOT_A_DISTRIBUTION_ARTIFACT, VERIFIABLE_KINDS
+def test_proposer_support_is_defined_by_handlers_not_by_routing():
+    """A routed kind is not automatically a proposable one.
 
-    assert set(VERIFIABLE_KINDS) == artifact_kinds() - NOT_A_DISTRIBUTION_ARTIFACT
-    assert NOT_A_DISTRIBUTION_ARTIFACT == {"arxiv"}
+    Deriving `VERIFIABLE_KINDS` from the routing table made any newly declared `artifact_key`
+    an accepted `--kind` with no pattern, verifier or renderer behind it. The two sets are
+    equal today, which is what made the coincidence look like a definition.
+    """
+    from build.propose_artifacts import (
+        _PUBLIC_URL,
+        _VERIFIABLE,
+        NOT_A_DISTRIBUTION_ARTIFACT,
+        PATTERNS,
+        VERIFIABLE_KINDS,
+    )
+
+    patterned = {kind for kind, _ in PATTERNS}
+    for kind in VERIFIABLE_KINDS:
+        assert kind in patterned, f"{kind} has no URL pattern to mine it from prose"
+        assert kind in _PUBLIC_URL, f"{kind} has no public URL renderer"
+        assert kind in _VERIFIABLE, f"{kind} has no live existence check"
+
+    # Supported must remain an intentional SUBSET of routed, with the gap named.
+    assert set(VERIFIABLE_KINDS) <= artifact_kinds()
+    assert artifact_kinds() - set(VERIFIABLE_KINDS) == NOT_A_DISTRIBUTION_ARTIFACT
 
 
 def test_capability_relation_deltas_match_the_schema_enum():
@@ -93,37 +150,46 @@ def test_capability_relation_deltas_match_the_schema_enum():
 
     schema = json.loads((ROOT / "docs" / "schemas" / "score.schema.json").read_text())
     enum = schema["properties"]["capability"]["properties"]["relation"]["enum"]
-    assert set(DELTA) == set(enum), (
-        "check_capability.DELTA and the schema disagree about the relation vocabulary; a "
-        "relation missing from DELTA would raise, but one missing from the schema would be "
-        "accepted by the gate and rejected by validate"
-    )
+    assert set(DELTA) == set(enum)
 
 
 def test_the_method_vocabulary_has_exactly_one_definition():
-    if not (ROOT / "build" / "prose_provenance.py").exists():
+    """`apply_provenance` held a narrower sibling until 2026-08-15, which is how
+    `substitute sources` passed as a document name.
+
+    AST-based, so an annotated assignment (`METHOD_WORDS: re.Pattern = ...`) is caught; the
+    first cut matched `^METHOD_WORDS\\s*=` and would not have been.
+    """
+    if not (BUILD / "prose_provenance.py").exists():
         pytest.skip("prose_provenance lands with #283; this activates when it merges")
-    """`apply_provenance` held a narrower sibling of `METHOD_WORDS` until 2026-08-15, which is
-    how `substitute sources` passed as a document name."""
-    method_defs = [
-        path.name
-        for path in sorted((ROOT / "build").glob("*.py"))
-        if re.search(r"^METHOD_WORDS\s*=", path.read_text(), re.M)
+    definers = [
+        name for name, source in _module_sources().items()
+        if "METHOD_WORDS" in _assigned_names(ast.parse(source))
     ]
-    assert method_defs == ["prose_provenance.py"], (
-        f"METHOD_WORDS is defined in {method_defs}; it must have one owner"
+    assert definers == ["prose_provenance.py"], (
+        f"METHOD_WORDS is assigned in {definers}; it must have exactly one owner"
     )
 
 
-@pytest.mark.parametrize("module", ["check_payload", "apply_provenance"])
-def test_dates_are_parsed_not_shape_matched(module):
-    """Both validated a date with `\\d{4}-\\d{2}-\\d{2}` and accepted 2026-99-99. The same
-    defect, in two modules, three days apart."""
-    path = ROOT / "build" / f"{module}.py"
-    if not path.exists():
-        pytest.skip(f"{module} lands with #283; this activates when it merges")
-    source = path.read_text()
-    assert "fromisoformat" in source, f"{module} must parse dates, not match their shape"
-    assert not re.search(r'r"\^?\\\\d\{4\}-\\\\d\{2\}-\\\\d\{2\}\$?"', source), (
-        f"{module} still shape-matches a date"
-    )
+def test_check_payload_rejects_impossible_dates():
+    """Behavioral, not textual. The first cut asserted `fromisoformat` appeared somewhere in
+    the file, which a module could satisfy while still shape-matching elsewhere."""
+    from build.check_payload import _is_date
+
+    for bad in ("2026-99-99", "2026-02-30", "not-a-date", "", "20260815", None):
+        assert not _is_date(bad), f"{bad!r} accepted as a date"
+    for good in ("2026-08-15", "2026-02-28"):
+        assert _is_date(good)
+
+
+def test_apply_provenance_rejects_impossible_dates():
+    """The same defect, in the module written three days after the first was fixed."""
+    if not (BUILD / "apply_provenance.py").exists():
+        pytest.skip("apply_provenance lands with #283; this activates when it merges")
+    from build.apply_provenance import Refused, check
+
+    for bad in ("2026-99-99", "2026-02-30", "August"):
+        with pytest.raises(Refused):
+            check({"product": "anythingllm", "verification_date": bad, "source_accessed": bad,
+                   "selected_document": "the README", "source_url": "https://example.com",
+                   "support": "x", "prose_digest": "d"})

--- a/tests/test_vocabulary_siblings.py
+++ b/tests/test_vocabulary_siblings.py
@@ -1,0 +1,114 @@
+"""No module may hold a private copy of a vocabulary that has a declarative owner.
+
+Four defects of this exact shape shipped in a fortnight, and none of them failed loudly —
+each reported success over a narrower question than the one it claimed to answer:
+
+  * `check_routing.SOURCE_ARTIFACT` named five sources where the routing table declared seven;
+  * `check_routing.artifacts_of` enumerated the same vocabulary again in the same file, so a
+    correctly declared new artifact kind was invisible to coverage;
+  * `apply_provenance` reimplemented `METHOD_WORDS` more narrowly, so `substitute sources`
+    passed as a document name;
+  * `check_payload` and `apply_provenance` each validated a date by shape.
+
+These tests are the ratchet. They do not stop a module defining a constant; they stop one
+defining a constant that silently disagrees with the source of truth.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+from build.vocabulary import ROOT, artifact_kinds, axes
+
+AXES_LITERAL = re.compile(r'\(\s*"openness"\s*,\s*"adoption"\s*,\s*"capability"\s*\)')
+
+
+def test_axes_come_from_the_schema():
+    """The schema lists them as properties and requires all three; it is the owner."""
+    schema = json.loads((ROOT / "docs" / "schemas" / "score.schema.json").read_text())
+    assert set(axes()) == set(schema["required"]) - {"product"}
+    assert set(axes()) == set(schema["properties"]) - {"product"}
+
+
+def test_no_module_holds_a_private_copy_of_the_axes():
+    """Seven modules did. A fourth axis would have silently narrowed seven denominators at
+    once, and a walk that quietly skips an axis passes green."""
+    offenders = []
+    for path in sorted((ROOT / "build").glob("*.py")):
+        if path.name == "vocabulary.py":
+            continue
+        if AXES_LITERAL.search(path.read_text()):
+            offenders.append(path.name)
+    assert not offenders, (
+        "these define the axis triple as a literal instead of importing "
+        f"build.vocabulary.axes(): {offenders}"
+    )
+
+
+def test_artifact_kinds_come_from_the_routing_table():
+    routing = yaml.safe_load((ROOT / "sources" / "signal_routing.yaml").read_text())
+    declared = {
+        s["artifact_key"] for s in routing["sources"].values() if s.get("artifact_key")
+    }
+    assert artifact_kinds() == declared
+    # The layering the first cut of #184 got wrong: a source and an artifact key are
+    # different things, and one source may consume a key that shares no name with it.
+    assert "arxiv" in artifact_kinds()
+    assert "arxiv" not in routing["sources"]
+
+
+def test_verifiable_kinds_are_derived_with_an_explicit_exclusion():
+    """`arxiv` is excluded on purpose. The test exists so the exclusion cannot silently widen
+    into the drift it used to look like — if another kind is dropped, this fails."""
+    from build.propose_artifacts import NOT_A_DISTRIBUTION_ARTIFACT, VERIFIABLE_KINDS
+
+    assert set(VERIFIABLE_KINDS) == artifact_kinds() - NOT_A_DISTRIBUTION_ARTIFACT
+    assert NOT_A_DISTRIBUTION_ARTIFACT == {"arxiv"}
+
+
+def test_capability_relation_deltas_match_the_schema_enum():
+    """`DELTA` maps each relation to an integer offset, which the schema cannot express — so
+    the dict stays. What it must not do is disagree about which relations exist."""
+    from build.check_capability import DELTA
+
+    schema = json.loads((ROOT / "docs" / "schemas" / "score.schema.json").read_text())
+    enum = schema["properties"]["capability"]["properties"]["relation"]["enum"]
+    assert set(DELTA) == set(enum), (
+        "check_capability.DELTA and the schema disagree about the relation vocabulary; a "
+        "relation missing from DELTA would raise, but one missing from the schema would be "
+        "accepted by the gate and rejected by validate"
+    )
+
+
+def test_the_method_vocabulary_has_exactly_one_definition():
+    if not (ROOT / "build" / "prose_provenance.py").exists():
+        pytest.skip("prose_provenance lands with #283; this activates when it merges")
+    """`apply_provenance` held a narrower sibling of `METHOD_WORDS` until 2026-08-15, which is
+    how `substitute sources` passed as a document name."""
+    method_defs = [
+        path.name
+        for path in sorted((ROOT / "build").glob("*.py"))
+        if re.search(r"^METHOD_WORDS\s*=", path.read_text(), re.M)
+    ]
+    assert method_defs == ["prose_provenance.py"], (
+        f"METHOD_WORDS is defined in {method_defs}; it must have one owner"
+    )
+
+
+@pytest.mark.parametrize("module", ["check_payload", "apply_provenance"])
+def test_dates_are_parsed_not_shape_matched(module):
+    """Both validated a date with `\\d{4}-\\d{2}-\\d{2}` and accepted 2026-99-99. The same
+    defect, in two modules, three days apart."""
+    path = ROOT / "build" / f"{module}.py"
+    if not path.exists():
+        pytest.skip(f"{module} lands with #283; this activates when it merges")
+    source = path.read_text()
+    assert "fromisoformat" in source, f"{module} must parse dates, not match their shape"
+    assert not re.search(r'r"\^?\\\\d\{4\}-\\\\d\{2\}-\\\\d\{2\}\$?"', source), (
+        f"{module} still shape-matches a date"
+    )


### PR DESCRIPTION
Bounded sweep for the construct behind four consecutive review findings. No product, score or provenance decisions; no warehouse changes; no general refactor.

## Why

None of the four failed loudly. Each reported success over a **narrower question than the one it claimed to answer**:

| defect | what it actually answered |
|---|---|
| `check_routing.SOURCE_ARTIFACT` named five sources; the table declared seven | "is this one of the five I know about?" |
| `check_routing.artifacts_of` enumerated the same vocabulary again, same file | "does it declare one of seven hardcoded keys?" |
| `apply_provenance` reimplemented `METHOD_WORDS` more narrowly | "is this one of three forbidden phrases?" |
| `check_payload` and `apply_provenance` each validated a date by shape | "does this string look like a date?" |

Three were found by review, and the fourth only because the third was. The pattern isn't carelessness about a particular constant — it's that the fix lands on the instance in front of you and the sibling is never searched for.

## Fixed

**Axis triple — ten modules, no owner.** Seven named constants plus three inline literals, including `validate.py`, the schema gate itself. `build/vocabulary.axes()` derives from `score.schema.json`, which lists them as properties and requires all three.

None had drifted; no fourth axis has ever been added. A fourth axis is also precisely the change that would narrow ten denominators at once, and *a walk that quietly skips an axis passes green*. **This is the one entry fixed before it failed rather than after.**

**`propose_artifacts.VERIFIABLE_KINDS`** — the third instance of the `check_routing` construct, and **already divergent** (missing `arxiv`). Now derived, with the exclusion written down rather than implied:

```python
NOT_A_DISTRIBUTION_ARTIFACT = frozenset({"arxiv"})
VERIFIABLE_KINDS = tuple(sorted(artifact_kinds() - NOT_A_DISTRIBUTION_ARTIFACT))
```

Behavior identical — the resulting set equals the old literal. `arxiv` is excluded because this constant asks whether a product carries an artifact a proposal would *target*, and a paper id is not a distribution artifact. Whether it should count is a curation question, not a sweep one.

## Intentionally distinct, with the reason recorded

So the next sweep doesn't rediscover them as findings:

- **Openness class→bucket map**, duplicated three ways — already gated by `tests/test_openness_buckets.py`, which asserts all three agree. That is this sweep's own protection, arrived at first; moving the constants would churn a working invariant for symmetry.
- **`check_adoption._DOWNLOAD_INSTRUMENTS`** — not a mirror of the `signal_type` enum but a named subset, with the module explaining why `unknown` is excluded. A narrower vocabulary with a written reason is a decision.
- **`check_capability.DELTA`** — maps relations to integer offsets, which the schema cannot express, so the dict stays. A test now pins that it agrees with the schema about which relations *exist*.

## Swept and clean

- **Date validators**: no live shape-matcher remains.
- **Exit narrower than the printed report**: read every checker. `check_verification` iterates all gates so its exit covers everything it prints; `check_rubric`'s non-gating lines are marked `~` with a written reason. No instances beyond the one already fixed in #276.
- **Malformed input becoming a pass**: the three `except` paths in `build/` each record the failure rather than falling through.

## Artifact

`docs/reference/sibling-invariants.md` — the full inventory, one entry per construct with `canonical_owner`, `duplicates`, `risk`, `disposition`, `regression_test`.

## Test plan

`tests/test_vocabulary_siblings.py` — 8 tests: axes come from the schema; **no module holds a private copy**; artifact kinds come from the routing table (including the source-vs-artifact-key layering); `VERIFIABLE_KINDS` derives with an explicit exclusion that cannot silently widen; `DELTA` matches the schema enum; `METHOD_WORDS` has exactly one definition; dates are parsed in both modules.

Two skip pending #283, which is where `prose_provenance` and `apply_provenance` land — **this PR should merge after it**, and those tests activate then.

Full suite: 587 passed, 2 skipped. All gates green including `check_adoption --strict` and `check_instrument --strict`. `serialize` + `render` parse; no bot-owned file committed.