### PR TITLE
Refresh edge_hardware: 20/20, and 472/472 canonical

### DIFF
--- a/build/sweep_status.py
+++ b/build/sweep_status.py
@@ -224,9 +224,17 @@ def survey(cutoff: date | None = None) -> list[dict]:
             "coverage": routable / len(roster) if roster else 1.0,
             "states": states,
         })
-    # Worst coverage first; a finished category sorts to the back whatever its coverage.
-    rows.sort(key=lambda r: (r["done"] >= r["products"], r["coverage"], r["category"]))
-    return rows
+    return order_rows(rows)
+
+
+def order_rows(rows: list[dict]) -> list[dict]:
+    """Worst coverage first; a finished category sorts to the back whatever its coverage.
+
+    Extracted so the ordering can be tested against a corpus the test builds. Asserting it on
+    the real corpus needs at least one unfinished category, and a test that needs work left to
+    do fails the moment the work is finished - which is what happened here.
+    """
+    return sorted(rows, key=lambda r: (r["done"] >= r["products"], r["coverage"], r["category"]))
 
 
 def main() -> int:

--- a/sources/products/arduino-uno-q.yaml
+++ b/sources/products/arduino-uno-q.yaml
@@ -1,13 +1,12 @@
 name: arduino-uno-q
 display_name: Arduino UNO Q
 type: hardware
-description: A hybrid single-board computer in the UNO form factor that pairs a Qualcomm Dragonwing QRB2210
-  quad-core applications processor (Adreno GPU, dual ISP, running Debian Linux) with an STM32U585 microcontroller
-  for real-time control. It targets AI-accelerated vision and sound applications, programmed via the open source
-  Arduino App Lab. Made by Arduino (now a Qualcomm company), it ships in 2GB/16GB and 4GB/32GB variants
-  around EUR 47-65, a low-cost on-ramp to Qualcomm edge-AI silicon for the maker community.
+description: Hybrid single-board computer in the Arduino UNO form factor, pairing a Qualcomm Dragonwing QRB2210
+  quad-core applications processor with an Adreno GPU and dual ISP running Debian Linux, alongside an STM32U585
+  microcontroller for real-time control. It targets AI-accelerated vision and sound applications, is programmed
+  through the Arduino App Lab, and ships in 2GB/16GB and 4GB/32GB variants.
 github:
 - url: https://github.com/arduino
-comments: Verified live 2026-08-14 via primary sources. Board schematics and gerbers are CC-BY-SA 4.0
-  and the App Lab toolchain is published as source (GPL-3.0, with the App Bricks library MPL-2.0), but
-  the QRB2210 SoC remains proprietary silicon needing firmware blobs.
+comments: Made by Arduino, now a Qualcomm company. The openness axis weighs published board design files and
+  toolchain against SoC silicon that requires vendor firmware blobs. Verified 2026-08-14 via the Arduino product
+  page, the App Lab and App Bricks repositories and the UNO Q user manual.

--- a/sources/products/axelera-metis-aipu.yaml
+++ b/sources/products/axelera-metis-aipu.yaml
@@ -1,12 +1,11 @@
 name: axelera-metis-aipu
 display_name: Axelera Metis AIPU
 type: hardware
-description: An edge AI inference accelerator from Axelera AI (Netherlands), built on a quad-core in-memory-compute
-  architecture and sold as M.2 modules, PCIe cards, and an integrated compute board. A single quad-core
-  Metis delivers on the order of 214 TOPS, with PCIe configurations scaling to multiple units. It is paired
-  with the Voyager SDK (100+ models) and targets computer-vision workloads such as multi-channel video
-  analytics and quality inspection.
+description: Edge AI inference accelerator from Axelera AI in the Netherlands, built on a quad-core digital
+  in-memory-compute architecture that performs matrix-vector multiplication in place. A single quad-core Metis
+  delivers on the order of 214 TOPS at about 15 TOPS per watt, sold as M.2 modules, PCIe cards and an integrated
+  compute board, and paired with the Voyager SDK covering more than a hundred models for computer-vision workloads.
 github:
 - url: https://github.com/axelera-ai-hub/voyager-sdk
-comments: Verified live 2026-08-13 via primary sources. Proprietary in-memory-compute silicon with a publicly
-  available Voyager SDK on GitHub and retail purchasing, but board design files are not open.
+comments: The openness axis weighs a publicly released SDK and retail availability against board design files
+  that are not published. Verified 2026-08-13 via the Axelera product site and the voyager-sdk repository.

--- a/sources/products/beagley-ai.yaml
+++ b/sources/products/beagley-ai.yaml
@@ -1,13 +1,12 @@
 name: beagley-ai
 display_name: BeagleY-AI
 type: hardware
-description: An open source single-board computer (SBC) from the BeagleBoard.org Foundation, built around
-  the Texas Instruments AM67A vision processor. It pairs a quad-core Cortex-A53 CPU at 1.4 GHz with a
-  TI C7x deep-learning accelerator subsystem (dual C7x DSP + MMA) rated at up to 4 TOPS, an IMG BXS GPU,
-  and Cortex-R5 real-time cores, with 4GB LPDDR4 and a 40-pin Raspberry Pi-compatible header (~$72). It
-  is OSHWA-certified and targets vision, robotics, and smart cameras.
+description: Open single-board computer from the BeagleBoard.org Foundation built around the Texas Instruments
+  AM67A vision processor. It pairs a quad-core Cortex-A53 at 1.4 GHz with a dual C7x DSP and matrix multiply
+  accelerator rated up to 4 TOPS, an IMG BXS GPU and Cortex-R5 real-time cores, with 4GB LPDDR4 and a 40-pin
+  Raspberry Pi-compatible header. It targets vision, robotics and smart cameras.
 github:
 - url: https://github.com/beagleboard/beagley-ai
-comments: Verified live 2026-08-13 via primary sources. Full board design files published under Creative
-  Commons and OSHWA-certified with an open toolchain and public datasheet, though proprietary AM67A silicon
-  and firmware blobs are a caveat.
+comments: OSHWA-certified with full board design files and a public datasheet; the AM67A silicon and its firmware
+  blobs are the caveat the openness axis weighs. Verified 2026-08-13 via the OSHWA certification record, the
+  beagley-ai repository, the design documentation and the TI product page.

--- a/sources/products/google-coral-dev-board.yaml
+++ b/sources/products/google-coral-dev-board.yaml
@@ -1,16 +1,12 @@
 name: google-coral-dev-board
 display_name: Google Coral Dev Board
 type: hardware
-description: A single-board computer from Google's Coral platform that pairs a removable System-on-Module
-  (NXP i.MX 8M SoC) with a baseboard and integrates Google's Edge TPU ASIC. The Edge TPU delivers 4 TOPS
-  at about 2 TOPS/watt, accelerating int8-quantized TensorFlow Lite models for local inference. It is
-  aimed at prototyping edge AI that can scale to production by reusing the SoM. The Edge TPU is designed
-  and supplied by Google.
+description: Single-board computer from Google's Coral platform, pairing a removable system-on-module built
+  on an NXP i.MX 8M with a baseboard carrying Google's Edge TPU. The Edge TPU delivers 4 TOPS at about 2 TOPS
+  per watt for int8-quantized TensorFlow Lite models, running inference locally, and the module can be reused
+  in a production design.
 github:
 - url: https://github.com/google-coral/libedgetpu
-comments: Verified live 2026-08-14 via primary sources. Public datasheet, baseboard design files
-  (schematic PDF, Altium source and Allegro layout, Apache-2.0) and an open runtime/TFLite path, but the
-  SoM design is withheld and the Edge TPU silicon and model compiler are proprietary closed binaries.
-  The platform is winding down and the score does not yet say so - libedgetpu and every other Edge TPU
-  library were archived read-only, the google-coral issue tracker followed in April 2026, and Seeed
-  marks both board variants Discontinued. Adoption and the retail component are escalated for a ruling.
+comments: 'The platform is winding down: the Edge TPU libraries are archived read-only, the product page redirects
+  to one naming no hardware, and both variants are discontinued at retail. Adoption and retail were resolved
+  on 2026-08-14. Verified 2026-08-14 via the datasheet, the electricals repository and the product page.'

--- a/sources/products/hailo-10h.yaml
+++ b/sources/products/hailo-10h.yaml
@@ -1,16 +1,12 @@
 name: hailo-10h
 display_name: Hailo-10H
 type: hardware
-description: Hailo's generative-AI edge accelerator, offered as an M.2 module and as a chip, delivering
-  40 TOPS at INT4 and 20 TOPS at INT8 with ~2.5W typical power. Unlike the Hailo-8, it adds a direct DDR
-  interface so it can run LLMs and vision-language models (VLMs) on-device. It targets PCs, automotive,
-  and edge devices needing local generative AI, supported by Hailo's software suite and a GenAI model
-  zoo.
+description: Hailo's generative-AI edge accelerator, sold as an M.2 module and as a bare chip, delivering 40
+  TOPS at INT4 and 20 TOPS at INT8 at about 2.5W typical power. Unlike the Hailo-8 it adds a direct DDR interface,
+  so it can run language and vision-language models on-device. It targets PCs, automotive and edge devices
+  needing local generative AI.
 github:
 - url: https://github.com/hailo-ai/hailo_model_zoo_genai
-comments: Verified live 2026-08-14 via substitute sources - hailo.ai answers 403 to every automated
-  request, so the description was re-checked against AAEON/UP's published spec table, which reproduces
-  40 TOPS at INT4 and 20 TOPS at INT8, 2.5W typical, M.2 2280 Key-M, and the direct DDR interface that
-  lets it run LLMs and VLMs on-device, and against Geniatech's independent Hailo-10 module listing.
-  Every claim in the description holds. Proprietary silicon with published datasheets and an open
-  GenAI model zoo, but the silicon and full toolchain are closed.
+comments: hailo.ai answers 403 to every automated request, so the figures above were checked against AAEON's
+  UP Board spec table and Geniatech's independent module listing. Verified 2026-08-14 via those two listings
+  and the GenAI model-zoo repository.

--- a/sources/products/hailo-8.yaml
+++ b/sources/products/hailo-8.yaml
@@ -1,17 +1,13 @@
 name: hailo-8
 display_name: Hailo-8
 type: hardware
-description: An edge AI inference accelerator delivering up to 26 TOPS at roughly 2.5W typical power,
-  built by Hailo Technologies (Israel). It is sold as a bare chip and in M.2, mPCIe, and PCIe card form
-  factors with on-die memory, supporting TensorFlow, TFLite, Keras, PyTorch, and ONNX via the Hailo Dataflow
-  Compiler and HailoRT runtime. It is widely deployed in robotics, ADAS, security cameras, and industrial
-  vision.
+description: Edge AI inference accelerator from Hailo Technologies in Israel, delivering up to 26 TOPS at roughly
+  2.5W typical power. It is sold as a bare chip and in M.2, mPCIe and PCIe card form factors with on-die memory,
+  and supports TensorFlow, TensorFlow Lite, Keras, PyTorch and ONNX through the Hailo Dataflow Compiler and
+  the HailoRT runtime.
 github:
 - url: https://github.com/hailo-ai/hailort
-comments: Verified live 2026-08-14 via substitute sources - hailo.ai answers 403 to every automated
-  request, so the description was re-checked against Geniatech's AIM-M-H8 spec table (26 TOPS INT8,
-  TensorFlow/TFLite/Keras/PyTorch/ONNX, memory by processor integration), Waveshare's listing (2.5W
-  typical, M.2), Hailo's own M.2 data sheet as mirrored by Premio, and the HailoRT and Model Zoo
-  READMEs for the runtime and Dataflow Compiler split. Every claim in the description holds.
-  Proprietary silicon with an open source runtime and public product briefs, but the model-compiler
-  toolchain requires registration and silicon is closed.
+comments: hailo.ai answers 403 to every automated request, so the figures were checked against Geniatech's
+  AIM-M-H8 spec table, Waveshare's listing and Hailo's M.2 datasheet mirrored by Premio. The compiler needs
+  registration while the runtime does not, which the openness axis weighs. Verified 2026-08-14 via those listings
+  and the HailoRT README.

--- a/sources/products/khadas-edge2.yaml
+++ b/sources/products/khadas-edge2.yaml
@@ -1,12 +1,12 @@
 name: khadas-edge2
 display_name: Khadas Edge2
 type: hardware
-description: A credit-card-sized single-board computer (SBC) built around the Rockchip RK3588S2, an 8nm
-  8-core 64-bit ARM SoC with a Mali-G610 MP4 GPU and a built-in NPU rated at 6 TOPS. It ships in Basic
-  (8GB + 32GB eMMC) and Pro (16GB + 64GB eMMC) configurations in a compact fanless design. Made by Khadas
-  (Shenzhen Wesion), it runs Ubuntu and Android with mainline Armbian support.
+description: Credit-card-sized single-board computer built around the Rockchip RK3588S2, an 8nm eight-core
+  64-bit Arm SoC with a Mali-G610 MP4 GPU and a built-in NPU rated at 6 TOPS. It ships in Basic and Pro configurations
+  with 8GB or 16GB of memory and 32GB or 64GB of eMMC in a compact fanless design, running Ubuntu and Android
+  with mainline Armbian support.
 github:
 - url: https://github.com/khadas/fenix
-comments: Verified live 2026-08-13 via primary sources. Khadas publishes versioned board schematics and
-  an open toolchain with mainline Armbian, but proprietary Rockchip silicon and required blobs keep it
-  at open_toolchain.
+comments: Made by Khadas, trading as Shenzhen Wesion. The openness axis weighs versioned board schematics and
+  a published toolchain against Rockchip silicon that requires binary blobs. Verified 2026-08-13 via the Khadas
+  schematics archive, the fenix toolchain repository, the Edge2 product page and the rkbin repository.

--- a/sources/products/memryx-mx3.yaml
+++ b/sources/products/memryx-mx3.yaml
@@ -1,13 +1,12 @@
 name: memryx-mx3
 display_name: MemryX MX3
 type: hardware
-description: An edge AI accelerator from MemryX (USA) built on a dataflow architecture, where each MX3
-  chip provides ~6 TOPS and an M.2 module packs four chips for up to 24 TOPS at roughly 6-8W with passive
-  cooling. The M.2 (2280, M-Key) module uses PCIe Gen3 and supports 4/8/16-bit weights plus BFloat16,
-  with no model-zoo lock-in. Sold at retail (~$149) via Amazon, Mouser, and distributors, it won a 2025
-  Edge AI & Vision Alliance Product of the Year award and is supported by the MemryX SDK and open source
-  tooling.
+description: Edge AI accelerator from MemryX in the United States, built on a dataflow architecture where each
+  MX3 chip provides about 6 TOPS and an M.2 2280 M-key module packs four of them for up to 24 TOPS at roughly
+  6 to 8 watts with passive cooling. It connects over PCIe Gen3 and supports 4, 8 and 16-bit weights alongside
+  BFloat16, with no model-zoo lock-in.
 github:
 - url: https://github.com/memryx/MxAccl
-comments: Verified live 2026-08-13 via primary sources. Proprietary dataflow silicon with public datasheets,
-  retail availability, and several open source runtime/driver repos, though the compiler core is closed.
+comments: The openness axis weighs public datasheets and several released runtime and driver repositories against
+  a closed compiler core. Verified 2026-08-13 via the M.2 datasheet, the MxAccl repository and Tom's Hardware's
+  launch coverage.

--- a/sources/products/nvidia-jetson-agx-orin.yaml
+++ b/sources/products/nvidia-jetson-agx-orin.yaml
@@ -1,11 +1,12 @@
 name: nvidia-jetson-agx-orin
 display_name: NVIDIA Jetson AGX Orin
 type: hardware
-description: NVIDIA's high-end edge-AI system-on-module (SoM), delivering up to 275 TOPS via a 2048-core
-  Ampere GPU with 64 Tensor Cores and a 12-core Arm Cortex-A78AE CPU. It ships in 32GB and 64GB LPDDR5
-  variants on a 699-pin module. Made by NVIDIA, it is the flagship Jetson module for robotics and autonomous
-  machines, able to run large LLMs/VLMs at the edge.
+description: NVIDIA's high-end edge-AI system-on-module, delivering up to 275 TOPS from a 2048-core Ampere
+  GPU with 64 tensor cores alongside a 12-core Arm Cortex-A78AE CPU. It ships in 32GB and 64GB LPDDR5 variants
+  on a 699-pin module, and is the flagship Jetson part for robotics and autonomous machines, able to run large
+  language and vision-language models at the edge.
 github:
 - url: https://github.com/OE4T/meta-tegra
-comments: Verified live 2026-08-13 via primary sources. Public datasheets and commercially purchasable,
-  but SDK relies on proprietary NVIDIA blobs under license, placing it in the documented tier.
+comments: The openness axis weighs public datasheets and commercial availability against an SDK that requires
+  NVIDIA-supplied binary drivers. Verified 2026-08-13 via the Jetson Orin product page and the Jetson Linux
+  developer page.

--- a/sources/products/nvidia-jetson-orin-nano-super-developer-kit.yaml
+++ b/sources/products/nvidia-jetson-orin-nano-super-developer-kit.yaml
@@ -1,13 +1,12 @@
 name: nvidia-jetson-orin-nano-super-developer-kit
 display_name: NVIDIA Jetson Orin Nano Super Developer Kit
 type: hardware
-description: An entry-level edge-AI developer kit pairing the Jetson Orin Nano 8GB module with a carrier
-  board; the 'Super' mode boosts it to 67 INT8 (sparse) TOPS. It uses an Ampere GPU with 1024 CUDA cores
-  and 32 Tensor Cores, a 6-core Arm Cortex-A78AE CPU, and 8GB LPDDR5. Made by NVIDIA, it was repriced
-  to $249 and is the cheapest on-ramp into the CUDA/Jetson generative-AI ecosystem, capable of running
-  small LLMs and VLMs locally.
+description: Entry-level edge-AI developer kit pairing an 8GB Jetson Orin Nano module with a carrier board,
+  where the Super mode raises throughput to 67 sparse INT8 TOPS. It uses an Ampere GPU with 1024 CUDA cores
+  and 32 tensor cores, a 6-core Arm Cortex-A78AE CPU and 8GB of LPDDR5, and runs small language and vision-language
+  models locally.
 github:
 - url: https://github.com/OE4T/meta-tegra
-comments: Verified live 2026-08-13 via primary sources. Public datasheets and globally purchasable, but
-  the SDK requires proprietary NVIDIA drivers/blobs under license, so it sits in the documented tier despite
-  the community OE4T BSP.
+comments: The openness axis weighs public datasheets and global availability against an SDK that requires NVIDIA-supplied
+  binary drivers, notwithstanding the community OE4T board support package. Verified 2026-08-13 via the developer-kit
+  page, the Jetson Orin product page and the Jetson Linux developer page.

--- a/sources/products/nvidia-jetson-orin-nx.yaml
+++ b/sources/products/nvidia-jetson-orin-nx.yaml
@@ -1,11 +1,12 @@
 name: nvidia-jetson-orin-nx
 display_name: NVIDIA Jetson Orin NX
 type: hardware
-description: A compact mid-range edge-AI system-on-module (SoM) in a 260-pin SO-DIMM form factor, delivering
-  up to 157 TOPS via a 1792-core Ampere GPU with 56 Tensor Cores and an 8-core Arm Cortex-A78AE CPU. It
-  comes in 8GB and 16GB LPDDR5 variants. Made by NVIDIA, it slots between the Orin Nano and AGX Orin and
-  is widely used in drones, cameras, and compact robotics for local LLM/vision workloads.
+description: Compact mid-range edge-AI system-on-module in a 260-pin SO-DIMM form factor, delivering up to
+  157 TOPS from a 1792-core Ampere GPU with 56 tensor cores and an 8-core Arm Cortex-A78AE CPU. It ships in
+  8GB and 16GB LPDDR5 variants and sits between the Orin Nano and AGX Orin, used in drones, cameras and compact
+  robotics.
 github:
 - url: https://github.com/OE4T/meta-tegra
-comments: Verified live 2026-08-13 via primary sources. Public datasheets and purchasable through distributors,
-  but the SDK depends on proprietary NVIDIA blobs under license.
+comments: The openness axis weighs public datasheets and distributor availability against an SDK that requires
+  NVIDIA-supplied binary drivers. Verified 2026-08-13 via the Jetson Orin product page and the Jetson Linux
+  developer page.

--- a/sources/products/nxp-imx-8m-plus.yaml
+++ b/sources/products/nxp-imx-8m-plus.yaml
@@ -1,15 +1,10 @@
 name: nxp-imx-8m-plus
 display_name: NXP i.MX 8M Plus
 type: hardware
-description: An NXP applications processor family with up to a quad Arm Cortex-A53 CPU, a Cortex-M7 real-time
-  core, and an integrated NPU delivering up to 2.3 TOPS for on-device ML and vision. It includes dual
-  ISPs and two camera inputs and targets smart home, building, city, and Industry 4.0 use cases. NXP provides
-  a Linux/Yocto BSP and public datasheets, and the part is commercially available with SoM options from
-  ADLINK, Toradex, and SolidRun.
-comments: Verified live 2026-08-14 via substitute sources - www.nxp.com answers 404 to every automated
-  request including its own root, so the description was re-checked against NXP's own IMX8MPCEC
-  datasheet as mirrored openly by DigiKey, which carries the quad Cortex-A53 at up to 1.8 GHz, the
-  800 MHz Cortex-M7, the 2.3 TOPS NPU and the dual-ISP two-camera vision engine, and against NXP's
-  meta-imx Yocto BSP repo and Toradex's Verdin module for the BSP and SoM-availability claims. Every
-  claim in the description holds. Public datasheets and a Linux BSP with broad commercial
-  availability, but proprietary silicon with no open board files.
+description: NXP applications processor family with up to a quad Arm Cortex-A53 at 1.8 GHz, an 800 MHz Cortex-M7
+  real-time core and an integrated NPU delivering up to 2.3 TOPS for on-device machine learning and vision.
+  It carries dual image signal processors and two camera inputs, and targets smart home, building, city and
+  industrial applications, with module options from ADLINK, Toradex and SolidRun.
+comments: nxp.com answers 404 to every automated request including its own root, so the figures were checked
+  against NXP's IMX8MPCEC datasheet as mirrored by DigiKey, its meta-imx Yocto layer and Toradex's Verdin module
+  page. Verified 2026-08-14 via those three.

--- a/sources/products/orange-pi-5.yaml
+++ b/sources/products/orange-pi-5.yaml
@@ -1,13 +1,11 @@
 name: orange-pi-5
 display_name: Orange Pi 5
 type: hardware
-description: A single-board computer (SBC) built around the Rockchip RK3588S SoC, an 8-core 64-bit ARM processor
-  (4x Cortex-A76 + 4x Cortex-A55) with a Mali-G610 GPU and a built-in NPU rated at 6 TOPS. It ships in 4/8/16GB
-  LPDDR4/4X configurations and is made by Orange Pi (Shenzhen Xunlong). Widely sold at retail for roughly $69-$115,
-  it supports Android 12, Debian, Ubuntu, and Orange Pi OS, and is among the more widely available RK3588S
-  edge-AI boards.
+description: Single-board computer built around the Rockchip RK3588S, an eight-core 64-bit Arm processor pairing
+  four Cortex-A76 with four Cortex-A55, a Mali-G610 GPU and a built-in NPU rated at 6 TOPS. It ships in 4GB,
+  8GB and 16GB LPDDR4 and LPDDR4X configurations and runs Android, Debian, Ubuntu and Orange Pi OS.
 github:
 - url: https://github.com/orangepi-xunlong/orangepi-build
-comments: Verified live 2026-08-13 via primary sources. Proprietary Rockchip silicon with an open GPL-2.0
-  BSP, public datasheet and schematics, and global retail availability, but bootable images depend on
-  Rockchip firmware blobs.
+comments: Made by Orange Pi, trading as Shenzhen Xunlong. The openness axis weighs a published board support
+  package, datasheet and schematics against bootable images that depend on Rockchip firmware binaries. Verified
+  2026-08-13 via the Orange Pi 5 product and support pages, the orangepi-build repository and the rkbin repository.

--- a/sources/products/qualcomm-dragonwing-rb3-gen-2.yaml
+++ b/sources/products/qualcomm-dragonwing-rb3-gen-2.yaml
@@ -1,16 +1,10 @@
 name: qualcomm-dragonwing-rb3-gen-2
 display_name: Qualcomm Dragonwing RB3 Gen 2 Development Kit
 type: hardware
-description: A Qualcomm edge AI and IoT development kit built around the QCS6490 SoC (Kryo 670 CPU, Adreno
-  643L GPU, Hexagon NPU) delivering up to 12 dense TOPS, with a QCS5430 variant also offered. It follows
-  the modular 96Boards form factor and ships with a Qualcomm Linux software stack plus Qualcomm AI Hub,
-  Edge Impulse, and Foundries.io support. It is a reference platform for prototyping commercial edge-AI
-  products on Qualcomm silicon.
-comments: Verified live 2026-08-14 via substitute sources - www.qualcomm.com serves a client-rendered
-  shell to a fetcher, so the description was re-checked against Qualcomm's own product brief 87-74789-1
-  Rev. A on docs.qualcomm.com, which carries the QCS6490 chipset, Kryo 670 CPU, Adreno 643L GPU, 12
-  TOPS AI, 96Boards mezzanine compliance and the Linux/Android SDK stack, and against Edge Impulse's
-  board page for the Edge Impulse support claim. Two clauses were NOT re-derived and rest on the
-  earlier read - the QCS5430 variant and Foundries.io support appear in neither substitute.
-  Proprietary Qualcomm silicon with public docs and a Linux SDK, sold through distributors, but the
-  board itself is not fully open hardware.
+description: Qualcomm edge AI and IoT development kit built around the QCS6490 SoC, pairing a Kryo 670 CPU,
+  an Adreno 643L GPU and a Hexagon NPU for up to 12 dense TOPS. It follows the modular 96Boards form factor
+  and ships with a Qualcomm Linux and Android SDK stack, with support in Qualcomm AI Hub and Edge Impulse.
+  It is a reference platform for prototyping commercial edge-AI products.
+comments: qualcomm.com serves a client-rendered shell to a fetcher, so the figures were checked against Qualcomm's
+  own product brief and Edge Impulse's board page. Two earlier clauses, a QCS5430 variant and Foundries.io
+  support, appear in neither and were dropped. Verified 2026-08-14 via those two.

--- a/sources/products/radxa-rock-5b.yaml
+++ b/sources/products/radxa-rock-5b.yaml
@@ -1,13 +1,11 @@
 name: radxa-rock-5b
 display_name: Radxa ROCK 5B
 type: hardware
-description: A single-board computer (SBC) built on the Rockchip RK3588 SoC, pairing a quad-core Cortex-A76
-  (up to 2.4 GHz) with a quad-core Cortex-A55 and a built-in 6 TOPS NPU, in a 100 x 75 mm form factor. It is
-  offered in 4/8/16GB LPDDR4X (ROCK 5B) and up to 32GB LPDDR5 (ROCK 5B+). Made by Radxa, which publishes complete
-  hardware design schematics and software source, it is one of the more widely available high-end RK3588 maker
-  boards.
+description: Single-board computer built on the Rockchip RK3588, pairing a quad-core Cortex-A76 at up to 2.4
+  GHz with a quad-core Cortex-A55 and a built-in 6 TOPS NPU, in a 100 by 75 millimetre form factor. It is offered
+  with 4GB to 16GB of LPDDR4X, and up to 32GB of LPDDR5 on the Plus variant.
 github:
 - url: https://github.com/radxa-repo/bsp
-comments: Verified live 2026-08-13 via primary sources. Schematics and mechanical files are publicly downloadable
-  and the BSP is open, but the RK3588 needs proprietary Rockchip blobs and editable PCB source is not
-  released.
+comments: Made by Radxa. The openness axis weighs downloadable schematics, mechanical files and a published
+  board support package against Rockchip binaries and editable PCB source that is not released. Verified 2026-08-13
+  via the Radxa download and introduction pages, the radxa-repo/bsp repository and the rkbin repository.

--- a/sources/products/raspberry-pi-5.yaml
+++ b/sources/products/raspberry-pi-5.yaml
@@ -1,12 +1,10 @@
 name: raspberry-pi-5
 display_name: Raspberry Pi 5
 type: hardware
-description: A credit-card-sized single-board computer (SBC) built on the Broadcom BCM2712 SoC with a 2.4GHz
-  quad-core Arm Cortex-A76 CPU and VideoCore VII GPU, offered with 1/2/4/8/16GB LPDDR4X RAM. It has no dedicated
-  NPU, so on-device AI runs on the CPU/GPU or via add-on accelerators (e.g. the AI HAT+). Made by Raspberry
-  Pi, it is a common reference platform for community edge-AI projects.
-comments: Verified live 2026-08-14 via primary sources. Runs an open Linux kernel tree
-  (github.com/raspberrypi/linux) and ships public datasheets, globally purchasable, though no schematic
-  is published for the Pi 5 - only a mechanical drawing and STEP files - and some firmware remains closed. No representative GitHub artifact is
-  declared; the product is hardware, and the kernel fork is a general-purpose OS mirror whose commit and
-  contributor signal is unrelated to the board as an AI platform (tracked in issue 54).
+description: Credit-card-sized single-board computer built on the Broadcom BCM2712, with a 2.4 GHz quad-core
+  Arm Cortex-A76 and a VideoCore VII GPU, offered with 1GB to 16GB of LPDDR4X. It carries no dedicated NPU,
+  so on-device inference runs on the CPU and GPU or through an add-on accelerator such as the AI HAT+.
+comments: No schematic is published for the Pi 5, only a mechanical drawing, and some firmware stays closed.
+  No representative GitHub artifact is declared, because the kernel fork is a general-purpose OS mirror whose
+  activity says nothing about the board as an AI platform. Verified 2026-08-14 via the product brief, the mechanical
+  drawing and the firmware README.

--- a/sources/products/raspberry-pi-ai-hat-plus.yaml
+++ b/sources/products/raspberry-pi-ai-hat-plus.yaml
@@ -1,14 +1,12 @@
 name: raspberry-pi-ai-hat-plus
 display_name: Raspberry Pi AI HAT+
 type: hardware
-description: 'An AI accelerator HAT+ add-on board for the Raspberry Pi 5 that integrates a Hailo neural-network
-  accelerator: the 13 TOPS Hailo-8L or the 26 TOPS Hailo-8 variant. It conforms to the Raspberry Pi HAT+
-  specification, connects over PCIe, and integrates with the Pi camera stack for tasks like object detection
-  and segmentation. Made by Raspberry Pi (silicon by Hailo); it is the official first-party way to add
-  meaningful NPU compute to a Pi 5.'
+description: Accelerator add-on board for the Raspberry Pi 5 that integrates a Hailo neural-network accelerator,
+  in a 13 TOPS Hailo-8L variant and a 26 TOPS Hailo-8 variant. It conforms to the Raspberry Pi HAT+ specification,
+  connects over PCIe and integrates with the Pi camera stack for object detection and segmentation. Raspberry
+  Pi makes the board; Hailo supplies the silicon.
 github:
 - url: https://github.com/raspberrypi/hailort
-comments: Verified live 2026-08-14 via primary sources. Officially supported open Pi software stack and
-  a public product brief, globally purchasable, but the underlying Hailo model-compiler toolchain is registration-gated.
-  Read against Raspberry Pi's own AI HAT+ product brief and HAT+ Specification on datasheets.raspberrypi.com
-  rather than the product page, which answers 403 to every automated request.
+comments: The Raspberry Pi product page answers 403 to every automated request, so the record was read against
+  Raspberry Pi's own AI HAT+ product brief and HAT+ specification. The Hailo model-compiler toolchain is registration-gated,
+  which the openness axis weighs. Verified 2026-08-14 via those two datasheets and the HailoRT README.

--- a/sources/products/rockchip-rk3588.yaml
+++ b/sources/products/rockchip-rk3588.yaml
@@ -1,13 +1,12 @@
 name: rockchip-rk3588
 display_name: Rockchip RK3588
 type: hardware
-description: An application-processor SoC/chipset (not a board) made by Fuzhou Rockchip. It is an octa-core
-  ARM SoC pairing 4x Cortex-A76 with 4x Cortex-A55, a Mali-G610 MC4 GPU, and a 6 TOPS triple-core NPU supporting
-  INT4/INT8/INT16/FP16/BF16/TF32, with LPDDR4x/LPDDR5 up to 32GB and PCIe 3.0. It is the chipset behind a broad
-  range of edge/SBC products (Orange Pi 5, Radxa Rock 5B, Khadas Edge2), making it a widely used high-end ARM
-  SBC SoC of its generation.
+description: Application-processor SoC from Fuzhou Rockchip rather than a board. It is an octa-core Arm design
+  pairing four Cortex-A76 with four Cortex-A55, a Mali-G610 MC4 GPU and a 6 TOPS triple-core NPU supporting
+  INT4, INT8, INT16, FP16, BF16 and TF32, with up to 32GB of LPDDR4X or LPDDR5 and PCIe 3.0. It is the silicon
+  behind boards including Orange Pi 5, Radxa Rock 5B and Khadas Edge2.
 github:
 - url: https://github.com/airockchip/rknn-toolkit2
-comments: Verified live 2026-08-13 via primary sources. Documentation is unusually open (full TRM and
-  datasheet public) and the RKNN toolkit is openly distributed, but the SDK ships as prebuilt binaries
-  under a proprietary license with closed firmware.
+comments: Documentation is unusually complete for this class, with a public technical reference manual and
+  datasheet, while the SDK ships as prebuilt binaries and the firmware stays closed. Verified 2026-08-13 via
+  the Rockchip brief datasheet, the product page, the rknn-toolkit2 repository and the rkbin repository.

--- a/sources/products/sipeed-maixcam.yaml
+++ b/sources/products/sipeed-maixcam.yaml
@@ -1,12 +1,11 @@
 name: sipeed-maixcam
 display_name: Sipeed MaixCAM
 type: hardware
-description: A compact AI vision and audio dev board built around the SOPHGO SG2002 SoC (a 1 GHz RISC-V
-  C906 big core plus a 700 MHz small core) with a 1 TOPS INT8 NPU that also supports BF16 models, 256MB
-  DDR3, a 2.3-inch IPS touchscreen, and dual MIPI-CSI camera input. It is programmed via the open source
-  MaixPy (Python) and MaixCDK (C/C++) SDKs and sold through Taobao/AliExpress. It matters as an ultra-low-cost
-  RISC-V edge-AI vision module with strong open tooling.
+description: Compact AI vision and audio development board built around the SOPHGO SG2002, pairing a 1 GHz
+  RISC-V C906 core with a 700 MHz companion core and a 1 TOPS INT8 NPU that also runs BF16 models. It carries
+  256MB of DDR3, a 2.3-inch IPS touchscreen and dual MIPI-CSI camera inputs, and is programmed through the
+  MaixPy and MaixCDK SDKs.
 github:
 - url: https://github.com/sipeed/MaixPy
-comments: Verified live 2026-08-13 via primary sources. Open Apache-2.0 SDKs, public schematics/datasheets,
-  and global retail availability, though the SG2002 silicon itself is proprietary.
+comments: The openness axis weighs published SDKs, schematics and datasheets against the SG2002 silicon itself.
+  Verified 2026-08-13 via the Sipeed MaixCam wiki page and the MaixPy repository.

--- a/sources/products/ti-am67a.yaml
+++ b/sources/products/ti-am67a.yaml
@@ -1,12 +1,12 @@
 name: ti-am67a
 display_name: Texas Instruments AM67A
 type: hardware
-description: A Texas Instruments edge-AI vision SoC built on a quad Arm Cortex-A53 CPU at 1.4 GHz plus
-  dual C7x DSP cores with Matrix Multiply Accelerators delivering 4 TOPS of deep-learning performance.
-  On 16nm FinFET, it integrates a multi-camera ISP (up to 4 CSI-2 inputs), PCIe Gen3, and Gigabit Ethernet
-  with TSN, supporting up to 8GB LPDDR4. It is supported by TI's Processor SDK and Edge AI Studio and
-  is the chip behind the BeagleY-AI SBC.
+description: Texas Instruments edge-AI vision SoC on a 16nm FinFET process, pairing a quad Arm Cortex-A53 at
+  1.4 GHz with dual C7x DSP cores and matrix multiply accelerators delivering 4 TOPS. It integrates a multi-camera
+  image signal processor taking up to four CSI-2 inputs, PCIe Gen3 and Gigabit Ethernet with TSN, and supports
+  up to 8GB of LPDDR4. It is the silicon behind the BeagleY-AI board.
 github:
 - url: https://github.com/TexasInstruments/edgeai-tidl-tools
-comments: Verified live 2026-08-13 via primary sources. Public datasheet and open SDK/TIDL tools on GitHub,
-  commercially active, but proprietary silicon and firmware keep it short of fully open hardware.
+comments: Supported by TI's Processor SDK and Edge AI Studio. The openness axis weighs a public datasheet and
+  released TIDL tooling against silicon and firmware supplied as binaries. Verified 2026-08-13 via the TI product
+  page, the edgeai-tidl-tools repository and the BeagleY-AI board page.

--- a/sources/provenance/edge_hardware.yaml
+++ b/sources/provenance/edge_hardware.yaml
@@ -1,0 +1,128 @@
+# Prose and provenance closeout for edge_hardware. 20 of 20 ready.
+#
+# This category closes the provenance sweep: with it, all 472 products are canonical and the
+# census reports zero unresolved records.
+#
+# ## The last four `substitute sources` records
+#
+# `hailo-8`, `hailo-10h`, `nxp-imx-8m-plus` and `qualcomm-dragonwing-rb3-gen-2` were the four
+# records pulled out of the class-A rewording in PR #282, because removing `live` from
+# "Verified live <date> via substitute sources" would have promoted a method into canonical
+# form. Each now names the documents actually read, and each says which vendor host refused:
+# hailo.ai answers 403, nxp.com answers 404 to its own root, qualcomm.com serves a
+# client-rendered shell. The substitutes are first-party where possible - NXP's own datasheet
+# mirrored by DigiKey, Qualcomm's own product brief on docs.qualcomm.com - and named as such.
+#
+# `qualcomm-dragonwing-rb3-gen-2` lost two clauses that no substitute could re-derive: a
+# QCS5430 variant and Foundries.io support. Neither appears in any reachable source.
+#
+# ## What came out
+#
+# Retail prices on seven records (EUR 47-65, $72, $70, $149, $249, $69-$115), which move; the
+# openness verdict, which for hardware is the whole substance of the axis; and framing that is
+# not description - "a low-cost on-ramp to Qualcomm edge-AI silicon for the maker community",
+# "the cheapest on-ramp into the CUDA/Jetson generative-AI ecosystem", "it matters as an
+# ultra-low-cost RISC-V edge-AI vision module with strong open tooling", "the official
+# first-party way to add meaningful NPU compute to a Pi 5".
+#
+# What stays is the part specification: TOPS at a named precision, core counts and clocks, GPU
+# and NPU blocks, memory configurations, form factor, process node, interfaces. For a board or
+# a chip that IS the record, and a new revision is a different record.
+#
+# Where the openness reading is genuinely load-bearing, `comments` names the tension without
+# resolving it - published board files and toolchain against silicon that needs vendor firmware
+# blobs; a released runtime against a registration-gated compiler; a public datasheet against
+# an SDK shipped as binaries.
+#
+# ## One record whose platform is ending
+#
+# `google-coral-dev-board`: the Edge TPU libraries are archived read-only, coral.ai's product
+# page redirects to one naming no hardware, and both variants are discontinued at retail. Its
+# adoption level and retail component were both resolved on 2026-08-14; the prose had still
+# said they were "escalated for a ruling", which is the sixth stale-prose instance in the sweep.
+#
+- product: arduino-uno-q
+  resolved_state: canonical
+  verified: '2026-08-14'
+  document: the Arduino product page, the App Lab and App Bricks repositories and the UNO Q user manual
+- product: axelera-metis-aipu
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Axelera product site and the voyager-sdk repository
+- product: beagley-ai
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the OSHWA certification record, the beagley-ai repository, the design documentation and
+    the TI product page
+- product: google-coral-dev-board
+  resolved_state: canonical
+  verified: '2026-08-14'
+  document: the datasheet, the electricals repository and the product page
+- product: hailo-10h
+  resolved_state: canonical
+  verified: '2026-08-14'
+  document: those two listings and the GenAI model-zoo repository
+- product: hailo-8
+  resolved_state: canonical
+  verified: '2026-08-14'
+  document: those listings and the HailoRT README
+- product: khadas-edge2
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Khadas schematics archive, the fenix toolchain repository, the Edge2 product page
+    and the rkbin repository
+- product: memryx-mx3
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the M
+- product: nvidia-jetson-agx-orin
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Jetson Orin product page and the Jetson Linux developer page
+- product: nvidia-jetson-orin-nano-super-developer-kit
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the developer-kit page, the Jetson Orin product page and the Jetson Linux developer page
+- product: nvidia-jetson-orin-nx
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Jetson Orin product page and the Jetson Linux developer page
+- product: nxp-imx-8m-plus
+  resolved_state: canonical
+  verified: '2026-08-14'
+  document: those three
+- product: orange-pi-5
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Orange Pi 5 product and support pages, the orangepi-build repository and the rkbin
+    repository
+- product: qualcomm-dragonwing-rb3-gen-2
+  resolved_state: canonical
+  verified: '2026-08-14'
+  document: those two
+- product: radxa-rock-5b
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Radxa download and introduction pages, the radxa-repo/bsp repository and the rkbin
+    repository
+- product: raspberry-pi-5
+  resolved_state: canonical
+  verified: '2026-08-14'
+  document: the product brief, the mechanical drawing and the firmware README
+- product: raspberry-pi-ai-hat-plus
+  resolved_state: canonical
+  verified: '2026-08-14'
+  document: those two datasheets and the HailoRT README
+- product: rockchip-rk3588
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Rockchip brief datasheet, the product page, the rknn-toolkit2 repository and the rkbin
+    repository
+- product: sipeed-maixcam
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Sipeed MaixCam wiki page and the MaixPy repository
+- product: ti-am67a
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the TI product page, the edgeai-tidl-tools repository and the BeagleY-AI board page

--- a/tests/test_sweep_status.py
+++ b/tests/test_sweep_status.py
@@ -72,14 +72,36 @@ def test_an_undated_axis_is_open():
 
 
 def test_the_real_corpus_surveys_and_orders_worst_coverage_first():
+    """The ordering invariant, which holds at every state of the sweep including finished.
+
+    This used to assert `pending`, with the message "the sweep is not finished, so something
+    must be pending" - which made completing the sweep a test failure. It is the fifth test in
+    this repository to fail because the work succeeded, so the rule is now explicit: a
+    real-corpus test may assert an INVARIANT, never that there is work left to do. The
+    non-empty ordering case is proved below on a corpus the test builds.
+    """
     rows = survey()
     assert len(rows) == 16
     assert sum(r["products"] for r in rows) == 472
-    pending = [r for r in rows if r["done"] < r["products"]]
-    assert pending, "the sweep is not finished, so something must be pending"
     # Finished categories sort last whatever their coverage; among the rest, worst first.
     coverages = [r["coverage"] for r in rows if r["done"] < r["products"]]
     assert coverages == sorted(coverages), "pending categories must be worst-coverage first"
+    assert all(r["done"] <= r["products"] for r in rows)
+
+
+def test_pending_categories_sort_worst_coverage_first_and_finished_ones_last():
+    """The ordering with something to order, on a synthetic survey."""
+    from build.sweep_status import order_rows
+
+    rows = [
+        {"category": "finished", "products": 3, "done": 3, "coverage": 1.0},
+        {"category": "mid", "products": 4, "done": 2, "coverage": 0.5},
+        {"category": "worst", "products": 4, "done": 1, "coverage": 0.25},
+        {"category": "best-pending", "products": 4, "done": 3, "coverage": 0.75},
+    ]
+    assert [r["category"] for r in order_rows(rows)] == [
+        "worst", "mid", "best-pending", "finished"
+    ]
 
 
 # --- the refresh window ---


### PR DESCRIPTION
**20 of 20 ready — and with this category, all 472 products are canonical.** `build.prose_provenance` now reports `unresolved 0`; `build.sweep_status` reports *every category is finished*.

## The last four `substitute sources` records

`hailo-8`, `hailo-10h`, `nxp-imx-8m-plus` and `qualcomm-dragonwing-rb3-gen-2` were the four records pulled out of the class-A rewording in #282, because dropping `live` from *"Verified live \<date\> via substitute sources"* would have promoted a **method** into canonical form.

Each now names the documents actually read, and says which vendor host refused: `hailo.ai` answers 403, `nxp.com` answers 404 to its own root, `qualcomm.com` serves a client-rendered shell. The substitutes are first-party wherever possible — NXP's own `IMX8MPCEC` datasheet mirrored by DigiKey, Qualcomm's own product brief on `docs.qualcomm.com` — and named as such.

`qualcomm-dragonwing-rb3-gen-2` lost two clauses no substitute could re-derive: a QCS5430 variant and Foundries.io support. Neither appears in any reachable source.

## What came out

Retail prices on seven records (EUR 47–65, $72, $70, $149, $249, $69–$115), which move. The openness verdict, which for hardware is the whole substance of the axis. And framing that is not description — "a low-cost on-ramp to Qualcomm edge-AI silicon for the maker community", "the cheapest on-ramp into the CUDA/Jetson generative-AI ecosystem", "it matters as an ultra-low-cost RISC-V edge-AI vision module with strong open tooling", "the official first-party way to add meaningful NPU compute to a Pi 5".

What stays is the part specification: TOPS at a named precision, core counts and clocks, GPU and NPU blocks, memory configurations, form factor, process node, interfaces. For a board or a chip that *is* the record.

Where the openness reading is load-bearing, `comments` names the tension without resolving it — published board files and toolchain against silicon needing vendor firmware blobs; a released runtime against a registration-gated compiler; a public datasheet against an SDK shipped as binaries.

## A platform that is ending

`google-coral-dev-board` — Edge TPU libraries archived read-only, `coral.ai`'s product page redirecting to one naming no hardware, both variants discontinued at retail. Its adoption level and retail component were **both resolved on 2026-08-14**; the prose still said they were "escalated for a ruling". Sixth stale-prose instance in the sweep.

## A fifth test that failed because the work succeeded

```
assert pending, "the sweep is not finished, so something must be pending"
```

`test_the_real_corpus_surveys_and_orders_worst_coverage_first` required at least one unfinished category. Finishing the last one broke it.

The rule is now written into the test: **a real-corpus test may assert an invariant, never that there is work left to do.** The ordering rule moved to a synthetic survey, which needed `sweep_status.order_rows` extracted from an inline `rows.sort` — three lines, and the smallest change that makes the behaviour testable without depending on corpus state.

## Verification

`validate`, `check_verification`, `check_capability`, `check_recipe`, `check_adoption --strict` clean. `check_freshness --category edge_hardware`: *all 60 axes carry a real last_verified*. 664 tests, no skips.

**Corpus: 415/472 prose-compliant · 472/472 canonical · 1,407/1,416 axes confirmed · 9 held.**
