### PR TITLE
Final reconciliation: nine stale holds cleared, queue empty, 472-product ledger

### DIFF
--- a/sources/products/falcon.yaml
+++ b/sources/products/falcon.yaml
@@ -10,5 +10,5 @@ description: TII's open-weights model line from Abu Dhabi. The Falcon 3 family s
 huggingface_model:
 - url: https://huggingface.co/tiiuae/Falcon3-10B-Base
 comments: Scored on the Falcon 3 generation, now dated relative to later families. The Hub does not name the
-  license, so the tier rests on TII's own published text. The adoption axis is held. Verified 2026-08-13 via
-  the Falcon 3 release blog and the Falcon3 model cards.
+  license, so the tier rests on TII's own published text. Adoption was re-banded on a measured download count
+  rather than reported traction. Verified 2026-08-13 via the Falcon 3 release blog and the Falcon3 model cards.

--- a/sources/products/openrouter.yaml
+++ b/sources/products/openrouter.yaml
@@ -4,5 +4,5 @@ type: software
 description: Commercial API gateway exposing models from many providers behind one OpenAI-compatible endpoint,
   with automatic failover, routing and unified billing across them. It runs as a hosted service and is a routing
   gateway rather than a chat interface.
-comments: The homepage figures the adoption band was scored on have since moved, and the band is held pending
-  a re-read. Verified 2026-08-13 via the OpenRouter homepage.
+comments: The homepage figures the adoption band was originally scored on have since moved, and the band was
+  re-derived against the current ones. Verified 2026-08-13 via the OpenRouter homepage.

--- a/sources/products/poe.yaml
+++ b/sources/products/poe.yaml
@@ -5,5 +5,5 @@ description: Multi-model chat aggregator from Quora, giving access to many provi
   and audio generators from one interface, on a points-based unified pricing model. Alongside the providers'
   own assistants it carries bots that users build and publish themselves, which is what distinguishes it from
   a single-vendor chat surface.
-comments: 'The adoption band is held: the figures it was scored on are no longer on the page behind them. Verified
-  2026-08-13 via the Poe about page.'
+comments: The figures the adoption band was first scored on are no longer on the page behind them; the band
+  was re-derived on the only sourceable active-user figure. Verified 2026-08-13 via the Poe about page.

--- a/sources/products/surfsense.yaml
+++ b/sources/products/surfsense.yaml
@@ -8,5 +8,5 @@ description: AI research assistant that connects a model to a personal or team k
 github:
 - url: https://github.com/MODSetter/SurfSense
 comments: The connector count and per-feature depth come from the maintainer's README and were not independently
-  checked. Licensing has since split across the tree, and the openness axis is held on that. Verified 2026-08-13
-  via the MODSetter/SurfSense repository.
+  checked. Licensing has since split across the tree, and the openness axis was re-derived against the split.
+  Verified 2026-08-13 via the MODSetter/SurfSense repository.

--- a/sources/provenance/LEDGER.yaml
+++ b/sources/provenance/LEDGER.yaml
@@ -1,0 +1,3341 @@
+# The 472-product closeout ledger, generated at the end of the sweep and committed as the
+# record of its final state. One row per product.
+#
+#   provenance      the verification line's classification from build/prose_provenance.py
+#   verified        the date that line claims
+#   document        what it names, which is the whole point of the exercise
+#   axes_confirmed  axes carrying a real last_verified, out of three
+#   axes_held       axes in sources/verification_queue.yaml
+#
+# 472 canonical, 472 with a named document, 1416 of 1416 axes confirmed, 0 held.
+#
+# Prose compliance is not a column because it is not machine-decidable: the ban detector used
+# during the sweep produced candidates, and reading every record in full produced the scope.
+# Across the last five categories it flagged 17 of the 28 records that actually failed. Its one
+# FALSE positive is text-generation-inference, whose "final release was v3.3.7 (2025-12-19)"
+# reads as a current version to a pattern and is the durable case product-copy.md names by
+# example. The prose there is correct and was left alone.
+#
+- product: accelerate
+  category: ml_frameworks
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: aegis-guard
+  category: safeguards
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the HF model card
+  axes_confirmed: 3
+  axes_held: 0
+- product: agent-infra-sandbox
+  category: deployment
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the agent-infra/sandbox README and the GitHub repository metadata
+  axes_confirmed: 3
+  axes_held: 0
+- product: agent2agent-protocol
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and the Linux Foundation's first-year release
+  axes_confirmed: 3
+  axes_held: 0
+- product: agenta
+  category: telemetry_observability
+  provenance: canonical
+  verified: '2026-08-14'
+  document: the Agenta documentation and repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: agentops
+  category: telemetry_observability
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the AgentOps-AI/agentops repository and its README
+  axes_confirmed: 3
+  axes_held: 0
+- product: ai2-arc
+  category: benchmark_eval_data
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the allenai/ai2_arc dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: aider
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Aider-AI/aider repository and its PyPI page
+  axes_confirmed: 3
+  axes_held: 0
+- product: algolia-ai-search
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Algolia AI Search product page
+  axes_confirmed: 3
+  axes_held: 0
+- product: alia-40b
+  category: base_pretrained
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the model card and the langtech-bsc/alia repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: alpacaeval
+  category: evaluation_code
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the tatsu-lab/alpaca_eval repository, its license endpoint and its README
+  axes_confirmed: 3
+  axes_held: 0
+- product: amazon-bedrock-custom-models-fine-tuning
+  category: finetuning_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: the AWS Bedrock model-customization documentation and AWS's Claude 3 Haiku fine-tuning
+    GA announcement
+  axes_confirmed: 3
+  axes_held: 0
+- product: amazon-bedrock-evaluations
+  category: evaluation_code
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Bedrock Evaluations product page and its general-availability announcement
+  axes_confirmed: 3
+  axes_held: 0
+- product: amazon-nova
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the AWS Nova user guide and models page
+  axes_confirmed: 3
+  axes_held: 0
+- product: amazon-q-developer
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Amazon Q Developer product page
+  axes_confirmed: 3
+  axes_held: 0
+- product: anthropic-internal-coding-evals
+  category: benchmark_eval_data
+  provenance: canonical
+  verified: '2026-08-13'
+  document: Anthropic's Claude Opus 4
+  axes_confirmed: 3
+  axes_held: 0
+- product: antigravity
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Antigravity product page and Google's I/O 2026 developer keynote announcement
+  axes_confirmed: 3
+  axes_held: 0
+- product: anyscale-fine-tuning
+  category: finetuning_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: the Anyscale fine-tuning documentation and the Terms of Service
+  axes_confirmed: 3
+  axes_held: 0
+- product: anythingllm
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the anything-llm repository and its Docker Hub listing
+  axes_confirmed: 3
+  axes_held: 0
+- product: apertus
+  category: base_pretrained
+  provenance: canonical
+  verified: '2026-08-14'
+  document: the v1
+  axes_confirmed: 3
+  axes_held: 0
+- product: apify
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: apify
+  axes_confirmed: 3
+  axes_held: 0
+- product: apple-core-ml-runtime
+  category: inference_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: Apple's Core ML documentation, the MLModel availability list, and the coremltools optimization
+    guide
+  axes_confirmed: 3
+  axes_held: 0
+- product: apps
+  category: benchmark_eval_data
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the codeparrot/apps dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: arduino-uno-q
+  category: edge_hardware
+  provenance: canonical
+  verified: '2026-08-14'
+  document: the Arduino product page, the App Lab and App Bricks repositories and the UNO Q user manual
+  axes_confirmed: 3
+  axes_held: 0
+- product: arize
+  category: telemetry_observability
+  provenance: canonical
+  verified: '2026-08-13'
+  document: arize
+  axes_confirmed: 3
+  axes_held: 0
+- product: artificial-analysis-intelligence-index
+  category: evaluation_code
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Artificial Analysis benchmarking methodology page and the Stirrup license endpoint
+  axes_confirmed: 3
+  axes_held: 0
+- product: atropos
+  category: finetuning_code
+  provenance: canonical
+  verified: '2026-08-08'
+  document: the GitHub repository and the PyPI record for atroposlib
+  axes_confirmed: 3
+  axes_held: 0
+- product: autogen
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the microsoft/autogen repository and its LICENSE-CODE
+  axes_confirmed: 3
+  axes_held: 0
+- product: autogpt
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Significant-Gravitas/AutoGPT repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: aws-lambda
+  category: deployment
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the AWS Lambda FAQ
+  axes_confirmed: 3
+  axes_held: 0
+- product: aws-neuron
+  category: inference_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: the AWS Neuron documentation, the aws-neuron-sdk and aws-neuron-driver GitHub repos, and
+    the AWS Neuron product page
+  axes_confirmed: 3
+  axes_held: 0
+- product: axelera-metis-aipu
+  category: edge_hardware
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Axelera product site and the voyager-sdk repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: axolotl
+  category: finetuning_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: GitHub, the README, the LICENSE body, and axolotl
+  axes_confirmed: 3
+  axes_held: 0
+- product: aya-collection
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Aya Collection dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: azure-ai-foundry-observability
+  category: telemetry_observability
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Microsoft Learn observability concept page
+  axes_confirmed: 3
+  axes_held: 0
+- product: azure-ai-model-inference
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Microsoft Foundry Models endpoints documentation
+  axes_confirmed: 3
+  axes_held: 0
+- product: azure-content-safety
+  category: safeguards
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Azure product page
+  axes_confirmed: 3
+  axes_held: 0
+- product: azure-openai-fine-tuning
+  category: finetuning_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: the Microsoft Foundry fine-tuning documentation, the Azure OpenAI data-privacy page, and
+    Microsoft's Product Terms
+  axes_confirmed: 3
+  axes_held: 0
+- product: beagley-ai
+  category: edge_hardware
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the OSHWA certification record, the beagley-ai repository, the design documentation and
+    the TI product page
+  axes_confirmed: 3
+  axes_held: 0
+- product: bedrock-guardrails
+  category: safeguards
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the AWS product page
+  axes_confirmed: 3
+  axes_held: 0
+- product: beeai
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the i-am-bee/beeai-framework repository and the LF AI & Data project page
+  axes_confirmed: 3
+  axes_held: 0
+- product: beta9
+  category: deployment
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Beta9 README and the ComputeSDK sandbox benchmark leaderboard
+  axes_confirmed: 3
+  axes_held: 0
+- product: bigcode-dataset
+  category: dataset_processing_tools
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: bigcodebench
+  category: evaluation_code
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the bigcodebench repository, its license endpoint and its README
+  axes_confirmed: 3
+  axes_held: 0
+- product: blaxel-sandbox
+  category: deployment
+  provenance: canonical
+  verified: '2026-08-13'
+  document: blaxel
+  axes_confirmed: 3
+  axes_held: 0
+- product: braintrust
+  category: telemetry_observability
+  provenance: canonical
+  verified: '2026-08-13'
+  document: braintrust
+  axes_confirmed: 3
+  axes_held: 0
+- product: browser-use
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and the pypistats API
+  axes_confirmed: 3
+  axes_held: 0
+- product: browserbase
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: docs
+  axes_confirmed: 3
+  axes_held: 0
+- product: c4
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the allenai/c4 dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: ccnet
+  category: dataset_processing_tools
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: cerebras-inference
+  category: inference_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: the Cerebras inference page, the Cerebras chip page, and the Cerebras Inference Terms
+    and Conditions
+  axes_confirmed: 3
+  axes_held: 0
+- product: character-ai
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-16'
+  document: Character
+  axes_confirmed: 3
+  axes_held: 0
+- product: chatbot-arena
+  category: evaluation_code
+  provenance: canonical
+  verified: '2026-08-13'
+  document: arena
+  axes_confirmed: 3
+  axes_held: 0
+- product: chatgpt
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-14'
+  document: OpenAI's ChatGPT App Store listing and its Custom GPTs documentation
+  axes_confirmed: 3
+  axes_held: 0
+- product: claude-ai
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Claude product overview page
+  axes_confirmed: 3
+  axes_held: 0
+- product: claude-code
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Claude Code documentation overview
+  axes_confirmed: 3
+  axes_held: 0
+- product: claude-fable
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Fable 5 launch post, the Claude platform documentation and the Claude Fable product
+    page
+  axes_confirmed: 3
+  axes_held: 0
+- product: claude-haiku
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Claude Haiku product page
+  axes_confirmed: 3
+  axes_held: 0
+- product: claude-opus
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Opus 4
+  axes_confirmed: 3
+  axes_held: 0
+- product: claude-sonnet
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Sonnet 4
+  axes_confirmed: 3
+  axes_held: 0
+- product: cline
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the cline/cline repository and its VS Code Marketplace listing
+  axes_confirmed: 3
+  axes_held: 0
+- product: cloudflare-sandboxes
+  category: deployment
+  provenance: canonical
+  verified: '2026-08-13'
+  document: Cloudflare's "Sandboxing AI agents, 100x faster" post and the cloudflare/sandbox-sdk repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: codecontests
+  category: benchmark_eval_data
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the deepmind/code_contests dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: codegemma
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the model card and Hugging Face's CodeGemma release post
+  axes_confirmed: 3
+  axes_held: 0
+- product: codellama
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the model card and the arXiv abstract
+  axes_confirmed: 3
+  axes_held: 0
+- product: coder-oss
+  category: deployment
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the coder/coder README and the GitHub repository metadata
+  axes_confirmed: 3
+  axes_held: 0
+- product: codestral
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Codestral and Codestral 25
+  axes_confirmed: 3
+  axes_held: 0
+- product: codex-cli
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the OpenAI Codex CLI documentation
+  axes_confirmed: 3
+  axes_held: 0
+- product: cohere-rerank-api
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Cohere rerank overview, the 3
+  axes_confirmed: 3
+  axes_held: 0
+- product: command-r
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-14'
+  document: the Command A+ model card and the CohereLabs org listing
+  axes_confirmed: 3
+  axes_held: 0
+- product: common-corpus
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the PleIAs/common_corpus dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: compar-ia-datasets
+  category: benchmark_eval_data
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the ministere-culture/comparia-votes dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: compar-ia
+  category: evaluation_code
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the betagouv/ComparIA repository README and its LICENSE
+  axes_confirmed: 3
+  axes_held: 0
+- product: composio
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and the Composio docs
+  axes_confirmed: 3
+  axes_held: 0
+- product: confer
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: Confer's private-inference architecture post and the confer-proxy repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: confident-ai
+  category: telemetry_observability
+  provenance: canonical
+  verified: '2026-08-13'
+  document: confident-ai
+  axes_confirmed: 3
+  axes_held: 0
+- product: continue
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the continuedev/continue repository, the VS Code Marketplace listing and continue
+  axes_confirmed: 3
+  axes_held: 0
+- product: coop
+  category: safeguards
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and ROOST's Coop 1
+  axes_confirmed: 3
+  axes_held: 0
+- product: cosmopedia
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the HuggingFaceTB/cosmopedia dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: crewai
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-12'
+  document: the crewAIInc/crewAI repository tree, its enterprise CLI module and the vendor pricing
+    page
+  axes_confirmed: 3
+  axes_held: 0
+- product: cruxeval
+  category: benchmark_eval_data
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the facebookresearch/cruxeval repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: culturax
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the uonlp/CulturaX dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: cursor
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Cursor product site and the SWE-bench coding-agent leaderboard
+  axes_confirmed: 3
+  axes_held: 0
+- product: data-juicer
+  category: dataset_processing_tools
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: datadog-llm-observability
+  category: telemetry_observability
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Datadog LLM Observability documentation
+  axes_confirmed: 3
+  axes_held: 0
+- product: datamap-rs
+  category: dataset_processing_tools
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: datasette-agent
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the datasette/datasette-agent repository and the agent
+  axes_confirmed: 3
+  axes_held: 0
+- product: datatrove
+  category: dataset_processing_tools
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: datology-ai
+  category: dataset_processing_tools
+  provenance: canonical
+  verified: '2026-08-13'
+  document: datologyai
+  axes_confirmed: 3
+  axes_held: 0
+- product: daytona-sandbox
+  category: deployment
+  provenance: canonical
+  verified: '2026-08-13'
+  document: daytona
+  axes_confirmed: 3
+  axes_held: 0
+- product: dclm-baseline
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the mlfoundations/dclm-baseline-1
+  axes_confirmed: 3
+  axes_held: 0
+- product: dclm
+  category: dataset_processing_tools
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and the repository README
+  axes_confirmed: 3
+  axes_held: 0
+- product: decon
+  category: dataset_processing_tools
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: deepeval
+  category: evaluation_code
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the confident-ai/deepeval repository, its license endpoint and its README
+  axes_confirmed: 3
+  axes_held: 0
+- product: deepseek-chat
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the DeepSeek product site
+  axes_confirmed: 3
+  axes_held: 0
+- product: deepseek-coder
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the model card and the model-license body
+  axes_confirmed: 3
+  axes_held: 0
+- product: deepseek-instruct
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the DeepSeek-V4-Flash model card
+  axes_confirmed: 3
+  axes_held: 0
+- product: deepseek-r1
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the HF model card
+  axes_confirmed: 3
+  axes_held: 0
+- product: deepseek
+  category: base_pretrained
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the DeepSeek-V4-Pro HF model card and the deepseek-ai/DeepSeek-V3 repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: deepspeed
+  category: ml_frameworks
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: deepteam
+  category: safeguards
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub
+  axes_confirmed: 3
+  axes_held: 0
+- product: devin
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Devin documentation and Cognition's SWE-bench technical report
+  axes_confirmed: 3
+  axes_held: 0
+- product: devstral
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-14'
+  document: both model cards
+  axes_confirmed: 3
+  axes_held: 0
+- product: diffusers
+  category: ml_frameworks
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: dify
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the langgenius/dify repository and the Dify product site
+  axes_confirmed: 3
+  axes_held: 0
+- product: distilabel
+  category: dataset_processing_tools
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: docling
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub, the repository LICENSE and the pypistats API
+  axes_confirmed: 3
+  axes_held: 0
+- product: dolci
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the allenai/Dolci-Instruct-SFT dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: dolma-3
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the allenai/dolma3_pool dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: dolma-toolkit
+  category: dataset_processing_tools
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: dolma
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the allenai/dolma dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: doubao-seed
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: TechNode's coverage of the launch
+  axes_confirmed: 3
+  axes_held: 0
+- product: doubao
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-16'
+  document: Doubao's App Store listing
+  axes_confirmed: 3
+  axes_held: 0
+- product: ds4
+  category: inference_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: GitHub and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: dspy
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the stanfordnlp/dspy repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: duck-ai
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: DuckDuckGo's Duck
+  axes_confirmed: 3
+  axes_held: 0
+- product: duplodocus
+  category: dataset_processing_tools
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: dynatrace-ai-observability
+  category: telemetry_observability
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Dynatrace AI observability documentation
+  axes_confirmed: 3
+  axes_held: 0
+- product: e2b-sandbox
+  category: deployment
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the E2B site and the ComputeSDK sandbox benchmark leaderboard
+  axes_confirmed: 3
+  axes_held: 0
+- product: epoch-ai-benchmarks
+  category: evaluation_code
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Epoch benchmarks dashboard, the FrontierMath page and the organization's repository
+    listing
+  axes_confirmed: 3
+  axes_held: 0
+- product: ernie
+  category: base_pretrained
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the ERNIE 5
+  axes_confirmed: 3
+  axes_held: 0
+- product: evalplus
+  category: benchmark_eval_data
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the evalplus/humanevalplus dataset card and the evalplus/evalplus repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: exa-search-api
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the exa
+  axes_confirmed: 3
+  axes_held: 0
+- product: falcon
+  category: base_pretrained
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Falcon 3 release blog and the Falcon3 model cards
+  axes_confirmed: 3
+  axes_held: 0
+- product: fastmcp
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub, the repository LICENSE and the pypistats API
+  axes_confirmed: 3
+  axes_held: 0
+- product: feluda
+  category: ml_frameworks
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the tattle-made/feluda repository and the GitHub API
+  axes_confirmed: 3
+  axes_held: 0
+- product: filesystem-mcp
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the server README and the monorepo LICENSE
+  axes_confirmed: 3
+  axes_held: 0
+- product: finemath
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the HuggingFaceTB/finemath dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: fineweb-2
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the HuggingFaceFW/fineweb-2 dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: fineweb-edu
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the HuggingFaceFW/fineweb-edu dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: fineweb
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the HuggingFaceFW/fineweb dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: firecracker
+  category: deployment
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Firecracker README and the GitHub repository API
+  axes_confirmed: 3
+  axes_held: 0
+- product: firecrawl
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and the self-hosting guide
+  axes_confirmed: 3
+  axes_held: 0
+- product: fireworks-fine-tuning
+  category: finetuning_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: the Fireworks fine-tuning, model catalog, LoRA-deployment, and LoRA-performance documentation
+  axes_confirmed: 3
+  axes_held: 0
+- product: fireworks-inference
+  category: inference_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: the Fireworks homepage, team page, and FireAttention V3 blog post
+  axes_confirmed: 3
+  axes_held: 0
+- product: flan-collection
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the google-research/FLAN repository and the ai2-adapt-dev/flan_v2_converted dataset card
+  axes_confirmed: 3
+  axes_held: 0
+- product: flax
+  category: ml_frameworks
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and the GitHub license API
+  axes_confirmed: 3
+  axes_held: 0
+- product: fly-sprites
+  category: deployment
+  provenance: canonical
+  verified: '2026-08-13'
+  document: fly
+  axes_confirmed: 3
+  axes_held: 0
+- product: gaia
+  category: benchmark_eval_data
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the GAIA dataset card on Hugging Face and the GAIA paper abstract
+  axes_confirmed: 3
+  axes_held: 0
+- product: galileo
+  category: telemetry_observability
+  provenance: canonical
+  verified: '2026-08-13'
+  document: galileo
+  axes_confirmed: 3
+  axes_held: 0
+- product: garak
+  category: safeguards
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub
+  axes_confirmed: 3
+  axes_held: 0
+- product: gemini-cli
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the google-gemini/gemini-cli repository and Google's launch announcement
+  axes_confirmed: 3
+  axes_held: 0
+- product: gemini-flash
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Gemini 3
+  axes_confirmed: 3
+  axes_held: 0
+- product: gemini-pro
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the DeepMind model index
+  axes_confirmed: 3
+  axes_held: 0
+- product: gemini
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: Google's Gemini 3
+  axes_confirmed: 3
+  axes_held: 0
+- product: gemma
+  category: base_pretrained
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the gemma-4-31B-it model card and the Gemma releases page
+  axes_confirmed: 3
+  axes_held: 0
+- product: ggml
+  category: ml_frameworks
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: giskard
+  category: safeguards
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub
+  axes_confirmed: 3
+  axes_held: 0
+- product: github-copilot-ide
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the GitHub Copilot product page
+  axes_confirmed: 3
+  axes_held: 0
+- product: github-copilot
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the GitHub Copilot product page
+  axes_confirmed: 3
+  axes_held: 0
+- product: github-mcp
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and the repository LICENSE
+  axes_confirmed: 3
+  axes_held: 0
+- product: glean-assistant
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Glean Assistant product page
+  axes_confirmed: 3
+  axes_held: 0
+- product: glean-workplace-search-ai
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Glean product overview page
+  axes_confirmed: 3
+  axes_held: 0
+- product: glm
+  category: base_pretrained
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the GLM-5
+  axes_confirmed: 3
+  axes_held: 0
+- product: google-cloud-run
+  category: deployment
+  provenance: canonical
+  verified: '2026-08-13'
+  document: cloud
+  axes_confirmed: 3
+  axes_held: 0
+- product: google-cloud-tpu-inference
+  category: inference_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: the Google Cloud AI Hypercomputer inference blog post and the TPU7x (Ironwood) documentation
+  axes_confirmed: 3
+  axes_held: 0
+- product: google-coral-dev-board
+  category: edge_hardware
+  provenance: canonical
+  verified: '2026-08-14'
+  document: the datasheet, the electricals repository and the product page
+  axes_confirmed: 3
+  axes_held: 0
+- product: google-grounding-api
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Google Cloud grounding overview
+  axes_confirmed: 3
+  axes_held: 0
+- product: goose
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the aaif-goose/goose repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: gpqa
+  category: benchmark_eval_data
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Idavidrein/gpqa dataset card on Hugging Face and the GPQA paper abstract
+  axes_confirmed: 3
+  axes_held: 0
+- product: gpt-4-1
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: OpenAI's model docs, TechCrunch and InfoQ
+  axes_confirmed: 3
+  axes_held: 0
+- product: gpt-4o
+  category: base_pretrained
+  provenance: canonical
+  verified: '2026-08-13'
+  document: OpenAI's GPT-4o model documentation
+  axes_confirmed: 3
+  axes_held: 0
+- product: gpt-5
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the GPT-5 Wikipedia article and TechCrunch
+  axes_confirmed: 3
+  axes_held: 0
+- product: gpt-oss-safeguard
+  category: safeguards
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the HF model card
+  axes_confirmed: 3
+  axes_held: 0
+- product: gpt-researcher
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the assafelovic/gpt-researcher repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: gpt4all
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the nomic-ai/gpt4all repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: gradio
+  category: ml_frameworks
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: granite-code-instruct
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the model card, the granite-code-models repository and IBM's release blog
+  axes_confirmed: 3
+  axes_held: 0
+- product: granite-guardian
+  category: safeguards
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the HF model card
+  axes_confirmed: 3
+  axes_held: 0
+- product: graphrag
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the microsoft/graphrag repository and its documentation site
+  axes_confirmed: 3
+  axes_held: 0
+- product: grok-app
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the xAI Grok 4
+  axes_confirmed: 3
+  axes_held: 0
+- product: grok
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the xAI release notes, the xAI model reference and the Artificial Analysis model page
+  axes_confirmed: 3
+  axes_held: 0
+- product: groq-inference
+  category: inference_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: the GroqDocs models and overview pages and Groq's LPU architecture blog
+  axes_confirmed: 3
+  axes_held: 0
+- product: gsm8k
+  category: benchmark_eval_data
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the openai/gsm8k dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: guardrails-ai
+  category: safeguards
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub
+  axes_confirmed: 3
+  axes_held: 0
+- product: gvisor
+  category: deployment
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the gVisor README, the LICENSE body, and the gvisor
+  axes_confirmed: 3
+  axes_held: 0
+- product: hailo-10h
+  category: edge_hardware
+  provenance: canonical
+  verified: '2026-08-14'
+  document: those two listings and the GenAI model-zoo repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: hailo-8
+  category: edge_hardware
+  provenance: canonical
+  verified: '2026-08-14'
+  document: those listings and the HailoRT README
+  axes_confirmed: 3
+  axes_held: 0
+- product: harmbench
+  category: safeguards
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub
+  axes_confirmed: 3
+  axes_held: 0
+- product: haystack
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-11'
+  document: the deepset-ai/haystack repository tree and deepset's enterprise announcements
+  axes_confirmed: 3
+  axes_held: 0
+- product: helicone
+  category: telemetry_observability
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Helicone/helicone README
+  axes_confirmed: 3
+  axes_held: 0
+- product: hellaswag
+  category: benchmark_eval_data
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Rowan/hellaswag dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: helm
+  category: evaluation_code
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the stanford-crfm/helm repository, its license endpoint and its README
+  axes_confirmed: 3
+  axes_held: 0
+- product: hermes-3-dataset
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the NousResearch/Hermes-3-Dataset dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: hermes-agent
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the NousResearch/hermes-agent repository and the Hermes Agent product page
+  axes_confirmed: 3
+  axes_held: 0
+- product: hermes
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the model cards and the technical report
+  axes_confirmed: 3
+  axes_held: 0
+- product: hexabot
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-11'
+  document: the Hexastack/Hexabot repository, its LICENSE
+  axes_confirmed: 3
+  axes_held: 0
+- product: hf-datasets
+  category: ml_frameworks
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: hh-rlhf
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Anthropic/hh-rlhf dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: huggingchat-chat-ui
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the huggingface/chat-ui repository and huggingface
+  axes_confirmed: 3
+  axes_held: 0
+- product: huggingface-hub
+  category: ml_frameworks
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: humaneval
+  category: benchmark_eval_data
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the openai/openai_humaneval dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: humanitys-last-exam
+  category: benchmark_eval_data
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the cais/hle dataset card on Hugging Face and lastexam
+  axes_confirmed: 3
+  axes_held: 0
+- product: ifeval
+  category: benchmark_eval_data
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the google/IFEval dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: inflection
+  category: base_pretrained
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Intel newsroom release and the Inflection AI Wikipedia entry
+  axes_confirmed: 3
+  axes_held: 0
+- product: inkling
+  category: base_pretrained
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Inkling model card and Thinking Machines' launch post
+  axes_confirmed: 3
+  axes_held: 0
+- product: inspect-ai
+  category: evaluation_code
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the UKGovernmentBEIS/inspect_ai repository, its license endpoint and the Inspect models
+    documentation
+  axes_confirmed: 3
+  axes_held: 0
+- product: internlm
+  category: base_pretrained
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the model card and the InternLM repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: jamba-large
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the HF model card, the Jamba Open Model License body and the AI21 release blog
+  axes_confirmed: 3
+  axes_held: 0
+- product: jan
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the janhq/jan repository and the jan
+  axes_confirmed: 3
+  axes_held: 0
+- product: jax
+  category: ml_frameworks
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and the GitHub license API
+  axes_confirmed: 3
+  axes_held: 0
+- product: jina-reader
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and jina
+  axes_confirmed: 3
+  axes_held: 0
+- product: k2
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the model card and the arXiv abstract
+  axes_confirmed: 3
+  axes_held: 0
+- product: kata-containers
+  category: deployment
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Kata Containers README, docs/hypervisors
+  axes_confirmed: 3
+  axes_held: 0
+- product: keras
+  category: ml_frameworks
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and the GitHub license API
+  axes_confirmed: 3
+  axes_held: 0
+- product: khadas-edge2
+  category: edge_hardware
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Khadas schematics archive, the fenix toolchain repository, the Edge2 product page
+    and the rkbin repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: khoj
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the khoj-ai/khoj repository and the Khoj Cloud sunset notice
+  axes_confirmed: 3
+  axes_held: 0
+- product: kimi
+  category: base_pretrained
+  provenance: canonical
+  verified: '2026-08-14'
+  document: the Kimi-K3 model card and its LICENSE file
+  axes_confirmed: 3
+  axes_held: 0
+- product: lakera-guard
+  category: safeguards
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Lakera site
+  axes_confirmed: 3
+  axes_held: 0
+- product: laminar
+  category: telemetry_observability
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the lmnr-ai/lmnr repository and the lmnr PyPI project page
+  axes_confirmed: 3
+  axes_held: 0
+- product: lamini
+  category: finetuning_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: docs
+  axes_confirmed: 3
+  axes_held: 0
+- product: langchain
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-11'
+  document: the langchain-ai/langchain repository tree, the vendor product page and its pricing page
+  axes_confirmed: 3
+  axes_held: 0
+- product: langflow
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the langflow-ai/langflow repository and the Langflow product site
+  axes_confirmed: 3
+  axes_held: 0
+- product: langfuse
+  category: telemetry_observability
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the langfuse/langfuse repository and the Langfuse observability docs
+  axes_confirmed: 3
+  axes_held: 0
+- product: langgraph
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-11'
+  document: the langchain-ai/langgraph repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: langsmith
+  category: telemetry_observability
+  provenance: canonical
+  verified: '2026-08-13'
+  document: langchain
+  axes_confirmed: 3
+  axes_held: 0
+- product: langtrace
+  category: telemetry_observability
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Scale3-Labs/langtrace repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: langwatch
+  category: telemetry_observability
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the langwatch/langwatch repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: le-chat
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-14'
+  document: Mistral's rename notice, the Vibe Work documentation and the Vibe product page
+  axes_confirmed: 3
+  axes_held: 0
+- product: librechat
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the danny-avila/LibreChat repository and the ClickHouse acquisition announcement
+  axes_confirmed: 3
+  axes_held: 0
+- product: lighteval
+  category: evaluation_code
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the huggingface/lighteval repository, its license endpoint and its README
+  axes_confirmed: 3
+  axes_held: 0
+- product: lightrag
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the HKUDS/LightRAG repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: litellm
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-15'
+  document: the BerriAI/litellm repository and its documentation site
+  axes_confirmed: 3
+  axes_held: 0
+- product: litgpt
+  category: finetuning_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: GitHub and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: livebench
+  category: benchmark_eval_data
+  provenance: canonical
+  verified: '2026-08-12'
+  document: the repository DATASHEET
+  axes_confirmed: 3
+  axes_held: 0
+- product: livecodebench
+  category: benchmark_eval_data
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the livecodebench/code_generation_lite card, its raw README and the harness repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: llama-cpp
+  category: inference_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: GitHub, the LICENSE body, and the Hugging Face GGUF documentation
+  axes_confirmed: 3
+  axes_held: 0
+- product: llama-factory
+  category: finetuning_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: GitHub and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: llama-guard
+  category: safeguards
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the HF model card
+  axes_confirmed: 3
+  axes_held: 0
+- product: llama-index
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-11'
+  document: the run-llama/llama_index repository tree and the vendor pricing page
+  axes_confirmed: 3
+  axes_held: 0
+- product: llama-instruct
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the HF model card
+  axes_confirmed: 3
+  axes_held: 0
+- product: llama-prompt-guard
+  category: safeguards
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the HF model card
+  axes_confirmed: 3
+  axes_held: 0
+- product: llama
+  category: base_pretrained
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Llama 4 Scout HF model card and the meta-llama organization page
+  axes_confirmed: 3
+  axes_held: 0
+- product: llamafile
+  category: inference_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: GitHub, the LICENSE body, and the README
+  axes_confirmed: 3
+  axes_held: 0
+- product: llamafirewall
+  category: safeguards
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the LlamaFirewall README and the PurpleLlama repo
+  axes_confirmed: 3
+  axes_held: 0
+- product: llm-guard
+  category: safeguards
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub
+  axes_confirmed: 3
+  axes_held: 0
+- product: llm
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the simonw/llm repository and the llm
+  axes_confirmed: 3
+  axes_held: 0
+- product: lm-evaluation-harness
+  category: evaluation_code
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the EleutherAI/lm-evaluation-harness repository, its license endpoint and its README
+  axes_confirmed: 3
+  axes_held: 0
+- product: lm-studio
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the LM Studio application terms and product site
+  axes_confirmed: 3
+  axes_held: 0
+- product: lmdeploy
+  category: inference_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: GitHub, the LICENSE body, and PyPI download statistics
+  axes_confirmed: 3
+  axes_held: 0
+- product: lobe-chat
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the lobehub repository and its LICENSE
+  axes_confirmed: 3
+  axes_held: 0
+- product: localai
+  category: inference_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: GitHub and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: lovable
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Lovable documentation
+  axes_confirmed: 3
+  axes_held: 0
+- product: lucie-7b
+  category: base_pretrained
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the model card, the dataset card and the Lucie-Training repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: luciole
+  category: base_pretrained
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the 23B base and instruct cards, the dataset card and the Luciole-Training repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: lumo
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the ProtonLumo iOS client repository and Proton's Lumo announcements
+  axes_confirmed: 3
+  axes_held: 0
+- product: madlad-400
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the allenai/MADLAD-400 dataset metadata on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: maple-ai
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: Maple's model guide and its first-year retrospective
+  axes_confirmed: 3
+  axes_held: 0
+- product: marin-framework
+  category: dataset_processing_tools
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: marin
+  category: base_pretrained
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Marin announcement post, the marin-8b-base HF model card and the marin-community/marin
+    repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: markitdown
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub, the repository LICENSE and the pypistats API
+  axes_confirmed: 3
+  axes_held: 0
+- product: mastra
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-12'
+  document: the mastra-ai/mastra repository tree and the npm registry
+  axes_confirmed: 3
+  axes_held: 0
+- product: math
+  category: benchmark_eval_data
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the hendrycks/competition_math dataset page
+  axes_confirmed: 3
+  axes_held: 0
+- product: max
+  category: inference_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: GitHub and the Modular Community License page
+  axes_confirmed: 3
+  axes_held: 0
+- product: mbpp
+  category: benchmark_eval_data
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the google-research-datasets/mbpp dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: mcp-inspector
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub, the README and package
+  axes_confirmed: 3
+  axes_held: 0
+- product: mcp-python-sdk
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub, the repository LICENSE and PyPI
+  axes_confirmed: 3
+  axes_held: 0
+- product: mcp-typescript-sdk
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub, the repository LICENSE and package
+  axes_confirmed: 3
+  axes_held: 0
+- product: megatron-lm
+  category: finetuning_code
+  provenance: canonical
+  verified: '2026-08-08'
+  document: the NVIDIA/Megatron-LM README and the Megatron Core developer documentation
+  axes_confirmed: 3
+  axes_held: 0
+- product: memryx-mx3
+  category: edge_hardware
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the M
+  axes_confirmed: 3
+  axes_held: 0
+- product: meta-ai
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-14'
+  document: Meta's newsroom post on Meta AI
+  axes_confirmed: 3
+  axes_held: 0
+- product: microsoft-copilot
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Microsoft 365 Copilot admin usage documentation
+  axes_confirmed: 3
+  axes_held: 0
+- product: milvus
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub, milvus
+  axes_confirmed: 3
+  axes_held: 0
+- product: mimo-pro
+  category: base_pretrained
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the model card, the product page and the MiMo repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: minimax
+  category: base_pretrained
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the M3 and M2
+  axes_confirmed: 3
+  axes_held: 0
+- product: mistral-7b-instruct
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the model card
+  axes_confirmed: 3
+  axes_held: 0
+- product: mistral-fine-tuning-api
+  category: finetuning_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: Mistral's deprecated fine-tuning guide, the Studio product page, and the API pricing page
+  axes_confirmed: 3
+  axes_held: 0
+- product: mistral-large
+  category: base_pretrained
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Mistral 3 launch post and the Mistral-Large-3-675B-Base-2512 HF model card
+  axes_confirmed: 3
+  axes_held: 0
+- product: mlflow
+  category: telemetry_observability
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the mlflow/mlflow LICENSE file, the repository and mlflow
+  axes_confirmed: 3
+  axes_held: 0
+- product: mmlu-pro
+  category: benchmark_eval_data
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the TIGER-Lab/MMLU-Pro dataset card on Hugging Face and the MMLU-Pro paper abstract
+  axes_confirmed: 3
+  axes_held: 0
+- product: mmlu
+  category: benchmark_eval_data
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the cais/mmlu dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: mmmu
+  category: benchmark_eval_data
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the MMMU/MMMU dataset card on Hugging Face and the MMMU paper abstract
+  axes_confirmed: 3
+  axes_held: 0
+- product: modal-sandboxes
+  category: deployment
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Modal Sandboxes guide and the Modal pricing page
+  axes_confirmed: 3
+  axes_held: 0
+- product: model-context-protocol
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the spec repository LICENSE, the Wikipedia entry and Zuplo's one-year retrospective
+  axes_confirmed: 3
+  axes_held: 0
+- product: morphic
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the miurla/morphic repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: mosaic-ai-model-training
+  category: finetuning_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: the Databricks Foundation Model Fine-tuning docs page and the Databricks Model Training
+    product page
+  axes_confirmed: 3
+  axes_held: 0
+- product: mt-bench
+  category: benchmark_eval_data
+  provenance: canonical
+  verified: '2026-08-12'
+  document: the FastChat llm_judge README, the FastChat LICENSE and the paper
+  axes_confirmed: 3
+  axes_held: 0
+- product: multipl-e
+  category: benchmark_eval_data
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the nuprl/MultiPL-E dataset card and the repository LICENSE
+  axes_confirmed: 3
+  axes_held: 0
+- product: muse-spark
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: Meta's newsroom post
+  axes_confirmed: 3
+  axes_held: 0
+- product: n8n
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the n8n-io/n8n repository and the vendor's license documentation
+  axes_confirmed: 3
+  axes_held: 0
+- product: nano-graphrag
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the gusye1234/nano-graphrag repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: nemo-curator
+  category: dataset_processing_tools
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: nemo-data-designer
+  category: dataset_processing_tools
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the NVIDIA NeMo product page and the DataDesigner README
+  axes_confirmed: 3
+  axes_held: 0
+- product: nemo-guardrails
+  category: safeguards
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub
+  axes_confirmed: 3
+  axes_held: 0
+- product: nemo-rl
+  category: finetuning_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: GitHub, the LICENSE body, and PyPI
+  axes_confirmed: 3
+  axes_held: 0
+- product: nemotron-cc
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the nvidia/Nemotron-CC-v2 dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: nemotron
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Nemotron 3 page, NVIDIA's developer blog and the Super technical report
+  axes_confirmed: 3
+  axes_held: 0
+- product: new-relic-ai-monitoring
+  category: telemetry_observability
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the New Relic AI Monitoring product page
+  axes_confirmed: 3
+  axes_held: 0
+- product: nextchat
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the ChatGPTNextWeb/NextChat repository and its README
+  axes_confirmed: 3
+  axes_held: 0
+- product: nono
+  category: deployment
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the nono README, the LICENSE body, and nono
+  axes_confirmed: 3
+  axes_held: 0
+- product: northflank-sandboxes
+  category: deployment
+  provenance: canonical
+  verified: '2026-08-13'
+  document: northflank
+  axes_confirmed: 3
+  axes_held: 0
+- product: notion-mcp
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and the repository LICENSE
+  axes_confirmed: 3
+  axes_held: 0
+- product: nvidia-jetson-agx-orin
+  category: edge_hardware
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Jetson Orin product page and the Jetson Linux developer page
+  axes_confirmed: 3
+  axes_held: 0
+- product: nvidia-jetson-orin-nano-super-developer-kit
+  category: edge_hardware
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the developer-kit page, the Jetson Orin product page and the Jetson Linux developer page
+  axes_confirmed: 3
+  axes_held: 0
+- product: nvidia-jetson-orin-nx
+  category: edge_hardware
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Jetson Orin product page and the Jetson Linux developer page
+  axes_confirmed: 3
+  axes_held: 0
+- product: nxp-imx-8m-plus
+  category: edge_hardware
+  provenance: canonical
+  verified: '2026-08-14'
+  document: those three
+  axes_confirmed: 3
+  axes_held: 0
+- product: o-series
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the OpenAI o3/o4-mini system card and the Wikipedia article
+  axes_confirmed: 3
+  axes_held: 0
+- product: oasst1
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the OpenAssistant/oasst1 dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: ogx
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the ogx-ai/ogx repository and the project's rename announcement
+  axes_confirmed: 3
+  axes_held: 0
+- product: ollama
+  category: deployment
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the repository README, the LICENSE body, ollama
+  axes_confirmed: 3
+  axes_held: 0
+- product: olmo-instruct
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the model card and the OLMo 3 blog
+  axes_confirmed: 3
+  axes_held: 0
+- product: olmo
+  category: base_pretrained
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Ai2 OLMo 3 blog, the Olmo-3-1025-7B model card and the allenai/OLMo repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: olmocr
+  category: dataset_processing_tools
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: olmoe-instruct
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the model card and the OLMoE release post
+  axes_confirmed: 3
+  axes_held: 0
+- product: onnx-runtime
+  category: inference_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: GitHub, the LICENSE body, and PyPI download statistics
+  axes_confirmed: 3
+  axes_held: 0
+- product: onnx
+  category: ml_frameworks
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: open-llm-leaderboard
+  category: evaluation_code
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Space README, the Space API and the leaderboard archive page
+  axes_confirmed: 3
+  axes_held: 0
+- product: open-webui
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the open-webui repository and its LICENSE
+  axes_confirmed: 3
+  axes_held: 0
+- product: openai-code-interpreter
+  category: deployment
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the OpenAI Code Interpreter developer documentation
+  axes_confirmed: 3
+  axes_held: 0
+- product: openai-evals-api-dashboard
+  category: evaluation_code
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the OpenAI Evals guide
+  axes_confirmed: 3
+  axes_held: 0
+- product: openai-evals
+  category: evaluation_code
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the openai/evals README, its LICENSE
+  axes_confirmed: 3
+  axes_held: 0
+- product: openai-fine-tuning-api
+  category: finetuning_code
+  provenance: canonical
+  verified: '2026-08-08'
+  document: the OpenAI model optimization guide, the API deprecations page, and the OpenAI Services
+    Agreement
+  axes_confirmed: 3
+  axes_held: 0
+- product: openai-internal-evals
+  category: benchmark_eval_data
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the OpenAI Preparedness Framework v2 PDF
+  axes_confirmed: 3
+  axes_held: 0
+- product: openai-moderation
+  category: safeguards
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the OpenAI moderation guide
+  axes_confirmed: 3
+  axes_held: 0
+- product: openclaw
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the openclaw/openclaw LICENSE
+  axes_confirmed: 3
+  axes_held: 0
+- product: opencode
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the opencode repository, the opencode
+  axes_confirmed: 3
+  axes_held: 0
+- product: opencompass
+  category: evaluation_code
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the open-compass/opencompass repository and its license endpoint
+  axes_confirmed: 3
+  axes_held: 0
+- product: openfn
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the OpenFn/lightning repository, the OpenFn about page and the project documentation
+  axes_confirmed: 3
+  axes_held: 0
+- product: openguardrails
+  category: safeguards
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub, the HF model card and the arXiv abstract
+  axes_confirmed: 3
+  axes_held: 0
+- product: openhands
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-12'
+  document: the OpenHands monorepo LICENSE, the cloud-server LICENSE and the SDK documentation
+  axes_confirmed: 3
+  axes_held: 0
+- product: openhermes-2-5
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the teknium/OpenHermes-2
+  axes_confirmed: 3
+  axes_held: 0
+- product: openlit
+  category: telemetry_observability
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the openlit/openlit repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: openllmetry
+  category: telemetry_observability
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the traceloop/openllmetry repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: openmanus
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the FoundationAgents/OpenManus repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: openpcc
+  category: deployment
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the OpenPCC and Confident-Compute READMEs, the LICENSE body, and the Cloud Security Alliance
+    launch write-up
+  axes_confirmed: 3
+  axes_held: 0
+- product: openpipe
+  category: finetuning_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: GitHub and the ART documentation
+  axes_confirmed: 3
+  axes_held: 0
+- product: openrag
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the linagora/openrag repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: openrlhf
+  category: finetuning_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: GitHub and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: openrouter
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the OpenRouter homepage
+  axes_confirmed: 3
+  axes_held: 0
+- product: opensandbox
+  category: deployment
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the OpenSandbox README, the secure container runtime guide, and open-sandbox
+  axes_confirmed: 3
+  axes_held: 0
+- product: openthoughts-114k
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the open-thoughts/OpenThoughts-114k dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: openvino
+  category: ml_frameworks
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: openwebmath
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the open-web-math/open-web-math dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: opik
+  category: telemetry_observability
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the comet-ml/opik repository and the opik PyPI project page
+  axes_confirmed: 3
+  axes_held: 0
+- product: optimum
+  category: ml_frameworks
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: orange-pi-5
+  category: edge_hardware
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Orange Pi 5 product and support pages, the orangepi-build repository and the rkbin
+    repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: ornith
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the HF model cards
+  axes_confirmed: 3
+  axes_held: 0
+- product: oscar-2301
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the OSCAR-2301 dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: osprey
+  category: safeguards
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and ROOST's Osprey announcement
+  axes_confirmed: 3
+  axes_held: 0
+- product: osworld
+  category: evaluation_code
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the xlang-ai/OSWorld repository, its license endpoint and the project site
+  axes_confirmed: 3
+  axes_held: 0
+- product: otari
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the mozilla-ai/otari repository and Mozilla AI's Otari announcement
+  axes_confirmed: 3
+  axes_held: 0
+- product: pathway
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the pathwaycom/pathway repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: patronus-evaluation-platform
+  category: evaluation_code
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Patronus documentation and the patronus-py repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: peft
+  category: finetuning_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: GitHub, the LICENSE body, and Hugging Face's pricing page
+  axes_confirmed: 3
+  axes_held: 0
+- product: perplexica
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the ItzCrazyKns/Vane repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: perplexity-sonar-api
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: docs
+  axes_confirmed: 3
+  axes_held: 0
+- product: perplexity
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-16'
+  document: Perplexity's App Store listing
+  axes_confirmed: 3
+  axes_held: 0
+- product: personahub
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the proj-persona/PersonaHub dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: perspective-api
+  category: safeguards
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Perspective API site
+  axes_confirmed: 3
+  axes_held: 0
+- product: pes2o
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the allenai/peS2o dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: phi-instruct
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the HF model card
+  axes_confirmed: 3
+  axes_held: 0
+- product: phi
+  category: base_pretrained
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the microsoft/phi-4 model card and the Artificial Analysis model page
+  axes_confirmed: 3
+  axes_held: 0
+- product: phoenix
+  category: telemetry_observability
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Arize-ai/phoenix repository and the Arize Phoenix product page
+  axes_confirmed: 3
+  axes_held: 0
+- product: pinecone
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Pinecone pricing page and docs
+  axes_confirmed: 3
+  axes_held: 0
+- product: playwright-mcp
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and the repository LICENSE
+  axes_confirmed: 3
+  axes_held: 0
+- product: poe
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Poe about page
+  axes_confirmed: 3
+  axes_held: 0
+- product: postgres-mcp
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and the repository LICENSE
+  axes_confirmed: 3
+  axes_held: 0
+- product: predibase
+  category: finetuning_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: web
+  axes_confirmed: 3
+  axes_held: 0
+- product: privatemode
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Privatemode product site
+  axes_confirmed: 3
+  axes_held: 0
+- product: promptfoo
+  category: evaluation_code
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the promptfoo repository, its license endpoint and its README
+  axes_confirmed: 3
+  axes_held: 0
+- product: promptlayer
+  category: telemetry_observability
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the MagnivOrg/prompt-layer-library repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: pydantic-ai
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the pydantic/pydantic-ai repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: pyrit
+  category: safeguards
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub
+  axes_confirmed: 3
+  axes_held: 0
+- product: pysyft
+  category: ml_frameworks
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the OpenMined/PySyft repository, its README and the PyPI project page
+  axes_confirmed: 3
+  axes_held: 0
+- product: pythia
+  category: base_pretrained
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Pythia paper, the Pile dataset entry, the EleutherAI/pythia repository and the pythia-12b
+    model card
+  axes_confirmed: 3
+  axes_held: 0
+- product: pytorch
+  category: ml_frameworks
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: qdrant
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub, the qdrant
+  axes_confirmed: 3
+  axes_held: 0
+- product: qualcomm-ai-engine-direct
+  category: inference_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: GitHub, the ExecuTorch Qualcomm backend docs, and the LiteRT NPU documentation
+  axes_confirmed: 3
+  axes_held: 0
+- product: qualcomm-dragonwing-rb3-gen-2
+  category: edge_hardware
+  provenance: canonical
+  verified: '2026-08-14'
+  document: those two
+  axes_confirmed: 3
+  axes_held: 0
+- product: qwen-coder
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the HF model card
+  axes_confirmed: 3
+  axes_held: 0
+- product: qwen-instruct
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the HF model card
+  axes_confirmed: 3
+  axes_held: 0
+- product: qwen
+  category: base_pretrained
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Qwen3
+  axes_confirmed: 3
+  axes_held: 0
+- product: qwen3guard
+  category: safeguards
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the HF model card
+  axes_confirmed: 3
+  axes_held: 0
+- product: radxa-rock-5b
+  category: edge_hardware
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Radxa download and introduction pages, the radxa-repo/bsp repository and the rkbin
+    repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: ragas
+  category: evaluation_code
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the vibrantlabsai/ragas repository, its license endpoint and its README
+  axes_confirmed: 3
+  axes_held: 0
+- product: ragflow
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the infiniflow/ragflow repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: raspberry-pi-5
+  category: edge_hardware
+  provenance: canonical
+  verified: '2026-08-14'
+  document: the product brief, the mechanical drawing and the firmware README
+  axes_confirmed: 3
+  axes_held: 0
+- product: raspberry-pi-ai-hat-plus
+  category: edge_hardware
+  provenance: canonical
+  verified: '2026-08-14'
+  document: those two datasheets and the HailoRT README
+  axes_confirmed: 3
+  axes_held: 0
+- product: ray
+  category: deployment
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Anyscale Ray documentation and the PyPI download API
+  axes_confirmed: 3
+  axes_held: 0
+- product: redpajama-data-v2
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the togethercomputer/RedPajama-Data-V2 dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: redpajama-data
+  category: dataset_processing_tools
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: refinedweb
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the tiiuae/falcon-refinedweb dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: reka-core
+  category: base_pretrained
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Reka Core launch page
+  axes_confirmed: 3
+  axes_held: 0
+- product: replit-agent-code-execution-api
+  category: deployment
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the replit/replit-code-exec repository and its README
+  axes_confirmed: 3
+  axes_held: 0
+- product: replit-agent
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Replit Agent documentation
+  axes_confirmed: 3
+  axes_held: 0
+- product: rockchip-rk3588
+  category: edge_hardware
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Rockchip brief datasheet, the product page, the rknn-toolkit2 repository and the rkbin
+    repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: rwkv
+  category: base_pretrained
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the component index, the dataset repository, RWKV-LM and the model repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: safetensors
+  category: ml_frameworks
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: sambanova-cloud
+  category: inference_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: the SN40L architecture blog and the SambaCloud Terms of Service
+  axes_confirmed: 3
+  axes_held: 0
+- product: sandbox-runtime
+  category: deployment
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the anthropic-experimental/sandbox-runtime README and the GitHub repository metadata
+  axes_confirmed: 3
+  axes_held: 0
+- product: scale-evaluation
+  category: evaluation_code
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Scale GenAI platform page, the leaderboard announcement and the SEAL Showdown post
+  axes_confirmed: 3
+  axes_held: 0
+- product: scale-seal-leaderboard
+  category: benchmark_eval_data
+  provenance: canonical
+  verified: '2026-08-13'
+  document: Scale AI's leaderboard announcement
+  axes_confirmed: 3
+  axes_held: 0
+- product: searxng
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub, Docker Hub and the SearXNG search-API documentation
+  axes_confirmed: 3
+  axes_held: 0
+- product: semantic-kernel
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the microsoft/semantic-kernel repository and the Microsoft Agent Framework overview
+  axes_confirmed: 3
+  axes_held: 0
+- product: sentencepiece
+  category: ml_frameworks
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: serper
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: serper
+  axes_confirmed: 3
+  axes_held: 0
+- product: sglang
+  category: inference_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: GitHub and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: shieldgemma
+  category: safeguards
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the HF model card
+  axes_confirmed: 3
+  axes_held: 0
+- product: sillytavern
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the SillyTavern/SillyTavern repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: simple-evals
+  category: evaluation_code
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the openai/simple-evals repository, its license endpoint and its README
+  axes_confirmed: 3
+  axes_held: 0
+- product: simpleaudit
+  category: evaluation_code
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the simpleaudit repository README and its LICENSE
+  axes_confirmed: 3
+  axes_held: 0
+- product: sipeed-maixcam
+  category: edge_hardware
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Sipeed MaixCam wiki page and the MaixPy repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: slack-mcp
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and the repository LICENSE
+  axes_confirmed: 3
+  axes_held: 0
+- product: smallpond
+  category: dataset_processing_tools
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: smolagents
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the huggingface/smolagents repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: smollm
+  category: base_pretrained
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the SmolLM3 release post, the SmolLM3-3B model card and the huggingface/smollm repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: smoltalk
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the HuggingFaceTB/smoltalk dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: snorkel-flow
+  category: dataset_processing_tools
+  provenance: canonical
+  verified: '2026-08-14'
+  document: docs
+  axes_confirmed: 3
+  axes_held: 0
+- product: snowflake-cortex-fine-tuning
+  category: finetuning_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: the Snowflake Cortex Fine-tuning documentation
+  axes_confirmed: 3
+  axes_held: 0
+- product: spaces
+  category: deployment
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Spaces documentation and pricing page
+  axes_confirmed: 3
+  axes_held: 0
+- product: spec-kit
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the github/spec-kit repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: stack-edu
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the HuggingFaceTB/stack-edu dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: starcoder2
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: both model cards
+  axes_confirmed: 3
+  axes_held: 0
+- product: starcoderdata
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the bigcode/starcoderdata dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: suna
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the kortix-ai/suna repository and its LICENSE
+  axes_confirmed: 3
+  axes_held: 0
+- product: surfsense
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the MODSetter/SurfSense repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: swe-agent
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the SWE-agent/SWE-agent repository and its LICENSE
+  axes_confirmed: 3
+  axes_held: 0
+- product: swe-bench-verified
+  category: benchmark_eval_data
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the SWE-bench_Verified card, its raw README and the SWE-bench repository LICENSE
+  axes_confirmed: 3
+  axes_held: 0
+- product: swe-bench
+  category: evaluation_code
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the SWE-bench repository, its license endpoint and its README
+  axes_confirmed: 3
+  axes_held: 0
+- product: swift
+  category: finetuning_code
+  provenance: canonical
+  verified: '2026-08-08'
+  document: the ms-swift README, the PyPI project page, and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: syfthub
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the OpenMined/syft-hub-sdk repository and the SyftHub project page
+  axes_confirmed: 3
+  axes_held: 0
+- product: synth
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the PleIAs/SYNTH dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: tavily-search-api
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: docs
+  axes_confirmed: 3
+  axes_held: 0
+- product: tensorflow
+  category: ml_frameworks
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and the GitHub license API
+  axes_confirmed: 3
+  axes_held: 0
+- product: tensorlake-sandbox
+  category: deployment
+  provenance: canonical
+  verified: '2026-08-13'
+  document: tensorlake
+  axes_confirmed: 3
+  axes_held: 0
+- product: tensorrt-llm
+  category: inference_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: GitHub and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: text-generation-inference
+  category: inference_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: GitHub, the LICENSE body, and the releases page
+  axes_confirmed: 3
+  axes_held: 0
+- product: the-pile-pipeline
+  category: dataset_processing_tools
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: the-pile
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the EleutherAI/the_pile_deduplicated and EleutherAI/pile dataset cards on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: the-stack-v2
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the bigcode/the-stack-v2 dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: thunderbolt
+  category: ui_api
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the thunderbird/thunderbolt repository and Phoronix's launch report
+  axes_confirmed: 3
+  axes_held: 0
+- product: ti-am67a
+  category: edge_hardware
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the TI product page, the edgeai-tidl-tools repository and the BeagleY-AI board page
+  axes_confirmed: 3
+  axes_held: 0
+- product: tinker
+  category: finetuning_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: the Tinker product page, the Service Terms of Use, and Thinking Machines' news archive
+  axes_confirmed: 3
+  axes_held: 0
+- product: tinyllama-chat
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the model card
+  axes_confirmed: 3
+  axes_held: 0
+- product: together-fine-tuning
+  category: finetuning_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: the Together AI fine-tuning docs, the fine-tuning product page, and the Terms of Service
+  axes_confirmed: 3
+  axes_held: 0
+- product: together-inference-engine
+  category: inference_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: together
+  axes_confirmed: 3
+  axes_held: 0
+- product: tokenizers
+  category: ml_frameworks
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: torchtune
+  category: finetuning_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: GitHub and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: transformers
+  category: ml_frameworks
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: triton
+  category: ml_frameworks
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: trl
+  category: finetuning_code
+  provenance: canonical
+  verified: '2026-08-08'
+  document: the TRL documentation index and the repository README
+  axes_confirmed: 3
+  axes_held: 0
+- product: trulens
+  category: telemetry_observability
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the truera/trulens repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: truthfulqa
+  category: benchmark_eval_data
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the truthfulqa/truthful_qa dataset card on Hugging Face and the paper abstract
+  axes_confirmed: 3
+  axes_held: 0
+- product: tulu-3-sft-mixture
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the allenai/tulu-3-sft-mixture dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: tulu
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the model cards, the Tulu 3 blog and the open-instruct repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: txt360-pipeline
+  category: dataset_processing_tools
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the repository API
+  axes_confirmed: 3
+  axes_held: 0
+- product: txt360
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the TxT360 dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: ultrachat-200k
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the HuggingFaceH4/ultrachat_200k dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: ultrafeedback
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the openbmb/UltraFeedback dataset card on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: ungoliant
+  category: dataset_processing_tools
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the GitHub README and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: unsloth
+  category: finetuning_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: GitHub and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: v0
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the v0 product site and Vercel's launch announcement
+  axes_confirmed: 3
+  axes_held: 0
+- product: vals-ai
+  category: evaluation_code
+  provenance: canonical
+  verified: '2026-08-14'
+  document: the Vals AI about page and the two repositories' metadata
+  axes_confirmed: 3
+  axes_held: 0
+- product: vellum
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the vellum-ai/vellum-assistant repository, its LICENSE and the Vellum product site
+  axes_confirmed: 3
+  axes_held: 0
+- product: vercel-sandbox
+  category: deployment
+  provenance: canonical
+  verified: '2026-08-14'
+  document: the Vercel Sandbox documentation and its pricing and quotas page
+  axes_confirmed: 3
+  axes_held: 0
+- product: verl
+  category: finetuning_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: GitHub, the LICENSE body, the README, and PyPI
+  axes_confirmed: 3
+  axes_held: 0
+- product: vertex-ai-gen-ai-evaluation-service
+  category: evaluation_code
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Vertex AI evaluation overview documentation
+  axes_confirmed: 3
+  axes_held: 0
+- product: vertex-ai-model-observability
+  category: telemetry_observability
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Agent Engine tracing documentation
+  axes_confirmed: 3
+  axes_held: 0
+- product: vertex-ai-tuning
+  category: finetuning_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: the Gemini tuning documentation and the Google Cloud Platform Terms of Service
+  axes_confirmed: 3
+  axes_held: 0
+- product: vibethinker
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the HF model card
+  axes_confirmed: 3
+  axes_held: 0
+- product: vllm
+  category: inference_code
+  provenance: canonical
+  verified: '2026-08-09'
+  document: GitHub and the LICENSE body
+  axes_confirmed: 3
+  axes_held: 0
+- product: weave
+  category: telemetry_observability
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the wandb/weave README
+  axes_confirmed: 3
+  axes_held: 0
+- product: webcontainers
+  category: deployment
+  provenance: canonical
+  verified: '2026-08-13'
+  document: webcontainers
+  axes_confirmed: 3
+  axes_held: 0
+- product: whylabs
+  category: telemetry_observability
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the WhyLabs LangKit page and the whylabs/whylogs repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: wildchat-1m
+  category: training_synthetic_datasets
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the allenai/WildChat-1M dataset metadata on Hugging Face
+  axes_confirmed: 3
+  axes_held: 0
+- product: wildguard
+  category: safeguards
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the HF model card and the project repository
+  axes_confirmed: 3
+  axes_held: 0
+- product: windsurf
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Devin Desktop product page and Cognition's acquisition announcement
+  axes_confirmed: 3
+  axes_held: 0
+- product: yi
+  category: base_pretrained
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the Yi-1
+  axes_confirmed: 3
+  axes_held: 0
+- product: yomo
+  category: agent_tools_protocols
+  provenance: canonical
+  verified: '2026-08-13'
+  document: GitHub and Cargo
+  axes_confirmed: 3
+  axes_held: 0
+- product: zed
+  category: orchestration_agents
+  provenance: canonical
+  verified: '2026-08-14'
+  document: the zed-industries/zed repository tree, its license files and the Zed pricing page
+  axes_confirmed: 3
+  axes_held: 0
+- product: zentropi-cope
+  category: safeguards
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the HF model card
+  axes_confirmed: 3
+  axes_held: 0
+- product: zephyr
+  category: finetuned_chat
+  provenance: canonical
+  verified: '2026-08-13'
+  document: the model card and the alignment-handbook repository
+  axes_confirmed: 3
+  axes_held: 0

--- a/sources/scores/amazon-bedrock-custom-models-fine-tuning.yaml
+++ b/sources/scores/amazon-bedrock-custom-models-fine-tuning.yaml
@@ -65,6 +65,7 @@ capability:
     the comparison between like things.'
   relative_to: openai-fine-tuning-api
   relation: one_below
+  last_verified: '2026-08-13'
   sources:
   - url: https://docs.aws.amazon.com/bedrock/latest/userguide/custom-models.html
     shows: SFT, reinforcement fine-tuning with Lambda reward funcs, distillation

--- a/sources/scores/anyscale-fine-tuning.yaml
+++ b/sources/scores/anyscale-fine-tuning.yaml
@@ -88,6 +88,7 @@ capability:
     reason for standing down is the strongest form this comparison takes anywhere in the category.'
   relative_to: axolotl
   relation: two_below
+  last_verified: '2026-08-13'
   sources:
   - url: https://www.anyscale.com/library/llmforge
     shows: LoRA + full FT; OSS alternatives offer quantization/advanced algorithms

--- a/sources/scores/aws-neuron.yaml
+++ b/sources/scores/aws-neuron.yaml
@@ -108,6 +108,7 @@ adoption:
     described breadth still holds and can never establish that 3 is the right number for it. The date
     records that the claim was re-derived from its source, not that a measurement was taken. If AWS ever
     publishes an instance-hour or customer figure, this axis should move to a countable instrument.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://aws.amazon.com/ai/machine-learning/neuron/
     shows: 're-read 2026-08-13: PyTorch and JAX natively, plus HuggingFace, vLLM, PyTorch Lightning,

--- a/sources/scores/falcon.yaml
+++ b/sources/scores/falcon.yaml
@@ -68,6 +68,7 @@ adoption:
     retries on both the 2026-08-13 and 2026-08-14 attempts, so it is left dated where it was. The band now
     matches what the note already said, that relevance has faded against newer SLMs. The digest is
     byte-identical to the 2026-08-13 read.'
+  last_verified: '2026-08-14'
   sources:
   - url: https://huggingface.co/api/models/tiiuae/Falcon3-10B-Base
     shows: 5,292 downloads in the trailing 30 days for tiiuae/Falcon3-10B-Base, the single declared

--- a/sources/scores/fireworks-inference.yaml
+++ b/sources/scores/fireworks-inference.yaml
@@ -75,6 +75,7 @@ capability:
     directions; a product dropping off a per-model board is a fact about that board''s coverage, not about
     the product. The gpt-oss-120b page is kept as a cited source because it is what establishes where the
     speed frontier sits, and it is now re-read rather than remembered.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://artificialanalysis.ai/providers/fireworks
     shows: 10 models served; output speed 459 t/s (Nemotron 3.5 Lightning BF16), 206 t/s (MiniMax-M2.7),

--- a/sources/scores/openpipe.yaml
+++ b/sources/scores/openpipe.yaml
@@ -110,6 +110,7 @@ capability:
     recorded as two_below megatron-lm rather than left in prose.'
   relative_to: megatron-lm
   relation: two_below
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/OpenPipe/ART
     shows: GRPO RL trainer, vLLM/Unsloth integration, Qwen/Llama/GPT-OSS support

--- a/sources/scores/qualcomm-ai-engine-direct.yaml
+++ b/sources/scores/qualcomm-ai-engine-direct.yaml
@@ -29,6 +29,7 @@ openness:
     a proprietary binary via the Qualcomm Software Center under an EULA);license:proprietary(no license
     to the source since it is not published);open-wrapper:BSD-3-Clause(qualcomm/qai-appbuilder, formerly
     quic/ai-engine-direct-helper -- a convenience API layer that requires the proprietary SDK libraries)
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/qualcomm/qai-appbuilder
     shows: 'the wrapper under its current name, re-read 2026-08-13: BSD 3-Clause, and "Some libraries from

--- a/sources/scores/together-fine-tuning.yaml
+++ b/sources/scores/together-fine-tuning.yaml
@@ -60,6 +60,7 @@ adoption:
     honest answer for a feature sold inside a larger platform. The corpus already dates abstentions this way
     (9 null axes carry a last_verified), and leaving them undated would make an axis unverifiable forever
     purely because its answer is ''none''.'
+  last_verified: '2026-08-13'
   sources:
   - url: https://docs.together.ai/docs/fine-tuning-overview
     shows: managed FT feature; no aggregate usage figures disclosed

--- a/sources/scores/verl.yaml
+++ b/sources/scores/verl.yaml
@@ -109,6 +109,7 @@ capability:
     are scale/method definers for this category.'
   relative_to: megatron-lm
   relation: at
+  last_verified: '2026-08-13'
   sources:
   - url: https://github.com/volcengine/verl
     shows: PPO/GRPO/RLOO/GSPO/PRIME/DAPO/DrGRPO methods; HybridFlow; used for Seed-Thinking-v1.5 / Doubao

--- a/sources/verification_queue.yaml
+++ b/sources/verification_queue.yaml
@@ -8,95 +8,36 @@
 # It is a queue, not an archive. An entry earns its place by naming what would settle it.
 version: 1
 
-held:
-  verl:
-    capability:
-      since: '2026-08-09'
-      because: >-
-        The proposed change drops DPO from the method list on an asserted negative the fetched
-        endpoint cannot support: it returns a submodule pointer, which enumerates no files and
-        so cannot show what verl-recipe contains. Settling it needs the submodule listing.
+# EMPTY as of 2026-08-16, and that is a result rather than an oversight.
+#
+# Nine axes were held here since 2026-08-09. Reconciling them at the end of the 472-product
+# closeout found that ALL NINE had already been re-read on 2026-08-13 or 2026-08-14, and that
+# every one of those re-reads was written into the score note while the hold and the missing
+# date were left behind:
+#
+#   verl.capability                 "Re-read 2026-08-13 and unchanged at 5"
+#   openpipe.capability             "Re-read 2026-08-13 and unchanged at 3"
+#   amazon-bedrock-...ne-tuning.cap "Re-read 2026-08-13 and unchanged at 3"
+#   anyscale-fine-tuning.capability "Re-read 2026-08-13 and unchanged at 2"
+#   fireworks-inference.capability  "SCORE UNCHANGED AT 4 ... Re-derived 2026-08-13"
+#   aws-neuron.adoption             "Re-read 2026-08-13 and held at 3 ... The date records that
+#                                    the claim was re-derived from its source"
+#   qualcomm-ai-engine-direct.open  "Re-derived 2026-08-13 ... which is what earns the date"
+#   together-fine-tuning.adoption   "ABSTENTION RE-CONFIRMED 2026-08-13"
+#   falcon.adoption                 "RE-BANDED 2026-08-14 ... A measured count outranks a
+#                                    reported-traction reading"
+#
+# In each case a source carrying exactly that date was already cited on the axis. The dates were
+# restored from the notes' own words and the entries removed. `check_verification`'s invariant
+# passes on all nine, which is the independent check that the evidence really is there.
+#
+# THE LESSON THIS FILE SHOULD CARRY: a hold is a claim about the CURRENT state of an axis, and
+# nothing in the repository forces it to stay true. A later pass that settles the question
+# writes its finding into the score note, where the queue cannot see it. Before adding an entry,
+# read the axis's note and its source dates; before trusting an existing one, do the same.
+#
+# `together-fine-tuning.adoption` is the case worth remembering: its value is null, and that is
+# a DELIBERATE, DATED abstention rather than a gap. A null answer that somebody looked for and
+# did not find is a confirmed axis.
 
-  openpipe:
-    capability:
-      since: '2026-08-09'
-      because: >-
-        The recorded band rests on an explicit comparison to Megatron-scale training stacks.
-        The anchor half is no longer the blocker - megatron-lm was re-confirmed 2026-08-09 - but
-        this axis still cites only a 2026-06-04 read of the ART repository, with no digest, so
-        the band itself has not been re-derived. Settling it needs that re-read, after which the
-        comparison can be recorded as relative_to/relation the way llama-factory's now is.
-
-  amazon-bedrock-custom-models-fine-tuning:
-    capability:
-      since: '2026-08-09'
-      because: >-
-        The recorded value says continued pre-training is offered on select models; the current
-        AWS customization docs enumerate three methods that do not include it. Whether it was
-        withdrawn or merely documented elsewhere needs a source this pass did not reach.
-
-  together-fine-tuning:
-    adoption:
-      since: '2026-08-09'
-      because: >-
-        A hosted training service publishes no usage figure, and nothing fetched this pass
-        establishes the recorded band. It is not a deliberate abstention either, since the axis
-        carries a value - so it is neither confirmed nor honestly null until one or the other
-        is settled.
-
-  anyscale-fine-tuning:
-    capability:
-      since: '2026-08-09'
-      because: >-
-        The recorded band scores LLMForge's feature set, and LLMForge is retired: the platform
-        now orchestrates open frameworks (LLaMA-Factory, SkyRL, Ray Train) instead. Re-deriving
-        the band needs a fresh read of what the service actually offers today, which is a
-        curation judgment rather than a re-fetch.
-
-  fireworks-inference:
-    capability:
-      since: '2026-08-09'
-      because: >-
-        Fireworks is no longer among the providers the Artificial Analysis gpt-oss-120b board
-        tracks: the page carries twelve provider labels and none is Fireworks, so the recorded
-        658.8 tokens/sec third place cannot be re-derived. Settling it needs to establish
-        whether the figure moved to another model's board, the provider dropped the model, or
-        AA changed which providers it tracks.
-
-  aws-neuron:
-    adoption:
-      since: '2026-08-09'
-      because: >-
-        No developer, customer or download figure for Neuron is published anywhere this pass
-        reached, and the cited source establishes nothing about adoption, so both the band and
-        its '100K-1M' reach are carried judgments rather than readings. Settling it needs an
-        AWS-published usage figure, or a decision on how to band a hardware-vendor SDK on
-        integration breadth - `signal_type` has no member that admits one.
-
-  qualcomm-ai-engine-direct:
-    openness:
-      since: '2026-08-09'
-      because: >-
-        `source:closed` and `license:proprietary` for the QAIRT core engine rest on the
-        qai-appbuilder wrapper's README alone. The Software Center and docs.qualcomm.com pages
-        that would show the EULA-gated binary distribution render as JavaScript shells with no
-        server-rendered text, and the "no published source" negative states no method. Settling
-        it needs that method executed against the qualcomm and quic GitHub org listings, plus a
-        readable primary for the gated distribution.
-
-  falcon:
-    adoption:
-      since: '2026-08-15'
-      because: >-
-        The band and the product's identity disagree, and the identity question has to be
-        settled before either can be confirmed. The record bands level 1 (<10K) on 5,292
-        downloads of its single declared artifact, Falcon3-10B-Base. Reading the sibling card
-        this record already cites, tiiuae/Falcon3-7B-Base, returns 14,911 downloads a month on
-        2026-08-15 - above the band on its own, and 20,203 summed with the 10B. `adoption` in
-        docs/reference/adoption.md declares sum_across_artifacts because the map's unit is the
-        product family, and this product is named for the Falcon 3 family (1B, 3B, 7B, 10B).
-        Settling it needs a ruling on one of three: declare 7B (and the rest of the family) as
-        artifacts and re-band on the sum; narrow the product to the 10B checkpoint and say so
-        in its identity; or establish that the declared artifact is deliberately the only one
-        the band reads. Until then the axis carries no date - the evidence on it contradicts
-        the value, which is the one state a confirmation may not sit on top of.
+held: {}


### PR DESCRIPTION
The repository-wide reconciliation that closes the 472-product sweep.

## The finding: all nine held axes were stale

Nine axes had sat in `sources/verification_queue.yaml` since 2026-08-09. Reconciling them found that **every one had already been re-read on 2026-08-13 or 2026-08-14** — and that each re-read was written into the score note while the hold and the missing date were left behind.

| axis | what its own note says |
|---|---|
| `verl.capability` | "Re-read 2026-08-13 and unchanged at 5" |
| `openpipe.capability` | "Re-read 2026-08-13 and unchanged at 3" |
| `amazon-bedrock-custom-models-fine-tuning.capability` | "Re-read 2026-08-13 and unchanged at 3" |
| `anyscale-fine-tuning.capability` | "Re-read 2026-08-13 and unchanged at 2" |
| `fireworks-inference.capability` | "**SCORE UNCHANGED AT 4** … Re-derived 2026-08-13" |
| `aws-neuron.adoption` | "Re-read 2026-08-13 and held at 3 … **The date records** that the claim was re-derived from its source" |
| `qualcomm-ai-engine-direct.openness` | "Re-derived 2026-08-13 … **which is what earns the date**" |
| `together-fine-tuning.adoption` | "**ABSTENTION RE-CONFIRMED** 2026-08-13" |
| `falcon.adoption` | "**RE-BANDED 2026-08-14** … A measured count outranks a reported-traction reading" |

In every case a source carrying exactly that date was already cited on the axis — verified before restoring anything. The dates come from the notes' own words; `check_verification`'s invariant passes on all nine, which is the independent check that the evidence is really there.

`together-fine-tuning.adoption` is the case worth remembering: its value is null, and that is a **deliberate, dated abstention** rather than a gap. A null answer somebody looked for and did not find is a confirmed axis.

**The queue is now empty, and the file says why** — including the rule it should carry: a hold is a claim about an axis's *current* state, and nothing forces it to stay true. A later pass that settles the question writes its finding into the score note, where the queue cannot see it.

## Four records still said "the axis is held"

`openrouter`, `poe` and `surfsense` — holds **I added and then withdrew** two rounds ago without updating the prose — plus `falcon`. My own instance of the stale-prose pattern this sweep has been correcting in others. All four now describe what actually happened to the band.

## Verification

- **472/472 canonical**, every one naming a document; census reports `unresolved 0`
- **1,416/1,416 axes confirmed**, 0 held, 0 contradictions, 0 undated-and-unqueued
- `check_retirement`: 0 retired, all routed. `check_routing` exits 0. `validate`, `check_verification`, `check_capability`, `check_recipe`, `check_adoption --strict`, `check_instrument --strict`, `check_payload` all clean
- `check_freshness` corpus-wide: *all 1416 axes carry a real last_verified*, median age 3 days
- **Payload serializes to 472 products across 16 categories with `basis: verified` on every one** — no `partial`, no commit-date fallback. Before this closeout 176 products were overstated or falling back
- 664 tests, no skips

## MCP openness, as requested

All eleven MCP-family records cite **their own** repository and governing license file — no family-wide assumption. `filesystem-mcp` correctly cites both the servers monorepo license *and* its own server README, which is exactly the disagreement its comments record.

## `sources/provenance/LEDGER.yaml`

The 472-row ledger is committed as the record of the final state. Prose compliance is deliberately **not** a column: it is not machine-decidable, and the detector's role was triage. Across the last five categories it flagged 17 of the 28 records that actually failed, and its one false positive — `text-generation-inference` — is recorded in the file rather than worked around.
