### PR TITLE
Refresh orchestration_agents: 51/51

### DIFF
--- a/sources/products/aider.yaml
+++ b/sources/products/aider.yaml
@@ -1,15 +1,12 @@
 name: aider
 display_name: Aider
 type: software
-description: Terminal-based AI pair programming tool that edits code directly in your local git repo.
-  Differentiates through deep git integration (automatic commits with sensible messages), support for
-  20+ LLM providers, and a sophisticated diff-based editing approach that minimizes token usage. 48K GitHub
-  stars; widely regarded as the benchmark for CLI-based coding agents and the tool that pioneered the
-  'agentic coding in terminal' pattern.
+description: Terminal AI pair-programming tool that edits code directly in a local git repository, planning
+  changes across the repo and committing them with generated messages. It supports 20+ model providers and
+  uses a diff-based editing approach that keeps token use down. It installs from PyPI and runs as a command-line
+  program.
 github:
 - url: https://github.com/Aider-AI/aider
 pypi:
 - url: https://pypi.org/project/aider-chat
-comments: Verified live 2026-08-13 via primary sources. Aider v0.86.2 (PyPI aider-chat, Feb 12 2026);
-  GitHub repo Aider-AI/aider active, 48.2k stars. Terminal AI pair-programming agent that plans edits
-  across a repo and applies git commits.
+comments: Verified 2026-08-13 via the Aider-AI/aider repository and its PyPI page.

--- a/sources/products/amazon-q-developer.yaml
+++ b/sources/products/amazon-q-developer.yaml
@@ -1,12 +1,9 @@
 name: amazon-q-developer
 display_name: Amazon Q Developer
 type: software
-description: AWS's AI-powered development assistant with an autonomous agent mode that can implement features,
-  fix bugs, write tests, and perform code transformations across entire codebases. Differentiates through
-  deep AWS service integration (can deploy, debug Lambda functions, query CloudWatch) and enterprise security
-  features. Available in IDE extensions, CLI, and AWS Console; included in AWS enterprise agreements,
-  giving it a large potential installed base.
-comments: Verified live 2026-08-13 via primary sources. Amazon Q Developer, AWS's agentic GenAI software-development
-  assistant across IDEs/CLI/Console/chat. Perpetual free tier (50 agentic chats a month, 1,000 lines of
-  code transformed) plus a Pro tier. AWS claims top SWE-Bench Leaderboard placement without publishing
-  a figure, and discloses no user count.
+description: AWS's AI development assistant with an autonomous agent mode that implements features, fixes bugs,
+  writes tests and performs code transformations across a codebase. It integrates with AWS services so it can
+  deploy, debug Lambda functions and query CloudWatch, and is delivered through IDE plugins, a CLI and the
+  AWS console.
+comments: AWS claims the highest SWE-Bench Leaderboard scores without publishing a figure, and discloses no
+  user count. Verified 2026-08-13 via the Amazon Q Developer product page.

--- a/sources/products/antigravity.yaml
+++ b/sources/products/antigravity.yaml
@@ -1,11 +1,9 @@
 name: antigravity
 display_name: Antigravity
 type: software
-description: Google's agent-first developer platform, launched as a standalone IDE in November 2025 (public
-  preview competing with Cursor), then expanded at Google I/O in May 2026 into Antigravity 2.0 with a
-  Go-based CLI, SDK, and multi-agent orchestration. The CLI replaces Gemini CLI (which sunsets for free
-  tiers in June 2026). Powered by Gemini 3.5 Flash with deep Google Cloud / Firebase / Android integration.
-comments: Verified live 2026-08-13 via primary sources. Google Antigravity 2.0, agent-first AI development
-  platform (desktop app + CLI + IDE + SDK); launched at Google I/O 2026, public preview free for individuals.
-  Not locked to Google models - the launch post offers model optionality across Gemini 3 Pro, Claude Sonnet
-  4.5 and GPT-OSS. Google publishes no usage figure for it.
+description: Google's agent-first development platform, shipping a desktop application, a CLI, an IDE and an
+  SDK. It runs agentic development workflows on macOS, Windows and Linux with model optionality across Google,
+  Anthropic and OpenAI models, and integrates with Google Cloud, Firebase and Android. Its CLI supersedes the
+  earlier Gemini CLI.
+comments: Google publishes no download, install or active-user figure for it. Verified 2026-08-13 via the Antigravity
+  product page and Google's I/O 2026 developer keynote announcement.

--- a/sources/products/autogen.yaml
+++ b/sources/products/autogen.yaml
@@ -1,13 +1,14 @@
 name: autogen
 display_name: AutoGen
 type: software
-description: Microsoft's framework for agentic AI centered on multi-agent conversation patterns where LLM agents
-  collaborate, critique, and run tools/code. Its event-driven v0.4 redesign and code-execution focus distinguish
-  it from graph- or role-based frameworks.
+description: Microsoft's framework for agentic AI built around multi-agent conversation, where model-backed
+  agents collaborate, critique each other and run tools and code. Its event-driven redesign and code-execution
+  focus distinguish it from graph- or role-based frameworks. Microsoft now directs new work to the Microsoft
+  Agent Framework, which merges AutoGen with Semantic Kernel.
 github:
 - url: https://github.com/microsoft/autogen
 pypi:
 - url: https://pypi.org/project/autogen-agentchat
-comments: Verified live 2026-08-13 via primary sources. Code is MIT (LICENSE-CODE; the repo's root LICENSE
-  is CC-BY-4.0 for docs, which mislabels the GitHub license field). In maintenance mode - Microsoft now
-  directs new work to the Microsoft Agent Framework (Semantic Kernel + AutoGen merge). 60.4k stars.
+comments: The repository carries separate license files for code and documentation, which makes GitHub's license
+  field misleading; the openness axis reads the code file. Verified 2026-08-13 via the microsoft/autogen repository
+  and its LICENSE-CODE.

--- a/sources/products/autogpt.yaml
+++ b/sources/products/autogpt.yaml
@@ -1,13 +1,11 @@
 name: autogpt
 display_name: AutoGPT
 type: software
-description: One of the earliest and most well-known autonomous AI agent platforms, AutoGPT lets users
-  define goals and the agent recursively breaks them into sub-tasks, executes actions, and learns from
-  results. Has evolved from a viral demo into a more mature platform with a visual builder and marketplace.
-  186.6K GitHub stars (highest in the category) and 46.1K forks, though much of the star count reflects
-  the 2023 hype wave. Still actively developed.
+description: Autonomous agent platform where a user defines a goal and the agent breaks it into sub-tasks,
+  executes them and adapts from the results. It began as a command-line experiment and is now centered on a
+  low-code visual builder with a marketplace, where agents run on demand, on a schedule or from a trigger.
+  Hosted and self-hosted deployment are both offered.
 github:
 - url: https://github.com/Significant-Gravitas/AutoGPT
-comments: Verified live 2026-08-13 via primary sources. AutoGPT (Significant-Gravitas/AutoGPT); 186.6k
-  GitHub stars. The original autonomous-agent project; now centered on the AutoGPT Platform (low-code
-  agent builder), with autogpt_platform/ under Polyform Shield and the classic components under MIT.
+comments: The repository ships two license files covering different parts of the tree, which the openness axis
+  resolves. Verified 2026-08-13 via the Significant-Gravitas/AutoGPT repository.

--- a/sources/products/beeai.yaml
+++ b/sources/products/beeai.yaml
@@ -1,16 +1,14 @@
 name: beeai
 display_name: BeeAI Framework
 type: software
-description: Open-source toolkit for production-ready multi-agent systems with full feature parity across Python
-  and TypeScript - its signature differentiator vs the Python-first peers. Emphasizes production concerns (caching,
-  memory, OpenTelemetry observability), constraint-based agent governance, native MCP + A2A interop, and 10+ LLM
-  backends.
+description: Toolkit for production multi-agent systems with feature parity across Python and TypeScript, which
+  sets it apart from the Python-first frameworks around it. It covers caching, memory and OpenTelemetry observability,
+  constraint-based agent governance, native MCP and A2A interoperability, and more than ten model backends.
 github:
 - url: https://github.com/i-am-bee/beeai-framework
 npm:
 - url: https://www.npmjs.com/package/beeai-framework
 pypi:
 - url: https://pypi.org/project/beeai-framework
-comments: Verified live 2026-08-13 via primary sources. Apache-2.0. IBM-originated, now under the Linux
-  Foundation (LF AI & Data), alongside Docling and Data Prep Kit. 3.4k stars, about 64k downloads a month
-  across PyPI and npm.
+comments: Originated at IBM and now hosted by the Linux Foundation under LF AI & Data. Verified 2026-08-13
+  via the i-am-bee/beeai-framework repository and the LF AI & Data project page.

--- a/sources/products/claude-code.yaml
+++ b/sources/products/claude-code.yaml
@@ -1,12 +1,11 @@
 name: claude-code
 display_name: Claude Code
 type: software
-description: Agentic coding tool from Anthropic that lives in the terminal, understands your entire codebase,
-  and autonomously executes multi-step development tasks including code generation, refactoring, git workflows,
-  and testing. Differentiates through deep integration with Claude models, a rich skill/hook system for customization,
-  and native MCP tool support. 125.7K GitHub stars; source-available but not open source (no license).
+description: Agentic coding tool from Anthropic that runs in the terminal, reads a whole codebase and executes
+  multi-step development tasks including code generation, refactoring, git workflows and testing. It extends
+  through a skills and hooks system and supports MCP tools natively, and also runs in VS Code, a desktop app,
+  the web, Slack and mobile.
 github:
 - url: https://github.com/anthropics/claude-code
-comments: Verified live 2026-08-13 via primary sources. Claude Code (Anthropic), agentic coding tool across
-  terminal, VS Code, desktop, web, Slack and mobile. Proprietary/SaaS. Most surfaces require a Claude
-  subscription or Anthropic Console account. About $2.5B run-rate revenue as of early 2026.
+comments: Most surfaces require a Claude subscription or an Anthropic Console account. Verified 2026-08-13
+  via the Claude Code documentation overview.

--- a/sources/products/cline.yaml
+++ b/sources/products/cline.yaml
@@ -1,12 +1,9 @@
 name: cline
 display_name: Cline
 type: software
-description: Autonomous coding agent available as a VS Code extension, CLI tool, and SDK. Can create and edit
-  files, run terminal commands, use the browser, and orchestrate multi-step development tasks with human-in-the-loop
-  approval. Differentiates through its IDE-native experience and extensible SDK for embedding agent capabilities
-  into other products. 66K GitHub stars and 7.1K forks, with very active development.
+description: Autonomous coding agent available as a VS Code extension, a CLI and an SDK. It creates and edits
+  files, runs terminal commands, drives a browser and orchestrates multi-step development tasks with human
+  approval at each step. The SDK exists so the agent can be embedded in other products.
 github:
 - url: https://github.com/cline/cline
-comments: Verified live 2026-08-13 via primary sources. Cline (Cline Bot Inc.); GitHub cline/cline 66.1k
-  stars, 4.97M VS Code Marketplace installs. Autonomous coding agent in IDE/terminal, plans tasks, edits
-  files, runs commands with human approval.
+comments: Verified 2026-08-13 via the cline/cline repository and its VS Code Marketplace listing.

--- a/sources/products/codex-cli.yaml
+++ b/sources/products/codex-cli.yaml
@@ -1,11 +1,10 @@
 name: codex-cli
 display_name: Codex CLI
 type: software
-description: Lightweight open source coding agent from OpenAI that runs in your terminal. Built in Rust
-  for speed, it reads your codebase, proposes a plan, and executes multi-file changes with sandboxed command
-  execution. Differentiates as OpenAI's official open source agent offering (Apache-2.0) with tight integration
-  to OpenAI models. 105.7K GitHub stars and 16.0K forks, one of the most rapidly developed OSS agents.
+description: Terminal coding agent from OpenAI, written in Rust. It reads a codebase, proposes a plan and executes
+  multi-file changes with sandboxed command execution, and documents writable roots, permission profiles, agent
+  approvals, auto-review, MCP connectors and skills. Desktop builds are offered for Linux and Windows.
 github:
 - url: https://github.com/openai/codex
-comments: Verified live 2026-08-13 via primary sources. GitHub openai/codex 105.7k stars, built in Rust.
-  Open-source terminal coding agent (the agent itself is OSS; it calls OpenAI models).
+comments: Codex runs against either a ChatGPT plan or an API key. Verified 2026-08-13 via the OpenAI Codex
+  CLI documentation.

--- a/sources/products/crewai.yaml
+++ b/sources/products/crewai.yaml
@@ -1,9 +1,12 @@
 name: crewai
 display_name: CrewAI
 type: software
-description: Role-based multi-agent orchestration framework built around crews and flows, MIT-licensed,
-  with the CrewAI AMP platform sold beside it. 57.0k GitHub stars and around 17M PyPI downloads a month.
+description: Role-based multi-agent orchestration framework built around crews and flows, where agents take
+  defined roles and hand work between them. A commercial platform is sold alongside it, adding SSO, role-based
+  access control, workload identity, PII redaction and deployment to the vendor's cloud, a customer VPC or
+  on-premises infrastructure.
 pypi:
 - url: https://pypi.org/project/crewai/
-comments: Verified live 2026-08-13 via primary sources. Active 2026; 57.0k GitHub stars, MIT framework
-  with the AMP platform sold alongside it.
+comments: The enterprise-named module in the tree is a configuration client rather than a separate product,
+  so the published framework is not feature-gated. Verified 2026-08-12 via the crewAIInc/crewAI repository
+  tree, its enterprise CLI module and the vendor pricing page.

--- a/sources/products/cursor.yaml
+++ b/sources/products/cursor.yaml
@@ -1,11 +1,8 @@
 name: cursor
 display_name: Cursor
 type: software
-description: AI-first code editor (VS Code fork) with an integrated agent mode that can autonomously make multi-file
-  changes, run terminal commands, and iterate on code based on errors. Differentiates through IDE integration
-  where the agent works alongside manual editing, plus frontier model access and a background agent feature
-  for asynchronous task completion. Reportedly 100K+ paying users at ~$20/month, making it the most commercially
-  successful AI coding tool outside GitHub Copilot. Raised $900M+ at a $9B+ valuation.
-comments: Verified live 2026-08-13 via primary sources. Cursor (Anysphere Inc.), AI coding IDE with agent
-  mode + Background Agent + CLI; proprietary SaaS. ~$2B ARR (Feb 2026), 1M+ DAU, 50K businesses. Scored
-  here for its autonomous agent mode (chat-editor surface would be ui_api).
+description: AI-first code editor, forked from VS Code, with an agent mode that makes multi-file changes autonomously,
+  runs terminal commands and iterates against errors. The agent works alongside manual editing rather than
+  replacing it, and a background agent completes tasks asynchronously.
+comments: Scored for the autonomous agent mode; the chat-editor surface would belong in ui_api. Verified 2026-08-13
+  via the Cursor product site and the SWE-bench coding-agent leaderboard.

--- a/sources/products/datasette-agent.yaml
+++ b/sources/products/datasette-agent.yaml
@@ -1,14 +1,13 @@
 name: datasette-agent
 display_name: Datasette Agent
 type: software
-description: 'LLM-powered agent assistant for Datasette, Simon Willison''s tool for exploring and publishing structured
-  data in SQLite. A chat interface at /-/agent answers natural-language questions against databases: the agent writes
-  and runs SQL (save_query, execute_write_sql tools), explores data in the background, and renders results. Uses
-  the datasette-llm plugin to call models and exposes an extensible tool surface (charts, image generation) for
-  third-party tools.'
+description: 'Agent plugin for Datasette, the tool for exploring and publishing structured data in SQLite.
+  A chat interface answers natural-language questions against a database: the agent writes and runs SQL, explores
+  the data in the background and renders results. It calls models through the datasette-llm plugin and exposes
+  an extensible tool surface for charts and image generation.'
 github:
 - url: https://github.com/datasette/datasette-agent
 pypi:
 - url: https://pypi.org/project/datasette-agent
-comments: 'Apache-2.0 (verified LICENSE body). EARLY/ALPHA: announced 21 May 2026, runs on Datasette 1.0a33.
-  110 stars, 6 forks, about 1.4k PyPI downloads a month. Verified live 2026-08-13 via primary sources.'
+comments: 'Early-stage: announced 21 May 2026 and running against a pre-1.0 Datasette. Verified 2026-08-13
+  via the datasette/datasette-agent repository and the agent.datasette.io demo.'

--- a/sources/products/devin.yaml
+++ b/sources/products/devin.yaml
@@ -1,12 +1,9 @@
 name: devin
 display_name: Devin
 type: software
-description: The first product marketed as a fully autonomous AI software engineer. Operates in a cloud-based
-  sandboxed environment with its own shell, browser, and editor, completing entire development tasks from
-  specification to pull request. Differentiates as the highest-profile 'autonomous developer' product
-  with full environment access rather than just file editing. Raised $175M at a $2B valuation; commercially
-  available via API and web interface, though real-world performance reviews are mixed compared to initial
-  demo claims.
-comments: Verified live 2026-08-13 via primary sources. Devin by Cognition AI, autonomous SaaS software-engineering
-  agent (cloud, CLI, desktop). Plans are Free, Pro $20/mo, Max $200/mo, Teams $80/mo plus $40 per dev
-  seat, and Enterprise. SWE 1.7 is the current in-house model.
+description: Autonomous software-engineering agent that runs in a cloud sandbox with its own shell, browser
+  and editor, taking a task from specification through to a pull request. It is reached through a web interface,
+  a CLI, a desktop app and an API, and runs on Cognition's own in-house model.
+comments: A previously cited SWE-bench figure is no longer on the page it came from, so the capability band
+  rests on the vendor's own report and a third-party leaderboard row. Verified 2026-08-13 via the Devin documentation
+  and Cognition's SWE-bench technical report.

--- a/sources/products/dify.yaml
+++ b/sources/products/dify.yaml
@@ -1,11 +1,8 @@
 name: dify
 display_name: Dify
 type: software
-description: Open-source platform for building LLM applications, combining a visual workflow builder, RAG pipelines,
-  agent tooling, and model management across providers in one workspace. Deployable on cloud, VPC, or self-hosted.
-  ~152K GitHub stars as of August 2026. Ships under the Dify Open Source License, which is Apache-2.0 plus
-  a multi-tenant service restriction and branding conditions, so the source is published and readable while
-  a class of use is charged for.
-comments: Verified live 2026-08-13 via primary sources. Active 2026; 152.3K GitHub stars. dify.ai describes
-  the product as source-available under an Apache-2.0-derivative license, self-hostable with one Docker
-  command.
+description: Platform for building LLM applications, combining a visual workflow builder, RAG pipelines, agent
+  tooling and model management across providers in one workspace. It deploys to the vendor's cloud, a customer
+  VPC or self-hosted infrastructure with a single Docker command.
+comments: The license is a custom derivative that GitHub declines to classify, which the openness axis resolves.
+  Verified 2026-08-13 via the langgenius/dify repository and the Dify product site.

--- a/sources/products/dspy.yaml
+++ b/sources/products/dspy.yaml
@@ -1,12 +1,12 @@
 name: dspy
 display_name: DSPy
 type: software
-description: 'Stanford framework for ''programming - not prompting - language models'': compose typed declarative
-  modules (signatures, Predict/ChainOfThought/ReAct) into pipelines, then hand them to optimizers (MIPROv2, BootstrapFewShot,
-  GEPA) that auto-tune prompts and/or weights against a metric.'
+description: Stanford framework for programming rather than prompting language models. Typed declarative modules
+  - signatures with Predict, ChainOfThought and ReAct - compose into pipelines, which optimizers such as MIPROv2,
+  BootstrapFewShot and GEPA then auto-tune against a metric, adjusting prompts or weights.
 github:
 - url: https://github.com/stanfordnlp/dspy
 pypi:
 - url: https://pypi.org/project/dspy
-comments: Verified live 2026-08-13 via primary sources. MIT, no commercial cloud from the project. 37.2k
-  stars, ~6.6M PyPI downloads a month.
+comments: The project sells no commercial service alongside the framework. Verified 2026-08-13 via the stanfordnlp/dspy
+  repository.

--- a/sources/products/gemini-cli.yaml
+++ b/sources/products/gemini-cli.yaml
@@ -1,13 +1,12 @@
 name: gemini-cli
 display_name: Gemini CLI
 type: software
-description: Google's open source terminal AI coding agent, bringing Gemini models into the shell for coding, debugging,
-  and task automation. Ships built-in tools (Google Search grounding, file ops, shell, web fetch), is extensible
-  via MCP and GEMINI.md system-prompt files, and offers a generous free tier on a personal Google account. Unlike
-  the closed peers (Cursor, Claude Code), it is fully Apache-2.0.
+description: Google's terminal coding agent, bringing Gemini models into the shell for coding, debugging and
+  task automation. It ships built-in tools for Google Search grounding, file operations, shell commands and
+  web fetch, and extends through MCP and GEMINI.md system-prompt files.
 github:
 - url: https://github.com/google-gemini/gemini-cli
 npm:
 - url: https://www.npmjs.com/package/@google/gemini-cli
-comments: Verified live 2026-08-13 via primary sources. Apache-2.0. 106.5k stars, ~1.85M npm downloads
-  a month. Free tier via personal Google account; paid via AI Studio/Vertex.
+comments: A free tier runs on a personal Google account, with paid access through AI Studio or Vertex. Verified
+  2026-08-13 via the google-gemini/gemini-cli repository and Google's launch announcement.

--- a/sources/products/github-copilot.yaml
+++ b/sources/products/github-copilot.yaml
@@ -1,11 +1,9 @@
 name: github-copilot
 display_name: GitHub Copilot
 type: software
-description: GitHub Copilot Agent Mode, assigns autonomous background coding tasks (plan/explore/execute),
-  supports first-party Copilot agent plus Claude (Anthropic) and Codex (OpenAI). Verified live 2026-08-13
-  via primary sources; 20M+ all-time users reported on the Microsoft earnings call, with no active-user
-  figure disclosed.
-comments: GitHub Copilot Agent Mode, assigns autonomous background coding tasks (plan/explore/execute),
-  supports first-party Copilot agent plus Claude (Anthropic) and Codex (OpenAI). Verified live 2026-08-13
-  via primary sources; 20M+ all-time users reported on the Microsoft earnings call, with no active-user
-  figure disclosed.
+description: GitHub Copilot's agent mode, which takes an assigned task and runs it as autonomous background
+  work, planning, exploring the repository and executing changes. It orchestrates the first-party Copilot agent
+  alongside Anthropic and OpenAI agents, and is built natively into GitHub across VS Code, Visual Studio, JetBrains
+  and Neovim.
+comments: Scored as the agent surface; the in-IDE assistant is a separate record in ui_api. GitHub reports
+  all-time users and no active-user figure. Verified 2026-08-13 via the GitHub Copilot product page.

--- a/sources/products/goose.yaml
+++ b/sources/products/goose.yaml
@@ -1,13 +1,11 @@
 name: goose
 display_name: Goose
 type: software
-description: Open-source extensible AI agent from Block (fka Square) that goes beyond code suggestions
-  to install packages, execute commands, edit files, and run tests with any LLM. Differentiates through
-  first-class MCP (Model Context Protocol) support and a Rust-based core for performance. 52.8K GitHub
-  stars and 6.0K forks, one of the most actively developed open source agents, now governed by the Agentic
-  AI Foundation at the Linux Foundation.
+description: Extensible on-machine AI agent from Block, written in Rust, that installs packages, executes commands,
+  edits files and runs tests against any model. It connects to more than seventy extensions over the Model
+  Context Protocol, works with over fifteen providers, and supports ACP so an existing model subscription can
+  be used.
 github:
 - url: https://github.com/aaif-goose/goose
-comments: 'Verified live 2026-08-13 via primary sources. Repo has moved from block/goose to aaif-goose/goose
-  under the Agentic AI Foundation (AAIF) at the Linux Foundation; 52.8k stars. General-purpose on-machine
-  AI agent (Rust) with 70+ MCP extensions, 15+ LLM providers, and ACP support for existing model subscriptions.'
+comments: The repository moved from block/goose to aaif-goose/goose under the Agentic AI Foundation at the
+  Linux Foundation. Verified 2026-08-13 via the aaif-goose/goose repository.

--- a/sources/products/gpt-researcher.yaml
+++ b/sources/products/gpt-researcher.yaml
@@ -1,15 +1,11 @@
 name: gpt-researcher
 display_name: GPT Researcher
 type: software
-description: Autonomous research agent that conducts deep web research on any topic by planning research
-  queries, browsing multiple sources, synthesizing findings, and generating comprehensive reports. Differentiates
-  as a purpose-built research agent (not coding-focused) that orchestrates search, scraping, and synthesis
-  into a coherent workflow. 29.0K GitHub stars and 3.9K forks; an early mover in the 'deep research'
-  agent pattern that inspired similar features in ChatGPT and Gemini.
+description: Autonomous research agent that plans sub-queries, searches web and local sources, and synthesizes
+  findings into a cited report. It is purpose-built for research rather than coding, orchestrating search,
+  scraping and synthesis into one workflow, and ships a frontend and Docker deployment alongside the library.
 github:
 - url: https://github.com/assafelovic/gpt-researcher
 pypi:
 - url: https://pypi.org/project/gpt-researcher
-comments: Verified live 2026-08-13 via primary sources. GPT Researcher (assafelovic/gpt-researcher); 29.0k
-  stars, Apache-2.0, about 80k PyPI downloads a month. Autonomous deep-research agent that plans sub-queries,
-  searches web/local sources, and writes cited reports.
+comments: Verified 2026-08-13 via the assafelovic/gpt-researcher repository.

--- a/sources/products/graphrag.yaml
+++ b/sources/products/graphrag.yaml
@@ -1,12 +1,13 @@
 name: graphrag
 display_name: GraphRAG
 type: software
-description: 'Microsoft Research''s modular graph-based RAG system: LLMs extract a knowledge graph (entities + relationships)
-  from unstructured text, cluster it into hierarchical communities, generate community summaries, and answer via
-  Global/Local/DRIFT search - built for corpus-wide ''sensemaking'' questions where naive vector RAG falls short.'
+description: Microsoft Research's graph-based RAG system. A model extracts entities and relationships from
+  unstructured text into a knowledge graph, clusters it into hierarchical communities, generates community
+  summaries, and answers through global, local and DRIFT search modes. It targets corpus-wide sensemaking questions
+  that vector retrieval alone handles poorly.
 github:
 - url: https://github.com/microsoft/graphrag
 pypi:
 - url: https://pypi.org/project/graphrag
-comments: Verified live 2026-08-13 via primary sources. MIT, no feature-gated core. 35.5k stars, about
-  69k PyPI downloads a month. Indexing is compute/cost-intensive.
+comments: Indexing is compute- and cost-intensive relative to a vector pipeline. Verified 2026-08-13 via the
+  microsoft/graphrag repository and its documentation site.

--- a/sources/products/haystack.yaml
+++ b/sources/products/haystack.yaml
@@ -1,13 +1,14 @@
 name: haystack
 display_name: Haystack
 type: software
-description: deepset's open source orchestration framework for production LLM apps in Python, built around composable
-  modular pipelines and agent workflows with explicit control over retrieval, routing, memory, and generation. Originally
-  RAG/search-focused; Haystack 2.x is a general orchestrator.
+description: deepset's Python orchestration framework for production LLM applications, built around composable
+  pipelines and agent workflows with explicit control over retrieval, routing, memory and generation. It began
+  as a RAG and search framework and is now a general orchestrator, shipping ready-made agents and progressive
+  skill discovery alongside the pipeline primitives.
 github:
 - url: https://github.com/deepset-ai/haystack
 pypi:
 - url: https://pypi.org/project/haystack-ai
-comments: Verified live 2026-08-13 via primary sources. Apache-2.0 core; commercial Haystack Enterprise
-  (managed/governance) makes the overall offering open-core. ~933k PyPI downloads a month (haystack-ai).
-  Now also ships Agent Pack ready-made agents and SkillToolset progressive skill discovery.
+comments: A commercial enterprise tier is sold beside the published framework, adding pipeline templates, deployment
+  charts and early access rather than core capability. Verified 2026-08-11 via the deepset-ai/haystack repository
+  tree and deepset's enterprise announcements.

--- a/sources/products/hermes-agent.yaml
+++ b/sources/products/hermes-agent.yaml
@@ -1,13 +1,10 @@
 name: hermes-agent
 display_name: Hermes Agent
 type: software
-description: 'Open-source autonomous agent that grows with the user through persistent memory, reusable
-  skills, and a built-in learning loop. It runs on a VPS or serverless backend, can be controlled through
-  Telegram and other messaging surfaces, and is designed to keep improving over long-lived sessions rather
-  than acting as a one-shot chat wrapper. Scale signal: the Hermes Agent repo is MIT-licensed, has 230K
-  GitHub stars, and the OpenRouter app listing puts it at daily global rank #1 on token volume.'
+description: Self-improving autonomous agent from Nous Research that grows through persistent memory, auto-generated
+  reusable skills and a built-in learning loop. It runs on a VPS or a serverless backend, is driven from Telegram
+  and other messaging surfaces, and ships subagent delegation, natural-language scheduling, sandboxing and
+  more than forty tools.
 github:
 - url: https://github.com/NousResearch/hermes-agent
-comments: Verified live 2026-08-13 via primary sources. Hermes Agent by Nous Research, open source self-improving
-  autonomous agent (auto-generates skills, persistent memory, 40+ tools, subagent delegation, NL cron,
-  multi-channel). MIT, v0.20.0, 230K stars, 35.8T cumulative tokens on OpenRouter.
+comments: Verified 2026-08-13 via the NousResearch/hermes-agent repository and the Hermes Agent product page.

--- a/sources/products/hexabot.yaml
+++ b/sources/products/hexabot.yaml
@@ -1,15 +1,14 @@
 name: hexabot
 display_name: Hexabot
 type: software
-description: Hexabot is an AI chatbot / agent builder by the company Hexastack for creating multi-channel,
-  multilingual conversational agents, deployed across North and East Africa. It offers a visual flow editor,
-  a plugin/extension system, and integrations with LLMs (ChatGPT, Gemini, Mistral, Ollama, Claude) plus
-  channels like WhatsApp, Telegram, Slack, and Facebook. v3 combines workflows, actions, agents, and conversational
-  channels in one runtime.
+description: Chatbot and agent builder from Hexastack for multi-channel, multilingual conversational agents.
+  It offers a visual flow editor, a plugin and extension system, and integrations with several model providers
+  alongside channels such as WhatsApp, Telegram, Slack and Facebook. Agentic workflows are defined in YAML
+  with typed runtime contracts, memory and MCP integration points.
 github:
 - url: https://github.com/hexabot-ai/Hexabot
 npm:
 - url: https://www.npmjs.com/package/@hexabot-ai/widget
-comments: Verified live 2026-08-13 via primary sources. Fair Core License is a delayed-open / fair-code
-  model, so the current core is source-available rather than open source. 1.2k GitHub stars; v3 leads
-  on agentic workflows defined in YAML with tools, MCP, memory and RAG.
+comments: The license changes after a delay, which GitHub cannot classify and the openness axis resolves. A
+  self-hosted community edition runs without a license key. Verified 2026-08-11 via the Hexastack/Hexabot repository,
+  its LICENSE.md and the vendor pricing page.

--- a/sources/products/langchain.yaml
+++ b/sources/products/langchain.yaml
@@ -1,8 +1,11 @@
 name: langchain
 display_name: LangChain
 type: software
-description: Active 2026; MIT core (langchain-core, langgraph, integrations); LangSmith is commercial
+description: Framework for building applications over language models, composing chains, agents, memory and
+  a large ecosystem of integrations across model providers, vector stores and tools. It provides the primitives
+  that LangGraph and the surrounding LangChain tooling build on, and is distributed as a set of Python packages.
 pypi:
 - url: https://pypi.org/project/langchain/
-comments: Verified live 2026-08-13 via primary sources. Active 2026; MIT core (langchain-core, langgraph,
-  integrations); LangSmith is the separately sold commercial platform. About 281M PyPI downloads a month.
+comments: LangSmith and the LangGraph Platform are sold separately as the managed layer; the framework packages
+  are not feature-gated against them. Verified 2026-08-11 via the langchain-ai/langchain repository tree, the
+  vendor product page and its pricing page.

--- a/sources/products/langflow.yaml
+++ b/sources/products/langflow.yaml
@@ -1,14 +1,14 @@
 name: langflow
 display_name: Langflow
 type: software
-description: Open-source, low-code visual builder for AI agents and RAG/workflow applications. You wire components
-  on a drag-and-drop canvas, then expose flows as APIs or run them as agents. Its differentiator vs code-first peers
-  (LangChain, LlamaIndex) is the visual editor with hundreds of pre-built components, while staying model-agnostic
-  and Python-extensible.
+description: Low-code visual builder for AI agents and RAG workflows. Components are wired on a drag-and-drop
+  canvas and flows are then exposed as APIs or run as agents. Against the code-first frameworks its differentiator
+  is the visual editor with hundreds of pre-built components, while staying model-agnostic and extensible in
+  Python.
 github:
 - url: https://github.com/langflow-ai/langflow
 pypi:
 - url: https://pypi.org/project/langflow
-comments: Verified live 2026-08-13 via primary sources. MIT. 153.2k stars, ~85k PyPI downloads a month
-  plus Docker as the main install path. Began as Logspace; acquired by DataStax (2024), now an IBM company;
-  IBM committed to the OSS community. Commercial managed cloud exists but does not gate the core.
+comments: Began as Logspace, was acquired by DataStax in 2024, and is now an IBM company. A managed cloud is
+  sold beside the published platform. Verified 2026-08-13 via the langflow-ai/langflow repository and the Langflow
+  product site.

--- a/sources/products/langgraph.yaml
+++ b/sources/products/langgraph.yaml
@@ -1,13 +1,13 @@
 name: langgraph
 display_name: LangGraph
 type: software
-description: Low-level orchestration framework from LangChain for building stateful, multi-actor agent applications.
-  Unlike higher-level frameworks it exposes an explicit graph/state-machine model (nodes, edges, persistence, human-in-the-loop
-  checkpoints), the production choice when you need fine-grained control over loops, branching, and durable resumable
-  execution.
+description: Low-level orchestration framework from LangChain for stateful, multi-actor agent applications.
+  It exposes an explicit graph and state-machine model - nodes, edges, persistence and human-in-the-loop checkpoints
+  - rather than a higher-level abstraction, which is what makes fine-grained control over loops, branching
+  and durable resumable execution possible.
 github:
 - url: https://github.com/langchain-ai/langgraph
 pypi:
 - url: https://pypi.org/project/langgraph
-comments: Verified live 2026-08-13 via primary sources. MIT core; commercial LangGraph Platform / LangSmith
-  is the managed layer (open-core). 39.6k stars, ~73M PyPI downloads a month (heavily transitive via LangChain).
+comments: The LangGraph Platform and LangSmith are the separately sold managed layer. Verified 2026-08-11 via
+  the langchain-ai/langgraph repository.

--- a/sources/products/lightrag.yaml
+++ b/sources/products/lightrag.yaml
@@ -1,12 +1,12 @@
 name: lightrag
 display_name: LightRAG
 type: software
-description: Lightweight graph-based RAG framework from HKU Data Science Lab (EMNLP 2025) combining knowledge graphs
-  with vector embeddings via dual-layer retrieval. Drops GraphRAG's expensive community-report step and supports
-  incremental updates (add data without rebuilding the global index).
+description: Lightweight graph-based RAG framework from HKU's Data Science Lab that combines a knowledge graph
+  with vector embeddings through dual-level retrieval. It drops GraphRAG's expensive community-report step
+  and supports incremental updates, so new data can be added without rebuilding the global index. It ships
+  naive, local, global and hybrid query modes, pluggable storage, an API server and a web UI.
 github:
 - url: https://github.com/HKUDS/LightRAG
 pypi:
 - url: https://pypi.org/project/lightrag-hku
-comments: Verified live 2026-08-13 via primary sources. MIT. 38.8k stars, ~313k monthly PyPI downloads
-  (lightrag-hku).
+comments: Verified 2026-08-13 via the HKUDS/LightRAG repository.

--- a/sources/products/llama-index.yaml
+++ b/sources/products/llama-index.yaml
@@ -1,13 +1,13 @@
 name: llama-index
 display_name: LlamaIndex
 type: software
-description: 'Open-source data framework (Python and TypeScript) for building LLM apps over private data: data connectors,
-  indexing/retrieval, and an agent/Workflows orchestration layer. Its depth is in RAG and data ingestion - ''document
-  agents'', many-format parsing, and structured extraction.'
+description: Data framework in Python and TypeScript for building LLM applications over private data. It provides
+  connectors across APIs, PDFs, documents and SQL, indices, retrievers, query engines and reranking, and an
+  agent and workflows orchestration layer. Its depth is in retrieval and ingestion - document agents, many-format
+  parsing and structured extraction.
 github:
 - url: https://github.com/run-llama/llama_index
 pypi:
 - url: https://pypi.org/project/llama-index
-comments: Verified live 2026-08-13 via primary sources. MIT core sold beside the commercial LlamaCloud
-  / LlamaParse parse-extract-index APIs, which gate nothing in the library. 51.6k stars, ~7.2M PyPI downloads
-  a month.
+comments: LlamaCloud and LlamaParse are sold beside the library as document-processing services and gate nothing
+  in it. Verified 2026-08-11 via the run-llama/llama_index repository tree and the vendor pricing page.

--- a/sources/products/lovable.yaml
+++ b/sources/products/lovable.yaml
@@ -1,9 +1,8 @@
 name: lovable
 display_name: Lovable
 type: software
-description: Lovable (formerly GPT Engineer), proprietary agentic AI app/website builder ('chat to build',
-  autonomous prototype-to-deploy). Verified live 2026-08-13 via docs.lovable.dev, lovable.dev itself now
-  blocking non-browser fetches. Around 8 million users and $400M ARR as of early 2026.
-comments: Lovable (formerly GPT Engineer), proprietary agentic AI app/website builder ('chat to build', autonomous
-  prototype-to-deploy). Verified 2026-08-13 via docs.lovable.dev, lovable.dev itself now blocking non-browser
-  fetches. Around 8 million users and $400M ARR as of early 2026.
+description: Agentic app and website builder driven from a chat interface, taking a prototype through to a
+  deployed application. It covers file generation, design, a managed cloud backend, testing, security, connectors,
+  git sync and a managed npm registry. It was formerly called GPT Engineer.
+comments: lovable.dev answers 403 to an automated fetch, so the record rests on the vendor's own documentation
+  site. Verified 2026-08-13 via the Lovable documentation.

--- a/sources/products/mastra.yaml
+++ b/sources/products/mastra.yaml
@@ -1,21 +1,15 @@
 name: mastra
 display_name: Mastra
 type: software
-description: TypeScript-native framework for building AI agents and agentic applications. Covers agents with
+description: TypeScript-native framework for building agents and agentic applications. It covers agents with
   tools and instructions, graph-based workflows with explicit control flow, conversation memory with semantic
-  recall, model routing across 90+ providers, and built-in evals, tracing and human-in-the-loop. Runs on Node.js,
-  integrates with React and Next.js, or deploys as a standalone server. The framework is Apache-2.0; enterprise
-  auth code under `ee/` directories carries a separate source-available license, and the hosted Mastra Platform
-  is commercial - open-core in the same shape as LangGraph and LlamaIndex. Notable as the most-used TypeScript
-  agent framework in a category whose open frameworks are otherwise almost entirely Python.
+  recall, model routing across many providers, and built-in evaluations, tracing and human-in-the-loop. It
+  runs on Node.js, integrates with React and Next.js, or deploys as a standalone server.
 github:
 - url: https://github.com/mastra-ai/mastra
 npm:
 - url: https://www.npmjs.com/package/@mastra/core
 - url: https://www.npmjs.com/package/mastra
-comments: Apache-2.0 framework by Kepler Software, Inc., trading as Mastra. LICENSE.md splits the repo - everything
-  outside `ee/` directories is Apache-2.0 (Copyright 2025 Kepler Software, Inc.), while `ee/` paths such as
-  packages/core/src/auth/ee/ fall under the Mastra Enterprise License. GitHub's classifier reports NOASSERTION
-  because of that preamble, so the license was read from the LICENSE.md body and confirmed against npm package
-  metadata (both @mastra/core and mastra declare Apache-2.0). Verified live 2026-08-13 via primary sources;
-  27.2k GitHub stars and about 5.26M npm downloads a month for @mastra/core.
+comments: GitHub's classifier cannot place the split license file, so it was read from the body and confirmed
+  against npm metadata. Enterprise authentication code sits under separate terms, and a hosted platform is
+  sold beside the framework. Verified 2026-08-12 via the mastra-ai/mastra repository tree and the npm registry.

--- a/sources/products/n8n.yaml
+++ b/sources/products/n8n.yaml
@@ -1,14 +1,13 @@
 name: n8n
 display_name: n8n
 type: software
-description: Fair-code workflow automation platform with native AI/agent capabilities. It pairs a visual node-based
-  canvas with drop-in JavaScript/Python code, 400+ integrations, and LangChain-based nodes for building LLM agents
-  and AI workflows. It is a general automation/iPaaS platform first, with AI as a native layer, and is self-hostable.
+description: Workflow automation platform with native AI and agent capabilities. It pairs a visual node-based
+  canvas with drop-in JavaScript and Python, several hundred integrations, and LangChain-based nodes for building
+  agents and AI workflows. It is a general automation platform first, with AI as a native layer, and runs self-hosted
+  or on the vendor's cloud.
 github:
 - url: https://github.com/n8n-io/n8n
 npm:
 - url: https://www.npmjs.com/package/n8n
-comments: 'Sustainable Use License (fair-code, NOT OSI: internal-business-use only, no resale/hosting-as-a-service)
-  + n8n Enterprise License; GitHub reports NOASSERTION. Verified live 2026-08-13 via primary sources;
-  200.5k stars, ~394k npm downloads a month with Docker the dominant install path. n8n Cloud + Enterprise
-  are the commercial tiers.'
+comments: The license is a fair-code variant that GitHub declines to classify, which the openness axis resolves.
+  Verified 2026-08-13 via the n8n-io/n8n repository and the vendor's license documentation.

--- a/sources/products/nano-graphrag.yaml
+++ b/sources/products/nano-graphrag.yaml
@@ -1,12 +1,12 @@
 name: nano-graphrag
 display_name: nano-graphrag
 type: software
-description: A simple, hackable ~1,100-line reimplementation of Microsoft's GraphRAG, built because the official
-  version is hard to read or modify. Portable, fully async/typed, with swappable graph/vector/LLM backends - a lightweight
-  reference and customization base rather than a production system.
+description: Small, hackable reimplementation of GraphRAG in roughly eleven hundred lines, written because
+  the official implementation is hard to read or modify. It is portable, fully asynchronous and typed, with
+  swappable graph, vector and model backends, and is meant as a reference and customization base rather than
+  a production system.
 github:
 - url: https://github.com/gusye1234/nano-graphrag
 pypi:
 - url: https://pypi.org/project/nano-graphrag
-comments: Verified live 2026-08-13 via primary sources. MIT. 4.0k stars, 155 commits, about 1.3k PyPI
-  downloads a month. Stale - no release since Oct 2024.
+comments: 'Stale: no release since October 2024. Verified 2026-08-13 via the gusye1234/nano-graphrag repository.'

--- a/sources/products/opencode.yaml
+++ b/sources/products/opencode.yaml
@@ -1,12 +1,12 @@
 name: opencode
 display_name: OpenCode
 type: software
-description: Open-source terminal (TUI) AI coding agent from the SST team (now Anomaly), aggressively provider-agnostic
-  with 75+ LLM providers (Claude, GPT, Gemini, Bedrock, local models). A polished native TUI with multi-session
-  agents, shareable sessions, built-in LSP, and a client/server architecture.
+description: Terminal coding agent from the Anomaly team, deliberately provider-agnostic across more than seventy
+  model providers including hosted and local models. It offers a native terminal interface with multi-session
+  parallel agents, shareable session links, automatic LSP loading, and a client/server architecture.
 github:
 - url: https://github.com/anomalyco/opencode
 npm:
 - url: https://www.npmjs.com/package/opencode-ai
-comments: Verified live 2026-08-13 via primary sources. MIT. 197.0k stars; repo renamed sst/opencode ->
-  anomalyco/opencode (old URL redirects). Distributed via npm (opencode-ai), about 8.6M downloads a month.
+comments: The repository was renamed from sst/opencode to anomalyco/opencode and the old URL redirects. Verified
+  2026-08-13 via the opencode repository, the opencode.ai product site and the npm registry.

--- a/sources/products/openfn.yaml
+++ b/sources/products/openfn.yaml
@@ -1,13 +1,10 @@
 name: openfn
 display_name: OpenFn
 type: software
-description: OpenFn (Open Function Group) is an open source workflow automation and data-integration platform
-  used by governments and NGOs to orchestrate service workflows across legacy systems, web APIs, databases,
-  and increasingly LLMs/AI tools. Its flagship product, Lightning, is built in Elixir/Phoenix and ships
-  with 70+ adaptors. It is a verified Digital Public Good and Digital Square Global Good, maintained by
-  a public benefit corporation since 2014.
+description: Workflow automation and data-integration platform used by governments and NGOs to orchestrate
+  service workflows across legacy systems, web APIs, databases and model-backed tools. Its Lightning platform
+  is built in Elixir and Phoenix and ships with an adaptor library as the connector layer. It is a verified
+  Digital Public Good, maintained by a public benefit corporation since 2014.
 github:
 - url: https://github.com/OpenFn/lightning
-comments: Verified live 2026-08-13 via primary sources. Fully open source DPG with copyleft licensing
-  and no feature-gated core. 292 GitHub stars; the vendor reports about 5 million workflow runs and 50
-  million records handled a year across 55+ countries.
+comments: Verified 2026-08-13 via the OpenFn/lightning repository, the OpenFn about page and the project documentation.

--- a/sources/products/openhands.yaml
+++ b/sources/products/openhands.yaml
@@ -1,11 +1,12 @@
 name: openhands
 display_name: OpenHands
 type: software
-description: Open-source autonomous coding agent (formerly OpenDevin) that can write code, run commands,
-  browse the web, and interact with APIs to complete software engineering tasks end-to-end. Differentiates
-  through a sandboxed execution environment and strong SWE-bench performance, consistently ranking among
-  the top open source agents. 83.9K GitHub stars and 10.9K forks, with very active development.
+description: Autonomous coding agent, formerly OpenDevin, that writes code, runs commands, browses the web
+  and calls APIs to complete software-engineering tasks end to end. It executes inside a sandboxed runtime,
+  works with many model providers on a bring-your-own-key basis, and ships an SDK for building on the agent
+  directly.
 github:
 - url: https://github.com/OpenHands/OpenHands
-comments: Verified live 2026-08-13 via primary sources. Active 2026 (All-Hands AI); 83.9k GitHub stars;
-  SWE-bench Verified 72% per the current published ranking
+comments: The monorepo carves an enterprise directory out to separate terms, and the cloud server is a separately
+  licensed repository. Verified 2026-08-12 via the OpenHands monorepo LICENSE, the cloud-server LICENSE and
+  the SDK documentation.

--- a/sources/products/openmanus.yaml
+++ b/sources/products/openmanus.yaml
@@ -1,10 +1,11 @@
 name: openmanus
 display_name: OpenManus
 type: software
-description: Open-source reimplementation of the Manus autonomous agent, built by MetaGPT/DeepWisdom team members
-  as a no-invite-code general agent that plans and executes tasks via tools, browser automation, and computer use.
-  Framed as a run-from-source product rather than a reusable library.
+description: Open reimplementation of the Manus autonomous agent, built by members of the MetaGPT team as a
+  general agent that needs no invite code. It plans and executes tasks through tools, browser automation and
+  computer-use actions, and supports MCP. It is framed as a product run from a clone rather than a reusable
+  library.
 github:
 - url: https://github.com/FoundationAgents/OpenManus
-comments: Verified live 2026-08-13 via primary sources. MIT, no paid/feature-gated core. 58.0k stars but
-  a vestigial PyPI package (144 downloads a month) - run via git clone, not pip.
+comments: The PyPI package is vestigial; the distribution channel is a git clone. Verified 2026-08-13 via the
+  FoundationAgents/OpenManus repository.

--- a/sources/products/openrag.yaml
+++ b/sources/products/openrag.yaml
@@ -1,16 +1,12 @@
 name: openrag
 display_name: OpenRAG
 type: software
-description: Linagora's lightweight, modular, and extensible retrieval-augmented generation (RAG) framework —
-  a batteries-included, self-hostable application stack rather than a bare library. It ingests multiple
-  document formats (PDFs, documents, audio, and images with AI captioning), organizes knowledge into
-  partitions, performs hybrid semantic + keyword search with multilingual reranking, and exposes indexed
-  content through a bundled web chat interface, an admin UI, and an OpenAI-compatible REST API. Backend in
-  Python with a TypeScript/JavaScript frontend; scales across machines and GPUs via Ray and deploys via
-  Docker Compose. AGPL-3.0, fully open source with no vendor lock-in.
+description: Linagora's modular retrieval-augmented generation framework, packaged as a self-hostable application
+  stack rather than a bare library. It ingests PDFs, documents, audio and images with AI captioning, organizes
+  knowledge into partitions, and runs hybrid semantic and keyword search with multilingual reranking. A bundled
+  chat interface, an admin UI and an OpenAI-compatible REST API sit in front, with Ray for distribution across
+  machines and GPUs.
 github:
 - url: https://github.com/linagora/openrag
-comments: "OpenRAG by Linagora, AGPL-3.0. Full application stack (admin UI + chat UI + OpenAI-compatible REST
-  API), Python backend / TS-JS frontend, Ray-based distributed processing, GPU acceleration, Docker Compose
-  deployment. ~237 GitHub stars (Aug 2026). No first-party PyPI/npm package; self-host is the primary
-  distribution. Verified live 2026-08-13 via primary sources; 238 stars, 55 forks."
+comments: There is no first-party package on PyPI or npm; Docker Compose is the distribution channel. Verified
+  2026-08-13 via the linagora/openrag repository.

--- a/sources/products/pathway.yaml
+++ b/sources/products/pathway.yaml
@@ -1,14 +1,13 @@
 name: pathway
 display_name: Pathway
 type: software
-description: Python ETL/stream-processing framework on a Rust dataflow engine, unifying batch and streaming under
-  one API with production RAG/LLM templates and live connectors. Unlike glue-layer frameworks it is an incremental
-  dataflow engine - it keeps vector indexes continuously synced with changing data (real-time RAG) instead of batch
-  re-indexing.
+description: Python stream-processing and ETL framework on a Rust dataflow engine, unifying batch and streaming
+  under one API with live connectors and production RAG templates. Unlike glue-layer frameworks it is an incremental
+  dataflow engine, keeping vector indexes continuously synced with changing data instead of re-indexing in
+  batches. It runs from a single node to Kubernetes.
 github:
 - url: https://github.com/pathwaycom/pathway
 pypi:
 - url: https://pypi.org/project/pathway
-comments: 'Business Source License 1.1 (BSL, NOT OSI): single-machine production limit + no-compete clause, converts
-  to Apache-2.0 on 2027-07-20. Commercial Scale/Enterprise tiers. Verified live 2026-08-13 via primary
-  sources; 62.5k stars, about 14k PyPI downloads a month.'
+comments: The license converts on a fixed future date, which GitHub cannot classify and the openness axis resolves.
+  Verified 2026-08-13 via the pathwaycom/pathway repository.

--- a/sources/products/pydantic-ai.yaml
+++ b/sources/products/pydantic-ai.yaml
@@ -1,11 +1,13 @@
 name: pydantic-ai
 display_name: PydanticAI
 type: software
-description: 'Python agent framework from the Pydantic team bringing type-safety to production LLM agents: structured/validated
-  outputs, typed dependency injection, and model-agnostic providers, with first-class Pydantic Logfire observability.'
+description: 'Python agent framework from the Pydantic team that brings type safety to production agents: structured
+  outputs validated as they stream, typed dependency injection, tools and dynamic instructions, MCP and UI
+  event streams, human-in-the-loop and graph support. It is model-agnostic across providers.'
 github:
 - url: https://github.com/pydantic/pydantic-ai
 pypi:
 - url: https://pypi.org/project/pydantic-ai
-comments: Verified live 2026-08-13 via primary sources. MIT library sold beside the commercially operated
-  Pydantic Logfire platform, which gates nothing in the library. About 16M PyPI downloads a month.
+comments: The PyPI project page now returns a stub with no description, so the feature set was read from the
+  repository. Logfire is sold beside the library and gates nothing in it. Verified 2026-08-13 via the pydantic/pydantic-ai
+  repository.

--- a/sources/products/ragflow.yaml
+++ b/sources/products/ragflow.yaml
@@ -1,12 +1,11 @@
 name: ragflow
 display_name: RAGFlow
 type: software
-description: Open-source RAG engine built around deep document understanding - template-based chunking and layout-aware
-  parsing of complex documents (PDFs, tables, figures, scans) to produce grounded, citation-backed answers. Unlike
-  general orchestration frameworks, it is a batteries-included RAG application/server with strong document parsing
-  and visible source citations, recently extended with agent capabilities.
+description: RAG engine built around deep document understanding, with template-based chunking and layout-aware
+  parsing of complex PDFs, tables, figures and scans, producing answers with visible citations. Unlike a general
+  orchestration framework it is a batteries-included RAG server, deployed with Docker Compose, and has since
+  been extended with agent capabilities.
 github:
 - url: https://github.com/infiniflow/ragflow
-comments: Verified live 2026-08-13 via primary sources. Apache-2.0, 87.9k stars. Deployed via Docker Compose
-  (no first-party PyPI/npm beyond the ragflow-sdk API client). Commercial managed cloud / enterprise edition
-  exists; the self-hosted engine is fully open.
+comments: A managed cloud is sold beside the published engine, and there is no first-party package beyond the
+  SDK client. Verified 2026-08-13 via the infiniflow/ragflow repository.

--- a/sources/products/replit-agent.yaml
+++ b/sources/products/replit-agent.yaml
@@ -1,12 +1,9 @@
 name: replit-agent
 display_name: Replit Agent
 type: software
-description: Cloud-based autonomous development agent embedded in Replit's online IDE that can build entire
-  applications from natural language descriptions, scaffolding projects, installing packages, writing
-  code, configuring databases, and deploying to production. Differentiates through zero-setup cloud execution
-  (no local environment needed) and end-to-end deployment capability, making it the most accessible agent
-  for non-developers. Replit has 30M+ registered users; raised $200M+ total funding.
-comments: Verified live 2026-08-13 via primary sources (docs.replit.com; replit.com itself now blocks
-  non-browser fetches). Replit Agent, autonomous AI app-building agent in the Replit cloud IDE, with plan
-  mode, agent skills, automations and end-to-end deployment. Proprietary, consumption-priced on top of
-  Replit subscriptions. Replit reports 50M+ platform users as of March 2026.
+description: Cloud development agent embedded in Replit's online IDE that builds applications from a natural-language
+  description, scaffolding projects, installing packages, writing code, configuring databases and deploying
+  to production. It runs entirely in the hosted environment, with plan mode, agent skills, automations, a task
+  board and end-to-end publishing.
+comments: replit.com answers 403 to an automated fetch, so the record rests on Replit's own documentation.
+  Verified 2026-08-13 via the Replit Agent documentation.

--- a/sources/products/semantic-kernel.yaml
+++ b/sources/products/semantic-kernel.yaml
@@ -1,14 +1,14 @@
 name: semantic-kernel
 display_name: Semantic Kernel
 type: software
-description: Microsoft's lightweight open source SDK for building AI agents and integrating LLMs into C#, Python,
-  or Java code. It exposes your code as model-callable 'plugins' (often via OpenAPI), with connectors to AI services
-  and vector stores, telemetry, and responsible-AI hooks. Its differentiator vs the Python-first frameworks is genuine,
-  first-class multi-language support (.NET and Java, not Python-only).
+description: Microsoft's SDK for building AI agents and integrating models into C#, Python or Java code. It
+  exposes application code as model-callable plugins, often through OpenAPI, with connectors to AI services
+  and vector stores, telemetry and responsible-AI hooks. Its first-class multi-language support distinguishes
+  it from the Python-first frameworks.
 github:
 - url: https://github.com/microsoft/semantic-kernel
 pypi:
 - url: https://pypi.org/project/semantic-kernel
-comments: Verified live 2026-08-13 via primary sources. MIT, 28.4k stars, ~2.6M PyPI downloads a month
-  for the Python package alone. Microsoft has converged Semantic Kernel + AutoGen into the Microsoft Agent
-  Framework (the successor), and the repo README now says so at the top; SK is in maintenance mode.
+comments: Microsoft has converged Semantic Kernel and AutoGen into the Microsoft Agent Framework, which the
+  repository names as its successor, and this project is in maintenance mode. Verified 2026-08-13 via the microsoft/semantic-kernel
+  repository and the Microsoft Agent Framework overview.

--- a/sources/products/smolagents.yaml
+++ b/sources/products/smolagents.yaml
@@ -1,16 +1,11 @@
 name: smolagents
 display_name: smolagents
 type: software
-description: Minimal code-first agent framework from Hugging Face (~1,000 lines of core code) whose headline
-  CodeAgent writes actions as executable Python rather than JSON tool calls, which research shows uses
-  ~30% fewer steps than traditional tool-calling agents on hard benchmarks. Differentiates through model-agnostic
-  design (Hugging Face Inference, OpenAI, Anthropic, local transformers/llama.cpp) and first-class MCP
-  support, making it the path of least resistance for HF users building agents. 28.8K GitHub stars and
-  2.9K forks, Apache-2.0, about 653K PyPI downloads a month; featured in Hugging Face's official agents
-  course and referenced in Anthropic and Cohere agent-building guides.
+description: Minimal code-first agent framework from Hugging Face, whose CodeAgent writes actions as executable
+  Python rather than JSON tool calls. The core is about a thousand lines. It runs actions in a sandbox, is
+  model-agnostic across hosted and local providers, and imports tools over MCP and from LangChain.
 github:
 - url: https://github.com/huggingface/smolagents
 pypi:
 - url: https://pypi.org/project/smolagents
-comments: Verified live 2026-08-13 via primary sources. smolagents by Hugging Face, minimal (~1k-LOC core)
-  code-writing agent framework ('agents that think in code'). Apache-2.0, 28.8k stars.
+comments: Verified 2026-08-13 via the huggingface/smolagents repository.

--- a/sources/products/spec-kit.yaml
+++ b/sources/products/spec-kit.yaml
@@ -1,11 +1,11 @@
 name: spec-kit
 display_name: Spec Kit
 type: software
-description: GitHub's open source toolkit for Spec-Driven Development that works with coding agents rather than
-  being one. A structured Specify -> Plan -> Tasks -> Implement workflow produces Markdown artifacts that feed each
-  phase, giving agents rich structured context instead of ad-hoc prompts. The specify CLI scaffolds these files
-  and orchestrates 30+ agents (Copilot, Claude Code, Cursor, Gemini CLI, Codex CLI, Windsurf, Zed, OpenCode).
+description: GitHub's toolkit for spec-driven development, which works with coding agents rather than being
+  one. A structured specify, plan, tasks and implement workflow produces Markdown artifacts that feed each
+  phase, giving an agent structured context instead of ad-hoc prompts. Its CLI scaffolds those files and orchestrates
+  more than thirty agents.
 github:
 - url: https://github.com/github/spec-kit
-comments: Verified live 2026-08-13 via primary sources. MIT (c) GitHub. 127.2k stars. Distributed both
-  from the repo and as specify-cli on PyPI, about 76k downloads a month. No paid tier.
+comments: Distributed both from the repository and as a CLI package on PyPI. Verified 2026-08-13 via the github/spec-kit
+  repository.

--- a/sources/products/suna.yaml
+++ b/sources/products/suna.yaml
@@ -1,13 +1,12 @@
 name: suna
 display_name: Suna
 type: software
-description: Open-source generalist AI agent positioned as an 'autonomous company operating system';
-  can browse the web, write and execute code, manage files, interact with APIs, and complete complex multi-step
-  business tasks. Differentiates through an ambitious scope beyond coding (document creation, data analysis,
-  web research) with a polished web UI. 20.1K GitHub stars and 3.4K forks, with heavy investment in rapid
-  iteration. Now presented under the Kortix name.
+description: Generalist AI agent positioned as an autonomous operating system for a company. It browses the
+  web, writes and executes code, manages files, calls APIs and completes multi-step business tasks, running
+  specialist agents in isolated sandboxes behind a web interface with a large connector library. It is now
+  branded Kortix.
 github:
 - url: https://github.com/kortix-ai/suna
-comments: Verified live 2026-08-13 via primary sources. Suna / Kortix (kortix-ai/suna); 20.1k stars. Open
-  generalist AI agent / 'AI Management System' with isolated-sandbox specialist agents and 3,000+ connectors.
-  Elastic License 2.0, so source-available rather than open source.
+comments: GitHub shows a bare license entry rather than a classification, which the openness axis resolves.
+  Self-hosting and a managed cloud are both offered. Verified 2026-08-13 via the kortix-ai/suna repository
+  and its LICENSE.

--- a/sources/products/swe-agent.yaml
+++ b/sources/products/swe-agent.yaml
@@ -1,15 +1,12 @@
 name: swe-agent
 display_name: SWE-agent
 type: software
-description: Research-driven autonomous coding agent from Princeton NLP that takes a GitHub issue and
-  attempts to automatically fix it using LLMs. Also supports offensive cybersecurity and competitive coding
-  challenges. Published at NeurIPS 2024 and served as an early benchmark-setter for the SWE-bench leaderboard.
-  20.1K stars with 2.2K forks; development pace has slowed in 2026 but the project remains influential
-  as a reference architecture.
+description: Research coding agent from Princeton NLP that takes a GitHub issue and attempts to fix it autonomously,
+  and also runs offensive-security and competitive-programming tasks. It was published at NeurIPS 2024, and
+  its agent-computer-interface scaffold became a reference architecture for later agents.
 github:
 - url: https://github.com/SWE-agent/SWE-agent
 pypi:
 - url: https://pypi.org/project/sweagent
-comments: Verified live 2026-08-13 via primary sources. SWE-agent (Princeton/Stanford); GitHub SWE-agent/SWE-agent
-  20.1k stars, 2.2k forks. Research agent that lets an LLM autonomously fix GitHub issues. Distributed
-  by clone rather than pip - the sweagent package on PyPI sees only about 600 downloads a month.
+comments: Distributed by clone rather than by package; the PyPI project sees little traffic. Verified 2026-08-13
+  via the SWE-agent/SWE-agent repository and its LICENSE.

--- a/sources/products/syfthub.yaml
+++ b/sources/products/syfthub.yaml
@@ -1,14 +1,11 @@
 name: syfthub
 display_name: SyftHub
 type: software
-description: An open, privacy-preserving federated RAG framework from OpenMined. Instead of centralizing
-  documents, a query is broadcast across a network of peers; each peer searches its own private index and
-  returns only the most relevant snippets, which are aggregated, ranked, and synthesized by an LLM into a
-  grounded answer. The SyftHub SDK loads data sources from the network, selects an LLM, and runs federated
-  RAG pipelines. Built on OpenMined's Syft privacy stack.
+description: Federated RAG framework from OpenMined. Rather than centralizing documents, a query is broadcast
+  across a network of peers; each peer searches its own private index and returns only the most relevant snippets,
+  which are aggregated, ranked and synthesized into a grounded answer. Its SDK loads data sources from the
+  network, selects a model and runs the pipeline, built on OpenMined's Syft privacy stack.
 github:
 - url: https://github.com/OpenMined/syft-hub-sdk
-comments: SyftHub federated RAG SDK, Apache-2.0, from OpenMined; ~2 GitHub stars (July 2026), created Aug
-  2025. Early-stage; part of OpenMined's federated-RAG work (alongside local-rag / local-rag-router) and
-  built on the Syft privacy stack (PySyft is tracked separately). Verified live 2026-08-13 via primary
-  sources; still 2 stars and 0 forks.
+comments: Early-stage, created August 2025, and part of OpenMined's wider federated-RAG work. Verified 2026-08-13
+  via the OpenMined/syft-hub-sdk repository and the SyftHub project page.

--- a/sources/products/v0.yaml
+++ b/sources/products/v0.yaml
@@ -1,12 +1,9 @@
 name: v0
 display_name: v0
 type: software
-description: AI-powered generative UI and full-stack development agent from Vercel that builds web applications
-  from natural language prompts. Can autonomously generate React/Next.js components, assemble full pages,
-  manage state, connect to APIs, and iterate based on visual feedback. Differentiates through frontend-first
-  design quality and tight Next.js/Vercel deployment integration. Evolved from a UI generation tool into
-  a full autonomous development agent in 2025.
-comments: 'Verified live 2026-08-13 via primary sources. v0 by Vercel (v0.app), agentic full-stack web
-  app builder (''agentic by default'', autonomous plan/create-tasks/connect-DB as it builds); web + iOS,
-  subscription. Vercel reports more than 4 million cumulative users since GA. (Note: the earlier record''s
-  ''powered by Claude Opus 4.8'' is still not confirmable - no model is named publicly.)'
+description: Generative UI and full-stack development agent from Vercel that builds web applications from natural-language
+  prompts. It generates React and Next.js components, assembles pages, manages state, connects to databases
+  and iterates on visual feedback, planning and creating its own tasks as it builds. It ships on the web and
+  iOS with one-click deployment to Vercel.
+comments: Vercel names no model behind the product. Verified 2026-08-13 via the v0 product site and Vercel's
+  launch announcement.

--- a/sources/products/vellum.yaml
+++ b/sources/products/vellum.yaml
@@ -1,13 +1,9 @@
 name: vellum
 display_name: Vellum
 type: software
-description: Consumer-facing 'Personal Intelligence' agent, a multi-platform (web, macOS, iOS, CLI) assistant
-  with episodic, semantic, and procedural memory that takes actions on the user's behalf. Pivoted in 2026
-  from an LLMops/prompt-engineering platform (prompts, workflows, evals) to a consumer agent product after
-  a $20M Series A in July 2025; legacy LLMops surface still available but no longer the headline.
-comments: Vellum (vellum.ai), a PERSONAL AI ASSISTANT/agent ('the AI layer for your life', 8-type structured
-  memory, multi-channel autonomous action across Mac/Web/iOS/Slack/Telegram, proactive hourly check-ins,
-  out-of-process credential isolation). The agent's full source ships MIT-licensed at github.com/vellum-ai/vellum-assistant
-  (backend gateway, multi-platform clients, skill framework); a managed cloud (memory/security) is offered
-  on top. Verified live 2026-08-13 via primary sources; 1.1k GitHub stars. Positions itself against Hermes
-  Agent and OpenClaw, and its own comparison post now calls Vellum open source.
+description: Personal AI assistant across web, macOS, iOS and a CLI, with episodic, semantic and procedural
+  memory, that takes actions on the user's behalf across channels including Slack and Telegram. It runs proactive
+  check-ins and isolates credentials out of process. The company pivoted to it in 2026 from an LLMops platform,
+  which remains available.
+comments: Verified 2026-08-13 via the vellum-ai/vellum-assistant repository, its LICENSE and the Vellum product
+  site.

--- a/sources/products/windsurf.yaml
+++ b/sources/products/windsurf.yaml
@@ -1,13 +1,10 @@
 name: windsurf
 display_name: Windsurf
 type: software
-description: AI-native IDE (VS Code fork) with 'Cascade', an agentic flow engine that maintains context
-  across multi-step coding tasks, automatically suggests and executes terminal commands, file edits, and
-  debugging steps. Differentiates through 'Flows' that blend co-pilot suggestions with autonomous agent
-  actions, plus strong context awareness across large codebases. Reportedly millions of users across free
-  and paid tiers; Codeium raised $150M at a $1.25B valuation before being acquired by Windsurf (the brand
-  name superseded Codeium).
-comments: Verified live 2026-08-13 via primary sources. Windsurf (formerly Codeium) acquired by Cognition
-  (definitive agreement July 2025) and rebranded 'Devin Desktop'; windsurf.com redirects to devin.ai/desktop.
-  Agent Command Center wrapped in a full IDE, multi-model and multi-agent over the Agent Client Protocol.
-  Vendor-stated 1M+ users and 4000+ enterprise customers.
+description: AI-native IDE, forked from VS Code, built around an agentic flow engine that keeps context across
+  multi-step coding tasks and suggests and executes terminal commands, file edits and debugging steps. It runs
+  multi-model and multi-agent over the Agent Client Protocol, blending inline suggestions with autonomous agent
+  actions.
+comments: Formerly Codeium, then Windsurf; acquired by Cognition in 2025 and now shipping as Devin Desktop,
+  with windsurf.com redirecting there. Verified 2026-08-13 via the Devin Desktop product page and Cognition's
+  acquisition announcement.

--- a/sources/products/zed.yaml
+++ b/sources/products/zed.yaml
@@ -1,13 +1,12 @@
 name: zed
 display_name: Zed
 type: software
-description: High-performance, multiplayer code editor written in Rust from the creators of Atom and Tree-sitter,
-  built for human-AI collaboration. A GUI editor (peer to Cursor/Windsurf) with agentic editing, parallel agents
-  across projects, an open source edit-prediction model (Zeta2), inline assistant, MCP servers, and pluggable external
-  agents (Claude, Codex, OpenCode) via the Agent Communication Protocol - BYO-key or Zed-hosted models.
+description: High-performance multiplayer code editor written in Rust by the creators of Atom and Tree-sitter,
+  built for human-AI collaboration. It offers agentic editing, parallel agents across projects, an inline assistant
+  and its own edit-prediction model, and plugs in external agents over the Agent Communication Protocol alongside
+  MCP servers. Models run on the user's own key or on Zed's hosting.
 github:
 - url: https://github.com/zed-industries/zed
-comments: Verified live 2026-08-13 via primary sources. Editor is GPL-3.0-or-later and the GPUI framework
-  Apache-2.0; the repo root now carries only LICENSE-GPL and LICENSE-APACHE, with no AGPL file, so the
-  recorded AGPL-3.0 entry for the collab server needs a curator ruling. Paid Pro ($10/mo, hosted AI) and
-  Business (per seat, governance) tiers layer on the OSS editor.
+comments: The collaboration server's recorded license entry does not match the files in the repository tree,
+  which needs a curator ruling. Paid tiers layer hosted models and governance on the published editor. Verified
+  2026-08-14 via the zed-industries/zed repository tree, its license files and the Zed pricing page.

--- a/sources/provenance/orchestration_agents.yaml
+++ b/sources/provenance/orchestration_agents.yaml
@@ -1,0 +1,236 @@
+# Provenance and prose closeout for orchestration_agents. 51 of 51 ready.
+#
+# Every record in this category was `generic` except `lovable`, which was already canonical and
+# still carried a description identical to its comments, both stating user counts and ARR. Two
+# other records had the same defect in a different form: `github-copilot` and `lovable` used one
+# string for both prose fields, and `langchain`'s description was a comments fragment
+# ("Active 2026; MIT core ...") rather than a description at all.
+#
+# The pass is the `ui_api` recipe: fix the prose first, then name the documents the score file
+# already proves were read on the date the line claims. No date moved, no axis was held, and no
+# source was refetched - every verification line names documents already in the score file, on
+# their own `accessed` date.
+#
+# What came out, in this category: star and fork counts on nearly every record; npm, PyPI and
+# Docker download figures; current version numbers; funding and valuation on cursor, devin,
+# replit-agent, windsurf and vellum; SWE-bench percentages, which belong on the capability axis;
+# rankings ("the most commercially successful", "consistently ranking among the top open source
+# agents", "the most-used TypeScript agent framework"); and license names and openness verdicts
+# throughout.
+#
+# Identity notes kept, because each is durable and load-bearing: goose moved from block/goose to
+# the Agentic AI Foundation; opencode from sst/ to anomalyco/; windsurf is Codeium then Windsurf
+# then Devin Desktop; suna is now branded Kortix; lovable was GPT Engineer; autogen and
+# semantic-kernel are both superseded by the Microsoft Agent Framework.
+#
+# One open question is recorded rather than resolved: `zed`'s collaboration server carries a
+# recorded license entry that does not match the files in the repository tree. The openness
+# VALUE is unaffected - every license file in the tree is an open one - so the axis stays
+# confirmed and the discrepancy is a components ruling for the identity workflow, not an
+# evidence hold.
+#
+- product: aider
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Aider-AI/aider repository and its PyPI page
+- product: amazon-q-developer
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Amazon Q Developer product page
+- product: antigravity
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Antigravity product page and Google's I/O 2026 developer keynote announcement
+- product: autogen
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the microsoft/autogen repository and its LICENSE-CODE
+- product: autogpt
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Significant-Gravitas/AutoGPT repository
+- product: beeai
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the i-am-bee/beeai-framework repository and the LF AI & Data project page
+- product: claude-code
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Claude Code documentation overview
+- product: cline
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the cline/cline repository and its VS Code Marketplace listing
+- product: codex-cli
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the OpenAI Codex CLI documentation
+- product: crewai
+  resolved_state: canonical
+  verified: '2026-08-12'
+  document: the crewAIInc/crewAI repository tree, its enterprise CLI module and the vendor pricing
+    page
+- product: cursor
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Cursor product site and the SWE-bench coding-agent leaderboard
+- product: datasette-agent
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the datasette/datasette-agent repository and the agent
+- product: devin
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Devin documentation and Cognition's SWE-bench technical report
+- product: dify
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the langgenius/dify repository and the Dify product site
+- product: dspy
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the stanfordnlp/dspy repository
+- product: gemini-cli
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the google-gemini/gemini-cli repository and Google's launch announcement
+- product: github-copilot
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the GitHub Copilot product page
+- product: goose
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the aaif-goose/goose repository
+- product: gpt-researcher
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the assafelovic/gpt-researcher repository
+- product: graphrag
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the microsoft/graphrag repository and its documentation site
+- product: haystack
+  resolved_state: canonical
+  verified: '2026-08-11'
+  document: the deepset-ai/haystack repository tree and deepset's enterprise announcements
+- product: hermes-agent
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the NousResearch/hermes-agent repository and the Hermes Agent product page
+- product: hexabot
+  resolved_state: canonical
+  verified: '2026-08-11'
+  document: the Hexastack/Hexabot repository, its LICENSE
+- product: langchain
+  resolved_state: canonical
+  verified: '2026-08-11'
+  document: the langchain-ai/langchain repository tree, the vendor product page and its pricing page
+- product: langflow
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the langflow-ai/langflow repository and the Langflow product site
+- product: langgraph
+  resolved_state: canonical
+  verified: '2026-08-11'
+  document: the langchain-ai/langgraph repository
+- product: lightrag
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the HKUDS/LightRAG repository
+- product: llama-index
+  resolved_state: canonical
+  verified: '2026-08-11'
+  document: the run-llama/llama_index repository tree and the vendor pricing page
+- product: lovable
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Lovable documentation
+- product: mastra
+  resolved_state: canonical
+  verified: '2026-08-12'
+  document: the mastra-ai/mastra repository tree and the npm registry
+- product: n8n
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the n8n-io/n8n repository and the vendor's license documentation
+- product: nano-graphrag
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the gusye1234/nano-graphrag repository
+- product: opencode
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the opencode repository, the opencode
+- product: openfn
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the OpenFn/lightning repository, the OpenFn about page and the project documentation
+- product: openhands
+  resolved_state: canonical
+  verified: '2026-08-12'
+  document: the OpenHands monorepo LICENSE, the cloud-server LICENSE and the SDK documentation
+- product: openmanus
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the FoundationAgents/OpenManus repository
+- product: openrag
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the linagora/openrag repository
+- product: pathway
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the pathwaycom/pathway repository
+- product: pydantic-ai
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the pydantic/pydantic-ai repository
+- product: ragflow
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the infiniflow/ragflow repository
+- product: replit-agent
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Replit Agent documentation
+- product: semantic-kernel
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the microsoft/semantic-kernel repository and the Microsoft Agent Framework overview
+- product: smolagents
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the huggingface/smolagents repository
+- product: spec-kit
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the github/spec-kit repository
+- product: suna
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the kortix-ai/suna repository and its LICENSE
+- product: swe-agent
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the SWE-agent/SWE-agent repository and its LICENSE
+- product: syfthub
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the OpenMined/syft-hub-sdk repository and the SyftHub project page
+- product: v0
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the v0 product site and Vercel's launch announcement
+- product: vellum
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the vellum-ai/vellum-assistant repository, its LICENSE and the Vellum product site
+- product: windsurf
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Devin Desktop product page and Cognition's acquisition announcement
+- product: zed
+  resolved_state: canonical
+  verified: '2026-08-14'
+  document: the zed-industries/zed repository tree, its license files and the Zed pricing page


### PR DESCRIPTION
**51 of 51 ready.** Prose compliant, provenance canonical, every axis confirmed. No holds added, no dates moved, no sources refetched.

## The pass

The `ui_api` recipe, applied whole: fix the prose first, then name the documents the score file already proves were read on the date the line claims. Every verification line names documents already in the record, on their own `accessed` date — which is why `crewai`, `haystack`, `langchain`, `langgraph`, `llama-index`, `mastra`, `openhands`, `hexabot` and `pydantic-ai` read 2026-08-11 or `-12` rather than `-13`.

Every record in the category was `generic` except `lovable`, which was **already canonical and still wrong** — its description was character-for-character its comments, and both carried user counts and ARR. That is the same finding as `perplexity` in `ui_api`, and it is why classifier state cannot scope this work.

Two more prose defects of the same shape: `github-copilot` also used one string for both fields, and `langchain`'s description was a comments fragment — `Active 2026; MIT core (langchain-core, langgraph, integrations); LangSmith is commercial` — rather than a description of what LangChain is.

## What came out

| removed | where |
|---|---|
| star, fork, download and pull counts | nearly every record |
| current version numbers | `aider`, `datasette-agent`, `mastra`, `opencode`, `hermes-agent` |
| funding, valuation and ARR | `cursor`, `devin`, `replit-agent`, `windsurf`, `vellum`, `lovable` |
| benchmark percentages | `openhands`, `devin`, `claude-code` — capability-axis content |
| rankings and superlatives | "the most commercially successful AI coding tool outside GitHub Copilot", "consistently ranking among the top open source agents", "the most-used TypeScript agent framework", "the most accessible agent for non-developers" |
| license names and openness verdicts | throughout — `smolagents`, `n8n`, `pathway`, `suna`, `hexabot`, `mastra`, `zed` and others |
| unsourced claims | smolagents' "research shows ~30% fewer steps" and its course/guide citations, hexabot's deployment geography |

Where a licensing question is genuinely load-bearing, `comments` now names the ambiguity without resolving it — "GitHub's classifier cannot place the split license file, so it was read from the body and confirmed against npm metadata" (`mastra`), "the repository carries separate license files for code and documentation, which makes GitHub's license field misleading" (`autogen`).

## Identity kept, because each is durable

`goose` moved from `block/goose` to the Agentic AI Foundation at the Linux Foundation. `opencode` moved from `sst/` to `anomalyco/`. `windsurf` is Codeium, then Windsurf, then Devin Desktop after the Cognition acquisition, with `windsurf.com` redirecting. `suna` is now branded Kortix. `lovable` was GPT Engineer. `autogen` and `semantic-kernel` are both superseded by the Microsoft Agent Framework, which their own repositories announce.

## One open question, recorded not resolved

`zed`'s collaboration server carries a recorded license entry that does not match the files in the repository tree. The openness **value** is unaffected — every license file in the tree is an open one — so the axis stays confirmed and the discrepancy is a components ruling for the identity workflow, not an evidence hold. It is in the product's comments and in the manifest.

## Verification

`validate`, `check_verification`, `check_capability`, `check_recipe`, `check_adoption --strict` all clean. `check_freshness --category orchestration_agents`: *all 153 axes carry a real last_verified*. 660 tests, no skips.

**Corpus: 261/472 ready · 363/472 canonical · 1,407/1,416 axes confirmed · 9 held.**
