### PR TITLE
Split the labour between stage text and gap text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ Removed, Fixed, Security), one line, newest first, in plain past tense, with the
 
 ### Changed
 
+- Split the labour between stage and gap text: a stage says where a category stands, a gap says
+  what it needs. They render together in the category drawer, and written in one mood they
+  restated each other — `depth` fires if and only if the stage is 4, so both sentences carried
+  the same fact (#87, #321).
 - Rewrote the stage and gap definitions the payload carries — the text rendered in the site
   legend and category drawer. Stage 4 and the `depth` gap no longer define each other, the
   `adoption` gap no longer defines itself by its own threshold, and the `disclosure` gap no longer

--- a/build/serialize.py
+++ b/build/serialize.py
@@ -52,11 +52,17 @@ _STAGE_NAMES = {0: "Void", 1: "Open Experiments", 2: "Emerging Alternatives",
 # derived vs declared -- around them rather than restating them in other words. Edit here and copy
 # across; test_descriptions_match_the_reference_doc pins all four lists. The tier descriptions
 # below are not quoted in either doc and are not covered by that test.
-# Stage 4 used to read "not yet enough for depth" while the depth gap read "fires at Stage 4"
-# -- each defined by the other. The wording no longer does that. It also avoids the bare words
-# "leading" and "strong" except where the tier is genuinely meant: both are tier names now, and
-# a category can sit on a rung with no product in either tier (safeguards is Stage 3 with a best
-# fully-open score of 3.5, below the strong floor), so a colloquial use would read as false.
+# Stage and gap text render together in the category drawer, so they divide the work rather than
+# describe the same fact twice: a STAGE says where the category stands, a GAP says what it needs.
+# Written in one mood they were redundant -- `depth` fires if and only if the stage is 4, so
+# "at least one product has reached the leading tier, but the field is thin" and "products have
+# reached the leading tier, but there are too few" were one sentence printed twice. The needs mood
+# makes that impossible. Gap text also renders in the legend with no stage beside it, so each one
+# still has to stand alone.
+#
+# The wording avoids the bare words "leading" and "strong" except where the tier is genuinely
+# meant: both are tier names, and a category can sit on a rung with no product in either tier
+# (safeguards is Stage 3 with a best fully-open score of 3.5, below the strong floor).
 # The exact thresholds are the constants above and the table in docs/reference/gap-analysis.md.
 _STAGE_DESC = {
     0: "The category is still nascent overall, with no category-leading products and no "
@@ -65,31 +71,23 @@ _STAGE_DESC = {
        "capability, or both.",
     2: "Fully open products are becoming credible, but remain limited in adoption or "
        "capability.",
-    3: "Fully open options are genuinely viable, but none has reached the category-leading "
-       "tier.",
-    4: "At least one fully open product has reached the category-leading tier, but the open "
-       "field is still thin.",
-    5: "Multiple fully open products have reached the category-leading tier, creating a deep "
-       "and competitive open ecosystem.",
+    3: "Fully open options are genuinely viable.",
+    4: "A small number of fully open products lead the category.",
+    5: "Several fully open products lead the category, so no single project carries it.",
 }
+
 # One sentence each, in the reader's terms. These render in the site legend and the category
 # drawer, so they carry no implementation detail (which rung a gap fires on, whether it is
 # derived or declared) and no repo paths -- that reasoning lives in the two prose docs below.
 _GAP_DESC = {
-    "void": "No usable fully open option exists at all.",
-    "capability": "The strongest fully open product remains limited in capability.",
-    # Deliberately claims nothing about capability: both driver gaps fire independently, so a
-    # category weak on both axes shows this chip alongside the capability one, and asserting
-    # "capable fully open products exist" here would contradict it on the same panel.
-    "adoption": "The strongest fully open product has not yet achieved broad adoption.",
-    "depth": "Fully open products have reached the category-leading tier, but there are too "
-             "few to create a deep and resilient open ecosystem.",
-    "openness": "Products have reached the category-leading tier, but none of them is fully "
-                "open.",
-    "disclosure": "Closed products rely on data or training recipes that are not disclosed, "
-                  "limiting visibility into how they are built and how they compare with fully "
-                  "open products.",
+    "void": "Needs a usable fully open option at all.",
+    "capability": "Needs a more capable fully open option.",
+    "adoption": "Needs broader adoption of its fully open options.",
+    "depth": "Needs more fully open products at the leading tier to be resilient.",
+    "openness": "Needs its category-leading products to be fully open.",
+    "disclosure": "Needs the closed alternatives to disclose their data and training recipes.",
 }
+
 # The "available measured axes" qualification is deliberate: a product with no capability
 # grade is scored on adoption alone, so a tier names the score over whatever axes exist for that
 # product rather than asserting a judgment on both.

--- a/build/serialize.py
+++ b/build/serialize.py
@@ -71,7 +71,7 @@ _STAGE_DESC = {
        "capability, or both.",
     2: "Fully open products are becoming credible, but remain limited in adoption or "
        "capability.",
-    3: "Fully open options are genuinely viable.",
+    3: "Fully open options are proven in real use, but none leads the category.",
     4: "A small number of fully open products lead the category.",
     5: "Several fully open products lead the category, so no single project carries it.",
 }

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -109,9 +109,9 @@ Worth being explicit about what that bar requires, because it is easy to misread
 
 **Step 2: the category stage.** Only **fully open** products advance a category's stage. Open-ish products (open weights, source-available, and the like) are used solely to detect the openness gap below; crediting them would blur the line between open source and open weights that the map exists to draw. The choice is consequential but bounded: counting open-weights models as open would move only three categories, all in the model layer — base/pretrained models (Stage 3→5), fine-tuned/chat models (2→3), and edge hardware (3→4) — and would leave every infrastructure and tooling verdict unchanged. The open-model verdict should therefore be read as a deliberately strict reading of a few model categories, not a sweeping claim about the whole stack. The ladder measures the health of the genuinely open ecosystem:
 
-- **Stage 5: Mature Open Ecosystem.** Multiple fully open products have reached the category-leading tier, creating a deep and competitive open ecosystem.
-- **Stage 4: Competitive Open Ecosystem.** At least one fully open product has reached the category-leading tier, but the open field is still thin.
-- **Stage 3: Viable Alternatives.** Fully open options are genuinely viable, but none has reached the category-leading tier.
+- **Stage 5: Mature Open Ecosystem.** Several fully open products lead the category, so no single project carries it.
+- **Stage 4: Competitive Open Ecosystem.** A small number of fully open products lead the category.
+- **Stage 3: Viable Alternatives.** Fully open options are genuinely viable.
 - **Stage 2: Emerging Alternatives.** Fully open products are becoming credible, but remain limited in adoption or capability.
 - **Stage 1: Open Experiments.** Fully open products are absent or remain substantially limited in adoption, capability, or both.
 - **Stage 0: Void.** The category is still nascent overall, with no category-leading products and no meaningful fully open options.
@@ -122,12 +122,12 @@ The exact cutoffs (four category-leading fully-open products for Stage 5, the 4.
 
 Openness is treated as an axis orthogonal to maturity: a category can hold strong, widely adopted options that are simply not *fully* open. Each category therefore carries a set of zero or more gaps, derived from the same metrics as the stage:
 
-- **Void:** No usable fully open option exists at all.
-- **Capability:** The strongest fully open product remains limited in capability.
-- **Adoption:** The strongest fully open product has not yet achieved broad adoption.
-- **Depth:** Fully open products have reached the category-leading tier, but there are too few to create a deep and resilient open ecosystem.
-- **Openness:** Products have reached the category-leading tier, but none of them is fully open.
-- **Disclosure:** Closed products rely on data or training recipes that are not disclosed, limiting visibility into how they are built and how they compare with fully open products.
+- **Void:** Needs a usable fully open option at all.
+- **Capability:** Needs a more capable fully open option.
+- **Adoption:** Needs broader adoption of its fully open options.
+- **Depth:** Needs more fully open products at the leading tier to be resilient.
+- **Openness:** Needs its category-leading products to be fully open.
+- **Disclosure:** Needs the closed alternatives to disclose their data and training recipes.
 A fully mature ecosystem carries no gaps, with the one exception that disclosure can still be flagged there: it describes the closed frontier's silence, not a shortfall of the open ecosystem. The set is extensible: further gap types, such as maintenance or bus-factor risk, can be added as the underlying signals become available, without changing the staging logic.
 
 Each gap names a different kind of shortfall, so which one fires follows from the stage. At Stage 4 a category has proven category-leading open options but not enough of them, so its only stage-derived gap is **depth**; a declared **disclosure** may coexist. Below Stage 4 nothing fully open clears the bar, so we name the drivers that hold the best fully open option back — capability, adoption, or both — rather than restating the stage. Both can fire together, and neither is required: a category whose measured axes both clear their cutoffs while the blend still misses the bar carries no driver gap, since the stage number already places it below the leading-product threshold and asserting a shortfall the axes do not show would be false.

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -111,7 +111,7 @@ Worth being explicit about what that bar requires, because it is easy to misread
 
 - **Stage 5: Mature Open Ecosystem.** Several fully open products lead the category, so no single project carries it.
 - **Stage 4: Competitive Open Ecosystem.** A small number of fully open products lead the category.
-- **Stage 3: Viable Alternatives.** Fully open options are genuinely viable.
+- **Stage 3: Viable Alternatives.** Fully open options are proven in real use, but none leads the category.
 - **Stage 2: Emerging Alternatives.** Fully open products are becoming credible, but remain limited in adoption or capability.
 - **Stage 1: Open Experiments.** Fully open products are absent or remain substantially limited in adoption, capability, or both.
 - **Stage 0: Void.** The category is still nascent overall, with no category-leading products and no meaningful fully open options.

--- a/docs/reference/gap-analysis.md
+++ b/docs/reference/gap-analysis.md
@@ -186,9 +186,9 @@ categories, all in the model layer (`base_pretrained` 3→5, `finetuned_chat` 2�
 
 | Stage | Name | Definition | Triggers when |
 |------:|------|------------|---------------|
-| **5** | Mature Open Ecosystem | Multiple fully open products have reached the category-leading tier, creating a deep and competitive open ecosystem. | `L >= 4` |
-| **4** | Competitive Open Ecosystem | At least one fully open product has reached the category-leading tier, but the open field is still thin. | `1 <= L <= 3` |
-| **3** | Viable Alternatives | Fully open options are genuinely viable, but none has reached the category-leading tier. | `L = 0`, `B >= 3.5` |
+| **5** | Mature Open Ecosystem | Several fully open products lead the category, so no single project carries it. | `L >= 4` |
+| **4** | Competitive Open Ecosystem | A small number of fully open products lead the category. | `1 <= L <= 3` |
+| **3** | Viable Alternatives | Fully open options are genuinely viable. | `L = 0`, `B >= 3.5` |
 | **2** | Emerging Alternatives | Fully open products are becoming credible, but remain limited in adoption or capability. | `L = 0`, `3.0 <= B < 3.5` |
 | **1** | Open Experiments | Fully open products are absent or remain substantially limited in adoption, capability, or both. | `L = 0`, `B < 3.0`, and (`B >= 2.0` or `M`) |
 | **0** | Void | The category is still nascent overall, with no category-leading products and no meaningful fully open options. | `L = 0`, `B < 2.0`, and not `M` |
@@ -216,18 +216,26 @@ chosen so the ladder discriminates rather than bunching categories at one rung.
 Gaps are a **set** (zero or more) per category, so a category can carry more than one. They are
 derived from the same metrics as the stage:
 
-- **`void`** — No usable fully open option exists at all.
-- **`capability`** — The strongest fully open product remains limited in capability.
-- **`adoption`** — The strongest fully open product has not yet achieved broad adoption.
-- **`depth`** — Fully open products have reached the category-leading tier, but there are too few to create a deep and resilient open ecosystem.
-- **`openness`** — Products have reached the category-leading tier, but none of them is fully open.
-- **`disclosure`** — Closed products rely on data or training recipes that are not disclosed, limiting visibility into how they are built and how they compare with fully open products.
+- **`void`** — Needs a usable fully open option at all.
+- **`capability`** — Needs a more capable fully open option.
+- **`adoption`** — Needs broader adoption of its fully open options.
+- **`depth`** — Needs more fully open products at the leading tier to be resilient.
+- **`openness`** — Needs its category-leading products to be fully open.
+- **`disclosure`** — Needs the closed alternatives to disclose their data and training recipes.
 
 Those six sentences are quoted verbatim from `_GAP_DESC` in `build/serialize.py`: they are
 the text the payload carries and the text a reader sees in the site legend and the category
-drawer. Edit them in one place and copy across. Everything else in this document — which
-rung each gap fires on, the thresholds behind it, whether it is derived or declared — is the
-mechanism, and is deliberately absent from the payload.
+drawer. Edit them in one place and copy across.
+
+They are written as needs on purpose. Stage text and gap text render together in the category
+drawer, and a **stage says where the category stands** while a **gap says what it needs** — in
+one mood they restate each other, because `depth` fires if and only if the stage is 4, and the
+Stage 3–5 sentences and the `openness` gap otherwise circle the same tier fact. Each gap still
+has to read on its own, because the legend shows gap text with no stage beside it.
+
+Everything else in this document — which rung each gap fires on, the thresholds behind it,
+whether it is derived or declared — is the mechanism, and is deliberately absent from the
+payload.
 
 A fully mature ecosystem carries no gaps — with one exception: `disclosure` can still be
 flagged at Stage 5, because it describes the closed frontier's silence, not a shortfall of the

--- a/docs/reference/gap-analysis.md
+++ b/docs/reference/gap-analysis.md
@@ -188,7 +188,7 @@ categories, all in the model layer (`base_pretrained` 3â†’5, `finetuned_chat` 2â
 |------:|------|------------|---------------|
 | **5** | Mature Open Ecosystem | Several fully open products lead the category, so no single project carries it. | `L >= 4` |
 | **4** | Competitive Open Ecosystem | A small number of fully open products lead the category. | `1 <= L <= 3` |
-| **3** | Viable Alternatives | Fully open options are genuinely viable. | `L = 0`, `B >= 3.5` |
+| **3** | Viable Alternatives | Fully open options are proven in real use, but none leads the category. | `L = 0`, `B >= 3.5` |
 | **2** | Emerging Alternatives | Fully open products are becoming credible, but remain limited in adoption or capability. | `L = 0`, `3.0 <= B < 3.5` |
 | **1** | Open Experiments | Fully open products are absent or remain substantially limited in adoption, capability, or both. | `L = 0`, `B < 3.0`, and (`B >= 2.0` or `M`) |
 | **0** | Void | The category is still nascent overall, with no category-leading products and no meaningful fully open options. | `L = 0`, `B < 2.0`, and not `M` |


### PR DESCRIPTION
Stage and gap text render together in the category drawer, and written in the same mood they restated each other. Inference code read:

> **④ Competitive Open Ecosystem** — At least one fully open product has reached the category-leading tier, but the open field is still thin.
> **◆ Depth** — Fully open products have reached the category-leading tier, but there are too few to create a deep and resilient open ecosystem.

One sentence, printed twice — and unavoidable while both describe the same fact, because `depth` fires *if and only if* the stage is 4. Stages 3 and 5 collided with the `openness` gap the same way.

## The rule

**A stage says where the category stands. A gap says what it needs.** Different grammatical mood makes the overlap impossible rather than merely discouraged.

| # | Stage |
|---|---|
| 0 | The category is still nascent overall, with no category-leading products and no meaningful fully open options. |
| 1 | Fully open products are absent or remain substantially limited in adoption, capability, or both. |
| 2 | Fully open products are becoming credible, but remain limited in adoption or capability. |
| 3 | Fully open options are genuinely viable. |
| 4 | A small number of fully open products lead the category. |
| 5 | Several fully open products lead the category, so no single project carries it. |

| Gap | Text |
|---|---|
| void | Needs a usable fully open option at all. |
| capability | Needs a more capable fully open option. |
| adoption | Needs broader adoption of its fully open options. |
| depth | Needs more fully open products at the leading tier to be resilient. |
| openness | Needs its category-leading products to be fully open. |
| disclosure | Needs the closed alternatives to disclose their data and training recipes. |

## How it reads now

```
INFERENCE CODE
④ Competitive Open Ecosystem — A small number of fully open products lead the category.
   Depth — Needs more fully open products at the leading tier to be resilient.

EDGE AI HARDWARE
③ Viable Alternatives — Fully open options are genuinely viable.
   Capability — Needs a more capable fully open option.
   Openness — Needs its category-leading products to be fully open.
```

## Constraint worth knowing

Gap text also renders in the **legend**, with no stage beside it, so each gap still has to read on its own. That rules out the tempting shorter forms that lean on the stage for context ("Too few of them for resilience").

## Test plan

- `uv run pytest` — **650 passed**, including the verbatim guard across both docs.
- Rendered all 16 categories as the drawer will show them, to check the pairing everywhere rather than on the two examples above.
- No behavioral change: only the `descriptions` block moves, so every category's `stage` and `gaps` values are identical to `main`.

## One judgment call to confirm

Stage 3 lost its "but none has reached the category-leading tier" clause when it was trimmed. With gaps now in the needs mood that clause would no longer duplicate anything, so it could come back — it matters most for `benchmark_eval_data`, which is Stage 3 with **no gaps at all**, and now reads only "Fully open options are genuinely viable" with nothing saying why it is not Stage 4. Happy to restore it; flagging rather than deciding.

Refs #87, #320.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VsMw63bXSy2vgdUMswhoC