### PR TITLE
Refresh the final five categories: 472/472 prose-compliant

### DIFF
--- a/sources/products/accelerate.yaml
+++ b/sources/products/accelerate.yaml
@@ -1,11 +1,10 @@
 name: accelerate
 display_name: Accelerate
 type: software
-description: Accelerate is a Hugging Face PyTorch library that lets users run raw PyTorch training scripts
-  across CPUs, multi-GPU, and TPU configurations with mixed precision, by adding only a few lines of code.
-  It abstracts the boilerplate of distributed setup and device placement while leaving the training loop
-  under the user's control, and provides a CLI for configuration. It is widely used as the distributed-training
-  backbone for other Hugging Face libraries.
+description: Accelerate is a Hugging Face PyTorch library that runs raw PyTorch training scripts across CPUs,
+  multiple GPUs and TPUs with mixed precision, adding only a few lines of code. It abstracts the boilerplate
+  of distributed setup and device placement while leaving the training loop under the caller's control, and
+  provides a CLI for configuration. Other Hugging Face libraries use it as their distributed-training backbone.
 github:
 - url: https://github.com/huggingface/accelerate
 pypi:

--- a/sources/products/aws-lambda.yaml
+++ b/sources/products/aws-lambda.yaml
@@ -3,9 +3,8 @@ display_name: AWS Lambda
 type: software
 description: AWS Lambda runs event-triggered functions on AWS-managed compute, with no server for the caller
   to provision. It supports Java, Go, PowerShell, Node.js, C#, Python and Ruby natively and any other language
-  through a Runtime API, and takes code as either a .zip archive or a container image. Each function runs
-  in its own isolated environment on Firecracker microVMs. Lambda MicroVMs extends the same substrate to
-  workloads that execute user- or AI-generated code, adding near-instant resume and state persistence across
-  interactions.
-comments: The service itself is proprietary and AWS-hosted; Firecracker, the microVM it runs on, is a
-  separate open-source entry on this map. Verified 2026-08-13 via the AWS Lambda FAQ.
+  through a Runtime API, taking code as a .zip archive or a container image. Each function runs isolated on
+  a Firecracker microVM, and Lambda MicroVMs extends the same substrate to user- and AI-generated code with
+  near-instant resume and state persistence.
+comments: Firecracker, the microVM Lambda runs on, is a separate record on this map. Verified 2026-08-13 via
+  the AWS Lambda FAQ.

--- a/sources/products/datology-ai.yaml
+++ b/sources/products/datology-ai.yaml
@@ -1,11 +1,8 @@
 name: datology-ai
 display_name: DatologyAI
 type: software
-description: 'Automated training-data curation platform: deduplication, model-based quality filtering,
-  embedding-based selection and pruning, data ordering, and synthetic-data steps for text and multimodal
-  pretraining corpora.'
-comments: DatologyAI, a proprietary curation platform deployed into the customer's own cloud; no
-  source-available product. Founded 2023 by Ari Morcos (ex-FAIR/DeepMind) and Matthew
-  Leavitt (ex-MosaicML). ~$57.5M raised (seed plus a $46M Series A in May 2024); angels
-  include Jeff Dean and Yann LeCun. No named frontier-lab customers disclosed. Verified
-  2026-08-13 via datologyai.com.
+description: 'Automated training-data curation platform: deduplication, model-based quality filtering, embedding-based
+  selection and pruning, data ordering, and synthetic-data steps for text and multimodal pretraining corpora.'
+comments: DatologyAI, a curation platform deployed into the customer's own cloud. Founded in 2023 by Ari Morcos
+  and Matthew Leavitt. No named frontier-lab customers are disclosed, which is why the adoption axis has nothing
+  to band. Verified 2026-08-13 via datologyai.com.

--- a/sources/products/firecracker.yaml
+++ b/sources/products/firecracker.yaml
@@ -1,12 +1,11 @@
 name: firecracker
 display_name: Firecracker
 type: software
-description: Firecracker is a virtual machine monitor written in Rust that uses KVM to run workloads in
-  lightweight microVMs, combining hardware-virtualization isolation with container-like startup and density.
-  It ships a deliberately minimal guest device model - network, block I/O, timer, KVM clock, serial console
-  and a partial keyboard - to shrink the memory footprint and attack surface, and jails its own process
-  with cgroups and seccomp BPF. AWS built it to run AWS Lambda and AWS Fargate, and Kata Containers and
-  Flintlock embed it as their runtime.
+description: Virtual machine monitor written in Rust that uses KVM to run workloads in lightweight microVMs,
+  combining hardware-virtualization isolation with container-like startup and density. It ships a deliberately
+  minimal guest device model - network, block I/O, timer, KVM clock, serial console and a partial keyboard
+  - to shrink the memory footprint and attack surface, and jails its own process with cgroups and seccomp BPF.
+  AWS built it to run Lambda and Fargate.
 github:
 - url: https://github.com/firecracker-microvm/firecracker
 comments: Verified 2026-08-13 via the Firecracker README and the GitHub repository API.

--- a/sources/products/flax.yaml
+++ b/sources/products/flax.yaml
@@ -1,10 +1,10 @@
 name: flax
 display_name: Flax
 type: software
-description: Flax is a neural network library and ecosystem for JAX designed for flexibility, providing
-  network components (Linear, Conv, BatchNorm, attention) plus training utilities like checkpointing and
-  serialization. It is developed and maintained by Google DeepMind as an open source project. Its newer
-  Flax NNX API emphasizes Python reference semantics for building networks with standard Python objects.
+description: Flax is a neural network library and ecosystem for JAX designed for flexibility, providing network
+  components such as Linear, Conv, BatchNorm and attention alongside training utilities like checkpointing
+  and serialization. It is developed and maintained by Google DeepMind. Its newer Flax NNX API emphasizes Python
+  reference semantics, so networks are built from ordinary Python objects.
 github:
 - url: https://github.com/google/flax
 pypi:

--- a/sources/products/google-cloud-run.yaml
+++ b/sources/products/google-cloud-run.yaml
@@ -1,10 +1,10 @@
 name: google-cloud-run
 display_name: Google Cloud Run
 type: software
-description: Runs any OCI container image as a fully managed Google Cloud service, autoscaling from zero
-  to thousands of instances and billing only while a request is in flight. Google exposes individual Cloud
-  Run instances for long-running background agents, and a built-in `sandbox` tool lets an agent spin up
-  an ephemeral, isolated environment to execute generated code. Container isolation is backed by gVisor.
-comments: Google Cloud Run, a fully managed serverless container platform with no self-hostable edition.
-  Scored as the proprietary SaaS deployment counterpart per the recipe. Verified 2026-08-13 via cloud.google.com/run,
-  the Cloud Run at Next '26 announcement post, and the google/gvisor repository.
+description: Runs any OCI container image as a fully managed Google Cloud service, autoscaling from zero to
+  thousands of instances and billing only while a request is in flight. Google exposes individual Cloud Run
+  instances for long-running background agents, and a built-in `sandbox` tool lets an agent spin up an ephemeral,
+  isolated environment to execute generated code. Container isolation is backed by gVisor.
+comments: Google Cloud Run, a fully managed serverless container platform. Scored as the managed deployment
+  counterpart in this category's recipe. Verified 2026-08-13 via cloud.google.com/run, the Cloud Run at Next
+  '26 announcement and the gVisor repository.

--- a/sources/products/gradio.yaml
+++ b/sources/products/gradio.yaml
@@ -1,11 +1,10 @@
 name: gradio
 display_name: Gradio
 type: software
-description: Gradio is an open source Python package for quickly building web demos and applications for
-  machine learning models, APIs, or arbitrary Python functions without JavaScript, CSS, or web-hosting
-  knowledge. It provides the Interface, Blocks, and ChatInterface classes plus built-in public sharing
-  of demos. Originally an independent project, it is now maintained under Hugging Face after the company
-  acquired Gradio.
+description: Gradio is a Python package for quickly building web demos and applications around machine-learning
+  models, APIs or arbitrary Python functions, without JavaScript, CSS or web-hosting knowledge. It provides
+  the Interface, Blocks and ChatInterface classes plus built-in public sharing of demos. Originally an independent
+  project, it is now maintained under Hugging Face, which acquired it.
 github:
 - url: https://github.com/gradio-app/gradio
 pypi:

--- a/sources/products/hf-datasets.yaml
+++ b/sources/products/hf-datasets.yaml
@@ -1,10 +1,10 @@
 name: hf-datasets
 display_name: Datasets
 type: software
-description: Datasets is a lightweight Hugging Face library providing one-line dataloaders for thousands
-  of public datasets and efficient data preprocessing for ML workflows. It supports CSV, JSON, Parquet,
-  audio, image, and video formats with streaming, memory-mapping, and multi-framework integration (PyTorch,
-  TensorFlow, JAX). It is widely used to feed training and evaluation pipelines.
+description: Datasets is a lightweight Hugging Face library providing one-line dataloaders for thousands of
+  public datasets and efficient preprocessing for machine-learning workflows. It supports CSV, JSON, Parquet,
+  audio, image and video formats with streaming and memory-mapping, and integrates with PyTorch, TensorFlow
+  and JAX. It is the loading layer that feeds training and evaluation pipelines.
 github:
 - url: https://github.com/huggingface/datasets
 pypi:

--- a/sources/products/jax.yaml
+++ b/sources/products/jax.yaml
@@ -1,10 +1,10 @@
 name: jax
 display_name: JAX
 type: software
-description: JAX is a Python library for accelerator-oriented array computation and program transformation,
-  combining NumPy-style arrays with composable function transforms (automatic differentiation, JIT compilation
-  via XLA, and auto-vectorization). It is developed by the jax-ml organization (originating at Google)
-  and is widely used for high-performance numerical computing and large-scale ML research.
+description: 'JAX is a Python library for accelerator-oriented array computation and program transformation,
+  combining NumPy-style arrays with composable function transforms: automatic differentiation, just-in-time
+  compilation through XLA, and automatic vectorization. It is developed by the jax-ml organization, having
+  originated at Google, and targets high-performance numerical computing and large-scale ML research.'
 github:
 - url: https://github.com/jax-ml/jax
 pypi:

--- a/sources/products/mistral-fine-tuning-api.yaml
+++ b/sources/products/mistral-fine-tuning-api.yaml
@@ -1,10 +1,10 @@
 name: mistral-fine-tuning-api
 display_name: Mistral Fine-Tuning API
 type: software
-description: Mistral Fine-Tuning API is Mistral's managed fine-tuning service on its Studio platform, offering
-  LoRA-based supervised fine-tuning for text and vision on Mistral Small and Medium (originally Mistral 7B
-  and Small), plus a Classifier Factory for classification tasks. Mistral's documentation now files the service
-  under deprecated, legacy features. A separate open source SDK, mistral-finetune, covers self-hosted training.
+description: Mistral's managed fine-tuning service on its Studio platform, offering LoRA-based supervised fine-tuning
+  for text and vision on Mistral Small and Medium, plus a Classifier Factory for classification tasks. Mistral's
+  documentation now files the service under deprecated, legacy features. A separate SDK, mistral-finetune,
+  covers self-hosted training.
 comments: 'The deprecated label is a docs classification, not evidence the API is retired: pricing still bills
   training and storage for the Classifier API tier. Verified 2026-08-09 via Mistral''s deprecated fine-tuning
   guide, the Studio product page, and the API pricing page.'

--- a/sources/products/nemo-data-designer.yaml
+++ b/sources/products/nemo-data-designer.yaml
@@ -1,13 +1,12 @@
 name: nemo-data-designer
 display_name: NVIDIA NeMo Data Designer
 type: software
-description: Generates synthetic datasets from scratch or from seed data using statistical samplers,
-  dependency-aware generation across correlated fields, Python/SQL/custom validators and
-  LLM-as-a-judge scoring. Published as the Apache-2.0 data-designer library; the NeMo Platform
-  runs the same configurations as a managed service.
+description: Generates synthetic datasets from scratch or from seed data using statistical samplers, dependency-aware
+  generation across correlated fields, Python, SQL and custom validators, and judge-model scoring. The data-designer
+  library runs locally, and the NeMo Platform runs the same configurations as a managed service.
 pypi:
 - url: https://pypi.org/project/data-designer/
-comments: The productized form of Gretel's technology after NVIDIA's 2025 acquisition; the Gretel
-  brand is retired (gretel.ai redirects to NVIDIA) and the gretel-synthetics OSS repo was
-  archived February 2026. Substituted for Gretel, which no longer exists as a standalone
-  product. Verified 2026-08-13 via the NVIDIA NeMo product page and the DataDesigner README.
+comments: The productized form of Gretel's technology after NVIDIA's 2025 acquisition; the Gretel brand is
+  retired (gretel.ai redirects to NVIDIA) and the gretel-synthetics OSS repo was archived February 2026. Substituted
+  for Gretel, which no longer exists as a standalone product. Verified 2026-08-13 via the NVIDIA NeMo product
+  page and the DataDesigner README.

--- a/sources/products/nemo-rl.yaml
+++ b/sources/products/nemo-rl.yaml
@@ -1,11 +1,10 @@
 name: nemo-rl
 display_name: NeMo-RL
 type: software
-description: NeMo-RL is NVIDIA's open source library for reinforcement-learning post-training of language and
-  vision-language models, re-architected from the earlier NeMo Aligner. It implements methods including GRPO,
-  GSPO, DAPO, DPO, SFT, on-policy distillation, and reward modeling on DTensor or Megatron Core training backends,
-  scaling from a single GPU to thousands across multi-node clusters. NVIDIA also offers NeMo Customizer, a
-  separate managed fine-tuning microservice, alongside the open library.
+description: NVIDIA's library for reinforcement-learning post-training of language and vision-language models,
+  re-architected from the earlier NeMo Aligner. It implements GRPO, GSPO, DAPO, DPO, SFT, on-policy distillation
+  and reward modeling on DTensor or Megatron Core backends, scaling from a single GPU to thousands across multi-node
+  clusters. NeMo Customizer is a separate managed fine-tuning microservice alongside it.
 github:
 - url: https://github.com/NVIDIA-NeMo/RL
 comments: The nemo-rl package on PyPI is a placeholder that points back to GitHub; the library ships from source

--- a/sources/products/openai-fine-tuning-api.yaml
+++ b/sources/products/openai-fine-tuning-api.yaml
@@ -1,11 +1,11 @@
 name: openai-fine-tuning-api
 display_name: OpenAI Fine-Tuning API
 type: software
-description: 'The OpenAI Fine-Tuning API trains custom versions of OpenAI''s closed models on OpenAI''s infrastructure,
-  exposing supervised fine-tuning, vision fine-tuning, direct preference optimization, and reinforcement fine-tuning
-  for reasoning models. Jobs run from the dashboard or the API against gpt-4.1, gpt-4o, and o4-mini snapshots.
-  OpenAI is winding the platform down: it is closed to new users, job creation ends in January 2027, and fine-tuned
-  models serve until their base models are deprecated.'
+description: 'Trains custom versions of OpenAI''s hosted models on OpenAI''s own infrastructure, covering supervised
+  fine-tuning, vision fine-tuning, direct preference optimization and reinforcement fine-tuning for reasoning
+  models. Jobs run from the dashboard or the API against gpt-4.1, gpt-4o and o4-mini snapshots. OpenAI is winding
+  the platform down: new sign-ups have stopped, job creation ends in January 2027, and fine-tuned models serve
+  until their base models are deprecated.'
 comments: Openness was read from the OpenAI Services Agreement, since the service publishes no repository or
   license file. No usage figure for the fine-tuning API alone is published, so adoption abstains. Verified
   2026-08-08 via the OpenAI model optimization guide, the API deprecations page, and the OpenAI Services Agreement.

--- a/sources/products/openvino.yaml
+++ b/sources/products/openvino.yaml
@@ -1,10 +1,10 @@
 name: openvino
 display_name: OpenVINO
 type: software
-description: OpenVINO is an open source toolkit for optimizing and deploying AI inference across computer
-  vision, speech, NLP, and generative AI. It converts models from PyTorch, TensorFlow, and ONNX and deploys
-  across CPUs (x86, ARM), Intel integrated/discrete GPUs, and Intel NPUs, with a GenAI API for LLM pipelines.
-  It is developed by Intel and integrates with Hugging Face Optimum Intel and vLLM.
+description: OpenVINO is a toolkit for optimizing and deploying AI inference across computer vision, speech,
+  NLP and generative AI. It converts models from PyTorch, TensorFlow and ONNX and deploys across x86 and Arm
+  CPUs, Intel integrated and discrete GPUs and Intel NPUs, with a GenAI API for LLM pipelines. It is developed
+  by Intel and integrates with Hugging Face Optimum Intel and vLLM.
 github:
 - url: https://github.com/openvinotoolkit/openvino
 pypi:

--- a/sources/products/predibase.yaml
+++ b/sources/products/predibase.yaml
@@ -1,11 +1,11 @@
 name: predibase
 display_name: Predibase
 type: software
-description: Predibase is a managed platform for fine-tuning and serving open source language models, offering
-  supervised fine-tuning, reinforcement fine-tuning (GRPO), and continued pretraining. It deploys as SaaS or
-  inside a customer's own VPC and serves models through LoRAX, the multi-LoRA inference engine its founders
-  publish as open source alongside Ludwig, a declarative ML framework. Rubrik acquired Predibase in June 2025
-  and now runs it as part of its AI Agent Operations platform.
+description: Managed platform for fine-tuning and serving language models, offering supervised fine-tuning,
+  reinforcement fine-tuning with GRPO, and continued pretraining. It deploys as SaaS or inside a customer's
+  own VPC and serves models through LoRAX, the multi-LoRA inference engine its founders publish alongside Ludwig,
+  a declarative ML framework. Rubrik acquired Predibase in June 2025 and runs it within its AI Agent Operations
+  platform.
 comments: Predibase's own pages return HTTP 403 and predibase.com now redirects to Rubrik's Agent Cloud page,
   so the descriptive facts here rest on archived captures rather than live vendor documentation. Verified 2026-08-09
   via web.archive.org captures of predibase.com and docs.predibase.com, PyPI, and GitHub.

--- a/sources/products/pysyft.yaml
+++ b/sources/products/pysyft.yaml
@@ -1,11 +1,10 @@
 name: pysyft
 display_name: Syft / PySyft
 type: software
-description: PySyft is OpenMined's open source library for privacy-preserving and remote data science,
-  letting data scientists run computations on private data they cannot see or copy via secure 'Datasite'
-  servers. It supports techniques associated with federated learning and differential privacy and offers
-  a NumPy-like remote analysis interface. It is one of the most established open frameworks for collaborative
-  analysis on sensitive data.
+description: PySyft is OpenMined's library for privacy-preserving and remote data science, letting a data scientist
+  run computations on private data they can neither see nor copy, through Datasite servers. It supports techniques
+  associated with federated learning and differential privacy, and offers a NumPy-like remote analysis interface
+  over data that never leaves its owner.
 github:
 - url: https://github.com/OpenMined/PySyft
 pypi:

--- a/sources/products/pytorch.yaml
+++ b/sources/products/pytorch.yaml
@@ -1,10 +1,10 @@
 name: pytorch
 display_name: PyTorch
 type: software
-description: PyTorch is a Python library for tensor computation with strong GPU acceleration and deep neural
-  networks built on a tape-based autograd system. Originally developed at Meta, it is now governed by the PyTorch
-  Foundation under the Linux Foundation. It is one of the two most widely used deep learning frameworks and
-  underpins most modern research and production model training.
+description: PyTorch is a Python library for tensor computation with GPU acceleration and deep neural networks
+  built on a tape-based autograd system. Originally developed at Meta, it is now governed by the PyTorch Foundation
+  under the Linux Foundation, and it is the framework most of the model records on this map are trained and
+  served with.
 github:
 - url: https://github.com/pytorch/pytorch
 pypi:

--- a/sources/products/ray.yaml
+++ b/sources/products/ray.yaml
@@ -1,12 +1,12 @@
 name: ray
 display_name: Ray
 type: software
-description: Ray is a framework for building and serving AI and ML applications across distributed compute,
-  scheduling work over many machines and over mixed CPU and GPU resources. Ray Core provides the task and
-  actor primitives; the libraries above it - Data, Train, Tune, Serve and RLlib - cover batch inference,
-  model serving, distributed training, hyperparameter tuning and feature engineering. Applications deploy
-  as Ray clusters on virtual machines or Kubernetes. Anyscale, founded by Ray's original creators, sells
-  a managed platform beside it, and the project is governed by the PyTorch Foundation.
+description: Framework for building and serving AI and ML applications across distributed compute, scheduling
+  work over many machines and mixed CPU and GPU resources. Ray Core provides task and actor primitives; the
+  libraries above it - Data, Train, Tune, Serve and RLlib - cover batch inference, model serving, distributed
+  training, hyperparameter tuning and feature engineering. Applications deploy as Ray clusters on virtual machines
+  or Kubernetes, and the project is governed by the PyTorch Foundation.
 pypi:
 - url: https://pypi.org/project/ray/
-comments: Verified 2026-08-13 via the Anyscale Ray documentation and the PyPI download API.
+comments: Anyscale, founded by Ray's original creators, sells a managed platform beside it. Verified 2026-08-13
+  via the Anyscale Ray documentation and the PyPI download API.

--- a/sources/products/safetensors.yaml
+++ b/sources/products/safetensors.yaml
@@ -1,11 +1,10 @@
 name: safetensors
 display_name: Safetensors
 type: software
-description: Safetensors is a file format and library for safely storing and loading tensors, designed
-  as a secure alternative to Python pickle that avoids arbitrary code execution and supports fast zero-copy
-  loading. It is implemented in Rust with Python bindings and works across PyTorch, TensorFlow, and other
-  frameworks. Maintained by Hugging Face, it has become the default weight format for models on the Hugging
-  Face Hub.
+description: Safetensors is a file format and library for storing and loading tensors safely, designed as an
+  alternative to Python pickle that avoids arbitrary code execution and supports fast zero-copy loading. It
+  is implemented in Rust with Python bindings and works across PyTorch, TensorFlow and other frameworks. Hugging
+  Face maintains it and publishes model weights in it.
 github:
 - url: https://github.com/safetensors/safetensors
 pypi:

--- a/sources/products/smallpond.yaml
+++ b/sources/products/smallpond.yaml
@@ -1,12 +1,12 @@
 name: smallpond
 display_name: smallpond
 type: software
-description: Lightweight distributed data-processing framework built on DuckDB and DeepSeek's 3FS, aimed
-  at PB-scale preprocessing.
+description: Lightweight distributed data-processing framework built on DuckDB and DeepSeek's 3FS, aimed at
+  PB-scale preprocessing.
 github:
 - url: https://github.com/deepseek-ai/smallpond
 pypi:
 - url: https://pypi.org/project/smallpond
-comments: DeepSeek smallpond, effectively dormant - no repo commits since March 2025. A rare open
-  data-infra release from an otherwise closed-data lab; strong launch-driven star count,
-  thin sustained use. Verified 2026-08-13 via the GitHub README and the LICENSE body.
+comments: DeepSeek smallpond, effectively dormant with no repository commits since March 2025. A rare data-infrastructure
+  release from a lab that publishes little else about its data, with a launch-driven star count and thin sustained
+  use. Verified 2026-08-13 via the GitHub README and the LICENSE body.

--- a/sources/products/snorkel-flow.yaml
+++ b/sources/products/snorkel-flow.yaml
@@ -1,16 +1,10 @@
 name: snorkel-flow
 display_name: Snorkel AI Data Development Platform
 type: software
-description: 'Snorkel AI''s commercial data-development platform, shipping as version 26.1: programmatic
-  labeling and weak supervision (heuristic and LLM-generated labeling functions), plus curation, slicing,
-  filtering, and fine-tuning/evaluation data workflows. Deployed by the customer rather than consumed as
-  a service - the documentation carries an administrator guide covering installation, users, roles and
-  permissions.'
-comments: 'Verified 2026-08-14 via docs.snorkel.ai. RENAMED, NOT RETIRED: the product ships today as the "Snorkel
-  AI Data Development Platform" (v26.1); "Snorkel Flow" is the former name and still labels the archived doc
-  versions. The slug stays `snorkel-flow` because slugs are immutable identities rather than labels - see docs/reference/identity.md
-  - and the rename is carried by display_name and here. A 2026-08-13 pass read only the marketing site, where
-  /snorkel-flow/ now 301s to /data-development/ and the copy sells data services, and concluded the platform
-  was gone; the documentation site shows it is not. A vendor reorganising its marketing is not evidence a product
-  has been withdrawn. Distinct from the Apache-2.0 snorkel-team/snorkel OSS library, which is stale (last release
-  0.10.0, Feb 2024) and is not this entry.'
+description: 'Snorkel AI''s commercial data-development platform: programmatic labeling and weak supervision
+  through heuristic and model-generated labeling functions, plus curation, slicing, filtering and fine-tuning
+  and evaluation data workflows. The customer deploys it rather than consuming it as a service, and the documentation
+  carries an administrator guide covering installation, users, roles and permissions.'
+comments: 'Renamed, not retired: it ships today as the Snorkel AI Data Development Platform, and Snorkel Flow
+  is the former name. An earlier pass read only the marketing site, where the old path redirects, and concluded
+  the product was gone; the documentation shows otherwise. Verified 2026-08-14 via docs.snorkel.ai.'

--- a/sources/products/spaces.yaml
+++ b/sources/products/spaces.yaml
@@ -1,15 +1,11 @@
 name: spaces
 display_name: Spaces
 type: software
-description: Spaces hosts interactive machine-learning apps on Hugging Face infrastructure, built with
-  the Gradio or Streamlit SDKs, an arbitrary Dockerfile, or static HTML and JavaScript. Hardware runs
-  from a free CPU tier through a shared ZeroGPU pool to hourly dedicated GPUs, alongside persistent
-  storage and an SSH dev mode. Hub integration deploys a Space from a model card, and a Space can be
-  exposed as an MCP server or API endpoint.
-comments: 'The GitHub artifact declared here was gradio-app/gradio, and it was removed 2026-08-14. That
-  repository is an app SDK that runs anywhere rather than the Spaces host, and it is already the declared
-  artifact of `gradio`, a separate product on this map - so the declaration double-counted one repo across
-  two products and would have banded Spaces on Gradio''s stars. Spaces publishes no source of its own and
-  no countable channel, so nothing replaces it; a route to a real Spaces signal is a backlog item, and
-  repointing without evidence would repeat the error. Verified 2026-08-13 via the Hugging Face Spaces Hub
-  documentation, the Hugging Face pricing page, and the Hugging Face terms of service.'
+description: Spaces hosts interactive machine-learning apps on Hugging Face infrastructure, built with the
+  Gradio or Streamlit SDKs, an arbitrary Dockerfile, or static HTML and JavaScript. Hardware runs from a free
+  CPU tier through a shared ZeroGPU pool to hourly dedicated GPUs, alongside persistent storage and an SSH
+  dev mode. Hub integration deploys a Space from a model card, and a Space can be exposed as an MCP server
+  or API endpoint.
+comments: 'The declared GitHub artifact was gradio-app/gradio, removed 2026-08-14: it is an app SDK that runs
+  anywhere, is already gradio''s own artifact, and would have banded Spaces on Gradio''s stars. Spaces publishes
+  no countable channel of its own. Verified 2026-08-13 via the Spaces documentation and pricing page.'

--- a/sources/products/tensorflow.yaml
+++ b/sources/products/tensorflow.yaml
@@ -1,10 +1,10 @@
 name: tensorflow
 display_name: TensorFlow
 type: software
-description: TensorFlow is an end-to-end open source platform for machine learning, offering stable Python
-  and C++ APIs for building and deploying ML models across CPUs, GPUs, and TPUs. It was developed by Google
-  Brain and remains maintained by Google with broad community involvement. It is one of the two most widely
-  used deep learning frameworks and powers large-scale research and production deployments.
+description: TensorFlow is an end-to-end platform for machine learning, offering stable Python and C++ APIs
+  for building and deploying models across CPUs, GPUs and TPUs. It was developed by Google Brain and remains
+  maintained by Google with broad community involvement, and it powers large-scale research and production
+  deployments.
 github:
 - url: https://github.com/tensorflow/tensorflow
 pypi:

--- a/sources/products/tensorrt-llm.yaml
+++ b/sources/products/tensorrt-llm.yaml
@@ -7,6 +7,6 @@ description: TensorRT-LLM is NVIDIA's inference library for optimizing and servi
   Server and NVIDIA Dynamo. Being built on CUDA, it is tightly coupled to NVIDIA hardware.
 github:
 - url: https://github.com/NVIDIA/TensorRT-LLM
-comments: The LICENSE file also bundles third-party MIT/BSD code and an LTX-2 Community License covering optional
-  model support; the openness score follows the primary repository license. Verified 2026-08-09 via GitHub
-  and the LICENSE body.
+comments: The repository's license file also bundles third-party code and a separate community license covering
+  optional model support; the openness axis follows the primary repository license. Verified 2026-08-09 via
+  GitHub and the LICENSE body.

--- a/sources/products/the-pile-pipeline.yaml
+++ b/sources/products/the-pile-pipeline.yaml
@@ -5,6 +5,6 @@ description: 'The original documented-corpus construction pipeline: downloads, c
   and formats 22 components into The Pile. Distinct from the released Pile dataset.'
 github:
 - url: https://github.com/EleutherAI/the-pile
-comments: EleutherAI the-pile construction code, distinct from the Pile dataset, and frozen since
-  April 2023. The canonical documented-corpus construction reference; underpinned GPT-Neo,
-  GPT-J and Pythia. Verified 2026-08-13 via the GitHub README and the LICENSE body.
+comments: EleutherAI's the-pile construction code, distinct from the Pile dataset, and frozen since April 2023.
+  It is the construction reference that underpinned GPT-Neo, GPT-J and Pythia. Verified 2026-08-13 via the
+  GitHub README and the LICENSE body.

--- a/sources/products/transformers.yaml
+++ b/sources/products/transformers.yaml
@@ -1,10 +1,10 @@
 name: transformers
 display_name: Transformers
 type: software
-description: Transformers is a model-definition framework for machine learning across text, vision, audio,
-  and multimodal models, supporting both inference and training. It is maintained by Hugging Face and provides
-  a unified API to load and run over a million pretrained model checkpoints from the Hugging Face Hub. It is
-  a foundational library underpinning much of the modern open source ML and LLM ecosystem.
+description: Transformers is a model-definition framework for machine learning across text, vision, audio and
+  multimodal models, covering both inference and training. Maintained by Hugging Face, it provides a unified
+  API to load and run over a million pretrained checkpoints from the Hugging Face Hub, and is the interface
+  most published model weights are consumed through.
 github:
 - url: https://github.com/huggingface/transformers
 pypi:

--- a/sources/products/triton.yaml
+++ b/sources/products/triton.yaml
@@ -1,11 +1,11 @@
 name: triton
 display_name: Triton
 type: software
-description: Triton is a Python-embedded language and compiler for writing highly efficient custom GPU
-  kernels (deep-learning primitives), aiming for higher productivity than CUDA with more flexibility than
-  other DSLs. It compiles via MLIR and targets NVIDIA GPUs and AMD GPUs, with CPU support in progress.
-  Originally created by Philippe Tillet at OpenAI, it is now developed under the triton-lang organization.
-  It is widely used as the kernel backend for projects like PyTorch's inductor.
+description: Triton is a Python-embedded language and compiler for writing efficient custom GPU kernels, aiming
+  for higher productivity than CUDA with more flexibility than other domain-specific languages. It compiles
+  through MLIR and targets NVIDIA and AMD GPUs, with CPU support in progress. Created by Philippe Tillet at
+  OpenAI, it is now developed under the triton-lang organization and serves as the kernel backend for PyTorch's
+  inductor.
 github:
 - url: https://github.com/triton-lang/triton
 pypi:

--- a/sources/products/txt360-pipeline.yaml
+++ b/sources/products/txt360-pipeline.yaml
@@ -2,11 +2,10 @@ name: txt360-pipeline
 display_name: TxT360 (pipeline)
 type: software
 description: 'Construction pipeline for the TxT360 open pretraining corpus: global deduplication and source
-  processing across 99 Common Crawl snapshots and 14 curated sources. Distinct from the released TxT360
-  dataset.'
+  processing across 99 Common Crawl snapshots and 14 curated sources. Distinct from the released TxT360 dataset.'
 github:
 - url: https://github.com/LLM360/TxT360
-comments: LLM360 TxT360 pipeline code, distinct from the dataset on HF; a reference/replication drop,
-  last push December 2024. The README badge asserts Apache-2.0 but the repo ships no LICENSE
-  file and the GitHub API reports a null license, which is why openness abstains rather than
-  scoring it open. Verified 2026-08-13 via the GitHub README and the repository API.
+comments: LLM360's TxT360 pipeline code, distinct from the dataset on the Hub; a reference and replication
+  drop, last pushed December 2024. The README badge asserts a license the repository ships no file for, and
+  the GitHub API reports none, which is why openness abstains rather than scoring it. Verified 2026-08-13 via
+  the GitHub README and the repository API.

--- a/sources/provenance/dataset_processing_tools.yaml
+++ b/sources/provenance/dataset_processing_tools.yaml
@@ -1,0 +1,101 @@
+# Prose closeout for dataset_processing_tools. 21 of 21 ready. Six failed; the ledger flagged 4.
+#
+# `datology-ai` carried the most banned content of any record in the sweep: "a proprietary
+# curation platform", "no source-available product", "~$57.5M raised (seed plus a $46M Series A
+# in May 2024)", and a named angel list. What survives is the founders and the fact that no
+# frontier-lab customer is disclosed, which is why the adoption axis has nothing to band.
+#
+# `snorkel-flow` carried a 120-word comments field, and it was long because it records something
+# worth keeping: a 2026-08-13 pass read only the marketing site, where the old path now
+# redirects and the copy sells data services, and concluded the platform had been withdrawn. The
+# documentation site showed it had only been renamed. THE LESSON IS THE POINT - a vendor
+# reorganising its marketing is not evidence a product is gone - and it now fits in 48 words.
+#
+# `txt360-pipeline` keeps its licensing ambiguity because it explains the treatment: the README
+# badge asserts a license the repository ships no file for, and the GitHub API reports none,
+# which is why openness abstains rather than scoring it.
+#
+- product: bigcode-dataset
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body
+- product: ccnet
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body
+- product: data-juicer
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body
+- product: datamap-rs
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body
+- product: datatrove
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body
+- product: datology-ai
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: datologyai
+- product: dclm
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and the repository README
+- product: decon
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body
+- product: distilabel
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body
+- product: dolma-toolkit
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body
+- product: duplodocus
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body
+- product: marin-framework
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body
+- product: nemo-curator
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body
+- product: nemo-data-designer
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the NVIDIA NeMo product page and the DataDesigner README
+- product: olmocr
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body
+- product: redpajama-data
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body
+- product: smallpond
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body
+- product: snorkel-flow
+  resolved_state: canonical
+  verified: '2026-08-14'
+  document: docs
+- product: the-pile-pipeline
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body
+- product: txt360-pipeline
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the repository API
+- product: ungoliant
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body

--- a/sources/provenance/deployment.yaml
+++ b/sources/provenance/deployment.yaml
@@ -1,0 +1,125 @@
+# Prose closeout for deployment. 27 of 27 ready. Five failed; the ledger flagged 2.
+#
+# Three failed on LENGTH alone, which no ban pattern catches: aws-lambda at 80 description
+# words, firecracker at 86, ray at 90, against the guide's 35-70 band. Long descriptions are
+# where the other violations hide, and reading for length is what surfaced them.
+#
+# `spaces` carried a 93-word comments field recording a real correction: its declared GitHub
+# artifact was gradio-app/gradio, removed 2026-08-14 because that repository is an app SDK that
+# runs anywhere, is already `gradio`'s declared artifact, and would have banded Spaces on
+# Gradio's stars. Spaces publishes no countable channel of its own, so nothing replaced it. The
+# correction is kept; the retelling is shorter.
+#
+# `aws-lambda` and `google-cloud-run` both stated the openness verdict outright. The
+# Lambda-to-Firecracker relationship stays, because one is the substrate of the other and both
+# are records on this map.
+#
+- product: agent-infra-sandbox
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the agent-infra/sandbox README and the GitHub repository metadata
+- product: aws-lambda
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the AWS Lambda FAQ
+- product: beta9
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Beta9 README and the ComputeSDK sandbox benchmark leaderboard
+- product: blaxel-sandbox
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: blaxel
+- product: cloudflare-sandboxes
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: Cloudflare's "Sandboxing AI agents, 100x faster" post and the cloudflare/sandbox-sdk repository
+- product: coder-oss
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the coder/coder README and the GitHub repository metadata
+- product: daytona-sandbox
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: daytona
+- product: e2b-sandbox
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the E2B site and the ComputeSDK sandbox benchmark leaderboard
+- product: firecracker
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Firecracker README and the GitHub repository API
+- product: fly-sprites
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: fly
+- product: google-cloud-run
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: cloud
+- product: gvisor
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the gVisor README, the LICENSE body, and the gvisor
+- product: kata-containers
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Kata Containers README, docs/hypervisors
+- product: modal-sandboxes
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Modal Sandboxes guide and the Modal pricing page
+- product: nono
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the nono README, the LICENSE body, and nono
+- product: northflank-sandboxes
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: northflank
+- product: ollama
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the repository README, the LICENSE body, ollama
+- product: openai-code-interpreter
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the OpenAI Code Interpreter developer documentation
+- product: openpcc
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the OpenPCC and Confident-Compute READMEs, the LICENSE body, and the Cloud Security Alliance
+    launch write-up
+- product: opensandbox
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the OpenSandbox README, the secure container runtime guide, and open-sandbox
+- product: ray
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Anyscale Ray documentation and the PyPI download API
+- product: replit-agent-code-execution-api
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the replit/replit-code-exec repository and its README
+- product: sandbox-runtime
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the anthropic-experimental/sandbox-runtime README and the GitHub repository metadata
+- product: spaces
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the Spaces documentation and pricing page
+- product: tensorlake-sandbox
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: tensorlake
+- product: vercel-sandbox
+  resolved_state: canonical
+  verified: '2026-08-14'
+  document: the Vercel Sandbox documentation and its pricing and quotas page
+- product: webcontainers
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: webcontainers

--- a/sources/provenance/finetuning_code.yaml
+++ b/sources/provenance/finetuning_code.yaml
@@ -1,0 +1,133 @@
+# Prose closeout for finetuning_code. 27 of 27 ready. Four records failed, as flagged.
+#
+# ## The distinction this category forced
+#
+# Most records here say they fine-tune "open-weight models". That is NOT this product's own
+# openness - it is the class of input the service accepts, which is a capability fact and the
+# single most useful thing in the entry. It stays on anyscale-fine-tuning,
+# azure-openai-fine-tuning, fireworks-fine-tuning, tinker and together-fine-tuning.
+#
+# What came out is the openness verdict applied to a NAMED ARTIFACT: nemo-rl's "NVIDIA's open
+# source library" about itself, predibase's "the multi-LoRA inference engine its founders
+# publish as open source", mistral-fine-tuning-api's "A separate open source SDK", and
+# openai-fine-tuning-api's "OpenAI's closed models".
+#
+# `openai-fine-tuning-api` keeps its wind-down in full - new sign-ups stopped, job creation ends
+# January 2027, fine-tuned models serve until their base models are deprecated - because "closed
+# to new users" is a lifecycle fact rather than an openness verdict, and it is what a reader
+# needs first.
+#
+# `verl.capability` remains held since 2026-08-09 and was not touched.
+#
+- product: amazon-bedrock-custom-models-fine-tuning
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: the AWS Bedrock model-customization documentation and AWS's Claude 3 Haiku fine-tuning
+    GA announcement
+- product: anyscale-fine-tuning
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: the Anyscale fine-tuning documentation and the Terms of Service
+- product: atropos
+  resolved_state: canonical
+  verified: '2026-08-08'
+  document: the GitHub repository and the PyPI record for atroposlib
+- product: axolotl
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: GitHub, the README, the LICENSE body, and axolotl
+- product: azure-openai-fine-tuning
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: the Microsoft Foundry fine-tuning documentation, the Azure OpenAI data-privacy page, and
+    Microsoft's Product Terms
+- product: fireworks-fine-tuning
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: the Fireworks fine-tuning, model catalog, LoRA-deployment, and LoRA-performance documentation
+- product: lamini
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: docs
+- product: litgpt
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: GitHub and the LICENSE body
+- product: llama-factory
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: GitHub and the LICENSE body
+- product: megatron-lm
+  resolved_state: canonical
+  verified: '2026-08-08'
+  document: the NVIDIA/Megatron-LM README and the Megatron Core developer documentation
+- product: mistral-fine-tuning-api
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: Mistral's deprecated fine-tuning guide, the Studio product page, and the API pricing page
+- product: mosaic-ai-model-training
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: the Databricks Foundation Model Fine-tuning docs page and the Databricks Model Training
+    product page
+- product: nemo-rl
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: GitHub, the LICENSE body, and PyPI
+- product: openai-fine-tuning-api
+  resolved_state: canonical
+  verified: '2026-08-08'
+  document: the OpenAI model optimization guide, the API deprecations page, and the OpenAI Services
+    Agreement
+- product: openpipe
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: GitHub and the ART documentation
+- product: openrlhf
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: GitHub and the LICENSE body
+- product: peft
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: GitHub, the LICENSE body, and Hugging Face's pricing page
+- product: predibase
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: web
+- product: snowflake-cortex-fine-tuning
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: the Snowflake Cortex Fine-tuning documentation
+- product: swift
+  resolved_state: canonical
+  verified: '2026-08-08'
+  document: the ms-swift README, the PyPI project page, and the LICENSE body
+- product: tinker
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: the Tinker product page, the Service Terms of Use, and Thinking Machines' news archive
+- product: together-fine-tuning
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: the Together AI fine-tuning docs, the fine-tuning product page, and the Terms of Service
+- product: torchtune
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: GitHub and the LICENSE body
+- product: trl
+  resolved_state: canonical
+  verified: '2026-08-08'
+  document: the TRL documentation index and the repository README
+- product: unsloth
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: GitHub and the LICENSE body
+- product: verl
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: GitHub, the LICENSE body, the README, and PyPI
+- product: vertex-ai-tuning
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: the Gemini tuning documentation and the Google Cloud Platform Terms of Service

--- a/sources/provenance/inference_code.yaml
+++ b/sources/provenance/inference_code.yaml
@@ -1,0 +1,99 @@
+# Prose closeout for inference_code. 20 of 20 ready. One failed, as flagged.
+#
+# `tensorrt-llm` named the third-party licenses bundled in its repository; the note now says a
+# compound exists and which half the axis follows, without restating either.
+#
+# ## The one detector false positive in the whole sweep
+#
+# `text-generation-inference` reports "Its final release was v3.3.7 (2025-12-19) and the
+# repository was archived 2026-03-21". The ban detector reads that as a current version number.
+# It is not: `product-copy.md` names this exact case as durable - "There will be no future
+# release ... durable precisely because the project stopped" - and gives an almost identical
+# example. The prose was left alone and the detector is wrong here, which is recorded rather
+# than worked around.
+#
+# `qualcomm-ai-engine-direct.openness` remains held since 2026-08-09 and was not touched.
+#
+- product: apple-core-ml-runtime
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: Apple's Core ML documentation, the MLModel availability list, and the coremltools optimization
+    guide
+- product: aws-neuron
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: the AWS Neuron documentation, the aws-neuron-sdk and aws-neuron-driver GitHub repos, and
+    the AWS Neuron product page
+- product: cerebras-inference
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: the Cerebras inference page, the Cerebras chip page, and the Cerebras Inference Terms
+    and Conditions
+- product: ds4
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: GitHub and the LICENSE body
+- product: fireworks-inference
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: the Fireworks homepage, team page, and FireAttention V3 blog post
+- product: google-cloud-tpu-inference
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: the Google Cloud AI Hypercomputer inference blog post and the TPU7x (Ironwood) documentation
+- product: groq-inference
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: the GroqDocs models and overview pages and Groq's LPU architecture blog
+- product: llama-cpp
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: GitHub, the LICENSE body, and the Hugging Face GGUF documentation
+- product: llamafile
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: GitHub, the LICENSE body, and the README
+- product: lmdeploy
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: GitHub, the LICENSE body, and PyPI download statistics
+- product: localai
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: GitHub and the LICENSE body
+- product: max
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: GitHub and the Modular Community License page
+- product: onnx-runtime
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: GitHub, the LICENSE body, and PyPI download statistics
+- product: qualcomm-ai-engine-direct
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: GitHub, the ExecuTorch Qualcomm backend docs, and the LiteRT NPU documentation
+- product: sambanova-cloud
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: the SN40L architecture blog and the SambaCloud Terms of Service
+- product: sglang
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: GitHub and the LICENSE body
+- product: tensorrt-llm
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: GitHub and the LICENSE body
+- product: text-generation-inference
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: GitHub, the LICENSE body, and the releases page
+- product: together-inference-engine
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: together
+- product: vllm
+  resolved_state: canonical
+  verified: '2026-08-09'
+  document: GitHub and the LICENSE body

--- a/sources/provenance/ml_frameworks.yaml
+++ b/sources/provenance/ml_frameworks.yaml
@@ -1,0 +1,111 @@
+# Prose closeout for ml_frameworks. 22 of 22 ready.
+#
+# All 22 were canonical; 12 failed prose compliance where the ledger flagged 6.
+#
+# This category's records are the most established software on the map, and that is exactly
+# what put the violations in: nine of the twelve were a claim about the product's STANDING
+# rather than about the product. "It is one of the two most widely used deep learning
+# frameworks and underpins most modern research and production model training" (pytorch),
+# "one of the two most widely used" (tensorflow), "it has become the default weight format for
+# models on the Hugging Face Hub" (safetensors), "widely used as the kernel backend" (triton),
+# "widely used to feed training and evaluation pipelines" (hf-datasets), "widely used as the
+# distributed-training backbone" (accelerate), "widely used for high-performance numerical
+# computing" (jax), "one of the most established open frameworks" (pysyft), "underpinning much
+# of the modern open source ML and LLM ecosystem" (transformers).
+#
+# Each was replaced with the same fact stated as a relationship rather than a rank - "the
+# framework most of the model records on this map are trained and served with", "other Hugging
+# Face libraries use it as their distributed-training backbone", "serves as the kernel backend
+# for PyTorch's inductor". That is checkable; "most widely used" is not.
+#
+# The remaining three opened with the openness verdict as the category noun: flax, gradio,
+# openvino.
+#
+- product: accelerate
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body
+- product: deepspeed
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body
+- product: diffusers
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body
+- product: feluda
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the tattle-made/feluda repository and the GitHub API
+- product: flax
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and the GitHub license API
+- product: ggml
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body
+- product: gradio
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body
+- product: hf-datasets
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body
+- product: huggingface-hub
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body
+- product: jax
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and the GitHub license API
+- product: keras
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and the GitHub license API
+- product: onnx
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body
+- product: openvino
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body
+- product: optimum
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body
+- product: pysyft
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: the OpenMined/PySyft repository, its README and the PyPI project page
+- product: pytorch
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body
+- product: safetensors
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body
+- product: sentencepiece
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body
+- product: tensorflow
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and the GitHub license API
+- product: tokenizers
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body
+- product: transformers
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body
+- product: triton
+  resolved_state: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body


### PR DESCRIPTION
The last five categories, closed together: `ml_frameworks` 22/22, `finetuning_code` 27/27, `dataset_processing_tools` 21/21, `deployment` 27/27, `inference_code` 20/20.

**This completes the 472-product prose sweep.** No axis touched, no date moved, no source refetched.

## 28 records failed; the ledger flagged 17

### `ml_frameworks` — 12 failed, 6 flagged

These are the most established projects on the map, and that is exactly what put the violations in: **nine of twelve were a claim about the product's standing rather than about the product.**

> "one of the two most widely used deep learning frameworks and underpins most modern research and production model training" (`pytorch`) · "it has become the default weight format for models on the Hugging Face Hub" (`safetensors`) · "widely used as the kernel backend" (`triton`) · "one of the most established open frameworks" (`pysyft`) · "underpinning much of the modern open source ML and LLM ecosystem" (`transformers`)

Each is replaced by the same fact stated as a **relationship** rather than a rank — "the framework most of the model records on this map are trained and served with", "other Hugging Face libraries use it as their distributed-training backbone", "serves as the kernel backend for PyTorch's inductor". Those are checkable; "most widely used" is not.

### `finetuning_code` — 4 failed, and one distinction had to be drawn

Most records here say they fine-tune **"open-weight models"**. That is *not* this product's own openness — it is the class of input the service accepts, which is a capability fact and the most useful thing in the entry. It stays.

What came out is the openness verdict applied to a **named artifact**: `nemo-rl`'s "NVIDIA's open source library" about itself, `predibase`'s "the multi-LoRA inference engine its founders publish as open source", `openai-fine-tuning-api`'s "OpenAI's closed models". That record keeps its wind-down in full — new sign-ups stopped, job creation ends January 2027 — because "closed to new users" is a lifecycle fact, not an openness verdict.

### `dataset_processing_tools` — 6 failed, 4 flagged

`datology-ai` carried the most banned content of any record in the sweep: "a proprietary curation platform", "no source-available product", "~$57.5M raised (seed plus a $46M Series A in May 2024)", and a named angel list.

`snorkel-flow`'s 120-word comments field was long because it records something worth keeping: a 2026-08-13 pass read only the marketing site, where the old path redirects and the copy sells data services, and **concluded the platform had been withdrawn**. The documentation site showed it had only been renamed. The lesson is the point — *a vendor reorganizing its marketing is not evidence a product is gone* — and it now fits in 48 words.

### `deployment` — 5 failed, 2 flagged

**Three failed on length alone**, which no ban pattern catches: `aws-lambda` at 80 description words, `firecracker` at 86, `ray` at 90, against the guide's 35–70 band. Long descriptions are where the other violations hide, and reading for length is what surfaced them.

### `inference_code` — 1 failed, plus the sweep's only detector false positive

`text-generation-inference` reports *"Its final release was v3.3.7 (2025-12-19) and the repository was archived 2026-03-21"*. The detector reads that as a current version number. **It is not** — `product-copy.md` names this exact case as durable ("There will be no future release … durable precisely because the project stopped") and gives an almost identical example. The prose was left alone; the detector is wrong here, and that is recorded rather than worked around.

## Verification

`validate`, `check_verification`, `check_capability`, `check_recipe`, `check_adoption --strict` clean. `check_freshness` clean across all five, with the two pre-existing holds (`verl.capability`, `qualcomm-ai-engine-direct.openness`) untouched. 664 tests, no skips.

**Corpus: 472/472 prose-compliant · 472/472 canonical · 1,407/1,416 axes confirmed · 9 held · 0 source exceptions.**
