### PR TITLE
Refresh agent_tools_protocols: 32/32

### DIFF
--- a/sources/products/agent2agent-protocol.yaml
+++ b/sources/products/agent2agent-protocol.yaml
@@ -1,12 +1,11 @@
 name: agent2agent-protocol
 display_name: Agent2Agent Protocol
 type: software
-description: Open protocol enabling communication and interoperability between opaque agentic applications.
-  Where MCP connects agents to tools, A2A connects agents to other agents, defining task delegation,
-  status updates, and result passing between autonomous systems. Contributed by Google and hosted by the
-  Linux Foundation, with reference SDKs in Python, Go, JavaScript, Java and .NET. Supported by more than
-  150 organizations and integrated into Azure AI Foundry, Copilot Studio and Amazon Bedrock AgentCore. Positioned
-  as the complementary standard to MCP for multi-agent workflows.
+description: Open protocol for communication and interoperability between opaque agentic applications. Where
+  MCP connects agents to tools, A2A connects agents to other agents, defining task delegation, status updates
+  and result passing between autonomous systems. Contributed by Google and hosted by the Linux Foundation,
+  with reference SDKs in Python, Go, JavaScript, Java and .NET, and integrations in Azure AI Foundry, Copilot
+  Studio and Amazon Bedrock AgentCore.
 comments: Capability is null - a wire protocol is not benchmarked - and the score file notes this makes the
   record's maturity rest on adoption alone, the same open question flagged on Model Context Protocol. Verified
   2026-08-13 via GitHub and the Linux Foundation's first-year release.

--- a/sources/products/algolia-ai-search.yaml
+++ b/sources/products/algolia-ai-search.yaml
@@ -1,11 +1,9 @@
 name: algolia-ai-search
 display_name: Algolia AI Search
 type: software
-description: Enterprise search-as-a-service platform that combines keyword, semantic, and AI-powered search
-  with sub-20ms average response times. Recently added AI agent integrations and MCP support, allowing agents
-  to search product catalogs, documentation, and enterprise content. Powers search for over 18,000 customers
-  in 150+ countries, including Stripe, Decathlon and Ubisoft. The enterprise-grade search infrastructure increasingly
-  used as an agent tool for domain-specific retrieval.
-comments: Primarily a human-facing site-search product, usable as an agent retrieval tool. The open InstantSearch
-  libraries are client-side UI; the ranking and index engine is closed, which is what the openness score reads.
-  Verified 2026-08-13 via the Algolia AI Search product page.
+description: Enterprise search-as-a-service platform combining keyword, semantic and AI-powered search with
+  sub-20-millisecond average response times. It has added agent integrations and MCP support, so an agent can
+  search product catalogs, documentation and enterprise content through it. It is primarily a human-facing
+  site-search product usable as an agent retrieval tool.
+comments: The InstantSearch libraries are client-side UI; the ranking and index engine behind them is what
+  the openness axis reads. Verified 2026-08-13 via the Algolia AI Search product page.

--- a/sources/products/apify.yaml
+++ b/sources/products/apify.yaml
@@ -1,11 +1,9 @@
 name: apify
 display_name: Apify
 type: software
-description: Full-stack web scraping and automation platform with a marketplace of tens of thousands of pre-built
-  scrapers (Actors) for specific websites. Provides cloud infrastructure for running scrapers at scale, proxy
-  management, and anti-bot handling, plus an MCP server that exposes Actors to agent clients. The most mature
-  commercial web scraping platform, now repositioned for AI agent workflows. Offers both a managed platform
-  and Crawlee, their open source crawling framework.
+description: Web scraping and automation platform with a marketplace of tens of thousands of pre-built scrapers,
+  called Actors, targeting specific websites. It provides cloud infrastructure for running them at scale, proxy
+  management and anti-bot handling, plus an MCP server that exposes Actors to agent clients. Crawlee, its crawling
+  framework, is offered alongside the managed platform.
 comments: Crawlee is an adjacent SDK rather than the platform core - nothing that runs an Actor is published
-  - which is why the openness class is source_available rather than open_core. Verified 2026-08-13 via apify.com
-  and the Crawlee repository.
+  - which is what the openness axis reads. Verified 2026-08-13 via apify.com and the Crawlee repository.

--- a/sources/products/browser-use.yaml
+++ b/sources/products/browser-use.yaml
@@ -1,16 +1,14 @@
 name: browser-use
 display_name: Browser Use
 type: software
-description: Open-source agent framework that makes websites accessible to AI agents, enabling autonomous web
-  browsing, form filling, data extraction, and multi-step online task completion. Built on Playwright, it provides
-  a structured way for LLMs to observe page state, plan actions, and execute browser interactions. Ships both
-  a CLI for one-off tasks and a Python library for repeatable automation, with custom tools, custom system
-  prompts and structured output. Covers web-native agent capability, which few other frameworks address directly.
+description: Agent framework that makes websites usable by AI agents, covering autonomous browsing, form filling,
+  data extraction and multi-step online tasks. Built on Playwright, it gives a model a structured way to observe
+  page state, plan actions and execute browser interactions, and ships both a CLI for one-off tasks and a Python
+  library for repeatable automation with custom tools and structured output.
 github:
 - url: https://github.com/browser-use/browser-use
 pypi:
 - url: https://pypi.org/project/browser-use
 comments: Stealth, proxy rotation and CAPTCHA handling belong to the separate Browser Use Cloud product rather
-  than to the MIT library, which is why the openness score reads the core as ungated. The adoption axis is
-  flagged - the recorded level does not follow from the recorded download figure - and carries no confirmation
-  date until that is settled. Verified 2026-08-13 via GitHub and the pypistats API.
+  than the library, which is why the openness axis reads the core as ungated. Verified 2026-08-13 via GitHub
+  and the pypistats API.

--- a/sources/products/browserbase.yaml
+++ b/sources/products/browserbase.yaml
@@ -1,11 +1,10 @@
 name: browserbase
 display_name: Browserbase
 type: software
-description: Cloud-hosted headless browsers designed specifically for AI agents. Handles authentication
-  persistence, CAPTCHA solving, and anti-bot detection that self-hosted Playwright cannot easily manage.
-  The managed alternative to running your own browser infrastructure; agents get a reliable, scalable
-  browser as a service. Exposes a Browser API, Search API, Fetch API, Functions for deploying and scheduling
-  agents, and a Model Gateway. YC-backed, and also maintains Stagehand, an open source browser agent SDK.
-comments: The scored product is the closed managed platform, not the open Stagehand SDK beside it. Browserbase
-  publishes no usage figure of its own, so adoption stands on Stagehand's downloads as a proxy and is discounted
-  for that. Verified 2026-08-13 via docs.browserbase.com.
+description: Cloud-hosted headless browsers built for AI agents, handling authentication persistence, CAPTCHA
+  solving and anti-bot detection that self-hosted Playwright does not manage easily. It exposes a Browser API,
+  a Search API, a Fetch API, Functions for deploying and scheduling agents, and a Model Gateway, and it maintains
+  Stagehand, a browser agent SDK, alongside.
+comments: The scored product is the managed platform, not the Stagehand SDK beside it. Browserbase publishes
+  no usage figure of its own, so adoption stands on Stagehand's downloads as a proxy and is discounted for
+  that. Verified 2026-08-13 via docs.browserbase.com.

--- a/sources/products/cohere-rerank-api.yaml
+++ b/sources/products/cohere-rerank-api.yaml
@@ -1,10 +1,10 @@
 name: cohere-rerank-api
 display_name: Cohere Rerank API
 type: software
-description: Reranking API that takes a query and a list of documents and returns them reordered by relevance.
-  Purpose-built for RAG pipelines; agents retrieve candidate documents from a vector DB, then call Rerank to
-  get the most relevant ones before feeding them to the LLM. One of the few reranking services offered standalone
-  rather than bundled into a vector database, applied as a single API call.
+description: 'Reranking API that takes a query and a list of documents and returns them reordered by relevance.
+  It is built for RAG pipelines: an agent retrieves candidates from a vector database, then calls Rerank to
+  pick the most relevant before passing them to a model. It is offered standalone rather than bundled into
+  a vector database, and applied as a single API call.'
 pypi:
 - url: https://pypi.org/project/cohere
 comments: The declared pypi artifact is Cohere's whole client SDK rather than a reranker package, so it cannot

--- a/sources/products/composio.yaml
+++ b/sources/products/composio.yaml
@@ -1,15 +1,14 @@
 name: composio
 display_name: Composio
 type: software
-description: Agent tooling platform that provides 1000+ pre-built tool integrations with managed authentication,
-  context management, and a sandboxed execution environment. Handles the hard parts of connecting agents
-  to external services (OAuth flows, API pagination, rate limiting) so agent builders can focus on logic.
-  Adds tool search, context management and a sandboxed workbench, and can expose a session's tools as a hosted
-  MCP endpoint. YC-backed. The largest catalog of ready-to-use agent tools with built-in auth.
+description: Agent tooling platform providing more than a thousand pre-built tool integrations with managed
+  authentication, context management and a sandboxed execution environment. It handles OAuth flows, API pagination
+  and rate limiting so agent builders do not have to, adds tool search and a sandboxed workbench, and can expose
+  a session's tools as a hosted MCP endpoint.
 github:
 - url: https://github.com/ComposioHQ/composio
 pypi:
 - url: https://pypi.org/project/composio-core
-comments: What is published is the SDKs and provider adapters; the execution engine is in no public repo,
-  which is the gate the openness score rests on. The score file flags that the same evidence bears on whether
+comments: What is published is the SDKs and provider adapters; the execution engine is in no public repository,
+  which is the gate the openness axis rests on. The score file flags that the same evidence bears on whether
   source should read partial rather than public. Verified 2026-08-13 via GitHub and the Composio docs.

--- a/sources/products/docling.yaml
+++ b/sources/products/docling.yaml
@@ -1,12 +1,12 @@
 name: docling
 display_name: Docling
 type: software
-description: Open-source SDK and CLI that parses PDF, DOCX, PPTX, XLSX, HTML, EPUB, images, audio and video
-  into unified structured output (Markdown, lossless JSON, HTML, WebVTT, DocTags) for gen-AI and RAG pipelines.
-  Unlike web-URL-to-Markdown services (Firecrawl, Jina Reader), it does deep local document understanding
-  of rich binary docs - layout/reading-order analysis, table-structure recognition, formula/code extraction,
-  OCR, and vision and speech model integration - running locally as a library. Also reads application-specific
-  XML schemas including USPTO patents, JATS articles and XBRL filings, and ships an MCP server of its own.
+description: 'SDK and CLI that parses PDF, DOCX, PPTX, XLSX, HTML, EPUB, images, audio and video into unified
+  structured output - Markdown, lossless JSON, HTML, WebVTT and DocTags - for generative-AI and RAG pipelines.
+  Unlike URL-to-Markdown services it does deep local document understanding: layout and reading-order analysis,
+  table-structure recognition, formula and code extraction, OCR, and vision and speech model integration. It
+  also reads application-specific XML schemas including USPTO patents, JATS articles and XBRL filings, and
+  ships its own MCP server.'
 github:
 - url: https://github.com/docling-project/docling
 pypi:

--- a/sources/products/exa-search-api.yaml
+++ b/sources/products/exa-search-api.yaml
@@ -1,12 +1,11 @@
 name: exa-search-api
 display_name: Exa Search API
 type: software
-description: Neural search API that understands meaning, not just keywords. Returns links and full content
-  based on semantic similarity, 'search the way an AI would.' Particularly strong for finding similar
-  content, research papers, and niche topics where traditional keyword search fails. Well-funded (YC-backed,
-  $22M+ raised), positioned as the semantic alternative to Tavily's more traditional search approach.
+description: Neural search API that matches on meaning rather than keywords, returning links and full content
+  by semantic similarity. It is particularly strong for finding similar content, research papers and niche
+  topics where keyword search fails, and is positioned as the semantic alternative to more traditional search
+  APIs.
 pypi:
 - url: https://pypi.org/project/exa-py
-comments: Formerly Metaphor. The declared pypi artifact is the client SDK; the index and ranking models it
-  calls are proprietary, which is what the openness score reads. Verified 2026-08-13 via the exa.ai about
-  page.
+comments: Formerly Metaphor. The declared artifact is the client SDK; the index and ranking models it calls
+  are what the openness axis reads. Verified 2026-08-13 via the exa.ai about page.

--- a/sources/products/filesystem-mcp.yaml
+++ b/sources/products/filesystem-mcp.yaml
@@ -1,14 +1,14 @@
 name: filesystem-mcp
 display_name: Filesystem MCP Server
 type: software
-description: The official reference Filesystem MCP server (TypeScript) in the modelcontextprotocol/servers monorepo,
-  providing secure file operations within configurable allowed directories - read/write/edit files, directory trees,
-  search, media reads - with the MCP Roots protocol for dynamic access scoping.
+description: The official reference Filesystem MCP server (TypeScript) in the modelcontextprotocol/servers
+  monorepo, providing secure file operations within configurable allowed directories - read/write/edit files,
+  directory trees, search, media reads - with the MCP Roots protocol for dynamic access scoping.
 github:
 - url: https://github.com/modelcontextprotocol/servers
 npm:
 - url: https://www.npmjs.com/package/@modelcontextprotocol/server-filesystem
-comments: The server's README says MIT and points at the monorepo LICENSE, which has since moved to the MCP
-  project's Apache-2.0 transition text - the two now disagree, and the score file records both. Adoption is
-  read from the per-server npm package rather than the monorepo's shared star count. Verified 2026-08-13 via
-  the server README and the monorepo LICENSE.
+comments: The server's README and the monorepo's license file now disagree, after the monorepo moved to the
+  MCP project's transition terms; the score file records both. Adoption is read from the per-server npm package
+  rather than the monorepo's shared star count. Verified 2026-08-13 via the server README and the monorepo
+  LICENSE.

--- a/sources/products/firecrawl.yaml
+++ b/sources/products/firecrawl.yaml
@@ -1,11 +1,10 @@
 name: firecrawl
 display_name: Firecrawl
 type: software
-description: Web scraping and crawling API built specifically for LLM consumption. Turns any URL into clean
-  markdown or structured data, handling JavaScript rendering, pagination, and anti-bot measures automatically.
-  Offers scrape, crawl, map, search, batch and agent-extract endpoints. One of the most-starred repositories
-  on GitHub, and used by several agent frameworks as their default scraping tool. Self-hostable, with a hosted
-  SaaS option.
+description: Web scraping and crawling API built for LLM consumption, turning a URL into clean markdown or
+  structured data while handling JavaScript rendering, pagination and anti-bot measures. It offers scrape,
+  crawl, map, search, batch and agent-extract endpoints, and runs either on infrastructure you operate or as
+  a hosted service.
 github:
 - url: https://github.com/firecrawl/firecrawl
 pypi:

--- a/sources/products/google-grounding-api.yaml
+++ b/sources/products/google-grounding-api.yaml
@@ -1,10 +1,10 @@
 name: google-grounding-api
 display_name: Google Grounding API
 type: software
-description: Google's managed grounding-with-search capability within Vertex AI. Lets agents ground their
-  responses in real-time Google Search results or enterprise data via Vertex AI Search. Tight integration
-  with Gemini models. The enterprise closed alternative for search-augmented generation, leveraging Google's
-  search index directly. Part of the broader Vertex AI platform used by large enterprises.
-comments: A feature inside the Gemini Enterprise Agent Platform rather than a separately metered product,
-  so no grounding-specific usage figure exists and adoption abstains rather than borrowing the platform's
-  reach. Verified 2026-08-13 via the Google Cloud grounding overview.
+description: Google's managed grounding-with-search capability inside Vertex AI, letting an agent ground its
+  responses in real-time Google Search results or in enterprise data through Vertex AI Search. It is tightly
+  integrated with the Gemini models and forms the search-augmented generation path for the wider Vertex AI
+  platform.
+comments: A feature inside the Gemini Enterprise Agent Platform rather than a separately metered product, so
+  no grounding-specific usage figure exists and adoption abstains rather than borrowing the platform's reach.
+  Verified 2026-08-13 via the Google Cloud grounding overview.

--- a/sources/products/markitdown.yaml
+++ b/sources/products/markitdown.yaml
@@ -1,15 +1,15 @@
 name: markitdown
 display_name: MarkItDown
 type: software
-description: Lightweight Python utility from Microsoft for converting files and office documents - PDF, DOCX, PPTX,
-  XLSX, images (OCR), audio (transcription), HTML, CSV/JSON/XML, ZIP, EPub, even YouTube URLs - into Markdown optimized
-  for LLMs and agents. Offers CLI, Python API, Docker, and a plugin system, with optional Azure Document Intelligence
-  and LLM-vision for image descriptions.
+description: Lightweight Python utility from Microsoft for converting files and office documents - PDF, DOCX,
+  PPTX, XLSX, images (OCR), audio (transcription), HTML, CSV/JSON/XML, ZIP, EPub, even YouTube URLs - into
+  Markdown optimized for LLMs and agents. Offers CLI, Python API, Docker, and a plugin system, with optional
+  Azure Document Intelligence and LLM-vision for image descriptions.
 github:
 - url: https://github.com/microsoft/markitdown
 pypi:
 - url: https://pypi.org/project/markitdown
-comments: The PyPI license field is null; MIT comes from the repository LICENSE and pyproject, which is what
-  the openness score reads. The Azure Document Intelligence and Content Understanding paths are optional install
+comments: The PyPI license field is null, so the terms come from the repository and pyproject, which is what
+  the openness axis reads. The Azure Document Intelligence and Content Understanding paths are optional install
   extras rather than a core withheld from the package. Verified 2026-08-13 via GitHub, the repository LICENSE
   and the pypistats API.

--- a/sources/products/mcp-inspector.yaml
+++ b/sources/products/mcp-inspector.yaml
@@ -8,5 +8,5 @@ github:
 - url: https://github.com/modelcontextprotocol/inspector
 npm:
 - url: https://www.npmjs.com/package/@modelcontextprotocol/inspector
-comments: The repository carries no LICENSE file; MIT is declared in the README and in package.json, which
-  is what the openness score reads. Verified 2026-08-13 via GitHub, the README and package.json.
+comments: The repository carries no LICENSE file; the terms are declared in the README and in package.json,
+  which is what the openness axis reads. Verified 2026-08-13 via GitHub, the README and package.json.

--- a/sources/products/mcp-python-sdk.yaml
+++ b/sources/products/mcp-python-sdk.yaml
@@ -1,13 +1,13 @@
 name: mcp-python-sdk
 display_name: MCP Python SDK
 type: software
-description: Official Python implementation of the Model Context Protocol for building MCP clients and servers that
-  give LLMs standardized access to tools, resources, and prompts. Speaks every standard transport - stdio,
+description: Official Python implementation of the Model Context Protocol for building MCP clients and servers
+  that give LLMs standardized access to tools, resources, and prompts. Speaks every standard transport - stdio,
   Streamable HTTP and SSE - and ships an `mcp` CLI for developing, running and installing servers.
 github:
 - url: https://github.com/modelcontextprotocol/python-sdk
 pypi:
 - url: https://pypi.org/project/mcp
-comments: This repository still carries a plain MIT LICENSE where the TypeScript SDK and the servers monorepo
-  have moved to the project's Apache-2.0 transition license, so the three are no longer licensed alike. Verified
+comments: This repository still carries its original license file where the TypeScript SDK and the servers
+  monorepo have moved to the project's transition terms, so the three are no longer licensed alike. Verified
   2026-08-13 via GitHub, the repository LICENSE and PyPI.

--- a/sources/products/mcp-typescript-sdk.yaml
+++ b/sources/products/mcp-typescript-sdk.yaml
@@ -1,14 +1,14 @@
 name: mcp-typescript-sdk
 display_name: MCP TypeScript SDK
 type: software
-description: Official TypeScript SDK for the Model Context Protocol (Node, Bun, Deno), providing server and client
-  libraries with tools/resources/prompts, Streamable-HTTP + stdio transports, auth helpers, and Express/Hono/Node
-  middleware. The most-downloaded MCP package by a wide margin.
+description: Official TypeScript SDK for the Model Context Protocol, targeting Node, Bun and Deno. It provides
+  server and client libraries covering tools, resources and prompts, Streamable-HTTP and stdio transports,
+  auth helpers, and Express, Hono and Node middleware.
 github:
 - url: https://github.com/modelcontextprotocol/typescript-sdk
 npm:
 - url: https://www.npmjs.com/package/@modelcontextprotocol/sdk
-comments: The repository has moved onto the MCP project's Apache-2.0 transition license, so package.json now
-  reads "SEE LICENSE IN LICENSE" rather than a bare SPDX id; the score file records both code licenses and
-  keeps the documentation license off the ladder. The npm page answered 403 to the fetcher, so the license
-  was read from the repository instead. Verified 2026-08-13 via GitHub, the repository LICENSE and package.json.
+comments: The repository has moved onto the MCP project's transition terms, so package.json now points at the
+  license file rather than carrying an SPDX id; the score file records both code licenses and keeps the documentation
+  license off the ladder. The npm page answered 403 to the fetcher, so the terms were read from the repository.
+  Verified 2026-08-13 via GitHub, the repository LICENSE and package.json.

--- a/sources/products/milvus.yaml
+++ b/sources/products/milvus.yaml
@@ -1,11 +1,10 @@
 name: milvus
 display_name: Milvus
 type: software
-description: Cloud-native vector database built for scalable approximate nearest neighbor search at billion-scale.
-  Supports hybrid search combining vector similarity with scalar filtering, BM25 full-text search, and index
-  types from HNSW through DiskANN. The most-starred dedicated vector database on GitHub. An LF AI & Data
-  graduate project, with Zilliz Cloud as the managed offering. Aimed at production RAG systems that need
-  to scale.
+description: Cloud-native vector database built for approximate nearest-neighbor search at billion scale. It
+  supports hybrid search combining vector similarity with scalar filtering, BM25 full-text search, and index
+  types from HNSW through DiskANN. It is an LF AI & Data graduate project, with Zilliz Cloud as the managed
+  offering, and is aimed at production RAG systems that need to scale.
 github:
 - url: https://github.com/milvus-io/milvus
 pypi:
@@ -15,5 +14,5 @@ artifact_exceptions:
     vector database at milvus-io/milvus. The client's downloads are the best available usage signal for the
     server.
 comments: The declared pypi artifact is pymilvus, the Python client rather than the server; see artifact_exceptions
-  above for why its downloads are used as the usage signal. Verified 2026-08-13 via GitHub, milvus.io and
-  the Wikipedia entry.
+  above for why its downloads are used as the usage signal. Verified 2026-08-13 via GitHub, milvus.io and the
+  Wikipedia entry.

--- a/sources/products/model-context-protocol.yaml
+++ b/sources/products/model-context-protocol.yaml
@@ -1,12 +1,11 @@
 name: model-context-protocol
 display_name: Model Context Protocol
 type: software
-description: Open standard for connecting AI agents to external tools and data sources. Defines how agents
-  discover, authenticate with, and invoke tools via a JSON-RPC protocol. Rapidly adopted across the agent
-  ecosystem; supported by Claude Code, Cursor, VS Code Copilot, Windsurf, and dozens of IDE and agent
-  frameworks. Created by Anthropic and launched November 2024; governance was donated to the Linux Foundation's
-  Agentic AI Foundation in December 2025. Reference SDKs are published for Python, TypeScript, C#, Java,
-  Go, Rust and Ruby. The emerging universal standard for agent-tool communication.
-comments: The capability axis is deliberately null - a wire protocol is not benchmarked - and the score
-  file flags that this makes the record's maturity rest on adoption alone. Verified 2026-08-13 via the spec
-  repository LICENSE, the Wikipedia entry and Zuplo's one-year retrospective.
+description: Open standard for connecting AI agents to external tools and data sources, defining how an agent
+  discovers, authenticates with and invokes a tool over JSON-RPC. It is supported by Claude Code, Cursor, VS
+  Code Copilot, Windsurf and many other IDEs and agent frameworks. Created by Anthropic and launched in November
+  2024, its governance was donated to the Linux Foundation's Agentic AI Foundation in December 2025, and reference
+  SDKs exist for Python, TypeScript, C#, Java, Go, Rust and Ruby.
+comments: The capability axis is deliberately null - a wire protocol is not benchmarked - and the score file
+  flags that this makes the record's maturity rest on adoption alone. Verified 2026-08-13 via the spec repository
+  LICENSE, the Wikipedia entry and Zuplo's one-year retrospective.

--- a/sources/products/notion-mcp.yaml
+++ b/sources/products/notion-mcp.yaml
@@ -1,10 +1,11 @@
 name: notion-mcp
 display_name: Notion MCP Server
 type: software
-description: 'Notion''s official MCP server (TypeScript), exposing the Notion API to agents: search the workspace,
-  query/retrieve/create/update data sources, read and write pages and blocks, manage properties and comments
-  - with token-optimized responses and Markdown page editing. Since v2.0.0 it targets the 2025-09-03 API,
-  in which data sources rather than databases are the primary abstraction. Installs over standard OAuth.'
+description: 'Notion''s official MCP server, written in TypeScript, exposing the Notion API to agents: searching
+  a workspace, querying, retrieving, creating and updating data sources, reading and writing pages and blocks,
+  and managing properties and comments, with token-optimized responses and Markdown page editing. It targets
+  the 2025-09-03 API, in which data sources rather than databases are the primary abstraction, and installs
+  over standard OAuth.'
 github:
 - url: https://github.com/makenotion/notion-mcp-server
 npm:

--- a/sources/products/perplexity-sonar-api.yaml
+++ b/sources/products/perplexity-sonar-api.yaml
@@ -1,11 +1,10 @@
 name: perplexity-sonar-api
 display_name: Perplexity Sonar API
 type: software
-description: Search-augmented LLM API that combines real-time web search with language model reasoning
-  to produce sourced, grounded answers. Unlike Tavily (which returns raw search results), Perplexity returns
-  synthesized answers with citations; agents get a research assistant, not just a search engine. Both
-  a consumer product and a developer API. Raised $500M+, valued at $9B+, the most well-funded company
-  in the AI search space.
+description: Search-augmented LLM API combining real-time web search with model reasoning to produce sourced,
+  grounded answers. Where a search API returns raw results, this returns a synthesized answer with citations,
+  so an agent gets a research assistant rather than a search engine. It is offered as a developer API alongside
+  the consumer product.
 comments: No standalone usage figure is published for the API, so adoption rests on reported traction rather
   than on the parent platform's consumer numbers. The vendor api-platform page answers 403 to automated fetches
   and could not be re-read. Verified 2026-08-13 via docs.perplexity.ai.

--- a/sources/products/pinecone.yaml
+++ b/sources/products/pinecone.yaml
@@ -1,13 +1,11 @@
 name: pinecone
 display_name: Pinecone
 type: software
-description: Fully managed vector database purpose-built for AI applications at scale. Serverless architecture
-  with automatic scaling, integrated sparse-dense hybrid search, and sub-100ms query latency. The most
-  widely adopted closed-source vector database, used by thousands of production RAG systems. Raised $138M+
-  (Series B at $750M valuation). The default choice for teams that want managed vector search without
-  operational overhead.
+description: Fully managed vector database built for AI applications at scale, with a serverless architecture
+  that scales automatically, integrated sparse-dense hybrid search and sub-100-millisecond query latency. It
+  targets teams that want managed vector search without operational overhead.
 pypi:
 - url: https://pypi.org/project/pinecone
 comments: Bring-your-own-cloud runs Pinecone's own software inside the customer's VPC rather than shipping
-  source, so the openness score treats it as managed hosting and not as self-hosting. Capability is calibrated
+  source, so the openness axis treats it as managed hosting rather than self-hosting. Capability is calibrated
   against the Milvus anchor. Verified 2026-08-13 via the Pinecone pricing page and docs.

--- a/sources/products/playwright-mcp.yaml
+++ b/sources/products/playwright-mcp.yaml
@@ -1,15 +1,14 @@
 name: playwright-mcp
 display_name: Playwright MCP
 type: software
-description: MCP server that gives AI agents full browser automation capabilities via Playwright. Agents
-  can navigate pages, click elements, fill forms, take screenshots, and extract structured data from web
-  pages, all through the MCP protocol. Works from structured accessibility snapshots rather than screenshots,
-  so the agent reads a page as a tree rather than as pixels. The standard open source approach for giving
-  agents a browser. Backed by Microsoft and tightly integrated with VS Code and Copilot.
+description: 'MCP server that gives agents browser automation through Playwright: navigating pages, clicking
+  elements, filling forms, taking screenshots and extracting structured data. It works from structured accessibility
+  snapshots rather than screenshots, so the agent reads a page as a tree rather than as pixels. It is backed
+  by Microsoft and integrated with VS Code and Copilot.'
 github:
 - url: https://github.com/microsoft/playwright-mcp
 npm:
 - url: https://www.npmjs.com/package/@playwright/mcp
-comments: 'The npm artifact was corrected 2026-08-14 from @anthropic-ai/mcp-playwright, which the registry
-  answers 404 for, to @playwright/mcp, the package the README installs and the one api.npmjs.org reports
-  25,901,643 monthly downloads for. Verified 2026-08-13 via GitHub and the repository LICENSE.'
+comments: The npm artifact was corrected 2026-08-14 from @anthropic-ai/mcp-playwright, which the registry answers
+  404 for, to @playwright/mcp, the package the README installs and the one api.npmjs.org reports 25,901,643
+  monthly downloads for. Verified 2026-08-13 via GitHub and the repository LICENSE.

--- a/sources/products/postgres-mcp.yaml
+++ b/sources/products/postgres-mcp.yaml
@@ -1,14 +1,14 @@
 name: postgres-mcp
 display_name: Postgres MCP Pro
 type: software
-description: 'Actively maintained PostgreSQL MCP server (Python) by Crystal DBA, ''Postgres MCP Pro'', that goes
-  beyond read-only querying to database performance and health tooling for agents: schema/object inspection, execute_sql
-  with access modes, EXPLAIN with hypothetical-index simulation, slow-query analysis, index advising, and health
-  checks.'
+description: 'Actively maintained PostgreSQL MCP server (Python) by Crystal DBA, ''Postgres MCP Pro'', that
+  goes beyond read-only querying to database performance and health tooling for agents: schema/object inspection,
+  execute_sql with access modes, EXPLAIN with hypothetical-index simulation, slow-query analysis, index advising,
+  and health checks.'
 github:
 - url: https://github.com/crystaldba/postgres-mcp
 pypi:
 - url: https://pypi.org/project/postgres-mcp
-comments: The original reference Postgres server was archived (read-only since May 2025) and only did read-only
-  queries, so this is the canonical maintained one. "Pro" is part of the product name, not a paid edition
-  - there is no second tier. Verified 2026-08-13 via GitHub and the repository LICENSE.
+comments: The original reference Postgres server was archived read-only in May 2025 and only did read-only
+  queries, so this is the maintained successor. "Pro" is part of the product name rather than a paid edition;
+  there is no second tier. Verified 2026-08-13 via GitHub and the repository LICENSE.

--- a/sources/products/searxng.yaml
+++ b/sources/products/searxng.yaml
@@ -1,16 +1,13 @@
 name: searxng
 display_name: SearXNG
 type: software
-description: Free, privacy-respecting open source metasearch engine that aggregates results from a long list
-  of search services without tracking or profiling users. Though it predates the LLM era and does no inference
-  itself, it is used as a self-hosted web-search backend for open AI answer engines and RAG - it exposes a
-  JSON API and runs entirely on your own infrastructure (no commercial search keys, no tracking), and is integrated
-  as a web-search provider by Open WebUI, Perplexica, Morphic, and LibreChat. It is the open peer to proprietary
-  AI search APIs like Tavily, Serper, and Exa.
+description: Privacy-respecting metasearch engine that aggregates results from many search services without
+  tracking or profiling users. It predates the LLM era and does no inference itself, but exposes a JSON API
+  and runs entirely on infrastructure you operate, which is why answer engines and RAG stacks use it as a web-search
+  backend - Open WebUI, Perplexica, Morphic and LibreChat all integrate it as a provider.
 github:
 - url: https://github.com/searxng/searxng
-comments: Community-run fork-successor of the older searx project. No official hosted SaaS - distributed as
-  source and Docker for self-hosting, alongside a network of community public instances, many of which disable
-  the JSON API. Docker is not a declared artifact here, so the adoption figure is computed in the score note
-  rather than fetched by a signal. Not itself an AI product; it is the search backend AI tools call. Verified
-  2026-08-13 via GitHub, Docker Hub and the SearXNG search-API documentation.
+comments: Community-run fork-successor of the older searx project. There is no hosted service; it is distributed
+  for self-hosting alongside a network of community public instances, many of which disable the JSON API. Docker
+  is not a declared artifact here, so the adoption figure is computed in the score note rather than fetched
+  by a signal. Verified 2026-08-13 via GitHub, Docker Hub and the SearXNG search-API documentation.

--- a/sources/products/serper.yaml
+++ b/sources/products/serper.yaml
@@ -1,10 +1,9 @@
 name: serper
 display_name: Serper
 type: software
-description: Fast, low-cost Google Search API designed for developers and AI agents. Returns structured
-  Google SERP data (organic results, knowledge graph, related searches) via a simple REST API. Positioned
-  as the cheapest way to give agents Google-quality search results, $0.001/query at scale. Widely used
-  in LangChain and agent frameworks as a cost-effective alternative to Tavily for high-volume use cases.
+description: Google Search API for developers and agents, returning structured search-results-page data including
+  organic results, the knowledge graph and related searches over a simple REST interface. It is positioned
+  on price and latency for high-volume use.
 comments: The vendor publishes price and latency copy but no user, customer or query-volume figure, and there
   is no package to count, so adoption abstains rather than banding on marketing claims. Verified 2026-08-13
   via serper.dev.

--- a/sources/products/slack-mcp.yaml
+++ b/sources/products/slack-mcp.yaml
@@ -1,12 +1,11 @@
 name: slack-mcp
 display_name: Slack MCP Server
 type: software
-description: Actively maintained community Slack MCP server (Go) connecting AI agents to Slack workspaces over stdio/SSE/HTTP,
-  with a 'stealth mode' needing no bot install or workspace permissions plus an OAuth mode. Exposes 18 tools (history,
-  search, posting, reactions, channel/user management).
+description: Actively maintained community Slack MCP server (Go) connecting AI agents to Slack workspaces over
+  stdio/SSE/HTTP, with a 'stealth mode' needing no bot install or workspace permissions plus an OAuth mode.
+  Exposes 18 tools (history, search, posting, reactions, channel/user management).
 github:
 - url: https://github.com/korotovsky/slack-mcp-server
-comments: There is no first-party official Slack MCP server - the original reference server was archived
-  (servers-archived), making this the most popular maintained one. The PyPI package of the same name is an
-  unedited template and is not this product; adoption reads the npm package. Verified 2026-08-13 via GitHub
-  and the repository LICENSE.
+comments: There is no first-party Slack MCP server; the original reference server was archived, and this is
+  the maintained community one. The PyPI package of the same name is an unedited template and is not this product,
+  so adoption reads the npm package. Verified 2026-08-13 via GitHub and the repository LICENSE.

--- a/sources/products/tavily-search-api.yaml
+++ b/sources/products/tavily-search-api.yaml
@@ -1,10 +1,9 @@
 name: tavily-search-api
 display_name: Tavily Search API
 type: software
-description: Search API purpose-built for AI agents, returning clean, structured results optimized for LLM
-  consumption rather than human browsing. Includes search, extract, crawl, and map endpoints. The default search
-  provider in most agent tutorials and frameworks; integrated into LangChain, CrewAI, and AutoGen out of the
-  box. YC-backed.
+description: Search API built for AI agents, returning clean structured results optimized for model consumption
+  rather than human browsing, across search, extract, crawl and map endpoints. It is integrated into LangChain,
+  CrewAI and AutoGen out of the box.
 pypi:
 - url: https://pypi.org/project/tavily-python
 comments: Nebius announced an agreement to acquire Tavily, which is an agreement rather than a closed deal;

--- a/sources/products/yomo.yaml
+++ b/sources/products/yomo.yaml
@@ -1,16 +1,16 @@
 name: yomo
 display_name: YoMo
 type: software
-description: Open-source LLM function-calling framework for building serverless AI agents on geo-distributed
-  edge infrastructure. Developers write strongly-typed tools/skills (TypeScript, Go) that YoMo deploys
-  and runs across edge nodes, exposed through an OpenAI-compatible chat completions API. Rust core with
-  QUIC transport and TLS 1.3; integrates MCP and A2A for agent tooling.
+description: LLM function-calling framework for building serverless AI agents on geo-distributed edge infrastructure.
+  Developers write strongly-typed tools in TypeScript or Go, which YoMo deploys and runs across edge nodes
+  behind an OpenAI-compatible chat-completions API. It has a Rust core with QUIC transport and TLS 1.3, and
+  integrates MCP and A2A for agent tooling.
 github:
 - url: https://github.com/yomorun/yomo
 crates:
 - url: https://crates.io/crates/yomo
-comments: A framework and runtime for the agent-tooling layer rather than a model. The license is declared
-  in Cargo.toml and the README rather than in a LICENSE file on the default branch, which is why the GitHub
-  API reports none - a LICENSE does resolve on the master branch, so the two branches disagree and the openness
-  record should say which governs. Backed by Vivgrid, which operates a separate managed platform. Added from
-  contributor issue 89. Verified 2026-08-13 via GitHub and Cargo.toml.
+comments: A framework and runtime for the agent-tooling layer rather than a model. The terms are declared in
+  Cargo.toml and the README rather than in a license file on the default branch, which is why the GitHub API
+  reports none; one does resolve on the master branch, so the two branches disagree and the openness record
+  should say which governs. Backed by Vivgrid, which operates a separate managed platform. Verified 2026-08-13
+  via GitHub and Cargo.toml.

--- a/sources/provenance/agent_tools_protocols.yaml
+++ b/sources/provenance/agent_tools_protocols.yaml
@@ -1,0 +1,176 @@
+# Prose closeout for agent_tools_protocols. 32 of 32 ready.
+#
+# All 32 were canonical; 28 failed prose compliance. The ban detector flagged 15. Thirteen more
+# were found only by reading the complete prose of every record, which is now the second
+# category running where the detector's recall was well under half.
+#
+# What it missed, and why the pattern is worth writing down:
+#
+#   ADOPTION CLAIMS wearing description clothes - "Supported by more than 150 organizations"
+#   (agent2agent-protocol), "Powers search for over 18,000 customers in 150+ countries,
+#   including Stripe, Decathlon and Ubisoft" (algolia-ai-search), "used by several agent
+#   frameworks as their default scraping tool" (firecrawl), "Widely used in LangChain and agent
+#   frameworks" (serper), "used by thousands of production RAG systems" (pinecone).
+#
+#   RANKINGS phrased as category placement - "The most mature commercial web scraping platform"
+#   (apify), "The most-starred dedicated vector database on GitHub" (milvus), "The
+#   most-downloaded MCP package by a wide margin" (mcp-typescript-sdk), "The emerging universal
+#   standard for agent-tool communication" (model-context-protocol), "The default search
+#   provider in most agent tutorials" (tavily-search-api), "the most popular maintained one"
+#   (slack-mcp), "the canonical maintained one" (postgres-mcp), "the cheapest way to give agents
+#   Google-quality search results" (serper).
+#
+#   FUNDING in three spellings the money pattern did not cover - "YC-backed" (composio,
+#   browserbase, tavily-search-api), "Well-funded (YC-backed, $22M+ raised)" (exa-search-api),
+#   "Raised $500M+, valued at $9B+, the most well-funded company in the AI search space"
+#   (perplexity-sonar-api), "Raised $138M+ (Series B at $750M valuation)" (pinecone).
+#
+#   THE WORD `closed` on its own - "The enterprise closed alternative for search-augmented
+#   generation" (google-grounding-api), which the pattern only caught as `closed-source` or
+#   `closed counterpart`.
+#
+# ## One more stale-prose record, the seventh
+#
+# `browser-use`'s comments read "The adoption axis is flagged ... and carries no confirmation
+# date until that is settled". The axis carries 2026-08-14. Removed.
+#
+# ## Licensing questions kept, because they are about our reading
+#
+# This category has more of them than any other, because the MCP project is mid-transition and
+# its repositories disagree: `mcp-python-sdk` still carries the original file where
+# `mcp-typescript-sdk` and the servers monorepo have moved to the transition terms, and
+# `filesystem-mcp`'s own README and the monorepo now contradict each other. Each record says so
+# without stating which terms apply, because that is the axis's job.
+#
+# `mcp-inspector` and `markitdown` have no license file at all in the place a reader would look
+# - one declares in README and package.json, the other has a null PyPI field - and `yomo`'s two
+# branches disagree, which its comments record as an open question for the openness record.
+#
+- product: agent2agent-protocol
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and the Linux Foundation's first-year release
+- product: algolia-ai-search
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Algolia AI Search product page
+- product: apify
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: apify
+- product: browser-use
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and the pypistats API
+- product: browserbase
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: docs
+- product: cohere-rerank-api
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Cohere rerank overview, the 3
+- product: composio
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and the Composio docs
+- product: docling
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub, the repository LICENSE and the pypistats API
+- product: exa-search-api
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the exa
+- product: fastmcp
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub, the repository LICENSE and the pypistats API
+- product: filesystem-mcp
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the server README and the monorepo LICENSE
+- product: firecrawl
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and the self-hosting guide
+- product: github-mcp
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and the repository LICENSE
+- product: google-grounding-api
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Google Cloud grounding overview
+- product: jina-reader
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and jina
+- product: markitdown
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub, the repository LICENSE and the pypistats API
+- product: mcp-inspector
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub, the README and package
+- product: mcp-python-sdk
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub, the repository LICENSE and PyPI
+- product: mcp-typescript-sdk
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub, the repository LICENSE and package
+- product: milvus
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub, milvus
+- product: model-context-protocol
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the spec repository LICENSE, the Wikipedia entry and Zuplo's one-year retrospective
+- product: notion-mcp
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and the repository LICENSE
+- product: perplexity-sonar-api
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: docs
+- product: pinecone
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Pinecone pricing page and docs
+- product: playwright-mcp
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and the repository LICENSE
+- product: postgres-mcp
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and the repository LICENSE
+- product: qdrant
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub, the qdrant
+- product: searxng
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub, Docker Hub and the SearXNG search-API documentation
+- product: serper
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: serper
+- product: slack-mcp
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and the repository LICENSE
+- product: tavily-search-api
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: docs
+- product: yomo
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and Cargo


### PR DESCRIPTION
**32 of 32 ready.** All were canonical; **28 failed prose compliance**. No axis touched, no date moved.

## The detector flagged 15. Thirteen more were found by reading everything.

Second category running where the detector's recall was well under half. The misses cluster into four shapes worth naming:

**Adoption claims wearing description clothes** — "Supported by more than 150 organizations" (`agent2agent-protocol`), "Powers search for over 18,000 customers in 150+ countries, including Stripe, Decathlon and Ubisoft" (`algolia-ai-search`), "used by several agent frameworks as their default scraping tool" (`firecrawl`), "used by thousands of production RAG systems" (`pinecone`).

**Rankings phrased as category placement** — "The most mature commercial web scraping platform" (`apify`), "The most-starred dedicated vector database on GitHub" (`milvus`), "The most-downloaded MCP package by a wide margin" (`mcp-typescript-sdk`), "The emerging universal standard for agent-tool communication" (`model-context-protocol`), "The default search provider in most agent tutorials" (`tavily-search-api`), "the most popular maintained one" (`slack-mcp`), "the cheapest way to give agents Google-quality search results" (`serper`).

**Funding in three spellings the money pattern did not cover** — "YC-backed" (`composio`, `browserbase`, `tavily-search-api`), "Well-funded (YC-backed, $22M+ raised)" (`exa-search-api`), "Raised $500M+, valued at $9B+, the most well-funded company in the AI search space" (`perplexity-sonar-api`), "Raised $138M+ (Series B at $750M valuation)" (`pinecone`).

**The word `closed` on its own** — "The enterprise closed alternative for search-augmented generation" (`google-grounding-api`), which the pattern only caught as `closed-source` or `closed counterpart`.

## A seventh stale-prose record

`browser-use`'s comments read *"The adoption axis is flagged … and carries no confirmation date until that is settled."* The axis carries `2026-08-14`. Removed.

## Licensing questions kept, because they are about our reading

This category has more of them than any other, because **the MCP project is mid-transition and its own repositories disagree**: `mcp-python-sdk` still carries the original license file where `mcp-typescript-sdk` and the servers monorepo have moved to the transition terms, and `filesystem-mcp`'s README and the monorepo now contradict each other. Each record says so without stating which terms apply — that is the axis's job.

`mcp-inspector` and `markitdown` have no license file where a reader would look (one declares in README and `package.json`, the other has a null PyPI field), and `yomo`'s two branches disagree, which its comments record as an open question for the openness record.

## Verification

`validate`, `check_verification`, `check_capability`, `check_recipe`, `check_adoption --strict` clean. `check_freshness --category agent_tools_protocols`: *all 96 axes carry a real last_verified*. 664 tests, no skips.

**Corpus: 446/472 prose-compliant · 472/472 canonical · 1,407/1,416 axes confirmed · 9 held.**
