### PR TITLE
Add publish-release skill and populate the changelog

### DIFF
--- a/.claude/skills/publish-release
+++ b/.claude/skills/publish-release
@@ -1,0 +1,1 @@
+../../skills/publish-release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,7 +287,8 @@ Claude Code session discovers them by name; if yours does not list them, read
 
 **Advanced / internal skills** (off the primary path): `build-rubric` (derive a category's
 openness ladder), `add-data-source` (register a fetcher), `refresh-all-categories` (drive the
-whole-corpus sweep), `pyoso-analyst` (read-only warehouse analysis).
+whole-corpus sweep), `pyoso-analyst` (read-only warehouse analysis), `publish-release` (cut a
+versioned release + changelog; maintainer).
 
 Invoke the relevant skill before doing editor work. Skills enforce the read-only boundary and
 walk through validation + preview steps.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 What a MAJOR, MINOR, or PATCH bump means for a data-and-schema repo is spelled out in
 `skills/publish-release/SKILL.md`; the `publish-release` skill cuts each release.
 
-Add your change to the `## [Unreleased]` section in the same PR that makes the change,
-under the matching heading (Added, Changed, Deprecated, Removed, Fixed, Security).
-Write one line per change, newest first, in plain past tense, and link the PR.
+Record a change under `## [Unreleased]`, in the same PR that makes it, only when it is
+**notable and user-facing** — a new or removed product, category, or data source; a schema or
+scoring change; a new skill or workflow. Routine maintenance stays out: bot regenerations,
+dependency bumps, internal refactors, and day-to-day evidence refreshes that do not move a
+published score. Put each entry under the matching heading (Added, Changed, Deprecated,
+Removed, Fixed, Security), one line, newest first, in plain past tense, with the PR linked.
 
 ## [Unreleased]
 
@@ -30,9 +33,9 @@ Grew and re-verified the corpus end to end, on top of a new evidence-based scori
 - **Evidence-based scoring:** openness scores are now computed from recorded evidence
   instead of being hand-authored — a machine-readable scoring rubric, an evidence store,
   and computed scores brought back into the repo for review (#98, #101, #102, #103, #108).
-- **Automated verification checks** that confirm each score against its cited source —
-  including one that fetches and reads the source page — plus a check that enforces the
-  scoring procedure itself (#127, #128, #134, #136, #148).
+- **Automated verification checks** for verification-date support, source attribution and
+  digests, sampled refetch reproducibility, and score reproduction from the declared rubrics
+  (#127, #128, #134, #136, #148).
 - **Structured openness and license records,** converted across the whole corpus, with each
   license part recorded as its own piece of evidence (#185, #186, #191–#198, #216, #217).
 - **A routing table** naming the authoritative source for each scoring dimension (#103),
@@ -44,9 +47,9 @@ Grew and re-verified the corpus end to end, on top of a new evidence-based scori
 
 ### Changed
 
-- **Re-verified all 472 products** against primary sources to a consistent, source-cited
-  standard — 385 product records and their scores updated — and edited all 15 existing
-  categories.
+- **Re-verified all 472 products** against named, reopenable evidence, preferring primary
+  sources where available — 385 product records and their scores updated — and edited all 15
+  existing categories.
 - **Made product descriptions neutral** rather than marketing copy, under one standard for
   the description and comments fields (#147, #222).
 - **Consolidated closed-model point releases** into the tier the vendor sells and fixed each
@@ -75,11 +78,11 @@ Grew and re-verified the corpus end to end, on top of a new evidence-based scori
   cache, and reverted the dates it had written (#115, #124).
 - Reconciled the verification tracking file and restored nine deferred items (#301).
 
-## [0.1.0] - 2026-06-30
+## [0.1.0] - 2026-07-01
 
-Initial release. The baseline AI Stack Map corpus as it stood at the end of June:
+Initial release: the first full snapshot of the AI Stack Map corpus, at the start of July —
 **458 products across 15 categories**, from **249 organizations**, each scored on openness,
-adoption, and capability.
+adoption, and capability. Tagged at commit `2e9d6eb`.
 
 [unreleased]: https://github.com/currentai-org/os-ai-map/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/currentai-org/os-ai-map/compare/v0.1.0...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this repository are recorded here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+What a MAJOR, MINOR, or PATCH bump means for a data-and-schema repo is spelled out in
+`skills/publish-release/SKILL.md`; the `publish-release` skill cuts each release.
+
+Add your change to the `## [Unreleased]` section in the same PR that makes the change,
+under the matching heading (Added, Changed, Deprecated, Removed, Fixed, Security).
+Write one line per change, newest first, in plain past tense, and link the PR.
+
+## [Unreleased]
+
+### Added
+
+- `publish-release` skill and this changelog, establishing a Keep a Changelog + Semantic
+  Versioning release process for the repository.
+
+[unreleased]: https://github.com/currentai-org/os-ai-map/commits/main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,74 @@ Write one line per change, newest first, in plain past tense, and link the PR.
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-08-16
+
+Grew and re-verified the corpus end to end, on top of a new evidence-based scoring pipeline.
+
 ### Added
 
-- `publish-release` skill and this changelog, establishing a Keep a Changelog + Semantic
-  Versioning release process for the repository.
+- **One new category** (Dataset Processing Tools) and **85 products** — a net gain of 14
+  after consolidation — bringing the map to **472 products across 16 categories** and 257
+  organizations.
+- **Scoring ladders:** a shared openness ladder for software across ten categories, shared
+  ladders for datasets and hardware, per-product-type variants, and a single license scale
+  used everywhere (#126, #129, #131, #137, #139).
+- **An adoption measure** with per-product-type bands, declared scales, and readings backed
+  by real usage signals (#171, #175, #176, #224, #227).
+- **Evidence-based scoring:** openness scores are now computed from recorded evidence
+  instead of being hand-authored — a machine-readable scoring rubric, an evidence store,
+  and computed scores brought back into the repo for review (#98, #101, #102, #103, #108).
+- **Automated verification checks** that confirm each score against its cited source —
+  including one that fetches and reads the source page — plus a check that enforces the
+  scoring procedure itself (#127, #128, #134, #136, #148).
+- **Structured openness and license records,** converted across the whole corpus, with each
+  license part recorded as its own piece of evidence (#185, #186, #191–#198, #216, #217).
+- **A routing table** naming the authoritative source for each scoring dimension (#103),
+  and freshness reporting behind a 30-day refresh window (#102, #162, #267).
+- **Artifact tooling:** an arXiv artifact type, a tool that proposes candidate artifacts,
+  and a check that declared artifacts resolve to what they claim (#100, #104, #165, #170).
+- **Skills:** `refresh-category` and `refresh-all-categories` to drive the re-verification
+  pass (#158).
 
-[unreleased]: https://github.com/currentai-org/os-ai-map/commits/main
+### Changed
+
+- **Re-verified all 472 products** against primary sources to a consistent, source-cited
+  standard — 385 product records and their scores updated — and edited all 15 existing
+  categories.
+- **Made product descriptions neutral** rather than marketing copy, under one standard for
+  the description and comments fields (#147, #222).
+- **Consolidated closed-model point releases** into the tier the vendor sells and fixed each
+  product's identifier so it stays stable; alternate names now live on the records they
+  identify (#114, #121, #157).
+- **Reorganized the docs** into five task-based workflows over a shared reference layer, with
+  a check that keeps them consistent and a skill registry (#269, #271, #274).
+- **Added a read-only copy** of the scoring and signal models that run on the OSO platform,
+  so they can be read from this repo (#272).
+
+### Removed
+
+- **Retired or consolidated 71 product entries** — collapsing point releases into vendor
+  tiers and dropping projects that were renamed or shut down.
+- Replaced the frozen GoodAI List CSV with a live data feed, and removed warehouse CSV files
+  that nothing used (#110, #309).
+- Removed an openness class the schema forbids, obsolete prose-cleanup tooling, historical
+  snapshots, and dead build code (#178, #179, #306, #310).
+
+### Fixed
+
+- Corrected score, license, and adoption records against reachable evidence across the
+  corpus (#204, #215, #226, #255, #260).
+- Dated each score file from its last content change, not its last file touch (#190).
+- Stopped the score-import step from overwriting the "last verified" date through a stale
+  cache, and reverted the dates it had written (#115, #124).
+- Reconciled the verification tracking file and restored nine deferred items (#301).
+
+## [0.1.0] - 2026-06-30
+
+Initial release. The baseline AI Stack Map corpus as it stood at the end of June:
+**458 products across 15 categories**, from **249 organizations**, each scored on openness,
+adoption, and capability.
+
+[unreleased]: https://github.com/currentai-org/os-ai-map/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/currentai-org/os-ai-map/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/currentai-org/os-ai-map/releases/tag/v0.1.0

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@ doors above:
 - **Advanced** — deep editorial skills for maintainers: `build-rubric` (derive a category's
   scoring ladder) and `refresh-all-categories` (drive the whole-corpus sweep).
 - **Internal** — infrastructure and analysis, not map-editing: `add-data-source` (register a
-  fetcher) and `pyoso-analyst` (read-only warehouse analysis).
+  fetcher), `pyoso-analyst` (read-only warehouse analysis), and `publish-release` (cut a
+  versioned release and update the changelog; maintainer only).
 
 For the repo map, build pipeline, and data model, see `AGENTS.md`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "os-ai-map"
-version = "0.1.0"
+version = "0.2.0"
 description = "Open Source AI Map: curated data + modeling behind the AI Stack Map"
 license = "MIT"
 requires-python = ">=3.12"

--- a/skills/publish-release/SKILL.md
+++ b/skills/publish-release/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: publish-release
-description: Use when cutting a versioned release of os-ai-map — deciding the version bump, moving the changelog's Unreleased notes into a dated release, tagging it, and pushing. Maintainer step. For adding a single changelog line, just edit the Unreleased section in your PR.
+description: Use when cutting a versioned release of os-ai-map — deciding the version bump, moving the changelog's Unreleased notes into a dated release through a review PR, then tagging the merged commit. Maintainer step. For adding a single changelog line, just edit the Unreleased section in your PR.
 ---
 
 # Publish a release
 
 Cut a versioned release of the repository: turn the accumulated `## [Unreleased]` changelog
-notes into a dated, numbered release, bump the version, tag it, and push. This is a
-**maintainer step** — it writes a git tag and pushes to `main`. Editors do not run it; they
-add one line to the Unreleased section in their PR and stop.
+notes into a dated, numbered release. This is a **maintainer step**. The release goes in
+through a normal review PR like any other change; the git tag is applied afterward, to the
+commit that actually landed on `main`. Editors do not run it — they add one line to the
+Unreleased section in their own PR and stop.
 
 This skill versions **the `os-ai-map` repository** — its source YAML, schemas, build
 pipeline, and docs. It does **not** publish the live notebook or the warehouse models; those
@@ -17,13 +18,19 @@ are separate maintainer runbooks (`docs/operations/publish-map.md`,
 
 ## What tracks a release
 
-- **`CHANGELOG.md`** — the human record, in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
-  format. One `## [Unreleased]` section collects changes as they land; a release freezes it
-  into a `## [X.Y.Z] - YYYY-MM-DD` section.
-- **`pyproject.toml` `version`** — the machine record. It must equal the latest released
-  version at all times.
-- **An annotated git tag `vX.Y.Z`** — the immutable marker. The tag and the two files above
-  always agree.
+A release's version is written in **four** places. They must all read the same string, or the
+release lies about itself:
+
+1. **`CHANGELOG.md`** — the newest dated heading, `## [X.Y.Z] - YYYY-MM-DD`
+   (the undated `## [Unreleased]` section does not count).
+2. **`pyproject.toml`** — `[project].version`.
+3. **`uv.lock`** — the root package (`source = { virtual = "." }`). Bumping `pyproject.toml`
+   without re-locking leaves this stale, so re-lock in the same commit.
+4. **The annotated git tag** — `vX.Y.Z`, on the merged `main` commit.
+
+`tests/test_release_metadata.py` enforces this. It checks the three in-tree records (1–3) on
+every PR, and the tag (4) as well when run in a tag context. Do not hand-eyeball the numbers;
+run the gate.
 
 ## Decide the version bump
 
@@ -41,57 +48,80 @@ MAJOR-worthy change bumps the MINOR instead (`0.y` may break); say so in the cha
 
 ## Steps
 
-1. **Confirm a clean tree on `main`.** `git status` is clean and `git pull` is current. Cut
-   releases from `main` so the tag matches the published history.
-2. **Choose the version** with the table above. Call it `X.Y.Z`.
+The tag must point at reviewed, merged history — never at a branch tip that has not landed.
+So the file changes go through a PR first, and only then does the tag get cut.
+
+1. **Start from current `main`.** `git checkout main && git pull --ff-only`; `git status`
+   clean. Choose the version `X.Y.Z` with the table above.
+2. **Branch:** `git checkout -b release/vX.Y.Z`.
 3. **Freeze the changelog.** In `CHANGELOG.md`:
    - Rename `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD` (today's date, ISO 8601).
    - Drop any now-empty subsections (keep only the headings that have entries).
    - Add a fresh, empty `## [Unreleased]` above it.
-   - Update the link definitions at the bottom:
+   - Update the link definitions at the bottom to **comparison links between consecutive
+     versions** (a release compares against the one before it):
      ```
      [unreleased]: https://github.com/currentai-org/os-ai-map/compare/vX.Y.Z...HEAD
-     [X.Y.Z]: https://github.com/currentai-org/os-ai-map/releases/tag/vX.Y.Z
+     [X.Y.Z]:      https://github.com/currentai-org/os-ai-map/compare/vPREV...vX.Y.Z
      ```
-     (On the first release only, replace the seed `[unreleased]: .../commits/main` line.)
-4. **Bump the version.** Set `version = "X.Y.Z"` in `pyproject.toml`. It must match the tag.
-5. **Commit** the changelog and version bump together:
+     The very first release has no predecessor, so it links to `releases/tag/vX.Y.Z` instead.
+4. **Bump and re-lock.** Set `version = "X.Y.Z"` in `pyproject.toml`, then run `uv lock` so
+   `uv.lock`'s root package matches. Both files are part of the commit.
+5. **Validate locally** before opening the PR:
    ```bash
-   git commit -am "chore(release): v X.Y.Z"   # write the version without the space
+   uv run python -m build.validate            # sources clean
+   uv run pytest -q                           # full suite, incl. test_release_metadata
    ```
-6. **Tag**, annotated, with the changelog section as the message body:
+6. **Open the release PR** (`release/vX.Y.Z` → `main`) and get it reviewed and merged like any
+   other change. Do not tag yet.
+7. **Verify the merged commit.** After merge:
    ```bash
-   git tag -a vX.Y.Z -m "vX.Y.Z"
+   git fetch origin main
+   git checkout main && git pull --ff-only
+   git rev-parse HEAD                          # the exact SHA the tag will point at
+   uv run pytest tests/test_release_metadata.py -q
    ```
-7. **Push the branch and the tag:**
+   Confirm the three in-tree records all read `X.Y.Z` before going further.
+8. **Tag the merged commit,** annotated, using that version's changelog section as the message
+   body (not a bare `-m "vX.Y.Z"`):
    ```bash
-   git push -u origin <branch> && git push origin vX.Y.Z
+   VERSION=X.Y.Z
+   awk -v v="$VERSION" '
+     $0 ~ "^## \\[" v "\\]" {f=1; print; next}
+     f && /^## \[/ {exit}
+     f {print}
+   ' CHANGELOG.md | git tag -a "v$VERSION" -F -
    ```
-8. **(Optional) GitHub Release.** Create a release from tag `vX.Y.Z`, pasting that version's
-   changelog section as the body. Use the GitHub MCP tools; do not invent release notes —
-   copy the changelog verbatim.
+9. **Push the tag,** and confirm the metadata gate passes in a tag context:
+   ```bash
+   git push origin "v$VERSION"
+   RELEASE_TAG="v$VERSION" uv run pytest tests/test_release_metadata.py -q
+   ```
+10. **(Optional) GitHub Release.** Create a release from tag `vX.Y.Z`, pasting that version's
+    changelog section (the same text the tag carries) as the body. Do not invent release notes.
 
 ## Rules
 
-- **The three records agree.** Tag `vX.Y.Z`, `pyproject.toml` version, and the newest
-  `CHANGELOG.md` heading are always the same string. A mismatch is a release bug.
+- **The four records agree.** The tag, `pyproject.toml`, the `uv.lock` root package, and the
+  newest dated `CHANGELOG.md` heading are all the same string. `tests/test_release_metadata.py`
+  is the gate; a mismatch is a release bug, not a formatting nit.
+- **A tag points only at merged `main` history.** Never tag a release-branch commit before it
+  merges — the merged SHA differs, and the tag would mark history that never shipped.
 - **Never edit a released section.** Once `## [X.Y.Z]` is dated and tagged, it is history.
   Corrections go in a new release.
 - **Tags are immutable.** Never move or delete a pushed tag. A mistake is fixed forward with
   the next PATCH.
 - **One line per change, in plain English.** Past tense, user-facing effect first, PR linked.
-  No AI tells, American English (per `CLAUDE.md`).
+  Only notable, user-facing changes earn an entry — not bot regenerations, dependency bumps,
+  internal refactors, or routine evidence refreshes. No AI tells, American English (per
+  `CLAUDE.md`).
 - **Do not commit** `build/notebook_data.json` or `notebooks/` — the bot owns them, and CI
   blocks hand edits.
 
 ## Validation
 
 ```bash
-# The three records must name the same version:
-grep '^version' pyproject.toml
-grep -m1 '^## \[' CHANGELOG.md
-git describe --tags --abbrev=0        # after tagging
-
-# The changelog parses as Keep a Changelog (Unreleased present, headings well-formed):
-grep -q '^## \[Unreleased\]' CHANGELOG.md && echo "Unreleased section present"
+uv run pytest tests/test_release_metadata.py -q   # the four-record gate (three in-tree, +tag)
+uv run python -m build.validate                   # sources still clean
+uv run pytest -q                                   # full suite
 ```

--- a/skills/publish-release/SKILL.md
+++ b/skills/publish-release/SKILL.md
@@ -72,9 +72,15 @@ So the file changes go through a PR first, and only then does the tag get cut.
    uv run python -m build.validate            # sources clean
    uv run pytest -q                           # full suite, incl. test_release_metadata
    ```
-6. **Open the release PR** (`release/vX.Y.Z` → `main`) and get it reviewed and merged like any
+6. **Commit and push the release branch:**
+   ```bash
+   git add CHANGELOG.md pyproject.toml uv.lock
+   git commit -m "chore(release): vX.Y.Z"
+   git push -u origin release/vX.Y.Z
+   ```
+7. **Open the release PR** (`release/vX.Y.Z` → `main`) and get it reviewed and merged like any
    other change. Do not tag yet.
-7. **Verify the merged commit.** After merge:
+8. **Verify the merged commit.** After merge:
    ```bash
    git fetch origin main
    git checkout main && git pull --ff-only
@@ -82,7 +88,7 @@ So the file changes go through a PR first, and only then does the tag get cut.
    uv run pytest tests/test_release_metadata.py -q
    ```
    Confirm the three in-tree records all read `X.Y.Z` before going further.
-8. **Tag the merged commit,** annotated, using that version's changelog section as the message
+9. **Tag the merged commit,** annotated, using that version's changelog section as the message
    body (not a bare `-m "vX.Y.Z"`):
    ```bash
    VERSION=X.Y.Z
@@ -92,12 +98,12 @@ So the file changes go through a PR first, and only then does the tag get cut.
      f {print}
    ' CHANGELOG.md | git tag -a "v$VERSION" -F -
    ```
-9. **Push the tag,** and confirm the metadata gate passes in a tag context:
+10. **Push the tag,** and confirm the metadata gate passes in a tag context:
    ```bash
    git push origin "v$VERSION"
    RELEASE_TAG="v$VERSION" uv run pytest tests/test_release_metadata.py -q
    ```
-10. **(Optional) GitHub Release.** Create a release from tag `vX.Y.Z`, pasting that version's
+11. **(Optional) GitHub Release.** Create a release from tag `vX.Y.Z`, pasting that version's
     changelog section (the same text the tag carries) as the body. Do not invent release notes.
 
 ## Rules

--- a/skills/publish-release/SKILL.md
+++ b/skills/publish-release/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: publish-release
+description: Use when cutting a versioned release of os-ai-map — deciding the version bump, moving the changelog's Unreleased notes into a dated release, tagging it, and pushing. Maintainer step. For adding a single changelog line, just edit the Unreleased section in your PR.
+---
+
+# Publish a release
+
+Cut a versioned release of the repository: turn the accumulated `## [Unreleased]` changelog
+notes into a dated, numbered release, bump the version, tag it, and push. This is a
+**maintainer step** — it writes a git tag and pushes to `main`. Editors do not run it; they
+add one line to the Unreleased section in their PR and stop.
+
+This skill versions **the `os-ai-map` repository** — its source YAML, schemas, build
+pipeline, and docs. It does **not** publish the live notebook or the warehouse models; those
+are separate maintainer runbooks (`docs/operations/publish-map.md`,
+`docs/operations/deploy-models.md`). A repo release and a notebook publish are different acts.
+
+## What tracks a release
+
+- **`CHANGELOG.md`** — the human record, in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+  format. One `## [Unreleased]` section collects changes as they land; a release freezes it
+  into a `## [X.Y.Z] - YYYY-MM-DD` section.
+- **`pyproject.toml` `version`** — the machine record. It must equal the latest released
+  version at all times.
+- **An annotated git tag `vX.Y.Z`** — the immutable marker. The tag and the two files above
+  always agree.
+
+## Decide the version bump
+
+Read the Unreleased notes and pick the largest applicable step. This project follows
+[Semantic Versioning](https://semver.org/), read for a data-and-schema repo:
+
+| Bump | When | Examples in this repo |
+|------|------|-----------------------|
+| **MAJOR** (`X`) | A breaking change to a published contract — anything a downstream consumer (e.g. `aipotluck.org`) must adapt to. | Renaming or removing a schema field; changing a slug convention; restructuring an openness/adoption/capability axis (a `migrate-axis` run); removing a category. |
+| **MINOR** (`Y`) | A backward-compatible addition. | New products, categories, or data sources; a new optional schema field; a new skill or workflow. |
+| **PATCH** (`Z`) | A correction that changes no structure. | Score-value corrections; prose or doc fixes; evidence refreshes; build-helper bug fixes. |
+
+If the Unreleased section is empty, there is nothing to release — stop. Before `1.0.0`, a
+MAJOR-worthy change bumps the MINOR instead (`0.y` may break); say so in the changelog.
+
+## Steps
+
+1. **Confirm a clean tree on `main`.** `git status` is clean and `git pull` is current. Cut
+   releases from `main` so the tag matches the published history.
+2. **Choose the version** with the table above. Call it `X.Y.Z`.
+3. **Freeze the changelog.** In `CHANGELOG.md`:
+   - Rename `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD` (today's date, ISO 8601).
+   - Drop any now-empty subsections (keep only the headings that have entries).
+   - Add a fresh, empty `## [Unreleased]` above it.
+   - Update the link definitions at the bottom:
+     ```
+     [unreleased]: https://github.com/currentai-org/os-ai-map/compare/vX.Y.Z...HEAD
+     [X.Y.Z]: https://github.com/currentai-org/os-ai-map/releases/tag/vX.Y.Z
+     ```
+     (On the first release only, replace the seed `[unreleased]: .../commits/main` line.)
+4. **Bump the version.** Set `version = "X.Y.Z"` in `pyproject.toml`. It must match the tag.
+5. **Commit** the changelog and version bump together:
+   ```bash
+   git commit -am "chore(release): v X.Y.Z"   # write the version without the space
+   ```
+6. **Tag**, annotated, with the changelog section as the message body:
+   ```bash
+   git tag -a vX.Y.Z -m "vX.Y.Z"
+   ```
+7. **Push the branch and the tag:**
+   ```bash
+   git push -u origin <branch> && git push origin vX.Y.Z
+   ```
+8. **(Optional) GitHub Release.** Create a release from tag `vX.Y.Z`, pasting that version's
+   changelog section as the body. Use the GitHub MCP tools; do not invent release notes —
+   copy the changelog verbatim.
+
+## Rules
+
+- **The three records agree.** Tag `vX.Y.Z`, `pyproject.toml` version, and the newest
+  `CHANGELOG.md` heading are always the same string. A mismatch is a release bug.
+- **Never edit a released section.** Once `## [X.Y.Z]` is dated and tagged, it is history.
+  Corrections go in a new release.
+- **Tags are immutable.** Never move or delete a pushed tag. A mistake is fixed forward with
+  the next PATCH.
+- **One line per change, in plain English.** Past tense, user-facing effect first, PR linked.
+  No AI tells, American English (per `CLAUDE.md`).
+- **Do not commit** `build/notebook_data.json` or `notebooks/` — the bot owns them, and CI
+  blocks hand edits.
+
+## Validation
+
+```bash
+# The three records must name the same version:
+grep '^version' pyproject.toml
+grep -m1 '^## \[' CHANGELOG.md
+git describe --tags --abbrev=0        # after tagging
+
+# The changelog parses as Keep a Changelog (Unreleased present, headings well-formed):
+grep -q '^## \[Unreleased\]' CHANGELOG.md && echo "Unreleased section present"
+```

--- a/skills/registry.yaml
+++ b/skills/registry.yaml
@@ -25,3 +25,4 @@ advanced:
 internal:
   - add-data-source
   - pyoso-analyst
+  - publish-release

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -1,0 +1,89 @@
+"""Release-metadata gate: the version records must agree, or a release lies about itself.
+
+A release states its version in more than one place, and every one of them is easy to bump
+in isolation. When they drift, nothing downstream errors — the wrong number just ships,
+which is precisely the metadata drift the `publish-release` skill exists to prevent. This
+test makes the agreement a gate instead of a hope.
+
+Four records name a release's version. Three live in the tree and are checked on every PR:
+
+  1. ``pyproject.toml``            -> ``[project].version``
+  2. ``uv.lock``                   -> the root package (``source = { virtual = "." }``)
+  3. ``CHANGELOG.md``              -> the newest DATED heading (``## [X.Y.Z] - DATE``),
+                                      skipping the undated ``## [Unreleased]`` section
+
+The fourth is the annotated git tag ``vX.Y.Z``. It only exists once a release is cut, so it
+is checked only when a tag context is present (a tag-triggered CI run, or a maintainer
+exporting ``RELEASE_TAG`` locally) — see ``test_git_tag_matches_when_in_tag_context``.
+"""
+
+import os
+import re
+import tomllib
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+SEMVER = r"\d+\.\d+\.\d+"
+
+
+def _pyproject_version() -> str:
+    data = tomllib.loads((REPO / "pyproject.toml").read_text(encoding="utf-8"))
+    return data["project"]["version"]
+
+
+def _uv_lock_root_version() -> str:
+    """The version of THIS package in uv.lock — the entry whose source is the repo itself."""
+    data = tomllib.loads((REPO / "uv.lock").read_text(encoding="utf-8"))
+    roots = [
+        p for p in data.get("package", [])
+        if isinstance(p.get("source"), dict) and p["source"].get("virtual") == "."
+    ]
+    assert len(roots) == 1, f"expected exactly one root package in uv.lock, found {len(roots)}"
+    return roots[0]["version"]
+
+
+def _changelog_newest_dated_version() -> str:
+    """The newest ``## [X.Y.Z] - YYYY-MM-DD`` heading, ignoring ``## [Unreleased]``."""
+    text = (REPO / "CHANGELOG.md").read_text(encoding="utf-8")
+    m = re.search(rf"^## \[({SEMVER})\]\s+-\s+\d{{4}}-\d{{2}}-\d{{2}}\s*$", text, re.M)
+    assert m, "CHANGELOG.md has no dated `## [X.Y.Z] - YYYY-MM-DD` release heading"
+    return m.group(1)
+
+
+def test_version_records_agree():
+    """pyproject.toml, uv.lock root package, and the newest dated changelog entry match."""
+    records = {
+        "pyproject.toml": _pyproject_version(),
+        "uv.lock (root package)": _uv_lock_root_version(),
+        "CHANGELOG.md (newest dated)": _changelog_newest_dated_version(),
+    }
+    distinct = set(records.values())
+    assert len(distinct) == 1, "version records disagree:\n" + "\n".join(
+        f"  {name}: {value}" for name, value in records.items()
+    )
+
+
+def test_changelog_has_unreleased_section():
+    """Keep a Changelog keeps a live `## [Unreleased]` section for the next change to land in."""
+    text = (REPO / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert re.search(r"^## \[Unreleased\]\s*$", text, re.M), (
+        "CHANGELOG.md is missing its `## [Unreleased]` section"
+    )
+
+
+def test_git_tag_matches_when_in_tag_context():
+    """On a tag-triggered run, the tag must be `v<the agreed version>`.
+
+    The tag is read from ``RELEASE_TAG`` or GitHub's ``GITHUB_REF_NAME`` (only meaningful when
+    ``GITHUB_REF_TYPE`` is ``tag``). Outside a tag context the check is skipped — the three
+    in-tree records above still gate every PR.
+    """
+    tag = os.environ.get("RELEASE_TAG")
+    if not tag and os.environ.get("GITHUB_REF_TYPE") == "tag":
+        tag = os.environ.get("GITHUB_REF_NAME")
+    if not tag:
+        return  # no tag context; nothing to assert
+    assert tag == f"v{_pyproject_version()}", (
+        f"tag {tag!r} does not match the release version v{_pyproject_version()}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -997,7 +997,7 @@ wheels = [
 
 [[package]]
 name = "os-ai-map"
-version = "0.1.0"
+version = "0.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "datasets" },


### PR DESCRIPTION
## What

Adds a `publish-release` skill and a `CHANGELOG.md`, establishing a versioned release
process for the repository based on [Keep a Changelog](https://keepachangelog.com/) and
[Semantic Versioning](https://semver.org/), and records the project history to date as two
releases.

**The skill** (`skills/publish-release/SKILL.md`, classified `internal`/maintainer): decides
the version bump using a SemVer mapping read for a data-and-schema repo, freezes the
changelog's `Unreleased` notes into a dated release, keeps `pyproject.toml` and the git tag
in agreement, and pushes. It explicitly does *not* publish the notebook or warehouse models —
those stay in `docs/operations/`.

**The changelog** records two releases:
- `0.1.0` — the pre-July baseline corpus (458 products, 15 categories, 249 organizations).
- `0.2.0` — the July–August work: the evidence-based scoring pipeline, the whole-corpus
  re-verification, and growth to 472 products across 16 categories. Described by counts
  rather than product names.

`pyproject.toml` is bumped to `0.2.0` to match the newest changelog heading. Wiring: the skill
is registered as `internal` in `skills/registry.yaml`, symlinked into `.claude/skills/`, and
listed in the `AGENTS.md` and `docs/README.md` internal-skill rosters.

No `sources/` files are touched — this is skill, changelog, and docs only.

### Follow-up (maintainer, after merge)

Tag pushes are out of this session's scope, so the tags are cut from `main` on merge:

```bash
git tag -a v0.1.0 2e9d6eb -m "v0.1.0 — initial baseline corpus"   # pre-July baseline commit
git tag -a v0.2.0 -m "v0.2.0"                                      # on the merged main tip
git push origin v0.1.0 v0.2.0
```

## Checklist

- [x] `uv run python -m build.validate` prints `0 error(s)`
- [x] New/changed scores cite sources (`url`, `shows`, `accessed`) — n/a, no score changes
- [x] I did not edit `build/notebook_data.json` or `notebooks/ai-stack-map.py`
      (a bot regenerates them on merge)
- [x] Product appears in exactly one category roster and one org roster — n/a, no product changes

---
_Generated by [Claude Code](https://claude.ai/code/session_011VDh5ah5tVreAnc177Qm62)_