### PR TITLE
Bind the reviewed clause to the claim it rewrites

### DIFF
--- a/build/apply_provenance.py
+++ b/build/apply_provenance.py
@@ -70,8 +70,14 @@ ROOT = Path(__file__).resolve().parents[1]
 # The whole dated clause, however it is currently worded, up to its terminator. Replaced
 # wholesale so `Verified live <date> via primary sources` and `verified live <date> via
 # primary-source research` collapse to the one canonical form.
+# A sentence-terminating "." is one followed by whitespace or end of string. A dot inside a
+# URL, a filename or a version number is not, and `[^.;]*` treated them alike: rewriting
+# `Verified live 2026-08-13 on huggingface.co/datasets/allenai/ai2_arc (474 downloads).`
+# stopped at the dot in `huggingface.co` and left `.co/datasets/allenai/ai2_arc (474
+# downloads).` orphaned after the new document name. 71 clauses in the corpus contain an
+# internal dot, so this was not an edge case.
 CLAUSE = re.compile(
-    r"[Vv]erified(?: live)?\s+(\d{4}-\d{2}-\d{2})\s*[,;]?\s*(?:via|on|against|using)?\s*[^.;]*",
+    r"[Vv]erified(?: live)?\s+(\d{4}-\d{2}-\d{2})\s*[,;]?\s*(?:via|on|against|using)?\s*(?:[^.;]|\.(?!\s|$))*",
 )
 
 

--- a/build/apply_provenance.py
+++ b/build/apply_provenance.py
@@ -63,7 +63,8 @@ from pathlib import Path
 import yaml
 
 from build.components import set_document_field
-from build.prose_provenance import AXES, HAS_WORD, METHOD_WORDS, classify, prose_digest
+from build.prose_provenance import (AXES, BOUND, HAS_WORD, METHOD_WORDS, classify,
+                                    prose_digest)
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -77,7 +78,7 @@ ROOT = Path(__file__).resolve().parents[1]
 # downloads).` orphaned after the new document name. 71 clauses in the corpus contain an
 # internal dot, so this was not an edge case.
 CLAUSE = re.compile(
-    r"[Vv]erified(?: live)?\s+(\d{4}-\d{2}-\d{2})\s*[,;]?\s*(?:via|on|against|using)?\s*(?:[^.;]|\.(?!\s|$))*",
+    r"[Vv]erified(?: live)?\s+(\d{4}-\d{2}-\d{2})\s*[,;]?\s*(?:via|on|against|using)?\s*" + BOUND
 )
 
 
@@ -99,7 +100,8 @@ def score_sources(slug: str) -> dict[str, str]:
 def check(packet: dict) -> None:
     """Raise `Refused` unless the packet carries every part of its own justification."""
     slug = packet.get("product")
-    for field in ("selected_document", "source_url", "source_accessed", "support", "prose_digest"):
+    for field in ("selected_document", "source_url", "source_accessed", "support",
+                  "prose_digest", "current_clause"):
         if not str(packet.get(field) or "").strip():
             raise Refused(f"{slug}: packet has no {field}")
 
@@ -155,13 +157,34 @@ def check(packet: dict) -> None:
         )
 
 
-def rewrite(comments: str, date: str, document: str) -> str:
-    """Replace the dated clause with the canonical form, leaving the rest of the prose alone."""
-    replacement = f"Verified {date} via {document.rstrip('.')}"
-    new, n = CLAUSE.subn(replacement, comments, count=1)
-    if n != 1:
-        raise Refused("could not locate exactly one dated verification clause")
-    return new
+def rewrite(comments: str, clause: str, document: str) -> str:
+    """Replace the EXACT reviewed `clause` with the canonical line. No boundary is re-derived.
+
+    The applier used to re-match the clause with a regex at write time, which made every
+    boundary bug a silent corruption: `[^.;]*` stopped inside `huggingface.co` and orphaned
+    the rest, and adding a whitespace test still split `the U.S. AI Safety Institute report`
+    into two grammatical-looking halves. A heuristic good enough to propose a clause for
+    review is not good enough to rewrite prose unsupervised.
+
+    So the boundary is decided once, in the packet, where a human sees the exact string that
+    will be replaced — and this does a literal substitution of that string, refusing if it is
+    not present exactly once.
+    """
+    if not clause:
+        raise Refused("packet carries no current_clause")
+    occurrences = comments.count(clause)
+    if occurrences != 1:
+        raise Refused(
+            f"the reviewed clause appears {occurrences} times in the live prose, not once; "
+            "the record has changed since review"
+        )
+    date_match = re.search(r"\d{4}-\d{2}-\d{2}", clause)
+    if not date_match:
+        raise Refused("the reviewed clause carries no date")
+    trailing = clause[-1] if clause and clause[-1] in ".;" else "."
+    return comments.replace(
+        clause, f"Verified {date_match.group(0)} via {document.rstrip('.')}{trailing}", 1
+    )
 
 
 def apply_one(packet: dict) -> bool:
@@ -172,7 +195,9 @@ def apply_one(packet: dict) -> bool:
     doc = yaml.safe_load(text) or {}
     comments = str(doc.get("comments") or "")
 
-    new_comments = rewrite(comments, str(packet["verification_date"]), str(packet["selected_document"]))
+    new_comments = rewrite(
+        comments, str(packet.get("current_clause") or ""), str(packet["selected_document"])
+    )
     if new_comments == comments:
         return False
     if not CANONICAL.search(" ".join(new_comments.split())):

--- a/build/apply_provenance.py
+++ b/build/apply_provenance.py
@@ -56,30 +56,22 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import re
 from datetime import date
 from pathlib import Path
 
 import yaml
 
 from build.components import set_document_field
-from build.prose_provenance import (AXES, BOUND, HAS_WORD, METHOD_WORDS, classify,
-                                    prose_digest)
+from build.prose_provenance import (ANY_DATED, AXES, CLAUSE_HEAD, HAS_WORD, METHOD_WORDS,
+                                    UNRESOLVED, classify, prose_digest)
 
 ROOT = Path(__file__).resolve().parents[1]
 
-# The whole dated clause, however it is currently worded, up to its terminator. Replaced
-# wholesale so `Verified live <date> via primary sources` and `verified live <date> via
-# primary-source research` collapse to the one canonical form.
-# A sentence-terminating "." is one followed by whitespace or end of string. A dot inside a
-# URL, a filename or a version number is not, and `[^.;]*` treated them alike: rewriting
-# `Verified live 2026-08-13 on huggingface.co/datasets/allenai/ai2_arc (474 downloads).`
-# stopped at the dot in `huggingface.co` and left `.co/datasets/allenai/ai2_arc (474
-# downloads).` orphaned after the new document name. 71 clauses in the corpus contain an
-# internal dot, so this was not an edge case.
-CLAUSE = re.compile(
-    r"[Vv]erified(?: live)?\s+(\d{4}-\d{2}-\d{2})\s*[,;]?\s*(?:via|on|against|using)?\s*" + BOUND
-)
+# This module deliberately holds NO clause pattern. It used to carry its own copy of the
+# boundary regex and re-match the clause at write time, which made every boundary bug a silent
+# corruption of prose. The boundary is now proposed once by `prose_provenance.clause_span`,
+# confirmed by a reviewer in the packet, and substituted here literally.
+# `tests/test_prose_provenance.py::test_the_applier_holds_no_clause_pattern` keeps it that way.
 
 
 class Refused(Exception):
@@ -101,7 +93,7 @@ def check(packet: dict) -> None:
     """Raise `Refused` unless the packet carries every part of its own justification."""
     slug = packet.get("product")
     for field in ("selected_document", "source_url", "source_accessed", "support",
-                  "prose_digest", "current_clause"):
+                  "prose_digest", "current_clause", "current_state"):
         if not str(packet.get(field) or "").strip():
             raise Refused(f"{slug}: packet has no {field}")
 
@@ -140,15 +132,41 @@ def check(packet: dict) -> None:
         raise Refused(f"{slug}: no product file")
     product = yaml.safe_load(path.read_text()) or {}
     state, live_date, _ = classify(product.get("comments"))
-    if state != "generic":
+    if state not in UNRESOLVED:
         raise Refused(
-            f"{slug}: live line is {state!r}, not generic — it has changed since review"
+            f"{slug}: live line is {state!r}, which this does not repair — it has changed "
+            "since review"
+        )
+    if state != str(packet["current_state"]):
+        raise Refused(
+            f"{slug}: reviewed as {packet['current_state']!r}, live line is now {state!r}"
         )
     if live_date != claimed:
         raise Refused(
             f"{slug}: live line is dated {live_date}, packet claims {claimed}; applying this "
             "would move the date"
         )
+
+    # The packet decides the clause BOUNDARY — a reviewer confirms the exact string. It does
+    # not get to decide which CLAIM is rewritten. Without the three checks below, a packet
+    # could nominate any other unique dated sentence: the rewrite would land there, the real
+    # verification line would survive untouched, and `CANONICAL.search` would still find the
+    # newly written one and call the result a success.
+    comments = " ".join(str(product.get("comments") or "").split())
+    clause = str(packet["current_clause"])
+    if comments.count(clause) != 1:
+        raise Refused(
+            f"{slug}: the reviewed clause appears {comments.count(clause)} times in the live "
+            "prose, not once"
+        )
+    head = CLAUSE_HEAD.match(clause)
+    if not head:
+        raise Refused(f"{slug}: current_clause is not a verification line: {clause[:60]!r}")
+    if head.group(1) != claimed:
+        raise Refused(
+            f"{slug}: current_clause is dated {head.group(1)}, packet claims {claimed}"
+        )
+
     live_digest = prose_digest(product)
     if live_digest != str(packet["prose_digest"]):
         raise Refused(
@@ -157,7 +175,7 @@ def check(packet: dict) -> None:
         )
 
 
-def rewrite(comments: str, clause: str, document: str) -> str:
+def rewrite(comments: str, clause: str, document: str, iso: str) -> str:
     """Replace the EXACT reviewed `clause` with the canonical line. No boundary is re-derived.
 
     The applier used to re-match the clause with a regex at write time, which made every
@@ -169,6 +187,10 @@ def rewrite(comments: str, clause: str, document: str) -> str:
     So the boundary is decided once, in the packet, where a human sees the exact string that
     will be replaced — and this does a literal substitution of that string, refusing if it is
     not present exactly once.
+
+    `date` is passed in already validated rather than scraped back out of the clause. Deriving
+    it here would have meant the written date came from whatever string the packet nominated,
+    while every check upstream was about `verification_date`.
     """
     if not clause:
         raise Refused("packet carries no current_clause")
@@ -178,30 +200,53 @@ def rewrite(comments: str, clause: str, document: str) -> str:
             f"the reviewed clause appears {occurrences} times in the live prose, not once; "
             "the record has changed since review"
         )
-    date_match = re.search(r"\d{4}-\d{2}-\d{2}", clause)
-    if not date_match:
-        raise Refused("the reviewed clause carries no date")
+    try:
+        date.fromisoformat(iso)
+    except (TypeError, ValueError):
+        raise Refused(f"{iso!r} is not a real date")
+    head = CLAUSE_HEAD.match(clause)
+    if not head:
+        raise Refused(f"the reviewed clause is not a verification line: {clause[:60]!r}")
+    if head.group(1) != iso:
+        raise Refused(f"the reviewed clause is dated {head.group(1)}, not {iso}")
     trailing = clause[-1] if clause and clause[-1] in ".;" else "."
     return comments.replace(
-        clause, f"Verified {date_match.group(0)} via {document.rstrip('.')}{trailing}", 1
+        clause, f"Verified {iso} via {document.rstrip('.')}{trailing}", 1
     )
 
 
 def apply_one(packet: dict) -> bool:
     check(packet)
     slug = packet["product"]
+    claimed = str(packet["verification_date"])
     path = ROOT / "sources" / "products" / f"{slug}.yaml"
     text = path.read_text()
     doc = yaml.safe_load(text) or {}
-    comments = str(doc.get("comments") or "")
+
+    # Normalized, because that is the form the clause was proposed and reviewed in: the corpus
+    # wraps `comments` across lines, so a clause spanning a wrap would never match the raw
+    # text literally. `set_document_field` re-wraps on write, and `prose_digest` normalizes,
+    # so this changes the whitespace of the stored line and nothing else.
+    comments = " ".join(str(doc.get("comments") or "").split())
 
     new_comments = rewrite(
-        comments, str(packet.get("current_clause") or ""), str(packet["selected_document"])
+        comments, str(packet["current_clause"]), str(packet["selected_document"]), claimed
     )
     if new_comments == comments:
         return False
-    if not CANONICAL.search(" ".join(new_comments.split())):
-        raise Refused(f"{slug}: rewrite did not produce a canonical line")
+
+    # Postconditions on the RESULT, not on "a canonical line exists somewhere in it".
+    state, live_date, _ = classify(new_comments)
+    if state != "canonical":
+        raise Refused(f"{slug}: rewrite produced a {state!r} line, not a canonical one")
+    if live_date != claimed:
+        raise Refused(f"{slug}: rewrite produced a line dated {live_date}, not {claimed}")
+    if len(ANY_DATED.findall(new_comments)) != 1:
+        raise Refused(
+            f"{slug}: rewrite left {len(ANY_DATED.findall(new_comments))} dated verification "
+            "lines; exactly one must remain"
+        )
+
     path.write_text(set_document_field(text, "comments", new_comments))
     return True
 

--- a/build/prose_provenance.py
+++ b/build/prose_provenance.py
@@ -82,9 +82,13 @@ METHOD_WORDS = re.compile(
     re.IGNORECASE,
 )
 
+# A sentence-terminating "." is one followed by whitespace or end of string; a dot inside a
+# URL or filename is not. See apply_provenance.CLAUSE for the defect this bound fixes.
+BOUND = r"(?:[^.;]|\.(?!\s|$))*"
+
 # The dated clause in any of its wordings, removed before digesting the surrounding prose.
 CLAUSE_ANY = re.compile(
-    r"[Vv]erified(?: live)?\s+\d{4}-\d{2}-\d{2}\s*[,;]?\s*(?:via|on|against|using)?\s*[^.;]*[.;]?"
+    r"[Vv]erified(?: live)?\s+\d{4}-\d{2}-\d{2}\s*[,;]?\s*(?:via|on|against|using)?\s*(?:[^.;]|\.(?!\s|$))*[.;]?"
 )
 
 # A document name has to contain an actual word. `Verified 2026-08-13 via .` is canonical in

--- a/build/prose_provenance.py
+++ b/build/prose_provenance.py
@@ -84,11 +84,24 @@ METHOD_WORDS = re.compile(
 
 # A sentence-terminating "." is one followed by whitespace or end of string; a dot inside a
 # URL or filename is not. See apply_provenance.CLAUSE for the defect this bound fixes.
-BOUND = r"(?:[^.;]|\.(?!\s|$))*"
+# A period ends the clause only when it is followed by whitespace or end of string AND is not
+# the dot of an initialism. `[^.;]*` alone stopped inside `huggingface.co`; adding only the
+# whitespace test still broke `the U.S. AI Safety Institute report` into
+# `the U.S` + `. AI Safety Institute report`, which is worse than the URL case because the
+# result reads as grammatical.
+#
+# This is a HEURISTIC and is treated as one: it proposes a clause for a human to review in the
+# packet. The applier never re-derives a boundary — it replaces the exact reviewed string. See
+# apply_provenance.rewrite.
+BOUND = r"(?:[^.;]|\.(?!\s|$)|(?<=\b[A-Z])\.(?=\s))*"
 
 # The dated clause in any of its wordings, removed before digesting the surrounding prose.
+# Interpolated from BOUND at import, not restated. Writing the expansion out here is how the
+# first cut of this fix silently kept the old boundary while BOUND advertised a new one.
 CLAUSE_ANY = re.compile(
-    r"[Vv]erified(?: live)?\s+\d{4}-\d{2}-\d{2}\s*[,;]?\s*(?:via|on|against|using)?\s*(?:[^.;]|\.(?!\s|$))*[.;]?"
+    r"[Vv]erified(?: live)?\s+\d{4}-\d{2}-\d{2}\s*[,;]?\s*(?:via|on|against|using)?\s*"
+    + BOUND
+    + r"[.;]?"
 )
 
 # A document name has to contain an actual word. `Verified 2026-08-13 via .` is canonical in
@@ -192,6 +205,18 @@ def candidates(slug: str, date: str, score: dict) -> list[dict]:
     return sorted(best.values(), key=lambda c: (not c["looks_like_document"], c["url"]))
 
 
+def clause_span(comments: str) -> str | None:
+    """The dated verification clause, as the text a rewrite would replace.
+
+    Best effort. Its output goes into a packet for a human to confirm, and the applier matches
+    it literally rather than re-deriving it, so a mis-bounded clause is a visible wrong string
+    in review rather than a silent mangling on write.
+    """
+    text = " ".join(str(comments or "").split())
+    match = CLAUSE_ANY.search(text)
+    return match.group(0) if match else None
+
+
 def prose_digest(product: dict) -> str:
     """A digest over the prose a verification line is provenance for.
 
@@ -235,6 +260,9 @@ def packets() -> list[dict]:
             "description": " ".join(str(product.get("description") or "").split()),
             "comments": " ".join(str(product.get("comments") or "").split()),
             "prose_digest": prose_digest(product),
+            # The exact text the applier will replace. Confirm it in review: if the clause
+            # boundary guessed wrong, it is visible here rather than in the written file.
+            "current_clause": clause_span(product.get("comments")),
             "candidates": cands,
             # A packet with no usable candidate cannot be derived from evidence, whatever a
             # reader thinks of it: there is no document in the record to name.

--- a/build/prose_provenance.py
+++ b/build/prose_provenance.py
@@ -108,6 +108,16 @@ CLAUSE_ANY = re.compile(
 # shape and names nothing.
 HAS_WORD = re.compile(r"[A-Za-z0-9]")
 
+# The opening a reviewed clause must have. The applier replaces the exact string a packet
+# carries, so without this a packet could nominate any other unique dated sentence in the
+# prose: the rewrite would land there, the real verification line would survive untouched, and
+# a postcondition looking only for "a canonical line somewhere" would still pass.
+CLAUSE_HEAD = re.compile(r"^[Vv]erified(?: live)?\s+(\d{4}-\d{2}-\d{2})\b")
+
+# The three states a packet may be raised against. `canonical` needs nothing and `missing`
+# needs research rather than a document already in the record, so neither is packetable.
+UNRESOLVED = ("generic", "ambiguous_noncanonical", "named_noncanonical")
+
 # URLs that are machine endpoints or count aggregators rather than documents a person reads.
 # A source like this can establish a score dimension and still say nothing about what the
 # product IS, which is what the prose line has to point at.
@@ -243,18 +253,43 @@ def census() -> dict[str, list[str]]:
     return by_state
 
 
-def packets() -> list[dict]:
-    """One decision packet per product needing evidence matching, decision left unset."""
+def category_roster(slug: str) -> set[str]:
+    """The product slugs a category lists. Membership lives on the category, not the product."""
+    path = ROOT / "sources" / "categories" / f"{slug}.yaml"
+    if not path.exists():
+        raise SystemExit(f"no such category: {slug}")
+    return set((yaml.safe_load(path.read_text()) or {}).get("products") or [])
+
+
+def packets(only: set[str] | None = None) -> list[dict]:
+    """One decision packet per UNRESOLVED product, decision left unset.
+
+    All three unresolved states go through this one path, and through the same `derive`
+    decision with the same justification. That is deliberate:
+
+      * `generic` names a method, so something has to supply a document;
+      * `ambiguous_noncanonical` names nothing at all;
+      * `named_noncanonical` names something in prose, but the name has to be a document the
+        record actually cites before it can be written as provenance. A second, weaker
+        "mechanical rewording" path would be exactly the shortcut this exercise is correcting
+        — it would let the prose vouch for itself.
+
+    Where a named record's document is not a date-aligned source in its score file, the honest
+    decision is `reread`, not a reword.
+    """
     all_scores = scores()
     out = []
     for slug, product in products().items():
         state, date, trailer = classify(product.get("comments"))
-        if state not in ("generic",):
+        if state not in UNRESOLVED:
+            continue
+        if only is not None and slug not in only:
             continue
         cands = candidates(slug, date, all_scores.get(slug) or {})
         usable = [c for c in cands if c["looks_like_document"] and not c["shows_is_measurement_only"]]
         out.append({
             "product": slug,
+            "current_state": state,
             "verification_date": date,
             "current_trailer": trailer,
             "description": " ".join(str(product.get("description") or "").split()),
@@ -267,6 +302,10 @@ def packets() -> list[dict]:
             # A packet with no usable candidate cannot be derived from evidence, whatever a
             # reader thinks of it: there is no document in the record to name.
             "hint": "reread" if not usable else "needs-judgment",
+            # What the prose currently offers, for the reviewer to weigh against the
+            # candidates. On a `named_noncanonical` record this is the name already in the
+            # line — which still has to turn out to be a cited document.
+            "current_trailer_names": bool(trailer and not METHOD_WORDS.match(trailer)),
             "decision": None,
             "selected_document": None,
             "source_url": None,
@@ -279,6 +318,7 @@ def packets() -> list[dict]:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--packets", help="write candidate decision packets to this path")
+    parser.add_argument("--category", help="restrict packets to one category's roster")
     args = parser.parse_args()
 
     by_state = census()
@@ -289,15 +329,24 @@ def main() -> int:
         n = len(by_state.get(state, []))
         print(f"  {state:22}{n:>5}")
 
+    unresolved = sum(len(by_state.get(s, [])) for s in UNRESOLVED)
+    print(f"\n  {'unresolved':22}{unresolved:>5}")
+
     if args.packets:
-        rows = packets()
+        only = category_roster(args.category) if args.category else None
+        rows = packets(only)
         Path(args.packets).write_text(yaml.safe_dump(rows, sort_keys=False, allow_unicode=True))
-        hints = {}
+        hints: dict[str, int] = {}
+        states: dict[str, int] = {}
         for r in rows:
             hints[r["hint"]] = hints.get(r["hint"], 0) + 1
-        print(f"\n{len(rows)} packets written to {args.packets}")
+            states[r["current_state"]] = states.get(r["current_state"], 0) + 1
+        scope = f" for {args.category}" if args.category else ""
+        print(f"\n{len(rows)} packets{scope} written to {args.packets}")
+        for state, n in sorted(states.items()):
+            print(f"  {state:22}{n:>5}")
         for hint, n in sorted(hints.items()):
-            print(f"  hint {hint:16}{n:>5}")
+            print(f"  hint {hint:17}{n:>5}")
     return 0
 
 

--- a/docs/reference/sibling-invariants.md
+++ b/docs/reference/sibling-invariants.md
@@ -108,6 +108,38 @@ and tested, so it stays a decision instead of becoming drift.
     `20260815` from Python 3.11, which would put a second date spelling into a corpus whose
     schema declares `format: date`.
 
+- construct: the verification-clause boundary
+  canonical_owner: build/prose_provenance.py BOUND — and only as a PROPOSAL
+  duplicates:
+    - build/apply_provenance.py   # CLAUSE, removed
+  risk: >-
+    The sibling copy re-matched the clause at write time, so every boundary bug became a
+    silent corruption of prose rather than a visible wrong string. `[^.;]*` stopped inside
+    `huggingface.co`; adding a whitespace test then split `the U.S. AI Safety Institute
+    report` into two grammatical-looking halves, which is worse, because nothing looks wrong.
+
+    Deduplicating it would have missed the point. A heuristic good enough to PROPOSE a clause
+    for review is not good enough to rewrite prose unsupervised, so the applier now holds no
+    pattern at all: the boundary is confirmed once by a reviewer in the packet and substituted
+    literally. `BOUND` stays a heuristic and is labelled as one.
+  disposition: fixed
+  regression_test: >-
+    test_the_applier_holds_no_clause_pattern — AST, asserting the module neither imports nor
+    references `re`. A text search would have matched the docstring quoting the very fragments
+    it no longer uses, and would then have been weakened until it matched nothing.
+
+- construct: a composition nothing exercises
+  canonical_owner: n/a
+  duplicates:
+    - build/apply_provenance.py   # apply_one
+  risk: >-
+    `check` and `rewrite` were each tested alone and thoroughly. `apply_one`, which joins
+    them, referenced an undefined `CANONICAL` — so every real application would have raised
+    `NameError` after passing every check it was subjected to. The same shape as the rest of
+    this table, one level up: the parts were verified, the composition was not.
+  disposition: fixed
+  regression_test: test_an_unresolved_packet_of_any_state_applies — end to end, on a synthetic corpus
+
 - construct: openness class → bucket map
   canonical_owner: docs/openness-class-map.json
   duplicates:

--- a/tests/test_prose_provenance.py
+++ b/tests/test_prose_provenance.py
@@ -9,11 +9,12 @@ cannot justify itself.
 
 from __future__ import annotations
 
+import re
 import pytest
 import yaml
 
 from build.apply_provenance import Refused, check, rewrite
-from build.prose_provenance import ROOT, census, classify
+from build.prose_provenance import ROOT, census, classify, clause_span
 
 
 @pytest.mark.parametrize(
@@ -61,7 +62,8 @@ def test_every_state_is_accounted_for():
 
 def test_rewrite_replaces_the_clause_and_keeps_the_rest():
     before = "Verified live 2026-08-13 via primary sources; v1.15.0 and 65k stars. MIT-licensed."
-    after = rewrite(before, "2026-08-13", "the anything-llm repository page")
+    after = rewrite(before, "Verified live 2026-08-13 via primary sources;",
+                    "the anything-llm repository page")
     assert after.startswith("Verified 2026-08-13 via the anything-llm repository page;")
     assert "v1.15.0 and 65k stars. MIT-licensed." in after
     assert "primary sources" not in after
@@ -70,7 +72,8 @@ def test_rewrite_replaces_the_clause_and_keeps_the_rest():
 def test_rewrite_never_moves_the_date():
     """A provenance repair is not a re-verification. Advancing the date would claim somebody
     re-confirmed the facts today, which nobody did."""
-    after = rewrite("Verified live 2026-08-13 via primary sources.", "2026-08-13", "the README")
+    after = rewrite("Verified live 2026-08-13 via primary sources.",
+                    "Verified live 2026-08-13 via primary sources.", "the README")
     assert "2026-08-13" in after
 
 
@@ -81,6 +84,7 @@ def _packet(**over):
     product = yaml.safe_load((ROOT / "sources" / "products" / "anythingllm.yaml").read_text())
     base = {
         "product": "anythingllm",
+        "current_clause": clause_span(product.get("comments")),
         "verification_date": "2026-08-13",
         "selected_document": "the anything-llm repository page",
         "source_url": "https://github.com/Mintplex-Labs/anything-llm",
@@ -198,35 +202,70 @@ def test_the_digest_catches_an_edit_to_either_prose_field():
 
 
 @pytest.mark.parametrize(
-    "before, expected",
+    "full, clause, expected",
     [
-        # The defect: `[^.;]*` stopped at the dot inside `huggingface.co` and left
-        # `.co/datasets/allenai/ai2_arc (474 downloads).` orphaned after the new document.
+        # A dot inside a URL is not a sentence end. `[^.;]*` stopped inside `huggingface.co`.
         ("Verified live 2026-08-13 on huggingface.co/datasets/allenai/ai2_arc (474 downloads).",
+         "Verified live 2026-08-13 on huggingface.co/datasets/allenai/ai2_arc (474 downloads).",
          "Verified 2026-08-13 via the dataset card."),
+        # Nor is the dot of an initialism, even though it IS followed by whitespace. Adding
+        # only the whitespace test split this into two grammatical-looking halves, which is
+        # worse than the URL case because nothing looks wrong.
+        ("Verified live 2026-08-13 via the U.S. AI Safety Institute report. Next sentence.",
+         "Verified live 2026-08-13 via the U.S. AI Safety Institute report.",
+         "Verified 2026-08-13 via the dataset card. Next sentence."),
         ("Verified live 2026-08-13 against the repository DATASHEET.md and arXiv:2406.19314.",
+         "Verified live 2026-08-13 against the repository DATASHEET.md and arXiv:2406.19314.",
          "Verified 2026-08-13 via the dataset card."),
+        # `;` terminates, and the prose after it survives.
         ("Verified live 2026-08-13 via primary sources; v1.15.0 and 65k stars. MIT-licensed.",
+         "Verified live 2026-08-13 via primary sources;",
          "Verified 2026-08-13 via the dataset card; v1.15.0 and 65k stars. MIT-licensed."),
     ],
 )
-def test_the_clause_bound_survives_a_dot_inside_a_url(before, expected):
-    """A sentence-terminating `.` is one followed by whitespace or end of string; a dot in a
-    URL, filename or version number is not. 71 clauses in the corpus contain an internal dot,
-    so treating them alike was not an edge case — it would have mangled the prose of every
-    one it rewrote."""
-    assert rewrite(before, "2026-08-13", "the dataset card") == expected
+def test_rewrite_replaces_the_exact_reviewed_clause(full, clause, expected):
+    assert rewrite(full, clause, "the dataset card") == expected
 
 
-def test_no_rewrite_leaves_an_orphaned_clause_fragment():
-    """The signature of the bug: a token beginning with `.` immediately after the document."""
+def test_rewrite_refuses_a_clause_that_is_not_present_exactly_once():
+    """The applier no longer re-derives a boundary, so its remaining risk is a stale packet.
+    A clause that is absent — or ambiguous — must refuse rather than guess."""
+    from build.apply_provenance import Refused
+
+    with pytest.raises(Refused):
+        rewrite("Verified 2026-08-13 via the README.", "a clause that is not there", "x")
+    with pytest.raises(Refused):
+        rewrite("A. A.", "A.", "x")   # two occurrences
+
+
+def test_the_clause_boundary_has_one_owner():
+    """BOUND is interpolated into both patterns rather than restated. The first cut of this
+    fix wrote the expansion into CLAUSE_ANY as a literal, so BOUND advertised a new boundary
+    while the pattern kept the old one — the sibling-copy defect, inside its own fix."""
+    from build.apply_provenance import CLAUSE
+    from build.prose_provenance import BOUND, CLAUSE_ANY
+
+    assert BOUND in CLAUSE.pattern
+    assert BOUND in CLAUSE_ANY.pattern
+
+
+def test_every_corpus_clause_round_trips_without_an_orphan():
+    """All 472, not a sample. The earlier version checked the first 60 files for one
+    signature (`the document.\w`), which is the URL case only — it would have passed the
+    initialism case, whose fragment starts with a space and a capital."""
     import glob
-    import re
 
-    for path in sorted(glob.glob(str(ROOT / "sources" / "products" / "*.yaml")))[:60]:
-        comments = str((yaml.safe_load(open(path)) or {}).get("comments") or "")
-        state, date, _ = classify(comments)
-        if state == "missing":
+    checked = 0
+    for path in sorted(glob.glob(str(ROOT / "sources" / "products" / "*.yaml"))):
+        product = yaml.safe_load(open(path)) or {}
+        comments = " ".join(str(product.get("comments") or "").split())
+        clause = clause_span(comments)
+        if not clause:
             continue
-        out = rewrite(" ".join(comments.split()), date, "the document")
-        assert not re.search(r"the document\.\w", out), f"orphaned fragment in {path}"
+        checked += 1
+        out = rewrite(comments, clause, "THE-DOCUMENT")
+        after = out.split("THE-DOCUMENT", 1)[1]
+        # Whatever follows the inserted name must start a new sentence or clause, never a
+        # fragment of the one just replaced.
+        assert re.match(r"^[.;]?(\s|$)", after), f"{path}: orphaned fragment {after[:60]!r}"
+    assert checked > 400, f"only {checked} products carried a clause; the walk has narrowed"

--- a/tests/test_prose_provenance.py
+++ b/tests/test_prose_provenance.py
@@ -195,3 +195,38 @@ def test_the_digest_catches_an_edit_to_either_prose_field():
                                                   "description": product["description"] + " Extra."})
     assert prose_digest(product) != prose_digest({**product,
                                                   "comments": product["comments"] + " Extra."})
+
+
+@pytest.mark.parametrize(
+    "before, expected",
+    [
+        # The defect: `[^.;]*` stopped at the dot inside `huggingface.co` and left
+        # `.co/datasets/allenai/ai2_arc (474 downloads).` orphaned after the new document.
+        ("Verified live 2026-08-13 on huggingface.co/datasets/allenai/ai2_arc (474 downloads).",
+         "Verified 2026-08-13 via the dataset card."),
+        ("Verified live 2026-08-13 against the repository DATASHEET.md and arXiv:2406.19314.",
+         "Verified 2026-08-13 via the dataset card."),
+        ("Verified live 2026-08-13 via primary sources; v1.15.0 and 65k stars. MIT-licensed.",
+         "Verified 2026-08-13 via the dataset card; v1.15.0 and 65k stars. MIT-licensed."),
+    ],
+)
+def test_the_clause_bound_survives_a_dot_inside_a_url(before, expected):
+    """A sentence-terminating `.` is one followed by whitespace or end of string; a dot in a
+    URL, filename or version number is not. 71 clauses in the corpus contain an internal dot,
+    so treating them alike was not an edge case — it would have mangled the prose of every
+    one it rewrote."""
+    assert rewrite(before, "2026-08-13", "the dataset card") == expected
+
+
+def test_no_rewrite_leaves_an_orphaned_clause_fragment():
+    """The signature of the bug: a token beginning with `.` immediately after the document."""
+    import glob
+    import re
+
+    for path in sorted(glob.glob(str(ROOT / "sources" / "products" / "*.yaml")))[:60]:
+        comments = str((yaml.safe_load(open(path)) or {}).get("comments") or "")
+        state, date, _ = classify(comments)
+        if state == "missing":
+            continue
+        out = rewrite(" ".join(comments.split()), date, "the document")
+        assert not re.search(r"the document\.\w", out), f"orphaned fragment in {path}"

--- a/tests/test_prose_provenance.py
+++ b/tests/test_prose_provenance.py
@@ -63,7 +63,7 @@ def test_every_state_is_accounted_for():
 def test_rewrite_replaces_the_clause_and_keeps_the_rest():
     before = "Verified live 2026-08-13 via primary sources; v1.15.0 and 65k stars. MIT-licensed."
     after = rewrite(before, "Verified live 2026-08-13 via primary sources;",
-                    "the anything-llm repository page")
+                    "the anything-llm repository page", "2026-08-13")
     assert after.startswith("Verified 2026-08-13 via the anything-llm repository page;")
     assert "v1.15.0 and 65k stars. MIT-licensed." in after
     assert "primary sources" not in after
@@ -73,8 +73,29 @@ def test_rewrite_never_moves_the_date():
     """A provenance repair is not a re-verification. Advancing the date would claim somebody
     re-confirmed the facts today, which nobody did."""
     after = rewrite("Verified live 2026-08-13 via primary sources.",
-                    "Verified live 2026-08-13 via primary sources.", "the README")
+                    "Verified live 2026-08-13 via primary sources.", "the README", "2026-08-13")
     assert "2026-08-13" in after
+
+
+def test_rewrite_writes_the_validated_date_not_one_scraped_from_the_clause():
+    """The written date comes from `verification_date`, which every upstream check is about.
+
+    Deriving it here instead meant the date written into the corpus came from whatever string
+    the packet nominated as its clause, while the validation ran against a different field.
+    """
+    with pytest.raises(Refused):
+        rewrite("Verified live 2026-08-13 via primary sources.",
+                "Verified live 2026-08-13 via primary sources.", "the README", "2026-08-14")
+    with pytest.raises(Refused):
+        rewrite("Verified live 2026-08-13 via primary sources.",
+                "Verified live 2026-08-13 via primary sources.", "the README", "2026-99-99")
+
+
+def test_rewrite_refuses_a_clause_that_is_not_a_verification_line():
+    """A packet may decide where the clause ENDS. It may not decide which claim is rewritten."""
+    with pytest.raises(Refused):
+        rewrite("Verified 2026-08-13 via primary sources. Released 2026-08-13 under MIT.",
+                "Released 2026-08-13 under MIT.", "the README", "2026-08-13")
 
 
 def _packet(**over):
@@ -84,6 +105,7 @@ def _packet(**over):
     product = yaml.safe_load((ROOT / "sources" / "products" / "anythingllm.yaml").read_text())
     base = {
         "product": "anythingllm",
+        "current_state": "generic",
         "current_clause": clause_span(product.get("comments")),
         "verification_date": "2026-08-13",
         "selected_document": "the anything-llm repository page",
@@ -127,6 +149,19 @@ def test_a_complete_packet_passes():
         ("no prose_digest at all", _packet(prose_digest="")),
         ("packet date disagrees with the live line",
          _packet(verification_date="2026-08-12", source_accessed="2026-08-12")),
+        # The clause decides a boundary, never which claim is rewritten. Without these, a
+        # packet could nominate another unique dated sentence: the rewrite would land there,
+        # the real verification line would survive, and a "canonical line exists" postcondition
+        # would still pass.
+        ("clause is not in the live prose", _packet(current_clause="Verified 2026-08-13 via X.")),
+        # Present in the live prose, unique, and not the claim under repair.
+        ("clause is not a verification line",
+         _packet(current_clause="MIT-licensed all-in-one local-first Desktop + Docker AI app")),
+        ("clause is dated differently from the packet",
+         _packet(current_clause="Verified live 2026-08-13 via primary sources;",
+                 verification_date="2026-08-12", source_accessed="2026-08-12")),
+        ("clause carries no state", _packet(current_state="")),
+        ("reviewed under a different state", _packet(current_state="named_noncanonical")),
     ],
 )
 def test_incomplete_packets_are_refused(name, packet):
@@ -224,7 +259,7 @@ def test_the_digest_catches_an_edit_to_either_prose_field():
     ],
 )
 def test_rewrite_replaces_the_exact_reviewed_clause(full, clause, expected):
-    assert rewrite(full, clause, "the dataset card") == expected
+    assert rewrite(full, clause, "the dataset card", "2026-08-13") == expected
 
 
 def test_rewrite_refuses_a_clause_that_is_not_present_exactly_once():
@@ -233,39 +268,196 @@ def test_rewrite_refuses_a_clause_that_is_not_present_exactly_once():
     from build.apply_provenance import Refused
 
     with pytest.raises(Refused):
-        rewrite("Verified 2026-08-13 via the README.", "a clause that is not there", "x")
+        rewrite("Verified 2026-08-13 via the README.", "a clause that is not there", "x",
+                "2026-08-13")
     with pytest.raises(Refused):
-        rewrite("A. A.", "A.", "x")   # two occurrences
+        rewrite("Verified 2026-08-13. Verified 2026-08-13.", "Verified 2026-08-13.", "x",
+                "2026-08-13")   # two occurrences
 
 
-def test_the_clause_boundary_has_one_owner():
-    """BOUND is interpolated into both patterns rather than restated. The first cut of this
-    fix wrote the expansion into CLAUSE_ANY as a literal, so BOUND advertised a new boundary
-    while the pattern kept the old one — the sibling-copy defect, inside its own fix."""
-    from build.apply_provenance import CLAUSE
+def test_the_applier_holds_no_clause_pattern():
+    """The boundary has one owner because the applier no longer needs one.
+
+    It used to carry a sibling copy and re-match the clause at write time, which is what made
+    every boundary bug a silent corruption. `BOUND` is a heuristic that proposes a clause for
+    review; nothing downstream of the review re-derives it.
+    """
+    import ast
+    import inspect
+
+    from build import apply_provenance
     from build.prose_provenance import BOUND, CLAUSE_ANY
 
-    assert BOUND in CLAUSE.pattern
     assert BOUND in CLAUSE_ANY.pattern
 
+    # AST, not a text search: the module's own docstring quotes the regex fragments it no
+    # longer uses, and a grep-shaped test would either fail on the prose or be weakened until
+    # it matched nothing that mattered.
+    tree = ast.parse(inspect.getsource(apply_provenance))
+    imports = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        for alias in node.names
+    }
+    assert "re" not in imports, "the applier imports `re`; it has no boundary to derive"
+    assert "re" not in {
+        node.id for node in ast.walk(tree) if isinstance(node, ast.Name)
+    }
 
-def test_every_corpus_clause_round_trips_without_an_orphan():
-    """All 472, not a sample. The earlier version checked the first 60 files for one
-    signature (`the document.\w`), which is the URL case only — it would have passed the
-    initialism case, whose fragment starts with a space and a capital."""
+
+def test_every_dated_product_emits_a_literally_replaceable_clause():
+    """Every product the census calls dated, not a sample and not a threshold.
+
+    The denominator is the census's own non-missing count, so a clause_span that quietly
+    stopped matching some wording would fail here instead of shrinking the walk. An earlier
+    version checked the first 60 files for one signature (`the document.\\w`) — the URL case
+    only — and would have passed the initialism case, whose fragment starts with a capital.
+
+    What this establishes is narrow and worth stating: every dated line yields a clause that
+    can be substituted literally without orphaning a fragment. It cannot establish that the
+    heuristic chose the semantically right boundary. Review does that, in the packet.
+    """
     import glob
 
     checked = 0
     for path in sorted(glob.glob(str(ROOT / "sources" / "products" / "*.yaml"))):
         product = yaml.safe_load(open(path)) or {}
         comments = " ".join(str(product.get("comments") or "").split())
-        clause = clause_span(comments)
-        if not clause:
+        state, date, _ = classify(comments)
+        if state == "missing":
             continue
+        clause = clause_span(comments)
+        assert clause, f"{path}: dated but no replaceable clause"
         checked += 1
-        out = rewrite(comments, clause, "THE-DOCUMENT")
+        out = rewrite(comments, clause, "THE-DOCUMENT", date)
         after = out.split("THE-DOCUMENT", 1)[1]
         # Whatever follows the inserted name must start a new sentence or clause, never a
         # fragment of the one just replaced.
         assert re.match(r"^[.;]?(\s|$)", after), f"{path}: orphaned fragment {after[:60]!r}"
-    assert checked > 400, f"only {checked} products carried a clause; the walk has narrowed"
+
+    by_state = census()
+    expected = sum(len(v) for state, v in by_state.items() if state != "missing")
+    assert checked == expected, f"walked {checked} of {expected} dated products"
+
+
+def test_packets_cover_every_unresolved_state():
+    """All three, not just `generic`.
+
+    The pipeline was specified as one uniform review over 201 records, but emitted packets for
+    only the 172 `generic` ones — so the 16 `ambiguous_noncanonical` and 13
+    `named_noncanonical` had no route through it at all. A second, weaker path for the named
+    ones would let the prose vouch for itself, which is the shortcut this exercise corrects.
+    """
+    from build.prose_provenance import UNRESOLVED, packets
+
+    by_state = census()
+    rows = packets()
+    assert len(rows) == sum(len(by_state.get(s, [])) for s in UNRESOLVED)
+    assert {r["current_state"] for r in rows} == set(UNRESOLVED)
+    for row in rows:
+        assert row["current_clause"], f"{row['product']}: no clause to review"
+        assert row["decision"] is None, "a packet decides nothing on its own"
+
+
+def test_packets_can_be_scoped_to_one_category():
+    """Review happens a category at a time, so the manifest has to be scopeable to a roster."""
+    from build.prose_provenance import category_roster, packets
+
+    roster = category_roster("ui_api")
+    rows = packets(roster)
+    assert rows and {r["product"] for r in rows} <= roster
+    assert {r["product"] for r in rows} == {r["product"] for r in packets()} & roster
+
+
+@pytest.mark.parametrize("state", ["ambiguous_noncanonical", "named_noncanonical"])
+def test_an_unresolved_packet_of_any_state_applies(tmp_path, monkeypatch, state):
+    """`apply_one` end to end, on a synthetic corpus.
+
+    Nothing exercised `apply_one` until now — `check` and `rewrite` were each tested alone,
+    and the function that joins them referenced an undefined name, so every real application
+    would have raised `NameError` after passing all its checks. The gap is the same shape as
+    everything else this PR fixes: the parts were verified, the composition was not.
+    """
+    import build.apply_provenance as ap
+    import build.prose_provenance as pp
+
+    line = {
+        "ambiguous_noncanonical": "Verified 2026-08-13.",
+        "named_noncanonical": "Verified live 2026-08-13 via the SPEC.md.",
+    }[state]
+    products = tmp_path / "sources" / "products"
+    scores = tmp_path / "sources" / "scores"
+    products.mkdir(parents=True)
+    scores.mkdir(parents=True)
+    (products / "widget.yaml").write_text(
+        yaml.safe_dump({"name": "widget", "description": "A widget.", "comments": line})
+    )
+    (scores / "widget.yaml").write_text(yaml.safe_dump({
+        "openness": {"sources": [{"url": "https://example.com/spec", "accessed": "2026-08-13",
+                                  "shows": "what the widget is"}]},
+    }))
+    monkeypatch.setattr(ap, "ROOT", tmp_path)
+    monkeypatch.setattr(pp, "ROOT", tmp_path)
+
+    product = yaml.safe_load((products / "widget.yaml").read_text())
+    packet = {
+        "product": "widget",
+        "current_state": state,
+        "current_clause": clause_span(product["comments"]),
+        "verification_date": "2026-08-13",
+        "selected_document": "the widget specification",
+        "source_url": "https://example.com/spec",
+        "source_accessed": "2026-08-13",
+        "support": "The spec describes the widget.",
+        "prose_digest": pp.prose_digest(product),
+        "decision": "derive",
+    }
+    assert ap.apply_one(packet) is True
+
+    after = yaml.safe_load((products / "widget.yaml").read_text())["comments"]
+    assert classify(after)[0] == "canonical"
+    assert classify(after)[1] == "2026-08-13"
+    assert "the widget specification" in after
+
+
+def test_apply_refuses_a_packet_that_would_leave_two_dated_lines(tmp_path, monkeypatch):
+    """The postcondition is about the result, not about a canonical line existing somewhere.
+
+    A clause nominated away from the real verification line would write a second, canonical
+    line and leave the original standing — and the old `CANONICAL.search` postcondition would
+    have found the new one and called that a success.
+    """
+    import build.apply_provenance as ap
+    import build.prose_provenance as pp
+
+    products = tmp_path / "sources" / "products"
+    scores = tmp_path / "sources" / "scores"
+    products.mkdir(parents=True)
+    scores.mkdir(parents=True)
+    (products / "widget.yaml").write_text(yaml.safe_dump({
+        "name": "widget", "description": "A widget.",
+        "comments": "Verified 2026-08-13 via primary sources. Shipped 2026-08-13 under MIT.",
+    }))
+    (scores / "widget.yaml").write_text(yaml.safe_dump({
+        "openness": {"sources": [{"url": "https://example.com/spec", "accessed": "2026-08-13"}]},
+    }))
+    monkeypatch.setattr(ap, "ROOT", tmp_path)
+    monkeypatch.setattr(pp, "ROOT", tmp_path)
+
+    product = yaml.safe_load((products / "widget.yaml").read_text())
+    packet = {
+        "product": "widget",
+        "current_state": "generic",
+        "current_clause": "Shipped 2026-08-13 under MIT.",
+        "verification_date": "2026-08-13",
+        "selected_document": "the widget specification",
+        "source_url": "https://example.com/spec",
+        "source_accessed": "2026-08-13",
+        "support": "The spec describes the widget.",
+        "prose_digest": pp.prose_digest(product),
+        "decision": "derive",
+    }
+    with pytest.raises(Refused):
+        ap.apply_one(packet)
+    assert "primary sources" in (products / "widget.yaml").read_text()


### PR DESCRIPTION
Provenance repair writes into hand-authored prose, so the failure that matters is not a crash — it is a plausible-looking sentence that says something nobody verified. This PR moves every judgment out of write time and binds what remains to the exact claim under repair.

## The clause boundary is proposed, never re-derived

The applier used to re-match the dated clause with its own regex as it wrote. That made every boundary bug a silent corruption:

```
in : Verified live 2026-08-13 on huggingface.co/datasets/allenai/ai2_arc (474 downloads).
out: Verified 2026-08-13 via the dataset card.co/datasets/allenai/ai2_arc (474 downloads).

in : Verified live 2026-08-13 via the U.S. AI Safety Institute report.
out: Verified 2026-08-13 via the document. AI Safety Institute report.
```

71 corpus clauses contain an internal dot, so the first was not an edge case; the second is worse, because the result reads as grammatical.

Tightening the regex would only have moved the failure to the next abbreviation. The defect was **where the heuristic was being used**. `BOUND` now belongs to `prose_provenance` alone, where it *proposes* a clause into the packet for a human to confirm, and `apply_provenance` holds no pattern at all — it substitutes the reviewed string literally, refusing unless it appears exactly once. A future boundary bug is now a visibly wrong string in review instead of a mangled file.

`BOUND` is also interpolated into `CLAUSE_ANY` rather than restated. The first cut wrote the expansion out as a literal in both patterns, so editing `BOUND` changed neither — the sibling-copy defect, inside the fix for sibling copies.

## A packet may decide a boundary, not which claim is rewritten

Occurring exactly once was the only thing bound about `current_clause`. A packet could nominate any other unique dated sentence: the rewrite would land there, the real verification line would survive untouched, and the old `CANONICAL.search` postcondition would have found the newly written one and called it a success.

`check` now also requires that the clause opens with the verification form and carries the packet's own `verification_date`; `rewrite` takes that validated date as an argument instead of scraping one back out of whatever string the packet supplied; and the postcondition is about the *result* — it must classify `canonical`, at the claimed date, with exactly one dated verification line remaining.

## All three unresolved states, one path

`packets()` emitted only the 172 `generic` records, so the 16 `ambiguous_noncanonical` and 13 `named_noncanonical` had no route through the pipeline at all. All 201 now go through the same review and the same `derive` decision, with the same justification required.

Deliberately one path, not two. A `named_noncanonical` record names something in prose, but that name has to turn out to be a document the record actually cites before it can be written as provenance — a separate "mechanical rewording" route would let the prose vouch for itself. Where the named document is not a date-aligned source in the score file, the honest decision is `reread`. Packets carry `current_state` and are refused if the live state has moved since review, and `--category` scopes them to one roster so review happens a batch at a time.

## `apply_one` had never been executed

It referenced an undefined `CANONICAL`, so every real application would have raised `NameError` after passing every check it was subjected to. `check` and `rewrite` were each tested alone and thoroughly; the function joining them was not tested at all. There is now an end-to-end test per state against a synthetic corpus, plus one asserting a mis-aimed clause refuses rather than leaving two dated lines.

`apply_one` also now normalizes `comments` before matching. The corpus wraps that field across lines, so a reviewed clause spanning a wrap could never have matched the raw text literally.

## Test denominators

`test_every_corpus_clause_round_trips_without_an_orphan` claimed the corpus and checked the first 60 files for one signature (`the document.\w`) — the URL case only, which the initialism case would have passed. It now walks every product the census calls dated, and its denominator is the census's own count rather than a `> 400` threshold.

Renamed to `test_every_dated_product_emits_a_literally_replaceable_clause`, which is what it can establish. Whether the heuristic picked the semantically right boundary is a reading, and review does that.

`test_the_applier_holds_no_clause_pattern` uses the AST rather than a text search: the module's docstring quotes the fragments it no longer uses, so a grep-shaped test would have failed on the prose and then been weakened until it matched nothing.

## Also

- Four hardware records reading `via substitute sources` were pulled out of #282's rewording — removing `live` would have promoted them into canonical form while they still named a method. Six benchmark records name a host rather than a document (`codecontests`, `gsm8k`, `humaneval`, `mbpp`, `ragas`, `swe-bench-verified`) and stay `named_noncanonical`.
- `docs/reference/sibling-invariants.md` records both constructs: the boundary, whose disposition is removal rather than deduplication, and the untested composition.

## Verification

649 tests, no skips. `validate`, `check_verification`, `check_payload` green. Census unchanged at 271 canonical / 201 unresolved — this PR writes no product prose.
