### PR TITLE
Refresh base_pretrained: 27/27

### DIFF
--- a/sources/products/alia-40b.yaml
+++ b/sources/products/alia-40b.yaml
@@ -2,24 +2,15 @@ name: alia-40b
 display_name: ALIA-40b
 type: model
 version_in_identity: BSC ships this as ALIA-40b; the size is the model's name
-description: "Spain's national open LLM: a 40.4B-parameter transformer decoder-only model pretrained from
-  scratch by the Barcelona Supercomputing Center (BSC-LT) on the MareNostrum 5 supercomputer, as part of
-  the ALIA project under Spain's National Language Technology Plan. Trained on 9.37 trillion tokens across
-  35 European languages plus 92 programming languages, with a focus on Spanish and the co-official languages
-  (Catalan, Valencian, Basque, Galician). Released under Apache 2.0 with downloadable weights and fully
-  published training code, though the pretraining corpus is documented rather than released. Distributed
-  through the broader ALIA Kit (models, corpora, integration tools, docs). Capability is mid-tier and below
-  the 2026 frontier; the value proposition is permissive licensing, multilingual breadth, and digital
-  sovereignty for the ~600M Spanish speakers and Iberian-language communities."
+description: 'Spain''s national open LLM: a 40.4B-parameter decoder-only transformer pretrained from scratch
+  by the Barcelona Supercomputing Center on the MareNostrum 5 supercomputer, under Spain''s National Language
+  Technology Plan. It was trained on 9.37 trillion tokens across 35 European languages and 92 programming languages,
+  focusing on Spanish and the co-official Catalan, Valencian, Basque and Galician, with 48 layers, a 32,768-token
+  context and a 256k vocabulary.'
 huggingface_model:
   - url: https://huggingface.co/BSC-LT/ALIA-40b
 github:
   - url: https://github.com/langtech-bsc/alia
-comments: "ALIA-40b base model from BSC-LT (Barcelona Supercomputing Center, Language Technologies Lab),
-  Apache 2.0. 40.4B params, 48 layers, 32,768 context, 256k vocab; 9.37T pretraining tokens (+6.3B for
-  context extension). Trained on MareNostrum 5 under Spain's National Language Technology Plan with EU
-  NextGenerationEU funds. Docs portal: langtech-bsc.gitbook.io/alia-kit. Instruct variant (ALIA-40b-instruct)
-  and the earlier Salamandra family exist but are not separately scored. The corpus is documented across
-  60+ named sources but explicitly \"will not be released or distributed to third parties\", which is
-  the single dimension keeping this at open_weights rather than in the Apertus/OLMo tier. Verified
-  2026-08-13 via the ALIA-40b HF model card and the langtech-bsc/alia repository."
+comments: The corpus is documented across more than sixty named sources but will not be distributed, which
+  is the one dimension keeping this below the Apertus and OLMo tier. An instruct variant and the earlier Salamandra
+  family are not separately scored. Verified 2026-08-13 via the model card and the langtech-bsc/alia repository.

--- a/sources/products/apertus.yaml
+++ b/sources/products/apertus.yaml
@@ -1,27 +1,17 @@
 name: apertus
 display_name: Apertus
 type: model
-description: 'Apertus is Switzerland''s national open LLM family from the Swiss AI Initiative (EPFL, ETH
-  Zurich, CSCS), released under Apache 2.0. Its current 1.5 models, 8B and 70B, take image and audio input
-  alongside text, run a deliberation mode, and handle a 262,144-token context. The line stays fully open
-  (open weights, training-data reconstruction scripts, full recipes) across 1,811 languages, about 40% of
-  them non-English including Swiss German and Romansh.'
+description: Switzerland's national open LLM family from the Swiss AI Initiative at EPFL, ETH Zurich and CSCS.
+  The current 1.5 models at 8B and 70B take image and audio input alongside text, run a deliberation mode and
+  handle a 262,144-token context. The line covers 1,811 languages, about 40 percent of them non-English, including
+  Swiss German and Romansh.
 github:
 - url: https://github.com/swiss-ai/pretrain-code
 huggingface_model:
 - url: https://huggingface.co/swiss-ai/Apertus-v1.5-70B
 - url: https://huggingface.co/swiss-ai/Apertus-v1.5-8B
 - url: https://huggingface.co/swiss-ai/Apertus-70B-2509
-comments: 'Apertus family from the Swiss AI Initiative (EPFL, ETH Zurich, CSCS). Current release Apertus
-  1.5 ("Omni"), shipped 2026-07-24 as v1.5-8B and v1.5-70B: multimodal (image + audio in, text out) via
-  continued pretraining of Apertus 1.0 on a multimodal mix (+4T tokens for the 8B, +2T for the 70B), same
-  decoder-only xIELU architecture, 262,144-token context (4x the 1.0 release), a thinking/deliberation
-  mode, and improved instruction-following and tool use. Apache-2.0 with a separate Acceptable Use Policy.
-  The 1.0 release (2 Sep 2025, Apertus-70B-2509) remains public with its full open stack: pretraining-data
-  reconstruction scripts (github.com/swiss-ai/pretrain-data), the Megatron-LM recipe, intermediate
-  checkpoints, and the technical report (arXiv 2509.14233). v1.5''s own benchmark results, training
-  pipelines and intermediate checkpoints are announced as "coming weeks" and not yet shipped; openness is
-  held on the family''s established fully-open practice and the still-public 1.0 stack (see the score note).
-  Openness rests on reconstruction scripts rather than a released corpus, the route to a 5 the map accepts
-  and the reason Apertus clears the bar where ALIA-40b does not. Verified 2026-08-14 via the Apertus-v1.5-70B
-  and v1.5-8B HF model cards, the swiss-ai/pretrain-data repository, and the HF download API.'
+comments: Apertus 1.5 shipped 2026-07-24 by continued pretraining of 1.0. Its own pipelines and checkpoints
+  are announced but not yet shipped, so openness rests on the still-public 1.0 stack and its data-reconstruction
+  scripts rather than a released corpus. Verified 2026-08-14 via the v1.5 model cards and the pretrain-data
+  repository.

--- a/sources/products/ernie.yaml
+++ b/sources/products/ernie.yaml
@@ -3,13 +3,11 @@ display_name: ERNIE 5.1
 type: model
 aliases:
 - ernie-5-1
-description: 'Baidu''s flagship fifth-generation LLM (released May 2026): a Mixture-of-Experts model with elastic
-  depth/width/sparsity, focused on text generation, reasoning, agentic tool-use, and creative writing. Baidu emphasizes
-  cost efficiency - total params ~1/3 and active params ~1/2 of ERNIE 5.0, trained at ~6% of comparable models''
-  pre-training cost. 128K context.'
-comments: 'Proprietary/API-only (Baidu Qianfan API, ernie.baidu.com, AI Studio). Note ERNIE 4.5 was open sourced
-  (Apache-2.0, June 2025) but the 5.x flagship line is closed, and the Baidu org on Hugging Face still lists
-  no 5.x repository. The release post claims 4th place globally on the Arena Search leaderboard with a score
-  of 1,223, not the "#13 Text" placement the capability record carries, and it publishes no usage figure at
-  all - so both the capability value and the adoption band need new sources. Verified 2026-08-13 via the ERNIE
-  5.1 release post and the Baidu Hugging Face organization page.'
+description: 'Baidu''s fifth-generation flagship, released May 2026: a mixture-of-experts model with elastic
+  depth, width and sparsity, aimed at text generation, reasoning, agentic tool use and creative writing, with
+  a 128K context. Baidu positions it on cost efficiency, with roughly a third the total parameters and half
+  the active parameters of the previous generation.'
+comments: ERNIE 4.5 was released openly; the 5.x line is API-only and Baidu's Hugging Face organization lists
+  no 5.x repository. Capability and adoption were re-sourced on 2026-08-14 to Baidu's quarterly results, which
+  the release post does not carry. Verified 2026-08-13 via the ERNIE 5.1 release post and the Baidu organization
+  page.

--- a/sources/products/falcon.yaml
+++ b/sources/products/falcon.yaml
@@ -3,16 +3,12 @@ display_name: Falcon 3
 type: model
 aliases:
 - falcon-3
-description: TII's open-weights model line from Abu Dhabi. The original Falcon 3 family (1B/3B/7B/10B Apache-2.0,
-  December 2024) has been extended in 2025-2026 by Falcon-H1 (a hybrid Mamba-Transformer architecture spanning 0.5B-34B
-  with native 18-language support) and Falcon-H1 Arabic (3B/7B/34B, January 2026), positioned as the world's leading
-  Arabic open model. Falcon H1R 7B (January 2026) outperforms Qwen and Nemotron variants up to 7x its size on reasoning.
-  Adoption remains modest vs Llama/Qwen at equivalent size (Falcon3-7B-Instruct ~23K monthly HF downloads).
+description: TII's open-weights model line from Abu Dhabi. The Falcon 3 family spans 1B to 10B and was trained
+  on 14 trillion tokens of web, code and STEM data. It has since been extended by Falcon-H1, a hybrid Mamba-transformer
+  architecture from 0.5B to 34B with native support for eighteen languages, and by an Arabic-specialized Falcon-H1
+  line at 3B, 7B and 34B.
 huggingface_model:
 - url: https://huggingface.co/tiiuae/Falcon3-10B-Base
-comments: Falcon 3 family (1B, 3B, 7B, 10B), released 17 Dec 2024 by TII. Trained on 14T tokens. Sub-13B SLMs; now
-  a dated generation relative to 2026 frontier. The Hub reports the license as `other`, so the TII Falcon
-  License 2.0 tier rests on TII's own published text rather than a Hub label. Adoption is still recorded as
-  reported traction, but the declared checkpoint now carries a real download count, which is a lower band -
-  flagged for review. Verified 2026-08-13 via the Falcon 3 release blog, the Falcon3-10B-Base and
-  Falcon3-7B-Base model cards and the TII launch announcement.
+comments: Scored on the Falcon 3 generation, now dated relative to later families. The Hub does not name the
+  license, so the tier rests on TII's own published text. The adoption axis is held. Verified 2026-08-13 via
+  the Falcon 3 release blog and the Falcon3 model cards.

--- a/sources/products/gpt-4o.yaml
+++ b/sources/products/gpt-4o.yaml
@@ -2,15 +2,9 @@ name: gpt-4o
 display_name: GPT-4o
 type: model
 version_in_identity: OpenAI markets GPT-4o as a distinct product, not a version of GPT
-description: 'OpenAI''s legacy multimodal foundation model (May 2024) that natively handled text, image,
-  and audio. Now two numerical generations behind: superseded by the GPT-5 line (GPT-5 in August 2025,
-  then 5.2, 5.3, 5.4, and GPT-5.5 on April 23, 2026, the first fully retrained base since GPT-4.5). All
-  access remains API-only via post-trained variants; GPT-4o is being sunset as the ChatGPT default in
-  favor of GPT-5.5 Instant (May 5, 2026). Listed as the historical closed-source baseline that open-weights
-  models were measured against through 2024-2025.'
-comments: OpenAI GPT-4o, multimodal (text+image in, text out), 128K context; first snapshot gpt-4o-2024-05-13,
-  knowledge cutoff Oct 2023. API-only, no released weights. A 2024-era flagship, since surpassed by the
-  GPT-5 line but still served via API/ChatGPT. The MMLU and MMMU figures behind the capability record are
-  launch-era external numbers - OpenAI's model page carries no benchmarks at all - and the adoption band
-  rests on a third-party WAU aggregator that now blocks automated reads. Verified 2026-08-13 via OpenAI's
-  GPT-4o model documentation.
+description: OpenAI's 2024 multimodal foundation model, natively handling text, image and audio with a 128K
+  context and an October 2023 knowledge cutoff. It is API-only with no released weights, and has been superseded
+  by the GPT-5 line; it is being retired as the ChatGPT default in favor of GPT-5.5 Instant.
+comments: OpenAI's model page carries no benchmarks, so the capability figures are launch-era external numbers.
+  The adoption band rests on a ChatGPT weekly-actives figure re-sourced 2026-08-14 after the original aggregator
+  began blocking automated reads. Verified 2026-08-13 via OpenAI's GPT-4o model documentation.

--- a/sources/products/inflection.yaml
+++ b/sources/products/inflection.yaml
@@ -3,15 +3,10 @@ display_name: Inflection 3.0
 type: model
 aliases:
 - inflection-3-0
-description: 'Inflection AI''s foundation model powering the Pi assistant and the company''s enterprise ''Inflection
-  for Enterprise'' tier. After key staff (Mustafa Suleyman et al.) departed to Microsoft AI in March 2024, Inflection
-  pivoted to enterprise. Inflection 3.0 is the current flagship, powered by Intel Gaudi 3 with on-prem or AI Cloud
-  deployment options; no new generation publicly confirmed by May 2026. Notable as a case study in foundation-model
-  market concentration dynamics: pace has slowed dramatically post-pivot.'
-comments: Inflection 3.0 (Pi 3.0 + Productivity 3.0), released 7 Oct 2024 with 'Inflection for Enterprise'. Proprietary/API
-  + enterprise-licensed; no open weights; fine-tuned models are customer-exclusive. Frontier research team absorbed
-  by Microsoft (2024-25); pivot to B2B. Existence confirmed via primary sources (Intel Newsroom press release
-  + BusinessWire 'Introducing Inflection for Enterprise', 7 Oct 2024), not aggregator-only. Over 12 months old
-  and scored best-effort. The Wikipedia entry confirms the acqui-hire but does not say Pi was sunset, so that
-  claim has been removed from the adoption reasoning. Verified 2026-08-13 via the Intel newsroom release and
-  the Inflection AI Wikipedia entry.
+description: Inflection AI's foundation model, powering the Pi assistant and the company's enterprise tier.
+  Inflection 3.0, released October 2024, pairs a Pi conversational model with a Productivity model and runs
+  on Intel Gaudi 3 hardware with on-premises or cloud deployment. Most of the original research team moved
+  to Microsoft in 2024, after which the company pivoted to enterprise work.
+comments: Over twelve months old and scored best-effort. Wikipedia confirms the acqui-hire but does not say
+  Pi was sunset, so that claim was removed from the adoption reasoning. Verified 2026-08-13 via the Intel newsroom
+  release and the Inflection AI Wikipedia entry.

--- a/sources/products/inkling.yaml
+++ b/sources/products/inkling.yaml
@@ -1,17 +1,13 @@
 name: inkling
 display_name: Inkling
 type: model
-description: Thinking Machines Lab's first open-weight foundation model, released 2026-07-15. A natively
-  multimodal MoE (975B total / 41B active) that accepts text, image, and audio inputs with a 1M-token
-  context window, trained on 45T tokens. Apache-2.0 weights on Hugging Face; positioned as a customizable
-  base (via Tinker LoRA) rather than the strongest overall open or closed model. Family also includes
-  Inkling-Small (276B / 12B active), folded into this entry.
+description: Thinking Machines Lab's first open-weight foundation model, released 15 July 2026. It is a natively
+  multimodal mixture of experts with 975 billion total and 41 billion active parameters, six of 256 experts
+  plus two shared, hybrid local and global attention, a one-million-token context and 45 trillion training
+  tokens. A 276B Small sibling with 12B active is part of the same family.
 huggingface_model:
 - url: https://huggingface.co/thinkingmachines/Inkling
 - url: https://huggingface.co/thinkingmachines/Inkling-NVFP4
-comments: Inkling, 975B total / 41B active MoE (6-of-256 + 2 shared experts), hybrid local/global attention,
-  native text/image/audio. Released 15 Jul 2026 under Apache-2.0. Inkling-Small (276B/12B) is a sibling
-  preview in the same family — not a separate map entry. Training data not redistributed. The NVFP4
-  quantization now pulls roughly three times the BF16 release, so adoption is summed across both rather
-  than read off the headline repository. Verified 2026-08-13 via the Inkling HF model card and Thinking
-  Machines' launch post.
+comments: The Small sibling is folded into this record. Training data is not redistributed. The NVFP4 quantization
+  pulls roughly three times the BF16 release, so adoption sums both rather than reading the headline repository.
+  Verified 2026-08-13 via the Inkling model card and Thinking Machines' launch post.

--- a/sources/products/internlm.yaml
+++ b/sources/products/internlm.yaml
@@ -3,15 +3,11 @@ display_name: InternLM 2.5
 type: model
 aliases:
 - internlm-2-5
-description: Shanghai AI Lab's open-weights model family. The InternLM 2.5 generation (7B/20B, July 2024, 1M context
-  via dynamic NTK interpolation) was superseded by InternLM3 in January 2025, an 8B model trained on only 4T tokens
-  that reportedly matches GPT-4o-mini, with integrated 'deep thinking' chain-of-thought mode and ~4x the data efficiency
-  (IQPT) of Llama 3.1. A leading Chinese academic-origin foundation model, heavily used in the Chinese research
-  community.
+description: Shanghai AI Lab's open-weights model family. The InternLM 2.5 generation at 7B and 20B reaches
+  a one-million-token context through dynamic NTK interpolation. It was superseded by InternLM3 in January
+  2025, an 8B model trained on four trillion tokens with an integrated deep-thinking chain-of-thought mode.
 huggingface_model:
 - url: https://huggingface.co/internlm/internlm2_5-7b
-comments: InternLM2.5-7B base (~8B params, 1M-token context), released 2024 (InternLM2 tech report arXiv:2403.17297).
-  Base SKU scored here; InternLM2.5-7B-Chat is the instruct SKU (finetuned_chat). The code is Apache-2.0 but
-  the weights carry a separate custom term - commercial use is free and granted on an application form - so
-  the compound resolves on the weights half, which is why this is open_weights rather than open_source.
-  Verified 2026-08-13 via the internlm2_5-7b HF model card and the InternLM/InternLM repository.
+comments: Scores the InternLM2.5-7B base; the Chat release is a separate finetuned_chat record. The code and
+  weights carry different terms and the compound resolves on the weights half. Verified 2026-08-13 via the
+  model card and the InternLM repository.

--- a/sources/products/kimi.yaml
+++ b/sources/products/kimi.yaml
@@ -4,19 +4,12 @@ type: model
 aliases:
 - kimi-k2-6
 - kimi-k3
-description: Moonshot AI's flagship 2.8T-parameter MoE (activating 16 of 896 experts) with native vision and a 1M-token
-  context window, announced 2026-07-16. Positioned as the world's first open 3T-class model; live on kimi.com /
-  Kimi Work / Kimi Code / the Kimi API at launch, with full weights scheduled for 2026-07-27. Built on Kimi Delta
-  Attention and Attention Residuals; Moonshot reports frontier-tier long-horizon coding and agentic knowledge-work
-  results trailing only Claude Fable 5 and GPT-5.6 Sol among tested models.
+description: Moonshot AI's flagship mixture of experts, announced 16 July 2026 with 2.8 trillion total parameters
+  activating sixteen of 896 experts, native vision and a one-million-token context. It is built on Kimi Delta
+  Attention and attention residuals, and runs on kimi.com, Kimi Work, Kimi Code and the Kimi API.
 huggingface_model:
 - url: https://huggingface.co/moonshotai/Kimi-K2.6
 - url: https://huggingface.co/moonshotai/Kimi-K3
-comments: Kimi K3, 2.8T total MoE, Stable LatentMoE (16/896 experts), 1M context, native multimodal. Consolidated
-  on 2026-07-29 from kimi-k2-6; openness follows kimi-k3, the release that currently governs. See
-  docs/reference/identity.md. The K3 weights landed on 2026-07-27 as promised - 96 safetensors shards, ungated -
-  under a "Kimi K3 License" that is MIT plus a Model-as-a-Service revenue threshold and an attribution
-  requirement above 100M MAU. The openness axis still records `weights - pending` and an assumed license,
-  so it is behind the artifact and is flagged for correction. Capability still describes K2.6, which is the
-  release with a published benchmark table. Verified 2026-08-13 via the Kimi-K3 HF model card and its LICENSE
-  file.
+comments: Consolidated 2026-07-29 from kimi-k2-6; openness follows K3, the governing release, whose weights
+  landed 2026-07-27 ungated. Capability still describes K2.6, which is the release with a published benchmark
+  table. Verified 2026-08-14 via the Kimi-K3 model card and its LICENSE file.

--- a/sources/products/lucie-7b.yaml
+++ b/sources/products/lucie-7b.yaml
@@ -2,20 +2,16 @@ name: lucie-7b
 display_name: Lucie 7B
 type: model
 version_in_identity: OpenLLM-France ships Lucie-7B under that name
-description: Linagora / OpenLLM-France's fully open multilingual 7B foundation model (Llama 3.1 architecture),
-  trained on ~3T tokens with roughly equal French and English shares plus German, Spanish, Italian, and
-  code. Apache-2.0 weights, redistributable Lucie Training Dataset, Megatron-DeepSpeed training code, and
-  intermediate checkpoints — one of the few European releases that clears the full open-source bar.
-  Instruct variants (v1.1 and human-data) are folded into this entry.
+description: Linagora and OpenLLM-France's fully open multilingual 7B foundation model on the Llama 3.1 architecture,
+  trained on roughly three trillion tokens with about equal French and English shares plus German, Spanish,
+  Italian and code. The weights ship with the Lucie Training Dataset, the Megatron-DeepSpeed training code
+  and intermediate checkpoints as repository branches.
 github:
 - url: https://github.com/OpenLLM-France/Lucie-Training
 huggingface_model:
 - url: https://huggingface.co/OpenLLM-France/Lucie-7B
 - url: https://huggingface.co/OpenLLM-France/Lucie-7B-Instruct-v1.1
-comments: Lucie-7B base + Instruct-v1.1 / Instruct-human-data. Apache-2.0 weights; training data at
-  OpenLLM-France/Lucie-Training-Dataset (not a separate map product for now); training code AGPL/community
-  stack on GitHub. Paper arXiv:2503.12294. Collection https://huggingface.co/collections/OpenLLM-France/lucie-llm.
-  The corpus is published and ungated but carries cc-by-nc-sa-4.0, so it is not commercially reusable - the
-  data dimension asks whether the corpus is released rather than on what terms, which is why the score holds
-  while the project's own OSI-compliance claim does not. Its successor Luciole fixes exactly this. Verified
-  2026-08-13 via the Lucie-7B model card, the Lucie-Training-Dataset card and the Lucie-Training repository.
+comments: 'Instruct variants are folded into this record. The corpus is published and ungated but non-commercial;
+  the data dimension asks whether a corpus is released rather than on what terms, which is why the score holds
+  while the project''s own compliance claim does not. Successor: Luciole. Verified 2026-08-13 via the model
+  card, the dataset card and the Lucie-Training repository.'

--- a/sources/products/luciole.yaml
+++ b/sources/products/luciole.yaml
@@ -1,14 +1,11 @@
 name: luciole
 display_name: Luciole
 type: model
-description: Linagora / OpenLLM-France's fully open multilingual (French–English) LLM family and the
-  successor to Lucie, released in 1B, 8B, and 23B sizes (base + Instruct-1.1). Apache-2.0 weights, the
-  redistributable Luciole-Training-Dataset (~4.65T tokens drawn only from openly licensed corpora), the
-  Luciole-Training pipeline on GitHub, and intermediate + final pretraining checkpoints — clearing the
-  full open-source bar. Base models are pretrained on roughly 30% French data (English 53%, French 16%,
-  plus German/Spanish/Italian/Portuguese/Dutch/Arabic and regional languages); the Instruct-1.1 models are
-  SFT + DPO aligned on math, science, coding, chat, RAG, and translation. Built by LINAGORA and the
-  OpenLLM-France consortium, funded by BPI France through the France 2030 program.
+description: Linagora and OpenLLM-France's fully open French-English model family and the successor to Lucie,
+  released at 1B, 8B and 23B in base and instruct forms. The weights ship with a 4.65-trillion-token training
+  dataset drawn only from openly licensed corpora, the training pipeline, and intermediate and final checkpoints.
+  Base models are pretrained on roughly 53 percent English and 16 percent French alongside German, Spanish,
+  Italian, Portuguese, Dutch and Arabic; the instruct models are aligned with SFT and DPO.
 github:
 - url: https://github.com/OpenLLM-France/Luciole-Training
 huggingface_model:
@@ -20,13 +17,6 @@ huggingface_model:
 - url: https://huggingface.co/OpenLLM-France/Luciole-1B-Instruct-1.1
 huggingface_dataset:
 - url: https://huggingface.co/datasets/OpenLLM-France/Luciole-Training-Dataset
-comments: "Luciole family (1B / 8B / 23B, base + Instruct-1.1) from LINAGORA / OpenLLM-France, successor to
-  Lucie-7B. Apache-2.0 weights; open Luciole-Training-Dataset (~4.65T tokens, open-licensed corpora only —
-  cleaner terms than Lucie's cc-by-nc-sa corpus); Luciole-Training pipeline on GitHub (GPL-3.0); intermediate
-  + final checkpoints published. Funded by BPI France / France 2030. Collection:
-  https://huggingface.co/collections/OpenLLM-France/luciole-llm. The training corpus card carries cc-by-sa-4.0,
-  so unlike Lucie's it is commercially reusable, and the 23B-Base card documents the intermediate-checkpoint
-  revision tags and their linagora.com mirror explicitly. An earlier read had to work from search snippets
-  because direct HF fetches were blocked; this one fetched the cards directly. Verified 2026-08-13 via the
-  Luciole-23B-Base and 23B-Instruct-1.1 model cards, the Luciole-Training-Dataset card and the
-  Luciole-Training repository."
+comments: The training corpus carries commercially reusable terms, unlike Lucie's. An earlier read worked from
+  search snippets because direct fetches were blocked; this one fetched the cards. Verified 2026-08-13 via
+  the 23B base and instruct cards, the dataset card and the Luciole-Training repository.

--- a/sources/products/mimo-pro.yaml
+++ b/sources/products/mimo-pro.yaml
@@ -3,16 +3,14 @@ display_name: MiMo-V2.5-Pro
 type: model
 aliases:
 - mimo-v2-5-pro
-description: 'Xiaomi''s open-weights MoE model (released April 2026): ~1.02T total / 42B active params (70 layers,
-  8 experts/token), hybrid attention interleaving sliding-window and global attention (6:1), 3-layer Multi-Token
-  Prediction, and a 1M-token context. Built for demanding agentic, complex software-engineering, and long-horizon
-  tasks.'
+description: Xiaomi's open-weights mixture of experts, released April 2026 with about 1.02 trillion total and
+  42 billion active parameters across 70 layers and eight experts per token. It interleaves sliding-window
+  and global attention at a six-to-one ratio, uses three-layer multi-token prediction, and reaches a one-million-token
+  context. It targets agentic, software-engineering and long-horizon tasks.
 github:
 - url: https://github.com/XiaomiMiMo/MiMo
 huggingface_model:
 - url: https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro
-comments: Open weights, MIT per the HF model card (an older MiMo GitHub repo lists Apache-2.0; the model card is
-  authoritative for this release). ~1.02T/42B MoE, 1M context. Xiaomi's own product page no longer carries the
-  evaluation tables and points to the Hugging Face card instead, so the benchmark figures are read there. The
-  LMArena position in the capability record is mirror-reported and has no cited source. Verified 2026-08-13
-  via the MiMo-V2.5-Pro HF model card, the Xiaomi product page and the XiaomiMiMo/MiMo repository.
+comments: An older MiMo repository carries different terms from the model card, and the card is authoritative
+  here. Xiaomi's product page no longer carries the evaluation tables and points to the card, so the figures
+  are read there. Verified 2026-08-13 via the model card, the product page and the MiMo repository.

--- a/sources/products/minimax.yaml
+++ b/sources/products/minimax.yaml
@@ -4,14 +4,11 @@ type: model
 aliases:
 - minimax-m2-5
 - minimax-m3
-description: 'MiniMax M3 launched 1 Jun 2026: API-first at launch with MiniMax Sparse Attention, 1M-token context,
-  native multimodal. Open weights have since been released on Hugging Face (ungated, ~131k downloads/month) under
-  a custom minimax-community license; training data and pipeline remain closed.'
+description: MiniMax's M3 flagship, launched 1 June 2026 with MiniMax Sparse Attention, a one-million-token
+  context and native multimodality. It was API-first at launch, with weights subsequently published on Hugging
+  Face alongside vLLM and SGLang deployment guides. The training data and pipeline are not released.
 huggingface_model:
 - url: https://huggingface.co/MiniMaxAI/MiniMax-M3
-comments: 'MiniMax M3 launched 1 Jun 2026: API-first at launch with MiniMax Sparse Attention, 1M-token context,
-  native multimodal. Open weights have since been released on Hugging Face (ungated, ~131k downloads/month)
-  under a custom minimax-community license; training data and pipeline remain closed. Consolidated on 2026-07-29
-  from minimax-m2-5; openness follows minimax-m3, the release that currently governs. See docs/reference/identity.md.
-  Capability is the one axis that does not describe M3 - MiniMax has published no benchmark table for it, so the
-  band still rests on the M2.5 card. Verified 2026-08-13 via the MiniMax-M3 and MiniMax-M2.5 HF model cards.'
+comments: Consolidated 2026-07-29 from minimax-m2-5; openness follows M3, the governing release. Capability
+  is the one axis that does not describe M3, because MiniMax has published no benchmark table for it, so the
+  band still rests on the M2.5 card. Verified 2026-08-13 via the M3 and M2.5 model cards.

--- a/sources/products/olmo.yaml
+++ b/sources/products/olmo.yaml
@@ -3,15 +3,13 @@ display_name: OLMo 3
 type: model
 aliases:
 - olmo-3
-description: 'Ai2''s OLMo 3 family (7B/32B; Base, Think, Instruct, RL-Zero), released Nov 2025 with a Dec 2025 3.1
-  update. Fully open: Apache-2.0 weights plus the 9.3T-token Dolma 3 corpus, training code, recipes and intermediate
-  checkpoints. The strongest fully-open base model to date; supersedes OLMo 2.'
+description: Ai2's OLMo 3 family at 7B and 32B in Base, Think, Instruct and RL-Zero variants, released November
+  2025 with a December update. The weights ship with the 9.3-trillion-token Dolma 3 corpus, the training code,
+  the data recipes and intermediate checkpoints, so the whole run can be inspected and modified. It supersedes
+  OLMo 2.
 github:
 - url: https://github.com/allenai/OLMo
 huggingface_model:
 - url: https://huggingface.co/allenai/Olmo-3-1125-32B
 - url: https://huggingface.co/allenai/Olmo-3-1025-7B
-comments: Fully-open weights + Dolma 3 data + training code + checkpoints. OLMo 3-Think 32B is the strongest
-  fully-open reasoning model, narrowing the gap to Qwen3-32B on ~6x fewer tokens; still below the trillion-param
-  open-weight frontier. Verified 2026-08-13 via the Ai2 Olmo 3 blog, the Olmo-3-1025-7B HF model card and
-  the allenai/OLMo repository.
+comments: Verified 2026-08-13 via the Ai2 OLMo 3 blog, the Olmo-3-1025-7B model card and the allenai/OLMo repository.

--- a/sources/products/phi.yaml
+++ b/sources/products/phi.yaml
@@ -3,16 +3,12 @@ display_name: Phi-4
 type: model
 aliases:
 - phi-4
-description: 'Microsoft''s 14B-parameter small language model that scores competitively with larger models
-  on reasoning, math, and code, released December 2024 under MIT license. Trained on heavily curated and synthetic
-  data, demonstrating the ''small models with high-quality data'' thesis. As of May 2026 the Phi-4 line is
-  still current: Microsoft has extended it with Phi-4-mini, Phi-4-multimodal, and Phi-4-reasoning / Phi-4-reasoning-plus
-  (May 2025), plus Phi-4-reasoning-vision-15B (March 2026). No Phi-5 has been announced.'
+description: Microsoft's 14B dense small language model, announced December 2024 and fully released the following
+  month, trained on 9.8 trillion tokens of heavily curated and synthetic data. It is the clearest expression
+  of the small-models-with-high-quality-data thesis, and the line has been extended with mini, multimodal,
+  reasoning and reasoning-vision variants.
 huggingface_model:
 - url: https://huggingface.co/microsoft/phi-4
-comments: Phi-4, 14B dense model, weights released on Hugging Face under MIT (full release Jan 2025 following Dec
-  2024 announcement). Reasoning variants (Phi-4-reasoning / -reasoning-plus) released later under open weights but
-  are separate SKUs; this record scores base Phi-4 14B. The whole thesis is data curation - 9.8T tokens of
-  synthetic and filtered material - and none of it is released, which is why a fully permissive license still
-  only reaches open_weights. Artificial Analysis ranks it 47th of 74 on its Intelligence Index. Verified
-  2026-08-13 via the microsoft/phi-4 HF model card and the Artificial Analysis model page.
+comments: Scores base Phi-4 14B; the reasoning variants are separate SKUs. The curated training data is not
+  released, which the openness axis weighs alongside the distribution terms. Verified 2026-08-13 via the microsoft/phi-4
+  model card and the Artificial Analysis model page.

--- a/sources/products/pythia.yaml
+++ b/sources/products/pythia.yaml
@@ -1,17 +1,14 @@
 name: pythia
 display_name: Pythia
 type: model
-description: EleutherAI's suite of 16 models ranging from 70M to 12B parameters, all trained on the same data
-  (The Pile) in the same order, with intermediate checkpoints released throughout training. Designed as a scientific
-  tool for studying how language models learn, not for production use. Fully open (model, data, training code,
-  intermediate checkpoints). Widely used in LLM interpretability and scaling research.
+description: EleutherAI's suite of sixteen models from 70M to 12B parameters, eight sizes trained twice on
+  The Pile and its deduplicated variant, in the same data order, with 154 intermediate checkpoints released
+  for each. It is a scientific instrument for studying how language models learn rather than a production family,
+  and the dataloader tooling makes the exact token order reconstructable.
 github:
 - url: https://github.com/EleutherAI/pythia
 huggingface_model:
 - url: https://huggingface.co/EleutherAI/pythia-12b
-comments: 'Pythia suite: 16 models, 70M-12B params (8 sizes x Pile/deduped-Pile), 154 intermediate checkpoints
-  each. Released 2023 (arXiv 2304.01373) and still the standard interpretability and training-dynamics suite.
-  What separates it from the other fully-open entries is the dataloader tooling - the exact token order is
-  reconstructable, not just the corpus downloadable. Capability is scored 1 on purpose: these are research
-  instruments, not models anyone deploys. Verified 2026-08-13 via the Pythia paper, the Pile dataset entry,
-  the EleutherAI/pythia repository and the pythia-12b model card.'
+comments: These are research instruments rather than models anyone deploys, which is what the capability axis
+  reflects. Verified 2026-08-13 via the Pythia paper, the Pile dataset entry, the EleutherAI/pythia repository
+  and the pythia-12b model card.

--- a/sources/products/qwen.yaml
+++ b/sources/products/qwen.yaml
@@ -6,9 +6,9 @@ aliases:
 - qwen-3-6
 - qwen-3-7-max
 - qwen3
-description: 'Qwen3.6 series, released early-mid 2026: open-weight variants incl Qwen3.6-35B-A3B (MoE, Apr 16 2026)
-  and dense Qwen3.6-27B (Apr 22 2026), plus hosted flagship tiers Qwen3.6-Plus and Qwen3.6-Max (Preview) that are
-  proprietary/API-only.'
+description: Alibaba's Qwen 3.6 series, released in the first half of 2026. It spans open-weight releases including
+  a 35B mixture of experts with 3B active parameters and a dense 27B, alongside hosted Plus and Max flagship
+  tiers that are reachable only through the API.
 github:
 - url: https://github.com/QwenLM/Qwen3.6
 huggingface_model:
@@ -18,10 +18,7 @@ huggingface_model:
 - url: https://huggingface.co/Qwen/Qwen3.6-35B-A3B
 - url: https://huggingface.co/Qwen/Qwen3-235B-A22B
 - url: https://huggingface.co/Qwen/Qwen3.5-397B-A17B
-comments: 'Qwen3.6 series, released early-mid 2026: open-weight variants incl Qwen3.6-35B-A3B (MoE, Apr 16
-  2026) and dense Qwen3.6-27B (Apr 22 2026), plus hosted flagship tiers Qwen3.6-Plus and Qwen3.6-Max (Preview)
-  that are proprietary/API-only. Consolidated on 2026-07-29 from qwen-2-5, qwen-3-7-max, qwen3; openness
-  follows qwen-3-6, the release that currently governs. See docs/reference/identity.md. The hosted Plus and
-  Max tiers are never distributed, so they sit outside the openness axis - that exclusion is what keeps
-  the family at Apache rather than pulling it to closed. Verified 2026-08-13 via the Qwen3.6-27B HF model
-  card and the QwenLM/Qwen3.6 repository.'
+comments: Consolidated 2026-07-29 from three earlier records; openness follows Qwen 3.6. The hosted Plus and
+  Max tiers are never distributed, so they sit outside the openness axis, and that exclusion is what keeps
+  the family from being pulled to closed. Verified 2026-08-13 via the Qwen3.6-27B model card and the QwenLM/Qwen3.6
+  repository.

--- a/sources/products/reka-core.yaml
+++ b/sources/products/reka-core.yaml
@@ -1,15 +1,10 @@
 name: reka-core
 display_name: Reka Core
 type: model
-description: Reka AI's multimodal foundation model that natively processes text, images, video, and audio
-  (128K context). Founded by ex-DeepMind / Google / Meta researchers, Reka Core was originally pitched
-  as a GPT-4V / Claude 3 Opus / Gemini Ultra rival. The company has since extended the stack with Reka
-  Flash 3 (open-weights, 2025) and Reka Nexus (a multi-agent 'AI workforce' product). Reka Core remains
-  API-only as the closed flagship; no verified 2026 successor to Core itself was found in this audit,
-  though the surrounding product line has evolved.
-comments: 'Reka Core, frontier-class multimodal LLM announced 15 Apr 2024; 128K context. Proprietary:
-  API/on-prem/on-device; no open weights. Instruction/multimodal-chat model. The launch page confirms
-  API/on-prem/on-device availability and the MMMU/Claude-3-Opus claims, but the ''~5T tokens / 32 languages
-  / from scratch'' details are NOT on it - they originate in Reka''s separate technical report - so verify
-  against that source if retained. The page is dated April 2024 and publishes no usage figure, which is why
-  adoption is directional. Verified 2026-08-13 via the Reka Core launch page.'
+description: Reka AI's multimodal foundation model, announced April 2024, natively processing text, images,
+  video and audio with a 128K context and delivered through an API or on-premises and on-device deployment.
+  Reka has since extended the stack with an open-weights Flash release and a multi-agent product, while Core
+  itself remains the closed flagship.
+comments: The launch page publishes no usage figure, so adoption is directional. The training-scale details
+  this record once carried are not on that page but in Reka's separate technical report. No 2026 successor
+  to Core itself was found. Verified 2026-08-13 via the Reka Core launch page.

--- a/sources/products/rwkv.yaml
+++ b/sources/products/rwkv.yaml
@@ -1,10 +1,10 @@
 name: rwkv
 display_name: RWKV
 type: model
-description: Open-weights LLM family with a novel architecture that is 100% RNN yet trains in parallel like a GPT
-  transformer - combining linear-time inference, constant memory (no KV-cache), and effectively unbounded context.
-  The current generation, RWKV-7 'Goose', introduces 'Dynamic State Evolution' for expressivity beyond the limits
-  of attention.
+description: Open-weights model family with an architecture that is fully recurrent at inference yet trains
+  in parallel like a transformer, giving linear-time inference, constant memory with no KV cache, and effectively
+  unbounded context. The current RWKV-7 Goose generation introduces dynamic state evolution for expressivity
+  beyond the limits of attention.
 github:
 - url: https://github.com/BlinkDL/RWKV-LM
 huggingface_model:
@@ -13,13 +13,9 @@ huggingface_model:
 huggingface_dataset:
 - url: https://huggingface.co/datasets/RWKV/RWKV-World-Listing
 - url: https://huggingface.co/datasets/Goose-World/RWKV-World-v3
-comments: Apache-2.0 with open weights and open training code. The pretraining data is documented rather than
-  released - an itemized machine-readable index naming every component dataset with a resolvable URL, plus 100k
-  and 1M preview subsamples, but no corpus and no reconstruction scripts (corrected 2026-07-28, see the openness
-  note; this comment previously claimed an open 3.1T-token corpus). The RWKV Project is an LF AI & Data
-  (Generative AI Commons) non-profit led by Bo Peng (BlinkDL). ~14.7k stars on RWKV-LM. Adoption is banded
-  across the two repositories the product declares rather than every repo under the BlinkDL and RWKV orgs,
-  which would give a higher number. Verified 2026-08-13 via the RWKV-World-Listing component index, the
-  Goose-World dataset repository, RWKV-LM and the rwkv-7-world model repository.
+comments: 'The pretraining data is documented rather than released: an index naming every component dataset
+  with a resolvable URL, plus preview subsamples, but no corpus and no reconstruction scripts. Adoption is
+  banded across the two declared repositories. Verified 2026-08-13 via the component index, the dataset repository,
+  RWKV-LM and the model repository.'
 arxiv:
 - url: https://arxiv.org/abs/2503.14456

--- a/sources/products/yi.yaml
+++ b/sources/products/yi.yaml
@@ -3,16 +3,11 @@ display_name: Yi-1.5
 type: model
 aliases:
 - yi-1-5
-description: Kai-Fu Lee's 01.AI foundation model family in 6B, 9B, and 34B variants, with continued pretraining
-  on 500B tokens over Yi-1.0. Strong performance on Chinese and English benchmarks. Apache 2.0 licensed. One of
-  the top Chinese-origin open-weights models, though increasingly competing with Qwen for mindshare in the Chinese
-  open source community.
+description: 01.AI's foundation model family at 6B, 9B and 34B with 32K-context variants, open sourced in May
+  2024. It continues pretraining from the original Yi release with a further 500 billion tokens, for 3.6 trillion
+  in total.
 huggingface_model:
 - url: https://huggingface.co/01-ai/Yi-1.5-34B
-comments: Yi-1.5 base family (6B/9B/34B + 32K context variants), open sourced 2024-05-13 by 01.AI. Continuously
-  pre-trained on Yi with +500B tokens (3.6T total). Base SKUs (Yi-1.5-9B, Yi-1.5-34B) scored here; Yi-1.5-*-Chat
-  are the instruct SKUs (finetuned_chat). A dated 2024-era generation against the 2026 frontier, and adoption
-  now sits barely above the 10K band floor. The benchmark figures behind the capability record are no longer
-  on the 01-ai/Yi-1.5 README, which defers to the model card; the model cards do not carry them either, so
-  that record needs a new source. Verified 2026-08-13 via the Yi-1.5-34B and Yi-1.5-9B HF model cards and
-  the 01-ai/Yi-1.5 repository.
+comments: Scores the base SKUs; the Chat releases are separate finetuned_chat records. A 2024-generation family,
+  with adoption barely above its band floor. The benchmark figures this record once carried are no longer on
+  the README or the model cards. Verified 2026-08-13 via the Yi-1.5-34B and Yi-1.5-9B model cards and the repository.

--- a/sources/provenance/base_pretrained.yaml
+++ b/sources/provenance/base_pretrained.yaml
@@ -1,0 +1,160 @@
+# Prose and provenance closeout for base_pretrained. 27 of 27 ready.
+#
+# Every record was already canonical; twenty still failed prose compliance. That is now the
+# second category in a row where the verification line was fine and the prose around it was not.
+#
+# ## Three records carried prose describing a score state the score had already left
+#
+#   ernie   "both the capability value and the adoption band need new sources" - both were
+#           re-sourced on 2026-08-14 to Baidu's own quarterly results.
+#   kimi    "the openness axis still records `weights - pending` and an assumed license, so it
+#           is behind the artifact" - the K3 LICENSE was read directly on 2026-08-14 and the
+#           axis moved with it.
+#   yi      "that record needs a new source" for capability - the axis carries a 2026-08-13 date
+#           against the model cards.
+#
+# With le-chat and vals-ai that makes five. The rule holds: a product's prose saying an axis is
+# unsettled is not evidence that it is, and the score note is what settles it.
+#
+# ## What came out
+#
+# Benchmark figures and leaderboard placements, as in finetuned_chat - `ernie`'s Arena rank and
+# score, `phi`'s "47th of 74 on the Artificial Analysis Intelligence Index", `kimi`'s ranking
+# against Claude Fable 5 and GPT-5.6 Sol, `falcon`'s "outperforms Qwen and Nemotron variants up
+# to 7x its size". Also download counts, license names throughout, and editorial framing that is
+# not description: `alia-40b`'s "the value proposition is permissive licensing, multilingual
+# breadth, and digital sovereignty", `inflection`'s "Notable as a case study in
+# foundation-model market concentration dynamics", `gpt-4o`'s "Listed as the historical
+# closed-source baseline that open-weights models were measured against".
+#
+# `minimax` and `qwen` each used ONE STRING for both prose fields - the seventh and eighth
+# instances found in the sweep.
+#
+# ## What stays, because for a base model it IS the record
+#
+# Parameter counts and active-versus-total for a mixture of experts, layer counts, context
+# windows, vocabulary size, training-token totals, language coverage, architecture, and who
+# trained it on what hardware. A new generation is a different record.
+#
+# The openness reasoning that distinguishes these entries also stays, because it is a judgment
+# call the score rests on rather than a restatement of it: `alia-40b`'s corpus is documented but
+# will not be distributed; `apertus` reaches the top tier on reconstruction scripts rather than
+# a released corpus; `lucie-7b`'s corpus is released but non-commercial, and the data dimension
+# asks whether it is released rather than on what terms; `rwkv` publishes an index of its
+# components but no corpus.
+#
+# ## One hold, unchanged
+#
+# `falcon.adoption` stays held since 2026-08-15: the declared checkpoint's real download count
+# lands a band below the recorded reported traction. Nothing in this pass touched it.
+#
+- product: alia-40b
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the model card and the langtech-bsc/alia repository
+- product: apertus
+  resolved_state: canonical
+  verified: '2026-08-14'
+  document: the v1
+- product: deepseek
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the DeepSeek-V4-Pro HF model card and the deepseek-ai/DeepSeek-V3 repository
+- product: ernie
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the ERNIE 5
+- product: falcon
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Falcon 3 release blog and the Falcon3 model cards
+- product: gemma
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the gemma-4-31B-it model card and the Gemma releases page
+- product: glm
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the GLM-5
+- product: gpt-4o
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: OpenAI's GPT-4o model documentation
+- product: inflection
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Intel newsroom release and the Inflection AI Wikipedia entry
+- product: inkling
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Inkling model card and Thinking Machines' launch post
+- product: internlm
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the model card and the InternLM repository
+- product: kimi
+  resolved_state: canonical
+  verified: '2026-08-14'
+  document: the Kimi-K3 model card and its LICENSE file
+- product: llama
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Llama 4 Scout HF model card and the meta-llama organization page
+- product: lucie-7b
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the model card, the dataset card and the Lucie-Training repository
+- product: luciole
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the 23B base and instruct cards, the dataset card and the Luciole-Training repository
+- product: marin
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Marin announcement post, the marin-8b-base HF model card and the marin-community/marin
+    repository
+- product: mimo-pro
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the model card, the product page and the MiMo repository
+- product: minimax
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the M3 and M2
+- product: mistral-large
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Mistral 3 launch post and the Mistral-Large-3-675B-Base-2512 HF model card
+- product: olmo
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Ai2 OLMo 3 blog, the Olmo-3-1025-7B model card and the allenai/OLMo repository
+- product: phi
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the microsoft/phi-4 model card and the Artificial Analysis model page
+- product: pythia
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Pythia paper, the Pile dataset entry, the EleutherAI/pythia repository and the pythia-12b
+    model card
+- product: qwen
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Qwen3
+- product: reka-core
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Reka Core launch page
+- product: rwkv
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the component index, the dataset repository, RWKV-LM and the model repository
+- product: smollm
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the SmolLM3 release post, the SmolLM3-3B model card and the huggingface/smollm repository
+- product: yi
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Yi-1


### PR DESCRIPTION
**27 of 27 ready.** One pre-existing hold unchanged; no date moved, no source refetched.

## Every record was already canonical. Twenty still failed.

Second category in a row where the verification line was fine and the prose around it was not.

## Three records described a score state the score had already left

| record | the prose said | the score file says |
|---|---|---|
| `ernie` | "both the capability value and the adoption band need new sources" | both re-sourced 2026-08-14 to Baidu's own quarterly results |
| `kimi` | "the openness axis still records `weights - pending` and an assumed license, so it is behind the artifact" | the K3 LICENSE was read directly on 2026-08-14 and the axis moved with it |
| `yi` | capability "needs a new source" | the axis carries a 2026-08-13 date against the model cards |

**With `le-chat` and `vals-ai` that makes five.** The rule holds and I am now applying it first: a product's prose saying an axis is unsettled is not evidence that it is — the score note is what settles it.

## What came out

Benchmark figures and leaderboard placements, as in `finetuned_chat`: `ernie`'s Arena rank and score, `phi`'s "47th of 74 on the Artificial Analysis Intelligence Index", `kimi`'s ranking against Claude Fable 5 and GPT-5.6 Sol, `falcon`'s "outperforms Qwen and Nemotron variants up to 7x its size".

Also download counts, license names throughout, and editorial framing that is not description:

- `alia-40b` — "the value proposition is permissive licensing, multilingual breadth, and digital sovereignty for the ~600M Spanish speakers"
- `inflection` — "Notable as a case study in foundation-model market concentration dynamics: pace has slowed dramatically post-pivot"
- `gpt-4o` — "Listed as the historical closed-source baseline that open-weights models were measured against"

`minimax` and `qwen` each used **one string for both prose fields** — the seventh and eighth instances in the sweep.

## What stays, because for a base model it *is* the record

Parameter counts and active-versus-total for a mixture of experts, layer counts, context windows, vocabulary size, training-token totals, language coverage, architecture, and who trained it on what hardware. A new generation is a different record.

The openness *reasoning* also stays, because it is a judgment call the score rests on rather than a restatement of it: `alia-40b`'s corpus is documented but will not be distributed; `apertus` reaches the top tier on reconstruction scripts rather than a released corpus; `lucie-7b`'s corpus is released but non-commercial, and the data dimension asks whether a corpus is released rather than on what terms; `rwkv` publishes an index of its components but no corpus.

## One hold, unchanged

`falcon.adoption` stays held since 2026-08-15 — the declared checkpoint's real download count lands a band below the recorded reported traction. Nothing here touched it.

## Verification

`validate`, `check_verification`, `check_capability`, `check_recipe`, `check_adoption --strict` clean. `check_freshness --category base_pretrained`: 80 of 81 axes dated, the 81st correctly held. 663 tests, no skips.

**Corpus: 395/472 ready · 452/472 canonical · 1,407/1,416 axes confirmed · 9 held.**
