### PR TITLE
Refresh training_synthetic_datasets: 38/38

### DIFF
--- a/sources/products/aya-collection.yaml
+++ b/sources/products/aya-collection.yaml
@@ -1,15 +1,14 @@
 name: aya-collection
 display_name: Aya Collection
 type: dataset
-description: The Aya Collection is a large multilingual instruction-tuning dataset spanning 114+ languages,
-  built from templated and translated subsets for tasks like classification, summarization, and translation.
-  It was created by Cohere Labs (formerly Cohere For AI) as part of the Aya open-science initiative. The
-  collection holds hundreds of millions of examples across 64 subsets.
+description: Multilingual instruction-tuning dataset spanning more than 114 languages, built from templated
+  and translated subsets for tasks including classification, summarization and translation. It holds hundreds
+  of millions of examples across 64 subsets, and was created by Cohere Labs as part of the Aya open-science
+  initiative.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/CohereLabs/aya_collection
 lineage:
   derived_from:
   - Aya crowdsourced annotations
   - templated NLP datasets
-comments: Verified live 2026-08-13 via primary sources. Ungated, Apache-2.0 licensed, with a complete dataset
-  card.
+comments: Verified 2026-08-13 via the Aya Collection dataset card on Hugging Face.

--- a/sources/products/c4.yaml
+++ b/sources/products/c4.yaml
@@ -1,10 +1,9 @@
 name: c4
 display_name: C4
 type: dataset
-description: C4 (Colossal Clean Crawled Corpus) is a cleaned version of Common Crawl created for the T5
-  paper, hosted on Hugging Face by AI2. It offers multiple variants, including the cleaned English split
-  (~305GB) and the multilingual mC4 covering 108 languages (~9.7TB). It is one of the most widely used
-  English pretraining corpora.
+description: Cleaned version of Common Crawl created for the T5 paper and hosted by AI2. It ships several variants,
+  including a cleaned English split of about 305GB and the multilingual mC4 covering 108 languages at roughly
+  9.7TB.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/allenai/c4
 lineage:
@@ -15,5 +14,4 @@ lineage:
   trains:
   - T5
   - UL2
-comments: Verified live 2026-08-13 via primary sources. Permissively licensed (ODC-BY) and ungated with a full
-  dataset card.
+comments: Verified 2026-08-13 via the allenai/c4 dataset card on Hugging Face.

--- a/sources/products/common-corpus.yaml
+++ b/sources/products/common-corpus.yaml
@@ -1,11 +1,10 @@
 name: common-corpus
 display_name: Common Corpus
 type: dataset
-description: Common Corpus is a multilingual pretraining dataset of roughly 2.27 trillion tokens containing
-  only uncopyrighted or openly licensed content across 367+ languages. It was assembled by PleIAs with
-  partners including the AI Alliance, organized into six curated collections (public-domain books, government
-  documents, academic content, code, semantic data, and web text) with document-level provenance and toxicity
-  filtering. It is one of the largest openly licensed text corpora for LLM training.
+description: Multilingual pretraining dataset of roughly 2.27 trillion tokens across more than 367 languages,
+  assembled by PleIAs with partners including the AI Alliance from uncopyrighted or openly licensed content
+  only. It is organized into six curated collections - public-domain books, government documents, academic
+  content, code, semantic data and web text - with document-level provenance and toxicity filtering.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/PleIAs/common_corpus
 lineage:
@@ -13,5 +12,4 @@ lineage:
   - public domain and openly licensed sources
   trains:
   - Pleias models
-comments: Verified live 2026-08-13 via primary sources. Ungated with a full dataset card and built exclusively
-  from uncopyrighted or openly licensed sources.
+comments: Verified 2026-08-13 via the PleIAs/common_corpus dataset card on Hugging Face.

--- a/sources/products/cosmopedia.yaml
+++ b/sources/products/cosmopedia.yaml
@@ -1,11 +1,10 @@
 name: cosmopedia
 display_name: Cosmopedia
 type: dataset
-description: Cosmopedia is a large-scale synthetic dataset of over 31 million textbooks, blog posts, stories,
-  and educational articles (~25 billion tokens) generated with Mixtral-8x7B-Instruct using seed samples
-  from web data, Stanford courses, OpenStax, Khan Academy, and WikiHow. It was created by Hugging Face's
-  Smol Models Research team and described as the largest open synthetic dataset of its kind at release.
-  It is a reference corpus for synthetic-data pretraining recipes.
+description: Synthetic pretraining dataset of more than 31 million textbooks, blog posts, stories and educational
+  articles, about 25 billion tokens, generated with Mixtral-8x7B-Instruct from seed samples drawn from web
+  data, Stanford courses, OpenStax, Khan Academy and WikiHow. It was built by Hugging Face's Smol Models Research
+  team as a reference corpus for synthetic-data pretraining recipes.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/HuggingFaceTB/cosmopedia
 lineage:
@@ -13,5 +12,5 @@ lineage:
   - Mixtral-8x7B synthetic generation
   trains:
   - rwkv
-comments: Verified live 2026-08-13 via primary sources. Permissive Apache-2.0 license, ungated, full dataset
-  card and downloadable parquet files.
+comments: Cosmopedia v2 is the direct successor. Verified 2026-08-13 via the HuggingFaceTB/cosmopedia dataset
+  card on Hugging Face.

--- a/sources/products/culturax.yaml
+++ b/sources/products/culturax.yaml
@@ -1,15 +1,14 @@
 name: culturax
 display_name: CulturaX
 type: dataset
-description: CulturaX is a multilingual web corpus for LLM pretraining containing 6.3 trillion tokens
-  across 167 languages, combined and cleaned from mC4 and OSCAR. It was created by the University of Oregon
-  NLP group (UONLP) and applies a multi-stage pipeline of language identification, URL filtering, metric-based
-  cleaning, document refinement, and MinHash fuzzy deduplication. Distributed as ~16TB of parquet.
+description: Multilingual web corpus for pretraining containing 6.3 trillion tokens across 167 languages, combined
+  and cleaned from mC4 and OSCAR by the University of Oregon NLP group. Its pipeline applies language identification,
+  URL filtering, metric-based cleaning, document refinement and MinHash fuzzy deduplication, and it is distributed
+  as roughly 16TB of parquet.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/uonlp/CulturaX
 lineage:
   derived_from:
   - mC4
   - OSCAR
-comments: Verified live 2026-08-13 via primary sources. Dataset card is rich but downloads require agreeing
-  to share contact information (auto gate).
+comments: Verified 2026-08-13 via the uonlp/CulturaX dataset card on Hugging Face.

--- a/sources/products/dclm-baseline.yaml
+++ b/sources/products/dclm-baseline.yaml
@@ -1,11 +1,9 @@
 name: dclm-baseline
 display_name: DCLM-baseline
 type: dataset
-description: DCLM-baseline-1.0 is a curated CommonCrawl-derived pretraining dataset of about 4 trillion
-  tokens across 3 billion documents (~7.2TB), produced by the DataComp-LM (ML Foundations) project. It
-  was built using heuristic cleaning, Bloom-filter deduplication, and fastText model-based quality filtering,
-  and is the reference dataset for the DCLM benchmark. It is positioned as a research dataset that outperforms
-  prior open web datasets when training 7B models.
+description: Curated pretraining dataset derived from Common Crawl, about 4 trillion tokens across 3 billion
+  documents and roughly 7.2TB, produced by the DataComp-LM project. It was built with heuristic cleaning, Bloom-filter
+  deduplication and fastText model-based quality filtering, and is the reference dataset for the DCLM benchmark.
 github:
 - url: https://github.com/mlfoundations/dclm
 huggingface_dataset:
@@ -20,5 +18,5 @@ lineage:
   - olmoe-instruct
   - marin
   - rwkv
-comments: Verified live 2026-08-13 via primary sources. Permissive CC-BY-4.0 license, ungated download, with
-  open code repo and dataset card.
+comments: OLMoE, SmolLM3, Marin and RWKV were built on it. Verified 2026-08-13 via the mlfoundations/dclm-baseline-1.0
+  dataset card on Hugging Face.

--- a/sources/products/dolci.yaml
+++ b/sources/products/dolci.yaml
@@ -1,9 +1,9 @@
 name: dolci
 display_name: Dolci
 type: dataset
-description: 'Dolci is Ai2''s post-training data suite for OLMo 3: SFT, DPO preference, and RLVR sets
-  for both Instruct and Think variants, released under ODC-BY. It is the successor to the Tulu mixtures,
-  folding in OpenThoughts3, FLAN v2, OpenAssistant, WildChat, and new Ai2 synthetic data.'
+description: Ai2's post-training data suite for OLMo 3, covering supervised fine-tuning, DPO preference and
+  RLVR sets for both the Instruct and Think variants. It is the successor to the Tulu mixtures, folding in
+  OpenThoughts3, FLAN v2, OpenAssistant, WildChat and new Ai2 synthetic data.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/allenai/Dolci-Instruct-SFT
 lineage:
@@ -18,5 +18,5 @@ lineage:
   - open-instruct
   trains:
   - olmo-instruct
-comments: 'Family bucket: Dolci-Instruct and Dolci-Think SFT/DPO/RL sets. Verified live 2026-08-13 via primary
-  sources. ODC-BY licensed, ungated, with a full dataset card.'
+comments: A family record covering the Dolci-Instruct and Dolci-Think SFT, DPO and RL sets. Verified 2026-08-13
+  via the allenai/Dolci-Instruct-SFT dataset card on Hugging Face.

--- a/sources/products/dolma-3.yaml
+++ b/sources/products/dolma-3.yaml
@@ -1,10 +1,10 @@
 name: dolma-3
 display_name: Dolma 3
 type: dataset
-description: 'Dolma 3 is Ai2''s ODC-BY pretraining data release behind OLMo 3: a ~9T-token pool from Common
-  Crawl, olmOCR-processed scientific PDFs, Stack-Edu code, and FineMath, plus the exact quality-upsampled
-  mixes (Dolma 3 Mix, Dolmino mid-training, Longmino long-context) used in training. The full pool, every
-  mix, and the curation tooling are public.'
+description: 'Ai2''s pretraining data release behind OLMo 3: a pool of about 9 trillion tokens drawn from Common
+  Crawl, olmOCR-processed scientific PDFs, Stack-Edu code and FineMath, alongside the quality-upsampled mixes
+  used in training - Dolma 3 Mix, Dolmino mid-training and Longmino long-context. The pool, every mix and the
+  curation tooling are released together.'
 huggingface_dataset:
 - url: https://huggingface.co/datasets/allenai/dolma3_pool
 lineage:
@@ -23,6 +23,5 @@ lineage:
   trains:
   - olmo
   - olmo-instruct
-comments: 'Family bucket: dolma3_pool plus the Mix/Dolmino/Longmino training mixes. Successor to the map''s
-  dolma entry (Dolma 1.x). Verified live 2026-08-13 via primary sources. ODC-BY licensed, ungated, with a full
-  dataset card.'
+comments: A family record covering the pool and the training mixes; successor to the map's Dolma 1.x entry.
+  Verified 2026-08-13 via the allenai/dolma3_pool dataset card on Hugging Face.

--- a/sources/products/dolma.yaml
+++ b/sources/products/dolma.yaml
@@ -1,10 +1,9 @@
 name: dolma
 display_name: Dolma
 type: dataset
-description: Dolma is an open pretraining corpus of roughly 3 trillion tokens drawn from Common Crawl
-  web text, academic publications, code, books, and encyclopedic material. It was created by the Allen
-  Institute for AI (AI2) and used to train the OLMo family of models. The release includes the corpus
-  plus an open source toolkit for replicating and curating the data.
+description: Open pretraining corpus of roughly 3 trillion tokens drawn from Common Crawl web text, academic
+  publications, code, books and encyclopedic material. It was created by the Allen Institute for AI and used
+  to train the OLMo family, and the release includes a toolkit for replicating and curating the data.
 github:
 - url: https://github.com/allenai/dolma
 huggingface_dataset:
@@ -22,5 +21,5 @@ lineage:
   - olmoe-instruct
   - marin
   - rwkv
-comments: Verified live 2026-08-13 via primary sources. Permissively licensed (ODC-BY), ungated download with
-  a full dataset card and replication toolkit.
+comments: Superseded by Dolma 3 for OLMo 3. Verified 2026-08-13 via the allenai/dolma dataset card on Hugging
+  Face.

--- a/sources/products/finemath.yaml
+++ b/sources/products/finemath.yaml
@@ -1,9 +1,9 @@
 name: finemath
 display_name: FineMath
 type: dataset
-description: FineMath is Hugging Face's classifier-filtered mathematical web corpus extracted from Common
-  Crawl (tens of billions of tokens at the 3+/4+ quality tiers), released under ODC-BY. It is a documented
-  pretraining component of SmolLM3, Apertus, Marin, and OLMo 3's Dolma 3 pool.
+description: Classifier-filtered mathematical web corpus from Hugging Face, extracted from Common Crawl and
+  released at graded quality tiers holding tens of billions of tokens. It is a documented pretraining component
+  of SmolLM3, Apertus, Marin and the Dolma 3 pool behind OLMo 3.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/HuggingFaceTB/finemath
 lineage:
@@ -16,4 +16,4 @@ lineage:
   - apertus
   - marin
   - olmo
-comments: Verified live 2026-08-13 via primary sources. ODC-BY licensed, ungated, with a full dataset card.
+comments: Verified 2026-08-13 via the HuggingFaceTB/finemath dataset card on Hugging Face.

--- a/sources/products/fineweb-2.yaml
+++ b/sources/products/fineweb-2.yaml
@@ -1,11 +1,9 @@
 name: fineweb-2
 display_name: FineWeb-2
 type: dataset
-description: FineWeb-2 is the multilingual successor to FineWeb, covering over 1,000 languages and writing
-  systems with more than 1 trillion tokens of filtered and deduplicated CommonCrawl text, released by
-  Hugging Face's FineWeb team. Each language is processed through a per-language pipeline with deduplication
-  and quality filtering. It extends the open-data pretraining work beyond English to support multilingual
-  LLM training.
+description: Multilingual successor to FineWeb, covering more than a thousand languages and writing systems
+  with over a trillion tokens of filtered and deduplicated Common Crawl text. Each language runs through its
+  own pipeline with deduplication and quality filtering, extending the FineWeb work beyond English.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/HuggingFaceFW/fineweb-2
 lineage:
@@ -17,5 +15,4 @@ lineage:
   - apertus
   - smollm
   - alia-40b
-comments: Verified live 2026-08-13 via primary sources. Permissive ODC-BY license, ungated, with a dataset
-  card spanning 1000+ languages.
+comments: Verified 2026-08-13 via the HuggingFaceFW/fineweb-2 dataset card on Hugging Face.

--- a/sources/products/fineweb-edu.yaml
+++ b/sources/products/fineweb-edu.yaml
@@ -1,10 +1,9 @@
 name: fineweb-edu
 display_name: FineWeb-Edu
 type: dataset
-description: FineWeb-Edu is an educational subset of FineWeb (~1.3 trillion tokens) created by Hugging
-  Face's FineWeb team. It was produced by filtering FineWeb with an educational-quality classifier trained
-  on Llama-3-70B annotations, retaining text scored as highly educational. It is intended to improve LLM
-  performance on knowledge- and reasoning-heavy benchmarks relative to unfiltered web data.
+description: Educational subset of FineWeb holding about 1.3 trillion tokens, produced by filtering FineWeb
+  with an educational-quality classifier trained on Llama-3-70B annotations and keeping the text scored as
+  highly educational. It targets knowledge- and reasoning-heavy evaluation relative to unfiltered web data.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/HuggingFaceFW/fineweb-edu
 lineage:
@@ -17,5 +16,4 @@ lineage:
   - smollm
   - alia-40b
   - rwkv
-comments: Verified live 2026-08-13 via primary sources. Permissive ODC-BY license with ungated download and
-  full dataset card.
+comments: Verified 2026-08-13 via the HuggingFaceFW/fineweb-edu dataset card on Hugging Face.

--- a/sources/products/fineweb.yaml
+++ b/sources/products/fineweb.yaml
@@ -1,11 +1,9 @@
 name: fineweb
 display_name: FineWeb
 type: dataset
-description: FineWeb is a large-scale English pretraining dataset of over 18.5 trillion tokens of cleaned
-  and deduplicated text derived from 96 CommonCrawl snapshots (2013-2024), released by Hugging Face's
-  FineWeb team. It is distributed as Parquet across ~114 date-based subsets. It was built to provide an
-  open, high-quality web corpus that outperforms other public web datasets for LLM training, and is a
-  widely cited reference in the open-data pretraining community.
+description: English pretraining dataset of more than 18.5 trillion tokens of cleaned and deduplicated text
+  derived from 96 Common Crawl snapshots between 2013 and 2024, released by Hugging Face's FineWeb team. It
+  is distributed as Parquet across roughly 114 date-based subsets.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/HuggingFaceFW/fineweb
 lineage:
@@ -13,5 +11,4 @@ lineage:
   - Common Crawl
   curated_with:
   - datatrove
-comments: Verified live 2026-08-13 via primary sources. Permissive ODC-BY license with ungated download and
-  a full dataset card.
+comments: Verified 2026-08-13 via the HuggingFaceFW/fineweb dataset card on Hugging Face.

--- a/sources/products/flan-collection.yaml
+++ b/sources/products/flan-collection.yaml
@@ -1,10 +1,9 @@
 name: flan-collection
 display_name: FLAN Collection (v2)
 type: dataset
-description: The FLAN Collection (v2) is Google Research's instruction-tuning compilation of 1,800+ tasks
-  (P3, Super-NaturalInstructions, chain-of-thought data) that trained Flan-T5 and Flan-PaLM. It remains
-  a canonical instruction-data building block, folded into Tulu 3, OLMo 3's Dolci, and Marin's Dolmino
-  mixes.
+description: Google Research's instruction-tuning compilation of more than 1,800 tasks, drawing on P3, Super-NaturalInstructions
+  and chain-of-thought data, which trained Flan-T5 and Flan-PaLM. It remains a building block for later instruction
+  mixes, folded into Tulu 3, OLMo 3's Dolci and Marin's Dolmino.
 github:
 - url: https://github.com/google-research/FLAN
 huggingface_dataset:
@@ -18,5 +17,6 @@ lineage:
   - tulu
   - olmo-instruct
   - marin
-comments: Verified live 2026-08-13 via primary sources. The Apache-2.0 recipe repo is public and the widely
-  used HF conversion is ungated, with a card that documents the conversion rather than the tasks.
+comments: The recipe repository is the primary artifact; the widely used Hugging Face conversion carries a
+  card documenting the conversion rather than the tasks. Verified 2026-08-13 via the google-research/FLAN repository
+  and the ai2-adapt-dev/flan_v2_converted dataset card.

--- a/sources/products/hermes-3-dataset.yaml
+++ b/sources/products/hermes-3-dataset.yaml
@@ -1,9 +1,9 @@
 name: hermes-3-dataset
 display_name: Hermes 3 Dataset
 type: dataset
-description: The Hermes 3 Dataset is Nous Research's Apache-2.0 release of the instruction and chat corpus behind
-  Hermes 3, mixing synthetic generation with curated community data. It seeds the (unreleased) Hermes 4 corpus and
-  documents the Hermes line's data recipe.
+description: Nous Research's release of the instruction and chat corpus behind Hermes 3, mixing synthetic generation
+  with curated community data. It seeds the unreleased Hermes 4 corpus and documents the data recipe behind
+  the Hermes line.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/NousResearch/Hermes-3-Dataset
 lineage:
@@ -11,4 +11,4 @@ lineage:
   - Nous synthetic instruction generation
   trains:
   - hermes
-comments: Verified live 2026-08-13 via primary sources. Apache-2.0 licensed, ungated, with a full dataset card.
+comments: Verified 2026-08-13 via the NousResearch/Hermes-3-Dataset dataset card on Hugging Face.

--- a/sources/products/hh-rlhf.yaml
+++ b/sources/products/hh-rlhf.yaml
@@ -1,10 +1,10 @@
 name: hh-rlhf
 display_name: HH-RLHF (Anthropic Helpful/Harmless)
 type: dataset
-description: HH-RLHF is Anthropic's human preference dataset for RLHF, containing ~169K rows of chosen-vs-rejected
-  response pairs on helpfulness and harmlessness, plus red-teaming dialogues. Released alongside Anthropic's
-  papers on training helpful and harmless assistants, it is intended for preference modeling rather than
-  supervised dialogue training. It is one of the most influential early open RLHF preference datasets.
+description: Anthropic's human preference dataset for RLHF, holding about 169,000 rows of chosen-versus-rejected
+  response pairs on helpfulness and harmlessness alongside red-teaming dialogues. It was released with Anthropic's
+  papers on training helpful and harmless assistants, and is intended for preference modeling rather than supervised
+  dialogue training.
 github:
 - url: https://github.com/anthropics/hh-rlhf
 huggingface_dataset:
@@ -12,5 +12,5 @@ huggingface_dataset:
 lineage:
   derived_from:
   - human preference annotations (Anthropic crowdworkers)
-comments: Verified live 2026-08-13 via primary sources. Publicly downloadable and ungated under the permissive
-  MIT license.
+comments: The Tulu 3 preference mixture does not use it. Verified 2026-08-13 via the Anthropic/hh-rlhf dataset
+  card on Hugging Face.

--- a/sources/products/madlad-400.yaml
+++ b/sources/products/madlad-400.yaml
@@ -1,14 +1,13 @@
 name: madlad-400
 display_name: MADLAD-400
 type: dataset
-description: MADLAD-400 is a document-level multilingual web corpus derived from Common Crawl, covering
-  419 languages, released by the Allen Institute for AI (AI2). It ships in a noisy (minimally filtered)
-  variant and a clean (quality-filtered) variant, totaling roughly 38TB, and was designed to improve coverage
-  of low-resource languages. It underpins the MADLAD-400 machine-translation models.
+description: Document-level multilingual web corpus derived from Common Crawl and covering 419 languages, published
+  by the Allen Institute for AI. It ships a noisy minimally-filtered variant and a clean quality-filtered variant
+  totalling roughly 38TB, designed to improve coverage of low-resource languages, and underpins the MADLAD-400
+  machine-translation models.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/allenai/MADLAD-400
 lineage:
   derived_from:
   - Common Crawl
-comments: Verified live 2026-08-13 via primary sources. Ungated with a permissive open-data license and a complete
-  dataset card.
+comments: Verified 2026-08-13 via the allenai/MADLAD-400 dataset metadata on Hugging Face.

--- a/sources/products/nemotron-cc.yaml
+++ b/sources/products/nemotron-cc.yaml
@@ -1,9 +1,8 @@
 name: nemotron-cc
 display_name: Nemotron-CC
 type: dataset
-description: Nemotron-CC is NVIDIA's Common Crawl-derived pretraining corpus family (v1/v2 plus Math,
-  Code, and Specialized sets), spanning trillions of tokens with synthetic rephrasing, released under
-  the NVIDIA Open Data License with gated access. It backs the Nemotron model line and is a documented
+description: NVIDIA's Common Crawl-derived pretraining corpus family, spanning trillions of tokens with synthetic
+  rephrasing across general, math, code and specialized sets. It backs the Nemotron model line and is a documented
   component of Marin 8B.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/nvidia/Nemotron-CC-v2
@@ -16,6 +15,5 @@ lineage:
   trains:
   - nemotron
   - marin
-comments: 'Family bucket: Nemotron-CC v1/v2, Nemotron-CC-Math, Nemotron-Pretraining-Code, and Nemotron-Pretraining-Specialized.
-  Verified live 2026-08-13 via primary sources. Manually gated behind an NVIDIA open-data agreement collecting
-  contact information.'
+comments: A family record covering the v1 and v2 corpora and the math, code and specialized sets. Verified
+  2026-08-13 via the nvidia/Nemotron-CC-v2 dataset card on Hugging Face.

--- a/sources/products/oasst1.yaml
+++ b/sources/products/oasst1.yaml
@@ -1,9 +1,9 @@
 name: oasst1
 display_name: OpenAssistant Conversations (OASST1)
 type: dataset
-description: OpenAssistant Conversations (OASST1) is the LAION-community crowdsourced human dialogue corpus
-  (161k messages in 35 languages, Apache-2.0) from the 2023 OpenAssistant project. It remains a staple
-  human-data ingredient in open post-training mixes, from Guanaco to Tulu 3 and OLMo 3's Dolci.
+description: Crowdsourced human dialogue corpus from the 2023 OpenAssistant project, holding about 161,000
+  messages across 35 languages contributed by the LAION community. It remains a staple human-data ingredient
+  in open post-training mixes, from Guanaco through Tulu 3 to OLMo 3's Dolci.
 github:
 - url: https://github.com/LAION-AI/Open-Assistant
 huggingface_dataset:
@@ -14,4 +14,4 @@ lineage:
   trains:
   - tulu
   - olmo-instruct
-comments: Verified live 2026-08-13 via primary sources. Apache-2.0 licensed, ungated, with a full dataset card.
+comments: Verified 2026-08-13 via the OpenAssistant/oasst1 dataset card on Hugging Face.

--- a/sources/products/openhermes-2-5.yaml
+++ b/sources/products/openhermes-2-5.yaml
@@ -1,10 +1,10 @@
 name: openhermes-2-5
 display_name: OpenHermes 2.5
 type: dataset
-description: OpenHermes 2.5 is a large synthetic instruction-following dataset of ~1M conversational examples
-  compiled and generated primarily from GPT-4 outputs across math, code, roleplay, and general-knowledge
-  tasks. Created by Teknium as an expansion of OpenHermes 1, it was used to train the popular OpenHermes
-  2.5 fine-tunes and is widely used as a base SFT mix for open instruction-tuned models.
+description: Synthetic instruction-following dataset of roughly a million conversational examples, compiled
+  and generated primarily from GPT-4 outputs across math, code, roleplay and general-knowledge tasks. Created
+  by Teknium as an expansion of OpenHermes 1, it trained the OpenHermes 2.5 fine-tunes and is used as a base
+  supervised-tuning mix by open instruction models.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/teknium/OpenHermes-2.5
 lineage:
@@ -13,5 +13,5 @@ lineage:
   - community datasets
   trains:
   - smollm
-comments: Verified live 2026-08-13 via primary sources. Publicly downloadable and ungated with a full card,
-  though an explicit license string is not stated on the card.
+comments: The dataset card declares no license and no license file ships with the data, which the openness
+  axis resolves. Verified 2026-08-13 via the teknium/OpenHermes-2.5 dataset card and its raw README.

--- a/sources/products/openthoughts-114k.yaml
+++ b/sources/products/openthoughts-114k.yaml
@@ -1,10 +1,9 @@
 name: openthoughts-114k
 display_name: OpenThoughts-114k
 type: dataset
-description: OpenThoughts-114k is a synthetic reasoning dataset of roughly 114,000 examples spanning math,
-  science, code, and puzzles, built by curating problem sets and generating reasoning traces with DeepSeek-R1
-  followed by correctness verification. It was created by the Open Thoughts team and documented in arXiv
-  2506.04178. It was used to train the OpenThinker-7B and OpenThinker-32B models.
+description: Synthetic reasoning dataset of roughly 114,000 examples spanning math, science, code and puzzles,
+  built by curating problem sets, generating reasoning traces with DeepSeek-R1 and then verifying correctness.
+  It was created by the Open Thoughts team and used to train the OpenThinker 7B and 32B models.
 github:
 - url: https://github.com/open-thoughts/open-thoughts
 huggingface_dataset:
@@ -16,5 +15,5 @@ lineage:
   - open-thoughts pipeline
   trains:
   - marin
-comments: Verified live 2026-08-13 via primary sources. Apache-2.0 licensed, ungated, with dataset card, code
-  repo, and paper.
+comments: OpenThoughts3-1.2M is the recommended successor. Verified 2026-08-13 via the open-thoughts/OpenThoughts-114k
+  dataset card on Hugging Face.

--- a/sources/products/openwebmath.yaml
+++ b/sources/products/openwebmath.yaml
@@ -1,9 +1,9 @@
 name: openwebmath
 display_name: OpenWebMath
 type: dataset
-description: OpenWebMath is a 14.7B-token corpus of mathematical web text extracted from Common Crawl
-  with LaTeX preserved, released under ODC-BY by researchers from the University of Toronto and collaborators.
-  It appears in Proof-Pile-2 (Llemma), OLMoE, Nemotron 3, and StarCoder2's math supplements.
+description: Corpus of 14.7 billion tokens of mathematical web text extracted from Common Crawl with LaTeX
+  preserved, released by researchers at the University of Toronto and collaborators. It appears in Proof-Pile-2
+  behind Llemma, and in OLMoE, Nemotron 3 and StarCoder2's math supplements.
 github:
 - url: https://github.com/keirp/OpenWebMath
 huggingface_dataset:
@@ -15,5 +15,4 @@ lineage:
   - olmoe-instruct
   - nemotron
   - starcoder2
-comments: Verified live 2026-08-13 via primary sources. ODC-BY 1.0 licensed alongside the Common Crawl ToU,
-  ungated, with a full dataset card.
+comments: Verified 2026-08-13 via the open-web-math/open-web-math dataset card on Hugging Face.

--- a/sources/products/oscar-2301.yaml
+++ b/sources/products/oscar-2301.yaml
@@ -1,11 +1,9 @@
 name: oscar-2301
 display_name: OSCAR-2301
 type: dataset
-description: OSCAR-2301 is a multilingual web corpus extracted and filtered from the late-2022 Common
-  Crawl snapshot, covering 151 languages and totaling ~3.57TB of raw unannotated text for LLM pretraining.
-  It is published by the OSCAR project (oscar-corpus) and includes KenLM-based content quality metrics
-  and deduplication hashes. The corpus content is from Common Crawl with no copyright held by the authors;
-  metadata is CC0-1.0.
+description: Multilingual web corpus extracted and filtered from the late-2022 Common Crawl snapshot, covering
+  151 languages and totalling about 3.57TB of raw unannotated text for pretraining. Published by the OSCAR
+  project, it includes KenLM-based content quality metrics and deduplication hashes.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/oscar-corpus/OSCAR-2301
 lineage:
@@ -13,5 +11,5 @@ lineage:
   - Common Crawl
   curated_with:
   - ungoliant
-comments: Verified live 2026-08-13 via primary sources. Manually gated and the card states access is temporarily
-  suspended pending clarification.
+comments: The card states that access is temporarily suspended pending clarification, so the data itself could
+  not be reached for this record. Verified 2026-08-13 via the OSCAR-2301 dataset card on Hugging Face.

--- a/sources/products/personahub.yaml
+++ b/sources/products/personahub.yaml
@@ -1,11 +1,10 @@
 name: personahub
 display_name: PersonaHub
 type: dataset
-description: PersonaHub is a persona-driven synthetic data resource from Tencent AI Lab, backed by the
-  paper 'Scaling Synthetic Data Creation with 1,000,000,000 Personas' (arXiv 2406.20094). The repo releases
-  a large set of distilled personas (200K preview plus ~370M elite personas) plus seed synthetic samples
-  such as 50K math problems, 50K logical-reasoning problems, and 50K instructions. It is a method and
-  dataset for generating diverse, scalable synthetic instruction and reasoning data.
+description: Persona-driven synthetic data resource from Tencent AI Lab, backed by the paper "Scaling Synthetic
+  Data Creation with 1,000,000,000 Personas". It releases a large set of distilled personas - a 200,000-persona
+  preview alongside roughly 370 million elite personas - plus seed synthetic samples including 50,000 math
+  problems, 50,000 logical-reasoning problems and 50,000 instructions.
 github:
 - url: https://github.com/tencent-ailab/persona-hub
 huggingface_dataset:
@@ -13,5 +12,5 @@ huggingface_dataset:
 lineage:
   derived_from:
   - persona-driven synthesis (GPT-4o)
-comments: Verified live 2026-08-13 via primary sources. Publicly downloadable and ungated under CC-BY-NC-SA-4.0,
-  which permits redistribution for non-commercial research.
+comments: Tulu 3's persona-math set expands the same methodology. Verified 2026-08-13 via the proj-persona/PersonaHub
+  dataset card on Hugging Face.

--- a/sources/products/pes2o.yaml
+++ b/sources/products/pes2o.yaml
@@ -1,9 +1,9 @@
 name: pes2o
 display_name: peS2o
 type: dataset
-description: peS2o is Ai2's ODC-BY corpus of ~40M cleaned academic papers derived from S2ORC (Semantic
-  Scholar). It is a standard open scientific-text component, documented in OLMoE, Marin, and NVIDIA's
-  Nemotron 3 pretraining data.
+description: Ai2's corpus of roughly 40 million cleaned academic papers derived from S2ORC on Semantic Scholar.
+  It is a standard open scientific-text component, documented in the pretraining mixes for OLMoE, Marin and
+  NVIDIA's Nemotron 3.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/allenai/peS2o
 lineage:
@@ -15,4 +15,5 @@ lineage:
   - olmoe-instruct
   - marin
   - nemotron
-comments: Verified live 2026-08-13 via primary sources. ODC-BY licensed, ungated, with a full dataset card.
+comments: It contributes about 57 billion tokens to the OLMoE pretraining mix. Verified 2026-08-13 via the
+  allenai/peS2o dataset card on Hugging Face.

--- a/sources/products/redpajama-data-v2.yaml
+++ b/sources/products/redpajama-data-v2.yaml
@@ -1,10 +1,9 @@
 name: redpajama-data-v2
 display_name: RedPajama-Data-v2
 type: dataset
-description: RedPajama-Data-v2 is a large open web dataset built from Common Crawl, containing over 100B
-  text documents with around 30B documents annotated with quality signals and ~20B deduplicated documents
-  (tens of trillions of tokens). It was created by Together Computer to support open language-model pretraining.
-  The processing scripts are Apache-2.0, while the underlying text follows Common Crawl's Terms of Use.
+description: Large open web dataset built from Common Crawl by Together Computer, holding more than 100 billion
+  text documents, of which around 30 billion carry quality-signal annotations and about 20 billion are deduplicated.
+  It is published raw and unfiltered so downstream users apply their own filtering.
 github:
 - url: https://github.com/togethercomputer/RedPajama-Data
 huggingface_dataset:
@@ -14,5 +13,4 @@ lineage:
   - Common Crawl
   curated_with:
   - ccnet
-comments: Verified live 2026-08-13 via primary sources. Ungated with a full dataset card; redistributable per
-  Common Crawl ToU with Apache-2.0 processing code.
+comments: Verified 2026-08-13 via the togethercomputer/RedPajama-Data-V2 dataset card on Hugging Face.

--- a/sources/products/refinedweb.yaml
+++ b/sources/products/refinedweb.yaml
@@ -1,10 +1,9 @@
 name: refinedweb
 display_name: RefinedWeb
 type: dataset
-description: Falcon RefinedWeb is a large English web dataset (~968M rows, ~2.8TB) built by the Technology
-  Innovation Institute (TII) via stringent filtering and exact-plus-fuzzy deduplication of CommonCrawl.
-  The public release is an extract of the larger corpus used to train the Falcon-7B/40B models. It demonstrated
-  that rigorously filtered web data alone can match or beat curated corpora for LLM pretraining.
+description: English web dataset of roughly 968 million rows and about 2.8TB, built by the Technology Innovation
+  Institute through stringent filtering and exact-plus-fuzzy deduplication of Common Crawl. The public release
+  is an extract of the larger corpus used to train the Falcon 7B and 40B models.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/tiiuae/falcon-refinedweb
 lineage:
@@ -14,5 +13,4 @@ lineage:
   - Macrodata Refinement pipeline
   trains:
   - Falcon 1/2
-comments: Verified live 2026-08-13 via primary sources. Permissive ODC-BY 1.0 license, ungated download, with
-  a dataset card (a public extract of the full corpus).
+comments: Verified 2026-08-13 via the tiiuae/falcon-refinedweb dataset card on Hugging Face.

--- a/sources/products/smoltalk.yaml
+++ b/sources/products/smoltalk.yaml
@@ -1,9 +1,9 @@
 name: smoltalk
 display_name: SmolTalk
 type: dataset
-description: SmolTalk (and SmolTalk2) is Hugging Face's open SFT mixture behind the SmolLM instruct models,
-  combining new Apache-2.0 synthetic sets (Smol-Magpie-Ultra and others) with established public datasets.
-  Marin 8B Instruct also trains on it; component licenses follow their sources.
+description: Hugging Face's supervised fine-tuning mixture behind the SmolLM instruct models, combining new
+  synthetic sets such as Smol-Magpie-Ultra with established public datasets. Marin 8B Instruct also trains
+  on it. The record covers both SmolTalk and its successor SmolTalk2.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/HuggingFaceTB/smoltalk
 lineage:
@@ -18,5 +18,5 @@ lineage:
   trains:
   - smollm
   - marin
-comments: 'Family bucket: SmolTalk and SmolTalk2. Verified live 2026-08-13 via primary sources. Ungated with
-  a full card; the four new subsets are Apache-2.0 and the rest keep their original licences.'
+comments: Component datasets keep the terms of their own sources, which the card documents. Verified 2026-08-13
+  via the HuggingFaceTB/smoltalk dataset card on Hugging Face.

--- a/sources/products/stack-edu.yaml
+++ b/sources/products/stack-edu.yaml
@@ -1,9 +1,9 @@
 name: stack-edu
 display_name: Stack-Edu
 type: dataset
-description: Stack-Edu is Hugging Face's education-filtered slice of StarCoder2Data (~125B tokens of high-quality
-  code), scored by an educational-value classifier. It is a documented component of SmolLM3 and OLMo 3's
-  Dolma 3 pool; licensing defers to The Stack v2's terms.
+description: Hugging Face's education-filtered slice of StarCoder2Data, about 125 billion tokens of code scored
+  by an educational-value classifier. It is a documented component of SmolLM3 and of the Dolma 3 pool behind
+  OLMo 3.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/HuggingFaceTB/stack-edu
 lineage:
@@ -15,5 +15,5 @@ lineage:
   trains:
   - smollm
   - olmo
-comments: Verified live 2026-08-13 via primary sources. Ungated with a full card; the data licence defers to
-  The Stack v2.
+comments: The data terms defer to The Stack v2, which the card records. Verified 2026-08-13 via the HuggingFaceTB/stack-edu
+  dataset card on Hugging Face.

--- a/sources/products/starcoderdata.yaml
+++ b/sources/products/starcoderdata.yaml
@@ -1,10 +1,9 @@
 name: starcoderdata
 display_name: StarCoderData
 type: dataset
-description: StarCoderData is the BigCode project's ~250B-token filtered code corpus drawn from The Stack
-  v1 (permissively licensed GitHub code plus issues and notebooks), used to train StarCoder. It became
-  a standard open code-pretraining component, documented in TinyLlama, IBM Granite Code, ALIA, Apertus,
-  Marin, and OLMoE.
+description: BigCode's filtered code corpus of roughly 250 billion tokens drawn from The Stack v1, covering
+  source files alongside issues and notebooks, used to train StarCoder. It became a standard open code-pretraining
+  component, documented in TinyLlama, IBM Granite Code, ALIA, Apertus, Marin and OLMoE.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/bigcode/starcoderdata
 lineage:
@@ -19,6 +18,5 @@ lineage:
   - apertus
   - marin
   - olmoe-instruct
-comments: Derived from The Stack v1 (the map's the-stack-v2 entry covers the Stack family's current version;
-  v1 is its direct predecessor). Verified live 2026-08-13 via primary sources. Downloading still requires accepting
-  the terms and sharing contact information, so access is gated.
+comments: Derived from The Stack v1; the map's the-stack-v2 record covers the family's current version. Verified
+  2026-08-13 via the bigcode/starcoderdata dataset card on Hugging Face.

--- a/sources/products/synth.yaml
+++ b/sources/products/synth.yaml
@@ -1,11 +1,11 @@
 name: synth
 display_name: SYNTH
 type: dataset
-description: SYNTH is a large-scale synthetic dataset from PleIAs (released with the AI Alliance) designed
-  for training small reasoning models end-to-end. It contains tens of millions of synthetic samples amplifying
-  content from tens of thousands of Wikipedia articles, Wikibooks, and internal documents, spanning exercise
-  types like arithmetic, creative writing, RAG, and information extraction. Samples include reasoning
-  traces and seed attribution, and roughly 20% covers non-English European languages.
+description: Large synthetic dataset from PleIAs, released with the AI Alliance, designed for training small
+  reasoning models end to end. It holds tens of millions of samples amplifying content from tens of thousands
+  of Wikipedia articles, Wikibooks and internal documents, across exercise types including arithmetic, creative
+  writing, RAG and information extraction. Samples carry reasoning traces and seed attribution, and roughly
+  a fifth covers non-English European languages.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/PleIAs/SYNTH
 lineage:
@@ -13,5 +13,5 @@ lineage:
   - open seed corpora (synthetic generation)
   trains:
   - Pleias models
-comments: Verified live 2026-08-13 via primary sources. Permissively licensed, ungated dataset with a documented
-  card.
+comments: PleIAs trained Baguettotron and Monad end to end on it. Verified 2026-08-13 via the PleIAs/SYNTH
+  dataset card on Hugging Face.

--- a/sources/products/the-pile.yaml
+++ b/sources/products/the-pile.yaml
@@ -1,11 +1,9 @@
 name: the-pile
 display_name: The Pile
 type: dataset
-description: The Pile is EleutherAI's 825 GiB, 22-source English pretraining corpus (2020), spanning web
-  text, academic papers, code, books, and forums. It set the template for documented open pretraining
-  data and trained Pythia, GPT-NeoX-20B, GPT-J, and Cerebras-GPT among others. The original mirrors are
-  offline; data is now served through the deduplicated Hugging Face repo, and component licenses vary
-  by subset.
+description: EleutherAI's 825 GiB English pretraining corpus from 2020, drawn from 22 sources spanning web
+  text, academic papers, code, books and forums. It set the template for documented open pretraining data and
+  trained Pythia, GPT-NeoX-20B, GPT-J and Cerebras-GPT among others.
 github:
 - url: https://github.com/EleutherAI/the-pile
 huggingface_dataset:
@@ -24,5 +22,6 @@ lineage:
   - the-pile-pipeline
   trains:
   - pythia
-comments: Covers the Pile family (original + deduplicated). Verified live 2026-08-13; canonical hosting moved
-  to the deduplicated repo after the original mirrors went offline.
+comments: A family record covering the original and deduplicated releases. The original mirrors are offline
+  and the data is now served from the deduplicated repository. Verified 2026-08-13 via the EleutherAI/the_pile_deduplicated
+  and EleutherAI/pile dataset cards on Hugging Face.

--- a/sources/products/the-stack-v2.yaml
+++ b/sources/products/the-stack-v2.yaml
@@ -1,10 +1,9 @@
 name: the-stack-v2
 display_name: The Stack v2
 type: dataset
-description: The Stack v2 is a large source-code dataset of 3.28B unique files (67.53TB uncompressed)
-  from 104.2M GitHub repositories spanning 658 programming languages, sourced via Software Heritage. It
-  was created by the BigCode project and used to train the StarCoder2 models. Files carry permissive licenses,
-  but access requires accepting terms of use tied to Software Heritage principles.
+description: Source-code dataset of 3.28 billion unique files, 67.53TB uncompressed, drawn from 104.2 million
+  GitHub repositories across 658 programming languages and sourced through Software Heritage. It was created
+  by the BigCode project and used to train the StarCoder2 models.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/bigcode/the-stack-v2
 lineage:
@@ -16,5 +15,4 @@ lineage:
   trains:
   - starcoder2
   - smollm
-comments: Verified live 2026-08-13 via primary sources. Requires acceptance of terms and sharing contact info
-  before download, so access is gated.
+comments: Verified 2026-08-13 via the bigcode/the-stack-v2 dataset card on Hugging Face.

--- a/sources/products/tulu-3-sft-mixture.yaml
+++ b/sources/products/tulu-3-sft-mixture.yaml
@@ -1,11 +1,9 @@
 name: tulu-3-sft-mixture
 display_name: Tulu 3 SFT Mixture
 type: dataset
-description: The Tulu 3 SFT Mixture is a supervised fine-tuning dataset of roughly 939k samples combining
-  18 data sources, created by the Allen Institute for AI (Ai2) for its Tulu 3 post-training recipe. It
-  covers conversation, instruction-following, math, code, safety, and multilingual data across 70+ languages.
-  The mixture is ODC-BY-1.0 licensed while incorporating subsets under varying licenses. It underpins
-  the open Tulu 3 model family.
+description: Supervised fine-tuning dataset of roughly 939,000 samples combining 18 data sources, created by
+  the Allen Institute for AI for its Tulu 3 post-training recipe. It covers conversation, instruction-following,
+  math, code, safety and multilingual data across more than 70 languages, and underpins the Tulu 3 model family.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/allenai/tulu-3-sft-mixture
 lineage:
@@ -23,5 +21,5 @@ lineage:
   - apertus
   - marin
   - smollm
-comments: Verified live 2026-08-13 via primary sources. ODC-BY licensed and ungated with a full dataset card,
-  though some subsets carry non-commercial licenses.
+comments: Some constituent subsets carry terms narrower than the mixture's own, which the card documents. Verified
+  2026-08-13 via the allenai/tulu-3-sft-mixture dataset card on Hugging Face.

--- a/sources/products/txt360.yaml
+++ b/sources/products/txt360.yaml
@@ -1,9 +1,10 @@
 name: txt360
 display_name: TxT360
 type: dataset
-description: TxT360 is LLM360's globally deduplicated pretraining corpus combining 99 Common Crawl snapshots
-  with 14 curated high-quality sources (FreeLaw, PG-19, arXiv, Wikipedia, StackExchange, and more) under
-  ODC-BY. It trains K2-V2 together with the TxT360-Midas mid-training and 3efforts SFT extensions.
+description: LLM360's globally deduplicated pretraining corpus, combining 99 Common Crawl snapshots with 14
+  curated sources including FreeLaw, PG-19, arXiv, Wikipedia and StackExchange. It holds about 5 trillion deduplicated
+  tokens and supports a recipe reaching beyond 15 trillion, and trains K2-V2 together with its mid-training
+  and SFT extensions.
 github:
 - url: https://github.com/LLM360/TxT360
 huggingface_dataset:
@@ -21,6 +22,5 @@ lineage:
   - txt360-pipeline
   trains:
   - k2
-comments: 'Family bucket: TxT360 plus the Midas mid-training and 3efforts SFT extensions. Verified live 2026-08-13
-  via primary sources. ODC-BY licensed, ungated, with a full dataset card; the LLM360 path now redirects to
-  the IFM org.'
+comments: A family record covering TxT360 with the Midas mid-training and 3efforts SFT extensions. The LLM360
+  path now redirects to the IFM organization. Verified 2026-08-13 via the TxT360 dataset card on Hugging Face.

--- a/sources/products/ultrachat-200k.yaml
+++ b/sources/products/ultrachat-200k.yaml
@@ -1,9 +1,9 @@
 name: ultrachat-200k
 display_name: UltraChat 200k
 type: dataset
-description: UltraChat 200k is Hugging Face H4's filtered 200k-dialogue slice of the ChatGPT-distilled
-  UltraChat corpus, released under MIT for supervised fine-tuning. It anchored the Zephyr recipe and became
-  a default open SFT set for chat alignment, also used by TinyLlama-Chat.
+description: Hugging Face H4's filtered 200,000-dialogue slice of the ChatGPT-distilled UltraChat corpus, prepared
+  for supervised fine-tuning of chat models. It anchored the Zephyr recipe and is also used by TinyLlama-Chat,
+  and remains a common starting point for open chat alignment work.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/HuggingFaceH4/ultrachat_200k
 lineage:
@@ -12,4 +12,5 @@ lineage:
   trains:
   - zephyr
   - tinyllama-chat
-comments: Verified live 2026-08-13 via primary sources. MIT licensed, ungated, with a full dataset card.
+comments: Tulu 3 does not use it as an SFT source. Verified 2026-08-13 via the HuggingFaceH4/ultrachat_200k
+  dataset card on Hugging Face.

--- a/sources/products/ultrafeedback.yaml
+++ b/sources/products/ultrafeedback.yaml
@@ -1,11 +1,10 @@
 name: ultrafeedback
 display_name: UltraFeedback
 type: dataset
-description: UltraFeedback is a large-scale GPT-4-annotated preference dataset comprising ~64K prompts,
-  ~256K responses, and ~380K fine-grained feedback annotations across instruction-following, truthfulness,
-  honesty, and helpfulness. Prompts are drawn from six public datasets with responses from 17 different
-  models. Built by OpenBMB, it is a foundational dataset for training reward and critic models and underpins
-  many open RLHF/DPO pipelines.
+description: GPT-4-annotated preference dataset of roughly 64,000 prompts, 256,000 responses and 380,000 fine-grained
+  feedback annotations across instruction-following, truthfulness, honesty and helpfulness. Prompts are drawn
+  from six public datasets with responses from 17 different models. Built by OpenBMB, it is used to train reward
+  and critic models in open RLHF and DPO pipelines.
 github:
 - url: https://github.com/OpenBMB/UltraFeedback
 huggingface_dataset:
@@ -17,5 +16,4 @@ lineage:
   - zephyr
   - tinyllama-chat
   - olmoe-instruct
-comments: Verified live 2026-08-13 via primary sources. Publicly downloadable and ungated under the permissive
-  MIT license.
+comments: Verified 2026-08-13 via the openbmb/UltraFeedback dataset card on Hugging Face.

--- a/sources/products/wildchat-1m.yaml
+++ b/sources/products/wildchat-1m.yaml
@@ -1,10 +1,9 @@
 name: wildchat-1m
 display_name: WildChat-1M
 type: dataset
-description: WildChat-1M is a corpus of around 838k real user-chatbot conversations collected by the Allen
-  Institute for AI (Ai2) by offering free access to GPT-3.5/GPT-4 in exchange for consenting to data collection.
-  It spans 74 languages and includes metadata such as timestamps, hashed IPs, geographic region, model
-  used, and moderation scores. It is a widely cited source of naturalistic instruction and chat data.
+description: Corpus of around 838,000 real user-chatbot conversations collected by the Allen Institute for
+  AI by offering free access to GPT-3.5 and GPT-4 in exchange for consent to data collection. It spans 74 languages
+  and carries metadata including timestamps, hashed IPs, geographic region, model used and moderation scores.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/allenai/WildChat-1M
 lineage:
@@ -13,5 +12,5 @@ lineage:
   trains:
   - tulu
   - olmo-instruct
-comments: Verified live 2026-08-13 via primary sources. ODC-BY licensed and reported ungated by the HF API,
-  though Ai2 datasets sometimes show an access notice.
+comments: A named source in the Tulu 3 SFT mixture. Verified 2026-08-13 via the allenai/WildChat-1M dataset
+  metadata on Hugging Face.

--- a/sources/provenance/training_synthetic_datasets.yaml
+++ b/sources/provenance/training_synthetic_datasets.yaml
@@ -1,0 +1,193 @@
+# Prose and provenance closeout for training_synthetic_datasets. 38 of 38 ready.
+#
+# All 38 were unresolved: 37 `generic` and `the-pile` `ambiguous_noncanonical`. No axis was held,
+# no date moved, and no source was refetched - every line names a document already in the score
+# file, on its own `accessed` date.
+#
+# ## What a dataset record may not say
+#
+# This category made one rule concrete that the software categories only touched: for a dataset,
+# the LICENSE and the GATE are both openness components. `sources/rubrics/dataset.yaml` scores
+# them, and `check_rubric` replays the score from them. So "ODC-BY licensed, ungated, with a full
+# dataset card" - which 20 of these records carried almost verbatim in `comments` - is a second
+# copy of the axis with none of its evidence, and it is gone.
+#
+# What stays is the dataset's own shape: token counts, row counts, language coverage, byte size,
+# how it was filtered, and what it was used to train. Those are not volatile in the sense the
+# guide means - a new release is a different record - so `fineweb`'s 18.5T tokens and
+# `the-stack-v2`'s 3.28B files stay, while download counts do not.
+#
+# Also removed: benchmark and ablation results, which belong on the capability axis
+# (`refinedweb`'s "demonstrated that rigorously filtered web data alone can match or beat curated
+# corpora", `fineweb`'s "outperforms other public web datasets"), and unsourced rankings
+# ("one of the most widely used English pretraining corpora", "the largest open synthetic dataset
+# of its kind at release", "one of the most influential early open RLHF preference datasets").
+#
+# ## Two evidence gaps kept, because they are about our reading
+#
+# `openhermes-2-5`: the card declares no license and no license file ships with the data. That is
+# recorded as an ambiguity for the axis to resolve rather than as a verdict.
+#
+# `oscar-2301`: the card states access is temporarily suspended pending clarification, so the
+# data itself could not be reached. The axis keeps its date - the card is the evidence and it was
+# read - and the prose says what could not be done.
+#
+# ## Family records
+#
+# `dolci`, `dolma-3`, `nemotron-cc`, `smoltalk`, `txt360` and `the-pile` each cover a family
+# rather than one artifact, and each says so. `starcoderdata` is The Stack v1 and points at the
+# `the-stack-v2` record for the current version; `dolma` points at `dolma-3`; `openthoughts-114k`
+# points at OpenThoughts3. Those pointers are identity, and they stay.
+#
+- product: aya-collection
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Aya Collection dataset card on Hugging Face
+- product: c4
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the allenai/c4 dataset card on Hugging Face
+- product: common-corpus
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the PleIAs/common_corpus dataset card on Hugging Face
+- product: cosmopedia
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the HuggingFaceTB/cosmopedia dataset card on Hugging Face
+- product: culturax
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the uonlp/CulturaX dataset card on Hugging Face
+- product: dclm-baseline
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the mlfoundations/dclm-baseline-1
+- product: dolci
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the allenai/Dolci-Instruct-SFT dataset card on Hugging Face
+- product: dolma
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the allenai/dolma dataset card on Hugging Face
+- product: dolma-3
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the allenai/dolma3_pool dataset card on Hugging Face
+- product: finemath
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the HuggingFaceTB/finemath dataset card on Hugging Face
+- product: fineweb
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the HuggingFaceFW/fineweb dataset card on Hugging Face
+- product: fineweb-2
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the HuggingFaceFW/fineweb-2 dataset card on Hugging Face
+- product: fineweb-edu
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the HuggingFaceFW/fineweb-edu dataset card on Hugging Face
+- product: flan-collection
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the google-research/FLAN repository and the ai2-adapt-dev/flan_v2_converted dataset card
+- product: hermes-3-dataset
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the NousResearch/Hermes-3-Dataset dataset card on Hugging Face
+- product: hh-rlhf
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Anthropic/hh-rlhf dataset card on Hugging Face
+- product: madlad-400
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the allenai/MADLAD-400 dataset metadata on Hugging Face
+- product: nemotron-cc
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the nvidia/Nemotron-CC-v2 dataset card on Hugging Face
+- product: oasst1
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the OpenAssistant/oasst1 dataset card on Hugging Face
+- product: openhermes-2-5
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the teknium/OpenHermes-2
+- product: openthoughts-114k
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the open-thoughts/OpenThoughts-114k dataset card on Hugging Face
+- product: openwebmath
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the open-web-math/open-web-math dataset card on Hugging Face
+- product: oscar-2301
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the OSCAR-2301 dataset card on Hugging Face
+- product: personahub
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the proj-persona/PersonaHub dataset card on Hugging Face
+- product: pes2o
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the allenai/peS2o dataset card on Hugging Face
+- product: redpajama-data-v2
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the togethercomputer/RedPajama-Data-V2 dataset card on Hugging Face
+- product: refinedweb
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the tiiuae/falcon-refinedweb dataset card on Hugging Face
+- product: smoltalk
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the HuggingFaceTB/smoltalk dataset card on Hugging Face
+- product: stack-edu
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the HuggingFaceTB/stack-edu dataset card on Hugging Face
+- product: starcoderdata
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the bigcode/starcoderdata dataset card on Hugging Face
+- product: synth
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the PleIAs/SYNTH dataset card on Hugging Face
+- product: the-pile
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the EleutherAI/the_pile_deduplicated and EleutherAI/pile dataset cards on Hugging Face
+- product: the-stack-v2
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the bigcode/the-stack-v2 dataset card on Hugging Face
+- product: tulu-3-sft-mixture
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the allenai/tulu-3-sft-mixture dataset card on Hugging Face
+- product: txt360
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the TxT360 dataset card on Hugging Face
+- product: ultrachat-200k
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the HuggingFaceH4/ultrachat_200k dataset card on Hugging Face
+- product: ultrafeedback
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the openbmb/UltraFeedback dataset card on Hugging Face
+- product: wildchat-1m
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the allenai/WildChat-1M dataset metadata on Hugging Face


### PR DESCRIPTION
**38 of 38 ready.** All were unresolved — 37 `generic`, `the-pile` `ambiguous_noncanonical`. No axis held, no date moved, no source refetched.

## The rule this category made concrete

For a dataset, the **license and the gate are both openness components**. `sources/rubrics/dataset.yaml` scores them and `check_rubric` replays the score from them. So a comments line reading *"ODC-BY licensed, ungated, with a full dataset card"* — which **20 of these 38 records carried almost verbatim** — is a second copy of the axis carrying none of its evidence. All of it is gone.

What stays is the dataset's own shape: token counts, row counts, language coverage, byte size, how it was filtered, and what it trained. Those pass the guide's volatility test — a new release is a different record — so `fineweb`'s 18.5T tokens and `the-stack-v2`'s 3.28B files stay while download counts do not.

## Also removed

- **Benchmark and ablation results**, which are capability-axis content: `refinedweb`'s "demonstrated that rigorously filtered web data alone can match or beat curated corpora", `fineweb`'s "outperforms other public web datasets for LLM training".
- **Unsourced rankings**: "one of the most widely used English pretraining corpora" (`c4`), "the largest open synthetic dataset of its kind at release" (`cosmopedia`), "one of the most influential early open RLHF preference datasets" (`hh-rlhf`), "a widely cited reference in the open-data pretraining community" (`fineweb`).

## Two evidence gaps kept, because they are about our reading

`openhermes-2-5` — the card declares no license and no license file ships with the data. Recorded as an ambiguity for the axis to resolve, not as a verdict.

`oscar-2301` — the card states access is temporarily suspended pending clarification, so the data itself could not be reached. The axis keeps its date, because the card *is* the evidence and it was read; the prose says plainly what could not be done.

## Family records and identity pointers

`dolci`, `dolma-3`, `nemotron-cc`, `smoltalk`, `txt360` and `the-pile` each cover a family rather than one artifact and now say so. `starcoderdata` is The Stack v1 and points at the `the-stack-v2` record; `dolma` points at `dolma-3`; `openthoughts-114k` points at OpenThoughts3. Those pointers are identity and they stay.

## Verification

`validate`, `check_verification`, `check_capability`, `check_recipe`, `check_adoption --strict` clean. `check_freshness --category training_synthetic_datasets`: *all 114 axes carry a real last_verified*. 660 tests, no skips.

**Corpus: 300/472 ready · 401/472 canonical · 1,407/1,416 axes confirmed · 9 held.**
