### PR TITLE
Refresh benchmark_eval_data: 27/27

### DIFF
--- a/sources/products/ai2-arc.yaml
+++ b/sources/products/ai2-arc.yaml
@@ -1,14 +1,11 @@
 name: ai2-arc
 display_name: AI2 ARC
 type: dataset
-description: A benchmark of 7,787 genuine grade-school science questions assembled to study advanced question
-  answering. The dataset is split into an Easy set and a Challenge set, and it remains one of the canonical
-  multiple-choice reasoning benchmarks for language models.
+description: Benchmark of 7,787 grade-school science questions assembled to study advanced question answering,
+  split into an Easy set of 5,197 and a Challenge set of 2,590. Published by the Allen Institute for AI in
+  2018, it remains a standard multiple-choice reasoning evaluation in model release reports.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/allenai/ai2_arc
-comments: 'AI2 Reasoning Challenge (ARC), Allen Institute for AI (Clark et al. 2018, arXiv:1803.05457).
-  7,787 grade-school science multiple-choice questions: ARC-Challenge (2,590) + ARC-Easy (5,197). Foundational
-  LLM commonsense/reasoning benchmark, still a standard in 2026 model release reports. Verified live 2026-08-13
-  on huggingface.co/datasets/allenai/ai2_arc (474,701 downloads in the trailing 30 days).'
+comments: Verified 2026-08-13 via the allenai/ai2_arc dataset card on Hugging Face.
 arxiv:
 - url: https://arxiv.org/abs/1803.05457

--- a/sources/products/anthropic-internal-coding-evals.yaml
+++ b/sources/products/anthropic-internal-coding-evals.yaml
@@ -1,12 +1,9 @@
 name: anthropic-internal-coding-evals
 display_name: Anthropic Internal Coding Evals
 type: dataset
-description: Anthropic maintains proprietary coding evaluation datasets used to benchmark Claude models
-  during development, including agentic coding tasks, multi-file editing scenarios, and tool-use evaluations.
-  Referenced in model cards and responsible scaling policy documents. Like other frontier labs, these
-  are kept private to prevent training data contamination and preserve evaluation signal.
-comments: Anthropic internal coding evaluations / benchmarks referenced (not released) in Claude model
-  launches and system cards (e.g. Claude Opus 4.5, Nov 2025; partners GitHub Copilot cite 'internal coding
-  benchmarks'). The scored artifact is the internal coding eval sets. Verified live 2026-08-13 against
-  anthropic.com/news/claude-opus-4-5, which still describes the take-home exam used as an internal benchmark.
-  These are distinct from the public benchmarks (SWE-bench Verified, Aider Polyglot) Anthropic also reports.
+description: Coding evaluation sets Anthropic uses internally to benchmark Claude during development, covering
+  agentic coding tasks, multi-file editing and tool use. They are referenced in model cards and responsible-scaling
+  documents, and the take-home exam Anthropic sets for performance-engineering candidates is used as one of
+  them.
+comments: Distinct from the public benchmarks Anthropic also reports, such as SWE-bench Verified and Aider
+  Polyglot. Verified 2026-08-13 via Anthropic's Claude Opus 4.5 announcement.

--- a/sources/products/apps.yaml
+++ b/sources/products/apps.yaml
@@ -1,17 +1,14 @@
 name: apps
 display_name: APPS
 type: dataset
-description: Automated Programming Progress Standard, 10,000 coding problems at three difficulty levels
-  (introductory, interview, competition) drawn from open-access coding challenge sites. Published at NeurIPS
-  2021. One of the first large-scale code benchmarks to test models across a realistic difficulty spectrum,
-  bridging the gap between simple function-completion tasks and full competitive programming. Still used
-  as a reference dataset for training and evaluation.
+description: 'Automated Programming Progress Standard: 10,000 coding problems split evenly between train and
+  test, at introductory, interview and competition difficulty, drawn from open-access coding challenge sites
+  and shipped with 131,777 test cases and Python solutions. Published at NeurIPS 2021, it spans the gap between
+  function-completion tasks and full competitive programming.'
 github:
 - url: https://github.com/hendrycks/apps
 huggingface_dataset:
 - url: https://huggingface.co/datasets/codeparrot/apps
-comments: 'APPS (Hendrycks et al., NeurIPS 2021, arXiv 2105.09938): 10,000 coding problems (5,000 train
-  / 5,000 test) with 131,777 test cases, Introductory/Interview/Competition difficulty, Python solutions.
-  HF dataset (codeparrot/apps) verified live 2026-08-13 (17,169 downloads in the trailing 30 days, MIT).'
+comments: Verified 2026-08-13 via the codeparrot/apps dataset card on Hugging Face.
 arxiv:
 - url: https://arxiv.org/abs/2105.09938

--- a/sources/products/codecontests.yaml
+++ b/sources/products/codecontests.yaml
@@ -1,19 +1,15 @@
 name: codecontests
 display_name: CodeContests
 type: dataset
-description: A competitive programming dataset containing ~13,000 problems collected from Codeforces,
-  CodeChef, and other contest platforms, each with problem descriptions, solutions in multiple languages,
-  and test cases. Introduced in the AlphaCode paper (2022). Designed to test models on problems requiring
-  algorithmic reasoning far beyond typical function-completion benchmarks, the hard end of code generation
-  evaluation.
+description: Competitive-programming dataset built for the AlphaCode paper, holding 4,044 problems collected
+  from Codeforces, CodeChef and other contest platforms, each with a description, correct and incorrect human
+  solutions in several languages, and public, private and generated test cases.
 github:
 - url: https://github.com/google-deepmind/code_contests
 huggingface_dataset:
 - url: https://huggingface.co/datasets/deepmind/code_contests
-comments: 'CodeContests (deepmind/code_contests), competitive-programming dataset built for AlphaCode
-  (arXiv:2203.07814). 3,760 train / 117 valid / 165 test problems (4,044 total per HF viewer), ~7.6 GB,
-  with public/private/generated test cases and correct+incorrect human solutions in multiple languages.
-  Verified live 2026-08-13 on HF (51,142 downloads in the trailing 30 days). [Verifier note: original record stated 13,328
-  train; HF dataset viewer shows 3,760 train / 4,044 total; corrected.]'
+comments: An earlier version of this record stated 13,328 training problems; the dataset viewer shows 3,760
+  train and 4,044 total, and the record was corrected. Verified 2026-08-13 via the deepmind/code_contests dataset
+  card on Hugging Face.
 arxiv:
 - url: https://arxiv.org/abs/2203.07814

--- a/sources/products/compar-ia-datasets.yaml
+++ b/sources/products/compar-ia-datasets.yaml
@@ -1,12 +1,10 @@
 name: compar-ia-datasets
 display_name: Compar:IA Datasets
 type: dataset
-description: The Compar:IA datasets are human-preference and conversation data released from the French
-  Government's Compar:IA LLM arena, published on Hugging Face by the Ministere de la Culture (SNUM). The
-  collection includes comparia-votes (150,000+ conversation-level pairwise preference annotations), comparia-conversations,
-  and comparia-reactions. The data is ~89% French and is intended for finetuning, alignment, and benchmarking
-  of multilingual LLMs.
+description: Human-preference and conversation data released from the French government's Compar:IA model arena,
+  published by the Ministere de la Culture. The collection covers conversation-level pairwise preference votes,
+  the conversations themselves and user reactions, is about 89 percent French, and is intended for fine-tuning,
+  alignment and multilingual benchmarking.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/ministere-culture/comparia-votes
-comments: Verified live 2026-08-13 via primary sources (29 downloads in the trailing 30 days). Open license
-  and documented, but gated access requiring agreement caps it at gated.
+comments: Verified 2026-08-13 via the ministere-culture/comparia-votes dataset card on Hugging Face.

--- a/sources/products/cruxeval.yaml
+++ b/sources/products/cruxeval.yaml
@@ -1,22 +1,15 @@
 name: cruxeval
 display_name: CRUXEval
 type: dataset
-description: '800 Python (function, input, output) triples evaluating code reasoning, understanding, and
-  execution via two paired tasks: CRUXEval-I (predict input given function + output) and CRUXEval-O (predict
-  output given function + input). Bootstrapped by Meta FAIR using Code Llama 34B and filtered to short,
-  low-compute problems, with a maintained public leaderboard at crux-eval.github.io. Published at ICML
-  2024, widely reported in code-model papers and model cards as the standard execution-reasoning eval
-  distinct from generation benchmarks like HumanEval/MBPP; spawned a community multilingual extension
-  (CRUXEval-X, 12.66K subjects across 19 languages). Repo archived read-only by its owner on 18 September
-  2025 but the benchmark remains in comparative use.'
+description: '800 Python function, input and output triples evaluating code reasoning and execution through
+  two paired tasks: predicting the input given a function and its output, and predicting the output given a
+  function and its input. Bootstrapped by Meta FAIR using Code Llama 34B and filtered to short, low-compute
+  problems, it was published at ICML 2024 and spawned a multilingual community extension.'
 github:
 - url: https://github.com/facebookresearch/cruxeval
 huggingface_dataset:
 - url: https://huggingface.co/datasets/cruxeval-org/cruxeval
-comments: 'CRUXEval (Code Reasoning, Understanding, and eXecution Evaluation) by Meta/FAIR (Gu, Roziere,
-  Leather, Solar-Lezama, Synnaeve, Wang; arXiv 2401.03065, 2024). 800 Python functions with input/output
-  pairs; two tasks: CRUXEval-I (input prediction) + CRUXEval-O (output prediction). Verified live 2026-08-13
-  on github.com/facebookresearch/cruxeval; the repo is MIT and public but archived read-only since 18
-  September 2025.'
+comments: The repository was archived read-only by its owner on 18 September 2025, though the benchmark remains
+  in comparative use. Verified 2026-08-13 via the facebookresearch/cruxeval repository.
 arxiv:
 - url: https://arxiv.org/abs/2401.03065

--- a/sources/products/evalplus.yaml
+++ b/sources/products/evalplus.yaml
@@ -1,14 +1,11 @@
 name: evalplus
 display_name: EvalPlus
 type: dataset
-description: HumanEval+ and MBPP+ extend the original benchmarks with 80x and 35x more test cases via
+description: Extensions of HumanEval and MBPP that add roughly 80 times and 35 times more test cases through
   automated mutation, exposing models that pass weak tests while emitting buggy code. Published at NeurIPS
-  2023; benchmarkers now prefer the Plus variants for discriminating among competitive frontier models,
-  since the originals are saturated above 90%. OpenAI's o1 hits ~89% pass@1 on EvalPlus; ~1.7K GitHub
-  stars and a maintained leaderboard make it the standard 'rigorous HumanEval' reference.
-comments: 'EvalPlus framework + datasets: HumanEval+ (164 problems, 80x more tests than original HumanEval)
-  and MBPP+ (35x more tests than original MBPP), plus EvalPerf. Apache-2.0. HumanEval+ HF dataset verified
-  live 2026-08-13 (27,670 downloads in the trailing 30 days). Published NeurIPS 2023 (EvalPlus) / COLM
-  2024 (EvalPerf).'
+  2023, with an EvalPerf companion for efficiency, and integrated with the bigcode evaluation harness.
+comments: The original benchmarks are saturated above 90 percent, which is why the Plus variants are used to
+  separate frontier models. Verified 2026-08-13 via the evalplus/humanevalplus dataset card and the evalplus/evalplus
+  repository.
 arxiv:
 - url: https://arxiv.org/abs/2305.01210

--- a/sources/products/gaia.yaml
+++ b/sources/products/gaia.yaml
@@ -1,14 +1,12 @@
 name: gaia
 display_name: GAIA (General AI Assistants)
 type: dataset
-description: 'A benchmark for General AI Assistants from Meta AI / Hugging Face: 466 real-world questions across
-  3 difficulty levels requiring reasoning, multi-modality, web browsing, and tool use. Simple for humans (92%) but
-  hard for frontier systems (GPT-4+plugins scored 15% at release). A 300-question test set with private answers
-  powers a submission-based leaderboard.'
+description: 'Benchmark for general AI assistants from Meta AI and Hugging Face: 466 real-world questions across
+  three difficulty levels requiring reasoning, multimodality, web browsing and tool use. Answers to 300 of
+  them are withheld to power a submission-scored leaderboard, leaving a fully public development split.'
 huggingface_dataset:
 - url: https://huggingface.co/datasets/gaia-benchmark/GAIA
-comments: 'Double-gated: test-set answers held out (server-side scoring) AND the HF dataset is access-gated (accept
-  terms, anti-resharing clause). Verified live 2026-08-13 (18,015 downloads in the trailing 30 days; the
-  card still describes a public dev set and a test set with private answers).'
+comments: Answers to the test split are held server-side, so a score cannot be reproduced locally. Verified
+  2026-08-13 via the GAIA dataset card on Hugging Face and the GAIA paper abstract.
 arxiv:
 - url: https://arxiv.org/abs/2311.12983

--- a/sources/products/gpqa.yaml
+++ b/sources/products/gpqa.yaml
@@ -1,15 +1,11 @@
 name: gpqa
 display_name: GPQA
 type: dataset
-description: GPQA (Graduate-Level Google-Proof Q&A), 448 expert-written multiple-choice questions in biology/physics/chemistry;
-  the 198-question 'GPQA Diamond' high-quality subset is the headline benchmark cited in most 2025-2026
-  frontier model reports. Paper arXiv:2311.12022. HF dataset Idavidrein/gpqa verified live 2026-08-13
-  (110,577 downloads in the trailing 30 days; access still gated behind a contact-information agreement).
+description: 'Graduate-level Google-proof question answering: 448 expert-written multiple-choice questions
+  across biology, physics and chemistry, written so that they resist quick web lookup. A 198-question Diamond
+  subset carries the highest-agreement items and is the figure most frontier model reports cite.'
 huggingface_dataset:
 - url: https://huggingface.co/datasets/Idavidrein/gpqa
-comments: GPQA (Graduate-Level Google-Proof Q&A), 448 expert-written multiple-choice questions in biology/physics/chemistry;
-  the 198-question 'GPQA Diamond' high-quality subset is the headline benchmark cited in most 2025-2026
-  frontier model reports. Paper arXiv:2311.12022. HF dataset Idavidrein/gpqa verified live 2026-08-13
-  (110,577 downloads in the trailing 30 days; access still gated behind a contact-information agreement).
+comments: Verified 2026-08-13 via the Idavidrein/gpqa dataset card on Hugging Face and the GPQA paper abstract.
 arxiv:
 - url: https://arxiv.org/abs/2311.12022

--- a/sources/products/gsm8k.yaml
+++ b/sources/products/gsm8k.yaml
@@ -1,13 +1,11 @@
 name: gsm8k
 display_name: GSM8K
 type: dataset
-description: 'Grade School Math 8K: a benchmark of grade-school-level math word problems used to test
-  chain-of-thought style reasoning and mathematical problem solving. It is a staple benchmark for evaluating
-  small and frontier models on concise, single-answer math tasks.'
+description: 'Grade School Math 8K: 8,500 grade-school math word problems, 7,473 for training and 1,319 for
+  test, used to evaluate chain-of-thought reasoning on concise single-answer tasks. It ships main and socratic
+  configurations and comes from the paper on training verifiers to solve math word problems.'
 huggingface_dataset:
 - url: https://huggingface.co/datasets/openai/gsm8k
-comments: GSM8K (openai/gsm8k), 8.5K grade-school math word problems (7,473 train / 1,319 test), ~5.9
-  MB, 'main' + 'socratic' configs. From 'Training Verifiers to Solve Math Word Problems' (arXiv:2110.14168).
-  Verified live 2026-08-13 on HF (974,089 downloads in the trailing 30 days).
+comments: Verified 2026-08-13 via the openai/gsm8k dataset card on Hugging Face.
 arxiv:
 - url: https://arxiv.org/abs/2110.14168

--- a/sources/products/hellaswag.yaml
+++ b/sources/products/hellaswag.yaml
@@ -1,15 +1,12 @@
 name: hellaswag
 display_name: HellaSwag
 type: dataset
-description: A commonsense NLI and sentence-completion benchmark introduced in 2019. It contains roughly
-  70,000 multiple-choice examples and is widely used to test whether models can choose the plausible continuation
-  of a sentence in everyday contexts.
+description: Commonsense natural-language-inference and sentence-completion benchmark from 2019, holding 59,950
+  four-way multiple-choice examples over contexts derived from ActivityNet. It tests whether a model picks
+  the plausible continuation of an everyday situation, and is reported in most language-model releases.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/Rowan/hellaswag
-comments: HellaSwag (Zellers et al., ACL 2019), commonsense NLI sentence-completion benchmark. 59,950
-  examples (39,905 train / 10,042 val / 10,003 test); 4-way multiple-choice over ActivityNet-derived contexts.
-  Canonical commonsense benchmark reported in nearly every LLM release. Verified live 2026-08-13 on huggingface.co/datasets/Rowan/hellaswag
-  (307,689 downloads in the trailing 30 days).
-  Registry attributes to AI2/Allen Institute; primary authors are UW/AI2 (Rowan Zellers).
+comments: The registry attributes the dataset to the Allen Institute; the primary authors are at the University
+  of Washington and AI2. Verified 2026-08-13 via the Rowan/hellaswag dataset card on Hugging Face.
 arxiv:
 - url: https://arxiv.org/abs/1905.07830

--- a/sources/products/humaneval.yaml
+++ b/sources/products/humaneval.yaml
@@ -1,15 +1,13 @@
 name: humaneval
 display_name: HumanEval
 type: dataset
-description: 164 hand-written Python programming problems with function signatures, docstrings, and unit tests.
-  The original code generation benchmark, introduced in the Codex paper (2021). Still widely cited; most code
-  model papers report pass@k on HumanEval, despite its small size and Python-only scope.
+description: 164 hand-written Python programming problems, each with a function signature, docstring and unit
+  tests, introduced in the Codex paper in 2021. It was the original code-generation benchmark and most code-model
+  papers still report pass@k on it, despite its small size and Python-only scope.
 github:
 - url: https://github.com/openai/human-eval
 huggingface_dataset:
 - url: https://huggingface.co/datasets/openai/openai_humaneval
-comments: HumanEval (openai/openai_humaneval), 164 hand-written Python problems (prompt + canonical solution
-  + unit tests), single test split, ~92 kB. From 'Evaluating LLMs Trained on Code' (Codex paper, arXiv:2107.03374).
-  Verified live 2026-08-13 on HF (285,003 downloads in the trailing 30 days).
+comments: Verified 2026-08-13 via the openai/openai_humaneval dataset card on Hugging Face.
 arxiv:
 - url: https://arxiv.org/abs/2107.03374

--- a/sources/products/humanitys-last-exam.yaml
+++ b/sources/products/humanitys-last-exam.yaml
@@ -1,17 +1,15 @@
 name: humanitys-last-exam
 display_name: Humanity's Last Exam (HLE)
 type: dataset
-description: 'A multi-modal frontier-knowledge benchmark from the Center for AI Safety and Scale AI, built with
-  ~1,000 subject-matter experts: 2,500 expert-written closed-ended questions (MC + short answer, text+image) across
-  100+ subjects, each with an unambiguous answer not quickly findable online. Positioned as the hardest frontier
-  academic benchmark.'
+description: Multimodal frontier-knowledge benchmark from the Center for AI Safety and Scale AI, built with
+  nearly a thousand subject-matter experts across more than 500 institutions. It holds 2,500 expert-written
+  closed-ended questions, multiple-choice and short answer with text and images, across more than a hundred
+  subjects, each with an unambiguous answer that is not quickly findable online.
 github:
 - url: https://github.com/centerforaisafety/hle
 huggingface_dataset:
 - url: https://huggingface.co/datasets/cais/hle
-comments: The 2,500 public questions include answers under MIT, but the HF dataset is access-gated (accept conditions,
-  no-redistribution + canary string) and a separate private held-out set detects overfitting -> scored gated (a
-  license-weighted reading could argue open). Verified live 2026-08-13 (35,249 downloads in the trailing
-  30 days; the holdout is stated on lastexam.ai rather than the HF card).
+comments: A separate private held-out set detects overfitting, and it is described on the project site rather
+  than the dataset card. Verified 2026-08-13 via the cais/hle dataset card on Hugging Face and lastexam.ai.
 arxiv:
 - url: https://arxiv.org/abs/2501.14249

--- a/sources/products/ifeval.yaml
+++ b/sources/products/ifeval.yaml
@@ -1,14 +1,11 @@
 name: ifeval
 display_name: IFEval
 type: dataset
-description: Instruction-Following Eval (IFEval) is a benchmark of 541 verifiable instructions used to
-  measure how well models follow explicit constraints such as word-count limits, keyword inclusion, and
-  format requirements. It is widely used for instruction-following and controllability evaluation.
+description: 'Instruction-Following Eval: 541 prompts carrying about 25 types of verifiable instruction - word-count
+  limits, keyword inclusion, format requirements - so that compliance can be scored programmatically rather
+  than by a judge model. It is a core component of the Hugging Face Open LLM Leaderboard.'
 huggingface_dataset:
 - url: https://huggingface.co/datasets/google/IFEval
-comments: IFEval (Instruction-Following Eval), 541 prompts with ~25 verifiable instruction types for programmatic
-  (rule-based) scoring of LLM instruction-following. Paper arXiv:2311.07911. A core component of the HF
-  Open LLM Leaderboard. HF dataset google/IFEval verified live 2026-08-13 (121,664 downloads in the trailing
-  30 days).
+comments: Verified 2026-08-13 via the google/IFEval dataset card on Hugging Face.
 arxiv:
 - url: https://arxiv.org/abs/2311.07911

--- a/sources/products/livebench.yaml
+++ b/sources/products/livebench.yaml
@@ -1,10 +1,10 @@
 name: livebench
 display_name: LiveBench
 type: dataset
-description: An open, contamination-limited LLM benchmark with objective ground-truth answers and automatic scoring
-  (no LLM judges), spanning six categories (math, coding, reasoning, language, instruction following, data analysis).
-  New questions are released monthly and older ones retired to limit contamination. Built by Abacus.AI, NYU, Nvidia,
-  UMD, USC; ICLR 2025 Spotlight.
+description: Contamination-limited language-model benchmark with objective ground-truth answers and automatic
+  scoring rather than judge models, spanning math, coding, reasoning, language, instruction following and data
+  analysis. New questions are released monthly and older ones retired to limit contamination. Built by Abacus.AI
+  with NYU, Nvidia, UMD and USC, and published as an ICLR 2025 spotlight.
 github:
 - url: https://github.com/livebench/livebench
 huggingface_dataset:
@@ -18,8 +18,8 @@ huggingface_dataset:
 - url: https://huggingface.co/datasets/livebench/liveswebench
 - url: https://huggingface.co/datasets/livebench/model_answer
 - url: https://huggingface.co/datasets/livebench/liveswebench-patches
-comments: Questions and ground-truth answers public (Apache-2.0/MIT). ~1.2k stars; multi-category HF dataset downloads.
-  Monthly rotation is freshness management, not gating. Verified live 2026-08-13 against the repository
-  DATASHEET.md, the repository LICENSE and arXiv:2406.19314.
+comments: The monthly rotation is freshness management rather than gating; questions ship with their ground-truth
+  answers. Verified 2026-08-12 via the repository DATASHEET.md, the repository LICENSE and the livebench/reasoning
+  dataset card.
 arxiv:
 - url: https://arxiv.org/abs/2406.19314

--- a/sources/products/livecodebench.yaml
+++ b/sources/products/livecodebench.yaml
@@ -1,19 +1,16 @@
 name: livecodebench
 display_name: LiveCodeBench
 type: dataset
-description: Continuously updated benchmark that scrapes fresh LeetCode/Codeforces/AtCoder problems after
-  a model's training cutoff, ensuring contamination-free evaluation across code generation, self-repair,
-  execution, and test-output prediction. v6 includes 1,000+ problems collected May 2023–2025. Per Artificial
-  Analysis (May 2026), Gemini 3 Pro Preview leads at 91.7%, followed by Gemini 3 Flash Reasoning at 90.8%
-  and DeepSeek V3.2 Speciale at 89.6%; DeepSeek V4-Pro-Max reached 93.5% on a later snapshot. ~870 GitHub
-  stars but disproportionate influence as the trusted dynamic complement to HumanEval/MBPP.
+description: Continuously updated coding benchmark that collects fresh problems from LeetCode, Codeforces and
+  AtCoder after a model's training cutoff, so evaluation stays contamination-free. It covers code generation,
+  self-repair, execution and test-output prediction, and ships release-versioned snapshots with hidden test
+  cases bundled.
 github:
 - url: https://github.com/LiveCodeBench/LiveCodeBench
 huggingface_dataset:
 - url: https://huggingface.co/datasets/livecodebench/code_generation_lite
-comments: LiveCodeBench code_generation_lite, release_v5 = 880 problems (May 2023-Jan 2025); a 'live',
-  continuously-updated contamination-free coding benchmark (problems from LeetCode/AtCoder/Codeforces)
-  covering code generation, self-repair, test-output prediction, execution. HF dataset verified live 2026-08-13
-  (93,572 downloads in the trailing 30 days).
+comments: The dataset card declares a bare Creative Commons tag naming no variant, and the harness repository's
+  terms make no statement about the problems, which the openness axis resolves. Verified 2026-08-13 via the
+  livecodebench/code_generation_lite card, its raw README and the harness repository.
 arxiv:
 - url: https://arxiv.org/abs/2403.07974

--- a/sources/products/math.yaml
+++ b/sources/products/math.yaml
@@ -1,15 +1,14 @@
 name: math
 display_name: MATH
 type: dataset
-description: A 12,500-problem benchmark of competition-style mathematics questions spanning algebra, counting,
-  geometry, number theory, prealgebra, precalculus, and more. It is the standard hard math benchmark for
-  measuring reasoning depth beyond GSM8K.
+description: Benchmark of 12,500 competition mathematics problems spanning algebra, counting and probability,
+  geometry, number theory, prealgebra and precalculus, split 7,500 train and 5,000 test, each with a step-by-step
+  solution in LaTeX and a difficulty level from 1 to 5. It measures reasoning depth beyond grade-school word
+  problems.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/EleutherAI/hendrycks_math
-comments: 'MATH (Hendrycks et al., NeurIPS 2021, arXiv 2103.03874): 12,500 competition math problems (7,500
-  train / 5,000 test) with step-by-step LaTeX solutions, Level 1-5, 7 subjects. Original HF dataset (hendrycks/competition_math)
-  verified live 2026-08-13 and still ACCESS DISABLED via DMCA takedown; no longer redistributable from
-  the canonical registry (0 downloads in the trailing 30 days against 1,034,712 all-time); license tag
-  is MIT.'
+comments: The canonical Hugging Face repository is access-disabled under a DMCA takedown, so the data is no
+  longer redistributable from the registry and the trailing-30-day download count is zero. Verified 2026-08-13
+  via the hendrycks/competition_math dataset page.
 arxiv:
 - url: https://arxiv.org/abs/2103.03874

--- a/sources/products/mbpp.yaml
+++ b/sources/products/mbpp.yaml
@@ -1,15 +1,12 @@
 name: mbpp
 display_name: MBPP
 type: dataset
-description: 'Mostly Basic Python Problems, 974 crowd-sourced Python programming tasks designed to be
-  solvable by entry-level programmers, each with a task description, solution, and three automated test
-  cases. Introduced alongside Google''s program synthesis work (2021). The complement to HumanEval: where
-  HumanEval tests function-level generation with detailed docstrings, MBPP tests natural-language-to-code
-  translation at a broader difficulty range. Widely used as a standard second benchmark alongside HumanEval.'
+description: 'Mostly Basic Python Problems: 974 crowd-sourced Python tasks solvable by an entry-level programmer,
+  each with a task description, a reference solution and three automated test cases, plus a 427-problem hand-verified
+  subset. Where HumanEval tests function-level generation from a detailed docstring, MBPP tests natural-language-to-code
+  translation across a broader difficulty range.'
 huggingface_dataset:
 - url: https://huggingface.co/datasets/google-research-datasets/mbpp
-comments: MBPP (google-research-datasets/mbpp), ~974 crowd-sourced basic Python problems (full) + 427
-  hand-verified (sanitized); splits train/test/validation/prompt. From 'Program Synthesis with LLMs' (Austin
-  et al., arXiv:2108.07732). Verified live 2026-08-13 on HF (217,014 downloads in the trailing 30 days).
+comments: Verified 2026-08-13 via the google-research-datasets/mbpp dataset card on Hugging Face.
 arxiv:
 - url: https://arxiv.org/abs/2108.07732

--- a/sources/products/mmlu-pro.yaml
+++ b/sources/products/mmlu-pro.yaml
@@ -1,13 +1,12 @@
 name: mmlu-pro
 display_name: MMLU-Pro
 type: dataset
-description: A harder successor to MMLU with 12,000 complex multiple-choice questions across many disciplines.
-  It is designed to benchmark large language models more rigorously than the original MMLU and has become
-  a common upgrade path for general knowledge and reasoning evals.
+description: Harder successor to MMLU with about 12,032 questions across 14 disciplines, expanding the choice
+  set from four options to ten and removing trivial and noisy items. It is expert-reviewed and contamination-hardened,
+  and ships a 12,000-question test split with a small validation set.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/TIGER-Lab/MMLU-Pro
-comments: MMLU-Pro, ~12,032 questions across 14 disciplines with 10 answer options (vs MMLU's 4), expert-reviewed
-  and contamination-hardened; test split (12,000) + small validation (70). Paper arXiv:2406.01574. HF
-  dataset TIGER-Lab/MMLU-Pro verified live 2026-08-13 (172,078 downloads in the trailing 30 days).
+comments: Verified 2026-08-13 via the TIGER-Lab/MMLU-Pro dataset card on Hugging Face and the MMLU-Pro paper
+  abstract.
 arxiv:
 - url: https://arxiv.org/abs/2406.01574

--- a/sources/products/mmlu.yaml
+++ b/sources/products/mmlu.yaml
@@ -1,14 +1,12 @@
 name: mmlu
 display_name: MMLU
 type: dataset
-description: 'Massive Multitask Language Understanding: a 15,908-question benchmark spanning 57 subjects,
-  designed to measure broad knowledge and reasoning across humanities, social sciences, STEM, and professional
-  domains. It became one of the default headline evals for frontier models.'
+description: 'Massive Multitask Language Understanding: 14,042 four-option multiple-choice test questions across
+  57 subjects spanning humanities, social sciences, STEM and professional domains, designed to measure broad
+  knowledge and reasoning. An auxiliary training split brings the repository to roughly 231,400 rows.'
 huggingface_dataset:
 - url: https://huggingface.co/datasets/cais/mmlu
-comments: 'MMLU (Massive Multitask Language Understanding; Hendrycks et al., ICLR 2021, arXiv 2009.03300):
-  57 subjects, ~14,042 test questions (231,400 total rows incl. auxiliary_train), 4-option multiple choice.
-  HF dataset (cais/mmlu) verified live 2026-08-13 (477,123 downloads in the trailing 30 days, MIT). Note: now largely saturated
-  (top models 88-94%) and largely superseded by MMLU-Pro for frontier differentiation.'
+comments: Largely superseded by MMLU-Pro for separating frontier models. Verified 2026-08-13 via the cais/mmlu
+  dataset card on Hugging Face.
 arxiv:
 - url: https://arxiv.org/abs/2009.03300

--- a/sources/products/mmmu.yaml
+++ b/sources/products/mmmu.yaml
@@ -1,17 +1,14 @@
 name: mmmu
 display_name: MMMU
 type: dataset
-description: 'MMMU (Massive Multi-discipline Multimodal Understanding), ~11,550 college-level multimodal
-  (image+text) questions across 30 subjects/183 subfields, 30 image types. Splits: dev 150 / validation
-  900 / test 10,500. Test-set answers were previously held out behind EvalAI but were RELEASED on 2026-02-12,
-  so all splits are now publicly answerable. CVPR 2024, paper arXiv:2311.16502. HF dataset MMMU/MMMU verified
-  live 2026-08-13 (51,175 downloads in the trailing 30 days).'
+description: 'Massive Multi-discipline Multimodal Understanding: about 11,550 college-level questions combining
+  images and text across 30 subjects and 183 subfields, using 30 image types, drawn from college exams, quizzes
+  and textbooks. It splits into a 150-question dev set, a 900-question validation set and a 10,500-question
+  test set.'
 huggingface_dataset:
 - url: https://huggingface.co/datasets/MMMU/MMMU
-comments: 'MMMU (Massive Multi-discipline Multimodal Understanding), ~11,550 college-level multimodal
-  (image+text) questions across 30 subjects/183 subfields, 30 image types. Splits: dev 150 / validation
-  900 / test 10,500. Test-set answers were previously held out behind EvalAI but were RELEASED on 2026-02-12,
-  so all splits are now publicly answerable. CVPR 2024, paper arXiv:2311.16502. HF dataset MMMU/MMMU verified
-  live 2026-08-13 (51,175 downloads in the trailing 30 days).'
+comments: Test-set answers were held out behind an evaluation server until 12 February 2026 and are now published,
+  so every split is locally answerable. Verified 2026-08-13 via the MMMU/MMMU dataset card on Hugging Face
+  and the MMMU paper abstract.
 arxiv:
 - url: https://arxiv.org/abs/2311.16502

--- a/sources/products/mt-bench.yaml
+++ b/sources/products/mt-bench.yaml
@@ -1,15 +1,15 @@
 name: mt-bench
 display_name: MT-Bench
 type: dataset
-description: An 80-question, multi-turn, open-ended benchmark for LLM instruction-following and conversational ability,
-  scored with a strong LLM (e.g. GPT-4) as judge. Created by LMSYS, it ships inside FastChat with both questions
-  and GPT-4 reference answers public. Introduced in the NeurIPS 2023 'LLM-as-a-Judge' paper.
+description: Multi-turn open-ended benchmark of 80 questions for instruction-following and conversational ability,
+  scored by a strong model acting as judge. Created by LMSYS, it ships inside FastChat with both the questions
+  and GPT-4 reference answers published, and was introduced in the NeurIPS 2023 paper on judging with language
+  models.
 github:
 - url: https://github.com/lm-sys/FastChat
 huggingface_dataset:
 - url: https://huggingface.co/datasets/lmsys/mt_bench_human_judgments
-comments: Questions + GPT-4 reference answers public in FastChat (Apache-2.0); companion human-judgments dataset
-  is CC-BY-4.0. Small (80 Q) and partly saturated now. Verified live 2026-08-13 against the FastChat
-  llm_judge README, the FastChat LICENSE and arXiv:2306.05685.
+comments: Small and partly saturated; a companion human-judgment dataset accompanies it. Verified 2026-08-12
+  via the FastChat llm_judge README, the FastChat LICENSE and the paper.
 arxiv:
 - url: https://arxiv.org/abs/2306.05685

--- a/sources/products/multipl-e.yaml
+++ b/sources/products/multipl-e.yaml
@@ -1,18 +1,16 @@
 name: multipl-e
 display_name: MultiPL-E
 type: dataset
-description: Multi-programming language translation of HumanEval and MBPP into 18+ languages (JavaScript,
-  TypeScript, C++, Java, Rust, Go, etc.). Enables comparing code generation performance across languages
-  rather than just Python. Published at TOCS 2023. The standard benchmark for evaluating multilingual
-  code models, used in the BigCode and Open LLM Leaderboard evaluations.
+description: Translation of HumanEval's 161 problems and MBPP's 397 into 22 to 23 programming languages including
+  Ada, C++, C#, Go, Haskell, Java, JavaScript, Lua, OCaml, PHP, R, Ruby, Rust, Scala, Shell, Swift and TypeScript.
+  It lets code-generation performance be compared across languages rather than in Python alone, and is integrated
+  into the BigCode evaluation harness.
 github:
 - url: https://github.com/nuprl/MultiPL-E
 huggingface_dataset:
 - url: https://huggingface.co/datasets/nuprl/MultiPL-E
-comments: 'MultiPL-E: translations of HumanEval (161 problems) and MBPP (397 problems) into 22-23 programming
-  languages (Ada, Clojure, C++, C#, D, Dart, Elixir, Go, Haskell, Java, Julia, JS, Lua, OCaml, PHP, Perl,
-  R, Ruby, Racket, Rust, Scala, Shell, Swift, TS). HF dataset (nuprl/MultiPL-E, 47 subsets) verified live
-  2026-08-13 (33,673 downloads in the trailing 30 days); integrated into the BigCode evaluation harness.
-  arXiv 2208.08227 (IEEE TSE).'
+comments: The repository terms carry a clause forbidding the contents' use as machine-learning training data,
+  which the openness axis resolves. Verified 2026-08-13 via the nuprl/MultiPL-E dataset card and the repository
+  LICENSE.
 arxiv:
 - url: https://arxiv.org/abs/2208.08227

--- a/sources/products/openai-internal-evals.yaml
+++ b/sources/products/openai-internal-evals.yaml
@@ -1,13 +1,8 @@
 name: openai-internal-evals
 display_name: OpenAI Internal Evals
 type: dataset
-description: OpenAI maintains proprietary internal evaluation suites for coding capability assessment,
-  used in model development and safety evaluations under their Preparedness Framework. These include harder
-  coding challenges, agentic task completions, and cybersecurity-related coding tests that are never publicly
-  released. Referenced in system cards and safety reports but datasets remain private to prevent contamination
-  and maintain evaluation integrity.
-comments: OpenAI internal dangerous-capability evaluations referenced in the Preparedness Framework (v2,
-  updated 15 Apr 2025). The scored artifact is the internal eval sets used for Tracked Categories. Verified
-  live 2026-08-13 against the OpenAI Preparedness Framework v2 PDF (cdn.openai.com), which still carries
-  the Tracked Categories section and the redaction clause.
-  NOT the separate open source openai/evals harness (that is evaluation_code, not a dataset).
+description: OpenAI's internal evaluation suites, used in model development and in safety assessment under
+  its Preparedness Framework. They cover harder coding challenges, agentic task completion and cybersecurity-related
+  tests, and are referenced in system cards and safety reports under the framework's tracked categories.
+comments: Distinct from the openai/evals harness, which is catalogued separately under evaluation_code. Verified
+  2026-08-13 via the OpenAI Preparedness Framework v2 PDF.

--- a/sources/products/scale-seal-leaderboard.yaml
+++ b/sources/products/scale-seal-leaderboard.yaml
@@ -1,12 +1,8 @@
 name: scale-seal-leaderboard
 display_name: Scale SEAL Leaderboard
 type: dataset
-description: Scale AI maintains proprietary evaluation datasets used for its SEAL (Systematic Evaluation
-  of AI Language models) Leaderboard, including coding-specific eval sets. Problems are held private to
-  prevent contamination and scored by expert annotators. Used by enterprise customers to evaluate models
-  before deployment. The commercial alternative to public benchmarks, trading reproducibility for contamination
-  resistance.
-comments: Scale AI SEAL Leaderboards (Safety, Evaluations, and Alignment Lab); launched 2024, regularly updated
-  with new domains (instruction-following, math, coding, multilinguality, etc.). The scored artifact is the
-  private held-out eval sets behind the leaderboard. Verified 2026-08-13 via scale.com/blog/leaderboard, which
-  still states the proprietary datasets remain private and unpublished.
+description: Scale AI's private evaluation sets behind its SEAL leaderboards, covering domains including instruction-following,
+  math, coding and multilinguality. Problems are held private to prevent contamination and are scored by expert
+  annotators, and the leaderboards rank frontier models rather than publishing the prompts.
+comments: Launched in 2024 and extended with new domains since. Verified 2026-08-13 via Scale AI's leaderboard
+  announcement.

--- a/sources/products/swe-bench-verified.yaml
+++ b/sources/products/swe-bench-verified.yaml
@@ -1,19 +1,15 @@
 name: swe-bench-verified
 display_name: SWE-bench Verified
 type: dataset
-description: 500 human-verified instances drawn from the broader SWE-bench dataset, each a real GitHub
-  issue paired with a test-verified solution patch. Created through collaboration between Princeton NLP
-  and OpenAI to reduce noise in the original 2,294-instance set. The gold-standard benchmark for evaluating
-  coding agents on realistic software engineering tasks. Leaderboard results drive agent development
-  across the industry. As of April 2026, OpenAI's internal audit found 59.4% of the hardest unsolved problems
-  had flawed test cases and that frontier models can reproduce gold patches verbatim. OpenAI now prefers
-  SWE-bench Pro for headline coding evaluations.
+description: 500 human-validated instances drawn from the wider SWE-bench dataset, each pairing a real GitHub
+  issue with a test-verified solution patch and the fail-to-pass and pass-to-pass test lists that grade it.
+  It was curated by OpenAI from the SWE-bench test set to reduce noise in the original 2,294-instance set.
 github:
 - url: https://github.com/SWE-bench/SWE-bench
 huggingface_dataset:
 - url: https://huggingface.co/datasets/princeton-nlp/SWE-bench_Verified
-comments: SWE-bench Verified (princeton-nlp/SWE-bench_Verified), 500 human-validated GitHub issue-resolution
-  task instances (~2.1 MB) curated by OpenAI from the SWE-bench test set. Leaderboard at swebench.com.
-  Verified live 2026-08-13 on HF (413,323 downloads in the trailing 30 days).
+comments: The dataset card declares no license, and the harness repository's README points at a LICENSE.md
+  path that does not exist. Verified 2026-08-13 via the SWE-bench_Verified card, its raw README and the SWE-bench
+  repository LICENSE.
 arxiv:
 - url: https://arxiv.org/abs/2310.06770

--- a/sources/products/truthfulqa.yaml
+++ b/sources/products/truthfulqa.yaml
@@ -1,15 +1,12 @@
 name: truthfulqa
 display_name: TruthfulQA
 type: dataset
-description: TruthfulQA, 817 questions across 38 categories crafted to elicit imitative falsehoods/misconceptions;
-  generation + multiple_choice configs. Paper arXiv:2109.07958 (2021). Now relatively dated and saturated
-  by frontier models but still a widely-cited truthfulness benchmark. HF dataset truthfulqa/truthful_qa
-  verified live 2026-08-13 (110,844 downloads in the trailing 30 days).
+description: 817 questions across 38 categories, written to elicit imitative falsehoods - the misconceptions
+  a model picks up from its training text rather than errors of reasoning. It ships generation and multiple-choice
+  configurations and dates from 2021.
 huggingface_dataset:
 - url: https://huggingface.co/datasets/truthfulqa/truthful_qa
-comments: TruthfulQA, 817 questions across 38 categories crafted to elicit imitative falsehoods/misconceptions;
-  generation + multiple_choice configs. Paper arXiv:2109.07958 (2021). Now relatively dated and saturated
-  by frontier models but still a widely-cited truthfulness benchmark. HF dataset truthfulqa/truthful_qa
-  verified live 2026-08-13 (110,844 downloads in the trailing 30 days).
+comments: Relatively dated and largely saturated by frontier models, though still widely reported. Verified
+  2026-08-13 via the truthfulqa/truthful_qa dataset card on Hugging Face and the paper abstract.
 arxiv:
 - url: https://arxiv.org/abs/2109.07958

--- a/sources/provenance/benchmark_eval_data.yaml
+++ b/sources/provenance/benchmark_eval_data.yaml
@@ -1,0 +1,145 @@
+# Prose and provenance closeout for benchmark_eval_data. 27 of 27 ready.
+#
+# This category held most of the corpus's `named_noncanonical` records - the ones whose lines
+# read `Verified live <date> on HF (285,003 downloads in the trailing 30 days)`. A host and a
+# download count is not a document, which is why they were never canonical: the line named where
+# somebody looked, not what settled it. Each now names the dataset card.
+#
+# Four records used ONE STRING for both prose fields - gpqa, mmmu, truthfulqa and, in the earlier
+# categories, lovable and github-copilot. A description repeated as a footnote is the failure
+# mode `product-copy.md`'s division of labor exists to prevent, and it is invisible to every gate.
+#
+# ## What a benchmark record may not carry
+#
+# Model scores. `livecodebench` listed four frontier models with their percentages;
+# `swe-bench-verified` carried an April 2026 audit finding no source in the record establishes;
+# `evalplus` quoted o1's pass@1. How a MODEL scores on a benchmark belongs to the model, and how
+# the benchmark itself scores belongs to its capability axis. Also removed: download counts,
+# GitHub stars, and rankings ("the gold-standard benchmark", "the standard benchmark for
+# multilingual code models", "the trusted dynamic complement to HumanEval/MBPP").
+#
+# Kept: sizes, splits, task counts, publication venue and construction method. Those are what the
+# dataset IS, and a new version would be a different record.
+#
+# ## Three access findings that are not evidence holds
+#
+# `math`: the canonical Hugging Face repository is access-disabled under a DMCA takedown, so the
+# data is no longer redistributable from the registry and its trailing download count is zero.
+# The axis keeps its date - the page is the evidence and it was read - and the prose says so.
+#
+# `swe-bench-verified` and `livecodebench`: the dataset cards declare no usable license (none at
+# all, and a bare `cc` naming no variant). Recorded as ambiguities for the openness axis to
+# resolve, not as verdicts in prose. `multipl-e` carries the opposite problem - a license clause
+# forbidding use of the contents as training data - noted the same way.
+#
+# `gaia` and `humanitys-last-exam` hold their answers server-side; `mmmu` used to and published
+# them on 2026-02-12. Those are facts about how the benchmark is scored, so they stay.
+#
+- product: ai2-arc
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the allenai/ai2_arc dataset card on Hugging Face
+- product: anthropic-internal-coding-evals
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: Anthropic's Claude Opus 4
+- product: apps
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the codeparrot/apps dataset card on Hugging Face
+- product: codecontests
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the deepmind/code_contests dataset card on Hugging Face
+- product: compar-ia-datasets
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the ministere-culture/comparia-votes dataset card on Hugging Face
+- product: cruxeval
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the facebookresearch/cruxeval repository
+- product: evalplus
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the evalplus/humanevalplus dataset card and the evalplus/evalplus repository
+- product: gaia
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the GAIA dataset card on Hugging Face and the GAIA paper abstract
+- product: gpqa
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Idavidrein/gpqa dataset card on Hugging Face and the GPQA paper abstract
+- product: gsm8k
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the openai/gsm8k dataset card on Hugging Face
+- product: hellaswag
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Rowan/hellaswag dataset card on Hugging Face
+- product: humaneval
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the openai/openai_humaneval dataset card on Hugging Face
+- product: humanitys-last-exam
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the cais/hle dataset card on Hugging Face and lastexam
+- product: ifeval
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the google/IFEval dataset card on Hugging Face
+- product: livebench
+  resolved_state: canonical
+  verified: '2026-08-12'
+  document: the repository DATASHEET
+- product: livecodebench
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the livecodebench/code_generation_lite card, its raw README and the harness repository
+- product: math
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the hendrycks/competition_math dataset page
+- product: mbpp
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the google-research-datasets/mbpp dataset card on Hugging Face
+- product: mmlu
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the cais/mmlu dataset card on Hugging Face
+- product: mmlu-pro
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the TIGER-Lab/MMLU-Pro dataset card on Hugging Face and the MMLU-Pro paper abstract
+- product: mmmu
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the MMMU/MMMU dataset card on Hugging Face and the MMMU paper abstract
+- product: mt-bench
+  resolved_state: canonical
+  verified: '2026-08-12'
+  document: the FastChat llm_judge README, the FastChat LICENSE and the paper
+- product: multipl-e
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the nuprl/MultiPL-E dataset card and the repository LICENSE
+- product: openai-internal-evals
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the OpenAI Preparedness Framework v2 PDF
+- product: scale-seal-leaderboard
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: Scale AI's leaderboard announcement
+- product: swe-bench-verified
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the SWE-bench_Verified card, its raw README and the SWE-bench repository LICENSE
+- product: truthfulqa
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the truthfulqa/truthful_qa dataset card on Hugging Face and the paper abstract

--- a/tests/test_prose_provenance.py
+++ b/tests/test_prose_provenance.py
@@ -392,16 +392,48 @@ def test_packets_cover_every_unresolved_state():
     only the 172 `generic` ones — so the 16 `ambiguous_noncanonical` and 13
     `named_noncanonical` had no route through it at all. A second, weaker path for the named
     ones would let the prose vouch for itself, which is the shortcut this exercise corrects.
+
+    The coverage claim is that `packets()` emits one row for every product in an unresolved
+    state, NOT that all three states still occur in the corpus. Asserting the latter is the
+    same defect as the two tests below it: closing out the last `ambiguous_noncanonical` record
+    made this fail for succeeding. The per-state behavior it used to pin is now proved on a
+    synthetic corpus, and the count identity against the census holds at every state including
+    all-zero.
     """
     from build.prose_provenance import UNRESOLVED, packets
 
     by_state = census()
     rows = packets()
     assert len(rows) == sum(len(by_state.get(s, [])) for s in UNRESOLVED)
-    assert {r["current_state"] for r in rows} == set(UNRESOLVED)
+    assert {r["current_state"] for r in rows} <= set(UNRESOLVED)
+    assert {r["product"] for r in rows} == {
+        slug for state in UNRESOLVED for slug in by_state.get(state, [])
+    }
     for row in rows:
         assert row["current_clause"], f"{row['product']}: no clause to review"
         assert row["decision"] is None, "a packet decides nothing on its own"
+
+
+@pytest.mark.parametrize("state", ["generic", "ambiguous_noncanonical", "named_noncanonical"])
+def test_every_unresolved_state_is_packetable(tmp_path, monkeypatch, state):
+    """The per-state coverage the real-corpus test can no longer prove as it empties out."""
+    import build.prose_provenance as pp
+
+    line = {"generic": "Verified 2026-08-13 via primary sources.",
+            "ambiguous_noncanonical": "Verified 2026-08-13.",
+            "named_noncanonical": "Verified live 2026-08-13 via the SPEC.md."}[state]
+    products = tmp_path / "sources" / "products"
+    scores = tmp_path / "sources" / "scores"
+    products.mkdir(parents=True)
+    scores.mkdir(parents=True)
+    (products / "widget.yaml").write_text(
+        yaml.safe_dump({"name": "widget", "description": "A widget.", "comments": line}))
+    (scores / "widget.yaml").write_text(yaml.safe_dump({"openness": {"sources": []}}))
+    monkeypatch.setattr(pp, "ROOT", tmp_path)
+
+    rows = pp.packets()
+    assert [r["current_state"] for r in rows] == [state]
+    assert rows[0]["current_clause"] and rows[0]["decision"] is None
 
 
 def test_packets_can_be_scoped_to_one_category():


### PR DESCRIPTION
**27 of 27 ready.** All were unresolved. No axis held, no date moved, no source refetched.

## Where the corpus's `named_noncanonical` records lived

This category held most of them, and the reason they were never canonical is visible in the line itself:

```
Verified live 2026-08-13 on HF (285,003 downloads in the trailing 30 days).
```

A host and a download count is not a document. The line named where somebody looked, not what settled it. Each now names the dataset card.

**Four records used one string for both prose fields** — `gpqa`, `mmmu`, `truthfulqa` here, after `lovable` and `github-copilot` in the earlier categories. A description repeated verbatim as its own footnote is exactly what `product-copy.md`'s division of labor exists to prevent, and no gate can see it.

## What a benchmark record may not carry: model scores

`livecodebench` listed four frontier models with their percentages. `evalplus` quoted o1's pass@1. `swe-bench-verified` carried an April 2026 audit finding that **no source in the record establishes**. How a *model* scores on a benchmark belongs to the model; how the benchmark itself rates belongs to its capability axis.

Also out: download counts, GitHub stars, and rankings — "the gold-standard benchmark for evaluating coding agents", "the standard benchmark for evaluating multilingual code models", "the trusted dynamic complement to HumanEval/MBPP", "positioned as the hardest frontier academic benchmark".

Kept: sizes, splits, task counts, publication venue, construction method. That is what the dataset *is*, and a new version would be a different record.

## Access findings that are not evidence holds

`math` — the canonical Hugging Face repository is **access-disabled under a DMCA takedown**, so the data is no longer redistributable from the registry and its trailing download count is zero. The axis keeps its date, because the page *is* the evidence and it was read; the prose says plainly what happened.

`swe-bench-verified` and `livecodebench` — the dataset cards declare no usable license: none at all, and a bare `cc` naming no variant. Recorded as ambiguities for the openness axis, not as verdicts in prose. `multipl-e` has the mirror-image problem, a license clause forbidding use of the contents as training data, noted the same way.

`gaia` and `humanitys-last-exam` hold answers server-side; `mmmu` did until 2026-02-12 and now publishes them. Those are facts about how the benchmark is scored, so they stay.

## A test that failed because the work succeeded, again

`test_packets_cover_every_unresolved_state` asserted all three unresolved states still occur in the corpus. Closing the last `ambiguous_noncanonical` record made it fail. That is the third variant of this defect in this file, so the per-state coverage moved to a synthetic corpus and the real-corpus assertion is now a count identity against the census, which holds at every state including all-zero.

I also found this the wrong way: my verification chain piped `pytest` through `tail`, which masked its exit code, and the commit went out before I saw the failure. The chain now sets `pipefail`.

## Verification

`validate`, `check_verification`, `check_capability`, `check_recipe`, `check_adoption --strict` clean. `check_freshness --category benchmark_eval_data`: *all 81 axes carry a real last_verified*. 663 tests, no skips.

**Corpus: 327/472 ready · 427/472 canonical · 1,407/1,416 axes confirmed · 9 held.**
