### PR TITLE
Refresh safeguards: 26/26

### DIFF
--- a/sources/products/aegis-guard.yaml
+++ b/sources/products/aegis-guard.yaml
@@ -1,12 +1,12 @@
 name: aegis-guard
 display_name: Aegis AI Content Safety
 type: model
-description: NVIDIA's content-safety classifier (now also called Llama Nemotron Safety Guard Defensive),
-  a LlamaGuard/Llama2-7B-based model parameter-efficiently tuned on NVIDIA's Aegis safety dataset to classify
+description: NVIDIA's content-safety classifier (now also called Llama Nemotron Safety Guard Defensive), a
+  LlamaGuard/Llama2-7B-based model parameter-efficiently tuned on NVIDIA's Aegis safety dataset to classify
   prompts and responses across 13 critical risk categories.
 huggingface_model:
 - url: https://huggingface.co/nvidia/Aegis-AI-Content-Safety-LlamaGuard-Defensive-1.0
-comments: NVIDIA Aegis AI Content Safety (Defensive 1.0), aka Llama Nemotron Safety Guard Defensive V1.
-  The adapter weights are public on the Hub, but the Llama Guard base must be obtained through Meta's
-  access request, so it is not fully open-weight. The Aegis safety dataset it was tuned on is published.
-  Verified 2026-08-13 via the HF model card.
+comments: NVIDIA Aegis AI Content Safety (Defensive 1.0), also called Llama Nemotron Safety Guard Defensive
+  V1. The adapter weights are on the Hub while the Llama Guard base needs Meta's access request, which the
+  openness axis weighs. The Aegis dataset it was tuned on is published. Verified 2026-08-13 via the HF model
+  card.

--- a/sources/products/azure-content-safety.yaml
+++ b/sources/products/azure-content-safety.yaml
@@ -2,9 +2,7 @@ name: azure-content-safety
 display_name: Azure AI Content Safety
 type: software
 description: 'Microsoft''s managed content-safety service on Azure: hosted APIs for text and image moderation
-  across hate, sexual, violence and self-harm categories, plus prompt-shield (jailbreak/injection) and
-  groundedness detection. Closed, managed service.'
-comments: Azure AI Content Safety, a managed Azure service covering text and image moderation, custom
-  filters, prompt shields for direct and indirect injection, groundedness detection, and protected-material
-  detection for copyrighted text and code. Sold on consumption pricing, with no self-hosted option.
-  Verified 2026-08-13 via the Azure product page.
+  across hate, sexual, violence and self-harm categories, plus prompt shields for direct and indirect injection,
+  groundedness detection and protected-material detection for copyrighted text and code.'
+comments: Sold on consumption pricing and run entirely as an Azure service, with custom filters configurable
+  per deployment. Verified 2026-08-13 via the Azure product page.

--- a/sources/products/bedrock-guardrails.yaml
+++ b/sources/products/bedrock-guardrails.yaml
@@ -1,11 +1,8 @@
 name: bedrock-guardrails
 display_name: Amazon Bedrock Guardrails
 type: software
-description: 'Managed guardrails for Amazon Bedrock: configurable policies for denied topics, content
-  filters, PII redaction, word filters, and contextual-grounding checks, applied to any Bedrock model.
-  Closed, managed service.'
-comments: Amazon Bedrock Guardrails, a managed AWS service covering content and word filters, prompt attack
-  detection, denied topics, sensitive-information redaction, contextual grounding and Automated Reasoning
-  checks. The ApplyGuardrail API applies the same safeguards to self-hosted models as well as Bedrock ones,
-  but the guardrail itself runs at AWS and there is no self-hosted build. Verified 2026-08-13 via the AWS
-  product page.
+description: 'Managed guardrails for Amazon Bedrock: configurable policies covering denied topics, content
+  and word filters, PII redaction, prompt-attack detection, contextual-grounding checks and Automated Reasoning
+  checks, applied to any Bedrock model.'
+comments: The ApplyGuardrail API applies the same policies to models hosted outside Bedrock, though the guardrail
+  itself runs at AWS. Verified 2026-08-13 via the AWS product page.

--- a/sources/products/deepteam.yaml
+++ b/sources/products/deepteam.yaml
@@ -1,12 +1,10 @@
 name: deepteam
 display_name: DeepTeam
 type: software
-description: An open-source red-teaming framework for LLM systems from Confident AI. It simulates adversarial
-  attacks (jailbreaking, prompt injection, multi-turn exploitation) with 50+ built-in vulnerability checks
-  and 20+ attack methods aligned to OWASP Top 10 for LLMs, NIST AI RMF, and MITRE ATLAS, and ships production
-  guardrails.
+description: Red-teaming framework for LLM systems from Confident AI, simulating adversarial attacks including
+  jailbreaking, prompt injection and multi-turn exploitation. It ships more than fifty vulnerability checks
+  and twenty attack methods mapped to the OWASP Top 10 for LLMs and for Agents, NIST AI RMF and MITRE ATLAS,
+  alongside seven runtime guardrails.
 github:
 - url: https://github.com/confident-ai/deepteam
-comments: DeepTeam, from Confident AI, built on their DeepEval evaluation framework and run locally. 50+
-  vulnerability checks and 20+ attack methods, mapped to OWASP Top 10 for LLMs and for Agents, NIST AI RMF
-  and MITRE ATLAS, plus seven runtime guardrails. Verified 2026-08-13 via GitHub.
+comments: Built on Confident AI's DeepEval evaluation framework and run locally. Verified 2026-08-13 via GitHub.

--- a/sources/products/garak.yaml
+++ b/sources/products/garak.yaml
@@ -1,11 +1,9 @@
 name: garak
 display_name: garak
 type: software
-description: An open LLM vulnerability scanner maintained by NVIDIA. It probes models for hallucination,
-  data leakage, prompt injection, misinformation, toxicity, and jailbreaks across many providers (Hugging
-  Face, OpenAI, Bedrock, and others), the nmap of LLM security testing.
+description: LLM vulnerability scanner maintained by NVIDIA. It probes models for hallucination, data leakage,
+  prompt injection, misinformation, toxicity generation and jailbreaks across many providers including Hugging
+  Face, OpenAI and Bedrock, run from the command line against your own endpoints.
 github:
 - url: https://github.com/NVIDIA/garak
-comments: garak, an LLM vulnerability scanner maintained by NVIDIA. It probes for hallucination, data
-  leakage, prompt injection, misinformation, toxicity generation and jailbreaks across many providers, run
-  from the command line against your own endpoints. Verified 2026-08-13 via GitHub.
+comments: Verified 2026-08-13 via GitHub.

--- a/sources/products/giskard.yaml
+++ b/sources/products/giskard.yaml
@@ -1,12 +1,11 @@
 name: giskard
 display_name: Giskard
 type: software
-description: An open-source Python library for testing and red-teaming LLM and agentic systems. Giskard
-  Scan automatically probes applications for vulnerabilities (prompt injection, harmful output, hallucination),
-  and Giskard Checks runs scenario-based evaluations, including multi-turn agent validation.
+description: Python library for testing and red-teaming LLM and agentic systems. Giskard Scan automatically
+  probes an application for vulnerabilities including prompt injection, harmful output and hallucination, and
+  Giskard Checks runs scenario-based evaluations including multi-turn agent validation.
 github:
 - url: https://github.com/Giskard-AI/giskard-oss
 comments: Giskard's v3 line is a rewrite aimed at dynamic, multi-turn testing of agents; the v2 Scan is now
-  vulnerability_scan, shipped in giskard-scan alongside knowledge-base and RAG evaluation. The repo is
-  Giskard-AI/giskard-oss, which the old Giskard-AI/giskard path redirects to. Verified 2026-08-13 via
-  GitHub.
+  vulnerability_scan, shipped in giskard-scan alongside knowledge-base and RAG evaluation. The repo is Giskard-AI/giskard-oss,
+  which the old Giskard-AI/giskard path redirects to. Verified 2026-08-13 via GitHub.

--- a/sources/products/gpt-oss-safeguard.yaml
+++ b/sources/products/gpt-oss-safeguard.yaml
@@ -1,13 +1,12 @@
 name: gpt-oss-safeguard
 display_name: gpt-oss-safeguard
 type: model
-description: OpenAI's open safety reasoning model, built on gpt-oss and released with Hugging Face and
-  ROOST. Rather than emitting a fixed label, it reasons over a safety policy you supply and returns a
-  reasoned decision, with configurable reasoning effort. Shipped in 20b and 120b variants under Apache
-  2.0.
+description: OpenAI's safety reasoning model, built on gpt-oss and released with Hugging Face and ROOST. Rather
+  than emitting a fixed label it reasons over a safety policy supplied at call time and returns a reasoned
+  decision, with configurable reasoning effort. It ships in 20b and 120b variants.
 huggingface_model:
 - url: https://huggingface.co/openai/gpt-oss-safeguard-20b
-comments: gpt-oss-safeguard (20b / 120b), released by OpenAI with Hugging Face and ROOST and distributed
-  through the ROOST Model Community. Built on gpt-oss, it interprets a policy you supply rather than a
-  fixed taxonomy and returns a reasoned decision. The card carries no training-data section at all.
-  Verified 2026-08-13 via the HF model card.
+comments: gpt-oss-safeguard (20b / 120b), released by OpenAI with Hugging Face and ROOST and distributed through
+  the ROOST Model Community. Built on gpt-oss, it interprets a policy you supply rather than a fixed taxonomy
+  and returns a reasoned decision. The card carries no training-data section at all. Verified 2026-08-13 via
+  the HF model card.

--- a/sources/products/guardrails-ai.yaml
+++ b/sources/products/guardrails-ai.yaml
@@ -1,12 +1,11 @@
 name: guardrails-ai
 display_name: Guardrails AI
 type: software
-description: An open framework for input/output guards on LLM applications, with a Hub of pre-built validators
-  (PII, toxicity, prompt injection, format/structure). Wraps model calls in guards that detect risks and
-  enforce structured output, self-hostable as a Python library.
+description: Framework for input and output guards on LLM applications, with a hub of pre-built validators
+  covering PII, toxicity, prompt injection and output format. It wraps a model call in guards that detect risks
+  and enforce structured output, and runs as a Python library on infrastructure you operate.
 github:
 - url: https://github.com/guardrails-ai/guardrails
 comments: The Guardrails AI framework, plus Guardrails Hub, a registry of pre-built validators that combine
-  into input and output guards around a model call. Guardrails-AI-owned validators moved from the private
-  registry to public PyPI in 0.11.0. A separate commercial product sits alongside it. Verified 2026-08-13
-  via GitHub.
+  into input and output guards around a model call. Guardrails-AI-owned validators moved from the private registry
+  to public PyPI in 0.11.0. A separate commercial product sits alongside it. Verified 2026-08-13 via GitHub.

--- a/sources/products/harmbench.yaml
+++ b/sources/products/harmbench.yaml
@@ -1,11 +1,10 @@
 name: harmbench
 display_name: HarmBench
 type: software
-description: A standardized evaluation framework for automated red-teaming from the Center for AI Safety.
-  It runs a common pipeline across many attack methods and target models so red-team attacks and defenses
-  can be compared rigorously and co-developed.
+description: A standardized evaluation framework for automated red-teaming from the Center for AI Safety. It
+  runs a common pipeline across many attack methods and target models so red-team attacks and defenses can
+  be compared rigorously and co-developed.
 github:
 - url: https://github.com/centerforaisafety/HarmBench
-comments: HarmBench, from the Center for AI Safety. A standardized red-teaming evaluation that shipped
-  covering 18 attack methods against 33 target models, run entirely from the public repo. Verified
-  2026-08-13 via GitHub.
+comments: HarmBench, from the Center for AI Safety. A standardized red-teaming evaluation that shipped covering
+  18 attack methods against 33 target models. Verified 2026-08-13 via GitHub.

--- a/sources/products/lakera-guard.yaml
+++ b/sources/products/lakera-guard.yaml
@@ -1,10 +1,7 @@
 name: lakera-guard
 display_name: Lakera Guard
 type: software
-description: 'Lakera''s hosted AI security product: a real-time API defending LLM applications against
-  prompt injection, jailbreaks, data leakage, and content risks. Closed/SaaS; Lakera was acquired by Check
-  Point in 2025.'
-comments: Lakera Guard, a hosted API defending LLM applications against prompt injection, jailbreaks and
-  data leakage at runtime. It now sits inside a three-product platform alongside Lakera's workforce-AI
-  security and red-teaming products, sold through sales rather than self-serve, with no self-hosted build.
-  Verified 2026-08-13 via the Lakera site.
+description: 'Lakera''s hosted AI security product: a real-time API defending LLM applications against prompt
+  injection, jailbreaks, data leakage and content risks. Lakera was acquired by Check Point in 2025.'
+comments: It now sits inside a three-product platform alongside Lakera's workforce-AI security and red-teaming
+  products, sold through sales rather than self-serve. Verified 2026-08-13 via the Lakera site.

--- a/sources/products/llama-guard.yaml
+++ b/sources/products/llama-guard.yaml
@@ -1,13 +1,10 @@
 name: llama-guard
 display_name: Llama Guard
 type: model
-description: Meta's input/output safety classifier built on Llama 3.1-8B, a widely deployed open guardrail
-  model. It labels both prompts and responses across 14 hazard categories (violent crime, child exploitation,
-  hate, self-harm, code-interpreter abuse, and more) and supports eight languages. Widely used as the moderation
-  layer in front of open chat and agent stacks.
+description: Meta's input and output safety classifier built on Llama 3.1 8B. It labels both prompts and responses
+  across fourteen hazard categories aligned to the MLCommons taxonomy - violent crime, child exploitation,
+  hate, self-harm, code-interpreter abuse and others - in eight languages.
 huggingface_model:
 - url: https://huggingface.co/meta-llama/Llama-Guard-3-8B
-comments: Llama Guard 3 (8B), built on Llama 3.1. Fourteen hazard categories aligned to the MLCommons
-  taxonomy, in eight languages, applied to both prompts and responses. The weights are behind Meta's access
-  request; the card publishes no training mixture and points at Llama Recipes for inference. Verified
-  2026-08-13 via the HF model card.
+comments: The weights need Meta's access request, so openness was read from the card, which publishes no training
+  mixture and points at Llama Recipes for inference. Verified 2026-08-13 via the HF model card.

--- a/sources/products/llm-guard.yaml
+++ b/sources/products/llm-guard.yaml
@@ -1,13 +1,11 @@
 name: llm-guard
 display_name: LLM Guard
 type: software
-description: An open security toolkit for LLM interactions from Protect AI, providing input and output
-  scanners for prompt-injection, PII/data-leakage, toxicity, and harmful-content detection and sanitization.
-  Self-hostable as a Python library.
+description: Security toolkit for LLM interactions from Protect AI, providing input and output scanners for
+  prompt injection, PII and data leakage, secrets, toxicity, bias and harmful content, with detection and sanitization.
+  It runs as a Python library on infrastructure you operate, or deployed as an API.
 github:
 - url: https://github.com/protectai/llm-guard
 pypi:
 - url: https://pypi.org/project/llm-guard/
-comments: LLM Guard, maintained by Protect AI. A library of prompt and output scanners - anonymization,
-  ban lists, prompt injection, secrets, toxicity, bias and more - that you run yourself or deploy as an
-  API. Protect AI's commercial platform is a separate product. Verified 2026-08-13 via GitHub.
+comments: Protect AI's commercial platform is a separate product. Verified 2026-08-13 via GitHub.

--- a/sources/products/nemo-guardrails.yaml
+++ b/sources/products/nemo-guardrails.yaml
@@ -1,14 +1,13 @@
 name: nemo-guardrails
 display_name: NeMo Guardrails
 type: software
-description: NVIDIA's open-source toolkit for adding programmable guardrails around LLM applications.
-  It wraps input/output moderation, dialog control, retrieval filtering, and tool-use control through
-  a small policy language (Colang), and works across multiple LLM providers. Deployable as a Python library,
-  CLI, Docker, or standalone server.
+description: NVIDIA's toolkit for adding programmable guardrails around LLM applications. It wraps input and
+  output moderation, dialog control, retrieval filtering and tool-use control in a small policy language called
+  Colang, works across multiple model providers, and deploys as a Python library, a CLI, a Docker image or
+  a standalone server.
 github:
 - url: https://github.com/NVIDIA-NeMo/Guardrails
 pypi:
 - url: https://pypi.org/project/nemoguardrails/
-comments: NeMo Guardrails is NVIDIA's programmable guardrail toolkit for LLM applications, self-hostable as
-  a library, CLI, Docker image or server. The repo now lives at NVIDIA-NeMo/Guardrails, which the old
-  NVIDIA/NeMo-Guardrails path redirects to. Verified 2026-08-13 via GitHub.
+comments: The repository now lives at NVIDIA-NeMo/Guardrails, which the older path redirects to. Verified 2026-08-13
+  via GitHub.

--- a/sources/products/openai-moderation.yaml
+++ b/sources/products/openai-moderation.yaml
@@ -1,10 +1,8 @@
 name: openai-moderation
 display_name: OpenAI Moderation API
 type: software
-description: OpenAI's hosted moderation endpoint, a free API that classifies text (and images) against
-  OpenAI's content-policy categories (hate, harassment, self-harm, sexual, violence, and more). Closed,
-  API-only; no weights or self-hosting.
-comments: OpenAI Moderation API. A free hosted endpoint, omni-moderation-latest, classifying text and
-  images across thirteen fixed content categories; it does not classify audio. No weights and no
-  self-hosting. Moderation scores can also be requested alongside a generated response rather than through
-  a separate call. Verified 2026-08-13 via the OpenAI moderation guide.
+description: 'OpenAI''s hosted moderation endpoint: a free API classifying text and images against OpenAI''s
+  content-policy categories including hate, harassment, self-harm, sexual content and violence. It does not
+  classify audio.'
+comments: Moderation scores can also be requested alongside a generated response rather than through a separate
+  call. Verified 2026-08-13 via the OpenAI moderation guide.

--- a/sources/products/openguardrails.yaml
+++ b/sources/products/openguardrails.yaml
@@ -1,19 +1,16 @@
 name: openguardrails
 display_name: OpenGuardrails
 type: software
-description: 'An open guardrails project with two halves. It publishes a safety and manipulation-detection
-  model (OpenGuardrails-Text-2510, a 3.3B quantized LLM covering content safety, prompt injection,
-  jailbreak, code-interpreter abuse and data leakage across 119 languages), and it maintains the
-  OpenGuardrails (OGR) specification - a vendor-neutral wire contract for AI agent safety, with reference
-  runtimes, Python and JavaScript SDKs, agent/gateway/sandbox integrations, and a detector benchmark. The
-  specification is deliberately not a detector - it defines the interface and referees the leaderboard so
-  vendors compete behind a common plug.'
+description: Project with two halves. It publishes a safety and manipulation-detection model, a 3.3B quantized
+  LLM covering content safety, prompt injection, jailbreak, code-interpreter abuse and data leakage across
+  119 languages; and it maintains the OpenGuardrails specification, a vendor-neutral wire contract for agent
+  safety with reference runtimes, Python and JavaScript SDKs, gateway and sandbox integrations, and a detector
+  benchmark. The specification defines the interface and referees the leaderboard rather than detecting anything
+  itself.
 github:
 - url: https://github.com/openguardrails/openguardrails
 huggingface_model:
 - url: https://huggingface.co/openguardrails/OpenGuardrails-Text-2510
-comments: 'The first project to open-source both a large-scale safety LLM and a production guardrails
-  platform, described in arXiv 2510.19169. The repo has since been reshaped into the monorepo for the OGR
-  specification and its reference implementations, so the paper and the repo now describe different things
-  and the paper is the better guide to the model. Verified 2026-08-13 via GitHub, the HF model card and the
-  arXiv abstract.'
+comments: The repository has since been reshaped into the monorepo for the specification and its reference
+  implementations, so the paper and the repository now describe different things and the paper is the better
+  guide to the model. Verified 2026-08-13 via GitHub, the HF model card and the arXiv abstract.

--- a/sources/products/osprey.yaml
+++ b/sources/products/osprey.yaml
@@ -1,14 +1,11 @@
 name: osprey
 display_name: Osprey
 type: software
-description: An open, high-performance safety rules engine for real-time abuse mitigation, originally
-  built at Discord and donated to ROOST. It evaluates events and their properties in real time using a
-  Python-based rules DSL (SML), ingesting signals — including ML classifier outputs — to automatically
-  detect and action spam, abuse, and policy violations at scale. Trust & Safety operational
-  infrastructure rather than an AI guardrail model.
+description: Safety rules engine for real-time abuse mitigation, originally built at Discord and donated to
+  ROOST. It evaluates events and their properties in real time using a Python-based rules DSL called SML, ingesting
+  signals including machine-learning classifier outputs to detect and action spam, abuse and policy violations.
+  It is Trust and Safety operational infrastructure rather than an AI guardrail model.
 github:
 - url: https://github.com/roostorg/osprey
-comments: Osprey, a safety rules engine and investigation console donated by Discord to ROOST and now on
-  the V1.0 line. In production at Discord, Bluesky and Matrix; ROOST's V1.0 announcement reports it
-  processing over 50M events daily in production. Rules are written in SML and extended with user-defined
-  functions. Verified 2026-08-13 via GitHub and ROOST's Osprey V1.0 announcement.
+comments: Donated by Discord to ROOST. Rules are written in SML and extended with user-defined functions, alongside
+  an investigation console. Verified 2026-08-13 via GitHub and ROOST's Osprey announcement.

--- a/sources/products/perspective-api.yaml
+++ b/sources/products/perspective-api.yaml
@@ -1,12 +1,9 @@
 name: perspective-api
 display_name: Perspective API
 type: software
-description: Jigsaw's (Google) free hosted API for scoring the toxicity of text (and related attributes
-  like insult, threat, and identity attack), widely used by platforms and researchers for comment moderation
-  since 2017. Closed, API-only; no weights or self-hosting. Jigsaw has announced that Perspective is
-  sunsetting and the API will be out of service after 2026.
-comments: Perspective API by Jigsaw (Google). A free, quota-limited hosted toxicity-scoring API with no
-  weights and no self-hosting. Jigsaw announced a sunset - the service runs until December 31, 2026, new
-  usage and quota requests closed in February 2026, and no migration support is being offered. The reason
-  given is that AI capabilities have evolved and there is less demand for a standalone tool in this area.
-  Verified 2026-08-13 via the Perspective API site.
+description: Jigsaw's free hosted API for scoring the toxicity of text and related attributes such as insult,
+  threat and identity attack. It has been used for comment moderation since 2017. Jigsaw has announced that
+  the service is sunsetting and will be out of operation after 2026.
+comments: The service runs until 31 December 2026; new usage and quota requests closed in February 2026 and
+  no migration support is offered. The reason given is that AI capabilities have evolved and demand for a standalone
+  tool in this area has fallen. Verified 2026-08-13 via the Perspective API site.

--- a/sources/products/wildguard.yaml
+++ b/sources/products/wildguard.yaml
@@ -1,12 +1,11 @@
 name: wildguard
 display_name: WildGuard
 type: model
-description: Ai2's open safety moderation model (7B, fine-tuned from Mistral-7B) that jointly detects
-  harmful prompts, harmful responses, and model refusals across 13 risk subcategories. Trained on the
-  open WildGuardMix corpus and benchmarked above GPT-4 on several moderation tasks.
+description: Ai2's safety moderation model at 7B, fine-tuned from Mistral 7B, that jointly detects harmful
+  prompts, harmful responses and model refusals across thirteen risk subcategories. It was trained on the WildGuardMix
+  corpus, which is published on the Hub alongside it.
 huggingface_model:
 - url: https://huggingface.co/allenai/wildguard
-comments: WildGuard (7B, Mistral-based), trained on the open WildGuardMix corpus, which is published on the
-  Hub alongside it. The project repo ships an inference and serving package rather than a training
-  pipeline, and the card sends readers to the paper appendix for training detail. Verified 2026-08-13 via
-  the HF model card and the project repo.
+comments: The project repository ships an inference and serving package rather than a training pipeline, and
+  the card sends readers to the paper appendix for training detail. Verified 2026-08-13 via the HF model card
+  and the project repository.

--- a/sources/provenance/safeguards.yaml
+++ b/sources/provenance/safeguards.yaml
@@ -1,0 +1,154 @@
+# Prose closeout for safeguards. 26 of 26 ready.
+#
+# All 26 were canonical; 18 failed prose compliance. The detector flagged 10 and missed 8.
+#
+# ## The failure shape specific to this category
+#
+# A guardrail product's deployment model is the first thing a reader wants to know, so eight
+# records ended their description with the verdict as a two-word sentence - "Closed, managed
+# service." (azure-content-safety, bedrock-guardrails), "Closed/SaaS" (lakera-guard), "Closed,
+# API-only; no weights or self-hosting" (openai-moderation, perspective-api) - or opened with
+# it: "An open-source red-teaming framework" (deepteam), "An open security toolkit" (llm-guard),
+# "An open framework" (guardrails-ai), "An open guardrails project" (openguardrails).
+#
+# That is the openness axis stated twice, once with evidence and once without. What replaced it
+# is the deployment mechanism, which is architecture a reader can act on: "run entirely as an
+# Azure service", "runs as a Python library on infrastructure you operate, or deployed as an
+# API", "deploys as a Python library, a CLI, a Docker image or a standalone server".
+#
+# ## What the detector missed
+#
+#   llama-guard        "a widely deployed open guardrail model" and "Widely used as the
+#                      moderation layer in front of open chat and agent stacks" - two adoption
+#                      claims in a description
+#   wildguard          "benchmarked above GPT-4 on several moderation tasks" - capability
+#   openguardrails     "The first project to open-source both a large-scale safety LLM and a
+#                      production guardrails platform"
+#   osprey             "processing over 50M events daily in production", plus a named
+#                      deployment list
+#   aegis-guard        "so it is not fully open-weight"
+#   gpt-oss-safeguard  "under Apache 2.0"
+#   garak              "the nmap of LLM security testing"
+#   harmbench          "run entirely from the public repo"
+#
+# ## Gating notes KEPT, because they explain treatment rather than making the verdict
+#
+# Four model records say their weights need an access request - aegis-guard, llama-guard,
+# llama-prompt-guard, shieldgemma - and each says it as the reason openness was read from the
+# card rather than from a download. That is a statement about how the evidence was obtained. It
+# is not the same as asserting a tier, and it stays.
+#
+# The same test keeps the missing-training-data notes on granite-guardian, qwen3guard,
+# shieldgemma and gpt-oss-safeguard, and the adapter-versus-full-model note on zentropi-cope.
+#
+# ## One lifecycle fact worth more than any score
+#
+# `perspective-api` is sunsetting: the service runs until 31 December 2026, new usage and quota
+# requests closed in February 2026, and Jigsaw is offering no migration support. That is in the
+# description and the comments both, because a reader choosing a toxicity API this year needs it
+# before anything else on the record.
+#
+- product: aegis-guard
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the HF model card
+- product: azure-content-safety
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Azure product page
+- product: bedrock-guardrails
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the AWS product page
+- product: coop
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and ROOST's Coop 1
+- product: deepteam
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub
+- product: garak
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub
+- product: giskard
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub
+- product: gpt-oss-safeguard
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the HF model card
+- product: granite-guardian
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the HF model card
+- product: guardrails-ai
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub
+- product: harmbench
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub
+- product: lakera-guard
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Lakera site
+- product: llama-guard
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the HF model card
+- product: llama-prompt-guard
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the HF model card
+- product: llamafirewall
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the LlamaFirewall README and the PurpleLlama repo
+- product: llm-guard
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub
+- product: nemo-guardrails
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub
+- product: openai-moderation
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the OpenAI moderation guide
+- product: openguardrails
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub, the HF model card and the arXiv abstract
+- product: osprey
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and ROOST's Osprey announcement
+- product: perspective-api
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Perspective API site
+- product: pyrit
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub
+- product: qwen3guard
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the HF model card
+- product: shieldgemma
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the HF model card
+- product: wildguard
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the HF model card and the project repository
+- product: zentropi-cope
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the HF model card


### PR DESCRIPTION
**26 of 26 ready.** All were canonical; 18 failed prose compliance. Detector flagged 10, missed 8. No axis touched, no date moved.

## The failure shape specific to this category

A guardrail product's deployment model is the first thing a reader wants, so eight records put the **openness verdict in as a two-word sentence** — "Closed, managed service." (`azure-content-safety`, `bedrock-guardrails`), "Closed/SaaS" (`lakera-guard`), "Closed, API-only; no weights or self-hosting" (`openai-moderation`, `perspective-api`) — or opened with it: "An open-source red-teaming framework" (`deepteam`), "An open security toolkit" (`llm-guard`), "An open framework" (`guardrails-ai`), "An open guardrails project" (`openguardrails`).

That is the openness axis stated twice, once with evidence and once without. What replaced it is the deployment **mechanism**, which is architecture a reader can act on: *"run entirely as an Azure service"*, *"runs as a Python library on infrastructure you operate, or deployed as an API"*, *"deploys as a Python library, a CLI, a Docker image or a standalone server"*.

## What the detector missed

| record | miss |
|---|---|
| `llama-guard` | "a widely deployed open guardrail model" **and** "Widely used as the moderation layer in front of open chat and agent stacks" — two adoption claims |
| `wildguard` | "benchmarked above GPT-4 on several moderation tasks" — capability |
| `openguardrails` | "The first project to open-source both a large-scale safety LLM and a production guardrails platform" |
| `osprey` | "processing over 50M events daily in production", plus a named deployment list |
| `aegis-guard` | "so it is not fully open-weight" |
| `gpt-oss-safeguard` | "under Apache 2.0" |
| `garak` | "the nmap of LLM security testing" |
| `harmbench` | "run entirely from the public repo" |

## Gating notes kept, because they explain treatment rather than making the verdict

Four model records say their weights need an access request — `aegis-guard`, `llama-guard`, `llama-prompt-guard`, `shieldgemma` — and each says it as **the reason openness was read from the card rather than from a download**. That is a statement about how the evidence was obtained, not an assertion of a tier, so it stays.

The same test keeps the missing-training-data notes on `granite-guardian`, `qwen3guard`, `shieldgemma` and `gpt-oss-safeguard`, and the adapter-versus-full-model note on `zentropi-cope`.

## One lifecycle fact worth more than any score

`perspective-api` is **sunsetting**: the service runs until 31 December 2026, new usage and quota requests closed in February 2026, and Jigsaw offers no migration support. That is in the description *and* the comments, because a reader choosing a toxicity API this year needs it before anything else on the record.

## Verification

`validate`, `check_verification`, `check_capability`, `check_recipe`, `check_adoption --strict` clean. `check_freshness --category safeguards`: *all 78 axes carry a real last_verified*. 664 tests, no skips.

**Corpus: 456/472 prose-compliant · 472/472 canonical · 1,407/1,416 axes confirmed · 9 held.**
