### PR TITLE
Stamp the payload with the release version and its date

### DIFF
--- a/build/serialize.py
+++ b/build/serialize.py
@@ -2,12 +2,13 @@
 
 Reproduces the exact structure the live notebook consumes:
   { descriptions, layer_order[], categories: {cid: {label, arc, layer, products[]}},
-    order[], n_total, generated, long_tail }
+    order[], n_total, generated, version, released, long_tail }
 """
 from datetime import date
 from pathlib import Path
 import json
 import re
+import tomllib
 import yaml
 
 from build.check_rubric import components_string
@@ -303,10 +304,44 @@ def _aliases(prods: dict, orgs: dict) -> dict:
     }
 
 
+def repo_version(root: Path | None = None) -> str:
+    """The release version this payload was built from, read from ``pyproject.toml``.
+
+    Consumers show it as the map's version, so it has to be the same string the release
+    carries. ``pyproject.toml`` is one of the records ``tests/test_release_metadata.py``
+    holds in agreement with the changelog and the git tag, so reading it here means the
+    payload cannot name a version the repo never released.
+    """
+    data = tomllib.loads(((root or ROOT) / "pyproject.toml").read_text(encoding="utf-8"))
+    return data["project"]["version"]
+
+
+def release_date(version: str, root: Path | None = None) -> str:
+    """The date ``version`` was released, from its dated heading in ``CHANGELOG.md``.
+
+    This is the date the release was cut, which is not the date the payload was built —
+    a rebuild between releases keeps the release date and moves ``generated``. Looking the
+    date up *by version* rather than taking the newest heading means a payload can never
+    pair one release's number with another's date; a version with no dated heading is an
+    error rather than a silent fallback.
+    """
+    text = ((root or ROOT) / "CHANGELOG.md").read_text(encoding="utf-8")
+    m = re.search(rf"^## \[{re.escape(version)}\]\s+-\s+(\d{{4}}-\d{{2}}-\d{{2}})\s*$",
+                  text, re.M)
+    if not m:
+        raise ValueError(f"CHANGELOG.md has no dated heading for release {version}")
+    return m.group(1)
+
+
 def build_payload(sources: dict, frozen_long_tail: dict, generated: str | None = None,
-                  freshness: dict | None = None) -> dict:
+                  freshness: dict | None = None, version: str | None = None,
+                  released: str | None = None) -> dict:
     if generated is None:
         generated = date.today().isoformat()
+    if version is None:
+        version = repo_version()
+    if released is None:
+        released = release_date(version)
     orgs, cats, prods, scores = (sources["organizations"], sources["categories"],
                                  sources["products"], sources["scores"])
     taxonomy = sources["taxonomy"]
@@ -374,6 +409,7 @@ def build_payload(sources: dict, frozen_long_tail: dict, generated: str | None =
             "organizations": _organizations(orgs, product_org),
             "aliases": _aliases(prods, orgs),
             "n_total": n, "generated": generated,
+            "version": version, "released": released,
             "long_tail": _filter_long_tail(frozen_long_tail, prods)}
 
 
@@ -384,10 +420,17 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--date", default=None,
                         help="value for the payload 'generated' field (default: today)")
+    parser.add_argument("--version", default=None,
+                        help="value for the payload 'version' field (default: pyproject.toml)")
+    parser.add_argument("--released", default=None,
+                        help="value for the payload 'released' field (default: CHANGELOG.md)")
     args = parser.parse_args()
     sources = load_sources(ROOT)
     frozen = json.load(open(ROOT / "sources" / "snapshots" / "long_tail.json"))
     payload = build_payload(sources, frozen, generated=args.date,
-                            freshness=resolve_freshness(ROOT))
+                            freshness=resolve_freshness(ROOT), version=args.version,
+                            released=args.released)
     (ROOT / "build" / "notebook_data.json").write_text(json.dumps(payload, indent=2, ensure_ascii=False))
-    print(f"wrote build/notebook_data.json ({payload['n_total']} products)")
+    print(f"wrote build/notebook_data.json "
+          f"({payload['n_total']} products, v{payload['version']} "
+          f"released {payload['released']}, built {payload['generated']})")

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1,4 +1,7 @@
-from build.serialize import build_payload, _stage_and_gaps
+import pytest
+
+from build.serialize import (build_payload, release_date, repo_version,
+                             _stage_and_gaps)
 
 
 def _p(cls, adoption, capability):
@@ -348,3 +351,58 @@ def test_a_product_with_no_aliases_contributes_nothing():
     """Most products carry none. The gather must not invent an empty entry for them."""
     payload = build_payload(_sources(), frozen_long_tail={}, generated="2026-01-01")
     assert payload["aliases"] == {"products": {}, "organizations": {}}
+
+
+# --- Payload version -------------------------------------------------------
+# The map surfaces this string as "which release am I looking at", so it has to be the
+# version the repo actually released, not a number that can be set independently here.
+
+def test_payload_carries_an_explicit_version():
+    payload = build_payload(_sources(), frozen_long_tail={}, generated="2026-06-10",
+                            version="1.2.3", released="2026-01-02")
+    assert payload["version"] == "1.2.3"
+
+
+def test_an_unreleased_version_is_rejected_rather_than_dated_from_elsewhere():
+    """Naming a version with no changelog entry fails instead of borrowing a date."""
+    with pytest.raises(ValueError, match="1.2.3"):
+        build_payload(_sources(), frozen_long_tail={}, generated="2026-06-10",
+                      version="1.2.3")
+
+
+def test_payload_version_defaults_to_the_release_version():
+    """Left unset, the payload names the same version pyproject.toml does."""
+    payload = build_payload(_sources(), frozen_long_tail={}, generated="2026-06-10")
+    assert payload["version"] == repo_version()
+
+
+def test_repo_version_agrees_with_the_newest_dated_changelog_entry():
+    """The payload's default cannot name a version the changelog never released."""
+    from tests.test_release_metadata import _changelog_newest_dated_version
+    assert repo_version() == _changelog_newest_dated_version()
+
+
+def test_payload_carries_an_explicit_release_date():
+    payload = build_payload(_sources(), frozen_long_tail={}, generated="2026-06-10",
+                            version="1.2.3", released="2026-01-02")
+    assert payload["released"] == "2026-01-02"
+
+
+def test_release_date_is_looked_up_by_version(tmp_path):
+    """The date comes from that version's own heading, not the newest one."""
+    (tmp_path / "CHANGELOG.md").write_text(
+        "## [Unreleased]\n\n## [0.3.0] - 2026-09-01\n\n## [0.2.0] - 2026-08-16\n")
+    assert release_date("0.2.0", root=tmp_path) == "2026-08-16"
+    assert release_date("0.3.0", root=tmp_path) == "2026-09-01"
+
+
+def test_release_date_rejects_a_version_with_no_dated_heading(tmp_path):
+    """An unreleased version is an error here, not a silent fallback to another date."""
+    (tmp_path / "CHANGELOG.md").write_text("## [Unreleased]\n\n## [0.2.0] - 2026-08-16\n")
+    with pytest.raises(ValueError, match="0.9.9"):
+        release_date("0.9.9", root=tmp_path)
+
+
+def test_payload_release_date_defaults_to_the_changelog_date():
+    payload = build_payload(_sources(), frozen_long_tail={}, generated="2026-06-10")
+    assert payload["released"] == release_date(repo_version())


### PR DESCRIPTION
## What

The gap map page shows a version number, but it is static and not tied to anything. Bob asked
in `#build-updates` for a real version in the JSON so the front end can pull it.

`build/notebook_data.json` now carries two new top-level fields next to the existing
`generated` build date:

- `version` — `0.2.0`, read from `pyproject.toml`
- `released` — `2026-08-16`, the date that version was cut

Three dates now mean three different things, which is the point: `generated` is when the
payload was built, `released` is when the release it belongs to was cut, and a product's
`freshness.date` is when its score was last confirmed.

## Why it reads them where it does

`version` comes from `pyproject.toml` because that is already one of the records
`tests/test_release_metadata.py` holds in agreement with the changelog and the git tag. The
payload therefore cannot name a version the repo never released.

`released` is looked up *by that version* in `CHANGELOG.md`, not taken from the newest dated
heading. Taking the newest would let a payload pair one release's number with another's date
during the window between a version bump and its release. A version with no dated heading
raises instead of falling back to some other date.

Both are overridable from the CLI (`--version`, `--released`) for the same reason `--date`
already exists.

## Test plan

- `uv run pytest -q` — 641 passed
- `uv run python -m build.validate` — `0 error(s)`
- `uv run python -m build.serialize --date 2026-08-17` prints
  `wrote build/notebook_data.json (472 products, v0.2.0 released 2026-08-16, built 2026-08-17)`

New tests cover the explicit and defaulted values for both fields, lookup by version rather
than newest heading, and the unreleased-version error.

## Checklist

- [x] `uv run python -m build.validate` prints `0 error(s)`
- [x] New/changed scores cite sources (`url`, `shows`, `accessed`) — n/a, no score changes
- [x] I did not edit `build/notebook_data.json` or `notebooks/ai-stack-map.py`
      (a bot regenerates them on merge)
- [x] Product appears in exactly one category roster and one org roster — n/a, no product changes