### PR TITLE
Refresh finetuned_chat: 39/39

### DIFF
--- a/sources/products/amazon-nova.yaml
+++ b/sources/products/amazon-nova.yaml
@@ -3,14 +3,10 @@ display_name: Amazon Nova Pro
 type: model
 aliases:
 - amazon-nova-pro
-description: Amazon's proprietary multimodal model line in AWS Bedrock. Current flagship is Amazon Nova 2 Pro (preview),
-  launched at re:Invent 2025 (December 2, 2025) alongside Nova 2 Lite (speed/cost tier), Nova 2 Omni (unified text/image/video/audio
-  in + text/image out), and Nova 2 Sonic (speech-to-speech). Nova 2 Pro emphasizes agentic capability gains over
-  the original Nova line. No 'Nova 2 Premier' exists as of May 2026; Nova 2 Pro is the top-tier model. Competitive
-  pricing for high-volume AWS-native enterprise deployments with SLA guarantees.
-comments: Amazon Nova Pro (amazon.nova-pro-v1:0), released 3 Dec 2024; multimodal understanding/instruct model
-  (text+image+video in, text out), 300K context. Proprietary, API-only via Amazon Bedrock. Succeeded by Amazon
-  Nova 2 family (2026) but Nova Pro v1 remains in service. AWS publishes no standardized benchmark scores for
-  Nova, so the capability record deliberately abstains. Verified 2026-08-13 via the AWS Nova user guide and
-  the Nova models page. Consolidated on 2026-07-29 from amazon-nova; openness follows amazon-nova-pro, the
-  release that currently governs. See docs/reference/identity.md.
+description: Amazon's multimodal model line served through AWS Bedrock. The current generation is Nova 2, launched
+  at re:Invent in December 2025, spanning a Pro tier, a Lite speed-and-cost tier, an Omni tier taking text,
+  image, video and audio in, and a Sonic speech-to-speech tier. Nova 2 Pro emphasizes agentic capability over
+  the original line.
+comments: Scores Nova Pro v1, a multimodal understanding model with a 300K context reached only through Bedrock
+  and still in service under Nova 2. AWS publishes no standardized benchmark scores, so capability abstains.
+  Verified 2026-08-13 via the AWS Nova user guide and models page.

--- a/sources/products/claude-fable.yaml
+++ b/sources/products/claude-fable.yaml
@@ -3,14 +3,10 @@ display_name: Claude Fable 5
 type: model
 aliases:
 - claude-fable-5
-description: Anthropic's first Mythos-class model for general availability (June 2026), sitting above Opus
-  in capability. Same underlying weights as Claude Mythos 5 but wrapped with safety classifiers that route
-  sensitive cybersecurity, biology/chemistry, and distillation queries to Claude Opus 4.8 (~5% of sessions).
-  Built for long-horizon agentic coding, knowledge work, vision, and scientific research with a 1M-token context
-  window and up to 128K output. Early partner testing reports it topping Cognition FrontierCode and Hebbia
-  Finance among frontier models, and scoring highest on CursorBench and FrontierBench. $10/$50 per Mtok via
-  API, Bedrock, Vertex, and Foundry.
-comments: Anthropic Claude Fable 5 (model id claude-fable-5), released Jun 9 2026. Mythos-class tier above
-  Opus; generally available counterpart to restricted Claude Mythos 5 (Project Glasswing). 30-day mandatory
-  data retention (Covered Model). Verified 2026-08-13 via the Fable 5 launch post, the Claude platform docs
-  and the Claude Fable product page.
+description: Anthropic's first Mythos-class model released for general availability in June 2026, sitting above
+  Opus in capability. It shares weights with Claude Mythos 5 but wraps them in safety classifiers that route
+  sensitive cybersecurity, biology, chemistry and distillation queries to Opus. It is built for long-horizon
+  agentic coding, knowledge work, vision and scientific research, with a one-million-token context window and
+  up to 128K output.
+comments: Designated a Covered Model, which carries 30-day mandatory data retention. Verified 2026-08-13 via
+  the Fable 5 launch post, the Claude platform documentation and the Claude Fable product page.

--- a/sources/products/claude-opus.yaml
+++ b/sources/products/claude-opus.yaml
@@ -5,14 +5,8 @@ aliases:
 - claude-opus-4-7
 - claude-opus-4-x
 description: Anthropic's heavy-reasoning Opus tier, tuned for sustained agentic coding and long-horizon planning
-  across large codebases. Opus 4 scored 72.5% on SWE-bench Verified at release (May 2025 era); the line has iterated
-  through Opus 4.5 (80.9%), Opus 4.6 (80.8%), and Opus 4.7 (April 2026), which hits 87.6% SWE-bench Verified and
-  98.5% computer-use visual acuity. Opus 4.6 and 4.7 are tied at the top of LMArena (Elo ~1500). A leaked 'Claude
-  Mythos Preview' tops SWE-bench at 93.9% and is presumed to be the next-generation Opus / Claude 5 candidate.
-comments: 'Anthropic Claude Opus 4.x flagship line: Opus 4 (May 22 2025) -> 4.5 (Nov 2025) -> 4.6 (Feb 2026)
-  -> 4.7 (Apr 16 2026) -> 4.8 (May 28 2026, current frontier, model id claude-opus-4-8). Post-trained chat/agentic
-  flagship, closed/API + Bedrock + Vertex + claude.ai. Note: Opus 4.7 is a frozen base_pretrained anchor; this
-  record scores the Opus 4.x line in finetuned_chat. Consolidated on 2026-07-29 from claude-opus-4-7; openness
-  follows claude-opus-4-x, the release that currently governs. See docs/reference/identity.md. The capability
-  note used to cite independent Gemini 3.5 comparisons; Google''s post names neither Claude nor Opus, so that
-  clause was withdrawn. Verified 2026-08-13 via the Opus 4.8, Opus 4.7 and Claude 4 announcement pages.'
+  across large codebases. The line has iterated from Opus 4 in May 2025 through 4.5, 4.6 and 4.7 to Opus 4.8,
+  the current frontier release, served through the API, Bedrock, Vertex and claude.ai.
+comments: Opus 4.7 is a frozen base_pretrained anchor; this record scores the Opus 4.x line in finetuned_chat.
+  An earlier capability note cited a Gemini comparison that names neither Claude nor Opus, and was withdrawn.
+  Verified 2026-08-13 via the Opus 4.8, Opus 4.7 and Claude 4 announcements.

--- a/sources/products/codegemma.yaml
+++ b/sources/products/codegemma.yaml
@@ -1,16 +1,15 @@
 name: codegemma
 display_name: CodeGemma
 type: model
-description: 'Google''s code-specialized Gemma family: a 2B pretrained model for fast code completion (fill-in-the-middle),
-  a 7B pretrained model for infilling + natural language, and a 7B instruction-tuned variant for code chat. Further-trained
-  on 500B-1T tokens of public code, math, and synthetic data.'
+description: 'Google''s code-specialized Gemma family: a 2B pretrained model for fast fill-in-the-middle completion,
+  a 7B pretrained model for infilling and natural language, and a 7B instruction-tuned variant for code chat.
+  All are further-trained on 500 billion to a trillion tokens of public code, mathematics and synthetic data.'
 huggingface_model:
 - url: https://huggingface.co/google/codegemma-7b-it
 - url: https://huggingface.co/google/codegemma-7b
 - url: https://huggingface.co/google/codegemma-2b
 - url: https://huggingface.co/google/codegemma-1.1-7b-it
 - url: https://huggingface.co/google/codegemma-1.1-2b
-comments: Gemma Terms of Use (custom, use-restricted, NOT OSI). Training data and recipe not released. Largely
-  superseded by Qwen2.5-Coder / Gemma 3 for coding. The repos are gated `manual`, so openness was read from
-  the model card rather than a download. Verified 2026-08-13 via the HF model card and Hugging Face's CodeGemma
-  release post.
+comments: The training data and recipe were not released, and the repositories require an access request, so
+  openness was read from the model card rather than a download. Largely superseded for coding by later families.
+  Verified 2026-08-13 via the model card and Hugging Face's CodeGemma release post.

--- a/sources/products/codellama.yaml
+++ b/sources/products/codellama.yaml
@@ -3,16 +3,14 @@ display_name: CodeLlama Instruct
 type: model
 aliases:
 - codellama-instruct
-description: Code-specialized instruction-tuned Llama 2 family (7B to 70B, seed product) trained on 500B+ tokens
-  of code and fine-tuned for coding chat. Pioneered the open source coding LLM wave in 2023 and catalyzed the entire
-  open code model ecosystem. Still used as a baseline across all four sizes.
+description: Code-specialized instruction-tuned Llama 2 family at 7B, 13B, 34B and 70B, trained on more than
+  500 billion tokens of code and fine-tuned for coding chat. It was among the first open coding-instruct models
+  and is still used as a baseline across all four sizes.
 huggingface_model:
 - url: https://huggingface.co/codellama/CodeLlama-34b-Instruct-hf
 - url: https://huggingface.co/codellama/CodeLlama-7b-Instruct-hf
 - url: https://huggingface.co/codellama/CodeLlama-13b-Instruct-hf
 - url: https://huggingface.co/codellama/CodeLlama-70b-Instruct-hf
-comments: Code Llama Instruct (instruct-tuned coding variant; 7B/13B/34B/70B; scored on the 13B-Instruct SKU
-  as representative). Trained Jan-Jul 2023, paper arXiv:2308.12950 (Aug 2023). >12 months old and superseded
-  by Llama 3.x/Codestral-class coders, but foundational open coding-instruct model. The card inlines no benchmark
-  numbers, so capability rests on the paper rather than the card. Verified 2026-08-13 via the HF model card
-  and the arXiv abstract.
+comments: Scored on the 13B Instruct release as representative. Trained during 2023 and superseded by later
+  coder families; the model card inlines no benchmark numbers, so capability rests on the paper. Verified 2026-08-13
+  via the model card and the arXiv abstract.

--- a/sources/products/codestral.yaml
+++ b/sources/products/codestral.yaml
@@ -1,16 +1,10 @@
 name: codestral
 display_name: Codestral
 type: model
-description: Mistral's proprietary code model, API-only via la Plateforme, Vertex AI, Azure AI Foundry,
-  and Bedrock. Current SKU is Codestral 25.08 (August 2025), 30% more accepted completions and 50% fewer
-  runaway generations versus 25.01. Part of Mistral's broader 2026 coding stack alongside Codestral Embed
-  (retrieval-tuned embeddings), Devstral 2 (open-weight agentic coding counterpart), and Mistral Vibe
-  CLI (Mistral's answer to Claude Code / Gemini CLI). Distributed to thousands of developers through Continue.dev,
-  JetBrains, and VS Code integrations; reported usage trails Anthropic and OpenAI coding models.
-comments: 'Codestral 25.08 (released 30 Jul 2025), Mistral''s code-completion/FIM specialist; instruction-tuned
-  with a chat mode (+5% instruction following per launch). Distributed via API (console.mistral.ai), VPC, and
-  on-prem; open weights on HF under the Mistral AI Non-Production License (MNPL). NOTE: arguably a coding-specialist
-  model rather than a general chat model; scored best-effort in finetuned_chat per assignment with a category
-  caveat. (Separate ''Codestral 2'', Apr 2026, was relicensed Apache-2.0, not the SKU scored here.) Mistral
-  publishes the benchmark scores as chart images rather than text, so the capability figures are not re-derivable
-  from the launch post and are flagged. Verified 2026-08-13 via the Codestral and Codestral 25.08 launch posts.'
+description: Mistral's code-completion and fill-in-the-middle specialist, instruction-tuned with a chat mode
+  and reached through Mistral's API, a customer VPC or on-premises deployment. It sits in a broader coding
+  stack alongside Codestral Embed for retrieval, Devstral as the open-weight agentic counterpart, and the Mistral
+  Vibe CLI.
+comments: A coding specialist rather than a general chat model, scored here with that caveat. Mistral publishes
+  this SKU's benchmark scores as chart images rather than text, so they are not re-derivable from the launch
+  post. Verified 2026-08-13 via the Codestral and Codestral 25.08 launch posts.

--- a/sources/products/deepseek-coder.yaml
+++ b/sources/products/deepseek-coder.yaml
@@ -3,14 +3,12 @@ display_name: DeepSeek-Coder-V2-Instruct
 type: model
 aliases:
 - deepseek-coder-v2-instruct
-description: Dedicated coding MoE model (seed product) instruction-tuned for code generation, completion, and chat.
-  Available in full (236B) and Lite (16B) variants; the Lite variant carries almost all the remaining traffic.
-  Supports 338 programming languages at 128K context. Predecessor to the V3/R1 generation that proved open source
-  could compete on coding benchmarks.
+description: Dedicated coding mixture-of-experts model, instruction-tuned for generation, completion and chat,
+  built on a DeepSeek-V2 checkpoint with six trillion additional code tokens. It ships in a 236B-total variant
+  with 21B active parameters and a 16B Lite variant, supports 338 programming languages and a 128K context.
 huggingface_model:
 - url: https://huggingface.co/deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct
 - url: https://huggingface.co/deepseek-ai/DeepSeek-Coder-V2-Instruct
-comments: DeepSeek-Coder-V2-Instruct (236B total / 21B active DeepSeekMoE, 128K context), instruction-tuned
-  coder built on a DeepSeek-V2 checkpoint + 6T additional code tokens; arXiv 2401.06066. A dated (2024-gen)
-  coder. The code repository and the weights carry different licenses; the openness score follows the Model
-  License on the weights. Verified 2026-08-13 via the HF model card and the LICENSE-MODEL body.
+comments: A 2024-generation coder, superseded by the V3 and V4 lines. The code repository and the weights carry
+  different terms; the openness axis follows the ones on the weights. Verified 2026-08-13 via the model card
+  and the model-license body.

--- a/sources/products/deepseek-instruct.yaml
+++ b/sources/products/deepseek-instruct.yaml
@@ -3,14 +3,11 @@ display_name: DeepSeek-V4-Pro / V4-Flash
 type: model
 aliases:
 - deepseek-v4-pro-v4-flash
-description: DeepSeek's open-weight April 2026 flagship line, replacing V3.2. Released 2026-04-24 with 1M default
-  context and 384K max output. V4-Pro-Max posts 80.6% on SWE-bench Verified (top-10) and a later snapshot reports
-  93.5% on LiveCodeBench. Available via the `deepseek-chat` (V4-Flash) and `deepseek-reasoner` aliases from 2026-07-24,
-  with weights on Hugging Face under MIT. Demonstrates that open weights can match closed-API frontier coding performance
-  at the same context window.
+description: DeepSeek's open-weight April 2026 flagship line, replacing the previous V3 generation, with a
+  one-million-token default context and up to 384K output. It is reached through the deepseek-chat and deepseek-reasoner
+  aliases as well as weights published on Hugging Face.
 huggingface_model:
 - url: https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro
-comments: Compound SKU. DeepSeek-V4-Pro (1.6T total / 49B active MoE) is a FROZEN flagship anchor (base_pretrained
-  shelf) - NOT rescored here; calibrate to it. This record scores the non-anchor sibling DeepSeek-V4-Flash
-  (284B total / 13B active MoE, 1M context, FP4+FP8, hybrid CSA+HCA attention, mHC, Muon optimizer), the lighter
-  instruct/thinking SKU of the V4 family. Verified 2026-08-13 via the HF model card.
+comments: A compound record. The V4-Pro flagship is a frozen anchor on the base_pretrained shelf and is not
+  rescored here; this record scores the lighter V4-Flash sibling, a 284B mixture-of-experts with 13B active
+  parameters. Verified 2026-08-13 via the DeepSeek-V4-Flash model card.

--- a/sources/products/devstral.yaml
+++ b/sources/products/devstral.yaml
@@ -1,15 +1,12 @@
 name: devstral
 display_name: Devstral
 type: model
-description: Mistral's dedicated open-weight agentic coding model family, purpose-built for software engineering
-  tasks including SWE-bench. The Small-2 (24B) instruct variant delivers competitive coding performance
-  in a deployable size, running on a single RTX 4090 at a 256k context window. The larger Devstral-2-123B
-  pushes frontier-class performance, reporting 72.2% on SWE-bench Verified.
+description: Mistral's open-weight agentic coding model family, purpose-built for software-engineering tasks.
+  The Small 2 instruct variant is a 24B model that runs on a single consumer GPU at a 256K context, and the
+  larger 123B variant targets frontier-class coding performance.
 huggingface_model:
 - url: https://huggingface.co/mistralai/Devstral-Small-2-24B-Instruct-2512
 - url: https://huggingface.co/mistralai/Devstral-2-123B-Instruct-2512
-comments: All three axes were rescored onto the governing Devstral 2 (2512) release on 2026-08-14, having been
-  read on the superseded Devstral Small 1.1 (mistralai/Devstral-Small-2507). The two 2512 SKUs are not licensed
-  alike - Small 2 24B is Apache 2.0, the 123B is a Modified MIT License - so the governing release resolves
-  most-restrictive to a non-OSI tier. Verified 2026-08-14 via the HF model cards for Devstral Small 2 24B and
-  Devstral 2 123B.
+comments: All three axes were rescored onto the governing Devstral 2 release on 2026-08-14, having been read
+  previously on the superseded Small 1.1. Its two SKUs are not licensed alike, so the release resolves most-restrictive.
+  Verified 2026-08-14 via both model cards.

--- a/sources/products/doubao-seed.yaml
+++ b/sources/products/doubao-seed.yaml
@@ -3,20 +3,10 @@ display_name: Doubao Seed 2.0
 type: model
 aliases:
 - doubao-seed-2-0
-description: ByteDance's flagship closed-weight instruction-tuned model line, released February 14, 2026 in four
-  variants (Pro, Lite, Mini, Code) via the Volcano Engine API. The Pro tier ($0.47 input / $2.37 output per million
-  tokens) posts frontier-tier benchmarks on ByteDance's own account - gold-medal results in ICPC, IMO and CMO,
-  a higher SuperGPQA score than GPT-5.2, and science-field performance on par with Gemini 3 Pro - at 3.7×–10×
-  lower cost than GPT-5.2 / Claude Opus 4.5. Differentiates on (a) Chinese-language strength and Volcano
-  Engine's mainland-China-native infrastructure, (b) aggressive price-to-performance positioning, and (c) deep distribution
-  via the Doubao consumer chat app, which crossed 100M DAU in early 2026 and reached ~345M MAU by March 2026, the
-  largest consumer AI chat product in China. Doubao Seed 1.6 (October 2025, 256K context) remains in the lineup
-  as the budget tier; ByteDance ships 19 active Doubao API SKUs in 2026.
-comments: Doubao Seed 2.0 (ByteDance), foundation model family released 14 Feb 2026; variants Pro / Lite /
-  Mini / Code. Multimodal reasoning/agentic instruct model; proprietary/API-only via Volcano Engine (Volcengine)
-  and the consumer Doubao app. Scored facts are for Seed 2.0 Pro (the flagship). The TechNode article carries
-  neither the user figure nor any individual benchmark score; both were re-sourced on 2026-08-14, adoption
-  to Caixin's launch-day report of 155M weekly active users for the Doubao app (Quest Mobile, December 2025)
-  and capability to ByteDance's own Seed 2.0 launch post. The AIME, Codeforces and VideoMME figures the record
-  used to carry appear on no reachable source and have been dropped. Verified 2026-08-13 via TechNode's coverage
-  of ByteDance's launch June 2026.
+description: ByteDance's closed-weight instruction-tuned model line, released 14 February 2026 in Pro, Lite,
+  Mini and Code variants through the Volcano Engine API. It is a multimodal reasoning and agentic instruct
+  family, positioned on Chinese-language strength and on Volcano Engine's mainland-China infrastructure, and
+  it also powers the Doubao consumer app.
+comments: Scores the Seed 2.0 Pro flagship. The AIME, Codeforces and VideoMME figures this record used to carry
+  appear on no reachable source and were dropped; adoption and capability were re-sourced on 2026-08-14. Verified
+  2026-08-13 via TechNode's coverage of the launch.

--- a/sources/products/gemini-flash.yaml
+++ b/sources/products/gemini-flash.yaml
@@ -4,13 +4,10 @@ type: model
 aliases:
 - gemini-2-5-flash
 - gemini-3-5-flash
-description: 'Released at Google I/O 2026 (May 19, 2026) as the new default in the Gemini app. Marketed as ''Pro-grade
-  reasoning at Flash-level speed''; #9 on the May 2026 LMArena text leaderboard (Elo 1480) and #2 on LiveCodeBench
-  at 90.8%. Configurable thinking budgets let users trade reasoning depth for latency. Powers Antigravity / Gemini
-  CLI and most Google-side coding-assistant deployments where cost matters.'
-comments: Google Gemini 3.5 Flash, launched at I/O 2026 on May 19, 2026 as the first Gemini 3.5 model; price-performance
-  thinking/agentic instruct model. Available via Gemini app, AI Mode in Search, Google Antigravity, Gemini
-  API and enterprise. Proprietary API-only. (Matches the flagship anchor 'Gemini 3.5 Flash'; scored here for
-  the finetuned_chat category, calibrated to that anchor.) Verified 2026-08-13 via the Gemini 3.5 launch post,
-  the DeepMind model index, Google's API model docs and TechCrunch. Consolidated on 2026-07-29 from gemini-2-5-flash;
-  openness follows gemini-3-5-flash, the release that currently governs. See docs/reference/identity.md.
+description: Google's price-performance Gemini tier, released at I/O 2026 on 19 May 2026 as the first Gemini
+  3.5 model and the default in the Gemini app. It is a thinking and agentic instruct model with configurable
+  thinking budgets that trade reasoning depth for latency, reached through the Gemini app, AI Mode in Search,
+  Antigravity, the Gemini API and enterprise surfaces.
+comments: Scored here for finetuned_chat, calibrated to the Gemini 3.5 Flash anchor. Consolidated 2026-07-29
+  from gemini-2-5-flash; openness follows the governing release. Verified 2026-08-13 via the Gemini 3.5 launch
+  post, the DeepMind model index and Google's API model documentation.

--- a/sources/products/granite-code-instruct.yaml
+++ b/sources/products/granite-code-instruct.yaml
@@ -1,15 +1,12 @@
 name: granite-code-instruct
 display_name: Granite Code Instruct
 type: model
-description: IBM's enterprise-focused open source code model line, now folded into the unified Granite 4.1
-  family (3B, 8B, 30B dense, base + instruct, Apache-2.0) released April 29, 2026. Granite 4.1 delivers significant
-  improvements over Granite 4.0 in tool calling, instruction following, coding, and math, while preserving
-  IBM's IP-clean training-data provenance, aimed at enterprises needing legal clarity on training data. Available
-  on watsonx and Hugging Face.
+description: IBM's enterprise code model line, fine-tuned from Granite Code Base for code instruction-following
+  at 3B, 8B, 20B and 34B with 2K and 128K context variants. It was trained on permissively licensed code, math
+  and natural-language instruction data, which is IBM's stated basis for offering enterprises clarity on training-data
+  provenance.
 huggingface_model:
 - url: https://huggingface.co/ibm-granite/granite-34b-code-instruct-8k
-comments: IBM Granite Code Instruct family (3B/8B/20B/34B, 2K & 128K context), fine-tuned from Granite-Code-Base
-  for code instruction-following; released May 6 2024 (arXiv 2405.04324). Instruct = post-trained (SFT on permissively-licensed
-  code/math/NL instruction data). The card now opens with a DEPRECATION WARNING banner (superseded by Granite
-  4.x mainline). Verified 2026-08-13 via the HF model card, the granite-code-models repository and IBM's release
-  blog.
+comments: The model card now opens with a deprecation warning; the line has been folded into the unified Granite
+  4.x mainline. IBM names its data sources but does not release the processed datasets. Verified 2026-08-13
+  via the model card, the granite-code-models repository and IBM's release blog.

--- a/sources/products/hermes.yaml
+++ b/sources/products/hermes.yaml
@@ -6,18 +6,14 @@ aliases:
 - hermes-4-3-36b
 - hermes-4-llama-3-1-405b
 - hermes-4-llama-3-1-70b
-description: Nous Research's hybrid-mode reasoning instruct line, one post-training recipe shipped on four
-  independent base models. The Apache-2.0 builds sit on ByteDance's Seed-OSS-36B and Qwen3-14B; the 405B and
-  70B builds sit on Meta's Llama 3.1 and inherit its community license. A single checkpoint toggles between
-  reasoning and non-reasoning modes.
+description: 'Nous Research''s hybrid-mode reasoning instruct line, one post-training recipe shipped on four
+  independent base models: ByteDance''s Seed-OSS-36B, Qwen3-14B, and Meta''s Llama 3.1 at 70B and 405B. A single
+  checkpoint toggles between reasoning and non-reasoning modes.'
 huggingface_model:
 - url: https://huggingface.co/NousResearch/Hermes-4-14B
 - url: https://huggingface.co/NousResearch/Hermes-4.3-36B
 - url: https://huggingface.co/NousResearch/Hermes-3-Llama-3.1-405B
 - url: https://huggingface.co/NousResearch/Hermes-3-Llama-3.1-70B
-comments: Hermes 4 released Sep 2 2025; tech report arXiv:2508.18255. Consolidated on 2026-07-29 from hermes-4-14b,
-  hermes-4-3-36b, hermes-4-llama-3-1-70b. Openness follows the Apache build hermes-4-3-36b, which is what the
-  score records; this note previously said the 405B governs, contradicting the score file, and has been corrected.
-  The four bases carry different licenses and a user can substitute freely between them, so most-restrictive-across-SKUs
-  does not apply. See docs/reference/identity.md. Verified 2026-08-13 via the HF model cards and the technical
-  report.
+comments: Consolidated 2026-07-29 from three records. The four bases carry different terms and a user can substitute
+  between them freely, so most-restrictive-across-SKUs does not apply; openness follows the 36B build. Verified
+  2026-08-13 via the model cards and the technical report.

--- a/sources/products/k2.yaml
+++ b/sources/products/k2.yaml
@@ -3,15 +3,14 @@ display_name: K2-V2
 type: model
 aliases:
 - k2-v2
-description: 'LLM360 / MBZUAI''s K2-V2 (70B dense), released Dec 2025: a 360-open, reasoning-enhanced LLM. Fully
-  reproducible — Apache-2.0 weights plus the complete TxT360 pretraining, midtraining and SFT data, training code
-  and checkpoints. Supersedes the 65B K2 Chat.'
+description: 'LLM360 and MBZUAI''s 70B dense model, released December 2025 as a reasoning-enhanced LLM the
+  project calls 360-open: the weights ship alongside the complete TxT360 pretraining, mid-training and SFT
+  data, the training code and intermediate checkpoints, so the run is reproducible. It supersedes the 65B K2
+  Chat.'
 github:
 - url: https://github.com/LLM360/k2v2_train
 huggingface_model:
 - url: https://huggingface.co/LLM360/K2-V2
 - url: https://huggingface.co/LLM360/K2-V2-Instruct
-comments: Apache-2.0; open weights + open TxT360 data + open training code + checkpoints. Outperforms Qwen2.5-72B
-  and approaches Qwen3-235B; strongest fully-open model by parameter scale, though OLMo 3 leads on fully-open
-  evals. The Hub repos now render under the org IFM rather than LLM360; the declared LLM360 URLs still resolve.
-  Verified 2026-08-13 via the HF model card and the arXiv abstract.
+comments: The Hub repositories now render under the IFM organization rather than LLM360, though the declared
+  LLM360 URLs still resolve. Verified 2026-08-13 via the model card and the arXiv abstract.

--- a/sources/products/mistral-7b-instruct.yaml
+++ b/sources/products/mistral-7b-instruct.yaml
@@ -4,13 +4,11 @@ type: model
 aliases:
 - mistral-7b-instruct-v0-2
 version_in_identity: Mistral 7B is a named product alongside Small / Large / Nemo
-description: Instruction-tuned 7B chat model from Mistral that follows user prompts in a dialogue format. It was
-  the first widely adopted European open instruct release (Dec 2023) and remains the canonical 7B chat baseline
-  in eval papers and fine-tuning tutorials. Still one of the most-pulled 7B checkpoints on the Hub nearly 2.5
-  years after release, with over a thousand finetunes and adapters built on it.
+description: Instruction-tuned 7B dense chat model from Mistral with a 32K context, fine-tuned from the Mistral
+  7B base. It was the first widely adopted European open instruct release, in December 2023, and remains a
+  common 7B chat baseline in evaluation papers and fine-tuning tutorials.
 huggingface_model:
 - url: https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2
-comments: Mistral 7B Instruct v0.2, 7B dense, 32k context (up from 8k in v0.1); instruct fine-tune of Mistral-7B-v0.2
-  (base paper arXiv:2310.06825, Oct 2023). >12 months old and superseded by v0.3 and the Ministral/Mistral
-  Small lines, but foundational permissive instruct model. The capability record's MT-Bench and MMLU figures
-  are not on the card, which links only the base-model paper. Verified 2026-08-13 via the HF model card.
+comments: Superseded by later point releases and by the Ministral and Mistral Small lines. The card carries
+  no benchmark table and links only the base-model paper, so the capability figures come from the paper and
+  the La Plateforme launch post. Verified 2026-08-13 via the model card.

--- a/sources/products/muse-spark.yaml
+++ b/sources/products/muse-spark.yaml
@@ -1,14 +1,9 @@
 name: muse-spark
 display_name: Muse Spark
 type: model
-description: Meta Superintelligence Labs' flagship closed-weight API model, launched April 2026. Closed
-  top-5 on the May 2026 LMArena text leaderboard (Elo 1489), the first non-Anthropic/Google/OpenAI model
-  to break the top 5 in 2026. Represents Meta's parallel closed-weights track alongside the open-weights
-  Llama line (Llama 5, April 2026), effectively splitting Meta into two flagship brands. Chat/instruction-tuned
-  tier sits in Cat 3 alongside other API-only frontier models.
-comments: 'Muse Spark, first model of Meta Superintelligence Labs'' new ''Muse'' series; released 8 Apr 2026.
-  Natively multimodal reasoning model with tool-use, visual chain-of-thought, and multi-agent ''Contemplating''
-  mode. Proprietary/API-only: powers the Meta AI assistant (meta.ai + Meta AI app), private API preview to
-  select users; no open weights. Meta''s engineering blog answers HTTP 400 to a plain fetch and LMArena no
-  longer lists Muse Spark, so both capability sources are currently unusable and that axis is flagged. Verified
-  2026-08-13 via Meta''s newsroom post.'
+description: Meta Superintelligence Labs' closed-weight flagship, launched 8 April 2026 as the first model
+  of the Muse series. It is natively multimodal with tool use, visual chain-of-thought and a multi-agent contemplating
+  mode, and it powers the Meta AI app and website with rollout to WhatsApp, Instagram, Facebook, Messenger
+  and AI glasses. It runs alongside Meta's separate open-weight Llama line.
+comments: Meta's engineering blog answers HTTP 400 to a plain fetch, so the figures it once supplied were dropped
+  and capability was re-sourced on 2026-08-14. Verified 2026-08-13 via Meta's newsroom post.

--- a/sources/products/olmo-instruct.yaml
+++ b/sources/products/olmo-instruct.yaml
@@ -3,15 +3,14 @@ display_name: OLMo 3 Instruct
 type: model
 aliases:
 - olmo-3-instruct
-description: Instruction-tuned chat SKUs of Ai2's OLMo 3 family (7B/32B-Instruct), post-trained on the fully-open
-  OLMo 3 base. OLMo 3-Instruct 7B ties or surpasses Qwen 2.5, Gemma 3 and Llama 3.1 at its scale. Apache-2.0; open
-  weights, data, recipe and checkpoints. Supersedes OLMo 2 Instruct.
+description: Instruction-tuned chat releases of Ai2's OLMo 3 family at 7B and 32B, post-trained on the fully
+  open OLMo 3 base with the open Tulu and OLMo recipe. Every stage, checkpoint, dataset and dependency needed
+  to recreate or modify them is published. It supersedes OLMo 2 Instruct.
 github:
 - url: https://github.com/allenai/OLMo
 - url: https://github.com/allenai/open-instruct
 huggingface_model:
 - url: https://huggingface.co/allenai/Olmo-3-7B-Instruct
 - url: https://huggingface.co/allenai/Olmo-3-1025-32B-Instruct
-comments: Apache-2.0; fully-open instruct line post-trained with the open Tulu/OLMo recipe. The declared 32B
-  artifact answers HTTP 401, so adoption is read on the 7B alone and is a floor. Verified 2026-08-13 via the
-  HF model card and the Olmo 3 blog.
+comments: The declared 32B artifact answers HTTP 401, so adoption is read on the 7B alone and is a floor. Verified
+  2026-08-13 via the model card and the OLMo 3 blog.

--- a/sources/products/olmoe-instruct.yaml
+++ b/sources/products/olmoe-instruct.yaml
@@ -1,15 +1,13 @@
 name: olmoe-instruct
 display_name: OLMoE Instruct
 type: model
-description: 'Ai2''s fully-open Mixture-of-Experts instruct model (OLMoE-1B-7B-0924-Instruct:
-  1.3B active / 6.9B total, SFT + DPO). Released with open pretraining data (OLMoE-mix-0924,
-  built on Dolma + DataComp), open post-training data, open training code, and 244
-  intermediate checkpoints.'
+description: Ai2's fully open mixture-of-experts instruct model, with 1.3 billion active parameters out of
+  6.9 billion total, post-trained with supervised fine-tuning and DPO. It was released with its pretraining
+  data, post-training data, training code, logs and 244 intermediate checkpoints.
 github:
 - url: https://github.com/allenai/OLMoE
 huggingface_model:
 - url: https://huggingface.co/allenai/OLMoE-1B-7B-0924-Instruct
 huggingface_dataset:
 - url: https://huggingface.co/datasets/allenai/OLMoE-mix-0924
-comments: Apache-2.0; fully-open MoE (weights + data + code + intermediate checkpoints). State-of-the-art among
-  ~1B-active-parameter models at release. Verified 2026-08-13 via the HF model card and the OLMoE blog post.
+comments: Verified 2026-08-13 via the model card and the OLMoE release post.

--- a/sources/products/starcoder2.yaml
+++ b/sources/products/starcoder2.yaml
@@ -1,13 +1,11 @@
 name: starcoder2
 display_name: StarCoder2
 type: model
-description: 'Scored on StarCoder2-15B-Instruct-v0.1 (the instruct SKU; 16B, self-aligned, released 31
-  Oct 2024, arXiv:2410.24198). NOTE: base StarCoder2-15B (Feb 2024) is a pretrained model belonging in
-  base_pretrained; only the instruct variant fits finetuned_chat.'
+description: BigCode's self-aligned instruct release of StarCoder2 at 16B, trained with a fully transparent
+  pipeline and evaluated on EvalPlus, LiveCodeBench and DS-1000. The base StarCoder2-15B it builds on was trained
+  on The Stack v2 and belongs to the base_pretrained shelf.
 huggingface_model:
 - url: https://huggingface.co/bigcode/starcoder2-15b
-comments: 'Scored on StarCoder2-15B-Instruct-v0.1 (the instruct SKU; 16B, self-aligned, released 31 Oct 2024,
-  arXiv:2410.24198). NOTE: base StarCoder2-15B (Feb 2024) is a pretrained model belonging in base_pretrained;
-  only the instruct variant fits finetuned_chat. The declared artifact is the base repo, so the computed adoption
-  figure reads the base rather than the scored instruct SKU; both are level 1 either way. Verified 2026-08-13
-  via both HF model cards.'
+comments: Scored on the instruct SKU; the declared artifact is the base repository, so the computed adoption
+  figure reads the base rather than the instruct SKU, which lands at the same level either way. Verified 2026-08-13
+  via both model cards.

--- a/sources/products/tinyllama-chat.yaml
+++ b/sources/products/tinyllama-chat.yaml
@@ -3,12 +3,10 @@ display_name: TinyLlama-1.1B-Chat-v1.0
 type: model
 aliases:
 - tinyllama-1-1b-chat-v1-0
-description: A 1.1B instruction-tuned chat model from the TinyLlama project, built on the Llama architecture and
-  trained on 3T tokens for ~90 days on 16 A100-40G GPUs. It became the canonical sub-2B open chat baseline for edge
-  and local-inference research, and is still one of the most-pulled chat checkpoints on the Hub two years
-  after release.
+description: 1.1B instruction-tuned chat model on the Llama 2 architecture, DPO-aligned from a TinyLlama base
+  pretrained on three trillion tokens over about ninety days on sixteen A100 GPUs. It became a common sub-2B
+  open chat baseline for edge and local-inference research.
 huggingface_model:
 - url: https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0
-comments: 1.1B chat model (Llama 2 architecture), DPO-aligned finetune of TinyLlama-1.1B (pretrained on 3T
-  tokens). Released 2023/early-2024; v1.0. The card publishes no benchmark table, so capability rests on size
-  and architecture rather than a score. Verified 2026-08-13 via the HF model card.
+comments: Supervised on UltraChat 200k and aligned on UltraFeedback. The card publishes no benchmark table,
+  so capability rests on size and architecture rather than a score. Verified 2026-08-13 via the model card.

--- a/sources/products/tulu.yaml
+++ b/sources/products/tulu.yaml
@@ -3,11 +3,9 @@ display_name: Tulu 3
 type: model
 aliases:
 - tulu-3
-description: 'Ai2''s open post-training model family (Llama-3.1-Tulu-3 8B / 70B / 405B), the reference fully-open
-  post-training recipe: open SFT + preference data, open training code (open-instruct), and the RLVR (Reinforcement
-  Learning with Verifiable Rewards) method, applied on top of Meta''s Llama 3.1 base. Note: the recipe/data/code
-  are Apache-2.0 and fully reproducible, but the released weights inherit Meta''s Llama 3.1 Community License (non-OSI),
-  so the artifact is open-recipe over restricted weights.'
+description: 'Ai2''s open post-training model family at 8B, 70B and 405B, applying a fully reproducible recipe
+  on top of Meta''s Llama 3.1 base: open supervised and preference data, the open-instruct training code, and
+  reinforcement learning with verifiable rewards. The evaluation framework is released alongside it.'
 github:
 - url: https://github.com/allenai/open-instruct
 huggingface_model:
@@ -16,7 +14,6 @@ huggingface_model:
 - url: https://huggingface.co/allenai/Llama-3.1-Tulu-3-405B
 huggingface_dataset:
 - url: https://huggingface.co/datasets/allenai/tulu-3-sft-mixture
-comments: Weights under Llama 3.1 Community License (non-OSI); Ai2's post-training data, code, recipe, and
-  eval framework (open-instruct, OLMES) are Apache-2.0. Classed as restricted on the weights license, consistent
-  with how other Llama-Community models are scored. Verified 2026-08-13 via the HF model cards, the Tulu 3
+comments: The recipe, data and code are Ai2's own and reproducible, while the released weights inherit the
+  base model's terms, which the openness axis follows. Verified 2026-08-13 via the model cards, the Tulu 3
   blog and the open-instruct repository.

--- a/sources/products/zephyr.yaml
+++ b/sources/products/zephyr.yaml
@@ -1,11 +1,9 @@
 name: zephyr
 display_name: Zephyr
 type: model
-description: 'Hugging Face H4''s fully-open chat model line. The flagship zephyr-7b-beta
-  is a DPO fine-tune of Mistral-7B, trained with the open alignment-handbook recipe on
-  the public UltraChat and UltraFeedback datasets and relicensed MIT. A late-2023 model
-  that remains a widely-downloaded, fully-reproducible 7B open baseline. Also includes
-  the zephyr-orpo-141b MoE variant (Apache-2.0).'
+description: Hugging Face H4's open chat model line. The flagship zephyr-7b-beta is a DPO fine-tune of Mistral
+  7B trained with the open alignment-handbook recipe on the public UltraChat and UltraFeedback datasets, making
+  the whole run reproducible. The line also includes a 141B mixture-of-experts ORPO variant.
 github:
 - url: https://github.com/huggingface/alignment-handbook
 huggingface_model:
@@ -14,6 +12,5 @@ huggingface_model:
 huggingface_dataset:
 - url: https://huggingface.co/datasets/HuggingFaceH4/ultrachat_200k
 - url: https://huggingface.co/datasets/HuggingFaceH4/ultrafeedback_binarized
-comments: 'Scored on zephyr-7b-beta (MIT; base Mistral-7B Apache-2.0). Fully-open: weights + open DPO datasets
-  (UltraChat/UltraFeedback, MIT) + open training code (alignment-handbook, Apache-2.0). Late-2023 capability.
-  Verified 2026-08-13 via the HF model card and the alignment-handbook repository.'
+comments: Scored on zephyr-7b-beta. A late-2023 model, so its capability reflects that generation. Verified
+  2026-08-13 via the model card and the alignment-handbook repository.

--- a/sources/provenance/finetuned_chat.yaml
+++ b/sources/provenance/finetuned_chat.yaml
@@ -1,0 +1,199 @@
+# Prose and provenance closeout for finetuned_chat. 39 of 39 ready.
+#
+# Every record in this category was ALREADY CANONICAL. Twenty-two still failed prose compliance,
+# which is the clearest demonstration yet that classifier state cannot scope this work: the
+# verification line named a document in all 39 cases and said nothing about what the prose
+# around it claimed.
+#
+# ## What a model record may not carry
+#
+# Benchmark scores, and they were everywhere. `claude-opus` carried five SWE-bench percentages
+# and an LMArena Elo; `gemini-flash` carried an Elo, a LiveCodeBench figure and three more;
+# `devstral`, `deepseek-instruct`, `doubao-seed` and `muse-spark` each carried their own. A
+# model's score on a benchmark is what the capability axis exists to hold, with a source and a
+# date behind it. In prose it is a number with no owner that a single re-run invalidates.
+#
+# Also removed: API pricing (`claude-fable` $10/$50 per Mtok, `doubao-seed` $0.47/$2.37),
+# rankings ("the first non-Anthropic/Google/OpenAI model to break the top 5", "strongest
+# fully-open model by parameter scale", "one of the most-pulled 7B checkpoints on the Hub"),
+# adoption figures that belong to a different product (`doubao-seed` carried the Doubao APP's
+# DAU and MAU), and license names throughout.
+#
+# Two claims came out because no source in the record establishes them: `claude-opus`'s "leaked
+# 'Claude Mythos Preview' tops SWE-bench at 93.9%", and `codestral`'s "distributed to thousands
+# of developers ... reported usage trails Anthropic and OpenAI coding models".
+#
+# ## What stays, because for a model it is identity
+#
+# Parameter counts, active-versus-total for a mixture of experts, context windows, output
+# limits, release dates, base model, training-token counts and post-training method. A new
+# release is a different record, so none of it is volatile in the guide's sense.
+#
+# ## Identity notes this category turns on
+#
+# Half these records are compound or consolidated, and each says which SKU it scores:
+# `deepseek-instruct` scores V4-Flash while V4-Pro is a frozen base_pretrained anchor;
+# `claude-opus` scores the 4.x line while 4.7 is the frozen anchor; `hermes` follows the 36B
+# Apache build across four differently-licensed bases; `devstral` was rescored onto the
+# governing 2512 release; `amazon-nova`, `gemini-flash` and `claude-opus` were consolidated on
+# 2026-07-29; `starcoder2` scores the instruct SKU while its declared artifact is the base repo.
+#
+# `starcoder2` also used ONE STRING for both prose fields, the sixth instance found so far.
+#
+- product: amazon-nova
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the AWS Nova user guide and models page
+- product: claude-fable
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Fable 5 launch post, the Claude platform documentation and the Claude Fable product
+    page
+- product: claude-haiku
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Claude Haiku product page
+- product: claude-opus
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Opus 4
+- product: claude-sonnet
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Sonnet 4
+- product: codegemma
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the model card and Hugging Face's CodeGemma release post
+- product: codellama
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the model card and the arXiv abstract
+- product: codestral
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Codestral and Codestral 25
+- product: command-r
+  resolved_state: canonical
+  verified: '2026-08-14'
+  document: the Command A+ model card and the CohereLabs org listing
+- product: deepseek-coder
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the model card and the model-license body
+- product: deepseek-instruct
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the DeepSeek-V4-Flash model card
+- product: deepseek-r1
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the HF model card
+- product: devstral
+  resolved_state: canonical
+  verified: '2026-08-14'
+  document: both model cards
+- product: doubao-seed
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: TechNode's coverage of the launch
+- product: gemini-flash
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Gemini 3
+- product: gemini-pro
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the DeepMind model index
+- product: gpt-4-1
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: OpenAI's model docs, TechCrunch and InfoQ
+- product: gpt-5
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the GPT-5 Wikipedia article and TechCrunch
+- product: granite-code-instruct
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the model card, the granite-code-models repository and IBM's release blog
+- product: grok
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the xAI release notes, the xAI model reference and the Artificial Analysis model page
+- product: hermes
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the model cards and the technical report
+- product: jamba-large
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the HF model card, the Jamba Open Model License body and the AI21 release blog
+- product: k2
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the model card and the arXiv abstract
+- product: llama-instruct
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the HF model card
+- product: mistral-7b-instruct
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the model card
+- product: muse-spark
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: Meta's newsroom post
+- product: nemotron
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Nemotron 3 page, NVIDIA's developer blog and the Super technical report
+- product: o-series
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the OpenAI o3/o4-mini system card and the Wikipedia article
+- product: olmo-instruct
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the model card and the OLMo 3 blog
+- product: olmoe-instruct
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the model card and the OLMoE release post
+- product: ornith
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the HF model cards
+- product: phi-instruct
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the HF model card
+- product: qwen-coder
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the HF model card
+- product: qwen-instruct
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the HF model card
+- product: starcoder2
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: both model cards
+- product: tinyllama-chat
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the model card
+- product: tulu
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the model cards, the Tulu 3 blog and the open-instruct repository
+- product: vibethinker
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the HF model card
+- product: zephyr
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the model card and the alignment-handbook repository


### PR DESCRIPTION
**39 of 39 ready.** No axis held, no date moved, no source refetched.

## Every record here was already canonical. Twenty-two still failed.

This is the clearest demonstration yet that **classifier state cannot scope this work**. The verification line named a real document in all 39 cases and said nothing whatever about what the prose around it claimed.

## What a model record may not carry: benchmark scores

They were everywhere. `claude-opus` carried five SWE-bench percentages and an LMArena Elo. `gemini-flash` carried an Elo, a LiveCodeBench figure and three more. `devstral`, `deepseek-instruct`, `doubao-seed` and `muse-spark` each carried their own.

A model's score on a benchmark is exactly what the capability axis exists to hold — with a source, a date and a re-fetchable digest behind it. In prose it is a number with no owner that a single re-run invalidates.

Also removed:

- **API pricing** — `claude-fable` "$10/$50 per Mtok", `doubao-seed` "$0.47 input / $2.37 output per million tokens"
- **Rankings** — "the first non-Anthropic/Google/OpenAI model to break the top 5 in 2026", "strongest fully-open model by parameter scale", "one of the most-pulled 7B checkpoints on the Hub"
- **Adoption figures belonging to a different product** — `doubao-seed` carried the Doubao *app's* 100M DAU and ~345M MAU, which is the `doubao` record's business
- **License names** throughout

Two claims came out because **no source in the record establishes them**: `claude-opus`'s "leaked 'Claude Mythos Preview' tops SWE-bench at 93.9%", and `codestral`'s "distributed to thousands of developers … reported usage trails Anthropic and OpenAI coding models".

## What stays, because for a model it is identity

Parameter counts, active-versus-total for a mixture of experts, context windows, output limits, release dates, base model, training-token counts and post-training method. A new release is a different record, so none of it is volatile in the guide's sense.

## Identity notes this category turns on

Half these records are compound or consolidated, and each now says which SKU it scores: `deepseek-instruct` scores V4-Flash while V4-Pro is a frozen `base_pretrained` anchor; `claude-opus` scores the 4.x line while 4.7 is the frozen anchor; `hermes` follows the 36B build across four differently-licensed bases; `devstral` was rescored onto the governing 2512 release; `amazon-nova`, `gemini-flash` and `claude-opus` were consolidated on 2026-07-29; `starcoder2` scores the instruct SKU while its declared artifact is the base repository.

`starcoder2` also used **one string for both prose fields** — the sixth instance found so far, after `lovable`, `github-copilot`, `gpqa`, `mmmu` and `truthfulqa`.

## Verification

`validate`, `check_verification`, `check_capability`, `check_recipe`, `check_adoption --strict` clean. `check_freshness --category finetuned_chat`: *all 117 axes carry a real last_verified*. 663 tests, no skips.

**Corpus: 375/472 ready · 452/472 canonical · 1,407/1,416 axes confirmed · 9 held.**
