### PR TITLE
Refresh telemetry_observability: 26/26

### DIFF
--- a/sources/products/agenta.yaml
+++ b/sources/products/agenta.yaml
@@ -1,14 +1,15 @@
 name: agenta
 display_name: Agenta
 type: software
-description: Open-source LLMOps platform combining prompt playground, prompt management, LLM evaluation,
-  and observability in a single tool. Covers the full lifecycle from prompt engineering through production
-  monitoring. Self-hostable with a cloud option. 4.1K GitHub stars.
+description: Multiplayer workspace for building and running agents without writing code, where a team builds
+  an agent by chatting with it. Each agent gets a shared folder, reusable skills and an isolated sandbox, with
+  more than a thousand integrations reachable directly or over MCP, human approval and permissions, and background
+  agents on a schedule or an event trigger. Tracing covers every model and tool call.
 github:
 - url: https://github.com/Agenta-AI/agenta
 pypi:
 - url: https://pypi.org/project/agenta
-comments: The repository has repositioned since this entry was scored - the README now describes an
-  open-source workspace for building agents that automate work, not an LLMOps prompt/eval platform. The
-  description above and the capability score both predate that and are flagged for review rather than
-  rewritten here. Verified 2026-08-13 via the Agenta-AI/agenta repository.
+comments: 'Agenta 2.0 repositioned from an LLMOps prompt and evaluation platform to an agent workspace; capability
+  was re-scored on 2026-08-14 with its peer anchor removed rather than repointed. The open question is placement,
+  not the band: this sits closer to orchestration_agents than to telemetry. Verified 2026-08-14 via the Agenta
+  documentation and repository.'

--- a/sources/products/agentops.yaml
+++ b/sources/products/agentops.yaml
@@ -1,13 +1,13 @@
 name: agentops
 display_name: AgentOps
 type: software
-description: Python SDK for AI agent monitoring, LLM cost tracking, and benchmarking. Purpose-built for
-  the agent era, tracks multi-step agent sessions, tool calls, and costs across frameworks (CrewAI, Agno,
-  OpenAI Agents SDK, LangChain, Autogen). Lightweight instrumentation with two-line setup, and a
-  self-hostable dashboard and API backend alongside the hosted app.
+description: Python SDK for AI agent monitoring, LLM cost tracking, and benchmarking. Purpose-built for the
+  agent era, tracks multi-step agent sessions, tool calls, and costs across frameworks (CrewAI, Agno, OpenAI
+  Agents SDK, LangChain, Autogen). Lightweight instrumentation with two-line setup, and a self-hostable dashboard
+  and API backend alongside the hosted app.
 github:
 - url: https://github.com/AgentOps-AI/agentops
 pypi:
 - url: https://pypi.org/project/agentops
-comments: The README calls the app MIT while app/LICENSE is the Elastic License 2.0; the openness score
-  follows the LICENSE file. Verified 2026-08-13 via the AgentOps-AI/agentops repository and its README.
+comments: The README and the application's own license file disagree about the terms; the openness axis follows
+  the license file. Verified 2026-08-13 via the AgentOps-AI/agentops repository and its README.

--- a/sources/products/arize.yaml
+++ b/sources/products/arize.yaml
@@ -1,10 +1,9 @@
 name: arize
 display_name: Arize
 type: software
-description: Cloud-native ML and LLM observability platform (the commercial offering complementing the
-  open source Phoenix). Production monitoring for model performance, data drift, embedding drift, and
-  LLM traces at enterprise scale. Supports real-time alerting and root cause analysis, an embedded AI
-  engineering agent called Alyx, and a GenAI datastore called adb. The closed counterpart to Phoenix,
-  built by the same team.
-comments: The scored entity is Arize AX, the managed platform, not the separate open source Phoenix.
-  Verified 2026-08-13 via arize.com.
+description: Cloud-native ML and LLM observability platform for production monitoring of model performance,
+  data drift, embedding drift and LLM traces at enterprise scale. It offers real-time alerting and root-cause
+  analysis, an embedded AI engineering agent called Alyx, and a GenAI datastore called adb. It is built by
+  the same team as Phoenix.
+comments: The scored entity is Arize AX, the managed platform, and Phoenix is a separate record. Verified 2026-08-13
+  via arize.com.

--- a/sources/products/azure-ai-foundry-observability.yaml
+++ b/sources/products/azure-ai-foundry-observability.yaml
@@ -1,15 +1,11 @@
 name: azure-ai-foundry-observability
 display_name: Azure AI Foundry Observability
 type: software
-description: Microsoft's GenAI observability product inside Azure AI Foundry (rebranded to Microsoft Foundry
-  in 2026), providing evaluations, distributed tracing, production monitoring, and content-safety logs
-  for LLM apps and agents. Built on OpenTelemetry and integrated with Azure Monitor Application Insights,
-  with built-in evaluators covering quality (coherence, fluency), RAG (groundedness, relevance), safety
-  (hate/unfairness, violence, protected materials), and agent-specific metrics (tool-call accuracy, task
-  completion). Supports tracing for LangChain, LangGraph, OpenAI Agents SDK, and the Microsoft Agent Framework.
-  Microsoft describes it as three core capabilities - evaluation, monitoring and tracing - working together
-  across the AI application lifecycle, and it is the default observability layer for Azure-hosted GenAI
-  workloads.
+description: Microsoft's GenAI observability surface inside Microsoft Foundry, providing evaluation, monitoring
+  and tracing for LLM applications and agents. It is built on OpenTelemetry and feeds Azure Monitor Application
+  Insights, with built-in evaluators for quality, RAG groundedness and relevance, safety, and agent-specific
+  measures such as tool-call accuracy and task completion. Tracing covers LangChain, LangGraph, the OpenAI
+  Agents SDK and the Microsoft Agent Framework.
 comments: Microsoft publishes no usage figure for this surface, so its adoption band leans on the reach of
-  Microsoft Foundry rather than on a measurement of the surface. Verified 2026-08-13 via the Microsoft
-  Learn observability concept page.
+  Microsoft Foundry rather than on a measurement of the surface. Verified 2026-08-13 via the Microsoft Learn
+  observability concept page.

--- a/sources/products/braintrust.yaml
+++ b/sources/products/braintrust.yaml
@@ -1,11 +1,9 @@
 name: braintrust
 display_name: Braintrust
 type: software
-description: Enterprise AI product development platform with logging, tracing, evaluation, and prompt
-  playground. Focuses on the eval-to-production workflow, iterate on prompts, evaluate with custom scorers,
-  deploy with confidence, monitor in production. Automates pattern discovery across production traffic,
-  scores outputs continuously, and blocks bad releases with quality gates. Runs on Brainstore, a purpose-built
-  database for agent observability, and is SOC 2 Type II certified.
-comments: The Apache-2.0 SDK repository is instrumentation only; the platform and its Brainstore backend
-  are closed, and the openness score follows the platform. Verified 2026-08-13 via braintrust.dev and the
-  braintrustdata/braintrust-sdk repository.
+description: Enterprise AI product development platform with logging, tracing, evaluation and a prompt playground,
+  built around the loop from evaluation to production. It discovers patterns across production traffic, scores
+  outputs continuously and gates releases on quality. It runs on Brainstore, a database purpose-built for agent
+  observability, and is SOC 2 Type II certified.
+comments: The published SDK is instrumentation only; the platform and its Brainstore backend are what the openness
+  axis scores. Verified 2026-08-13 via braintrust.dev and the braintrust-sdk repository.

--- a/sources/products/confident-ai.yaml
+++ b/sources/products/confident-ai.yaml
@@ -1,11 +1,11 @@
 name: confident-ai
 display_name: Confident AI
 type: software
-description: Hosted SaaS layered on the open source DeepEval library, adds dataset management, regression
-  tracking, human annotation, custom dashboards, online evals against live traffic, alerting, and incident
-  response. Also covers red teaming against adversarial attacks and AI governance, and gates CI so a build
-  fails when quality drops below a defined threshold. Self-hosting into a customer VPC or on-prem is an
-  Enterprise-plan option.
-comments: The scored entity is the platform, not the separate Apache-2.0 DeepEval framework, which has its
-  own entry and whose openness is not credited here. Verified 2026-08-13 via confident-ai.com and the
-  confident-ai/deepeval repository.
+description: Hosted platform layered on the DeepEval library, adding dataset management, regression tracking,
+  human annotation, custom dashboards, online evaluations against live traffic, alerting and incident response.
+  It also covers red teaming against adversarial attacks and AI governance, and gates CI so a build fails when
+  quality drops below a defined threshold. Self-hosting into a customer VPC or on-premises is an enterprise
+  option.
+comments: The scored entity is the hosted platform, not the separate DeepEval framework, which has its own
+  record and whose openness is not credited here. Verified 2026-08-13 via confident-ai.com and the confident-ai/deepeval
+  repository.

--- a/sources/products/galileo.yaml
+++ b/sources/products/galileo.yaml
@@ -1,10 +1,9 @@
 name: galileo
 display_name: Galileo
 type: software
-description: AI observability and reliability platform that combines offline evals, online production
-  guardrails, and tracing, powered by their proprietary Luna-2 small judge models that detect hallucinations,
-  tool errors, and policy violations. The vendor's claim for Luna is that customized evals monitor all
-  production traffic at a fraction of LLM-as-judge cost. Deployed as SaaS, in a customer VPC, or on-prem;
-  the platform itself is not published.
-comments: Galileo names no customers and publishes no usage figure, so the adoption band stands on an
-  unquantified vendor claim and is directional. Verified 2026-08-13 via galileo.ai.
+description: AI observability and reliability platform combining offline evaluation, online production guardrails
+  and tracing, driven by the vendor's own Luna-2 small judge models that detect hallucinations, tool errors
+  and policy violations. Galileo's claim for Luna is that customized evaluations can monitor all production
+  traffic at a fraction of the cost of a large judge model. It deploys as SaaS, into a customer VPC, or on-premises.
+comments: Galileo names no customers and publishes no usage figure, so the adoption band stands on an unquantified
+  vendor claim and is directional. Verified 2026-08-13 via galileo.ai.

--- a/sources/products/helicone.yaml
+++ b/sources/products/helicone.yaml
@@ -1,13 +1,12 @@
 name: helicone
 display_name: Helicone
 type: software
-description: LLM proxy that captures logs, costs, and latency with a one-line integration (swap your API
-  base URL). Clean dashboard for monitoring request volumes, token usage, costs, and error rates. Positioned
-  as the lowest-friction entry point for LLM monitoring, no SDK needed, just a proxy URL change. Also an
-  AI gateway reaching 100+ models through one API key, with automatic fallbacks, caching, prompt
-  management and datasets. Self-hostable from the repository, and sold as a hosted cloud alongside.
+description: LLM proxy that captures logs, costs and latency through a one-line change to the API base URL,
+  with a dashboard for request volume, token usage, cost and error rates. It is also an AI gateway reaching
+  more than a hundred models behind one API key, with automatic fallbacks, caching, prompt management and datasets.
+  It runs from the repository or as a hosted service.
 github:
 - url: https://github.com/Helicone/helicone
-comments: The pricing page lists SAML SSO on the Enterprise tier and the repository contains no SSO
-  implementation; that absence is the weakest point in the openness reading and is recorded in the score
-  rather than smoothed over. Verified 2026-08-13 via the Helicone/helicone README.
+comments: The pricing page lists SAML SSO on the Enterprise tier and the repository contains no SSO implementation;
+  that absence is the weakest point in the openness reading and is recorded in the score rather than smoothed
+  over. Verified 2026-08-13 via the Helicone/helicone README.

--- a/sources/products/laminar.yaml
+++ b/sources/products/laminar.yaml
@@ -1,14 +1,13 @@
 name: laminar
 display_name: Laminar
 type: software
-description: Open-source observability platform purpose-built for AI agents. Provides tracing, evaluation,
-  and analytics for agentic workflows with an emphasis on multi-step agent debugging. Rust backend with a
-  TypeScript UI, self-hostable from the repository's docker-compose files, and traces, spans, metrics and
-  events are queryable with SQL.
+description: Observability platform built for AI agents, providing tracing, evaluation and analytics for agentic
+  workflows with an emphasis on debugging multi-step runs. It has a Rust backend and a TypeScript UI, deploys
+  from the repository's docker-compose files, and makes traces, spans, metrics and events queryable with SQL.
 github:
 - url: https://github.com/lmnr-ai/lmnr
 pypi:
 - url: https://pypi.org/project/lmnr
-comments: The lmnr PyPI download count runs far above what a project of this size plausibly serves and is
-  treated as mirror-inflated, so the adoption band is discounted rather than read straight off it.
-  Verified 2026-08-13 via the lmnr-ai/lmnr repository and the lmnr PyPI project page.
+comments: The lmnr PyPI download count runs far above what a project of this size plausibly serves and is treated
+  as mirror-inflated, so the adoption band is discounted rather than read straight off it. Verified 2026-08-13
+  via the lmnr-ai/lmnr repository and the lmnr PyPI project page.

--- a/sources/products/langfuse.yaml
+++ b/sources/products/langfuse.yaml
@@ -1,9 +1,9 @@
 name: langfuse
 display_name: Langfuse
 type: software
-description: Open-source LLM engineering platform providing tracing, prompt management, evaluations, cost tracking,
-  and datasets. Self-hostable or cloud-hosted. Instruments applications through OpenTelemetry and through
-  direct integrations with LangChain, the OpenAI SDK and LiteLLM.
+description: LLM engineering platform providing tracing, prompt management, evaluations, cost tracking and
+  datasets, deployable on infrastructure you run or as a hosted service. It instruments applications through
+  OpenTelemetry and through direct integrations with LangChain, the OpenAI SDK and LiteLLM.
 github:
 - url: https://github.com/langfuse/langfuse
 pypi:

--- a/sources/products/langsmith.yaml
+++ b/sources/products/langsmith.yaml
@@ -1,13 +1,12 @@
 name: langsmith
 display_name: LangSmith
 type: software
-description: Proprietary observability and testing platform from the LangChain team. Provides tracing,
-  datasets, evaluations, prompt hub, and annotation queues, plus deployment and sandbox infrastructure for
-  agents. Tightly integrated with the LangChain ecosystem but supports any LLM application through
-  OpenTelemetry SDKs. Offered as managed cloud, bring-your-own-cloud, or a self-hosted enterprise
-  deployment of closed software.
+description: Observability and testing platform from the LangChain team, providing tracing, datasets, evaluations,
+  a prompt hub and annotation queues, alongside deployment and sandbox infrastructure for agents. It is tightly
+  integrated with the LangChain ecosystem but instruments any application through OpenTelemetry SDKs, and is
+  offered as managed cloud, bring-your-own-cloud or a self-hosted enterprise deployment.
 pypi:
 - url: https://pypi.org/project/langsmith
 comments: The declared langsmith PyPI package is a hard dependency of langchain-core, so its download count
-  measures LangChain installs rather than platform use and is not used to band adoption. Verified
-  2026-08-13 via langchain.com/langsmith.
+  measures LangChain installs rather than platform use and is not used to band adoption. Verified 2026-08-13
+  via langchain.com/langsmith.

--- a/sources/products/langtrace.yaml
+++ b/sources/products/langtrace.yaml
@@ -1,10 +1,10 @@
 name: langtrace
 display_name: Langtrace
 type: software
-description: Open-source, OpenTelemetry-based end-to-end observability tool for LLM applications. Provides
-  real-time tracing, evaluations, and metrics for popular LLMs, frameworks, and vector databases. TypeScript
-  and Python SDKs. Differentiated by strict OTel standards compliance and support for vector DB tracing,
-  and self-hostable from the repository's docker-compose file.
+description: OpenTelemetry-based end-to-end observability tool for LLM applications, providing real-time tracing,
+  evaluations and metrics across model providers, frameworks and vector databases, with TypeScript and Python
+  SDKs. It is distinguished by strict OTel compliance and vector-database tracing, and deploys from the repository's
+  docker-compose file.
 github:
 - url: https://github.com/Scale3-Labs/langtrace
 pypi:
@@ -13,5 +13,5 @@ artifact_exceptions:
   pypi_repo_mismatch: langtrace-python-sdk is published from scale3-labs/langtrace-python-sdk, the SDK's own
     repo, while the product is the platform at scale3-labs/langtrace. Two repos in one org, both correct for
     what they name.
-comments: The application and the SDKs carry different licenses; the openness score follows the
+comments: The application and the SDKs are distributed under different terms; the openness axis follows the
   application's. Verified 2026-08-13 via the Scale3-Labs/langtrace repository.

--- a/sources/products/langwatch.yaml
+++ b/sources/products/langwatch.yaml
@@ -1,11 +1,11 @@
 name: langwatch
 display_name: LangWatch
 type: software
-description: Open-source platform for LLM evaluations and AI agent testing with production monitoring
-  capabilities. Combines observability traces with automated quality checks and guardrails. Provides dashboards
-  for cost, latency, and quality metrics. Runs end-to-end agent simulations against a full stack before
-  release, so evaluation and production observability sit in one loop.
+description: Platform for LLM evaluation and agent testing with production monitoring, combining observability
+  traces with automated quality checks and guardrails and dashboards for cost, latency and quality. It runs
+  end-to-end agent simulations against a full stack before release, so evaluation and production observability
+  sit in one loop.
 github:
 - url: https://github.com/langwatch/langwatch
-comments: No download or user figure is published, so the adoption band is read from GitHub stars, which
-  the scale caps at level 3. Verified 2026-08-13 via the langwatch/langwatch repository.
+comments: No download or user figure is published, so the adoption band is read from GitHub stars, which the
+  scale caps at level 3. Verified 2026-08-13 via the langwatch/langwatch repository.

--- a/sources/products/mlflow.yaml
+++ b/sources/products/mlflow.yaml
@@ -1,11 +1,11 @@
 name: mlflow
 display_name: MLflow
 type: software
-description: Open source AI engineering platform covering the ML and LLM lifecycle in one tool. Combines
-  distributed tracing of agents and LLM calls, automated evaluation, a prompt registry, an AI gateway, and
-  the experiment tracking and model registry it began as. Self-hosted from the published source, with
-  Databricks Managed MLflow sold beside it as hosting rather than as a paid tier of the product.
+description: AI engineering platform covering the machine-learning and LLM lifecycle in one tool, combining
+  distributed tracing of agents and model calls, automated evaluation, a prompt registry and an AI gateway
+  with the experiment tracking and model registry it began as. Databricks Managed MLflow is sold beside it
+  as hosting rather than as a paid tier.
 pypi:
 - url: https://pypi.org/project/mlflow
-comments: The product entry does not declare its GitHub repository, so its adoption band routes through
-  PyPI only. Verified 2026-08-13 via the mlflow/mlflow LICENSE file, the repository and mlflow.org.
+comments: The product entry does not declare its GitHub repository, so its adoption band routes through PyPI
+  only. Verified 2026-08-13 via the mlflow/mlflow LICENSE file, the repository and mlflow.org.

--- a/sources/products/opik.yaml
+++ b/sources/products/opik.yaml
@@ -1,10 +1,9 @@
 name: opik
 display_name: Opik
 type: software
-description: Open-source platform for debugging, evaluating, and monitoring LLM applications, RAG systems,
-  and agentic workflows. Provides comprehensive tracing, automated evaluations, and production-ready dashboards.
-  Built by Comet ML. The server, web application and evaluation components are all self-hostable, with
-  Comet's cloud as optional managed hosting.
+description: Platform for debugging, evaluating and monitoring LLM applications, RAG systems and agentic workflows,
+  providing tracing, automated evaluations and production dashboards. Built by Comet ML, its server, web application
+  and evaluation components all run on infrastructure you operate, with Comet's cloud as optional managed hosting.
 github:
 - url: https://github.com/comet-ml/opik
 pypi:

--- a/sources/products/phoenix.yaml
+++ b/sources/products/phoenix.yaml
@@ -1,13 +1,12 @@
 name: phoenix
 display_name: Phoenix
 type: software
-description: Open-source AI observability and evaluation toolkit by Arize AI. Provides tracing, embeddings
-  analysis, experiment tracking, and LLM evaluation in a local-first workflow. Instruments applications
-  through OpenTelemetry, with integrations for LlamaIndex and LangChain. Built by the team behind the
-  Arize production ML monitoring platform, and self-hostable via Docker or a Helm chart.
+description: AI observability and evaluation toolkit from Arize AI, providing tracing, embeddings analysis,
+  experiment tracking and LLM evaluation in a local-first workflow. It instruments applications through OpenTelemetry
+  with integrations for LlamaIndex and LangChain, and deploys via Docker or a Helm chart.
 github:
 - url: https://github.com/Arize-ai/phoenix
 pypi:
 - url: https://pypi.org/project/arize-phoenix
-comments: The open-source-positioned companion to the closed Arize AX platform, and scored separately from
-  it. Verified 2026-08-13 via the Arize-ai/phoenix repository and the Arize Phoenix product page.
+comments: The companion to the Arize AX platform, built by the same team and scored separately from it. Verified
+  2026-08-13 via the Arize-ai/phoenix repository and the Arize Phoenix product page.

--- a/sources/products/promptlayer.yaml
+++ b/sources/products/promptlayer.yaml
@@ -1,12 +1,12 @@
 name: promptlayer
 display_name: PromptLayer
 type: software
-description: Prompt management and monitoring platform that logs every LLM API request. Maintains a complete
-  history of prompts, responses, costs, and latency. Enables prompt versioning, A/B testing, and analytics.
-  One of the earliest LLM monitoring tools, focused on the prompt lifecycle rather than full tracing. The
-  platform is reached over an API key; only the client library is published.
+description: Prompt management and monitoring platform that logs every LLM API request, keeping a full history
+  of prompts, responses, costs and latency, and supporting prompt versioning, A/B testing and analytics. It
+  was one of the earliest LLM monitoring tools and focuses on the prompt lifecycle rather than full tracing.
+  It is reached over an API key.
 pypi:
 - url: https://pypi.org/project/promptlayer
-comments: The Apache-2.0 client library is the only published part; the prompt registry, logging and eval
-  services are hosted and the openness score follows those. Verified 2026-08-13 via the
-  MagnivOrg/prompt-layer-library repository.
+comments: The client library is a separate artifact from the prompt registry, logging and evaluation services,
+  which are hosted; the openness axis follows those. Verified 2026-08-13 via the MagnivOrg/prompt-layer-library
+  repository.

--- a/sources/products/trulens.yaml
+++ b/sources/products/trulens.yaml
@@ -1,14 +1,14 @@
 name: trulens
 display_name: TruLens
 type: software
-description: Open-source library for evaluation and tracing of LLM apps and AI agents. Its differentiator is 'feedback
-  functions' - programmatic evaluators including the RAG triad (groundedness, context relevance, answer relevance)
-  plus toxicity and others - combined with app instrumentation and tracing, making it more eval-first than gateway/observability-first
-  peers.
+description: Library for evaluation and tracing of LLM applications and agents. Its differentiator is feedback
+  functions, programmatic evaluators including the RAG triad of groundedness, context relevance and answer
+  relevance alongside toxicity and others, combined with application instrumentation and tracing, which makes
+  it more evaluation-first than the gateway and observability-first tools around it.
 github:
 - url: https://github.com/truera/trulens
 pypi:
 - url: https://pypi.org/project/trulens
-comments: The GitHub org is still 'truera' after Snowflake's acquisition, so the repository name is not a
-  guide to who maintains it. A separate hosted Snowflake Cortex AI Observability product exists and is not
-  scored here. Verified 2026-08-13 via the truera/trulens repository.
+comments: The GitHub org is still 'truera' after Snowflake's acquisition, so the repository name is not a guide
+  to who maintains it. A separate hosted Snowflake Cortex AI Observability product exists and is not scored
+  here. Verified 2026-08-13 via the truera/trulens repository.

--- a/sources/products/vertex-ai-model-observability.yaml
+++ b/sources/products/vertex-ai-model-observability.yaml
@@ -1,13 +1,11 @@
 name: vertex-ai-model-observability
 display_name: Vertex AI Model Observability
 type: software
-description: Google Cloud's built-in production monitoring surface for Gen AI on Vertex AI, a predefined
-  Cloud Monitoring dashboard tracking usage, throughput, token consumption, latency, and error rates (including
-  429 capacity errors) for Gemini and other Vertex AI Model Garden foundation models. Extended in 2026
-  by Vertex AI Agent Builder with sessions, traces, logs, agent performance dashboards, multi-turn auto-raters,
-  online evaluation against live traffic, and a Unified Trace Viewer for debugging agent reasoning paths.
-  Differentiated as the default zero-config observability surface for organizations already on Vertex AI,
-  with no separate SDK required for managed-model usage.
+description: 'Google Cloud''s production monitoring surface for generative AI on Vertex AI: a predefined Cloud
+  Monitoring dashboard tracking usage, throughput, token consumption, latency and error rates, including capacity
+  errors, for Gemini and other Model Garden foundation models. Vertex AI Agent Builder extends it with sessions,
+  traces, logs, agent performance dashboards, multi-turn auto-raters, online evaluation against live traffic
+  and a unified trace viewer for debugging agent reasoning.'
 comments: Google publishes no usage figure for this surface specifically, so its adoption band leans on the
   reach of Vertex AI rather than on a measurement of the surface. Verified 2026-08-13 via the Agent Engine
   tracing documentation.

--- a/sources/products/weave.yaml
+++ b/sources/products/weave.yaml
@@ -1,10 +1,10 @@
 name: weave
 display_name: Weave
 type: software
-description: Toolkit for developing and monitoring AI-powered applications, built by Weights & Biases.
-  Provides tracing, evaluation, and dataset management for LLM applications. Leverages W&B's established
-  ML experiment tracking platform and enterprise customer base. Functions are traced with a decorator, and
-  the published package requires a Weights & Biases account to send traces to.
+description: Toolkit for developing and monitoring AI applications from Weights & Biases, providing tracing,
+  evaluation and dataset management for LLM applications. Functions are traced with a decorator, and it builds
+  on the same platform as W&B's experiment tracking. The published package requires a Weights & Biases account
+  to send traces to.
 github:
 - url: https://github.com/wandb/weave
 pypi:

--- a/sources/products/whylabs.yaml
+++ b/sources/products/whylabs.yaml
@@ -1,12 +1,10 @@
 name: whylabs
 display_name: WhyLabs
 type: software
-description: AI observability platform for monitoring ML models and LLM applications in production. Provides
-  data drift detection, performance monitoring, and LLM security guardrails. Built on the open source
-  whylogs profiling library and LangKit LLM monitoring toolkit. Differentiated by statistical profiling
-  approach, monitors distributions rather than individual requests, enabling cost-effective monitoring
-  at scale.
-comments: 'WhyLabs, Inc. has discontinued operations and open sourced the platform, so the entry is scored
-  on what remains runnable: the whylogs and LangKit libraries. This product declares no artifacts, which
-  is why its adoption band has no signal route behind it. Verified 2026-08-13 via the WhyLabs LangKit page
-  and the whylabs/whylogs repository.'
+description: AI observability platform for monitoring machine-learning models and LLM applications in production,
+  covering data drift detection, performance monitoring and LLM security guardrails. It is built on the whylogs
+  profiling library and the LangKit monitoring toolkit, and takes a statistical profiling approach that monitors
+  distributions rather than individual requests.
+comments: 'WhyLabs, Inc. has discontinued operations, so the entry is scored on what remains runnable: the
+  whylogs and LangKit libraries. The record declares no artifacts, which is why its adoption band has no signal
+  route behind it. Verified 2026-08-13 via the WhyLabs LangKit page and the whylabs/whylogs repository.'

--- a/sources/provenance/telemetry_observability.yaml
+++ b/sources/provenance/telemetry_observability.yaml
@@ -1,0 +1,153 @@
+# Prose closeout for telemetry_observability. 26 of 26 ready.
+#
+# All 26 were canonical before this pass; 21 still failed prose compliance. Sixteen were caught
+# by the ban detector and FIVE WERE NOT, which is why the complete prose of all 26 was read
+# rather than only the flagged ones:
+#
+#   agentops    comments named two licenses by name, which the detector's pattern missed
+#   azure-ai-foundry-observability  116-word description ending "it is the default
+#               observability layer for Azure-hosted GenAI workloads"
+#   vertex-ai-model-observability   107-word description, "Differentiated as the default
+#               zero-config observability surface"
+#   helicone    "Positioned as the lowest-friction entry point for LLM monitoring"
+#   weave       "Leverages W&B's established ML experiment tracking platform and enterprise
+#               customer base" - an adoption claim in a description
+#
+# The detector produces candidates. It does not define the scope.
+#
+# ## The dominant violation here was the openness verdict in the first clause
+#
+# Nine records opened with "Open-source X" or "Proprietary X" as the product's category noun -
+# langfuse, laminar, langwatch, mlflow, opik, phoenix, trulens, langtrace, langsmith. For this
+# category that reads naturally, because these vendors market themselves that way. It is still
+# the openness axis's content, and it is still a second copy with no evidence behind it.
+#
+# What replaced it is the deployment fact, which is architecture: "deploys from the repository's
+# docker-compose file", "runs on infrastructure you operate", "offered as managed cloud,
+# bring-your-own-cloud or a self-hosted enterprise deployment".
+#
+# ## agenta: the description described a product that no longer exists
+#
+# Agenta 2.0 repositioned from an LLMOps prompt and evaluation platform to a no-code agent
+# workspace. The capability axis was re-scored 4 -> 3 on 2026-08-14 with its peer anchor REMOVED
+# rather than repointed, because nothing else in this category is an agent workspace to compare
+# it against. The description still described the old product; it now describes the new one.
+#
+# The score note's open question is recorded and not resolved here: a no-code agent workspace
+# sits closer to orchestration_agents than to telemetry, and that is a recategorization for a
+# human rather than a re-score.
+#
+# ## Evidence-gap footnotes kept, because they are about our reading
+#
+# `helicone` records that the pricing page lists enterprise SSO the repository does not
+# implement. `laminar` records that its PyPI count is mirror-inflated and discounted rather than
+# read straight. `langsmith` records that its declared package is a hard dependency of
+# langchain-core, so the download count measures LangChain installs. `openllmetry` records that
+# the band was read on a different package than the one declared. `mlflow` records that it
+# declares no repository, so adoption routes through PyPI alone. `whylabs` records that the
+# company has discontinued operations.
+#
+- product: agenta
+  resolved_state: canonical
+  verified: '2026-08-14'
+  document: the Agenta documentation and repository
+- product: agentops
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the AgentOps-AI/agentops repository and its README
+- product: arize
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: arize
+- product: azure-ai-foundry-observability
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Microsoft Learn observability concept page
+- product: braintrust
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: braintrust
+- product: confident-ai
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: confident-ai
+- product: datadog-llm-observability
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Datadog LLM Observability documentation
+- product: dynatrace-ai-observability
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Dynatrace AI observability documentation
+- product: galileo
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: galileo
+- product: helicone
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Helicone/helicone README
+- product: laminar
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the lmnr-ai/lmnr repository and the lmnr PyPI project page
+- product: langfuse
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the langfuse/langfuse repository and the Langfuse observability docs
+- product: langsmith
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: langchain
+- product: langtrace
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Scale3-Labs/langtrace repository
+- product: langwatch
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the langwatch/langwatch repository
+- product: mlflow
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the mlflow/mlflow LICENSE file, the repository and mlflow
+- product: new-relic-ai-monitoring
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the New Relic AI Monitoring product page
+- product: openlit
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the openlit/openlit repository
+- product: openllmetry
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the traceloop/openllmetry repository
+- product: opik
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the comet-ml/opik repository and the opik PyPI project page
+- product: phoenix
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Arize-ai/phoenix repository and the Arize Phoenix product page
+- product: promptlayer
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the MagnivOrg/prompt-layer-library repository
+- product: trulens
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the truera/trulens repository
+- product: vertex-ai-model-observability
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Agent Engine tracing documentation
+- product: weave
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the wandb/weave README
+- product: whylabs
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the WhyLabs LangKit page and the whylabs/whylogs repository


### PR DESCRIPTION
**26 of 26 ready.** All were already canonical; 21 failed prose compliance. No axis touched, no date moved.

## The detector produces candidates. It does not define the scope.

Sixteen were flagged. **Five were not**, and I found them by reading the complete prose of all 26 as instructed:

| record | what the detector missed |
|---|---|
| `agentops` | comments named two licenses by name, in a pattern the regex did not cover |
| `azure-ai-foundry-observability` | 116-word description ending "it is the default observability layer for Azure-hosted GenAI workloads" |
| `vertex-ai-model-observability` | 107-word description, "Differentiated as the default zero-config observability surface" |
| `helicone` | "Positioned as the lowest-friction entry point for LLM monitoring" |
| `weave` | "Leverages W&B's established ML experiment tracking platform and **enterprise customer base**" — an adoption claim in a description |

## The dominant violation: the openness verdict as the opening noun

Nine records began with *"Open-source X"* or *"Proprietary X"* as the product's category label — `langfuse`, `laminar`, `langwatch`, `mlflow`, `opik`, `phoenix`, `trulens`, `langtrace`, `langsmith`. In this category that reads naturally, because these vendors market themselves exactly that way. It is still the openness axis's content, and still a second copy with no evidence behind it.

What replaced it is the deployment fact, which *is* architecture: "deploys from the repository's docker-compose file", "runs on infrastructure you operate", "offered as managed cloud, bring-your-own-cloud or a self-hosted enterprise deployment".

## `agenta` described a product that no longer exists

Agenta 2.0 repositioned from an LLMOps prompt-and-evaluation platform to a **no-code agent workspace**. The capability axis was re-scored 4 → 3 on 2026-08-14 with its peer anchor **removed rather than repointed**, because nothing else in this category is an agent workspace to compare against. The description still described the old product; it now describes the new one, from the vendor's own docs.

The score note's open question is recorded, not resolved: a no-code agent workspace sits closer to `orchestration_agents` than to telemetry, and that is a recategorization for a human.

## Evidence-gap footnotes kept, because they are about our reading

`helicone` records that the pricing page lists enterprise SSO the repository does not implement. `laminar` records that its PyPI count is mirror-inflated and discounted rather than read straight. `langsmith` records that its declared package is a hard dependency of `langchain-core`, so the download count measures LangChain installs. `openllmetry` records that the band was read on a different package than the one declared. `mlflow` records that it declares no repository, so adoption routes through PyPI alone. `whylabs` records that the company has discontinued operations, so the entry is scored on what remains runnable.

## Verification

`validate`, `check_verification`, `check_capability`, `check_recipe`, `check_adoption --strict` clean. `check_freshness --category telemetry_observability`: *all 78 axes carry a real last_verified*. 664 tests, no skips.

**Corpus: 431/472 prose-compliant · 472/472 canonical · 1,407/1,416 axes confirmed · 9 held.**
