### PR TITLE
Thin the entry points and drop the historical snapshots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,10 +51,14 @@ tests/                 pytest suite for build helpers and serializer behavior
 
 ### What is in `build/`
 
-Every module is a CLI with a docstring that explains why it exists. **`uv run python -m
-build.<module> --help` is the authority on any one of them**; this section is a map of the
-stages, not an inventory. An earlier version of it claimed to be complete, named a count, and
-was wrong within a fortnight.
+This section maps the stages; it is not an inventory. An earlier version claimed to be
+complete, named a count, and was wrong within a fortnight.
+
+Every module carries a docstring explaining why it exists, and that docstring is the
+authority. **The ones that are CLIs answer `uv run python -m build.<module> --help`** — the
+pipeline stages, the gates, the proposers, `sweep_status`, `fetch_source`, `product_prose`.
+The shared helpers are code APIs rather than commands and answer nothing: `vocabulary`,
+`rubrics`, `warehouse`, `components`, `freshness_payload`. Read their docstrings.
 
 ```
 Notebook build     validate -> serialize -> render, plus freshness_payload and update_readme.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,62 +51,59 @@ tests/                 pytest suite for build helpers and serializer behavior
 
 ### What is in `build/`
 
-Every module is a CLI with a docstring that explains why it exists; run any of them with
-`--help`. Grouped by what they are for:
-
-This list is complete as of 2026-08-14 — 30 modules. If you find one missing here, the
-module's own `--help` wins and this map is stale.
+Every module is a CLI with a docstring that explains why it exists. **`uv run python -m
+build.<module> --help` is the authority on any one of them**; this section is a map of the
+stages, not an inventory. An earlier version of it claimed to be complete, named a count, and
+was wrong within a fortnight.
 
 ```
-Notebook build      validate.py           sources/ schema + cross-file invariants
-                    serialize.py          sources/ -> build/notebook_data.json
-                    render.py             notebook_data.json -> notebooks/ai-stack-map.py
-                    freshness_payload.py  per-product freshness for the payload
-                    update_readme.py      syncs the README stat badges
+Notebook build     validate -> serialize -> render, plus freshness_payload and update_readme.
+                   sources/ in, build/notebook_data.json and notebooks/ai-stack-map.py out.
 
-Config bridge out   serialize_registry.py  identity: what exists
-                    serialize_rubric.py    each category's rubric + recorded evidence
-                    publish_registry.py    pushes both table sets to OSO as static models
+Config bridge out  serialize_registry, serialize_rubric, publish_registry.
+                   Identity and rubric tables, pushed to OSO as static models.
 
-Scores back in      apply_scores.py   reads computed scores from OSO, writes
-                                      openness.score and openness.class into
-                                      sources/scores/ and nothing else. The ONLY
-                                      inbound data path. It writes no dates -- see
-                                      docs/reference/evidence-and-freshness.md.
+Scores back in     apply_scores. Reads computed openness score and class from OSO and writes
+                   nothing else. The ONLY inbound data path, and it writes no dates.
 
-Editing library     components.py     the ONLY supported way to edit an
-                                      openness.components field in place. Never
-                                      load-modify-dump a corpus file (its docstring
-                                      says why a module rather than a re.sub).
+Editing library    components, the only supported way to edit openness.components in place.
+                   Never load-modify-dump a corpus file.
 
-Gates (14)          check_rubric.py        does the recipe reproduce the recorded scores
-                    check_recipe.py        is the recipe's form legal (no dead rules, etc.)
-                    check_verification.py  is a claimed confirmation supported; is a
-                                           score/class pair even producible
-                    check_components.py    structured components say what the string said
-                    check_parity.py         repo-computed vs warehouse-published, per product
-                    check_payload.py        the serialized payload's identity invariants
-                    check_retirement.py     a slug left the payload without a redirect
-                    check_freshness.py      how stale is each axis
-                    check_refetch.py        sampled re-fetch: did a recorded fetch happen
-                    check_artifacts.py      a declared artifact drifted from what it names
-                    check_adoption.py       band matches the scale its rubric declares
-                    check_instrument.py     adoption record has what its instrument requires
-                    check_capability.py     capability comparisons consistent and fresh
-                    check_routing.py        how much of the map signal_routing can answer
+Gates              check_*, one module per question. Four families:
+                     scoring    check_rubric, check_recipe, check_capability, check_adoption,
+                                check_instrument, check_components
+                     evidence   check_verification, check_freshness, check_refetch
+                     payload    check_payload, check_retirement, check_parity
+                     coverage   check_routing, check_artifacts
+                   `check_verification` runs several sub-gates and its exit covers all of
+                   them. A line a gate prints but does not exit on is marked `~` with a
+                   written reason; anything else printed is a failure.
 
-Shared helpers      rubrics.py       resolves scoring_recipe inheritance
-                    warehouse.py     the ONLY supported way to read OSO from build/
-                    fetch_source.py  fetches a cited source the way check_refetch will
-                    sweep_status.py  where the verification sweep has got to
+Shared helpers     vocabulary (the one owner of any vocabulary two modules need), rubrics,
+                   warehouse (the only supported way to read OSO), fetch_source,
+                   product_prose, sweep_status.
 
-Proposers           propose_arxiv.py     candidate arXiv ids, verified live
-                    propose_artifacts.py candidate artifacts, verified live
+Proposers          propose_arxiv, propose_artifacts.
 ```
 
 Proposers deliberately **print rather than write**. Matching artifacts by name measured 2
 correct in 10 on this data, and a wrong artifact attaches another project's license and
 downloads to a product, which is indistinguishable from a real score until someone checks.
+
+### One fact, one owner
+
+The rule that cost this repo four defects in a fortnight, none of which failed loudly:
+
+> **A vocabulary with a declarative owner is derived from it, never copied.** Where a literal
+> genuinely differs from its source, write the difference down and test it, so it stays a
+> decision instead of becoming drift.
+
+Each of the four reported success over a *narrower* question than the one it claimed to
+answer — five sources checked where the table declared seven, a date validated by shape so
+`2026-99-99` passed. `build/vocabulary.py` owns the derivations;
+`tests/test_vocabulary_siblings.py` enforces them by AST and by calling the code, never by
+matching source text. `docs/reference/sibling-invariants.md` has the case-by-case record,
+including the copies that are deliberately kept and why.
 
 ## Data model
 
@@ -222,6 +219,38 @@ retired, the frozen copy still listed 300 repos the site had delisted (169 of th
 `currentai.signal_goodailist.repo_catalog`, on a daily cron. Reserve the fetcher route
 for sources needing credentials or shaping a UDM cannot do, or for genuinely fixed
 reference data.
+
+## Writing to `sources/`
+
+One policy, three cases. Normative:
+
+1. **A new file** — `yaml.safe_dump(..., sort_keys=False, allow_unicode=True)`. Fine; there is
+   no existing formatting to destroy.
+2. **An existing corpus file** — `build/components.py` for `openness.components`, and surgical
+   single-field edits (`set_document_field`) for everything else.
+3. **Never load-modify-dump a file in `sources/`.** The corpus prose is hand-wrapped; a
+   round-trip through PyYAML rewraps every string and buries the one change you meant. A
+   hand-rolled line splice is not the fallback either — it shipped a 7-product defect, which is
+   why `set_document_field` exists.
+
+After any `components` edit, regenerate `raw` or CI fails.
+
+### Traps worth knowing before you start
+
+- **Adding a product touches five files**, not four: product, score, category roster, org
+  roster, and `sources/snapshots/long_tail.json` (gated in `validate.py`).
+- **Every schema sets `additionalProperties: false`.** An invented field fails `validate`
+  rather than being ignored — there is no `litmus` field on a category.
+- **Counts written in prose drift.** Regenerate a number before repeating it; `check_recipe`,
+  `check_freshness` and `sweep_status` print the live ones.
+- **`notebooks/ai-stack-map.py` and `build/notebook_data.json` are bot-owned.** Preview
+  locally, leave them out of the commit; CI blocks hand edits.
+- **The scoring-chain SQL is not in this repo.** It lives on the OSO platform, and its deploy
+  script and `.sql` sit one directory up in `currentai-org/{tools,udms}/`, not under version
+  control. See `docs/operations/deploy-models.md`.
+- **The chain does not run on a schedule.** Its crons were set at the model-revision layer; the
+  platform schedules from the dataset, and zero scheduled runs have ever fired. Treat every
+  scoring-chain recompute as manual, and check run history before believing a freshness claim.
 
 ## Editor posture (read-only on the warehouse)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,63 +1,18 @@
 # CLAUDE.md
 
-Entry point for agent sessions in `os-ai-map`. Read this, then the one workflow your task maps
-to. `docs/README.md` is the human version of the same routing; `AGENTS.md` is the repo map
-(directory layout, the 30 `build/` modules, the data model, the editor/maintainer boundary).
+Entry point for agent sessions in `os-ai-map`. Four things, then get to work:
 
-## Route to a workflow first
-
-Find your task, open its workflow doc, and follow it. The skills are thin wrappers that point at
-these same docs and add agent orchestration — they are registered under `.claude/skills/`, so
-the Skill tool should list them; if it does not, read `skills/<name>/SKILL.md` directly. Either
-way, **do not improvise a procedure a workflow already carries.**
-
-| Your task | Workflow | Skill |
-|---|---|---|
-| Add a product | `docs/workflows/add-product.md` | `add-product` |
-| Change an existing product (identity, prose, a score, rosters, retirement) | `docs/workflows/update-product.md` | `update-product` |
-| Create or edit a category | `docs/workflows/edit-category.md` | `edit-category` |
-| Re-verify a whole category | `docs/workflows/refresh-category.md` | `refresh-category` |
-| Change an axis's schema or meaning, corpus-wide | `docs/workflows/migrate-axis.md` | `migrate-axis` |
-
-`update-product` is a router — if you are unsure which door, start there. Advanced skills
-(`build-rubric`, `add-data-source`, `refresh-all-categories`, `pyoso-analyst`) are off the
-primary path. The rules each workflow relies on live once under `docs/reference/`.
-
-Nothing above touches the warehouse. Warehouse writes — UDM revisions, static-model reloads,
-notebook publishes — are maintainer steps under `docs/operations/`, and an editor session does
-not do them.
-
-## Writing YAML: one policy, three cases
-
-Normative:
-
-1. **A new file** — `yaml.safe_dump(..., sort_keys=False, allow_unicode=True)`. Fine, there is no
-   existing formatting to destroy.
-2. **An existing corpus file** — use `build/components.py` for `openness.components`, and surgical
-   single-field edits (`set_document_field`) for everything else.
-3. **Never load-modify-dump a file in `sources/`.** The corpus prose is hand-wrapped; a round-trip
-   through PyYAML rewraps every string and buries the one change you meant. A hand-rolled line
-   splice is not the fallback either — it shipped a 7-product defect, which is why
-   `set_document_field` exists.
-
-After any `components` edit, regenerate `raw` or CI fails.
-
-## Traps worth knowing before you start
-
-- **Adding a product touches five files**, not four: product, score, category roster, org roster,
-  and `sources/snapshots/long_tail.json` (gated in `validate.py`).
-- **Every schema sets `additionalProperties: false`.** An invented field fails `validate` rather
-  than being ignored — there is no `litmus` field on a category.
-- **Counts written in prose drift.** Regenerate a number before repeating it; `check_recipe`,
-  `check_freshness` and `sweep_status` print the live ones.
-- **`notebooks/ai-stack-map.py` and `build/notebook_data.json` are bot-owned.** Preview locally,
-  leave them out of the commit; CI blocks hand edits.
-- **The scoring-chain SQL is not in this repo.** It lives on the OSO platform, and its deploy
-  script and `.sql` sit one directory up in `currentai-org/{tools,udms}/`, not under version
-  control. See `docs/operations/deploy-models.md`.
-- **The chain does not run on a schedule.** Its crons were set at the model-revision layer; the
-  platform schedules from the dataset, and zero scheduled runs have ever fired. Treat every
-  scoring-chain recompute as manual, and check run history before believing a freshness claim.
+1. **`AGENTS.md` is the repo map** — directory layout, the `build/` stages, the data model,
+   how to write to `sources/`, and the traps that have caught people before. Read it.
+2. **`docs/README.md` routes your task to its workflow.** Find yours there and follow the
+   workflow document; do not improvise a procedure one already carries.
+3. **Use the registered skill for that workflow.** They live under `.claude/skills/` (symlinks
+   into `skills/`), so the Skill tool should list them by name; if it does not, read
+   `skills/<name>/SKILL.md` directly. `update-product` is the router if you are unsure which
+   door.
+4. **Warehouse writes are maintainer-only.** UDM revisions, static-model reloads and notebook
+   publishes are steps under `docs/operations/`. An editor session works in `sources/`, `docs/`
+   and `notebooks/`, and opens a PR.
 
 ## Conventions
 

--- a/docs/reference/evidence-and-freshness.md
+++ b/docs/reference/evidence-and-freshness.md
@@ -423,15 +423,18 @@ axes that carry a `last_verified`. So they cover exactly what has been done, nev
 and never permit a regression on ground already taken. A big-bang gate over every axis at once
 would have failed on day one and been switched off, which is how gates die.
 
-**The ratchet has effectively closed.** That count was 137 when this section was written; the
-08-13/14 sweep dated all 1,416 axes, and the subsequent audit removed eight unsupported
-confirmations, leaving **1,408 confirmed and eight explicitly held** as of 2026-08-14. So the
-invariant and the digest requirement cover the 1,408 confirmed axes — not literally every axis —
-and the eight holds are governed instead by the queue-consistency gate (they may not carry a date
-at all). "Closed" now means there are no *silent* gaps, not that every axis is confirmed. The age
-gate above became possible only because coverage got this close: gating on age while most axes
-carried no date would have measured the backlog rather than staleness. Read the live count from
-`check_freshness` rather than from this paragraph, which will drift again.
+**The ratchet has closed.** That count was 137 when this section was written. The 08-13/14
+sweep dated every axis, an audit then removed the confirmations it could not support, and the
+08-16 reconciliation settled the last of those: as of the `baseline-472-2026-08-16` tag all
+1,416 axes are confirmed and the queue is empty. So the invariant and the digest requirement
+now cover every axis. The age gate above became possible only because coverage got this close:
+gating on age while most axes carried no date would have measured the backlog rather than
+staleness.
+
+The queue being empty is a state, not a property. A hold is still the correct answer when
+evidence contradicts a value, and the queue-consistency gate governs one when it exists — a
+held axis may not carry a date at all. Read the live counts from `check_freshness`, not from
+this paragraph.
 
 The producible-pair check and the parity gate apply in full immediately — nothing has to be
 populated first.
@@ -563,13 +566,13 @@ work the way openness got four.
 | deliberately null — not claims | 46 (26 capability, 20 adoption) |
 | **real claims to verify** | **1370** |
 | of those, citing at least one source URL | 1370 |
-| carrying a real `last_verified` | 1408 |
-| explicitly held in `verification_queue.yaml` (read via commit fallback) | 8 |
-| distinct source URLs behind all of it | 1824 |
+| carrying a real `last_verified` | 1416 |
+| explicitly held in `verification_queue.yaml` | 0 |
+| distinct source URLs behind all of it | 1827 |
 
-`check_freshness` reports median age 1d, oldest 6d, with eight axes resting on the commit-date
-fallback. Regenerate these rather than trusting them; the corpus grows most weeks, and the
-figures in this table have already been wrong once for exactly that reason.
+Read 2026-08-16. `check_freshness` reported median age 3d, oldest 8d, with no axis resting on
+the commit-date fallback. Regenerate these rather than trusting them; the corpus grows most
+weeks, and the figures in this table have already been wrong twice for exactly that reason.
 
 The null axes are two different abstentions and both are deliberate. Capability is null where
 the axis does not apply — datasets and a wire protocol are not capable of anything a benchmark
@@ -770,9 +773,9 @@ run unattended and why it must be fenced to those axes only.
 
 ### 4. The re-read pass — roughly 1106 URLs ✅ **done 2026-08-14**
 
-Closed by the 08-13/14 all-corpus sweep, which dated all 1,416 axes; a follow-up audit then
-removed eight unsupported confirmations, leaving **1,408 confirmed and eight held** (median age
-1d). The description below is kept as the standing procedure for re-running it.
+Closed by the 08-13/14 all-corpus sweep, which dated all 1,416 axes; a follow-up audit removed
+the confirmations it could not support, and the 08-16 reconciliation settled those. The
+description below is kept as the standing procedure for re-running it.
 
 Everything else, all of openness included. **Fold the deferral backlog into this pass rather
 than clearing it first.** Reading a product's sources to determine `core-gated` *is* the
@@ -810,9 +813,9 @@ score for this reason.
 category whose oldest axis is 50 days old is a category to go and look at. Gating earlier would
 only have failed on the pre-automation backlog rather than on genuine staleness; step 4 closed
 that, and on the day the gate landed all 1,416 axes carried a real `last_verified` and the
-oldest category read 6 days. (A later audit removed eight unsupported confirmations, so the
-current state is 1,408 confirmed and eight held — the eight ride the commit-date fallback and do
-not evade the age gate.)
+oldest category read 6 days. (An audit then removed the confirmations it could not support;
+those were settled on 08-16, and a held axis rides the commit-date fallback rather than evading
+the age gate.)
 
 **The window is 30 days, decided 2026-08-09.** It is a judgment about how much re-reading the
 map is worth rather than anything derivable, so it is recorded here with its date and its owner

--- a/docs/reference/evidence-and-freshness.md
+++ b/docs/reference/evidence-and-freshness.md
@@ -56,12 +56,14 @@ Somebody committed that file on that date and left the score standing, which is 
 review rather than a reading. Git records it, and nobody can inflate it. As #102 put
 it, the git history of a score file *is* its verification record.
 
-As of 2026-08-15, 1,407 of the 1,416 axes carry a real `last_verified`; the other **nine are
-explicitly held** in `sources/verification_queue.yaml` and read through the fallback (the sweep
-dated them, then the audit removed those unsupported confirmations — see Part 3; `falcon.adoption`
-joined them on 2026-08-15 when a fresh fetch disproved its own band). So the fallback is not idle:
-a held axis and a product added tomorrow both rely on it until somebody confirms them, and the age
-gate below reads whichever signal an axis has.
+**When the fallback applies**, rather than how many axes are on it today: an axis with no
+`last_verified` at all. Two things put an axis in that state — it is explicitly held in
+`sources/verification_queue.yaml`, or nobody has confirmed it yet, which is where every newly
+added product starts. The age gate below reads whichever signal an axis has.
+
+The live count is in "Current state" further down, and `check_freshness` prints it. It is
+recorded once in this document on purpose: the same number written in two places is how this
+section spent a week disagreeing with the table below it.
 
 A held axis reaches the payload as `basis: partial` rather than through the fallback — see
 "What the payload publishes" below. The fallback covers products with **no** dated axis at all.
@@ -439,21 +441,25 @@ this paragraph.
 The producible-pair check and the parity gate apply in full immediately — nothing has to be
 populated first.
 
-The parity gate runs on its own weekly schedule rather than inside the publish job, and that
-placement is deliberate rather than a stopgap in disguise. Publishing pushes and materializes the
-static models. The three user models that read them are scheduled to recompute on Monday at
-03:00, 04:00 and 05:00 UTC, upstream first, with parity grading the result at 06:00. If parity
-were chained onto a publish instead, it would compare fresh rules against a warehouse that has not
-recomputed and fail for a reason that is not a drift. (The repo does not verify that the weekly
-recompute fired — `docs/operations/deploy-models.md` — so a red parity means "check the run
-history first.")
+The parity gate runs on its own weekly schedule rather than inside the publish job.
+Publishing pushes and materializes the static models; the three user models that read them do
+not recompute on their own.
 
-**The gate's schedule has to match the chain's.** A daily gate over a weekly chain would fail
-every day between a merge and the following Monday, always saying "the warehouse has not caught
-up", which is how a gate earns its way into being ignored. A Tuesday merge is scheduled to be
-scored the following Monday; parity can move into `registry.yml` on the day `publish_registry` triggers those three
-runs and waits for them. For a check sooner, refresh the three models and run `check_parity` by
-hand (`docs/operations/deploy-models.md`).
+**The scoring-chain recompute is manual.** Those models carry a declared cron, and a declared
+cron is not a schedule: they were set at the model-revision layer, the platform schedules from
+the dataset, and run history shows every run of the `scores` dataset as `triggerType: MANUAL`.
+Read the run history and check `triggerType` before believing any freshness claim that rests on
+a cadence — see `docs/operations/deploy-models.md`.
+
+**So parity is a drift-and-staleness detector, and it cannot tell those two apart.** A red
+parity means the repo and the warehouse disagree; whether that is because the scoring logic
+drifted or because nobody has recomputed since the last merge is a question for the run
+history, and it is usually the second. That is also why parity is not chained onto a publish:
+it would compare fresh rules against a warehouse that has not recomputed and fail for a reason
+that is not a drift.
+
+For a check now, refresh the three models by hand and run `check_parity`
+(`docs/operations/deploy-models.md`).
 
 The producible-pair check found 17 impossible pairs on its first run, not the two that were
 known. `vellum`, `whylabs` and `tensorrt-llm` were recorded `4 / open_source`, a pair no rule
@@ -558,7 +564,7 @@ prose by `check_rubric`'s own measure, against the 71% that stopped `edge_hardwa
 four different instruments sharing one field name, there is no shared ladder at the end of that
 work the way openness got four.
 
-## Current state, 2026-08-14
+## Current state
 
 | | count |
 |---|---|

--- a/docs/reference/sibling-invariants.md
+++ b/docs/reference/sibling-invariants.md
@@ -1,180 +1,74 @@
 # Sibling invariants
 
-A record of every place in `build/` where the same fact was stated twice, and what was done
-about each. Written 2026-08-15 after four defects of that exact shape shipped in a fortnight.
+The rule is in `AGENTS.md` ("One fact, one owner"). This file is what it leaves behind: the
+register of constructs in `build/` that state the same fact in more than one place **and are
+meant to**, each with the reason and the test that holds it.
 
-## Why this exists
+It is a decision register, not an incident log. The four defects that produced the rule in
+August 2026 are fixed and each has a named regression test; git carries the narrative. What a
+future sweep needs is the other half — which duplicates are deliberate — because without it
+the same three constants get rediscovered as findings every time somebody greps for them.
 
-None of the four failed loudly. Each reported success over a **narrower question than the one
-it claimed to answer**:
+## Owned, and derived rather than copied
 
-| defect | the narrower question it actually answered |
-|---|---|
-| `check_routing.SOURCE_ARTIFACT` named five sources; the table declared seven | "is this one of the five sources I know about?" |
-| `check_routing.artifacts_of` enumerated the same vocabulary again, in the same file | "does the product declare one of seven hardcoded keys?" |
-| a second, narrower `METHOD_WORDS` in the prose applier | "is this document name one of three forbidden phrases?" |
-| two modules each validated a date by shape | "does this string look like a date?" |
+| construct | owner | derived via | test |
+|---|---|---|---|
+| the three scored axes | `docs/schemas/score.schema.json` | `build/vocabulary.axes` | `test_no_module_holds_a_private_copy_of_the_axes` |
+| product artifact kinds | `sources/signal_routing.yaml` `artifact_key` | `build/vocabulary.artifact_kinds` | `test_proposer_support_is_defined_by_handlers_not_by_routing` |
+| method words a provenance line may not name | `build/product_prose.py` `METHOD_WORDS` | imported | `test_the_method_vocabulary_has_exactly_one_definition` |
+| date handling | `build/vocabulary.py` — `is_iso_date`, `parse_date` | imported | `test_date_validation_rejects_impossible_dates`, `test_date_handling_has_exactly_one_owner` |
 
-Three were found by review rather than by any gate, and the fourth was found only because the
-third was. The pattern is not carelessness about a particular constant — it is that a fix gets
-applied to the instance in front of the author and the sibling is never searched for.
+Two of these carry a decision worth keeping in view.
 
-**The rule this settles on: a vocabulary with a declarative owner is derived from it, never
-copied.** Where a literal genuinely differs from its source, the difference is written down
-and tested, so it stays a decision instead of becoming drift.
+**`render.py` is not exempt from the axes rule**, though it was briefly, on the grounds that it
+was the only build module invoked as a script and so could not import from the package. That
+exemption was unsound — a fourth axis would have left the rendered methodology silently
+omitting its sources while every other test passed — and the invocation moved to `-m` instead.
 
-## Inventory
+**Proposable is not the same set as routed.** The first fix derived `propose_artifacts`'
+supported kinds *from* the routing table, which fails in the other direction: a newly declared
+`artifact_key` would become an accepted `--kind` with no URL pattern, no live check and no
+renderer behind it. Support is defined by the three handlers a kind needs, and asserted to be
+an intentional subset with `arxiv` the named gap.
 
-```yaml
-- construct: vocabulary — the three scored axes
-  canonical_owner: docs/schemas/score.schema.json (via build/vocabulary.axes)
-  duplicates:
-    - build/check_freshness.py
-    - build/check_refetch.py
-    - build/check_verification.py
-    - build/freshness_payload.py
-    - build/serialize_rubric.py
-    - build/sweep_status.py
-    - build/check_payload.py
-    - build/validate.py          # inline, in the schema gate itself
-    - build/render.py            # inline
-  risk: >-
-    A fourth axis narrows ten denominators at once, and a walk that quietly skips an axis
-    passes green. None had drifted — no axis has ever been added — so this is the one entry
-    fixed before it failed rather than after.
+**There are two date helpers, and the split is deliberate.** `is_iso_date` GATES a field's
+spelling and requires both the hyphenated shape and a successful parse: shape alone accepts
+`2026-99-99`, and parse alone accepts Python 3.11's compact `20260815`, which would put a
+second date spelling into a corpus whose schema declares `format: date`. `parse_date` is the
+permissive one, and exists to COMPARE — refusing to compare a date because it was spelled
+unusually would fail a freshness check for a formatting reason.
 
-    render.py was briefly EXEMPTED here because it was the only build module invoked as a
-    script, so it could not import from the package. That exemption was unsound: a fourth
-    axis would have left the rendered methodology silently omitting its sources while every
-    other test passed, which is the very defect this entry is about. The invocation moved to
-    `-m` instead — two workflows and three docs — and the exemption is gone.
-  disposition: fixed
-  regression_test: test_no_module_holds_a_private_copy_of_the_axes
+Five modules held four definitions between them before 2026-08-16. The two `parse_date` copies
+differed in one line — one accepted a `date` object and the other did not — and PyYAML returns
+an object for an unquoted date and a string from a payload, so the same freshness question was
+answered differently depending on which side of the pipeline the value came from.
 
-- construct: vocabulary — product artifact kinds
-  canonical_owner: sources/signal_routing.yaml `artifact_key` (via build/vocabulary.artifact_kinds)
-  duplicates:
-    - build/propose_artifacts.py  # VERIFIABLE_KINDS, already missing arxiv
-  risk: >-
-    Already divergent. The same construct as the two check_routing defects, in a third module.
+Its regression test matches on what a function RETURNS, not on its name. A name test let
+`validate_sources` through as a false positive because it parses a date inline, and the fix
+for that must never be to name the exception: a test that passes by listing whatever it
+happens to find has stopped being a test.
 
-    The first fix derived it FROM the routing table, which was wrong in the other direction:
-    a newly declared `artifact_key` would have become an accepted `--kind` with no URL
-    pattern, no live check and no renderer behind it. Routed and proposable are different
-    questions, and the two sets being equal today is what made the coincidence look like a
-    definition. Support is now defined by the three handlers a kind needs, and asserted to be
-    an intentional subset of routed kinds with `arxiv` the named gap.
-  disposition: fixed
-  regression_test: test_proposer_support_is_defined_by_handlers_not_by_routing
+## Deliberately distinct — do not "fix" these
 
-- construct: vocabulary — capability `relation`
-  canonical_owner: docs/schemas/score.schema.json
-  duplicates:
-    - build/check_capability.py   # DELTA
-  risk: >-
-    DELTA maps each relation to an integer offset, which the schema cannot express, so the
-    dict stays. What it must not do is disagree about which relations EXIST: a relation in the
-    schema but missing from DELTA is accepted by validate and raises in the gate.
-  disposition: intentionally_distinct
-  regression_test: test_capability_relation_deltas_match_the_schema_enum
+| construct | where | why it stays |
+|---|---|---|
+| capability `relation` → integer offset | `check_capability.DELTA` | the schema cannot express the offset. What DELTA may not do is disagree about which relations *exist*, and `test_capability_relation_deltas_match_the_schema_enum` holds that. |
+| openness class → bucket | `serialize._GAP_OPEN` / `_GAP_OPENISH`, `render._OPEN` | `tests/test_openness_buckets.py` already asserts all three agree with `docs/openness-class-map.json`. Same protection, arrived at first; moving the constants would churn a working invariant for symmetry. |
+| adoption instrument subset | `check_adoption._DOWNLOAD_INSTRUMENTS` | not a mirror of the `signal_type` enum. It names the subset measured on a download scale, and the module states why `unknown` is excluded. A narrower vocabulary with a written reason is a decision. |
 
-- construct: vocabulary — the method words a provenance line may not name
-  canonical_owner: build/product_prose.py METHOD_WORDS
-  duplicates:
-    - the prose applier   # fixed in #283, module retired in the 2026-08 cleanup
-  risk: >-
-    The sibling was narrower and let `substitute sources` through as a document name — the
-    exact phrase behind four hardware records that a rewording pass nearly promoted into
-    canonical form.
-  disposition: fixed
-  regression_test: test_the_method_vocabulary_has_exactly_one_definition
+## Two related shapes, both swept clean
 
-- construct: date handling — validating a field, and parsing one to compare
-  canonical_owner: build/vocabulary.py `is_iso_date` and `parse_date`
-  duplicates:
-    - build/check_payload.py        # _is_date, fixed then moved here
-    - build/check_capability.py     # parse_date, accepted a date object
-    - build/check_verification.py   # parse_date, did NOT accept a date object
-    - build/sweep_status.py         # _on_or_after, a third spelling of the same parse
-    - the prose applier             # fixed in #283, module retired
-  risk: >-
-    Five modules, four definitions of "a date". A `\d{4}-\d{2}-\d{2}` regex accepts
-    2026-99-99 and 2026-02-30 in a check whose stated job on that field is validating a date;
-    that defect appeared in two modules three days apart, the second written after the first
-    was fixed, and a fourth copy arrived with the prose classifier's canonical gate.
+**A status or exit derived from fewer conditions than the printed report.** `check_instrument
+--strict` once printed a violation, followed it with `[OK]`, and exited 0. Every checker was
+read after that: `check_verification` iterates all its sub-gates so its exit covers everything
+it prints, and a line that is deliberately non-gating is marked `~` with a written reason
+(`check_rubric`'s no-tier lines). Held by
+`test_strict_exits_nonzero_on_an_unattributed_figure`.
 
-    The two parse_date copies differed in ONE line: one accepted a `date` object and the other
-    did not. PyYAML returns an object for an unquoted `2026-08-15` and a string from a payload,
-    so the same freshness question was answered differently depending on which side of the
-    pipeline the value came from.
-
-    The split into two functions is deliberate. `is_iso_date` GATES a field's spelling and
-    requires both the hyphenated shape and a successful parse. `parse_date` is permissive and
-    exists to COMPARE: refusing to compare a date because it was spelled unusually would fail
-    a freshness check for a formatting reason, which answers the wrong question.
-  disposition: fixed
-  regression_test: >-
-    test_date_validation_rejects_impossible_dates — behavioral, calling the validator rather
-    than grepping for `fromisoformat` — and test_date_handling_has_exactly_one_owner, which
-    matches on what a function RETURNS rather than on its name. A name test let
-    `validate_sources` through as a false positive because it parses a date inline, and the
-    fix for that must never be to name the exception: a test that passes by listing whatever
-    it happens to find has stopped being a test.
-
-- construct: openness class → bucket map
-  canonical_owner: docs/openness-class-map.json
-  duplicates:
-    - build/serialize.py          # _GAP_OPEN / _GAP_OPENISH
-    - build/render.py             # _OPEN
-  risk: >-
-    A divergence would make the gap stage disagree with the published bucket, silently.
-  disposition: intentionally_distinct
-  regression_test: >-
-    tests/test_openness_buckets.py already asserts all three copies agree. That is the same
-    protection this sweep adds elsewhere, arrived at first; moving the constants would churn a
-    working invariant for symmetry.
-
-- construct: adoption instrument subset
-  canonical_owner: none — not a copy
-  duplicates:
-    - build/check_adoption.py     # _DOWNLOAD_INSTRUMENTS
-  risk: none
-  disposition: intentionally_distinct
-  regression_test: >-
-    Not a mirror of the signal_type enum. It names the subset measured on a download scale,
-    and the module states why `unknown` is excluded. A narrower vocabulary with a written
-    reason is a decision, not a duplicate.
-
-- construct: status/exit derived from fewer conditions than the printed report
-  canonical_owner: n/a
-  duplicates:
-    - build/check_instrument.py   # fixed in #276
-  risk: >-
-    `--strict` printed an unattributed-figure violation, followed it with `[OK]`, and exited
-    0. Every other checker was read: `check_verification` iterates all gates so its exit
-    covers everything it prints, and `check_rubric`'s non-gating lines are marked `~` with a
-    written reason. No further instances.
-  disposition: fixed
-  regression_test: test_strict_exits_nonzero_on_an_unattributed_figure
-
-- construct: malformed or unknown input becoming a pass
-  canonical_owner: n/a
-  duplicates: []
-  risk: >-
-    Swept and clean. The three `except` paths in build/ each record the failure — `False`, an
-    `unreachable` list, or an error — rather than falling through to success.
-  disposition: intentionally_distinct
-  regression_test: none needed
-```
+**Malformed or unknown input becoming a pass.** The `except` paths in `build/` each record the
+failure — `False`, an `unreachable` list, or an error — rather than falling through to success.
 
 ## What was deliberately not done
 
 No new abstraction for the sake of deduplication. `build/vocabulary.py` holds two functions,
 both deriving from a file that already owns the fact.
-
-Three entries were dropped in the 2026-08 cleanup along with the prose applier they described
-— a clause-boundary regex the applier should never have held, a `url -> accessed` map that
-flattened a many-valued fact, and an untested composition. Their lesson is the general one at
-the top of this file, and git carries the detail. Constants that are genuinely local, or
-that already have a working gate, were left where they are — noted above with the reason, so
-the next sweep does not rediscover them as findings.

--- a/warehouse/models/README.md
+++ b/warehouse/models/README.md
@@ -84,8 +84,8 @@ The OSAI/Raffi v2 taxonomy layer (scores.taxonomy, scores.investment_ranking) wa
 |-------|-----|----------|------|-------------|
 | `currentai.scores.dependency_graph` | [scores_dependency_graph.sql](scores_dependency_graph.sql) | declared 6am | ~26K | Transitive AI→AI deps (direct + depth-2) |
 | `currentai.scores.fragility` | [scores_fragility.sql](scores_fragility.sql) | declared 6am | ~600 | Dependency reach × maintainer capacity |
-| `currentai.scores.project_summary` | [scores_project_summary.sql](scores_project_summary.sql) | Daily 7am | ~14K | Rolled-up snapshot per project |
-| `currentai.scores.repos_summary` | [scores_repos_summary.sql](scores_repos_summary.sql) | Daily 7am | ~15K | Per-repo snapshot: catalog metadata + 90-day activity + contributors |
+| `currentai.scores.project_summary` | [scores_project_summary.sql](scores_project_summary.sql) | declared 7am | ~14K | Rolled-up snapshot per project |
+| `currentai.scores.repos_summary` | [scores_repos_summary.sql](scores_repos_summary.sql) | declared 7am | ~15K | Per-repo snapshot: catalog metadata + 90-day activity + contributors |
 | `currentai.scores.ossd_coverage` | [scores_ossd_coverage.sql](scores_ossd_coverage.sql) | declared 6am | ~10K | Per-org oss-directory match rates |
 | `currentai.scores.stack_contributors` | [scores_stack_contributors.sql](scores_stack_contributors.sql) | @manual | ~68K | Distinct GitHub code committers (12mo, bots excluded) per scored product, bridged to stack-map category/layer/openness via `catalog.stack_map` |
 

--- a/warehouse/models/README.md
+++ b/warehouse/models/README.md
@@ -5,6 +5,12 @@ This file covers the five that this repo maintains — `catalog`, `entities`, `e
 and `scores` — including the 12 SQL models in this directory. The rest are signal, snapshot and
 raw-ingestion datasets deployed straight to the platform, with no SQL kept here.
 
+**A declared cron is not a schedule.** The `Declared cron` column below records what the
+model revision asks for. The platform schedules from the DATASET, not the revision, and these
+were set at the revision layer — so the fields are populated and the runs do not fire. Before
+believing any freshness claim that rests on a cadence here, read the run history and check
+`triggerType`; treat every recompute as manual until one says SCHEDULED.
+
 ## Dataset Layout
 
 ```
@@ -43,28 +49,28 @@ shown it.
 
 Resolved identities and relationships. `entities.repos` is the foundation — everything chains off it.
 
-| Table | SQL | Schedule | Rows | Description |
+| Table | SQL | Declared cron | Rows | Description |
 |-------|-----|----------|------|-------------|
-| `currentai.entities.repos` | [entities_repos.sql](entities_repos.sql) | Daily 6am | ~15K | Deduped repo catalog + oss_directory IDs and project resolution |
-| `currentai.entities.projects` | [entities_projects.sql](entities_projects.sql) | Daily 6am | ~14K | OSO projects where matched, standalone repos otherwise |
-| `currentai.entities.packages` | [entities_packages.sql](entities_packages.sql) | Daily 6am | ~2.8K | Published packages linked to repos via `package_owners_v0` |
-| `currentai.entities.models` | [entities_models.sql](entities_models.sql) | Daily 6am | ~6.4K | HF models with repo links, benchmarks, foundation model family |
+| `currentai.entities.repos` | [entities_repos.sql](entities_repos.sql) | declared 6am | ~15K | Deduped repo catalog + oss_directory IDs and project resolution |
+| `currentai.entities.projects` | [entities_projects.sql](entities_projects.sql) | declared 6am | ~14K | OSO projects where matched, standalone repos otherwise |
+| `currentai.entities.packages` | [entities_packages.sql](entities_packages.sql) | declared 6am | ~2.8K | Published packages linked to repos via `package_owners_v0` |
+| `currentai.entities.models` | [entities_models.sql](entities_models.sql) | declared 6am | ~6.4K | HF models with repo links, benchmarks, foundation model family |
 
 ## Events (User Defined Models)
 
 Pre-filtered event logs scoped to our catalog repos.
 
-| Table | SQL | Schedule | Rows | Description |
+| Table | SQL | Declared cron | Rows | Description |
 |-------|-----|----------|------|-------------|
-| `currentai.events.github_events` | [events_github_events.sql](events_github_events.sql) | Daily 5am | ~24M | GitHub Archive events for catalog repos, 12-month rolling window |
+| `currentai.events.github_events` | [events_github_events.sql](events_github_events.sql) | declared 5am | ~24M | GitHub Archive events for catalog repos, 12-month rolling window |
 
 ## Metrics (User Defined Models)
 
 Normalized time-series activity.
 
-| Table | SQL | Schedule | Rows | Description |
+| Table | SQL | Declared cron | Rows | Description |
 |-------|-----|----------|------|-------------|
-| `currentai.metrics.daily` | [metrics_daily.sql](metrics_daily.sql) | Daily 6am | ~5M | Long format: repo × day × metric → value (8 metric types) |
+| `currentai.metrics.daily` | [metrics_daily.sql](metrics_daily.sql) | declared 6am | ~5M | Long format: repo × day × metric → value (8 metric types) |
 
 Metric types: `stars`, `forks`, `commits`, `pull_requests`, `issues_opened`, `contributors`, `full_time`, `part_time`
 
@@ -74,13 +80,13 @@ Interpretive layer — taxonomy, dependencies, fragility, rankings, summaries.
 
 The OSAI/Raffi v2 taxonomy layer (scores.taxonomy, scores.investment_ranking) was removed in favor of the sources/categories model.
 
-| Table | SQL | Schedule | Rows | Description |
+| Table | SQL | Declared cron | Rows | Description |
 |-------|-----|----------|------|-------------|
-| `currentai.scores.dependency_graph` | [scores_dependency_graph.sql](scores_dependency_graph.sql) | Daily 6am | ~26K | Transitive AI→AI deps (direct + depth-2) |
-| `currentai.scores.fragility` | [scores_fragility.sql](scores_fragility.sql) | Daily 6am | ~600 | Dependency reach × maintainer capacity |
+| `currentai.scores.dependency_graph` | [scores_dependency_graph.sql](scores_dependency_graph.sql) | declared 6am | ~26K | Transitive AI→AI deps (direct + depth-2) |
+| `currentai.scores.fragility` | [scores_fragility.sql](scores_fragility.sql) | declared 6am | ~600 | Dependency reach × maintainer capacity |
 | `currentai.scores.project_summary` | [scores_project_summary.sql](scores_project_summary.sql) | Daily 7am | ~14K | Rolled-up snapshot per project |
 | `currentai.scores.repos_summary` | [scores_repos_summary.sql](scores_repos_summary.sql) | Daily 7am | ~15K | Per-repo snapshot: catalog metadata + 90-day activity + contributors |
-| `currentai.scores.ossd_coverage` | [scores_ossd_coverage.sql](scores_ossd_coverage.sql) | Daily 6am | ~10K | Per-org oss-directory match rates |
+| `currentai.scores.ossd_coverage` | [scores_ossd_coverage.sql](scores_ossd_coverage.sql) | declared 6am | ~10K | Per-org oss-directory match rates |
 | `currentai.scores.stack_contributors` | [scores_stack_contributors.sql](scores_stack_contributors.sql) | @manual | ~68K | Distinct GitHub code committers (12mo, bots excluded) per scored product, bridged to stack-map category/layer/openness via `catalog.stack_map` |
 
 ## Subscribed External Datasets
@@ -118,7 +124,7 @@ uv run python warehouse/ingest/fetch_model_benchmarks.py    # then upload via MC
 # The GoodAI roster needs no fetcher: signal_goodailist.repo_catalog reads
 # goodailist.com directly on its own cron.
 
-# UDMs refresh on their daily cron schedule, or trigger manually via MCP:
+# UDMs carry a declared cron, which is NOT evidence that they run. Trigger manually via MCP:
 # createUserModelRunRequest with the dataset ID
 ```
 

--- a/warehouse/sources.yaml
+++ b/warehouse/sources.yaml
@@ -1,5 +1,11 @@
 # Registry of external data sources the pipeline ingests.
 # Each entry links a source to its fetcher in warehouse/ingest/.
+#
+# `refresh` is what actually runs, not an intention. Every fetcher below is driven by
+# .github/workflows/refresh-data.yml on one weekly cron (Mondays 05:17 UTC); the per-source
+# monthly and quarterly cadences this file used to declare were never implemented anywhere.
+# A source with no fetcher is read by a UDM on the platform, and a cron set on a UDM is a
+# DECLARATION — see warehouse/models/README.md on why that does not prove it fires.
 sources:
   - id: goodailist
     name: Good AI List
@@ -11,42 +17,42 @@ sources:
     # than the live table, and it was: the frozen CSV still listed 300 repos
     # goodailist.com had delisted.
     ingested_by: currentai.signal_goodailist.repo_catalog
-    refresh: daily (UDM cron)
+    refresh: declared daily on the UDM; verify in run history
 
   - id: huggingface
     name: Hugging Face models and datasets
     homepage: https://huggingface.co/
     provides: Model and dataset catalogs from the Hugging Face Hub
     fetcher: warehouse/ingest/fetch_huggingface.py
-    refresh: monthly
+    refresh: weekly (refresh-data.yml)
 
   - id: huggingface_benchmarks
     name: Hugging Face / Open LLM Leaderboard
     homepage: https://huggingface.co/
     provides: Model and dataset catalogs, benchmark scores
     fetcher: warehouse/ingest/fetch_model_benchmarks.py
-    refresh: monthly
+    refresh: weekly (refresh-data.yml)
 
   - id: github_orgs
     name: GitHub AI org/repo catalog
     homepage: https://github.com/
     provides: AI-tagged repos and orgs
     fetcher: warehouse/ingest/fetch_github_orgs.py
-    refresh: monthly
+    refresh: weekly (refresh-data.yml)
 
   - id: github_ai_repos
     name: GitHub AI repo search
     homepage: https://github.com/
     provides: AI repos discovered via GitHub topic and keyword search
     fetcher: warehouse/ingest/fetch_github_ai_repos.py
-    refresh: monthly
+    refresh: weekly (refresh-data.yml)
 
   - id: ai_incidents
     name: AI Incident Database
     homepage: https://incidentdatabase.ai/
     provides: Safety / safeguards incidents
     fetcher: warehouse/ingest/fetch_incidents.py
-    refresh: quarterly
+    refresh: weekly (refresh-data.yml)
 
   - id: stack_map
     name: Stack-map taxonomy bridge (internal)


### PR DESCRIPTION
Stacked on #307, which is stacked on #306. Review in that order; the base retargets to `main` as each merges.

Four documents claimed things that are no longer true, and two claimed a completeness they cannot hold.

## `CLAUDE.md` → four pointers

It restated `AGENTS.md`'s routing table, the YAML-writing policy and the traps list, so a change had to land in two files to be true in one. It is now the repo map, the task router, the skill, and the warehouse boundary. The YAML policy and the traps moved into `AGENTS.md`, which is where a reader looking for either would go.

## `AGENTS.md` → stages, not an inventory

It claimed a complete list of "30 build modules" and had drifted to ~40 within a fortnight. A hand-maintained list of every module is a second copy of a fact the modules already carry — the failure this repo has now shipped five times. It becomes a map of the stages and the four checker families, with `--help` named as the authority. The sibling-invariant rule moves in beside it, because it belongs where somebody about to write a module will read it.

## `sibling-invariants.md` → a decision register

The four defects are fixed and each has a named regression test; git carries the narrative. What a sweep actually needs from this file is the other half — **which duplicates are deliberate, and why** — so `check_capability.DELTA`, `_GAP_OPEN`/`_OPEN` and `_DOWNLOAD_INSTRUMENTS` keep their entries and their reasons. Deleting the file outright would lose those, and they would be rediscovered as findings by the next sweep. Roughly 165 lines down to 70.

## `evidence-and-freshness.md` → the current state

It still described "1,408 confirmed and eight explicitly held" in four places. The 08-16 reconciliation settled those: **1,416 confirmed, empty queue.** The counts table is re-read live (1,827 distinct source URLs, median age 3d) and dated. The paragraph now says the queue being empty is a *state*, not a property — a hold is still the right answer when evidence contradicts a value, and the consistency gate still governs one.

## The warehouse cadence claims were wrong in both directions

`warehouse/sources.yaml` declared monthly and quarterly refreshes that were never implemented anywhere; every fetcher in it runs on one weekly cron in `refresh-data.yml`.

`warehouse/models/README.md` presented declared crons as a `Schedule` column — the exact claim the platform does not honor. Those crons are set at the model-revision layer, the platform schedules from the dataset, and no scheduled run has ever fired. The column is now `Declared cron`, under a header saying to read run history and check `triggerType` before believing any freshness claim that rests on it.

## Test plan

- 27 tests across docs-integrity, vocabulary-siblings and warehouse pass.
- No dangling internal link or backticked repo path anywhere in `*.md` (swept; the two remaining hits are a deliberate `foo.yaml` example and a correctly past-tense reference to a file removed in 2026-08).

---

Supersedes #308, which GitHub auto-closed when its base branch was deleted on merge. Same branch, same commits, retargeted to `main`.