### PR TITLE
Take the verification log out of the product copy

### DIFF
--- a/.claude/skills/clean-score-notes
+++ b/.claude/skills/clean-score-notes
@@ -1,0 +1,1 @@
+../../skills/clean-score-notes

--- a/docs/reference/evidence-and-freshness.md
+++ b/docs/reference/evidence-and-freshness.md
@@ -196,6 +196,56 @@ confirmation are different questions, and "never confirmed" is `build/sweep_stat
 `build/check_verification.py`'s. The report prints how many of its ages rest on the fallback so
 a pass can never quietly be resting on the weaker signal.
 
+## The note is not the log
+
+A score `note` says why the score is what it is. Between 2026-04 and 2026-08 the re-read passes
+appended their own narrative to it — "Re-read 2026-08-13 - the source still says X … No change."
+— until that text was 44% of all note prose, in 1,035 of 1,416 notes across 446 of 472 files.
+
+Every fact those clauses state is already a field on the same record:
+
+| The clause says | The field that holds it |
+|---|---|
+| when it was re-read | `last_verified` |
+| that a source was fetched | `sources[].accessed`, `sources[].http_status` |
+| that the source is unchanged | `sources[].content_sha256` |
+| what the source says | `sources[].shows` |
+
+And the product page already prints `Verified <date>` beneath the record, from `last_verified`.
+So the prose was not adding a fact; it was moving a structured one into the copy a visitor reads
+to understand a score, three times per product, once per axis.
+
+**The rule.** A note holds durable reasoning: what was assessed, against what, and why that lands
+on this rung. Anything whose truth depends on *when you read it* belongs in a field, not the note.
+A re-read that finds nothing changed leaves no trace in the note — that is what `last_verified`
+moving is for. A re-read that finds something changed edits the note to say the new durable thing,
+not to narrate the discovery.
+
+### Where the history lives
+
+Removing the narrative from the note does not discard it. **The scoring history is the git
+history of the score file**, which is complete, dated by commit, and maintained by the act of
+committing rather than by anyone remembering to append a paragraph:
+
+```bash
+git log -p --follow sources/scores/<slug>.yaml     # every pass, with what each one changed
+git log -L '/^  note:/,+20:sources/scores/<slug>.yaml'   # just one axis's note over time
+```
+
+An agent re-reading a product consults that before deciding a score has not moved. What it finds
+there is richer than the prose ever was: not only what a previous pass concluded, but the exact
+`content_sha256` it saw and the diff it produced.
+
+This is a deliberate choice against the alternative — a `verification_log` field carried in the
+score file and withheld from the payload. That would put the history where a file-reading agent
+trips over it, at the cost of duplicating what git already holds and obliging every future pass
+to maintain the copy. Duplicated history drifts; git's does not.
+
+The public payload publishes `note` and `sources` verbatim, so anything written into a note is
+published. That is the reason this boundary is a rule and not a style preference.
+
+Cleaning the corpus is `skills/clean-score-notes/SKILL.md`, and issue #322 carries the audit.
+
 ## Who may write `last_verified`
 
 **A person, and only a person.** No tool in this repo writes the field.

--- a/docs/schemas/score.schema.json
+++ b/docs/schemas/score.schema.json
@@ -47,7 +47,7 @@
             "documented",
             "closed"
           ],
-          "description": "The openness VOCABULARY: the band a reader sees, paired with `score`. Eleven values, one per rung any ladder can emit \u2014 the software, model, dataset and hardware ladders do not share a vocabulary, which is why this is longer than the five a single ladder uses. `docs/openness-class-map.json` maps each to a display label, a gradient and the three-way open / open-ish / closed bucket the payload carries. Until 2026-08-08 this was an unconstrained string and the vocabulary lived only in that map and in build/render.py."
+          "description": "The openness VOCABULARY: the band a reader sees, paired with `score`. Eleven values, one per rung any ladder can emit — the software, model, dataset and hardware ladders do not share a vocabulary, which is why this is longer than the five a single ladder uses. `docs/openness-class-map.json` maps each to a display label, a gradient and the three-way open / open-ish / closed bucket the payload carries. Until 2026-08-08 this was an unconstrained string and the vocabulary lived only in that map and in build/render.py."
         },
         "components": {
           "type": "object",
@@ -55,7 +55,9 @@
           "properties": {
             "free_text": {
               "type": "array",
-              "items": { "type": "string" },
+              "items": {
+                "type": "string"
+              },
               "minItems": 1
             }
           },
@@ -63,11 +65,19 @@
             "oneOf": [
               {
                 "type": "object",
-                "required": ["value"],
+                "required": [
+                  "value"
+                ],
                 "properties": {
-                  "value": { "type": "string" },
-                  "detail": { "type": "string" },
-                  "raw": { "type": "string" }
+                  "value": {
+                    "type": "string"
+                  },
+                  "detail": {
+                    "type": "string"
+                  },
+                  "raw": {
+                    "type": "string"
+                  }
                 },
                 "additionalProperties": false
               },
@@ -76,11 +86,19 @@
                 "minItems": 1,
                 "items": {
                   "type": "object",
-                  "required": ["name"],
+                  "required": [
+                    "name"
+                  ],
                   "properties": {
-                    "name": { "type": "string" },
-                    "detail": { "type": "string" },
-                    "raw": { "type": "string" }
+                    "name": {
+                      "type": "string"
+                    },
+                    "detail": {
+                      "type": "string"
+                    },
+                    "raw": {
+                      "type": "string"
+                    }
                   },
                   "additionalProperties": false
                 }
@@ -103,7 +121,7 @@
         },
         "note": {
           "type": "string",
-          "description": "Why these components add up to this rung, in a sentence or two of prose. Hand-written, parsed by nothing, rendered as `Why` in the product detail panel. It is the axis's escape valve and therefore its hazard: a judgment recorded only here cannot be checked, refreshed, or noticed when it goes stale. That is exactly what happened on capability, where the peer comparison placing roughly a hundred bands sat in the note until `relative_to` and `relation` pulled it out. So the reasoning belongs here and the facts belong in `components`. Prose in sources/products/<slug>.yaml must not restate what this note and the score already carry; docs/reference/product-copy.md, 'Scored fields', is normative on that."
+          "description": "Why these components add up to this rung, in a sentence or two of prose. Hand-written, parsed by nothing, rendered as `Why` in the product detail panel. It is the axis's escape valve and therefore its hazard: a judgment recorded only here cannot be checked, refreshed, or noticed when it goes stale. That is exactly what happened on capability, where the peer comparison placing roughly a hundred bands sat in the note until `relative_to` and `relation` pulled it out. So the reasoning belongs here and the facts belong in `components`. Prose in sources/products/<slug>.yaml must not restate what this note and the score already carry; docs/reference/product-copy.md, 'Scored fields', is normative on that. A note states why the score is what it is, in terms that stay true until the score changes. It is not the verification log: when it was last checked is `last_verified`, that a source was fetched is `sources[].accessed` and `http_status`, and that it is unchanged is `sources[].content_sha256`. A 'Re-read <date> - still says X. No change.' clause restates all three into the prose a visitor reads on the product page, which already renders `Verified <date>` of its own accord. See issue #322."
         },
         "sources": {
           "type": "array",
@@ -138,14 +156,14 @@
           ],
           "minimum": 1,
           "maximum": 5,
-          "description": "The adoption band, 1-5, and the axis's ONLY stored value. The human-readable range (`<10K` \u2026 `>10M`) is derived from it in build/serialize.py and emitted as `reach` in the payload, never recorded here: it is the same fact twice, and when it was stored 125 of 417 files contradicted their own level. Null where no usage figure exists to band \u2014 a hosted feature of a larger platform, or an internal eval suite. Null is an abstention, not a gap."
+          "description": "The adoption band, 1-5, and the axis's ONLY stored value. The human-readable range (`<10K` … `>10M`) is derived from it in build/serialize.py and emitted as `reach` in the payload, never recorded here: it is the same fact twice, and when it was stored 125 of 417 files contradicted their own level. Null where no usage figure exists to band — a hosted feature of a larger platform, or an internal eval suite. Null is an abstention, not a gap."
         },
         "reach": {
           "type": [
             "string",
             "null"
           ],
-          "description": "The band's human-readable label, and the UNIT it was read in. Not `level` restated: 20k stars and 20k downloads are not the same reach, so the same level maps to different labels depending on what was counted. The scale is a property of the product TYPE - software and model band package and hub downloads (`<10K` \u2026 `>10M`), dataset bands two orders lower (`<1k` \u2026 `>1M`) because fetching a corpus is rarer than installing a package, and hardware is qualitative (`niche` / `broad` / `mass-market`) because units shipped are not countable from an artifact. `sources/categories/base_pretrained.yaml` is the only category that declares its bands today, under `scoring_recipe.adoption.bands`; the other fifteen follow a convention that exists nowhere but in the agreement of their own files. Measured 2026-08-08 the corpus holds 34 distinct values, of which roughly eight are real bands and the rest are casing splits (`10k-100k` vs `10K-100K`) and free text (`~14.9k stars`, `50M+ total Docker pulls`) that belongs in `note`."
+          "description": "The band's human-readable label, and the UNIT it was read in. Not `level` restated: 20k stars and 20k downloads are not the same reach, so the same level maps to different labels depending on what was counted. The scale is a property of the product TYPE - software and model band package and hub downloads (`<10K` … `>10M`), dataset bands two orders lower (`<1k` … `>1M`) because fetching a corpus is rarer than installing a package, and hardware is qualitative (`niche` / `broad` / `mass-market`) because units shipped are not countable from an artifact. `sources/categories/base_pretrained.yaml` is the only category that declares its bands today, under `scoring_recipe.adoption.bands`; the other fifteen follow a convention that exists nowhere but in the agreement of their own files. Measured 2026-08-08 the corpus holds 34 distinct values, of which roughly eight are real bands and the rest are casing splits (`10k-100k` vs `10K-100K`) and free text (`~14.9k stars`, `50M+ total Docker pulls`) that belongs in `note`."
         },
         "signal_type": {
           "enum": [
@@ -158,8 +176,11 @@
           "description": "WHICH INSTRUMENT the band was read with. Capability's `basis` is the same concept under a different name and a different vocabulary, because the two axes were built at different times; openness's equivalent is the category's ladder, which is why openness carries no such field. `active_users` and `usage_volume` are measured figures, `reported_traction` is a vendor's or a tracker's claim rather than a count, `stars_fallback` is repository popularity standing in for usage, `unknown` is an abstention. The distinction is enforced rather than descriptive: build/validate.py rejects `stars_fallback` above level 3, because stars measure attention rather than use. Measured 2026-08-08: usage_volume 237, reported_traction 108, stars_fallback 84, active_users 23, unknown 20. Also the `Signal` row in the product detail panel."
         },
         "banded_quantity": {
-          "type": ["string", "null"],
-          "description": "What the level was actually read off, whenever that is not a current usage figure for this product. Absent means the level is a judgment about the product itself with no borrowed quantity behind it \u2014 `claude-opus` and `claude-fable` both record a market-position reading and cite no number at all, which is a real state rather than a gap. Four shapes recur: a parent platform's reach where the product is a feature inside something larger ('Replit platform registered users (50M+, March 2026), not an agent active count'); a real count of the product that is not a current active one (cumulative, all-time, lifetime, or weekly where the scale is written monthly); a proxy of a different kind entirely (revenue, funding, GitHub stars, research citations); and nothing at all, where the note cites a figure only to reject it. Mostly relevant to `reported_traction`, the instrument defined by having no count behind it and the one where the substitution is most common \u2014 measured 2026-08-15, 19 of its 109 records band on a parent platform and every one said so in prose a machine could not read. `active_users` had already solved this through the `attribution_note` on its route in sources/signal_routing.yaml; this is that rule given a field. tests/test_banded_quantity.py requires one wherever a `reported_traction` note cites a magnitude, because a number in the prose of an instrument that claims no count is exactly what a reader mistakes for a measurement of the product."
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "What the level was actually read off, whenever that is not a current usage figure for this product. Absent means the level is a judgment about the product itself with no borrowed quantity behind it — `claude-opus` and `claude-fable` both record a market-position reading and cite no number at all, which is a real state rather than a gap. Four shapes recur: a parent platform's reach where the product is a feature inside something larger ('Replit platform registered users (50M+, March 2026), not an agent active count'); a real count of the product that is not a current active one (cumulative, all-time, lifetime, or weekly where the scale is written monthly); a proxy of a different kind entirely (revenue, funding, GitHub stars, research citations); and nothing at all, where the note cites a figure only to reject it. Mostly relevant to `reported_traction`, the instrument defined by having no count behind it and the one where the substitution is most common — measured 2026-08-15, 19 of its 109 records band on a parent platform and every one said so in prose a machine could not read. `active_users` had already solved this through the `attribution_note` on its route in sources/signal_routing.yaml; this is that rule given a field. tests/test_banded_quantity.py requires one wherever a `reported_traction` note cites a magnitude, because a number in the prose of an instrument that claims no count is exactly what a reader mistakes for a measurement of the product."
         },
         "confidence": {
           "enum": [
@@ -171,7 +192,7 @@
         },
         "note": {
           "type": "string",
-          "description": "The prose behind the band: which figure was banded, from where, and what it excludes - 'the OLMo family measured ~14.8M cumulative HF downloads in early 2026; below the Qwen/Llama scale'. Hand-written, read by no tool, rendered as `Detail` in the product detail panel. Where `level` is null this is where the reason for abstaining belongs: 20 products carry no level because no standalone usage figure exists, mostly hosted features of a larger platform (Azure, Bedrock, Vertex, Together) and internal eval suites, and banding those off vendor prose would be inventing the number."
+          "description": "The prose behind the band: which figure was banded, from where, and what it excludes - 'the OLMo family measured ~14.8M cumulative HF downloads in early 2026; below the Qwen/Llama scale'. Hand-written, read by no tool, rendered as `Detail` in the product detail panel. Where `level` is null this is where the reason for abstaining belongs: 20 products carry no level because no standalone usage figure exists, mostly hosted features of a larger platform (Azure, Bedrock, Vertex, Together) and internal eval suites, and banding those off vendor prose would be inventing the number. A note states why the score is what it is, in terms that stay true until the score changes. It is not the verification log: when it was last checked is `last_verified`, that a source was fetched is `sources[].accessed` and `http_status`, and that it is unchanged is `sources[].content_sha256`. A 'Re-read <date> - still says X. No change.' clause restates all three into the prose a visitor reads on the product page, which already renders `Verified <date>` of its own accord. See issue #322."
         },
         "sources": {
           "type": "array",
@@ -232,7 +253,7 @@
         },
         "note": {
           "type": "string",
-          "description": "The prose behind the band: what the product does well, what it sits a step below, and against whom. Hand-written and parsed by nothing. This is where the axis's real instrument lived until 2026-08-08: roughly a hundred notes place the band against a named peer in the same category ('one tier below the Megatron-LM anchor'), and in `finetuning_code` every one of the 27 notes does it. `relative_to` and `relation` now record that comparison as data, on 27 products as of 2026-08-08, and `build/check_capability.py --candidates` reports the notes that look like they should carry it. Rendered as `Detail` in the product detail panel."
+          "description": "The prose behind the band: what the product does well, what it sits a step below, and against whom. Hand-written and parsed by nothing. This is where the axis's real instrument lived until 2026-08-08: roughly a hundred notes place the band against a named peer in the same category ('one tier below the Megatron-LM anchor'), and in `finetuning_code` every one of the 27 notes does it. `relative_to` and `relation` now record that comparison as data, on 27 products as of 2026-08-08, and `build/check_capability.py --candidates` reports the notes that look like they should carry it. Rendered as `Detail` in the product detail panel. A note states why the score is what it is, in terms that stay true until the score changes. It is not the verification log: when it was last checked is `last_verified`, that a source was fetched is `sources[].accessed` and `http_status`, and that it is unchanged is `sources[].content_sha256`. A 'Re-read <date> - still says X. No change.' clause restates all three into the prose a visitor reads on the product page, which already renders `Verified <date>` of its own accord. See issue #322."
         },
         "sources": {
           "type": "array",
@@ -319,7 +340,7 @@
         "content_sha256": {
           "type": "string",
           "pattern": "^[0-9a-f]{64}$",
-          "description": "SHA-256 of the fetched response body at `accessed` time. A changed digest says the page moved under a claim that still cites it \u2014 a reason to re-check rather than a failure on its own, since pages legitimately change. A MISSING digest on a newly claimed confirmation is a hard failure, because it means the tool fetched nothing."
+          "description": "SHA-256 of the fetched response body at `accessed` time. A changed digest says the page moved under a claim that still cites it — a reason to re-check rather than a failure on its own, since pages legitimately change. A MISSING digest on a newly claimed confirmation is a hard failure, because it means the tool fetched nothing."
         }
       }
     }

--- a/docs/workflows/refresh-category.md
+++ b/docs/workflows/refresh-category.md
@@ -83,6 +83,11 @@ Each is a defect this project shipped, not a precaution against one.
 4. **A plain YAML scalar cannot contain `": "`.** Write ` - ` or single-quote the whole scalar.
    This cost four parse failures in one day.
 
+The **scoring history is git**, not the note: `git log -p --follow sources/scores/<slug>.yaml`
+carries every previous pass and the digests it saw. A note records durable reasoning only, and is
+published verbatim in the payload — a verification narrative written into one ships to the public
+product page. See `docs/reference/evidence-and-freshness.md`.
+
 A **null axis is a finding and earns a date too**: re-read the page, confirm nothing has
 appeared, and date it, citing the page that publishes nothing. See
 [`../reference/evidence-and-freshness.md`](../reference/evidence-and-freshness.md).

--- a/docs/workflows/update-product.md
+++ b/docs/workflows/update-product.md
@@ -48,6 +48,10 @@ Run standalone, this is the prose pass (formerly the `verify-product` skill). Va
 
 ### Re-verify the affected axes — a score's evidence or value moved
 A score change is evidence work, and it earns a date. Do **not** just edit the number.
+- **Before re-reading, read the history:** `git log -p --follow sources/scores/<slug>.yaml` is
+  the scoring history — what each previous pass concluded, and the digests it saw. Notes carry
+  durable reasoning only; they are published verbatim in the payload, so a verification narrative
+  written into one ships to the public product page. See `docs/reference/evidence-and-freshness.md`.
 - **One product:** re-read its cited sources, re-derive the axis, record the evidence and a real
   `last_verified` per [`../reference/evidence-and-freshness.md`](../reference/evidence-and-freshness.md).
   If it places a capability band against a peer, the peer must be confirmed at least as recently.

--- a/skills/clean-score-notes/SKILL.md
+++ b/skills/clean-score-notes/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: clean-score-notes
+description: Use when clearing the verification log out of score notes — the "Re-read 2026-08-13 - the source still says X. No change." prose that renders on the public product page. One product per unit of work, edited by hand, in os-ai-map.
+---
+
+# Clean score notes
+
+A score `note` says why the score is what it is. It is **not** the log of who checked it and
+when — that is `last_verified`, `sources[].accessed` and `sources[].content_sha256`, all of
+which are already structured, and all of which the product page already renders as
+`Verified <date>`. The prose restates them into the copy a visitor reads.
+
+Measured 2026-08-18: **1,035 of 1,416 notes across 446 of 472 score files**, 370,810 characters,
+**44% of all note prose**. See issue #322 for the full audit.
+
+## Trigger
+A category's score notes still carry verification prose. Run one category per pass. For a single
+product that needs a *score* change, this is the wrong door — use `update-product`.
+
+## Required reading
+- `docs/reference/evidence-and-freshness.md` — what `last_verified` means, and who may write it.
+  This skill may not.
+- `docs/schemas/score.schema.json` — the three `note` descriptions, which are the contract.
+- `docs/reference/product-copy.md` — the prose spec for the surrounding record.
+
+## One objective, and a log for everything else
+
+**The objective is the verification prose.** Not better notes, not corrected scores, not a tidier
+argument. A pass that stops to fix what it finds never finishes, and the corpus keeps shipping
+the log in the meantime.
+
+**Everything a pass may not fix, it writes down.** A note whose surviving prose contradicts its
+own score, a fact that looks stale, an argument that no longer matches the product — record it
+with slug, axis and one sentence, and move on. The log lands on the PR; each entry is somebody's
+later `update-product`.
+
+**A score file must still hold everything needed to settle a disagreement afterwards.** That is
+the constraint that decides every marginal call: if deleting a clause would leave a reader unable
+to reconstruct why the score is what it is, the clause is durable and it stays — reworded into
+the present tense, not deleted.
+
+**The verification history is not discarded, it is relocated to where it already lived.** The
+scoring history is the git history of the score file — `git log -p --follow
+sources/scores/<slug>.yaml` — which is complete, dated by commit, and needs no upkeep. A pass
+removes the narrative from the note precisely because the payload publishes `note` and `sources`
+verbatim, so anything written into a note ships to the public product page. The mechanics stay
+readable by the agents that need them and stop being product copy.
+
+## This is hand work, not a regex
+
+A scripted strip is wrong for a third of the corpus. Classify every tail before touching it:
+
+| Bucket | Share | What to do |
+|---|---:|---|
+| **Pure log** — "still says X … No change." | 68% | Delete the tail. |
+| **Durable detail in log framing** — a price, a version, a percentage | 29% | Move the fact into the note body in the present tense; delete the framing. |
+| **Record-changing** — a claim withdrawn, a band revised | 1% | Keep only the durable claim ("no independent comparison supports this band"); delete the narrative. |
+
+The middle bucket is why this is manual. "Re-read 2026-08-13 — still in stock at Seeed, now
+listed at $70.00 rather than $71.99" carries a live fact wearing a log's clothes. Deleting the
+sentence loses the price; keeping it dates the note.
+
+## The unit of work is one product file
+
+Not one axis. A curator reading a record needs all three notes at once, because the same tail
+often repeats an argument the axis above already made.
+
+1. Read the whole score file, including `last_verified` and every `sources[].shows`.
+2. In each axis note, find the tail: the first `Re-read` / `Re-checked` / `Re-fetched` to the end.
+3. Classify it against the table above, and act.
+4. **Re-read what remains, cold.** Does it explain the score to someone who has not seen the
+   sources? If it now reads thin, that is a finding, not a cosmetic problem: the note was never
+   doing its job and the tail was hiding it. Write the missing rationale from the sources already
+   cited in the record. Do not fetch anything.
+5. Apply the same rule to `sources[].shows` — 96 carry the log too, 45 of them in
+   `evaluation_code`.
+6. Update the category's count in the backlog ledger.
+
+## What a pass may never do
+
+- **Change a score.** If cleaning reveals the score is wrong, stop and file it. That is evidence
+  work with its own re-read and its own date, which is `update-product`.
+- **Touch `last_verified`.** This is a prose edit. Nothing here re-verifies anything, so nothing
+  here earns a date — `docs/reference/evidence-and-freshness.md` is explicit about who may write
+  it, and a prose pass is not on the list.
+- **Remove a source, or edit `accessed`, `http_status`, `content_sha256`.** Only `shows` prose.
+- **Leave a note that no longer stands alone.** The tail was often carrying the whole argument.
+
+## Order and size
+
+**One category per agent, all categories into one PR.** The category is the unit because a
+reviewer reads it as one editorial voice; the single PR is because this is one mechanical change
+with one contract behind it, and sixteen PRs would take sixteen reviews of the same rule.
+
+Worst-first by note count:
+
+| category | files | notes | `shows` |
+|---|---:|---:|---:|
+| orchestration_agents | 51 | 120 | 4 |
+| ui_api | 43 | 118 | 2 |
+| finetuned_chat | 39 | 100 | 4 |
+| training_synthetic_datasets | 38 | 76 | 0 |
+| evaluation_code | 26 | 75 | 45 |
+| agent_tools_protocols | 32 | 69 | 3 |
+| telemetry_observability | 26 | 67 | 4 |
+| deployment | 27 | 65 | 3 |
+| ml_frameworks | 22 | 63 | 0 |
+| safeguards | 26 | 60 | 5 |
+| benchmark_eval_data | 27 | 58 | 9 |
+| base_pretrained | 27 | 56 | 11 |
+| dataset_processing_tools | 21 | 42 | 0 |
+| edge_hardware | 19 | 39 | 0 |
+| finetuning_code | 12 | 15 | 1 |
+| inference_code | 10 | 12 | 5 |
+
+**Cleared 2026-08-18.** That table is the state the sweep started from, kept because it is the
+only record of what was there — the corpus now holds zero, and the guard below is strict. A
+future pass over a different prose defect should measure its own table the same way rather than
+work from a vague sense of the scale.
+
+Three hazards the sweep hit, all of which cost a repair and none of which was obvious up front:
+
+- **A marker mid-sentence.** "...no source was re-read." is not a tail. Cutting there truncates
+  the note and the cut looks clean, because the text after it starts with the marker. Match only
+  sentence-initial markers, and audit by re-reading what survived, not by checking the cut point.
+- **A verb list is not a rule.** `Re-derived` was not in the marker set and survived 23 times
+  until an agent noticed. The guard now matches the shape of the thing, not a vocabulary.
+- **`set_source` addresses by URL and takes the first match.** An axis citing the same URL twice
+  has an unreachable second entry, and the reparse assertion still passes because the expected
+  document is built from that same first index. Address by index where a URL repeats.
+
+## Validation
+
+```bash
+uv run python -m build.validate
+uv run pytest tests/test_score_notes.py     # the ratchet: measured must equal recorded
+uv run pytest
+```
+
+The guard is strict rather than a ratchet, because the pass clears the whole corpus at once: no
+`note` and no `sources[].shows` may carry a re-read marker. A ratchet with an allowlist would be
+right for an incremental cleanup and is wrong here — there is no backlog left to name.
+
+Edits go through `build/components.py` (`set_field`, `set_source`), never a load-modify-dump. It
+reparses after every edit and asserts the document is unchanged apart from the one field, which
+is what catches a spliced tail landing in a neighbouring key. It caught exactly that on
+`agent2agent-protocol`, whose note carries an embedded paragraph break the renderer cannot
+round-trip; a handful of records like it are hand-edited.
+
+## Stop and escalate
+- A note's argument turns out to be wrong, not just badly framed → `update-product`.
+- The whole category's evidence is stale → `refresh-category`.
+- The `note` contract itself needs to change → `migrate-axis`.
+
+## Related
+- Issue #322 — the audit this skill works from.
+- `docs/reference/evidence-and-freshness.md` — the date's home.
+- `skills/update-product/SKILL.md` — the door for anything that moves a score.

--- a/skills/registry.yaml
+++ b/skills/registry.yaml
@@ -20,6 +20,7 @@ primary:
 
 advanced:
   - build-rubric
+  - clean-score-notes
   - refresh-all-categories
 
 internal:

--- a/sources/scores/accelerate.yaml
+++ b/sources/scores/accelerate.yaml
@@ -13,10 +13,9 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: 'LICENSE file is the standard, unmodified Apache 2.0 text. Re-read 2026-08-13: the cited LICENSE
-    body still carries the Apache-2.0 terms, the GitHub API reports the repository public, unarchived and
-    licensed Apache-2.0, and the README describes the whole library with no paid, enterprise or hosted tier
-    beside it, so source stays public and core-gated stays ungated.'
+  note: LICENSE file is the standard, unmodified Apache 2.0 text. The repository is public and unarchived,
+    and the README describes the whole library with no paid, enterprise or hosted tier beside it, so source
+    is public and the core ungated.
   raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -50,13 +49,12 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: 'Re-scored 4->5. 25.01M PyPI downloads in the last 30 days. The map''s prevailing usage_volume level-5
+  note: Re-scored 4->5. 25.01M PyPI downloads in the last 30 days. The map's prevailing usage_volume level-5
     floor is >10M/mo (cf. pydantic-ai ~31M, llama-index ~10.18M at level 5); the prior note bucketed it
     into a 5M-50M=L4 band used only in one ml_frameworks batch, below map peers of equal volume. Accelerate
     is the standard distributed-training launcher under the HF stack (TRL/PEFT depend on it) and clears
-    the prevailing floor. Re-read 2026-08-13 from the cited pepy.tech reading of the declared PyPI artifact
-    `accelerate`: 27,451,175 downloads in the trailing 30 days, which bands at >10M, level 5 on the software
-    scale. Unchanged.'
+    the prevailing floor. The reading is 27,451,175 downloads in the trailing 30 days for the declared PyPI
+    artifact `accelerate`, which bands at >10M.
   last_verified: '2026-08-13'
   sources:
   - url: https://pepy.tech/projects/accelerate
@@ -70,8 +68,7 @@ capability:
   value: 'Distributed-training abstraction: launches and runs PyTorch training on CPU/GPU/multi-GPU/TPU
     with mixed precision via minimal code changes.'
   confidence: high
-  note: 'Central infrastructure for distributed training but scoped to orchestration, not modeling. Re-read
-    2026-08-13: the cited repository page still describes the product as recorded, so the band is unchanged.'
+  note: Central infrastructure for distributed training but scoped to orchestration, not modeling.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/huggingface/accelerate

--- a/sources/scores/aegis-guard.yaml
+++ b/sources/scores/aegis-guard.yaml
@@ -13,11 +13,8 @@ openness:
     - name: Llama-2-Community
       detail: NOT OSI
   confidence: medium
-  note: Open-weights at the adapter level but the LlamaGuard base is access-gated through Meta and the
-    license is the non-OSI Llama 2 Community License, so it lands at open_weights (3) with a gating caveat.
-    Re-read 2026-08-13 and unchanged - the card still opens with 'The use of this model is governed by the
-    Llama 2 Community License Agreement', the repo is ungated and ships adapter_model.safetensors, and the
-    Aegis-AI-Content-Safety-Dataset-1.0 is still the declared training set.
+  note: Open-weights at the adapter level but the LlamaGuard base is access-gated through Meta and the license
+    is the non-OSI Llama 2 Community License, so it lands at open_weights (3) with a gating caveat.
   raw: weights:adapter-open(HF) but base LlamaGuard gated via Meta access;data:Aegis safety dataset documented;license:Llama-2-Community(NOT
     OSI)
   last_verified: '2026-08-13'
@@ -51,9 +48,9 @@ adoption:
   reach: <10K
   signal_type: usage_volume
   confidence: low
-  note: 4,303 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (nvidia/Aegis-AI-Content-Safety-LlamaGuard-Defensive-1.0 4,303). Bands at level 1 (<10K) on the software
-    and model adoption scale. Corrected from level 2, which the declared artifacts do not support.
+  note: 4,303 downloads in the trailing 30 days summed across the 1 declared artifact(s) (nvidia/Aegis-AI-Content-Safety-LlamaGuard-Defensive-1.0
+    4,303). Bands at level 1 (<10K) on the software and model adoption scale. Corrected from level 2, which
+    the declared artifacts do not support.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/models/nvidia/Aegis-AI-Content-Safety-LlamaGuard-Defensive-1.0
@@ -73,8 +70,6 @@ capability:
   note: Broad risk taxonomy with a documented training dataset; comparable coverage to Llama Guard, its
     base. The peer comparison the band rests on is recorded rather than left in prose - it is a tune of
     Llama Guard over a taxonomy of the same order (13 categories against 14), so it sits at the same rung.
-    Re-read 2026-08-13 - the card still describes 13 critical safety risk categories and the Defensive
-    variant.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/nvidia/Aegis-AI-Content-Safety-LlamaGuard-Defensive-1.0

--- a/sources/scores/agent-infra-sandbox.yaml
+++ b/sources/scores/agent-infra-sandbox.yaml
@@ -16,12 +16,8 @@ openness:
     free_text:
     - no feature-gated core observed
   confidence: high
-  note: Apache-2.0, fully self-hostable single-container runtime; no separate proprietary/managed tier
-    gating the core. Re-read 2026-08-13 - the GitHub API reports the repository public, unarchived
-    and licensed Apache-2.0, the root LICENSE body is the verbatim Apache License 2.0, and the README
-    ships the entire runtime as one public image (ghcr.io/agent-infra/sandbox, with a mainland-China
-    mirror) plus Docker Compose and Kubernetes deployment manifests, with no paid, hosted or
-    feature-gated tier anywhere in it.
+  note: Apache-2.0, fully self-hostable single-container runtime; no separate proprietary/managed tier gating
+    the core.
   raw: license:Apache-2.0(OSI);source:public(GitHub);packaging:self-hostable Docker image + K8s deploy examples;no
     feature-gated core observed;core-gated:ungated
   last_verified: '2026-08-13'
@@ -62,9 +58,9 @@ adoption:
   reach: <10K
   signal_type: usage_volume
   confidence: low
-  note: 4,670 npm downloads in the trailing 30 days for @agent-infra/sandbox, read 2026-08-12. The level
-    was previously placed at 1 by hand, explicitly 'on the absence of any usage_volume evidence'. That evidence
-    exists and bands at 1 - the judgment was right and now rests on a measurement rather than on an absence.
+  note: 4,670 npm downloads in the trailing 30 days for @agent-infra/sandbox. The level was previously placed
+    at 1 by hand, explicitly 'on the absence of any usage_volume evidence'. That evidence exists and bands
+    at 1 - the judgment was right and now rests on a measurement rather than on an absence.
   last_verified: '2026-08-12'
   sources:
   - url: https://api.npmjs.org/downloads/point/last-month/@agent-infra/sandbox
@@ -80,13 +76,8 @@ capability:
     within container; scale:K8s high-density deploy examples but no published concurrency limit
   confidence: medium
   note: Unusually broad multi-modal feature set (browser+shell+file+MCP+IDE in one) but isolation is container-level
-    only, below the Firecracker/gVisor isolation strength of the frontier deployment runtimes; scored
-    3.
-    Re-read 2026-08-13 - the README still describes one Docker container carrying Browser/VNC, Shell,
-    File, MCP, Jupyter and VSCode Server over a shared filesystem, still deploys through Compose or a
-    plain Kubernetes Deployment, and still names no isolation primitive stronger than the container
-    (the quick start actually relaxes one, running with seccomp unconfined). Breadth and isolation
-    both read as recorded, so the band holds at 3.
+    only, below the Firecracker/gVisor isolation strength of the frontier deployment runtimes; scored 3.
+    The quick start relaxes isolation further still, running with seccomp unconfined.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/agent-infra/sandbox

--- a/sources/scores/agent2agent-protocol.yaml
+++ b/sources/scores/agent2agent-protocol.yaml
@@ -20,15 +20,15 @@ openness:
         registries
   confidence: high
   note: 'Reference spec and SDKs are Apache-2.0 under neutral LF governance; for a protocol this is the
-    openness ceiling. `core-gated: ungated` transcribed 2026-08-12 from a read of the repo, and it rests
-    on there being nothing to gate with rather than on a pricing page saying so. The root tree is LICENSE,
-    GOVERNANCE.md, MAINTAINERS.md, specification/, docs/ and adrs/ with no ee/, enterprise/ or commercial/
-    path, and the README''s closing section reads "The A2A Protocol is an open source project under the
-    Linux Foundation, contributed by Google. It is licensed under the Apache License 2.0 and is open to
-    contributions from the community." All six reference SDKs are separate public a2aproject repos installable
-    from public registries - a2a-sdk on PyPI, github.com/a2aproject/a2a-go, @a2a-js/sdk on npm, Maven, NuGet
-    and a2a-lf on crates.io. There is no vendor product beside the protocol, so there is no paid tier, no
-    license key and no closed package.'
+    openness ceiling. `core-gated: ungated` comes from a direct read of the repo, and it rests on there
+    being nothing to gate with rather than on a pricing page saying so. The root tree is LICENSE, GOVERNANCE.md,
+    MAINTAINERS.md, specification/, docs/ and adrs/ with no ee/, enterprise/ or commercial/ path, and the
+    README''s closing section reads "The A2A Protocol is an open source project under the Linux Foundation,
+    contributed by Google. It is licensed under the Apache License 2.0 and is open to contributions from
+    the community." All six reference SDKs are separate public a2aproject repos installable from public
+    registries - a2a-sdk on PyPI, github.com/a2aproject/a2a-go, @a2a-js/sdk on npm, Maven, NuGet and a2a-lf
+    on crates.io. There is no vendor product beside the protocol, so there is no paid tier, no license key
+    and no closed package.'
   raw: license:Apache-2.0(OSI);source:public(spec + reference SDKs in 6 languages);governance:Linux Foundation
     (vendor-neutral, Google-contributed);core-gated:ungated(the Linux Foundation project sells nothing -
     one Apache-2.0 LICENSE at the root, no ee/ or enterprise/ path, and all six reference SDKs published
@@ -74,19 +74,15 @@ adoption:
   confidence: medium
   banded_quantity: supporting organizations (150+) and shipped integrations, a breadth count rather than
     a usage figure
-  note: 'Protocol adoption-breadth signal (per recipe): LF press (Apr 2026 one-year mark) reports 150+
-    supporting organizations, in-production use at Microsoft (Azure AI Foundry, Copilot Studio), AWS (Bedrock
-    AgentCore), Salesforce, SAP, ServiceNow, and embedding into Google Cloud. Breadth across the three
-    major clouds + enterprise production puts effective downstream reach in the 1-10M band; this is a
-    breadth/traction count, not a measured per-user figure. Re-read 2026-08-13 and every recorded claim
-    holds. The Linux Foundation release, dated 2026-04-09, states that supporting organizations "grown from
-    more than 50 to over 150 - including AWS, Cisco, Google, IBM, Microsoft, Salesforce, SAP, and ServiceNow",
-    that "Microsoft integrated A2A into Azure AI Foundry and Copilot Studio and AWS added support through
-    Amazon Bedrock AgentCore Runtime", and that the SDK ecosystem now spans five production-ready languages.
-    Note the correction the re-read forced on the SDK count - the release says five, not the six this record
-    carried, and the repo shows 25,336 stars against the 22,000 the release quotes. Neither figure is the
-    band''s basis: the instrument here is breadth of organizational support, no per-user count is published
-    anywhere, and level 4 is unchanged.'
+  note: 'Protocol adoption-breadth signal (per recipe): LF press (Apr 2026 one-year mark) reports 150+ supporting
+    organizations, in-production use at Microsoft (Azure AI Foundry, Copilot Studio), AWS (Bedrock AgentCore),
+    Salesforce, SAP, ServiceNow, and embedding into Google Cloud. Breadth across the three major clouds
+    + enterprise production puts effective downstream reach in the 1-10M band; this is a breadth/traction
+    count, not a measured per-user figure. The Linux Foundation release records supporting organizations
+    grown from more than 50 to over 150, including AWS, Cisco, Google, IBM, Microsoft, Salesforce, SAP and
+    ServiceNow, with Azure AI Foundry, Copilot Studio and Amazon Bedrock AgentCore Runtime integrating it,
+    and five production-ready SDK languages. The instrument is breadth of organizational support; no per-user
+    count is published anywhere.'
   last_verified: '2026-08-13'
   sources:
   - url: https://www.linuxfoundation.org/press/a2a-protocol-surpasses-150-organizations-lands-in-major-cloud-platforms-and-sees-enterprise-production-use-in-first-year
@@ -119,15 +115,12 @@ capability:
 
     DECLARED 2026-08-14, on the owner''s ruling, and it does cover both. GRADING POLICY - A WIRE PROTOCOL
     IS GRADED ON OPENNESS AND ADOPTION ONLY, AND ITS CAPABILITY IS NULL BY POLICY RATHER THAN BY FALLBACK.
-    No score is invented. The reasoning is recorded in full on model-context-protocol and in
-    docs/reference/gap-analysis.md, "The two nulls are not symmetric": implementation breadth is adoption
-    wearing a capability label, and this record''s adoption is already banded on exactly that - the count
-    of supporting organizations, 150+ per the Linux Foundation - so scoring breadth here would let one
-    instrument vote twice. The known cost stands and is stated rather than fixed here: serialize.py falls
-    through to adoption alone for a null capability, so this record computes its maturity from one axis.
-    Re-read 2026-08-14 and the premise holds. The repository still publishes a specification, ADRs,
-    governance documents and reference SDKs, and no benchmark, leaderboard or measured performance figure
-    for the protocol appears on it or anywhere the project points.'
+    No score is invented. The reasoning is recorded in full on model-context-protocol and in docs/reference/gap-analysis.md,
+    "The two nulls are not symmetric": implementation breadth is adoption wearing a capability label, and
+    this record''s adoption is already banded on exactly that - the count of supporting organizations, 150+
+    per the Linux Foundation - so scoring breadth here would let one instrument vote twice. The known cost
+    stands and is stated rather than fixed here: serialize.py falls through to adoption alone for a null
+    capability, so this record computes its maturity from one axis.'
   last_verified: '2026-08-14'
   sources:
   - url: https://github.com/a2aproject/A2A
@@ -137,10 +130,8 @@ capability:
     http_status: 200
     content_sha256: 1165fc1e34756203cf564d09b228b277c3efedb7a0a62a30fac58cb0067a6bd1
   - url: https://github.com/a2aproject/A2A
-    shows: 'Re-read 2026-08-14 for the policy declaration. Still a specification repository - spec, ADRs,
-      governance, maintainers and the six reference SDK links - with no benchmark, leaderboard or
-      performance figure anywhere on it. The digest differs from the 2026-08-13 read because the star
-      count moved.'
+    shows: A specification repository - spec, ADRs, governance, maintainers and the reference SDK links
+      - with no benchmark, leaderboard or performance figure anywhere on it.
     accessed: '2026-08-14'
     http_status: 200
     content_sha256: 7123045c8469aa4c558e83b2a967c153f6590170693f8a93cb50cdb28c695a94

--- a/sources/scores/agenta.yaml
+++ b/sources/scores/agenta.yaml
@@ -20,7 +20,7 @@ openness:
     - self-hostable
   confidence: high
   note: 'MIT core with a commercially licensed enterprise half in the same repository, self-hostable either
-    way. `core-gated: gated` verified 2026-08-12 by a direct read, and it does NOT rest on Agenta Cloud
+    way. `core-gated: gated` comes from a direct read of the repo, and it does NOT rest on Agenta Cloud
     existing. The root LICENSE splits the repo: "All content that resides under any ''ee/'' directory of
     this repository, if such directories exist, are licensed under the license defined in ''ee/LICENSE''",
     everything else MIT Expat. ee/LICENSE is the Agenta Enterprise License - the software "may only be used
@@ -84,8 +84,8 @@ adoption:
   signal_type: usage_volume
   confidence: high
   note: agenta ~16k PyPI downloads/month (10K-100K band); ~4.2k GitHub stars corroborates only. Early-adopter
-    scale, smallest in this batch. Re-read 2026-08-13 - pypistats now reports 15,013 downloads last month
-    for agenta, effectively unchanged and still inside the 10K-100K band, so level 2 stands.
+    scale, smallest in this batch. pypistats reports 15,013 downloads in the last month, inside the 10K-100K
+    band.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/packages/agenta
@@ -110,42 +110,23 @@ capability:
     catalogue, no datasets or experiments, no prompt management, and no OTel/OpenLLMetry/OpenInference
     claim.'
   confidence: medium
-  note: 'Broad feature matrix across prompt mgmt, evals, and OTel observability, comparable to Langfuse
-    anchor (C4). Capability is decoupled from its lower adoption. Re-read 2026-08-14, and the recorded
-    value describes a product that no longer exists. Agenta 2.0 repositioned to an agent workspace - the
-    site headline is now "The open-source workspace for your agents" and the docs open "Agenta is a
-    workspace where you and your team build agents and automations. You do not need to know how to code.
-    You build agents by chatting with them." Every clause of the recorded value is gone or reduced. There
-    is no evaluator catalogue anywhere in the docs and the prompt-engineering section 404s; the OTel,
-    OpenLLMetry and OpenInference compatibility claims are gone, leaving "Tracing and usage. Inspect
-    every model and tool call."; the multi-model playground is replaced by harness selection across
-    Claude Code, Codex and Pi. What is there instead is a multiplayer workspace with per-agent folders,
-    1000+ integrations and MCP servers, reusable skills, permissions with human approval, scheduled and
-    event-triggered background agents, per-agent isolated sandboxes and version history. The blog still
-    carries the old title, which is stale metadata rather than a live product claim.
-
-    This is not a freshness problem. The comparison CLASS changed, so relative_to - langfuse and
-    relation - at no longer describe anything - Langfuse is an observability and eval platform and
-    Agenta is now an agent workspace. ESCALATED for a re-score against what the product now is,
-    including a new anchor. No last_verified claimed and nothing changed here beyond recording the
-    evidence.
-
-    RE-SCORED 4 -> 3 on 2026-08-14, on the owner''s ruling, and the anchor is REMOVED rather than
-    repointed. Removed because there is nowhere to point it: the field takes a peer in the same category,
-    and nothing else in telemetry_observability is an agent workspace, so any target here would assert a
-    comparison class that does not exist. Re-read of the docs and the repo today confirms the 2.0
-    reposition in the vendor''s own words - "Agenta is a workspace where you and your team build agents
-    and automations. You do not need to know how to code."
-    The 3 is derived from what the product now does against the coverage this category grades, which is
-    the only ruler the axis has here. Its whole remaining observability surface is tracing with token,
-    latency and estimated-cost tracking. The rungs above it in this category require an eval layer,
-    datasets and experiments, or prompt management on top of tracing, and Agenta 2.0 has none of the
-    three - the evaluator catalogue is gone, the prompt-engineering docs 404, and the OTel compatibility
-    claims are withdrawn. The rung below is for monitoring that does not trace individual model and tool
-    calls, which this does. So 3, at medium confidence, and the honest caveat is that the product is
-    strong at something this category does not measure. The real open question is not the band but the
-    placement - a no-code agent workspace is closer to orchestration_agents than to telemetry, and that
-    is a recategorization for a human rather than a re-score.'
+  note: 'Broad feature matrix across prompt mgmt, evals, and OTel observability, comparable to Langfuse anchor
+    (C4). Capability is decoupled from its lower adoption. The recorded value describes a product that has
+    been repositioned: Agenta 2.0 is an agent workspace, and the docs open "Agenta is a workspace where you
+    and your team build agents and automations. You do not need to know how to code." Against what this
+    category grades, the whole remaining observability surface is tracing with request, token, latency and
+    estimated-cost tracking. There is no evaluator catalogue anywhere in the docs, the prompt-engineering
+    section 404s, and the OTel, OpenLLMetry and OpenInference compatibility claims are gone; what is there
+    instead is a multiplayer workspace with per-agent folders, 1000+ integrations and MCP servers, reusable
+    skills, permissions with human approval, scheduled and event-triggered background agents, per-agent
+    isolated sandboxes and version history. The rungs above 3 in this category require an eval layer, datasets
+    and experiments, or prompt management on top of tracing, and Agenta 2.0 has none of the three; the rung
+    below is for monitoring that does not trace individual model and tool calls, which this does. So 3, at
+    medium confidence, with the honest caveat that the product is strong at something this category does not
+    measure. No anchor is recorded because `relative_to` takes a peer in the same category and nothing else in
+    telemetry_observability is an agent workspace, so any target would assert a comparison class that does not
+    exist. The open question is placement rather than band - a no-code agent workspace is closer to
+    orchestration_agents than to telemetry, which is a recategorization for a human rather than a re-score.'
   last_verified: '2026-08-14'
   sources:
   - url: https://agenta.ai/docs/
@@ -165,17 +146,16 @@ capability:
     http_status: 200
     content_sha256: 3d66acb69bfd18abbca6c63500256b6e5da6a145f7e79bf2e0c60fc61e3aaf3e
   - url: https://agenta.ai/docs/
-    shows: 'Re-fetched for the re-score, digest byte-identical to the read earlier the same day. Beyond
-      the features already recorded, the page carries harness choice across Claude Code, Codex and Pi,
-      per-agent isolated sandboxes, and role-based access with SSO - and the whole of what this category
-      grades is one line, "Tracing and usage. Inspect every model and tool call. Track requests, tokens,
-      latency, and estimated cost."'
+    shows: 'Beyond the features already recorded, the page carries harness choice across Claude Code, Codex
+      and Pi, per-agent isolated sandboxes, and role-based access with SSO - and the whole of what this
+      category grades is one line, "Tracing and usage. Inspect every model and tool call. Track requests,
+      tokens, latency, and estimated cost."'
     accessed: '2026-08-14'
     http_status: 200
     content_sha256: 5d642d3f7328864865f1909a64ea2e386d38adfa8a14f9138cfc90c672f770bb
   - url: https://api.github.com/repos/Agenta-AI/agenta
-    shows: 'Repo metadata read 2026-08-14 - description "The open-source workspace for building and running
-      agents", corroborating the reposition from the repository side rather than from the marketing site.'
+    shows: Repo metadata - description "The open-source workspace for building and running agents", corroborating
+      the reposition from the repository side rather than from the marketing site.
     accessed: '2026-08-14'
     http_status: 200
     content_sha256: a86b82756ac56213d576ca7efb2f229fee53477f99dbd4c45e132e2b9c17f311

--- a/sources/scores/agentops.yaml
+++ b/sources/scores/agentops.yaml
@@ -92,11 +92,10 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: agentops ~585k PyPI downloads/month; multi-framework integrations (CrewAI, AG2, OpenAI Agents
-    SDK, LangChain, Camel); ~5.6k stars corroborates only. 100K-1M monthly-download band. Re-read
-    2026-08-13 - pypistats now reports 275,111 downloads last month for agentops, roughly half the 584,603
-    recorded and still inside the 100K-1M band, so level 3 is unchanged. The fall is consistent with the
-    stalled release cadence already recorded on the capability axis.
+  note: agentops ~585k PyPI downloads/month; multi-framework integrations (CrewAI, AG2, OpenAI Agents SDK,
+    LangChain, Camel); ~5.6k stars corroborates only. 100K-1M monthly-download band. pypistats reports 275,111
+    downloads in the last month, inside the 100K-1M band; the fall from 584,603 is consistent with the stalled
+    release cadence recorded on the capability axis.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/packages/agentops
@@ -118,10 +117,9 @@ capability:
   relative_to: langfuse
   relation: one_below
   note: Solid agent-tracing + cost + basic evals, but narrower feature matrix than MLflow/Langfuse/Opik/Phoenix;
-    stale SDK (no 2026 release) reinforces a mid score. The comparison is now recorded rather than left in
-    prose - one rung below the langfuse anchor at 4. Re-read 2026-08-13 on the repository README, whose
-    feature table is Replay Analytics and Debugging, LLM Cost Management, Agent Benchmarking, integrations
-    and Self-Host, with evaluations still carried as a roadmap table rather than a shipped surface.
+    stale SDK (no 2026 release) reinforces a mid score. The comparison is now recorded rather than left
+    in prose - one rung below the langfuse anchor at 4. Evaluations are carried as a roadmap table rather
+    than a shipped surface.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/AgentOps-AI/agentops

--- a/sources/scores/ai2-arc.yaml
+++ b/sources/scores/ai2-arc.yaml
@@ -17,9 +17,6 @@ openness:
       detail: train/val/test splits all released, not held-out
   confidence: high
   note: Fully open under CC-BY-SA-4.0 with dataset card; the canonical open-data benchmark profile.
-    Re-read 2026-08-13 - `license:cc-by-sa-4.0` is still in the repo tags, the embedded repo state
-    reads `"gated":false`, and the dataset card still renders with the ARC-Easy and ARC-Challenge
-    configs. No change.
   raw: data:open(7,787 questions, downloadable on HF);license:CC-BY-SA-4.0(open data license, redistributable);datasheet:yes(HF
     dataset card + arXiv paper);access:public(train/val/test splits all released, not held-out)
   last_verified: '2026-08-13'
@@ -37,10 +34,10 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: 472,342 Hugging Face downloads in the trailing 30 days (allenai/ai2_arc), read 2026-08-12. Bands
-    at level 4 (100K-1M) on the dataset adoption scale, whose top band is >1M - one order of magnitude below
-    the software and model scales, because no dataset artifact in the corpus has ever exceeded 10M. One
-    of the most-cited standard reasoning benchmarks, routinely reported in frontier model release cards.
+  note: 472,342 Hugging Face downloads in the trailing 30 days (allenai/ai2_arc). Bands at level 4 (100K-1M)
+    on the dataset adoption scale, whose top band is >1M - one order of magnitude below the software and
+    model scales, because no dataset artifact in the corpus has ever exceeded 10M. One of the most-cited
+    standard reasoning benchmarks, routinely reported in frontier model release cards.
   last_verified: '2026-08-12'
   sources:
   - url: https://huggingface.co/api/datasets/allenai/ai2_arc
@@ -53,9 +50,7 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: Capability not a meaningful axis for an eval dataset. Re-read 2026-08-13 and the abstention
-    stands - the page publishes a static question set and no performance or feature claim the capability
-    axis could band.
+  note: Capability not a meaningful axis for an eval dataset.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/allenai/ai2_arc

--- a/sources/scores/aider.yaml
+++ b/sources/scores/aider.yaml
@@ -15,11 +15,8 @@ openness:
     - no feature-gated core
     - model-agnostic (Claude/DeepSeek/OpenAI/local)
   confidence: high
-  note: 'Verified Apache-2.0 OSI, full source public, no managed/enterprise tier gating the core. Repo
-    owner Aider-AI/aider. Re-read 2026-08-13 - the repo page still reports an Apache-2.0 license over
-    the whole tree, publishes the running CLI rather than a client, and carries no paid tier, cloud offering
-    or enterprise directory; stars are now 48.2k. PyPI still serves aider-chat 0.86.2, the same build,
-    so what ships is what is published. Nothing moved.'
+  note: Verified Apache-2.0 OSI, full source public, no managed/enterprise tier gating the core. Repo owner
+    Aider-AI/aider.
   raw: license:Apache-2.0(OSI);source:public(GitHub);no feature-gated core; model-agnostic (Claude/DeepSeek/OpenAI/local);core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -45,12 +42,12 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: medium
-  note: '796,686 PyPI downloads in the trailing 30 days for aider-chat, read 2026-08-13. Bands at level
-    3 (100K-1M) on the software adoption scale, which is where this axis already sat. The band no longer
-    rests on the GitHub dependent-repo count it was authored from - that figure is rendered client-side
-    and is not present in the page a fetcher receives, so it could not be re-derived. aider-chat is the
-    product''s declared and primary distribution channel, so the download figure is a measurement rather
-    than a substitute, and it replaces the dependent count as the basis. Level and reach unchanged.'
+  note: 796,686 PyPI downloads in the trailing 30 days for aider-chat. Bands at level 3 (100K-1M) on the
+    software adoption scale, which is where this axis already sat. The band no longer rests on the GitHub
+    dependent-repo count it was authored from - that figure is rendered client-side and is not present in
+    the page a fetcher receives, so it could not be re-derived. aider-chat is the product's declared and
+    primary distribution channel, so the download figure is a measurement rather than a substitute, and
+    it replaces the dependent count as the basis. Level and reach unchanged.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/aider-chat/recent
@@ -74,10 +71,8 @@ capability:
   confidence: medium
   note: 'Mid-tier on SWE-bench Verified; well below OpenHands (68.4%) and Cline (59.8%). NOTE: headline
     figure sourced from aggregator leaderboard (awesomeagents.ai), not a primary SWE-bench publication;
-    kept at medium confidence. Re-read 2026-08-13 - the leaderboard still ranks Aider (architect mode)
-    on Claude Sonnet 4.5 at 31.4% Verified and 24.0% Full, row 13, against OpenHands + CodeAct v3 at
-    68.4% and Cline at 59.8%. The two_below relation to the openhands anchor still holds arithmetically
-    and in the underlying figures.'
+    kept at medium confidence. The leaderboard ranks Aider in architect mode on Claude Sonnet 4.5 at 31.4%
+    Verified and 24.0% Full, against OpenHands + CodeAct v3 at 68.4% and Cline at 59.8%.'
   last_verified: '2026-08-13'
   sources:
   - url: https://awesomeagents.ai/leaderboards/swe-bench-coding-agent-leaderboard/

--- a/sources/scores/algolia-ai-search.yaml
+++ b/sources/scores/algolia-ai-search.yaml
@@ -15,11 +15,8 @@ openness:
     managed:
       value: Algolia-Cloud
   confidence: high
-  note: 'Closed proprietary hosted search engine; only client/UI integration libraries are open. Core ranking/index
-    engine is not OSS or self-hostable. Re-read 2026-08-13: the product page sells a hosted platform - NeuralSearch,
-    AI ranking, personalization - reached through an API, and offers no self-host, on-premise or source-available
-    build of the engine anywhere on it. The open InstantSearch family remains client-side UI, which cannot
-    reclassify the closed core. source stays closed and the score stays 1.'
+  note: Closed proprietary hosted search engine; only client/UI integration libraries are open. Core ranking/index
+    engine is not OSS or self-hostable.
   raw: license:proprietary(SaaS, API-first);source:closed(search engine core);oss:client/UI-libraries-only(InstantSearch);managed:Algolia-Cloud
   last_verified: '2026-08-13'
   sources:
@@ -39,16 +36,12 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: 18,000+ customers across 150+ countries; processes over 1 billion queries every 5 seconds at sub-20ms
-    average latency. Named users incl. Stripe, Decathlon, Ubisoft. Query volume is enormous; end-user
-    reach (consumers hitting Algolia-powered search) is effectively mass-scale, but as a B2B tool the direct
-    customer base sits in the heavy-trending band; placed at 4 on verified query-volume. Re-read 2026-08-13
-    and both headline figures are still on the page as written - "More than 18,000 customers in 150+ countries
-    trust Algolia" and "Algolia processes more than 1 billion queries every 5 seconds, with an average response
-    time under 20 milliseconds" - with Stripe, Decathlon and Ubisoft still named. The customer count is what
-    the band actually rests on and 18,000 is nowhere near the 1M-10M reach label recorded beside it; that
-    label reads as an estimate of downstream end users rather than of anything counted here, and it is worth
-    a ruling on whether this axis should carry a numeric reach at all. Level 4 unchanged.
+  note: '18,000+ customers across 150+ countries; processes over 1 billion queries every 5 seconds at sub-20ms
+    average latency. Named users incl. Stripe, Decathlon, Ubisoft. Query volume is enormous; end-user reach
+    (consumers hitting Algolia-powered search) is effectively mass-scale, but as a B2B tool the direct customer
+    base sits in the heavy-trending band; placed at 4 on verified query-volume. The figures the band rests
+    on are Algolia''s own: more than 18,000 customers in 150+ countries, and more than 1 billion queries
+    every 5 seconds at an average response time under 20 milliseconds.'
   last_verified: '2026-08-13'
   sources:
   - url: https://www.algolia.com/products/ai-search/
@@ -66,12 +59,9 @@ capability:
   confidence: high
   note: 'Mature hybrid search feature matrix (semantic + keyword, personalization, AI ranking) at very low
     latency and massive scale, frontier-adjacent for managed site/retrieval search. Rated 4; closed system
-    so no independent ANN-Benchmarks number, basis is feature_matrix. Re-read 2026-08-13: NeuralSearch, AI
-    ranking and personalization are all still on the page, and the latency-at-scale claim is stated as "more
-    than 1 billion queries every 5 seconds, with an average response time under 20 milliseconds". The absence
-    was re-checked too - ann-benchmarks.com was fetched the same day and lists 38 algorithms, none of them
-    Algolia - so the "no independent number" half of this note is a confirmed finding. Band unchanged at
-    4.'
+    so no independent ANN-Benchmarks number, basis is feature_matrix. The absence of an independent number
+    is a confirmed finding rather than an unexamined one: ann-benchmarks.com lists 38 algorithms and none
+    of them is Algolia.'
   last_verified: '2026-08-13'
   sources:
   - url: https://www.algolia.com/products/ai-search/

--- a/sources/scores/alia-40b.yaml
+++ b/sources/scores/alia-40b.yaml
@@ -23,11 +23,7 @@ openness:
     weights plus the complete training code/recipe published on GitHub, but the pretraining corpus is only
     documented (60+ named sources) rather than released or reconstructable. That missing open-data component
     is the bright line that keeps it at open_weights (4) rather than the OLMo/Pythia/Apertus open_source
-    (5) tier, where Apertus reaches 5 by shipping data-reconstruction scripts. No intermediate checkpoints.
-    Re-read 2026-08-13: the card still says the corpus "will not be released or distributed to third
-    parties", still records 9.37 trillion training tokens and apache-2.0, and still points at the GitHub
-    repository for "all training scripts and configuration files". The repository is public and
-    Apache-2.0. Nothing moved.'
+    (5) tier, where Apertus reaches 5 by shipping data-reconstruction scripts. No intermediate checkpoints.'
   last_verified: '2026-08-13'
   raw: weights:open(Apache-2.0, safetensors on HF BSC-LT/ALIA-40b);data:documented-not-released(60+ named
     sources described in the model card, but the pretraining corpus "will not be released or distributed
@@ -56,15 +52,13 @@ adoption:
   reach: <10K
   signal_type: usage_volume
   confidence: medium
-  note: 'Public-funded sovereign model (Spain''s national LLM, BSC / MareNostrum 5) with strong institutional
-    and policy interest but modest raw volume. HF BSC-LT/ALIA-40b shows ~59 downloads/month and 88 likes (June
-    2026); the niche multilingual focus (Spanish + co-official + 35 European languages) keeps adoption below
-    Apertus''s tier. Cumulative across the wider ALIA Kit (instruct, GGUF, Salamandra) would be higher, but
-    the base model alone sits in the low band. Read live 2026-08-13: 475 Hugging Face downloads in the
-    trailing 30 days across the declared artifact(s), which bands at <10K, level 1. The previous reach
-    ''1K-10K'' was a band off a different scale. Re-derived from the API endpoint on 2026-08-13: 475
-    downloads in the trailing 30 days and 88 likes for the single declared artifact, so the level-1 band
-    stands and the axis is now confirmed rather than part-read.'
+  note: Public-funded sovereign model (Spain's national LLM, BSC / MareNostrum 5) with strong institutional
+    and policy interest but modest raw volume. HF BSC-LT/ALIA-40b shows ~59 downloads/month and 88 likes
+    (June 2026); the niche multilingual focus (Spanish + co-official + 35 European languages) keeps adoption
+    below Apertus's tier. Cumulative across the wider ALIA Kit (instruct, GGUF, Salamandra) would be higher,
+    but the base model alone sits in the low band. The API endpoint returns 475 Hugging Face downloads in
+    the trailing 30 days and 88 likes for the single declared artifact, which bands at <10K, level 1. The
+    previous reach '1K-10K' was a band off a different scale.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/models/BSC-LT/ALIA-40b
@@ -85,12 +79,9 @@ capability:
     mid-tier and below the 2026 frontier. Detailed benchmarks are deferred to a forthcoming technical report;
     the model card cites the Salamandra technical report (arXiv:2502.08489) for the shared methodology.
   confidence: low
-  note: 'A serious 40B multilingual base model, but smaller than Apertus-70B (capability 3) and below the
+  note: A serious 40B multilingual base model, but smaller than Apertus-70B (capability 3) and below the
     2026 frontier on reasoning/knowledge. Positioned for Iberian and European-language coverage and digital
     sovereignty rather than SOTA capability. Score kept conservative pending published benchmarks.
-    Re-read 2026-08-13 - the card still carries the scale facts the band rests on and still defers
-    benchmarks to a forthcoming report, so the conservative 2 stands. The `one_below` relation to
-    apertus (capability 3) still holds arithmetically, and apertus was re-confirmed the same day.'
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/BSC-LT/ALIA-40b

--- a/sources/scores/alpacaeval.yaml
+++ b/sources/scores/alpacaeval.yaml
@@ -14,12 +14,9 @@ openness:
     - no-feature-gated-core
   confidence: high
   last_verified: '2026-08-13'
-  note: Fully Apache-2.0. Re-read 2026-08-13 - the license endpoint reports Apache-2.0 against a single
-    LICENSE file, and a directory listing of the repo shows no DATA_LICENSE beside it. Worth recording
-    because the README's header carries a 'Data License CC By NC 4.0' badge, but both badges link to
-    the sibling tatsu-lab/alpaca_farm repo rather than to anything in this one, so the NC term is not
-    a license this product makes you accept. The README installs and runs the whole evaluator locally
-    with no paid tier.
+  note: Fully Apache-2.0. The README header carries a 'Data License CC By NC 4.0' badge, but both badges
+    link to the sibling tatsu-lab/alpaca_farm repository rather than to anything in this one, so the NC
+    term is not a license this product makes you accept.
   raw: license:Apache-2.0(OSI);source:public;no-feature-gated-core;core-gated:ungated
   sources:
   - url: https://github.com/tatsu-lab/alpaca_eval
@@ -48,10 +45,10 @@ adoption:
   level: 2
   signal_type: stars_fallback
   confidence: medium
-  note: 2,012 GitHub stars on tatsu-lab/alpaca_eval, read 2026-08-12. Bands at level 2 (1K-10K stars) on
-    the stars fallback scale, which caps at 3 because a star is not a use. Resynced because the only figure
-    the note carries is the star count. No download, install or customer figure is published for this product,
-    so stars remain the only honest signal and the level is directional.
+  note: 2,012 GitHub stars on tatsu-lab/alpaca_eval. Bands at level 2 (1K-10K stars) on the stars fallback
+    scale, which caps at 3 because a star is not a use. Resynced because the only figure the note carries
+    is the star count. No download, install or customer figure is published for this product, so stars remain
+    the only honest signal and the level is directional.
   reach: 1K-10K stars
   last_verified: '2026-08-12'
   sources:
@@ -67,9 +64,7 @@ capability:
   confidence: medium
   last_verified: '2026-08-13'
   note: De-facto standard for its niche with an influential LC metric; narrower than multi-task harnesses.
-    Feature matrix re-read 2026-08-13 and unchanged - length-controlled win rates are still the default,
-    the reference-model comparison and leaderboard are still there. No `relative_to` is recorded because
-    the note names no peer, only a class of harness.
+    Feature matrix No `relative_to` is recorded because the note names no peer, only a class of harness.
   sources:
   - url: https://github.com/tatsu-lab/alpaca_eval
     shows: AlpacaEval 2.0 LC win-rate

--- a/sources/scores/amazon-bedrock-custom-models-fine-tuning.yaml
+++ b/sources/scores/amazon-bedrock-custom-models-fine-tuning.yaml
@@ -56,13 +56,9 @@ capability:
     real-time metrics), distillation (teacher->student). Continued pre-training also offered on select
     models.'
   confidence: medium
-  note: 'Solid managed method set (SFT + RFT + distillation), but a black-box service with no exposed
-    parallelism/precision/scale controls and no benchmark basis. Scored 3: capable managed FT across a model
-    catalog, below the RFT-on-frontier-reasoning depth of the OpenAI/Vertex offerings and far below the OSS
-    scale-frontier libs. Re-read 2026-08-13 and unchanged at 3. The note placed this "below the RFT-on-
-    frontier-reasoning depth of the OpenAI/Vertex offerings", so that is recorded as one_below openai-fine-
-    tuning-api, the nearer of the two named peers and itself a managed API rather than a library - which keeps
-    the comparison between like things.'
+  note: 'Solid managed method set (SFT + RFT + distillation), but a black-box service with no exposed parallelism/precision/scale
+    controls and no benchmark basis. Scored 3: capable managed FT across a model catalog, below the RFT-on-frontier-reasoning
+    depth of the OpenAI/Vertex offerings and far below the OSS scale-frontier libs.'
   relative_to: openai-fine-tuning-api
   relation: one_below
   last_verified: '2026-08-13'

--- a/sources/scores/amazon-bedrock-evaluations.yaml
+++ b/sources/scores/amazon-bedrock-evaluations.yaml
@@ -17,8 +17,6 @@ openness:
   confidence: high
   last_verified: '2026-08-13'
   note: Proprietary AWS managed service; no source, no self-host, runs as billed Bedrock evaluation jobs.
-    Re-read 2026-08-13 - the product page still offers only AWS-hosted evaluation jobs with a link to
-    Bedrock pricing, mentions no source code and no self-host option, and offers no license to anything.
   raw: license:proprietary(AWS managed service);source:closed;deployment:cloud-only(AWS-hosted eval jobs,
     S3 I/O);billing:pay-as-you-go(judge-model inference + AWS-managed human workforce)
   sources:
@@ -30,10 +28,10 @@ openness:
     shows: AWS-hosted feature, AWS-managed human evaluator workforce option, directs to pricing page
     accessed: '2026-06-04'
   - url: https://aws.amazon.com/bedrock/evaluations/
-    shows: 'Re-read 2026-08-13: an AWS-hosted evaluation capability inside Amazon Bedrock, offering LLM-as-a-Judge,
-      programmatic and human evaluation, with AWS able to ''engage a team managed by AWS to perform the
-      human evaluation''. The page links to Bedrock pricing. No source code, repository or self-host option
-      is mentioned anywhere on it, and no license is offered.'
+    shows: An AWS-hosted evaluation capability inside Amazon Bedrock, offering LLM-as-a-Judge, programmatic
+      and human evaluation, with AWS able to 'engage a team managed by AWS to perform the human evaluation'.
+      The page links to Bedrock pricing. No source code, repository or self-host option is mentioned anywhere
+      on it, and no license is offered.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 497a0b9715a40cf67566a85976e07341a9a1c944621d678bd70c463be217b863
@@ -46,24 +44,21 @@ adoption:
   confidence: low
   last_verified: '2026-08-13'
   banded_quantity: Amazon Bedrock platform footprint, not the Evaluations feature
-  note: GA since 2025-03-20 and distributed inside Amazon Bedrock (a large enterprise AI surface), but
-    AWS publishes no standalone usage count for the Evaluations feature specifically. Level 3 = reported
-    traction via the Bedrock platform footprint, not a measured figure; low confidence because the signal
-    is the parent surface, not the feature. No stars fallback (closed service). Re-read 2026-08-13 - looked
-    on both the GA post and the product page for an evaluation-job count, a customer count or any usage
-    statistic and found none, so the level's basis is unchanged.
+  note: GA since 2025-03-20 and distributed inside Amazon Bedrock (a large enterprise AI surface), but AWS
+    publishes no standalone usage count for the Evaluations feature specifically. Level 3 = reported traction
+    via the Bedrock platform footprint, not a measured figure; low confidence because the signal is the
+    parent surface, not the feature. No stars fallback (closed service).
   sources:
   - url: https://aws.amazon.com/blogs/machine-learning/evaluate-models-or-rag-systems-using-amazon-bedrock-evaluations-now-generally-available/
     shows: GA announcement (2025-03-20) of model + RAG evaluations as a broadly available Bedrock feature
     accessed: '2026-06-04'
   - url: https://aws.amazon.com/blogs/machine-learning/evaluate-models-or-rag-systems-using-amazon-bedrock-evaluations-now-generally-available/
-    shows: 'Re-read 2026-08-13: the GA announcement for model and RAG evaluations is still published and
-      still carries no usage, customer or job-count figure.'
+    shows: The GA announcement for model and RAG evaluations carries no usage, customer or job-count figure.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 5dc48da40f91c8b507c404bbe1f85f434c9afd8ede884216e6b57512636f92e5
   - url: https://aws.amazon.com/bedrock/evaluations/
-    shows: 'Re-read 2026-08-13: no published usage or customer count for the Evaluations feature.'
+    shows: No published usage or customer count for the Evaluations feature.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 497a0b9715a40cf67566a85976e07341a9a1c944621d678bd70c463be217b863
@@ -78,22 +73,22 @@ capability:
   last_verified: '2026-08-13'
   note: Broad managed eval suite covering model + RAG + agent, judge/programmatic/human modes, and four
     metric families with BYO-responses portability. Comprehensive but a custom-dataset eval product, not
-    a standardized public benchmark leaderboard; placed at 4. Feature matrix re-read 2026-08-13 and unchanged.
+    a standardized public benchmark leaderboard; placed at 4.
   sources:
   - url: https://aws.amazon.com/bedrock/evaluations/
     shows: model eval (LLM-as-judge/programmatic/human) + RAG eval (retrieval, retrieve-and-generate)
       with safety/quality metrics
     accessed: '2026-06-04'
   - url: https://aws.amazon.com/bedrock/evaluations/
-    shows: 'Re-read 2026-08-13: LLM-as-a-Judge over custom prompt datasets, programmatic metrics including
-      BERTScore and F1, human evaluation with your own or an AWS-managed workforce, and both retrieval
-      and retrieve-and-generate RAG evaluation.'
+    shows: LLM-as-a-Judge over custom prompt datasets, programmatic metrics including BERTScore and F1,
+      human evaluation with your own or an AWS-managed workforce, and both retrieval and retrieve-and-generate
+      RAG evaluation.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 497a0b9715a40cf67566a85976e07341a9a1c944621d678bd70c463be217b863
   - url: https://aws.amazon.com/blogs/machine-learning/evaluate-models-or-rag-systems-using-amazon-bedrock-evaluations-now-generally-available/
-    shows: 'Re-read 2026-08-13: the four metric areas (quality, user experience, instruction compliance,
-      safety) and the citation precision and coverage metrics are still documented.'
+    shows: The four metric areas (quality, user experience, instruction compliance, safety) and the citation
+      precision and coverage metrics are documented.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 5dc48da40f91c8b507c404bbe1f85f434c9afd8ede884216e6b57512636f92e5

--- a/sources/scores/amazon-nova.yaml
+++ b/sources/scores/amazon-nova.yaml
@@ -14,11 +14,9 @@ openness:
       detail: API-only via Amazon Bedrock
   governing_release: amazon-nova-pro
   confidence: high
-  note: Served only through Amazon Bedrock with no weights released, so 1/closed. Nova Pro governs and carries adoption
-    4; the broader Nova record scored 3. Consolidated because Amazon markets Nova as one family with Micro, Lite
-    and Pro as tiers within it. Re-read 2026-08-13 - the user guide still states "To start building with
-    Amazon Nova, you must access the models through an API using Amazon Bedrock", with no weights, corpus
-    or training code offered anywhere. No change.
+  note: Served only through Amazon Bedrock with no weights released, so 1/closed. Nova Pro governs and carries
+    adoption 4; the broader Nova record scored 3. Consolidated because Amazon markets Nova as one family
+    with Micro, Lite and Pro as tiers within it.
   raw: weights:closed;data:closed;code:closed;license:Proprietary(API-only via Amazon Bedrock)
   last_verified: '2026-08-13'
   sources:
@@ -33,14 +31,10 @@ adoption:
   level: 4
   signal_type: reported_traction
   confidence: low
-  note: Distributed broadly through Amazon Bedrock across many AWS regions (with fine-tuning, provisioned throughput,
-    Bedrock Agents/KB support) and positioned as the price-performance default of the Nova family. No standalone
-    per-model user/usage count published; level 4 reflects Bedrock's enterprise distribution surface rather than
-    a verified figure. Re-read 2026-08-13 - the guide still lists Nova Pro across AWS regions on Bedrock as
-    the "highly capable multimodal model with best combination of accuracy, speed, and cost", and still
-    publishes no user or usage count, so the abstention from a number stands. `reach` correctly absent - it
-    used to carry a numeric label, which was stripped on 2026-08-13 as illegal for this instrument, and it
-    has not come back. No change.
+  note: Distributed broadly through Amazon Bedrock across many AWS regions (with fine-tuning, provisioned
+    throughput, Bedrock Agents/KB support) and positioned as the price-performance default of the Nova family.
+    No standalone per-model user/usage count published; level 4 reflects Bedrock's enterprise distribution
+    surface rather than a verified figure.
   last_verified: '2026-08-13'
   sources:
   - url: https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html
@@ -55,11 +49,9 @@ capability:
   basis: benchmark
   value: null
   confidence: low
-  note: Live vendor page confirms NO standardized benchmark scores; positioning is price-performance + case studies.
-    Mid-tier vs 2026 frontier; scored 3 directionally. Re-read 2026-08-13 and the absence is confirmed - the
-    word "benchmark" does not appear on the page at all, and the framing is still price-performance,
-    customization and content-moderation controls. The null `value` is a searched absence, not an unexamined
-    one. No change.
+  note: 'Live vendor page confirms NO standardized benchmark scores; positioning is price-performance +
+    case studies. Mid-tier vs 2026 frontier; scored 3 directionally. The null `value` is a searched absence
+    rather than an unexamined one: the word "benchmark" does not appear on the product page at all.'
   last_verified: '2026-08-13'
   sources:
   - url: https://aws.amazon.com/nova/models/

--- a/sources/scores/amazon-q-developer.yaml
+++ b/sources/scores/amazon-q-developer.yaml
@@ -11,10 +11,7 @@ openness:
     self-host:
       value: 'no'
   confidence: high
-  note: 'Proprietary AWS managed service; free and Pro tiers but no source or self-hosting. Re-read 2026-08-13
-    - the product page still sells it as a managed AWS service delivered through IDE plugins and the console,
-    with a perpetual Free Tier of 50 agentic chat interactions a month and a paid Q Developer Pro tier.
-    No source is published and there is no self-hostable implementation. Nothing moved.'
+  note: Proprietary AWS managed service; free and Pro tiers but no source or self-hosting.
   raw: source:closed;license:proprietary(AWS managed service);self-host:no
   last_verified: '2026-08-13'
   sources:
@@ -33,11 +30,8 @@ adoption:
   level: 3
   signal_type: reported_traction
   confidence: low
-  note: 'Distributed across AWS''s large developer base via IDEs/CLI/Console with free + Pro tiers and
-    enterprise case studies, but AWS discloses no hard Q Developer user count. Placed at 3 on reported
-    traction. Re-read 2026-08-13 - the page still describes the same free and Pro distribution and still
-    publishes no user, seat, install or download figure anywhere. Nothing countable exists, so the instrument
-    stays reported_traction and the level is unchanged.'
+  note: Distributed across AWS's large developer base via IDEs/CLI/Console with free + Pro tiers and enterprise
+    case studies, but AWS discloses no hard Q Developer user count. Placed at 3 on reported traction.
   last_verified: '2026-08-13'
   sources:
   - url: https://aws.amazon.com/q/developer/
@@ -52,13 +46,11 @@ capability:
   value: Agentic autonomy (implement/document/test/review/refactor), AWS-stated top SWE-Bench Leaderboard/Lite
     scores; specific 2026 SWE-bench Verified number not independently on a public leaderboard
   confidence: medium
-  note: 'AWS claims top SWE-Bench Leaderboard placement but no clean current SWE-bench Verified figure
-    is independently verifiable, so the benchmark claim is downgraded to vendor-stated and capability
-    scored on feature matrix at 4, strong agentic breadth, below a verified-benchmark ceiling. Re-read
-    2026-08-13 - the page still says "Amazon Q Developer agentic capabilities have achieved the highest
-    scores on the SWE-Bench Leaderboard and Leaderboard Lite" and still attaches no number to it, so the
-    claim is exactly as unverifiable as when it was scored. Feature matrix and band unchanged, one below
-    the openhands anchor.'
+  note: AWS claims top SWE-Bench Leaderboard placement but no clean current SWE-bench Verified figure is
+    independently verifiable, so the benchmark claim is downgraded to vendor-stated and capability scored
+    on feature matrix at 4, strong agentic breadth, below a verified-benchmark ceiling. AWS claims the highest
+    scores on the SWE-Bench Leaderboard and Leaderboard Lite but attaches no number to the claim, which
+    is why it cannot lift the band.
   relative_to: openhands
   relation: one_below
   last_verified: '2026-08-13'

--- a/sources/scores/anthropic-internal-coding-evals.yaml
+++ b/sources/scores/anthropic-internal-coding-evals.yaml
@@ -15,9 +15,6 @@ openness:
       detail: referenced in announcements/system cards, not distributed
   confidence: high
   note: Internal proprietary coding eval sets; only narrative results are mentioned, the data is not redistributable.
-    Re-read 2026-08-13 - the Claude Opus 4.5 announcement still describes a performance-engineering
-    take-home exam reused "as an internal benchmark", and partner quotes still reference "internal coding
-    benchmarks". Nothing on the page publishes the sets, a license or a datasheet, so all four values stand.
   raw: data:closed(internal coding eval/take-home exam sets, never published);datasheet:no;license:none;access:internal-only(referenced
     in announcements/system cards, not distributed)
   last_verified: '2026-08-13'
@@ -36,10 +33,9 @@ adoption:
   reach: null
   signal_type: unknown
   confidence: high
-  note: Internal-only eval sets used solely by Anthropic; no external users, downloads, or third-party
-    citation as a runnable standard. No honest external adoption signal. Re-read 2026-08-13 - the
-    announcement still describes the evaluations as internal, publishes no artifact anyone outside
-    Anthropic could run, and gives no usage figure. The null is a deliberate abstention and it stands.
+  note: Internal-only eval sets used solely by Anthropic; no external users, downloads, or third-party citation
+    as a runnable standard. No honest external adoption signal. The null is a deliberate abstention rather
+    than an unmeasured value.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.anthropic.com/news/claude-opus-4-5
@@ -53,9 +49,8 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: Capability not a meaningful axis for an eval dataset. Re-read 2026-08-13 and the abstention
-    stands - the scored artifact is an unpublished eval set, and the announcement reports the model's
-    scores rather than any capability of the set itself.
+  note: Capability not a meaningful axis for an eval dataset. The announcement reports the model's scores
+    rather than any capability of the eval sets themselves.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.anthropic.com/news/claude-opus-4-5

--- a/sources/scores/antigravity.yaml
+++ b/sources/scores/antigravity.yaml
@@ -11,13 +11,10 @@ openness:
     self-host:
       value: 'no'
   confidence: high
-  note: 'Proprietary Google agentic dev platform; free in preview but not open source. Re-read 2026-08-13
-    - the product site still ships Antigravity 2.0, the CLI, the IDE and the SDK as downloads with no
-    source repository and no self-host path, and Google''s own developer blog still presents it as its
-    agent-first development platform. One thing in the old note no longer holds - the platform is not
-    locked to Google models, the launch post offering "model optionality" across Gemini 3 Pro, Anthropic''s
-    Claude Sonnet 4.5 and OpenAI''s GPT-OSS. That is a claim about model choice rather than about source,
-    so the closed score is unaffected and only the wording changed.'
+  note: Proprietary Google agentic dev platform; free in preview but not open source. The platform is not
+    locked to Google models - the launch post offers model optionality across Gemini 3 Pro, Anthropic's
+    Claude Sonnet 4.5 and OpenAI's GPT-OSS - but that is a claim about model choice rather than about source,
+    so the closed score is unaffected.
   raw: source:closed;license:proprietary(Google product, free public preview);self-host:no
   last_verified: '2026-08-13'
   sources:
@@ -44,11 +41,10 @@ adoption:
   reach: null
   signal_type: unknown
   confidence: low
-  note: 'Free public preview launched at I/O 2026; Google discloses no user count for Antigravity specifically.
-    No honest adoption signal yet. Re-checked 2026-08-13 - the I/O developer-highlights post describes
-    the Antigravity ecosystem, the 2.0 desktop app and Managed Agents in the Gemini API, and gives no
-    download, install, developer or active-user count for Antigravity anywhere. Nothing was looked for
-    and found, so the abstention is re-confirmed rather than replaced by a band.'
+  note: Free public preview launched at I/O 2026; Google discloses no user count for Antigravity specifically.
+    No honest adoption signal yet. The I/O developer-highlights post describes the Antigravity ecosystem,
+    the 2.0 desktop app and Managed Agents in the Gemini API and gives no download, install, developer or
+    active-user count anywhere, so the abstention is a searched absence rather than an unexamined gap.
   last_verified: '2026-08-13'
   sources:
   - url: https://blog.google/innovation-and-ai/technology/developers-tools/google-io-2026-developer-highlights/
@@ -66,12 +62,9 @@ capability:
     backbone, deep Google-surface integration, desktop app + CLI + SDK; no first-party SWE-bench number
     published for the platform itself
   confidence: medium
-  note: 'Strong agentic feature breadth (autonomous multi-agent plan-code-test-deploy) on a frontier Gemini
-    backbone; no published SWE-bench for the platform so scored on feature matrix. Below the OpenHands
-    benchmark anchor absent a verified score. Re-read 2026-08-13 - the launch post still describes the
-    platform across macOS, Windows and Linux with model optionality across Gemini 3 Pro, Claude Sonnet
-    4.5 and GPT-OSS, and the I/O post adds the 2.0 desktop app and Managed Agents in the Gemini API. Still
-    no first-party benchmark placement, so the band remains a feature-matrix judgment one below the anchor.'
+  note: Strong agentic feature breadth (autonomous multi-agent plan-code-test-deploy) on a frontier Gemini
+    backbone; no published SWE-bench for the platform so scored on feature matrix. Below the OpenHands benchmark
+    anchor absent a verified score.
   last_verified: '2026-08-13'
   sources:
   - url: https://developers.googleblog.com/build-with-google-antigravity-our-new-agentic-development-platform/

--- a/sources/scores/anyscale-fine-tuning.yaml
+++ b/sources/scores/anyscale-fine-tuning.yaml
@@ -23,11 +23,9 @@ openness:
     docs; Anyscale's fine-tuning capability continues live, now orchestrating open frameworks (LLaMA-Factory,
     SkyRL, Ray Train) instead of LLMForge. The platform itself stays closed regardless. Anyscale's Terms
     of Service define it as a proprietary SaaS delivered in object code only, so openness follows the platform,
-    not the open frameworks running underneath it. Source was already recorded here, but spelled `not-public`,
-    which is outside software.yaml's source enum of public/partial/closed and carries no value_alias, so
-    the dimension read as unanswered and the ladder abstained. Normalized to `closed` on the evidence already
-    on file plus a re-read of the fine-tuning docs; the deferral was a vocabulary problem rather than a
-    missing read.
+    not the open frameworks running underneath it. Source is recorded `closed`; it was previously spelled
+    `not-public`, which is outside software.yaml's source enum of public/partial/closed and carries no value_alias,
+    so the dimension read as unanswered and the ladder abstained.
   last_verified: '2026-08-11'
   raw: license:proprietary(Anyscale-platform-only);source:closed(managed SaaS platform, Terms of Service
     deliver Platform Services in object code format only and no Anyscale-authored fine-tuning implementation
@@ -44,13 +42,12 @@ openness:
     - source
     - license
   - url: https://docs.anyscale.com/llm/fine-tuning
-    shows: Describes Anyscale's current LLM post-training capability as delivered through the managed console
-      orchestrating open frameworks (LLaMA-Factory, SkyRL, Ray Train) on Ray clusters; a full-text search
-      of the fetched page for "LLMForge" found zero occurrences, where the score's prior evidence cited
-      that library by name. Re-read on 2026-08-11, the page still states "Anyscale supports multiple frameworks
-      for LLM post-training, including LLaMA-Factory, SkyRL, and Ray Train", names no Anyscale-authored
-      library, and points at the Anyscale console for every workflow. No self-hostable Anyscale fine-tuning
-      implementation is offered.
+    shows: 'Describes Anyscale''s current LLM post-training capability as delivered through the managed
+      console orchestrating open frameworks on Ray clusters: the page states "Anyscale supports multiple
+      frameworks for LLM post-training, including LLaMA-Factory, SkyRL, and Ray Train", names no Anyscale-authored
+      library, and points at the Anyscale console for every workflow. A full-text search of the fetched
+      page for "LLMForge" finds zero occurrences, where the score''s prior evidence cited that library by
+      name. No self-hostable Anyscale fine-tuning implementation is offered.'
     accessed: '2026-08-11'
     http_status: 200
     content_sha256: b9de20e4993be9e071e8d2e8a5e545aa6aac1155c22a0783f914ba0953d89f31
@@ -81,11 +78,8 @@ capability:
     No advanced quantization/algorithm coverage; Anyscale itself cites Axolotl/LLaMA-Factory as providing
     enhanced functionality, the reason for deprecation.'
   confidence: medium
-  note: 'Modest method/feature coverage relative to live OSS peers; Anyscale''s own deprecation rationale
-    (Axolotl/LLaMA-Factory have more features) caps this low. Re-read 2026-08-13 and unchanged at 2. The note
-    already named its peers - Anyscale''s own deprecation rationale says Axolotl and LLaMA-Factory carry more
-    features - so that is recorded as two_below axolotl rather than left as prose. Using the vendor''s own
-    reason for standing down is the strongest form this comparison takes anywhere in the category.'
+  note: Modest method/feature coverage relative to live OSS peers; Anyscale's own deprecation rationale
+    (Axolotl/LLaMA-Factory have more features) caps this low.
   relative_to: axolotl
   relation: two_below
   last_verified: '2026-08-13'

--- a/sources/scores/anythingllm.yaml
+++ b/sources/scores/anythingllm.yaml
@@ -15,13 +15,8 @@ openness:
     - optional hosted instance tier (managed convenience, not a gated core)
   confidence: high
   note: Fully OSI (MIT), full source public; a hosted instance is offered but the self-hosted Desktop/Docker
-    app is the complete product.
-    Re-read 2026-08-13. The repository still carries MIT and the README still presents the self-hosted
-    Desktop and Docker builds as the complete product, with the Hosted Instance offered beside it as a
-    convenience rather than as a tier that unlocks anything. Two features are marked Docker-version-only
-    - multi-user permissioning and the embeddable chat widget - but both ship in the MIT repository, so
-    nothing is withheld from the published source. Repo now at 64,687 stars, latest release v1.15.0.
-    Value unchanged at 5 / open_source.
+    app is the complete product. Multi-user permissioning and the embeddable chat widget are marked Docker-version-only,
+    but both ship in the MIT repository, so nothing is withheld from the published source.
   raw: license:MIT(OSI);source:public;no-feature-gated-core;optional hosted instance tier (managed convenience,
     not a gated core);core-gated:ungated
   last_verified: '2026-08-13'
@@ -39,11 +34,8 @@ adoption:
   confidence: medium
   note: Docker Hub mintplexlabs/anythingllm shows 1M+ total pulls and ~46k pulls/week (primary); 53-61k
     GitHub stars; Desktop distributed standalone. Placed at 4 on cumulative pull volume; medium confidence
-    as exact all-time count isn't published and Desktop installs aren't separately counted.
-    Re-read 2026-08-13 - the Docker Hub page for mintplexlabs/anythingllm now reports 3,983,336
-    cumulative pulls, last updated the same day, against the 1M-plus the source line records. That is an
-    exact figure where the earlier read had only a floor, and it still sits inside the 1M-10M band.
-    Desktop installs remain uncounted, so the caveat above stands. Level unchanged at 4.
+    as exact all-time count isn't published and Desktop installs aren't separately counted. Docker Hub now
+    publishes an exact cumulative figure of 3,983,336 pulls, still inside the 1M-10M band.
   last_verified: '2026-08-13'
   sources:
   - url: https://hub.docker.com/r/mintplexlabs/anythingllm
@@ -59,13 +51,8 @@ capability:
     web browsing); recent meeting-recording/summarization features
   confidence: high
   note: Strong full-stack chat+RAG+agent surface hitting all category dimensions; provider/vector-DB breadth
-    and no-code agents put it on par with LibreChat/Open WebUI. Reserved 5 for the OSI leaders on raw
-    breadth.
-    Re-read 2026-08-13. The README still shows the full-stack surface the band rests on - many local and
-    cloud LLM providers with dynamic model routing, document ingestion and vector databases as the core
-    use case, multimodal support across open and closed models, multi-user instances with per-user
-    permissioning, and a no-code agent builder with web browsing and MCP compatibility. Scheduled cron
-    tasks, managed memories and intelligent skill selection have been added since. Band unchanged at 4.
+    and no-code agents put it on par with LibreChat/Open WebUI. Reserved 5 for the OSI leaders on raw breadth.
+    Scheduled cron tasks, managed memories and intelligent skill selection have since been added.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/Mintplex-Labs/anything-llm

--- a/sources/scores/apertus.yaml
+++ b/sources/scores/apertus.yaml
@@ -19,17 +19,17 @@ openness:
     - name: Apache-2.0
       detail: OSI
   confidence: high
-  note: 'Held at 5 on 2026-08-14 for the Apertus family, whose current release is the multimodal Apertus
-    1.5 (shipped 2026-07-24). The 1.0/2509 release remains public with its full open stack: pretraining-data
-    reconstruction scripts (respecting opt-out/robots.txt and stripping personal data), the Megatron-LM
-    training recipe, intermediate checkpoints, and the technical report (arXiv 2509.14233), all Apache-2.0,
-    which is the OLMo/Pythia full-openness tier. Apertus 1.5 is likewise Apache-2.0 and declares a "fully
-    open model: open weights + open data + open values + full training details including all data and
-    training recipes", but its own multimodal-mix data-reconstruction scripts, training pipelines and
-    intermediate checkpoints are announced as "coming weeks" and not yet shipped. The 5 rests on the
-    family''s established practice and the still-public 1.0 stack, re-read 2026-08-14; the v1.5-specific
-    artifacts are tracked to confirm on release. An Acceptable Use Policy accompanies the Apache-2.0 grant,
-    restricting conduct (illegal/abusive use) rather than commerce or scale, so the license tier stays OSI.'
+  note: 'The Apertus family''s current release is the multimodal Apertus 1.5 (shipped 2026-07-24). The 1.0/2509
+    release remains public with its full open stack: pretraining-data reconstruction scripts (respecting
+    opt-out/robots.txt and stripping personal data), the Megatron-LM training recipe, intermediate checkpoints,
+    and the technical report (arXiv 2509.14233), all Apache-2.0, which is the OLMo/Pythia full-openness
+    tier. Apertus 1.5 is likewise Apache-2.0 and declares a "fully open model: open weights + open data
+    + open values + full training details including all data and training recipes", but its own multimodal-mix
+    data-reconstruction scripts, training pipelines and intermediate checkpoints are announced as "coming
+    weeks" and not yet shipped. The 5 therefore rests on the family''s established practice and the still-public
+    1.0 stack; the v1.5-specific artifacts are tracked to confirm on release. An Acceptable Use Policy accompanies
+    the Apache-2.0 grant, restricting conduct (illegal/abusive use) rather than commerce or scale, so the
+    license tier stays OSI.'
   last_verified: '2026-08-14'
   raw: weights:open(Apache-2.0, BF16 safetensors);data:open(full pretraining-data reconstruction scripts,
     github.com/swiss-ai/pretrain-data);code:open(Megatron-LM training recipe + reconstruction scripts);checkpoints:open(intermediate
@@ -83,10 +83,10 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: medium
-  note: '17,574 downloads in the trailing 30 days summed across the family''s shipped SKUs, read 2026-08-14
-    (swiss-ai/Apertus-v1.5-8B 11,501; Apertus-v1.5-70B 5,520; Apertus-70B-2509 553). Bands at level 2
-    (10K-100K) on the model adoption scale, up from level 1 as the multimodal v1.5 release (2026-07-24)
-    drew the bulk of the downloads, while the original 2509 flagship now sees little traffic.'
+  note: 17,574 downloads in the trailing 30 days summed across the family's shipped SKUs (swiss-ai/Apertus-v1.5-8B
+    11,501; Apertus-v1.5-70B 5,520; Apertus-70B-2509 553). Bands at level 2 (10K-100K) on the model adoption
+    scale, up from level 1 as the multimodal v1.5 release (2026-07-24) drew the bulk of the downloads, while
+    the original 2509 flagship now sees little traffic.
   last_verified: '2026-08-14'
   sources:
   - url: https://huggingface.co/api/models/swiss-ai/Apertus-v1.5-8B
@@ -119,16 +119,11 @@ capability:
   note: 'Mid-tier capability: competitive with the prior open generation (Llama 3.1-70B class) on pretraining
     benchmarks and unusually strong multilingually, but below the 2026 frontier on MMLU-style reasoning/knowledge.
     The value proposition is full openness + multilingual breadth + legal compliance, not raw SOTA, same
-    profile as OLMo 2. Re-read 2026-08-13 - the card''s pretraining table still shows 67.5% against
-    Llama 3.1-70B''s 67.3% and MMLU 69.6% for the Instruct variant, so the `at` relation to the
-    llama tier still holds arithmetically and in substance. Worth stating precisely, because the
-    llama record moved the same day: llama''s capability reading is now Llama 4 Maverick rather than
-    Llama 3.1 405B, and both tiers score 3, so the relation survives a change in what the peer is
-    measured on. Noted 2026-08-14: Apertus 1.5 (2026-07-24) adds multimodal input (image + audio), a
-    thinking/deliberation mode, and a 262,144-token context, and claims performance "comparable to other
-    models of similar size"; quantified v1.5 benchmarks await the technical report ("coming weeks"), so
-    the score stays 3 on the last citable (2509) numbers, and the `at llama` relation stands from the
-    2026-08-13 joint comparison rather than being re-derived today.'
+    profile as OLMo 2. Apertus 1.5 adds multimodal input (image and audio), a thinking/deliberation mode
+    and a 262,144-token context, and claims performance "comparable to other models of similar size", but
+    quantified v1.5 benchmarks await its technical report, so the score rests on the last citable 2509 numbers.
+    The `at llama` relation holds even though llama''s own capability reading is now Llama 4 Maverick rather
+    than Llama 3.1 405B, since both tiers score 3.'
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/swiss-ai/Apertus-70B-2509

--- a/sources/scores/apify.yaml
+++ b/sources/scores/apify.yaml
@@ -21,12 +21,7 @@ openness:
     most value stays behind the managed cloud. Class corrected from open_core on 2026-07-30. In this ladder
     open_core means an OSI core with functionality withheld for a paid tier, and there is no open core here,
     only an open periphery. A repo that exists while the runtime does not ship is source:partial, which
-    the ladder scores 2/source_available. The score itself was already 2. Re-read 2026-08-13 and the shape
-    holds exactly. apify.com still files Crawlee under a navigation heading literally labelled "Open source"
-    - "Web scraping and crawling library" - beside the closed platform pieces, Actors, Proxy, Anti-blocking,
-    Integrations and the MCP server. Crawlee's own repo confirms Apache-2.0 in both the badge and the GitHub
-    metadata (spdxId Apache-2.0). Nothing that RUNS an Actor is published anywhere, so `source - partial`
-    stands and so does 2/source_available.
+    the ladder scores 2/source_available. The score itself was already 2.
   raw: platform:proprietary(Apify-Cloud,Actor-store,managed);source:partial(Crawlee SDK published, the platform
     that runs Actors is not);oss-sdk:Crawlee(Apache-2.0,OSI, JS+Python);license:mixed(platform closed, SDK
     open)
@@ -57,15 +52,11 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: medium
-  note: Crawlee at 23.7k GitHub stars (corroborating, not basis); platform serves named enterprises (T-Mobile,
-    Microsoft, Accenture) and a 15,000+ member Discord. 35,000+ published Actors implies a sizable active
-    developer base. No precise account/API-call count published; placed at 3 on combined developer/usage
-    signal across platform + OSS SDK. Re-read 2026-08-13, and the Actor count has moved a long way - the
-    store now says 59,817 Actors against the 35,000+ recorded, and Crawlee is at 25,373 stars against 23.7k.
-    The named enterprises are still on the page. The 15,000+ Discord figure is NOT - the page links to a
-    Discord invite without stating a member count, so that clause has been dropped from the note rather than
-    carried on nothing. None of these is a usage figure in the scale''s sense; Apify still publishes no account,
-    run or API-call count, so the level remains an aggregate judgment and stays at 3.
+  note: Crawlee at 25,373 GitHub stars (corroborating, not basis); the platform serves named enterprises
+    (T-Mobile, Microsoft, Accenture) and the store advertises 59,817 published Actors, which implies a sizable
+    active developer base. The site links a Discord invite without stating a member count, so no community
+    figure is carried. No precise account, run or API-call count is published, so the level stays an aggregate
+    judgment across platform + OSS SDK and remains 3.
   last_verified: '2026-08-13'
   sources:
   - url: https://apify.com
@@ -87,13 +78,9 @@ capability:
     and JSDOM; proxy rotation and session management; anti-blocking; structured output of tabular data and
     files; serverless custom Actors; an Apify MCP server for agent clients'
   confidence: high
-  note: 'Broad scrape/browse feature matrix, multi-engine crawling, proxy/anti-block, structured extraction,
+  note: Broad scrape/browse feature matrix, multi-engine crawling, proxy/anti-block, structured extraction,
     serverless deploy, and MCP integration for agents. Among the most complete scrape platforms; rated 4
-    (frontier-adjacent for the browser/scrape sub-segment). Re-read 2026-08-13. Every dimension holds and
-    two figures were corrected upward - the store now advertises 59,817 Actors, and Crawlee''s own description
-    names Puppeteer, Playwright, Cheerio, JSDOM and raw HTTP rather than the Selenium this record had, in
-    both headful and headless mode with integrated proxy rotation and session management. The Apify MCP server
-    is now a first-class navigation item, "Give your AI access to Actors". Band unchanged at 4.'
+    (frontier-adjacent for the browser/scrape sub-segment).
   last_verified: '2026-08-13'
   sources:
   - url: https://apify.com

--- a/sources/scores/apps.yaml
+++ b/sources/scores/apps.yaml
@@ -18,10 +18,7 @@ openness:
       value: public
       detail: NeurIPS 2021
   confidence: high
-  note: 'Clean open data: MIT, downloadable, documented datasheet, public paper: full open class.
-    Re-read 2026-08-13: `license:mit` is still in the repo tags, the embedded repo state reads
-    `"gated":false` so the parquet is still freely downloadable, and the dataset card still renders.
-    No change.'
+  note: 'Clean open data: MIT, downloadable, documented datasheet, public paper: full open class.'
   raw: data:downloadable(HF parquet, codeparrot/apps);license:MIT(OSI/open);datasheet:present(card documents
     10k problems, 131,777 tests, difficulty levels, schema);redistributable:yes;paper:public(NeurIPS 2021)
   last_verified: '2026-08-13'
@@ -39,11 +36,10 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: medium
-  note: 17,673 Hugging Face downloads in the trailing 30 days (codeparrot/apps), read 2026-08-12. Bands
-    at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M - one order of magnitude
-    below the software and model scales, because no dataset artifact in the corpus has ever exceeded 10M.
-    A well-established code-generation benchmark cited since 2021, partly superseded by harder contamination-free
-    suites (LiveCodeBench, SWE-bench).
+  note: 17,673 Hugging Face downloads in the trailing 30 days (codeparrot/apps). Bands at level 3 (10K-100K)
+    on the dataset adoption scale, whose top band is >1M - one order of magnitude below the software and
+    model scales, because no dataset artifact in the corpus has ever exceeded 10M. A well-established code-generation
+    benchmark cited since 2021, partly superseded by harder contamination-free suites (LiveCodeBench, SWE-bench).
   last_verified: '2026-08-12'
   sources:
   - url: https://huggingface.co/api/datasets/codeparrot/apps
@@ -56,8 +52,8 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: Dataset, not capability-scored. Re-read 2026-08-13 and the abstention stands - the page publishes
-    a static problem set and no performance or feature claim the capability axis could band.
+  note: Dataset, not capability-scored. The page publishes a static problem set with no performance or feature
+    claim the capability axis could band.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/codeparrot/apps

--- a/sources/scores/arduino-uno-q.yaml
+++ b/sources/scores/arduino-uno-q.yaml
@@ -22,30 +22,25 @@ openness:
       detail: global
       raw: open_market (global)
   confidence: high
-  note: 'Board schematics and gerbers are openly licensed under CC-BY-SA 4.0 and the App Lab toolchain
-    is open, which is the same open-and-open pair that puts beagley-ai at 5. Corrected from 3/documented
-    on 2026-08-12. This ladder scores design-file openness rather than silicon: the level-5 rung says
-    so in its own text, and every board in the category runs on proprietary silicon, so the QRB2210
-    firmware blobs the old note cited are a reason no rung applies. Re-derived 2026-08-14, because the
-    toolchain half of the pair rested on a vendor claim rather than on source. The FAQ still answers
-    "Is UNO Q open source?" with schematics and gerbers only, and its App Lab answer still reads
-    "we are working to publish corresponding source code repositories, they will become available
-    soon" - but that sentence is now stale. github.com/arduino/arduino-app-lab is public under
-    GPL-3.0, 19MB of Go and TypeScript with the app, ui-packages and standalone-apps trees, last
-    pushed 2026-08-12, and github.com/arduino/app-bricks-py is public under MPL-2.0, pushed
-    2026-08-13. The 5 stands and now rests on the repositories rather than on the promise of them.
-    The remaining three components were read the same day and the axis is dated on all five.
-    `datasheets` is `public` on the 109-page UNO Q user manual for ABX00162-ABX00173, modified
-    12/08/2026, served from docs.arduino.cc as a plain PDF with no registration, alongside the
-    schematics, pinout, CAD and STEP downloads. `retail` is `open_market` on the FAQ naming the
-    channels - "UNO Q is available to order from the official Arduino Store, RS Components, Digikey,
-    Mouser, Macfos" - and on the store still selling both SKUs at EUR59,90 and EUR82,90. `blobs` stays
-    `required` on the proprietary Dragonwing QRB2210 the board is built around, which is what every
-    other part in this category records for the same fact, but the manual narrows what that covers and
-    the narrowing is worth recording - the Adreno 702 graphics stack is open, "hardware-accelerated 3D
-    graphics rendering through open-source Mesa drivers", freedreno for OpenGL and turnip for Vulkan,
-    with video encode and decode reached through plain V4L2. What remains closed is the SoC boot chain,
-    which Arduino publishes nothing of.'
+  note: 'Board schematics and gerbers are openly licensed under CC-BY-SA 4.0 and the App Lab toolchain is
+    open, which is the same open-and-open pair that puts beagley-ai at 5; this corrects an earlier 3/documented.
+    This ladder scores design-file openness rather than silicon: the level-5 rung says so in its own text,
+    and every board in the category runs on proprietary silicon, so the QRB2210 firmware blobs the old note
+    cited are a reason no rung applies. The toolchain half rests on published source rather than on a vendor
+    claim - github.com/arduino/arduino-app-lab is public under GPL-3.0, 19MB of Go and TypeScript carrying
+    the app, ui-packages and standalone-apps trees, and github.com/arduino/app-bricks-py is public under
+    MPL-2.0. The FAQ is stale on this point: it still answers "Is UNO Q open source?" with schematics and
+    gerbers only, and its App Lab answer still reads "we are working to publish corresponding source code
+    repositories, they will become available soon". `datasheets` is `public` on the 109-page UNO Q user
+    manual for ABX00162-ABX00173, served from docs.arduino.cc as a plain PDF with no registration, alongside
+    the schematics, pinout, CAD and STEP downloads. `retail` is `open_market` on the FAQ naming the channels
+    - "UNO Q is available to order from the official Arduino Store, RS Components, Digikey, Mouser, Macfos"
+    - and on the store selling both SKUs at EUR59,90 and EUR82,90. `blobs` stays `required` on the proprietary
+    Dragonwing QRB2210 the board is built around, which is what every other part in this category records
+    for the same fact, but the manual narrows what that covers and the narrowing is worth recording - the
+    Adreno 702 graphics stack is open, "hardware-accelerated 3D graphics rendering through open-source Mesa
+    drivers", freedreno for OpenGL and turnip for Vulkan, with video encode and decode reached through plain
+    V4L2. What remains closed is the SoC boot chain, which Arduino publishes nothing of.'
   raw: schematics:open (gerbers + schematics CC-BY-SA 4.0);toolchain:open (App Lab GPL-3.0 + App
     Bricks MPL-2.0, source published);datasheets:public;blobs:required (proprietary Qualcomm SoC
     firmware);retail:open_market (global)
@@ -111,10 +106,9 @@ adoption:
   signal_type: reported_traction
   confidence: high
   note: Sold globally through Arduino Store plus Digikey, Mouser, and RS Components, backed by Arduino's
-    large maker community. Re-read 2026-08-13 - the Arduino Store still sells both SKUs, at EUR59,90
-    (2GB) and EUR82,90 (4GB), and still carries a Distributors link, though it names no distributor on
-    the page, so the Digikey/Mouser/RS half of the note rests on the earlier read. Level and reach
-    unchanged.
+    large maker community. The Arduino Store lists both SKUs at EUR59,90 (2GB) and EUR82,90 (4GB) and carries
+    a Distributors link but names no distributor on the page, so the Digikey/Mouser/RS half of the claim
+    rests on the FAQ channel list rather than on the store.
   last_verified: '2026-08-13'
   sources:
   - url: https://store.arduino.cc/pages/uno-q
@@ -129,11 +123,10 @@ capability:
   value: QRB2210 quad-core 2.0 GHz + Adreno GPU; up to 4GB RAM; AI acceleration
   confidence: medium
   note: Capable Linux+MCU hybrid with GPU/ISP-based AI acceleration, but no published TOPS figure so throughput
-    is modest versus dedicated-NPU kits. Re-derived 2026-08-13 - the product page still describes a
-    quad-core Qualcomm Dragonwing QRB2210 with a GPU and an STM32U585 MCU, 2GB or 4GB RAM, "integrated
-    AI acceleration" and "lightweight AI", and still publishes no TOPS number anywhere. The absence of a
-    figure is what keeps it below every dedicated-NPU part in this category and level with the other
-    general-purpose boards.
+    is modest versus dedicated-NPU kits. The product page describes a quad-core Qualcomm Dragonwing QRB2210
+    with a GPU and an STM32U585 MCU, 2GB or 4GB RAM, "integrated AI acceleration" and "lightweight AI",
+    and publishes no TOPS number anywhere. The absence of a figure is what keeps it below every dedicated-NPU
+    part in this category and level with the other general-purpose boards.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.arduino.cc/product-uno-q

--- a/sources/scores/arize.yaml
+++ b/sources/scores/arize.yaml
@@ -18,9 +18,7 @@ openness:
       raw: open source Phoenix is a separate companion product, not the AX platform
   confidence: high
   note: Arize AX is closed/proprietary SaaS with no self-hostable core; only the separate Phoenix project
-    is source-available. Re-read 2026-08-13 and unchanged - the site's own product menu still separates
-    "Arize AX - Managed AI engineering platform" from "Phoenix Open Source - Open-source observability and
-    evals", and AX ships no repository or self-host path of its own.
+    is source-available.
   raw: license:Proprietary;weights:n/a;source:closed(proprietary SaaS);self-host:none for core AX features;note:open
     source Phoenix is a separate companion product, not the AX platform
   last_verified: '2026-08-13'
@@ -44,11 +42,9 @@ adoption:
   confidence: medium
   banded_quantity: platform throughput (~1T spans and ~1B evals a month), not an account or user count
   note: Vendor discloses ~1 trillion spans/month and ~1 billion evals/month plus named enterprise customers;
-    no per-account user count, so reported_traction rather than active_users. Re-read 2026-08-13 - both
-    throughput figures are still on the homepage unchanged. The named-customer roster has been cut back
-    to testimonials from Atlassian and PepsiCo; DoorDash, Roblox, Booking.com and Reddit are no longer on
-    the page, and that half of the evidence is recorded as gone rather than carried forward. The two
-    throughput figures on their own still place the band at 4.
+    no per-account user count, so reported_traction rather than active_users. Both throughput figures are
+    on the homepage; the named-customer roster there is now testimonials from Atlassian and PepsiCo only,
+    and the two throughput figures on their own place the band at 4.
   last_verified: '2026-08-13'
   sources:
   - url: https://arize.com/
@@ -65,9 +61,7 @@ capability:
     embedded AI engineering agent, adb GenAI datastore, alerting/monitoring at trillion-span scale
   confidence: medium
   note: Frontier-tier closed observability platform for this category; enterprise-scale managed tracing/eval/monitoring
-    exceeding the OSS feature sets. A 5 reflects category-leading closed capability. Re-read 2026-08-13 -
-    the product tabs still read Observe, Evaluate, Develop and Alyx, and the trillion-span figure still
-    backs the scale claim, so the band is unchanged.
+    exceeding the OSS feature sets. A 5 reflects category-leading closed capability.
   last_verified: '2026-08-13'
   sources:
   - url: https://arize.com/

--- a/sources/scores/artificial-analysis-intelligence-index.yaml
+++ b/sources/scores/artificial-analysis-intelligence-index.yaml
@@ -29,13 +29,12 @@ openness:
     of ten evals. Class corrected from open_core on 2026-07-30. In this ladder open_core means an OSI core
     with functionality withheld for a paid tier, and there is no open core here, only an open periphery.
     A repo that exists while the runtime does not ship is source:partial, which the ladder scores 2/source_available.
-    The score itself was already 2. Re-read 2026-08-13 and the dimension holds, but two recorded details
-    have gone stale and should be corrected in a components edit. The methodology page is now v4.1.1 with
-    NINE evals rather than ten, and the four categories are no longer equally weighted (Agents 34%, Coding
-    24%, Scientific Reasoning 24%, General 18%). Stirrup now backs more than one eval - GDPval-AA v2, AA-Briefcase
-    and Harvey LAB-AA - so ''covers one of ten evals'' understates it. Neither change touches `source`:
-    Artificial Analysis still states ''We maintain internal copies of all evaluation datasets'' and still
-    publishes no end-to-end Index pipeline, so a repo exists while the runtime does not ship.'
+    The score itself was already 2. The methodology page is at v4.1.1 with nine evals across four unequally
+    weighted categories (Agents 34%, Coding 24%, Scientific Reasoning 24%, General 18%), and Stirrup backs
+    GDPval-AA v2, AA-Briefcase and Harvey LAB-AA rather than a single eval, so the recorded components understate
+    it. Neither detail touches `source`: Artificial Analysis still states ''We maintain internal copies
+    of all evaluation datasets'' and still publishes no end-to-end Index pipeline, so a repo exists while
+    the runtime does not ship.'
   raw: platform:closed(proprietary benchmarking site + methodology); source:partial(Stirrup covers one of
     ten evals; the Index pipeline does not ship); methodology:documented(public methodology page, per-eval
     breakdown, temp/token params); datasets:closed(maintains internal copies of all eval datasets); harness:partial-open(Stirrup
@@ -50,12 +49,11 @@ openness:
     shows: Stirrup MIT-licensed agent harness, 413 stars (the only open component)
     accessed: '2026-06-04'
   - url: https://artificialanalysis.ai/methodology/intelligence-benchmarking
-    shows: 'Re-read 2026-08-13. Intelligence Index v4.1.1, nine evals across four unequally weighted categories
-      - Agents 34%, Coding 24%, Scientific Reasoning 24%, General 18% - namely GDPval-AA v2, tau-cubed
-      Banking, Terminal-Bench v2.1, SciCode, AA-LCR, AA-Omniscience, Humanity''s Last Exam, GPQA Diamond
-      and CritPt. ''We maintain internal copies of all evaluation datasets''. Stirrup is named as ''our
-      open source agentic harness'' for GDPval-AA v2, AA-Briefcase and Harvey LAB-AA. The Index pipeline
-      itself is not published.'
+    shows: Intelligence Index v4.1.1, nine evals across four unequally weighted categories - Agents 34%,
+      Coding 24%, Scientific Reasoning 24%, General 18% - namely GDPval-AA v2, tau-cubed Banking, Terminal-Bench
+      v2.1, SciCode, AA-LCR, AA-Omniscience, Humanity's Last Exam, GPQA Diamond and CritPt. 'We maintain
+      internal copies of all evaluation datasets'. Stirrup is named as 'our open source agentic harness'
+      for GDPval-AA v2, AA-Briefcase and Harvey LAB-AA. The Index pipeline itself is not published.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 28dbab4467e0dcf4f509bfb51f365af7f28526b02ca02fae9e86e7689e9bd521
@@ -75,11 +73,10 @@ adoption:
   confidence: medium
   last_verified: '2026-08-13'
   note: The AA Intelligence Index is one of the most-cited independent model-ranking standards in frontier
-    release coverage and the flagship_scores set itself uses it as a capability basis (e.g. Grok 4.20,
-    Gemini 3.5 Flash records). Widely referenced across vendor launches and tech press as the go-to cross-model
-    index. No disclosed unique-visitor count; level 4 reflects its standard-citation reach across the
-    industry, banded conservatively. Directional. Re-read 2026-08-13 - the live Index is still running
-    and still publishes no visitor, subscriber or API-usage figure, so the basis of the level is unchanged.
+    release coverage and the flagship_scores set itself uses it as a capability basis (e.g. Grok 4.20, Gemini
+    3.5 Flash records). Widely referenced across vendor launches and tech press as the go-to cross-model
+    index. No disclosed unique-visitor count; level 4 reflects its standard-citation reach across the industry,
+    banded conservatively. Directional.
   sources:
   - url: https://artificialanalysis.ai/
     shows: live Intelligence Index leaderboard positioned as the cross-model standard reference
@@ -88,14 +85,14 @@ adoption:
     shows: independent standardized index cited as the reference methodology
     accessed: '2026-06-04'
   - url: https://artificialanalysis.ai/
-    shows: 'Re-read 2026-08-13: the live cross-model Intelligence Index leaderboard is still published
-      and still carries no unique-visitor, subscriber or usage count.'
+    shows: The live cross-model Intelligence Index leaderboard carries no unique-visitor, subscriber or
+      usage count.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: e718e2c4fbe94a1de20e00a9a37353d06ba75508ba735617100bb73bf2d68636
   - url: https://artificialanalysis.ai/methodology/intelligence-benchmarking
-    shows: 'Re-read 2026-08-13: methodology v4.1.1, still published in full as the reference for the index.
-      No adoption or traffic figure appears on it.'
+    shows: Methodology v4.1.1, published in full as the reference for the index. No adoption or traffic
+      figure appears on it.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 28dbab4467e0dcf4f509bfb51f365af7f28526b02ca02fae9e86e7689e9bd521
@@ -111,11 +108,7 @@ capability:
   last_verified: '2026-08-13'
   note: 'Frontier-grade composite coverage spanning agentic/coding/general/scientific with contamination-resistant
     internal datasets and standardized running. Strong capability. Not a 5: it is a curated index/methodology
-    rather than an open community harness, and held-out/proprietary running limits external reproducibility.
-    Re-read 2026-08-13 and the band is unchanged, but the value was stale and is corrected here: the index
-    moved from v4.0.4 to v4.1.1, from ten evals to nine (IFBench dropped, tau2-Telecom replaced by tau-cubed
-    Banking, Terminal-Bench Hard by Terminal-Bench v2.1), and the four categories are now weighted 34/24/24/18
-    rather than equally.'
+    rather than an open community harness, and held-out/proprietary running limits external reproducibility.'
   sources:
   - url: https://artificialanalysis.ai/methodology/intelligence-benchmarking
     shows: 10-eval composite, 4 equal-weighted categories, standardized params, internal dataset copies

--- a/sources/scores/autogen.yaml
+++ b/sources/scores/autogen.yaml
@@ -15,11 +15,8 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: 'Code is MIT and fully open; the GitHub-surfaced CC-BY-4.0 is only the docs license. Re-read 2026-08-13
-    - LICENSE-CODE still carries the MIT text, "Copyright (c) Microsoft Corporation", and the repo README
-    still spells the split out, granting "a license to any code in the repository under the MIT License,
-    see the LICENSE-CODE file" while LICENSE governs the documentation. The whole framework is published
-    with no enterprise directory and no paid tier. Stars are now 60.4k. Nothing moved.'
+  note: Code is MIT and fully open; the GitHub-surfaced CC-BY-4.0 is only the docs license. The whole framework
+    is published with no enterprise directory and no paid tier.
   raw: license:MIT(code,via LICENSE-CODE);docs:CC-BY-4.0;source:public;no-feature-gated-core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -45,9 +42,8 @@ adoption:
   level: 4
   signal_type: usage_volume
   confidence: medium
-  note: 1,058,837 PyPI downloads in the trailing 30 days for autogen-agentchat, read 2026-08-12. Bands at
-    level 4 (1M-10M) on the software and model adoption scale. Trajectory is flat to declining as the project
-    enters maintenance.
+  note: 1,058,837 PyPI downloads in the trailing 30 days for autogen-agentchat. Bands at level 4 (1M-10M)
+    on the software and model adoption scale. Trajectory is flat to declining as the project enters maintenance.
   reach: 1M-10M
   last_verified: '2026-08-12'
   sources:
@@ -62,10 +58,7 @@ capability:
   value: multi-agent conversation orchestration; preset team patterns; tool use; code execution; async/event-driven;
     AutoGen Studio
   confidence: medium
-  note: 'Strong multi-agent conversation model; less durable-execution depth than LangGraph and now in
-    maintenance. Re-read 2026-08-13 - the repo still publishes the same multi-agent conversation framework
-    with preset team patterns, tool use, code execution and AutoGen Studio, and still shows no benchmark
-    placement. One below langgraph, which is where the durable-execution depth sits.'
+  note: Strong multi-agent conversation model; less durable-execution depth than LangGraph and now in maintenance.
   relative_to: langgraph
   relation: one_below
   last_verified: '2026-08-13'

--- a/sources/scores/autogpt.yaml
+++ b/sources/scores/autogpt.yaml
@@ -17,12 +17,12 @@ openness:
     the tier lookup reading the word itself; `DUAL` describes the arrangement, not the terms, so the governing
     license is now recorded by name and the MIT half stays beside it. Score corrected from 3 to 2 on 2026-07-30.
     The software ladder has rungs at 1, 2, 4 and 5 and none at 3, so 3/source_available was not a pair any
-    rule could produce; the ladder scores "you can read it and not run it freely" at 2. Re-read 2026-08-13
-    - the README still carries a per-component license table putting autogpt_platform/ under Polyform
-    Shield, described there as "free for personal and internal business use; cannot be sold as a competing
-    hosted service", with the classic components under MIT. GitHub still shows a bare "License" entry
-    rather than a recognized SPDX badge, which is what a split license looks like to the classifier. The
-    whole platform source is published and self-hosting is offered with no license fee. Nothing moved.'
+    rule could produce; the ladder scores "you can read it and not run it freely" at 2. The README carries
+    a per-component license table putting autogpt_platform/ under Polyform Shield, described there as "free
+    for personal and internal business use; cannot be sold as a competing hosted service", with the classic
+    components under MIT; GitHub shows a bare "License" entry rather than a recognized SPDX badge, which
+    is what a split license looks like to the classifier. The whole platform source is published and self-hosting
+    is offered with no license fee.'
   raw: license:PolyForm-Shield(non-OSI, source-available, anti-compete; governs autogpt_platform/, the active
     product); everything else (Classic, Forge, agbenchmark) MIT(OSI);source:public
   last_verified: '2026-08-13'
@@ -42,14 +42,11 @@ adoption:
   reach: '>10K stars'
   signal_type: stars_fallback
   confidence: low
-  note: '185k stars (one of the most-starred repos on GitHub) reflects huge historical interest, but stars
+  note: 185k stars (one of the most-starred repos on GitHub) reflects huge historical interest, but stars
     cannot exceed level 3 and recent production-usage signal is unclear. No published platform MAU/download
-    volume found; capped at 3, directional. Stars read 2026-08-13: 186,583 across the 1 declared repo, which
-    bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The previous reach ''100K-1M'' was
-    not a label this instrument offers - stars have their own vocabulary because a star is not a download.
-    Re-read 2026-08-13 from the repo page, which reports 186.6k stars and 46.1k forks. The platform ships
-    as a hosted plan or a Docker self-host and publishes no user, install or download count, so the stars
-    fallback is still the only instrument available and the cap still holds the level at 3.'
+    volume found; capped at 3, directional. 186,583 stars across the 1 declared repo, which bands at >10K
+    stars, level 3 on the stars scale in signal_routing.yaml. The previous reach '100K-1M' was not a label
+    this instrument offers - stars have their own vocabulary because a star is not a download.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/Significant-Gravitas/AutoGPT
@@ -64,10 +61,8 @@ capability:
     blocks; model-agnostic: yes; eval/reliability: agbenchmark + monitoring. No headline SWE-bench/GAIA
     placement.'
   confidence: medium
-  note: 'Pioneering but the autonomous loop has been surpassed; the low-code platform is its current value.
-    No competitive agent-benchmark number published; scored low-mid on feature matrix. Re-read 2026-08-13
-    - the README now leads on the visual builder, running agents on demand, on a schedule or from a trigger,
-    and still publishes no benchmark placement of any kind. The feature matrix and the band are unchanged.'
+  note: Pioneering but the autonomous loop has been surpassed; the low-code platform is its current value.
+    No competitive agent-benchmark number published; scored low-mid on feature matrix.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/Significant-Gravitas/AutoGPT

--- a/sources/scores/aws-lambda.yaml
+++ b/sources/scores/aws-lambda.yaml
@@ -16,13 +16,9 @@ openness:
     source:
       value: closed
   confidence: high
-  note: Lambda is a proprietary managed serverless service (closed), per recipe's explicit 'Lambda as
-    closed counterpart'. Firecracker (the microVM substrate) is separately open source but is a different
-    artifact; Lambda itself is not self-hostable. Re-read 2026-08-13 on the Lambda FAQ, which describes
-    deployment only as uploading .zip archives or container images to AWS and offers no self-hosted or
-    source-available build of the service. It confirms the substrate relationship from the other side -
-    Lambda MicroVMs are "built on the same Firecracker virtualization" - while publishing nothing of the
-    control or data plane. Score and class unchanged.
+  note: Lambda is a proprietary managed serverless service (closed), per recipe's explicit 'Lambda as closed
+    counterpart'. Firecracker (the microVM substrate) is separately open source but is a different artifact;
+    Lambda itself is not self-hostable.
   raw: license:Proprietary;service:proprietary AWS-only SaaS (no self-host);underlying-microVM:Firecracker
     is Apache-2.0 OSS but the Lambda control/data plane is closed;weights:n/a;source:closed
   last_verified: '2026-08-13'
@@ -50,13 +46,12 @@ adoption:
   confidence: high
   note: 'AWS states Lambda ''processes trillions of executions for hundreds of thousands of active customers
     every month'' - mass-market serverless deployment substrate, unambiguously >10M reach. (Adoption attributed
-    to general serverless usage, not specifically agent-code-execution.) Re-read 2026-08-13 and the figure
-    has been superseded upward on AWS''s own current page - the Lambda FAQ now states "15 trillion+ monthly
-    Lambda Function invocations", against the 2018 launch post''s "trillions". Level unchanged at 5.
-    Instrument caveat, recorded rather than fixed: `usage_volume` names a count and Lambda has no countable
-    artifact - it is a hosted AWS service with no package, repo or registry entry any signal model reads.
-    The invocation figure is a vendor-reported platform total, not a per-user count, so the instrument is
-    flagged for a human ruling rather than relabelled here.'
+    to general serverless usage, not specifically agent-code-execution.) AWS''s current Lambda FAQ supersedes
+    that figure upward, stating "15 trillion+ monthly Lambda Function invocations" against the 2018 launch
+    post''s "trillions". Instrument caveat, recorded rather than fixed: `usage_volume` names a count and
+    Lambda has no countable artifact - no package, repo or registry entry any signal model reads - and the
+    invocation figure is a vendor-reported platform total rather than a per-user count, so the instrument
+    is flagged for a human ruling rather than relabelled here.'
   last_verified: '2026-08-13'
   sources:
   - url: https://aws.amazon.com/blogs/aws/firecracker-lightweight-virtualization-for-serverless-computing/
@@ -76,21 +71,16 @@ capability:
     Node/Python/Java/Go/Ruby/.NET + custom runtimes/container images, arbitrary code); persistence:stateless+attachable
     storage (EFS, /tmp); scale:trillions of executions/mo, effectively unbounded autoscale
   confidence: high
-  note: 'Frontier-definer for this category: microVM-grade isolation, the widest runtime breadth, and
-    the largest proven scale of any deployment runtime here. Scored 5. Re-read 2026-08-13 on the Lambda
-    FAQ, which confirms every part of the recorded matrix and adds one thing to it. Runtime breadth is
-    still the widest here - "Java, Go, PowerShell, Node.js, C#, Python, and Ruby" natively plus a Runtime
-    API for any other language, and both .zip archives and container images. Isolation is per-function
-    and Firecracker-backed. Since the last read AWS has shipped Lambda MicroVMs, a primitive explicitly
-    "purpose-built for workloads that execute user- or AI-generated code" with VM-level isolation,
-    near-instant launch and resume, and state persistence across interactions, which puts Lambda directly
-    on the agent-sandbox feature axis this category scores rather than only adjacent to it. Score unchanged
-    at 5. Read again 2026-08-14, as the anchor for `vercel-sandbox`, which records `one_below` and cannot
-    be dated ahead of what it derives from. The FAQ carries the same matrix and puts numbers on the two
-    parts of it a peer comparison turns on - Lambda MicroVMs persist state up to 8 hours and take
-    containers to 32GB and 16 vCPUs on Amazon Linux 2023, and functions scale "at a rate of up to 1000
-    concurrent executions every 10 seconds" on top of the 15 trillion monthly invocations. Score unchanged
-    at 5.'
+  note: 'Frontier-definer for this category: microVM-grade isolation, the widest runtime breadth, and the
+    largest proven scale of any deployment runtime here. Scored 5. Runtime breadth is the widest here -
+    Java, Go, PowerShell, Node.js, C#, Python and Ruby natively plus a Runtime API for any other language,
+    and both .zip archives and container images - and isolation is per-function and Firecracker-backed.
+    AWS has since shipped Lambda MicroVMs, a primitive explicitly "purpose-built for workloads that execute
+    user- or AI-generated code" with VM-level isolation, near-instant launch and resume, and state persistence
+    up to 8 hours, which puts Lambda directly on the agent-sandbox feature axis this category scores rather
+    than only adjacent to it; MicroVM containers reach 32GB of memory and 16 vCPUs on Amazon Linux 2023,
+    and functions scale at up to 1000 concurrent executions every 10 seconds on top of 15 trillion monthly
+    invocations.'
   last_verified: '2026-08-14'
   sources:
   - url: https://aws.amazon.com/blogs/aws/firecracker-lightweight-virtualization-for-serverless-computing/
@@ -98,15 +88,14 @@ capability:
     accessed: '2026-06-04'
   - url: https://aws.amazon.com/lambda/faqs/
     shows: '"AWS Lambda natively supports Java, Go, PowerShell, Node.js, C#, Python, and Ruby code, and
-      provides a Runtime API which allows you to use any additional programming languages"; functions
-      deploy "as .zip file archives ... or as container images. Both methods provide the same execution
-      environment"; "Each AWS Lambda function runs in its own isolated environment". Lambda MicroVMs
-      "combines VM-level isolation, near-instant launch and resume, and state persistence across
-      interactions ... purpose-built for workloads that execute user- or AI-generated code", built on
-      "the same Firecracker virtualization powering 15 trillion+ monthly Lambda Function invocations".
-      Read again 2026-08-14 - every quote above still stands, and the page also states that functions
-      scale "at a rate of up to 1000 concurrent executions every 10 seconds", and that MicroVMs persist
-      state up to 8 hours with containers up to 32 GB memory and 16 vCPUs on Amazon Linux 2023.'
+      provides a Runtime API which allows you to use any additional programming languages"; functions deploy
+      "as .zip file archives ... or as container images. Both methods provide the same execution environment";
+      "Each AWS Lambda function runs in its own isolated environment"; functions scale "at a rate of up
+      to 1000 concurrent executions every 10 seconds". Lambda MicroVMs "combines VM-level isolation, near-instant
+      launch and resume, and state persistence across interactions ... purpose-built for workloads that
+      execute user- or AI-generated code", built on "the same Firecracker virtualization powering 15 trillion+
+      monthly Lambda Function invocations", persisting state up to 8 hours with containers up to 32 GB memory
+      and 16 vCPUs on Amazon Linux 2023.'
     accessed: '2026-08-14'
     http_status: 200
     content_sha256: f75cb1da877f31f25f580f27df64810d86cf59c98f0fdad546b0aec9aaa13e0d

--- a/sources/scores/aws-neuron.yaml
+++ b/sources/scores/aws-neuron.yaml
@@ -37,11 +37,10 @@ openness:
   sources:
   - url: https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/oss/index.html
     shows: AWS Neuron provides open source code and samples for some of its components, libraries, and tools
-      under the Apache 2.0 license. The current public repositories open to contribution at this time are
-      listed below. Re-read on 2026-08-11 (the URL now redirects to /about-neuron/oss/index.html), the
-      catalog lists exactly six public repositories -- TorchNeuron PyTorch Extension, Neuron Agentic Development,
-      Neuron Explorer CDK, Neuron Kernel Library, vLLM for Neuron, NKI Samples -- and neither the Neuron
-      Runtime nor the Neuron Compiler appears among them.
+      under the Apache 2.0 license, and lists the public repositories open to contribution. The URL redirects
+      to /about-neuron/oss/index.html, where the catalog lists exactly six public repositories -- TorchNeuron
+      PyTorch Extension, Neuron Agentic Development, Neuron Explorer CDK, Neuron Kernel Library, vLLM for
+      Neuron, NKI Samples -- and neither the Neuron Runtime nor the Neuron Compiler appears among them.
     accessed: '2026-08-11'
     establishes:
     - license
@@ -61,11 +60,11 @@ openness:
   - url: https://github.com/aws-neuron/aws-neuron-sdk
     shows: '"path":"LICENSE-DOCUMENTATION","preferredFileType":"license","tabName":"License" alongside "path":"LICENSE-SAMPLECODE",..."tabName":"MIT-0"
       -- repo carries a generic, GitHub-unclassified license for docs and a separate MIT-0 license for sample
-      code, i.e. no single OSI license covers the SDK repo. Re-read on 2026-08-11, the repo''s top-level
-      directories are .github, compiler, frameworks, deploy, general, libraries, neuron-runtime, neuron-customops,
-      nki, release-notes, setup and tools -- the "compiler" and "neuron-runtime" directories hold documentation
-      for those components, not their source. The repo points readers at the hosted Neuron SDK documentation
-      site and carries an open issue tracker.'
+      code, i.e. no single OSI license covers the SDK repo. The repo''s top-level directories are .github,
+      compiler, frameworks, deploy, general, libraries, neuron-runtime, neuron-customops, nki, release-notes,
+      setup and tools -- the "compiler" and "neuron-runtime" directories hold documentation for those components,
+      not their source. The repo points readers at the hosted Neuron SDK documentation site and carries
+      an open issue tracker.'
     accessed: '2026-08-11'
     establishes:
     - license
@@ -97,24 +96,19 @@ adoption:
   level: 3
   signal_type: reported_traction
   confidence: low
-  note: 'Re-read 2026-08-13 and held at 3. AWS publishes no customer count, download count or usage figure
-    for Neuron anywhere on the product page - confirmed by re-reading it rather than assumed from the
-    previous pass - and names no customers and makes no quantified scale claim. What the page does
-    establish is integration breadth: PyTorch and JAX natively, plus HuggingFace Transformers and Optimum
-    Neuron, vLLM, PyTorch Lightning and TorchTitan, "without modifying your code".
-
-    THIS IS A QUALITATIVE CONFIRMATION AND THE BAND IS ONLY AS GOOD AS THAT. reported_traction is the
-    correct instrument precisely because nothing here is countable, so re-reading can establish that the
-    described breadth still holds and can never establish that 3 is the right number for it. The date
-    records that the claim was re-derived from its source, not that a measurement was taken. If AWS ever
-    publishes an instance-hour or customer figure, this axis should move to a countable instrument.'
+  note: 'AWS publishes no customer count, download count or usage figure for Neuron anywhere on the product
+    page, names no customers and makes no quantified scale claim. What the page does establish is integration
+    breadth: PyTorch and JAX natively, plus HuggingFace Transformers and Optimum Neuron, vLLM, PyTorch Lightning
+    and TorchTitan, "without modifying your code". The band is qualitative and only as good as that - reported_traction
+    is the correct instrument precisely because nothing here is countable, so the described breadth can
+    support a band but can never establish that 3 is the right number for it. If AWS ever publishes an instance-hour
+    or customer figure, this axis should move to a countable instrument.'
   last_verified: '2026-08-13'
   sources:
   - url: https://aws.amazon.com/ai/machine-learning/neuron/
-    shows: 're-read 2026-08-13: PyTorch and JAX natively, plus HuggingFace, vLLM, PyTorch Lightning,
-      TorchTitan and Optimum Neuron, "without modifying your code". NO customer count, download count,
-      usage figure or named customer anywhere on the page - the absence is what the reported_traction
-      instrument rests on'
+    shows: PyTorch and JAX natively, plus HuggingFace, vLLM, PyTorch Lightning, TorchTitan and Optimum Neuron,
+      "without modifying your code". No customer count, download count, usage figure or named customer anywhere
+      on the page - the absence is what the reported_traction instrument rests on.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 4ccd6ea8ed04015f8c2729eec22575613ca21e969c4ff77b7483f5dfcec65965
@@ -124,9 +118,11 @@ capability:
   value: vLLM V1 API on Trainium/Inferentia with Expert Parallelism, disaggregated inference, speculative
     decoding; native PyTorch + JAX; compiler/runtime/profiler stack
   confidence: medium
-  note: No peer comparison was recorded for this product and none was found in today's read, so relative_to/relation
-    stay unset. Still no MLPerf Inference figure surfaced for Neuron, so basis remains feature_matrix rather
-    than benchmark. Feature set re-confirmed unchanged from the readthedocs overview.
+  note: 'C4 rests on the feature matrix: the Neuron runtime supports Expert Parallelism for MoE models,
+    disaggregated inference architectures and speculative decoding, a server-class inference feature set
+    that is nonetheless locked to AWS Inferentia/Trainium hardware. No MLPerf Inference figure has surfaced
+    for Neuron, so the basis stays feature_matrix rather than benchmark. No peer comparison is recorded
+    for this product, so relative_to/relation stay unset.'
   basis_detail: vLLM V1 API on Trainium/Inferentia with Expert Parallelism, disaggregated inference, speculative
     decoding; native PyTorch + JAX; compiler/runtime/profiler stack
   last_verified: '2026-08-09'

--- a/sources/scores/axelera-metis-aipu.yaml
+++ b/sources/scores/axelera-metis-aipu.yaml
@@ -23,10 +23,7 @@ openness:
       raw: open_market (webstore + partners)
   confidence: medium
   note: Proprietary in-memory-compute silicon with a publicly available Voyager SDK on GitHub and retail
-    purchasing, but board design files are not open. Re-read 2026-08-13 - axelera.ai still publishes
-    product briefs and a Shop, still describes D-IMC as its own silicon, and offers no board design
-    files anywhere in its document set; voyager-sdk is still a public repository shipping a v1.8
-    production release. No dimension moved.
+    purchasing, but board design files are not open.
   raw: schematics:none;toolchain:open (Voyager SDK on public GitHub);datasheets:brief (product pages/briefs
     public);blobs:required (proprietary AIPU silicon + firmware);retail:open_market (webstore + partners)
   last_verified: '2026-08-13'
@@ -57,9 +54,8 @@ adoption:
   signal_type: reported_traction
   confidence: medium
   note: Commercially available via webstore and partners with a public, versioned SDK, but a younger ecosystem
-    than Hailo/Coral. Re-read 2026-08-13 - the SDK is at v1.8 with release notes and a release
-    compatibility matrix in-tree, the site still carries a Shop, and it now also announces an ASRock
-    Industrial collaboration integrating Metis AIPU cards into edge platforms. Level and reach unchanged.
+    than Hailo/Coral. The Voyager SDK is at v1.8 with release notes and a release-compatibility matrix in-tree,
+    and Axelera announces an ASRock Industrial collaboration integrating Metis AIPU cards into edge platforms.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/axelera-ai-hub/voyager-sdk
@@ -79,11 +75,10 @@ capability:
   value: ~214 TOPS per quad-core Metis; PCIe x4 scales across 4 units; Voyager SDK with 100+ CV models
   confidence: medium
   note: High raw inference throughput via in-memory compute, currently oriented toward CNN/computer-vision
-    pipelines. Re-read 2026-08-13 - the site no longer prints the ~214 TOPS aggregate the recorded value
-    quotes; it now states "50+ TOPs per core" and "15 TOPs/W" for the quad-core Metis, and Voyager still
-    claims "100+ supported models". Four cores at 50+ TOPS is the same order as the recorded aggregate
-    and the band is unchanged, but the specific 214 figure is no longer citable and the wording of the
-    recorded value is flagged for a curator ruling.
+    pipelines. The site no longer prints the ~214 TOPS aggregate the recorded value quotes; it states "50+
+    TOPs per core" and "15 TOPs/W" for the quad-core Metis, and Voyager still claims "100+ supported models".
+    Four cores at 50+ TOPS is the same order as the recorded aggregate so the band holds, but the specific
+    214 figure is no longer citable and the wording of the recorded value is flagged for a curator ruling.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.axelera.ai/

--- a/sources/scores/axolotl.yaml
+++ b/sources/scores/axolotl.yaml
@@ -15,9 +15,8 @@ openness:
         the only paid thing offered is dedicated support by email
   confidence: high
   note: 'Fully OSI-licensed (Apache-2.0) with no proprietary managed training service, only deployment templates
-    for third-party clouds. core-gated recorded ungated on 2026-08-11: the repo has no ee/ or enterprise
-    directory, no license-key gate and no closed package the open one depends on, and the only paid offering
-    is dedicated support. Closes the deferral without moving the score.'
+    for third-party clouds. core-gated is ungated: the repo has no ee/ or enterprise directory, no license-key
+    gate and no closed package the open one depends on, and the only paid offering is dedicated support.'
   last_verified: '2026-08-11'
   raw: license:Apache-2.0(OSI);source:public(axolotl-ai-cloud/axolotl);core-gated:ungated(Apache-2.0 across
     the repo, no ee/ or enterprise directory, no license key and no closed package; the only paid thing
@@ -92,9 +91,8 @@ capability:
     FSDP1/FSDP2, DeepSpeed, multi-node Torchrun/Ray, Sequence Parallelism + ND Parallelism (CP+TP+FSDP);
     precision: BF16/4-8bit. Broadest single-tool method+parallelism matrix in this batch.'
   confidence: high
-  note: 'Very wide method and parallelism coverage (ND parallelism, multi-node), strong C4; below Megatron-LM
-    frontier-scale-training anchor on demonstrated extreme scale. Re-read 2026-08-13 as an anchor for this
-    category''s closing pass; unchanged at 4.'
+  note: Very wide method and parallelism coverage (ND parallelism, multi-node), strong C4; below Megatron-LM
+    frontier-scale-training anchor on demonstrated extreme scale.
   last_verified: '2026-08-13'
   sources:
   - url: https://raw.githubusercontent.com/axolotl-ai-cloud/axolotl/main/README.md

--- a/sources/scores/aya-collection.yaml
+++ b/sources/scores/aya-collection.yaml
@@ -10,8 +10,7 @@ openness:
     card:
       value: present
   confidence: high
-  note: 'Ungated, Apache-2.0 licensed, with a complete dataset card. Re-read 2026-08-13: apache-2.0 on the
-    Hub, gated false, card intact.'
+  note: Ungated, Apache-2.0 licensed, with a complete dataset card.
   raw: license:apache-2.0;gated:false;card:present
   last_verified: '2026-08-13'
   sources:
@@ -29,9 +28,8 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 11,190 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (CohereLabs/aya_collection 11,190). Bands at level 3 (10K-100K) on the dataset adoption scale, whose
-    top band is >1M.
+  note: 11,190 downloads in the trailing 30 days summed across the 1 declared artifact(s) (CohereLabs/aya_collection
+    11,190). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/CohereLabs/aya_collection
@@ -46,16 +44,13 @@ capability:
   value: null
   confidence: high
   note: 'Instruction collection behind Aya 101 (2024), Aya 23, and Aya Expanse, which beat Gemma 2 / Qwen
-    2.5 / Llama 3.1 in their size class; strong, multiple notable open models. Re-read 2026-08-14 - the
-    HF blog post no longer carries the 76.6% figure this axis cited. It now reports the 8B range only,
-    "win rates ranging from 60.4% to 70.6%" against Gemma 2 9B, Llama 3.1 8B and Ministral 8B. The
-    figure survives on the Aya Expanse paper, whose abstract states 8B and 32B outperform Gemma 2, Qwen
-    2.5 and Llama 3.1 in their parameter classes "achieving up to a 76.6% win-rate", and whose body
-    pins that maximum to the 32B against Mixtral 8x22B on m-ArenaHard. Both the old and the new
-    comparison sets are open models this collection fed, so the band of 4 is unaffected and only the
-    citation moves. FLAGGED for a later pass, not for this one - no primary source states that the Aya
-    COLLECTION specifically trained Aya Expanse. The Expanse paper does not name it, and neither does
-    the CohereLabs/aya-expanse-8b card; the lineage rests on the Medium secondary already cited.'
+    2.5 / Llama 3.1 in their size class; strong, multiple notable open models. The 76.6% win-rate figure
+    comes from the Aya Expanse paper abstract, where it is the maximum, attained by the 32B against Mixtral
+    8x22B on m-ArenaHard; the HF blog post reports the 8B range only, at win rates of 60.4% to 70.6% against
+    Gemma 2 9B, Llama 3.1 8B and Ministral 8B. Either comparison set is open models this collection fed,
+    so the band is unaffected. Flagged for a later pass: no primary source states that the Aya Collection
+    specifically trained Aya Expanse - neither the Expanse paper nor the CohereLabs/aya-expanse-8b card
+    names it, and the lineage rests on the Medium secondary cited here.'
   last_verified: '2026-08-14'
   sources:
   - url: https://arxiv.org/abs/2412.04261
@@ -67,8 +62,8 @@ capability:
     http_status: 200
     content_sha256: 061c6359ac9b1a00d36b521f7179ec338370ca420d44d3b0c4254aa4b518baa0
   - url: https://huggingface.co/blog/aya-expanse
-    shows: no longer carries the 76.6% figure; now reports the 8B only, with "win rates ranging from
-      60.4% to 70.6%" against Gemma 2 9B, Llama 3.1 8B and Ministral 8B
+    shows: Reports the Aya Expanse 8B only, with "win rates ranging from 60.4% to 70.6%" against Gemma 2
+      9B, Llama 3.1 8B and Ministral 8B
     accessed: '2026-07-04'
   - url: https://ritvik19.medium.com/papers-explained-151-aya-23-d01605c3ee80
     shows: Aya Collection (513M examples, 114+ langs) feeds Aya 101 and Aya 23/Expanse instruction data

--- a/sources/scores/azure-ai-foundry-observability.yaml
+++ b/sources/scores/azure-ai-foundry-observability.yaml
@@ -15,9 +15,7 @@ openness:
         is proprietary and Azure-locked
   confidence: high
   note: Proprietary Microsoft Azure managed offering. OTel is the wire standard (trace data is portable)
-    but the service itself is closed. Re-read 2026-08-13 and unchanged - the page describes three core
-    capabilities delivered by Microsoft Foundry, built on OpenTelemetry and integrated with Azure Monitor
-    Application Insights, and publishes no source, license or self-hostable build of the service.
+    but the service itself is closed.
   raw: license:proprietary(Azure managed service);source:closed;note:tracing built on open OTel standard
     + Azure Monitor App Insights, but the observability product is proprietary and Azure-locked
   last_verified: '2026-08-13'
@@ -41,10 +39,8 @@ adoption:
   banded_quantity: Microsoft Foundry platform reach, not usage of the observability surface
   note: A feature surface within Microsoft Foundry on Azure; no standalone usage figures published for the
     observability capability specifically. Level 3 reflects availability inside a large cloud AI platform,
-    not a measured user count; directional. Re-read 2026-08-13 - the quantity actually banded here is the
-    reach of Microsoft Foundry, not usage of its observability surface, and the page discloses no figure
-    for either. The "GA March 2026" claim this note used to carry is not on the cited page and is dropped
-    rather than carried forward.
+    not a measured user count; directional. The quantity actually banded is the reach of Microsoft Foundry
+    rather than usage of its observability surface, and the cited page discloses no figure for either.
   last_verified: '2026-08-13'
   sources:
   - url: https://learn.microsoft.com/en-us/azure/foundry/concepts/observability
@@ -67,8 +63,7 @@ capability:
   note: Three pillars (eval/monitoring/tracing) with strong OTel + framework coverage, but matrix breadth
     on prompt versioning/datasets/annotation is thinner than the dedicated OSS platforms; scored 3 below
     the C4 anchors. The comparison is now recorded rather than left in prose - one rung below the langfuse
-    anchor at 4. Re-read 2026-08-13 - the page still names exactly three core capabilities and still
-    describes no prompt-versioning, dataset or annotation surface.
+    anchor at 4.
   last_verified: '2026-08-13'
   sources:
   - url: https://learn.microsoft.com/en-us/azure/foundry/concepts/observability

--- a/sources/scores/azure-ai-model-inference.yaml
+++ b/sources/scores/azure-ai-model-inference.yaml
@@ -14,11 +14,6 @@ openness:
       value: Azure-managed
   confidence: high
   note: Fully proprietary managed Azure service; no source released. Scored closed.
-    Re-read 2026-08-13. The Foundry Models endpoints page still describes a wholly Azure-managed service
-    - deployments are Azure resources subject to Azure policy, reached through a single Foundry
-    inference endpoint with an OpenAI-compatible surface, and nothing about the serving stack is
-    published. No source, no self-host path, no license other than the Azure product terms. Value
-    unchanged at 1 / closed.
   raw: license:proprietary(Azure managed service);source:closed;interface:OpenAI-compatible REST endpoint
     over Foundry model deployments;hardware:Azure-managed
   last_verified: '2026-08-13'
@@ -36,13 +31,8 @@ adoption:
   confidence: low
   banded_quantity: Azure enterprise base, not this inference endpoint
   note: Default inference surface for Microsoft Foundry across Azure's enterprise base; broad distribution
-    but no published per-service usage number. Level 4 reflects Azure-enterprise scale (reported), not
-    a measured count.
-    Re-read 2026-08-13. The page still presents this as the one endpoint in front of every Foundry model
-    deployment for an Azure subscription, and it still publishes no per-service usage figure of any kind
-    - no call volume, no customer count, no deployment count. The band therefore remains a reported
-    reach rather than a measured one, and reported_traction with no numeric reach is the honest
-    instrument here. Level unchanged at 4.
+    but no published per-service usage number. Level 4 reflects Azure-enterprise scale (reported), not a
+    measured count.
   last_verified: '2026-08-13'
   sources:
   - url: https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/endpoints
@@ -56,15 +46,10 @@ capability:
   value: unified OpenAI-compatible endpoint; multi-provider model deployments (OpenAI, DeepSeek, MAI-DS-R1,
     etc.); keyless Entra ID auth; content filtering, rate limiting, batch inference
   confidence: medium
-  note: Capability is managed-endpoint breadth (multi-model routing, auth, governance), not raw engine
-    throughput. This is closer to a managed API gateway over model deployments than a weight-loading inference
-    engine; see recategorize flag.
-    Re-read 2026-08-13. The page still shows the whole feature set the band rests on - one endpoint
-    switching between many model deployments without code changes, per-deployment content filtering and
-    rate limiting, keyless authentication through Microsoft Entra ID role assignments, and batch
-    inference. It now also carries a deprecation banner for the Azure AI Inference beta SDK, retiring 26
-    August 2026 in favour of the OpenAI/v1 API, which is a migration of the client surface rather than a
-    change in what the service does. Band unchanged at 3.
+  note: Capability is managed-endpoint breadth (multi-model routing, auth, governance), not raw engine throughput.
+    This is closer to a managed API gateway over model deployments than a weight-loading inference engine;
+    see recategorize flag. The Azure AI Inference beta SDK is deprecated in favour of the OpenAI/v1 API,
+    which migrates the client surface rather than changing what the service does.
   last_verified: '2026-08-13'
   sources:
   - url: https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/endpoints

--- a/sources/scores/azure-content-safety.yaml
+++ b/sources/scores/azure-content-safety.yaml
@@ -15,7 +15,7 @@ openness:
     license:
     - name: proprietary
   confidence: high
-  note: Closed managed cloud service; no weights or source. Re-read 2026-08-13 and unchanged.
+  note: Closed managed cloud service; no weights or source.
   raw: service:proprietary managed Azure service(no self-host);features:text/image moderation, prompt shields,
     groundedness;source:closed;license:proprietary
   last_verified: '2026-08-13'
@@ -37,12 +37,16 @@ adoption:
   confidence: low
   banded_quantity: none published; the level reads the default content-safety layer's distribution in front
     of Azure AI
-  note: 'INSTRUMENT CORRECTED on 2026-08-13, level unchanged. usage_volume claims a download or install count and Microsoft
-    publishes none for this service - the product page carries no customer count, no request volume and no
-    developer count. The 100K-1M label therefore asserts a measurement nobody made, which adoption.md rules
-    out on this instrument. The reading underneath it - the default content-safety layer in front of the
-    Azure AI customer base - is a reported_traction claim. Recommend reported_traction with no reach; the
-    level is an owner call and is not taken here. The instrument now reads reported_traction, which is what a credible claim with no count behind it is for, and the illegal numeric reach is gone. The LEVEL is deliberately unchanged: correcting how a band was read is not a reason to move where it sits, and nothing re-read today argues the standing is different. What changes is that the record no longer claims a measurement nobody made.'
+  note: 'INSTRUMENT CORRECTED on 2026-08-13, level unchanged. usage_volume claims a download or install
+    count and Microsoft publishes none for this service - the product page carries no customer count, no
+    request volume and no developer count. The 100K-1M label therefore asserts a measurement nobody made,
+    which adoption.md rules out on this instrument. The reading underneath it - the default content-safety
+    layer in front of the Azure AI customer base - is a reported_traction claim. Recommend reported_traction
+    with no reach; the level is an owner call and is not taken here. The instrument now reads reported_traction,
+    which is what a credible claim with no count behind it is for, and the illegal numeric reach is gone.
+    The LEVEL is deliberately unchanged: correcting how a band was read is not a reason to move where it
+    sits, and nothing in the cited sources argues the standing is different. What changes is that the record
+    no longer claims a measurement nobody made.'
   last_verified: '2026-08-13'
   sources:
   - url: https://azure.microsoft.com/en-us/products/ai-services/ai-content-safety
@@ -58,8 +62,7 @@ capability:
     in one managed service.
   confidence: low
   note: Broad managed feature set (moderation + prompt shields + groundedness); strong coverage, closed.
-    Re-read 2026-08-13 and unchanged, with protected-material detection listed alongside the three the
-    value names.
+    Protected-material detection for copyrighted text and code sits alongside the three the value names.
   last_verified: '2026-08-13'
   sources:
   - url: https://azure.microsoft.com/en-us/products/ai-services/ai-content-safety

--- a/sources/scores/beagley-ai.yaml
+++ b/sources/scores/beagley-ai.yaml
@@ -21,13 +21,10 @@ openness:
       raw: required (TI DSP/WiFi firmware blobs a caveat)
   confidence: high
   note: Full board design files published under Creative Commons and OSHWA-certified with an open toolchain
-    and public datasheet, though proprietary AM67A silicon and firmware blobs are a caveat. Re-read
-    2026-08-13 - the OSHWA certification directory still carries US002616 for BeagleY-AI (certified
-    2024-03-27) recording Hardware CC-BY-4.0, Software GPL and Documentation CC-BY-SA-4.0, the repo is
-    still CC-BY-4.0 and still links that certificate, the design page still says design materials and
-    license live in the BeagleY-AI git repository, and TI still publishes the AM67x datasheet (Rev. B)
-    openly. No dimension moved. One drift worth recording - the design page no longer prints the OSHWA
-    UID itself; the certificate and the repo README still do.
+    and public datasheet, though proprietary AM67A silicon and firmware blobs are a caveat. The OSHWA certification
+    is US002616, recording Hardware CC-BY-4.0, Software GPL and Documentation CC-BY-SA-4.0; one drift worth
+    recording is that the design page no longer prints the OSHWA UID itself, though the certificate and
+    the repo README still do.
   raw: schematics:open (schematics + 3D/mechanical files, CC-BY/CC-BY-SA-4.0, OSHWA-certified US002616);toolchain:open
     (open Linux/U-Boot BSP);datasheets:public (public TI AM67A datasheet);blobs:required (TI DSP/WiFi firmware
     blobs a caveat)
@@ -72,11 +69,9 @@ adoption:
   reach: niche
   signal_type: reported_traction
   confidence: medium
-  note: In stock at $71.99 with volume pricing at Seeed and orderable via TI, backed by the established
-    BeagleBoard.org community, though recent (2024) so installed base trails Raspberry Pi. Re-read
-    2026-08-13 - still in stock at Seeed, now listed at $70.00 rather than $71.99, and the AM67A it is
-    built on is still ACTIVE at TI with evaluation boards in stock. Level and reach unchanged; the price
-    figure in the note is a cent-level drift, corrected here rather than escalated.
+  note: In stock at $70.00 with volume pricing at Seeed and orderable via TI, backed by the established
+    BeagleBoard.org community, though recent (2024) so installed base trails Raspberry Pi. The AM67A it
+    is built on is ACTIVE at TI with evaluation boards in stock.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.seeedstudio.com/BeagleYr-AI-beagleboard-orgr-4-TOPS-AI-Acceleration-powered-by-TI-AM67A.html
@@ -90,10 +85,10 @@ capability:
   value: 4 TOPS (TI C7x DL accelerator); 4GB LPDDR4; runs quantized CNNs / small object-detection and
     classification models
   confidence: high
-  note: 4 TOPS plus an IMG BXS GPU suits edge vision and quantized CNNs, but fixed 4GB RAM and modest
-    TOPS rule out large LLMs. Re-derived 2026-08-13 - the board page still reads "Dual general-purpose
-    C7x DSP with Matrix Multiply Accelerator (MMA) capable of 4 TOPs" and 4GB LPDDR4, which sits below
-    the 6 TOPS RK3588 boards and well below the Jetson Orin line.
+  note: 4 TOPS plus an IMG BXS GPU suits edge vision and quantized CNNs, but fixed 4GB RAM and modest TOPS
+    rule out large LLMs. The board page reads "Dual general-purpose C7x DSP with Matrix Multiply Accelerator
+    (MMA) capable of 4 TOPs" and 4GB LPDDR4, which sits below the 6 TOPS RK3588 boards and well below the
+    Jetson Orin line.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.beagleboard.org/boards/beagley-ai

--- a/sources/scores/bedrock-guardrails.yaml
+++ b/sources/scores/bedrock-guardrails.yaml
@@ -15,9 +15,9 @@ openness:
     license:
     - name: proprietary
   confidence: high
-  note: Closed managed cloud service; no weights or source. Re-read 2026-08-13 and unchanged. One wrinkle
-    worth recording - the ApplyGuardrail API can now be pointed at self-hosted models, but that is the
-    managed guardrail reaching outward, not a self-hostable guardrail, so source stays closed.
+  note: Closed managed cloud service; no weights or source. The ApplyGuardrail API can be pointed at self-hosted
+    models, but that is the managed guardrail reaching outward, not a self-hostable guardrail, so source
+    stays closed.
   raw: service:proprietary managed AWS service(no self-host);features:denied topics, content filters, PII
     redaction, contextual grounding;source:closed;license:proprietary
   last_verified: '2026-08-13'
@@ -38,11 +38,15 @@ adoption:
   signal_type: reported_traction
   confidence: low
   banded_quantity: named customer logos, not a count of anything
-  note: 'INSTRUMENT CORRECTED on 2026-08-13, level unchanged. usage_volume claims a download or install count and AWS publishes
-    none for this service - the page names customers (''Companies like Chime Financial, KONE, Panorama,
-    Strava, Remitly, and PwC trust Bedrock Guardrails for their AI applications'') but gives no count of
-    anything. Named logos are exactly the reported_traction shape, and the 100K-1M label asserts a
-    measurement nobody made. The instrument now reads reported_traction, which is what a credible claim with no count behind it is for, and the illegal numeric reach is gone. The LEVEL is deliberately unchanged: correcting how a band was read is not a reason to move where it sits, and nothing re-read today argues the standing is different. What changes is that the record no longer claims a measurement nobody made.'
+  note: 'INSTRUMENT CORRECTED on 2026-08-13, level unchanged. usage_volume claims a download or install
+    count and AWS publishes none for this service - the page names customers (''Companies like Chime Financial,
+    KONE, Panorama, Strava, Remitly, and PwC trust Bedrock Guardrails for their AI applications'') but gives
+    no count of anything. Named logos are exactly the reported_traction shape, and the 100K-1M label asserts
+    a measurement nobody made. The instrument now reads reported_traction, which is what a credible claim
+    with no count behind it is for, and the illegal numeric reach is gone. The LEVEL is deliberately unchanged:
+    correcting how a band was read is not a reason to move where it sits, and nothing in the cited sources
+    argues the standing is different. What changes is that the record no longer claims a measurement nobody
+    made.'
   last_verified: '2026-08-13'
   sources:
   - url: https://aws.amazon.com/bedrock/guardrails/
@@ -58,8 +62,8 @@ capability:
   value: Denied topics, content filters, PII redaction, word filters, and contextual-grounding checks
     across any Bedrock model.
   confidence: low
-  note: Broad configurable managed guardrail set; strong coverage, closed. Re-read 2026-08-13 and unchanged,
-    with Automated Reasoning checks now listed as a sixth policy beside the five the value names.
+  note: Broad configurable managed guardrail set; strong coverage, closed. Automated Reasoning checks sit
+    as a sixth policy beside the five the value names.
   last_verified: '2026-08-13'
   sources:
   - url: https://aws.amazon.com/bedrock/guardrails/

--- a/sources/scores/beeai.yaml
+++ b/sources/scores/beeai.yaml
@@ -14,9 +14,7 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: 'Apache-2.0 across Python + TypeScript with no commercial gating. Re-read 2026-08-13 - the repo
-    page still reports Apache-2.0 over the whole tree and publishes both language implementations in full,
-    with no enterprise directory, paid tier or license key. Stars are now 3.4k. Nothing moved.'
+  note: Apache-2.0 across Python + TypeScript with no commercial gating.
   raw: license:Apache-2.0(OSI);source:public(Python+TS);no-feature-gated-core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -34,11 +32,11 @@ adoption:
   level: 2
   signal_type: usage_volume
   confidence: medium
-  note: '63,527 downloads in the trailing 30 days (beeai-framework 49,921; beeai-framework 13,606), read
-    2026-08-12. Bands at level 2 (10K-100K) on the software and model adoption scale. Moved off the stars
-    fallback: a real download signal exists, and docs/reference/adoption.md says to re-band when one does.
-    The package is both language bindings, summed. This LOWERS the recorded level from 3 - the star count
-    had been flattering it.'
+  note: '63,527 downloads in the trailing 30 days (beeai-framework 49,921; beeai-framework 13,606). Bands
+    at level 2 (10K-100K) on the software and model adoption scale. Moved off the stars fallback: a real
+    download signal exists, and docs/reference/adoption.md says to re-band when one does. The package is
+    both language bindings, summed. This LOWERS the recorded level from 3 - the star count had been flattering
+    it.'
   reach: 10K-100K
   last_verified: '2026-08-12'
   sources:
@@ -58,11 +56,7 @@ capability:
   value: Python+TS parity; agents/multi-agent workflows; RAG; tools; memory; YAML + decorator orchestration (parallelism/retries/replanning);
     constraint governance; MCP + A2A; OpenTelemetry; 10+ LLM backends
   confidence: medium
-  note: 'Distinctive dual-language parity and production focus; smaller adoption than the leading frameworks.
-    Re-read 2026-08-13 - the LF AI & Data project page still hosts it as a dual-language production agent
-    framework, and the repo still leads on building production-ready multi-agent systems in Python or
-    TypeScript with the same workflow, memory, tooling and observability surface. At autogen on feature
-    breadth, which is where this note already placed it.'
+  note: Distinctive dual-language parity and production focus; smaller adoption than the leading frameworks.
   relative_to: autogen
   relation: at
   last_verified: '2026-08-13'

--- a/sources/scores/beta9.yaml
+++ b/sources/scores/beta9.yaml
@@ -72,17 +72,15 @@ adoption:
   reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
-  note: 'No PyPI/usage figure for the OSS runtime surfaced and no disclosed Beam customer/usage count; only
-    ~1.7k GitHub stars available as a signal. stars_fallback caps level at 3; placed at 2 given the small star
-    base and absence of any volume signal. Low confidence. Stars read 2026-08-13: 1,742 across the 1 declared
-    repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach
-    ''10K-100K'' was not a label this instrument offers - stars have their own vocabulary because a star is
-    not a download. Re-read in full 2026-08-13 against the GitHub API - 1,742 stars, 156 forks - the same
-    figure and the same 1K-10K stars band, level 2. The digest below will drift on every refetch because
-    a star count moves daily; that is expected of this instrument and does not weaken the band, which depends
-    only on the order of magnitude. One thing did change and is escalated rather than applied - the README
-    now installs the SDK with `pip install beam-client`, so a countable channel exists where this note said
-    none had surfaced. It is not declared here.'
+  note: 'No PyPI or usage figure for the OSS runtime has surfaced and Beam discloses no customer or usage
+    count, so GitHub stars are the only signal: 1,742 stars and 156 forks across the 1 declared repo, which
+    bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. stars_fallback caps level
+    at 3; placed at 2 given the small star base and the absence of any volume signal. The reach label uses
+    the stars vocabulary rather than a download band, because a star is not a download. Low confidence,
+    and the source digest drifts on every refetch because a star count moves daily - expected of this instrument,
+    and no weaker a band for it, since the band depends only on order of magnitude. One thing is escalated
+    rather than applied: the README now installs the SDK with `pip install beam-client`, so a countable
+    channel exists that this axis does not declare.'
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/beam-cloud/beta9
@@ -109,21 +107,18 @@ capability:
     container launch; language/runtime breadth:Python AI workloads + GPU (4090/H100); persistence:volume
     storage; scale:parallelize across hundreds of containers + autoscaling
   confidence: medium
-  note: Capable serverless container runtime with GPU support, volumes, autoscaling and sandbox primitives,
+  note: 'Capable serverless container runtime with GPU support, volumes, autoscaling and sandbox primitives,
     but container-level (not VM/microVM) isolation places it below the VM-grade peers on the isolation-strength
-    dimension; mid-tier. Independent ComputeSDK TTI benchmarks of Beam (the managed beta9 cloud) corroborate
-    the fast container launch (~380ms median cold-start, 8th of 19 sandbox providers). Re-read 2026-08-13.
-    The feature matrix still reads as described - the README claims container launches "in under a second"
-    from a custom runtime, scheduler and embedded cache, fan-out to hundreds of containers, scale-to-zero,
-    distributed volume storage, GPU support on 4090s and H100s or bring-your-own, and a Sandbox primitive
-    for running model-generated code. The isolation ceiling is unchanged, and it is what holds the score
-    at 3 - the README describes containers throughout and names no VM, microVM or application-kernel tier,
-    where the category''s frontier-definers do. The prose comparison to the VM-grade peers is now recorded
-    as relative_to firecracker with relation `two_below`, which holds arithmetically - Firecracker is 5,
-    this is 3, and Firecracker''s capability was re-derived the same day. The independent benchmark moved
-    in this product''s favor rather than against it and does not move the band, since the band turns on
-    isolation strength - on the ComputeSDK run of 2026-08-07, Beam is 4th-fastest by median of 24 providers
-    at 0.29s, up from 8th of 19 at ~380ms.'
+    dimension; mid-tier. The README claims container launches "in under a second" from a custom runtime,
+    scheduler and embedded cache, fan-out to hundreds of containers, scale-to-zero, distributed volume storage,
+    GPU support on 4090s and H100s or bring-your-own, and a Sandbox primitive for running model-generated
+    code - but it describes containers throughout and names no VM, microVM or application-kernel tier where
+    the category''s frontier-definers do, and that isolation ceiling is what holds the score at 3. The comparison
+    to the VM-grade peers is recorded as relative_to firecracker with relation `two_below`, which holds
+    arithmetically: Firecracker is 5 and this is 3. Independent ComputeSDK TTI benchmarks of Beam (the managed
+    beta9 cloud) corroborate the fast container launch at a 0.29s median, 4th-fastest by median of 24 providers,
+    up from ~380ms and 8th of 19 on the earlier run; the band turns on isolation strength rather than latency,
+    so a faster benchmark does not move it.'
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/beam-cloud/beta9

--- a/sources/scores/bigcode-dataset.yaml
+++ b/sources/scores/bigcode-dataset.yaml
@@ -16,9 +16,7 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (Apache-2.0), full source public. Re-read 2026-08-13 - the LICENSE body still
-    carries the same license and the README still builds the whole product from the published repo, with
-    no paid tier, enterprise edition or license key anywhere in it.
+  note: Fully OSI-licensed (Apache-2.0), full source public.
   raw: license:Apache-2.0(OSI);source:public(bigcode-project/bigcode-dataset);governance:BigCode;no feature-gated
     core;core-gated:ungated
   last_verified: '2026-08-13'
@@ -45,11 +43,11 @@ adoption:
   reach: <1K stars
   signal_type: stars_fallback
   confidence: medium
-  note: 497 GitHub stars on bigcode-project/bigcode-dataset, read 2026-08-12. Bands at level 1 (<1K stars)
-    on the stars fallback scale, which caps at 3 because a star is not a use. Resynced because the recorded
-    2 rests on importance - the pipeline behind The Stack and StarCoder - not on adoption. The repo is dormant
-    since 2024 with under 500 stars. No download, install or customer figure is published for this product,
-    so stars remain the only honest signal and the level is directional.
+  note: 497 GitHub stars on bigcode-project/bigcode-dataset. Bands at level 1 (<1K stars) on the stars fallback
+    scale, which caps at 3 because a star is not a use. Resynced because the recorded 2 rests on importance
+    - the pipeline behind The Stack and StarCoder - not on adoption. The repo is dormant since 2024 with
+    under 500 stars. No download, install or customer figure is published for this product, so stars remain
+    the only honest signal and the level is directional.
   last_verified: '2026-08-12'
   sources:
   - url: https://api.github.com/repos/bigcode-project/bigcode-dataset
@@ -63,8 +61,7 @@ capability:
   value: Quality filtering (line length, alphanumeric %), decontamination, and PII detection/anonymization
     for code corpora.
   confidence: medium
-  note: Solid code-corpus curation coverage; specialized to code, not actively developed. Re-read 2026-08-13
-    - the README still describes the feature set above.
+  note: Solid code-corpus curation coverage; specialized to code, not actively developed.
   last_verified: '2026-08-13'
   sources:
   - url: https://raw.githubusercontent.com/bigcode-project/bigcode-dataset/main/README.md

--- a/sources/scores/bigcodebench.yaml
+++ b/sources/scores/bigcodebench.yaml
@@ -16,10 +16,8 @@ openness:
     - execution harness + leaderboard public
   confidence: high
   last_verified: '2026-08-13'
-  note: Apache-2.0, fully public; OSI -> open_source. Re-read 2026-08-13 - the license endpoint still
-    reports Apache-2.0 and the README still offers `--execution local`. The repo has since been ARCHIVED
-    (read-only, last push 2026-01-03), which freezes the source rather than withdrawing it, so both `source`
-    and `core-gated` are unchanged.
+  note: Apache-2.0, fully public; OSI -> open_source. The repo is archived and read-only, which freezes
+    the source rather than withdrawing it, so both `source` and `core-gated` stand.
   raw: license:Apache-2.0(OSI);source:public(GitHub);execution harness + leaderboard public;core-gated:ungated(no
     paid tier or license key, harness runs locally with --execution local)
   sources:
@@ -49,9 +47,9 @@ openness:
     establishes:
     - license
   - url: https://raw.githubusercontent.com/bigcode-project/bigcodebench/main/README.md
-    shows: 'Re-read 2026-08-13: the evaluation command still declares `--execution [e2b|gradio|local]`,
-      so the harness still runs end to end on the reader''s own machine, and nothing in the README offers
-      a paid tier, a commercial edition or a license key.'
+    shows: The evaluation command still declares `--execution [e2b|gradio|local]`, so the harness runs end
+      to end on the reader's own machine, and nothing in the README offers a paid tier, a commercial edition
+      or a license key.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 4aa8cbfa3111e92db886583d554a3c9e8f14561d47261d6441c069835e3bdc28
@@ -63,15 +61,14 @@ adoption:
   reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: medium
-  note: 'Narrow, specialist code-gen benchmark: 503 GitHub stars, active HF leaderboard with 163 models
-    evaluated. No clean PyPI/download figure for the harness; no published install volume. stars_fallback ->
-    capped at level 3, set to 2 on the modest star + leaderboard footprint. Stars read 2026-08-13: 1,573
-    across the 2 declared repos, which bands at 1K-10K stars, level 2 on the stars scale in
-    signal_routing.yaml. The previous reach ''10K-100K'' was not a label this instrument offers - stars have
-    their own vocabulary because a star is not a download. Re-read against the GitHub API for both declared
-    repos on 2026-08-13 - bigcodebench 519 stars and bigcode-evaluation-harness 1,054, 1,573 together, so
-    the band is unchanged. The bigcodebench repo is now archived and read-only (last push 2026-01-03),
-    which is a reason the star count will stop moving rather than a reason to move the level.'
+  note: 'Narrow, specialist code-gen benchmark: 1,573 GitHub stars across the two declared repos (bigcodebench
+    519, bigcode-evaluation-harness 1,054) and an active HF leaderboard with 163 models evaluated. No clean
+    PyPI/download figure for the harness and no published install volume, so stars_fallback -> capped at
+    level 3, set to 2 on the modest star + leaderboard footprint. 1,573 bands at 1K-10K stars, level 2 on
+    the stars scale in signal_routing.yaml; the previous reach ''10K-100K'' was not a label this instrument
+    offers - stars have their own vocabulary because a star is not a download. The bigcodebench repo is
+    archived and read-only, which is a reason the star count will stop moving rather than a reason to move
+    the level.'
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/bigcode-project/bigcodebench
@@ -101,9 +98,8 @@ capability:
   relation: one_below
   last_verified: '2026-08-13'
   note: Solid, rigorous code-gen eval but single-benchmark scope -- below the broad multi-task harnesses
-    (lm-eval, OpenCompass) on coverage breadth. Feature matrix re-read 2026-08-13 and unchanged - the
-    README still describes 1140 tasks and the Complete/Instruct splits. The peer comparison in that sentence
-    is now recorded structurally against OpenCompass, whose 4 sits one rung above this 3.
+    (lm-eval, OpenCompass) on coverage breadth. The peer comparison is recorded structurally against OpenCompass,
+    whose 4 sits one rung above this 3.
   sources:
   - url: https://github.com/bigcode-project/bigcodebench
     shows: 1140 tasks, Complete/Instruct splits, execution-based eval

--- a/sources/scores/blaxel-sandbox.yaml
+++ b/sources/scores/blaxel-sandbox.yaml
@@ -85,21 +85,14 @@ adoption:
   reach: <1K stars
   signal_type: stars_fallback
   confidence: low
-  note: 'Very nascent: ~22 stars on the sandbox repo, a $7.3M seed (First Round, YC S2025), and an unverified
-    vendor claim of billions of agent requests. No usage or download signal. stars_fallback with a low-double-
-    digit star base places this at 1. Added on openness and mission-fit grounds despite the low prominence;
-    scored honestly. Low confidence. Stars read 2026-08-13: 27 across the 1 declared repo, which bands at <1K
-    stars, level 1 on the stars scale in signal_routing.yaml. The record carried no reach label at all before
-    this. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every
-    refetch, and the rest of the axis was not re-read. That last sentence is superseded - the rest of
-    the axis has now been re-read. The repository metadata endpoint reports 27 stars and 13 forks on
-    2026-08-13, which is the <1K stars band and level 1, and the vendor page was re-read for anything
-    bandable rather than the count being copied forward. Nothing bandable appeared. blaxel.ai/sandbox
-    publishes no customer, request or sandbox-count figure at all, and the "billions of agent requests"
-    line the note records is not on it today; the page sells on 25ms resumes and perpetual standby
-    instead. So stars remain the only signal, the level is unchanged, and the digest-drift objection is
-    accepted rather than avoided - a later refetch showing a different hash means the count moved, which
-    is what a star signal does.'
+  note: 'Very nascent: 27 stars and 13 forks on the sandbox repo, the only declared repo, which bands at
+    <1K stars, level 1 on the stars scale in signal_routing.yaml. stars_fallback with a low-double-digit
+    star base places this at 1. No usage or download signal exists: blaxel.ai/sandbox publishes no customer,
+    request or sandbox-count figure at all - it sells on 25ms resumes and perpetual standby - and the "billions
+    of agent requests" the vendor once claimed is no longer on the page, so stars remain the only instrument.
+    Backed by a $7.3M seed (First Round, YC S2025). Added on openness and mission-fit grounds despite the
+    low prominence; scored honestly. Low confidence, and the source digest drifts on every refetch because
+    a star count moves, which is what a star signal does.'
   last_verified: '2026-08-13'
   sources:
   - url: https://api.github.com/repos/blaxel-ai/sandbox
@@ -121,19 +114,14 @@ capability:
     breadth:agent code execution; persistence:perpetual standby with full FS/memory state; scale:vendor-claimed
     billions of agent requests (unverified)
   confidence: medium
-  note: 'MicroVM isolation and the perpetual-standby resume model are a genuinely strong, distinctive feature
-    set, but proven scale is unverified and the product is early, so held at 3 rather than level with
-    the proven microVM 4s. Independent ComputeSDK TTI benchmarks measure ~450ms median fresh cold-start
-    (11th of 19 sandbox providers), mid-pack. Re-read 2026-08-13. The vendor page still carries every
-    recorded feature - microVMs, ~25ms resume from standby, full filesystem and memory snapshots,
-    auto-suspend after 15s idle, and persistence across months - and now also lists batch jobs across
-    thousands of sandboxes, outbound allow-lists, static IPs and self-hosted and VPC deployment options.
-    BENCHMARK FIGURE SUPERSEDED - the ComputeSDK leaderboard has re-run since (last run 7 August 2026)
-    and now covers 24 providers, so the cited "~450ms, 11th of 19" no longer appears. Blaxel now reads
-    0.51s median time-to-interactive, 0.60s P95, 0.61s P99, 100% success and a composite of 94.5, which
-    is 9th of 24 and still mid-pack, still sub-second, and ahead of E2B, Modal, Vercel and Cloud Run. The
-    band is unchanged and the reason it is held at 3 is unchanged too, since the missing evidence is
-    proven scale rather than latency.'
+  note: MicroVM isolation and the perpetual-standby resume model are a genuinely strong, distinctive feature
+    set, but proven scale is unverified and the product is early, so held at 3 rather than level with the
+    proven microVM 4s. The vendor page carries microVMs, ~25ms resume from standby, full filesystem and
+    memory snapshots, auto-suspend after 15s idle, persistence across months, batch jobs across thousands
+    of sandboxes, outbound allow-lists, static IPs, and self-hosted and VPC deployment options. Independent
+    ComputeSDK TTI benchmarks put Blaxel at a 0.51s median time-to-interactive, 0.60s P95, composite 94.5,
+    9th of 24 sandbox providers - mid-pack, sub-second, and ahead of E2B, Modal, Vercel and Cloud Run. Latency
+    is not what holds the band at 3; the missing evidence is proven scale.
   last_verified: '2026-08-13'
   sources:
   - url: https://blaxel.ai/sandbox

--- a/sources/scores/braintrust.yaml
+++ b/sources/scores/braintrust.yaml
@@ -15,13 +15,12 @@ openness:
       value: enterprise-only
       detail: hybrid
   confidence: high
-  note: Open SDKs but a closed SaaS core (Brainstore backend, dashboards, automation are proprietary);
-    no OSS core, so 'closed' (not open_core) like LangSmith/Galileo per recipe's closed examples. The
-    Apache-2.0 client SDK is instrumentation only and does not open the product. Re-read 2026-08-13 and
-    unchanged on the score. One detail has moved - braintrustdata/braintrust-sdk now states that it holds
-    "Braintrust's JavaScript/TypeScript SDKs and integrations" rather than the five-language set the
-    components clause records, so that clause overstates what this repository covers. It remains Apache-2.0
-    and it remains a client SDK, so neither the score nor the class turns on it.
+  note: 'Open SDKs but a closed SaaS core (Brainstore backend, dashboards, automation are proprietary);
+    no OSS core, so ''closed'' (not open_core) like LangSmith/Galileo per recipe''s closed examples. The
+    Apache-2.0 client SDK is instrumentation only and does not open the product. One components detail overstates
+    the evidence: braintrustdata/braintrust-sdk now describes itself as holding Braintrust''s JavaScript/TypeScript
+    SDKs and integrations rather than the five-language set the clause records. It remains Apache-2.0 and
+    remains a client SDK, so neither the score nor the class turns on it.'
   raw: source:closed;license:Apache-2.0(OSI, client SDKs only, Python/TS/Go/Ruby/C#);platform:proprietary(Brainstore
     custom DB, evals/tracing/automation all SaaS);self-host:enterprise-only(hybrid)
   last_verified: '2026-08-13'
@@ -52,11 +51,10 @@ adoption:
   signal_type: usage_volume
   confidence: high
   note: '~6.08M PyPI downloads in the last month for the `braintrust` package (primary: pypistats); named
-    production users. 1-10M monthly-download band; strongest adoption of the closed-platform set here.
-    Re-read 2026-08-13 - pypistats now reports 7,366,065 downloads last month, up from the 6,080,857
-    recorded and still inside the 1M-10M band, so level 4 is unchanged. The customer roster on the homepage
-    has changed: Notion and Coursera are still named, Vercel, Dropbox and Replit are not, and those three
-    are dropped from this note rather than carried forward. The band rests on the download count anyway.'
+    production users. 1-10M monthly-download band; strongest adoption of the closed-platform set here. pypistats
+    now reports 7,366,065 downloads in the last month, above the 6,080,857 this note was set on and still
+    inside the 1M-10M band. Of the named users, Notion and Coursera are on the homepage while Vercel, Dropbox
+    and Replit are not, so the band rests on the download count.'
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/packages/braintrust
@@ -83,8 +81,7 @@ capability:
   confidence: high
   note: Deepest eval+automation feature surface in this batch (CI-style quality gates, Topics auto-clustering,
     continuous scoring), a frontier-definer for eval-first LLM observability; rated 5 above the MLflow/Langfuse
-    C4 anchors on feature breadth. Re-read 2026-08-13 - Topics, continuous online scoring and quality gates
-    are all still front-of-page and still the thing no anchor matches, so the one-above comparison holds.
+    C4 anchors on feature breadth.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.braintrust.dev/

--- a/sources/scores/browser-use.yaml
+++ b/sources/scores/browser-use.yaml
@@ -111,15 +111,10 @@ capability:
   value: 'agent browser control: navigate/click/fill-forms/extract/multi-step tasks; LLM-driven DOM interaction;
     cloud infra adds proxy rotation, stealth fingerprinting, CAPTCHA solving, 1000+ integrations'
   confidence: medium
-  note: 'Leading OSS browser-automation-for-agents library with broad action coverage and a production cloud
-    tier; widely adopted as the default agent browsing layer. Rated 4 on feature_matrix (multi-step web tasks,
-    structured extraction, anti-block infra); no standard benchmark applies to a browser-control library.
-    Re-read 2026-08-13: the README still describes the same surface - a CLI for one-off tasks and a Python
-    library for repeatable automation, "custom tools, custom system prompts, structured output, fine-grained
-    browser control", with a skills/ directory in the tree - and it still places stealth and proxy rotation
-    on the cloud browsers rather than in the library, which is what the recorded value says. No standardized
-    benchmark for browser-control libraries has appeared, so the basis stays feature_matrix and the band
-    stays 4.'
+  note: Leading OSS browser-automation-for-agents library with broad action coverage and a production cloud
+    tier; widely adopted as the default agent browsing layer. Rated 4 on feature_matrix (multi-step web
+    tasks, structured extraction, anti-block infra); no standard benchmark applies to a browser-control
+    library.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/browser-use/browser-use

--- a/sources/scores/browserbase.yaml
+++ b/sources/scores/browserbase.yaml
@@ -15,13 +15,8 @@ openness:
       raw: companion Stagehand SDK IS open source (Apache/MIT) but the Browserbase service being scored
         is the closed managed platform
   confidence: high
-  note: 'The scored product is the managed browser-infrastructure service, which is closed/proprietary; only
-    the separate Stagehand client SDK is open; do not let the open SDK reclassify the closed service. Re-read
-    2026-08-13: the docs still document a hosted platform reached with one API key - Browser API, Search
-    API, Fetch API, Functions and Model Gateway - with no self-host, on-premise or source-available option
-    anywhere in them. Stagehand is still called out as "The SDK for browser agents ... Built by Browserbase"
-    and links out to its own docs site, which is exactly the separation this note warns against collapsing.
-    source stays closed and the score stays 1.'
+  note: The scored product is the managed browser-infrastructure service, which is closed/proprietary; only
+    the separate Stagehand client SDK is open; do not let the open SDK reclassify the closed service.
   raw: license:Proprietary(API-only managed browser infra);source:closed(cloud browser fleet/session infra);note:companion
     Stagehand SDK IS open source (Apache/MIT) but the Browserbase service being scored is the closed managed
     platform
@@ -44,15 +39,12 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: medium
-  note: No primary usage figure for the Browserbase managed service itself was published. Best primary
-    proxy is its own SDK, Stagehand, which Browserbase docs cite at 22k GitHub stars and 700k+ weekly
-    downloads, a strong open-SDK adoption signal that approximates the platform's developer reach (100K-1M
-    band). The closed service's own user/session count is undisclosed. Re-read 2026-08-13 and the proxy figures
-    are unchanged - the docs still say of Stagehand "22k GitHub stars, 700k+ weekly downloads. Built by Browserbase"
-    - and the platform still publishes no session, request or customer count of its own, which is what was
-    looked for and not found. 700k weekly is roughly 3M monthly, which would band at 4 if it were the product's
-    own figure; it is not, it is a companion SDK standing in, so the level stays at 3 with the discount that
-    substitution deserves. Level and reach unchanged.
+  note: No primary usage figure for the Browserbase managed service itself was published. Best primary proxy
+    is its own SDK, Stagehand, which Browserbase docs cite at 22k GitHub stars and 700k+ weekly downloads,
+    a strong open-SDK adoption signal that approximates the platform's developer reach (100K-1M band). The
+    closed service's own user/session count is undisclosed. 700k weekly downloads is roughly 3M monthly,
+    which would band at 4 if it were the platform's own figure; it is a companion SDK standing in, so the
+    level stays at 3 with the discount that substitution deserves.
   last_verified: '2026-08-13'
   sources:
   - url: https://docs.browserbase.com/
@@ -69,12 +61,8 @@ capability:
     Model Gateway (100+ LLM providers); Stagehand: natural-language selectors, self-healing actions, caching
     at scale'
   confidence: medium
-  note: 'Broad browser-automation-for-agents feature set (control + search + fetch + deploy + model routing)
-    plus a capable agent SDK; near-frontier among agent browser/scrape platforms. Re-read 2026-08-13: the
-    five components in the recorded value are all still documented - Browser API, Search API, Fetch API,
-    Functions and Model Gateway - as are Stagehand''s natural-language selectors, self-healing actions and
-    caching at scale. No independent benchmark for hosted browser platforms exists, so the basis stays feature_matrix
-    and the band stays 4.'
+  note: Broad browser-automation-for-agents feature set (control + search + fetch + deploy + model routing)
+    plus a capable agent SDK; near-frontier among agent browser/scrape platforms.
   last_verified: '2026-08-13'
   sources:
   - url: https://docs.browserbase.com/

--- a/sources/scores/c4.yaml
+++ b/sources/scores/c4.yaml
@@ -10,8 +10,7 @@ openness:
     dataset_card:
       value: 'yes'
   confidence: high
-  note: 'Permissively licensed (ODC-BY) and ungated with a full dataset card. Re-read 2026-08-13: odc-by
-    on the Hub, gated false, card intact.'
+  note: Permissively licensed (ODC-BY) and ungated with a full dataset card.
   raw: license:ODC-BY;ungated:yes;dataset_card:yes
   last_verified: '2026-08-13'
   sources:
@@ -29,8 +28,8 @@ adoption:
   reach: '>1M'
   signal_type: usage_volume
   confidence: high
-  note: 1,414,303 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (allenai/c4 1,414,303). Bands at level 5 (>1M) on the dataset adoption scale, whose top band is >1M.
+  note: 1,414,303 downloads in the trailing 30 days summed across the 1 declared artifact(s) (allenai/c4
+    1,414,303). Bands at level 5 (>1M) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/allenai/c4
@@ -44,9 +43,8 @@ capability:
   basis_detail: superseded
   value: null
   confidence: high
-  note: 'Powered T5 (2019) and UL2 (2022); now a baseline that FineWeb and DCLM beat, superseded by modern
-    filtered web corpora. Re-read 2026-08-13: the FineWeb listing still claims better-performing LLMs than
-    other open pretraining datasets, C4 among them, so the supersession stands.'
+  note: Powered T5 (2019) and UL2 (2022); now a baseline that FineWeb and DCLM beat, superseded by modern
+    filtered web corpora.
   relative_to: fineweb
   relation: one_below
   last_verified: '2026-08-13'

--- a/sources/scores/ccnet.yaml
+++ b/sources/scores/ccnet.yaml
@@ -13,9 +13,7 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (MIT), full source public. Re-read 2026-08-13 - the LICENSE body still carries
-    the same license and the README still builds the whole product from the published repo, with no paid
-    tier, enterprise edition or license key anywhere in it.
+  note: Fully OSI-licensed (MIT), full source public.
   raw: license:MIT(OSI);source:public;no feature-gated core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -41,12 +39,12 @@ adoption:
   reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: medium
-  note: 1,045 GitHub stars on facebookresearch/cc_net, read 2026-08-13 from the repository API. Bands at
-    level 2 (1K-10K stars) on the stars fallback scale in signal_routing.yaml, which caps at 3 because a
-    star is not a use. Archived read-only since October 2023 but foundational and widely reused; no PyPI
-    package, so stars are the only signal. The API response is digested here the way bigcode-dataset and
-    ungoliant already are in this category; a star count drifts, so a later digest mismatch reads as drift
-    rather than as fabrication.
+  note: 1,045 GitHub stars on facebookresearch/cc_net, read from the repository API. Bands at level 2 (1K-10K
+    stars) on the stars fallback scale in signal_routing.yaml, which caps at 3 because a star is not a use.
+    Archived read-only since October 2023 but foundational and widely reused; no PyPI package, so stars
+    are the only signal. The API response is digested here the way bigcode-dataset and ungoliant already
+    are in this category; a star count drifts, so a later digest mismatch reads as drift rather than as
+    fabrication.
   last_verified: '2026-08-13'
   sources:
   - url: https://api.github.com/repos/facebookresearch/cc_net
@@ -60,8 +58,7 @@ capability:
   value: Language ID + KenLM perplexity filtering + dedup to build monolingual corpora from Common Crawl;
     single-approach, foundational, now dated.
   confidence: medium
-  note: Historically foundational (CC-100), but a single-method pipeline and frozen since 2023. Re-read
-    2026-08-13 - the README still describes the feature set above.
+  note: Historically foundational (CC-100), but a single-method pipeline and frozen since 2023.
   last_verified: '2026-08-13'
   sources:
   - url: https://raw.githubusercontent.com/facebookresearch/cc_net/main/README.md

--- a/sources/scores/character-ai.yaml
+++ b/sources/scores/character-ai.yaml
@@ -15,10 +15,6 @@ openness:
       detail: closed
   confidence: high
   note: Proprietary consumer chat app; closed counterpart on the shelf.
-    Re-read 2026-08-13. The Business of Apps profile still describes a proprietary consumer
-    companion-chat product built on its own models, with the 2024 Google arrangement covering a
-    non-exclusive licence rather than any code release. Nothing is published and there is no self-host
-    path. Value unchanged at 1 / closed.
   raw: license:proprietary(SaaS);source:closed;self-host:none;models:own+licensed(closed)
   last_verified: '2026-08-13'
   sources:
@@ -33,25 +29,17 @@ adoption:
   reach: '>10M users'
   signal_type: active_users
   confidence: low
-  note: Reported ~20M MAU and ~180M monthly site visits (Apr 2026); peaked ~28M MAU mid-2024 then declined.
-    ~20M MAU bands at >10M users, level 5 on the active_users scale declared 2026-08-13. RAISED from 4,
-    and the reason is the whole case for declaring the scale - this record read level 4 against a reach
-    of '10M-100M', a band nothing in the repo offered. Its own conservative figure clears the top
-    threshold, so the level was held down by a label that had no scale behind it to check it against.
-    Figures are aggregator-compiled (no first-party MAU disclosure fetched) and sources disagree (20M vs
-    higher visit-based counts), so confidence stays low; the 10M boundary is not close on either read.
-    Re-read 2026-08-13, and the aggregator has restated its numbers. The page now leads with 45 million
-    active users in September 2025 and over 75 million downloads since launch - the ~20M MAU, ~180M
-    monthly visits and ~28M mid-2024 peak recorded above are no longer on it. 45 million is still an
-    active count and still far above the >10M users threshold, so the level is unchanged at 5 and only
-    the supporting number has moved. It is still an aggregator compilation rather than a first-party
-    disclosure, so confidence stays low.
+  note: The aggregator profile reports 45 million active users (September 2025) and over 75 million downloads
+    since launch. 45M bands at >10M users, level 5 on the active_users scale. RAISED from 4, and the reason
+    is the whole case for declaring the scale - this record read level 4 against a reach of '10M-100M',
+    a band nothing in the repo offered. Its own conservative figure clears the top threshold, so the level
+    was held down by a label that had no scale behind it to check it against. The figures are aggregator-compiled
+    rather than a first-party MAU disclosure, and aggregators disagree, so confidence stays low; the 10M
+    boundary is not close on any reading.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.businessofapps.com/data/character-ai-statistics/
-    shows: 45 million active users (September 2025) and 75M+ downloads since launch, read 2026-08-13; the
-      ~20M MAU, ~180M monthly visits and ~28M mid-2024 peak this record was scored on are no longer on the
-      page (compiled)
+    shows: 45 million active users (September 2025) and 75M+ downloads since launch (compiled, not first-party)
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 3abe2ed8d0992caf18f31685c5447c6233be84052d73a59a1c585eae83bd6a50
@@ -66,10 +54,6 @@ capability:
   note: Specialized companion-chat UI; rich in persona/voice features but narrow on the general feature
     matrix (no model breadth, weak grounding); low capability relative to the general-assistant frontier
     in this category.
-    Re-read 2026-08-13. The profile still describes the same narrow shape the band rests on - a
-    companion and roleplay product organized around user-created characters, on its own and licensed
-    models rather than a provider menu, with no document grounding or general-assistant tooling. Band
-    unchanged at 2.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.businessofapps.com/data/character-ai-statistics/

--- a/sources/scores/chatbot-arena.yaml
+++ b/sources/scores/chatbot-arena.yaml
@@ -29,10 +29,9 @@ openness:
     from open_core on 2026-07-30. In this ladder open_core means an OSI core with functionality withheld
     for a paid tier, and there is no open core here, only an open periphery. A repo that exists while the
     runtime does not ship is source:partial, which the ladder scores 2/source_available. The score itself
-    was already 2. Re-read 2026-08-13 and unchanged. FastChat still says it powers the arena and its newest
-    release is still v0.2.36 from February 2024, so the staleness the class rests on has widened rather
-    than closed. The hosted platform''s canonical domain is now arena.ai, with lmarena.ai redirecting
-    to it, and the ranking pipeline behind it still does not ship.'
+    was already 2. FastChat''s newest published release is still the stale v0.2.36, so the gap the class
+    rests on has widened rather than closed, and the hosted platform''s canonical domain is now arena.ai
+    with lmarena.ai redirecting to it; the ranking pipeline behind it still does not ship.'
   raw: platform:closed(hosted arena.ai, proprietary live leaderboard + private vote data); source:partial(FastChat
     is a real arena implementation but stale relative to the operating platform; the current ranking pipeline
     does not ship); reference-code:FastChat Apache-2.0 (powers Chatbot Arena but stale, last release Feb
@@ -61,10 +60,9 @@ openness:
     establishes:
     - source
   - url: https://arena.ai/
-    shows: 'Re-read 2026-08-13: still the hosted ranking and battle platform, and now the canonical domain
-      - lmarena.ai 301-redirects here. It offers no repository, no self-hostable ranking pipeline and
-      no license to the evaluation code, and states that conversations are disclosed to the relevant AI
-      providers.'
+    shows: Still the hosted ranking and battle platform, and now the canonical domain - lmarena.ai 301-redirects
+      here. It offers no repository, no self-hostable ranking pipeline and no license to the evaluation
+      code, and states that conversations are disclosed to the relevant AI providers.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 3961d21eeadc354e9fb8622a2371ea206f9a6b30f509892498a48f6fe0b443e0
@@ -79,10 +77,9 @@ adoption:
   note: FastChat README (primary) states Chatbot Arena has served 'over 10 million chat requests for 70+
     LLMs'; Arena Elo is the most-cited human-preference leaderboard in frontier model releases (LMArena
     Elo appears across vendor launch posts). Headline = the 10M+ chat-request figure (primary, FastChat
-    repo). Banded 1M-10M conservatively on request volume; could be higher cumulatively. Re-read 2026-08-13
-    - the FastChat README still carries the same 10M chat requests and 1.5M human votes figures, unchanged
-    since 2024, and the platform is still operating at arena.ai. The band is confirmed, and the figure
-    behind it is a frozen one, which is why it stays banded conservatively.
+    repo). Banded 1M-10M conservatively on request volume; could be higher cumulatively. The 10M chat-request
+    and 1.5M human-vote figures in the FastChat README have not moved since 2024, so the headline is a frozen
+    figure - another reason the band stays conservative - while the platform itself still operates at arena.ai.
   sources:
   - url: https://github.com/lm-sys/FastChat
     shows: '''serving over 10 million chat requests for 70+ LLMs'''
@@ -112,11 +109,11 @@ capability:
     approximation'
   confidence: medium
   last_verified: '2026-08-13'
-  note: Reference platform for human-preference evaluation and the de-facto Elo standard cited everywhere;
+  note: 'Reference platform for human-preference evaluation and the de-facto Elo standard cited everywhere;
     not a 5 because as eval CODE it is largely closed/hosted and narrower than execution-based harnesses
-    on agentic/task coverage. Capability assessed on its evaluation methodology breadth. Feature matrix
-    re-read 2026-08-13 and unchanged - Arena-Hard-Auto v2.0 still ships 500 hard queries plus 250 creative
-    writing ones with GPT-4.1 and Gemini-2.5 judges, and the hosted arena still runs blind pairwise battles.
+    on agentic/task coverage. Capability assessed on its evaluation methodology breadth: Arena-Hard-Auto
+    v2.0 ships 500 hard queries plus 250 creative writing ones with GPT-4.1 and Gemini-2.5 judges, and the
+    hosted arena runs blind pairwise battles.'
   sources:
   - url: https://github.com/lmarena/arena-hard-auto
     shows: 500 SWE/math queries + 250 creative prompts, GPT-4.1/Gemini-2.5 judges, highest correlation

--- a/sources/scores/chatgpt.yaml
+++ b/sources/scores/chatgpt.yaml
@@ -11,12 +11,7 @@ openness:
     license:
     - name: proprietary
       detail: SaaS app + API
-  note: Proprietary, SaaS-only consumer app; no source, no self-host. Closed counterpart in the ui_api
-    shelf.
-    Re-read 2026-08-13. The cited OpenAI page is still up and still describes ChatGPT as the OpenAI
-    consumer service studied through a privacy-preserving analysis of conversations held on that
-    service. Nothing about the app or the models behind it is published, there is no self-host path and
-    no license beyond the consumer terms. Value unchanged at 1 / closed.
+  note: Proprietary, SaaS-only consumer app; no source, no self-host. Closed counterpart in the ui_api shelf.
   raw: source:closed;self-host:none;license:proprietary(SaaS app + API)
   last_verified: '2026-08-13'
   sources:
@@ -31,14 +26,8 @@ adoption:
   reach: '>10M users'
   signal_type: active_users
   confidence: high
-  note: OpenAI officially announced ~900M weekly active users (27 Feb 2026), up from 800M (Oct 2025),
-    with 50M paying subscribers. Mass-market scale, far above the >10M threshold. Attributed to the ChatGPT
-    surface.
-    Re-read 2026-08-13 - the TechCrunch report is still up and still carries the same two figures, 900
-    million weekly active users announced by OpenAI in February 2026 and 50 million paying subscribers.
-    That is an active count rather than a cumulative one and it is a vendor announcement rather than an
-    aggregator estimate, so nothing is being substituted here. Still far above the >10M users threshold.
-    Level unchanged at 5.
+  note: OpenAI officially announced ~900M weekly active users (27 Feb 2026), up from 800M (Oct 2025), with
+    50M paying subscribers. Mass-market scale, far above the >10M threshold. Attributed to the ChatGPT surface.
   last_verified: '2026-08-13'
   sources:
   - url: https://techcrunch.com/2026/02/27/chatgpt-reaches-900m-weekly-active-users/
@@ -53,22 +42,16 @@ capability:
     Advanced Voice Mode, image generation); custom GPTs with document knowledge and third-party actions;
     connectors (OpenAI-maintained MCP wrappers, as in ChatGPT)'
   confidence: high
-  note: 'Frontier consumer chat product within ui_api: full multimodal, code execution, web search, custom
-    GPTs, memory, Team/Enterprise multi-user. Sets the bar for the category''s chat-UI feature matrix.
-    Re-read 2026-08-14 - the cited page was an NBER-style usage study that enumerates none of the recorded
-    features, so the whole feature matrix was unsourced. Replaced with the two OpenAI-primary surfaces
-    that are actually reachable. openai.com and chatgpt.com return HTTP 403 to the repo''s fetcher after
-    three attempts, which is a host declining rather than an absence, so the consumer marketing pages
-    could not be read at all. What the reachable pages establish - the frontier model family
-    (gpt-5.6-sol "Frontier model for complex professional work", gpt-5.6-terra, gpt-5.6-luna), custom
-    GPTs with attached document knowledge and third-party actions, connectors described as the ones
-    "available in ChatGPT", and image generation, Advanced Voice Mode and photo upload from OpenAI''s own
-    App Store listing. Three clauses NOT re-sourced and dropped from the value - memory, Team/Enterprise
-    multi-user, and code interpreter and web search AS CHATGPT FEATURES. The last two are documented as
-    model tools on the API docs, which never mention ChatGPT, and the only reachable plan list shows
-    consumer tiers only (Go, Plus, Pro). The 5 rests on the surviving matrix, which is still the broadest
-    in the category. The note keeps the original claim above for history; the value now records only what
-    a source shows.'
+  note: Frontier consumer chat product within ui_api, and the broadest chat-UI feature matrix in the category,
+    which is what the 5 rests on. What a source establishes is the frontier model family (gpt-5.6-sol "Frontier
+    model for complex professional work", gpt-5.6-terra, gpt-5.6-luna), custom GPTs with attached document
+    knowledge and third-party actions, OpenAI-maintained connectors described as the ones available in ChatGPT,
+    and image generation, Advanced Voice Mode and photo upload from OpenAI's own App Store listing. Three
+    clauses are deliberately not claimed - memory, Team/Enterprise multi-user, and code interpreter and
+    web search as ChatGPT features. The last two are documented only as model tools in the API docs, which
+    never mention ChatGPT, and the only reachable plan list shows consumer tiers only (Go, Plus, Pro). openai.com
+    and chatgpt.com return HTTP 403 to the repo's fetcher, so the consumer marketing pages cannot be read
+    at all, which is a host declining rather than an absence.
   last_verified: '2026-08-14'
   sources:
   - url: https://developers.openai.com/api/docs/actions/introduction

--- a/sources/scores/claude-ai.yaml
+++ b/sources/scores/claude-ai.yaml
@@ -11,11 +11,7 @@ openness:
     license:
     - name: proprietary
       detail: SaaS app + API
-  note: Proprietary, SaaS-only consumer app; no source, no self-host. Closed counterpart in the ui_api
-    shelf.
-    Re-read 2026-08-13. claude.com/product/overview is still a marketing page for a hosted service - it
-    offers a sign-in and a set of prompts, publishes no source, and describes no self-host path. Value
-    unchanged at 1 / closed.
+  note: Proprietary, SaaS-only consumer app; no source, no self-host. Closed counterpart in the ui_api shelf.
   raw: source:closed;self-host:none;license:proprietary(SaaS app + API)
   last_verified: '2026-08-13'
   sources:
@@ -31,23 +27,17 @@ adoption:
   reach: '>10M users'
   signal_type: active_users
   confidence: low
-  note: Anthropic does NOT disclose official Claude.ai MAU. Third-party estimates (no primary vendor figure
-    available) put consumer MAU ~18.9M web at start of 2026 rising toward ~30M by mid-2026, which bands
-    at >10M users, level 5 on the active_users scale declared 2026-08-13. RAISED from 4, which had been
-    recorded against a reach of '1M-10M' - a label its own cited figure contradicted by roughly twofold
-    at the low end. The scale is what makes that contradiction visible - nothing previously compared the
-    number in the note to the band above it. Level 5 here does not claim parity with ChatGPT or the Gemini
-    app, which are two orders larger; it says all three are mass-market, which is what the map's top band
-    means. Confidence stays low - the headline number is a third-party estimate, not a vendor disclosure.
-    Re-read 2026-08-14 against a substitute, demandsage.com being unfetchable - it answered 403 to
-    eight consecutive requests under every header set tried. SEOProfy carries the same headline,
-    "Claude has around 18.9 million monthly active users worldwide", with AICPB putting about 7.38M of
-    those on mobile, so the figure the band rests on re-derives from an independent aggregator. One
-    correction to the note's shape rather than its level - SEOProfy reads MAU as having "largely
-    plateaued" since late 2024 rather than rising toward 30M, so the trajectory clause is not
-    corroborated and should not be relied on. The band is unaffected either way - 18.9M clears the
-    >10M floor by nearly twofold and the alternative reading is lower, not higher. Level 5 and low
-    confidence both unchanged.
+  note: Anthropic does NOT disclose official Claude.ai MAU. Third-party estimates put consumer MAU at around
+    18.9M worldwide, roughly 7.38M of them on mobile, which bands at >10M users, level 5 on the active_users
+    scale. RAISED from 4, which had been recorded against a reach of '1M-10M' - a label its own cited figure
+    contradicted by roughly twofold at the low end. The scale is what makes that contradiction visible -
+    nothing previously compared the number in the note to the band above it. Level 5 here does not claim
+    parity with ChatGPT or the Gemini app, which are two orders larger; it says all three are mass-market,
+    which is what the map's top band means. An earlier reading of the trajectory as rising toward ~30M is
+    not corroborated - the aggregator reads MAU as having largely plateaued since late 2024 - but the band
+    is unaffected either way, since 18.9M clears the >10M floor by nearly twofold and the alternative reading
+    is lower, not higher. Confidence stays low - the headline number is a third-party estimate, not a vendor
+    disclosure.
   last_verified: '2026-08-14'
   sources:
   - url: https://claude.com/product/overview
@@ -76,11 +66,7 @@ capability:
   confidence: high
   note: 'Frontier consumer chat product within ui_api: Artifacts, Projects, web search, code execution,
     MCP connectors, voice, multimodal file analysis, Team/Enterprise. Among the category''s most capable
-    chat surfaces.
-    Re-read 2026-08-13. The product overview still shows Artifacts described as turning ideas into
-    shareable creations, Projects for organizing conversations with persistent context, connectors
-    including Google Drive and web search reachable from a prompt, and Enterprise plans alongside the
-    consumer tiers. Band unchanged at 5.'
+    chat surfaces.'
   last_verified: '2026-08-13'
   sources:
   - url: https://claude.com/product/overview

--- a/sources/scores/claude-code.yaml
+++ b/sources/scores/claude-code.yaml
@@ -17,13 +17,13 @@ openness:
       detail: anthropics/claude-code ships plugins, examples and scripts; no runtime source and LICENSE.md
         is all-rights-reserved
   note: 'Closed/proprietary product gated behind an Anthropic subscription; the coding agent itself is not
-    open source. `source: closed` transcribed 2026-08-11 from a read of the repo: the GitHub contents API
-    lists only `.claude-plugin`, `.claude`, `.devcontainer`, `Script`, `examples`, `plugins`, `scripts`
-    and docs at the root, and LICENSE.md is a bare all-rights-reserved notice pointing at Anthropic''s Commercial
-    Terms. The published Agent SDK is a client that spawns the closed CLI, which the corpus already treats
-    as `closed` rather than `partial` (braintrust, promptlayer, openrouter, tavily-search-api all record
-    client SDKs under `source: closed`). `core-gated` is left unrecorded because the rubric says it is meaningful
-    only where source is public.'
+    open source. `source: closed` comes from a direct read of the repo: the GitHub contents API lists only
+    `.claude-plugin`, `.claude`, `.devcontainer`, `Script`, `examples`, `plugins`, `scripts` and docs at
+    the root, and LICENSE.md is a bare all-rights-reserved notice pointing at Anthropic''s Commercial Terms.
+    The published Agent SDK is a client that spawns the closed CLI, which the corpus already treats as `closed`
+    rather than `partial` (braintrust, promptlayer, openrouter, tavily-search-api all record client SDKs
+    under `source: closed`). `core-gated` is left unrecorded because the rubric says it is meaningful only
+    where source is public.'
   last_verified: '2026-08-11'
   raw: license:Proprietary(closed-source CLI/app, requires Claude subscription or Console account);model:Claude(proprietary,
     API-only);note:Agent SDK published but the product is closed SaaS;source:closed(anthropics/claude-code
@@ -54,14 +54,9 @@ adoption:
   signal_type: reported_traction
   confidence: medium
   banded_quantity: revenue run-rate (~$2.5B, February 2026), not a developer count
-  note: 'Reuters (Feb 2026): Claude Code exceeded ~$2.5B run-rate revenue, with business subscriptions
-    quadrupled since the start of 2026 and enterprise now >half of Claude Code revenue. No clean user-count,
-    so reported_traction; revenue scale implies well into the 1-10M+ developer band. Re-read 2026-08-13
-    - the SaaStr piece still carries the figure under its own heading, "Claude Code - $2.5 Billion ARR.
-    Doubled Since January", against $14B Anthropic ARR, and the product docs still describe a paid multi-surface
-    product across terminal, VS Code, desktop, web, Slack and mobile, most surfaces requiring a Claude
-    subscription or Console account. Anthropic still discloses no user count, so the instrument stays
-    reported_traction and the level is unchanged.'
+  note: 'Reuters (Feb 2026): Claude Code exceeded ~$2.5B run-rate revenue, with business subscriptions quadrupled
+    since the start of 2026 and enterprise now >half of Claude Code revenue. No clean user-count, so reported_traction;
+    revenue scale implies well into the 1-10M+ developer band.'
   last_verified: '2026-08-13'
   sources:
   - url: https://code.claude.com/docs/en/overview
@@ -82,15 +77,13 @@ capability:
   value: Backed by frontier Claude Opus models leading SWE-bench Verified (Claude Opus 4.8 ~88.6%, 4.7
     ~87.6%); Claude Code is the reference agent harness for these scores.
   confidence: high
-  note: 'Frontier-defining coding agent, pairs the leading SWE-bench Verified models with a mature multi-surface
-    agent harness (sub-agents, hooks, MCP, scheduling). One of the 1-2 capability frontier-definers in
-    this category. Re-read 2026-08-13, and two of the three cited sources no longer serve the figure to
-    a fetcher - llm-stats.com now answers with a "confirm you''re human" interstitial rather than the
-    leaderboard, and the Anthropic Opus 4.8 announcement renders its comparison table outside the fetched
-    HTML, so neither can be digested for the 88.6%. The claim was re-derived instead from the Marktechpost
-    benchmark-driven ranking, which places Claude Code first of the field at 87.6% SWE-bench Verified
-    on Opus 4.7 and 80.8% on Opus 4.6, above every other agent it ranks. The band is unchanged; what moved
-    is which source carries it.'
+  note: Frontier-defining coding agent, pairs the leading SWE-bench Verified models with a mature multi-surface
+    agent harness (sub-agents, hooks, MCP, scheduling). One of the 1-2 capability frontier-definers in this
+    category. Two of the three cited sources no longer serve the figure to a fetcher - llm-stats.com answers
+    a bot-check interstitial rather than the leaderboard, and the Anthropic Opus 4.8 announcement renders
+    its comparison table outside the fetched HTML - so the placement rests on the Marktechpost benchmark-driven
+    ranking, which puts Claude Code first of the field at 87.6% SWE-bench Verified on Opus 4.7 and 80.8%
+    on Opus 4.6.
   last_verified: '2026-08-13'
   sources:
   - url: https://llm-stats.com/benchmarks/swe-bench-verified

--- a/sources/scores/claude-fable.yaml
+++ b/sources/scores/claude-fable.yaml
@@ -13,11 +13,9 @@ openness:
     - name: Proprietary
       detail: API-only
   confidence: high
-  note: 'No weights, data or code released. Served through the Anthropic API only, so 1/closed on every dimension.
-    Recorded here rather than in base_pretrained because a closed model has no observable base checkpoint to score,
-    which is the convention #114 settled. Re-read 2026-08-13 - the platform docs still list Fable 5 by API
-    model ID only, still designate it a Covered Model with 30-day data retention, and still offer no weights,
-    corpus or training code. No change.'
+  note: 'No weights, data or code released. Served through the Anthropic API only, so 1/closed on every
+    dimension. Recorded here rather than in base_pretrained because a closed model has no observable base
+    checkpoint to score, which is the convention #114 settled.'
   raw: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
   last_verified: '2026-08-13'
   sources:
@@ -39,16 +37,10 @@ adoption:
   reach: null
   signal_type: reported_traction
   confidence: low
-  note: Directional market-position estimate (not a measured usage figure). Anthropic's most capable GA model, with
-    day-one enterprise testimonials (Stripe, GitHub, Cursor, Cognition) and a staged subscription rollout. Capped
-    at 4 rather than 5 because it launched Jun 9 2026 (~2 weeks before scoring), so sustained reach is unproven.
-    Overrides the prior frozen-anchor convention (held null) for dominant closed incumbents. Re-read
-    2026-08-13 - the launch post still carries partner testimonials and no quantitative usage figure, so
-    the abstention from a number stands and `reach` correctly stays null. As on claude-opus, the OpenRouter
-    rankings page renders no model names to a plain fetch, so it corroborates the existence of a usage
-    leaderboard rather than Fable's place on it. Two months past launch the "sustained reach unproven"
-    reason for capping at 4 is weaker than it was, which is a scoring question rather than a freshness one
-    and is flagged. No change made.
+  note: Directional market-position estimate (not a measured usage figure). Anthropic's most capable GA
+    model, with day-one enterprise testimonials (Stripe, GitHub, Cursor, Cognition) and a staged subscription
+    rollout. Capped at 4 rather than 5 because it launched Jun 9 2026 (~2 weeks before scoring), so sustained
+    reach is unproven. Overrides the prior frozen-anchor convention (held null) for dominant closed incumbents.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.anthropic.com/news/claude-fable-5-mythos-5
@@ -70,14 +62,10 @@ capability:
   basis_detail: FrontierCode
   value: null
   confidence: high
-  note: 'Anthropic-reported: highest among frontier models on Cognition FrontierCode (even at medium effort); top
-    on Hebbia Finance Benchmark; SOTA on CursorBench and FrontierBench per partner testing; leads Opus 4.8 on long-horizon
-    coding, knowledge work, vision, and memory tasks. Vendor-reported; underlying Mythos weights with classifier
-    fallback on ~5% of sessions. Re-read 2026-08-13 - the launch post still states Fable 5 "scores highest
-    among frontier models, even at medium effort" on Cognition''s FrontierCode, still reports the highest
-    score of any model on Hebbia''s Finance Benchmark, and still carries Cursor''s "state of the art model
-    on CursorBench" testimonial. The product page still calls it "our most capable generally available
-    model". No change.'
+  note: 'Anthropic-reported: highest among frontier models on Cognition FrontierCode (even at medium effort);
+    top on Hebbia Finance Benchmark; SOTA on CursorBench and FrontierBench per partner testing; leads Opus
+    4.8 on long-horizon coding, knowledge work, vision, and memory tasks. Vendor-reported; underlying Mythos
+    weights with classifier fallback on ~5% of sessions.'
   last_verified: '2026-08-13'
   sources:
   - url: https://www.anthropic.com/news/claude-fable-5-mythos-5

--- a/sources/scores/claude-haiku.yaml
+++ b/sources/scores/claude-haiku.yaml
@@ -13,10 +13,10 @@ openness:
     - name: Proprietary
       detail: API-only
   confidence: high
-  note: Closed by construction and stable across generations. Measured against Claude Haiku 4.5, the
-    generation shipping at the time of scoring. Re-read 2026-08-13 - the page still sells Haiku 4.5 by the
-    token ("$1 per million input tokens and $5 per million output tokens") across Claude.ai, the Claude
-    Platform, Bedrock, Vertex AI and Microsoft Foundry, with no weight download offered. No change.
+  note: Closed by construction and stable across generations. Measured against Claude Haiku 4.5, the generation
+    shipping at the time of scoring. Haiku 4.5 is sold by the token at $1 per million input tokens and $5
+    per million output tokens across Claude.ai, the Claude Platform, Bedrock, Vertex AI and Microsoft Foundry,
+    with no weight download offered.
   raw: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
   last_verified: '2026-08-13'
   sources:
@@ -33,10 +33,7 @@ adoption:
   signal_type: reported_traction
   confidence: medium
   note: High-volume tier by design, but no per-model usage figure is published and it is chosen less often
-    than Sonnet as a default. Directional. Re-read 2026-08-13 - the page still positions Haiku for scaled,
-    latency-sensitive deployments ("powering free tier products", customer-service agents, coding
-    sub-agents) and still publishes no usage or user count, so the abstention from a number stands.
-    `reach` correctly absent. No change.
+    than Sonnet as a default. Directional.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.anthropic.com/claude/haiku
@@ -53,12 +50,10 @@ capability:
   value: null
   confidence: medium
   note: Haiku 4.5 is strong for its size class and competitive with the previous Sonnet generation, but
-    below the current Sonnet, Opus and Fable tiers. Confidence medium - SWE-bench Verified's leaderboard has
-    no submissions since 2025-12-15, so figures are vendor-reported. Re-read 2026-08-13 - the page now
-    carries an explicit figure the record did not have, 73.3% on SWE-bench Verified, alongside the claim
-    that Haiku 4.5 matches Sonnet 4 on coding, computer use and agent tasks. That is below the current
-    Sonnet 4.6 generation and well below Opus and Fable, which is exactly the position the 4 encodes. No
-    change.
+    below the current Sonnet, Opus and Fable tiers. Confidence medium - SWE-bench Verified's leaderboard
+    has no submissions since 2025-12-15, so figures are vendor-reported. Anthropic reports 73.3% on SWE-bench
+    Verified and parity with Sonnet 4 on coding, computer use and agent tasks, which is below the current
+    Sonnet generation and well below Opus and Fable - exactly the position the 4 encodes.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.anthropic.com/claude/haiku

--- a/sources/scores/claude-opus.yaml
+++ b/sources/scores/claude-opus.yaml
@@ -15,11 +15,9 @@ openness:
   governing_release: claude-opus-4-x
   confidence: high
   note: No weights distributed in any form. Served only through the Anthropic API, Bedrock, Vertex and claude.ai,
-    so 1/closed on every dimension. Opus 4.x governs as the current release; 4.7 scored identically, and nothing
-    about the tier's openness turns on which release is read. Consolidated because Anthropic markets Claude Opus
-    as the product and 4.7 and 4.8 are versions of it. Re-read 2026-08-13 - the Opus 4.8 post still sells
-    the model by the token ("$5 per million input tokens and $25 per million output tokens", fast mode
-    $10/$50) with no weights download anywhere on it, and the Claude 4 launch post is unchanged. No change.
+    so 1/closed on every dimension. Opus 4.x governs as the current release; 4.7 scored identically, and
+    nothing about the tier's openness turns on which release is read. Consolidated because Anthropic markets
+    Claude Opus as the product and 4.7 and 4.8 are versions of it.
   raw: weights:closed;data:closed;code:closed;license:Proprietary(API/Bedrock/Vertex/claude.ai)
   last_verified: '2026-08-13'
   sources:
@@ -41,16 +39,14 @@ adoption:
   reach: null
   signal_type: reported_traction
   confidence: medium
-  note: Directional market-position estimate (not a measured usage figure). Opus is Anthropic's premium tier top-tier
-    reach but lower volume than the Sonnet workhorse, so 4 rather than 5. Anthropic's launch post lists 28 enterprise
-    testimonials (Stripe, Replit, Vercel, etc.); Opus flagships appear on public LLM marketplace leaderboards (e.g.
-    OpenRouter). Overrides the prior frozen-anchor convention (held null), which systematically understated dominant
-    closed incumbents and could mask the openness gap. Re-read 2026-08-13 - the Opus 4.7 post still carries
-    named enterprise testimonials (Cursor, Harvey, Replit and others) and still publishes no usage or user
-    count, so the abstention from a number stands and the instrument is right. `reach` correctly stays null.
-    One caveat recorded rather than hidden - the OpenRouter rankings page renders no model names to a plain
-    fetch, so it corroborates the existence of a live usage leaderboard and not Claude's place on it. No
-    change.
+  note: Directional market-position estimate (not a measured usage figure). Opus is Anthropic's premium
+    tier top-tier reach but lower volume than the Sonnet workhorse, so 4 rather than 5. Anthropic's launch
+    post lists 28 enterprise testimonials (Stripe, Replit, Vercel, etc.); Opus flagships appear on public
+    LLM marketplace leaderboards (e.g. OpenRouter). Overrides the prior frozen-anchor convention (held null),
+    which systematically understated dominant closed incumbents and could mask the openness gap. No per-model
+    usage or user figure is published, so `reach` stays null, and the OpenRouter rankings page corroborates
+    the existence of a live usage leaderboard rather than Claude's place on it, because the rankings render
+    client-side.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.anthropic.com/news/claude-opus-4-7
@@ -72,11 +68,10 @@ capability:
   basis_detail: GDPval-AA
   value: null
   confidence: high
-  note: 'Anthropic-reported: state-of-the-art on GDPval-AA and Finance Agent; CursorBench 70% (vs 58% for Opus 4.6);
-    BigLaw Bench 90.9% at high effort; gains on SWE-bench Verified/Pro/Multilingual. Vendor-reported. Re-read
-    2026-08-13 - every Anthropic-side figure is still on the Opus 4.7 post verbatim. The sentence claiming
-    independent Gemini 3.5 Flash comparisons did NOT survive: the cited Google post does not mention Claude
-    or Opus anywhere, so that clause has been removed rather than re-dated. The score does not rest on it.'
+  note: 'Anthropic-reported: state-of-the-art on GDPval-AA and Finance Agent; CursorBench 70% (vs 58% for
+    Opus 4.6); BigLaw Bench 90.9% at high effort; gains on SWE-bench Verified/Pro/Multilingual. Vendor-reported.
+    No independent comparison stands behind these figures: the cited Google Gemini 3.5 post names neither
+    Claude nor Opus, and the score does not rest on it.'
   last_verified: '2026-08-13'
   sources:
   - url: https://www.anthropic.com/news/claude-opus-4-7
@@ -87,8 +82,8 @@ capability:
     http_status: 200
     content_sha256: daa397e03d077f0dac261a7b154c0aa2ee00bb2bd745e35069d598e4575cf499
   - url: https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/
-    shows: Google's Gemini 3.5 launch post. Re-read 2026-08-13 and it names neither Claude nor Opus, so
-      it corroborates nothing about this product.
+    shows: Google's Gemini 3.5 launch post. It names neither Claude nor Opus, so it corroborates nothing
+      about this product.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: bcfcef8f1a7ca1f6a43f67d199a3686d96f50a066e159a5e464bc2107a47e5bd

--- a/sources/scores/claude-sonnet.yaml
+++ b/sources/scores/claude-sonnet.yaml
@@ -14,12 +14,10 @@ openness:
       detail: API-only
   confidence: high
   note: Closed by construction and stable across generations - no Sonnet release has ever shipped weights,
-    so this axis does not move when the tier advances. Measured against Claude Sonnet 4.6 (released
-    2026-02-17), Anthropic's production default coding tier at the time of scoring. Re-read 2026-08-13 -
-    the launch post still lists availability as "all Claude plans, Claude Cowork, Claude Code, our API,
-    and all major cloud platforms" and offers no weight download, and the tier has since advanced to Sonnet
-    5 (2026-06-30), which is sold the same way at $2/$10 per million tokens. Closed on both releases. No
-    change.
+    so this axis does not move when the tier advances. Measured against Claude Sonnet 4.6 (released 2026-02-17),
+    Anthropic's production default coding tier at the time of scoring. The tier has since advanced to Sonnet
+    5, sold the same way at $2 per million input tokens and $10 per million output tokens, so the axis reads
+    closed on both releases.
   raw: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
   last_verified: '2026-08-13'
   sources:
@@ -44,12 +42,10 @@ adoption:
   signal_type: reported_traction
   confidence: medium
   note: Highest-adoption tier of the three Claude model tiers - Sonnet is the production default for coding
-    and the model most API traffic lands on. Directional rather than measured; no per-model usage figure is
-    published, so this is a reported-traction judgment. Re-read 2026-08-13 - the post still puts Sonnet 4.6
-    on every Claude plan including a free tier upgraded to it by default, which is the breadth the 5 rests
-    on, and still publishes no usage or user count. The tier has since advanced to Sonnet 5, which is "the
-    default model for Free and Pro plans", so the breadth argument is if anything stronger. `reach` correctly
-    absent. No change.
+    and the model most API traffic lands on. Directional rather than measured; no per-model usage figure
+    is published, so this is a reported-traction judgment. The current Sonnet 5 release is the default model
+    for Free and Pro plans, which makes the breadth argument stronger rather than weaker; no per-model usage
+    or user count is published, so `reach` is correctly absent.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.anthropic.com/news/claude-sonnet-4-6

--- a/sources/scores/cline.yaml
+++ b/sources/scores/cline.yaml
@@ -14,10 +14,7 @@ openness:
     free_text:
     - no feature-gated core
     - model-agnostic (30+ providers + MCP)
-  note: 'Verified Apache-2.0 OSI, full source public; free extension with no proprietary core gating.
-    Re-read 2026-08-13 - the repo page still reports Apache-2.0 over the whole tree, publishes the extension,
-    CLI and SDK rather than a client stub, describes itself as "the open source coding agent" and offers
-    no paid tier or enterprise directory. Stars are now 66.1k. Nothing moved.'
+  note: Verified Apache-2.0 OSI, full source public; free extension with no proprietary core gating.
   raw: license:Apache-2.0(OSI, (c)2026 Cline Bot Inc.);source:public;no feature-gated core; model-agnostic
     (30+ providers + MCP);core-gated:ungated
   last_verified: '2026-08-13'
@@ -37,12 +34,11 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: 'One of the most-installed agentic coding extensions. Re-read 2026-08-13 - the VS Code Marketplace
-    listing now reports 4,974,003 installs, up from the 4,191,569 recorded here. WHAT WAS BANDED - a Marketplace
-    install count is cumulative rather than a trailing-30-day download figure, so it is a substitution
-    in the sense of docs/reference/adoption.md and it runs high against a monthly scale. Even so it lands
-    in the same band it did before, and Cline ships through the Marketplace rather than PyPI or npm, so
-    no monthly channel figure exists to prefer. Level unchanged at 4.'
+  note: One of the most-installed agentic coding extensions. The VS Code Marketplace listing reports 4,974,003
+    installs. WHAT WAS BANDED - a Marketplace install count is cumulative rather than a trailing-30-day
+    download figure, so it is a substitution in the sense of docs/reference/adoption.md and it runs high
+    against a monthly scale. Even so it lands at level 4, and Cline ships through the Marketplace rather
+    than PyPI or npm, so no monthly channel figure exists to prefer.
   last_verified: '2026-08-13'
   sources:
   - url: https://marketplace.visualstudio.com/items?itemName=saoudrizwan.claude-dev
@@ -58,9 +54,7 @@ capability:
   confidence: medium
   note: 'Second only to OpenHands (68.4%) among open coding agents on the April 2026 leaderboard; above
     SWE-agent and Aider. NOTE: figure from aggregator leaderboard (awesomeagents.ai), not primary; kept
-    at medium confidence. Re-read 2026-08-13 - the leaderboard still ranks Cline (Autonomous Mode) on
-    Claude Sonnet 4.6 at 59.8% Verified and 44.1% Full, row 5, and its commentary still contrasts that
-    with SWE-agent v1 at 43.2% on the same base model. Unchanged.'
+    at medium confidence.'
   last_verified: '2026-08-13'
   sources:
   - url: https://awesomeagents.ai/leaderboards/swe-bench-coding-agent-leaderboard/

--- a/sources/scores/cloudflare-sandboxes.yaml
+++ b/sources/scores/cloudflare-sandboxes.yaml
@@ -23,14 +23,10 @@ openness:
   confidence: high
   note: 'Closed managed service. The Sandbox SDK is Apache-2.0, but execution requires Cloudflare''s proprietary
     managed edge network (no self-host of the isolate/container plane); an open client SDK over a closed
-    runtime is not open_core. Reclassified from open_core. Re-read 2026-08-13 - the Dynamic Workers
-    post still describes an API onto Cloudflare''s own Workers platform, priced at $0.002 per unique
-    Worker loaded per day on top of ordinary Workers charges, with no self-hosted form of the isolate
-    or container plane. The SDK half also still holds, with one wrinkle worth recording - GitHub
-    classifies cloudflare/sandbox-sdk as NOASSERTION because the root LICENSE file is a one-line
-    pointer to packages/sandbox/LICENSE; that file is the verbatim Apache License 2.0, so the SDK is
-    Apache-2.0 as recorded and the classifier is simply defeated by the redirect. Source and license
-    both read as recorded.'
+    runtime is not open_core. Reclassified from open_core. One classification wrinkle is worth recording:
+    GitHub reports cloudflare/sandbox-sdk as NOASSERTION because the root LICENSE file is a one-line pointer
+    to packages/sandbox/LICENSE, and that file is the verbatim Apache License 2.0 - the SDK is Apache-2.0
+    as recorded, and the classifier is simply defeated by the redirect.'
   raw: license:Proprietary;source:closed;service:proprietary Cloudflare edge (Workers/Durable Objects/Dynamic
     Worker Loader - no self-host of the isolate/container plane);open-part:Sandbox SDK only (@cloudflare/sandbox
     Apache-2.0, cloudflare/sandbox-sdk on GitHub);pricing:Workers paid plan, Dynamic Workers $0.002/unique-worker/day
@@ -120,20 +116,15 @@ capability:
   note: Distinctive isolate-based approach gives best-in-class cold-start and density on the JS/TS isolate
     path, plus a container path for arbitrary code; held at 4 because isolate sandboxing is JS/TS-centric
     (narrower than microVM any-image), Dynamic Workers is still open beta, and overall scale evidence is
-    per-customer rather than category-leading. Scored as a combined product per the registry name.
-    Independent ComputeSDK TTI benchmarks measure the container-backed sandbox path (what runs arbitrary
-    code) at ~1.8s median cold-start, 18th of 19 sandbox providers, degrading to ~4.3s under 100-concurrent
-    burst; the sub-ms figures apply to the JS/TS Dynamic Workers path, not the arbitrary-code sandbox the
-    benchmark exercises. On measured full-sandbox latency alone this would be a 3; held at 4 on the strength
-    of the dual isolate-plus-container isolation model. Re-read 2026-08-13 - the Dynamic Workers post
-    still claims ms-scale isolate start, ~100x the density of containers and no global concurrency or
-    creation-rate limit, and the SDK repository still exposes the container-backed path for arbitrary
-    commands, files, background processes and exposed services. The latency picture has got worse
-    rather than better - ComputeSDK''s 2026-08-07 run puts the container-backed sandbox at a 4.42s
-    median TTI, 21st of 24 providers, against the ~1.76s/18th-of-19 recorded above. The band is held
-    at 4 on the same reasoning as before, that the isolate path is a genuinely different and
-    much faster instrument than the one the benchmark exercises, but the measured gap is now wide
-    enough that the hold is the weakest part of this score.
+    per-customer rather than category-leading. Scored as a combined product per the registry name. The Dynamic
+    Workers post claims ms-scale isolate start, ~100x the density of containers and no limit on global concurrent
+    sandboxes or creation rate, and the SDK repository exposes the container-backed path for arbitrary commands,
+    files, background processes and exposed services. Independent ComputeSDK TTI benchmarks measure that
+    container-backed path - the one that runs arbitrary code - at a 4.42s median cold-start, 21st of 24
+    sandbox providers, where an earlier run had it at ~1.76s and 18th of 19; the sub-ms figures apply to
+    the JS/TS Dynamic Workers path, not the arbitrary-code sandbox the benchmark exercises. On measured
+    full-sandbox latency alone this would be a 3, and it is held at 4 on the strength of the dual isolate-plus-container
+    isolation model, but the measured gap is now wide enough that the hold is the weakest part of this score.
   last_verified: '2026-08-13'
   sources:
   - url: https://blog.cloudflare.com/dynamic-workers/

--- a/sources/scores/codecontests.yaml
+++ b/sources/scores/codecontests.yaml
@@ -19,9 +19,7 @@ openness:
       detail: MIT)+CodeNet(Apache-2.0
   confidence: high
   note: 'Fully open: CC-BY-4.0, ungated, downloadable, with a thorough datasheet documenting provenance.
-    Clean open-data case on the dataset-openness path. Re-read 2026-08-13: `license:cc-by-4.0` is still
-    in the repo tags, the embedded repo state reads `"gated":false`, and the dataset card still renders.
-    No change.'
+    Clean open-data case on the dataset-openness path.'
   raw: license:CC-BY-4.0(open data license, attribution-only);redistributability:full(downloadable, ungated);datasheet:yes(comprehensive
     dataset card + arXiv:2203.07814);size:~4k problems w/ rich test cases;sources:Codeforces/AtCoder/CodeChef/Aizu/HackerEarth
     + Description2Code(MIT)+CodeNet(Apache-2.0)
@@ -39,11 +37,11 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: medium
-  note: 50,563 Hugging Face downloads in the trailing 30 days (deepmind/code_contests), read 2026-08-12.
-    Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M - one order of magnitude
-    below the software and model scales, because no dataset artifact in the corpus has ever exceeded 10M.
-    The AlphaCode competitive-programming dataset, a recurring reference for code-reasoning evals but less
-    ubiquitous than HumanEval/GSM8K in current release reports.
+  note: 50,563 Hugging Face downloads in the trailing 30 days (deepmind/code_contests). Bands at level 3
+    (10K-100K) on the dataset adoption scale, whose top band is >1M - one order of magnitude below the software
+    and model scales, because no dataset artifact in the corpus has ever exceeded 10M. The AlphaCode competitive-programming
+    dataset, a recurring reference for code-reasoning evals but less ubiquitous than HumanEval/GSM8K in
+    current release reports.
   last_verified: '2026-08-12'
   sources:
   - url: https://huggingface.co/api/datasets/deepmind/code_contests
@@ -57,8 +55,7 @@ capability:
   value: null
   confidence: high
   note: Dataset, not 'capable'. High difficulty / good discriminating power for code reasoning, but per
-    recipe capability is n/a. Re-read 2026-08-13 and the abstention stands - the page publishes a static
-    problem set and no performance or feature claim the capability axis could band.
+    recipe capability is n/a.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/deepmind/code_contests

--- a/sources/scores/codegemma.yaml
+++ b/sources/scores/codegemma.yaml
@@ -13,20 +13,14 @@ openness:
     - name: Gemma-Terms-of-Use
       detail: custom,use-restricted,non-OSI
   confidence: high
-  note: >-
-    Open weights under Google's custom Gemma terms, with no open training data or code. Was 3,
-    corrected to 2 on 2026-07-29 on the rule that a use cap lands at 2 in every category, and
-    returned to 3 on 2026-08-01 when the universal license scale replaced that rule: a bounded
-    commercial license caps at 3, and a license forbidding commerce outright caps at 2. Gemma's
-    terms are the former. The 2026-07-29 note cited gemma-2 and gemma-3 as siblings scoring
-    2/restricted on the same license. Neither slug exists after the slug migration, and the
-    surviving `gemma` records an Apache-2.0 license rather than Gemma terms, so that comparison no
-    longer holds - and whether `gemma`'s recorded license is right is a separate question worth a
-    look.
-
-    Re-read 2026-08-13 - the 7b-it card still carries `license:gemma` and now reads `"gated":"manual"`,
-    an access request against the Gemma terms rather than a barrier to obtaining the weights, and the
-    card still publishes neither the training corpus nor any training code. No change.
+  note: 'Open weights under Google''s custom Gemma terms, with no open training data or code. Was 3, corrected
+    to 2 on 2026-07-29 on the rule that a use cap lands at 2 in every category, and returned to 3 on 2026-08-01
+    when the universal license scale replaced that rule: a bounded commercial license caps at 3, and a license
+    forbidding commerce outright caps at 2. Gemma''s terms are the former. The 2026-07-29 note cited gemma-2
+    and gemma-3 as siblings scoring 2/restricted on the same license. Neither slug exists after the slug
+    migration, and the surviving `gemma` records an Apache-2.0 license rather than Gemma terms, so that
+    comparison no longer holds - and whether `gemma`''s recorded license is right is a separate question
+    worth a look.'
   raw: weights:open;data:closed;code:closed;license:Gemma-Terms-of-Use(custom,use-restricted,non-OSI)
   last_verified: '2026-08-13'
   sources:
@@ -42,11 +36,11 @@ adoption:
   signal_type: usage_volume
   confidence: medium
   note: '28,295 Hugging Face downloads in the trailing 30 days summed across the five CodeGemma repos the
-    tier covers, read 2026-08-12 (google/codegemma-7b-it 4,573; google/codegemma-7b 4,262; google/codegemma-2b
-    19,078; google/codegemma-1.1-7b-it 50; google/codegemma-1.1-2b 332). Bands at level 2 (10K-100K). All
-    5 repos are now DECLARED in the product file: the band was previously read on the family while only
-    one repo was declared, so it could not be re-derived by machine. Slugs on this map are tier-level, and
-    docs/reference/identity.md sums adoption across a tier’s releases.'
+    tier covers (google/codegemma-7b-it 4,573; google/codegemma-7b 4,262; google/codegemma-2b 19,078; google/codegemma-1.1-7b-it
+    50; google/codegemma-1.1-2b 332). Bands at level 2 (10K-100K). All 5 repos are now DECLARED in the product
+    file: the band was previously read on the family while only one repo was declared, so it could not be
+    re-derived by machine. Slugs on this map are tier-level, and docs/reference/identity.md sums adoption
+    across a tier’s releases.'
   reach: 10K-100K
   last_verified: '2026-08-12'
   sources:
@@ -81,15 +75,11 @@ capability:
   basis_detail: HumanEval/MBPP
   value: competent FIM/code completion at 2B/7B circa 2024
   confidence: medium
-  note: >-
-    A 2024 code-completion family, competent for its size and generation and well below the 2026
-    coders. The note that stood here until 2026-08-13 was a verbatim copy of the openness note and
-    described the license rather than the capability; it is replaced.
-
-    Re-read 2026-08-13 against the Hugging Face release post, whose comparison table still puts
-    CodeGemma 7B at 40.13 on HumanEval Python against DeepSeek Coder 7B's 45.83 and StarCoder 2 15B's
-    44.15, on 500B tokens of extra training. That is the "competent, not leading" position the 3
-    records. No change.
+  note: A 2024 code-completion family, competent for its size and generation and well below the 2026 coders.
+    The note that stood here until 2026-08-13 was a verbatim copy of the openness note and described the
+    license rather than the capability; it is replaced. The Hugging Face release post's comparison table
+    puts CodeGemma 7B at 40.13 on HumanEval Python against DeepSeek Coder 7B's 45.83 and StarCoder 2 15B's
+    44.15, on 500B tokens of extra training, which is the competent-not-leading position the 3 records.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/huggingface/blog/blob/main/codegemma.md

--- a/sources/scores/codellama.yaml
+++ b/sources/scores/codellama.yaml
@@ -15,18 +15,13 @@ openness:
     - name: Llama-2-Community
       detail: custom Meta license, non-OSI; AUP + commercial conditions
   confidence: high
-  note: >-
-    Weights downloadable under Meta's non-OSI Llama-2 Community license. Marketed as open, which
-    the openness class deliberately does not accept at face value. Moved from 2/restricted on
-    2026-08-01 by the universal license scale, which caps a bounded commercial license at 3 rather
-    than 2. The test at that boundary is whether the license permits commercial use AT ALL: this
-    one does, for everyone inside the bound. A license that forbids commerce outright - CC-BY-NC,
-    Mistral Non-Production - stays at 2. Nine other products carry a bounded license and all now
-    score 3; four of them were already recorded there, which is the inconsistency this resolves.
-
-    Re-read 2026-08-13 - the 13B-Instruct card still carries `license:llama2` with a LICENSE file in the
-    repo, still reads `"gated":false`, and still ships a usage snippet with no training pipeline and no
-    corpus. No change.
+  note: 'Weights downloadable under Meta''s non-OSI Llama-2 Community license. Marketed as open, which the
+    openness class deliberately does not accept at face value. Moved from 2/restricted on 2026-08-01 by
+    the universal license scale, which caps a bounded commercial license at 3 rather than 2. The test at
+    that boundary is whether the license permits commercial use AT ALL: this one does, for everyone inside
+    the bound. A license that forbids commerce outright - CC-BY-NC, Mistral Non-Production - stays at 2.
+    Nine other products carry a bounded license and all now score 3; four of them were already recorded
+    there, which is the inconsistency this resolves.'
   raw: weights:open(downloadable on HF);data:closed;code:partial(inference utils, no training pipeline);license:Llama-2-Community(custom
     Meta license, non-OSI; AUP + commercial conditions)
   last_verified: '2026-08-13'
@@ -45,7 +40,7 @@ adoption:
   signal_type: usage_volume
   confidence: medium
   note: '110,069 Hugging Face downloads in the trailing 30 days summed across the four Code Llama Instruct
-    SKUs the tier covers, read 2026-08-12 (codellama/CodeLlama-34b-Instruct-hf 24,545; codellama/CodeLlama-7b-Instruct-hf
+    SKUs the tier covers (codellama/CodeLlama-34b-Instruct-hf 24,545; codellama/CodeLlama-7b-Instruct-hf
     73,688; codellama/CodeLlama-13b-Instruct-hf 11,336; codellama/CodeLlama-70b-Instruct-hf 500). Bands
     at level 3 (100K-1M). All 4 repos are now DECLARED in the product file: the band was previously read
     on the family while only one repo was declared, so it could not be re-derived by machine. Slugs on this
@@ -79,23 +74,12 @@ capability:
   value: Code Llama - Instruct 13B HumanEval pass@1 42.7%, MBPP pass@1 49.4%; 70B-Instruct higher at 67.8%
     HumanEval, 34B-Instruct lower at 41.5%; all 2023-era
   confidence: medium
-  note: >-
-    A 2023-generation code model, state of the art among open models at release and well below the
-    2026 coders in this category. The note that stood here until 2026-08-13 was a verbatim copy of
-    the openness note and described the license rather than the capability; it is replaced.
-
-    Re-read 2026-08-13, and the recorded value did not survive it. The HF card inlines no benchmark
-    table at all, and the paper it links (arXiv:2308.12950) reports "up to 67% and 65% on HumanEval
-    and MBPP" for the family rather than any 13B-Instruct figure. The recorded ~42% appears on
-    neither cited source.
-
-    Replacement found 2026-08-14, and it vindicates the figure. The abstract carries only the family
-    headline; Table 2 of the paper PDF, "Code Llama pass@ scores on HumanEval and MBPP", carries the
-    per-size rows, and Code Llama - Instruct 13B reads 42.7% HumanEval pass@1 and 49.4% MBPP pass@1. The
-    recorded ~42% was right and was simply cited to a page that does not show it. One clause corrected
-    while the table is open - "family 34B/70B-Instruct higher" is only half true. 70B-Instruct is higher
-    at 67.8%, but 34B-Instruct is 41.5%, BELOW the 13B, and only its MBPP column (57.0%) beats the 13B.
-    The value now says so. Score unchanged at 3.
+  note: A 2023-generation code model, state of the art among open models at release and well below the 2026
+    coders in this category. The note that stood here until 2026-08-13 was a verbatim copy of the openness
+    note and described the license rather than the capability; it is replaced. Table 2 of the Code Llama
+    paper puts Code Llama - Instruct 13B at 42.7% HumanEval pass@1 and 49.4% MBPP pass@1; 70B-Instruct is
+    higher at 67.8% but 34B-Instruct is lower at 41.5%, so the family is not monotonic in size. The HF card
+    itself carries no benchmark table and the arXiv abstract carries only the family headline.
   last_verified: '2026-08-14'
   sources:
   - url: https://arxiv.org/pdf/2308.12950

--- a/sources/scores/coder-oss.yaml
+++ b/sources/scores/coder-oss.yaml
@@ -18,9 +18,9 @@ openness:
         features
   confidence: high
   note: 'AGPL-3.0 OSI core (Community Edition) with a separate proprietary Premium/Enterprise tier => open_core.
-    The bare `gated` was transcribed 2026-08-12 from a read of the repo and both LICENSE files, and it holds
-    on a named mechanism rather than on the paid tier existing. coder/coder carries two top-level licenses:
-    the root AGPL-3.0 and LICENSE.enterprise, the latter scoped by its own text to "directory named enterprise".
+    The bare `gated` comes from a direct read of the repo and both LICENSE files, and it holds on a named
+    mechanism rather than on the paid tier existing. coder/coder carries two top-level licenses: the root
+    AGPL-3.0 and LICENSE.enterprise, the latter scoped by its own text to "directory named enterprise".
     That directory is in the published tree but not under the open license, it contains the audit log, group/RBAC
     and AI seat-tracking implementations, and the enterprise license forbids circumventing the license key
     that unlocks them. This is the litellm shape - a carve-out inside the repo - not the otari one.'
@@ -68,17 +68,14 @@ adoption:
   signal_type: stars_fallback
   reach: '>10K stars'
   confidence: low
-  note: 'No published install/active-user count for the OSS edition; ~13.4k GitHub stars is the only concrete
-    signal. Stars-fallback caps at level 3; placed at 3 (not higher) on broad enterprise positioning + star
-    base, but reach is unverified by usage_volume. Stars read 2026-08-13: 14,142 across the 1 declared repo,
-    which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The previous reach
-    ''100K-1M'' was not a label this instrument offers - stars have their own vocabulary because a star is not
-    a download. Re-read 2026-08-13 against the GitHub API - 14,143 stars, still >10K stars and still level 3.
-    The absence of a download channel was re-checked too, and it holds for a second reason now - the
-    codercom/coder Docker Hub repository is deprecated, its description redirecting to GitHub Container
-    Registry, and it has taken 31,179 pulls in total since 2021 with no push since 2024. GHCR publishes
-    no pull count, so no usage_volume signal exists to re-band on and stars_fallback remains the
-    instrument. A digest over a star count drifts on every refetch by construction; that is noise on
+  note: 'No published install or active-user count for the OSS edition; GitHub stars are the only concrete
+    signal - 14,143 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in
+    signal_routing.yaml. Stars-fallback caps at level 3; placed at 3 (not higher) on broad enterprise positioning
+    plus the star base, with reach unverified by usage_volume. The reach label uses the stars vocabulary
+    rather than a download band, because a star is not a download. There is no download channel to band
+    on instead: the codercom/coder Docker Hub repository is deprecated, its description redirecting to GitHub
+    Container Registry, with 31,179 pulls in total since 2021 and no push since 2024, and GHCR publishes
+    no pull count. A digest over a star count drifts on every refetch by construction; that is noise on
     this endpoint rather than evidence of change.'
   last_verified: '2026-08-13'
   sources:
@@ -106,14 +103,11 @@ capability:
     long-lived workspaces; scale:org-scale self-hosted
   confidence: medium
   note: Strong as a persistent governed dev-environment platform but a poor fit for the deployment litmus
-    'safely run arbitrary agent-generated code in an ephemeral sandbox' - isolation/cold-start depend
-    on the infra template, not a purpose-built sandbox; scored 3. Belongs more in a dev-environment shelf
-    than the agent-sandbox sub-segment. Re-read 2026-08-13 - the README still defines workspaces in
-    Terraform over EC2 VMs, Kubernetes pods or Docker containers, still connects them over a Wireguard
-    tunnel, and still describes long-lived environments that idle-shut-down rather than ephemeral
-    per-task sandboxes. The agent story has grown - Coder Agents now runs the agent loop in the control
-    plane so no model credentials sit in the workspace - but that is governance rather than isolation
-    strength or cold-start, so the band holds at 3.
+    'safely run arbitrary agent-generated code in an ephemeral sandbox' - isolation/cold-start depend on
+    the infra template, not a purpose-built sandbox; scored 3. Belongs more in a dev-environment shelf than
+    the agent-sandbox sub-segment. Coder Agents runs the agent loop in the control plane so that no model
+    credentials sit in the workspace, but that is governance rather than isolation strength or cold-start,
+    so the band holds at 3.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/coder/coder

--- a/sources/scores/codestral.yaml
+++ b/sources/scores/codestral.yaml
@@ -16,11 +16,7 @@ openness:
       detail: MNPL, non-OSI, research/testing only; commercial license on demand
   confidence: high
   note: Weights downloadable but under MNPL (non-OSI, non-production); open-weights gated by a use-restricted
-    license, so restricted not open_weights. Re-read 2026-08-13 - the launch post still reads "Codestral is
-    a 22B open-weight model licensed under the new Mistral AI Non-Production License, which means that you
-    can use it for research and testing purposes ... Commercial licenses are also available on demand",
-    which is the commercial_forbidden tier the 2 rests on, and neither post publishes a corpus or a training
-    pipeline. No change.
+    license, so restricted not open_weights.
   raw: weights:open(downloadable on HF);data:closed;code:closed(no training pipeline);license:Mistral-AI-Non-Production-License(MNPL,
     non-OSI, research/testing only; commercial license on demand)
   last_verified: '2026-08-13'
@@ -42,13 +38,10 @@ adoption:
   level: 3
   signal_type: reported_traction
   confidence: low
-  note: Embedded as the default FIM/code-completion backend in IDE assistants (Continue, Tabnine, and
-    Mistral's own coding stack) and on multiple API gateways; Mistral reports per-version completion-acceptance
-    gains but discloses no hard download/user count. Level 3 reflects multi-platform IDE distribution,
-    not a verified usage_volume figure. Re-read 2026-08-13 - the 25.08 post still reports "+30% increase in
-    accepted completions, +10% more retained code after suggestion, 50% fewer runaway generations" and still
-    publishes no download or user count, so the abstention from a number stands and the instrument is right.
-    `reach` correctly absent. No change.
+  note: Embedded as the default FIM/code-completion backend in IDE assistants (Continue, Tabnine, and Mistral's
+    own coding stack) and on multiple API gateways; Mistral reports per-version completion-acceptance gains
+    but discloses no hard download/user count. Level 3 reflects multi-platform IDE distribution, not a verified
+    usage_volume figure.
   last_verified: '2026-08-13'
   sources:
   - url: https://mistral.ai/news/codestral-25-08/
@@ -66,20 +59,9 @@ capability:
     completion and FIM, but a code-completion specialist rather than an agentic coder
   confidence: medium
   note: Strong code-completion specialist for its size, but a narrow FIM model, mid-tier on a chat/agentic
-    capability axis where the comparison set is 2026 frontier agentic coders. Re-read 2026-08-13, and the
-    recorded figures did not survive. The launch post names the benchmark suite - HumanEval pass@1, MBPP
-    sanitised pass@1, CruxEval, RepoBench EM, Spider, plus six-language HumanEval and FIM - and publishes
-    the scores as charts, so neither the ~86.6% HumanEval nor the ~91.2% MBPP is anywhere in the fetched
-    body. What the text does support is the qualitative claim that Codestral "outperforms all other models
-    in RepoBench" on a 32k context. Replacement found 2026-08-14 - the later Codestral 25.01 post
-    publishes the same suite as HTML tables rather than charts, so the numbers are in the fetched body.
-    Three corrections it forces. HumanEval 86.6% is real but belongs to Codestral-2501 at 256k context,
-    not to the 22B, whose row reads 81.1%. MBPP ~91.2% is on no Mistral page at all; the 2501 table
-    gives MBPP 80.2% for 2501 and 78.2% for the 22B, and the nearest 91.x on the page is the 22B FIM
-    pass@1 average of 91.8%, a different metric, which is the likely source of the transcription. And no
-    SWE-bench figure for Codestral exists on any Mistral page, so the "weak on agentic SWE-bench" clause
-    is dropped rather than carried unsourced. The value now records both releases explicitly. Score
-    unchanged at 3.
+    capability axis where the comparison set is 2026 frontier agentic coders. No SWE-bench figure for Codestral
+    appears on any Mistral page, so the mid-tier agentic placement rests on the completion and FIM benchmarks
+    rather than on an agentic score.
   last_verified: '2026-08-14'
   sources:
   - url: https://mistral.ai/news/codestral-2501

--- a/sources/scores/codex-cli.yaml
+++ b/sources/scores/codex-cli.yaml
@@ -20,7 +20,7 @@ openness:
         no enterprise or commercial directory
   note: 'Verified Apache-2.0 OSI with public Rust source (96.1% Rust); OpenAI''s own docs call it open source.
     Backing models are proprietary, but the orchestration agent scored here is fully open. License/version/stars
-    confirmed via primary GitHub source. `core-gated: ungated` transcribed 2026-08-11: a full recursive
+    confirmed via primary GitHub source. `core-gated: ungated` comes from a direct read: a full recursive
     tree of openai/codex@main (untruncated) carries exactly one governing LICENSE, the root Apache-2.0,
     with the only other license files being vendored third-party deps (third_party/wezterm, codex-rs/vendor/bubblewrap)
     and sample skill assets. There is no enterprise or commercial directory, which is the test LiteLLM''s
@@ -71,16 +71,14 @@ adoption:
   signal_type: reported_traction
   confidence: high
   banded_quantity: weekly active developers (6M+), weekly rather than the monthly the scale is written in
-  note: 'OpenAI confirmed Codex surpassed 4M weekly developers (Apr 21 2026 announcement). Firmly in the
-    1-10M band on disclosed developer count. Re-read 2026-08-13 - openai.com now answers 403 to any non-browser
-    fetch, so the original announcement cannot be digested and the figure was re-derived instead from
-    the Wikipedia article on the agent, which tracks the disclosures with citations and now records more
-    than 6 million weekly active users alongside named enterprise deployments. That is a larger number
-    than the one recorded here and lands in the same band, so the level is unchanged. WHAT WAS BANDED
-    - a weekly active user count, which is an active figure rather than a cumulative one, but weekly rather
-    than the monthly the scale is written in, so it understates a monthly reading if anything. The instrument
-    is left at reported_traction rather than moved to active_users, which is a call for a curator rather
-    than a re-read.'
+  note: OpenAI confirmed Codex surpassed 4M weekly developers (Apr 21 2026 announcement). Firmly in the
+    1-10M band on disclosed developer count. The OpenAI announcement carrying that figure is no longer fetchable
+    - openai.com answers 403 to a non-browser request - so the disclosure is tracked instead through the
+    Wikipedia article on the agent, which cites more than 6 million weekly active users, a larger number
+    in the same band. WHAT WAS BANDED - a weekly active user count, which is an active figure rather than
+    a cumulative one, but weekly rather than the monthly the scale is written in, so it understates a monthly
+    reading if anything. The instrument stays at reported_traction rather than moving to active_users, which
+    is a call for a curator.
   last_verified: '2026-08-13'
   sources:
   - url: https://openai.com/index/scaling-codex-to-enterprises-worldwide/
@@ -106,13 +104,9 @@ capability:
     yes (parallel sessions); model-agnostic: largely OpenAI-locked; reliability: sandboxed exec. No agent-attributed
     SWE-bench number on the April 2026 leaderboard.'
   confidence: medium
-  note: 'Capable, heavily-used coding agent backed by frontier OpenAI models, but no standalone agent SWE-bench
+  note: Capable, heavily-used coding agent backed by frontier OpenAI models, but no standalone agent SWE-bench
     placement published. Scored on feature matrix; high but not the open-agent benchmark frontier-definer
-    (OpenHands 68.4%). Re-read 2026-08-13 - the OpenAI Codex CLI docs still document the same surface,
-    now with named sections for sandboxing and writable roots, permissions and profiles, agent approvals,
-    auto-review, MCP and connectors, skills and plugins, and desktop apps for Linux and Windows. Still
-    no first-party SWE-bench placement for the agent itself, so the band stays a feature-matrix judgment
-    one below the openhands benchmark anchor.'
+    (OpenHands 68.4%).
   relative_to: openhands
   relation: one_below
   last_verified: '2026-08-13'

--- a/sources/scores/cohere-rerank-api.yaml
+++ b/sources/scores/cohere-rerank-api.yaml
@@ -13,12 +13,8 @@ openness:
     managed:
       value: Cohere+Azure/AWS/Oracle
   confidence: high
-  note: 'Proprietary closed reranking models served via API and cloud marketplaces; no open weights or source.
-    Marketed as ''open'' in search-relevance contexts but is not OSS. Re-read 2026-08-13: the overview documents
-    rerank-v4.0-pro, rerank-v4.0-fast, rerank-v3.5 and the 3.0 pair as hosted models called through the API
-    and billed in search units. No weights download, no model card on a hub and no self-hosted build is offered
-    for any of them; the only "open" thing on the page is the list of open-source vector stores it integrates
-    with. weights stay not-released and the score stays 1.'
+  note: Proprietary closed reranking models served via API and cloud marketplaces; no open weights or source.
+    Marketed as 'open' in search-relevance contexts but is not OSS.
   raw: license:proprietary(hosted-API; also cloud-marketplace deploy);source:closed;weights:not-released;managed:Cohere+Azure/AWS/Oracle
   last_verified: '2026-08-13'
   sources:
@@ -46,14 +42,9 @@ adoption:
   level: 3
   signal_type: reported_traction
   confidence: medium
-  note: De facto default managed reranker for RAG, distributed across Azure AI Foundry, AWS SageMaker
-    JumpStart / OpenSearch, and Oracle GenAI in addition to Cohere's API. No hard call-volume/user count
-    published; placed at 3 on broad multi-cloud distribution (reported_traction). Re-read 2026-08-13. The
-    AWS Big Data blog is still published, co-written with Cohere, on integrating Rerank 3.5 with Amazon OpenSearch
-    Service; the Azure AI Foundry catalog still carries Cohere as a model provider and describes deploying
-    "Command or Rerank side-by-side with Azure AI Search". Neither publishes a call volume, a customer count
-    or a developer count, which is what was looked for and not found, so the instrument stays reported_traction
-    and the level stays 3.
+  note: De facto default managed reranker for RAG, distributed across Azure AI Foundry, AWS SageMaker JumpStart
+    / OpenSearch, and Oracle GenAI in addition to Cohere's API. No hard call-volume/user count published;
+    placed at 3 on broad multi-cloud distribution (reported_traction).
   last_verified: '2026-08-13'
   sources:
   - url: https://aws.amazon.com/blogs/big-data/enhancing-search-relevancy-with-cohere-rerank-3-5-and-amazon-opensearch-service/
@@ -77,18 +68,12 @@ capability:
     nDCG@10 over an in-house 18-language suite; trained across 100+ languages, with 4.0 shipping fast and
     pro variants
   confidence: medium
-  note: 'Vendor reports SOTA on BEIR and multilingual nDCG@10; widely treated as the reference managed reranker.
+  note: Vendor reports SOTA on BEIR and multilingual nDCG@10; widely treated as the reference managed reranker.
     Concrete nDCG numbers not disclosed on primary pages (claims are vendor-run, not an independent leaderboard),
     so rated 4 rather than 5. Capability basis is feature_matrix as no standard public reranker leaderboard
-    applies. Re-read 2026-08-13, and the value needed re-attributing and one figure correcting. The BEIR
-    claim is real but lives on the CHANGELOG, not the blog this record cited it to - "Rerank 3.5 has SOTA
-    performance on BEIR and domains such as Finance, E-commerce, Hospitality, Project Management, and Email/Messaging
-    Retrieval tasks" - and the string BEIR appears nowhere on the blog page. The recorded "~25% gain over
-    embedding-only retrieval" is not on either page; what the blog says is "+26.4% improvement on cross-lingual
-    search" against Cohere''s own previous Rerank 3, which is a different comparison against a different baseline,
-    so the value now states it that way. The vendor-run caveat is if anything stronger than recorded - the
-    multilingual suite is Cohere''s own, "external datasets covering 18 different languages" scored by nDCG@10
-    - so the 4 rather than 5 stands.'
+    applies. The BEIR claim lives in the Rerank 3.5 changelog, and the +26.4% cross-lingual gain is measured
+    against Cohere's own previous Rerank 3 on an in-house 18-language suite scored by nDCG@10, so both headline
+    figures are vendor-run against vendor baselines.
   last_verified: '2026-08-13'
   sources:
   - url: https://cohere.com/blog/rerank-3pt5

--- a/sources/scores/command-r.yaml
+++ b/sources/scores/command-r.yaml
@@ -68,18 +68,16 @@ adoption:
   confidence: high
   note: '~3,258 HF downloads/mo on the original checkpoint (gated + superseded by 08-2024 revision + newer
     Command models). Non-commercial license and 104B size cap self-host adoption; some legacy use via Cohere
-    API. Hobbyist/legacy scale on the download signal. Artifact declared and read live 2026-08-13: 109,596
+    API. Hobbyist/legacy scale on the download signal. With the artifact declared, the figure is 109,596
     Hugging Face downloads in the trailing 30 days. Bands at 100K-1M, level 3. This record previously claimed
     usage_volume - a download count - while declaring no artifact any signal model reads, so no computed
-    figure existed for the recorded band to disagree with. LEVEL CORRECTED FROM 1, by two bands, and the cause
-    is the max-across-releases rule in identity.md rather than a mismeasurement. The old note banded on the
-    2024 Command R+ checkpoint at ~3,258/mo, a superseded SKU, while the product''s own description says the
-    line is now anchored by Command A+. Declared artifacts are command-a-plus-05-2026-bf16 (84,821) and c4ai-
-    command-r-v01 (24,775), summed per sum_across_artifacts. DELIBERATELY EXCLUDED: command-a-vision-07-2025,
-    the transcribe models and the embed models, which are separate Cohere product lines rather than SKUs of
-    this one - including them would be over-attribution. Re-read in full 2026-08-13 and the sum reproduces
-    exactly - command-a-plus-05-2026-bf16 84,821 plus c4ai-command-r-v01 24,775 is 109,596, level 3. The
-    2024 checkpoint the old band was read on has fallen further, to 707. No change.'
+    figure existed for the recorded band to disagree with. LEVEL CORRECTED FROM 1, by two bands, and the
+    cause is the max-across-releases rule in identity.md rather than a mismeasurement. The old note banded
+    on the 2024 Command R+ checkpoint at ~3,258/mo, a superseded SKU, while the product''s own description
+    says the line is now anchored by Command A+. Declared artifacts are command-a-plus-05-2026-bf16 (84,821)
+    and c4ai- command-r-v01 (24,775), summed per sum_across_artifacts. DELIBERATELY EXCLUDED: command-a-vision-07-2025,
+    the transcribe models and the embed models, which are separate Cohere product lines rather than SKUs
+    of this one - including them would be over-attribution.'
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/models/CohereLabs/command-a-plus-05-2026-bf16

--- a/sources/scores/common-corpus.yaml
+++ b/sources/scores/common-corpus.yaml
@@ -11,10 +11,7 @@ openness:
     dataset_card:
       value: 'yes'
   confidence: high
-  note: 'Ungated with a full dataset card and built exclusively from uncopyrighted or openly licensed sources.
-    Re-read 2026-08-13: the card still states that all data is either uncopyrighted or freely licensed and
-    usable commercially, the per-row licence column carries only Public Domain, CC0, CC-BY-SA and open-source
-    licences, and the API reports gated false.'
+  note: Ungated with a full dataset card and built exclusively from uncopyrighted or openly licensed sources.
   raw: license:open(uncopyrighted/freely-licensed only);ungated:yes;dataset_card:yes
   last_verified: '2026-08-13'
   sources:
@@ -32,9 +29,8 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 61,684 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (PleIAs/common_corpus 61,684). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top
-    band is >1M.
+  note: 61,684 downloads in the trailing 30 days summed across the 1 declared artifact(s) (PleIAs/common_corpus
+    61,684). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/PleIAs/common_corpus
@@ -48,10 +44,9 @@ capability:
   basis_detail: downstream
   value: null
   confidence: high
-  note: 'Trains the Pleias 1.0 SLM family and several European models (2024-25), but small demonstrator
-    models with no controlled ablation wins; leads on ethical sourcing rather than capability. Re-read 2026-08-13:
-    the paper still lists the Pleias 1.0 family and the European models trained on Common Corpus, and the
-    card still puts the corpus at 2.27 trillion tokens with no controlled ablation win claimed.'
+  note: Trains the Pleias 1.0 SLM family and several European models (2024-25), but small demonstrator models
+    with no controlled ablation wins; leads on ethical sourcing rather than capability. The corpus is 2.27
+    trillion tokens.
   last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/html/2506.01732v1

--- a/sources/scores/compar-ia-datasets.yaml
+++ b/sources/scores/compar-ia-datasets.yaml
@@ -14,10 +14,7 @@ openness:
   confidence: high
   note: Open license and documented, but gated access requiring agreement caps it at gated. The gate was
     recorded as a sentence rather than a token; it is a click-through agreement that also collects contact
-    details, which is terms-acceptance+contact-info. Re-read 2026-08-13 - the repo still tags
-    `license:etalab-2.0` with cardData.license the same, the embedded repo state reads `"gated":"auto"`
-    and the page still says "You need to agree to share your contact information to access this dataset",
-    and the dataset card still renders. All three values stand.
+    details, which is terms-acceptance+contact-info.
   raw: license:Etalab-2.0(permissive French-gov open license);gated:terms-acceptance+contact-info(HF contact-info
     agreement required);dataset_card:present
   last_verified: '2026-08-13'
@@ -35,7 +32,7 @@ adoption:
   reach: <1K
   signal_type: usage_volume
   confidence: high
-  note: 31 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13 (ministere-culture/comparia-votes
+  note: 31 downloads in the trailing 30 days summed across the 1 declared artifact(s) (ministere-culture/comparia-votes
     31). Bands at level 1 (<1K) on the dataset adoption scale, whose top band is >1M. Corrected from level
     2, which the declared artifacts do not support.
   last_verified: '2026-08-13'
@@ -50,9 +47,8 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: a dataset is not 'capable'. Re-read 2026-08-13 and the abstention stands - the repo publishes
-    a static corpus of pairwise preference annotations with no performance or feature claim the capability
-    axis could band.
+  note: a dataset is not 'capable'. The repo publishes a static corpus of pairwise preference annotations
+    with no performance or feature claim the capability axis could band.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/ministere-culture/comparia-votes

--- a/sources/scores/compar-ia.yaml
+++ b/sources/scores/compar-ia.yaml
@@ -15,10 +15,9 @@ openness:
     - self-hostable
   confidence: high
   last_verified: '2026-08-13'
-  note: Permissive OSI license with full public source code. Re-read 2026-08-13 - the LICENSE body is
-    still the Apache 2.0 text, and the README still bills the project as 'The open-source LLM arena.
-    Deploy it for your organisation, sector, or language', with Docker self-hosting instructions for the
-    whole platform and no paid tier to withhold anything for.
+  note: Permissive OSI license with full public source code. The README bills the project as 'The open-source
+    LLM arena. Deploy it for your organisation, sector, or language', with Docker self-hosting instructions
+    for the whole platform and no paid tier to withhold anything for.
   raw: license:Apache-2.0(OSI; verified LICENSE body);source:public;self-hostable;core-gated:ungated(publicly
     funded, README documents full Docker self-hosting)
   sources:
@@ -44,17 +43,17 @@ openness:
     establishes:
     - core-gated
   - url: https://raw.githubusercontent.com/betagouv/ComparIA/develop/LICENSE
-    shows: 'Re-read 2026-08-13: the LICENSE body is still ''Apache License, Version 2.0''.'
+    shows: LICENSE body is 'Apache License, Version 2.0'.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
     establishes:
     - license
   - url: https://raw.githubusercontent.com/betagouv/ComparIA/develop/README.md
-    shows: 'Re-read 2026-08-13: README still leads ''The open-source LLM arena. Deploy it for your organisation,
-      sector, or language'', still documents ''Self-host with Docker (single server, automatic HTTPS via
-      Caddy)'' for the whole platform, and still says ''The whole platform is open source''. No commercial
-      tier, license key or enterprise edition appears in it.'
+    shows: README leads 'The open-source LLM arena. Deploy it for your organisation, sector, or language',
+      documents 'Self-host with Docker (single server, automatic HTTPS via Caddy)' for the whole platform,
+      and says 'The whole platform is open source'. No commercial tier, license key or enterprise edition
+      appears in it.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: cc2e4c8623b499641a1bae909b31531cfa770a9342ae9c56f0067dd642d6bb8d
@@ -92,11 +91,10 @@ capability:
   relative_to: chatbot-arena
   relation: at
   last_verified: '2026-08-13'
-  note: Broad arena feature set comparable to LMArena plus environmental tracking and dataset generation.
-    Feature matrix re-read 2026-08-13 and unchanged - blind pairwise voting, a public leaderboard shipped
-    Nov 2025, published open datasets on Hugging Face, data.gouv.fr and Mozilla, Docker self-hosting,
-    and EcoLogits still on the roadmap board as a maintained component. The comparison to LMArena the
-    note already draws is now recorded structurally against chatbot-arena, both at 4.
+  note: 'Broad arena feature set comparable to LMArena plus environmental tracking and dataset generation:
+    blind pairwise voting, a public leaderboard, open datasets published to Hugging Face, data.gouv.fr and
+    Mozilla, Docker self-hosting, and EcoLogits maintained on the roadmap. The comparison to LMArena is
+    recorded structurally against chatbot-arena, both at 4.'
   sources:
   - url: https://github.com/betagouv/ComparIA
     shows: 'Feature list: model comparison, voting, EcoLogits, dataset publishing, self-hosting'

--- a/sources/scores/composio.yaml
+++ b/sources/scores/composio.yaml
@@ -20,20 +20,19 @@ openness:
         behind a COMPOSIO_API_KEY with no self-host option documented
   confidence: high
   note: 'SDK/core is MIT and public; the hosted multi-app integration/auth platform is the proprietary tier,
-    classic open-core. `core-gated: gated` verified 2026-08-12 by a direct read, and it does NOT rest on
-    Composio selling a hosted platform. The gate is not a directory but an absence: the execution engine
-    is in no public repo. What is published is SDKs and provider adapters - python/composio with providers/,
-    and ts/packages/ holding core, cli, cli-local-tools, cli-keyring, providers, slim, experimental and
-    the schema converters. Toolkit execution, the 1000+ app catalog and managed OAuth all run on Composio''s
-    servers: the README''s first instruction is to "Grab a COMPOSIO_API_KEY from the dashboard first", sessions
-    are created against the hosted API, the docs give the REST base URL as https://backend.composio.dev/api/v3.1
-    and describe Composio-managed auth as the default, and no self-hosting or on-premise option is documented.
-    Nothing in the published source executes a toolkit without that platform. FLAG FOR A HUMAN: the same
-    evidence bears on `source`, which this record still gives as public. software.yaml defines partial as
-    "a repo exists but the runtime does not ship - a client, an SDK, or an issue tracker standing in for
-    the engine", which describes what Composio publishes, and partial fires at rung 1 for 2/source_available.
-    Re-reading `source` was outside this sweep''s remit so the value was left alone, but it should be looked
-    at.'
+    classic open-core. `core-gated: gated` comes from a direct read, and it does NOT rest on Composio selling
+    a hosted platform. The gate is not a directory but an absence: the execution engine is in no public
+    repo. What is published is SDKs and provider adapters - python/composio with providers/, and ts/packages/
+    holding core, cli, cli-local-tools, cli-keyring, providers, slim, experimental and the schema converters.
+    Toolkit execution, the 1000+ app catalog and managed OAuth all run on Composio''s servers: the README''s
+    first instruction is to "Grab a COMPOSIO_API_KEY from the dashboard first", sessions are created against
+    the hosted API, the docs give the REST base URL as https://backend.composio.dev/api/v3.1 and describe
+    Composio-managed auth as the default, and no self-hosting or on-premise option is documented. Nothing
+    in the published source executes a toolkit without that platform. FLAG FOR A HUMAN: the same evidence
+    bears on `source`, which this record still gives as public. software.yaml defines partial as "a repo
+    exists but the runtime does not ship - a client, an SDK, or an issue tracker standing in for the engine",
+    which describes what Composio publishes, and partial fires at rung 1 for 2/source_available. The `source`
+    value was left alone here and should be looked at.'
   raw: license:MIT(OSI, SDK/core public on GitHub);source:public(Python + TypeScript SDKs);managed-tier:Composio
     hosted platform + Rube MCP server (auth, hosted tool execution) is the commercial layer;core-gated:gated(the
     execution engine is in no public repo. The MIT tree is SDKs and provider adapters only and toolkit execution
@@ -90,9 +89,9 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: medium
-  note: 194,657 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (composio-core 194,657). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected
-    from level 4, which the declared artifacts do not support.
+  note: 194,657 downloads in the trailing 30 days summed across the 1 declared artifact(s) (composio-core
+    194,657). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected from level
+    4, which the declared artifacts do not support.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/composio-core/recent
@@ -106,14 +105,9 @@ capability:
   value: 1000+ toolkits, tool search, context management, managed OAuth/auth, sandboxed workbench, a per-session
     hosted MCP endpoint, multi-framework SDKs (OpenAI/Anthropic/LangChain/LlamaIndex)
   confidence: medium
-  note: 'Broad tool-coverage and auth/sandbox feature set make it one of the most capable agent tool-integration
+  note: Broad tool-coverage and auth/sandbox feature set make it one of the most capable agent tool-integration
     layers; strong on the {coverage, structured output, breadth} matrix, just short of a frontier-defining
-    5. Re-read 2026-08-13. The repository description still reads "Composio powers 1000+ toolkits, tool search,
-    context management, authentication, and a sandboxed workbench", and the README still offers a hosted
-    MCP endpoint per session - "Pass mcp: true to composio.create()". One recorded clause did not survive:
-    the value named "500+ apps (Rube MCP)" and the string Rube appears nowhere on the page now, so it has
-    been replaced with the per-session MCP endpoint the README does describe and with "context management",
-    which the description adds. The band is unchanged at 4 - the surface is the same size, described differently.'
+    5.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/ComposioHQ/composio

--- a/sources/scores/confer.yaml
+++ b/sources/scores/confer.yaml
@@ -16,16 +16,9 @@ openness:
       value: open source
       detail: undisclosed
   confidence: high
-  note: 'Marketed as open source, but neither public repo declares any license (GitHub reports license:null),
+  note: Marketed as open source, but neither public repo declares any license (GitHub reports license:null),
     so re-use rights are undefined, and the end-user client is not public. Source is published for verifiability/reproducible
     builds, not for self-deployment. Accurate classification is source-available, not open_source.
-    Re-read 2026-08-13. The private-inference post is still up, still dated 5 January 2026, and still
-    describes the same architecture - inference inside a confidential VM, prompts encrypted from the
-    device into the TEE over Noise Pipes, with reproducible builds and a transparency log so the running
-    image can be checked. That is publication for verifiability, not for deployment - there is still no
-    self-hostable implementation, and it still depends on the Confer attestation infrastructure.
-    confer-proxy is still public and still has no LICENSE file, so the GitHub API still reports no
-    declared license and re-use rights remain undefined. Value unchanged at 2 / source_available.'
   raw: license:none-declared(no LICENSE file in either public repo);source:partial(confer-proxy + confer-image
     public,client-app private);self-host:no(depends on vendor attestation infra);models:open source(undisclosed)
   last_verified: '2026-08-13'
@@ -47,13 +40,9 @@ adoption:
   level: 2
   signal_type: reported_traction
   confidence: low
-  note: Young product (repos created Dec 2025, launched late 2025/early 2026); ~70-75 stars per repo and a
-    reported partnership "bringing foundational AI privacy to Meta", but no user/usage numbers. Notability
+  note: Young product (repos created Dec 2025, launched late 2025/early 2026); ~70-75 stars per repo and
+    a reported partnership "bringing foundational AI privacy to Meta", but no user/usage numbers. Notability
     is driven mainly by the founder's reputation.
-    Re-read 2026-08-13. The blog index still carries the March 2026 post announcing that Confer is
-    bringing foundational AI privacy to Meta, and confer-proxy now shows 76 stars, consistent with the
-    70-75 recorded. No user, customer or usage number has appeared in the months since, so there is
-    still nothing countable to band. Level unchanged at 2.
   last_verified: '2026-08-13'
   sources:
   - url: https://confer.to/blog/
@@ -68,14 +57,8 @@ capability:
     chat history (passkey-derived keys); encrypted folders; cross-conversation memory; emerging connectors;
     models: multiple open source (task-routed via vLLM, names undisclosed); self-host: no; web client'
   confidence: medium
-  note: Strong, genuinely novel on the privacy/crypto dimension, but a relatively standard chat feature set,
-    no self-hosting, and undisclosed models cap it at mid-tier.
-    Re-read 2026-08-13. The private-inference post still establishes the crypto half of the band -
-    end-to-end encrypted chat, TEE inference in a confidential VM, remote attestation, reproducible
-    builds and a transparency log - and the blog index shows the product surface has filled out since,
-    with cross-conversation memory in March 2026, connectors in April, and folder files in August that
-    put PDFs, Office documents, HTML and Markdown into every conversation in a folder. Still no
-    self-hosting and still undisclosed model names. Band unchanged at 3.
+  note: Strong, genuinely novel on the privacy/crypto dimension, but a relatively standard chat feature
+    set, no self-hosting, and undisclosed models cap it at mid-tier.
   last_verified: '2026-08-13'
   sources:
   - url: https://confer.to/blog/2026/01/private-inference/

--- a/sources/scores/confident-ai.yaml
+++ b/sources/scores/confident-ai.yaml
@@ -15,10 +15,7 @@ openness:
       value: enterprise-tier
   confidence: high
   note: The scored entity is the Confident AI platform itself, which is proprietary SaaS. DeepEval (the
-    open Apache-2.0 framework) is a distinct product; do not credit the platform with the framework's
-    openness. Re-read 2026-08-13 and unchanged - the platform's own FAQ still puts self-hosting behind the
-    Enterprise plan and a demo booking, and publishes no source for the platform, while DeepEval's
-    repository still resolves to Apache-2.0.
+    open Apache-2.0 framework) is a distinct product; do not credit the platform with the framework's openness.
   raw: license:proprietary(platform);source:closed(platform);note:companion OSS framework DeepEval is Apache-2.0
     but is a separate registry-scope product;self-host:enterprise-tier
   last_verified: '2026-08-13'
@@ -48,11 +45,10 @@ adoption:
   banded_quantity: a vendor customer claim (500+ companies), corroborated by DeepEval's GitHub stars (17,578)
   note: Vendor discloses '500+ leading AI companies'. Corroborated by the strong pull of its open source
     funnel DeepEval, which drives platform signups. Level 3 on disclosed customer-count traction; no precise
-    active-user/usage-volume number for the platform itself. Re-read 2026-08-13 - the "TRUSTED BY 500+
-    LEADING AI COMPANIES" line is still on the page and still carries no figure behind it, and DeepEval's
-    repository has grown to 17,578 stars. The named roster has changed, though - Humach is still quoted,
-    while Panasonic, Samsung and Epic Games are no longer on the page, and those three are dropped from
-    this note rather than carried forward. The 500+ claim on its own still places the band at 3.
+    active-user/usage-volume number for the platform itself. The "TRUSTED BY 500+ LEADING AI COMPANIES"
+    line carries no figure behind it, DeepEval's repository has grown to 17,578 stars, and of the named
+    roster only Humach is still quoted - Panasonic, Samsung and Epic Games are no longer on the page. The
+    500+ claim on its own places the band at 3.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.confident-ai.com/
@@ -79,10 +75,8 @@ capability:
   relative_to: langfuse
   relation: at
   note: Broad coverage across all recipe dimensions; the deep DeepEval metric library (50+ incl LLM-as-judge)
-    and red-teaming are strengths. Capped at 4 alongside the OSS anchors; not a frontier-definer over
-    MLflow/Langfuse. The comparison is now recorded rather than left in prose - at the langfuse anchor.
-    Re-read 2026-08-13 - the product menu is still LLM Evaluation, LLM Observability, AI Red Teaming and
-    AI Governance, with dataset management, tracing, real-time monitoring and CI regression gating beneath.
+    and red-teaming are strengths. Capped at 4 alongside the OSS anchors; not a frontier-definer over MLflow/Langfuse.
+    The comparison is now recorded rather than left in prose - at the langfuse anchor.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.confident-ai.com/

--- a/sources/scores/continue.yaml
+++ b/sources/scores/continue.yaml
@@ -21,15 +21,9 @@ openness:
         key is itself published Apache-2.0 code carrying only customerId/expiresAt/apiUrl and unlocks no
         client feature
   note: Apache-2.0, full source public for the IDE extensions and CLI; no feature-gated core in the editor
-    itself (a hosted Hub exists alongside but the assistant is OSS).
-    Re-read 2026-08-13. The repository root still holds actions, binary, core, docs, eval, extensions,
-    gui, media, packages, scripts, skills and sync with a single LICENSE and no ee/ or enterprise/
-    directory. mdm.ts is still published Apache-2.0 code whose validated payload carries only
-    customerId, createdAt, expiresAt and apiUrl, read out of MDM-managed OS configuration, and it still
-    switches on no client feature. continue.dev now leads with the Cursor acquisition and still states
-    that the open-source codebase remains freely available as a foundation for others, with no pricing
-    page. The VS Code Marketplace listing still shows the licence as Apache 2.0. Value unchanged at 5 /
-    open_source.
+    itself (a hosted Hub exists alongside but the assistant is OSS). Continue has since been acquired by
+    Cursor; the vendor states the open-source codebase remains freely available, and no pricing page is
+    linked any more.
   raw: license:Apache-2.0(OSI);source:public(github.com/continuedev/continue);clients:VSCode+JetBrains+CLI;hub:continue.dev(hosted
     config/model hub adjacent, core OSS);core-gated:ungated(Apache-2.0 across the whole monorepo, no ee/
     or enterprise directory; the enterprise license key is itself published Apache-2.0 code carrying only
@@ -87,12 +81,10 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: VS Code Marketplace shows ~3.21M installs of the Continue extension; plus JetBrains plugin and
-    CLI installs on top. Install volume places it solidly in the 1-10M band. 33.5k GitHub stars corroborates
-    only.
-    Re-read 2026-08-13 - the VS Code Marketplace listing now reports 3,907,333 installs, up from the
-    3,209,395 recorded, and the repo shows 35,474 stars. JetBrains and CLI installs still sit on top and
-    are still uncounted. Comfortably inside 1M-10M. Level unchanged at 4.
+  note: VS Code Marketplace shows ~3.21M installs of the Continue extension; plus JetBrains plugin and CLI
+    installs on top. Install volume places it solidly in the 1-10M band. 33.5k GitHub stars corroborates
+    only. The Marketplace count has since risen to 3,907,333 installs against 35,474 stars, comfortably
+    inside 1M-10M, with JetBrains and CLI installs still uncounted on top.
   last_verified: '2026-08-13'
   sources:
   - url: https://marketplace.visualstudio.com/items?itemName=Continue.continue
@@ -114,10 +106,6 @@ capability:
   note: Leading open source in-IDE AI assistant; broad model-agnostic coverage with chat/edit/autocomplete/agent
     and codebase RAG. Strong feature breadth for an open editor assistant, just below the polished closed
     frontier (Copilot/Cursor).
-    Re-read 2026-08-13. The Marketplace listing still breaks the product into Agent, Chat, Edit and
-    Autocomplete plus source-controlled AI checks enforceable in CI, and the repository is still
-    model-agnostic across VS Code, JetBrains and the CLI. Nothing in the Cursor acquisition has
-    withdrawn a feature. Band unchanged at 4.
   last_verified: '2026-08-13'
   sources:
   - url: https://marketplace.visualstudio.com/items?itemName=Continue.continue

--- a/sources/scores/coop.yaml
+++ b/sources/scores/coop.yaml
@@ -16,8 +16,7 @@ openness:
     core-gated:
       value: ungated
   confidence: high
-  note: 'Fully open source: Apache-2.0 self-hosted moderation review console from ROOST. Re-read 2026-08-13
-    and unchanged.'
+  note: 'Fully open source: Apache-2.0 self-hosted moderation review console from ROOST.'
   raw: license:Apache-2.0(OSI);source:public(github.com/roostorg/coop);self-host:yes;service:none;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -41,22 +40,20 @@ adoption:
   banded_quantity: adopter deployments including Notion and carried-over Cove clients; the 150M+ messages
     figure is one adopter's platform, not Coop's own use
   note: 'GitHub breadth is modest, but Coop is deployed across varied production environments. Coop is the
-    open-sourced productization of the acquired Cove codebase, and former Cove clients carried over as
-    users. Notion is publicly committed and is likely Coop''s largest production deployment to date. The
-    v1.0 announcement adds named production feedback from Kyodo (a community-first messaging platform with
-    over 150 million messages sent; CEO testimonial) and an unnamed large-scale adopter (tens of millions
-    of users, ~95% cut in safety-tooling costs), plus NCMEC as a CSAM-reporting integration partner.
-    Adoption rests on named production deployments rather than community breadth, mirroring sibling Osprey.
-    Re-read 2026-08-13. The blogs still carry every named deployment; the repo does not - its ''Used in
-    production'' list is now empty, so the Notion/Kyodo/Musubi names recorded off GitHub on 2026-07-03 now
-    rest on the announcements alone, and Musubi appears on ROOST''s Coop page as a hosted provider rather
-    than an adopter. Stars are 77. The level and the niche reach stand.'
+    open-sourced productization of the acquired Cove codebase, and former Cove clients carried over as users.
+    Notion is publicly committed and is likely Coop''s largest production deployment to date. The v1.0 announcement
+    adds named production feedback from Kyodo (a community-first messaging platform with over 150 million
+    messages sent; CEO testimonial) and an unnamed large-scale adopter (tens of millions of users, ~95%
+    cut in safety-tooling costs), plus NCMEC as a CSAM-reporting integration partner. Adoption rests on
+    named production deployments rather than community breadth, mirroring sibling Osprey. The repo carries
+    none of this: its ''Used in production'' list is empty and it shows 77 stars, so the Notion/Kyodo/Musubi
+    names rest on the announcements alone, and Musubi appears on ROOST''s Coop page as a hosted provider
+    rather than an adopter. The level and the niche reach stand on the named deployments.'
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/roostorg/coop
     shows: stargazerCount 77 for roostorg/coop. The README's 'Used in production' section reads 'Coop is
-      used by:' with nothing under it, so the named list recorded here on 2026-07-03 is no longer on the
-      page.
+      used by:' with nothing under it.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 62edfbfeecfc59d655ad77f82b7494dbc384e39a620032d8cc40a4c33c4a746a
@@ -84,7 +81,7 @@ capability:
     Safety integrations.
   confidence: low
   note: Broad moderation-console feature set, now on the v1.0 line (announced June 2026); functional and
-    proven at named deployments but still young. Re-read 2026-08-13 and unchanged.
+    proven at named deployments but still young.
   last_verified: '2026-08-13'
   sources:
   - url: https://roost.tools/coop/

--- a/sources/scores/cosmopedia.yaml
+++ b/sources/scores/cosmopedia.yaml
@@ -12,8 +12,7 @@ openness:
     free_text:
     - parquet downloadable
   confidence: high
-  note: 'Permissive Apache-2.0 license, ungated, full dataset card and downloadable parquet files. Re-read
-    2026-08-13: apache-2.0 on the Hub, gated false, card and parquet files intact.'
+  note: Permissive Apache-2.0 license, ungated, full dataset card and downloadable parquet files.
   raw: license:apache-2.0;access:ungated;dataset_card:present;parquet downloadable
   last_verified: '2026-08-13'
   sources:
@@ -31,9 +30,8 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 22,057 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (HuggingFaceTB/cosmopedia 22,057). Bands at level 3 (10K-100K) on the dataset adoption scale, whose
-    top band is >1M.
+  note: 22,057 downloads in the trailing 30 days summed across the 1 declared artifact(s) (HuggingFaceTB/cosmopedia
+    22,057). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/HuggingFaceTB/cosmopedia
@@ -47,10 +45,7 @@ capability:
   basis_detail: superseded
   value: null
   confidence: high
-  note: 'Cosmo-1B beats TinyLlama on ARC/MMLU but trails Phi-1.5; explicitly superseded by Cosmopedia v2.
-    Re-read 2026-08-13: the Cosmopedia post still reports Cosmo-1B ahead of TinyLlama 1.1B on ARC-easy,
-    ARC-challenge, OpenBookQA and MMLU while noting performance gaps against Phi-1.5, and the v2 card is
-    still the named successor.'
+  note: Cosmo-1B beats TinyLlama on ARC/MMLU but trails Phi-1.5; explicitly superseded by Cosmopedia v2.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/blog/cosmopedia

--- a/sources/scores/crewai.yaml
+++ b/sources/scores/crewai.yaml
@@ -93,14 +93,12 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: '27M+ cumulative PyPI downloads with ~5M in the last month, 2B+ agent executions in past 12 months.
-    Monthly download volume places it in the 1-10M range. Artifact declared and read live 2026-08-13:
-    17,374,215 PyPI downloads in the trailing 30 days. Bands at >10M, level 5. This record previously claimed
-    usage_volume - a download count - while declaring no artifact any signal model reads, so no computed
-    figure existed for the recorded band to disagree with. Level corrected from 4. Re-read 2026-08-13
-    against the pypistats API, which returns 17,374,215 downloads in the trailing 30 days for crewai,
-    the same figure the correction rested on. PyPI is the framework''s declared and primary channel, so
-    this is a measurement rather than a substitute. Level and reach unchanged.'
+  note: 27M+ cumulative PyPI downloads with ~5M in the last month, 2B+ agent executions in past 12 months.
+    Monthly download volume places it in the 1-10M range. With the artifact declared, the figure is 17,374,215
+    PyPI downloads in the trailing 30 days. Bands at >10M, level 5. This record previously claimed usage_volume
+    - a download count - while declaring no artifact any signal model reads, so no computed figure existed
+    for the recorded band to disagree with. Level corrected from 4. PyPI is the framework's declared and
+    primary channel, so that figure is a measurement rather than a substitute.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/crewai/recent
@@ -125,11 +123,8 @@ capability:
   basis: feature_matrix
   value: null
   confidence: high
-  note: 'Role-based multi-agent orchestration framework (crews/flows). No first-party SWE-bench/GAIA score
+  note: Role-based multi-agent orchestration framework (crews/flows). No first-party SWE-bench/GAIA score
     verified for the framework itself; rated on feature matrix as an opinionated agent-orchestration library.
-    Re-read 2026-08-13 - the repo still presents crews and flows as the two orchestration primitives and
-    still publishes no benchmark placement, and the agents concept doc still describes the role/goal/backstory
-    abstraction the band was scored on. Two below the openhands anchor, unchanged.'
   relative_to: openhands
   relation: two_below
   last_verified: '2026-08-13'

--- a/sources/scores/cruxeval.yaml
+++ b/sources/scores/cruxeval.yaml
@@ -16,12 +16,9 @@ openness:
       value: public
       detail: downloadable, fully released, not held-out
   confidence: high
-  note: Fully open public benchmark dataset under MIT with documented construction methodology. Re-read
-    2026-08-13 - the repository still declares MIT (license tab and the README line "CRUXEval is MIT
-    licensed, as found in the LICENSE file"), the README still documents the 800-sample construction
-    and the two tasks, and the samples are still public. The repo banner now reads "This repository was
-    archived by the owner on Sep 18, 2025. It is now read-only", which changes maintenance rather than
-    openness - an archived public repo is still downloadable and still MIT.
+  note: Fully open public benchmark dataset under MIT with documented construction methodology. The repository
+    is archived by its owner and read-only, which changes maintenance rather than openness - an archived
+    public repo is still downloadable and still MIT.
   raw: data:open(800 samples public on GitHub + HF);license:MIT(permissive, redistributable);datasheet:yes(README
     + arXiv paper documenting construction);access:public(downloadable, fully released, not held-out)
   last_verified: '2026-08-13'
@@ -53,9 +50,8 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: Capability not a meaningful axis for an eval dataset. Re-read 2026-08-13 and the abstention
-    stands - the repo publishes a static set of 800 function/input/output triples with no performance
-    or feature claim the capability axis could band.
+  note: Capability not a meaningful axis for an eval dataset. The repo publishes a static set of 800 function/input/output
+    triples with no performance or feature claim the capability axis could band.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/facebookresearch/cruxeval

--- a/sources/scores/culturax.yaml
+++ b/sources/scores/culturax.yaml
@@ -11,9 +11,7 @@ openness:
     card:
       value: present
   confidence: high
-  note: 'Dataset card is rich but downloads require agreeing to share contact information (auto gate). Re-read
-    2026-08-13: the Hub still requires agreeing to the conditions before access and the API reports gated
-    auto, and the card''s License Information section still defers to the mC4 and OSCAR-2301 terms.'
+  note: Dataset card is rich but downloads require agreeing to share contact information (auto gate).
   raw: license:follows mC4 + OSCAR-2301 terms;gated:auto(contact-info agreement);card:present
   last_verified: '2026-08-13'
   sources:
@@ -32,9 +30,8 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 13,746 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (uonlp/CulturaX 13,746). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is
-    >1M.
+  note: 13,746 downloads in the trailing 30 days summed across the 1 declared artifact(s) (uonlp/CulturaX
+    13,746). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/uonlp/CulturaX
@@ -48,9 +45,8 @@ capability:
   basis_detail: superseded
   value: null
   confidence: high
-  note: 'A strong 2023-24 default multilingual corpus, but explicitly beaten by FineWeb-2 in controlled
-    per-language ablations. Re-read 2026-08-13: the FineWeb-2 card still reports beating CulturaX on FineTasks,
-    and the CulturaX card still describes a 6.3T-token, 167-language corpus built from mC4 and OSCAR.'
+  note: A strong 2023-24 default multilingual corpus, but explicitly beaten by FineWeb-2 in controlled per-language
+    ablations. CulturaX is a 6.3T-token, 167-language corpus built from mC4 and OSCAR.
   relative_to: fineweb-2
   relation: two_below
   last_verified: '2026-08-13'

--- a/sources/scores/cursor.yaml
+++ b/sources/scores/cursor.yaml
@@ -16,10 +16,10 @@ openness:
       detail: cursor/cursor holds only .github, README.md and SECURITY.md; no license, no language, no editor
         source
   note: 'Fully proprietary commercial product; no open source license or public source. `source: closed`
-    transcribed 2026-08-11 from a read of the repo and the terms: the GitHub contents API shows `cursor/cursor`
-    holds exactly three entries (`.github`, `README.md`, `SECURITY.md`), the repo API reports `license:
-    null` and `language: null`, and the Terms of Service state that Anysphere and its licensors retain all
-    right, title and interest in the Service and reserve all rights not granted. Nothing of the editor runtime
+    comes from a direct read of the repo and the terms: the GitHub contents API shows `cursor/cursor` holds
+    exactly three entries (`.github`, `README.md`, `SECURITY.md`), the repo API reports `license: null`
+    and `language: null`, and the Terms of Service state that Anysphere and its licensors retain all right,
+    title and interest in the Service and reserve all rights not granted. Nothing of the editor runtime
     is published, so the ladder settles on `source` alone and `core-gated` stays unrecorded.'
   last_verified: '2026-08-11'
   raw: license:Proprietary(closed SaaS IDE, no public source);model:multi-provider (OpenAI/Anthropic/Gemini/xAI)
@@ -60,13 +60,10 @@ adoption:
   reach: 1M-10M users
   signal_type: active_users
   confidence: high
-  note: '1M+ daily active users (reported 2025, sustained Dec 2025) and ~$2B ARR by Feb 2026. Confirmed
-    via press coverage of company-reported figures. 1M+ DAU puts it in the 1-10M band (not yet a confirmed
-    >10M mass-market count). Re-read 2026-08-13 - the Contrary Research profile still states over 1 million
-    daily active users as of December 2025, 50K businesses and 9,900% year-over-year ARR growth, and cursor.com
-    still claims it is "trusted by over half of the Fortune 500". WHAT WAS BANDED - a DAILY active count
-    read against a monthly scale, so the monthly figure is higher than the number banded and this level
-    is a floor rather than a ceiling. Level and reach unchanged.'
+  note: 1M+ daily active users (reported 2025, sustained Dec 2025) and ~$2B ARR by Feb 2026. Confirmed via
+    press coverage of company-reported figures. 1M+ DAU puts it in the 1-10M band (not yet a confirmed >10M
+    mass-market count). WHAT WAS BANDED - a DAILY active count read against a monthly scale, so the monthly
+    figure is higher than the number banded and this level is a floor rather than a ceiling.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.cursor.com/
@@ -88,10 +85,8 @@ capability:
   value: Cursor Background Agent SWE-bench Verified 65.7% (April 2026 coding-agent leaderboard)
   confidence: medium
   note: 'High-tier autonomous coding agent (Background Agent 65.7%), just below OpenHands (68.4%); mature
-    Composer/agent UX. NOTE: figure from aggregator leaderboard (awesomeagents.ai), not primary; kept
-    at medium confidence. Re-read 2026-08-13 - the leaderboard still ranks Cursor Background Agent on
-    Claude Sonnet 4.6 at 65.7% Verified and 48.9% Full, row 3, immediately below OpenHands + CodeAct v3
-    at 68.4%. One below the openhands anchor, unchanged.'
+    Composer/agent UX. NOTE: figure from aggregator leaderboard (awesomeagents.ai), not primary; kept at
+    medium confidence.'
   relative_to: openhands
   relation: one_below
   last_verified: '2026-08-13'

--- a/sources/scores/data-juicer.yaml
+++ b/sources/scores/data-juicer.yaml
@@ -13,9 +13,7 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (Apache-2.0), full source public. Re-read 2026-08-13 - the LICENSE body still
-    carries the same license and the README still builds the whole product from the published repo, with
-    no paid tier, enterprise edition or license key anywhere in it.
+  note: Fully OSI-licensed (Apache-2.0), full source public.
   raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -41,9 +39,9 @@ adoption:
   reach: <10K
   signal_type: usage_volume
   confidence: high
-  note: 2,962 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (py-data-juicer 2,962). Bands at level 1 (<10K) on the software and model adoption scale. Corrected
-    from level 2, which the declared artifacts do not support.
+  note: 2,962 downloads in the trailing 30 days summed across the 1 declared artifact(s) (py-data-juicer
+    2,962). Bands at level 1 (<10K) on the software and model adoption scale. Corrected from level 2, which
+    the declared artifacts do not support.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/py-data-juicer/recent
@@ -59,8 +57,7 @@ capability:
     data-centric challenges.
   confidence: medium
   note: Broadest operator coverage among the open tools; multimodal. Benchmark participation but no single
-    frontier-topping corpus of its own. Re-read 2026-08-13 - the README still describes the feature set
-    above.
+    frontier-topping corpus of its own.
   last_verified: '2026-08-13'
   sources:
   - url: https://raw.githubusercontent.com/datajuicer/data-juicer/main/README.md

--- a/sources/scores/datadog-llm-observability.yaml
+++ b/sources/scores/datadog-llm-observability.yaml
@@ -15,9 +15,7 @@ openness:
     - product itself closed
   confidence: high
   note: Closed proprietary SaaS; only Datadog's tracing client libraries are open, the LLM Observability
-    product and backend are closed. Re-read 2026-08-13 and unchanged - the documentation still describes
-    a hosted Datadog product configured from the Datadog app, with no repository, no license and no
-    self-hosted build offered for the LLM Observability backend anywhere in it.
+    product and backend are closed.
   raw: license:Proprietary;source:closed;platform:proprietary SaaS(no source);only the ddtrace instrumentation
     SDK is open;product itself closed
   last_verified: '2026-08-13'
@@ -38,13 +36,11 @@ adoption:
   signal_type: reported_traction
   confidence: low
   banded_quantity: Datadog platform installed base, not the LLM Observability module
-  note: 'Rides the large installed base of Datadog APM (a major enterprise observability vendor); LLM
-    Observability is a newer add-on with no disclosed standalone user/usage count. Placed at 4 on
-    parent-platform enterprise reach as a directional estimate, not a measured figure for this module
-    specifically. Re-read 2026-08-13 and still true in both directions - the quantity actually banded here
-    is the reach of the Datadog platform, not usage of the LLM Observability module, and the docs still
-    disclose no figure of any kind for the module. Stating that plainly - the band is a substitution, and
-    the substituted quantity is named.'
+  note: 'Rides the large installed base of Datadog APM (a major enterprise observability vendor); LLM Observability
+    is a newer add-on with no disclosed standalone user/usage count. Placed at 4 on parent-platform enterprise
+    reach as a directional estimate, not a measured figure for this module specifically. The band is a substitution
+    and the substituted quantity is named: the reach of the Datadog platform, not usage of the LLM Observability
+    module, for which the docs disclose no figure of any kind.'
   last_verified: '2026-08-13'
   sources:
   - url: https://docs.datadoghq.com/llm_observability/
@@ -67,8 +63,6 @@ capability:
   note: Broad enterprise-grade feature matrix (tracing, evals, cost, security/redaction, clustering, anomaly
     detection) integrated with the wider Datadog APM suite; comparable to C4 anchors. Closed, but capability
     scored independently. The comparison is now recorded rather than left in prose - at the langfuse anchor.
-    Re-read 2026-08-13 - the documentation navigation still carries Quality Monitoring, Agent Monitoring,
-    Prompt Tracking, Prompt Management, Patterns and correlation with APM, so the breadth is intact.
   last_verified: '2026-08-13'
   sources:
   - url: https://docs.datadoghq.com/llm_observability/

--- a/sources/scores/datamap-rs.yaml
+++ b/sources/scores/datamap-rs.yaml
@@ -16,9 +16,7 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (Apache-2.0), full source public. Re-read 2026-08-13 - the LICENSE body still
-    carries the same license and the README still builds the whole product from the published repo, with
-    no paid tier, enterprise edition or license key anywhere in it.
+  note: Fully OSI-licensed (Apache-2.0), full source public.
   raw: license:Apache-2.0(OSI);source:public(allenai/datamap-rs);governance:Allen Institute for AI;no feature-gated
     core;core-gated:ungated
   last_verified: '2026-08-13'
@@ -45,11 +43,11 @@ adoption:
   reach: <1K stars
   signal_type: stars_fallback
   confidence: medium
-  note: 56 GitHub stars on allenai/datamap-rs, read 2026-08-13 from the repository API. Bands at level 1
-    (<1K stars) on the stars fallback scale in signal_routing.yaml, which caps at 3 because a star is not
-    a use. A 2026 single-purpose Rust CLI used in the Dolma 3 pipeline; real but niche. The API response
-    is digested here the way bigcode-dataset and ungoliant already are in this category; a star count drifts,
-    so a later digest mismatch reads as drift rather than as fabrication.
+  note: 56 GitHub stars on allenai/datamap-rs, read from the repository API. Bands at level 1 (<1K stars)
+    on the stars fallback scale in signal_routing.yaml, which caps at 3 because a star is not a use. A 2026
+    single-purpose Rust CLI used in the Dolma 3 pipeline; real but niche. The API response is digested here
+    the way bigcode-dataset and ungoliant already are in this category; a star count drifts, so a later
+    digest mismatch reads as drift rather than as fabrication.
   last_verified: '2026-08-13'
   sources:
   - url: https://api.github.com/repos/allenai/datamap-rs
@@ -62,8 +60,7 @@ capability:
   basis: feature_matrix
   value: Single-purpose JSONL map/filter/annotate cleaning stage; focused, not a full pipeline.
   confidence: medium
-  note: One capability slot (cleaning) of the Dolma 3 toolchain. Re-read 2026-08-13 - the README still describes
-    the feature set above.
+  note: One capability slot (cleaning) of the Dolma 3 toolchain.
   last_verified: '2026-08-13'
   sources:
   - url: https://raw.githubusercontent.com/allenai/datamap-rs/main/README.md

--- a/sources/scores/datasette-agent.yaml
+++ b/sources/scores/datasette-agent.yaml
@@ -15,10 +15,7 @@ openness:
     - PyPI
     - no feature-gated core
   confidence: high
-  note: 'Apache-2.0 verified against LICENSE body; full source public on the datasette org; no gated tier.
-    Re-read 2026-08-13 - the LICENSE file still carries the full Apache License 2.0 text and the repo
-    page still reports Apache-2.0 over the whole tree, publishing the plugin in full with no paid tier
-    or enterprise directory. Stars are now 110. Nothing moved.'
+  note: Apache-2.0 verified against LICENSE body; full source public on the datasette org; no gated tier.
   raw: license:Apache-2.0(OSI);source:public(GitHub);PyPI;no feature-gated core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -43,15 +40,14 @@ adoption:
   reach: <1K stars
   signal_type: stars_fallback
   confidence: high
-  note: 'Pre-release alpha (PyPI 0.3a0, Jun 2026) roughly one month old; ~96 GitHub stars. Minimal adoption to
-    date, included as an emerging on-thesis structured-data agent. Stars read 2026-08-13: 110 across the 1
-    declared repo, which bands at <1K stars, level 1 on the stars scale in signal_routing.yaml. The previous
-    reach ''<10K'' was not a label this instrument offers - stars have their own vocabulary because a star is
-    not a download. Re-read 2026-08-13 from the repo page, which reports 110 stars and 6 forks, and against
-    the pypistats API, which returns 1,396 downloads in the trailing 30 days for datasette-agent. The
-    download figure bands at level 1 on its own scale, the same level the stars fallback gives, so the
-    level is unchanged either way. Moving the instrument to usage_volume would also change the reach label,
-    so it is flagged rather than applied here.'
+  note: Pre-release alpha (PyPI 0.3a0, Jun 2026) roughly one month old; ~96 GitHub stars. Minimal adoption
+    to date, included as an emerging on-thesis structured-data agent. 110 stars across the 1 declared repo,
+    which bands at <1K stars, level 1 on the stars scale in signal_routing.yaml. The previous reach '<10K'
+    was not a label this instrument offers - stars have their own vocabulary because a star is not a download.
+    The pypistats API returns 1,396 downloads in the trailing 30 days for datasette-agent, which bands at
+    level 1 on its own scale, the same level the stars fallback gives, so the level is unchanged either
+    way. Moving the instrument to usage_volume would also change the reach label, so it is flagged rather
+    than applied here.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/datasette/datasette-agent
@@ -71,11 +67,9 @@ capability:
     exploration, and pluggable tools (charts, image gen). Domain-specific; not a general coding agent; no standardized
     benchmark.
   confidence: medium
-  note: 'Narrow, early structured-data agent on an alpha release; capable within its domain but limited
-    in scope and maturity, so scored 2. Re-read 2026-08-13 - the project site still describes it as an
-    AI assistant for Datasette to explore and analyse data in SQLite, with a live demo and the same extensible
-    tool surface announced in May 2026, and publishes no benchmark. Below every general agent in the category
-    by design; no peer comparison is recorded because the scale bottoms out before the anchor is reachable.'
+  note: Narrow, early structured-data agent on an alpha release; capable within its domain but limited in
+    scope and maturity, so scored 2. No peer comparison is recorded because the scale bottoms out before
+    the anchor is reachable.
   last_verified: '2026-08-13'
   sources:
   - url: https://agent.datasette.io/

--- a/sources/scores/datatrove.yaml
+++ b/sources/scores/datatrove.yaml
@@ -18,9 +18,7 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (Apache-2.0), full source public, no proprietary core or managed gate. Re-read
-    2026-08-13 - the LICENSE body still carries the same license and the README still builds the whole product
-    from the published repo, with no paid tier, enterprise edition or license key anywhere in it.
+  note: Fully OSI-licensed (Apache-2.0), full source public, no proprietary core or managed gate.
   raw: license:Apache-2.0(OSI);source:public(huggingface/datatrove);governance:Hugging Face;no feature-gated
     core;managed-tier:none;core-gated:ungated
   last_verified: '2026-08-13'
@@ -47,9 +45,9 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 65,009 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (datatrove 65,009). Bands at level 2 (10K-100K) on the software and model adoption scale. Corrected
-    from level 3, which the declared artifacts do not support.
+  note: 65,009 downloads in the trailing 30 days summed across the 1 declared artifact(s) (datatrove 65,009).
+    Bands at level 2 (10K-100K) on the software and model adoption scale. Corrected from level 3, which
+    the declared artifacts do not support.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/datatrove/recent
@@ -65,10 +63,8 @@ capability:
     filter lifts MMLU ~33->37 and ARC ~46->57.
   confidence: high
   note: 'Benchmark-anchored on the output corpus (a proxy for the tool): FineWeb-Edu leads public pretraining
-    corpora on the FineWeb ablation suite. Re-read 2026-08-13 - the arXiv abstract still states that FineWeb
-    outperforms other open pretraining datasets and that FineWeb-Edu lifts MMLU and ARC sharply. The per-task
-    ablation numbers in the value above are plotted in the paper rather than printed on the abstract page,
-    so this re-read confirms the ranking claim rather than the exact figures.'
+    corpora on the FineWeb ablation suite. The arXiv abstract supports the ranking claim; the per-task ablation
+    figures in the value above are plotted in the paper rather than printed on the abstract page.'
   last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2406.17557

--- a/sources/scores/datology-ai.yaml
+++ b/sources/scores/datology-ai.yaml
@@ -13,8 +13,7 @@ openness:
     - no OSS core
   confidence: high
   note: Fully proprietary automated-curation engine; the closed analogue to datatrove/NeMo Curator, science-of-data-curation
-    niche. Re-read 2026-08-13 - the site still describes a closed data refinery deployed into the customer's
-    own cloud, with no source, no self-host path and no published license.
+    niche.
   raw: license:Proprietary;source:closed;proprietary curation platform (VPC-deployed); no source available;
     no OSS core
   last_verified: '2026-08-13'
@@ -34,9 +33,8 @@ adoption:
   confidence: medium
   banded_quantity: funding raised ($57.5M), which is credibility rather than usage
   note: ~$57.5M raised with high-profile backers, but early-stage with no named frontier-lab deployments;
-    traction is credibility/funding rather than proven scale. Directional. Re-read 2026-08-13 - the article
-    still reports the $46M Series A and the $57.5M total. That is a May 2024 figure and the only funding
-    number this axis cites, so the level stays directional.
+    traction is credibility/funding rather than proven scale. Directional. The $57.5M total is the Series
+    A announcement figure and the only funding number this axis cites, so the level stays directional.
   last_verified: '2026-08-13'
   sources:
   - url: https://aibusiness.com/data/startup-raises-46m-to-revolutionize-ai-dataset-curation
@@ -50,8 +48,7 @@ capability:
   value: Automated dedup, model-based filtering, embedding-based selection/pruning, ordering, and synthetic
     steps; specialized, no human-labeling/RLHF.
   confidence: medium
-  note: Strong specialized curation engine, narrow scope and early adoption. Re-read 2026-08-13 - the site
-    still describes the same clean, curate, create and compose stages, with no human-labeling or RLHF offering.
+  note: Strong specialized curation engine, narrow scope and early adoption.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.datologyai.com

--- a/sources/scores/daytona-sandbox.yaml
+++ b/sources/scores/daytona-sandbox.yaml
@@ -79,18 +79,17 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: medium
-  note: 'PyPI - ~8.31M downloads last month for the daytona package (primary). Part of this volume is
-    inherited from the prior dev-environment product line, but the package now ships the sandbox SDK.
-    Re-banded 2026-08-14. The pypistats API reports 10,225,169 downloads in the trailing month, which
-    crosses the 10M floor and bands at level 5 / >10M rather than the 1M-10M recorded. This is a
-    near-boundary crossing and is recorded as one, the way `synth` and `the-pile` were - the figure
-    clears the floor by 2.25%, a month of ordinary variance would put it back at level 4, and the
-    trailing-month window moves daily, so the digest below will drift on every refetch and confidence
-    is dropped from high to medium. Unlike the npm bands re-read in the same pass, this one is on a
-    bridged route - the product declares a pypi artifact, so a signal model can recompute the figure
-    from downloads_30d and disagree with it. The package is the product''s own; its PyPI metadata gives
-    the author as Daytona Platforms Inc. at support@daytona.io and the summary as "Python SDK for
-    Daytona", so this is not a same-name match.'
+  note: 'PyPI reports 10,225,169 downloads in the trailing month for the daytona package (primary), which
+    crosses the 10M floor and bands at level 5 / >10M rather than the 1M-10M previously recorded. Part of
+    this volume is inherited from the prior dev-environment product line, but the package now ships the
+    sandbox SDK. This is a near-boundary crossing and is recorded as one, the way `synth` and `the-pile`
+    were - the figure clears the floor by 2.25%, a month of ordinary variance would put it back at level
+    4, and the trailing-month window moves daily, so the digest below drifts on every refetch and confidence
+    is dropped from high to medium. Unlike the npm bands elsewhere in this category, this one is on a bridged
+    route: the product declares a pypi artifact, so a signal model can recompute the figure from downloads_30d
+    and disagree with it. The package is the product''s own - its PyPI metadata gives the author as Daytona
+    Platforms Inc. at support@daytona.io and the summary as "Python SDK for Daytona" - so this is not a
+    same-name match.'
   last_verified: '2026-08-14'
   sources:
   - url: https://pypistats.org/packages/daytona

--- a/sources/scores/dclm-baseline.yaml
+++ b/sources/scores/dclm-baseline.yaml
@@ -12,8 +12,7 @@ openness:
     github:
       value: mlfoundations/dclm
   confidence: high
-  note: 'Permissive CC-BY-4.0 license, ungated download, with open code repo and dataset card. Re-read 2026-08-13:
-    cc-by-4.0 on the Hub, gated false, card and linked mlfoundations/dclm repo intact.'
+  note: Permissive CC-BY-4.0 license, ungated download, with open code repo and dataset card.
   raw: license:CC-BY-4.0;gated:false;dataset_card:present;github:mlfoundations/dclm
   last_verified: '2026-08-13'
   sources:
@@ -31,9 +30,8 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: 309,488 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (mlfoundations/dclm-baseline-1.0 309,488). Bands at level 4 (100K-1M) on the dataset adoption scale,
-    whose top band is >1M.
+  note: 309,488 downloads in the trailing 30 days summed across the 1 declared artifact(s) (mlfoundations/dclm-baseline-1.0
+    309,488). Bands at level 4 (100K-1M) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/mlfoundations/dclm-baseline-1.0
@@ -47,9 +45,9 @@ capability:
   basis_detail: ablation
   value: null
   confidence: high
-  note: 'Leads the DataComp-LM leaderboard (beats C4/RefinedWeb/RedPajama/Dolma); current 2024-26 default
-    of OLMoE, Marin, SmolLM3, and RWKV. Re-read 2026-08-13: the DCLM listing still reports 64% 5-shot MMLU
-    at 2.6T tokens and a 6.6-point MMLU gain over MAP-Neo, the prior open-data state of the art.'
+  note: Leads the DataComp-LM leaderboard (beats C4/RefinedWeb/RedPajama/Dolma); current 2024-26 default
+    of OLMoE, Marin, SmolLM3, and RWKV. DCLM-Baseline 7B reaches 64% 5-shot MMLU at 2.6T tokens, a 6.6-point
+    MMLU gain over MAP-Neo, the prior open-data state of the art.
   last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2406.11794

--- a/sources/scores/dclm.yaml
+++ b/sources/scores/dclm.yaml
@@ -13,9 +13,7 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (MIT), full source public. Re-read 2026-08-13 - the LICENSE body still carries
-    the same license and the README still builds the whole product from the published repo, with no paid
-    tier, enterprise edition or license key anywhere in it.
+  note: Fully OSI-licensed (MIT), full source public.
   raw: license:MIT(OSI);source:public;no feature-gated core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -41,13 +39,12 @@ adoption:
   reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: medium
-  note: 1,463 GitHub stars on mlfoundations/dclm, read 2026-08-13 from the repository API. Bands at level
-    2 (1K-10K stars) on the stars fallback scale in signal_routing.yaml, which caps at 3 because a star
-    is not a use. No PyPI package is published, so the toolkit installs from source and stars are the only
-    signal; as the reference DataComp-LM harness its importance runs well ahead of its adoption, and the
-    level is directional. The API response is digested here the way bigcode-dataset and ungoliant already
-    are in this category; a star count drifts, so a later digest mismatch reads as drift rather than as
-    fabrication.
+  note: 1,463 GitHub stars on mlfoundations/dclm, read from the repository API. Bands at level 2 (1K-10K
+    stars) on the stars fallback scale in signal_routing.yaml, which caps at 3 because a star is not a use.
+    No PyPI package is published, so the toolkit installs from source and stars are the only signal; as
+    the reference DataComp-LM harness its importance runs well ahead of its adoption, and the level is directional.
+    The API response is digested here the way bigcode-dataset and ungoliant already are in this category;
+    a star count drifts, so a later digest mismatch reads as drift rather than as fabrication.
   last_verified: '2026-08-13'
   sources:
   - url: https://api.github.com/repos/mlfoundations/dclm
@@ -62,9 +59,7 @@ capability:
     7B model on 2.6T tokens reaches ~64% MMLU, beating RefinedWeb/C4/Dolma), so it defines the curation
     frontier the other tools are scored against.
   confidence: high
-  note: 'Benchmark-defining: DCLM-baseline is the reference-topping corpus of the DataComp-LM leaderboard.
-    Re-read 2026-08-13 - the arXiv abstract still reports the 64% MMLU result at 7B on 2.6T tokens and the
-    6.6-point lead over MAP-Neo.'
+  note: 'Benchmark-defining: DCLM-baseline is the reference-topping corpus of the DataComp-LM leaderboard.'
   last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2406.11794

--- a/sources/scores/decon.yaml
+++ b/sources/scores/decon.yaml
@@ -16,9 +16,7 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (Apache-2.0), full source public. Re-read 2026-08-13 - the LICENSE body still
-    carries the same license and the README still builds the whole product from the published repo, with
-    no paid tier, enterprise edition or license key anywhere in it.
+  note: Fully OSI-licensed (Apache-2.0), full source public.
   raw: license:Apache-2.0(OSI);source:public(allenai/decon);governance:Allen Institute for AI;no feature-gated
     core;core-gated:ungated
   last_verified: '2026-08-13'
@@ -45,11 +43,11 @@ adoption:
   reach: <1K stars
   signal_type: stars_fallback
   confidence: medium
-  note: 36 GitHub stars on allenai/decon, read 2026-08-13 from the repository API. Bands at level 1 (<1K
-    stars) on the stars fallback scale in signal_routing.yaml, which caps at 3 because a star is not a use.
-    A 2026 single-purpose Rust CLI used in the Dolma 3 pipeline; niche. The API response is digested here
-    the way bigcode-dataset and ungoliant already are in this category; a star count drifts, so a later
-    digest mismatch reads as drift rather than as fabrication.
+  note: 36 GitHub stars on allenai/decon, read from the repository API. Bands at level 1 (<1K stars) on
+    the stars fallback scale in signal_routing.yaml, which caps at 3 because a star is not a use. A 2026
+    single-purpose Rust CLI used in the Dolma 3 pipeline; niche. The API response is digested here the way
+    bigcode-dataset and ungoliant already are in this category; a star count drifts, so a later digest mismatch
+    reads as drift rather than as fabrication.
   last_verified: '2026-08-13'
   sources:
   - url: https://api.github.com/repos/allenai/decon
@@ -62,8 +60,7 @@ capability:
   basis: feature_matrix
   value: Flags/removes train docs overlapping eval benchmarks; focused decontamination tool.
   confidence: medium
-  note: One capability slot (decontamination) of the Dolma 3 toolchain. Re-read 2026-08-13 - the README
-    still describes the feature set above.
+  note: One capability slot (decontamination) of the Dolma 3 toolchain.
   last_verified: '2026-08-13'
   sources:
   - url: https://raw.githubusercontent.com/allenai/decon/main/README.md

--- a/sources/scores/deepeval.yaml
+++ b/sources/scores/deepeval.yaml
@@ -19,9 +19,7 @@ openness:
   last_verified: '2026-08-13'
   note: Apache-2.0 library whose metrics and test runs execute locally with no account. Confident AI is
     a separate hosted platform, scored on the map as its own product; selling it alongside does not gate
-    the library, and no component is withheld from the published source. Re-read 2026-08-13 - the license
-    endpoint still reports Apache-2.0 and the README still says the metrics run locally with the Confident
-    AI account offered as optional reporting.
+    the library, and no component is withheld from the published source.
   raw: license:Apache-2.0(OSI, OSS framework);source:public(GitHub);commercial-tier:Confident AI managed
     eval/observability cloud on top;core-gated:ungated(Confident AI is a separate hosted platform scored
     as its own product, the library evaluates locally without an account, no enterprise directory in the
@@ -62,9 +60,9 @@ openness:
     establishes:
     - license
   - url: https://raw.githubusercontent.com/confident-ai/deepeval/main/README.md
-    shows: 'Re-read 2026-08-13: the README still states the metrics ''run locally on your machine'' and
-      still frames the Confident AI account as optional reporting that ''is free, takes no additional
-      code to setup''. No metric is described as paid, licensed or enterprise-only.'
+    shows: README states the metrics 'run locally on your machine' and frames the Confident AI account as
+      optional reporting that 'is free, takes no additional code to setup'. No metric is described as paid,
+      licensed or enterprise-only.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 88d983b58c4725a6aaa88488a79029acc9e41046c0095fb15a492b643fa5b949
@@ -77,10 +75,9 @@ adoption:
   signal_type: usage_volume
   confidence: high
   last_verified: '2026-08-13'
-  note: ~4.63M monthly PyPI downloads (deepeval); 15.9k stars, used-by 1.3k projects. Headline = PyPI
-    primary source; download volume places it firmly in the 1-10M band. Re-read 2026-08-13 - the pypistats
-    API now reports 6,218,151 deepeval downloads in the trailing 30 days, still inside the same 1M-10M
-    band, and the repo is at 17.6k stars.
+  note: ~4.63M monthly PyPI downloads (deepeval); 15.9k stars, used-by 1.3k projects. Headline = PyPI primary
+    source; download volume places it firmly in the 1-10M band. The pypistats API reports 6,218,151 deepeval
+    downloads in the trailing 30 days, inside the same 1M-10M band, against 17.6k stars.
   sources:
   - url: https://pypistats.org/packages/deepeval
     shows: ~4,628,371 monthly PyPI downloads
@@ -103,9 +100,8 @@ capability:
   relation: one_below
   last_verified: '2026-08-13'
   note: Strong, broad app/RAG/agentic eval coverage with LLM-as-judge -- top-tier for product-eval, just
-    below the academic-benchmark standards (lm-eval) on benchmark-standardization breadth. Feature matrix
-    re-read 2026-08-13 and unchanged; the comparison to lm-eval the note already made is now recorded
-    structurally.
+    below the academic-benchmark standards (lm-eval) on benchmark-standardization breadth. That comparison
+    is recorded structurally against lm-evaluation-harness.
   sources:
   - url: https://github.com/confident-ai/deepeval
     shows: G-Eval, RAG/agentic/conversational metrics, pytest-style eval

--- a/sources/scores/deepseek-chat.yaml
+++ b/sources/scores/deepseek-chat.yaml
@@ -19,12 +19,6 @@ openness:
         releases, not the chat application
   note: The DeepSeek chat surface is a proprietary hosted service; openness of the V3/V4 weights it serves
     is a separate (model-layer) score. Scored as closed counterpart per ui_api recipe.
-    Re-read 2026-08-13. deepseek.com still offers exactly the two routes recorded - free access to the
-    chat at chat.deepseek.com, and the paid API platform - and the Research section still links only
-    model-weights and inference repositories, none of which is the chat application. The headline has
-    moved on from V4 Preview to the official DeepSeek-V4-Pro release, with agent capabilities, the
-    Responses API and Codex integration, available across web, app and API. There is still no
-    self-hostable implementation of the chat surface. Value unchanged at 1 / closed.
   raw: client:proprietary(no public source for chat.deepseek.com app);backend:hosted-SaaS;note:underlying
     models open(MIT) but the chat application/service is closed;source:closed(hosted chat service at chat.deepseek.com;
     DeepSeek's public repos are model and inference releases, not the chat application)
@@ -38,11 +32,11 @@ openness:
     content_sha256: a592024875e8d8b59c7b487cf7b456f29309e7dbacd2e2d6b5ff55ab44579158
     establishes: [source]
   - url: https://www.deepseek.com/en
-    shows: Re-read for this dimension. The site offers exactly two ways to use DeepSeek - 'Free access
+    shows: The site offers exactly two ways to use DeepSeek - 'Free access
       to DeepSeek' pointing at chat.deepseek.com, and 'Build with the latest DeepSeek models' pointing
       at the hosted API platform with its own pricing. The Research section links GitHub repositories
       (DeepSeek R1, V3, Coder V2 and others), and every one of them is a model-weights or research/inference
-      release; none is the chat application. So there is no self-hostable implementation of the chat
+      release; none is the chat application. There is no self-hostable implementation of the chat
       surface being scored here, which is what the ladder calls a closed source.
     accessed: '2026-08-13'
     http_status: 200
@@ -78,13 +72,11 @@ capability:
     long-context; web/app multimodal; agent capabilities (V4 Preview); no multi-provider model hub; consumer
     single-user (no enterprise multi-user/RAG-over-corp-data)'
   confidence: medium
-  note: Capable single-vendor consumer chat UI with strong underlying model, but narrow on the ui_api
-    feature axes (one provider, limited enterprise/RAG/plugin breadth) vs frontier multi-model chat UIs.
-    Not a category frontier-definer.
-    Re-read 2026-08-13. The site still shows the same shape the band rests on - one vendor family, now
-    DeepSeek-V4-Pro, reached through web, mobile app and API, with significantly enhanced agent
-    capabilities plus Responses API and Codex integration. Still no provider menu, no enterprise
-    multi-user tier and no grounding over corporate data. Band unchanged at 3.
+  note: Capable single-vendor consumer chat UI with strong underlying model, but narrow on the ui_api feature
+    axes (one provider, limited enterprise/RAG/plugin breadth) vs frontier multi-model chat UIs. Not a category
+    frontier-definer. The current family is DeepSeek-V4-Pro, reached through web, app and API, with enhanced
+    agent capabilities plus a Responses API and Codex integration, and still no provider menu, enterprise
+    multi-user tier or grounding over corporate data.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.deepseek.com/en/

--- a/sources/scores/deepseek-coder.yaml
+++ b/sources/scores/deepseek-coder.yaml
@@ -16,16 +16,13 @@ openness:
       detail: non-OSI; Attachment A acceptable-use restrictions - military/illegal/discrimination/etc.;
         commercial allowed but use-based restrictions must propagate to derivatives
   confidence: high
-  note: 'MIT-licensed inference code with downloadable weights under the DeepSeek Model License, corpus not released,
-    so 3/open_weights. Corrected from 2/restricted on 2026-07-29 under issue #117. The license''s Attachment A forbids
-    military, illegal and discriminatory use and requires those terms to propagate to derivatives, but permits commercial
-    use at any scale - a conduct restriction, not a commercial one. This also removes the contradiction that opened
-    #117: base_pretrained already tiered the same license permissive_non_osi, so the same terms were producing a
-    3 in one category and a 2 in another. Now consistent with the `deepseek` tier, which reaches 3 under plain MIT.
-    Re-read 2026-08-13 - the card''s License section still splits the two (code repository under the MIT License,
-    model use subject to the Model License), the repo still reads `"gated":false`, and the LICENSE-MODEL body
-    still carries the Attachment A use-based restrictions with commercial use permitted. Nothing on the card
-    releases a corpus. No change.'
+  note: 'MIT-licensed inference code with downloadable weights under the DeepSeek Model License, corpus
+    not released, so 3/open_weights. Corrected from 2/restricted on 2026-07-29 under issue #117. The license''s
+    Attachment A forbids military, illegal and discriminatory use and requires those terms to propagate
+    to derivatives, but permits commercial use at any scale - a conduct restriction, not a commercial one.
+    This also removes the contradiction that opened #117: base_pretrained already tiered the same license
+    permissive_non_osi, so the same terms were producing a 3 in one category and a 2 in another. Now consistent
+    with the `deepseek` tier, which reaches 3 under plain MIT.'
   raw: weights:open(downloadable on HF);data:closed;code:open(MIT, repo code);model-license:DeepSeek-Model-License(non-OSI;
     Attachment A acceptable-use restrictions - military/illegal/discrimination/etc.; commercial allowed
     but use-based restrictions must propagate to derivatives)
@@ -76,12 +73,9 @@ capability:
   value: 'Vendor: comparable to GPT-4 Turbo on code-specific tasks, beats Claude 3 Opus / Gemini 1.5 Pro on coding+math
     at 2024 release; 338-language support'
   confidence: medium
-  note: GPT-4-Turbo-class open coder at its 2024 release, but a 2024-generation model now mid-tier vs 2026 frontier
-    coders (Qwen3-Coder, DeepSeek-V4, GLM-5.1, Kimi K2.6). HF card defers exact HumanEval/MBPP/SWE-bench numbers
-    to the paper; scored 3 with medium confidence on vendor positioning. Re-read 2026-08-13 - the card still
-    claims "superior performance compared to closed-source models such as GPT4-Turbo, Claude 3 Opus, and Gemini
-    1.5 Pro in coding and math benchmarks" and still records the 86 -> 338 language expansion, with the numbers
-    still deferred to the paper. No change.
+  note: GPT-4-Turbo-class open coder at its 2024 release, but a 2024-generation model now mid-tier vs 2026
+    frontier coders (Qwen3-Coder, DeepSeek-V4, GLM-5.1, Kimi K2.6). HF card defers exact HumanEval/MBPP/SWE-bench
+    numbers to the paper; scored 3 with medium confidence on vendor positioning.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/deepseek-ai/DeepSeek-Coder-V2-Instruct

--- a/sources/scores/deepseek-instruct.yaml
+++ b/sources/scores/deepseek-instruct.yaml
@@ -15,12 +15,8 @@ openness:
     - name: MIT
       detail: OSI-style permissive, no use restrictions
   confidence: high
-  note: V4-Flash weights are MIT open (matching the V4-Pro anchor's open_weights class); training data/code closed
-    -> open_weights. Consistent with the frozen V4-Pro anchor's openness ladder. Re-read 2026-08-13 - the
-    card's License section still reads "This repository and the model weights are licensed under the MIT
-    License", the repo still reads `"gated":false`, and the card ships only an encoding folder and local-inference
-    instructions. The post-training pipeline is described in prose (two-stage expert cultivation via SFT
-    and GRPO, then on-policy distillation) but neither the scripts nor the mixture is released. No change.
+  note: V4-Flash weights are MIT open (matching the V4-Pro anchor's open_weights class); training data/code
+    closed -> open_weights. Consistent with the frozen V4-Pro anchor's openness ladder.
   raw: weights:open(MIT, on HF);data:closed;code:partial(inference/serving; no training pipeline or data);license:MIT(OSI-style
     permissive, no use restrictions)
   last_verified: '2026-08-13'
@@ -39,11 +35,10 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: ~3.50M downloads last month for V4-Flash on HF; the cheaper/faster sibling of V4-Pro is attractive for self-hosting,
-    driving strong pull volume. Squarely 1-10M on measured monthly downloads (V4-Pro anchor itself sits at level
-    4). Re-read 2026-08-13 - V4-Flash now reads 2,213,519 downloads in the trailing 30 days and the declared
-    V4-Pro repo reads 1,385,596; both sit inside 1M-10M, so the band holds whichever SKU the tier is read
-    on. No change.
+  note: ~3.50M downloads last month for V4-Flash on HF; the cheaper/faster sibling of V4-Pro is attractive
+    for self-hosting, driving strong pull volume. Squarely 1-10M on measured monthly downloads (V4-Pro anchor
+    itself sits at level 4). V4-Flash reads 2,213,519 downloads in the trailing 30 days and the declared
+    V4-Pro repo 1,385,596; both sit inside 1M-10M, so the band holds whichever SKU the tier is read on.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash
@@ -58,11 +53,9 @@ capability:
   value: 'Instruct (Max mode): MMLU-Pro 86.2, LiveCodeBench 91.6, MRCR-1M 78.7; base MMLU 88.7, HumanEval 69.5,
     GSM8K 90.8 (HF card)'
   confidence: medium
-  note: Near-frontier capability (MMLU-Pro 86.2, LiveCodeBench 91.6) but deliberately the lighter sibling of the
-    V4-Pro anchor (capability 5); placed at 4 to keep the family curve consistent - Flash trails Pro. Figures DeepSeek-reported
-    on the HF card. Re-read 2026-08-13 - the "Comparison across Modes" table still gives V4-Flash Max MMLU-Pro
-    86.2, LiveCodeBench 91.6 and MRCR 1M 78.7, each below the V4-Pro Max column (87.5 / 93.5 / 83.5), which
-    is the family curve the 4 encodes. No change.
+  note: Near-frontier capability (MMLU-Pro 86.2, LiveCodeBench 91.6) but deliberately the lighter sibling
+    of the V4-Pro anchor (capability 5); placed at 4 to keep the family curve consistent - Flash trails
+    Pro. Figures DeepSeek-reported on the HF card.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash

--- a/sources/scores/deepseek-r1.yaml
+++ b/sources/scores/deepseek-r1.yaml
@@ -17,9 +17,7 @@ openness:
       detail: OSI-style permissive, no use restrictions
   confidence: high
   note: MIT-licensed open weights with distillation rights, but RL/SFT post-training data and full training
-    code are not released -> open_weights. Re-read 2026-08-13 - the card still carries `license:mit`, still
-    reads `"gated":false`, and still publishes evaluation tables and inference instructions with no RL
-    training pipeline and no SFT or RL mixture. No change.
+    code are not released -> open_weights.
   raw: weights:open(MIT, on HF; distillation explicitly permitted);data:closed(RL/SFT training data not
     released);code:partial(inference; no full RL training pipeline);license:MIT(OSI-style permissive, no
     use restrictions)
@@ -41,9 +39,8 @@ adoption:
   note: ~5.58M downloads last month for the base R1 repo on HF, plus a very large family of R1 distills
     and the DeepSeek app/API surface. The R1 release was a landmark open-reasoning event; measured monthly
     downloads place it firmly in 1-10M, with broader app/API/derivative reach pushing toward the top of
-    the band. Re-read 2026-08-13 - the base R1 repo now reads 8,316,405 downloads in the trailing 30 days,
-    and summed with the declared R1-0528 SKU (148,234) the tier reads 8,464,639, still inside 1M-10M. No
-    change.
+    the band. The base R1 repo reads 8,316,405 downloads in the trailing 30 days, and summed with the declared
+    R1-0528 SKU (148,234) the tier reads 8,464,639, still inside 1M-10M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/deepseek-ai/DeepSeek-R1
@@ -60,9 +57,8 @@ capability:
   confidence: high
   note: 'Frontier open reasoning model at its Jan 2025 release (o1-class: matched/beat o1 on AIME, MATH-500,
     LiveCodeBench). As of June 2026 it is surpassed by DeepSeek-V3.2-Speciale/V4 and other 2026 frontier
-    reasoners, so a 4 rather than a category-5 in mid-2026 terms. Figures are DeepSeek-reported on the
-    HF card. Re-read 2026-08-13 - the card''s evaluation table still reports AIME 2024 pass@1 79.8 and SWE
-    Verified 49.2 for DeepSeek-R1 against the OpenAI o1 column, unchanged. No change.'
+    reasoners, so a 4 rather than a category-5 in mid-2026 terms. Figures are DeepSeek-reported on the HF
+    card.'
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/deepseek-ai/DeepSeek-R1

--- a/sources/scores/deepseek.yaml
+++ b/sources/scores/deepseek.yaml
@@ -16,16 +16,11 @@ openness:
       detail: permissive, no use restrictions
   governing_release: deepseek-v4-pro
   confidence: high
-  note: 'MIT weights across the V4 line, training corpus not released, inference and serving code only, so 3. V4-Pro
-    governs and both it and V4-Pro-Base are plain MIT, which keeps the tier clear of an unsettled question: the
-    retired deepseek-v3-base record carried a compound `code MIT + model DeepSeek-Model-License`, and whether that
-    license''s acceptable-use restrictions count as use-restricting is open in issue #117. The tier does not depend
-    on that ruling. Re-read 2026-08-13 - the V4-Pro card still says "This repository and the model
-    weights are licensed under the MIT License", still describes pretraining as "more than 32T diverse
-    and high-quality tokens" without releasing the corpus, and the DeepSeek-V3 repository is still
-    public MIT inference and serving code with no training pipeline. Nothing moved. The old closing
-    sentence about adoption is dropped rather than carried - the adoption axis was recomputed on
-    2026-08-13 across six declared artifacts and now sits at level 4, not 5.'
+  note: 'MIT weights across the V4 line, training corpus not released, inference and serving code only,
+    so 3. V4-Pro governs and both it and V4-Pro-Base are plain MIT, which keeps the tier clear of an unsettled
+    question: the retired deepseek-v3-base record carried a compound `code MIT + model DeepSeek-Model-License`,
+    and whether that license''s acceptable-use restrictions count as use-restricting is open in issue #117.
+    The tier does not depend on that ruling.'
   last_verified: '2026-08-13'
   raw: weights:open(MIT, on HF, both Pro and Flash);data:closed;code:partial(inference/serving; no training
     pipeline or data);license:MIT(permissive, no use restrictions)
@@ -70,11 +65,11 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: 5,180,104 downloads in the trailing 30 days summed across the 6 declared artifact(s), read 2026-08-13
-    (deepseek-ai/DeepSeek-V3.2 1,093,344; deepseek-ai/DeepSeek-V3-Base 31,718; deepseek-ai/DeepSeek-V4-Pro
-    1,411,583; deepseek-ai/DeepSeek-V4-Flash 2,283,943; deepseek-ai/DeepSeek-V4-Pro-Base 14,769; deepseek-ai/DeepSeek-V4-Flash-Base
-    344,747). Bands at level 4 (1M-10M) on the software and model adoption scale. Corrected from level 5,
-    which the declared artifacts do not support.
+  note: 5,180,104 downloads in the trailing 30 days summed across the 6 declared artifact(s) (deepseek-ai/DeepSeek-V3.2
+    1,093,344; deepseek-ai/DeepSeek-V3-Base 31,718; deepseek-ai/DeepSeek-V4-Pro 1,411,583; deepseek-ai/DeepSeek-V4-Flash
+    2,283,943; deepseek-ai/DeepSeek-V4-Pro-Base 14,769; deepseek-ai/DeepSeek-V4-Flash-Base 344,747). Bands
+    at level 4 (1M-10M) on the software and model adoption scale. Corrected from level 5, which the declared
+    artifacts do not support.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/models/deepseek-ai/DeepSeek-V3.2
@@ -115,9 +110,7 @@ capability:
   confidence: high
   note: SWE-bench Verified 80.6% (trails Claude Opus 4.6 by ~0.2), MMLU-Pro 87.5, GPQA Diamond 90.1, LiveCodeBench
     Pass@1 93.5 (reported best of any model). V4-Pro-Max described as the strongest open source model available,
-    at/near closed frontier on coding and reasoning. Re-read 2026-08-13 - benchlm still carries all
-    four headline figures and codersera carries two of them, so the band is re-derived and unchanged
-    at 5. The third source could not be reached and nothing rests on it alone.
+    at/near closed frontier on coding and reasoning.
   last_verified: '2026-08-13'
   sources:
   - url: https://benchlm.ai/models/deepseek-v4-pro-high
@@ -132,6 +125,6 @@ capability:
     http_status: 200
     content_sha256: 0654905390b5684a1e914f5646453f7c86f5d4128ba1e12a44aaf4f737cc4f33
   - url: https://www.morphllm.com/deepseek-v4
-    shows: 'NOT RE-READ: the host answered HTTP 429 to the 2026-08-13 attempt after retries, so this source
-      was not re-confirmed and is not part of this axis''s date.'
+    shows: Third-party DeepSeek V4 write-up; the host answers HTTP 429, and no part of the band rests on
+      this source alone.
     accessed: '2026-06-04'

--- a/sources/scores/deepspeed.yaml
+++ b/sources/scores/deepspeed.yaml
@@ -13,10 +13,9 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: 'Apache-2.0 license body confirmed; full source public. Re-read 2026-08-13: the cited LICENSE body
-    still carries the Apache-2.0 terms, the GitHub API reports the repository public, unarchived and licensed
-    Apache-2.0, and the README describes the whole library with no paid, enterprise or hosted tier beside
-    it, so source stays public and core-gated stays ungated.'
+  note: Apache-2.0 license body confirmed; full source public. The repository is public and unarchived,
+    and the README describes the whole library with no paid, enterprise or hosted tier beside it, so source
+    is public and the core ungated.
   raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -50,13 +49,10 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: 'PyPI last_month downloads ~1.37M. Read live 2026-08-13: 1,112,723 PyPI downloads in the trailing
-    30 days across the declared artifact(s), which bands at 1M-10M, level 4. Level corrected from 3. The
-    previous reach ''~1.4M/mo'' was free text carrying a figure rather than a band the scale declares, so
-    nothing could check it against the level beside it. No last_verified claimed: only the figure was re-read,
-    not the whole axis. Re-read 2026-08-13 from the cited pypistats reading of the declared PyPI artifact
-    `deepspeed`: 1,112,723 downloads in the trailing 30 days, which bands at 1M-10M, level 4 on the software
-    scale. Unchanged.'
+  note: 1,112,723 PyPI downloads in the trailing 30 days for the declared artifact `deepspeed`, which bands
+    at 1M-10M, level 4 on the software scale. Level corrected from 3; the previous reach '~1.4M/mo' was
+    free text carrying a figure rather than a band the scale declares, so nothing could check it against
+    the level beside it.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/deepspeed/recent
@@ -69,8 +65,7 @@ capability:
   basis: feature_matrix
   value: Large-scale distributed training/inference optimization library (ZeRO, 3D parallelism, MoE).
   confidence: high
-  note: 'Foundational scale-out training stack used for many of the largest published models. Re-read 2026-08-13:
-    the cited repository page still describes the product as recorded, so the band is unchanged.'
+  note: Foundational scale-out training stack used for many of the largest published models.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/deepspeedai/DeepSpeed

--- a/sources/scores/deepteam.yaml
+++ b/sources/scores/deepteam.yaml
@@ -15,9 +15,9 @@ openness:
     core-gated:
       value: ungated
   confidence: high
-  note: 'Fully open source: Apache-2.0 red-teaming framework, self-hostable. Re-read 2026-08-13 and
-    unchanged. Confident AI sells a hosted place for red-teaming results to live, but that is a separate
-    product beside an ungated core rather than functionality withheld from it.'
+  note: 'Fully open source: Apache-2.0 red-teaming framework, self-hostable. Confident AI sells a hosted
+    place for red-teaming results to live, but that is a separate product beside an ungated core rather
+    than functionality withheld from it.'
   raw: license:Apache-2.0(OSI);source:public;self-host:yes;service:none;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -38,11 +38,11 @@ adoption:
   reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
-  note: 'Stars-only proxy, capped at 3 because a star is not a use. Re-read 2026-08-13 - the repo shows
-    2,442 stargazers, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The
-    download route was checked rather than assumed away: the deepteam package on PyPI shows 85,819
-    downloads in the trailing 30 days, level 2 on the software scale, so both instruments agree on the
-    band. Re-banding onto downloads needs a declared PyPI artifact and is raised rather than taken here.'
+  note: 'Stars-only proxy, capped at 3 because a star is not a use. The repo shows 2,442 stargazers, which
+    bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The download route was checked
+    rather than assumed away: the deepteam package on PyPI shows 85,819 downloads in the trailing 30 days,
+    level 2 on the software scale, so both instruments agree on the band. Re-banding onto downloads needs
+    a declared PyPI artifact and is raised rather than taken here.'
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/confident-ai/deepteam
@@ -59,7 +59,7 @@ capability:
     OWASP Top 10 for LLMs, NIST AI RMF, and MITRE ATLAS, plus production guardrails.
   confidence: medium
   note: Strong standards alignment (OWASP/NIST/MITRE) and broad attack coverage; also ships runtime guardrails.
-    Re-read 2026-08-13 and unchanged, with the framework mapping added since to OWASP Top 10 for Agents 2026.
+    The framework also maps to OWASP Top 10 for Agents 2026.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/confident-ai/deepteam

--- a/sources/scores/devin.yaml
+++ b/sources/scores/devin.yaml
@@ -11,10 +11,8 @@ openness:
     self-host:
       value: 'no'
   confidence: high
-  note: 'Proprietary subscription SaaS; no source or self-hosting, matching the recipe''s ''closed'' example
-    (Devin). Re-read 2026-08-13 - the docs still describe a hosted product across Cloud, CLI, Desktop,
-    Enterprise, API and Federal with no self-hostable implementation and no published source, and the
-    pricing page still sells the whole thing as a subscription. Nothing moved.'
+  note: Proprietary subscription SaaS; no source or self-hosting, matching the recipe's 'closed' example
+    (Devin).
   raw: source:closed;license:proprietary(SaaS-only);self-host:no
   last_verified: '2026-08-13'
   sources:
@@ -41,11 +39,9 @@ adoption:
   level: 3
   signal_type: reported_traction
   confidence: low
-  note: 'Widely adopted commercial coding agent with paid Individual/Teams/Enterprise tiers, but Cognition
+  note: Widely adopted commercial coding agent with paid Individual/Teams/Enterprise tiers, but Cognition
     discloses no hard user count. Placed at 3 on reported commercial traction; no verified usage_volume
-    figure. Re-read 2026-08-13 - the pricing page still runs Free, Pro $20, Max $200, Teams $80 plus $40
-    per dev seat and Enterprise, and still publishes no user, seat or install figure of any kind. The
-    standing claim holds and the level is unchanged.'
+    figure.
   last_verified: '2026-08-13'
   sources:
   - url: https://devin.ai/pricing
@@ -63,13 +59,10 @@ capability:
   value: 'Cognition''s own technical report: 13.86% (2024, 570-problem subset); Devin 2.0 ~45.8% SWE-bench
     Verified (unassisted single-agent, vendor-reported and corroborated)'
   confidence: medium
-  note: 'Devin 2.0 at 45.8% SWE-bench Verified is independently corroborated (single-agent, no human-in-loop),
-    mid-tier, well below the OpenHands SWE-bench-Verified SOTA anchor. Scored 3. Re-read 2026-08-13 -
-    Cognition''s own technical report still states Devin resolves 13.86% of SWE-bench issues under its
-    unassisted methodology. The 45.8% figure has DISAPPEARED from the Tembo post that used to carry it,
-    so it was re-derived from the awesomeagents SWE-bench coding-agent leaderboard, which lists Devin
-    2.0 at 45.8% Verified and 35.6% Full in row 7. The band is unchanged and the two_below relation to
-    the openhands anchor still holds.'
+  note: Devin 2.0 at 45.8% SWE-bench Verified is independently corroborated (single-agent, no human-in-loop),
+    mid-tier, well below the OpenHands SWE-bench-Verified SOTA anchor. Scored 3. The 45.8% figure now rests
+    on the awesomeagents SWE-bench coding-agent leaderboard, which lists Devin 2.0 at 45.8% Verified and
+    35.6% Full; the Tembo post cited beside it no longer carries it.
   last_verified: '2026-08-13'
   sources:
   - url: https://cognition.ai/blog/swe-bench-technical-report
@@ -79,8 +72,8 @@ capability:
     http_status: 200
     content_sha256: 9e1c937f6e75754f30533cc0f6893d73d2e2154009545ed40f9b0c1ffbc877c0
   - url: https://www.tembo.io/blog/devin-alternatives-2025
-    shows: 'previously cited for Devin 2.0 at 45.8% SWE-Bench Verified. Re-read 2026-08-13 - the figure
-      no longer appears anywhere on the page.'
+    shows: Previously cited for Devin 2.0 at 45.8% SWE-Bench Verified; the figure no longer appears anywhere
+      on the page.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: c3dabd1bbfed02db1d036e2a329c7244c333fcee05db7f509a147a3cf281e3ad

--- a/sources/scores/devstral.yaml
+++ b/sources/scores/devstral.yaml
@@ -72,15 +72,13 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: 'Specialist coding-agent model with real but non-mass-market uptake, in the OpenHands / coding-agent
+  note: Specialist coding-agent model with real but non-mass-market uptake, in the OpenHands / coding-agent
     niche rather than the chat mainstream. RE-BANDED 2026-08-14 from 2/10K-100K on the max-across-releases
-    rule in docs/reference/identity.md - the old band was read on the superseded Small-2507 SKU at ~37k. The two
-    DECLARED artifacts are the Devstral 2 (2512) pair and they sum to 221,596 downloads in the trailing 30
-    days (Devstral-Small-2-24B-Instruct-2512 188,901; Devstral-2-123B-Instruct-2512 32,695), which lands in
-    100K-1M under sum_across_artifacts. Both figures were re-read against the API on 2026-08-14 and both
-    digests are byte-identical to the 2026-08-13 read. The superseded 2507 SKU has itself risen to 97,969,
-    which would still be level 2 on its own - so the move comes from reading the right release rather than
-    from growth.'
+    rule in docs/reference/identity.md - the old band was read on the superseded Small-2507 SKU at ~37k.
+    The two DECLARED artifacts are the Devstral 2 (2512) pair and they sum to 221,596 downloads in the trailing
+    30 days (Devstral-Small-2-24B-Instruct-2512 188,901; Devstral-2-123B-Instruct-2512 32,695), which lands
+    in 100K-1M under sum_across_artifacts. The superseded 2507 SKU has itself risen to 97,969, which would
+    still be level 2 on its own - so the move comes from reading the right release rather than from growth.
   last_verified: '2026-08-14'
   sources:
   - url: https://huggingface.co/api/models/mistralai/Devstral-Small-2-24B-Instruct-2512

--- a/sources/scores/diffusers.yaml
+++ b/sources/scores/diffusers.yaml
@@ -13,10 +13,9 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: 'LICENSE file is the standard, unmodified Apache 2.0 text. Re-read 2026-08-13: the cited LICENSE
-    body still carries the Apache-2.0 terms, the GitHub API reports the repository public, unarchived and
-    licensed Apache-2.0, and the README describes the whole library with no paid, enterprise or hosted tier
-    beside it, so source stays public and core-gated stays ungated.'
+  note: LICENSE file is the standard, unmodified Apache 2.0 text. The repository is public and unarchived,
+    and the README describes the whole library with no paid, enterprise or hosted tier beside it, so source
+    is public and the core ungated.
   raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -50,13 +49,9 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: 'PyPI last_month downloads of 7,406,705 fall in the 5M-50M Level 4 band. Read live 2026-08-13: 8,248,209
-    PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at 1M-10M, level
-    4. The previous reach ''7M+/month'' was free text carrying a figure rather than a band the scale declares,
-    so nothing could check it against the level beside it. No last_verified claimed: only the figure was
-    re-read, not the whole axis. Re-read 2026-08-13 from the cited pypistats reading of the declared PyPI
-    artifact `diffusers`: 8,248,209 downloads in the trailing 30 days, which bands at 1M-10M, level 4 on
-    the software scale. Unchanged.'
+  note: 8,248,209 PyPI downloads in the trailing 30 days for the declared artifact `diffusers`, which bands
+    at 1M-10M, level 4 on the software scale. The previous reach '7M+/month' was free text carrying a figure
+    rather than a band the scale declares, so nothing could check it against the level beside it.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/diffusers/recent
@@ -70,8 +65,7 @@ capability:
   value: 'Diffusion-model toolkit: inference pipelines, swappable schedulers, and pretrained models for
     image, audio, and 3D generation.'
   confidence: high
-  note: 'Deep but domain-specific to diffusion/generative models rather than general-purpose ML. Re-read
-    2026-08-13: the cited repository page still describes the product as recorded, so the band is unchanged.'
+  note: Deep but domain-specific to diffusion/generative models rather than general-purpose ML.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/huggingface/diffusers

--- a/sources/scores/dify.yaml
+++ b/sources/scores/dify.yaml
@@ -16,10 +16,10 @@ openness:
     public source does not make the product freely runnable. Cloud and enterprise tiers sit alongside it.
     Score corrected from 3 to 2 on 2026-07-30. The software ladder has rungs at 1, 2, 4 and 5 and none at
     3, so 3/source_available was not a pair any rule could produce; the ladder scores "you can read it and
-    not run it freely" at 2. Re-read 2026-08-13 - dify.ai now says so in the vendor''s own words, describing
-    the product as source-available under an "Apache-2.0-derivative license", self-hostable with a single
-    Docker command, alongside its cloud tier. The repo publishes the whole runtime and GitHub still declines
-    to place the license under an SPDX badge. Stars are now 152.3k. Nothing moved.'
+    not run it freely" at 2. The vendor says so in its own words, describing the product as source-available
+    under an "Apache-2.0-derivative license", self-hostable with a single Docker command, alongside its
+    cloud tier; the repo publishes the whole runtime and GitHub declines to place the license under an SPDX
+    badge.'
   raw: license:Dify-Open-Source-License(Apache-2.0-based,non-OSI,added-conditions:multi-tenant/branding-restrictions);source:public;cloud+enterprise-tiers
   last_verified: '2026-08-13'
   sources:
@@ -45,16 +45,15 @@ adoption:
   reach: '>10K stars'
   signal_type: stars_fallback
   confidence: high
-  note: '~144K GitHub stars plus Dify Cloud managed tier; no honest active-user/download volume figure
-    verified, so capped at 3 on stars fallback. Stars read 2026-08-13 on langgenius/dify: 152,331, which bands
-    at >10K stars, level 3 on the stars scale. The previous reach ''100K-1M'' was a download label, which this
-    instrument does not offer - a star is not a download. THE REAL DEFECT is upstream: this product declares
-    no artifacts at all, so a stars_fallback band had no stars source behind it and the count lived only in
-    this note. Declaring langgenius/dify would fix it, and is deliberately not done here because a declared
-    code repo also re-routes the openness license dimension. Re-read 2026-08-13 from the repo page, which
-    reports 152.3k stars and 24.0k forks. Dify ships as a Docker Compose stack with a managed cloud beside
-    it, publishes no install, download or user figure, and has no first-party registry package, so the
-    stars fallback is still the only instrument and the cap still holds the level at 3.'
+  note: '~144K GitHub stars plus Dify Cloud managed tier; no honest active-user/download volume figure verified,
+    so capped at 3 on stars fallback. 152,331 stars on langgenius/dify, which bands at >10K stars, level
+    3 on the stars scale. The previous reach ''100K-1M'' was a download label, which this instrument does
+    not offer - a star is not a download. THE REAL DEFECT is upstream: this product declares no artifacts
+    at all, so a stars_fallback band had no stars source behind it and the count lived only in this note.
+    Declaring langgenius/dify would fix it, and is deliberately not done here because a declared code repo
+    also re-routes the openness license dimension. Dify ships as a Docker Compose stack with a managed cloud
+    beside it, publishes no install, download or user figure, and has no first-party registry package, so
+    the stars fallback is the only instrument available and the cap holds the level at 3.'
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/langgenius/dify
@@ -67,12 +66,10 @@ capability:
   basis: feature_matrix
   value: null
   confidence: high
-  note: 'Production agentic-workflow builder: visual workflow, RAG pipeline, agent capabilities, model
-    management across hundreds of LLMs, and built-in observability (Langfuse, Opik, Arize Phoenix). Rated
-    on feature breadth. Re-read 2026-08-13 - dify.ai still advertises a full agent runtime plus workflow
-    builder deployable with one Docker command, and the repo still publishes the same surface. No benchmark
-    placement exists for a workflow builder, so this stays a feature-matrix judgment. One below the openhands
-    anchor, unchanged.'
+  note: 'Production agentic-workflow builder: visual workflow, RAG pipeline, agent capabilities, model management
+    across hundreds of LLMs, and built-in observability (Langfuse, Opik, Arize Phoenix). Rated on feature
+    breadth. No benchmark placement exists for a workflow builder, so this stays a feature-matrix judgment,
+    one below the openhands anchor.'
   relative_to: openhands
   relation: one_below
   last_verified: '2026-08-13'

--- a/sources/scores/distilabel.yaml
+++ b/sources/scores/distilabel.yaml
@@ -16,9 +16,7 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (Apache-2.0), full source public, no proprietary core. Re-read 2026-08-13 - the
-    LICENSE body still carries the same license and the README still builds the whole product from the published
-    repo, with no paid tier, enterprise edition or license key anywhere in it.
+  note: Fully OSI-licensed (Apache-2.0), full source public, no proprietary core.
   raw: license:Apache-2.0(OSI);source:public(argilla-io/distilabel);governance:Argilla/Hugging Face;no feature-gated
     core;core-gated:ungated
   last_verified: '2026-08-13'
@@ -45,10 +43,10 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 16,308 downloads in the trailing 30 days for distilabel, read 2026-08-13 from the pypistats API.
-    Bands at level 2 (10K-100K) on the software and model adoption scale. The previous reach '1K-10K' was
-    a band off a different scale. Established in the Hugging Face synthetic-data workflow, though the README
-    now says the original authors have moved on and community collaborators maintain the project.
+  note: 16,308 downloads in the trailing 30 days for distilabel, read from the pypistats API. Bands at level
+    2 (10K-100K) on the software and model adoption scale. The previous reach '1K-10K' was a band off a
+    different scale. Established in the Hugging Face synthetic-data workflow, though the README now says
+    the original authors have moved on and community collaborators maintain the project.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/distilabel/recent
@@ -66,9 +64,7 @@ capability:
     vs 53.51).
   confidence: medium
   note: 'Indirect proxy: tool quality inferred from models where distilabel-curated data was the only changed
-    variable. Confidence capped because there is no head-to-head against other synthetic-data frameworks.
-    Re-read 2026-08-13 - both model cards still carry the numbers cited, 91.42 against 90.60 on AlpacaEval
-    and 54.04 against 53.51 on the Nous suite.'
+    variable. Confidence capped because there is no head-to-head against other synthetic-data frameworks.'
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/argilla/notus-7b-v1

--- a/sources/scores/docling.yaml
+++ b/sources/scores/docling.yaml
@@ -16,13 +16,7 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: 'MIT, local-first document parsing, fully self-hostable with integrated open-weight models. Re-read
-    2026-08-13: the repository LICENSE is the plain MIT License, "Copyright (c) 2024 International Business
-    Machines", and the repo page carries the matching badge. Self-hosting is not merely allowed but the point
-    - the README advertises "Local execution capabilities for sensitive data and air-gapped environments"
-    - and the VLM and ASR models it reaches for are open weights on the Hub (GraniteDocling) rather than
-    a hosted service. docling-serve runs the same code as an API server. Nothing is withheld and nothing
-    is sold beside it.'
+  note: MIT, local-first document parsing, fully self-hostable with integrated open-weight models.
   raw: license:MIT(OSI);source:public(github.com/docling-project/docling);self-host:primary;no-feature-gated-core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -47,10 +41,10 @@ adoption:
   level: 5
   signal_type: usage_volume
   confidence: medium
-  note: '12,493,111 downloads in the trailing 30 days (docling 12,493,111), read 2026-08-12. Bands at level
-    5 (>10M) on the software and model adoption scale. Moved off the stars fallback: a real download signal
-    exists, and docs/reference/adoption.md says to re-band when one does. The package is the first-party package;
-    docling-core adds more again. Recorded level was 3.'
+  note: '12,493,111 downloads in the trailing 30 days (docling 12,493,111). Bands at level 5 (>10M) on the
+    software and model adoption scale. Moved off the stars fallback: a real download signal exists, and
+    docs/reference/adoption.md says to re-band when one does. The package is the first-party package; docling-core
+    adds more again. Recorded level was 3.'
   reach: '>10M'
   last_verified: '2026-08-12'
   sources:
@@ -66,13 +60,8 @@ capability:
     JSON; layout + reading-order; table-structure recognition; formula/code extraction; image classification;
     OCR; VLM and ASR models; application-specific XML schemas (DocLang, USPTO patents, JATS, XBRL); MCP server
   confidence: high
-  note: 'Deepest local document understanding among RAG ingestion tools; web-URL parsers lack rich binary-doc
-    depth. Re-read 2026-08-13, and the surface has grown rather than merely held, so the value has been restated.
-    Everything recorded is still there - "Advanced PDF understanding incl. page layout, reading order, table
-    structure, code, formulas, image classification", extensive OCR, VLM support - and the README now adds
-    audio with ASR models, video parsing, WebVTT and DocLang export, application-specific XML schemas for
-    USPTO patents, JATS articles and XBRL filings, and an MCP server of its own. The band was already 5 and
-    stays there.'
+  note: Deepest local document understanding among RAG ingestion tools; web-URL parsers lack rich binary-doc
+    depth.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/docling-project/docling

--- a/sources/scores/dolci.yaml
+++ b/sources/scores/dolci.yaml
@@ -10,8 +10,7 @@ openness:
     dataset_card:
       value: present
   confidence: high
-  note: 'ODC-BY, ungated, per-stage dataset cards. Re-read 2026-08-13: odc-by on the Hub, gated false, card
-    intact.'
+  note: ODC-BY, ungated, per-stage dataset cards.
   raw: license:ODC-BY;gated:false;dataset_card:present
   last_verified: '2026-08-13'
   sources:
@@ -29,9 +28,9 @@ adoption:
   reach: 1K-10K
   signal_type: usage_volume
   confidence: high
-  note: 3,807 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (allenai/Dolci-Instruct-SFT 3,807). Bands at level 2 (1K-10K) on the dataset adoption scale, whose top
-    band is >1M. Corrected from level 3, which the declared artifacts do not support.
+  note: 3,807 downloads in the trailing 30 days summed across the 1 declared artifact(s) (allenai/Dolci-Instruct-SFT
+    3,807). Bands at level 2 (1K-10K) on the dataset adoption scale, whose top band is >1M. Corrected from
+    level 3, which the declared artifacts do not support.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/allenai/Dolci-Instruct-SFT
@@ -45,10 +44,8 @@ capability:
   basis_detail: downstream
   value: null
   confidence: high
-  note: 'The current fully-open frontier post-training suite; OLMo 3-Think 32B leads the fully-open thinking-model
-    class in documented benchmarks. Re-read 2026-08-13: the OLMo 3 announcement still reports OLMo 3-Think
-    32B leading the fully open thinking-model class, and the Dolci card still presents the suite as the
-    successor to the Tulu mixtures.'
+  note: The current fully-open frontier post-training suite; OLMo 3-Think 32B leads the fully-open thinking-model
+    class in documented benchmarks. The Dolci card presents the suite as the successor to the Tulu mixtures.
   last_verified: '2026-08-13'
   sources:
   - url: https://allenai.org/blog/olmo3

--- a/sources/scores/dolma-3.yaml
+++ b/sources/scores/dolma-3.yaml
@@ -10,8 +10,7 @@ openness:
     dataset_card:
       value: present
   confidence: high
-  note: 'ODC-BY, ungated, fully documented pool and training mixes. Re-read 2026-08-13: odc-by on the Hub,
-    gated false, card intact.'
+  note: ODC-BY, ungated, fully documented pool and training mixes.
   raw: license:ODC-BY;gated:false;dataset_card:present
   last_verified: '2026-08-13'
   sources:
@@ -29,9 +28,9 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 36,467 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (allenai/dolma3_pool 36,467). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band
-    is >1M. Corrected from level 4, which the declared artifacts do not support.
+  note: 36,467 downloads in the trailing 30 days summed across the 1 declared artifact(s) (allenai/dolma3_pool
+    36,467). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M. Corrected
+    from level 4, which the declared artifacts do not support.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/allenai/dolma3_pool
@@ -45,10 +44,8 @@ capability:
   basis_detail: downstream
   value: null
   confidence: high
-  note: 'The current (2025) corpus behind OLMo 3, the strongest fully-open base and thinking models; uses
-    documented quality-aware upsampling and data-mix ablations. Re-read 2026-08-13: the OLMo 3 announcement
-    still presents Dolma 3 as the corpus behind every OLMo 3 variant and OLMo 3-Base 32B as the strongest
-    fully open base model.'
+  note: The current (2025) corpus behind OLMo 3, the strongest fully-open base and thinking models; uses
+    documented quality-aware upsampling and data-mix ablations.
   last_verified: '2026-08-13'
   sources:
   - url: https://allenai.org/blog/olmo3

--- a/sources/scores/dolma-toolkit.yaml
+++ b/sources/scores/dolma-toolkit.yaml
@@ -16,9 +16,7 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (Apache-2.0), full source public. Re-read 2026-08-13 - the LICENSE body still
-    carries the same license and the README still builds the whole product from the published repo, with
-    no paid tier, enterprise edition or license key anywhere in it.
+  note: Fully OSI-licensed (Apache-2.0), full source public.
   raw: license:Apache-2.0(OSI);source:public(allenai/dolma);governance:Allen Institute for AI;no feature-gated
     core;core-gated:ungated
   last_verified: '2026-08-13'
@@ -45,9 +43,9 @@ adoption:
   reach: <10K
   signal_type: usage_volume
   confidence: high
-  note: 4,390 downloads in the trailing 30 days for dolma, read 2026-08-13 from the pypistats API. Bands
-    at level 1 (<10K) on the software and model adoption scale, corrected from level 2. The curation toolkit
-    behind the Dolma corpus and the OLMo family, so its importance runs ahead of its raw volume.
+  note: 4,390 downloads in the trailing 30 days for dolma, read from the pypistats API. Bands at level 1
+    (<10K) on the software and model adoption scale, corrected from level 2. The curation toolkit behind
+    the Dolma corpus and the OLMo family, so its importance runs ahead of its raw volume.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/dolma/recent
@@ -66,10 +64,7 @@ capability:
     frontier.
   confidence: high
   note: 'Benchmark-anchored on the output corpus (proxy): capable and fully open, but its released corpus
-    trails the datatrove / NeMo Curator frontier on DCLM. Down from a feature-only read of 4. Re-read 2026-08-13
-    against the DataComp-LM full text, where Table 2 still shows Dolma-V1 at 35.0 Core against RefinedWeb
-    36.9 at the 7B-1x scale. The cited abstract page never carried that table, so the source now points
-    at the HTML full text. The gap to the datatrove frontier is recorded as relative_to.'
+    trails the datatrove / NeMo Curator frontier on DCLM. Down from a feature-only read of 4.'
   last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/html/2406.11794v3

--- a/sources/scores/dolma.yaml
+++ b/sources/scores/dolma.yaml
@@ -12,8 +12,7 @@ openness:
     code:
       value: apache-2.0-toolkit
   confidence: high
-  note: 'Permissively licensed (ODC-BY), ungated download with a full dataset card and replication toolkit.
-    Re-read 2026-08-13: odc-by, gated false, card intact, and the allenai/dolma toolkit repo still public.'
+  note: Permissively licensed (ODC-BY), ungated download with a full dataset card and replication toolkit.
   raw: license:ODC-BY;ungated:yes;dataset_card:yes;code:apache-2.0-toolkit
   last_verified: '2026-08-13'
   sources:
@@ -31,8 +30,8 @@ adoption:
   reach: 1K-10K
   signal_type: usage_volume
   confidence: high
-  note: 2,724 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (allenai/dolma 2,724). Bands at level 2 (1K-10K) on the dataset adoption scale, whose top band is >1M.
+  note: 2,724 downloads in the trailing 30 days summed across the 1 declared artifact(s) (allenai/dolma
+    2,724). Bands at level 2 (1K-10K) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/allenai/dolma
@@ -46,10 +45,8 @@ capability:
   basis_detail: superseded
   value: null
   confidence: high
-  note: 'Proven training corpus for OLMo 1/2 and OLMoE, but loses to FineWeb in the canonical FineWeb ablation
-    and is superseded by Dolma 3. Re-read 2026-08-13: the FineWeb listing still claims better-performing
-    LLMs than other open pretraining datasets, and the OLMo 3 announcement still runs on Dolma 3 rather
-    than this.'
+  note: Proven training corpus for OLMo 1/2 and OLMoE, but loses to FineWeb in the canonical FineWeb ablation
+    and is superseded by Dolma 3.
   relative_to: fineweb
   relation: one_below
   last_verified: '2026-08-13'

--- a/sources/scores/doubao-seed.yaml
+++ b/sources/scores/doubao-seed.yaml
@@ -13,9 +13,7 @@ openness:
     - name: Proprietary
       detail: Doubao app + Volcano Engine API only; no downloadable weights
   confidence: high
-  note: No weights released, served only through the Doubao app and Volcano Engine API. Fully closed. Re-read
-    2026-08-13 - the article still reads "The model is now available on the Doubao app and through Volcano
-    Engine API services", with no weight release mentioned. No change.
+  note: No weights released, served only through the Doubao app and Volcano Engine API. Fully closed.
   raw: weights:closed;data:closed;code:closed;license:Proprietary(Doubao app + Volcano Engine API only;
     no downloadable weights)
   last_verified: '2026-08-13'
@@ -32,17 +30,17 @@ adoption:
   reach: '>10M users'
   signal_type: active_users
   confidence: medium
-  note: 'Powers the Doubao app, China''s largest consumer AI chat product; Seed 2.0 is the model behind
-    that surface plus the Volcano Engine enterprise API. Far above >10M. Attributed to the Doubao app
-    surface the model powers, not a standalone Seed 2.0 figure, and that is stated here deliberately -
-    a model may band on the surface it powers as long as the record says which surface.
-    Closed 2026-08-14 on a source that carries a number. The TechNode launch piece never did - it is
-    four paragraphs with no user count - so it is kept only for the availability fact and the figure
-    moves to Caixin''s launch-day report, which attributes to Quest Mobile that Doubao led with 155
-    million weekly active users in December 2025. The sibling `doubao` record independently bands the
-    same app at 382M MAU as of May 2026 (QuestMobile 2026 H1 report, re-verified 2026-08-13), so the two
-    reads agree on the order of magnitude and both sit far above the >10M threshold. Level unchanged at
-    5. Confidence stays medium - Quest Mobile is read through press coverage rather than the report.'
+  note: Powers the Doubao app, China's largest consumer AI chat product; Seed 2.0 is the model behind that
+    surface plus the Volcano Engine enterprise API. Far above >10M. Attributed to the Doubao app surface
+    the model powers, not a standalone Seed 2.0 figure, and that is stated here deliberately - a model may
+    band on the surface it powers as long as the record says which surface. Closed 2026-08-14 on a source
+    that carries a number. The TechNode launch piece never did - it is four paragraphs with no user count
+    - so it is kept only for the availability fact and the figure moves to Caixin's launch-day report, which
+    attributes to Quest Mobile that Doubao led with 155 million weekly active users in December 2025. The
+    sibling `doubao` record independently bands the same app at 382M MAU as of May 2026 (QuestMobile 2026
+    H1 report), so the two reads agree on the order of magnitude and both sit far above the >10M threshold.
+    Level unchanged at 5. Confidence stays medium - Quest Mobile is read through press coverage rather than
+    the report.
   last_verified: '2026-08-14'
   sources:
   - url: https://www.caixinglobal.com/2026-02-15/bytedance-unveils-doubao-20-ai-model-to-tackle-complex-tasks-102414865.html
@@ -54,9 +52,9 @@ adoption:
     http_status: 200
     content_sha256: ebe0a1b57b2d83f7152217cbe76706ecc4451049c8b2a705b574dd63267aaa06
   - url: https://technode.com/2026/02/14/bytedance-releases-doubao-seed-2-0-positions-pro-model-against-gpt-5-2-and-gemini-3-pro/
-    shows: 'Doubao Seed 2.0 launch coverage - "available on the Doubao app and through Volcano Engine API
-      services", which is the link between this model and the surface it bands on. Re-read 2026-08-13 and
-      it carries no user count and no "#1 AI chatbot" claim.'
+    shows: 'Doubao Seed 2.0 launch coverage - available on the Doubao app and through Volcano Engine API
+      services, which is the link between this model and the surface it bands on. It carries no user count
+      and no #1 AI chatbot claim.'
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 9b52ba5c8ede6f1f93d4278edcf05611cb47a356f6b9402f7f40d9a25d6efb57

--- a/sources/scores/doubao.yaml
+++ b/sources/scores/doubao.yaml
@@ -17,14 +17,8 @@ openness:
     source:
       value: closed
       detail: hosted consumer service plus a compiled client download; no published source for the assistant
-  note: Doubao is a closed proprietary consumer assistant; no public source for the app and the Doubao
-    models are not open-weight. Closed counterpart per ui_api recipe.
-    Re-read 2026-08-13. The Wikipedia infobox still records the licence as Proprietary, the developer as
-    ByteDance and the platforms as iOS, Android and Web, with the stable release now Doubao Seed 2.0 of
-    14 February 2026. The ByteDance download page still returns almost nothing to a plain fetch because
-    it renders client-side, which is the same weak corroboration the source line already flags rather
-    than new evidence - it still offers a compiled client and nothing else. Value unchanged at 1 /
-    closed.
+  note: Doubao is a closed proprietary consumer assistant; no public source for the app and the Doubao models
+    are not open-weight. Closed counterpart per ui_api recipe.
   raw: client:proprietary(closed consumer app);backend:hosted-SaaS on Volcano Engine;models:proprietary
     Doubao(closed);license:Proprietary;source:closed(hosted consumer service plus a compiled client download;
     no published source for the assistant)
@@ -83,11 +77,6 @@ capability:
   confidence: medium
   note: Feature-rich consumer assistant with multimodal + emerging agentic e-commerce, but narrow on the
     ui_api feature axes (single provider, consumer-only). Not a category frontier-definer on capability.
-    Re-read 2026-08-13. The AIBase report is still up and still describes the March 2026 grey-scale test
-    of one-sentence shopping, where the assistant turns a vague spoken need into a matched product and a
-    checkout hand-off, wiring the model into the Douyin e-commerce supply chain. It still frames Doubao
-    as a single-vendor consumer assistant rather than a provider hub, which is what holds the band down.
-    Band unchanged at 3.
   last_verified: '2026-08-13'
   sources:
   - url: https://news.aibase.com/news/26405

--- a/sources/scores/ds4.yaml
+++ b/sources/scores/ds4.yaml
@@ -41,11 +41,11 @@ adoption:
   reach: '>10K stars'
   signal_type: stars_fallback
   confidence: low
-  note: 21,258 GitHub stars on antirez/ds4, read 2026-08-12. Bands at level 3 (>10K stars) on the stars
-    fallback scale, which caps at 3 because a star is not a use. Resynced because the recorded 2 came from
-    placing ~21k stars in a `10K-100K` band, which is the download vocabulary; the stars scale's top band
-    is >10K stars. No download, install or customer figure is published for this product, so stars remain
-    the only honest signal and the level is directional.
+  note: 21,258 GitHub stars on antirez/ds4, which bands at level 3 (>10K stars) on the stars fallback scale;
+    that scale caps at 3 because a star is not a use. The previously recorded 2 came from placing ~21k stars
+    in a `10K-100K` band, which is the download vocabulary rather than the stars scale. No download, install
+    or customer figure is published for this product, so stars remain the only honest signal and the level
+    is directional.
   last_verified: '2026-08-12'
   sources:
   - url: https://api.github.com/repos/antirez/ds4
@@ -59,9 +59,9 @@ capability:
   value: 'Backends: Metal/CUDA/ROCm; DeepSeek V4 Flash/PRO specialization; OpenAI-compatible HTTP server; RAM +
     SSD KV streaming; integrated coding agent. No MLPerf submission.'
   confidence: medium
-  note: No peer comparison recorded for this product; the brief records no relative_to and none was found
-    in the re-read, so none is added. Specialized single-model-family engine rather than the breadth of
-    llama.cpp (C4) or the datacenter-throughput frontier (C5).
+  note: No peer comparison is recorded for this product, so relative_to/relation stay unset. Specialized
+    single-model-family engine rather than the breadth of llama.cpp (C4) or the datacenter-throughput frontier
+    (C5).
   basis_detail: feature matrix re-read from the repository README; no benchmark or MLPerf submission
   last_verified: '2026-08-09'
   sources:

--- a/sources/scores/dspy.yaml
+++ b/sources/scores/dspy.yaml
@@ -14,10 +14,7 @@ openness:
     - no-feature-gated-core
     - no-commercial-saas
   confidence: high
-  note: 'Fully MIT with no commercial tier. Re-read 2026-08-13 - the repo page still reports MIT over
-    the whole tree, publishes the complete framework, and offers no hosted product, enterprise directory
-    or license key; the project site it links is documentation rather than a commercial tier. Stars are
-    now 37.2k. Nothing moved.'
+  note: Fully MIT with no commercial tier.
   raw: license:MIT(OSI);source:public;no-feature-gated-core;no-commercial-saas;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -35,8 +32,8 @@ adoption:
   level: 4
   signal_type: usage_volume
   confidence: high
-  note: 6,589,078 PyPI downloads in the trailing 30 days for dspy, read 2026-08-12. Bands at level 4 (1M-10M)
-    on the software and model adoption scale. A widely used prompt-programming framework.
+  note: 6,589,078 PyPI downloads in the trailing 30 days for dspy. Bands at level 4 (1M-10M) on the software
+    and model adoption scale. A widely used prompt-programming framework.
   reach: 1M-10M
   last_verified: '2026-08-12'
   sources:
@@ -51,11 +48,7 @@ capability:
   value: declarative modules + typed signatures; automatic prompt optimization/compilation; weight fine-tuning;
     ReAct/CoT/RAG patterns; assertions; eval
   confidence: high
-  note: 'Best-in-class on prompt-optimization/compilation; thinner multi-agent coordination than CrewAI/AutoGen.
-    Re-read 2026-08-13 - the repo still leads on "DSPy - programming, not prompting, language models",
-    publishing the same declarative modules, typed signatures and optimizer/compilation surface, and still
-    shows no benchmark placement for the framework itself. At autogen, which is where the note already
-    put it.'
+  note: Best-in-class on prompt-optimization/compilation; thinner multi-agent coordination than CrewAI/AutoGen.
   relative_to: autogen
   relation: at
   last_verified: '2026-08-13'

--- a/sources/scores/duck-ai.yaml
+++ b/sources/scores/duck-ai.yaml
@@ -13,10 +13,6 @@ openness:
       detail: SaaS app + browser integration
   note: Proprietary anonymizing proxy in front of closed model APIs; no source, no self-host. Closed privacy-chat
     surface in the ui_api shelf.
-    Re-read 2026-08-13. The privacy help page still describes an anonymizing layer in front of other
-    companies models - metadata including the IP address is stripped before prompting, so requests reach
-    Anthropic, OpenAI, Mistral, Azure and now Tinfoil as though they came from DuckDuckGo. Nothing about
-    that proxy is published and there is no self-host path. Value unchanged at 1 / closed.
   raw: source:closed;self-host:none;license:proprietary(SaaS app + browser integration)
   last_verified: '2026-08-13'
   sources:
@@ -32,10 +28,6 @@ adoption:
   confidence: low
   note: Backed by DuckDuckGo's large user base and integrated into its browser, but no Duck.ai-specific
     usage figures are published. Conservative reported_traction pending a disclosed active-user signal.
-    Re-read 2026-08-13. The launch post is still up and DuckDuckGo still publishes no Duck.ai-specific
-    usage figure - no active-user count, no query volume, nothing beyond the browser and search
-    distribution it rides on. The abstention from a counted signal therefore stands. Level unchanged at
-    3.
   last_verified: '2026-08-13'
   sources:
   - url: https://spreadprivacy.com/ai-chat/
@@ -52,11 +44,8 @@ capability:
   confidence: high
   note: Anonymizing multi-model chat proxy - strong on privacy and model choice, but a deliberately minimal
     surface (no RAG, plugins, agents, or multimodal generation). Lower-tier on the chat-UI feature matrix.
-    Re-read 2026-08-13. The models page still lists the same free-tier lineup the band rests on - Claude
-    4.5 Haiku, Llama 3.3 70B, Mistral Small 3 24B and GPT-4o mini - with the paid tiers now reaching
-    Claude Sonnet 4.6 and, at the top, Claude Opus 4.8 with higher reasoning effort. The surface is
-    still deliberately minimal, with no RAG, no plugins, no agents and no accounts. Mistral Small 4 has
-    appeared on a paid tier. Band unchanged at 2.
+    Paid tiers reach Claude Sonnet 4.6, Mistral Small 4 and, at the top, Claude Opus 4.8 with higher reasoning
+    effort.
   last_verified: '2026-08-13'
   sources:
   - url: https://duckduckgo.com/duckduckgo-help-pages/duckai/chat-models

--- a/sources/scores/duplodocus.yaml
+++ b/sources/scores/duplodocus.yaml
@@ -16,9 +16,7 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (Apache-2.0), full source public. Re-read 2026-08-13 - the LICENSE body still
-    carries the same license and the README still builds the whole product from the published repo, with
-    no paid tier, enterprise edition or license key anywhere in it.
+  note: Fully OSI-licensed (Apache-2.0), full source public.
   raw: license:Apache-2.0(OSI);source:public(allenai/duplodocus);governance:Allen Institute for AI;no feature-gated
     core;core-gated:ungated
   last_verified: '2026-08-13'
@@ -45,11 +43,11 @@ adoption:
   reach: <1K stars
   signal_type: stars_fallback
   confidence: medium
-  note: 93 GitHub stars on allenai/duplodocus, read 2026-08-13 from the repository API. Bands at level 1
-    (<1K stars) on the stars fallback scale in signal_routing.yaml, which caps at 3 because a star is not
-    a use. A 2026 single-purpose Rust CLI used in the Dolma 3 pipeline; niche. The API response is digested
-    here the way bigcode-dataset and ungoliant already are in this category; a star count drifts, so a later
-    digest mismatch reads as drift rather than as fabrication.
+  note: 93 GitHub stars on allenai/duplodocus, read from the repository API. Bands at level 1 (<1K stars)
+    on the stars fallback scale in signal_routing.yaml, which caps at 3 because a star is not a use. A 2026
+    single-purpose Rust CLI used in the Dolma 3 pipeline; niche. The API response is digested here the way
+    bigcode-dataset and ungoliant already are in this category; a star count drifts, so a later digest mismatch
+    reads as drift rather than as fabrication.
   last_verified: '2026-08-13'
   sources:
   - url: https://api.github.com/repos/allenai/duplodocus
@@ -62,8 +60,7 @@ capability:
   basis: feature_matrix
   value: Exact + fuzzy MinHash-LSH deduplication; focused single-purpose tool.
   confidence: medium
-  note: One capability slot (dedup) of the Dolma 3 toolchain. Re-read 2026-08-13 - the README still describes
-    the feature set above.
+  note: One capability slot (dedup) of the Dolma 3 toolchain.
   last_verified: '2026-08-13'
   sources:
   - url: https://raw.githubusercontent.com/allenai/duplodocus/main/README.md

--- a/sources/scores/dynatrace-ai-observability.yaml
+++ b/sources/scores/dynatrace-ai-observability.yaml
@@ -15,10 +15,7 @@ openness:
       value: closed
   confidence: high
   note: Fully proprietary Dynatrace platform; AI Observability is a commercial app/module. OTel + OpenLLMetry
-    ingestion are open standards consumed by a closed product. Scored closed (1). Re-read 2026-08-13 and
-    unchanged - the documentation still frames Traceloop OpenLLMetry, OpenTelemetry with GenAI semantic
-    conventions and OpenInference as ways of getting data into Dynatrace, and publishes no source for the
-    product consuming it.
+    ingestion are open standards consumed by a closed product. Scored closed (1).
   raw: platform:proprietary-SaaS(Grail-powered, Davis AI);license:commercial;ingestion:OpenTelemetry+OpenLLMetry(via
     Traceloop)+GenAI-semconv(open standards, not open product);source:closed
   last_verified: '2026-08-13'
@@ -39,12 +36,11 @@ adoption:
   reach: null
   signal_type: unknown
   confidence: low
-  note: Dynatrace is a large public observability vendor, but I found no primary, AI-Observability-specific
+  note: 'Dynatrace is a large public observability vendor, but I found no primary, AI-Observability-specific
     usage figure this run (vendor docs confirm the product exists but disclose no module adoption count).
     Declining to assign a level rather than attribute platform-wide numbers I could not source primarily.
-    Re-read 2026-08-13 and the abstention stands - the documentation still carries no customer count, no
-    account count and no ingested-volume figure for this capability. Recorded as a confirmed null rather
-    than an unanswered axis.
+    This is a confirmed null rather than an unanswered axis: the documentation carries no customer count,
+    no account count and no ingested-volume figure for this capability.'
   last_verified: '2026-08-13'
   sources:
   - url: https://docs.dynatrace.com/docs/observe/dynatrace-for-ai-observability
@@ -64,11 +60,9 @@ capability:
   confidence: medium
   relative_to: langfuse
   relation: at
-  note: Strong full-stack AI observability (no-sampling capture, predictive cost, agentic tracing) at
-    the anchor C4 tier; not an eval/prompt-mgmt frontier-definer, so 4. The comparison is now recorded
-    rather than left in prose - at the langfuse anchor. Re-read 2026-08-13 - the documentation still covers
-    end-to-end tracing of LLM calls, tool use and RAG, cost as token usage and service fees, model-drift
-    monitoring, and multi-provider coverage, with no eval or prompt-versioning surface of its own.
+  note: Strong full-stack AI observability (no-sampling capture, predictive cost, agentic tracing) at the
+    anchor C4 tier; not an eval/prompt-mgmt frontier-definer, so 4. The comparison is now recorded rather
+    than left in prose - at the langfuse anchor.
   last_verified: '2026-08-13'
   sources:
   - url: https://docs.dynatrace.com/docs/observe/dynatrace-for-ai-observability

--- a/sources/scores/e2b-sandbox.yaml
+++ b/sources/scores/e2b-sandbox.yaml
@@ -78,14 +78,11 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: 'PyPI: ~4.58M downloads last month for the e2b package (primary). Vendor reports 1B+ sandboxes
-    started, 94% of Fortune 100 as customers; named users incl. Perplexity, Hugging Face, Manus, Groq.
-    Solidly 1M-10M monthly install band. Re-read 2026-08-13 and both legs still hold, with the primary
-    signal up. PyPI now reports 5,845,335 downloads in the trailing 30 days for the e2b package - well
-    inside 1M-10M and nowhere near the 10M level-5 floor. Every vendor figure cited above is still on
-    e2b.dev - "94% of Fortune 100 companies", "1b+ started sandboxes" - and it now also publishes "7M+
-    monthly downloads", which is consistent with the PyPI count once the npm SDK is added and lands in
-    the same band. Level 4 and reach 1M-10M unchanged.'
+  note: 'PyPI reports 5,845,335 downloads in the trailing 30 days for the e2b package (primary), solidly
+    inside the 1M-10M band and nowhere near the 10M level-5 floor. Vendor figures corroborate: 1B+ sandboxes
+    started, 94% of Fortune 100 as customers, "7M+ monthly downloads" across the Python and npm SDKs, and
+    named production users including Perplexity, Hugging Face, Manus, Groq, Rogo, Lindy and Gumloop. Level
+    4, reach 1M-10M.'
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/packages/e2b
@@ -116,19 +113,15 @@ capability:
     breadth:Python+JS/TS code interpreter + custom templates; persistence:filesystem; scale:1B+ sandboxes
     started
   confidence: high
-  note: VM-grade isolation (Firecracker) is the strongest tier in the feature matrix; broad SDK/runtime
-    support and proven scale. Below the frontier-definer Firecracker itself (which it builds on), so 4
-    not 5. Independent ComputeSDK TTI benchmarks corroborate the sub-second cold-start (~370ms median
-    time-to-interactive, mid-pack of 19 sandbox providers). Re-read 2026-08-13. The feature matrix is
-    unchanged where it matters - e2b.dev still states "Each sandbox is powered by Firecracker, a microVM
-    made to run untrusted workflows", still offers sessions up to 24 hours, and still reports 1b+ started
-    sandboxes. The relation to the anchor was re-derived rather than carried forward - Firecracker is 5
-    and this is 4, so one_below holds, and Firecracker''s capability was re-confirmed the same day. The
-    corroborating benchmark has moved and is recorded here rather than left implied - on the ComputeSDK
-    run of 2026-08-07 E2B posts a 0.66s median against 24 providers, 12th by median, where the 2026-07-09
-    read had it at ~370ms and 7th of 19. Still sub-second, so the recorded cold-start class survives, but
-    the corroboration is weaker than when it was written and the band now rests on isolation strength and
-    scale rather than on speed.'
+  note: 'VM-grade isolation (Firecracker) is the strongest tier in the feature matrix, with broad SDK/runtime
+    support and proven scale: e2b.dev states "Each sandbox is powered by Firecracker, a microVM made to
+    run untrusted workflows", offers sessions up to 24 hours with configurable CPU and RAM, and reports
+    1b+ started sandboxes. Below the frontier-definer Firecracker itself (which it builds on), so 4 not
+    5 - recorded as relative_to firecracker with relation `one_below`, which holds arithmetically since
+    Firecracker is 5. Independent ComputeSDK TTI benchmarks put E2B at a 0.66s median time-to-interactive,
+    12th by median of 24 providers, where an earlier run had it at ~370ms and 7th of 19: still sub-second,
+    so the recorded cold-start class survives, but the corroboration is weaker than when it was written
+    and the band now rests on isolation strength and scale rather than on speed.'
   last_verified: '2026-08-13'
   sources:
   - url: https://e2b.dev/

--- a/sources/scores/epoch-ai-benchmarks.yaml
+++ b/sources/scores/epoch-ai-benchmarks.yaml
@@ -22,11 +22,7 @@ openness:
   last_verified: '2026-08-13'
   note: 'Mixed-tier: public results dashboard plus some MIT/Apache-licensed eval components, but the headline
     benchmark (FrontierMath) is deliberately private and there is no single OSI-licensed end-to-end harness,
-    closer to source_available than fully open_source. Re-read 2026-08-13 and unchanged. The org listing
-    still shows a scatter of separately-licensed component repos - SWE-bench and SWE-bench-c7d4d9d4 (MIT),
-    eci-public (MIT), MirrorCode (MIT) with MirrorCode-data carrying no license, epochutils, ftm, benchmark-stitching
-    - and no unified harness among the 33. FrontierMath is still ''a benchmark of several hundred unpublished,
-    highly challenging mathematics problems''. Source stays partial.'
+    closer to source_available than fully open_source.'
   raw: dashboard:public(free to browse);eval-code:partial-open(several org repos MIT/Apache - SWE-bench
     docker registry, eci-public, MirrorCode-data);benchmark-data:mixed(FrontierMath gated/private to prevent
     contamination; some public);no-unified-OSI-harness-product;source:partial(public dashboard and MIT component
@@ -60,9 +56,9 @@ openness:
     establishes:
     - source
   - url: https://epoch.ai/frontiermath
-    shows: 'Re-read 2026-08-13: still ''A benchmark of several hundred unpublished, highly challenging
-      mathematics problems'', with Tiers 1-3 and Tier 4 deliberately withheld, so the headline benchmark
-      behind the dashboard still cannot be run by a reader.'
+    shows: Still 'A benchmark of several hundred unpublished, highly challenging mathematics problems',
+      with Tiers 1-3 and Tier 4 deliberately withheld, so the headline benchmark behind the dashboard cannot
+      be run by a reader.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 4a967d0a80e23496af0898979877b10ee40a79ff36432c59a8629acc47f835f6
@@ -73,21 +69,21 @@ adoption:
   signal_type: reported_traction
   confidence: medium
   last_verified: '2026-08-13'
-  note: Epoch's benchmark results (esp. FrontierMath) are a widely-referenced capability signal cited
-    across frontier-model coverage and research; the public dashboard is a recognized trends source. No
-    standalone usage/traffic count published, so reported_traction; level 3 reflects broad authoritative
-    reference rather than a measured figure. No stars-only fallback used. Re-read 2026-08-13 - the dashboard
-    is still free to browse and now spans roughly 60 benchmarks across Epoch-run, creator-run and developer-run
-    sets. It still publishes no visitor or usage count of any kind, so the level's basis is unchanged.
+  note: Epoch's benchmark results (esp. FrontierMath) are a widely-referenced capability signal cited across
+    frontier-model coverage and research; the public dashboard is a recognized trends source. No standalone
+    usage/traffic count published, so reported_traction; level 3 reflects broad authoritative reference
+    rather than a measured figure. No stars-only fallback used. The dashboard is free to browse and spans
+    roughly 60 benchmarks across Epoch-run, creator-run and developer-run sets, none of it accompanied by
+    a visitor or usage count.
   sources:
   - url: https://epoch.ai/benchmarks
     shows: public database of leading-model benchmark results positioned as authoritative AI-capability
       tracker
     accessed: '2026-06-04'
   - url: https://epoch.ai/benchmarks
-    shows: 'Re-read 2026-08-13: free public dashboard letting a reader ''explore trends in AI capabilities
-      across time, by benchmark, or by model'', spanning roughly 60 benchmarks in three groups. No traffic,
-      visitor or usage figure is published on it.'
+    shows: Free public dashboard letting a reader 'explore trends in AI capabilities across time, by benchmark,
+      or by model', spanning roughly 60 benchmarks in three groups. No traffic, visitor or usage figure
+      is published on it.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 05cf0f548e1d61fe4914055c2aca1febbac1bf4f476328bab38e86573d048367
@@ -102,12 +98,12 @@ capability:
   relative_to: lm-evaluation-harness
   relation: one_below
   last_verified: '2026-08-13'
-  note: Strong feature_matrix on hard/frontier benchmark coverage and trusted standardized results, especially
+  note: 'Strong feature_matrix on hard/frontier benchmark coverage and trusted standardized results, especially
     math. Not a general agentic-eval harness; held-out design limits self-serve reproducibility. Placed
-    at 4, authoritative but not a frontier-defining general harness like lm-eval-harness. Feature matrix
-    re-read 2026-08-13 and if anything wider - the Epoch-run set is now eleven benchmarks, adding MirrorCode,
-    Earthborne Rangers and Mystery Game Puzzles and splitting FrontierMath into Tier 4 (v2) and Tiers
-    1-3 (v2). The comparison to lm-eval-harness the note already makes is now recorded structurally.
+    at 4, authoritative but not a frontier-defining general harness like lm-eval-harness, a comparison now
+    recorded structurally. The Epoch-run set is wider than the recorded value: eleven benchmarks, adding
+    MirrorCode, Earthborne Rangers and Mystery Game Puzzles and splitting FrontierMath into Tier 4 (v2)
+    and Tiers 1-3 (v2).'
   sources:
   - url: https://epoch.ai/benchmarks
     shows: 'operated benchmarks list: FrontierMath, GPQA Diamond, SWE-bench Verified, SimpleQA Verified,

--- a/sources/scores/ernie.yaml
+++ b/sources/scores/ernie.yaml
@@ -15,9 +15,7 @@ openness:
     free_text:
     - API-only(ERNIE 4.5 was open, 5.x flagship closed)
   confidence: high
-  note: No weights distributed for the 5.x flagship; closed API model. Re-read 2026-08-13 - the Baidu
-    org on the Hub still publishes only ERNIE-4.5 variants and the ERNIE-Image line, with no 5.x
-    repository of any kind, so the closed reading for the flagship holds.
+  note: No weights distributed for the 5.x flagship; closed API model.
   last_verified: '2026-08-13'
   raw: weights:closed;data:closed;code:closed;license:proprietary(Baidu Qianfan API);API-only(ERNIE 4.5
     was open, 5.x flagship closed)
@@ -34,16 +32,11 @@ adoption:
   signal_type: reported_traction
   confidence: low
   banded_quantity: the ERNIE/Wenxiaoyan assistant app's MAU (~200M), which is app-level rather than model-level
-  note: Baidu's ERNIE/Wenxiaoyan assistant app reported ~200M MAUs around the 5.0 launch (app-level, not 5.1-specific);
-    not on HF. Attempted re-read 2026-08-13 - the ~200M MAU figure is not on the cited release post
-    and no user, MAU or request count appears on it anywhere. The band therefore has no live source
-    and this axis carries no confirmation until one is found. Replacement found 2026-08-14 - Baidu's
-    own Q4/FY2025 earnings release states "ERNIE Assistant's MAU reached 202 million in December
-    2025", which is a dated, first-party, app-level figure and is what the ~200M in this note was
-    always reaching for. App-level rather than 5.1-specific, which is how the note already framed it.
-    The Q1 2026 release gives no ERNIE MAU at all, only Baidu App at 655M for March 2026, so December
-    2025 is the freshest published ERNIE figure; Q2 2026 results are due 2026-08-18 and may carry a
-    newer one.
+  note: 'Baidu''s Q4/FY2025 earnings release states that ERNIE Assistant''s MAU reached 202 million in December
+    2025 - a first-party, app-level figure for the ERNIE/Wenxiaoyan assistant rather than a 5.1-specific
+    count, and the freshest published ERNIE user number: the Q1 2026 release gives no ERNIE MAU at all,
+    only Baidu App at 655M for March 2026. The models are not on HF, so there is no download signal to band
+    instead.'
   last_verified: '2026-08-14'
   sources:
   - url: https://www.prnewswire.com/news-releases/baidu-announces-fourth-quarter-and-fiscal-year-2025-results-302698026.html
@@ -53,8 +46,8 @@ adoption:
     http_status: 200
     content_sha256: 0c9367297e14ad3eb49187931abcf73a8dbd6e46bd8f6f65c93f57a37f070d92
   - url: https://ernie.baidu.com/blog/posts/ernie-5.1-0508-release/
-    shows: ERNIE 5.1 release and API access. Re-read 2026-08-13 - it carries no usage figure, so it
-      does not support the ~200M MAU number the level rests on
+    shows: ERNIE 5.1 release and API access. It carries no usage figure, so it does not support the MAU
+      number the level rests on.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: f0e1b7863cab4e1ae612b3f7c9a959bf7f418cd666fa202995865a35ba52f8fd
@@ -66,20 +59,13 @@ capability:
     5.1 ranks first among Chinese models on the text leaderboard and fourth globally on the search
     leaderboard'
   confidence: medium
-  note: Frontier proprietary model; Arena rank disputed between mirrors (#28) and Baidu's own claim (#13 Text).
-    Attempted re-read 2026-08-13 - two of the three recorded facts hold and one does not. AIME26 with
-    tool use at 99.6 is on the page, and so is the GPQA / MMLU-Pro framing. The '#13 Text' claim is
-    not - the post now says ERNIE 5.1 scored 1,223 to claim 4th place globally and 1st among Chinese
-    models on the Arena Search leaderboard, which is a different leaderboard and a different rank. The
-    128K context figure is not on this page either. The value needs rewriting against what the page
-    says, so this axis carries no confirmation. Replacement found 2026-08-14, and the value is rewritten
-    against it. Baidu's Q1 2026 earnings release states "Recently on LMArena, ERNIE 5.1 ranked first
-    among Chinese models on the text leaderboard and topped the LMArena search leaderboard among Chinese
-    models, ranking fourth globally", which is the same shape of claim as the dead '#13 Text' but with a
-    dated first-party home, and consistent with the 1,223 / 4th-globally figure on the release post.
-    Both remain vendor claims rather than leaderboard reads, which is why confidence stays medium. The
-    128K context figure is dropped - the only 128K evidence is on an ERNIE-4.5 card, a different model
-    line - and the AIME26 99.6 figure keeps its existing source. Score unchanged at 5.
+  note: 'Frontier proprietary model. The Arena standing is a vendor claim rather than a leaderboard read,
+    which is why confidence stays medium: the 5.1 release post reports a score of 1,223 for 4th place globally
+    and 1st among Chinese models on the Arena search leaderboard, and Baidu''s Q1 2026 earnings release
+    states ERNIE 5.1 ranked first among Chinese models on the text leaderboard and fourth globally on search.
+    An earlier ''#13 Text'' reading is not supported by either page and is dropped, as is a 128K context
+    figure whose only evidence sits on an ERNIE-4.5 card, a different model line. AIME 2026 with tool use
+    at 99.6 and the GPQA / MMLU-Pro framing are on the release post.'
   last_verified: '2026-08-14'
   sources:
   - url: https://www.prnewswire.com/news-releases/baidu-announces-first-quarter-2026-results-302774476.html

--- a/sources/scores/evalplus.yaml
+++ b/sources/scores/evalplus.yaml
@@ -18,10 +18,8 @@ openness:
       value: open
       detail: Apache-2.0
   confidence: high
-  note: 'Clean open data: Apache-2.0 on both datasets and the evaluation framework, downloadable with
-    a documented schema, full open class. Re-read 2026-08-13: `license:apache-2.0` is still in the
-    humanevalplus repo tags with `"gated":false`, and the evalplus repository still shows Apache-2.0
-    as its license tab. No change.'
+  note: 'Clean open data: Apache-2.0 on both datasets and the evaluation framework, downloadable with a
+    documented schema, full open class.'
   raw: 'data:downloadable(HF parquet, evalplus/humanevalplus + mbppplus);license:Apache-2.0(OSI/open, on
     both framework and datasets);datasheet:present(card documents structure: task_id/prompt/canonical_solution/test);redistributable:yes;framework-code:open(Apache-2.0)'
   last_verified: '2026-08-13'
@@ -46,11 +44,11 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: medium
-  note: 51,081 Hugging Face downloads in the trailing 30 days (evalplus/humanevalplus + evalplus/mbppplus),
-    read 2026-08-12. Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M -
-    one order of magnitude below the software and model scales, because no dataset artifact in the corpus
-    has ever exceeded 10M. Contamination-hardened HumanEval+/MBPP+ variants, reported adopted by Meta and
-    others; the figure sums both corpora.
+  note: 51,081 Hugging Face downloads in the trailing 30 days (evalplus/humanevalplus + evalplus/mbppplus).
+    Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M - one order of magnitude
+    below the software and model scales, because no dataset artifact in the corpus has ever exceeded 10M.
+    Contamination-hardened HumanEval+/MBPP+ variants, reported adopted by Meta and others; the figure sums
+    both corpora.
   last_verified: '2026-08-12'
   sources:
   - url: https://huggingface.co/api/datasets/evalplus/humanevalplus
@@ -68,10 +66,8 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: Dataset, not capability-scored. Its distinguishing quality (far denser test suites that catch
-    overfitting vs base HumanEval/MBPP) is a quality strength, noted but not on the 1-5 axis. Re-read
-    2026-08-13 and the abstention stands - the corpora are static problem sets and no performance or
-    feature claim on the page is something the capability axis could band.
+  note: Dataset, not capability-scored. Its distinguishing quality (far denser test suites that catch overfitting
+    vs base HumanEval/MBPP) is a quality strength, noted but not on the 1-5 axis.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/evalplus/humanevalplus

--- a/sources/scores/exa-search-api.yaml
+++ b/sources/scores/exa-search-api.yaml
@@ -14,11 +14,7 @@ openness:
       detail: usage-based pricing
       raw: cloud SaaS with API keys, usage-based pricing
   confidence: high
-  note: 'Closed neural-search API; no self-hostable core, the index and ranking models are proprietary. Re-read
-    2026-08-13: the about page still describes Exa as a search engine sold as a service - "Exa: The Search
-    Engine for Developers" - powering search for named customers through an API, with Websets layered on
-    top. It offers no self-host, on-premise or source-available path, and neither the index nor the ranking
-    models are published. source stays closed and the score stays 1.'
+  note: Closed neural-search API; no self-hostable core, the index and ranking models are proprietary.
   raw: license:Proprietary(API-only);source:closed(neural search models + index proprietary; only client
     SDKs public);managed:cloud SaaS with API keys, usage-based pricing
   last_verified: '2026-08-13'
@@ -41,10 +37,7 @@ adoption:
   confidence: high
   note: Exa's own about page states it powers search for Cursor, Cognition, HubSpot, OpenRouter, Monday.com
     and 400,000+ developers. Developer reach in the 100K-1M band; large enterprise/agent customers but below
-    the 1M-developer Tavily tier. Re-read 2026-08-13 and the sentence is still there verbatim - "search for
-    Cursor, Cognition, HubSpot, OpenRouter, Monday.com and over 400,000 developers" - so the figure, the
-    named customers and the 100K-1M band are all unchanged, as is the comparison to Tavily, whose 2M+ developer
-    claim was re-read the same day.
+    the 1M-developer Tavily tier.
   last_verified: '2026-08-13'
   sources:
   - url: https://exa.ai/about
@@ -60,11 +53,9 @@ capability:
     entity lists); positioned for high-compute complex queries; scaling to hundreds of thousands of searches/sec
     (vendor)
   confidence: medium
-  note: 'Strong on {coverage, structured output}; Websets'' verify-and-enrich pipeline is a differentiated
-    capability beyond plain search; near-frontier among agent search APIs. Re-read 2026-08-13: the about
-    page still positions Exa as a neural search engine for developers with Websets on top, and still frames
-    the roadmap around search volume growing as agents rather than people issue the queries. No independent
-    benchmark for semantic search APIs exists, so the basis stays feature_matrix and the band stays 4.'
+  note: Strong on {coverage, structured output}; Websets' verify-and-enrich pipeline is a differentiated
+    capability beyond plain search; near-frontier among agent search APIs. No independent benchmark for
+    semantic search APIs exists, so the basis is feature_matrix rather than benchmark.
   last_verified: '2026-08-13'
   sources:
   - url: https://exa.ai/about

--- a/sources/scores/falcon.yaml
+++ b/sources/scores/falcon.yaml
@@ -13,17 +13,14 @@ openness:
     - name: TII-Falcon-License-2.0
       detail: Apache-based+AUP,non-OSI
   confidence: high
-  note: 'Weights downloadable and freely usable commercially at any scale, corpus not released, no training code,
-    so 3/open_weights. Corrected from 2/restricted on 2026-07-29 under issue #117: TII-Falcon-License-2.0 is Apache-based
-    with an acceptable-use policy, and a conduct restriction caps neither who may use the model nor at what scale.
-    It therefore sits in permissive_non_osi beside attribution requirements rather than in the capped tier beside
-    Llama''s 700M-MAU ceiling. Not 4 or 5: the corpus and the pipeline are both closed, and the license is non-OSI
-    regardless, since the OSD forbids discriminating against a field of endeavor. The Hub reports this license as
-    `other`, an abstention rather than an answer, so the tier rests on TII''s published text. Re-read
-    2026-08-13 - the Hub still reports `other` and ungated for Falcon3-10B-Base, and the release blog
-    still describes a single 14-trillion-token pretraining run over "web, code, STEM, and curated
-    high-quality and multilingual data" without releasing either the corpus or the pipeline. Nothing
-    moved.'
+  note: 'Weights downloadable and freely usable commercially at any scale, corpus not released, no training
+    code, so 3/open_weights. Corrected from 2/restricted on 2026-07-29 under issue #117: TII-Falcon-License-2.0
+    is Apache-based with an acceptable-use policy, and a conduct restriction caps neither who may use the
+    model nor at what scale. It therefore sits in permissive_non_osi beside attribution requirements rather
+    than in the capped tier beside Llama''s 700M-MAU ceiling. Not 4 or 5: the corpus and the pipeline are
+    both closed, and the license is non-OSI regardless, since the OSD forbids discriminating against a field
+    of endeavor. The Hub reports this license as `other`, an abstention rather than an answer, so the tier
+    rests on TII''s published text.'
   last_verified: '2026-08-13'
   raw: weights:open;data:closed;code:closed;license:TII-Falcon-License-2.0(Apache-based+AUP,non-OSI)
   sources:
@@ -59,15 +56,12 @@ adoption:
   reach: <10K
   signal_type: usage_volume
   confidence: high
-  note: 'RE-BANDED 2026-08-14 from 2/reported_traction under the measured-figure ruling in
-    docs/reference/adoption.md, and the instrument moved with the level. The old record assumed no download
-    signal existed, but the single declared artifact tiiuae/Falcon3-10B-Base returns 5,292 downloads in the
-    trailing 30 days (41 likes), which lands in <10K on the model scale in sources/rubrics/model.yaml. A
-    measured count outranks a reported-traction reading, and the reported-traction reading could not be
-    re-confirmed in any case - the VentureBeat article the old level rested on has answered HTTP 429 after
-    retries on both the 2026-08-13 and 2026-08-14 attempts, so it is left dated where it was. The band now
-    matches what the note already said, that relevance has faded against newer SLMs. The digest is
-    byte-identical to the 2026-08-13 read.'
+  note: 'The single declared artifact tiiuae/Falcon3-10B-Base returns 5,292 downloads in the trailing 30
+    days (41 likes), which lands in <10K on the model scale in sources/rubrics/model.yaml. Re-banded from
+    2/reported_traction under the measured-figure ruling in docs/reference/adoption.md: a measured count
+    outranks a reported-traction reading, and the VentureBeat article the old level rested on answers HTTP
+    429 in any case. The band now matches what the note already said, that relevance has faded against newer
+    SLMs.'
   last_verified: '2026-08-14'
   sources:
   - url: https://huggingface.co/api/models/tiiuae/Falcon3-10B-Base
@@ -77,8 +71,8 @@ adoption:
     http_status: 200
     content_sha256: a30e8c22259eeba58788b6836ec9c25dd7a988e565317f1bb9e2ca40875d89d1
   - url: https://venturebeat.com/ai/uaes-falcon-3-challenges-open-source-leaders-amid-surging-demand-for-small-ai-models
-    shows: 'NOT RE-READ: the host answered HTTP 429 to the 2026-08-13 attempt after retries, so this source
-      was not re-confirmed and is not part of this axis''s date.'
+    shows: VentureBeat piece on Falcon 3 and demand for small models; the host answers HTTP 429, so it is
+      not a live source for the band.
     accessed: '2026-06-04'
   - url: https://huggingface.co/tiiuae/Falcon3-7B-Base
     shows: 'Model card for tiiuae/Falcon3-7B-Base, licence tag `falcon-llm-license`, reporting 14,911 downloads
@@ -93,9 +87,8 @@ capability:
   basis_detail: MMLU-Pro
   value: null
   confidence: high
-  note: 'Falcon3-10B-Base: MMLU 73.1, MMLU-Pro 42.5, GSM8K 83.0; Falcon3-7B-Base: MMLU 67.4, MMLU-Pro 39.2. Competitive
-    among sub-13B in 2024 but low vs 2026 frontier. Re-read 2026-08-13 - all five recorded figures
-    are still in the release blog benchmark tables, so the band is re-derived and unchanged at 2.'
+  note: 'Falcon3-10B-Base: MMLU 73.1, MMLU-Pro 42.5, GSM8K 83.0; Falcon3-7B-Base: MMLU 67.4, MMLU-Pro 39.2.
+    Competitive among sub-13B in 2024 but low vs 2026 frontier.'
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/blog/falcon3

--- a/sources/scores/fastmcp.yaml
+++ b/sources/scores/fastmcp.yaml
@@ -14,10 +14,9 @@ openness:
     - no-feature-gated-core
     - maintained-by-Prefect
   confidence: high
-  note: 'Fully OSI-licensed, no open-core split observed on the repo. Re-read 2026-08-13: the repository
-    LICENSE resolves to the full Apache License 2.0 text and the repo page carries the matching badge. The
-    whole framework - servers, apps and clients - is in the published tree and installs from PyPI with no
-    key; Prefect maintains it rather than selling a tier of it, so there is nothing withheld from the source.'
+  note: Fully OSI-licensed, no open-core split observed on the repo. The LICENSE is the full Apache-2.0
+    text, the whole framework - servers, apps and clients - is in the published tree and installs from PyPI
+    with no key, and Prefect maintains it rather than selling a tier of it.
   raw: license:Apache-2.0(OSI);source:public;no-feature-gated-core;maintained-by-Prefect;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -42,14 +41,10 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: 'fastmcp ~72.7M PyPI downloads in the last month; README reports ~1M downloads/day and powering
-    ~70% of MCP servers across languages. Mass-market reach for MCP server tooling. Re-derived 2026-08-13
-    from the pypistats API rather than the rendered page: last_month = 94,141,215 downloads for fastmcp,
-    up from the 72.7M recorded and still comfortably above the >10M level-5 floor, so level 5 and reach
-    >10M are unchanged. The README''s own claims re-read the same day and both still stand as written -
-    "downloaded a million times a day, and some version of FastMCP powers 70% of MCP servers across all
-    languages" - and both remain vendor statements, corroborating rather than carrying the band. The
-    "~10k dependent projects" clause was dropped: it appears nowhere on the repo page now.'
+  note: fastmcp draws 94,141,215 PyPI downloads in the last month, comfortably above the >10M level-5 floor,
+    which is what carries the band. The README's own claims corroborate rather than carry it - "downloaded
+    a million times a day, and some version of FastMCP powers 70% of MCP servers across all languages" -
+    and both remain vendor statements. Mass-market reach for MCP server tooling.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/fastmcp/recent
@@ -76,12 +71,8 @@ capability:
   value: auto schema generation/validation, tool/resource/prompt primitives, server+client, auth, deployment,
     protocol lifecycle management; the standard high-level MCP server framework
   confidence: medium
-  note: 'Most feature-complete framework for authoring the tool-protocol layer (MCP); scored 4 on protocol-tooling
-    feature breadth; a 5 is reserved for the protocol/category-definer (MCP itself). Re-read 2026-08-13:
-    the README now organizes the framework around "three pillars" - Servers exposing tools, resources and
-    prompts; Apps giving those tools an interactive surface; and the client side - which is the same surface
-    the recorded value describes rather than a new one. FastMCP 1.0 remains upstreamed into the official
-    Python SDK, with this the standalone successor. Band unchanged at 4.'
+  note: Most feature-complete framework for authoring the tool-protocol layer (MCP); scored 4 on protocol-tooling
+    feature breadth; a 5 is reserved for the protocol/category-definer (MCP itself).
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/jlowin/fastmcp

--- a/sources/scores/feluda.yaml
+++ b/sources/scores/feluda.yaml
@@ -13,8 +13,8 @@ openness:
       detail: all nine analysis operators ship in operators/ under the one GPL-3.0 license. Tattle offers
         no hosted edition and no paid tier
   confidence: high
-  note: 'GPL-3.0 licensed open source project with public source. `core-gated: ungated` transcribed 2026-08-12
-    from a read of the repo. Feluda is Tattle''s civic-tech content-analysis library and there is no commercial
+  note: 'GPL-3.0 licensed open source project with public source. `core-gated: ungated` comes from a direct
+    read of the repo. Feluda is Tattle''s civic-tech content-analysis library and there is no commercial
     side to gate with: no hosted edition, no pricing page and no enterprise path in the tree. Every operator
     the engine offers ships in operators/ - classify_video_zero_shot, cluster_embeddings, detect_lewd_images,
     detect_text_in_image, dimension_reduction, image_vec_rep, vid_vec_rep and video_hash - under the one
@@ -53,10 +53,10 @@ adoption:
   reach: <1K stars
   signal_type: stars_fallback
   confidence: high
-  note: 95 GitHub stars on tattle-made/feluda, read 2026-08-12. Bands at level 1 (<1K stars) on the stars
-    fallback scale, which caps at 3 because a star is not a use. Resynced because under 100 stars and no
-    package distribution found. No download, install or customer figure is published for this product, so
-    stars remain the only honest signal and the level is directional.
+  note: 95 GitHub stars on tattle-made/feluda. Bands at level 1 (<1K stars) on the stars fallback scale,
+    which caps at 3 because a star is not a use. Resynced because under 100 stars and no package distribution
+    found. No download, install or customer figure is published for this product, so stars remain the only
+    honest signal and the level is directional.
   last_verified: '2026-08-12'
   sources:
   - url: https://api.github.com/repos/tattle-made/feluda
@@ -70,8 +70,7 @@ capability:
   value: 'Configurable multilingual/multimodal content-analysis engine with modular operators: vector
     embeddings, hash-based search, image text extraction, entity extraction.'
   confidence: high
-  note: 'Flexible modular engine focused on multimodal content analysis. Re-read 2026-08-13: the repository
-    page still describes the modular operator engine as recorded, so the band is unchanged.'
+  note: Flexible modular engine focused on multimodal content analysis.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/tattle-made/feluda

--- a/sources/scores/filesystem-mcp.yaml
+++ b/sources/scores/filesystem-mcp.yaml
@@ -68,11 +68,11 @@ adoption:
   level: 4
   signal_type: usage_volume
   confidence: low
-  note: '1,945,615 downloads in the trailing 30 days (@modelcontextprotocol/server-filesystem 1,945,615),
-    read 2026-08-12. Bands at level 4 (1M-10M) on the software and model adoption scale. Moved off the stars
-    fallback: a real download signal exists, and docs/reference/adoption.md says to re-band when one does.
-    The package is a per-server npm package, which resolves the recorded objection that the monorepo''s
-    stars are shared across every server in it. Recorded level was 3.'
+  note: '1,945,615 downloads in the trailing 30 days (@modelcontextprotocol/server-filesystem 1,945,615).
+    Bands at level 4 (1M-10M) on the software and model adoption scale. Moved off the stars fallback: a
+    real download signal exists, and docs/reference/adoption.md says to re-band when one does. The package
+    is a per-server npm package, which resolves the recorded objection that the monorepo''s stars are shared
+    across every server in it. Recorded level was 3.'
   reach: 1M-10M
   last_verified: '2026-08-12'
   sources:
@@ -87,13 +87,9 @@ capability:
   value: granular read/write/edit; directory tree; search; media reads; sandboxed allowed-directory access; Roots
     support
   confidence: high
-  note: 'Full local-filesystem surface with sandboxed access controls. Re-read 2026-08-13 against the server''s
-    README and every clause of the recorded value holds. The tool table runs read_text_file (with head/tail),
-    read_media_file returning base64 with a MIME type, read_multiple_files, list_directory, list_directory_with_sizes,
-    directory_tree, get_file_info, plus write, edit, create, move, delete and search. Access is confined
-    to Allowed directories set either by command-line argument or, preferred, dynamically by the client through
-    the MCP Roots protocol, and the server refuses to initialize if neither is provided. Band unchanged at
-    4.'
+  note: Full local-filesystem surface with sandboxed access controls. Access is confined to allowed directories
+    set either by command-line argument or, preferred, dynamically by the client through the MCP Roots protocol,
+    and the server refuses to initialize if neither is provided.
   last_verified: '2026-08-13'
   sources:
   - url: https://raw.githubusercontent.com/modelcontextprotocol/servers/main/src/filesystem/README.md

--- a/sources/scores/finemath.yaml
+++ b/sources/scores/finemath.yaml
@@ -10,7 +10,7 @@ openness:
     dataset_card:
       value: present
   confidence: high
-  note: 'ODC-BY, ungated, full dataset card. Re-read 2026-08-13: odc-by on the Hub, gated false, card intact.'
+  note: ODC-BY, ungated, full dataset card.
   raw: license:ODC-BY;gated:false;dataset_card:present
   last_verified: '2026-08-13'
   sources:
@@ -28,9 +28,8 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 29,279 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (HuggingFaceTB/finemath 29,279). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top
-    band is >1M.
+  note: 29,279 downloads in the trailing 30 days summed across the 1 declared artifact(s) (HuggingFaceTB/finemath
+    29,279). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/HuggingFaceTB/finemath
@@ -44,10 +43,8 @@ capability:
   basis_detail: ablation
   value: null
   confidence: high
-  note: 'Leads controlled math ablations (FineMath-4+ ~2x GSM8K and ~6x MATH over InfiMM-WebMath, beats
-    OpenWebMath); current 2025 default in SmolLM3, Apertus, Marin, and OLMo 3. Re-read 2026-08-13: the FineMath
-    card still reports the GSM8K and MATH gains over InfiMM-WebMath and OpenWebMath, and the SmolLM2 paper
-    still documents the ablation.'
+  note: Leads controlled math ablations (FineMath-4+ ~2x GSM8K and ~6x MATH over InfiMM-WebMath, beats OpenWebMath);
+    current 2025 default in SmolLM3, Apertus, Marin, and OLMo 3.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/HuggingFaceTB/finemath

--- a/sources/scores/fineweb-2.yaml
+++ b/sources/scores/fineweb-2.yaml
@@ -12,8 +12,7 @@ openness:
     languages:
       value: 1000+
   confidence: high
-  note: 'Permissive ODC-BY license, ungated, with a dataset card spanning 1000+ languages. Re-read 2026-08-13:
-    odc-by, gated false, and the multilingual card still spans 1000+ languages.'
+  note: Permissive ODC-BY license, ungated, with a dataset card spanning 1000+ languages.
   raw: license:ODC-BY;gated:false;dataset_card:present;languages:1000+
   last_verified: '2026-08-13'
   sources:
@@ -31,9 +30,8 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 82,352 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (HuggingFaceFW/fineweb-2 82,352). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top
-    band is >1M.
+  note: 82,352 downloads in the trailing 30 days summed across the 1 declared artifact(s) (HuggingFaceFW/fineweb-2
+    82,352). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/HuggingFaceFW/fineweb-2
@@ -47,10 +45,9 @@ capability:
   basis_detail: downstream
   value: null
   confidence: high
-  note: 'Primary web corpus for Apertus 8B/70B (2025), 1811 languages; the current multilingual default,
-    and its HQ variant leads multilingual data-selection work. Re-read 2026-08-13: the Apertus listing still
-    records 15T tokens over more than 1800 languages at 8B and 70B, and the FineWeb-2 card still reports
-    the FineTasks wins over CulturaX, mC4, CC-100 and HPLT.'
+  note: Primary web corpus for Apertus 8B/70B (2025), 1811 languages; the current multilingual default,
+    and its HQ variant leads multilingual data-selection work. Its card reports FineTasks wins over CulturaX,
+    mC4, CC-100 and HPLT, and Apertus is trained on 15T tokens at 8B and 70B.
   last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2509.14233

--- a/sources/scores/fineweb-edu.yaml
+++ b/sources/scores/fineweb-edu.yaml
@@ -12,8 +12,7 @@ openness:
     format:
       value: parquet
   confidence: high
-  note: 'Permissive ODC-BY license with ungated download and full dataset card. Re-read 2026-08-13: odc-by
-    on the Hub, gated false on the API, card intact.'
+  note: Permissive ODC-BY license with ungated download and full dataset card.
   raw: license:ODC-BY;gated:false;dataset_card:present;format:parquet
   last_verified: '2026-08-13'
   sources:
@@ -31,9 +30,8 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: 395,837 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (HuggingFaceFW/fineweb-edu 395,837). Bands at level 4 (100K-1M) on the dataset adoption scale, whose
-    top band is >1M.
+  note: 395,837 downloads in the trailing 30 days summed across the 1 declared artifact(s) (HuggingFaceFW/fineweb-edu
+    395,837). Bands at level 4 (100K-1M) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/HuggingFaceFW/fineweb-edu
@@ -47,10 +45,8 @@ capability:
   basis_detail: ablation
   value: null
   confidence: high
-  note: 'Dominates FineWeb and all peers on MMLU/ARC, matching full FineWeb with ~10x fewer tokens; current
-    default web corpus for SmolLM2/3 and Apertus. Re-read 2026-08-13: the FineWeb listing still states that
-    LLMs pretrained on FineWeb-Edu do dramatically better on MMLU and ARC, and the SmolLM2 listing still
-    describes an 11T-token mix of web text with specialised math, code and instruction data.'
+  note: Dominates FineWeb and all peers on MMLU/ARC, matching full FineWeb with ~10x fewer tokens; current
+    default web corpus for SmolLM2/3 and Apertus.
   last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2406.17557

--- a/sources/scores/fineweb.yaml
+++ b/sources/scores/fineweb.yaml
@@ -12,9 +12,7 @@ openness:
     format:
       value: parquet
   confidence: high
-  note: 'Permissive ODC-BY license with ungated download and a full dataset card. Re-read 2026-08-13: the
-    Hub still tags the release odc-by, the API reports gated false, and the card is intact, so licence,
-    availability and documentation are unchanged.'
+  note: Permissive ODC-BY license with ungated download and a full dataset card.
   raw: license:ODC-BY;gated:false;dataset_card:present;format:parquet
   last_verified: '2026-08-13'
   sources:
@@ -32,9 +30,8 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: 418,578 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (HuggingFaceFW/fineweb 418,578). Bands at level 4 (100K-1M) on the dataset adoption scale, whose top
-    band is >1M.
+  note: 418,578 downloads in the trailing 30 days summed across the 1 declared artifact(s) (HuggingFaceFW/fineweb
+    418,578). Bands at level 4 (100K-1M) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/HuggingFaceFW/fineweb
@@ -48,11 +45,8 @@ capability:
   basis_detail: ablation
   value: null
   confidence: high
-  note: 'The FineWeb paper''s 1.7B ablation beats C4, RefinedWeb, RedPajama, Dolma, The Pile, and OSCAR;
-    but its FineWeb-Edu subset is the preferred quality source. Re-read 2026-08-13: the arXiv listing still
-    describes FineWeb as a 15T-token Common Crawl dataset that produces better-performing LLMs than other
-    open pretraining datasets, and still introduces FineWeb-Edu as the filtered subset with dramatically
-    better MMLU and ARC results, which is the reason this sits a band below it.'
+  note: The FineWeb paper's 1.7B ablation beats C4, RefinedWeb, RedPajama, Dolma, The Pile, and OSCAR; but
+    its FineWeb-Edu subset is the preferred quality source.
   relative_to: fineweb-edu
   relation: one_below
   last_verified: '2026-08-13'

--- a/sources/scores/firecracker.yaml
+++ b/sources/scores/firecracker.yaml
@@ -17,11 +17,7 @@ openness:
     - no-feature-gated-core
   confidence: high
   note: Fully Apache-2.0, source public, no gated core; AWS-developed but openly governed (recipe lists
-    Firecracker as an open_source exemplar). Re-read 2026-08-13 against the GitHub repo API and the raw
-    README rather than the rendered repo page. The API reports spdx_id Apache-2.0, language Rust, not
-    archived, and a push the same day; the README states Firecracker "is open sourced under Apache version
-    2.0", gives build-from-source instructions for the whole VMM, and names no paid or withheld edition.
-    Score and class unchanged.
+    Firecracker as an open_source exemplar).
   raw: license:Apache-2.0(OSI);source:public(Rust 78.7%);governance:AWS-led open project;no-feature-gated-core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -55,17 +51,13 @@ adoption:
   signal_type: usage_volume
   confidence: high
   note: 'Underpins AWS Lambda and AWS Fargate, among the highest-volume serverless platforms in the world
-    (trillions of invocations), plus downstream use in Kata Containers, Flintlock, and E2B. Production
-    reach far exceeds >10M end-equivalent. (36,040 stars corroborate only.) Re-read 2026-08-13: the README
-    still states Firecracker was developed at AWS to accelerate AWS Lambda and AWS Fargate and has been
-    integrated into Kata Containers and Flintlock, and the AWS launch post still carries "Lambda processes
-    trillions of executions for hundreds of thousands of active customers every month" and Fargate running
-    "tens of millions of containers for AWS customers every week". Level unchanged at 5. Instrument
-    caveat, recorded rather than fixed: `usage_volume` names a count, and there is no countable artifact
-    behind this - Firecracker ships as a statically linked Rust binary from GitHub releases, not as a
-    package on any registry a signal model reads, and its PyPI namesake is not its distribution channel.
-    The band rests on reported AWS platform volume, so the instrument is flagged for a human ruling
-    rather than relabelled here.'
+    (trillions of invocations), plus downstream use in Kata Containers, Flintlock, and E2B. Production reach
+    far exceeds >10M end-equivalent. (36,040 stars corroborate only.) Instrument caveat, recorded rather
+    than fixed: `usage_volume` names a count and there is no countable artifact behind this - Firecracker
+    ships as a statically linked Rust binary from GitHub releases rather than as a package on any registry
+    a signal model reads, and its PyPI namesake is not its distribution channel. The band rests on reported
+    AWS platform volume - trillions of Lambda executions monthly and tens of millions of Fargate containers
+    weekly - so the instrument is flagged for a human ruling rather than relabelled here.'
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/firecracker-microvm/firecracker
@@ -99,10 +91,7 @@ capability:
   confidence: high
   note: 'Frontier-definer for the deployment category: hardware-VM isolation at container-like speed/density,
     the reference microVM that the managed sandbox layer (E2B, others) builds on. Defines the strongest
-    point on the isolation x cold-start x scale matrix. Re-read 2026-08-13. Both cited figures are still
-    on the AWS launch post - "you can launch a microVM in as little as 125 ms today" and "Firecracker
-    consumes about 5 MiB of memory per microVM" - and the README still describes a KVM-based VMM with a
-    deliberately minimal device model running container and function workloads. Score unchanged at 5.'
+    point on the isolation x cold-start x scale matrix.'
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/firecracker-microvm/firecracker

--- a/sources/scores/firecrawl.yaml
+++ b/sources/scores/firecrawl.yaml
@@ -18,12 +18,12 @@ openness:
         both require Fire-engine
   confidence: high
   note: 'AGPL-3.0 OSI core is fully open, but a piece of the product is withheld from it. `core-gated: gated`
-    verified 2026-08-12 by a direct read, replacing a justification that rested on the managed cloud carrying
-    "additional features" - an inference from the pricing page, which the rubric does not accept as evidence.
-    The mechanism has a name: Fire-engine, Firecrawl''s scraping engine, whose source is in no public repo.
-    What firecrawl/firecrawl ships at apps/api/src/scraper/scrapeURL/engines/fire-engine is a client - index.ts,
-    scrape.ts, checkStatus.ts, delete.ts, brandingScript.ts - pointed at a URL you must be given, and apps/api/.env.example
-    says so in one line: "# set if you''d like to use the fire engine closed beta" above FIRE_ENGINE_BETA_URL=.
+    comes from a direct read, replacing a justification that rested on the managed cloud carrying "additional
+    features" - an inference from the pricing page, which the rubric does not accept as evidence. The mechanism
+    has a name: Fire-engine, Firecrawl''s scraping engine, whose source is in no public repo. What firecrawl/firecrawl
+    ships at apps/api/src/scraper/scrapeURL/engines/fire-engine is a client - index.ts, scrape.ts, checkStatus.ts,
+    delete.ts, brandingScript.ts - pointed at a URL you must be given, and apps/api/.env.example says so
+    in one line: "# set if you''d like to use the fire engine closed beta" above FIRE_ENGINE_BETA_URL=.
     The self-hosting guide then states what the open build cannot do without it - screenshots and page actions
     are "Not available in the default stack. Fetch and Playwright both report no support; both require Fire-engine",
     Fire-engine must be "run and configured separately; it is not included", and the agent, browser, interact
@@ -90,17 +90,14 @@ adoption:
   reach: '>10K stars'
   signal_type: stars_fallback
   confidence: low
-  note: 'No verified download/API-volume or customer count disclosed on repo or pricing page; only ~129k
-    GitHub stars available as an honest signal. Capped at level 3 per stars_fallback rule. Widely integrated
-    as an agent scrape tool (LangChain, etc.) but no primary usage figure found this run. Stars read
-    2026-08-13: 166,749 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in
-    signal_routing.yaml. The previous reach ''100K-1M'' was not a label this instrument offers - stars have
-    their own vocabulary because a star is not a download. Re-read in full 2026-08-13: the repo page reports
-    166,863 stargazers, which is the same band, and the repo and the pricing page still publish no download,
-    request-volume or customer count of any kind - a paid API sells credits rather than reporting usage,
-    so there is nothing here to band as usage_volume. The stars fallback and its level-3 cap therefore both
-    stand. The digest below is of a page carrying a live star counter and will not match on a later refetch;
-    that is expected drift on this source rather than a signal about the claim.'
+  note: 'Neither the repo nor the pricing page publishes a download, request-volume or customer count of
+    any kind - a paid API sells credits rather than reporting usage - so there is nothing here to band as
+    usage_volume. The only honest signal is GitHub stars: 166,863 across the 1 declared repo, which bands
+    at >10K stars, level 3 on the stars scale in signal_routing.yaml, and the stars_fallback rule caps the
+    level there. Widely integrated as an agent scrape tool (LangChain, etc.). The previous reach ''100K-1M''
+    was not a label this instrument offers - stars have their own vocabulary because a star is not a download.
+    The digest below is of a page carrying a live star counter and will not match on a later refetch; that
+    is expected drift on this source rather than a signal about the claim.'
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/mendableai/firecrawl
@@ -116,11 +113,7 @@ capability:
   confidence: medium
   note: 'Broad scrape/browse feature coverage (the recipe''s search/scrape dimensions: coverage, freshness,
     structured output, rate limits), among the most capable open scrape tools; not a 5 (no benchmark, and
-    frontier reserved for category-definers). Re-read 2026-08-13: the README still carries both figures
-    the recorded value quotes, verbatim - "Industry-leading reliability: Covers 96% of the web, including
-    JS-heavy pages" and "Blazingly fast: P95 latency of 3.4s across millions of pages" - and both remain
-    vendor-run rather than independently benchmarked, which is why the basis stays feature_matrix and the
-    band stays 4.'
+    frontier reserved for category-definers).'
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/mendableai/firecrawl

--- a/sources/scores/fireworks-fine-tuning.yaml
+++ b/sources/scores/fireworks-fine-tuning.yaml
@@ -38,14 +38,11 @@ adoption:
   reach: null
   signal_type: unknown
   confidence: low
-  note: 'No disclosed standalone usage figure for the Fireworks fine-tuning feature located this run (jobs run
-    / customers tuning). Fireworks serves notable inference volume, but no honest signal specific to the FT
-    SKU was found; declining to assign a level.  ABSTENTION RE-CONFIRMED 2026-08-13, and the date records that
-    rather than a measurement. Re-read the cited page and no usage figure has appeared - no jobs run,
-    customers tuning, models fine-tuned or developer count. A null level is a value here, not a gap: it says
-    somebody looked and the vendor publishes nothing, which is the honest answer for a feature sold inside a
-    larger platform. The corpus already dates abstentions this way (9 null axes carry a last_verified), and
-    leaving them undated would make an axis unverifiable forever purely because its answer is ''none''.'
+  note: 'No disclosed standalone usage figure exists for the Fireworks fine-tuning feature - no jobs run,
+    customers tuning, models fine-tuned or developer count. Fireworks serves notable inference volume, but
+    no honest signal specific to the FT SKU is published, so no level is assigned. A null level is a value
+    here rather than a gap: it says somebody looked and the vendor publishes nothing, which is the honest
+    answer for a feature sold inside a larger platform.'
   last_verified: '2026-08-13'
   sources:
   - url: https://docs.fireworks.ai/fine-tuning/fine-tuning-models

--- a/sources/scores/fireworks-inference.yaml
+++ b/sources/scores/fireworks-inference.yaml
@@ -13,12 +13,11 @@ openness:
     license:
     - name: Proprietary
   confidence: high
-  note: 'Proprietary FireAttention inference engine offered only as a managed cloud service; closed per
-    recipe. Re-checked 2026-08-09: fireworks.ai homepage carries no self-host, on-prem, VPC/BYOC, or repository
-    link anywhere on the page (searched for ''self-host'', ''on-prem'', ''VPC'', ''BYOC'', ''github.com'';
-    none found), consistent with source:closed. No LICENSE or license grant is published for the engine
-    itself, consistent with license:Proprietary under this ladder''s own definition (''no license to the
-    source, because the source is not published'').'
+  note: Proprietary FireAttention inference engine offered only as a managed cloud service; closed per recipe.
+    The fireworks.ai homepage carries no self-host, on-prem, VPC/BYOC or repository link anywhere on the
+    page (searched for 'self-host', 'on-prem', 'VPC', 'BYOC', 'github.com'; none found), consistent with
+    source:closed, and no LICENSE or license grant is published for the engine itself, consistent with license:Proprietary
+    under this ladder's own definition ('no license to the source, because the source is not published').
   last_verified: '2026-08-09'
   raw: engine:proprietary(FireAttention kernels);source:closed;access:managed-cloud-API-only;license:Proprietary
   sources:
@@ -38,11 +37,11 @@ adoption:
   confidence: medium
   banded_quantity: named high-volume production customers, not a user count
   note: 'Strong named-customer roster including Cursor, Vercel, Notion, Sourcegraph, UiPath, Quora, Cresta,
-    StackBlitz; serves top open models for many high-traffic AI products. No raw user count disclosed; reported_traction.
-    Breadth of high-volume production customers supports the 1-10M-equivalent band. Re-confirmed 2026-08-09:
-    all eight customer logos/case studies still present on the homepage, including the Notion quote (Sarah
-    Sachs, AI Lead: latency cut from about 2 seconds to 350 milliseconds) and the Quora quote (Spencer Chan,
-    Product Lead: 3x speedup in response time).'
+    StackBlitz; serves top open models for many high-traffic AI products. All eight customer logos and case
+    studies are present on the homepage, including the Notion quote (Sarah Sachs, AI Lead: latency cut from
+    about 2 seconds to 350 milliseconds) and the Quora quote (Spencer Chan, Product Lead: 3x speedup in
+    response time). No raw user count disclosed; reported_traction. Breadth of high-volume production customers
+    supports the 1-10M-equivalent band.'
   last_verified: '2026-08-09'
   sources:
   - url: https://fireworks.ai/
@@ -64,17 +63,12 @@ capability:
     Customer case studies, re-confirmed 2026-08-13: Notion ~2s -> 350ms latency (Sarah Sachs, AI Lead),
     Quora 3x speedup (Spencer Chan, Product Lead).'
   confidence: medium
-  note: 'Top-tier GPU-based inference (FireAttention), below the wafer/LPU speed frontier. SCORE UNCHANGED
-    AT 4; what changed is that it can now be re-derived. The 2026-08-09 pass held this axis undated rather
-    than re-date it, because the basis it cited - 3rd on the AA gpt-oss-120b providers board at 658.8 t/s,
-    read 2026-06-04 - had ceased to exist: Fireworks no longer appears on that board at all. Refusing the
-    date was right, and it left the axis stuck, because the missing evidence was never replaced.
-
-    Re-derived 2026-08-13 on AA''s own Fireworks PROVIDER page, which does carry current figures for the
-    10 models it serves. The model board and the provider page are the same instrument read from two
-    directions; a product dropping off a per-model board is a fact about that board''s coverage, not about
-    the product. The gpt-oss-120b page is kept as a cited source because it is what establishes where the
-    speed frontier sits, and it is now re-read rather than remembered.'
+  note: Top-tier GPU-based inference (FireAttention), below the wafer/LPU speed frontier. The band rests
+    on Artificial Analysis's Fireworks provider page, which carries current figures for the 10 models Fireworks
+    serves, topping out at 459 t/s output speed. Fireworks does not appear on AA's per-model gpt-oss-120b
+    providers board, which is a fact about that board's coverage rather than about the product; that board
+    is kept as a cited source because it is what establishes where the speed frontier sits (Cerebras 1,820.3,
+    SambaNova 701.3, Groq 475.9 output t/s).
   last_verified: '2026-08-13'
   sources:
   - url: https://artificialanalysis.ai/providers/fireworks
@@ -85,9 +79,9 @@ capability:
     http_status: 200
     content_sha256: 7eb36fe33f25847786dcfc510fb3783d4447d433122bf1f0b895bdc53912fb7d
   - url: https://artificialanalysis.ai/models/gpt-oss-120b/providers
-    shows: 'the speed frontier this band is placed against, re-read 2026-08-13: Cerebras 1,820.3, SambaNova
-      701.3, Groq 475.9, Google Vertex 362.7, Azure 310.5 output t/s - and still no Fireworks entry, which
-      is why the provider page rather than this one carries the basis'
+    shows: 'The speed frontier this band is placed against: Cerebras 1,820.3, SambaNova 701.3, Groq 475.9,
+      Google Vertex 362.7, Azure 310.5 output t/s - and no Fireworks entry, which is why the provider page
+      rather than this one carries the basis.'
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 5071ab85b53372112bbdfe4b54e7e94e570db319d44f626ae098d9d3538a20ca

--- a/sources/scores/flan-collection.yaml
+++ b/sources/scores/flan-collection.yaml
@@ -13,14 +13,11 @@ openness:
     dataset_card:
       value: partial
   confidence: medium
-  note: 'Released as an Apache-2.0 recipe/repo; the widely used HF conversion (ai2-adapt-dev) is ungated.
+  note: Released as an Apache-2.0 recipe/repo; the widely used HF conversion (ai2-adapt-dev) is ungated.
     Underlying task datasets keep their own licenses, so the Apache-2.0 covers the recipe and not the corpus
     - the license defers to its components, as `the-pile` and `stack-edu` do. Scored 4 until 2026-08-11
     on a resolver that truncated the license at the first parenthesis and so read a clean Apache-2.0; reading
-    the whole value puts it on the deferred-license rung, and a partial card takes it to 3. Re-read 2026-08-13:
-    the google-research/FLAN repo is still Apache-2.0 for the recipe code, and the ai2-adapt-dev conversion
-    is still ungated with a card that documents the conversion and defers the licence to the original FLAN
-    v2 repo.'
+    the whole value puts it on the deferred-license rung, and a partial card takes it to 3.
   raw: access:ungated(conversion);license:Apache-2.0(recipe)+per-task;dataset_card:partial
   last_verified: '2026-08-13'
   sources:
@@ -45,9 +42,8 @@ adoption:
   reach: <1K
   signal_type: usage_volume
   confidence: high
-  note: 108 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (ai2-adapt-dev/flan_v2_converted 108). Bands at level 1 (<1K) on the dataset adoption scale, whose top
-    band is >1M.
+  note: 108 downloads in the trailing 30 days summed across the 1 declared artifact(s) (ai2-adapt-dev/flan_v2_converted
+    108). Bands at level 1 (<1K) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/ai2-adapt-dev/flan_v2_converted
@@ -61,10 +57,10 @@ capability:
   basis_detail: superseded
   value: null
   confidence: high
-  note: 'Strong historical comparative ablations (Flan 2022 beats P3/T0/SNI on the same T5-XL) and still
-    a component in Tulu 3, Dolci, and Marin''s mixes, but dated as a standalone chat-era recipe. Re-read
-    2026-08-13: the Flan Collection listing still reports Flan-T5 outperforming prior work by 3-17%+ across
-    evaluation settings, and the Dolci SFT card still consumes FLAN v2.'
+  note: Strong historical comparative ablations (Flan 2022 beats P3/T0/SNI on the same T5-XL) and still
+    a component in Tulu 3, Dolci, and Marin's mixes, but dated as a standalone chat-era recipe. The Flan
+    Collection reports Flan-T5 outperforming prior work by 3-17%+ across evaluation settings, and the Dolci
+    SFT card still consumes FLAN v2.
   last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2301.13688

--- a/sources/scores/flax.yaml
+++ b/sources/scores/flax.yaml
@@ -13,10 +13,9 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: 'Apache-2.0 licensed with full public source. Re-read 2026-08-13: the cited repo page still carries
-    the Apache-2.0 terms, the GitHub API reports the repository public, unarchived and licensed Apache-2.0,
-    and the README describes the whole library with no paid, enterprise or hosted tier beside it, so source
-    stays public and core-gated stays ungated.'
+  note: Apache-2.0 licensed with full public source. The repository is public and unarchived, and the README
+    describes the whole library with no paid, enterprise or hosted tier beside it, so source is public and
+    the core ungated.
   raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -51,13 +50,9 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: '5.3M PyPI downloads in the last 30 days, just above the 5M Level-4 threshold. Read live 2026-08-13:
-    4,482,096 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at 1M-10M,
-    level 4. The previous reach ''5M+/mo'' was free text carrying a figure rather than a band the scale
-    declares, so nothing could check it against the level beside it. No last_verified claimed: only the
-    figure was re-read, not the whole axis. Re-read 2026-08-13 from the cited pepy.tech reading of the declared
-    PyPI artifact `flax`: 4,666,653 downloads in the trailing 30 days, which bands at 1M-10M, level 4 on
-    the software scale. Unchanged.'
+  note: 4,666,653 PyPI downloads in the trailing 30 days for the declared artifact `flax`, which bands at
+    1M-10M, level 4 on the software scale. The previous reach '5M+/mo' was free text carrying a figure rather
+    than a band the scale declares, so nothing could check it against the level beside it.
   last_verified: '2026-08-13'
   sources:
   - url: https://pepy.tech/projects/flax
@@ -70,10 +65,7 @@ capability:
   basis: feature_matrix
   value: 'Neural network library on top of JAX: layers, attention, training utilities, Flax NNX API.'
   confidence: high
-  note: 'Key NN layer for the JAX ecosystem but built atop JAX rather than foundational itself. Re-read
-    2026-08-13: the cited repository page still describes the product as recorded, so the band is unchanged.
-    The ''built atop JAX rather than foundational itself'' placement this note already made is now recorded
-    as relative_to/relation - one below JAX''s 5.'
+  note: Key NN layer for the JAX ecosystem but built atop JAX rather than foundational itself.
   relative_to: jax
   relation: one_below
   last_verified: '2026-08-13'

--- a/sources/scores/fly-sprites.yaml
+++ b/sources/scores/fly-sprites.yaml
@@ -19,10 +19,9 @@ openness:
       detail: Firecracker itself is OSS/AWS, but the Sprites product/orchestration is proprietary
   confidence: high
   note: Proprietary managed sandbox SaaS; no open source runtime published (only client SDKs). Underlying
-    Firecracker is OSS but the product is not. Re-read 2026-08-13 - sprites.dev now redirects to fly.io/sprites,
-    which still ships only client surfaces (a CLI installer, a REST API, and JavaScript, Go, Elixir and
-    Python SDKs) against a hosted Fly.io control plane, with metered CPU, memory and storage pricing and
-    no self-hostable runtime or source release.
+    Firecracker is OSS but the product is not. The product page (now fly.io/sprites) ships only client surfaces
+    - a CLI installer, a REST API, and JavaScript, Go, Elixir and Python SDKs - against a hosted Fly.io
+    control plane, with metered CPU, memory and storage pricing and no self-hostable runtime or source release.
   raw: license:Proprietary;service:proprietary(Fly.io managed);source:closed;clients:CLI/REST/JS/Go SDKs
     (client libs only, no open runtime);isolation:Firecracker(Firecracker itself is OSS/AWS, but the Sprites
     product/orchestration is proprietary)
@@ -41,11 +40,10 @@ adoption:
   confidence: low
   note: Launched Jan 2026 (~5 months at scoring time) as Fly.io's answer to E2B. No disclosed user/customer/usage
     counts on the product page or launch coverage; positioned for AI coding-agent sessions (Claude Code/Codex).
-    Early-stage; placed at 1 on reported traction with low confidence pending real numbers. Re-read 2026-08-13
-    - the product page (now fly.io/sprites) still publishes no user, customer, session or sprite count of
-    any kind; the only numbers on it are the per-CPU-hour, per-GB-hour and per-GB-hour-storage prices, which
-    are unchanged at $0.07/CPU-hr. The abstention from a count is re-confirmed, so the record stays
-    reported_traction with no reach word.
+    Early-stage; placed at 1 on reported traction with low confidence pending real numbers. The product
+    page (now fly.io/sprites) publishes no user, customer, session or sprite count of any kind; the only
+    numbers on it are the per-CPU-hour, per-GB-hour and per-GB-hour-storage prices, $0.07 per CPU-hour among
+    them. That abstention from a count is why the record stays reported_traction with no reach word.
   last_verified: '2026-08-13'
   sources:
   - url: https://sprites.dev/
@@ -67,16 +65,15 @@ capability:
     sessions (a key differentiator); language/runtime breadth: arbitrary Linux (''any code blob''); scale:
     Fly.io global infra'
   confidence: medium
-  note: Top-tier microVM isolation plus persistent stateful sandboxes (explicitly anti-ephemeral) is a
-    strong, differentiated feature set. Not a 5 only because it is brand-new with unproven scale vs incumbents;
-    isolation + persistence are best-in-class. Re-read 2026-08-13 - the product page moved to fly.io/sprites
-    and was rewritten around persistence and checkpointing; it now describes tiered storage backed by object
-    storage, a 100 GB POSIX volume, live copy-on-write checkpoints taken automatically on idle and shutdown,
-    per-sprite URLs and an outbound API gateway, but it no longer states the isolation mechanism or the
-    1-12s cold and sub-1s restore latencies the band was written against. Those were re-derived instead
-    from the vendor Sprites overview, which states that each Sprite is a Firecracker microVM with its own
-    kernel and filesystem, isolated in hardware from every other Sprite, and that it spins up in seconds.
-    Vendor prose no longer publishes a bounded cold-start figure.
+  note: Top-tier microVM isolation plus persistent stateful sandboxes (explicitly anti-ephemeral) is a strong,
+    differentiated feature set. Not a 5 only because it is brand-new with unproven scale vs incumbents;
+    isolation + persistence are best-in-class. The product page is now written around persistence and checkpointing
+    - tiered storage backed by object storage, a 100 GB POSIX volume, live copy-on-write checkpoints taken
+    automatically on idle and shutdown, per-sprite URLs and an outbound API gateway - and it no longer states
+    the isolation mechanism or the 1-12s cold and sub-1s restore latencies the band was written against.
+    Those rest instead on the vendor Sprites overview, which states that each Sprite is a Firecracker microVM
+    with its own kernel and filesystem, isolated in hardware from every other Sprite, and that it spins
+    up in seconds. Vendor prose publishes no bounded cold-start figure.
   last_verified: '2026-08-13'
   sources:
   - url: https://sprites.dev/

--- a/sources/scores/gaia.yaml
+++ b/sources/scores/gaia.yaml
@@ -17,13 +17,10 @@ openness:
       value: HF-gated
       detail: accept-terms,anti-resharing
   confidence: high
-  note: 'Test answers are private and the dataset itself is access-gated. A read on 2026-08-12 established
-    that no license is stated anywhere the project publishes: the Hub API returns no license field and no
-    license tag, the gated card states only the no-resharing condition, and the paper states no release
-    terms. Recorded as unstated, which is a fact rather than a guess; the held-out answers decide the score
-    either way. Re-read 2026-08-13 - the Hub API still returns no license key and no license tag, the
-    card still reads "a test set with private answers and metadata" alongside a fully public dev set,
-    and the gate is still `"gated":"auto"` with the no-resharing checkbox. All four values stand.'
+  note: 'Test answers are private and the dataset itself is access-gated. No license is stated anywhere
+    the project publishes: the Hub API returns no license field and no license tag, the gated card states
+    only the no-resharing condition, and the paper states no release terms. Recorded as unstated, which
+    is a fact rather than a guess; the held-out answers decide the score either way.'
   raw: license:not-clearly-stated-on-card(the Hub API cardData carries no license key and no license tag;
     the card states only the no-resharing condition, and the paper states no release terms);questions:public(val);answers:held-out(300-Q
     test,private);access:HF-gated(accept-terms,anti-resharing)
@@ -40,7 +37,7 @@ openness:
     establishes: [access, answers]
   - url: https://huggingface.co/api/datasets/gaia-benchmark/GAIA
     shows: cardData carries no license key and the tags array carries no license tag; gating is auto with
-      a no-resharing condition. Re-read 2026-08-13 and still true
+      a no-resharing condition
     accessed: '2026-08-13'
     establishes:
     - license
@@ -50,10 +47,10 @@ adoption:
   level: 3
   signal_type: usage_volume
   confidence: high
-  note: 17,975 Hugging Face downloads in the trailing 30 days for gaia-benchmark/GAIA, read 2026-08-12.
-    Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M - one order of magnitude
-    below software and model. Cited across agent evaluation harnesses; the figure has fallen sharply since
-    June. Corrected from level 4, which the recorded evidence did not support.
+  note: 17,975 Hugging Face downloads in the trailing 30 days for gaia-benchmark/GAIA. Bands at level 3
+    (10K-100K) on the dataset adoption scale, whose top band is >1M - one order of magnitude below software
+    and model. Cited across agent evaluation harnesses; the figure has fallen sharply since June. Corrected
+    from level 4, which the recorded evidence did not support.
   reach: 10K-100K
   last_verified: '2026-08-12'
   sources:
@@ -67,11 +64,8 @@ capability:
   basis: feature_matrix
   value: 466 questions, 3 levels; multi-step tool use, live browsing, multi-modal files with one checkable answer
   confidence: high
-  note: The canonical end-to-end agentic-assistant benchmark; distinct from knowledge and code benchmarks, contamination-resistant.
-    Re-read 2026-08-13 - the abstract still gives all three facts the recorded value states, the 466
-    questions, the three difficulty levels resting on tool use and browsing, and the retained answers
-    behind the leaderboard. Band unchanged at 5. No peer is named in this note, so relative_to/relation
-    stay unset.
+  note: The canonical end-to-end agentic-assistant benchmark; distinct from knowledge and code benchmarks,
+    contamination-resistant. No peer is named in this note, so relative_to and relation stay unset.
   last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2311.12983

--- a/sources/scores/galileo.yaml
+++ b/sources/scores/galileo.yaml
@@ -14,9 +14,7 @@ openness:
     - no-OSS-core(open source contributions exist as separate tools/benchmarks, not the product)
   confidence: high
   note: Proprietary platform; recipe lists Galileo explicitly as a closed example. No OSI-licensed core
-    product. Re-read 2026-08-13 and unchanged - the homepage sells an Agent Reliability platform and its
-    Luna evaluation models, links no repository for either, and offers no license text or self-hosted build
-    of the product.
+    product.
   raw: license:proprietary;source:closed;deploy:SaaS/VPC/on-prem(managed);no-OSS-core(open source contributions
     exist as separate tools/benchmarks, not the product)
   last_verified: '2026-08-13'
@@ -38,9 +36,7 @@ adoption:
   confidence: low
   note: Vendor states 'trusted by leading enterprises' but discloses no named customers or quantitative
     user/usage figures on the homepage. Level 3 reflects established commercial traction without a verified
-    count; treat as directional. Re-read 2026-08-13 and unchanged - the phrase is still there verbatim and
-    there is still no number of any kind beside it, so the band stays where an unquantified vendor claim
-    puts it.
+    count; treat as directional.
   last_verified: '2026-08-13'
   sources:
   - url: https://galileo.ai/
@@ -62,9 +58,8 @@ capability:
   relation: at
   note: Strong feature coverage across the recipe matrix; the offline-eval-to-production-guardrail loop
     and purpose-built Luna eval models are differentiators. OTel support not confirmed on the homepage.
-    Capped at 4 (MLflow/Langfuse anchors hold C4); not a frontier-definer over the OSS anchors. The
-    comparison is now recorded rather than left in prose - at the langfuse anchor. Re-read 2026-08-13 -
-    the Luna models and the measure/protect/improve loop are still the page's central claim.
+    Capped at 4 (MLflow/Langfuse anchors hold C4); not a frontier-definer over the OSS anchors. The comparison
+    is now recorded rather than left in prose - at the langfuse anchor.
   last_verified: '2026-08-13'
   sources:
   - url: https://galileo.ai/

--- a/sources/scores/garak.yaml
+++ b/sources/scores/garak.yaml
@@ -15,8 +15,7 @@ openness:
     core-gated:
       value: ungated
   confidence: high
-  note: 'Fully open source: Apache-2.0 scanner, self-hostable, no proprietary tier. Re-read 2026-08-13 and
-    unchanged.'
+  note: 'Fully open source: Apache-2.0 scanner, self-hostable, no proprietary tier.'
   raw: license:Apache-2.0(OSI);source:public;self-host:yes;service:none;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -37,10 +36,10 @@ adoption:
   reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
-  note: 8,783 GitHub stars on NVIDIA/garak, read 2026-08-12. Bands at level 2 (1K-10K stars) on the stars
-    fallback scale, which caps at 3 because a star is not a use. Resynced because the note says 'stars-only
-    proxy, capped per methodology' and recorded the cap. No download, install or customer figure is published
-    for this product, so stars remain the only honest signal and the level is directional.
+  note: 8,783 GitHub stars on NVIDIA/garak. Bands at level 2 (1K-10K stars) on the stars fallback scale,
+    which caps at 3 because a star is not a use. Resynced because the note says 'stars-only proxy, capped
+    per methodology' and recorded the cap. No download, install or customer figure is published for this
+    product, so stars remain the only honest signal and the level is directional.
   last_verified: '2026-08-12'
   sources:
   - url: https://api.github.com/repos/NVIDIA/garak
@@ -55,8 +54,7 @@ capability:
   value: Large library of vulnerability probes (hallucination, leakage, injection, misinformation, toxicity,
     jailbreaks) across many model providers.
   confidence: medium
-  note: Broadest open library of LLM vulnerability probes; multi-provider coverage. Re-read 2026-08-13 and
-    unchanged.
+  note: Broadest open library of LLM vulnerability probes; multi-provider coverage.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/NVIDIA/garak

--- a/sources/scores/gemini-cli.yaml
+++ b/sources/scores/gemini-cli.yaml
@@ -13,11 +13,7 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: 'Fully Apache-2.0; commercial relationship is on model quotas, not the tool. Re-read 2026-08-13
-    - the repo page still reports Apache-2.0 and the README says so three times over, listing "Open source
-    - Apache 2.0 licensed" as a headline property, stating "Gemini CLI is fully open source (Apache 2.0)"
-    under contributing, and naming Apache License 2.0 under Legal. The full TypeScript source is published
-    with no enterprise directory or license key. Stars are now 106.5k. Nothing moved.'
+  note: Fully Apache-2.0; commercial relationship is on model quotas, not the tool.
   raw: license:Apache-2.0(OSI);source:public;no-feature-gated-core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -36,9 +32,9 @@ adoption:
   level: 4
   signal_type: usage_volume
   confidence: high
-  note: 1,850,744 npm downloads in the trailing 30 days for @google/gemini-cli, read 2026-08-12. Bands at
-    level 4 (1M-10M) on the software and model adoption scale. Google's first-party terminal agent. Corrected
-    from level 5, which the recorded evidence did not support.
+  note: 1,850,744 npm downloads in the trailing 30 days for @google/gemini-cli. Bands at level 4 (1M-10M)
+    on the software and model adoption scale. Google's first-party terminal agent. Corrected from level
+    5, which the recorded evidence did not support.
   reach: 1M-10M
   last_verified: '2026-08-12'
   sources:
@@ -53,11 +49,8 @@ capability:
   value: agentic terminal loop (read/write, shell, planning); MCP extensibility; built-in Google Search grounding;
     large context; OAuth/API-key/Vertex auth; VS Code + Actions integration
   confidence: high
-  note: 'Top-tier coding agent; Search grounding is a standout vs peers. Re-read 2026-08-13 - the launch
-    post still documents the same free tier, MCP extensibility and GEMINI.md system prompts, and the repo
-    still describes the terminal-first agentic loop with built-in Google Search grounding. No benchmark
-    placement is published for the CLI itself, so this stays a feature-matrix judgment. At the openhands
-    anchor on breadth.'
+  note: Top-tier coding agent; Search grounding is a standout vs peers. No benchmark placement is published
+    for the CLI itself, so this stays a feature-matrix judgment, at the openhands anchor on breadth.
   relative_to: openhands
   relation: at
   last_verified: '2026-08-13'

--- a/sources/scores/gemini-flash.yaml
+++ b/sources/scores/gemini-flash.yaml
@@ -14,13 +14,10 @@ openness:
       detail: Gemini app/Search/API/enterprise, no downloadable weights
   governing_release: gemini-3-5-flash
   confidence: high
-  note: Proprietary and API-only across the Flash line, no downloadable weights, so 1/closed. Gemini 3.5 Flash governs
-    as the current release and is a genuine capability jump - it scores 5 where 2.5 Flash scored 3 - which is why
-    the versions were worth combining rather than keeping the older figure. Held apart from Gemini Pro, which Google
-    prices and positions as a separate tier. Re-read 2026-08-13 - the Gemini 3.5 launch post still offers no
-    weight download, and DeepMind's own model index still files Gemini under the API and app products while
-    putting Gemma under a separate "Open models" heading, so the line is still drawn by the vendor rather
-    than inferred. No change.
+  note: Proprietary and API-only across the Flash line, no downloadable weights, so 1/closed. Gemini 3.5
+    Flash governs as the current release and is a genuine capability jump - it scores 5 where 2.5 Flash
+    scored 3 - which is why the versions were worth combining rather than keeping the older figure. Held
+    apart from Gemini Pro, which Google prices and positions as a separate tier.
   raw: weights:closed;data:closed;code:closed;license:Proprietary(Gemini app/Search/API/enterprise, no downloadable
     weights)
   last_verified: '2026-08-13'
@@ -43,13 +40,9 @@ adoption:
   reach: '>10M users'
   signal_type: active_users
   confidence: medium
-  note: High-volume cheap tier powering the Gemini app and AI Mode in Search plus heavy API/Vertex traffic; Gemini
-    app >750M MAU (TechCrunch, Feb 2026). Flash is the default high-volume serving model so its real usage is firmly
-    >10M-equivalent. Attributed to the app/Search surface, not a standalone download count. Re-read 2026-08-13
-    - the TechCrunch headline still reads "Google's Gemini app has surpassed 750M monthly active users",
-    which is roughly two orders above the >10M users floor, so the band is unambiguous. The banded quantity
-    is the app's monthly active users and the note says so out loud, which is what the active_users scale
-    requires. No change.
+  note: High-volume cheap tier powering the Gemini app and AI Mode in Search plus heavy API/Vertex traffic;
+    Gemini app >750M MAU (TechCrunch, Feb 2026). Flash is the default high-volume serving model so its real
+    usage is firmly >10M-equivalent. Attributed to the app/Search surface, not a standalone download count.
   last_verified: '2026-08-13'
   sources:
   - url: https://techcrunch.com/2026/02/04/googles-gemini-app-has-surpassed-750m-monthly-active-users/
@@ -69,10 +62,8 @@ capability:
   value: Terminal-Bench 2.1 76.2%, MCP Atlas 83.6%, CharXiv Reasoning 84.2%, GDPval-AA 1656 Elo; reported to lead
     Opus 4.7 and GPT-5.5 on several agentic/multimodal suites
   confidence: high
-  note: Frontier-tier; top-right of Artificial Analysis Intelligence Index. Scored 5, consistent with the flagship
-    anchor (cap 5). Google-reported figures. Re-read 2026-08-13 - all four figures are still on the launch
-    post in one sentence, and the "top-right quadrant of the Artificial Analysis" claim is still there too.
-    No change.
+  note: Frontier-tier; top-right of Artificial Analysis Intelligence Index. Scored 5, consistent with the
+    flagship anchor (cap 5). Google-reported figures.
   last_verified: '2026-08-13'
   sources:
   - url: https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/

--- a/sources/scores/gemini-pro.yaml
+++ b/sources/scores/gemini-pro.yaml
@@ -15,9 +15,7 @@ openness:
   confidence: high
   note: Closed by construction and stable across generations. Google's own model index files Gemini under
     API and app access while placing Gemma separately under "Open models", so the line is drawn by the vendor
-    rather than inferred. Measured against Gemini 3 Pro, the GA Pro release at the time of scoring. Re-read
-    2026-08-13 - the index still files Gemma under "Open models" and Gemini under the API and app products,
-    with no weight download anywhere for Gemini. No change.
+    rather than inferred. Measured against Gemini 3 Pro, the GA Pro release at the time of scoring.
   raw: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
   last_verified: '2026-08-13'
   sources:
@@ -34,11 +32,9 @@ adoption:
   confidence: medium
   banded_quantity: the Gemini app, AI Studio, API and Vertex surfaces the Pro tier powers, not a per-model
     count
-  note: Distributed through the Gemini API, AI Studio, Vertex AI and the Gemini apps, whose combined reach is
-    far above the >10M band floor. Attributed to the surfaces the Pro tier powers rather than a standalone
-    per-model count, so directional. Re-read 2026-08-13 - the index still shows the Pro tier across the Gemini
-    app, AI Studio, the API and Vertex, and Google still publishes no per-model count, so the abstention from
-    a number stands and `reach` correctly stays absent. No change.
+  note: Distributed through the Gemini API, AI Studio, Vertex AI and the Gemini apps, whose combined reach
+    is far above the >10M band floor. Attributed to the surfaces the Pro tier powers rather than a standalone
+    per-model count, so directional.
   last_verified: '2026-08-13'
   sources:
   - url: https://deepmind.google/models/gemini/
@@ -53,29 +49,16 @@ capability:
   basis_detail: GPQA-Diamond/HLE/SWE-bench Verified/LiveCodeBench Pro
   value: null
   confidence: medium
-  note: 'Frontier tier. Gemini 3 Pro is competitive at the top of LMArena, GPQA-Diamond and HLE, and the 3.1
-    Pro preview leads LiveCodeBench Pro with 80.6% on SWE-bench Verified. Confidence medium because the
-    strongest coding figures come from a preview checkpoint that is deliberately not tracked as a product.
-    Re-read 2026-08-13, and the cited source does NOT carry any of the figures in the note - the DeepMind
-    model index is a product listing, and the LMArena, GPQA-Diamond, HLE and SWE-bench claims appear nowhere
-    on it. The 5 rests on frontier positioning the page does support, but the specific numbers have no
-    source behind them on this axis.
-
-    Replacement found 2026-08-14 - the family index carries nothing, but the Pro page one level down
-    carries a full benchmark table in text, and it is DeepMind''s own. Gemini 3.1 Pro (Thinking High)
-    reads GPQA Diamond 94.3%, Humanity''s Last Exam 44.4% no tools, SWE-Bench Verified 80.6% single
-    attempt, LiveCodeBench Pro 2887 Elo, ARC-AGI-2 77.1%, Terminal-Bench 2.0 68.5%, against Sonnet 4.6,
-    Opus 4.6 and GPT-5.2 in the same table. It tops the comparison set on HLE, GPQA Diamond, ARC-AGI-2,
-    Terminal-Bench and LiveCodeBench Pro, which is what a 5 rests on.
-
-    Two things the page corrects. The old note said Gemini "leads LiveCodeBench Pro with 80.6% on
-    SWE-bench Verified", which conflated two benchmarks - the LiveCodeBench Pro lead is real at 2887 vs
-    2439 and 2393, but the 80.6% is SWE-bench Verified and is SECOND to Opus 4.6''s 80.8%, not leading.
-    And the reason confidence was held at medium - that the strongest figures came from a preview
-    checkpoint not tracked as a product - no longer holds, since 3.1 Pro is GA on DeepMind''s own Pro
-    page. Confidence is left at medium and FLAGGED for a ruling rather than raised here. The LMArena
-    clause is dropped from basis_detail and the note - arena.ai''s text board carries no Gemini Pro entry
-    in its top ten, so that claim has no source.'
+  note: 'Frontier tier. DeepMind''s own Gemini Pro page carries a benchmark table in body text: Gemini 3.1
+    Pro (Thinking High) reads GPQA Diamond 94.3%, Humanity''s Last Exam 44.4% with no tools, ARC-AGI-2 77.1%,
+    Terminal-Bench 2.0 68.5%, LiveCodeBench Pro 2887 Elo and SWE-bench Verified 80.6% single attempt, against
+    Sonnet 4.6, Opus 4.6 and GPT-5.2 in the same table. It tops that comparison set on HLE, GPQA Diamond,
+    ARC-AGI-2, Terminal-Bench and LiveCodeBench Pro, which is what the 5 rests on. Two limits on the reading:
+    the 80.6% is SWE-bench Verified and is SECOND to Opus 4.6''s 80.8% rather than leading, and no LMArena
+    placement is claimed, because arena.ai''s text board carries no Gemini Pro entry in its top ten. Confidence
+    stays medium and is FLAGGED for a ruling - the reason it was held there, that the strongest figures
+    came from a preview checkpoint not tracked as a product, no longer holds now that 3.1 Pro is GA on DeepMind''s
+    own Pro page.'
   last_verified: '2026-08-14'
   sources:
   - url: https://deepmind.google/models/gemini/pro/
@@ -87,8 +70,8 @@ capability:
     http_status: 200
     content_sha256: a61e8e87c170b874697552062b72480281ec5a1bfc0685af01b44b74ea3586e0
   - url: https://deepmind.google/models/gemini/
-    shows: Pro presented as the flagship reasoning tier of the Gemini family. Re-read 2026-08-13 - a product
-      listing only, carrying no benchmark figures.
+    shows: Pro presented as the flagship reasoning tier of the Gemini family; a product listing only, carrying
+      no benchmark figures.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: e2cdef7176ad7a1743962bc074f7b4bbe003b3f84f35f53d76858e22f1e92c24

--- a/sources/scores/gemini.yaml
+++ b/sources/scores/gemini.yaml
@@ -11,12 +11,7 @@ openness:
     license:
     - name: proprietary
       detail: SaaS app
-  note: Proprietary, SaaS-only consumer app; no source, no self-host. Closed counterpart in the ui_api
-    shelf.
-    Re-read 2026-08-13. The cited Google post is now the Gemini 3.5 launch and still describes a wholly
-    Google-operated product - 3.5 Flash reaching people through the Gemini app and AI Mode in Search,
-    developers through the Gemini API, and organizations through Gemini Enterprise. No weights, no
-    source, no self-host path. Value unchanged at 1 / closed.
+  note: Proprietary, SaaS-only consumer app; no source, no self-host. Closed counterpart in the ui_api shelf.
   raw: source:closed;self-host:none;license:proprietary(SaaS app)
   last_verified: '2026-08-13'
   sources:
@@ -31,13 +26,9 @@ adoption:
   reach: '>10M users'
   signal_type: active_users
   confidence: high
-  note: Google CEO Sundar Pichai officially stated the Gemini app surpassed 750M monthly active users
-    (Q4 2025 earnings, 4 Feb 2026), up from 450M earlier in 2025. Mass-market scale, far above >10M (broader
+  note: Google CEO Sundar Pichai officially stated the Gemini app surpassed 750M monthly active users (Q4
+    2025 earnings, 4 Feb 2026), up from 450M earlier in 2025. Mass-market scale, far above >10M (broader
     AI Overviews surface reaches ~2B, but the app itself is the cited figure).
-    Re-read 2026-08-13 - the TechCrunch report is still up and still carries Pichai stating the Gemini
-    app surpassed 750 million monthly active users. That is an active count from the vendor rather than
-    an aggregator estimate or a cumulative total, so nothing is substituted here, and the app figure
-    remains the one banded rather than the far larger AI Overviews reach. Level unchanged at 5.
   last_verified: '2026-08-13'
   sources:
   - url: https://techcrunch.com/2026/02/04/googles-gemini-app-has-surpassed-750m-monthly-active-users/
@@ -52,12 +43,8 @@ capability:
     audio, image-gen, voice/Live); tools: yes (web/Search grounding, Workspace, extensions); multi-user:
     yes (Workspace/Enterprise); deep Google ecosystem integration'
   confidence: high
-  note: 'Frontier consumer chat product within ui_api: full multimodal (Live voice, image-gen), Search
-    grounding, Workspace integration, extensions, enterprise. Sets the category bar alongside ChatGPT.
-    Re-read 2026-08-13. The cited post has moved on from Gemini 3.x to the Gemini 3.5 launch of 19 May
-    2026 and still supports the band - a frontier family reaching billions through the Gemini app and AI
-    Mode in Search, leading multimodal understanding, long-horizon agentic and coding work, and an
-    enterprise tier in Gemini Enterprise. Band unchanged at 5.'
+  note: 'Frontier consumer chat product within ui_api: full multimodal (Live voice, image-gen), Search grounding,
+    Workspace integration, extensions, enterprise. Sets the category bar alongside ChatGPT.'
   last_verified: '2026-08-13'
   sources:
   - url: https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/

--- a/sources/scores/gemma.yaml
+++ b/sources/scores/gemma.yaml
@@ -16,17 +16,14 @@ openness:
   governing_release: gemma-4
   confidence: medium
   note: 'Apache-2.0 weights, no open training data and no training code, so open_weights rather than a fully-open
-    pipeline. The tier reads 3 because Gemma 4 relicensed: Gemma 2 and 3 shipped under the non-OSI Gemma License
-    with a Prohibited-Use-Policy and scored 2, while all six Gemma 4 SKUs are Apache-2.0 and ungated, verified against
-    the Hub on 2026-07-29. The current release governs, so a family that becomes more open is recorded as such rather
-    than pinned to its worst historical release. Adoption 5 is carried from Gemma 2, which still out-downloads Gemma
-    4. Re-read 2026-08-13, and the re-read corrected a source rather than a value. The releases page
-    cited for the Apache-2.0 claim does not carry it - the only Apache text on that page is the site
-    footer covering code samples - so the license now rests on the Gemma 4 model card front matter and
-    on ai.google.dev/gemma/docs/gemma_4_license, which redirects to ai.google.dev/gemma/apache_2. The
-    card documents the pretraining mixture without releasing it and links no training pipeline, so
-    data and code are unchanged. The closing sentence about adoption being carried from Gemma 2 no
-    longer holds either - Gemma 4 now supplies 99% of the downloads.'
+    pipeline. The tier reads 3 because Gemma 4 relicensed: Gemma 2 and 3 shipped under the non-OSI Gemma
+    License with a Prohibited-Use-Policy and scored 2, while all six Gemma 4 SKUs are Apache-2.0 and ungated
+    on the Hub. The current release governs, so a family that becomes more open is recorded as such rather
+    than pinned to its worst historical release. The Apache-2.0 claim rests on the Gemma 4 model card front
+    matter and on ai.google.dev/gemma/docs/gemma_4_license, which redirects to ai.google.dev/gemma/apache_2;
+    the releases page carries no Apache statement for the models, only a site footer covering code samples.
+    The card documents the pretraining mixture without releasing it and links no training pipeline, so data
+    and code stay closed.'
   last_verified: '2026-08-13'
   raw: weights:open(Apache-2.0);data:closed;code:closed;license:Apache-2.0(OSI,but no open data/code)
   sources:
@@ -53,9 +50,8 @@ openness:
     content_sha256: b68286e35c25d3293e8013e7d988db561ba8100c1cc5308988640c948d60e193
     establishes: [license]
   - url: https://ai.google.dev/gemma/docs/releases
-    shows: Gemma 4 sizes and release dates. Re-read 2026-08-13 - it does NOT carry an Apache-2.0
-      statement for the models; the only Apache text is the site footer covering code samples. The
-      earlier `shows` claimed more than the page says.
+    shows: Gemma 4 sizes and release dates. It carries no Apache-2.0 statement for the models - the only
+      Apache text on the page is the site footer covering code samples.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 1bba6e91a79dd4550686b2372bd3515627156c92e56776b15ef672931b9ecc33
@@ -64,13 +60,12 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: medium
-  note: 20,118,549 downloads in the trailing 30 days summed across the 6 declared artifact(s), read
-    2026-08-13 (google/gemma-2-27b 6,087; google/gemma-2-9b 77,700; google/gemma-3-27b-pt 10,455;
-    google/gemma-3-12b-pt 34,590; google/gemma-4-31B-it 9,915,701; google/gemma-4-26B-A4B-it
-    10,074,016). Bands at level 5 (>10M) on the software and model adoption scale, unchanged. The
-    composition inverts what the openness note assumed - the two Gemma 4 SKUs are 99.4% of the total
-    and the Gemma 2 repos are now a rounding error, so adoption is no longer carried from an older
-    generation.
+  note: 20,118,549 downloads in the trailing 30 days summed across the 6 declared artifact(s) (google/gemma-2-27b
+    6,087; google/gemma-2-9b 77,700; google/gemma-3-27b-pt 10,455; google/gemma-3-12b-pt 34,590; google/gemma-4-31B-it
+    9,915,701; google/gemma-4-26B-A4B-it 10,074,016). Bands at level 5 (>10M) on the software and model
+    adoption scale, unchanged. The composition inverts what the openness note assumed - the two Gemma 4
+    SKUs are 99.4% of the total and the Gemma 2 repos are now a rounding error, so adoption is no longer
+    carried from an older generation.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/models/google/gemma-2-27b
@@ -111,17 +106,12 @@ capability:
     LiveCodeBench v6 80.0%, MMMU Pro 76.9%; multimodal on text and image across all sizes, audio native
     only on E2B/E4B/12B'
   confidence: medium
-  note: 'Frontier-class for an open model. Re-read 2026-08-14, and the cited Google Cloud post turned out
-    to be a deployment-availability announcement carrying neither the multimodal statement nor any
-    ranking, so both halves of the recorded value were unsourced. Replaced with the gemma-4-31B-it model
-    card, which carries the multimodal statement verbatim and a real evaluation table in text. Two
-    corrections the card forces. Audio is not native on the 31B - the card scopes it to E2B, E4B and 12B
-    - so "vision+audio" overstated the flagship SKU. And the "top-tier Arena rankings" clause is dropped
-    rather than re-sourced - lmarena.ai now 301s to arena.ai, where gemma-4-31b sits at rank 60 of 391
-    with a score of 1451 +/-8, roughly sixth among openly-licensed entries and behind glm-5.2-max,
-    mimo-v2.5-pro, glm-5.1, glm-5 and hy3. That is a strong open placement and not a top-tier one. The
-    basis_detail moves off LMArena to the card''s own table for the same reason. The 5 rests on the
-    benchmark table, which is what the card actually publishes.'
+  note: 'Frontier-class for an open model. The 5 rests on the gemma-4-31B-it model card''s own evaluation
+    table, which is what Google publishes, and the basis_detail sits there rather than on LMArena. Audio
+    is native only on E2B, E4B and 12B, so the flagship 31B is multimodal on text and image but not audio.
+    No top-tier Arena placement backs the score: lmarena.ai now redirects to arena.ai, where gemma-4-31b
+    sits at rank 60 of 391 with a score of 1451 +/-8, roughly sixth among openly-licensed entries and behind
+    glm-5.2-max, mimo-v2.5-pro, glm-5.1, glm-5 and hy3 - a strong open placement rather than a leading one.'
   last_verified: '2026-08-14'
   sources:
   - url: https://huggingface.co/google/gemma-4-31B-it

--- a/sources/scores/ggml.yaml
+++ b/sources/scores/ggml.yaml
@@ -13,10 +13,9 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: 'MIT license body confirmed (Copyright 2023-2026 The ggml authors); full source public. Re-read
-    2026-08-13: the cited LICENSE body still carries the MIT terms, the GitHub API reports the repository
-    public, unarchived and licensed MIT, and the README describes the whole library with no paid, enterprise
-    or hosted tier beside it, so source stays public and core-gated stays ungated.'
+  note: MIT license body confirmed (Copyright 2023-2026 The ggml authors); full source public. The repository
+    is public and unarchived, and the README describes the whole library with no paid, enterprise or hosted
+    tier beside it, so source is public and the core ungated.
   raw: license:MIT(OSI);source:public;no feature-gated core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -51,15 +50,11 @@ adoption:
   reach: '>10K stars'
   signal_type: stars_fallback
   confidence: medium
-  note: 'No PyPI package; GitHub shows ~14.9k stars (and underpins much higher-adoption llama.cpp). Stars
-    read 2026-08-13: 15,159 across the 1 declared repo, which bands at >10K stars, level 3 on the stars
-    scale in signal_routing.yaml. The previous reach ''~14.9k stars'' was not a label this instrument offers
-    - stars have their own vocabulary because a star is not a download. No last_verified claimed: a star
-    count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis
-    was not re-read. Re-read 2026-08-13: the GitHub API reports 15,159 stargazers on ggml-org/ggml, which
-    bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. ggml publishes no package of
-    its own - it is vendored as source into llama.cpp and whisper.cpp - so stars remain the only available
-    signal and the level stays directional and capped at 3. Unchanged.'
+  note: ggml publishes no package of its own - it is vendored as source into llama.cpp and whisper.cpp -
+    so stars remain the only available signal and the level stays directional, capped at 3. The GitHub API
+    reports 15,159 stargazers on ggml-org/ggml, which bands at >10K stars, level 3 on the stars scale in
+    signal_routing.yaml. The previous reach '~14.9k stars' was not a label this instrument offers - stars
+    have their own vocabulary because a star is not a download.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/ggml-org/ggml
@@ -78,8 +73,7 @@ capability:
   value: Dependency-free C tensor library with quantization and autodiff; backbone of llama.cpp/whisper.cpp
     inference.
   confidence: high
-  note: 'Foundational low-level runtime enabling efficient on-device LLM/ASR inference. Re-read 2026-08-13:
-    the cited repository page still describes the product as recorded, so the band is unchanged.'
+  note: Foundational low-level runtime enabling efficient on-device LLM/ASR inference.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/ggml-org/ggml

--- a/sources/scores/giskard.yaml
+++ b/sources/scores/giskard.yaml
@@ -16,10 +16,9 @@ openness:
     core-gated:
       value: ungated
   confidence: high
-  note: 'Fully open source: Apache-2.0 Python library, self-hostable; no commercial tier mentioned on
-    the repo. Re-read 2026-08-13 and unchanged. The cited URL now redirects to Giskard-AI/giskard-oss,
-    which is the repo the product declares, and the project has shipped a v3 rewrite since the last read;
-    neither moves the score.'
+  note: 'Fully open source: Apache-2.0 Python library, self-hostable; no commercial tier mentioned on the
+    repo. The cited URL redirects to Giskard-AI/giskard-oss, which is the repo the product declares, and
+    the project has shipped a v3 rewrite; neither moves the score.'
   raw: license:Apache-2.0(OSI);source:public;self-host:yes;service:none(per the repo);core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -40,12 +39,11 @@ adoption:
   reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
-  note: 'Stars-only proxy, capped at 3 because a star is not a use. Re-read 2026-08-13 - the repo shows
-    5,748 stargazers, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. A
-    download route does exist and was checked rather than assumed away: the giskard package on PyPI shows
-    24,423 downloads in the trailing 30 days, which is level 2 on the software scale, so both instruments
-    agree on the band. Re-banding onto downloads needs a declared PyPI artifact and is raised rather than
-    taken here.'
+  note: 'Stars-only proxy, capped at 3 because a star is not a use. The repo shows 5,748 stargazers, which
+    bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. A download route does exist
+    and was checked rather than assumed away: the giskard package on PyPI shows 24,423 downloads in the
+    trailing 30 days, level 2 on the software scale, so both instruments agree on the band. Re-banding onto
+    downloads needs a declared PyPI artifact and is raised rather than taken here.'
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/Giskard-AI/giskard
@@ -62,9 +60,9 @@ capability:
     and multi-turn agent evaluations.
   confidence: medium
   note: Combines automated red-team scanning with structured evaluation; broad coverage for both safety
-    and reliability. Re-read 2026-08-13. The v3 rewrite renamed Scan to vulnerability_scan and shipped it
-    in giskard-scan alongside knowledge-base and RAG evaluation, so the shape of the coverage moved but
-    not its breadth, and the band holds.
+    and reliability. The v3 rewrite renamed Scan to vulnerability_scan and ships it in giskard-scan alongside
+    knowledge-base and RAG evaluation, so the shape of the coverage moved but not its breadth, and the band
+    holds.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/Giskard-AI/giskard

--- a/sources/scores/github-copilot-ide.yaml
+++ b/sources/scores/github-copilot-ide.yaml
@@ -13,9 +13,6 @@ openness:
       detail: subscription SaaS
   note: Proprietary, closed-source subscription product; no self-host. Closed counterpart in the ui_api
     shelf.
-    Re-read 2026-08-13. The Copilot product page still sells a subscription with plans and pricing,
-    still publishes nothing of the product itself, and still offers no self-host path - the only thing a
-    customer runs locally is an extension talking to the GitHub service. Value unchanged at 1 / closed.
   raw: source:closed;self-host:none;license:proprietary(subscription SaaS)
   last_verified: '2026-08-13'
   sources:
@@ -31,16 +28,11 @@ adoption:
   signal_type: active_users
   confidence: high
   note: Microsoft CEO confirmed 20M all-time Copilot users (earnings call, 30 Jul 2025); free tier opened
-    to 150M GitHub developers (Dec 2024); ~4.7M paid subscribers by Jan 2026. Bands at >10M users, level 5
-    on the active_users scale declared 2026-08-13. WHAT WAS BANDED - the 20M is ALL-TIME rather
-    than active, and the one genuinely active-adjacent figure available - 4.7M paid subscribers - sits
-    a band lower, at 4. The level is unchanged from what this record already carried; what changed is
-    that the label under it is now one a declared scale offers, and that the substitution is named.
-    Re-read 2026-08-13 - the TechCrunch report is still up and still quotes Satya Nadella on 20 million
-    users, with the accompanying line that 20 million people have continued to use the tool on a monthly
-    or daily basis. The GitHub product page still carries the phrase about millions of individual users
-    and tens of thousands of business customers. The all-time-versus-active substitution named above is
-    unchanged and still the reason the number is not simply an active count. Level unchanged at 5.
+    to 150M GitHub developers (Dec 2024); ~4.7M paid subscribers by Jan 2026. Bands at >10M users, level
+    5 on the active_users scale declared 2026-08-13. WHAT WAS BANDED - the 20M is ALL-TIME rather than active,
+    and the one genuinely active-adjacent figure available - 4.7M paid subscribers - sits a band lower,
+    at 4. The level is unchanged from what this record already carried; what changed is that the label under
+    it is now one a declared scale offers, and that the substitution is named.
   last_verified: '2026-08-13'
   sources:
   - url: https://techcrunch.com/2025/07/30/github-copilot-crosses-20-million-all-time-users/
@@ -62,12 +54,9 @@ capability:
   confidence: high
   note: 'Most widely adopted, feature-complete AI developer assistant: chat + inline + agent mode + multi-model
     selection, deeply IDE/GitHub-integrated, enterprise controls. Frontier of the in-IDE-assistant slice
-    of ui_api.
-    Re-read 2026-08-13. The product page still shows the surface the band rests on - a choice of leading
-    LLMs, inline completion and explanation with agent mode in the editor, a CLI, GitHub-native and
-    custom agents plus third-party ones over MCP servers, Copilot Spaces for shared repository and
-    document context, and enterprise-grade governance controls. It still calls itself the most widely
-    adopted AI developer tool. Band unchanged at 5.'
+    of ui_api. The surface also includes a CLI, GitHub-native and custom agents plus third-party ones over
+    MCP servers, Copilot Spaces for shared repository and document context, and enterprise-grade governance
+    controls.'
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/features/copilot

--- a/sources/scores/github-copilot.yaml
+++ b/sources/scores/github-copilot.yaml
@@ -11,10 +11,8 @@ openness:
     self-host:
       value: 'no'
   confidence: high
-  note: 'Proprietary GitHub/Microsoft product; agent mode is a closed SaaS feature, model-agnostic on the
-    backend but not open source. Re-read 2026-08-13 - the features page still sells Copilot as a hosted
-    GitHub product across the IDE, GitHub itself and the CLI, natively built into GitHub, with no source
-    distribution and no self-host path. Nothing moved.'
+  note: Proprietary GitHub/Microsoft product; agent mode is a closed SaaS feature, model-agnostic on the
+    backend but not open source.
   raw: source:closed;license:proprietary(GitHub/Microsoft SaaS);self-host:no
   last_verified: '2026-08-13'
   sources:
@@ -33,18 +31,12 @@ adoption:
   reach: '>10M users'
   signal_type: active_users
   confidence: high
-  note: 'GitHub Copilot surpassed 20M+ all-time users (Microsoft July 2025 earnings): ''world''s most
-    widely adopted AI developer tool.'' Agent mode is the autonomous surface of that base. Bands at >10M users,
-    level 5 on the active_users scale declared 2026-08-13. WHAT WAS BANDED - 20M is an ALL-TIME
-    cumulative count, not an active one, and no agent-mode-specific figure is disclosed - so this is a
-    substitution in the sense of docs/reference/adoption.md and the true active figure is lower, not higher.
-    The level is unchanged; what changed is that the label under it is now one a
-    declared scale offers. Re-read 2026-08-13 - the TechCrunch report still records more than 20 million
-    users from Satya Nadella on the Microsoft earnings call, with GitHub confirming to TechCrunch that
-    the figure is "all-time users" and noting that Microsoft and GitHub do not report monthly or daily
-    actives. The features page still says "growing to millions of individual users and tens of thousands
-    of business customers" and calls Copilot the world''s most widely adopted AI developer tool. The substitution
-    is therefore confirmed as still being a substitution, and the level is unchanged.'
+  note: 'GitHub Copilot surpassed 20M+ all-time users (Microsoft July 2025 earnings): ''world''s most widely
+    adopted AI developer tool.'' Agent mode is the autonomous surface of that base. Bands at >10M users,
+    level 5 on the active_users scale declared 2026-08-13. WHAT WAS BANDED - 20M is an ALL-TIME cumulative
+    count, not an active one, and no agent-mode-specific figure is disclosed - so this is a substitution
+    in the sense of docs/reference/adoption.md and the true active figure is lower, not higher. The level
+    is unchanged; what changed is that the label under it is now one a declared scale offers.'
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/features/copilot
@@ -65,12 +57,9 @@ capability:
   value: Autonomous background agents (plan/explore/execute), multi-model orchestration (Copilot + Claude
     + Codex), deep GitHub/PR/CI integration; no first-party SWE-bench number on the agent-mode page
   confidence: medium
-  note: 'Broad agentic feature set with frontier-model backends and best-in-class repo integration; no
-    published SWE-bench for Copilot agent mode itself, so feature_matrix at 4, strong but below a verified-benchmark
-    ceiling. Re-read 2026-08-13 - the page still documents agent mode in the editor, assigning tasks to
-    agents including Copilot, and support across VS Code, Visual Studio, JetBrains IDEs and Neovim, and
-    still publishes no benchmark figure for the agent. Feature matrix and band unchanged, one below the
-    openhands anchor.'
+  note: Broad agentic feature set with frontier-model backends and best-in-class repo integration; no published
+    SWE-bench for Copilot agent mode itself, so feature_matrix at 4, strong but below a verified-benchmark
+    ceiling.
   relative_to: openhands
   relation: one_below
   last_verified: '2026-08-13'

--- a/sources/scores/github-mcp.yaml
+++ b/sources/scores/github-mcp.yaml
@@ -13,12 +13,10 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: 'Fully MIT, first-party GitHub server, no feature-gated core. Re-read 2026-08-13: the repository LICENSE
-    is the plain MIT License, "Copyright (c) 2025 GitHub", and the repo page carries the matching badge.
-    The whole Go server is in the tree with a Dockerfile and a goreleaser config beside it, so the self-hosted
-    build is the published build. GitHub also runs a hosted Remote GitHub MCP Server, and that is a managed
-    endpoint for the same server rather than a tier holding features back - the toolset list is the same
-    one, configured by header instead of by flag - which is the langchain shape the ladder settles as ungated.'
+  note: Fully MIT, first-party GitHub server, no feature-gated core. GitHub also runs a hosted Remote GitHub
+    MCP Server, but that is a managed endpoint for the same server rather than a tier holding features back
+    - the toolset list is the same one, configured by header instead of by flag - which is the langchain
+    shape the ladder settles as ungated.
   raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -44,13 +42,11 @@ adoption:
   reach: '>10K stars'
   signal_type: stars_fallback
   confidence: medium
-  note: '~31k stars; no download metric for Go/Docker distribution - stars_fallback (first-party backing
-    implies higher real usage). Stars read 2026-08-13: 32,212 across the 1 declared repo, which bands at >10K
-    stars, level 3 on the stars scale in signal_routing.yaml. The record carried no reach label at all before
-    this. Re-read in full 2026-08-13: the repo page reports 32,220 stargazers, the same band, and the fallback
-    is still forced rather than chosen - the server is distributed as a Go binary and a Docker image plus
-    GitHub''s own hosted remote endpoint, none of which publishes a count, and there is no npm or PyPI package
-    to read. So the stars instrument and its level-3 cap both stand. The digest below is of a page carrying
+  note: 'No download metric exists for the distribution channels in use: the server ships as a Go binary,
+    a Docker image and GitHub''s own hosted remote endpoint, none of which publishes a count, and there
+    is no npm or PyPI package to read. The stars fallback is therefore forced rather than chosen. 32,220
+    stargazers across the 1 declared repo band at >10K stars, level 3 on the stars scale in signal_routing.yaml,
+    and first-party backing implies higher real usage than that. The digest below is of a page carrying
     a live star counter and will not match on a later refetch; that is expected drift on this source rather
     than a signal about the claim.'
   last_verified: '2026-08-13'
@@ -66,12 +62,7 @@ capability:
   basis: feature_matrix
   value: '20+ toolsets: repos, issues, PRs, Actions, code security, Dependabot, Discussions, Projects, Copilot'
   confidence: high
-  note: 'The most comprehensive GitHub-platform tool surface among MCP servers. Re-read 2026-08-13: the toolset
-    table still spans repositories, issues, pull requests, Actions, code security, Dependabot, discussions,
-    projects and Copilot, grouped in the README as repository management, CI/CD intelligence, code analysis
-    and team collaboration, with a default toolset applied when none is named and an Insiders mode for the
-    rest. It runs locally as a binary or Docker image and remotely against GitHub''s hosted endpoint with
-    the same toolsets. Band unchanged at 5.'
+  note: The most comprehensive GitHub-platform tool surface among MCP servers.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/github/github-mcp-server

--- a/sources/scores/glean-assistant.yaml
+++ b/sources/scores/glean-assistant.yaml
@@ -12,11 +12,8 @@ openness:
       value: closed
     license:
     - name: Proprietary
-  note: Glean Assistant is a proprietary enterprise SaaS, no public source, no open-core/self-host OSS
-    tier. Closed.
-    Re-read 2026-08-13. The product site still sells a hosted enterprise platform with a demo request
-    and no download, no repository and no self-hosted edition anywhere on it. Value unchanged at 1 /
-    closed.
+  note: Glean Assistant is a proprietary enterprise SaaS, no public source, no open-core/self-host OSS tier.
+    Closed.
   raw: client:proprietary;deployment:single-tenant SaaS;source:closed;license:Proprietary
   last_verified: '2026-08-13'
   sources:
@@ -37,11 +34,6 @@ adoption:
     operating in 28 countries. ARR/enterprise-seat scale implies low-millions of enterprise seats; placed
     at 4 on reported enterprise traction. No raw seat/user count disclosed, so confidence medium and signal_type
     reported_traction (revenue + deployment breadth, not a measured user count).
-    Re-read 2026-08-13. The press release is still up and still carries every figure the band rests on -
-    $300 million in annual recurring revenue reached just fifteen months after $100 million, 85%+ of
-    customers using Glean across five or more departments, a 45% weekly DAU to MAU ratio described as
-    more than twice the SaaS industry norm, and operations in 28 countries. Still no raw seat or user
-    count, so the signal stays reported_traction with no numeric reach. Level unchanged at 4.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.glean.com/press/glean-surpasses-300m-arr-unrivaled-enterprise-context-fuels-ai-adoption
@@ -59,13 +51,10 @@ capability:
     permissions-aware); strong across all five ui_api chat-UI axes; plus agentic sub-agent orchestration'
   confidence: high
   note: Among the most feature-complete enterprise assistant UIs, multi-model hub, deep enterprise RAG,
-    multimodal, actions, permissions-aware multi-user. Top-tier within ui_api for enterprise context;
-    scored 4 (reserving 5 for an unambiguous category frontier-definer).
-    Re-read 2026-08-13. The site still carries every dimension the band rests on and the connector count
-    has grown - the navigation now advertises more than 250 connectors against the 100+ recorded here,
-    alongside the Model Hub, an AI Gateway, the Enterprise and Personal Graphs, hybrid search, agent
-    building, orchestration, governance and a reusable agent library, plus security controls for scaling
-    AI at work. Band unchanged at 4.
+    multimodal, actions, permissions-aware multi-user. Top-tier within ui_api for enterprise context; scored
+    4 (reserving 5 for an unambiguous category frontier-definer). The connector count has grown to more
+    than 250 against the 100+ recorded in the value, alongside an AI Gateway, agent building and orchestration,
+    governance and a reusable agent library.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.glean.com/product/assistant

--- a/sources/scores/glean-workplace-search-ai.yaml
+++ b/sources/scores/glean-workplace-search-ai.yaml
@@ -13,8 +13,6 @@ openness:
     license:
     - name: Proprietary
   note: Glean Search is proprietary enterprise SaaS; no public source, no OSS/self-host tier. Closed.
-    Re-read 2026-08-13. The platform overview still sells a hosted enterprise product with no source, no
-    download and no self-hosted edition. Value unchanged at 1 / closed.
   raw: client:proprietary;deployment:single-tenant SaaS;source:closed;license:Proprietary
   last_verified: '2026-08-13'
   sources:
@@ -30,15 +28,11 @@ adoption:
   confidence: medium
   banded_quantity: the same Glean platform ARR and seat base as the Assistant record, not an independent
     measurement
-  note: 'Search is the foundational layer of the same Glean platform that crossed $300M ARR (May 2026)
-    with near-doubled Fortune 500 count and 85%+ multi-department usage; effectively co-extensive with
-    Glean''s deployed seat base. Same caveat as Glean Assistant: no raw user count disclosed, so reported_traction
+  note: 'Search is the foundational layer of the same Glean platform that crossed $300M ARR (May 2026) with
+    near-doubled Fortune 500 count and 85%+ multi-department usage; effectively co-extensive with Glean''s
+    deployed seat base. Same caveat as Glean Assistant: no raw user count disclosed, so reported_traction
     at confidence medium. Adoption shared with the Assistant record (same platform), not an independent
-    measurement.
-    Re-read 2026-08-13. The same press release still carries the $300M ARR milestone, the 85%+
-    five-department figure and the 45% weekly engagement ratio, and search is still described as the
-    foundation the rest of the platform sits on, so this axis is still co-extensive with the Assistant
-    record rather than an independent measurement. Level unchanged at 4.'
+    measurement.'
   last_verified: '2026-08-13'
   sources:
   - url: https://www.glean.com/press/glean-surpasses-300m-arr-unrivaled-enterprise-context-fuels-ai-adoption
@@ -55,11 +49,8 @@ capability:
   confidence: high
   note: Best-in-class enterprise search on connector breadth, knowledge-graph relevance, and permissions-aware
     retrieval, a recognized leader in the enterprise-search-for-AI space. Scored 4 (top-tier; 5 reserved
-    for an unambiguous frontier-definer).
-    Re-read 2026-08-13. The overview still shows Enterprise Search as the foundation for answers, the
-    Enterprise Graph and Personal Graph as the relevance and personalization layers, hybrid search
-    grounded in context, and permissions honoured on every agent action. The connector count has grown
-    to more than 250 from the 100+ recorded. Band unchanged at 4.
+    for an unambiguous frontier-definer). The connector count has grown to more than 250 against the 100+
+    recorded in the value, and permissions are honoured on every agent action.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.glean.com/product/overview

--- a/sources/scores/glm.yaml
+++ b/sources/scores/glm.yaml
@@ -16,13 +16,11 @@ openness:
       detail: OSI
   governing_release: glm-5-2
   confidence: high
-  note: 'MIT weights on the current release, data closed, no training pipeline, so 3. Z.ai moved to MIT partway
-    through the family: GLM-4 and GLM-4-9B carried the GLM-4 License, which requires commercial-use registration
-    and a ''Built with GLM'' attribution and scored 2, while GLM-4.6, GLM-5.1 and GLM-5.2 are plain MIT. GLM-5.2
-    governs as the current release. Capability 5 comes from the GLM-5 line; the GLM-4 line scored 2.
-    Re-read 2026-08-13 - the GLM-5.2 LICENSE file is still a plain MIT License, Copyright (c) 2026
-    Zhipu AI, the Hub card still reads `mit` and ungated, and zai-org/GLM-5 is still a public
-    Apache-2.0 inference and deployment repository with no training pipeline or corpus. Nothing moved.'
+  note: 'MIT weights on the current release, data closed, no training pipeline, so 3. Z.ai moved to MIT
+    partway through the family: GLM-4 and GLM-4-9B carried the GLM-4 License, which requires commercial-use
+    registration and a ''Built with GLM'' attribution and scored 2, while GLM-4.6, GLM-5.1 and GLM-5.2 are
+    plain MIT. GLM-5.2 governs as the current release. Capability 5 comes from the GLM-5 line; the GLM-4
+    line scored 2.'
   last_verified: '2026-08-13'
   raw: weights:open(MIT);data:closed;code:open(inference);license:MIT(OSI)
   sources:
@@ -52,15 +50,13 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: 'RE-BANDED 2026-08-14 from 3/100K-1M to 4/1M-10M. The old band had been set on GLM-4-9B-Chat alone -
-    a SKU that is not a declared artifact and is a generation behind - which is both the wrong release under
-    the max-across-releases rule in docs/reference/identity.md and the wrong scope under sum_across_artifacts.
-    Recomputed across the 4 declared artifacts, the family sums to 2,774,206 downloads in the trailing 30
-    days (zai-org/GLM-4.6 28,016; zai-org/glm-4-9b 11,688; zai-org/GLM-5.1 72,174; zai-org/GLM-5.2
-    2,662,328), which lands in 1M-10M on the model scale in sources/rubrics/model.yaml. GLM-5.2 supplies
-    96% of that total, so this is the current release carrying the tier, which is what the rule intends. All
-    four were re-read against the API on 2026-08-14; three digests are byte-identical to the 2026-08-13 read
-    and GLM-5.2''s moved without its download figure changing. THUDM/glm-4-9b now redirects to zai-org.'
+  note: Re-banded from 3/100K-1M to 4/1M-10M. The old band had been set on GLM-4-9B-Chat alone - a SKU that
+    is not a declared artifact and is a generation behind - which is both the wrong release under the max-across-releases
+    rule in docs/reference/identity.md and the wrong scope under sum_across_artifacts. Recomputed across
+    the 4 declared artifacts, the family sums to 2,774,206 downloads in the trailing 30 days (zai-org/GLM-4.6
+    28,016; zai-org/glm-4-9b 11,688; zai-org/GLM-5.1 72,174; zai-org/GLM-5.2 2,662,328), which lands in
+    1M-10M on the model scale in sources/rubrics/model.yaml. GLM-5.2 supplies 96% of that total, so the
+    current release carries the tier, which is what the rule intends. THUDM/glm-4-9b now redirects to zai-org.
   last_verified: '2026-08-14'
   sources:
   - url: https://huggingface.co/api/models/zai-org/GLM-4.6
@@ -94,10 +90,7 @@ capability:
   value: null
   confidence: high
   note: 'SWE-Bench Pro 58.4 (reported #1 at release, edging GPT-5.4 57.7 and Claude Opus 4.6 57.3); Terminal-Bench
-    2.0 63.5. Frontier-tier agentic coding for an open-weights model. Re-read 2026-08-13 - all four
-    figures are still on the serenitiesai comparison and the SWE-bench Pro number is corroborated by
-    modemguides, so the band is re-derived and unchanged at 5. The third source has gone (see below)
-    and nothing rested on it alone.'
+    2.0 63.5. Frontier-tier agentic coding for an open-weights model.'
   last_verified: '2026-08-13'
   sources:
   - url: https://serenitiesai.com/articles/glm-5-1-zhipu-coding-benchmark-claude-opus-comparison-2026
@@ -113,8 +106,7 @@ capability:
     http_status: 200
     content_sha256: 085dfa43e483cf6c070ab17dcff0ca703b6034aedac439ce215bbaba6505b646
   - url: https://www.vals.ai/models/zai_glm-5.1-thinking
-    shows: Returned HTTP 404 on the 2026-08-13 re-read - the page has gone. It establishes nothing and
-      the band does not rest on it.
+    shows: The page returns HTTP 404 - it establishes nothing and the band does not rest on it.
     accessed: '2026-08-13'
     http_status: 404
     content_sha256: 3a10a4f308f993b3d25a0750a8a5597ded7e2e8ce11f5552853d1b083301e835

--- a/sources/scores/google-cloud-run.yaml
+++ b/sources/scores/google-cloud-run.yaml
@@ -18,10 +18,7 @@ openness:
     - managed-only(no self-host)
   confidence: high
   note: Proprietary managed serverless platform; only the underlying gVisor sandbox runtime is OSS, not
-    Cloud Run itself. Re-read 2026-08-13 - cloud.google.com/run still presents Cloud Run as a fully managed
-    Google platform billed only while code runs, with no source release and no self-hostable edition offered,
-    and google/gvisor remains a separately maintained Apache-2.0 repository rather than the Cloud Run
-    control plane.
+    Cloud Run itself.
   raw: license:Proprietary;service:proprietary(Google SaaS);source:closed;isolation-runtime:gVisor(open
     source, github.com/google/gvisor) but the Cloud Run product/control-plane is proprietary;managed-only(no
     self-host)
@@ -46,12 +43,11 @@ adoption:
   signal_type: usage_volume
   confidence: high
   note: 'Google Next ''26 blog (primary, verified verbatim): external active developers and apps on Cloud
-    Run doubled YoY, more new customers/apps in 2025 than its first 6 years combined; Replit VP quote:
-    >1M live projects hosted on Replit with Cloud Run as primary target. Hyperscaler serverless reach
-    is well into the >10M band. Re-read 2026-08-13 - both claims are still on the Next ''26 post verbatim,
-    the developer/app doubling and the Replit VP quote about over 1 million live projects. Instrument caveat
-    - the record is labeled usage_volume but Cloud Run publishes no countable artifact any signal model
-    can read, so the band rests on the vendor claim rather than a recomputable count.'
+    Run doubled YoY, more new customers/apps in 2025 than its first 6 years combined; Replit VP quote: >1M
+    live projects hosted on Replit with Cloud Run as primary target. Hyperscaler serverless reach is well
+    into the >10M band. Instrument caveat: the record is labeled usage_volume but Cloud Run publishes no
+    countable artifact any signal model can read, so the band rests on the vendor claim rather than a recomputable
+    count.'
   last_verified: '2026-08-13'
   sources:
   - url: https://cloud.google.com/blog/products/serverless/whats-new-for-cloud-run-at-next26
@@ -68,16 +64,13 @@ capability:
     OCI container (very broad); persistence: stateless request model + volume mounts; scale: 0 to thousands
     of instances autoscaling on a hyperscaler'
   confidence: medium
-  note: Very broad runtime/language coverage and hyperscaler scale; new agent `sandbox` tool (announced
-    Next '26, 'coming soon') adds first-class AI-code-execution via a `sandbox do --` command. gVisor
-    isolation is process/syscall-level rather than full microVM (Sprites/Northflank), so not the top isolation
-    tier. Strong but not the single frontier-definer. Independent ComputeSDK TTI benchmarks corroborate
-    the sub-second cold-start (~430ms median, 10th of 19 sandbox providers). Re-read 2026-08-13 - the Next
-    '26 post still describes the built-in `sandbox` tool as coming soon and adds Cloud Run instances in
-    preview for long-running background agents, and cloud.google.com/run still shows any-container deploy,
-    scale-to-zero and 20+ regions. The ComputeSDK leaderboard has been rerun since (2026-08-07, 24 providers)
-    and now places Cloud Run at 0.65s median time-to-interactive, 13th by composite score, still sub-second
-    and still mid-field.'
+  note: Very broad runtime/language coverage and hyperscaler scale; the built-in agent `sandbox` tool (announced
+    Next '26, still 'coming soon') adds first-class AI-code-execution via a `sandbox do --` command, alongside
+    Cloud Run instances in preview for long-running background agents. gVisor isolation is process/syscall-level
+    rather than full microVM (Sprites/Northflank), so not the top isolation tier. Strong but not the single
+    frontier-definer. Independent ComputeSDK TTI benchmarks corroborate the sub-second cold-start, placing
+    Cloud Run at a 0.65s median time-to-interactive, 13th by composite of 24 sandbox providers - still sub-second
+    and still mid-field.
   last_verified: '2026-08-13'
   sources:
   - url: https://cloud.google.com/blog/products/serverless/whats-new-for-cloud-run-at-next26

--- a/sources/scores/google-coral-dev-board.yaml
+++ b/sources/scores/google-coral-dev-board.yaml
@@ -22,30 +22,33 @@ openness:
       detail: broadly purchasable
       raw: open_market (broadly purchasable)
   confidence: high
-  note: 'RETAIL RESOLVED 2026-08-14 and the axis dated. `retail` had blocked this confirmation because no declared value described the board''s actual state - Seeed marks both variants Discontinued and out of stock, and coral.ai/products/dev-board 302s to a page naming no hardware. `restricted` was the nearest word and is wrong: it means gated by NDA or design win, which is a part somebody CAN buy under terms. A withdrawn part is a different fact, so `discontinued` was added to the vocabulary - score-neutral, since no rung reads `retail`. Public datasheet, published baseboard design files and an open runtime/TFLite path, but the
-    Edge TPU silicon and the model compiler are proprietary closed binaries. The `schematics: none`
-    this record used to carry was wrong from the first pass rather than stale - its own cited
-    datasheet page has linked design files throughout. Corrected 2026-08-14: the datasheet offers a
-    baseboard schematic PDF, the Altium schematic source, an Allegro .brd layout and a STEP model of
-    baseboard and SoM together, all served from github.com/google-coral/electricals, which carries an
-    Apache-2.0 LICENSE. That is more than `radxa-rock-5b` releases, and it stops short of `open`
-    because only half the product is covered - the SoM that carries the i.MX 8M and the Edge TPU has
-    no design files. The score does not move: `published` reaches 4 only with a stack that builds from
-    source, and the Edge TPU compiler is a closed binary, so the ladder lands on 3/documented either
-    way. What changes is that the 3 is now derived from what Google actually publishes. The remaining
-    four components were read on 2026-08-14 and three of them hold. `datasheets` is `public` on the
-    same v1.7 datasheet. `toolchain` is `partial` on libedgetpu shipping its runtime source under
-    Apache-2.0 against an Edge TPU Compiler distributed only as an apt binary from
-    packages.cloud.google.com with no source anywhere - archived is not closed, so the value does not
-    move. `blobs` is `required` on the same closed compiler standing between any model and the
-    proprietary Edge TPU. THE AXIS IS NOT DATED, and `retail` is the component that blocks it. The
-    board reads as withdrawn rather than open-market - Seeed, which is its named reseller, marks both
-    the 1GB at $129.99 and the 4GB at $169.99 Discontinued and out of stock; coral.ai/products/dev-board
-    now 302s to developers.google.com/coral, a page that names no hardware and links no purchase route;
-    and no reachable distributor confirms stock, Mouser serving a bot-denial page and Farnell and
-    Digi-Key 403. The rubric''s vocabulary is open_market/distributor/restricted and none of the three
-    describes a discontinued part, so this is escalated for a ruling rather than guessed at. Escalated
-    with it - `adoption` below, which rests on the same wind-down.'
+  note: 'RETAIL RESOLVED and the axis dated. `retail` had blocked this confirmation because no declared
+    value described the board''s actual state - Seeed marks both variants Discontinued and out of stock,
+    and coral.ai/products/dev-board 302s to a page naming no hardware. `restricted` was the nearest word
+    and is wrong: it means gated by NDA or design win, which is a part somebody CAN buy under terms. A withdrawn
+    part is a different fact, so `discontinued` was added to the vocabulary - score-neutral, since no rung
+    reads `retail`. Public datasheet, published baseboard design files and an open runtime/TFLite path,
+    but the Edge TPU silicon and the model compiler are proprietary closed binaries. The `schematics: none`
+    this record used to carry was wrong from the first pass rather than stale - its own cited datasheet
+    page has linked design files throughout. Corrected: the datasheet offers a baseboard schematic PDF,
+    the Altium schematic source, an Allegro .brd layout and a STEP model of baseboard and SoM together,
+    all served from github.com/google-coral/electricals, which carries an Apache-2.0 LICENSE. That is more
+    than `radxa-rock-5b` releases, and it stops short of `open` because only half the product is covered
+    - the SoM that carries the i.MX 8M and the Edge TPU has no design files. The score does not move: `published`
+    reaches 4 only with a stack that builds from source, and the Edge TPU compiler is a closed binary, so
+    the ladder lands on 3/documented either way. What changes is that the 3 is now derived from what Google
+    actually publishes. The remaining four components were read and three of them hold. `datasheets` is
+    `public` on the same v1.7 datasheet. `toolchain` is `partial` on libedgetpu shipping its runtime source
+    under Apache-2.0 against an Edge TPU Compiler distributed only as an apt binary from packages.cloud.google.com
+    with no source anywhere - archived is not closed, so the value does not move. `blobs` is `required`
+    on the same closed compiler standing between any model and the proprietary Edge TPU. THE AXIS IS NOT
+    DATED, and `retail` is the component that blocks it. The board reads as withdrawn rather than open-market
+    - Seeed, which is its named reseller, marks both the 1GB at $129.99 and the 4GB at $169.99 Discontinued
+    and out of stock; coral.ai/products/dev-board now 302s to developers.google.com/coral, a page that names
+    no hardware and links no purchase route; and no reachable distributor confirms stock, Mouser serving
+    a bot-denial page and Farnell and Digi-Key 403. The rubric''s vocabulary is open_market/distributor/restricted
+    and none of the three describes a discontinued part, so this is escalated for a ruling rather than guessed
+    at. Escalated with it - `adoption` below, which rests on the same wind-down.'
   raw: schematics:published (baseboard schematic + Altium source + Allegro layout, Apache-2.0; SoM
     withheld);toolchain:partial (open runtime (libedgetpu) + TFLite, closed Edge TPU compiler);datasheets:public;blobs:required
     (proprietary Edge TPU ASIC + closed compiler);retail:open_market (broadly purchasable)

--- a/sources/scores/google-grounding-api.yaml
+++ b/sources/scores/google-grounding-api.yaml
@@ -11,11 +11,8 @@ openness:
     managed:
       value: Vertex-AI/Gemini-Agent-Platform
   confidence: high
-  note: 'Fully proprietary Google Cloud managed grounding service; no open source component or self-host.
-    Tied to Gemini + Google Search index. Re-read 2026-08-13: Grounding with Google Search is still one row
-    in a table of managed grounding options inside the Gemini Enterprise Agent Platform, beside Google Maps,
-    Agent Search, RAG, Elasticsearch, Parallel and Exa. It is a platform feature reached through the Gemini
-    API, with no source, no weights and no self-hostable component of any kind. Score stays 1.'
+  note: Fully proprietary Google Cloud managed grounding service; no open source component or self-host.
+    Tied to Gemini + Google Search index.
   raw: license:proprietary(GCP-managed API);source:closed;managed:Vertex-AI/Gemini-Agent-Platform
   last_verified: '2026-08-13'
   sources:
@@ -37,13 +34,11 @@ adoption:
   reach: null
   signal_type: unknown
   confidence: low
-  note: 'Bundled feature of Vertex AI / Gemini Enterprise Agent Platform with no standalone usage figure disclosed.
-    The broad Vertex AI / Gemini surface is large, but no honest grounding-API-specific adoption signal is
-    verifiable; not scoring on the parent platform''s reach. Abstention re-confirmed 2026-08-13. What was
-    looked for on the overview page and not found - a request count, a customer count, a developer count
-    or a named-customer list for grounding specifically. What is there is a capability table and a benefits
-    list. Grounding remains a feature inside a platform rather than a product with its own meter, and there
-    is no package or registry artifact to band, so the abstention stands and is now dated.'
+  note: Bundled feature of Vertex AI / Gemini Enterprise Agent Platform with no standalone usage figure
+    disclosed. The overview page carries a capability table and a benefits list, but no request count, customer
+    count, developer count or named-customer list for grounding specifically, and there is no package or
+    registry artifact to band. The broad Vertex AI / Gemini surface is large, but no honest grounding-API-specific
+    adoption signal is verifiable and the parent platform's reach is not a substitute, so the axis abstains.
   last_verified: '2026-08-13'
   sources:
   - url: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/grounding/overview
@@ -59,14 +54,10 @@ capability:
   value: 'coverage: full Google Search index grounding; freshness=live web; structured grounding metadata
     + citations/grounding-support attribution returned to the model'
   confidence: medium
-  note: 'Grounds LLM output in the full Google Search index with citation/grounding-support metadata, best-in-class
+  note: Grounds LLM output in the full Google Search index with citation/grounding-support metadata, best-in-class
     web freshness/coverage for agent grounding. Rated 4 on the coverage/freshness/structured-output matrix;
     capped below 5 as detailed per-feature confirmation came from the overview page only (deeper feature
-    docs not fetched this run). Re-read 2026-08-13 against the same overview page, so the cap''s stated reason
-    still applies exactly. The page confirms the coverage claim - "Connect your model to world knowledge
-    and a wide possible range of topics using results from Google''s search engine" - and the structured-output
-    claim, which it words as "Provides auditability by providing grounding support, which are links to sources".
-    Band unchanged at 4.'
+    docs not fetched this run).
   last_verified: '2026-08-13'
   sources:
   - url: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/grounding/overview

--- a/sources/scores/goose.yaml
+++ b/sources/scores/goose.yaml
@@ -19,12 +19,8 @@ openness:
     - model-agnostic
     - MCP-native
     - no feature-gated core
-  note: 'Verified Apache-2.0 OSI, now under Linux Foundation (AAIF) governance; full source public, no
-    proprietary tier. Repo confirmed relocated to aaif-goose/goose (block/goose redirects). Re-read 2026-08-13
-    - the repo page still reports Apache-2.0, still states goose is part of the Agentic AI Foundation
-    at the Linux Foundation, publishes the whole Rust agent including the desktop and CLI surfaces, and
-    offers no paid tier; what you can pay for is a model subscription you bring yourself. Stars are now
-    52.8k. Nothing moved.'
+  note: Verified Apache-2.0 OSI, now under Linux Foundation (AAIF) governance; full source public, no proprietary
+    tier. Repo confirmed relocated to aaif-goose/goose (block/goose redirects).
   raw: license:Apache-2.0(OSI);source:public;governance:Agentic AI Foundation/Linux Foundation (neutral
     foundation); model-agnostic; MCP-native; no feature-gated core;core-gated:ungated
   last_verified: '2026-08-13'
@@ -45,15 +41,11 @@ adoption:
   reach: '>10K stars'
   signal_type: stars_fallback
   confidence: low
-  note: '46.4k stars and active multi-surface distribution (desktop/CLI/API), backed by Block and now Linux
+  note: 46.4k stars and active multi-surface distribution (desktop/CLI/API), backed by Block and now Linux
     Foundation. No published download/MAU figure found, so capped at level 3 on stars-fallback; directional.
-    Stars read 2026-08-13: 52,753 across the 1 declared repo, which bands at >10K stars, level 3 on the stars
-    scale in signal_routing.yaml. The previous reach ''100K-1M'' was not a label this instrument offers -
-    stars have their own vocabulary because a star is not a download. Re-read 2026-08-13 from the repo
-    page, which reports 52.8k stars and 6.0k forks. Goose ships as a desktop app and a Rust CLI with no
-    first-party PyPI or npm package, and neither the repo nor the docs site publishes an install or user
-    count, so the stars fallback is still the only instrument available and >10K stars still bands at
-    3.'
+    52,753 stars across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml.
+    The previous reach '100K-1M' was not a label this instrument offers - stars have their own vocabulary
+    because a star is not a download.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/aaif-goose/goose
@@ -68,11 +60,8 @@ capability:
     model-agnostic: 15+ providers; eval/reliability tooling: limited. No headline SWE-bench/GAIA leaderboard
     placement found.'
   confidence: medium
-  note: 'Broad general-purpose agent with strong MCP tool breadth and model-agnosticism, but no published
-    SWE-bench/GAIA number; scored on feature matrix. Below benchmark-frontier coding agents. Re-read 2026-08-13
-    - the repo page still states 15+ providers and 70+ extensions over the Model Context Protocol, adds
-    ACP support and custom distributions, and still publishes no benchmark placement, so the feature matrix
-    is unchanged and so is the band. Two below the openhands benchmark anchor.'
+  note: Broad general-purpose agent with strong MCP tool breadth and model-agnosticism, but no published
+    SWE-bench/GAIA number; scored on feature matrix. Below benchmark-frontier coding agents.
   relative_to: openhands
   relation: two_below
   last_verified: '2026-08-13'

--- a/sources/scores/gpqa.yaml
+++ b/sources/scores/gpqa.yaml
@@ -18,15 +18,12 @@ openness:
       detail: no hidden held-out test
   confidence: high
   note: Open CC-BY-4.0 license and fully redistributable, but access is login-walled with an anti-contamination
-    click-through agreement, so the headline class is gated rather than open. Scored 3 with every
-    other gated corpus on the map rather than 4 - a gate caps a dataset at 3 whatever its license
-    says, because a corpus you need a login for is not more open than one you do not. The
-    anti-contamination purpose is a fair argument for treating this gate as gentler than a
-    restrictive one, but only this product records why its gate exists, and a rung for that would
-    turn on evidence one product carries. Corrected 2026-08-01 from 4 when the dataset ladder made
-    the pair checkable; no source was re-read. Re-read 2026-08-13 and all three values stand -
-    `license:cc-by-4.0` is still in the repo tags, the embedded repo state reads `"gated":"auto"`
-    with the contact-information gate still in place, and the card still renders.
+    click-through agreement, so the headline class is gated rather than open. Scored 3 with every other
+    gated corpus on the map rather than 4 - a gate caps a dataset at 3 whatever its license says, because
+    a corpus you need a login for is not more open than one you do not. The anti-contamination purpose is
+    a fair argument for treating this gate as gentler than a restrictive one, but only this product records
+    why its gate exists, and a rung for that would turn on evidence one product carries. Corrected from
+    4 when the dataset ladder made the pair checkable, on the recorded evidence rather than a fresh read.
   raw: license:CC-BY-4.0(open,redistributable+attribution);access:gated(HF login + click-through agreement
     NOT to publish examples in plaintext, to limit training-corpus contamination);datasheet:present(paper+card);splits:public(no
     hidden held-out test)
@@ -51,13 +48,11 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: '~129,881 HF downloads in the trailing month (primary, from the dataset page); GPQA Diamond is a de-
-    facto-standard reasoning benchmark cited across frontier model release reports (appears as a capability
-    basis throughout the v3 flagship set), which is the top adoption signal for a benchmark. Read live
-    2026-08-13: 110,577 Hugging Face downloads in the trailing 30 days across the declared artifact(s), which
-    bands at 100K-1M, level 4. Re-read again on 2026-08-13 against the Hub API: 110,577 downloads in
-    the trailing 30 days, unchanged, so level 4 / 100K-1M stands and the axis is now dated. The
-    129,881 figure the June source cited no longer appears on the dataset page.'
+  note: 110,577 Hugging Face downloads in the trailing 30 days across the declared artifact(s), which bands
+    at 100K-1M, level 4. GPQA Diamond is a de-facto-standard reasoning benchmark cited across frontier model
+    release reports (it appears as a capability basis throughout the v3 flagship set), which is the top
+    adoption signal for a benchmark. An earlier 129,881 figure taken from the dataset page no longer appears
+    there.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/Idavidrein/gpqa
@@ -71,8 +66,7 @@ capability:
   value: null
   confidence: high
   note: Per recipe, a benchmark dataset is not 'capable'; openness and adoption carry this category. No
-    capability axis assessed. Re-read 2026-08-13 and the abstention stands - the page publishes a static
-    question set and no performance or feature claim the capability axis could band.
+    capability axis assessed.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/Idavidrein/gpqa

--- a/sources/scores/gpt-4-1.yaml
+++ b/sources/scores/gpt-4-1.yaml
@@ -13,13 +13,9 @@ openness:
     - name: Proprietary
       detail: API-only
   confidence: high
-  note: Proprietary OpenAI API model; no weights/data/code released. Absorbed the duplicate
-    base_pretrained record on 2026-07-29, which contributed OpenAI's own model docs as a primary source
-    alongside the press coverage, and the exact context window (1,047,576 tokens). Re-read 2026-08-13 -
-    OpenAI's own model page still lists GPT-4.1 with a 1,047,576-token context window and no weights
-    download of any kind, and TechCrunch still describes the family as "exclusively available through the
-    company's API". The knowledge-cutoff detail the old note quoted no longer renders to a plain fetch and
-    has been dropped from the source's `shows` rather than re-asserted. No change.
+  note: Proprietary OpenAI API model; no weights/data/code released. Absorbed the duplicate base_pretrained
+    record on 2026-07-29, which contributed OpenAI's own model docs as a primary source alongside the press
+    coverage, and the exact context window (1,047,576 tokens).
   raw: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
   last_verified: '2026-08-13'
   sources:
@@ -48,10 +44,7 @@ adoption:
   note: GPT-4.1 was an API-first developer/coding model (initially not in ChatGPT default), widely adopted
     as a cheaper GPT-4o replacement and integrated across tooling. No primary per-model usage count disclosed;
     level 4 reflects broad developer-platform distribution as a major OpenAI API model rather than a verified
-    figure. Treat as directional. Re-read 2026-08-13 - the source still describes an API-exclusive coding
-    family and still publishes no usage or user count, so the abstention from a number stands and the
-    instrument is right. `reach` is correctly absent, which is what a reported_traction record owes. No
-    change.
+    figure. Treat as directional.
   last_verified: '2026-08-13'
   sources:
   - url: https://techcrunch.com/2025/04/14/openais-new-gpt-4-1-models-focus-on-coding/
@@ -68,16 +61,14 @@ capability:
   confidence: high
   note: Solid non-reasoning coding model at Apr 2025 (54.6 SWE-bench, +21pts over GPT-4o), but well below
     2026 reasoning frontier (o3 71.7, GPT-5 74.9, Opus 4.8 88.6). Mid-tier, frontier-relative. Headline
-    54.6% re-sourced to OpenAI primary announcement (was aggregator-only). Re-read 2026-08-13 - InfoQ still
-    reports "GPT-4.1 achieves 54.6% accuracy ... a 21-point increase over GPT-4o (33.2%) and 26.6 points
-    higher than GPT-4.5", and Helicone gives the same three figures. The OpenAI primary announcement returned
-    HTTP 403 to a plain fetch on both attempts, so its accessed date is left where it was rather than
-    re-dated; the figure is confirmed on the two secondary sources instead.
+    54.6% re-sourced to OpenAI primary announcement (was aggregator-only). The OpenAI primary announcement
+    returns HTTP 403 to a plain fetch, so the headline 54.6% is confirmed on InfoQ and Helicone instead,
+    both of which report it against GPT-4o's 33.2%.
   last_verified: '2026-08-13'
   sources:
   - url: https://openai.com/index/gpt-4-1/
     shows: 'OpenAI primary announcement: GPT-4.1 SWE-bench Verified 54.6% vs GPT-4o 33.2%, 1M-token context
-      (corroborated by InfoQ/TechCrunch). Returned HTTP 403 to a plain fetch on 2026-08-13, so not re-dated.'
+      (corroborated by InfoQ/TechCrunch). Returns HTTP 403 to a plain fetch.'
     accessed: '2026-06-04'
   - url: https://www.helicone.ai/blog/gpt-4.1-full-developer-guide
     shows: '"GPT-4.1 scored 54.6%, far outperforming GPT-4o (33.2%) and GPT-4.5 (28%)" on SWE-bench Verified'

--- a/sources/scores/gpt-4o.yaml
+++ b/sources/scores/gpt-4o.yaml
@@ -13,10 +13,7 @@ openness:
     - name: Proprietary
       detail: API-only
   confidence: high
-  note: No downloadable weights; API/ChatGPT-only, like the GPT-5 anchor (O1 closed). Re-read
-    2026-08-13 - the model page still lists a 128,000 context window and an Oct 01, 2023 knowledge
-    cutoff, describes GPT-4o as accepting text and image inputs, and offers no weight download,
-    dataset or training code anywhere on it. Nothing moved.
+  note: No downloadable weights; API/ChatGPT-only, like the GPT-5 anchor (O1 closed).
   last_verified: '2026-08-13'
   raw: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
   sources:
@@ -33,20 +30,12 @@ adoption:
   reach: '>10M users'
   signal_type: active_users
   confidence: medium
-  note: GPT-4o was the default ChatGPT model for much of 2024-2025 before GPT-5; ChatGPT crossed ~900M
-    WAU (Feb 2026) and ~1B (May 2026). Attributed honestly to the ChatGPT surface GPT-4o powered, not
-    a standalone GPT-4o count; well above the >10M threshold. WAU figure corroborated via aggregator (demandsage),
-    not a primary OpenAI disclosure, but the threshold is not close so no downgrade. Attempted re-read
-    2026-08-13 - the aggregator that carries the WAU figure answered HTTP 403 after retries, so the
-    only source for the number the band rests on could not be opened and this axis carries no
-    confirmation. The OpenAI docs page was re-read and still establishes that GPT-4o is an API and
-    ChatGPT model, but it publishes no usage figure and never did. Closed 2026-08-14 against a
-    substitute - demandsage.com is genuinely unfetchable, 403 to eight consecutive requests under
-    every header set tried, so the same figure was taken from the source gpt-5 adoption already uses,
-    which reports 'On February 27, 2026, OpenAI announced that ChatGPT had surpassed 900 million
-    weekly active users'. That is a report of a primary OpenAI announcement rather than an aggregator
-    estimate, so it is the better citation of the two. Two orders above the >10M floor; level 5
-    unchanged.
+  note: GPT-4o was the default ChatGPT model for much of 2024-2025 before GPT-5; ChatGPT crossed ~900M WAU
+    (February 2026) and ~1B (May 2026). Attributed honestly to the ChatGPT surface GPT-4o powered, not a
+    standalone GPT-4o count; well above the >10M threshold. The WAU figure is sourced to the same report
+    gpt-5 adoption uses, which relays OpenAI's own announcement that ChatGPT had surpassed 900 million weekly
+    active users - a report of a primary disclosure rather than an aggregator estimate. demandsage, which
+    the band formerly rested on, answers HTTP 403 to every request. Two orders above the >10M floor.
   last_verified: '2026-08-14'
   sources:
   - url: https://developers.openai.com/api/docs/models/gpt-4o
@@ -72,14 +61,11 @@ capability:
   value: 'GPT-4o launch-era external figures: MMLU ~88.7, MMMU ~69.1 (NOT confirmed on current OpenAI
     docs, which carry no benchmark numbers); a 2024 frontier non-reasoning multimodal model.'
   confidence: medium
-  note: 'Frontier in 2024 but surpassed by 2026 reasoning frontier (GPT-5 C5, Gemini 3.5 C5); per the
+  note: 'Frontier in 2024 but surpassed by the 2026 reasoning frontier (GPT-5 C5, Gemini 3.5 C5); per the
     recipe, a mid-2025-and-earlier model that has been surpassed scores 3, not 5. Caveat: the cited OpenAI
-    docs page (verified 2026-06-04) shows NO benchmark figures; it only calls GPT-4o ''our most capable
-    model outside our o-series''; the MMLU/MMMU values are launch-era external numbers and need a primary
-    benchmark source to back the headline. Re-read 2026-08-13 - the caveat still holds exactly as
-    written. The page carries the phrase "our most capable model outside of our o-series models" and
-    zero benchmark figures, so what is confirmed is the positioning the 3 rests on, not the MMLU and
-    MMMU numbers in the value.'
+    docs page shows NO benchmark figures - it only calls GPT-4o "our most capable model outside of our o-series
+    models" - so what is sourced is the positioning the 3 rests on, not the MMLU ~88.7 and MMMU ~69.1 launch-era
+    external numbers in the value, which still need a primary benchmark source.'
   last_verified: '2026-08-13'
   sources:
   - url: https://developers.openai.com/api/docs/models/gpt-4o

--- a/sources/scores/gpt-5.yaml
+++ b/sources/scores/gpt-5.yaml
@@ -14,12 +14,10 @@ openness:
       detail: API + ChatGPT only
   governing_release: gpt-5-line
   confidence: high
-  note: No downloadable weights, no published training data or code. Served through the OpenAI API and ChatGPT only,
-    so 1/closed. Kept apart from GPT-4o and GPT-4.1 because OpenAI markets those as distinct products rather than
-    versions of a single line, which is the same reason their slugs keep their version tokens. Adoption 5 reflects
-    ChatGPT-scale reach. Re-read 2026-08-13 - the line is still distributed only through ChatGPT, Microsoft
-    Copilot and the OpenAI API, with no weights, corpus or training code published for any release in it,
-    and TechCrunch still records GPT-5.5 Instant as the current ChatGPT default. No change.
+  note: No downloadable weights, no published training data or code. Served through the OpenAI API and ChatGPT
+    only, so 1/closed. Kept apart from GPT-4o and GPT-4.1 because OpenAI markets those as distinct products
+    rather than versions of a single line, which is the same reason their slugs keep their version tokens.
+    Adoption 5 reflects ChatGPT-scale reach.
   raw: weights:closed;data:closed;code:closed;license:Proprietary(API + ChatGPT only)
   last_verified: '2026-08-13'
   sources:
@@ -41,12 +39,9 @@ adoption:
   reach: '>10M users'
   signal_type: active_users
   confidence: high
-  note: GPT-5 was rolled out as the default model for logged-in ChatGPT users (Aug 2025). ChatGPT reached ~900M
-    weekly active users (Feb 2026) and ~1B by May 2026, far exceeding the >10M threshold. Adoption attributed to
-    the surface GPT-5 powers, not a standalone GPT-5 download count. Re-read 2026-08-13 - the source still
-    states ChatGPT "crossed 900 million weekly active users in February 2026", which is two orders above
-    the >10M users floor, so the band is unambiguous whichever way the figure has since moved. The second
-    source returned HTTP 403 to a plain fetch and was not re-dated. No change.
+  note: GPT-5 was rolled out as the default model for logged-in ChatGPT users (Aug 2025). ChatGPT reached
+    ~900M weekly active users (Feb 2026) and ~1B by May 2026, far exceeding the >10M threshold. Adoption
+    attributed to the surface GPT-5 powers, not a standalone GPT-5 download count.
   last_verified: '2026-08-13'
   sources:
   - url: https://almcorp.com/blog/chatgpt-900-million-weekly-active-users/
@@ -55,8 +50,7 @@ adoption:
     http_status: 200
     content_sha256: 36a725f2b702f9589be963dce5c0bd331512809aa07a9f7997fce3949f718acc
   - url: https://www.demandsage.com/chatgpt-statistics/
-    shows: ChatGPT usage statistics aggregator. Returned HTTP 403 to a plain fetch on 2026-08-13, so not
-      re-dated.
+    shows: ChatGPT usage statistics aggregator. Returns HTTP 403 to a plain fetch.
     accessed: '2026-06-04'
 capability:
   score: 5
@@ -64,20 +58,12 @@ capability:
   basis_detail: SWE-bench Verified
   value: null
   confidence: high
-  note: 'OpenAI-reported at launch: SWE-bench Verified 74.9%, MMMU 84.2%, AIME 2025 94.6% (no tools), Aider Polyglot
-    88%. Frontier-tier coding/reasoning. Vendor-reported figures. Re-read 2026-08-14 and ALL FOUR
-    re-derive from the primary source. The launch post was recorded unreachable on 2026-08-13, but
-    openai.com does not refuse automated requests outright - it challenges most of them and lets roughly
-    one in eight through, so the axis was blocked by the fetcher''s retry budget rather than by the host.
-    With that raised, the retrieved body carries every recorded figure verbatim: "74.9% on SWE-bench
-    Verified", "84.2% on MMMU", "94.6% on AIME 2025 without tools", "88% on Aider Polyglot". OpenAI''s
-    system card is kept as a second source because it documents the harness behind the basis figure -
-    a fixed subset of n=477 verified tasks at default verbosity - which the launch post does not.
-    A 2026-08-14 pass had dropped the other three figures as unsourceable; that was correct on the
-    evidence then available and is superseded now. Recorded while the card is open: Artificial Analysis
-    rates plain GPT-5 (high) at 35, #84 of 188 on their recalibrated index, but the tier takes the max
-    across its releases and its current flagship there is GPT-5.6 Sol (max) at 61, so the 5 is not in
-    doubt. No change to the score.'
+  note: 'OpenAI-reported at launch: SWE-bench Verified 74.9%, MMMU 84.2%, AIME 2025 94.6% (no tools), Aider
+    Polyglot 88%. Frontier-tier coding/reasoning. Vendor-reported figures. Artificial Analysis rates plain
+    GPT-5 (high) at 35, #84 of 188 on their recalibrated index, but the tier takes the max across its releases
+    and its current flagship there is GPT-5.6 Sol (max) at 61, so the 5 is not in doubt. OpenAI''s system
+    card is kept as a second source because it documents the harness behind the basis figure - a fixed subset
+    of n=477 verified tasks at default verbosity - which the launch post does not.'
   last_verified: '2026-08-14'
   sources:
   - url: https://cdn.openai.com/gpt-5-system-card.pdf

--- a/sources/scores/gpt-oss-safeguard.yaml
+++ b/sources/scores/gpt-oss-safeguard.yaml
@@ -14,9 +14,8 @@ openness:
   confidence: medium
   note: Open weights under Apache-2.0 (OSI) with no released training data and no published fine-tuning
     pipeline. The 4-rung requires both, so this scores 3, the same rung as every other model that ships
-    permissive weights without a recipe. Notable as a policy-conditioned safety reasoning model rather
-    than a fixed classifier, but that shapes capability, not openness. Re-read 2026-08-13 and unchanged -
-    the card still carries no training-data section at all.
+    permissive weights without a recipe. Notable as a policy-conditioned safety reasoning model rather than
+    a fixed classifier, but that shapes capability, not openness.
   raw: weights:open(gpt-oss-safeguard-20b/120b on HF);data:not-released;license:Apache-2.0(OSI)
   last_verified: '2026-08-13'
   sources:
@@ -45,9 +44,9 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: 100,632 downloads in the trailing 30 days (openai/gpt-oss-safeguard-20b 100,632), read 2026-08-12.
-    Bands at level 3 (100K-1M). Corrected from level 4. Sits barely above the 100K boundary, so this level
-    is fragile in either direction.
+  note: 100,632 downloads in the trailing 30 days (openai/gpt-oss-safeguard-20b 100,632). Bands at level
+    3 (100K-1M). Corrected from level 4. Sits barely above the 100K boundary, so this level is fragile in
+    either direction.
   last_verified: '2026-08-12'
   sources:
   - url: https://huggingface.co/api/models/openai/gpt-oss-safeguard-20b
@@ -63,7 +62,7 @@ capability:
     scores, configurable reasoning effort; 20b and 120b.
   confidence: medium
   note: 'A different shape from fixed classifiers: reasons over an arbitrary supplied policy, which generalizes
-    to novel categories at some latency cost. Re-read 2026-08-13 and unchanged.'
+    to novel categories at some latency cost.'
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/openai/gpt-oss-safeguard-20b

--- a/sources/scores/gpt-researcher.yaml
+++ b/sources/scores/gpt-researcher.yaml
@@ -15,11 +15,7 @@ openness:
     - no feature-gated core
     - model-agnostic
     - Docker + frontend included
-  note: 'Verified Apache-2.0 OSI, full source public, no proprietary tier. Re-read 2026-08-13 - the repo
-    page still reports Apache-2.0 over the whole tree, the README repeats that the code is shared under
-    the Apache 2 license, and the tree carries the backend, the frontend and both Dockerfiles rather than
-    a client. No paid tier, enterprise directory or license-key mechanism anywhere on the page. Stars
-    are now 29.0k. Nothing moved.'
+  note: Verified Apache-2.0 OSI, full source public, no proprietary tier.
   raw: license:Apache-2.0(OSI);source:public;no feature-gated core; model-agnostic; Docker + frontend included;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -38,9 +34,9 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: medium
-  note: 80,472 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (gpt-researcher 80,472). Bands at level 2 (10K-100K) on the software and model adoption scale. Corrected
-    from level 3, which the declared artifacts do not support.
+  note: 80,472 downloads in the trailing 30 days summed across the 1 declared artifact(s) (gpt-researcher
+    80,472). Bands at level 2 (10K-100K) on the software and model adoption scale. Corrected from level
+    3, which the declared artifacts do not support.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/gpt-researcher/recent
@@ -55,11 +51,8 @@ capability:
     yes (research sub-agents); model-agnostic: yes; reliability: cited multi-source reports. No GAIA/agent-benchmark
     placement published.'
   confidence: medium
-  note: 'Solid, focused deep-research agent; no headline GAIA/benchmark number, scored on feature matrix.
-    Narrower than general coding/multi-tool agents; mid-tier. Re-read 2026-08-13 - the repo still describes
-    the same planner/executor deep-research loop over web and local sources producing cited reports, and
-    still publishes no benchmark placement. Two below the openhands anchor, which is the only benchmark-placed
-    agent in the category.'
+  note: Solid, focused deep-research agent; no headline GAIA/benchmark number, scored on feature matrix.
+    Narrower than general coding/multi-tool agents; mid-tier.
   relative_to: openhands
   relation: two_below
   last_verified: '2026-08-13'

--- a/sources/scores/gpt4all.yaml
+++ b/sources/scores/gpt4all.yaml
@@ -13,12 +13,8 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: Fully MIT.
-    Re-read 2026-08-13. The repository still carries MIT and still ships the whole application -
-    installers for Windows, Windows ARM, macOS and Ubuntu plus the Python client - with nothing withheld
-    and no paid tier. Repo now at 77,413 stars. Development is still stalled, with the last push in May
-    2025 and v3.10.0 of February 2025 still the latest release, but that is a maintenance observation
-    rather than an openness one. Value unchanged at 5 / open_source.
+  note: Fully MIT. The repository ships the whole application - installers for Windows, Windows ARM, macOS
+    and Ubuntu plus the Python client - with nothing withheld and no paid tier.
   raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -32,11 +28,11 @@ adoption:
   level: 2
   signal_type: usage_volume
   confidence: medium
-  note: '60,336 downloads in the trailing 30 days (gpt4all 58,808; gpt4all 1,528), read 2026-08-12. Bands
-    at level 2 (10K-100K) on the software and model adoption scale. Moved off the stars fallback: a real
-    download signal exists, and docs/reference/adoption.md says to re-band when one does. The package is the
-    Python bindings plus the Node bindings from the same org. This LOWERS the recorded level from 3 - the
-    star count had been flattering it.'
+  note: '60,336 downloads in the trailing 30 days (gpt4all 58,808; gpt4all 1,528). Bands at level 2 (10K-100K)
+    on the software and model adoption scale. Moved off the stars fallback: a real download signal exists,
+    and docs/reference/adoption.md says to re-band when one does. The package is the Python bindings plus
+    the Node bindings from the same org. This LOWERS the recorded level from 3 - the star count had been
+    flattering it.'
   reach: 10K-100K
   last_verified: '2026-08-12'
   sources:
@@ -56,11 +52,6 @@ capability:
   value: chat UI; LocalDocs private RAG; OpenAI-compatible local server; Vulkan GPU
   confidence: medium
   note: Solid core but behind faster-moving peers on newest-model support due to the maintenance slowdown.
-    Re-read 2026-08-13. The README still shows the chat application running LLMs privately on ordinary
-    desktops and laptops with no API calls or GPU required, the Python client around llama.cpp, and the
-    DeepSeek R1 distillation support that was its last notable addition. The maintenance slowdown the
-    band already accounts for has deepened - nothing has been pushed to the repository since May 2025.
-    Band unchanged at 3.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/nomic-ai/gpt4all

--- a/sources/scores/gradio.yaml
+++ b/sources/scores/gradio.yaml
@@ -13,10 +13,9 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: 'LICENSE file is the standard, unmodified Apache 2.0 text. Re-read 2026-08-13: the cited LICENSE
-    body still carries the Apache-2.0 terms, the GitHub API reports the repository public, unarchived and
-    licensed Apache-2.0, and the README describes the whole library with no paid, enterprise or hosted tier
-    beside it, so source stays public and core-gated stays ungated.'
+  note: LICENSE file is the standard, unmodified Apache 2.0 text. The repository is public and unarchived,
+    and the README describes the whole library with no paid, enterprise or hosted tier beside it, so source
+    is public and the core ungated.
   raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -55,8 +54,7 @@ adoption:
     it into a 5M-50M=L4 band that only this ml_frameworks batch used, below map peers of equal volume. Gradio
     is the default ML demo/UI framework (the standard backend for HF Spaces) and clears the prevailing floor.
     Conservative: it sits just above 10M, so the bump rests on volume plus ecosystem-standard status, not
-    volume alone. Re-read 2026-08-13 from the cited pepy.tech reading of the declared PyPI artifact `gradio`:
-    15,829,897 downloads in the trailing 30 days, which bands at >10M, level 5 on the software scale. Unchanged.'
+    volume alone.'
   last_verified: '2026-08-13'
   sources:
   - url: https://pepy.tech/projects/gradio
@@ -70,9 +68,7 @@ capability:
   value: 'UI/demo framework: build shareable web interfaces and chatbots for ML models and Python functions
     with no frontend code.'
   confidence: high
-  note: 'Broad and widely used for demos and apps but scoped to the interface layer, not model training.
-    Re-read 2026-08-13: the cited repository page still describes the product as recorded, so the band is
-    unchanged.'
+  note: Broad and widely used for demos and apps but scoped to the interface layer, not model training.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/gradio-app/gradio

--- a/sources/scores/granite-code-instruct.yaml
+++ b/sources/scores/granite-code-instruct.yaml
@@ -27,13 +27,8 @@ openness:
   confidence: high
   note: OSI Apache-2.0 + downloadable weights + paper + model card, but training/post-training data only
     described (not redistributable) and no full training pipeline => open_weights, not open_source. Strong
-    within the open_weights class (genuinely permissive, no use caps). Re-read 2026-08-13 - the card still
-    carries `license:apache-2.0` and `"gated":false`, still NAMES its training sets as dataset tags
-    (bigcode/commitpackft, TIGER-Lab/MathInstruct, meta-math/MetaMathQA, glaiveai/glaive-code-assistant-v3,
-    garage-bAInd/Open-Platypus, nvidia/HelpSteer) without publishing the processed mixture, and the repo
-    still ships only inference and fine-tune samples via Dolomite Engine. The card now opens with a
-    "DEPRECATION WARNING - NOT RECOMMENDED FOR USE IN NEW PROJECTS" banner, which does not move openness.
-    No change.
+    within the open_weights class (genuinely permissive, no use caps). The card now opens with a DEPRECATION
+    WARNING - NOT RECOMMENDED FOR USE IN NEW PROJECTS banner, which does not move openness.
   raw: weights:open(Apache-2.0,on HF);code:partial(inference + fine-tune sample scripts via Dolomite Engine;
     no full training pipeline in repo);data:described_not_released(CommitPackFT/MathInstruct/Glaive/HelpSteer/Open-Platypus
     named in card but processed corpus not redistributable);post-training-data:described(SFT mixture named,
@@ -70,10 +65,9 @@ adoption:
   confidence: medium
   note: HF shows ~1,925 downloads/month on the granite-3b-code-instruct-2k variant; model is officially
     deprecated and superseded by Granite 4.x. Even summed across the four Instruct sizes the active monthly
-    pull volume is small. Hobbyist/legacy-research tier. Re-read 2026-08-13 - the declared artifact,
-    granite-34b-code-instruct-8k, reads 628 downloads in the trailing 30 days and the 3b SKU the note
-    banded on reads 5,601. Both are level 1 (<10K) and so is any sum of the family's Instruct SKUs, so
-    the band holds on either reading. No change.
+    pull volume is small. Hobbyist/legacy-research tier. The declared artifact, granite-34b-code-instruct-8k,
+    reads 628 downloads in the trailing 30 days and the 3b SKU reads 5,601; both are level 1 (<10K), as
+    is any sum of the family's Instruct SKUs.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/ibm-granite/granite-3b-code-instruct-2k
@@ -96,9 +90,7 @@ capability:
   confidence: high
   note: Strong-for-size 2024 code SLMs (matched open code LLMs of their era), but sub-13B and ~51% HumanEval
     Python is far below 2026 frontier chat/agentic coders (Opus 4.8 88.6 SWE-bench). Low-mid on a frontier-relative
-    scale. Re-read 2026-08-13 - the card's model-index still records HumanEvalSynthesis(Python) pass@1
-    51.2 for granite-3b-code-instruct, alongside the HumanEvalExplain and HumanEvalFix rows, unchanged.
-    No change.
+    scale.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/ibm-granite/granite-3b-code-instruct-2k

--- a/sources/scores/granite-guardian.yaml
+++ b/sources/scores/granite-guardian.yaml
@@ -14,9 +14,9 @@ openness:
   confidence: medium
   note: Open weights under Apache-2.0 (permissive, OSI), but neither the post-training data nor the fine-tuning
     pipeline is released. The 4-rung requires both, so this scores 3, the rung every comparable Apache-2.0
-    guardrail model sits on. A strong open-weights release even so, and the license is not what holds
-    it back. Re-read 2026-08-13 and unchanged - the card has a Training Data section that names the
-    ingredients without publishing the mixture, which is the state the rung was set on.
+    guardrail model sits on. A strong open-weights release even so, and the license is not what holds it
+    back. The card has a Training Data section that names the ingredients without publishing the mixture,
+    which is the state the rung was set on.
   raw: weights:open(granite-guardian-3.2-5b on HF);data:not-released;license:Apache-2.0(OSI)
   last_verified: '2026-08-13'
   sources:
@@ -45,9 +45,9 @@ adoption:
   reach: <10K
   signal_type: usage_volume
   confidence: medium
-  note: 1,837 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (ibm-granite/granite-guardian-3.2-5b 1,837). Bands at level 1 (<10K) on the software and model adoption
-    scale. Corrected from level 2, which the declared artifacts do not support.
+  note: 1,837 downloads in the trailing 30 days summed across the 1 declared artifact(s) (ibm-granite/granite-guardian-3.2-5b
+    1,837). Bands at level 1 (<10K) on the software and model adoption scale. Corrected from level 2, which
+    the declared artifacts do not support.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/models/ibm-granite/granite-guardian-3.2-5b
@@ -63,7 +63,7 @@ capability:
     relevance, groundedness, answer relevance); broader than pure I/O moderation.
   confidence: medium
   note: 'One of the broadest open guardrails: standard harm taxonomy plus RAG-specific groundedness/hallucination
-    checks. Re-read 2026-08-13 and unchanged.'
+    checks.'
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/ibm-granite/granite-guardian-3.2-5b

--- a/sources/scores/graphrag.yaml
+++ b/sources/scores/graphrag.yaml
@@ -13,9 +13,8 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: 'Fully MIT. Re-read 2026-08-13 - the repo page still reports MIT over the whole tree, publishes
-    the complete indexing and query pipeline, and offers no hosted tier, enterprise directory or license
-    key. Stars are now 35.5k. Nothing moved.'
+  note: 'Fully MIT: the repo publishes the complete indexing and query pipeline and offers no hosted tier,
+    enterprise directory or license key, so the core is ungated as well as OSI-licensed.'
   raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -55,11 +54,8 @@ capability:
   value: KG extraction; hierarchical community detection; community summarization; Global/Local/DRIFT query modes;
     auto prompt-tuning
   confidence: medium
-  note: 'Turnkey for graph-RAG sensemaking but a deliberately narrow single technique. Re-read 2026-08-13
-    - the documentation site still describes the same pipeline, knowledge-graph extraction, hierarchical
-    community detection and summarization, and the Global/Local/DRIFT query modes, with auto prompt tuning.
-    No benchmark placement exists for a RAG technique, so this stays a feature-matrix judgment. One below
-    the openhands anchor, unchanged.'
+  note: Turnkey for graph-RAG sensemaking but a deliberately narrow single technique. No benchmark placement
+    exists for a RAG technique, so this stays a feature-matrix judgment, one below the openhands anchor.
   relative_to: openhands
   relation: one_below
   last_verified: '2026-08-13'

--- a/sources/scores/grok-app.yaml
+++ b/sources/scores/grok-app.yaml
@@ -15,9 +15,6 @@ openness:
       detail: closed weights
   confidence: high
   note: Proprietary chat UI (and its underlying model is closed); closed counterpart on the shelf.
-    Re-read 2026-08-13. The xAI release note is still up and still describes a product delivered only
-    through grok.com, X and the iOS and Android apps, with a model picker rather than any weights or
-    source, and nothing self-hostable. Value unchanged at 1 / closed.
   raw: license:proprietary(SaaS/embedded in X);source:closed;self-host:none;model:xAI Grok(closed weights)
   last_verified: '2026-08-13'
   sources:
@@ -33,15 +30,9 @@ adoption:
   signal_type: active_users
   confidence: low
   note: App reported ~60-64M MAU and ~8-10M DAU early 2026, plus default availability to X Premium subscribers
-    within X's ~350-400M MAU base. Clears >10M as a surface. Figures are aggregator-compiled (xAI does
-    not publish a primary MAU page) and the X-embedded reach is hard to attribute cleanly, so low confidence
+    within X's ~350-400M MAU base. Clears >10M as a surface. Figures are aggregator-compiled (xAI does not
+    publish a primary MAU page) and the X-embedded reach is hard to attribute cleanly, so low confidence
     on the exact number; reach band is robust.
-    Re-read 2026-08-13. SEOProfy still reports 60 million monthly active users for the Grok app and
-    separately about 30 million active users reached through X and the app together, consistent with the
-    60-64M recorded. The xAI release note and the xAI post on X are both still up and still confirm the
-    consumer surface - Grok 4.1 free on grok.com, X and the mobile apps. The figures are still
-    aggregator-compiled because xAI publishes no MAU page, so confidence stays low, but the band is
-    nowhere near its boundary. Level unchanged at 5.
   last_verified: '2026-08-13'
   sources:
   - url: https://seoprofy.com/blog/grok-ai-statistics/
@@ -67,16 +58,12 @@ capability:
     (differentiator), image generation, voice mode, multimodal, large context; multi-user via X/SuperGrok.
     Locked to xAI models (no provider breadth), lighter enterprise/RAG-over-private-data story.'
   confidence: high
-  note: 'Capable general assistant UI with a unique real-time X-search edge; high feature breadth but
-    single-provider-locked, so not the category frontier-definer. [verifier: Grok 4.1 features (real-time
-    X-grounded search, multimodal, reasoning, free on grok.com/X/apps) confirmed via xAI''s own release
-    + X post; x.ai/news/grok-4-1 is live (403 to bot-fetch only). Capability evidence now primary.]
-    Re-read 2026-08-13, and this time the page answered a plain fetch rather than returning 403, so the
-    note above about bot-blocking no longer applies. The release note still describes Grok 4.1 as a
-    frontier model with real-time search integration, rolled out in Auto mode and selectable in the
-    model picker across grok.com, X and the mobile apps, trained with the same large-scale
-    reinforcement-learning infrastructure as Grok 4. Still locked to xAI models with no provider
-    breadth. Band unchanged at 4.'
+  note: Capable general assistant UI with a unique real-time X-search edge; high feature breadth but single-provider-locked,
+    so not the category frontier-definer. Grok 4.1 is a frontier model with real-time search integration,
+    rolled out in Auto mode and selectable in the model picker across grok.com, X and the mobile apps, trained
+    with the same large-scale reinforcement-learning infrastructure as Grok 4. The features are established
+    by xAI's own release note and X post, so the capability evidence is primary. Still locked to xAI models
+    with no provider breadth.
   last_verified: '2026-08-13'
   sources:
   - url: https://x.ai/news/grok-4-1

--- a/sources/scores/grok.yaml
+++ b/sources/scores/grok.yaml
@@ -14,14 +14,11 @@ openness:
       detail: API-only
   governing_release: grok-4-20
   confidence: high
-  note: Proprietary, served through the xAI API, grok.com and X, with no downloadable weights, so 1/closed. Grok
-    4.20 governs and contributes capability 4; adoption 3 is carried from Grok 3, which had wider reach. The bare
-    `grok` slug names this model line - the consumer chat app is a separate product recorded as grok-app.
-    Re-read 2026-08-13 - the release notes still carry the "Grok 4.20 and Grok 4.20 Multi-agent are live"
-    entry with no weight release beside it, and the model reference is still an API document with no
-    distribution path. Two things to record for the other axes rather than this one - the model reference
-    now headlines grok-4.6 as the flagship, so `governing_release - grok-4-20` is stale, and the vendor now
-    brands itself SpaceXAI. Neither moves a closed score. No change.
+  note: Proprietary, served through the xAI API, grok.com and X, with no downloadable weights, so 1/closed.
+    Grok 4.20 governs and contributes capability 4; adoption 3 is carried from Grok 3, which had wider reach.
+    The bare `grok` slug names this model line - the consumer chat app is a separate product recorded as
+    grok-app. The model reference now headlines grok-4.6 as the flagship, so the recorded `governing_release`
+    of grok-4-20 is stale, and the vendor now brands itself SpaceXAI; neither moves a closed score.
   raw: weights:closed;data:closed;code:closed;license:Proprietary(API-only)
   last_verified: '2026-08-13'
   sources:
@@ -44,19 +41,19 @@ adoption:
   signal_type: reported_traction
   confidence: low
   banded_quantity: the X and grok.com surfaces the tier powers, not a per-model count
-  note: 'RE-BANDED 2026-08-14 from 3 to 5 on the max-across-releases rule in docs/reference/identity.md. The old
-    band was set on Grok 3 and marked the tier DOWN explicitly because Grok 3 is superseded - which inverts
-    the rule, since a tier scores on its BEST release and is never penalized for having moved on. Re-read
-    2026-08-14, xAI''s model reference still headlines "Meet grok-4.6 ... Our flagship model for code and
-    everything else" and lists grok-4.3, grok-4.5 and grok-4.6 above the grok-4.20 the record is named for,
-    so the tier''s current release is grok-4.6 and it is the default across the same X and grok.com surfaces
-    the old note credited at app-surface 5 before discounting them away. SAY WHAT WAS BANDED, per
-    docs/reference/adoption.md - this is the surface the tier powers, not a per-model count. xAI publishes no
-    standalone per-model user or usage figure, so the instrument stays reported_traction, no reach is
-    recorded (the honest default), and confidence stays low. This is the same treatment claude-sonnet and
-    gemini-pro already carry - reported_traction, level 5, no reach, attributed to the surfaces the tier
-    powers - and the same shape as the command-r correction. The consumer app itself is a separate product,
-    grok-app; the bare `grok` slug is the model line.'
+  note: RE-BANDED 2026-08-14 from 3 to 5 on the max-across-releases rule in docs/reference/identity.md.
+    The old band was set on Grok 3 and marked the tier DOWN explicitly because Grok 3 is superseded - which
+    inverts the rule, since a tier scores on its BEST release and is never penalized for having moved on.
+    xAI's model reference headlines "Meet grok-4.6 ... Our flagship model for code and everything else"
+    and lists grok-4.3, grok-4.5 and grok-4.6 above the grok-4.20 the record is named for, so the tier's
+    current release is grok-4.6 and it is the default across the same X and grok.com surfaces the old note
+    credited at app-surface 5 before discounting them away. SAY WHAT WAS BANDED, per docs/reference/adoption.md
+    - this is the surface the tier powers, not a per-model count. xAI publishes no standalone per-model
+    user or usage figure, so the instrument stays reported_traction, no reach is recorded (the honest default),
+    and confidence stays low. This is the same treatment claude-sonnet and gemini-pro already carry - reported_traction,
+    level 5, no reach, attributed to the surfaces the tier powers - and the same shape as the command-r
+    correction. The consumer app itself is a separate product, grok-app; the bare `grok` slug is the model
+    line.
   last_verified: '2026-08-14'
   sources:
   - url: https://docs.x.ai/docs/models
@@ -81,43 +78,21 @@ capability:
     the only distinct models above it are Claude Opus 5 at 63 and Claude Fable 5 at 62, and it is level
     with GPT-5.6 Sol at 61'
   confidence: high
-  note: 'Artificial Analysis Intelligence Index v4.0 score of 49, ranked #24 of 150 (median 36); index includes
-    GPQA Diamond and SciCode (individual subscores not disclosed). Provisional LMSYS/LMArena Elo ~1505-1535 (vs
-    1483 for Grok 4.1). Strong but a notch below the GPT-5/Gemini 3.5/Opus 4.7 leaders on the AA index.
-
-    Re-read 2026-08-13, and NONE of the AA figures survives. The page now reports Grok 4.20 0309 v2
-    (Reasoning) at 38 on the Artificial Analysis Intelligence Index, ranked #62 of 184, against a median of
-    34 - not 49, not #24 of 150, and not against a median of 36. Artificial Analysis recalibrated the index,
-    so this is not the same number moving; the figure the record cites no longer exists on their scale. The
-    page also banners the model as deprecated and points at Grok 4.3 (high) instead, and xAI''s own docs now
-    headline grok-4.6. The LMArena estimate still stands on the NextBigFuture source, which is an estimate
-    rather than a measurement and says so. ESCALATED rather than changed - no last_verified claimed on this
-    axis, and the score needs re-deriving on a current release.
-
-    Re-derived on the current release 2026-08-14, as that note asked. Artificial Analysis publishes a
-    grok-4.6 page with no deprecation banner - "Grok 4.6 (high) scores 61 on the Artificial Analysis
-    Intelligence Index", Intelligence rank "# 6 / 188", median 34. On that same recalibrated scale the
-    leaders are Claude Opus 5 (max/xhigh) at 63 and Claude Fable 5 at 62, and grok-4.6 ties GPT-5.6 Sol
-    (max) at 61 while sitting above Kimi K3 (max) 60, GPT-5.6 Sol (xhigh) 59, Muse Spark 1.2 57 and every
-    Gemini entry. So the replacement source exists and is clean, but it does not support the recorded
-    band: "a notch below the GPT-5/Gemini/Opus leaders" is no longer true of the tier''s flagship, which
-    is two index points off the top and inside the leading group. That is a band question rather than a
-    freshness one. ESCALATED for a ruling on 4 -> 5 - no last_verified claimed, because dating a 4 on a
-    source that reads #6 of 188 would be the rubber stamp this gate exists to catch.
-
-    RE-BANDED 4 -> 5 on 2026-08-14, on the owner''s ruling, and re-confirmed against the page rather
-    than against the escalation. Artificial Analysis publishes "Grok 4.6 (high) scores 61 on the
-    Artificial Analysis Intelligence Index, placing it well above average among comparable models
-    (median - 34)", and the page''s own model record carries `deprecated - false`, unlike the grok-4-20
-    page that banners a replacement. Ranking the 456 model records the page embeds by their index, the
-    only distinct models scoring above Grok 4.6 (high) at 60.92 are Claude Opus 5 at 63.05 and Claude
-    Fable 5 at 62.07, with GPT-5.6 Sol level at 60.93 and Kimi K3 next at 59.70. The rank badge itself
-    is drawn client-side and is not in the served body, so this is re-derived from the embedded data
-    rather than read off the badge - it agrees with the "# 6 / 188" the 2026-08-13 read recorded.
-    grok-4.6 is the release the band is taken on, which docs/reference/identity.md licenses directly -
-    adoption and capability take the MAX across a tier''s releases - and xAI''s own model reference
-    still headlines "Meet grok-4.6" above grok-4.3, grok-4.5 and the older grok-4.20. A model inside the
-    top three of the index it is scored on is not a 4.'
+  note: 'RE-BANDED 4 -> 5 on 2026-08-14, on the owner''s ruling. Artificial Analysis publishes "Grok 4.6
+    (high) scores 61 on the Artificial Analysis Intelligence Index, placing it well above average among
+    comparable models (median - 34)", and the page''s own model record carries `deprecated - false`, unlike
+    the grok-4-20 page that banners a replacement. Ranking the 456 model records the page embeds by their
+    index, the only distinct models scoring above Grok 4.6 (high) at 60.92 are Claude Opus 5 at 63.05 and
+    Claude Fable 5 at 62.07, with GPT-5.6 Sol level at 60.93 and Kimi K3 next at 59.70. The rank badge itself
+    is drawn client-side and is not in the served body, so this is derived from the embedded data rather
+    than read off the badge; it agrees with the "# 6 / 188" the page reports. grok-4.6 is the release the
+    band is taken on, which docs/reference/identity.md licenses directly - adoption and capability take
+    the MAX across a tier''s releases - and xAI''s own model reference headlines "Meet grok-4.6" above grok-4.3,
+    grok-4.5 and the older grok-4.20. A model inside the top three of the index it is scored on is not a
+    4. What the band does NOT rest on: the older grok-4-20 page reads 38 and rank #62 of 184 on the same
+    recalibrated scale and banners a replacement, and Artificial Analysis recalibrated the index, so the
+    49 / #24 of 150 this record once carried no longer exists on their scale rather than having merely moved.
+    The ~1505-1535 LMArena figure on NextBigFuture is an explicit estimate rather than a measurement.'
   last_verified: '2026-08-14'
   sources:
   - url: https://artificialanalysis.ai/models/grok-4-20
@@ -143,13 +118,12 @@ capability:
     http_status: 200
     content_sha256: c2773a64aef99b6926d22f7fd870e6ab5d327197d6c8b8bae33ef923497fa238
   - url: https://artificialanalysis.ai/models/grok-4-6
-    shows: 'Re-fetched for the 4 -> 5 ruling. Body carries "Grok 4.6 (high) scores 61 on the Artificial
-      Analysis Intelligence Index, placing it well above average among comparable models (median - 34)"
-      and the model record `"deprecated":false,"deprecatedTo":null`. Ranking the 456 embedded model
-      records by `intelligenceIndex`, Grok 4.6 (high) is at 60.92 behind only Claude Opus 5 (63.05) and
-      Claude Fable 5 (62.07), level with GPT-5.6 Sol (60.93) and ahead of Kimi K3 (59.70). The digest
-      differs from the read four hours earlier because the page carries live pricing and throughput
-      figures.'
+    shows: The same page, fetched again for the 4 -> 5 ruling. Body carries "Grok 4.6 (high) scores 61 on
+      the Artificial Analysis Intelligence Index, placing it well above average among comparable models
+      (median - 34)" and the model record `"deprecated":false,"deprecatedTo":null`. Ranking the 456 embedded
+      model records by `intelligenceIndex`, Grok 4.6 (high) is at 60.92 behind only Claude Opus 5 (63.05)
+      and Claude Fable 5 (62.07), level with GPT-5.6 Sol (60.93) and ahead of Kimi K3 (59.70). The digest
+      drifts between fetches because the page carries live pricing and throughput figures.
     accessed: '2026-08-14'
     http_status: 200
     content_sha256: 113b8be449d39724cbc969e08846bdb98da6729fd3203cd2be64c6b80a5ac63b

--- a/sources/scores/gsm8k.yaml
+++ b/sources/scores/gsm8k.yaml
@@ -17,9 +17,7 @@ openness:
     splits:
       value: train/test public
   confidence: high
-  note: 'Fully open: MIT, ungated, downloadable, with a dataset card. Clean open-data case. Re-read
-    2026-08-13: `license:mit` is still in the repo tags, the embedded repo state reads `"gated":false`,
-    and the dataset card still renders. No change.'
+  note: 'Fully open: MIT, ungated, downloadable, with a dataset card. Clean open-data case.'
   raw: license:MIT(OSI-style permissive, fully redistributable);redistributability:full(downloadable parquet,
     ungated);datasheet:yes(dataset card);size:8.5K problems;splits:train/test public
   last_verified: '2026-08-13'
@@ -36,10 +34,10 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: 960,715 Hugging Face downloads in the trailing 30 days (openai/gsm8k), read 2026-08-12. Bands at
-    level 4 (100K-1M) on the dataset adoption scale, whose top band is >1M - one order of magnitude below
-    the software and model scales, because no dataset artifact in the corpus has ever exceeded 10M. The
-    standard grade-school math-reasoning benchmark, cited near-universally in LLM release reports.
+  note: 960,715 Hugging Face downloads in the trailing 30 days (openai/gsm8k). Bands at level 4 (100K-1M)
+    on the dataset adoption scale, whose top band is >1M - one order of magnitude below the software and
+    model scales, because no dataset artifact in the corpus has ever exceeded 10M. The standard grade-school
+    math-reasoning benchmark, cited near-universally in LLM release reports.
   last_verified: '2026-08-12'
   sources:
   - url: https://huggingface.co/api/datasets/openai/gsm8k
@@ -52,9 +50,7 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: Dataset, not 'capable'. Now largely saturated by frontier models but per recipe capability is
-    n/a. Re-read 2026-08-13 and the abstention stands - the page publishes a static problem set and
-    no performance or feature claim the capability axis could band.
+  note: Dataset, not 'capable'. Now largely saturated by frontier models but per recipe capability is n/a.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/openai/gsm8k

--- a/sources/scores/guardrails-ai.yaml
+++ b/sources/scores/guardrails-ai.yaml
@@ -16,12 +16,12 @@ openness:
     core-gated:
       value: gated
   confidence: medium
-  note: 'INCONCLUSIVE, reported rather than resolved. Read 2026-08-12 and the bare `gated` is not supported,
-    but neither is the 4 it produces. On core-gated itself nothing is withheld from the published source:
-    the 661-entry tree of guardrails-ai/guardrails carries one Apache-2.0 LICENSE and no ee/ or enterprise
-    directory, the FastAPI server ships as its own public repo with a Dockerfile and compose file, and the
-    private validator registry that used to need a token is gone - 0.11.0 moved every Guardrails-AI validator
-    from pypi.guardrailsai.com to public PyPI, the vendor''s own migration guide tabulating "Private registry
+  note: 'INCONCLUSIVE, reported rather than resolved. The bare `gated` is not supported, but neither is
+    the 4 it produces. On core-gated itself nothing is withheld from the published source: the 661-entry
+    tree of guardrails-ai/guardrails carries one Apache-2.0 LICENSE and no ee/ or enterprise directory,
+    the FastAPI server ships as its own public repo with a Dockerfile and compose file, and the private
+    validator registry that used to need a token is gone - 0.11.0 moved every Guardrails-AI validator from
+    pypi.guardrailsai.com to public PyPI, the vendor''s own migration guide tabulating "Private registry
     pypi.guardrailsai.com (token required)" against "Public PyPI (no token)". The commercial product beside
     it is Snowglobe, a separate simulation product. That reads ungated and would compute 5. What stops it
     is the license component, not this one: guardrails-ai/guardrails-api, the server the main package''s
@@ -75,10 +75,10 @@ adoption:
   reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
-  note: 7,279 GitHub stars on guardrails-ai/guardrails, read 2026-08-12. Bands at level 2 (1K-10K stars)
-    on the stars fallback scale, which caps at 3 because a star is not a use. Resynced because the note
-    says 'stars-only proxy, capped per methodology' and recorded the cap. No download, install or customer
-    figure is published for this product, so stars remain the only honest signal and the level is directional.
+  note: 7,279 GitHub stars on guardrails-ai/guardrails. Bands at level 2 (1K-10K stars) on the stars fallback
+    scale, which caps at 3 because a star is not a use. Resynced because the note says 'stars-only proxy,
+    capped per methodology' and recorded the cap. No download, install or customer figure is published for
+    this product, so stars remain the only honest signal and the level is directional.
   last_verified: '2026-08-12'
   sources:
   - url: https://api.github.com/repos/guardrails-ai/guardrails
@@ -93,8 +93,8 @@ capability:
   value: Input/output guards plus a Hub of pre-built validators (PII, toxicity, injection, structure)
     and structured-output enforcement.
   confidence: medium
-  note: Broad validator ecosystem via the Hub; strong on structured-output enforcement in addition to
-    safety checks. Re-read 2026-08-13 and unchanged.
+  note: Broad validator ecosystem via the Hub; strong on structured-output enforcement in addition to safety
+    checks.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/guardrails-ai/guardrails

--- a/sources/scores/gvisor.yaml
+++ b/sources/scores/gvisor.yaml
@@ -16,15 +16,14 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: 'Fully Apache-2.0 application kernel, source public, no gated core (recipe lists gVisor as an open_source
-    exemplar). Re-read 2026-08-13. The LICENSE body is the verbatim Apache License 2.0, with two appended
-    notices saying some files carry MIT or BSD terms noted at the top of each file - both permissive and
-    OSI, so the governing Apache-2.0 stands and the most restrictive part does not move the tier. The
-    untruncated default-branch tree carries one LICENSE and the whole runtime in the open - runsc/, pkg/,
-    shim/, sandboxexec/, webhook/, vdso/ - with no ee/, enterprise/, commercial/ or proprietary/ path,
-    and neither the README nor gvisor.dev names a paid or enterprise edition. Google runs gVisor as a
-    hosted service inside Cloud Run and GKE Sandbox, but sells no gVisor SKU and withholds no runtime
-    feature from the source, so core-gated stays ungated.'
+  note: Fully Apache-2.0 application kernel, source public, no gated core (recipe lists gVisor as an open_source
+    exemplar). Some files carry MIT or BSD terms noted at the top of each file - both permissive and OSI
+    - so the governing Apache-2.0 stands and the most restrictive part does not move the tier. The untruncated
+    default-branch tree carries one LICENSE and the whole runtime in the open (runsc/, pkg/, shim/, sandboxexec/,
+    webhook/, vdso/) with no ee/, enterprise/, commercial/ or proprietary/ path, and neither the README
+    nor gvisor.dev names a paid or enterprise edition. Google runs gVisor as a hosted service inside Cloud
+    Run and GKE Sandbox but sells no gVisor SKU and withholds no runtime feature from the source, so core-gated
+    stays ungated.
   raw: license:Apache-2.0(OSI);source:public(Go);governance:Google-led open project;no-feature-gated-core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -73,24 +72,21 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: 'Underpins Google Cloud Run (''Powered by gVisor'' on gvisor.dev) and is the sandbox layer for GKE
-    Sandbox / App Engine / Cloud Functions, billions of container executions across Google Cloud. Reach far
-    exceeds >10M end-equivalent. (18.5k stars corroborate only.) ARTIFACT DELIBERATELY NOT DECLARED, checked
-    2026-08-13. A PyPI package named `gvisor` exists and is genuinely this project''s, so declaring it would
-    satisfy check_instrument and would be wrong. gVisor is a Go application-kernel shipped as a binary (runsc)
-    and consumed through container runtimes; the PyPI package sees 223 downloads a month. Banding on it would
-    take this record from 5 to 1 on a channel almost nobody uses. That is the under-coverage rule in
-    docs/reference/adoption.md - if the declared artifact is not the product''s primary distribution channel,
-    banding on it is a substitution rather than a measurement - applied before the mistake rather than after.
-    The band stands on the evidence already cited here; what this record needs is a route to its real channel,
-    not a convenient one. Re-read 2026-08-13 and the band holds, on stronger evidence than was cited before.
-    The "Powered by gVisor" badge is still on gvisor.dev and still links to Google Cloud Run, and gvisor.dev/users
-    now states plainly that "there are millions of gVisor sandbox instances running daily" and that gVisor
-    powers GKE Sandbox, Cloud Run and App Engine, alongside named production users - Anthropic (code execution
-    inside claude.ai), Cloudflare Pages builds, DigitalOcean App Platform, Ant Group, Modal, Beam and
-    Docker for Mac. Instrument caveat, recorded rather than papered over - signal_type is usage_volume
-    while the product declares no artifact any signal model can read, so this level cannot be recomputed
-    from a feed and rests on a documented read.'
+  note: 'Underpins Google Cloud Run ("Powered by gVisor" on gvisor.dev) and is the sandbox layer for GKE
+    Sandbox, App Engine and Cloud Functions, billions of container executions across Google Cloud. gvisor.dev/users
+    states plainly that "there are millions of gVisor sandbox instances running daily", alongside named
+    production users - Anthropic (code execution inside claude.ai), Cloudflare Pages builds, DigitalOcean
+    App Platform, Ant Group, Modal, Beam and Docker for Mac. Reach far exceeds >10M end-equivalent. (19,073
+    stars corroborate only.) ARTIFACT DELIBERATELY NOT DECLARED: a PyPI package named `gvisor` exists and
+    is genuinely this project''s, so declaring it would satisfy check_instrument and would be wrong. gVisor
+    is a Go application-kernel shipped as a binary (runsc) and consumed through container runtimes, and
+    the PyPI package sees 223 downloads a month, so banding on it would take this record from 5 to 1 on
+    a channel almost nobody uses. That is the under-coverage rule in docs/reference/adoption.md - if the
+    declared artifact is not the product''s primary distribution channel, banding on it is a substitution
+    rather than a measurement - applied before the mistake rather than after. What this record needs is
+    a route to its real channel, not a convenient one. Instrument caveat, recorded rather than papered over:
+    signal_type is usage_volume while the product declares no artifact any signal model can read, so this
+    level cannot be recomputed from a feed and rests on a documented read.'
   last_verified: '2026-08-13'
   sources:
   - url: https://gvisor.dev/docs/
@@ -131,14 +127,8 @@ capability:
   confidence: high
   note: 'Frontier-definer: a novel application-kernel isolation model giving VM-class security at userspace
     footprint/startup, the reference sandbox for Google Cloud''s serverless containers. Co-frontier with
-    Firecracker (different isolation philosophy). Re-read 2026-08-13. The README and gvisor.dev still describe
-    the same instrument - a memory-safe Go application kernel that intercepts application system calls and
-    acts as the guest kernel "without the need for translation through virtualized hardware", explicitly
-    neither a syscall filter nor a VM but "a distinct third approach", giving "many security benefits of
-    VMs while maintaining the lower resource footprint, fast startup, and flexibility of regular userspace
-    applications", shipped as the OCI runtime runsc for Docker and Kubernetes. The prose co-frontier
-    comparison is now recorded as relative_to firecracker with relation `at`, which holds arithmetically -
-    both capability scores are 5, and Firecracker''s was re-derived the same day. Score unchanged at 5.'
+    Firecracker (different isolation philosophy). The prose co-frontier comparison is recorded as relative_to
+    firecracker with relation `at`, which holds arithmetically since both capability scores are 5.'
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/google/gvisor

--- a/sources/scores/hailo-10h.yaml
+++ b/sources/scores/hailo-10h.yaml
@@ -22,14 +22,13 @@ openness:
       detail: M.2 modules purchasable
       raw: open_market (M.2 modules purchasable)
   confidence: high
-  note: Proprietary silicon with published datasheets and an open GenAI model zoo, but the silicon and
-    full toolchain are closed. Re-read 2026-08-14 against substitutes, hailo.ai being unfetchable at
-    403. Each component re-derived - the GenAI model zoo is still MIT by the GitHub API's own
-    `spdx_id`, and HailoRT is MIT/LGPL-2.1 with the developer-zone documentation behind registration
-    and the Dataflow Compiler behind a customer relationship, which is the closed half of `toolchain`;
-    `blobs` from HailoRT's driver shipping device firmware; `datasheets` from AAEON's UP page carrying
-    the full published spec table for the module; `retail` from the same page plus Geniatech shipping
-    an independent Hailo-10 module. No change.
+  note: 'Proprietary silicon with published datasheets and an open GenAI model zoo, but the silicon and
+    full toolchain are closed. Component detail: the GenAI model zoo is MIT by the GitHub API''s own `spdx_id`;
+    HailoRT is MIT/LGPL-2.1 while the developer-zone documentation sits behind registration and the Dataflow
+    Compiler behind a customer relationship, which is the closed half of `toolchain`; `blobs` rests on HailoRT''s
+    driver shipping device firmware; `datasheets` on AAEON''s UP page carrying the full published spec table
+    for the module; `retail` on that same page plus Geniatech shipping an independent Hailo-10 module. hailo.ai
+    itself is unfetchable at 403, so these rest on substitutes.'
   raw: schematics:none;toolchain:partial (open runtime + MIT GenAI model zoo);datasheets:public (June 2025);blobs:required
     (proprietary silicon/firmware);retail:open_market (M.2 modules purchasable)
   last_verified: '2026-08-14'
@@ -76,11 +75,10 @@ adoption:
   signal_type: reported_traction
   confidence: medium
   note: Newer generative-AI part; purchasable M.2 modules and a dedicated GenAI repo, but smaller install
-    base than the Hailo-8. Re-read 2026-08-14 against substitutes. Both halves hold - the part is
-    productized and purchasable through at least two independent module vendors (AAEON/UP, Geniatech),
-    and it is still visibly the smaller surface next to the Hailo-8, with the GenAI model zoo at 100
-    stars and last pushed 2026-04-15 against HailoRT's 215 stars and 2026-08-11. Niche at level 3,
-    one below the Hailo-8, is unchanged.
+    base than the Hailo-8. The part is productized and purchasable through at least two independent module
+    vendors (AAEON/UP and Geniatech), and it is visibly the smaller surface next to the Hailo-8 - the GenAI
+    model zoo carries 100 stars against HailoRT's 215 - which is why niche at level 3, one below the Hailo-8,
+    is where it sits.
   last_verified: '2026-08-14'
   sources:
   - url: https://hailo.ai/products/ai-accelerators/hailo-10h-m-2-ai-acceleration-module/
@@ -109,12 +107,11 @@ capability:
   value: 40 TOPS INT4 / 20 TOPS INT8; runs LLMs & VLMs via direct DDR interface
   confidence: high
   note: Edge-first part that runs generative models locally via a DDR interface, a step beyond CNN-only
-    edge accelerators. Re-derived 2026-08-14 against substitutes, hailo.ai being unfetchable. AAEON/UP
-    reproduces the recorded value exactly - "AI Performance 40 TOPS @ INT4 | 20 TOPS @ INT8" and
-    "Hailo-10H includes a direct DDR interface, allowing it to scale for large models such as LLMs,
-    VLMs, Stable Diffusion" - and Geniatech independently states up to 40 TOPS running LLMs and VLMs
-    locally. Still one band above the Hailo-8, which is CNN/vision-only and bounded by on-die memory.
-    No change.
+    edge accelerators. AAEON/UP reproduces the recorded value exactly - "AI Performance 40 TOPS @ INT4 |
+    20 TOPS @ INT8" and "Hailo-10H includes a direct DDR interface, allowing it to scale for large models
+    such as LLMs, VLMs, Stable Diffusion" - and Geniatech independently states up to 40 TOPS running LLMs
+    and VLMs locally. That is one band above the Hailo-8, which is CNN/vision-only and bounded by on-die
+    memory. hailo.ai itself is unfetchable, so both rest on substitutes.
   last_verified: '2026-08-14'
   sources:
   - url: https://hailo.ai/products/ai-accelerators/hailo-10h-m-2-ai-acceleration-module/

--- a/sources/scores/hailo-8.yaml
+++ b/sources/scores/hailo-8.yaml
@@ -22,17 +22,16 @@ openness:
       detail: global modules
       raw: open_market (global modules)
   confidence: high
-  note: Proprietary silicon with an open source runtime and public product briefs, but the model-compiler
-    toolchain requires registration and silicon is closed. Re-read 2026-08-14 against substitutes,
-    because hailo.ai answers 403 to every automated request and is not re-fetchable. Every component
-    re-derived - HailoRT's README carries the open half of `toolchain` ('libhailort, pyhailort &
-    hailortcli - distributed under the MIT license', hailonet under LGPL 2.1) and the gated half is
-    named by the Model Zoo README, which instructs 'Install Hailo Dataflow Compiler ... In case you
-    are not Hailo customer please contact hailo.ai'; `blobs` by the same README noting the PCIe driver
-    'includes the Hailo-8 firmware that runs on the Hailo device'; `datasheets` by Hailo's own Hailo-8
-    M.2 data sheet Rev 1.1, mirrored publicly by distributor Premio and stamped 'Hailo proprietary -
-    unauthorized reproduction prohibited', which is also why `schematics` stays none; `retail` by
-    Waveshare listing the module at $179.99 with Add to Cart. No change.
+  note: 'Proprietary silicon with an open source runtime and public product briefs, but the model-compiler
+    toolchain requires registration and silicon is closed. Component detail: HailoRT''s README carries the
+    open half of `toolchain` ("libhailort, pyhailort & hailortcli - distributed under the MIT license",
+    hailonet under LGPL 2.1) and the gated half is named by the Model Zoo README, which instructs "Install
+    Hailo Dataflow Compiler ... In case you are not Hailo customer please contact hailo.ai"; `blobs` by
+    the same README noting the PCIe driver "includes the Hailo-8 firmware that runs on the Hailo device";
+    `datasheets` by Hailo''s own Hailo-8 M.2 data sheet Rev 1.1, mirrored publicly by distributor Premio
+    and stamped "Hailo proprietary - unauthorized reproduction prohibited", which is also why `schematics`
+    stays none; `retail` by Waveshare listing the module at $179.99 with Add to Cart. hailo.ai answers 403
+    to every automated request, so these rest on substitutes.'
   raw: schematics:none;toolchain:partial (open runtime (HailoRT) + closed/registration Dataflow Compiler);datasheets:brief
     (public briefs);blobs:required (proprietary silicon + firmware);retail:open_market (global modules)
   last_verified: '2026-08-14'
@@ -79,16 +78,14 @@ adoption:
   signal_type: reported_traction
   confidence: high
   banded_quantity: a vendor-reported user count (100K+) that is not re-derivable — hailo.ai answers 403
-  note: Retail-available modules and a large developer base; vendor reports 100K+ users and hundreds of
-    deployed customer products, with an active GitHub org. Re-read 2026-08-14. The vendor's own
-    100K-users figure is NOT re-derivable - hailo.ai answers 403 to every automated request - and no
-    substitute publishes it, so that number rests on the 2026-06-22 read and nothing here refreshes it.
-    What the substitutes do re-establish is the standing the band was placed on - the part is stocked
-    and sold by several independent distributors on three continents (Waveshare at $179.99, Geniatech
-    AIM-M-H8, AAEON/UP, Advantech via Mouser), and HailoRT is a live repo at 215 stars and 80 forks
-    last pushed 2026-08-11. That is broad standing for an edge accelerator, so level 4 / broad is
-    unchanged. `reported_traction` claims no count, which is exactly why the missing figure does not
-    move it.
+  note: 'Retail-available modules and a large developer base; vendor reports 100K+ users and hundreds of
+    deployed customer products, with an active GitHub org. The vendor''s own 100K-users figure is not independently
+    derivable - hailo.ai answers 403 to every automated request and no substitute publishes it - so that
+    number rests on an earlier read. What the substitutes do establish is the standing the band was placed
+    on: the part is stocked and sold by several independent distributors on three continents (Waveshare
+    at $179.99, Geniatech AIM-M-H8, AAEON/UP, Advantech via Mouser), and HailoRT is a live repo at 215 stars
+    and 80 forks. That is broad standing for an edge accelerator, so level 4 / broad holds. `reported_traction`
+    claims no count, which is exactly why the unverifiable figure does not move it.'
   last_verified: '2026-08-14'
   sources:
   - url: https://hailo.ai/products/ai-accelerators/hailo-8-ai-accelerator/
@@ -120,13 +117,12 @@ capability:
   value: 26 TOPS; CNN/vision inference; supports TF/TFLite/PyTorch/ONNX; on-die memory
   confidence: high
   note: Strong dedicated CNN inference throughput for the edge, but vision-oriented and limited to models
-    that fit on-die memory. Re-derived 2026-08-14 against substitutes, hailo.ai being unfetchable.
-    Every element of the recorded value reproduces - Geniatech's AIM-M-H8 spec table reads "AI
-    performance 26 TOPS(INT8)", "AI Model Frameworks Supported TensorFlow,TensorFlow Lite,Keras,
-    PyTorch&ONNX" and "Memory - Processor integration", which is the on-die claim stated as a
-    specification rather than as marketing; Waveshare independently lists 26 TOPS at 2.5W typical.
-    Still one band below the Hailo-10H, which adds a DDR interface and generative-model support.
-    No change.
+    that fit on-die memory. Every element of the recorded value reproduces against substitutes, hailo.ai
+    being unfetchable - Geniatech's AIM-M-H8 spec table reads "AI performance 26 TOPS(INT8)", "AI Model
+    Frameworks Supported TensorFlow,TensorFlow Lite,Keras, PyTorch&ONNX" and "Memory - Processor integration",
+    which is the on-die claim stated as a specification rather than as marketing; Waveshare independently
+    lists 26 TOPS at 2.5W typical. That is one band below the Hailo-10H, which adds a DDR interface and
+    generative-model support.
   last_verified: '2026-08-14'
   sources:
   - url: https://hailo.ai/products/ai-accelerators/hailo-8-ai-accelerator/

--- a/sources/scores/harmbench.yaml
+++ b/sources/scores/harmbench.yaml
@@ -15,8 +15,7 @@ openness:
     core-gated:
       value: ungated
   confidence: high
-  note: 'Fully open source: MIT-licensed standardized red-teaming evaluation framework, self-hostable.
-    Re-read 2026-08-13 and unchanged.'
+  note: 'Fully open source: MIT-licensed standardized red-teaming evaluation framework, self-hostable.'
   raw: license:MIT(OSI);source:public;self-host:yes;service:none;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -36,10 +35,10 @@ adoption:
   reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
-  note: 'Stars-only proxy, capped at 3 because a star is not a use; widely cited as the standardized
-    red-teaming benchmark in research. Re-read 2026-08-13 - the repo shows 1,029 stargazers, which bands
-    at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. HarmBench ships no package on PyPI
-    or npm, so there is no download route to re-band onto and stars remain the only signal.'
+  note: Stars-only proxy, capped at 3 because a star is not a use; widely cited as the standardized red-teaming
+    benchmark in research. The repo shows 1,029 stargazers, which bands at 1K-10K stars, level 2 on the
+    stars scale in signal_routing.yaml. HarmBench ships no package on PyPI or npm, so there is no download
+    route to re-band onto and stars remain the only signal.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/centerforaisafety/HarmBench
@@ -55,8 +54,7 @@ capability:
   value: A standardized pipeline spanning 18 automated attack methods and 33 target models, enabling rigorous
     attack/defense comparison and co-development.
   confidence: medium
-  note: The reference standardized harness for comparing red-team attacks and defenses; research-grade
-    breadth. Re-read 2026-08-13 and unchanged.
+  note: The reference standardized harness for comparing red-team attacks and defenses; research-grade breadth.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/centerforaisafety/HarmBench

--- a/sources/scores/haystack.yaml
+++ b/sources/scores/haystack.yaml
@@ -15,18 +15,17 @@ openness:
       detail: deepset names the free tier a Community Edition and sells Haystack Enterprise Starter with
         a private template/Helm repo plus early access to security features not yet in OSS
   confidence: high
-  note: 'Apache-2.0 self-hostable core with a commercial enterprise tier. `core-gated: gated` transcribed
-    2026-08-11 from a read of the repo and deepset''s own product pages. The repo itself is clean - a full
-    untruncated recursive tree of deepset-ai/haystack@main carries one governing Apache-2.0 LICENSE and
-    no enterprise/ or ee/ directory - so this is not the LiteLLM shape. What makes it gated is that the
-    withheld directory is a separate private REPOSITORY rather than a subdirectory: Haystack Enterprise
-    Starter ships ''curated pipeline templates'', a ''Helm chart and guides'', and ''early access to enterprise-grade
-    features ... like prompt injection countermeasures and other security-oriented features ahead of broader
-    release''. deepset''s own tiering calls the free product ''Haystack OSS (Community Edition)'', and a
-    commercial edition is one of the three things the rubric''s gated definition names. Distinguished from
-    the otari precedent deliberately: otari''s paid offering was a hosted platform running the same published
-    code, whereas this is code and features that the published source does not contain at the time they
-    are sold.'
+  note: 'Apache-2.0 self-hostable core with a commercial enterprise tier. `core-gated: gated` from a direct
+    read of the repo and deepset''s own product pages. The repo itself is clean - a full untruncated recursive
+    tree of deepset-ai/haystack@main carries one governing Apache-2.0 LICENSE and no enterprise/ or ee/
+    directory - so this is not the LiteLLM shape. What makes it gated is that the withheld directory is
+    a separate private REPOSITORY rather than a subdirectory: Haystack Enterprise Starter ships ''curated
+    pipeline templates'', a ''Helm chart and guides'', and ''early access to enterprise-grade features ...
+    like prompt injection countermeasures and other security-oriented features ahead of broader release''.
+    deepset''s own tiering calls the free product ''Haystack OSS (Community Edition)'', and a commercial
+    edition is one of the three things the rubric''s gated definition names. Distinguished from the otari
+    precedent deliberately: otari''s paid offering was a hosted platform running the same published code,
+    whereas this is code and features that the published source does not contain at the time they are sold.'
   last_verified: '2026-08-11'
   raw: license:Apache-2.0(core);commercial:Haystack-Enterprise;source:public;core-gated:gated(deepset names
     the free tier a Community Edition and sells Haystack Enterprise Starter with a private template/Helm
@@ -78,9 +77,9 @@ adoption:
   level: 3
   signal_type: usage_volume
   confidence: high
-  note: 933,408 PyPI downloads in the trailing 30 days for haystack-ai, read 2026-08-12. Bands at level
-    3 (100K-1M) on the software and model adoption scale. The 2.x package; sits just under the 1M boundary
-    and could cross either way. Corrected from level 4, which the recorded evidence did not support.
+  note: 933,408 PyPI downloads in the trailing 30 days for haystack-ai. Bands at level 3 (100K-1M) on the
+    software and model adoption scale. The 2.x package; sits just under the 1M boundary and could cross
+    either way. Corrected from level 4, which the recorded evidence did not support.
   reach: 100K-1M
   last_verified: '2026-08-12'
   sources:
@@ -95,11 +94,10 @@ capability:
   value: modular pipeline/DAG composition; retrievers + document stores (RAG); routing; memory; agent workflows;
     tool calling; evaluation; broad integrations
   confidence: high
-  note: 'Most mature combined RAG + orchestration feature set among the peers. Re-read 2026-08-13 - the
-    repo still describes modular pipelines and agent workflows with explicit control over retrieval, routing,
-    memory and generation, covering RAG, multimodal applications, semantic search, question answering
-    and autonomous agents, and now adds ready-made agents through Agent Pack and progressive skill discovery
-    through SkillToolset. The feature matrix that placed this band is unchanged.'
+  note: Most mature combined RAG + orchestration feature set among the peers. The repo publishes modular
+    pipelines and agent workflows with explicit control over retrieval, routing, memory and generation,
+    covering RAG, multimodal applications, semantic search, question answering and autonomous agents, and
+    adds ready-made agents through Agent Pack and progressive skill discovery through SkillToolset.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/deepset-ai/haystack

--- a/sources/scores/helicone.yaml
+++ b/sources/scores/helicone.yaml
@@ -104,11 +104,10 @@ adoption:
   reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
-  note: 6,058 GitHub stars on Helicone/helicone, read 2026-08-12. Bands at level 2 (1K-10K stars) on the
-    stars fallback scale, which caps at 3 because a star is not a use. Resynced because the note says 'capped
-    at level 3 via stars fallback' and recorded the cap; no request or customer count is disclosed. No download,
-    install or customer figure is published for this product, so stars remain the only honest signal and
-    the level is directional.
+  note: 6,058 GitHub stars on Helicone/helicone. Bands at level 2 (1K-10K stars) on the stars fallback scale,
+    which caps at 3 because a star is not a use. Resynced because the note says 'capped at level 3 via stars
+    fallback' and recorded the cap; no request or customer count is disclosed. No download, install or customer
+    figure is published for this product, so stars remain the only honest signal and the level is directional.
   last_verified: '2026-08-12'
   sources:
   - url: https://api.github.com/repos/Helicone/helicone
@@ -127,9 +126,6 @@ capability:
   confidence: high
   note: Broad feature matrix with a strong gateway/routing + caching angle on top of tracing, prompt mgmt,
     cost, and datasets; on par with Langfuse C4. Held at 4 (no frontier-definer claim over anchors).
-    Re-read 2026-08-13 - the README's own feature grid is still Observability, Agent Tracing, LLM Routing,
-    Cost & Latency Tracking, Datasets & Fine-tuning and Automatic Fallbacks, with a playground and prompt
-    management beneath it, so the recorded comparison at the langfuse anchor still holds.
   last_verified: '2026-08-13'
   sources:
   - url: https://raw.githubusercontent.com/Helicone/helicone/main/README.md

--- a/sources/scores/hellaswag.yaml
+++ b/sources/scores/hellaswag.yaml
@@ -16,10 +16,8 @@ openness:
       value: public
       detail: train/val/test all released, not held-out
   confidence: high
-  note: Fully open under MIT with dataset card; canonical open-data benchmark profile. Re-read 2026-08-13
-    - the card's Licensing Information section still reads "MIT" and links the rowanz/hellaswag LICENSE,
-    the embedded repo state reads `"gated":false`, and all three splits still download. Note the repo
-    carries no `license:` tag, so the MIT is established by the card body rather than the tag.
+  note: Fully open under MIT with dataset card; canonical open-data benchmark profile. The repo carries
+    no `license:` tag, so the MIT is established by the card body rather than the tag.
   raw: data:open(59,950 examples, downloadable on HF);license:MIT(permissive, redistributable);datasheet:yes(HF
     dataset card + ACL 2019 paper);access:public(train/val/test all released, not held-out)
   last_verified: '2026-08-13'
@@ -38,10 +36,10 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: 309,927 Hugging Face downloads in the trailing 30 days (Rowan/hellaswag), read 2026-08-12. Bands
-    at level 4 (100K-1M) on the dataset adoption scale, whose top band is >1M - one order of magnitude below
-    the software and model scales, because no dataset artifact in the corpus has ever exceeded 10M. A commonsense
-    benchmark cited across LLM release reports and the Open LLM Leaderboard.
+  note: 309,927 Hugging Face downloads in the trailing 30 days (Rowan/hellaswag). Bands at level 4 (100K-1M)
+    on the dataset adoption scale, whose top band is >1M - one order of magnitude below the software and
+    model scales, because no dataset artifact in the corpus has ever exceeded 10M. A commonsense benchmark
+    cited across LLM release reports and the Open LLM Leaderboard.
   last_verified: '2026-08-12'
   sources:
   - url: https://huggingface.co/api/datasets/Rowan/hellaswag
@@ -54,9 +52,7 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: Capability not a meaningful axis for an eval dataset. Re-read 2026-08-13 and the abstention
-    stands - the page publishes a static sentence-completion corpus and no performance or feature claim
-    the capability axis could band.
+  note: Capability not a meaningful axis for an eval dataset.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/Rowan/hellaswag

--- a/sources/scores/helm.yaml
+++ b/sources/scores/helm.yaml
@@ -19,9 +19,7 @@ openness:
   confidence: high
   last_verified: '2026-08-13'
   note: Fully OSI (Apache-2.0); framework, standardized data formats, web UI, and leaderboards all public.
-    Re-read 2026-08-13 - the license endpoint still reports Apache-2.0 and the README still documents
-    reproducing every published leaderboard from the framework itself. HELM entered maintenance mode on
-    2026-06-01, which slows the code without withdrawing or gating any of it.
+    HELM is in maintenance mode, which slows the code without withdrawing or gating any of it.
   raw: license:Apache-2.0(OSI);source:public(framework + standardized datasets + web UI + leaderboard code);governance:Stanford
     CRFM(academic); no gated core;core-gated:ungated
   sources:
@@ -58,13 +56,11 @@ adoption:
   note: 'Headline signal is influence/standard-setting, not install volume: HELM is a widely-cited standardized
     public leaderboard from Stanford CRFM spanning multiple modalities (capabilities/safety/vision/medical),
     referenced across the research community. PyPI distribution (crfm-helm) is only ~3,142 downloads/month;
-    most usage is via the hosted leaderboard and academic citation rather than pip, so download volume
-    understates reach. Level 3 reflects meaningful research/standard adoption short of mass production
-    deployment. Re-read 2026-08-13 - the README still lists the flagship HELM Capabilities, Safety, VHELM,
-    HEIM, ToRR, MedHELM and audio leaderboards with their papers, and crfm-helm is now at 5,097 downloads
-    a month. That download figure would band at level 1 on its own; it is deliberately not the instrument
-    here, for the reason already recorded, and the 5,097 is offered as the same corroboration the 3,142
-    was.'
+    most usage is via the hosted leaderboard and academic citation rather than pip, so download volume understates
+    reach. Level 3 reflects meaningful research/standard adoption short of mass production deployment. crfm-helm
+    is at 5,097 downloads a month, a figure that would band at level 1 on its own; it is deliberately not
+    the instrument here, for the reason already recorded, and stands as the same corroboration the earlier
+    3,142 was.'
   sources:
   - url: https://github.com/stanford-crfm/helm
     shows: multiple public leaderboards (HELM Capabilities/Safety/VHELM/HEIM/MedHELM); Stanford CRFM standardized
@@ -96,12 +92,12 @@ capability:
   relative_to: inspect-ai
   relation: at
   last_verified: '2026-08-13'
-  note: Frontier-defining on coverage and standardization, the holistic multi-modality leaderboard standard.
-    One of the 1-2 category leaders, scored 5. (Weaker than Inspect AI on agentic-eval support, but broader
-    on benchmark/modality coverage.) That trade is why the recorded comparison is `at` rather than above
-    or below Inspect AI. Feature matrix re-read 2026-08-13 and unchanged - the same leaderboard family
-    across text, vision-language, text-to-image, table reasoning, medical and audio. HELM entered maintenance
-    mode on 2026-06-01, which caps future breadth without narrowing what is there.
+  note: 'Frontier-defining on coverage and standardization, the holistic multi-modality leaderboard standard:
+    the same leaderboard family across text, vision-language, text-to-image, table reasoning, medical and
+    audio. One of the 1-2 category leaders, scored 5. (Weaker than Inspect AI on agentic-eval support, but
+    broader on benchmark/modality coverage.) That trade is why the recorded comparison is `at` rather than
+    above or below Inspect AI. HELM is in maintenance mode, which caps future breadth without narrowing
+    what is there.'
   sources:
   - url: https://github.com/stanford-crfm/helm
     shows: standardized datasets, unified model access, metrics beyond accuracy, web UI, multi-modal leaderboards

--- a/sources/scores/hermes-3-dataset.yaml
+++ b/sources/scores/hermes-3-dataset.yaml
@@ -10,8 +10,7 @@ openness:
     dataset_card:
       value: present
   confidence: high
-  note: 'Apache-2.0, ungated, dataset card. Re-read 2026-08-13: apache-2.0 on the Hub, gated false, card
-    intact.'
+  note: Apache-2.0, ungated, dataset card.
   raw: license:Apache-2.0;gated:false;dataset_card:present
   last_verified: '2026-08-13'
   sources:
@@ -29,9 +28,9 @@ adoption:
   reach: <1K
   signal_type: usage_volume
   confidence: high
-  note: 688 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (NousResearch/Hermes-3-Dataset 688). Bands at level 1 (<1K) on the dataset adoption scale, whose top
-    band is >1M. Corrected from level 2, which the declared artifacts do not support.
+  note: 688 downloads in the trailing 30 days summed across the 1 declared artifact(s) (NousResearch/Hermes-3-Dataset
+    688). Bands at level 1 (<1K) on the dataset adoption scale, whose top band is >1M. Corrected from level
+    2, which the declared artifacts do not support.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/NousResearch/Hermes-3-Dataset
@@ -45,10 +44,9 @@ capability:
   basis_detail: downstream
   value: null
   confidence: high
-  note: 'Proven value with documented Hermes 3 results and explicitly folded into Hermes 4 (2025), but independent
-    reuse is limited to community quantizers. Re-read 2026-08-13: the Hermes 4 report still states that
-    a significant portion of the Hermes 3 dataset was retained, and Table 5 of the Hermes 3 report still
-    has Hermes 3 ahead of Llama 3.1 Instruct on the majority of the seventeen benchmarks at all three sizes.'
+  note: Proven value with documented Hermes 3 results and explicitly folded into Hermes 4 (2025), but independent
+    reuse is limited to community quantizers. Table 5 of the Hermes 3 report puts Hermes 3 ahead of Llama
+    3.1 Instruct on the majority of its seventeen benchmarks at all three sizes.
   last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/pdf/2508.18255

--- a/sources/scores/hermes-agent.yaml
+++ b/sources/scores/hermes-agent.yaml
@@ -16,11 +16,7 @@ openness:
     - model-agnostic(multi-provider)
     - self-host-by-design
   confidence: high
-  note: 'Fully MIT-licensed, complete public source, self-hosted by design, no proprietary core; top openness.
-    Re-read 2026-08-13 - the repo still carries an MIT badge and the README still ends "License - MIT,
-    see LICENSE. Built by Nous Research.", and the product page still labels the download "Open Source
-    - MIT License" and footers "Hermes Agent v0.20.0, Nous Research, MIT License - 2026". Stars are now
-    230.0k. Nothing moved.'
+  note: Fully MIT-licensed, complete public source, self-hosted by design, no proprietary core; top openness.
   raw: license:MIT(OSI);source:public(github.com/NousResearch/hermes-agent);no-feature-gated-core;model-agnostic(multi-provider);self-host-by-design;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -49,18 +45,16 @@ adoption:
   signal_type: usage_volume
   confidence: medium
   note: 'Real usage signal beyond stars (adoption!=stars rule): Hermes Agent reported #1 on OpenRouter''s
-    GLOBAL token rankings, confirmed by Nous Research''s own announcement (~271B tokens, May 6 2026)
-    and an OpenRouter app page; secondary reports give ~224B daily tokens by May 10 (surpassing OpenClaw''s
-    ~186B). Both figures are reported; token-volume mapped to 1-10M-equivalent reach (inference, not a
-    disclosed installed-user count). GitHub stars (~181K, <4 months) corroborate but are not the basis.
-    Level 4 / medium confidence: deciding metric now backed by a primary source, but reach is inferred
-    from token volume. Re-read 2026-08-13 - the OpenRouter app page now states 35.8T total tokens, a daily
-    global rank of #1, active since March 2026, 417 models used, and #1 in both Productivity and Coding
-    Agents; the Nous Research post announcing the #1 global ranking is still live. WHAT WAS BANDED - inference
-    token volume, which is not a download count and not a user count, so the numeric reach label on this
-    record is a download label over a token figure. The magnitude has grown by two orders since the score
-    was authored and the level is unchanged; the instrument and label are left as recorded rather than
-    switched in a re-read.'
+    GLOBAL token rankings, confirmed by Nous Research''s own announcement (~271B tokens, May 6 2026) and
+    an OpenRouter app page; secondary reports give ~224B daily tokens by May 10 (surpassing OpenClaw''s
+    ~186B). Both figures are reported; token-volume mapped to 1-10M-equivalent reach (inference, not a disclosed
+    installed-user count). GitHub stars (~181K, <4 months) corroborate but are not the basis. Level 4 /
+    medium confidence: deciding metric now backed by a primary source, but reach is inferred from token
+    volume. The OpenRouter app page states 35.8T total tokens, a daily global rank of #1, active since March
+    2026, 417 models used, and #1 in both Productivity and Coding Agents. WHAT WAS BANDED - inference token
+    volume, which is not a download count and not a user count, so the numeric reach label on this record
+    is a download label over a token figure. The magnitude has grown by two orders since the score was authored
+    while the level is unchanged; the instrument and label are left as recorded.'
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/NousResearch/hermes-agent
@@ -91,12 +85,9 @@ capability:
     40+ tools, subagent delegation, NL cron scheduling, containerized sandboxing, web/browser control,
     multi-channel, model-agnostic; no first-party SWE-bench/GAIA headline
   confidence: medium
-  note: 'Distinctive autonomy (self-improvement loop + persistent memory + subagent delegation) and very
-    broad tool/channel coverage place it high on the feature matrix; no published benchmark so scored
-    4, just below a verified-benchmark ceiling. Re-read 2026-08-13 - the repo still documents the same
-    self-improving skill loop, persistent memory, tool breadth, subagents, scheduling and sandboxing,
-    and the OpenRouter listing independently describes web search, browser automation, vision, scheduled
-    automations and subagents. Still no benchmark placement. One below the openhands anchor, unchanged.'
+  note: Distinctive autonomy (self-improvement loop + persistent memory + subagent delegation) and very
+    broad tool/channel coverage place it high on the feature matrix; no published benchmark so scored 4,
+    just below a verified-benchmark ceiling.
   relative_to: openhands
   relation: one_below
   last_verified: '2026-08-13'

--- a/sources/scores/hermes.yaml
+++ b/sources/scores/hermes.yaml
@@ -19,22 +19,18 @@ openness:
     license:
     - name: Apache-2.0
       detail: OSI
-  note: 'Nous ships one Hermes 4 post-training recipe on four independent base models, and the base determines the
-    license the weights carry: Seed-OSS-36B and Qwen3-14B are Apache-2.0, while the Llama-3.1 405B and 70B builds
-    inherit Meta''s Llama-3.1-Community terms (700M-MAU commercial cap, acceptable-use policy, naming requirements).
-    Scored 3 on the Apache builds rather than 2 on the Llama ones, because most-restrictive-across-SKUs is a rule
-    about variants you cannot substitute away from - Qwen 2.5''s restricted 72B caps Qwen because the 7B is not
-    a substitute for the flagship - and here the base is a free choice. Anyone wanting Apache-licensed Hermes 4
-    takes the 36B or 14B build and gets it, so the family genuinely offers open weights. Not 4 or 5: the post-training
-    corpus is proprietary and only inference code ships, so the recipe is not reproducible. Corrected from 2/restricted
-    on 2026-07-29 after the tier consolidation initially applied most-restrictive across all four bases.
-
-    Re-read 2026-08-13. The axis records `governing_release - hermes-4-3-36b` and scores the Apache build,
-    but the only source it cited was the 405B FP8 repo, which is `license:llama3`. The governing repo is
-    now cited alongside it - NousResearch/Hermes-4.3-36B carries `license:apache-2.0`, `"gated":false` and
-    base ByteDance-Seed/Seed-OSS-36B-Base, which is the fact the 3 rests on and which the file previously
-    asserted with no source behind it. Nothing on either card releases the post-training corpus. No change
-    to the score.'
+  note: 'Nous ships one Hermes 4 post-training recipe on four independent base models, and the base determines
+    the license the weights carry: Seed-OSS-36B and Qwen3-14B are Apache-2.0, while the Llama-3.1 405B and
+    70B builds inherit Meta''s Llama-3.1-Community terms (700M-MAU commercial cap, acceptable-use policy,
+    naming requirements). Scored 3 on the Apache builds rather than 2 on the Llama ones, because most-restrictive-across-SKUs
+    is a rule about variants you cannot substitute away from - Qwen 2.5''s restricted 72B caps Qwen because
+    the 7B is not a substitute for the flagship - and here the base is a free choice. Anyone wanting Apache-licensed
+    Hermes 4 takes the 36B or 14B build and gets it, so the family genuinely offers open weights. Not 4
+    or 5: the post-training corpus is proprietary and only inference code ships, so the recipe is not reproducible.
+    Corrected from 2/restricted on 2026-07-29 after the tier consolidation initially applied most-restrictive
+    across all four bases. The governing release NousResearch/Hermes-4.3-36B carries `license:apache-2.0`,
+    `"gated":false` and base ByteDance-Seed/Seed-OSS-36B-Base, which is the fact the 3 rests on; neither
+    it nor the 405B Llama-based build releases the post-training corpus.'
   raw: weights:open(Apache-2.0);base:Seed-OSS-36B-Base;post-training-data:closed(proprietary ~5M-sample
     corpus);code:partial(inference only);license:Apache-2.0(OSI)
   last_verified: '2026-08-13'
@@ -58,11 +54,10 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: ~35,066 HF downloads/mo, the most-downloaded Hermes 4 SKU (small size + permissive license drive uptake).
-    Early-adopter scale. Re-read 2026-08-13 - the four declared SKUs now sum to 34,445 downloads in the
-    trailing 30 days (Hermes-4.3-36B 18,158; Hermes-3-Llama-3.1-70B 10,217; Hermes-4-14B 5,401;
-    Hermes-3-Llama-3.1-405B 669), still level 2. The most-downloaded SKU is now the 36B rather than the
-    14B, which does not move the band. No change.
+  note: ~35,066 HF downloads/mo, the most-downloaded Hermes 4 SKU (small size + permissive license drive
+    uptake). Early-adopter scale. The four declared SKUs sum to 34,445 downloads in the trailing 30 days
+    (Hermes-4.3-36B 18,158; Hermes-3-Llama-3.1-70B 10,217; Hermes-4-14B 5,401; Hermes-3-Llama-3.1-405B 669),
+    still level 2, with the 36B now the most-downloaded SKU rather than the 14B.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/models/NousResearch/Hermes-4.3-36B
@@ -82,15 +77,10 @@ capability:
   value: MATH-500 96.2, AIME'24 81.9, AIME'25 78.1, GPQA Diamond 70.6, MMLU-Pro 80.6, LCBv6 61.4, BBH 86.3
     (Hermes 4 technical report, 405B reasoning column)
   confidence: medium
-  note: >-
-    Strongest Hermes 4 SKU; near-frontier on math/knowledge for an open instruct model, though coding
+  note: Strongest Hermes 4 SKU; near-frontier on math/knowledge for an open instruct model, though coding
     trails the 2026 frontier coders. Not a category-defining 5 (those are DeepSeek-V4/Qwen3.6/Kimi-class).
-
-    Re-read 2026-08-13 against the technical report, which carries every figure in the reasoning column
-    unchanged. Two corrections that do not move the score. The coding row is LCBv6 (Aug2024+) at 61.4,
-    not 61.3, so the value was off by a tenth against its own source. And the OpenRouter model page no
-    longer renders any benchmark figure to a fetch, so it corroborates nothing; it is kept as evidence
-    of distribution rather than of capability.
+    The technical report's coding row is LCBv6 (Aug2024+) at 61.4. The OpenRouter model page renders no
+    benchmark figure to a fetch, so it evidences distribution rather than capability.
   last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/pdf/2508.18255

--- a/sources/scores/hexabot.yaml
+++ b/sources/scores/hexabot.yaml
@@ -15,11 +15,11 @@ openness:
         compose
   confidence: high
   note: 'Fair Core License is a delayed-open / fair-code model, so the current core is source-available
-    rather than open source. `source: public` transcribed 2026-08-11 from a read of the repo: Hexastack/Hexabot
-    publishes the whole runtime as a pnpm/turbo TypeScript monorepo (packages/api, frontend, widget, agentic,
-    graph, cli) with docker/ compose files, 55MB, GitHub reporting language TypeScript. The ladder settles
-    this on rung 2 (competition_restricted + public), so core-gated is never consulted. Worth recording
-    that a read of the pricing page found a license-key mechanism that the ladder does not see here: Community
+    rather than open source. `source: public` from a direct read of the repo: Hexastack/Hexabot publishes
+    the whole runtime as a pnpm/turbo TypeScript monorepo (packages/api, frontend, widget, agentic, graph,
+    cli) with docker/ compose files, 55MB, GitHub reporting language TypeScript. The ladder settles this
+    on rung 2 (competition_restricted + public), so core-gated is never consulted. Worth recording that
+    a read of the pricing page found a license-key mechanism that the ladder does not see here: Community
     is free and self-hosted with no key, and the $19/$59/$149 plans raise user, workflow and activation
     quotas via license-key activations, while LICENSE.md forbids circumventing that key functionality. That
     is a capacity cap rather than a withheld feature, and since no rung reads it on this product it is left
@@ -76,13 +76,10 @@ adoption:
   reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: medium
-  note: '974 GitHub stars and 218 forks; no package download figures available. Stars read 2026-08-13: 1,164
-    across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in
-    signal_routing.yaml. Level corrected from 3. The previous reach ''niche'' was not a label this instrument
-    offers - stars have their own vocabulary because a star is not a download. Re-read 2026-08-13 from
-    the repo page, which reports 1.2k stars and 230 forks. Hexabot ships as a self-hosted Docker/pnpm
-    monorepo and publishes no install or user count, so the stars fallback is still the only instrument
-    and 1K-10K stars still bands at 2.'
+  note: 974 GitHub stars and 218 forks; no package download figures available. 1,164 stars across the 1
+    declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. Level
+    corrected from 3. The previous reach 'niche' was not a label this instrument offers - stars have their
+    own vocabulary because a star is not a download.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/Hexastack/Hexabot
@@ -96,12 +93,10 @@ capability:
   value: Visual chatbot flow editor, multilingual support, plugin marketplace, multi-channel connectors
     (WhatsApp/Telegram/Slack/Facebook), LLM+NLU integration, and (v3) agentic workflows with MCP support.
   confidence: high
-  note: 'Broad conversational-AI platform spanning authoring, channels, LLM integration, and agentic workflows.
-    Re-read 2026-08-13 - the repo now leads with "build and run agentic workflows across channels with
-    YAML, tools, MCP, memory and RAG", and its core capabilities list YAML workflow definitions with typed
-    runtime contracts, action-based execution, explicit memory definitions, MCP integration points and
-    multi-channel continuity. That is a wider agentic surface than the record described, and it holds
-    the band. At dify on feature breadth.'
+  note: Broad conversational-AI platform spanning authoring, channels, LLM integration, and agentic workflows.
+    The repo leads on agentic workflows across channels defined in YAML, with typed runtime contracts, action-based
+    execution, explicit memory definitions, MCP integration points and multi-channel continuity - a wider
+    agentic surface than the rest of this record describes, and one that holds the band at dify.
   relative_to: dify
   relation: at
   last_verified: '2026-08-13'

--- a/sources/scores/hf-datasets.yaml
+++ b/sources/scores/hf-datasets.yaml
@@ -13,10 +13,9 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: 'LICENSE file is the standard, unmodified Apache 2.0 text. Re-read 2026-08-13: the cited LICENSE
-    body still carries the Apache-2.0 terms, the GitHub API reports the repository public, unarchived and
-    licensed Apache-2.0, and the README describes the whole library with no paid, enterprise or hosted tier
-    beside it, so source stays public and core-gated stays ungated.'
+  note: LICENSE file is the standard, unmodified Apache 2.0 text. The repository is public and unarchived,
+    and the README describes the whole library with no paid, enterprise or hosted tier beside it, so source
+    is public and the core ungated.
   raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -50,13 +49,9 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: 'PyPI last_month downloads of 120,316,114 exceed the 50M+ Level 5 threshold. Read live 2026-08-13:
-    159,958,389 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at >10M,
-    level 5. The previous reach ''120M+/month'' was free text carrying a figure rather than a band the scale
-    declares, so nothing could check it against the level beside it. No last_verified claimed: only the
-    figure was re-read, not the whole axis. Re-read 2026-08-13 from the cited pypistats reading of the declared
-    PyPI artifact `datasets`: 159,958,389 downloads in the trailing 30 days, which bands at >10M, level
-    5 on the software scale. Unchanged.'
+  note: 159,958,389 PyPI downloads in the trailing 30 days for the declared artifact `datasets`, which bands
+    at >10M, level 5 on the software scale. The previous reach '120M+/month' was free text carrying a figure
+    rather than a band the scale declares, so nothing could check it against the level beside it.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/datasets/recent
@@ -70,8 +65,7 @@ capability:
   value: 'Data loading and preprocessing library: one-line dataset loading from the Hub plus fast manipulation
     of multi-format, multi-modal data with streaming.'
   confidence: high
-  note: 'Broad and central to data pipelines but scoped to data handling rather than modeling. Re-read 2026-08-13:
-    the cited repository page still describes the product as recorded, so the band is unchanged.'
+  note: Broad and central to data pipelines but scoped to data handling rather than modeling.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/huggingface/datasets

--- a/sources/scores/hh-rlhf.yaml
+++ b/sources/scores/hh-rlhf.yaml
@@ -16,8 +16,7 @@ openness:
     size:
       value: 94.7MB
   confidence: high
-  note: 'Publicly downloadable and ungated under the permissive MIT license. Re-read 2026-08-13: mit on
-    the Hub, gated false, card intact.'
+  note: Publicly downloadable and ungated under the permissive MIT license.
   raw: license:mit;card:present;ungated:yes;rows:169,352;size:94.7MB
   last_verified: '2026-08-13'
   sources:
@@ -35,9 +34,8 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 32,927 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (Anthropic/hh-rlhf 32,927). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band
-    is >1M.
+  note: 32,927 downloads in the trailing 30 days summed across the 1 declared artifact(s) (Anthropic/hh-rlhf
+    32,927). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/Anthropic/hh-rlhf
@@ -51,10 +49,8 @@ capability:
   basis_detail: superseded
   value: null
   confidence: high
-  note: 'Documented 2022 RLHF results and huge historical influence, but dropped from frontier open preference
-    mixes (absent from Tulu 3 and OLMo 3 Dolci DPO). Re-read 2026-08-13: the Anthropic listing still reports
-    RLHF on this data improving almost all NLP evaluations, and HH-RLHF is still absent from the Tulu 3
-    preference mixture card.'
+  note: Documented 2022 RLHF results and huge historical influence, but dropped from frontier open preference
+    mixes (absent from Tulu 3 and OLMo 3 Dolci DPO).
   last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2204.05862

--- a/sources/scores/huggingchat-chat-ui.yaml
+++ b/sources/scores/huggingchat-chat-ui.yaml
@@ -15,11 +15,6 @@ openness:
   confidence: high
   note: Fully OSI (Apache-2.0); the public codebase is exactly what powers the hosted HuggingChat, self-hostable
     end to end.
-    Re-read 2026-08-13. The repository still declares Apache-2.0 and the README still opens by saying
-    the SvelteKit app powers HuggingChat on hf.co/chat. It is self-hostable end to end against any
-    MongoDB 6/7 deployment, an embedded fallback, or the bundled ghcr.io/huggingface/chat-ui-db image,
-    with nothing withheld. Latest release is still v0.10.0 of 11 May 2026 and the repo now shows 10,885
-    stars. Value unchanged at 5 / open_source.
   raw: license:Apache-2.0(OSI);source:public;no-feature-gated-core(self-hostable SvelteKit app, MongoDB
     backend);core-gated:ungated
   last_verified: '2026-08-13'
@@ -36,18 +31,16 @@ adoption:
   confidence: medium
   banded_quantity: lifetime users of the hosted product (1M+), a vendor statement at one remove
   note: 'Hosted HuggingChat served 1M+ users and 100k+ assistants over its lifetime before the July 2025
-    sunset; relaunched as HuggingChat Omni and live again on hf.co/chat. chat-ui repo itself
-    is a modest 10.7k stars (self-host base is niche). Placed at 3 on the disclosed lifetime user reach
-    of the hosted product; the discontinuity + relaunch lowers confidence. Re-read 2026-08-14, and the
-    attribution was wrong rather than the figure. The sunset article carries no user count of any kind,
-    and neither does the primary sunset announcement, huggingface.co/spaces/huggingchat/chat-ui
-    discussion 747, which was read in full. The figure traces to Victor Mustar, HF Head of Product, on X
-    in July 2025, relayed by trade press - "HuggingChat has supported over 20 open-source models ...
-    helped more than 1 million users, and powered over 100,000 assistants." That is a vendor statement
-    at one remove, not a first-party page, and the note now says so. It is still the only reach figure
-    anyone has published for the hosted product, and reported_traction is the instrument for exactly
-    that, so the band of 3 stands. Countable alongside it today - 10,885 GitHub stars and 1,659 forks on
-    huggingface/chat-ui. The relaunch is confirmed - Omni is live and the model picker reads 132.'
+    sunset; relaunched as HuggingChat Omni and live again on hf.co/chat. The chat-ui repo itself is a modest
+    10,885 stars and 1,659 forks (the self-host base is niche). Placed at 3 on the disclosed lifetime user
+    reach of the hosted product; the discontinuity and relaunch lower confidence. The attribution is at
+    one remove, which is why the reach is banded as reported_traction: the sunset article carries no user
+    count of any kind, and neither does the primary sunset announcement, huggingface.co/spaces/huggingchat/chat-ui
+    discussion 747. The figure traces to Victor Mustar, HF Head of Product, on X in July 2025 and relayed
+    by trade press - "HuggingChat has supported over 20 open-source models ... helped more than 1 million
+    users, and powered over 100,000 assistants". That is a vendor statement at one remove rather than a
+    first-party page, but it is still the only reach figure anyone has published for the hosted product,
+    so the band of 3 stands. The relaunch is confirmed - Omni is live and the model picker reads 132.'
   last_verified: '2026-08-14'
   sources:
   - url: https://www.thelettertwo.com/2025/07/01/hugging-face-ends-huggingchat-teases-more-integrated-future/
@@ -81,12 +74,8 @@ capability:
   confidence: medium
   note: Good model breadth + smart routing + MCP, but the rebuilt v0.10 deliberately stripped RAG/provider
     integrations present in the legacy branch, so the self-host feature surface is leaner than Open WebUI/LibreChat.
-    Mid-tier for the category.
-    Re-read 2026-08-13. The README still states that Chat UI speaks only to OpenAI-compatible APIs and
-    that the legacy provider integrations, GGUF discovery, embeddings and web-search helpers have been
-    removed, with the old code left on a legacy branch. hf.co/chat still runs the Omni router and its
-    model picker now offers 132 open models, up from the 123 recorded here. The anchor, open-webui, was
-    re-derived at 4 on the same day, so one_below still arrives at 3. Band unchanged.
+    Mid-tier for the category. The model picker now offers 132 open models, up from the 123 recorded in
+    the value, and the anchor open-webui sits at 4, so one_below arrives at 3.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/huggingface/chat-ui

--- a/sources/scores/huggingface-hub.yaml
+++ b/sources/scores/huggingface-hub.yaml
@@ -13,10 +13,9 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: 'LICENSE body is verbatim Apache License 2.0; full source public. Re-read 2026-08-13: the cited
-    LICENSE body still carries the Apache-2.0 terms, the GitHub API reports the repository public, unarchived
-    and licensed Apache-2.0, and the README describes the whole library with no paid, enterprise or hosted
-    tier beside it, so source stays public and core-gated stays ungated.'
+  note: LICENSE body is verbatim Apache License 2.0; full source public. The repository is public and unarchived,
+    and the README describes the whole library with no paid, enterprise or hosted tier beside it, so source
+    is public and the core ungated.
   raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -50,13 +49,9 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: 'PyPI last-month downloads of 331,796,503 exceed the 50M+ threshold. Read live 2026-08-13: 493,557,521
-    PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at >10M, level 5.
-    The previous reach ''331M+/month'' was free text carrying a figure rather than a band the scale declares,
-    so nothing could check it against the level beside it. No last_verified claimed: only the figure was
-    re-read, not the whole axis. Re-read 2026-08-13 from the cited pypistats reading of the declared PyPI
-    artifact `huggingface-hub`: 493,557,521 downloads in the trailing 30 days, which bands at >10M, level
-    5 on the software scale. Unchanged.'
+  note: 493,557,521 PyPI downloads in the trailing 30 days for the declared artifact `huggingface-hub`,
+    which bands at >10M, level 5 on the software scale. The previous reach '331M+/month' was free text carrying
+    a figure rather than a band the scale declares, so nothing could check it against the level beside it.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/huggingface-hub/recent
@@ -69,8 +64,7 @@ capability:
   basis: feature_matrix
   value: Foundational client for Hub up/download, repo management, inference, and library integration.
   confidence: high
-  note: 'Central dependency across the Hugging Face ecosystem. Re-read 2026-08-13: the cited repository
-    page still describes the product as recorded, so the band is unchanged.'
+  note: Central dependency across the Hugging Face ecosystem.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/huggingface/huggingface_hub

--- a/sources/scores/humaneval.yaml
+++ b/sources/scores/humaneval.yaml
@@ -19,10 +19,8 @@ openness:
       detail: per design
       raw: hand-written to avoid GitHub-dump overlap (per design)
   confidence: high
-  note: 'Fully open: MIT license, ungated, downloadable, with a dataset card. Textbook open-data case
-    for this category. Re-read 2026-08-13: the repo still carries the `license:mit` tag, `gated` is
-    false in the embedded repo state, and the dataset card still renders, so all three recorded values
-    stand unchanged.'
+  note: 'Fully open: MIT license, ungated, downloadable, with a dataset card. Textbook open-data case for
+    this category.'
   raw: license:MIT(OSI-style permissive, fully redistributable);redistributability:full(downloadable parquet,
     no gating);datasheet:yes(dataset card);size:164 problems/test split;contamination:hand-written to avoid
     GitHub-dump overlap (per design)
@@ -40,11 +38,11 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: 279,859 Hugging Face downloads in the trailing 30 days (openai/openai_humaneval), read 2026-08-12.
-    Bands at level 4 (100K-1M) on the dataset adoption scale, whose top band is >1M - one order of magnitude
-    below the software and model scales, because no dataset artifact in the corpus has ever exceeded 10M.
-    The foundational code-generation benchmark; the pass@k metric originated here and it is still reported
-    in most code-model releases.
+  note: 279,859 Hugging Face downloads in the trailing 30 days (openai/openai_humaneval). Bands at level
+    4 (100K-1M) on the dataset adoption scale, whose top band is >1M - one order of magnitude below the
+    software and model scales, because no dataset artifact in the corpus has ever exceeded 10M. The foundational
+    code-generation benchmark; the pass@k metric originated here and it is still reported in most code-model
+    releases.
   last_verified: '2026-08-12'
   sources:
   - url: https://huggingface.co/api/datasets/openai/openai_humaneval
@@ -58,9 +56,7 @@ capability:
   value: null
   confidence: high
   note: A dataset is not 'capable'. Worth noting it is now largely saturated/contaminated as a discriminator,
-    but per recipe capability is n/a here. Re-read 2026-08-13 and the abstention stands - the dataset
-    page publishes a static problem set and no performance, throughput or feature claim the capability
-    axis could band.
+    but per recipe capability is n/a here.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/openai/openai_humaneval

--- a/sources/scores/humanitys-last-exam.yaml
+++ b/sources/scores/humanitys-last-exam.yaml
@@ -15,14 +15,11 @@ openness:
     holdout:
       value: private
   confidence: medium
-  note: Public set is MIT-licensed with answers, but access is gated and a private held-out set exists.
+  note: 'Public set is MIT-licensed with answers, but access is gated and a private held-out set exists.
     The MIT was recorded inside the compound questions+answers key, where no dimension could read it; it
-    is now recorded under license, and the private holdout is what decides the score. Re-read 2026-08-13
-    - the HF repo still tags `license:mit`, is still `"gated":"auto"` behind a contact-information
-    agreement, and the card still documents the 2,500 public questions and the BIG-bench-superset canary
-    string. The holdout is NOT stated on the card, so lastexam.ai is now cited for it - it reads "We
-    publicly release these questions, while maintaining a private test set of held out questions to
-    assess model overfitting." All four values stand.
+    is now recorded under license, and the private holdout is what decides the score. The private holdout
+    is not stated on the Hugging Face card, so lastexam.ai is cited for it: it reads "We publicly release
+    these questions, while maintaining a private test set of held out questions to assess model overfitting."'
   raw: license:MIT(the public 2,500-question set);questions+answers:public(2500-Q);access:HF-gated(accept-conditions,no-redistribution,canary);holdout:private
   last_verified: '2026-08-13'
   sources:
@@ -48,10 +45,10 @@ adoption:
   level: 3
   signal_type: usage_volume
   confidence: high
-  note: 34,715 Hugging Face downloads in the trailing 30 days for cais/hle, read 2026-08-12. Bands at level
-    3 (10K-100K) on the dataset adoption scale, whose top band is >1M - one order of magnitude below software
-    and model. A frontier-difficulty benchmark; volume essentially flat since June. Corrected from level
-    4, which the recorded evidence did not support.
+  note: 34,715 Hugging Face downloads in the trailing 30 days for cais/hle. Bands at level 3 (10K-100K)
+    on the dataset adoption scale, whose top band is >1M - one order of magnitude below software and model.
+    A frontier-difficulty benchmark; volume essentially flat since June. Corrected from level 4, which the
+    recorded evidence did not support.
   reach: 10K-100K
   last_verified: '2026-08-12'
   sources:
@@ -66,11 +63,9 @@ capability:
   value: 2,500 expert questions across 100+ subjects; multimodal; private held-out set; designed as successor to
     saturated MMLU/MATH
   confidence: high
-  note: Far harder and broader than MMLU/MATH; GPQA is a narrower difficulty peer. Re-read 2026-08-13 -
-    the project site still gives every element of the recorded value, the 2,500 expert questions, the
-    hundred-plus subjects, the multimodal scope and the private held-out set. Band unchanged at 5. The
-    note names gpqa as a peer, but that product's capability is a deliberate null, so there are not two
-    integers for a relation to be arithmetic over and relative_to/relation stay unset.
+  note: Far harder and broader than MMLU/MATH; GPQA is a narrower difficulty peer. The note names gpqa as
+    a peer, but that product's capability is a deliberate null, so there are not two integers for a relation
+    to be arithmetic over and relative_to/relation stay unset.
   last_verified: '2026-08-13'
   sources:
   - url: https://lastexam.ai

--- a/sources/scores/ifeval.yaml
+++ b/sources/scores/ifeval.yaml
@@ -16,9 +16,7 @@ openness:
       value: public
       detail: single train split, no held-out
   confidence: high
-  note: 'Fully open: Apache-2.0, ungated, redistributable, with a complete dataset card. Re-read
-    2026-08-13: `license:apache-2.0` is still in the repo tags, the embedded repo state reads
-    `"gated":false`, and the dataset card still renders over the single public train split. No change.'
+  note: 'Fully open: Apache-2.0, ungated, redistributable, with a complete dataset card.'
   raw: license:Apache-2.0(OSI/open,redistributable);access:public(not gated);datasheet:present(card+structure+citation);splits:public(single
     train split, no held-out)
   last_verified: '2026-08-13'
@@ -36,10 +34,10 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: 116,029 Hugging Face downloads in the trailing 30 days (google/IFEval), read 2026-08-12. Bands at
-    level 4 (100K-1M) on the dataset adoption scale, whose top band is >1M - one order of magnitude below
-    the software and model scales, because no dataset artifact in the corpus has ever exceeded 10M. A core
-    benchmark on the HF Open LLM Leaderboard and the standard instruction-following eval.
+  note: 116,029 Hugging Face downloads in the trailing 30 days (google/IFEval). Bands at level 4 (100K-1M)
+    on the dataset adoption scale, whose top band is >1M - one order of magnitude below the software and
+    model scales, because no dataset artifact in the corpus has ever exceeded 10M. A core benchmark on the
+    HF Open LLM Leaderboard and the standard instruction-following eval.
   last_verified: '2026-08-12'
   sources:
   - url: https://huggingface.co/api/datasets/google/IFEval
@@ -52,9 +50,7 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: Dataset, not 'capable'; openness and adoption carry this category per recipe. Re-read 2026-08-13
-    and the abstention stands - the page publishes a static prompt set and no performance or feature
-    claim the capability axis could band.
+  note: Dataset, not 'capable'; openness and adoption carry this category per recipe.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/google/IFEval

--- a/sources/scores/inflection.yaml
+++ b/sources/scores/inflection.yaml
@@ -13,11 +13,8 @@ openness:
     - name: Proprietary
       detail: API/enterprise-licensed, no weights
   confidence: high
-  note: Closed proprietary models via API + enterprise licensing; no downloadable weights; fine-tuned models are
-    the customer's alone. Re-read 2026-08-13 - the Intel newsroom release still describes Inflection
-    for Enterprise as built on Inflection 3.0 and delivered through the Intel Tiber AI Cloud and a
-    Gaudi 3 appliance, with no weight distribution, no corpus and no code anywhere in it. Nothing
-    moved.
+  note: Closed proprietary models via API + enterprise licensing; no downloadable weights; fine-tuned models
+    are the customer's alone.
   last_verified: '2026-08-13'
   raw: weights:closed;data:closed;code:closed;license:Proprietary(API/enterprise-licensed, no weights)
   sources:
@@ -41,12 +38,10 @@ adoption:
   confidence: low
   banded_quantity: the $650M technology licence and acqui-hire, neither of which is an adoption figure
   note: Post-Microsoft acqui-hire pivot to B2B. Enterprise API exists but no disclosed usage; effectively
-    stalled. Level 1 directional. Re-read 2026-08-13 and the note is narrowed to what the source
-    carries. The Wikipedia article confirms the March 2024 acqui-hire of nearly the whole 70-person
-    workforce and the $650M technology license, and publishes no usage figure of any kind, which is
-    the absence a directional level 1 rests on. It does NOT say Pi was sunset - it still describes Pi
-    as the company's first widely released product - so that clause is dropped. The enterprise pivot
-    is established by the Intel release cited on the openness axis rather than by this page.
+    stalled. Level 1 directional. The Wikipedia article confirms the March 2024 acqui-hire of nearly the
+    whole 70-person workforce and the $650M technology license, and publishes no usage figure of any kind,
+    which is the absence the directional level 1 rests on; the enterprise pivot is established by the Intel
+    release cited on the openness axis.
   last_verified: '2026-08-13'
   sources:
   - url: https://en.wikipedia.org/wiki/Inflection_AI
@@ -61,11 +56,8 @@ capability:
   basis: benchmark
   value: null
   confidence: low
-  note: 2024 EQ/productivity-focused model, never a leaderboard frontier model; development effectively halted after
-    Microsoft talent move. Low vs 2026 anchors. No fresh independent benchmark. Scored 2. Re-read
-    2026-08-13 - the cited article still describes Inflection 3.0 as EQ and productivity positioning
-    and still makes no frontier-benchmark claim, which is the absence the 2 rests on rather than a
-    measurement.
+  note: 2024 EQ/productivity-focused model, never a leaderboard frontier model; development effectively
+    halted after Microsoft talent move. Low vs 2026 anchors. No fresh independent benchmark. Scored 2.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.maginative.com/article/inflection-ai-unveils-enterprise-offering-with-new-inflection-3-0-models-2/

--- a/sources/scores/inkling.yaml
+++ b/sources/scores/inkling.yaml
@@ -16,12 +16,9 @@ openness:
     - name: Apache-2.0
       detail: OSI for weights only
   confidence: high
-  note: Apache-2.0 weights are OSI-licensed, but training data and full training code are withheld —
-    open_weights / 3, not open_source / 5. Press often calls this 'open source' because of the license
-    tag; our spectrum requires open data + code for class open_source. Re-read 2026-08-13 - the card
-    still carries the apache-2.0 tag, the 975B/41B MoE description, the day-0 runtime list
-    (transformers/SGLang/vLLM/llama.cpp) and the statement that training data came from public,
-    third-party and synthetic sources without being released. Nothing moved.
+  note: Apache-2.0 weights are OSI-licensed, but training data and full training code are withheld — open_weights
+    / 3, not open_source / 5. Press often calls this 'open source' because of the license tag; our spectrum
+    requires open data + code for class open_source.
   last_verified: '2026-08-13'
   raw: weights:open(Apache-2.0 on HF, BF16 + NVFP4);data:closed(public+third-party+synthetic, not redistributed);code:partial(day-0
     transformers/SGLang/vLLM/llama.cpp; no training pipeline);license:Apache-2.0(OSI for weights only)
@@ -44,12 +41,12 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: medium
-  note: 368,909 downloads in the trailing 30 days summed across the 2 declared artifact(s), read
-    2026-08-13 (thinkingmachines/Inkling 96,344; thinkingmachines/Inkling-NVFP4 272,565). Bands at
-    level 3 (100K-1M) on the software and model adoption scale, unchanged - the July reading of ~13.5K
-    was days after launch and the band was a forward judgment; a month of accumulation has now put a
-    counted figure under it. The NVFP4 quantization outpulls the BF16 release almost three to one,
-    which is why the tier is summed rather than banded on the headline repo.
+  note: 368,909 downloads in the trailing 30 days summed across the 2 declared artifact(s) (thinkingmachines/Inkling
+    96,344; thinkingmachines/Inkling-NVFP4 272,565). Bands at level 3 (100K-1M) on the software and model
+    adoption scale, unchanged - the July reading of ~13.5K was days after launch and the band was a forward
+    judgment; a month of accumulation has now put a counted figure under it. The NVFP4 quantization outpulls
+    the BF16 release almost three to one, which is why the tier is summed rather than banded on the headline
+    repo.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/models/thinkingmachines/Inkling
@@ -70,12 +67,9 @@ capability:
   relation: one_below
   value: 'SWE-bench Verified 77.6%; SWE-bench Pro 54.3%; GPQA Diamond 87.2%; AIME 2026 97.1% (effort=0.99)'
   confidence: high
-  note: Strong open-weight multimodal base — beats Nemotron 3 Ultra on SWE Verified (77.6 vs 70.7) but
-    trails Kimi K2.6 (80.2) and DeepSeek-V4-Pro (80.6). Vendor card is explicit that Inkling is not the
-    strongest overall model; scored 4 (high open-weight tier, not frontier-defining 5). Re-read
-    2026-08-13 - all four figures are still on the card, the comparison rows against Nemotron 3 Ultra,
-    Kimi K2.6 and DeepSeek-V4-Pro are unchanged, and the `one_below` relation to kimi (capability 5)
-    still holds. kimi was re-confirmed the same day.
+  note: Strong open-weight multimodal base — beats Nemotron 3 Ultra on SWE Verified (77.6 vs 70.7) but trails
+    Kimi K2.6 (80.2) and DeepSeek-V4-Pro (80.6). Vendor card is explicit that Inkling is not the strongest
+    overall model; scored 4 (high open-weight tier, not frontier-defining 5).
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/thinkingmachines/Inkling

--- a/sources/scores/inspect-ai.yaml
+++ b/sources/scores/inspect-ai.yaml
@@ -19,9 +19,7 @@ openness:
     - no managed/gated tier
   confidence: high
   last_verified: '2026-08-13'
-  note: Fully OSI (MIT), government-backed, no proprietary core, full pipeline open. Re-read 2026-08-13
-    - the license endpoint still reports MIT and the README still builds and runs the whole framework,
-    web UI included, from the checkout with no paid tier.
+  note: Fully OSI (MIT), government-backed, no proprietary core, full pipeline open.
   raw: license:MIT(OSI);source:public(full framework, 200+ evals);governance:public-sector(UK AISI)+Meridian
     Labs; no managed/gated tier;core-gated:ungated
   sources:
@@ -55,26 +53,21 @@ adoption:
   last_verified: '2026-08-13'
   banded_quantity: frontier-lab adoption; the ~9.9M PyPI downloads are treated as CI-inflated corroboration
     rather than the basis
-  note: 'Headline signal (per recipe: adoption by frontier labs / cited in release-grade safety work):
-    adopted as the evaluation framework of choice by major labs incl. Anthropic, Google DeepMind, and
-    xAI/Grok, and powers nearly all of UK AISI''s automated frontier-model evaluations. Corroborated by
-    ~9.9M PyPI downloads in the last 30 days (pepy.tech) / 10.5M (pypistats), though that figure is inflated
-    by CI/dependency traffic, so lab adoption is treated as the primary basis. Placed at level 4, not
-    5, because the human-operator base (eval engineers at labs/AISI) is far smaller than mass-market scale.
-    Re-read 2026-08-13, with one correction. The AISI post cited here does NOT say AISI runs thousands
-    of evaluations on Inspect - it reports evaluating 16 models in its first year, and says of Inspect
-    only that ''now it is used by other governments and some of the leading AI developers''. The lab
-    names in this note come from elsewhere and are not established by the cited page, so the basis is
-    narrowed to what the post actually asserts. The download corroboration holds and got sharper: 9,278,867
-    inspect-ai downloads in the trailing 30 days on pypistats, against the 9.86M pepy figure recorded
-    before. Level 4 unchanged. The inspect-ai PyPI package is not declared as an artifact on this product
-    and should be; flagged rather than declared here.'
+  note: 'Headline signal (per recipe: adoption by frontier labs / cited in release-grade safety work): UK
+    AISI open-sourced Inspect as its evaluations platform and reports that it ''is used by other governments
+    and some of the leading AI developers''. The cited AISI post does not name the individual labs and carries
+    no ''thousands of evaluations'' figure - it reports evaluations on 16 models in AISI''s first year -
+    so the basis is what that post asserts rather than the specific lab names this note previously carried.
+    Corroborated by PyPI volume: 9,278,867 inspect-ai downloads in the trailing 30 days on pypistats, against
+    ~9.86M on pepy, though that figure is inflated by CI/dependency traffic, so lab adoption is treated
+    as the primary basis. Placed at level 4, not 5, because the human-operator base (eval engineers at labs
+    and AISI) is far smaller than mass-market scale. The inspect-ai PyPI package is not declared as an artifact
+    on this product and should be; flagged rather than declared here.'
   sources:
   - url: https://www.aisi.gov.uk/blog/our-first-year
-    shows: 'Re-read 2026-08-13: ''we open sourced our evaluations platform, Inspect ... now it is used
-      by other governments and some of the leading AI developers''. The post reports evaluations on 16
-      models in AISI''s first year. It does NOT carry the ''thousands of evaluations'' figure this source
-      was previously recorded as showing.'
+    shows: '''we open sourced our evaluations platform, Inspect ... now it is used by other governments
+      and some of the leading AI developers''. The post reports evaluations on 16 models in AISI''s first
+      year, and carries no ''thousands of evaluations'' figure.'
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 607848ae11534d6e9699c8073624bfef2c07f2be9899531adde35ef981639f65
@@ -98,10 +91,9 @@ capability:
   confidence: high
   last_verified: '2026-08-13'
   note: 'Frontier-defining for this category: combines the broadest backend coverage, agentic-eval support,
-    and de-facto-standard status among frontier-safety labs. One of the 1-2 leaders, so scored 5. Feature
-    matrix re-read 2026-08-13 and unchanged, and if anything wider - the providers page now also lists
-    Mistral, DeepSeek, Moonshot, Perplexity, SageMaker, Fireworks, SambaNova, SGLang and TransformerLens
-    behind the same interface.'
+    and de-facto-standard status among frontier-safety labs. One of the 1-2 leaders, so scored 5. The providers
+    page is wider than the recorded value, also listing Mistral, DeepSeek, Moonshot, Perplexity, SageMaker,
+    Fireworks, SambaNova, SGLang and TransformerLens behind the same interface.'
   sources:
   - url: https://inspect.aisi.org.uk/models.html
     shows: single interface over OpenAI/Anthropic/Google/xAI/Bedrock/Azure/local vLLM/Ollama/llama-cpp
@@ -110,10 +102,10 @@ capability:
     shows: 200+ pre-built evals; tool use, multi-turn, model-graded eval components
     accessed: '2026-06-04'
   - url: https://inspect.aisi.org.uk/models.html
-    shows: 'Re-read 2026-08-13: one naming convention (`openai/gpt-4o`, `anthropic/claude-sonnet-4-0`)
-      over lab APIs (OpenAI, Anthropic, Google, Grok, Mistral, DeepSeek, Moonshot, Perplexity), cloud
-      APIs (Bedrock, SageMaker, Azure AI), hosted open models (Groq, Together, Fireworks, Cloudflare,
-      HF Inference Providers, SambaNova) and local ones (HF, vLLM, Ollama, llama-cpp-python, SGLang, TransformerLens).'
+    shows: One naming convention (`openai/gpt-4o`, `anthropic/claude-sonnet-4-0`) over lab APIs (OpenAI,
+      Anthropic, Google, Grok, Mistral, DeepSeek, Moonshot, Perplexity), cloud APIs (Bedrock, SageMaker,
+      Azure AI), hosted open models (Groq, Together, Fireworks, Cloudflare, HF Inference Providers, SambaNova)
+      and local ones (HF, vLLM, Ollama, llama-cpp-python, SGLang, TransformerLens).
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 587a29f7b185efc120a0692c0b7d308d4c45d1971a4dd6926d5227492d1a6e4e

--- a/sources/scores/internlm.yaml
+++ b/sources/scores/internlm.yaml
@@ -22,11 +22,8 @@ openness:
       raw: ' custom weights license(non-OSI, application step)'
   confidence: medium
   note: Code is OSI (Apache-2.0) but the weights license is a custom non-OSI 'Free Commercial License' requiring
-    a commercial-license application form, so open_weights not open_source; flagged for the non-OSI
-    weights term. Re-read 2026-08-13 - the card still says "The code is licensed under Apache-2.0,
-    while model weights are fully open for academic research and also allow free commercial usage. To
-    apply for a commercial license, please fill in the application form", the InternLM repository is
-    still public Apache-2.0, and no pretraining corpus is named. Nothing moved.
+    a commercial-license application form, so open_weights not open_source; flagged for the non-OSI weights
+    term.
   last_verified: '2026-08-13'
   raw: weights:open(custom 'Free Commercial License', academic free, commercial use free but requires an
     application form);data:closed(pretraining corpus not released);code:open(Apache-2.0 training/inference
@@ -52,9 +49,9 @@ adoption:
   reach: <10K
   signal_type: usage_volume
   confidence: medium
-  note: 3,095 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (internlm/internlm2_5-7b 3,095). Bands at level 1 (<10K) on the software and model adoption scale. Corrected
-    from level 2, which the declared artifacts do not support.
+  note: 3,095 downloads in the trailing 30 days summed across the 1 declared artifact(s) (internlm/internlm2_5-7b
+    3,095). Bands at level 1 (<10K) on the software and model adoption scale. Corrected from level 2, which
+    the declared artifacts do not support.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/models/internlm/internlm2_5-7b
@@ -68,10 +65,8 @@ capability:
   basis_detail: MMLU
   value: 'InternLM2.5-7B base: MMLU 71.6 (5-shot, OpenCompass); matches Yi-1.5-9B, beats Llama-3-8B (66.4).'
   confidence: medium
-  note: Strong sub-8B model for 2024 with 1M-context, but below 2026 frontier; calibrates near Falcon 3 (C2) / Yi-1.5
-    (C2) on the dated small-model ladder. Re-read 2026-08-13 - the OpenCompass table on the card still
-    shows MMLU 71.6 for InternLM2.5-7B against Llama3-8B 66.4 and Yi-1.5-9B 71.6, which is the
-    comparison the band rests on, and the standalone model card carries the same figure. Unchanged.
+  note: Strong sub-8B model for 2024 with 1M-context, but below 2026 frontier; calibrates near Falcon 3
+    (C2) / Yi-1.5 (C2) on the dated small-model ladder.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/internlm/internlm2_5-7b

--- a/sources/scores/jamba-large.yaml
+++ b/sources/scores/jamba-large.yaml
@@ -15,21 +15,13 @@ openness:
     - name: Jamba-Open-Model-License
       detail: 'non-OSI: $50M annual-revenue commercial cap + AUP + naming/attribution requirements'
   confidence: high
-  note: >-
-    Weights downloadable under the Jamba Open Model License: non-OSI, with a $50M annual-revenue
-    cap that bars large-entity commercial use. The 'Open Model' branding overstates it. Moved from
-    2/restricted on 2026-08-01 by the universal license scale, which caps a bounded commercial
-    license at 3 rather than 2. The test at that boundary is whether the license permits
-    commercial use AT ALL: this one does, for everyone inside the bound. A license that forbids
-    commerce outright - CC-BY-NC, Mistral Non-Production - stays at 2. Nine other products carry a
-    bounded license and all now score 3; four of them were already recorded there, which is the
-    inconsistency this resolves.
-
-    Re-read 2026-08-13 - the license body still carries the clause verbatim ("if at any time You and/or
-    Your affiliate(s) ... generate more than fifty million US Dollars (USD $50,000,000) in annual
-    revenue"), and the card still describes the terms as "a permissive license allowing full research
-    use and commercial use under the license terms", with `"gated":"auto"` and no training corpus or
-    pipeline published. No change.
+  note: 'Weights downloadable under the Jamba Open Model License: non-OSI, with a $50M annual-revenue cap
+    that bars large-entity commercial use. The ''Open Model'' branding overstates it. Moved from 2/restricted
+    on 2026-08-01 by the universal license scale, which caps a bounded commercial license at 3 rather than
+    2. The test at that boundary is whether the license permits commercial use AT ALL: this one does, for
+    everyone inside the bound. A license that forbids commerce outright - CC-BY-NC, Mistral Non-Production
+    - stays at 2. Nine other products carry a bounded license and all now score 3; four of them were already
+    recorded there, which is the inconsistency this resolves.'
   raw: 'weights:open(downloadable on HF, contact-info gate);data:closed;code:partial(inference/usage only,
     no training pipeline);license:Jamba-Open-Model-License(non-OSI: $50M annual-revenue commercial cap +
     AUP + naming/attribution requirements)'
@@ -57,11 +49,10 @@ adoption:
   reach: <10K
   signal_type: usage_volume
   confidence: high
-  note: '45 Hugging Face downloads in the trailing 30 days summed across the scored release, read 2026-08-12
-    (ai21labs/AI21-Jamba-1.5-Large 45). Bands at level 1 (<10K). All 1 repos are now DECLARED in the product
-    file: the band was previously read on the family while only none was declared, so it could not be re-derived
-    by machine. Slugs on this map are tier-level, and docs/reference/identity.md sums adoption across a tier’s
-    releases.'
+  note: '45 Hugging Face downloads in the trailing 30 days summed across the scored release (ai21labs/AI21-Jamba-1.5-Large
+    45). Bands at level 1 (<10K). All 1 repos are now DECLARED in the product file: the band was previously
+    read on the family while only none was declared, so it could not be re-derived by machine. Slugs on
+    this map are tier-level, and docs/reference/identity.md sums adoption across a tier’s releases.'
   last_verified: '2026-08-12'
   sources:
   - url: https://huggingface.co/api/models/ai21labs/AI21-Jamba-1.5-Large
@@ -76,15 +67,9 @@ capability:
   value: Arena Hard 65.4 (AI21-reported, outpacing Llama 3.1 70B and 405B at launch); MMLU (CoT) 81.2; GSM-8K 87;
     RULER 256K effective context (93.9% at full length)
   confidence: medium
-  note: >-
-    A 2024 hybrid SSM-Transformer that led open models on long context at release and is now
-    mid-tier against the 2026 frontier. The note that stood here until 2026-08-13 was a verbatim
-    copy of the openness note and described the license rather than the capability; it is replaced.
-
-    Re-read 2026-08-13 - the AI21 blog still reads "Jamba 1.5 Large, with a score of 65.4, outpaces
-    both Llama 3.1 70B and 405B", and the card's benchmark table still gives the Jamba 1.5 Large
-    column Arena Hard 65.4, MMLU (CoT) 81.2 and MMLU Pro (CoT) 53.5, with a RULER effective-context
-    section beneath it. Every recorded figure holds. No change.
+  note: A 2024 hybrid SSM-Transformer that led open models on long context at release and is now mid-tier
+    against the 2026 frontier. The note that stood here until 2026-08-13 was a verbatim copy of the openness
+    note and described the license rather than the capability; it is replaced.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.ai21.com/blog/announcing-jamba-model-family/

--- a/sources/scores/jan.yaml
+++ b/sources/scores/jan.yaml
@@ -17,14 +17,10 @@ openness:
       value: ungated
     free_text:
     - no-feature-gated-core
-  note: Fully OSI-licensed (Apache-2.0), full source public, no proprietary feature-gated core, a true
-    open chat UI.
-    Re-read 2026-08-13. The LICENSE still licenses Jan under Apache-2.0 by reference, with one added
-    sentence asking that attribution appear in user-facing materials - a request, not a condition, which
-    is why GitHub reports the repo as NOASSERTION rather than Apache-2.0. The README still ships the
-    whole desktop app buildable from source with make dev, with local models, cloud providers, custom
-    assistants, an OpenAI-compatible server on localhost:1337 and MCP, and nothing held back for a paid
-    tier. Value unchanged at 5 / open_source.
+  note: Fully OSI-licensed (Apache-2.0), full source public, no proprietary feature-gated core, a true open
+    chat UI. The LICENSE applies Apache-2.0 by reference with one added sentence asking that attribution
+    appear in user-facing materials - a request, not a condition, which is why GitHub reports the repository
+    as NOASSERTION rather than Apache-2.0.
   raw: license:Apache-2.0(OSI);source:public(github.com/janhq/jan);no-feature-gated-core;self-host:primary(desktop
     app, 100% offline-capable);core-gated:ungated
   last_verified: '2026-08-13'
@@ -48,10 +44,8 @@ adoption:
   confidence: medium
   note: Vendor site reports 5.7M+ cumulative downloads of the desktop app; 42.9k GitHub stars corroborates
     but is not the basis. Cumulative-download volume places it in the 1-10M band, though these are lifetime
-    installs not active users.
-    Re-read 2026-08-13 - jan.ai now states 6.1M downloads on its homepage, up from the 5.7M-plus
-    recorded here, and shows 43.8K GitHub stars. Still lifetime installs rather than active users, and
-    still inside the 1M-10M band. Level unchanged at 4.
+    installs not active users. The vendor homepage now states 6.1M downloads against 43.8K GitHub stars,
+    still lifetime installs rather than active users and still inside 1M-10M.
   last_verified: '2026-08-13'
   sources:
   - url: https://jan.ai/
@@ -74,11 +68,6 @@ capability:
   note: Solid open desktop chat UI with broad model selection and a local OpenAI-compatible server, but
     single-user and lighter on RAG/multimodal than the frontier consumer apps in this category. Mid-tier
     on the chat-UI feature matrix.
-    Re-read 2026-08-13. The README still lists local GGUF models from Hugging Face alongside OpenAI,
-    Anthropic, Mistral, Groq and MiniMax cloud providers, custom assistants, the local OpenAI-compatible
-    server and MCP for agentic use, and jan.ai still shows a single-user desktop product with memory
-    listed as coming soon. RAG and multimodal are still thin next to the frontier consumer apps and
-    there is still no multi-user mode. Band unchanged at 3.
   last_verified: '2026-08-13'
   sources:
   - url: https://jan.ai/

--- a/sources/scores/jax.yaml
+++ b/sources/scores/jax.yaml
@@ -13,10 +13,9 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: 'Apache-2.0 licensed with full public source. Re-read 2026-08-13: the cited repo page still carries
-    the Apache-2.0 terms, the GitHub API reports the repository public, unarchived and licensed Apache-2.0,
-    and the README describes the whole library with no paid, enterprise or hosted tier beside it, so source
-    stays public and core-gated stays ungated.'
+  note: Apache-2.0 licensed with full public source. The repository is public and unarchived, and the README
+    describes the whole library with no paid, enterprise or hosted tier beside it, so source is public and
+    the core ungated.
   raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -51,13 +50,11 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: 'Re-scored 4->5. 18.92M PyPI downloads in the last 30 days. The map''s prevailing usage_volume level-5
+  note: Re-scored 4->5. 18.92M PyPI downloads in the last 30 days. The map's prevailing usage_volume level-5
     floor is >10M/mo (cf. pydantic-ai ~31M, llama-index ~10.18M, langgraph ~58M, all level 5); the prior
     level 4 applied a stricter 5M-50M band used only in one ml_frameworks batch, which sat below map peers
     of equal volume. JAX at ~19M/mo is the foundation of a major ML ecosystem (Flax, the Google research
-    stack) and clears the prevailing floor. Re-read 2026-08-13 from the cited pypistats reading of the declared
-    PyPI artifact `jax`: 20,195,276 downloads in the trailing 30 days, which bands at >10M, level 5 on the
-    software scale. Unchanged.'
+    stack) and clears the prevailing floor.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/jax/recent
@@ -71,8 +68,7 @@ capability:
   value: 'Composable function transforms over array code: autodiff, XLA JIT compilation for GPU/TPU, vectorization;
     foundation of a major ML ecosystem.'
   confidence: high
-  note: 'Defines the functional/accelerated-compute layer for ML research. Re-read 2026-08-13: the cited
-    repository page still describes the product as recorded, so the band is unchanged.'
+  note: Defines the functional/accelerated-compute layer for ML research.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/jax-ml/jax

--- a/sources/scores/jina-reader.yaml
+++ b/sources/scores/jina-reader.yaml
@@ -17,14 +17,14 @@ openness:
       detail: free tier + paid API key) on top of the same OSS core
       raw: r.jina.ai/s.jina.ai hosted SaaS (free tier + paid API key) on top of the same OSS core
   confidence: high
-  note: 'Apache-2.0 throughout with no enterprise directory and no license key, and a read on 2026-08-12
-    found the paid tiers buying throughput on the hosted endpoint rather than functionality: jina.ai/reader
-    lists Reader at 20 RPM without a key, 500 RPM with a free key and 5,000 RPM on Premium, with PDF,
-    MS-Office, image captioning and search available at every tier. The published branch does have the
-    MongoDB-backed SaaS storage layer stripped out, which the README states plainly, but it is accounting
-    and persistence for the hosted service rather than a piece of the reader the open build needs - the
-    README says the branch "runs in stateless mode out of the box, with optional MinIO/S3-compatible bucket
-    caching". Nothing is withheld from the published source, so core-gated is ungated.'
+  note: 'Apache-2.0 throughout with no enterprise directory and no license key, and the paid tiers buy throughput
+    on the hosted endpoint rather than functionality: jina.ai/reader lists Reader at 20 RPM without a key,
+    500 RPM with a free key and 5,000 RPM on Premium, with PDF, MS-Office, image captioning and search available
+    at every tier. The published branch does have the MongoDB-backed SaaS storage layer stripped out, which
+    the README states plainly, but it is accounting and persistence for the hosted service rather than a
+    piece of the reader the open build needs - the README says the branch "runs in stateless mode out of
+    the box, with optional MinIO/S3-compatible bucket caching". Nothing is withheld from the published source,
+    so core-gated is ungated.'
   raw: license:Apache-2.0(OSI);source:public(TypeScript, stateless mode self-hostable via Docker);core-gated:ungated(no
     enterprise directory or license key; the paid tiers buy rate limit on the hosted endpoint);managed-tier:r.jina.ai/s.jina.ai
     hosted SaaS (free tier + paid API key) on top of the same OSS core
@@ -67,15 +67,13 @@ adoption:
   reach: '>10K stars'
   signal_type: stars_fallback
   confidence: low
-  note: 'No verified download or API-call volume found from a primary source. ~11k GitHub stars on the OSS
-    repo plus a widely-used hosted r.jina.ai endpoint; capped at 3 on stars/reported-traction fallback in the
-    absence of a measured usage figure. Stars read 2026-08-13: 11,862 across the 1 declared repo, which bands
-    at >10K stars, level 3 on the stars scale in signal_routing.yaml. The previous reach ''100K-1M'' was not a
-    label this instrument offers - stars have their own vocabulary because a star is not a download. Re-read
-    in full 2026-08-13: the repo page reports 11,865 stargazers, the same band, and neither it nor jina.ai/reader
-    publishes a request count, a user count or any downloadable package for the reader itself - the product
-    is consumed as a URL prefix, so there is no registry to band. The stars fallback and its level-3 cap
-    therefore both stand. The digest below is of a page carrying a live star counter and will not match on
+  note: 'No verified download or API-call volume is published by a primary source: neither the repo nor
+    jina.ai/reader gives a request count or a user count, and the reader is consumed as a URL prefix rather
+    than a package, so there is no registry artifact to band. 11,865 stargazers across the 1 declared repo
+    band at >10K stars, level 3 on the stars scale in signal_routing.yaml, and the stars fallback caps the
+    level at 3. The hosted r.jina.ai endpoint is widely used but unmetered publicly. The previous reach
+    ''100K-1M'' was not a label this instrument offers - stars have their own vocabulary because a star
+    is not a download. The digest below is of a page carrying a live star counter and will not match on
     a later refetch; that is expected drift on this source rather than a signal about the claim.'
   last_verified: '2026-08-13'
   sources:
@@ -91,12 +89,9 @@ capability:
   value: URL->LLM-friendly markdown; handles HTML/PDF/MS-Office/images (AI captioning); web search via
     s.jina.ai; stateless + optional caching; self-host or hosted
   confidence: medium
-  note: 'Solid single-purpose reader/scrape tool with multi-format coverage and a search mode; mid-tier on
+  note: Solid single-purpose reader/scrape tool with multi-format coverage and a search mode; mid-tier on
     the {coverage, freshness, structured output, rate limits} feature matrix vs full agentic browse/search
-    platforms. Re-read 2026-08-13: the README still describes the same surface - URL to LLM-friendly markdown
-    via the r.jina.ai prefix, PDF and MS-Office input, image captioning, web search through s.jina.ai, and
-    a stateless mode with optional bucket caching. Nothing has been added that would move it against the
-    agentic browse platforms it is banded below, so the 3 stands.'
+    platforms.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/jina-ai/reader

--- a/sources/scores/k2.yaml
+++ b/sources/scores/k2.yaml
@@ -19,11 +19,8 @@ openness:
       detail: OSI
   confidence: high
   note: '360-open / fully reproducible: Apache-2.0 weights + complete TxT360 data + training code + checkpoints.
-    A clean fully-open exemplar at 70B. Re-read 2026-08-13 - the card still carries `license:apache-2.0`,
-    reads `"gated":false`, and still links Training Code, Evaluation Code and all three data mixtures
-    (TxT360 pretraining, TxT360-Midas midtraining, TxT360-3efforts SFT) with a "Using specific checkpoints"
-    section. Note the repo now renders under the org `IFM` rather than `LLM360`; the LLM360 URL still
-    resolves. No change to the score.'
+    A clean fully-open exemplar at 70B. The repo now renders under the org IFM rather than LLM360; the LLM360
+    URL still resolves.'
   raw: weights:open(Apache-2.0);data:open(TxT360 pretraining + midtraining + SFT);code:open(k2v2_train);checkpoints:open;license:Apache-2.0(OSI)
   last_verified: '2026-08-13'
   sources:
@@ -71,10 +68,7 @@ capability:
   value: Outperforms Qwen2.5-72B; approaches Qwen3-235B
   confidence: medium
   note: Strongest fully-open model by parameter scale (70B dense), with strong long-context and math/reasoning;
-    OLMo 3 still leads on fully-open evals. Card/report-reported numbers -> medium confidence. Re-read
-    2026-08-13 - the abstract still reads "It stands as the strongest fully open model, rivals open-weight
-    leaders in its size class, outperforms Qwen2.5-72B and approaches the performance of Qwen3-235B",
-    which is the recorded value verbatim. No change.
+    OLMo 3 still leads on fully-open evals. Card/report-reported numbers -> medium confidence.
   last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2512.06201

--- a/sources/scores/kata-containers.yaml
+++ b/sources/scores/kata-containers.yaml
@@ -17,14 +17,8 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: 'Fully Apache-2.0, source public, vendor-neutral open-foundation governance, no managed-tier gating
-    from the project itself. Re-read 2026-08-13. The LICENSE body is the verbatim Apache License 2.0 with
-    nothing appended, and the README states the same in prose. The untruncated default-branch tree carries
-    one LICENSE and the whole product - src/ holds runtime, runtime-rs, agent and the built-in Dragonball
-    VMM, with tools/, tests/ and docs/ beside them - and there is no ee/, enterprise/, commercial/ or
-    proprietary/ path. katacontainers.io sells nothing - it is a community site stewarded by the OpenInfra
-    Foundation that points at GitHub for the code and at a user survey for feedback - so there is no managed
-    tier to gate against and core-gated stays ungated.'
+  note: Fully Apache-2.0, source public, vendor-neutral open-foundation governance, no managed-tier gating
+    from the project itself.
   raw: license:Apache-2.0(OSI);source:public;governance:open community (OpenInfra Foundation);no-feature-gated-core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -75,13 +69,12 @@ adoption:
   note: 'Established CNCF/OpenInfra-adjacent container-runtime project integrated into Kubernetes runtimeclass
     deployments; broad but operator-concentrated infrastructure adoption rather than a mass per-user count.
     No clean download/user figure verified; ~8k stars (corroborate only, not the basis). Level 3 reflects
-    specialist infra reach. Re-read 2026-08-13 and the abstention from a numeric reach still holds. katacontainers.io
-    publishes no download, install, cluster or user count anywhere - what it publishes instead is a running
-    user survey asking operators to self-report, plus one named production deployment (Baidu, for Function
-    Computing, Cloud Container Instances and Edge Computing). The project ships as release tarballs and a
-    kata-deploy Helm chart rather than through a countable package registry, so there is no channel to band
-    on. Stars read 2026-08-13 - 8,531, unchanged in magnitude and still corroboration only. No reach recorded,
-    which is what reported_traction requires absent a published figure.'
+    specialist infra reach. The abstention from a numeric reach is deliberate: katacontainers.io publishes
+    no download, install, cluster or user count anywhere - what it publishes instead is a running user survey
+    asking operators to self-report, plus one named production deployment (Baidu, for Function Computing,
+    Cloud Container Instances and Edge Computing) - and the project ships as release tarballs and a kata-deploy
+    Helm chart rather than through a countable package registry, so there is no channel to band on. No reach
+    is recorded, which is what reported_traction requires absent a published figure.'
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/kata-containers/kata-containers
@@ -117,14 +110,12 @@ capability:
     K8s-native); persistence:container lifecycle; scale:K8s clusters
   confidence: high
   note: 'VM-grade isolation with OCI/Kubernetes compatibility and pluggable hypervisors; very strong isolation
-    but higher cold-start than microVM/userspace frontier-definers, so 4. Re-read 2026-08-13. The feature
-    matrix still reads as described - the README states lightweight VMs "that feel and perform like containers,
-    but provide the workload isolation and security advantages of VMs", on x86_64, aarch64, ppc64le and
-    s390x, with a containerd shimv2 runtime and an in-VM agent; docs/hypervisors.md still lists five pluggable
-    VMMs (QEMU, Cloud Hypervisor, Firecracker, Dragonball, StratoVirt), with QEMU the best-supported for
-    NVIDIA GPUs and confidential computing. The prose comparison to the frontier-definers is now recorded
-    as relative_to firecracker with relation `one_below`, which holds arithmetically - Firecracker is 5,
-    Kata is 4, and Firecracker''s capability was re-derived the same day. Score unchanged at 4.'
+    but higher cold-start than microVM/userspace frontier-definers, so 4. Five hypervisors are pluggable
+    - QEMU, Cloud Hypervisor, Firecracker, Dragonball and StratoVirt - with QEMU the best-supported for
+    NVIDIA GPUs and confidential computing, and the runtime ships as a containerd shimv2 shim with an in-VM
+    agent across x86_64, aarch64, ppc64le and s390x. The comparison to the frontier-definers is recorded
+    as relative_to firecracker with relation `one_below`, which holds arithmetically: Firecracker is 5 and
+    Kata is 4.'
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/kata-containers/kata-containers

--- a/sources/scores/keras.yaml
+++ b/sources/scores/keras.yaml
@@ -13,10 +13,9 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: 'Apache-2.0 licensed with full public source. Re-read 2026-08-13: the cited repo page still carries
-    the Apache-2.0 terms, the GitHub API reports the repository public, unarchived and licensed Apache-2.0,
-    and the README describes the whole library with no paid, enterprise or hosted tier beside it, so source
-    stays public and core-gated stays ungated.'
+  note: Apache-2.0 licensed with full public source. The repository is public and unarchived, and the README
+    describes the whole library with no paid, enterprise or hosted tier beside it, so source is public and
+    the core ungated.
   raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -51,12 +50,10 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: 'Re-scored 4->5. 21.53M PyPI downloads in the last 30 days. The map''s prevailing usage_volume level-5
+  note: Re-scored 4->5. 21.53M PyPI downloads in the last 30 days. The map's prevailing usage_volume level-5
     floor is >10M/mo (cf. pydantic-ai ~31M, llama-index ~10.18M at level 5); the prior level 4 applied a
     stricter 5M-50M band used only in one ml_frameworks batch, below map peers of equal volume. Keras is
-    the standard high-level training API across TF/JAX/PyTorch and clears the prevailing floor. Re-read
-    2026-08-13 from the cited pepy.tech reading of the declared PyPI artifact `keras`: 18,774,405 downloads
-    in the trailing 30 days, which bands at >10M, level 5 on the software scale. Unchanged.'
+    the standard high-level training API across TF/JAX/PyTorch and clears the prevailing floor.
   last_verified: '2026-08-13'
   sources:
   - url: https://pepy.tech/projects/keras
@@ -70,9 +67,7 @@ capability:
   value: High-level multi-backend deep learning API for building/training models over JAX, TensorFlow,
     PyTorch, and OpenVINO.
   confidence: high
-  note: 'Central API layer but sits atop lower-level frameworks rather than defining the compute layer.
-    Re-read 2026-08-13: the cited repository page still describes the product as recorded, so the band is
-    unchanged.'
+  note: Central API layer but sits atop lower-level frameworks rather than defining the compute layer.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/keras-team/keras

--- a/sources/scores/khadas-edge2.yaml
+++ b/sources/scores/khadas-edge2.yaml
@@ -25,12 +25,9 @@ openness:
       raw: open_market (global)
   confidence: high
   note: Khadas publishes versioned board schematics and an open toolchain with mainline Armbian, but proprietary
-    Rockchip silicon and required blobs keep it at open_toolchain. Re-read 2026-08-13 - the schematics
-    directory still lists edge2-sch-v11/v12/v13 plus silkscreen PDFs, Fenix is still GPL-2.0, the product
-    page still publishes the full RK3588S2 spec and carries Buy Now links, and Rockchip's rkbin still
-    ships the boot binaries as prebuilt files. The recorded datasheets detail names an S2 TRM; what is
-    re-readable today is Rockchip's public RK3588 brief datasheet plus Khadas's own published spec, which
-    is flagged in the pass report rather than silently rewritten. No dimension moved.
+    Rockchip silicon and required blobs keep it at open_toolchain. The recorded datasheets detail names
+    an S2 TRM; what is publicly readable is Rockchip's RK3588 brief datasheet plus Khadas's own published
+    spec, which is flagged for a curator ruling rather than silently rewritten.
   raw: schematics:published (versioned PDFs published);toolchain:open (open GPL-2.0 Fenix + mainline Armbian);datasheets:public
     (public SoC TRM);blobs:required (Rockchip NPU/boot blobs required);retail:open_market (global)
   last_verified: '2026-08-13'
@@ -73,11 +70,11 @@ adoption:
   signal_type: reported_traction
   confidence: high
   note: Sold on Amazon US and Newegg (Basic and Pro), with an active community forum and mainline Armbian
-    support, but smaller than Raspberry Pi-class platforms. Re-read 2026-08-13 - the Amazon listing could
-    not be re-read (the host returns a "Click the button below to continue shopping" interstitial to an
-    automated fetch), so availability was re-derived from Khadas's own store, which sells both the Basic
-    8GB and Pro 16GB SKUs and runs a distributor programme. An independent Armbian community comparison
-    still ranks the Edge 2 Pro alongside the other RK3588 boards. Level and reach unchanged.
+    support, but smaller than Raspberry Pi-class platforms. The Amazon listing is not machine-readable (the
+    host returns a "Click the button below to continue shopping" interstitial to an automated fetch), so
+    availability rests on Khadas's own store, which sells both the Basic 8GB and Pro 16GB SKUs and runs
+    a distributor programme, plus an independent Armbian community comparison that ranks the Edge 2 Pro
+    alongside the other RK3588 boards.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.khadas.com/edge2
@@ -102,9 +99,9 @@ capability:
     via RKNN
   confidence: high
   note: The RK3588S2 NPU delivers 6 TOPS, handling real-time CV and small quantized LLMs, mid-tier versus
-    Jetson Orin. Re-derived 2026-08-13 - the product page still reads "up to 6 TOPS" on the RK3588S2 NPU
-    with 8GB or 16GB LPDDR4X, which is level with orange-pi-5 (also 6 TOPS, also 3) and below radxa-rock-5b,
-    whose 32GB LPDDR5 option carries it to 4.
+    Jetson Orin. The product page reads "up to 6 TOPS" on the RK3588S2 NPU with 8GB or 16GB LPDDR4X, which
+    is level with orange-pi-5 (also 6 TOPS, also 3) and below radxa-rock-5b, whose 32GB LPDDR5 option carries
+    it to 4.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.khadas.com/edge2

--- a/sources/scores/khoj.yaml
+++ b/sources/scores/khoj.yaml
@@ -20,11 +20,6 @@ openness:
   note: OSI-licensed (AGPL-3.0), full source public, self-hostable via Docker or pip. The paid Khoj Cloud
     tier was discontinued 2026-04-15 and the team frames self-hosting as the complete replacement, so the
     earlier open-core characteristics no longer apply to the shipping product.
-    Re-read 2026-08-13. The repository still carries AGPL-3.0 and the README still says Khoj is
-    open-source and self-hostable, always, with Docker and pip both documented. The sunset notice at
-    app.khoj.dev is still up, still dated 15 April 2026, and still ends with the line that Khoj remains
-    fully open-source and can be self-hosted for complete data ownership, so there is still no paid tier
-    left to gate anything. Repo now at 36,480 stars. Value unchanged at 5 / open_source.
   raw: license:AGPL-3.0(OSI);source:public(github.com/khoj-ai/khoj);self-host:primary(Docker+pip);cloud-tier-sunset-2026-04(no
     remaining feature-gating);core-gated:ungated
   last_verified: '2026-08-13'
@@ -46,9 +41,8 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: medium
-  note: 19,532 PyPI downloads in the trailing 30 days for khoj, read 2026-08-13. Bands at level 2 (10K-100K)
-    on the software and model adoption scale. Corrected from level 3, which the declared artifact does not
-    support.
+  note: 19,532 PyPI downloads in the trailing 30 days for khoj. Bands at level 2 (10K-100K) on the software
+    and model adoption scale. Corrected from level 3, which the declared artifact does not support.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/khoj/recent
@@ -65,12 +59,6 @@ capability:
   confidence: medium
   note: Broad feature surface across providers, personal RAG, agents, automations, multimodality and many
     client integrations - on par with the leading open self-hosted assistants. Top-tier for the category.
-    Re-read 2026-08-13. The README still lists the whole surface the band rests on - any local or online
-    model from llama3 and qwen through gpt, claude, gemini and deepseek, answers grounded in both the
-    web and personal documents spanning image, pdf, markdown, org-mode, word and notion, clients for
-    browser, Obsidian, Emacs, desktop, phone and WhatsApp, custom agents with their own knowledge and
-    tools, automated research with scheduled newsletters and notifications, semantic search, and image
-    generation with speech in and out. Band unchanged at 4.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/khoj-ai/khoj

--- a/sources/scores/kimi.yaml
+++ b/sources/scores/kimi.yaml
@@ -17,18 +17,14 @@ openness:
         attribution requirement
   governing_release: kimi-k3
   confidence: high
-  note: 'Modified-MIT weights - standard MIT below a 100M-MAU and $20M-monthly-revenue threshold - with a
-    closed corpus, so 3. RESOLVED 2026-08-14, and the score does not move. The record had `weights - pending,
-    scheduled 2026-07-27` and a license recorded as `assumed-Modified-MIT` by continuity with K2.x rather
-    than read. K3 shipped on the scheduled day, so both placeholders are now answered by direct reads
-    instead of by inference. The Hub API for moonshotai/Kimi-K3 reads `"gated":false` and `"private":false`
-    over 96 safetensors shards, so the weights are open and downloadable. Its own LICENSE file carries the
-    Modified-MIT terms rather than an inherited assumption - MIT text, with the grant excepted for a
-    licensee''s commercial products or services having "more than 100 million monthly active users, or more
-    than 20 million US dollars" of monthly revenue, and a prominent-display attribution clause. That is the
-    same instrument K2.6 carries, so the continuity assumption was correct; it is now confirmed, which is
-    why confidence moves medium -> high. The tier still publishes no corpus and only inference and
-    deployment code, so the ladder still falls through to 3/open_weights.'
+  note: 'Modified-MIT weights - standard MIT below a 100M-MAU and $20M-monthly-revenue threshold - with
+    a closed corpus, so 3. The Hub API for moonshotai/Kimi-K3 reads `"gated":false` and `"private":false`
+    over 96 safetensors shards, so the weights are open and downloadable, and K3''s own LICENSE file carries
+    the Modified-MIT terms: MIT text, with the grant excepted for a licensee''s commercial products or services
+    having "more than 100 million monthly active users, or more than 20 million US dollars" of monthly revenue,
+    plus a prominent-display attribution clause. That is the same instrument K2.6 carries, read directly
+    rather than assumed by continuity with K2.x, which is why confidence is high. The tier publishes no
+    corpus and only inference and deployment code, so the ladder falls through to 3/open_weights.'
   raw: weights:open(shipped 2026-07-27, ungated, 96 safetensors shards);data:closed;code:partial(inference/deploy
     only; no training data or full pipeline);license:Modified-MIT(non-OSI; MIT below a 100M-MAU and $20M-monthly-revenue
     threshold, plus a prominent-display attribution requirement)
@@ -63,11 +59,11 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: 2,676,581 downloads in the trailing 30 days summed across the 2 declared artifact(s), read
-    2026-08-13 (moonshotai/Kimi-K2.6 805,006; moonshotai/Kimi-K3 1,871,575). Bands at level 4 (1M-10M)
-    on the software and model adoption scale, unchanged. The band no longer rests on a
-    production-traction reading - K3's weights shipped on 2026-07-27, so a download count now exists
-    for the release that governs, and it lands in the same band the earlier judgment did.
+  note: 2,676,581 downloads in the trailing 30 days summed across the 2 declared artifact(s) (moonshotai/Kimi-K2.6
+    805,006; moonshotai/Kimi-K3 1,871,575). Bands at level 4 (1M-10M) on the software and model adoption
+    scale, unchanged. The band no longer rests on a production-traction reading - K3's weights shipped on
+    2026-07-27, so a download count now exists for the release that governs, and it lands in the same band
+    the earlier judgment did.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/models/moonshotai/Kimi-K2.6
@@ -86,13 +82,11 @@ capability:
   basis_detail: SWE-bench/Terminal-Bench
   value: null
   confidence: high
-  note: SWE-bench Verified 80.2%, SWE-bench Pro 58.6% (up from 50.7% in K2.5), Terminal-Bench 2.0 66.7% (up from
-    50.8%). Reported tying GPT-5.5 on coding and beating some top US models; specialized for long-horizon agentic
-    coding (300-agent swarms, 4,000 coordinated steps). Frontier-tier for agentic/coding work.
-    Re-read 2026-08-13 - all three headline figures are still on the cited pages and the band is
-    unchanged at 5, which is the ceiling. One thing the re-read did not settle - the figures describe
-    K2.6, while K3 is the release the tier records as governing, and Moonshot has published no
-    comparable benchmark table for K3. A 5 cannot rise, so the band holds either way, but the value
+  note: SWE-bench Verified 80.2%, SWE-bench Pro 58.6% (up from 50.7% in K2.5), Terminal-Bench 2.0 66.7%
+    (up from 50.8%). Reported tying GPT-5.5 on coding and beating some top US models; specialized for long-horizon
+    agentic coding (300-agent swarms, 4,000 coordinated steps). Frontier-tier for agentic/coding work. The
+    figures describe K2.6, while K3 is the release the tier records as governing and Moonshot has published
+    no comparable benchmark table for it - immaterial to the band, since 5 is the ceiling, but the value
     describes the older release.
   last_verified: '2026-08-13'
   sources:

--- a/sources/scores/lakera-guard.yaml
+++ b/sources/scores/lakera-guard.yaml
@@ -14,9 +14,9 @@ openness:
     - name: proprietary
   confidence: high
   note: Closed SaaS security product; no weights or source. (Lakera also runs the public Gandalf prompt-injection
-    game, but Guard itself is proprietary.) Re-read 2026-08-13 and unchanged. The site has been restructured
-    around a three-product platform - Workforce AI Security, AI Agent Security and AI Red Teaming - and no
-    longer mentions the Check Point acquisition on the front page; neither moves the score.
+    game, but Guard itself is proprietary.) The site is structured around a three-product platform - Workforce
+    AI Security, AI Agent Security and AI Red Teaming - and no longer mentions the Check Point acquisition
+    on the front page; neither moves the score.
   raw: service:proprietary SaaS API(no self-host);note:vendor Lakera acquired by Check Point Nov 2025;source:closed;license:proprietary
   last_verified: '2026-08-13'
   sources:
@@ -37,13 +37,11 @@ adoption:
   confidence: low
   banded_quantity: a '1M+ hackers' figure from the Gandalf game and 1,000 Slack members, neither of which
     counts users of the product
-  note: 'Established prompt-injection-defense vendor with notable enterprise customers; acquired by Check
-    Point in 2025. Re-read 2026-08-13 and the absence holds - the site publishes no customer count, no
-    request volume and no revenue figure, and the only numbers on it are a ''1M+ hackers'' learning claim
-    from the Gandalf game and 1,000 members of the vendor''s Slack community, neither of which is a count
-    of the product''s users. reported_traction with no reach is the honest record and it stays. The Check
-    Point acquisition is no longer stated on the front page; it is a corporate event rather than an
-    adoption signal, so nothing rests on it.'
+  note: Established prompt-injection-defense vendor with notable enterprise customers; acquired by Check
+    Point in 2025. The site publishes no customer count, no request volume and no revenue figure; its only
+    numbers are a '1M+ hackers' learning claim from the Gandalf game and 1,000 members of the vendor's Slack
+    community, neither of which counts users of the product, so reported_traction with no reach is the honest
+    record.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.lakera.ai/
@@ -61,8 +59,7 @@ capability:
   value: Real-time prompt-injection, jailbreak, data-leakage, and content-risk defense for LLM apps.
   confidence: low
   note: Category-defining prompt-injection defense; strong coverage, now part of Check Point's platform.
-    Re-read 2026-08-13 and unchanged, with the runtime defense now sitting beside a red-teaming product and
-    a workforce/shadow-AI product.
+    The runtime defense now sits beside a red-teaming product and a workforce/shadow-AI product.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.lakera.ai/

--- a/sources/scores/laminar.yaml
+++ b/sources/scores/laminar.yaml
@@ -18,10 +18,7 @@ openness:
     - managed Laminar Cloud is hosting not a gated tier
   confidence: medium
   note: Repo and SDKs Apache-2.0 with full source; a hosted cloud exists but no enterprise-gated module
-    split was visible in the repo (less explicit open-core boundary than Langfuse/LangWatch). Re-read
-    2026-08-13 and unchanged - GitHub's license endpoint still resolves the single root LICENSE.md to
-    Apache-2.0, the PyPI SDK still declares the Apache-2.0 license expression, and the repository root
-    still carries five docker-compose files, so the published tree is what a self-hoster runs.
+    split was visible in the repo (less explicit open-core boundary than Langfuse/LangWatch).
   raw: license:Apache-2.0(OSI);source:public(Rust core + TS UI);SDKs:Apache-2.0;no feature-gated core observed
     in repo;managed Laminar Cloud is hosting not a gated tier;core-gated:ungated
   last_verified: '2026-08-13'
@@ -71,8 +68,8 @@ adoption:
     can recompute, and the only count available here is a PyPI figure the note has said since it was
     written is mirror-inflated. Keeping the instrument while discounting the figure by an order of
     magnitude was the incoherent part.
-    The measured figure is recorded as a dated, digested source rather than as the basis of the band -
-    re-fetched 2026-08-14, pypistats answers last_month 34,062,990 for lmnr (last_week 9,228,203, last_day
+    The measured figure is recorded as a dated, digested source rather than as the basis of the band:
+    pypistats answers last_month 34,062,990 for lmnr (last_week 9,228,203, last_day
     1,293,104). That is a level-5 figure on the download scale and it is not believed: at ~1.3M downloads
     a day lmnr outruns langfuse, a project an order of magnitude larger by stars, contributors and
     customers, which is the tell for transitive or mirror pulls of an OTel auto-instrumentation SDK. What
@@ -88,9 +85,8 @@ adoption:
     http_status: 200
     content_sha256: aa10188d675f0504f79dac9f41d84fa85384cec1f0e4c07b7b12526adb5aba7a
   - url: https://pypistats.org/api/packages/lmnr/recent
-    shows: 'Re-fetched for the instrument change - `{"data":{"last_day":1293104,"last_month":34062990,"last_week":9228203},"package":"lmnr"}`.
-      Recorded as a measurement of the PyPI channel, explicitly NOT as the basis of the band; the digest
-      differs from the earlier read the same day because the counters move.'
+    shows: 'pypistats for lmnr: `{"data":{"last_day":1293104,"last_month":34062990,"last_week":9228203},"package":"lmnr"}`.
+      Recorded as a measurement of the PyPI channel, explicitly NOT as the basis of the band.'
     accessed: '2026-08-14'
     http_status: 200
     content_sha256: 652866567c724684a441cbee54a76c05b64249d3e60253faedf3f55ab00f46cd
@@ -108,9 +104,7 @@ capability:
   relation: one_below
   note: Solid tracing+evals+datasets coverage with a differentiated SQL/dashboard layer; below Langfuse/MLflow
     (C4 anchors) on prompt management and cost-tracking breadth, hence 3. The comparison is now recorded
-    rather than left in prose - one rung below the langfuse anchor at 4. Re-read 2026-08-13 - the README
-    checklist still covers evals via SDK and CLI, an eval-comparison UI and SQL query over traces, spans,
-    metrics and events, with no prompt-versioning section.
+    rather than left in prose - one rung below the langfuse anchor at 4.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/lmnr-ai/lmnr

--- a/sources/scores/langchain.yaml
+++ b/sources/scores/langchain.yaml
@@ -85,14 +85,12 @@ adoption:
   signal_type: usage_volume
   confidence: high
   note: 'LangChain + LangGraph open source frameworks surpassed 1B cumulative downloads with 90M+ combined
-    monthly downloads. Monthly volume exceeds 10M, placing it at the top band. Artifact declared and read live
-    2026-08-13: 281,508,705 PyPI downloads in the trailing 30 days. Bands at >10M, level 5. This record
-    previously claimed usage_volume - a download count - while declaring no artifact any signal model reads,
-    so no computed figure existed for the recorded band to disagree with. PyPI is LangChain''s primary channel
-    and the package is the product, not an SDK for a hosted service. Level unchanged; what changed is that a
-    model can now recompute it. Re-read 2026-08-13 against the pypistats API, which returns 281,508,705
-    downloads in the trailing 30 days for langchain, the same figure the declaration rested on. Level
-    and reach unchanged.'
+    monthly downloads. Monthly volume exceeds 10M, placing it at the top band. Artifact declared: 281,508,705
+    PyPI downloads in the trailing 30 days. Bands at >10M, level 5. This record previously claimed usage_volume
+    - a download count - while declaring no artifact any signal model reads, so no computed figure existed
+    for the recorded band to disagree with. PyPI is LangChain''s primary channel and the package is the
+    product, not an SDK for a hosted service. Level unchanged; what changed is that a model can now recompute
+    it.'
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/langchain/recent
@@ -116,11 +114,8 @@ capability:
   basis: feature_matrix
   value: null
   confidence: high
-  note: 'Broadest LLM/agent orchestration ecosystem: chains, LangGraph stateful agent graphs, hundreds
-    of model/tool integrations. No single benchmark for the framework; rated on feature breadth. Re-read
-    2026-08-13 - the repo and the product page still present the same breadth of integrations and the
-    same agent surface, and no benchmark exists for an orchestration library. One below the openhands
-    anchor, unchanged.'
+  note: 'Broadest LLM/agent orchestration ecosystem: chains, LangGraph stateful agent graphs, hundreds of
+    model/tool integrations. No single benchmark for the framework; rated on feature breadth.'
   relative_to: openhands
   relation: one_below
   last_verified: '2026-08-13'

--- a/sources/scores/langflow.yaml
+++ b/sources/scores/langflow.yaml
@@ -16,10 +16,7 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: 'MIT core, fully open; managed cloud does not gate the OSS core. Re-read 2026-08-13 - the repo
-    page still reports MIT over the whole tree and publishes the whole platform, with the DataStax-hosted
-    cloud sold beside it rather than withholding anything from the published source. Stars are now 153.2k.
-    Nothing moved.'
+  note: MIT core, fully open; managed cloud does not gate the OSS core.
   raw: license:MIT(OSI);source:public;no-feature-gated-core;commercial:DataStax-hosted(separate);core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -37,10 +34,9 @@ adoption:
   level: 3
   signal_type: usage_volume
   confidence: medium
-  note: 'About 166,141 downloads a month across the product''s real distribution channels, read 2026-08-12.
-    Docker Hub reports 3,408,830 cumulative pulls of langflowai/langflow since 2023-02-08, which over 42
-    months averages roughly 81,003 a month; 85,138 come from PyPI  in the trailing 30 days. Bands at level
-    3 (100K-1M).
+  note: 'About 166,141 downloads a month across the product''s real distribution channels. Docker Hub reports
+    3,408,830 cumulative pulls of langflowai/langflow since 2023-02-08, which over 42 months averages roughly
+    81,003 a month; 85,138 come from PyPI in the trailing 30 days. Bands at level 3 (100K-1M).
 
 
     Langflow is distributed mainly as a Docker image and a desktop app; the PyPI package is one of several
@@ -67,10 +63,7 @@ capability:
   value: visual drag-and-drop flow builder; 100s of pre-built components; agent + multi-agent; RAG pipelines; MCP;
     API/playground deployment; Python-extensible custom components
   confidence: medium
-  note: 'Mature low-code visual builder (peer to Dify); model/vendor-agnostic. Re-read 2026-08-13 - langflow.org
-    still presents the same drag-and-drop builder with pre-built components, agent and RAG flows and API
-    deployment, and the repo still publishes the Python-extensible custom component surface. At dify,
-    which is the peer this note names.'
+  note: Mature low-code visual builder (peer to Dify); model/vendor-agnostic.
   relative_to: dify
   relation: at
   last_verified: '2026-08-13'

--- a/sources/scores/langfuse.yaml
+++ b/sources/scores/langfuse.yaml
@@ -19,8 +19,8 @@ openness:
         and UI customization
   confidence: high
   note: 'MIT core with a commercially licensed enterprise directory in the same repository. `core-gated:
-    gated` verified 2026-08-12 by a direct read, and it does NOT rest on Langfuse Cloud or on the ClickHouse
-    acquisition. The root LICENSE splits the repo itself: "All content that resides under the ''ee/'', ''web/src/ee/'',
+    gated` comes from a direct read, and it does NOT rest on Langfuse Cloud or on the ClickHouse acquisition.
+    The root LICENSE splits the repo itself: "All content that resides under the ''ee/'', ''web/src/ee/'',
     and/or ''worker/src/ee/'' directories of this repository, if these directories exist, is licensed under
     the license defined in ''ee/LICENSE''", and everything outside them is MIT Expat. ee/LICENSE opens by
     calling Langfuse "an open core project" and requires "a valid Langfuse Enterprise License". The carve-out
@@ -139,11 +139,8 @@ capability:
   value: null
   confidence: high
   note: End-to-end tracing, prompt management, evals (incl. LLM-as-judge), datasets, annotation queues,
-    playground; OpenTelemetry + LangChain/OpenAI/LiteLLM integrations. Rated on feature matrix. Re-read
-    2026-08-13 - the repository README and the observability docs still describe the same feature set, and
-    the docs sidebar still lists Observability, Prompt Management, Evaluation and Playground as the four
-    product areas. Nothing was added or withdrawn that would move the band, so 4 stands as the category
-    anchor the peer comparisons in this category are recorded against.
+    playground; OpenTelemetry + LangChain/OpenAI/LiteLLM integrations. Rated on feature matrix. This 4 is
+    the category anchor that the peer comparisons in telemetry_observability are recorded against.
   sources:
   - url: https://github.com/langfuse/langfuse
     shows: Repository overview. The README still describes tracing, prompt management, evaluations, datasets

--- a/sources/scores/langgraph.yaml
+++ b/sources/scores/langgraph.yaml
@@ -16,16 +16,16 @@ openness:
         it needs LANGGRAPH_CLOUD_LICENSE_KEY
   confidence: high
   note: 'MIT-licensed self-hostable core with a commercial managed deployment platform. `core-gated: gated`
-    transcribed 2026-08-11 from a read of the repo, PyPI and the deployment docs, and it does NOT rest on
-    the managed platform existing. A full untruncated recursive tree of langchain-ai/langgraph@main is 830
-    entries with nine LICENSE files, all of them per-package copies of the MIT root, and no enterprise/
-    or ee/ directory - so the gate is not inside the repo. It is that a piece of the runtime is not in the
-    repo at all: PyPI reports langgraph-api, the Agent Server, under Elastic-2.0 while langgraph itself
-    is MIT, no langgraph-api source repo exists under the langchain-ai org, and LangChain''s own self-host
-    doc requires LANGGRAPH_CLOUD_LICENSE_KEY plus egress to beacon.langchain.com for license verification.
-    A license key you must hold to run the server is functionality withheld from the published source for
-    a paid tier, which is the dimension''s question stated directly. This is the axis on which langgraph
-    and langchain differ despite recording the same 4/open_core - see the langchain note.'
+    from a direct read of the repo, PyPI and the deployment docs, and it does NOT rest on the managed platform
+    existing. A full untruncated recursive tree of langchain-ai/langgraph@main is 830 entries with nine
+    LICENSE files, all of them per-package copies of the MIT root, and no enterprise/ or ee/ directory -
+    so the gate is not inside the repo. It is that a piece of the runtime is not in the repo at all: PyPI
+    reports langgraph-api, the Agent Server, under Elastic-2.0 while langgraph itself is MIT, no langgraph-api
+    source repo exists under the langchain-ai org, and LangChain''s own self-host doc requires LANGGRAPH_CLOUD_LICENSE_KEY
+    plus egress to beacon.langchain.com for license verification. A license key you must hold to run the
+    server is functionality withheld from the published source for a paid tier, which is the dimension''s
+    question stated directly. This is the axis on which langgraph and langchain differ despite recording
+    the same 4/open_core - see the langchain note.'
   last_verified: '2026-08-11'
   raw: license:MIT(core);commercial:LangGraph-Platform/LangSmith;source:public;core-gated:gated(the Agent
     Server runtime ships as the closed Elastic-2.0 langgraph-api package and self-hosting it needs LANGGRAPH_CLOUD_LICENSE_KEY)
@@ -74,8 +74,8 @@ adoption:
   level: 5
   signal_type: usage_volume
   confidence: high
-  note: 72,717,229 PyPI downloads in the trailing 30 days for langgraph, read 2026-08-12. Bands at level
-    5 (>10M) on the software and model adoption scale. Largely transitive via LangChain, so directional.
+  note: 72,717,229 PyPI downloads in the trailing 30 days for langgraph. Bands at level 5 (>10M) on the
+    software and model adoption scale. Largely transitive via LangChain, so directional.
   reach: '>10M'
   last_verified: '2026-08-12'
   sources:
@@ -90,12 +90,7 @@ capability:
   value: graph control flow; checkpointing/persistence; durable resumable execution; HITL interrupts; streaming;
     subgraphs
   confidence: high
-  note: 'Deepest durable-execution control among the orchestration peers. Re-read 2026-08-13 - the repo
-    README still leads on exactly that, describing "durable execution - build agents that persist through
-    failures and can run for extended periods, automatically resuming from exactly where they left off"
-    and human-in-the-loop oversight that inspects and modifies agent state mid-run, plus guides for streaming,
-    memory and persistence, branching and subgraphs. Stars are now 39.6k. The feature matrix that placed
-    this band is unchanged.'
+  note: Deepest durable-execution control among the orchestration peers.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/langchain-ai/langgraph

--- a/sources/scores/langsmith.yaml
+++ b/sources/scores/langsmith.yaml
@@ -14,12 +14,9 @@ openness:
     - self-hosting=licensed enterprise deployment of closed software, not OSS
     - OSS siblings(LangChain/LangGraph) are separate products not scored here
   confidence: high
-  note: LangSmith the observability/eval platform is closed/proprietary; only the LangChain/LangGraph
-    frameworks (separate registry entries) are open. Self-host/BYOC are licensed deployments of closed
-    software, not source-available. Re-read 2026-08-13 and unchanged - the page's Open Source Frameworks
-    section still names deepagents and the LangChain/LangGraph line rather than LangSmith itself, and its
-    FAQ answers "Can I self-host LangSmith?" with managed cloud, BYOC and self-hosted options for data
-    residency, which is a deployment choice rather than published source.
+  note: LangSmith the observability/eval platform is closed/proprietary; only the LangChain/LangGraph frameworks
+    (separate registry entries) are open. Self-host/BYOC are licensed deployments of closed software, not
+    source-available.
   raw: license:Proprietary;source:closed;platform:proprietary(no public source for LangSmith itself);self-hosting=licensed
     enterprise deployment of closed software, not OSS;OSS siblings(LangChain/LangGraph) are separate products
     not scored here
@@ -43,19 +40,13 @@ adoption:
   signal_type: reported_traction
   confidence: medium
   note: 'Default observability/eval platform for the very widely used LangChain ecosystem, placed at 4 on
-    ecosystem reach plus the published enterprise roster. RE-SOURCED 2026-08-14 rather than re-banded. The
-    band had been resting on an undated, undigested 2026-06-04 read, which is the class docs/reference/adoption.md
-    calls unfalsifiable, so the vendor page was re-fetched and digested and the axis now decays against the
-    refresh window like any other. What the page still shows - a named enterprise roster including Klarna,
-    Lyft, LinkedIn, Coinbase, Nvidia, Workday, Rakuten, Elastic and Harvey, and no quantitative user,
-    customer or download count anywhere on it. Two corrections the re-read forces on the old prose - the
-    "25+" count is not stated on the page and could not be re-derived from it, and Cloudflare is no longer
-    among the names, so both have been dropped from this note. The instrument stays reported_traction and
-    the record carries no reach, which is the honest default for it. DELIBERATELY NOT re-banded on the
-    langsmith PyPI package under the SDK-is-the-platform ruling of 2026-08-14, which excludes this product
-    by name - langsmith is a hard dependency of langchain-core, so its download count measures LangChain
-    installs rather than LangSmith use. A transitive dependency of a DIFFERENT product measures that
-    product.'
+    ecosystem reach plus the published enterprise roster. The vendor page names Klarna, Lyft, LinkedIn,
+    Coinbase, Nvidia, Workday, Rakuten, Elastic and Harvey, and carries no quantitative user, customer or
+    download count anywhere on it. The instrument stays reported_traction and the record carries no reach,
+    which is the honest default for it. The band is deliberately NOT taken from the langsmith PyPI package
+    under the SDK-is-the-platform ruling, which excludes this product by name: langsmith is a hard dependency
+    of langchain-core, so its download count measures LangChain installs rather than LangSmith use, and
+    a transitive dependency of a DIFFERENT product measures that product.'
   last_verified: '2026-08-14'
   sources:
   - url: https://www.langchain.com/langsmith
@@ -77,9 +68,7 @@ capability:
   relation: at
   note: Mature, broad feature matrix across tracing/evals/prompt/datasets/cost plus agent deployment surface;
     comparable to the C4 anchors. Closed-source, but capability is assessed independently of openness. The
-    comparison is now recorded rather than left in prose - at the langfuse anchor. Re-read 2026-08-13 - the
-    four product pillars on the page are still Observability, Evaluation, Agent Infrastructure Deployment
-    and Sandboxes, with monitoring carrying cost tracking and online LLM-as-judge evals.
+    comparison is now recorded rather than left in prose - at the langfuse anchor.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.langchain.com/langsmith

--- a/sources/scores/langtrace.yaml
+++ b/sources/scores/langtrace.yaml
@@ -76,8 +76,7 @@ adoption:
   signal_type: usage_volume
   confidence: medium
   note: ~34.5K langtrace-python-sdk downloads/mo; ~1.2k GitHub stars. Real but small footprint; early-adopter
-    tier. Re-read 2026-08-13 - pypistats now reports 34,666 downloads last month, within a couple of
-    hundred of the 34,497 recorded and still inside the 10K-100K band, so level 2 stands.
+    tier.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/packages/langtrace-python-sdk
@@ -94,11 +93,9 @@ capability:
   confidence: medium
   relative_to: langfuse
   relation: one_below
-  note: Strong tracing+cost+integration breadth but thinner prompt-mgmt/datasets surface than Langfuse
-    C4; scored 3. The comparison is now recorded rather than left in prose - one rung below the langfuse
-    anchor at 4. Re-read 2026-08-13 - the repository still describes tracing, evaluations and metrics, and
-    the README's own Features list has narrowed to OTel support, real-time monitoring, performance
-    insights and debug tools, which is if anything narrower than the band already assumed.
+  note: Strong tracing+cost+integration breadth but thinner prompt-mgmt/datasets surface than Langfuse C4;
+    scored 3. The comparison is now recorded rather than left in prose - one rung below the langfuse anchor
+    at 4.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/Scale3-Labs/langtrace

--- a/sources/scores/langwatch.yaml
+++ b/sources/scores/langwatch.yaml
@@ -20,10 +20,10 @@ openness:
       for production
   confidence: high
   note: 'Explicit open core: Apache-2.0 platform, MIT SDKs, and an enterprise directory under a commercial
-    license. `core-gated: gated` verified 2026-08-12 by a direct read, and it does NOT rest on LangWatch
-    selling a hosted tier. NOTICE names the split component by component - "platform/app/ee/ LangWatch Enterprise
-    License (platform/app/ee/LICENSE.md)" against MIT sdks/typescript, sdks/python and mcp/typescript, with
-    everything else Apache-2.0. That license says the enterprise directory "implements the enterprise capabilities
+    license. `core-gated: gated` comes from a direct read, and it does NOT rest on LangWatch selling a hosted
+    tier. NOTICE names the split component by component - "platform/app/ee/ LangWatch Enterprise License
+    (platform/app/ee/LICENSE.md)" against MIT sdks/typescript, sdks/python and mcp/typescript, with everything
+    else Apache-2.0. That license says the enterprise directory "implements the enterprise capabilities
     of LangWatch, including single sign-on, SCIM provisioning, audit logging, gateway webhooks, licensing,
     billing, and back-office tooling" and that "each verifies a license at runtime before it can be used".
     A runtime license check on shipped features is the dimension''s question answered directly. The recorded
@@ -82,15 +82,15 @@ adoption:
   reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
-  note: 'No verified download/active-user figure located this run; ~3.3k GitHub stars is the only honest
-    signal, so capped at level 2 via stars fallback (cannot exceed 3 on stars regardless). Stars read
-    2026-08-13: 3,486 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in
-    signal_routing.yaml. The previous reach ''10K-100K'' was not a label this instrument offers - stars have
-    their own vocabulary because a star is not a download. The earlier pass declined to claim a date on the
-    ground that a star count is volatile and would read as drift on every refetch. That is true and it is not
-    a reason to leave the axis unconfirmed - `check_refetch` reports drift rather than failing on it, and
-    `helicone` in this same category already carries a dated stars_fallback band over the same endpoint. The
-    count was re-read from the repository API on 2026-08-13 and is recorded with its digest.'
+  note: No verified download/active-user figure located this run; ~3.3k GitHub stars is the only honest
+    signal, so capped at level 2 via stars fallback (cannot exceed 3 on stars regardless). 3,486 stars across
+    the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml.
+    The previous reach '10K-100K' was not a label this instrument offers - stars have their own vocabulary
+    because a star is not a download. The earlier pass declined to claim a date on the ground that a star
+    count is volatile and would read as drift on every refetch. That is true and it is not a reason to leave
+    the axis unconfirmed - `check_refetch` reports drift rather than failing on it, and `helicone` in this
+    same category already carries a dated stars_fallback band over the same endpoint. The count is read
+    from the repository API and is recorded with its digest.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/langwatch/langwatch
@@ -112,10 +112,8 @@ capability:
     control, failover); broad framework/provider integrations.'
   confidence: high
   note: Full feature matrix across all six recipe dimensions plus distinctive agent-simulation/scenario
-    testing and a built-in gateway; on par with Langfuse C4. Held at 4 (no frontier-definer claim over
-    the anchors). Re-read 2026-08-13 - the README still leads on end-to-end agent simulations and on
-    "Eval + observability + prompts in one loop", so the breadth the band rests on is intact and the
-    recorded comparison at the langfuse anchor still holds.
+    testing and a built-in gateway; on par with Langfuse C4. Held at 4 (no frontier-definer claim over the
+    anchors).
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/langwatch/langwatch

--- a/sources/scores/le-chat.yaml
+++ b/sources/scores/le-chat.yaml
@@ -13,19 +13,16 @@ openness:
     self-host:
       value: none
   confidence: high
-  note: 'The Le Chat product/service is proprietary SaaS (closed), distinct from Mistral''s open-weight
-    models scored elsewhere; closed counterpart on the shelf. Re-read 2026-08-14 - the only source this
-    axis carried was a TechCrunch download-milestone brief that establishes none of the openness
-    components. Replaced with Mistral primaries, which confirm the class and add one thing the record
-    did not have. Mistral''s EU consumer terms, which govern this product, read "As between you and
-    Mistral AI, we own all right, title, and interest in and to the Mistral AI Products" and grant only
-    "a non-exclusive right to access and use", with no source and no self-host offer on the product
-    page. So 1/closed holds. FLAGGED, not changed - the product was RENAMED. Mistral''s help centre says
-    "Le Chat has become Vibe" and "Same URL, same login. Open chat.mistral.ai and you will land in Vibe
-    with your existing conversations." The slug and the product record still say le-chat, which is a
-    naming question for the orchestrator. Also worth a ruling - the Vibe Code CLI shipped as
-    mistralai/mistral-vibe under Apache-2.0, so a component of the same product family is now genuinely
-    open, which source - closed for the hosted surface does not capture on its own.'
+  note: The Le Chat product/service is proprietary SaaS (closed), distinct from Mistral's open-weight models
+    scored elsewhere; closed counterpart on the shelf. Mistral's EU consumer terms, which govern this product,
+    read "As between you and Mistral AI, we own all right, title, and interest in and to the Mistral AI
+    Products" and grant only "a non-exclusive right to access and use", with no source and no self-host
+    offer on the product page, so 1 / closed holds. FLAGGED, not changed - the product was RENAMED. Mistral's
+    help centre says "Le Chat has become Vibe" and "Same URL, same login. Open chat.mistral.ai and you will
+    land in Vibe with your existing conversations." The slug and the product record still say le-chat, which
+    is a naming question for the orchestrator. Also worth a ruling - the Vibe Code CLI ships as mistralai/mistral-vibe
+    under Apache-2.0, so a component of the same product family is genuinely open, which source - closed
+    for the hosted surface does not capture on its own.
   raw: license:proprietary(SaaS app);source:closed(the Le Chat product; underlying Mistral models are open-weights
     but the chat UI/service is not);self-host:none
   last_verified: '2026-08-14'
@@ -60,16 +57,13 @@ adoption:
   signal_type: active_users
   confidence: medium
   note: ~1.7M app downloads by May 2026 (TechCrunch reported 1M in 14 days at Feb 2025 launch); Mistral
-    states EU monthly active recipients below 45M (a DSA ceiling, not a measured MAU); ~10.8M desktop
-    visits to mistral.ai Mar 2026. Honest read places real active users in the 1-10M band, level 4. The
-    <45M is a regulatory cap not an actual count, so not used as the headline.
-    Re-read 2026-08-13. The TechCrunch brief is still up and still carries the one milestone it ever
-    carried - Mistral telling Le Parisien that Le Chat passed one million downloads fourteen days after
-    release, topping the free iOS chart in France. WHAT WAS BANDED - downloads, not an active count. No
-    active-user figure for Le Chat exists from Mistral or anyone else; the EU recipient ceiling is a
-    regulatory cap and the mistral.ai visit count is site traffic, so the level is an inference from
-    install volume and is labelled active_users only because that is the instrument the map offers for a
-    consumer surface. Level unchanged at 4.
+    states EU monthly active recipients below 45M (a DSA ceiling, not a measured MAU); ~10.8M desktop visits
+    to mistral.ai Mar 2026. Honest read places real active users in the 1-10M band, level 4. The <45M is
+    a regulatory cap not an actual count, so not used as the headline. WHAT WAS BANDED - downloads, not
+    an active count. No active-user figure for Le Chat exists from Mistral or anyone else; the EU recipient
+    ceiling is a regulatory cap and the mistral.ai visit count is site traffic, so the level is an inference
+    from install volume and is labelled active_users only because that is the instrument the map offers
+    for a consumer surface.
   last_verified: '2026-08-13'
   sources:
   - url: https://techcrunch.com/2025/02/19/mistrals-le-chat-tops-1m-downloads-in-just-14-days/
@@ -89,18 +83,15 @@ capability:
     document/Flash answers (fast inference), connectors/agents, enterprise (Le Chat Enterprise) + flash-fast
     responses on Cerebras. Locked primarily to Mistral models (limited provider breadth).'
   confidence: medium
-  note: 'Feature-broad general assistant UI (search, multimodal, code, enterprise) with a speed differentiator;
-    high breadth but single-provider-leaning, not the category frontier-definer. Re-read 2026-08-14 - the
-    TechCrunch brief this rested on carries a downloads milestone and nothing else, so the whole feature
-    matrix was unsourced. Replaced with Mistral''s own product and docs pages, which corroborate every
-    clause of the recorded value and then some. The product is now called Vibe, and the surface the
-    record describes is Vibe Work. Documented there - Connectors, Libraries, Skills, Files and Canvas,
-    web search and Open URL, image generation, voice mode, Projects, Workflows and scheduled tasks; the
-    product page adds deep research, spreadsheet and database analysis, and "100+ tools including email,
-    calendar, Slack, GitHub, Jira ... through connectors and full MCP compatibility", with voice "powered
-    by Voxtral". The single-provider-leaning judgment that holds this at 4 rather than 5 is unchanged -
-    the docs name no model choice beyond Mistral''s own. Score unchanged at 4. The rename is FLAGGED on
-    the openness axis.'
+  note: Feature-broad general assistant UI (search, multimodal, code, enterprise) with a speed differentiator;
+    high breadth but single-provider-leaning, so not the category frontier-definer. The product is now called
+    Vibe and the surface this record describes is Vibe Work. Mistral's own product and docs pages corroborate
+    every clause of the recorded value and then some - Connectors, Libraries, Skills, Files and Canvas,
+    web search and Open URL, image generation, voice mode powered by Voxtral, Projects, Workflows and scheduled
+    tasks, plus deep research, spreadsheet and database analysis and "100+ tools including email, calendar,
+    Slack, GitHub, Jira ... through connectors and full MCP compatibility". The single-provider-leaning
+    judgment that holds this at 4 rather than 5 is unchanged - the docs name no model choice beyond Mistral's
+    own. The rename is FLAGGED on the openness axis.
   last_verified: '2026-08-14'
   sources:
   - url: https://docs.mistral.ai/vibe/work

--- a/sources/scores/librechat.yaml
+++ b/sources/scores/librechat.yaml
@@ -14,13 +14,8 @@ openness:
     - no-feature-gated-core(RAG API is a separate companion OSS repo)
   confidence: high
   note: Fully OSI (MIT), full source public, no paid feature-gated core. Enterprise backing via ClickHouse
-    acquisition has not introduced a closed core.
-    Re-read 2026-08-13. The repository still carries the MIT badge and the full self-hostable stack, now
-    at 41,990 stars and 8,686 forks, and the code interpreter it ships points at the open
-    ClickHouse/code-interpreter project rather than a paid tier. The ClickHouse acquisition post still
-    states that for existing LibreChat deployments operations continue unchanged with ongoing investment
-    in the open-source project and community, so no closed core has appeared. The post itself names no
-    license; MIT comes from the repository. Value unchanged at 5 / open_source.
+    acquisition has not introduced a closed core. The code interpreter it ships points at the open ClickHouse/code-interpreter
+    project rather than a paid tier. The acquisition post itself names no license; MIT comes from the repository.
   raw: license:MIT(OSI);source:public;no-feature-gated-core(RAG API is a separate companion OSS repo);core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -42,35 +37,20 @@ adoption:
   reach: '>10K stars'
   signal_type: stars_fallback
   confidence: medium
-  note: '23M+ cumulative Docker pulls by early 2026 (includes CI/upgrades, so a soft upper bound); 38.1k
-    GitHub stars, 6,800+ forks, 9,000+ Discord members; ClickHouse acquisition signals enterprise deployment.
-    Placed at 4 on Docker-pull volume; medium confidence because pulls overcount unique deployments.
-    Re-read 2026-08-14, and the signal the band rests on does not exist in any checkable form. Three
-    numbers, none of which agree. Docker Hub''s API reports 372,272 pulls on librechat/librechat and
-    roughly 732,090 summed across all nine librechat org repos. LibreChat''s own site counter now claims
-    47.3M Docker pulls, not the 23M recorded, and nothing corroborates it - the primary image is on
-    GHCR, which publishes no pull count at all, so the vendor figure cannot be checked against any
-    registry. The site''s star counter, by contrast, matches the GitHub API exactly (42k against 41,995),
-    so the counter is live rather than invented; it is the pull number specifically that has no
-    reachable basis. What IS countable today is 41,995 GitHub stars and 8,686 forks. ESCALATED rather
-    than changed - a usage_volume band of 4 at reach 1M-10M sits above the ~732k that Docker Hub can
-    actually account for and far below the 47.3M the vendor claims, and choosing between them is a
-    banding decision, not a freshness one. No last_verified claimed. Recommendation - re-band on the
-    GitHub star signal, or re-route the axis off usage_volume, rather than keep a Docker-pull band that
-    no registry can produce.
-
-    RE-BANDED 2026-08-14 on that recommendation, on the owner''s ruling. SAY WHAT WAS BANDED - the
-    quantity is GITHUB STARS on danny-avila/LibreChat, 42,002 read from the GitHub API today, which is
-    >10K stars and level 3 on the stars scale in signal_routing.yaml. The instrument moves to
-    stars_fallback and the level drops 4 -> 3, which is the ceiling that instrument allows however large
-    the count, because a star is attention rather than use.
-    The 23M Docker pulls the old band rested on is not merely stale, it is unreachable. Docker Hub''s API
-    accounts for 372,272 pulls on the primary librechat/librechat repo and roughly 732,090 across the
-    whole org; the image people actually run is on GHCR, which publishes no pull count at all; and the
-    vendor''s own counter now claims 47.3M, two orders above what any registry can produce and checkable
-    against nothing. A usage_volume band needs a count somebody can recompute, and this product has
-    none - so the honest move is down onto the one signal that is countable, not sideways onto a bigger
-    unverifiable number. Deployment reach is certainly higher than 42k; nothing published measures it.'
+  note: 'SAY WHAT WAS BANDED - the quantity is GITHUB STARS on danny-avila/LibreChat, 42,002 read from
+    the GitHub API, which is >10K stars and level 3 on the stars scale in signal_routing.yaml. The
+    instrument is stars_fallback and the level is 3 rather than 4, which is the ceiling that instrument
+    allows however large the count, because a star is attention rather than use. RE-BANDED down from a
+    usage_volume 4 at reach 1M-10M, on the owner''s ruling: the 23M Docker pulls the old band rested on
+    is not merely stale, it is unreachable. Docker Hub''s API accounts for 372,272 pulls on the primary
+    librechat/librechat repo and roughly 732,090 across the whole librechat org; the image people
+    actually run is on GHCR, which publishes no pull count at all; and the vendor''s own counter claims
+    47.3M, two orders above what any registry can produce and checkable against nothing. The vendor''s
+    star counter, by contrast, matches the GitHub API exactly (42k against 41,995), so the counter is
+    live rather than invented - it is the pull number specifically that has no reachable basis. A
+    usage_volume band needs a count somebody can recompute and this product has none, so the honest move
+    is down onto the one signal that is countable rather than sideways onto a bigger unverifiable
+    number. Deployment reach is certainly higher than 42k; nothing published measures it.'
   sources:
   - url: https://api.github.com/repos/danny-avila/LibreChat
     shows: 'GitHub API for danny-avila/LibreChat - 41,995 stars, 8,686 forks, 201 watchers, MIT. A
@@ -79,9 +59,9 @@ adoption:
     http_status: 200
     content_sha256: 957b025965cba8d0cf6ceb3934a22c819604d302a798c4a57ea5059941656eb5
   - url: https://api.github.com/repos/danny-avila/LibreChat
-    shows: 'Re-read for the re-band. 42,002 stargazers, 8,687 forks, 201 watchers, MIT, last pushed
-      2026-08-14. This is the figure the level 3 band is taken on. The digest differs from the earlier
-      read the same day because the star and fork counts moved.'
+    shows: 'GitHub API for danny-avila/LibreChat - 42,002 stargazers, 8,687 forks, 201 watchers, MIT.
+      This is the figure the level 3 band is taken on. The digest differs from the other read of the
+      same endpoint because the star and fork counts moved.'
     accessed: '2026-08-14'
     http_status: 200
     content_sha256: c335ab422ad0dded7e2a11d20059a2600c02e75099d5695305516cd568b07a76
@@ -106,12 +86,7 @@ capability:
     artifacts (React/HTML/Mermaid), web search
   confidence: high
   note: 'Frontier feature surface for the category: code interpreter, MCP, agents/subagents and artifacts
-    on top of the standard chat-UI matrix. At/above Open WebUI on breadth.
-    Re-read 2026-08-13. The README still lists the whole surface the band rests on - a sandboxed code
-    interpreter across nine languages, MCP tool support, agents with an agent marketplace, Skills
-    bundles and subagents, code artifacts in React, HTML and Mermaid, web search with rerankers, image
-    generation and editing, speech in and out, and multi-user auth over OAuth2, LDAP and email with
-    moderation and token-spend controls. Band unchanged at 5.'
+    on top of the standard chat-UI matrix. At/above Open WebUI on breadth.'
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/danny-avila/LibreChat

--- a/sources/scores/lighteval.yaml
+++ b/sources/scores/lighteval.yaml
@@ -18,8 +18,6 @@ openness:
   confidence: high
   last_verified: '2026-08-13'
   note: Fully OSI-licensed (MIT), full source public, no managed/commercial tier gating the eval engine.
-    Re-read 2026-08-13 - the license endpoint still reports MIT and the README still runs every backend
-    locally with no paid tier or license key.
   raw: license:MIT(OSI);source:public(github.com/huggingface/lighteval);no feature-gated core; multi-backend
     (Accelerate/vLLM/SGLang/TGI/LiteLLM/inspect-ai); 1000+ tasks;core-gated:ungated
   sources:
@@ -54,8 +52,8 @@ adoption:
   note: ~37,239 PyPI downloads in the last month (pypistats). Powers the HF Open LLM Leaderboard and is
     the reproducible eval suite behind it; meaningful in the eval/research community but a smaller install
     base than general-purpose harnesses. 2.4k GitHub stars corroborate only. Headline = PyPI volume (primary).
-    Re-read 2026-08-13 - the pypistats API now reports 24,962 lighteval downloads in the trailing 30 days,
-    down from 37,239 but still inside the same 10K-100K band, so level 2 stands. 2.5k stars.
+    The pypistats API reports 24,962 lighteval downloads in the trailing 30 days, down from 37,239 but still
+    inside the same 10K-100K band, so level 2 stands, with 2.5k stars.
   sources:
   - url: https://pypistats.org/packages/lighteval
     shows: ~37,239 lighteval downloads in the last month
@@ -86,10 +84,9 @@ capability:
   relation: one_below
   last_verified: '2026-08-13'
   note: Strong across the recipe's feature-matrix dimensions (coverage, backend breadth, reproducibility,
-    some agentic support). Not a 5; lm-evaluation-harness remains the broader de-facto standard cited
-    in more frontier release reports; lighteval is the HF-leaderboard-tied counterpart. Feature matrix
-    re-read 2026-08-13 and unchanged, and the comparison the note already made to lm-eval is now recorded
-    structurally.
+    some agentic support). Not a 5; lm-evaluation-harness remains the broader de-facto standard cited in
+    more frontier release reports, a comparison now recorded structurally; lighteval is the HF-leaderboard-tied
+    counterpart.
   sources:
   - url: https://github.com/huggingface/lighteval
     shows: 1000+ tasks, 8+ model backends, reproduces Open LLM Leaderboard evals

--- a/sources/scores/lightrag.yaml
+++ b/sources/scores/lightrag.yaml
@@ -13,9 +13,8 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: 'Fully MIT. Re-read 2026-08-13 - the repo page still reports MIT over the whole tree, publishes
-    the full retrieval stack including the API server and web UI, and offers no hosted tier, enterprise
-    directory or license key. Stars are now 38.8k. Nothing moved.'
+  note: 'Fully MIT: the repo publishes the full retrieval stack including the API server and web UI, with
+    no hosted tier, enterprise directory or license key, so the core is ungated as well as OSI-licensed.'
   raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -33,9 +32,9 @@ adoption:
   level: 3
   signal_type: usage_volume
   confidence: medium
-  note: 313,096 PyPI downloads in the trailing 30 days for lightrag-hku, read 2026-08-12. Bands at level
-    3 (100K-1M) on the software and model adoption scale. Corroborated by a large star count. Corrected
-    from level 4, which the recorded evidence did not support.
+  note: 313,096 PyPI downloads in the trailing 30 days for lightrag-hku. Bands at level 3 (100K-1M) on the
+    software and model adoption scale. Corroborated by a large star count. Corrected from level 4, which
+    the recorded evidence did not support.
   reach: 100K-1M
   last_verified: '2026-08-12'
   sources:
@@ -50,10 +49,7 @@ capability:
   value: dual-level (local+global) graph retrieval; KG construction; incremental updates; naive/local/global/hybrid
     query; pluggable storage; multimodal parsing; API + web UI
   confidence: medium
-  note: 'Deeper and more efficient than GraphRAG for graph-RAG; narrower than general orchestrators. Re-read
-    2026-08-13 - the repo still publishes the same dual-level local and global graph retrieval, knowledge-graph
-    construction, incremental updates, the naive/local/global/hybrid query modes, pluggable storage and
-    the bundled API server and web UI. At graphrag, which is the peer this note already measured against.'
+  note: Deeper and more efficient than GraphRAG for graph-RAG; narrower than general orchestrators.
   relative_to: graphrag
   relation: at
   last_verified: '2026-08-13'

--- a/sources/scores/litellm.yaml
+++ b/sources/scores/litellm.yaml
@@ -16,14 +16,14 @@ openness:
         a paid subscription for production use, and the proxy gates premium features on a LITELLM_LICENSE
         key verified against license.litellm.ai
   confidence: high
-  note: 'MIT core with a proprietary enterprise directory in the same repository. `core-gated: gated` verified
-    2026-08-11 by a direct read, and it does NOT rest on BerriAI selling a hosted gateway. The root LICENSE
-    is explicitly split - "All content that resides under the ''enterprise/'' directory of this repository,
-    if that directory exists, is licensed under the license defined in ''enterprise/LICENSE''" - and everything
-    outside it is MIT. That enterprise license says the software "may only be used in production, if you
-    (and any entity that you represent) have agreed to, and are in compliance with, the BerriAI Subscription
-    Terms of Service ... and otherwise have a valid BerriAI Enterprise license for the correct number of
-    user seats", with copying, distribution and sale forbidden. The directory is not a stub: it ships litellm_enterprise,
+  note: 'MIT core with a proprietary enterprise directory in the same repository. `core-gated: gated` comes
+    from a direct read, and it does NOT rest on BerriAI selling a hosted gateway. The root LICENSE is explicitly
+    split - "All content that resides under the ''enterprise/'' directory of this repository, if that directory
+    exists, is licensed under the license defined in ''enterprise/LICENSE''" - and everything outside it
+    is MIT. That enterprise license says the software "may only be used in production, if you (and any entity
+    that you represent) have agreed to, and are in compliance with, the BerriAI Subscription Terms of Service
+    ... and otherwise have a valid BerriAI Enterprise license for the correct number of user seats", with
+    copying, distribution and sale forbidden. The directory is not a stub: it ships litellm_enterprise,
     enterprise_hooks, enterprise_ui and a cloudformation_stack. The proxy then enforces it in code - litellm/proxy/auth/litellm_license.py
     reads a LITELLM_LICENSE environment variable and verifies it against license.litellm.ai to set premium_user.
     A license key you must hold for the paid features to run is the dimension''s question answered directly,
@@ -100,19 +100,14 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: 'Used-by 21.7k dependent repos on GitHub; ~49.2k stars, 1,342 releases. Treated as 100K-1M range on
-    dependent/usage volume; stars not the basis. Artifact declared and read live 2026-08-13: 741,403,911 PyPI
-    downloads in the trailing 30 days. Bands at >10M, level 5. This record previously claimed usage_volume - a
-    download count - while declaring no artifact any signal model reads, so no computed figure existed for the
-    recorded band to disagree with. Level corrected from 3, by two bands. The figure is internally consistent
-    across windows (207.8M weekly, 28.5M daily) - litellm is a proxy library pulled on nearly every CI run
-    that touches a model provider. No last_verified claimed: only the figure was re-read.
-    Re-read 2026-08-13. The download figure the band rests on now has a cited source rather than living
-    only in this note - pypistats returns 741,403,911 for the trailing thirty days, the same number to
-    the unit, with 207,823,088 weekly and 28,463,811 daily still internally consistent. Still far above
-    the >10M threshold. The GitHub source line remains a phase-C placeholder and is retained only as the
-    repository pointer. Level unchanged at 5, and the earlier refusal to claim a date is superseded now
-    that the figure is sourced.'
+  note: Used-by 21.7k dependent repos on GitHub; ~49.2k stars and 1,342 releases, which are not the basis.
+    The declared artifact is the PyPI download count, and pypistats returns 741,403,911 downloads in the
+    trailing 30 days, which bands at >10M, level 5. This record previously claimed usage_volume - a download
+    count - while declaring no artifact any signal model reads, so no computed figure existed for the recorded
+    band to disagree with; the level is corrected from 3, by two bands. The figure is internally consistent
+    across windows (207,823,088 weekly, 28,463,811 daily) - litellm is a proxy library pulled on nearly
+    every CI run that touches a model provider. The GitHub source line remains a phase-C placeholder, retained
+    only as the repository pointer.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/BerriAI/litellm
@@ -133,15 +128,9 @@ capability:
   confidence: high
   note: Unified gateway to 140+ LLM providers in OpenAI format with cost tracking, guardrails, load balancing,
     virtual keys/budgets, logging. No standard benchmark applies to a gateway; rated on breadth of provider
-    coverage and production features.
-    Re-read 2026-08-13, replacing the phase-C placeholder source lines with an actual reading. The
-    README still describes an open source AI gateway giving one OpenAI-format interface over LLM
-    providers, usable as a Python SDK or deployed as a proxy server, with virtual keys, spend tracking,
-    guardrails, load balancing and an admin dashboard, and it quotes 8ms P95 latency at 1k RPS. The docs
-    still show budgets per project, guardrails, caching, load balancing and cost tracking. One drift
-    worth recording - both the README and the docs now say 100+ providers where this record says 140+,
-    so the headline count has been restated downward rather than grown. The band does not turn on that
-    number. Band unchanged at 4.
+    coverage and production features. One drift worth recording - the README and docs now say 100+ providers
+    where this record says 140+, so the headline count has been restated downward rather than grown; the
+    band does not turn on that number.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/BerriAI/litellm

--- a/sources/scores/litgpt.yaml
+++ b/sources/scores/litgpt.yaml
@@ -57,9 +57,9 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: medium
-  note: 15,680 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (litgpt 15,680). Bands at level 2 (10K-100K) on the software and model adoption scale. Corrected from
-    level 3, which the declared artifacts do not support.
+  note: 15,680 downloads in the trailing 30 days summed across the 1 declared artifact(s) (litgpt 15,680).
+    Bands at level 2 (10K-100K) on the software and model adoption scale. Corrected from level 3, which
+    the declared artifacts do not support.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/litgpt/recent

--- a/sources/scores/livebench.yaml
+++ b/sources/scores/livebench.yaml
@@ -62,12 +62,11 @@ adoption:
   signal_type: usage_volume
   confidence: medium
   note: '36,032 Hugging Face downloads in the trailing 30 days summed across the ten LiveBench category
-    corpora, read 2026-08-12 (math 6,923; reasoning 5,633; model_judgment 5,365; coding 4,761; data_analysis
-    4,270; instruction_following 4,250; language 4,165; liveswebench 370; model_answer 150; liveswebench-patches
-    145). Bands at level 3 (10K-100K) on the dataset scale. All ten are now declared in the product file
-    with the /datasets/ path segment: they were first declared without it, which the registry drops silently,
-    so the artifacts were absent from currentai.registry.product_artifacts and no signal could route to
-    them.'
+    corpora (math 6,923; reasoning 5,633; model_judgment 5,365; coding 4,761; data_analysis 4,270; instruction_following
+    4,250; language 4,165; liveswebench 370; model_answer 150; liveswebench-patches 145). Bands at level
+    3 (10K-100K) on the dataset scale. All ten are now declared in the product file with the /datasets/
+    path segment: they were first declared without it, which the registry drops silently, so the artifacts
+    were absent from currentai.registry.product_artifacts and no signal could route to them.'
   reach: 10K-100K
   last_verified: '2026-08-12'
   sources:
@@ -127,13 +126,10 @@ capability:
   value: 6 domains; objective ground-truth auto-scoring (no LLM judge); monthly question rotation for contamination
     resistance
   confidence: high
-  note: Among the most influential contamination-resistant benchmarks; broader than code-only LiveCodeBench and
-    judge-free. Re-read 2026-08-13 - the abstract still states the three properties the band rests on -
-    frequently-updated questions from recent sources, automatic scoring "according to objective
-    ground-truth values", and coverage spanning math, coding, reasoning, language, instruction following
-    and data analysis - plus monthly question rotation. Band unchanged at 5. The note compares against
-    livecodebench, but that product's capability is a deliberate null, so there are not two integers for
-    a relation to be arithmetic over and relative_to/relation stay unset.
+  note: Among the most influential contamination-resistant benchmarks; broader than code-only LiveCodeBench
+    and judge-free. The note compares against livecodebench, but that product's capability is a deliberate
+    null, so there are not two integers for a relation to be arithmetic over and relative_to/relation stay
+    unset.
   last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2406.19314

--- a/sources/scores/livecodebench.yaml
+++ b/sources/scores/livecodebench.yaml
@@ -19,16 +19,13 @@ openness:
       value: public problems with hidden test cases bundled
   confidence: medium
   note: 'Downloadable with a datasheet, but the only license statement the project makes about the corpus
-    is a bare cc naming no variant, and CC-BY and CC-BY-NC sit two tiers apart. A read on 2026-08-12 went
-    looking for the variant across the card front matter, the Hub API, the sibling code_generation and test_generation
-    corpora, the repository LICENSE (MIT, covering the lcb_runner harness rather than the problems), the
-    README, ERRATA.md, the project site, the leaderboard and the paper, and did not find one. Files that
-    download freely without a grant are not open, and not closed either, so the recorded 4/open drops to
-    3/gated: the barrier is the missing permission rather than a login. The problems are collected from
-    LeetCode, AtCoder and Codeforces, which is a plausible reason no variant has been committed to.
-    Re-fetched on 2026-08-13 - the card README and the repository LICENSE both return unchanged digests,
-    the Hub API still reports cardData.license as the bare string "cc", and the repo is still ungated,
-    so nothing has moved and no variant has appeared.'
+    is a bare cc naming no variant, and CC-BY and CC-BY-NC sit two tiers apart. No variant is stated anywhere
+    the project publishes: not in the card front matter, the Hub API, the sibling code_generation and test_generation
+    corpora, the repository LICENSE (MIT, which covers the lcb_runner harness rather than the problems),
+    the README, ERRATA.md, the project site, the leaderboard or the paper. Files that download freely without
+    a grant are not open, and not closed either, so the recorded 4/open drops to 3/gated: the barrier is
+    the missing permission rather than a login. The problems are collected from LeetCode, AtCoder and Codeforces,
+    which is a plausible reason no variant has been committed to.'
   raw: data:downloadable(HF parquet);license:cc(the card YAML names the Creative Commons family and no variant;
     no variant is stated on the card, the GitHub repository, the project site or the paper);datasheet:present(README
     documents versions/sources/structure);redistributable:yes;splits:public problems with hidden test cases
@@ -47,46 +44,49 @@ openness:
     shows: 'YAML metadata license: cc'
     accessed: '2026-06-04'
   - url: https://huggingface.co/datasets/livecodebench/code_generation_lite/raw/main/README.md
-    shows: 'card front matter is `license: cc` with tags, pretty_name and size_categories, and nothing
-      naming a Creative Commons variant; the body is a change log of release_v1..v5, a dataset description
-      and usage instructions. Re-read 2026-08-12 and re-fetched 2026-08-13 with an unchanged digest'
+    shows: 'card front matter is `license: cc` with tags, pretty_name and size_categories, and nothing naming
+      a Creative Commons variant; the body is a change log of release_v1..v5, a dataset description and
+      usage instructions'
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: fbf0df23c9fb430778f037691bd191ece41d49373c0695151d87549b6f45d809
-    establishes: [license]
+    establishes:
+    - license
   - url: https://huggingface.co/api/datasets/livecodebench/code_generation_lite
-    shows: 'cardData.license is the string "cc" and the repository tags carry `license:cc`; the sibling
-      corpora code_generation and test_generation carry the same bare `cc`, and execution carries no
-      license at all. The open discussions on the repo are about loading, parquet conversion and version
-      sizes - none asks or answers what the CC variant is. Re-read 2026-08-13 and cardData.license
-      is still the bare string "cc"'
+    shows: cardData.license is the string "cc" and the repository tags carry `license:cc`; the sibling corpora
+      code_generation and test_generation carry the same bare `cc`, and execution carries no license at
+      all. The open discussions on the repo are about loading, parquet conversion and version sizes - none
+      asks or answers what the CC variant is
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 0f17aeab9c94cf4a6269259748edf887c3ab5daa9aa2ad2cf387716c06ce18c2
-    establishes: [license]
+    establishes:
+    - license
   - url: https://raw.githubusercontent.com/LiveCodeBench/LiveCodeBench/main/LICENSE
-    shows: MIT License, copyright 2024 LiveCodeBench. This is the repository holding lcb_runner, the
-      evaluation harness; the problems are distributed from the Hugging Face repos and this file makes
-      no statement about them. Re-fetched 2026-08-13 with an unchanged digest
+    shows: MIT License, copyright 2024 LiveCodeBench. This is the repository holding lcb_runner, the evaluation
+      harness; the problems are distributed from the Hugging Face repos and this file makes no statement
+      about them
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 104099948b78ebc36f2e951b3a7973b956adfa7d39aaec0d1512f97a2686d15d
-    establishes: [license]
+    establishes:
+    - license
   - url: https://raw.githubusercontent.com/LiveCodeBench/LiveCodeBench/main/README.md
     shows: 217 lines covering install, running the harness, scenarios and submissions, with no licensing
-      or terms section at all. Re-fetched 2026-08-13 with an unchanged digest
+      or terms section at all
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: ee0029cddc1d9051f35818f3348a4327819a3e35a9e597732519245605195cf6
-    establishes: [license]
+    establishes:
+    - license
 adoption:
   level: 3
   reach: 10K-100K
   signal_type: usage_volume
   confidence: medium
-  note: 91,719 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (livecodebench/code_generation_lite 91,719). Bands at level 3 (10K-100K) on the dataset adoption scale,
-    whose top band is >1M. Corrected from level 4, which the declared artifacts do not support.
+  note: 91,719 downloads in the trailing 30 days summed across the 1 declared artifact(s) (livecodebench/code_generation_lite
+    91,719). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M. Corrected
+    from level 4, which the declared artifacts do not support.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/livecodebench/code_generation_lite
@@ -99,10 +99,9 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: A dataset is not 'capable'. Contamination-resistance (the 'live' continuously-updated design)
-    is a quality strength but not scored on the 1-5 capability axis per the recipe; openness + adoption
-    carry this category. Re-read 2026-08-13 and the abstention stands - the page publishes a rotating
-    problem set and no performance or feature claim the capability axis could band.
+  note: A dataset is not 'capable'. Contamination-resistance (the 'live' continuously-updated design) is
+    a quality strength but not scored on the 1-5 capability axis per the recipe; openness + adoption carry
+    this category.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/livecodebench/code_generation_lite

--- a/sources/scores/llama-cpp.yaml
+++ b/sources/scores/llama-cpp.yaml
@@ -45,11 +45,10 @@ adoption:
   confidence: medium
   note: 'De facto standard local/edge inference engine: the Hugging Face Hub documents GGUF usage separately
     for llama.cpp, Ollama, LM Studio, and GPT4All, reflecting the format''s centrality across that ecosystem.
-    GitHub stars grew from ~115k (June 2026) to 123,185 (today), consistent with the warehouse-recorded
-    123,037 as of 2026-08-07. No clean PyPI/download count exists for the C++ engine itself, so usage is
-    inferred from ecosystem centrality and star growth rather than a direct install count; placed at 4 (1-10M-equivalent).
-    The prior note''s specific claim that GGUF is ">60% of all quantized models on HF" was dropped: no source
-    fetched today states that figure, and it did not appear on the pages re-read.'
+    GitHub stars grew from ~115k (June 2026) to 123,185, consistent with the warehouse-recorded 123,037.
+    No clean PyPI/download count exists for the C++ engine itself, so usage is inferred from ecosystem centrality
+    and star growth rather than a direct install count; placed at 4 (1-10M-equivalent). An earlier claim
+    that GGUF is ">60% of all quantized models on HF" is not carried here: no cited source states that figure.'
   last_verified: '2026-08-09'
   sources:
   - url: https://github.com/ggml-org/llama.cpp

--- a/sources/scores/llama-guard.yaml
+++ b/sources/scores/llama-guard.yaml
@@ -16,7 +16,7 @@ openness:
   confidence: medium
   note: Open-weights safety classifier under Meta's Llama Community License, which carries use restrictions
     and is not OSI-approved, so it lands at the open_weights tier (3) like the rest of the Llama family
-    rather than open_source. Re-read 2026-08-13 and unchanged on every recorded dimension.
+    rather than open_source.
   raw: weights:open(Llama-Guard-3-8B safetensors on HF);data:not-released;code:inference recipe public;license:Llama-3.1-Community(NOT
     OSI, >700M-MAU restriction)
   last_verified: '2026-08-13'
@@ -50,9 +50,9 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: 164,619 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (meta-llama/Llama-Guard-3-8B 164,619). Bands at level 3 (100K-1M) on the software and model adoption
-    scale. Corrected from level 4, which the declared artifacts do not support.
+  note: 164,619 downloads in the trailing 30 days summed across the 1 declared artifact(s) (meta-llama/Llama-Guard-3-8B
+    164,619). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected from level
+    4, which the declared artifacts do not support.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/models/meta-llama/Llama-Guard-3-8B
@@ -68,9 +68,7 @@ capability:
     and widely-benchmarked safety classifier, the reference open baseline.
   confidence: medium
   note: Broad hazard taxonomy and multilingual coverage; the reference open guardrail others are measured
-    against, and several bands in this category are recorded relative to it. Re-read 2026-08-13 - the
-    card's chat template still enumerates S1 to S14 and the card still claims moderation in 8 languages
-    against the MLCommons taxonomy.
+    against, and several bands in this category are recorded relative to it.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/meta-llama/Llama-Guard-3-8B

--- a/sources/scores/llama-index.yaml
+++ b/sources/scores/llama-index.yaml
@@ -64,9 +64,9 @@ adoption:
   level: 4
   signal_type: usage_volume
   confidence: high
-  note: 7,203,303 PyPI downloads in the trailing 30 days for llama-index, read 2026-08-12. Bands at level
-    4 (1M-10M) on the software and model adoption scale. Briefly cleared 10M when the score was authored
-    and has since fallen back. Corrected from level 5, which the recorded evidence did not support.
+  note: 7,203,303 PyPI downloads in the trailing 30 days for llama-index. Bands at level 4 (1M-10M) on the
+    software and model adoption scale. Briefly cleared 10M when the score was authored and has since fallen
+    back. Corrected from level 5, which the recorded evidence did not support.
   reach: 1M-10M
   last_verified: '2026-08-12'
   sources:
@@ -81,11 +81,7 @@ capability:
   value: data connectors (LlamaHub); multiple index/retrieval strategies; query engines; agentic Workflows; structured
     extraction; multimodal/OCR; TS port
   confidence: high
-  note: 'Best-in-class RAG/data-ingestion depth plus an agent layer. Re-read 2026-08-13 - the repo README
-    still describes LlamaIndex as a data framework offering data connectors for APIs, PDFs, docs and SQL,
-    ways to structure that data into indices, retrievers and query engines, lower-level APIs for customizing
-    any module, and end-to-end document agents built with Workflows and Agent Builder. Stars are now 51.6k.
-    The feature matrix that placed this band is unchanged.'
+  note: Best-in-class RAG/data-ingestion depth plus an agent layer.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/run-llama/llama_index

--- a/sources/scores/llama-instruct.yaml
+++ b/sources/scores/llama-instruct.yaml
@@ -15,20 +15,15 @@ openness:
     - name: Llama-3.1-Community
       detail: non-OSI; 700M-MAU commercial cap + use policy
   confidence: high
-  note: >-
-    Weights open under Meta's non-OSI Llama 3.1 Community License, with its 700M-MAU commercial
-    cap. Commonly marketed as open. Moved from 2/restricted on 2026-08-01 by the universal license
-    scale, which caps a bounded commercial license at 3 rather than 2. The test at that boundary
-    is whether the license permits commercial use AT ALL: this one does, for everyone inside the
-    bound. A license that forbids commerce outright - CC-BY-NC, Mistral Non-Production - stays at
-    2. Nine other products carry a bounded license and all now score 3; four of them were already
-    recorded there, which is the inconsistency this resolves.
-
-    Re-read 2026-08-13 - the card still carries `license:llama3.1` and reproduces the license body, whose
-    Additional Commercial Terms still name the 700 million monthly active user threshold. The repo reads
-    `"gated":"manual"`, so the weights are behind an access request rather than a paywall; that is how Meta
-    has always distributed them and it does not change `weights:open`. Post-training is described as SFT
-    plus DPO with no pipeline or mixture published. No change.
+  note: 'Weights open under Meta''s non-OSI Llama 3.1 Community License, with its 700M-MAU commercial cap.
+    Commonly marketed as open. Moved from 2/restricted on 2026-08-01 by the universal license scale, which
+    caps a bounded commercial license at 3 rather than 2. The test at that boundary is whether the license
+    permits commercial use AT ALL: this one does, for everyone inside the bound. A license that forbids
+    commerce outright - CC-BY-NC, Mistral Non-Production - stays at 2. Nine other products carry a bounded
+    license and all now score 3; four of them were already recorded there, which is the inconsistency this
+    resolves. The repo reads `"gated":"manual"`, an access request rather than a paywall, which does not
+    change `weights:open`; post-training is described as SFT plus DPO with neither pipeline nor mixture
+    published.'
   raw: weights:open(downloadable);data:closed;code:partial(no training pipeline);license:Llama-3.1-Community(non-OSI;
     700M-MAU commercial cap + use policy)
   last_verified: '2026-08-13'
@@ -47,9 +42,9 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: 7,345,657 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (meta-llama/Llama-3.1-8B-Instruct 7,345,657). Bands at level 4 (1M-10M) on the software and model adoption
-    scale. Corrected from level 5, which the declared artifacts do not support.
+  note: 7,345,657 downloads in the trailing 30 days summed across the 1 declared artifact(s) (meta-llama/Llama-3.1-8B-Instruct
+    7,345,657). Bands at level 4 (1M-10M) on the software and model adoption scale. Corrected from level
+    5, which the declared artifacts do not support.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/models/meta-llama/Llama-3.1-8B-Instruct
@@ -63,14 +58,11 @@ capability:
   basis_detail: MMLU/IFEval
   value: Llama 3.1 8B-Instruct ~MMLU ~69, solid 8B chat; no reasoning/agentic frontier scores
   confidence: medium
-  note: >-
-    A competent 2024-generation 8B chat model, a long way below the 2026 frontier and below the larger
-    Llama 3.1 SKUs. The note that stood here until 2026-08-13 was a verbatim copy of the openness note
-    and described the license rather than the capability; it is replaced.
-
-    Re-read 2026-08-13 - the card's benchmark table still gives Llama 3.1 8B Instruct MMLU 69.4
-    (5-shot, macro_avg/acc) against 83.6 for 70B and 87.3 for 405B, which is the ~69 the value
-    records, and still publishes no reasoning or agentic frontier scores. No change.
+  note: A competent 2024-generation 8B chat model, a long way below the 2026 frontier and below the larger
+    Llama 3.1 SKUs. The note that stood here until 2026-08-13 was a verbatim copy of the openness note and
+    described the license rather than the capability; it is replaced. The card's benchmark table gives Llama
+    3.1 8B Instruct MMLU 69.4 (5-shot, macro_avg/acc) against 83.6 for the 70B and 87.3 for the 405B, and
+    publishes no reasoning or agentic frontier scores.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct

--- a/sources/scores/llama-prompt-guard.yaml
+++ b/sources/scores/llama-prompt-guard.yaml
@@ -13,7 +13,7 @@ openness:
       detail: NOT OSI
   confidence: medium
   note: Open weights under Meta's Llama 4 Community License, which is use-restricted and not OSI-approved,
-    so open_weights (3) like the rest of the Llama family. Re-read 2026-08-13 and unchanged.
+    so open_weights (3) like the rest of the Llama family.
   raw: weights:open(Llama-Prompt-Guard-2-86M/22M on HF);data:not-released;license:Llama-4-Community(NOT
     OSI)
   last_verified: '2026-08-13'
@@ -45,9 +45,9 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: 111,334 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (meta-llama/Llama-Prompt-Guard-2-86M 111,334). Bands at level 3 (100K-1M) on the software and model
-    adoption scale. Corrected from level 4, which the declared artifacts do not support.
+  note: 111,334 downloads in the trailing 30 days summed across the 1 declared artifact(s) (meta-llama/Llama-Prompt-Guard-2-86M
+    111,334). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected from level
+    4, which the declared artifacts do not support.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/models/meta-llama/Llama-Prompt-Guard-2-86M
@@ -63,7 +63,7 @@ capability:
     8 languages, sub-100ms latency; narrow but best-in-class at its job.
   confidence: medium
   note: Specialized injection/jailbreak classifier with strong accuracy and very low latency; complements
-    full-taxonomy guards. Re-read 2026-08-13 and the numbers still stand as recorded.
+    full-taxonomy guards.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/meta-llama/Llama-Prompt-Guard-2-86M

--- a/sources/scores/llama.yaml
+++ b/sources/scores/llama.yaml
@@ -16,20 +16,14 @@ openness:
       detail: 'non-OSI: 700M MAU commercial cap as of Apr 2025 + no-compete/no-train-competing-LLM clause'
   governing_release: llama-4-scout-maverick
   confidence: high
-  note: >-
-    Weights downloadable under Meta's Llama-4-Community terms: a 700M-MAU commercial cap, an
-    acceptable-use policy and naming requirements. No relicensing to record - Llama 3.1 carried
-    the equivalent terms, and Llama 4 Scout and Maverick govern as the current release. Moved from
-    2/restricted on 2026-08-01 by the universal license scale, which caps a bounded commercial
-    license at 3 rather than 2. The test at that boundary is whether the license permits
-    commercial use AT ALL: this one does, for everyone inside the bound. A license that forbids
-    commerce outright - CC-BY-NC, Mistral Non-Production - stays at 2. Nine other products carry a
-    bounded license and all now score 3; four of them were already recorded there, which is the
-    inconsistency this resolves.
-    Re-read 2026-08-13. The Llama 4 Community License text is still on the Scout card verbatim,
-    including the 700M-MAU clause; the card's Training Data section describes the corpus without
-    releasing it; and the llama-models repository is still utilities rather than a training
-    pipeline. Every component holds and the score is unchanged.
+  note: 'Weights downloadable under Meta''s Llama-4-Community terms: a 700M-MAU commercial cap, an acceptable-use
+    policy and naming requirements. No relicensing to record - Llama 3.1 carried the equivalent terms, and
+    Llama 4 Scout and Maverick govern as the current release. Moved from 2/restricted on 2026-08-01 by the
+    universal license scale, which caps a bounded commercial license at 3 rather than 2. The test at that
+    boundary is whether the license permits commercial use AT ALL: this one does, for everyone inside the
+    bound. A license that forbids commerce outright - CC-BY-NC, Mistral Non-Production - stays at 2. Nine
+    other products carry a bounded license and all now score 3; four of them were already recorded there,
+    which is the inconsistency this resolves.'
   last_verified: '2026-08-13'
   raw: 'weights:open(downloadable on HF);data:closed;code:partial(inference/utils via llama-models, no training
     code);license:Llama-4-Community(non-OSI: 700M MAU commercial cap as of Apr 2025 + no-compete/no-train-competing-LLM
@@ -85,14 +79,13 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: medium
-  note: 1,335,865 downloads in the trailing 30 days summed across the 5 declared artifact(s), read
-    2026-08-13 (meta-llama/Llama-3.1-405B 114,146; meta-llama/Llama-3.1-70B 41,103;
-    meta-llama/Llama-3.1-8B 1,158,435; meta-llama/Llama-4-Scout-17B-16E 18,815;
-    meta-llama/Llama-4-Maverick-17B-128E 3,366). Bands at level 4 (1M-10M) on the software and
-    model adoption scale, unchanged. The 3.1 8B checkpoint still carries the family, which is worth
-    recording alongside the capability axis reading on Llama 4 - reach and capability sit on
-    different releases of the same tier. The note this replaces was a duplicate of the openness
-    note and described a license rather than a usage figure.
+  note: 1,335,865 downloads in the trailing 30 days summed across the 5 declared artifact(s) (meta-llama/Llama-3.1-405B
+    114,146; meta-llama/Llama-3.1-70B 41,103; meta-llama/Llama-3.1-8B 1,158,435; meta-llama/Llama-4-Scout-17B-16E
+    18,815; meta-llama/Llama-4-Maverick-17B-128E 3,366). Bands at level 4 (1M-10M) on the software and model
+    adoption scale, unchanged. The 3.1 8B checkpoint still carries the family, which is worth recording
+    alongside the capability axis reading on Llama 4 - reach and capability sit on different releases of
+    the same tier. The note this replaces was a duplicate of the openness note and described a license rather
+    than a usage figure.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/models/meta-llama/Llama-3.1-405B

--- a/sources/scores/llamafile.yaml
+++ b/sources/scores/llamafile.yaml
@@ -55,13 +55,10 @@ adoption:
   reach: '>10K stars'
   signal_type: stars_fallback
   confidence: low
-  note: 'No PyPI/download or pull-count signal available (distributed as single-file binaries, not a package);
-    GitHub stars is the only honest signal. Capped at 3 per stars_fallback rule. Popular local-inference
-    convenience tool but no verified usage_volume figure. Stars read 2026-08-13: 25,548 across the 1 declared
-    repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. The previous reach
-    ''100K-1M'' was not a label this instrument offers - stars have their own vocabulary because a star is not
-    a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on
-    every refetch, and the rest of the axis was not re-read.'
+  note: No PyPI/download or pull-count signal available (distributed as single-file binaries, not a package);
+    GitHub stars are the only honest signal, and stars_fallback caps the level at 3. 25,548 stars across
+    the 1 declared repo band at >10K stars, level 3 on the stars scale in signal_routing.yaml. Popular local-inference
+    convenience tool but no verified usage_volume figure.
   last_verified: '2026-08-09'
   sources:
   - url: https://github.com/mozilla-ai/llamafile

--- a/sources/scores/llamafirewall.yaml
+++ b/sources/scores/llamafirewall.yaml
@@ -73,10 +73,10 @@ adoption:
   reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
-  note: 4,344 GitHub stars on meta-llama/PurpleLlama, read 2026-08-12. Bands at level 2 (1K-10K stars) on
-    the stars fallback scale, which caps at 3 because a star is not a use. Resynced because the note says
-    'stars-only proxy, capped per methodology' and recorded the cap. No download, install or customer figure
-    is published for this product, so stars remain the only honest signal and the level is directional.
+  note: 4,344 GitHub stars on meta-llama/PurpleLlama. Bands at level 2 (1K-10K stars) on the stars fallback
+    scale, which caps at 3 because a star is not a use. Resynced because the note says 'stars-only proxy,
+    capped per methodology' and recorded the cap. No download, install or customer figure is published for
+    this product, so stars remain the only honest signal and the level is directional.
   last_verified: '2026-08-12'
   sources:
   - url: https://api.github.com/repos/meta-llama/PurpleLlama
@@ -92,10 +92,9 @@ capability:
     checks, and insecure-code filtering (CodeShield) in one real-time firewall.'
   confidence: medium
   note: One of the few guardrail systems aimed specifically at agent security, with alignment checks and
-    code filtering beyond I/O moderation. Re-read 2026-08-13. The PurpleLlama root README no longer names
-    LlamaFirewall or the alignment checks at all - its component table now lists only the Llama Guard
-    family, Prompt Guard and Code Shield - so the LlamaFirewall directory README is cited alongside it as
-    the source that actually carries the scanner list. The band is unchanged.
+    code filtering beyond I/O moderation. The PurpleLlama root README does not name LlamaFirewall or the
+    alignment checks - its component table lists only the Llama Guard family, Prompt Guard and Code Shield
+    - so the LlamaFirewall directory README is the source that carries the scanner list.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/meta-llama/PurpleLlama
@@ -108,8 +107,8 @@ capability:
     content_sha256: 507ec485f07e6b4ebe6f32218b9a72c84f01c769127022fe77a496b41c10669b
   - url: https://github.com/meta-llama/PurpleLlama/blob/main/LlamaFirewall/README.md
     shows: The directory README lists the scanners the harness composes - PromptGuard 2, AlignmentCheck,
-      regex/custom and CodeShield - all in the published package, installed with `pip install
-      llamafirewall` and instantiated in-process. Re-fetched 2026-08-13 with an unchanged digest.
+      regex/custom and CodeShield - all in the published package, installed with `pip install llamafirewall`
+      and instantiated in-process.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 9bf4c794eae9870c6d9403490949eec85568c275229775f9477a72e48b679d12

--- a/sources/scores/llm-guard.yaml
+++ b/sources/scores/llm-guard.yaml
@@ -18,7 +18,7 @@ openness:
       value: ungated
   confidence: high
   note: 'Fully open source: MIT-licensed, complete source, self-hostable. (Protect AI''s commercial platform
-    is a separate product; this is the standalone OSS toolkit.) Re-read 2026-08-13 and unchanged.'
+    is a separate product; this is the standalone OSS toolkit.)'
   raw: license:MIT(OSI);source:public(full Python implementation);self-host:yes;service:none(the OSS toolkit;
     Protect AI's platform is separate);core-gated:ungated
   last_verified: '2026-08-13'
@@ -40,14 +40,13 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: '212,987 downloads in the trailing 30 days on the newly declared PyPI artifact `llm-guard`,
-    read live 2026-08-13. Bands at 100K-1M, level 3. LEVEL CORRECTED FROM 2, and the cause is that
-    the band was set on the wrong instrument: it read stars_fallback, which adoption.md defines as
-    meaning no download signal existed when it was set, and which caps at 3 for the good reason that
-    a star is not a use. A download signal does exist, and the guide is explicit that a stars band
-    re-bands once one appears. The package is the product''s own rather than a same-named stranger -
-    its PyPI project_urls point at https://github.com/protectai/llm-guard - and for a Python library PyPI is the primary channel,
-    not a minority one.'
+  note: '212,987 downloads in the trailing 30 days on the newly declared PyPI artifact `llm-guard`. Bands
+    at 100K-1M, level 3. LEVEL CORRECTED FROM 2, and the cause is that the band was set on the wrong instrument:
+    it read stars_fallback, which adoption.md defines as meaning no download signal existed when it was
+    set, and which caps at 3 for the good reason that a star is not a use. A download signal does exist,
+    and the guide is explicit that a stars band re-bands once one appears. The package is the product''s
+    own rather than a same-named stranger - its PyPI project_urls point at https://github.com/protectai/llm-guard
+    - and for a Python library PyPI is the primary channel, not a minority one.'
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/llm-guard/recent
@@ -62,10 +61,9 @@ capability:
   value: Input/output scanners for prompt injection, PII/data leakage, toxicity, and harmful content,
     with sanitization.
   confidence: medium
-  note: Solid set of I/O scanners; lighter-weight orchestration than NeMo Guardrails but easy to drop
-    in. That comparison is the instrument, so it is recorded rather than left in prose - a scanner library
-    without a policy language or dialog control sits one rung below NeMo Guardrails. Re-read 2026-08-13 and
-    unchanged.
+  note: Solid set of I/O scanners; lighter-weight orchestration than NeMo Guardrails but easy to drop in.
+    That comparison is the instrument, so it is recorded rather than left in prose - a scanner library without
+    a policy language or dialog control sits one rung below NeMo Guardrails.
   relative_to: nemo-guardrails
   relation: one_below
   last_verified: '2026-08-13'

--- a/sources/scores/llm.yaml
+++ b/sources/scores/llm.yaml
@@ -16,12 +16,8 @@ openness:
     - plugin-extensible
     - no feature-gated core
   confidence: high
-  note: Apache-2.0 verified against LICENSE body; full source public; CLI/library with no gated tier (model providers
-    need their own API keys, external to the tool).
-    Re-read 2026-08-13. The LICENSE is still the full Apache License 2.0 text, the repository still
-    publishes the whole CLI and library, and there is still no gated tier - the API keys a user needs
-    belong to the model providers, not to this tool. Repo now at 12,358 stars. Value unchanged at 5 /
-    open_source.
+  note: Apache-2.0 verified against LICENSE body; full source public; CLI/library with no gated tier (model
+    providers need their own API keys, external to the tool).
   raw: license:Apache-2.0(OSI);source:public(GitHub);PyPI;plugin-extensible;no feature-gated core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -36,14 +32,11 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: medium
-  note: Established CLI/library distributed on PyPI (package 'llm', v0.31) with ~12.1k GitHub stars and a broad
-    plugin ecosystem; widely used across Simon Willison's tooling. No exact monthly download figure captured, so
-    placed at 3 on PyPI-presence + ecosystem signal.
-    Re-read 2026-08-13, and the missing download figure now exists. pypistats returns 601,475 downloads
-    for the trailing thirty days, which lands in 100K-1M and confirms the band that had been placed on
-    PyPI presence and ecosystem reasoning alone. The repository shows 12,358 stars and the latest
-    release is now 0.32 of 4 August 2026, past the v0.31 the PyPI source line records. Level unchanged
-    at 3, now on a measured signal rather than an inferred one.
+  note: Established CLI/library distributed on PyPI (package 'llm') with a broad plugin ecosystem, widely
+    used across Simon Willison's tooling. pypistats returns 601,475 downloads for the trailing thirty days,
+    which lands in 100K-1M and places the band at 3 on a measured signal rather than the PyPI-presence and
+    ecosystem reasoning it originally rested on. The repository shows 12,358 stars, and the latest release
+    is 0.32, past the v0.31 the PyPI source line records.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypi.org/project/llm
@@ -67,13 +60,8 @@ capability:
   value: 'Model breadth: 100+ remote and local models via plugins; embeddings; prompt templates; SQLite logging
     of prompts/responses; Python API. CLI/library surface, not a full chat UI.'
   confidence: high
-  note: Strong on model breadth and extensibility, but a developer CLI/library rather than a multi-user surface;
-    lacks the built-in RAG/multimodal/auth feature stack of top ui_api entries, so scored 3.
-    Re-read 2026-08-13. The documentation still describes a CLI tool and Python library for OpenAI,
-    Claude, Gemini, Llama and dozens of other models both remote and local, with plugins, tools,
-    schemas, templates, fragments, model aliases, embeddings and SQLite logging of prompts and
-    responses. It is still a developer surface with no multi-user layer, no built-in RAG stack and no
-    auth. Band unchanged at 3.
+  note: Strong on model breadth and extensibility, but a developer CLI/library rather than a multi-user
+    surface; lacks the built-in RAG/multimodal/auth feature stack of top ui_api entries, so scored 3.
   last_verified: '2026-08-13'
   sources:
   - url: https://llm.datasette.io/

--- a/sources/scores/lm-evaluation-harness.yaml
+++ b/sources/scores/lm-evaluation-harness.yaml
@@ -15,8 +15,7 @@ openness:
     - no feature-gated core
   confidence: high
   last_verified: '2026-08-13'
-  note: MIT-licensed, fully public; OSI -> open_source. Re-read 2026-08-13 - the license endpoint still
-    reports MIT and the README still ships the whole harness with no paid tier or license key.
+  note: MIT-licensed, fully public; OSI -> open_source.
   raw: license:MIT(OSI);source:public(GitHub);no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/EleutherAI/lm-evaluation-harness
@@ -47,11 +46,11 @@ adoption:
   signal_type: usage_volume
   confidence: high
   last_verified: '2026-08-13'
-  note: ~1.57M monthly PyPI downloads (lm-eval); backs HuggingFace Open LLM Leaderboard and is used in
-    hundreds of papers and model release reports -- the strongest 'cited as standard' signal in the category.
-    Headline = PyPI primary source; standard-status corroborates. Re-read 2026-08-13 - the pypistats
-    API reports 1,658,820 lm-eval downloads in the trailing 30 days, which still bands at level 4 (1M-10M),
-    and the README still names the Open LLM Leaderboard task group.
+  note: ~1.57M monthly PyPI downloads (lm-eval); backs HuggingFace Open LLM Leaderboard and is used in hundreds
+    of papers and model release reports -- the strongest 'cited as standard' signal in the category. Headline
+    = PyPI primary source; standard-status corroborates. The pypistats API reports 1,658,820 lm-eval downloads
+    in the trailing 30 days, which still bands at level 4 (1M-10M), and the README names the Open LLM Leaderboard
+    task group.
   sources:
   - url: https://pypistats.org/packages/lm-eval
     shows: ~1,571,581 monthly PyPI downloads
@@ -79,9 +78,8 @@ capability:
   confidence: high
   last_verified: '2026-08-13'
   note: Frontier-definer within evaluation_code -- widest task + backend coverage and the standardization
-    reference harness for LLM eval. Feature matrix re-read 2026-08-13 and unchanged - the README still
-    states 'Over 60 standard academic benchmarks for LLMs, with hundreds of subtasks and variants implemented'
-    and still lists the same backend spread.
+    reference harness for LLM eval. The README states 'Over 60 standard academic benchmarks for LLMs, with
+    hundreds of subtasks and variants implemented' and lists the backend spread the value records.
   sources:
   - url: https://github.com/EleutherAI/lm-evaluation-harness
     shows: 60+ benchmarks, multi-backend support, Open LLM Leaderboard backend

--- a/sources/scores/lm-studio.yaml
+++ b/sources/scores/lm-studio.yaml
@@ -17,11 +17,6 @@ openness:
       value: closed
   confidence: high
   note: Core app/engine is closed proprietary freeware; only peripheral CLI/SDKs are open.
-    Re-read 2026-08-13. The app terms still forbid the three things the score turns on - modifying,
-    adapting, altering or creating derivative works; reverse engineering, decompiling or disassembling;
-    and sublicensing, distributing or selling. The homepage still says the app is free for home and work
-    use and still offers only compiled downloads, with the MIT SDKs and CLI beside it. Value unchanged
-    at 1 / closed.
   raw: license:Proprietary;source:closed;app:proprietary-freeware(ToS forbids modify/reverse-engineer/redistribute);sdk+cli:MIT(public);core-engine:closed
   last_verified: '2026-08-13'
   sources:
@@ -36,9 +31,6 @@ adoption:
   signal_type: reported_traction
   confidence: medium
   note: Widely-used consumer app but no primary-verified install count; conservative level 3.
-    Re-read 2026-08-13. The homepage still publishes no install or user count of any kind - it offers a
-    download and the free-for-home-and-work-use line and nothing countable - so the conservative
-    reported_traction band stands. Level unchanged at 3.
   last_verified: '2026-08-13'
   sources:
   - url: https://lmstudio.ai/
@@ -52,11 +44,9 @@ capability:
   value: polished chat UI; model browser; OpenAI-compatible local server; headless mode; native Apple MLX
   confidence: medium
   note: Strong UX/polish on par with the open local UIs; loses on openness/extensibility (closed source).
-    Re-read 2026-08-13. The homepage still shows the chat app, the model browser over gpt-oss, Qwen3.6,
-    Gemma4 and DeepSeek, OpenAI-compatible serving, Apple MLX support and a headless deployment path -
-    now named llmster and described as the LM Studio core without the GUI, installable by one-line
-    script on Linux, cloud servers or CI. JS and Python SDKs, an lms CLI and MCP client support are also
-    listed. Current version 0.4.21. Band unchanged at 4.
+    The headless deployment path is now named llmster - the LM Studio core without the GUI, installable
+    by one-line script on Linux, cloud servers or CI - alongside JS and Python SDKs, an lms CLI and MCP
+    client support.
   last_verified: '2026-08-13'
   sources:
   - url: https://lmstudio.ai/

--- a/sources/scores/lobe-chat.yaml
+++ b/sources/scores/lobe-chat.yaml
@@ -16,14 +16,7 @@ openness:
     CLA lets LobeHub relicense contributions for its cloud editions. Both exceed Apache-2.0, though it is
     still presented publicly as open source. Score corrected from 3 to 2 on 2026-07-30. The software ladder
     has rungs at 1, 2, 4 and 5 and none at 3, so 3/source_available was not a pair any rule could produce;
-    the ladder scores "you can read it and not run it freely" at 2.
-    Re-read 2026-08-13. The LICENSE is still the LobeHub Community License, Apache-2.0 plus two
-    additions - clause 1b requires a commercial license from the producer to develop and distribute a
-    derivative work, and clause 2 has contributors agree that the producer may tighten or relax the
-    terms and may use contributed code commercially including in its cloud edition. The repository still
-    publishes the full self-hostable app with Docker and Vercel paths and still links a paid Pricing
-    tier alongside. GitHub classifies the license as NOASSERTION, which is consistent with a non-OSI
-    text. Value unchanged at 2 / source_available.'
+    the ladder scores "you can read it and not run it freely" at 2.'
   raw: 'license:LobeHub-Community-License(Apache-2.0-based, non-OSI: commercial license required to develop+distribute
     a derivative work; CLA lets LobeHub relicense contributions for cloud editions);source:public;cloud-tier:LobeHub
     Cloud'
@@ -47,19 +40,11 @@ adoption:
   reach: '>10K stars'
   signal_type: stars_fallback
   confidence: low
-  note: '78.2k GitHub stars, 15.4k forks; Docker image (lobehub/lobehub) and LobeHub Cloud exist but no
-    verified pull/MAU figure was obtainable from a primary source this run. Capped at 3 on stars fallback per
-    rubric. Stars read 2026-08-13: 81,633 across the 1 declared repo, which bands at >10K stars, level 3 on
-    the stars scale in signal_routing.yaml. The previous reach ''100K-1M'' was not a label this instrument
-    offers - stars have their own vocabulary because a star is not a download. No last_verified claimed: a
-    star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis
-    was not re-read.
-    Re-read 2026-08-13 - the repository now shows 81,647 stars and 15,804 forks, which still bands at
-    >10K stars, level 3 on the stars scale. No download, pull or MAU figure has appeared on the repo or
-    in the LobeHub README, so the stars fallback still stands and the level is unchanged. This
-    supersedes the refusal above to claim a date - the axis was re-read in full rather than aggregated,
-    and the recorded digest is of the repository page, whose drift on refetch is expected for exactly
-    the reason the earlier note gives.'
+  note: 81,647 GitHub stars and 15,804 forks on lobehub/lobehub, which bands at >10K stars, level 3 on the
+    stars scale in signal_routing.yaml. A Docker image (lobehub/lobehub) and LobeHub Cloud exist but no
+    verified pull or MAU figure is obtainable from a primary source, and none appears on the repository
+    or in the README, so the stars fallback stands and is capped at 3 per rubric. The previous reach '100K-1M'
+    was not a label this instrument offers - stars have their own vocabulary, because a star is not a download.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/lobehub/lobehub
@@ -73,15 +58,11 @@ capability:
   value: model breadth (multi-model/multi-provider 'Unified Intelligence'); plugins (10,000+ skills, MCP-compatible);
     multi-user/agent-groups for team collaboration; knowledge base/RAG; multimodal; agent memory + scheduling
   confidence: medium
-  note: Strong feature surface across model breadth, MCP plugins, knowledge base and multi-user. Below
-    Open WebUI/LibreChat on enterprise auth/RAG depth verifiability; agent-orchestration framing edges
-    toward orchestration_agents but core remains human-driven chat.
-    Re-read 2026-08-13. The README still claims 10,000+ Skills connecting agents to tools and
-    MCP-compatible plugins via an MCP Registry, transparent per-agent memory the user can inspect and
-    control, and agent teams with scheduling and an IM gateway, on a self-hostable base. The
-    knowledge-base and multi-model wording has dropped out of the README in favour of agent-team
-    framing, but neither feature is withdrawn from the product and the enterprise-auth gap against Open
-    WebUI and LibreChat that placed the band is unchanged. Band unchanged at 4.
+  note: Strong feature surface across model breadth, MCP plugins, knowledge base and multi-user. Below Open
+    WebUI/LibreChat on enterprise auth/RAG depth verifiability; agent-orchestration framing edges toward
+    orchestration_agents but core remains human-driven chat. The knowledge-base and multi-model wording
+    has dropped out of the README in favour of agent-team framing, though neither feature is withdrawn from
+    the product.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/lobehub/lobehub

--- a/sources/scores/localai.yaml
+++ b/sources/scores/localai.yaml
@@ -40,14 +40,14 @@ adoption:
   level: 3
   signal_type: usage_volume
   confidence: medium
-  note: 'About 156,880 downloads a month across the product’s real distribution channels, read 2026-08-13
-    (Docker Hub 6,411,259 cumulative since 2023-03-18, about 156,880 a month). Bands at level 3 (100K-1M).
-    LocalAI is distributed as a Docker image; it publishes no first-party PyPI or npm package. Moved off
-    the stars fallback under the under-coverage rule in docs/reference/adoption.md: banding on a channel the
-    product does not ship through is a substitution rather than a measurement. The level is UNCHANGED at
-    3 - the stars cap happened to give the right answer here - but it now rests on a measured figure instead
-    of a capped proxy. The Docker component is a lifetime average, not a trailing-30-day count, so this
-    is a floor.'
+  note: 'About 156,880 downloads a month across the product''s real distribution channels (Docker Hub records
+    6,411,259 cumulative pulls since 2023-03-18, about 156,880 a month). Bands at level 3 (100K-1M). LocalAI
+    is distributed as a Docker image; it publishes no first-party PyPI or npm package. Moved off the stars
+    fallback under the under-coverage rule in docs/reference/adoption.md: banding on a channel the product
+    does not ship through is a substitution rather than a measurement. The level is unchanged at 3 - the
+    stars cap happened to give the right answer here - but it now rests on a measured figure instead of
+    a capped proxy. The Docker component is a lifetime average, not a trailing-30-day count, so this is
+    a floor.'
   last_verified: '2026-08-13'
   reach: 100K-1M
   sources:
@@ -63,10 +63,10 @@ capability:
     diffusers, MLX, MLX-VLM, and more); drop-in OpenAI, Anthropic, and ElevenLabs API compatibility; CPU-only
     capable; built-in agents + RAG + MCP
   confidence: high
-  note: No peer comparison is recorded for this product and none was found in the re-read; the band rests
-    on feature breadth alone, per the brief's note that this product carries no peer comparison. Backend
-    count updated from the prior '36+' to the current README's '60+', matching what description already
-    stated.
+  note: 'No peer comparison is recorded for this product, so relative_to/relation stay unset and the band
+    rests on feature breadth alone: the README records 60+ backends (up from the prior ''36+''), drop-in
+    OpenAI/Anthropic/ElevenLabs API compatibility across every backend, and built-in agents with tool use,
+    RAG and MCP.'
   last_verified: '2026-08-09'
   sources:
   - url: https://github.com/mudler/LocalAI

--- a/sources/scores/lovable.yaml
+++ b/sources/scores/lovable.yaml
@@ -11,12 +11,12 @@ openness:
     self-host:
       value: 'no'
   confidence: high
-  note: 'Proprietary SaaS app builder; closed source. (GPT Engineer, its open source predecessor, is a
-    separate legacy repo; the scored product is the proprietary Lovable platform.) Re-read 2026-08-13
-    - lovable.dev now answers 403 to a non-browser fetch, so the claim was re-derived from Lovable''s
-    own documentation instead. The docs describe a hosted platform throughout - account creation, dashboard,
-    enterprise tier, a managed Cloud backend, connectors, git sync and a managed npm registry - with no
-    source distribution and no self-host path. Nothing moved.'
+  note: 'Proprietary SaaS app builder; closed source. (GPT Engineer, its open source predecessor, is a separate
+    legacy repo; the scored product is the proprietary Lovable platform.) The product site is no longer
+    fetchable - lovable.dev answers 403 to a non-browser request - so the claim rests on Lovable''s own
+    documentation, which describes a hosted platform throughout: account creation, dashboard, enterprise
+    tier, a managed Cloud backend, connectors, git sync and a managed npm registry, with no source distribution
+    and no self-host path.'
   raw: source:closed;license:proprietary(SaaS);self-host:no
   last_verified: '2026-08-13'
   sources:
@@ -40,13 +40,11 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: medium
-  note: 'Lovable reports millions of projects built; ~8M users reported and $400M ARR (Feb/Mar 2026, 146
-    employees). Usage volume in the 1-10M band. Re-read 2026-08-13 - the TechCrunch report still states
-    Lovable crossed $400 million in annual recurring revenue in February, confirmed by the company, and
-    that it has attracted "some 8 million users". WHAT WAS BANDED - a vendor user total with no period
-    attached, which is not a download count and not an active count, so the numeric reach label sitting
-    on it is a download label over a user figure. The level is right on either scale and is unchanged;
-    the instrument and label are left as recorded rather than switched in a re-read.'
+  note: Lovable reports millions of projects built; ~8M users reported and $400M ARR (Feb/Mar 2026, 146
+    employees). Usage volume in the 1-10M band. WHAT WAS BANDED - a vendor user total with no period attached,
+    which is not a download count and not an active count, so the numeric reach label sitting on it is a
+    download label over a user figure. The level is right on either scale; the instrument and label are
+    left as recorded.
   last_verified: '2026-08-13'
   sources:
   - url: https://techcrunch.com/2026/03/11/lovable-says-it-added-100m-in-revenue-last-month-alone-with-just-146-employees/
@@ -61,12 +59,8 @@ capability:
   value: Autonomous chat-to-app generation, screenshot/doc input, real-time prototype build, one-click
     deploy, MCP server, integrations; no published SWE-bench/GAIA
   confidence: low
-  note: 'Capable autonomous app builder targeted at non-developers; full-app generation rather than benchmark
-    SWE work, no first-party benchmark; scored 3 on feature matrix. Re-read 2026-08-13 from Lovable''s
-    documentation, lovable.dev itself no longer being fetchable. The docs cover the agent, context and
-    knowledge, file generation, design, a managed Cloud backend, AI for your app, testing, security, npm
-    packages, connectors and git sync - a broad app-building surface with no benchmark placement. Two
-    below the openhands anchor, unchanged.'
+  note: Capable autonomous app builder targeted at non-developers; full-app generation rather than benchmark
+    SWE work, no first-party benchmark; scored 3 on feature matrix.
   relative_to: openhands
   relation: two_below
   last_verified: '2026-08-13'

--- a/sources/scores/lucie-7b.yaml
+++ b/sources/scores/lucie-7b.yaml
@@ -21,14 +21,12 @@ openness:
   confidence: high
   note: 'Full open-source tier alongside OLMo / Apertus: open weights, open training data, open training
     code, intermediate checkpoints. Authors position Lucie as OSI-definition-compliant for open-source AI.
-    Training-dataset product deferred — artifacts cited here for openness only. Caveat found on the
-    2026-07-30 re-read: Lucie-Training-Dataset carries `cc-by-nc-sa-4.0`, so the corpus is published
-    and ungated but NOT commercially reusable. The `data` dimension asks whether the corpus is released,
-    not under what terms, so the score is unchanged — but the authors'' OSI-compliance claim does not
-    survive a strict reading, and Lucie is a weaker full-openness exemplar than OLMo, whose Dolma is
-    `odc-by`. Re-read 2026-08-13: the corpus is still ungated and still `cc-by-nc-sa-4.0` (now 3,663
-    downloads), the 7B card still reads apache-2.0 with the `step0005000` style checkpoint branches,
-    and Lucie-Training is still the published pretraining code. Nothing moved.'
+    Training-dataset product deferred — artifacts cited here for openness only. Caveat: Lucie-Training-Dataset
+    carries `cc-by-nc-sa-4.0`, so the corpus is published and ungated but NOT commercially reusable. The
+    `data` dimension asks whether the corpus is released, not under what terms, so the score is unchanged
+    — but the authors'' OSI-compliance claim does not survive a strict reading, and Lucie is a weaker full-openness
+    exemplar than OLMo, whose Dolma is `odc-by`. The 7B card reads apache-2.0 with `step0005000`-style checkpoint
+    branches, and Lucie-Training is the published pretraining code.'
   last_verified: '2026-08-13'
   raw: weights:open(Apache-2.0);data:open(Lucie-Training-Dataset on HF, redistributed in training form);code:open(Lucie-Training
     Megatron-DeepSpeed fork);checkpoints:open(intermediate HF revisions);license:Apache-2.0(OSI)
@@ -49,13 +47,13 @@ openness:
     establishes: [weights, license, checkpoints]
   - url: https://huggingface.co/datasets/OpenLLM-France/Lucie-Training-Dataset
     shows: 'Dataset page for the multilingual pretraining corpus: `isGated: false`, `isPrivate: false`,
-      Parquet format present. Cited previously WITHOUT the `/datasets/` path segment, which the Hub
-      resolves as a model repo and answers 401; the URL was corrected on re-read rather than the
-      dataset having become gated.'
+      Parquet format present. The URL needs its `/datasets/` path segment - without it the Hub resolves
+      the path as a model repo and answers 401.'
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 60cb981d75e94530c0f674f95661d4377e7c774c37f4fb945d56321a52c4cdeb
-    establishes: [data]
+    establishes:
+    - data
   - url: https://github.com/OpenLLM-France/Lucie-Training
     shows: Repository described as "Code for continual pretraining of LUCIE" - the Megatron-DeepSpeed
       fork used for the run.
@@ -74,10 +72,9 @@ adoption:
   reach: <10K
   signal_type: usage_volume
   confidence: medium
-  note: 1,945 downloads in the trailing 30 days summed across the 2 declared artifact(s), read 2026-08-13
-    (OpenLLM-France/Lucie-7B 1,315; OpenLLM-France/Lucie-7B-Instruct-v1.1 630). Bands at level 1 (<10K)
-    on the software and model adoption scale. Corrected from level 2, which the declared artifacts do not
-    support.
+  note: 1,945 downloads in the trailing 30 days summed across the 2 declared artifact(s) (OpenLLM-France/Lucie-7B
+    1,315; OpenLLM-France/Lucie-7B-Instruct-v1.1 630). Bands at level 1 (<10K) on the software and model
+    adoption scale. Corrected from level 2, which the declared artifacts do not support.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/models/OpenLLM-France/Lucie-7B
@@ -96,12 +93,10 @@ capability:
   basis_detail: multilingual-pretrain-suite
   value: null
   confidence: medium
-  note: 7B multilingual base prioritizing French cultural representation and data-rights constraints —
-    competitive for its size/language mix on French/English evals in the paper, but well below the 2026
-    open-weight frontier (trillion-param MoEs). Capability 2 reflects small-scale fully-open sovereign
-    model, not frontier performance. Value is openness + FR/EU language coverage. Re-read 2026-08-13 -
-    the paper and the card still present Lucie against contemporary open baselines at its own size
-    rather than against frontier models, which is the comparison the 2 encodes. Unchanged.
+  note: 7B multilingual base prioritizing French cultural representation and data-rights constraints — competitive
+    for its size/language mix on French/English evals in the paper, but well below the 2026 open-weight
+    frontier (trillion-param MoEs). Capability 2 reflects small-scale fully-open sovereign model, not frontier
+    performance. Value is openness + FR/EU language coverage.
   last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2503.12294

--- a/sources/scores/luciole.yaml
+++ b/sources/scores/luciole.yaml
@@ -23,14 +23,12 @@ openness:
     training code, and intermediate checkpoints. Notably a cleaner full-openness exemplar than its Lucie
     predecessor — the Luciole-Training-Dataset is described as containing only openly licensed corpora,
     where Lucie-Training-Dataset carried a non-commercial cc-by-nc-sa license. The weights are Apache-2.0
-    (OSI) across every distributed size, so the data + code + OSI-license rule lands at 5. Re-read
-    2026-08-13, this time by direct fetch rather than through search snippets, which is what the
-    previous read had to settle for. Every claim holds and two firm up. The training corpus is
-    ungated and its card license is `cc-by-sa-4.0` - share-alike but commercially reusable, so the
-    contrast with Lucie''s non-commercial corpus is real rather than inferred from the prose. And the
-    intermediate checkpoints are concrete - the 23B-Base card documents revision tags every 1,000
-    steps to 5,000, every 5,000 to 30,000 and every 10,000 beyond, plus one at the end of each
-    training phase, mirrored at dl.labs.linagora.com. Luciole-Training is still GPL-3.0 and public.'
+    (OSI) across every distributed size, so the data + code + OSI-license rule lands at 5. The training
+    corpus is ungated and its card license is `cc-by-sa-4.0` - share-alike but commercially reusable, so
+    the contrast with Lucie''s non-commercial corpus is real rather than inferred from the prose. The intermediate
+    checkpoints are concrete: the 23B-Base card documents revision tags every 1,000 steps to 5,000, every
+    5,000 to 30,000 and every 10,000 beyond, plus one at the end of each training phase, mirrored at dl.labs.linagora.com.
+    Luciole-Training is public under GPL-3.0.'
   last_verified: '2026-08-13'
   raw: weights:open(Apache-2.0, safetensors on HF for 1B/8B/23B base + Instruct-1.1);data:open(Luciole-Training-Dataset
     on HF, ~4.65T tokens, "only corpora under open licenses");code:open(Luciole-Training pretraining + data-processing
@@ -88,12 +86,12 @@ adoption:
   reach: <10K
   signal_type: usage_volume
   confidence: medium
-  note: 7,631 downloads in the trailing 30 days summed across the 6 declared artifact(s), read
-    2026-08-13 (Luciole-23B-Base 746; Luciole-23B-Instruct-1.1 1,266; Luciole-8B-Base 965;
-    Luciole-8B-Instruct-1.1 1,821; Luciole-1B-Base 693; Luciole-1B-Instruct-1.1 2,140). Bands at
-    level 1 (<10K) on the software and model adoption scale, unchanged - a niche sovereign French
-    open-LLM audience. The whole family together is still under the 10K level-2 floor, though it has
-    roughly tripled since the 2026-08-07 read and is now within a month or two of crossing it.
+  note: 7,631 downloads in the trailing 30 days summed across the 6 declared artifact(s) (Luciole-23B-Base
+    746; Luciole-23B-Instruct-1.1 1,266; Luciole-8B-Base 965; Luciole-8B-Instruct-1.1 1,821; Luciole-1B-Base
+    693; Luciole-1B-Instruct-1.1 2,140). Bands at level 1 (<10K) on the software and model adoption scale,
+    unchanged - a niche sovereign French open-LLM audience. The whole family together is still under the
+    10K level-2 floor, though it has roughly tripled since the previous reading and is now within a month
+    or two of crossing it.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/models/OpenLLM-France/Luciole-23B-Base
@@ -135,10 +133,9 @@ capability:
   note: Multilingual French–English family up to 23B, prioritizing French cultural representation and open
     data rights over frontier performance. Larger than Lucie-7B (capability 2) but the same sovereign-model
     tier — mid-scale and well below the 2026 open-weight frontier (trillion-param MoEs). Positioned like
-    Alia-40b (capability 2); kept conservative pending published benchmarks. Value is openness + FR/EU
-    language coverage. Re-read 2026-08-13 - the 23B-Base card still publishes no benchmark table
-    against external models, only training-convergence and evaluation curves, so the conservative 2
-    still rests on scale and positioning rather than a measured comparison. Unchanged.
+    Alia-40b (capability 2); kept conservative pending published benchmarks. Value is openness + FR/EU language
+    coverage. The 23B-Base card publishes no benchmark table against external models, only training-convergence
+    and evaluation curves, so the conservative 2 rests on scale and positioning rather than a measured comparison.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/OpenLLM-France/Luciole-23B-Base

--- a/sources/scores/lumo.yaml
+++ b/sources/scores/lumo.yaml
@@ -21,13 +21,9 @@ openness:
     note that only the clients are open. Corrected from 3/open_core on 2026-07-30, and both values were
     wrong: the ladder has no rung at 3, and a published client standing in for an unpublished engine is
     source:partial, which it scores 2/source_available. open_core would mean an OSI core with a paid tier
-    withheld.
-    Re-read 2026-08-13. The iOS client is still GPLv3 and its README makes the split unusually clear -
-    the app is a SwiftUI shell around a WKWebView pointed at lumo.proton.me, with native payment and
-    speech handling, so what is published is a client and the service behind it is not. isitreallyfoss
-    still concludes the same, that only the mobile and web apps are open and that no source for the
-    service or for the model interaction could be found, and it still quotes the European Open Source AI
-    Index reaching that conclusion independently. Value unchanged at 2 / source_available.'
+    withheld. The published iOS client is a SwiftUI shell around a WKWebView pointed at lumo.proton.me,
+    with native payment and speech handling, which is the split exactly: a client is published and the service
+    behind it is not. The European Open Source AI Index reaches the same conclusion independently.'
   raw: source:partial(GPLv3 clients only; backend, routing and model-serving are not published);clients:open(GPLv3
     - web in ProtonMail/WebClients, iOS/Android in ProtonLumo);service:closed(backend, routing, model-serving
     not public);license:GPLv3(clients)
@@ -53,11 +49,6 @@ adoption:
   note: Launched July 2025 with Lumo 1.1 following; distributed across Proton's large account base (100M+
     Proton accounts) and available on web + iOS + Android with no account required. No Lumo-specific usage
     numbers disclosed, so reported_traction at a mid level.
-    Re-read 2026-08-13. The July 2025 launch announcement is still up and still discloses no
-    Lumo-specific usage figure, and none has appeared since - the only number Proton attaches is its own
-    account base, which is the distribution channel rather than a measure of Lumo. So the abstention
-    from a counted signal stands and reported_traction with no numeric reach remains the right
-    instrument. Level unchanged at 3.
   last_verified: '2026-08-13'
   sources:
   - url: https://proton.me/blog/lumo-ai
@@ -72,14 +63,9 @@ capability:
     Drive); web search: yes; reasoning: yes (Lumo 1.1); multimodal: limited; multi-user: single-user; privacy:
     zero-access encryption + ghost mode'
   confidence: medium
-  note: Capable privacy assistant with file upload, web search, and a reasoning mode, but confined to
-    open-weight models and the Proton ecosystem; lighter on multimodal/plugins than frontier consumer
-    apps. Mid-tier on the chat-UI feature matrix.
-    Re-read 2026-08-13. The Lumo 1.1 post is still up and still describes the same upgrade the band
-    rests on - faster and more thorough answers, better awareness of recent events, multi-step planning
-    and better code generation, funded by more GPUs and Lumo Plus subscriptions. Still confined to
-    open-weight models Proton serves itself, still single-user, still light on multimodal. Band
-    unchanged at 3.
+  note: Capable privacy assistant with file upload, web search, and a reasoning mode, but confined to open-weight
+    models and the Proton ecosystem; lighter on multimodal/plugins than frontier consumer apps. Mid-tier
+    on the chat-UI feature matrix.
   last_verified: '2026-08-13'
   sources:
   - url: https://proton.me/blog/lumo-1-1

--- a/sources/scores/madlad-400.yaml
+++ b/sources/scores/madlad-400.yaml
@@ -11,8 +11,7 @@ openness:
     card:
       value: present
   confidence: high
-  note: 'Ungated with a permissive open-data license and a complete dataset card. Re-read 2026-08-13: the
-    Hub API still returns odc-by and gated false for allenai/MADLAD-400 with the card present.'
+  note: Ungated with a permissive open-data license and a complete dataset card.
   raw: license:odc-by(API tag; card cites CC-BY-4.0);gated:false;card:present
   last_verified: '2026-08-13'
   sources:
@@ -30,9 +29,8 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 15,089 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (allenai/MADLAD-400 15,089). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band
-    is >1M.
+  note: 15,089 downloads in the trailing 30 days summed across the 1 declared artifact(s) (allenai/MADLAD-400
+    15,089). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/allenai/MADLAD-400
@@ -46,10 +44,10 @@ capability:
   basis_detail: downstream
   value: null
   confidence: high
-  note: 'Underpins Google''s MADLAD-400 MT models (10.7B/8B, 2023) competitive with NLLB-54B; a strong documented
-    downstream training result, not the current leader. Re-read 2026-08-13: Table 4 of the paper still shows
-    MT-10.7B averaging 31.8 BLEU against NLLB-54B''s 32.7 on WMT, which is the competitive-but-not-leading
-    result the band rests on.'
+  note: Underpins Google's MADLAD-400 MT models (10.7B/8B, 2023) competitive with NLLB-54B; a strong documented
+    downstream training result, not the current leader. Table 4 of the paper has MT-10.7B averaging 31.8
+    BLEU against NLLB-54B's 32.7 on WMT, which is the competitive-but-not-leading result the band rests
+    on.
   last_verified: '2026-08-13'
   sources:
   - url: https://proceedings.neurips.cc/paper_files/paper/2023/file/d49042a5d49818711c401d34172f9900-Paper-Datasets_and_Benchmarks.pdf

--- a/sources/scores/maple-ai.yaml
+++ b/sources/scores/maple-ai.yaml
@@ -22,18 +22,17 @@ openness:
       value: paid
       detail: managed-enclaves
   confidence: medium
-  note: 'Both halves of the stack are open under standard OSI licenses (Maple client MIT, OpenSecret platform
+  note: Both halves of the stack are open under standard OSI licenses (Maple client MIT, OpenSecret platform
     AGPL-3.0) and the served models are open-weight - unusually clean for a "private AI" product. Scored
     open_source because the privacy guarantee is only credible because the code is open and attestable.
-    A repo read on 2026-08-12 settled the open_core alternative against itself. The Maple README makes
-    the billing and feature-flag services optional external clients, VITE_MAPLE_BILLING_API_URL and
-    VITE_OS_FLAGS_BASE_URL, and the OpenSecret README says their "server implementations are not part
-    of this repository setup"; a self-hosted backend runs without either, so what the subscription buys
-    is usage on the hosted enclaves rather than functionality withheld from the source. Neither repo has
-    an enterprise directory or a license key. The one closed-looking artifact is the 15MB
-    continuum-proxy-x86_64 binary vendored into opensecret, and it is the third-party TEE proxy from
-    Edgeless Systems, carried alongside a git submodule of edgelesssys/privatemode-public rather than
-    being anything OpenSecret withholds from a self-hoster.'
+    A direct read of both repos settles the open_core alternative against itself. The Maple README makes
+    the billing and feature-flag services optional external clients, VITE_MAPLE_BILLING_API_URL and VITE_OS_FLAGS_BASE_URL,
+    and the OpenSecret README says their "server implementations are not part of this repository setup";
+    a self-hosted backend runs without either, so what the subscription buys is usage on the hosted enclaves
+    rather than functionality withheld from the source. Neither repo has an enterprise directory or a license
+    key. The one closed-looking artifact is the 15MB continuum-proxy-x86_64 binary vendored into opensecret,
+    and it is the third-party TEE proxy from Edgeless Systems, carried alongside a git submodule of edgelesssys/privatemode-public
+    rather than being anything OpenSecret withholds from a self-hoster.
   raw: license:MIT(Maple-client)+AGPL-3.0(OpenSecret-platform),both-OSI;source:public(github.com/OpenSecretCloud);core-gated:ungated(billing
     and feature-flag APIs are optional and external; no enterprise directory, no license key);models:open-weight;hosted-tier:paid(managed-enclaves)
   last_verified: '2026-08-12'
@@ -87,10 +86,6 @@ adoption:
   note: Launched Jan 2025; vendor reports "5x user growth in the last six months", >90% month-over-month
     paid retention, and "billions of tokens" in year one, but no absolute user count is published. Self-reported
     figures only, hence low confidence.
-    Re-read 2026-08-13. The one-year post is still up and still carries the same self-reported figures -
-    5x user growth in the last six months and over 90% of paying customers retained month over month -
-    and still publishes no absolute user count, so there is still nothing countable to band and
-    reported_traction with no numeric reach remains the right instrument. Level unchanged at 3.
   last_verified: '2026-08-13'
   sources:
   - url: https://blog.trymaple.ai/one-year-of-private-ai-how-maple-ai-made-encryption-easy/
@@ -105,12 +100,8 @@ capability:
     E2EE chat in TEEs with remote attestation; image/vision (gated to paid tiers); voice/transcription; OpenAI-compatible
     API (Maple Proxy); platforms: web/iOS/Android/macOS/desktop; teams/multi-seat'
   confidence: medium
-  note: Broad multi-model, multi-platform private chat with vision, API, and teams. Short of top because it
-    is a focused private-chat product without a confirmed agentic tool-use/web-browsing ecosystem.
-    Re-read 2026-08-13. The model guide still lists the same open-weight lineup the band rests on -
-    gpt-oss-120b, kimi-k2.5, deepseek-r1-0528, llama-3.3-70b, qwen3-vl-30b and gemma-3-27b - with the
-    tier structure gating vision and image work to paid plans. Still a focused private-chat product with
-    no agentic tool-use or browsing ecosystem. Band unchanged at 4.
+  note: Broad multi-model, multi-platform private chat with vision, API, and teams. Short of top because
+    it is a focused private-chat product without a confirmed agentic tool-use/web-browsing ecosystem.
   last_verified: '2026-08-13'
   sources:
   - url: https://blog.trymaple.ai/maple-ai-model-guide-with-example-prompts/

--- a/sources/scores/marin-framework.yaml
+++ b/sources/scores/marin-framework.yaml
@@ -17,9 +17,7 @@ openness:
     - no feature-gated core
   confidence: high
   note: Fully OSI-licensed (Apache-2.0), full source public. Repo is the framework; the Marin model is a
-    separate artifact. Re-read 2026-08-13 - the LICENSE body still carries the same license and the README
-    still builds the whole product from the published repo, with no paid tier, enterprise edition or license
-    key anywhere in it.
+    separate artifact.
   raw: license:Apache-2.0(OSI);source:public(marin-community/marin);governance:Marin community/Stanford
     CRFM;no feature-gated core;core-gated:ungated
   last_verified: '2026-08-13'
@@ -46,12 +44,12 @@ adoption:
   reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: medium
-  note: 1,261 GitHub stars on marin-community/marin, read 2026-08-13 from the repository API. Bands at level
-    2 (1K-10K stars) on the stars fallback scale in signal_routing.yaml, which caps at 3 because a star
-    is not a use. A research framework with adoption concentrated around the Marin project rather than broad
-    external use, and no published package. The API response is digested here the way bigcode-dataset and
-    ungoliant already are in this category; a star count drifts, so a later digest mismatch reads as drift
-    rather than as fabrication.
+  note: 1,261 GitHub stars on marin-community/marin, read from the repository API. Bands at level 2 (1K-10K
+    stars) on the stars fallback scale in signal_routing.yaml, which caps at 3 because a star is not a use.
+    A research framework with adoption concentrated around the Marin project rather than broad external
+    use, and no published package. The API response is digested here the way bigcode-dataset and ungoliant
+    already are in this category; a star count drifts, so a later digest mismatch reads as drift rather
+    than as fabrication.
   last_verified: '2026-08-13'
   sources:
   - url: https://api.github.com/repos/marin-community/marin
@@ -65,8 +63,7 @@ capability:
   value: End-to-end reproducible data curation + mixture orchestration + training/eval with step-dependency
     execution scaled to TPU clusters.
   confidence: medium
-  note: Broad end-to-end framework; adoption, not capability, is its weak axis. Re-read 2026-08-13 - the
-    README still describes the feature set above.
+  note: Broad end-to-end framework; adoption, not capability, is its weak axis.
   last_verified: '2026-08-13'
   sources:
   - url: https://raw.githubusercontent.com/marin-community/marin/main/README.md

--- a/sources/scores/marin.yaml
+++ b/sources/scores/marin.yaml
@@ -21,10 +21,7 @@ openness:
       detail: OSI
   confidence: high
   note: 'Stanford CRFM ''open lab'': Apache-2.0 weights plus documented code, data, experiments, hyperparameters
-    and training logs, with bit-for-bit reproducible training. Re-read 2026-08-13: the announcement
-    still describes every experiment as a tracked GitHub issue with a "full reproducible execution"
-    behind the 8B run, and the model card is still apache-2.0 with downloadable safetensors. Nothing
-    moved.'
+    and training logs, with bit-for-bit reproducible training.'
   last_verified: '2026-08-13'
   raw: weights:open(Apache-2.0);data:open(documented mixtures);code:open(marin + Levanter, JAX);checkpoints:open;reproducibility:bit-for-bit;license:Apache-2.0(OSI)
   sources:
@@ -54,11 +51,10 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: low
-  note: 12,168 downloads in the trailing 30 days summed across the 2 declared artifact(s), read
-    2026-08-13 (marin-community/marin-8b-base 8,604; marin-community/marin-8b-instruct 3,564). Bands
-    at level 2 (10K-100K) on the software and model adoption scale, unchanged. Research-stage
-    fully-open project; included as a fully-open exemplar rather than on popularity, and the band now
-    rests on a counted figure rather than that judgment.
+  note: 12,168 downloads in the trailing 30 days summed across the 2 declared artifact(s) (marin-community/marin-8b-base
+    8,604; marin-community/marin-8b-instruct 3,564). Bands at level 2 (10K-100K) on the software and model
+    adoption scale, unchanged. Research-stage fully-open project; included as a fully-open exemplar rather
+    than on popularity, and the band now rests on a counted figure rather than that judgment.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/models/marin-community/marin-8b-base
@@ -80,11 +76,10 @@ capability:
   value: Marin 8B Base competitive among fully-open models; 32B Base released
   confidence: medium
   note: Mid-tier fully-open capability at 8B/32B; OLMo 3 outperforms it on fully-open model evaluations.
-    Re-read 2026-08-13 - both sides of the comparison still hold. Marin's own announcement puts 8B
-    Base above Llama 3.1 8B Base on 14 of 19 evals and 8B Instruct above OLMo 2 but short of Llama 3.1
-    Tulu, and Ai2's Olmo 3 post claims the strongest performance among fully open base models. So the
-    `one_below` relation to olmo (capability 4) is what both vendors' own pages say, and olmo was
-    re-confirmed the same day.
+    Marin's own announcement puts 8B Base above Llama 3.1 8B Base on 14 of 19 evals and 8B Instruct above
+    OLMo 2 but short of Llama 3.1 Tulu, while Ai2's Olmo 3 post claims the strongest performance among fully
+    open base models, so the `one_below` relation to olmo (capability 4) is what both vendors' own pages
+    say.
   last_verified: '2026-08-13'
   sources:
   - url: https://developers.googleblog.com/stanfords-marin-foundation-model-first-fully-open-model-developed-using-jax/

--- a/sources/scores/markitdown.yaml
+++ b/sources/scores/markitdown.yaml
@@ -13,13 +13,10 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: 'Fully MIT; optional Azure/LLM features are pluggable, not gating. Re-read 2026-08-13, and the pluggable
-    claim was checked rather than assumed. The LICENSE is the plain MIT License, "Copyright (c) Microsoft
-    Corporation", and the repo page carries the matching badge. Azure Document Intelligence and Azure Content
-    Understanding are optional extras - the `[az-doc-intel]` and `[az-content-understanding]` install groups
-    - sitting in a capability table beside the built-in converters, which the README describes as offline
-    and format-specific. So the conversion the product exists to do runs entirely in the published package;
-    the Azure paths are alternatives you may buy, not a core withheld from it. core-gated stays ungated.'
+  note: Fully MIT; optional Azure/LLM features are pluggable, not gating. Azure Document Intelligence and
+    Azure Content Understanding are optional install extras - the `[az-doc-intel]` and `[az-content-understanding]`
+    groups - sitting beside built-in offline converters, so the conversion the product exists to do runs
+    entirely in the published package and core-gated stays ungated.
   raw: license:MIT(OSI; repo LICENSE + pyproject, PyPI field null);source:public;no-feature-gated-core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -45,10 +42,10 @@ adoption:
   level: 5
   signal_type: usage_volume
   confidence: medium
-  note: '12,755,994 downloads in the trailing 30 days (markitdown 12,755,994), read 2026-08-12. Bands at
-    level 5 (>10M) on the software and model adoption scale. Moved off the stars fallback: a real download
-    signal exists, and docs/reference/adoption.md says to re-band when one does. The package is the PyPI package,
-    not the unrelated npm package of the same name. Recorded level was 3.'
+  note: '12,755,994 downloads in the trailing 30 days (markitdown 12,755,994). Bands at level 5 (>10M) on
+    the software and model adoption scale. Moved off the stars fallback: a real download signal exists,
+    and docs/reference/adoption.md says to re-band when one does. The package is the PyPI package, not the
+    unrelated npm package of the same name. Recorded level was 3.'
   reach: '>10M'
   last_verified: '2026-08-12'
   sources:
@@ -63,13 +60,7 @@ capability:
   value: converts PDF/DOCX/PPTX/XLSX/images(OCR)/audio/HTML/CSV/JSON/XML/ZIP/EPub/YouTube -> Markdown; CLI + Python
     API + Docker; plugins; optional Azure Doc Intelligence + LLM vision
   confidence: medium
-  note: 'Broadest format coverage among RAG ingestion tools; lighter on deep layout parsing than Docling.
-    Re-read 2026-08-13 and the recorded value holds clause for clause: the format list still runs PDF, Office
-    documents, images with OCR, audio with speech transcription, HTML, CSV/JSON/XML, ZIP (iterating over
-    contents), YouTube URLs and EPubs, and the optional-extra list still carries `[audio-transcription]`,
-    `[youtube-transcription]`, `[az-doc-intel]` and `[az-content-understanding]` alongside a plugin section
-    and a Dockerfile. Band unchanged at 4 - the depth gap against Docling on layout and table structure is
-    the same one.'
+  note: Broadest format coverage among RAG ingestion tools; lighter on deep layout parsing than Docling.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/microsoft/markitdown

--- a/sources/scores/mastra.yaml
+++ b/sources/scores/mastra.yaml
@@ -19,8 +19,8 @@ openness:
   note: 'Open-core in the LangGraph/LlamaIndex shape rather than the n8n one - the framework itself is a
     real OSI license, not fair-code. LICENSE.md scopes the commercial carve-out narrowly to `ee/` auth directories,
     so the agent, workflow, memory and eval surfaces a user actually builds on are Apache-2.0. The bare
-    `gated` was transcribed 2026-08-12 to a named mechanism: ee/LICENSE is a separate Enterprise Edition
-    license forbidding production use without a written agreement with Kepler Software, and packages/_internals/auth/src/ee/license.ts
+    `gated` resolves to a named mechanism: ee/LICENSE is a separate Enterprise Edition license forbidding
+    production use without a written agreement with Kepler Software, and packages/_internals/auth/src/ee/license.ts
     disables the EE features unless MASTRA_LICENSE_KEY validates against the Mastra license server, which
     returns entitlements for rbac, sso and fga. So functionality is withheld from the published source by
     a license key, not merely sold beside it. Not 5 for that reason; the managed Mastra Cloud is separate
@@ -46,7 +46,7 @@ openness:
     shows: 'Registry metadata declares `license: Apache-2.0`, latest 1.57.0 (was 1.55.0 on 2026-07-30),
       confirming the framework still ships to consumers under the OSI license rather than only being licensed
       that way in-repo. The npmjs.com package page answers 403 to any non-browser fetch behind a Cloudflare
-      interstitial; this registry endpoint serves the same fact and can actually be re-checked.'
+      interstitial; this registry endpoint serves the same fact and stays fetchable.'
     accessed: '2026-08-12'
     http_status: 200
     content_sha256: a4361185051f473caffd3e3cd222e17f108be4f873c688dca43548149dbba9c1
@@ -100,12 +100,12 @@ adoption:
   signal_type: usage_volume
   confidence: high
   note: '@mastra/core at 4,931,561 downloads in the last month, which places it in the 1-10M band. Deliberately
-    NOT summed with the `mastra` package (2,151,411/mo): npm counts increment for transitively fetched
-    dependencies, and `mastra` pulls @mastra/core through @mastra/deployer, so adding them double-counts the
-    same installs. @mastra/core is the package everything resolves to and is the better single proxy. The band
-    is the same either way. Raw download volume includes CI and mirror traffic, so this is install volume rather
-    than a user count. Re-read 2026-08-13 - the npm download API now returns 5,264,387 downloads for @mastra/core
-    over the trailing month, up from 4,931,561 and still inside the 1M-10M band. Level and reach unchanged.'
+    NOT summed with the `mastra` package (2,151,411/mo): npm counts increment for transitively fetched dependencies,
+    and `mastra` pulls @mastra/core through @mastra/deployer, so adding them double-counts the same installs.
+    @mastra/core is the package everything resolves to and is the better single proxy. The band is the same
+    either way. Raw download volume includes CI and mirror traffic, so this is install volume rather than
+    a user count. The npm download API now returns 5,264,387 downloads for @mastra/core over the trailing
+    month, still inside the 1M-10M band.'
   last_verified: '2026-08-13'
   sources:
   - url: https://api.npmjs.org/downloads/point/last-month/@mastra/core
@@ -125,13 +125,10 @@ capability:
   value: null
   confidence: medium
   note: Feature coverage comparable to LangChain and Pydantic-AI (both 4) - agents with tools, graph workflows
-    with explicit control flow, memory with semantic recall, model routing across 90+ providers, evals, tracing
-    and human-in-the-loop. Not 5 like LangGraph or LlamaIndex, which have deeper ecosystems and longer track
-    records. Confidence is medium rather than high because no first-party SWE-bench or GAIA result exists for
-    the framework itself, so this is a feature-matrix judgment rather than a measurement. Re-read 2026-08-13
-    - mastra.ai still documents the same framework surface and now lists Observability, Studio and Agent
-    Builder as separate platform products beside it, which is the open-core shape already recorded rather
-    than a change in the framework''s own capability. At langchain and pydantic-ai, unchanged.
+    with explicit control flow, memory with semantic recall, model routing across 90+ providers, evals,
+    tracing and human-in-the-loop. Not 5 like LangGraph or LlamaIndex, which have deeper ecosystems and
+    longer track records. Confidence is medium rather than high because no first-party SWE-bench or GAIA
+    result exists for the framework itself, so this is a feature-matrix judgment rather than a measurement.
   relative_to: langchain
   relation: at
   last_verified: '2026-08-13'

--- a/sources/scores/math.yaml
+++ b/sources/scores/math.yaml
@@ -25,11 +25,9 @@ openness:
     problem rights, so the corpus is not distributed from its primary registry. The takedown was recorded
     only as prose; it is now recorded as access:closed, which is the ladder rung for data that is not distributed
     however it came to be that way, and that rung produces 1/closed rather than the 2/gated this record
-    carried. Mirrors and eval harnesses still embed the problems; revisit if the takedown is resolved.
-    Re-read 2026-08-13 - the page still shows "Access to this dataset has been disabled" with the DMCA
-    notice pointing at discussions/5, the `license:mit` tag and the card are still present, and the
-    Hub API reports 0 downloads in the trailing 30 days against 1,034,712 all-time, which is what a
-    disabled repo looks like. The 12,500-problem figure the June source cited is no longer rendered.
+    carried. Mirrors and eval harnesses still embed the problems; revisit if the takedown is resolved. The
+    Hub API reports 0 downloads in the trailing 30 days against 1,034,712 all-time, which is what a disabled
+    repo looks like.
   raw: license:MIT(declared);access:closed(canonical HF repo access-disabled under a DMCA takedown);data:NOT
     downloadable from canonical HF repo (access disabled, DMCA takedown);datasheet:present(card still documents
     schema);redistributability:BLOCKED on the primary registry;problems sourced from AMC/AIME competitions,
@@ -51,23 +49,16 @@ adoption:
   confidence: medium
   banded_quantity: all-time downloads (1,034,712) of a takedown-walled repo now reporting 0 in the trailing
     30 days
-  note: 'MATH is one of the most-cited math-reasoning standards, and the band rests on release-report
-    standing rather than a download count. The canonical Hugging Face repo is takedown-walled and now
-    reports 0 downloads in the trailing 30 days against 1,034,712 all-time, so no usage_volume figure
-    is obtainable from it - which is why the instrument is reported_traction and not usage_volume.
-
-    EVIDENCE REPLACED 2026-08-13. The category pass re-read this axis and correctly REFUSED to date it:
-    the only cited source was the disabled HF page, which establishes the takedown and nothing whatever
-    about release-report standing, and the "12,500-problem, NeurIPS 2021" text its shows quoted is no
-    longer rendered anywhere on it. A band cited to a page that does not support it is unfalsifiable
-    however true the band happens to be.
-
-    So a source that actually shows the standing is now cited: OLMo 3''s official model card carries an
-    evaluation table with MATH as a row (65.1 through 91.6 across nine compared models), alongside AIME
-    2024/2025, GPQA, MMLU, IFEval, LiveCodeBench and thirteen others. That is the claim stated exactly -
-    a frontier open model reporting MATH as a headline metric in its release evaluation - rather than
-    the broader "across frontier model release reports", which one card cannot establish on its own.
-    The takedown page is kept as the second source because it is what rules usage_volume out.'
+  note: 'MATH is one of the most-cited math-reasoning standards, and the band rests on
+    release-report standing rather than a download count. The canonical Hugging Face repo is
+    takedown-walled and reports 0 downloads in the trailing 30 days against 1,034,712 all-time, so no
+    usage_volume figure is obtainable from it - which is why the instrument is reported_traction and
+    not usage_volume. The standing is cited to OLMo 3''s official model card, whose evaluation table
+    carries MATH as a row (65.1 through 91.6 across nine compared models) alongside AIME 2024/2025,
+    GPQA, MMLU, IFEval, LiveCodeBench and thirteen others: a frontier open model reporting MATH as a
+    headline metric in its release evaluation, which is what one card can establish, rather than the
+    broader "across frontier model release reports". The takedown page is kept as the second source
+    because it is what rules usage_volume out.'
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/allenai/Olmo-3-7B-Instruct/raw/main/README.md
@@ -89,9 +80,7 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: Dataset, not capability-scored. Re-read 2026-08-13 and the abstention stands - the page is a
-    takedown notice over a static problem set, with no performance or feature claim the capability axis
-    could band.
+  note: Dataset, not capability-scored.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/hendrycks/competition_math

--- a/sources/scores/max.yaml
+++ b/sources/scores/max.yaml
@@ -15,15 +15,14 @@ openness:
     commercial-tier:
       value: Modular enterprise/managed deployment
   confidence: high
-  note: 'Large public codebase; the repo''s own LICENSE is Apache-2.0 with LLVM Exceptions. GitHub''s repo
+  note: Large public codebase; the repo's own LICENSE is Apache-2.0 with LLVM Exceptions. GitHub's repo
     page still states "Modular, MAX and Mojo usage and distribution are licensed under the Modular Community
-    License", which is not OSI approved. Re-read 2026-08-09 on the license page itself: it splits capacity
-    by device architecture (no cap on X86/ARM/NVIDIA-PTX devices; an 8-device cap on any other accelerator
-    type), grants only "a limited right to redistribute certain components of the SDK", and the community
-    variant is "provided free of charge" but Modular "may at any time change its provision" with only commercially-reasonable
-    notice. So the source is readable and not unconditionally freely runnable/redistributable at scale.
-    Marketed as "open"; flag open_washed. Score corrected from 3 to 2 on 2026-07-30 and unchanged on this
-    re-read.'
+    License", which is not OSI approved. The Modular Community License itself splits capacity by device
+    architecture (no cap on X86/ARM/NVIDIA-PTX devices; an 8-device cap on any other accelerator type),
+    grants only "a limited right to redistribute certain components of the SDK", and the community variant
+    is "provided free of charge" but Modular "may at any time change its provision" with only commercially-reasonable
+    notice. So the source is readable and not unconditionally freely runnable or redistributable at scale.
+    Marketed as "open"; flag open_washed. Score corrected from 3 to 2.
   last_verified: '2026-08-09'
   raw: license:Modular-Community-License(non-OSI, per-device licensing and a limited redistribution grant,
     governs MAX/Mojo usage+distribution);repo-license:Apache-2.0-WITH-LLVM-exception(the source in modular/modular);source:public(~450k
@@ -56,18 +55,15 @@ adoption:
   reach: '>10K stars'
   signal_type: stars_fallback
   confidence: low
-  note: 'No published download/user/tokens figure for MAX serving specifically. GitHub stargazerCount on
-    modular/modular (covers MAX+Mojo) is the only signal; capped per stars_fallback and placed at 2 given no
-    verified production-deployment count and a still-maturing serving ecosystem vs the established OSS
-    engines. Stars read 2026-08-13 on modular/modular: 26,777, which bands at >10K stars, level 3 on the stars
-    scale. The previous reach ''10K-100K'' was a download label, which this instrument does not offer - a star
-    is not a download. Level corrected from 2. OVER-ATTRIBUTION, named rather than resolved: modular/modular
-    is one repo covering MAX and Mojo together, so these stars are not all MAX''s. That is the cohere-rerank-
-    api shape and the guide has no settled rule for it yet, so the instrument''s answer stands and confidence
-    stays low. THE REAL DEFECT is upstream: this product declares no artifacts at all, so a stars_fallback
-    band had no stars source behind it and the count lived only in this note. Declaring modular/modular would
-    fix it, and is deliberately not done here because a declared code repo also re-routes the openness license
-    dimension. No last_verified claimed: a star count is volatile.'
+  note: 'No published download/user/tokens figure for MAX serving specifically. GitHub stars on modular/modular,
+    which covers MAX and Mojo together, are the only signal: 26,777 stars band at >10K stars, level 3 on
+    the stars scale. The previous reach ''10K-100K'' was a download label this instrument does not offer
+    - a star is not a download - and the level was corrected from 2. Over-attribution is named rather than
+    resolved: modular/modular is one repo covering both products, so these stars are not all MAX''s, the
+    guide has no settled rule for that shape yet, and confidence stays low. The real defect is upstream:
+    this product declares no artifacts at all, so a stars_fallback band has no stars source behind it and
+    the count lives only in this note. Declaring modular/modular would fix it, and is deliberately not done
+    here because a declared code repo also re-routes the openness license dimension.'
   last_verified: '2026-08-09'
   sources:
   - url: https://github.com/modular/modular
@@ -82,12 +78,12 @@ capability:
     (NVIDIA/AMD/Apple) + CPU, custom-kernel authoring in Mojo, cloud deployment; designed as high-performance
     inference + hardware-abstraction layer
   confidence: medium
-  note: 'Re-read 2026-08-09: docs confirm serving 500+ Hugging Face models via an OpenAI-compatible REST
-    API, a graph compiler with op-level fusions, and native MAX/PyTorch execution across GPUs and CPUs;
-    the GitHub README confirms separate NVIDIA and AMD GPU containers plus Apple-silicon GPU support, and
-    custom op/kernel authoring in Mojo. No standardized MLPerf/AA inference-engine submission found, so
-    basis stays feature_matrix rather than benchmark. No peer comparison is recorded in the brief and none
-    was found to rest the band on, so relative_to/relation stay unset.'
+  note: Docs record serving 500+ Hugging Face models via an OpenAI-compatible REST API, a graph compiler
+    with op-level fusions, and native MAX/PyTorch execution across GPUs and CPUs; the GitHub README records
+    separate NVIDIA and AMD GPU containers plus Apple-silicon GPU support, and custom op/kernel authoring
+    in Mojo. No standardized MLPerf/AA inference-engine submission has been found, so the basis stays feature_matrix
+    rather than benchmark. No peer comparison is recorded for this product, so relative_to/relation stay
+    unset.
   last_verified: '2026-08-09'
   sources:
   - url: https://docs.modular.com/max/intro

--- a/sources/scores/mbpp.yaml
+++ b/sources/scores/mbpp.yaml
@@ -17,10 +17,8 @@ openness:
     splits:
       value: train/test/validation/prompt public
   confidence: high
-  note: 'Fully open: CC-BY-4.0, ungated, downloadable, with an extensive dataset card. Clean open-data
-    case; the standard companion to HumanEval for basic Python code-gen eval. Re-read 2026-08-13:
-    `license:cc-by-4.0` is still in the repo tags, the embedded repo state reads `"gated":false`, and
-    the dataset card still renders. No change.'
+  note: 'Fully open: CC-BY-4.0, ungated, downloadable, with an extensive dataset card. Clean open-data case;
+    the standard companion to HumanEval for basic Python code-gen eval.'
   raw: license:CC-BY-4.0(open data license);redistributability:full(downloadable, ungated);datasheet:yes(extensive
     dataset card);size:~974 full / 427 sanitized problems w/ test_list;splits:train/test/validation/prompt
     public
@@ -39,11 +37,10 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: medium
-  note: 208,317 Hugging Face downloads in the trailing 30 days (google-research-datasets/mbpp), read 2026-08-12.
-    Bands at level 4 (100K-1M) on the dataset adoption scale, whose top band is >1M - one order of magnitude
-    below the software and model scales, because no dataset artifact in the corpus has ever exceeded 10M.
-    A standard basic-Python code-generation benchmark, routinely paired with HumanEval in code-model release
-    reports.
+  note: 208,317 Hugging Face downloads in the trailing 30 days (google-research-datasets/mbpp). Bands at
+    level 4 (100K-1M) on the dataset adoption scale, whose top band is >1M - one order of magnitude below
+    the software and model scales, because no dataset artifact in the corpus has ever exceeded 10M. A standard
+    basic-Python code-generation benchmark, routinely paired with HumanEval in code-model release reports.
   last_verified: '2026-08-12'
   sources:
   - url: https://huggingface.co/api/datasets/google-research-datasets/mbpp
@@ -57,8 +54,6 @@ capability:
   value: null
   confidence: high
   note: Dataset, not 'capable'. Largely saturated by frontier models; per recipe capability is n/a.
-    Re-read 2026-08-13 and the abstention stands - the page publishes a static problem set and no
-    performance or feature claim the capability axis could band.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/google-research-datasets/mbpp

--- a/sources/scores/mcp-inspector.yaml
+++ b/sources/scores/mcp-inspector.yaml
@@ -13,13 +13,11 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: 'Fully MIT, no feature-gated core. Re-read 2026-08-13, and the cited evidence had to be replaced:
-    this record said "MIT license file" and there is no LICENSE file in the repository at all - not at LICENSE,
-    not at LICENSE.md, and not in the root listing. MIT is still the right answer and is now sourced where
-    the project actually states it, in the README''s License section ("MIT.") and in package.json ("license":
-    "MIT"). Worth noting alongside the sibling repos: typescript-sdk and servers have both moved to the MCP
-    Apache-2.0 transition license and this one has not, so the org is no longer uniform. The whole tool is
-    in the published tree and runs via `npx @modelcontextprotocol/inspector` with no key or paid tier.'
+  note: 'Fully MIT, no feature-gated core. There is no LICENSE file in the repository at all; MIT is stated
+    in the README''s License section and in package.json ("license": "MIT"). Worth noting beside the sibling
+    repos: typescript-sdk and servers have both moved to the MCP Apache-2.0 transition license and this
+    one has not, so the org is no longer uniform. The whole tool is in the published tree and runs via `npx
+    @modelcontextprotocol/inspector` with no key or paid tier.'
   raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -51,9 +49,9 @@ adoption:
   level: 3
   signal_type: usage_volume
   confidence: high
-  note: 905,396 npm downloads in the trailing 30 days for @modelcontextprotocol/inspector, read 2026-08-12.
-    Bands at level 3 (100K-1M) on the software and model adoption scale. The reference MCP debugging tool;
-    sits just under the 1M boundary. Corrected from level 4, which the recorded evidence did not support.
+  note: 905,396 npm downloads in the trailing 30 days for @modelcontextprotocol/inspector. Bands at level
+    3 (100K-1M) on the software and model adoption scale. The reference MCP debugging tool; sits just under
+    the 1M boundary. Corrected from level 4, which the recorded evidence did not support.
   reach: 100K-1M
   last_verified: '2026-08-12'
   sources:
@@ -69,14 +67,7 @@ capability:
     CI, and an Ink terminal UI; all transports including stateless streamable-HTTP; OAuth with discovery and
     mid-session recovery; multi-server config
   confidence: high
-  note: 'Best-in-class for its debugging niche; narrower scope than the SDKs by design. Re-read 2026-08-13
-    and the surface has GROWN since this value was written, so it has been restated rather than confirmed.
-    The tool is now at v2 and ships three clients from one `mcp-inspector` binary - Web (Vite + React + Mantine),
-    CLI ("a scriptable command-line client for automation, CI, and fast agent feedback loops") and TUI (Ink)
-    - where the record had only "visual + CLI". OAuth has grown into providers, discovery, storage and mid-session
-    recovery, and the connection can negotiate the modern 2026-07-28 protocol era alongside the legacy one.
-    The one clause dropped is "request history/visualization", which the README no longer mentions. The band
-    stays 4: this is still a debugger rather than a runtime, which is what puts it a rung under the SDKs.'
+  note: Best-in-class for its debugging niche; narrower scope than the SDKs by design.
   last_verified: '2026-08-13'
   sources:
   - url: https://raw.githubusercontent.com/modelcontextprotocol/inspector/main/README.md

--- a/sources/scores/mcp-python-sdk.yaml
+++ b/sources/scores/mcp-python-sdk.yaml
@@ -13,13 +13,11 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: 'Fully MIT reference SDK. Re-read 2026-08-13. The repository LICENSE is still the plain MIT License,
-    "Copyright (c) 2024 Anthropic, PBC" - worth stating because the sibling MCP repos are not: modelcontextprotocol/typescript-sdk
-    and modelcontextprotocol/servers have both moved to the project''s Apache-2.0 transition license, and
-    this one has not. PyPI agrees, classifying `mcp` as "OSI Approved :: MIT License", though its Author
-    field now reads "Model Context Protocol a Series of LF Projects, LLC" where this record had Anthropic
-    PBC. The whole SDK is in the published repo and installs from PyPI with no key or paid tier, so core-gated
-    stays ungated.'
+  note: 'Fully MIT reference SDK. The LICENSE is the plain MIT License, "Copyright (c) 2024 Anthropic, PBC"
+    - worth stating because the sibling MCP repos are not: modelcontextprotocol/typescript-sdk and modelcontextprotocol/servers
+    have both moved to the project''s Apache-2.0 transition license, and this one has not. PyPI agrees,
+    classifying `mcp` as "OSI Approved :: MIT License". The whole SDK is in the published repo and installs
+    from PyPI with no key or paid tier, so core-gated stays ungated.'
   raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -53,11 +51,11 @@ adoption:
   level: 5
   signal_type: usage_volume
   confidence: medium
-  note: '333,111,291 downloads in the trailing 30 days (mcp 333,111,291), read 2026-08-12. Bands at level
-    5 (>10M) on the software and model adoption scale. Moved off the stars fallback: a real download signal
-    exists, and docs/reference/adoption.md says to re-band when one does. The package is PyPI `mcp` carries
-    Repository = github.com/modelcontextprotocol/python-sdk and author ''Model Context Protocol a Series
-    of LF Projects, LLC'', so the name is first-party rather than squatted. Recorded level was 3.'
+  note: '333,111,291 downloads in the trailing 30 days (mcp 333,111,291). Bands at level 5 (>10M) on the
+    software and model adoption scale. Moved off the stars fallback: a real download signal exists, and
+    docs/reference/adoption.md says to re-band when one does. The package is PyPI `mcp` carries Repository
+    = github.com/modelcontextprotocol/python-sdk and author ''Model Context Protocol a Series of LF Projects,
+    LLC'', so the name is first-party rather than squatted. Recorded level was 3.'
   reach: '>10M'
   last_verified: '2026-08-12'
   sources:
@@ -72,14 +70,10 @@ capability:
   value: client+server; every standard transport - stdio, Streamable HTTP and SSE; tools, resources and prompts;
     an `mcp` CLI (dev/run/install)
   confidence: high
-  note: 'Most complete Python MCP toolkit. Re-read 2026-08-13, and the recorded value did not fully survive
-    it. The README has been trimmed to three bullets - build servers exposing "tools, resources, and prompts
-    to any MCP host", build clients, and "Speak every standard transport: stdio, Streamable HTTP, and SSE"
-    - and no longer mentions FastMCP, structured output, OAuth 2.1 or elicitation anywhere on the page. Those
-    clauses are removed rather than restated elsewhere, because a capability value has to be traceable to
-    the source under it and these now are not. The band is left at 5: what the page does show is still the
-    reference implementation of the protocol in Python, carrying every transport the spec defines, and nothing
-    suggests capability was lost - only that the README stopped enumerating it.'
+  note: 'Most complete Python MCP toolkit. The README enumerates servers exposing "tools, resources, and
+    prompts to any MCP host", clients, and "Speak every standard transport: stdio, Streamable HTTP, and
+    SSE"; the value is held to what that page supports, and the 5 rests on this still being the reference
+    implementation of the protocol in Python, carrying every transport the spec defines.'
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/modelcontextprotocol/python-sdk

--- a/sources/scores/mcp-typescript-sdk.yaml
+++ b/sources/scores/mcp-typescript-sdk.yaml
@@ -34,8 +34,8 @@ openness:
   last_verified: '2026-08-13'
   sources:
   - url: https://www.npmjs.com/package/@modelcontextprotocol/sdk
-    shows: The npm package page. Not re-read this pass - the registry answered HTTP 403 to the fetcher on
-      2026-08-13 - so the license was re-derived from the repository LICENSE and package.json instead.
+    shows: The npm package page. The registry answers HTTP 403 to the fetcher, so the license is derived
+      from the repository LICENSE and package.json instead.
     accessed: '2026-06-17'
   - url: https://raw.githubusercontent.com/modelcontextprotocol/typescript-sdk/main/LICENSE
     shows: 'The MCP transition license, whose digest is byte-identical to the spec repo''s: "The MCP project
@@ -70,9 +70,9 @@ adoption:
   level: 5
   signal_type: usage_volume
   confidence: high
-  note: 198,046,096 npm downloads in the trailing 30 days for @modelcontextprotocol/sdk, read 2026-08-12.
-    Bands at level 5 (>10M) on the software and model adoption scale. The reference TypeScript MCP SDK,
-    and the highest download figure on the map.
+  note: 198,046,096 npm downloads in the trailing 30 days for @modelcontextprotocol/sdk. Bands at level
+    5 (>10M) on the software and model adoption scale. The reference TypeScript MCP SDK, and the highest
+    download figure on the map.
   reach: '>10M'
   last_verified: '2026-08-12'
   sources:
@@ -86,11 +86,7 @@ capability:
   basis: feature_matrix
   value: client+server; Node/Bun/Deno; Streamable-HTTP/stdio; auth + framework middleware
   confidence: high
-  note: 'Feature parity with the Python SDK; the canonical JS/TS MCP implementation. Re-read 2026-08-13:
-    the repository still publishes the full client and server libraries across the Node/Bun/Deno runtimes
-    with the stdio and Streamable-HTTP transports, and it remains the reference implementation the spec repo
-    points at. The recorded value is unchanged and the 5 stands - the same rung as the Python SDK, which
-    is what parity means here.'
+  note: Feature parity with the Python SDK; the canonical JS/TS MCP implementation.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/modelcontextprotocol/typescript-sdk

--- a/sources/scores/megatron-lm.yaml
+++ b/sources/scores/megatron-lm.yaml
@@ -151,13 +151,10 @@ capability:
     weak-scaling benchmark to a 462B-parameter GPT on 6,144 H100 GPUs at 47–48% MFU, strong scaling of a
     ~175B GPT-3 from 96 to 4,608 H100 GPUs.'
   confidence: high
-  note: 'Reference-grade large-scale transformer training infrastructure, and the capability anchor the rest
+  note: Reference-grade large-scale transformer training infrastructure, and the capability anchor the rest
     of this category places itself against. The parallelism, precision and scaling facts now sit in `value`
-    with establishing sources rather than being asserted here. No MLPerf-Training submission verified for the
-    library itself, so the basis is feature_matrix plus NVIDIA-reported scaling benchmarks. Re-read 2026-08-13
-    as the anchor for this category''s closing pass. Nothing moved; the date is bumped because three products
-    in finetuning_code now record a relation against this score, and check_capability will not let a derived
-    band claim a confirmation more recent than the anchor it derives from.'
+    with establishing sources rather than being asserted here. No MLPerf-Training submission verified for
+    the library itself, so the basis is feature_matrix plus NVIDIA-reported scaling benchmarks.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/NVIDIA/Megatron-LM

--- a/sources/scores/memryx-mx3.yaml
+++ b/sources/scores/memryx-mx3.yaml
@@ -21,11 +21,7 @@ openness:
       raw: open_market (Amazon/Mouser ~$149)
   confidence: high
   note: Proprietary dataflow silicon with public datasheets, retail availability, and several open source
-    runtime/driver repos, though the compiler core is closed. Re-read 2026-08-13 - the M.2 datasheet is
-    still published openly and still offers module specification, pinout, placement and strap-pin tables
-    and no board design files; MxAccl is still MPL-2.0 and still directs users to the MemryX SDK for
-    "precompiled libraries, drivers, and tools", which is the closed half of `toolchain - partial`. No
-    dimension moved.
+    runtime/driver repos, though the compiler core is closed.
   raw: schematics:none;toolchain:partial (open runtime (MxAccl) + utils + driver mirror, closed NeuralCompiler);datasheets:public;blobs:required
     (proprietary silicon);retail:open_market (Amazon/Mouser ~$149)
   last_verified: '2026-08-13'
@@ -63,11 +59,9 @@ adoption:
   reach: niche
   signal_type: reported_traction
   confidence: medium
-  note: Low-cost retail availability (Amazon, Mouser), independent reviews, a 2025 industry award, and
-    an active GitHub org point to growing but emerging traction. Re-read 2026-08-13 - the Tom's Hardware
-    launch coverage still stands and still puts the module at $149, and MxAccl is still a live public
-    repo. The article names no distributor, so the Amazon/Mouser half of the note rests on the earlier
-    read rather than on anything re-confirmed today. Level and reach unchanged.
+  note: Low-cost retail availability (Amazon, Mouser), independent reviews, a 2025 industry award, and an
+    active GitHub org point to growing but emerging traction. Tom's Hardware's launch coverage puts the
+    module at $149 but names no distributor, so the Amazon/Mouser half of the note rests on an earlier read.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.tomshardware.com/tech-industry/artificial-intelligence/memryx-launches-usd149-mx3-m-2-ai-accelerator-module-capable-of-24-tops-compute-power
@@ -87,14 +81,13 @@ capability:
   value: 6 TOPS/chip, up to 24 TOPS (4-chip M.2); 4/8/16-bit weights + BFloat16; ~42M params per module
   confidence: high
   note: Moderate throughput with flexible precision, but on-chip parameter capacity caps deployable model
-    size. Re-read 2026-08-13 - the M.2 datasheet no longer carries a TOPS figure, a data-format list or
-    a parameter-capacity number at all; its specification table is now system, electrical, mechanical,
-    environmental and compliance only. The throughput half of the recorded value was re-derived instead
-    from the launch coverage, which still reads "Each MX3 chip is said to deliver 6 TOPS ... offering a
-    total of up to 24 TOPS" and "particularly those optimized for 8-bit weights". The 4/8/16-bit plus
-    BFloat16 formats and the ~42M-parameter capacity are no longer supported by any cited source and are
-    flagged for a curator ruling. The band is unchanged - 24 TOPS still sits above the 6 TOPS SBCs and
-    below the Jetson Orin line.
+    size. The M.2 datasheet no longer carries a TOPS figure, a data-format list or a parameter-capacity
+    number at all - its specification table is now system, electrical, mechanical, environmental and compliance
+    only. The throughput half of the recorded value rests instead on the launch coverage, which reads "Each
+    MX3 chip is said to deliver 6 TOPS ... offering a total of up to 24 TOPS" and "particularly those optimized
+    for 8-bit weights". The 4/8/16-bit plus BFloat16 formats and the ~42M-parameter capacity are supported
+    by no cited source and are flagged for a curator ruling. The band holds - 24 TOPS still sits above the
+    6 TOPS SBCs and below the Jetson Orin line.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.tomshardware.com/tech-industry/artificial-intelligence/memryx-launches-usd149-mx3-m-2-ai-accelerator-module-capable-of-24-tops-compute-power

--- a/sources/scores/meta-ai.yaml
+++ b/sources/scores/meta-ai.yaml
@@ -18,17 +18,11 @@ openness:
     source:
       value: closed
       detail: assistant Meta hosts and operates; the Meta AI Terms grant rights of access and use only
-  note: 'Meta AI the assistant/UI is a closed proprietary consumer product; scored as closed counterpart.
-    (Llama-the-model openness is a separate restricted-class score.)
-    Re-checked 2026-08-14. The Meta AI Terms cited below still cannot be fetched - facebook.com answers
-    an automated request with HTTP 400 on every path tried, and so do the meta.com, about.meta.com and
-    whatsapp.com mirrors, so that source keeps its 2026-08-11 read and is not re-dated. The confirmation
-    rests instead on Meta''s own newsroom, which describes Meta AI as an assistant Meta builds and runs,
-    powered by Meta''s own Muse Spark 1.1 and delivered through the Meta AI app and meta.ai. Nothing on
-    that page offers source, a repository or a self-hostable build - a managed service with no
-    self-hostable implementation is the ladder''s closed rung. The demandsage aggregator line that also
-    sat here was dropped - it answers 403 and the terms source already superseded it. Score unchanged
-    at 1.'
+  note: Meta AI the assistant/UI is a closed proprietary consumer product; scored as closed counterpart.
+    (Llama-the-model openness is a separate restricted-class score.) Meta's own newsroom describes an assistant
+    Meta builds and runs, powered by its own Muse Spark 1.1 and delivered through the Meta AI app and meta.ai,
+    offering no source, no repository and no self-hostable build - a managed service with no self-hostable
+    implementation is the ladder's closed rung.
   raw: client:proprietary(closed consumer app/embedded surface);backend:hosted-SaaS;note:underlying Llama
     weights are restricted (non-OSI) and model-layer scored elsewhere;the assistant product is closed;source:closed(assistant
     Meta hosts and operates; the Meta AI Terms grant rights of access and use only)
@@ -66,14 +60,7 @@ adoption:
     reported growing to ~1.2B MAU by Q1 2026, ~63% of interactions on WhatsApp. Far above the >10M threshold.
     CAVEAT: a portion of these MAU reflect surfaced/embedded exposure inside WhatsApp/IG rather than deliberate
     assistant use (one analyst, Kantrowitz, argues engaged usage is far lower than OpenAI''s). Attributed
-    honestly to the embedded surface, not a standalone assistant count.
-    Re-read 2026-08-13. The TechCrunch report is still up and still carries Zuckerberg at the annual
-    shareholder meeting saying Meta AI has one billion monthly active users across the apps, doubling
-    the 500 million of September 2024. The Yahoo Finance piece is still up and still carries the Alex
-    Kantrowitz counter-argument that engaged usage is far below that headline. The Facebook post
-    carrying the same quote could not be refetched - facebook.com answers an automated request with HTTP
-    400 - so it keeps its earlier read and the confirmation rests on the other two. The
-    embedded-exposure caveat above is unchanged. Level unchanged at 5.'
+    honestly to the embedded surface, not a standalone assistant count.'
   last_verified: '2026-08-13'
   sources:
   - url: https://www.facebook.com/yahoofinance/posts/zuck-says-meta-ai-has-more-than-one-billion-monthly-active-users-/1194397235888386/
@@ -98,16 +85,13 @@ capability:
     delivered through the Meta AI app, meta.ai and Meta''s messaging surfaces; consumer single-user (no
     enterprise RAG / multi-provider model hub / org-data grounding)'
   confidence: medium
-  note: 'Broad-reach consumer assistant but narrow on the ui_api feature axes, one provider, consumer-only,
-    no enterprise/org-data depth. Not a category frontier-definer on capability.
-    Re-checked 2026-08-14 against Meta''s own newsroom, replacing the demandsage aggregator line, which
-    answers 403 and was in any case a third-party summary. The newsroom post moves two things and
-    narrows a third. The assistant now runs on Muse Spark 1.1 from Meta Superintelligence Labs rather
-    than Llama 4, so the model line is restated. It now connects to email and calendar apps, generates
-    slides and executes multi-step plans, so the old ''limited plugin/tool breadth'' clause is dropped
-    as no longer true. What the page still shows no sign of is enterprise or org-data grounding or any
-    third-party model choice, which is what holds the band down. Score unchanged at 3, but the agentic
-    expansion is worth a re-banding look - FLAGGED, not changed.'
+  note: Broad-reach consumer assistant but narrow on the ui_api feature axes, one provider, consumer-only,
+    no enterprise/org-data depth. Not a category frontier-definer on capability. The assistant now runs
+    on Muse Spark 1.1 from Meta Superintelligence Labs rather than Llama 4, and it connects to email and
+    calendar apps, generates slides and executes multi-step plans, so the earlier limited-plugin/tool-breadth
+    clause no longer holds. What still does not appear is enterprise or org-data grounding or any third-party
+    model choice, which is what holds the band down. The agentic expansion is worth a re-banding look -
+    FLAGGED, not changed.
   last_verified: '2026-08-14'
   sources:
   - url: https://about.fb.com/news/2026/07/meta-ai-muse-spark-doesnt-just-think-it-acts/

--- a/sources/scores/microsoft-copilot.yaml
+++ b/sources/scores/microsoft-copilot.yaml
@@ -15,9 +15,6 @@ openness:
       detail: closed
   confidence: high
   note: Fully proprietary, SaaS/embedded, the closed counterpart on the UI/API shelf.
-    Re-read 2026-08-13. The admin usage doc still describes a Microsoft-operated service reported on
-    through the Microsoft 365 admin center, with nothing published and no self-host path anywhere in it.
-    Value unchanged at 1 / closed.
   raw: license:proprietary(SaaS/embedded);source:closed;self-host:none;model:OpenAI+Microsoft(closed)
   last_verified: '2026-08-13'
   sources:
@@ -33,24 +30,19 @@ adoption:
   reach: '>10M users'
   signal_type: active_users
   confidence: medium
-  note: ~420M monthly active users across all Copilot surfaces (Windows/Edge/M365/Bing/mobile) reported
-    Q1 2026, with ~160M enterprise-licensed; far above the >10M threshold. Actively-engaged M365 seats
-    are much lower (~33M), but the consumer + embedded surface reach is mass-market. Headline aggregated
-    figure traces to Microsoft disclosures via aggregators; primary per-surface breakdown not directly
-    fetched, so medium confidence.
-    Re-read 2026-08-13, and the aggregator has restated its numbers. Business of Apps now leads with 218
-    million active users across Windows, the app and the website, plus 88 million downloads since launch
-    - the ~420M all-surfaces figure and the ~160M enterprise-licensed figure recorded above are no
-    longer on the page. 218 million is still an active count and still far above the >10M users
-    threshold, so the level is unchanged at 5 and only the supporting number has moved. The Microsoft
-    admin doc still exists as the vendor-side reporting surface and still publishes no aggregate count
-    itself.
+  note: Business of Apps reports 218 million active users across Windows, the app and the website, plus
+    88 million downloads since launch - far above the >10M threshold. An earlier read of the same aggregator
+    carried ~420M across all Copilot surfaces with ~160M enterprise-licensed, and those figures are no longer
+    on the page; the supporting number moved, not the band. Actively-engaged M365 seats are much lower (~33M),
+    but the consumer and embedded surface reach is mass-market. The headline traces to Microsoft disclosures
+    via an aggregator rather than a primary per-surface breakdown, so confidence is medium; Microsoft's
+    own admin reporting surface publishes no aggregate count of its own.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.businessofapps.com/data/microsoft-copilot-statistics/
-    shows: 218 million active users across Windows, the app and the website, plus 88M downloads since launch,
-      read 2026-08-13; the ~420M all-surfaces and ~160M enterprise-licensed figures this record was scored
-      on are no longer on the page (aggregator compiling Microsoft disclosures)
+    shows: 218 million active users across Windows, the app and the website, plus 88M downloads since launch;
+      the ~420M all-surfaces and ~160M enterprise-licensed figures this record was scored on are no longer
+      on the page (aggregator compiling Microsoft disclosures)
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 04c097ae27fcca82a43519f2690785da7ec504948cf6ceaf1817f6b08d11f2cd
@@ -69,12 +61,10 @@ capability:
     (locked to OpenAI/Microsoft).'
   confidence: medium
   note: Feature-rich chat UI with class-leading enterprise grounding/integration; not frontier-defining
-    within this category because it is locked to one model provider and not self-hostable.
-    Re-read 2026-08-13. The usage doc still enumerates Copilot working inside Teams meetings, chat and
-    channels, Word, Excel, Outlook and the rest of Microsoft 365, alongside a separately reported
-    Copilot Chat surface, which is the embedded-grounding breadth the band rests on. The page does not
-    name the Graph by that word, so the grounding claim is read from the app coverage rather than
-    quoted. The provider lock to OpenAI and Microsoft models is unchanged. Band unchanged at 4.
+    within this category because it is locked to one model provider and not self-hostable. The cited usage
+    doc enumerates Copilot working inside Teams meetings, chat and channels, Word, Excel, Outlook and the
+    rest of Microsoft 365, which is the embedded-grounding breadth the band rests on; it does not name the
+    Graph by that word, so the grounding claim is read from app coverage rather than quoted.
   last_verified: '2026-08-13'
   sources:
   - url: https://learn.microsoft.com/en-us/microsoft-365/admin/activity-reports/microsoft-365-copilot-usage?view=o365-worldwide

--- a/sources/scores/milvus.yaml
+++ b/sources/scores/milvus.yaml
@@ -12,12 +12,10 @@ openness:
     free_text:
     - LF-AI&Data-governed(Zilliz-Cloud is managed hosting, not gated core)
   confidence: high
-  note: 'license:Apache-2.0;source:public;LF-AI&Data-governed(Zilliz-Cloud is managed hosting, not gated
-    core). Re-read 2026-08-13: the LICENSE file resolves to the full Apache License 2.0 text, the repo
-    page carries an "Apache-2.0 license" badge, docker-compose self-host instructions and Zilliz Cloud
-    named only as the managed offering beside it, and Wikipedia''s infobox records Apache License 2.0 with
-    LF AI & Data graduation in June 2021. Nothing is withheld from the published tree, so source:public
-    and core-gated:ungated both hold.'
+  note: license:Apache-2.0;source:public;LF-AI&Data-governed(Zilliz-Cloud is managed hosting, not gated
+    core). The LICENSE file resolves to the full Apache-2.0 text, the repo carries the matching badge and
+    docker-compose self-host instructions, and Zilliz Cloud is named only as the managed offering beside
+    it, so nothing is withheld from the published tree.
   raw: license:Apache-2.0;source:public;LF-AI&Data-governed(Zilliz-Cloud is managed hosting, not gated core);core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -88,15 +86,10 @@ capability:
   basis_detail: ANN-Benchmarks
   value: null
   confidence: high
-  note: 'High-performance cloud-native vector ANN search; covered by independent ANN-Benchmarks and first-party
-    VectorDBBench. v2.6 adds Storage Format V2, advanced JSON, BM25 full-text search. Rated on ANN benchmark
-    coverage / scale. Re-read 2026-08-13: milvus.io now leads with "Announcing Milvus 3.0 - Lake-Native
-    Vector Search, S3-based storage, and a More Powerful Retrieval Engine", so the released line has moved
-    past the v2.6 the note describes; the first-party benchmark harness is still there, now branded VDB
-    Bench ("Setting up a Milvus cluster for performance testing or benchmarking? Refer to VDB Bench"), and
-    the index-selection guidance still spans HNSW / IVF_SQ8 / IVF_PQ / DiskANN up to billion scale. BM25
-    full-text search is still described. The band 4 rests on that benchmark coverage and scale and is unchanged;
-    only the version prose above is now behind the product.'
+  note: High-performance cloud-native vector ANN search, covered by independent ANN-Benchmarks and by the
+    first-party VDB Bench harness. The released line is Milvus 3.0 - lake-native vector search, S3-based
+    storage and a more powerful retrieval engine - and index-selection guidance spans HNSW / IVF_SQ8 / IVF_PQ
+    / DiskANN up to billion scale, with BM25 full-text search. Rated 4 on ANN benchmark coverage and scale.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/milvus-io/milvus

--- a/sources/scores/mimo-pro.yaml
+++ b/sources/scores/mimo-pro.yaml
@@ -15,9 +15,6 @@ openness:
       detail: HF card; older GitHub repo shows Apache-2.0
   confidence: medium
   note: Open weights under a permissive license (MIT per the model card); no open training data -> open_weights.
-    Re-read 2026-08-13 - the Hub still reports `mit` and ungated for MiMo-V2.5-Pro, the card names no
-    training corpus, and XiaomiMiMo/MiMo is still a public Apache-2.0 repository. The recorded
-    license note already flags that split and it still holds.
   last_verified: '2026-08-13'
   raw: weights:open(MIT per HF card);data:closed;code:open;license:MIT(HF card; older GitHub repo shows
     Apache-2.0)
@@ -46,10 +43,9 @@ adoption:
   level: 2
   signal_type: usage_volume
   confidence: medium
-  note: 59,525 Hugging Face downloads in the trailing 30 days for XiaomiMiMo/MiMo-V2.5-Pro, read 2026-08-12.
-    Bands at level 2 (10K-100K) on the software and model adoption scale. Recorded 4 against its own cited
-    figure of 66,027, which is level 2 on this scale. Corrected from level 4, which the recorded evidence
-    did not support.
+  note: 59,525 Hugging Face downloads in the trailing 30 days for XiaomiMiMo/MiMo-V2.5-Pro. Bands at level
+    2 (10K-100K) on the software and model adoption scale. Recorded 4 against its own cited figure of 66,027,
+    which is level 2 on this scale. Corrected from level 4, which the recorded evidence did not support.
   reach: 10K-100K
   last_verified: '2026-08-12'
   sources:
@@ -66,12 +62,9 @@ capability:
     band (~#29 per mirrors)
   confidence: medium
   note: Frontier open-weights model, efficiency-focused; official benchmarks, Arena rank mirror-reported.
-    Re-read 2026-08-13, and the evidence moved even though the band did not. Xiaomi's own page now
-    defers the numbers - "See the model card on Hugging Face for architecture details, evaluation
-    tables" - so all four recorded figures were re-derived from the model card instead, where MMLU
-    89.4, MMLU-Pro 68.5, GSM8K 99.6 and HumanEval+ 75.6 are all present. The LMArena rank in the value
-    is mirror-reported and was NOT re-confirmed; it has no cited source and the band does not rest on
-    it, resting instead on the card benchmarks.
+    Xiaomi's own page defers the numbers to the Hugging Face model card, where MMLU 89.4, MMLU-Pro 68.5,
+    GSM8K 99.6 and HumanEval+ 75.6 all appear; the LMArena rank in the value is mirror-reported with no
+    cited source, and the band rests on the card's benchmarks rather than on it.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro

--- a/sources/scores/minimax.yaml
+++ b/sources/scores/minimax.yaml
@@ -16,12 +16,10 @@ openness:
       detail: custom, see HF LICENSE
   governing_release: minimax-m3
   confidence: high
-  note: Weights distributed under the custom minimax-community license with a closed corpus, so 3. M3 governs as
-    the current release. Capability 5 is carried from M2.5 because M3 records no capability score at all, so the
-    tier's capability describes the older release and should be re-read when M3 is benchmarked - it is the one axis
-    here not sourced to the governing release. Re-read 2026-08-13 - the M3 repository is still ungated
-    and still names minimax-community as its license, created 2026-06-02, and the card ships
-    deployment instructions for vLLM and SGLang but no corpus and no training pipeline. Nothing moved.
+  note: Weights distributed under the custom minimax-community license with a closed corpus, so 3. M3 governs
+    as the current release. Capability 5 is carried from M2.5 because M3 records no capability score at
+    all, so the tier's capability describes the older release and should be revisited when M3 is benchmarked
+    - it is the one axis here not sourced to the governing release.
   last_verified: '2026-08-13'
   raw: weights:open(on HF; ungated; safetensors/BF16; MoE);data:closed;code:partial(inference only; no training
     pipeline/data);license:minimax-community(custom, see HF LICENSE)
@@ -42,23 +40,21 @@ openness:
     content_sha256: 4ec7abb96a3e52ca379834d74b8352101ac5de0b391b70a2b2c7af0fc6ffc393
     establishes: [weights, data, code, license]
   - url: https://venturebeat.com/technology/minimax-m3-debuts-eclipsing-gpt-5-5-and-gemini-3-1-pro-on-key-benchmark-performance-for-just-5-10-of-the-cost
-    shows: 'NOT RE-READ: the host answered HTTP 429 to the 2026-08-13 attempt after retries, so this source
-      was not re-confirmed and is not part of this axis''s date.'
+    shows: VentureBeat piece on the MiniMax M3 debut; the host answers HTTP 429, so it is not a live source
+      for this axis.
     accessed: '2026-06-04'
 adoption:
   level: 3
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: 'HF model card reports ~693,331 downloads in the last month (100K-1M band); additionally served via
-    OpenRouter and free in coding tools (Kilo Code). Headline figure is the HF monthly download count.
-    Artifact declared and read live 2026-08-13: 169,325 Hugging Face downloads in the trailing 30 days. Bands
-    at 100K-1M, level 3. This record previously claimed usage_volume - a download count - while declaring no
-    artifact any signal model reads, so no computed figure existed for the recorded band to disagree with.
-    Declared artifact is MiniMaxAI/MiniMax-M3, the release the product record says currently governs. Level
-    unchanged; the note''s previous ~693k figure was not re-derivable by anything. Re-derived again from
-    the API endpoint on 2026-08-13 as part of the category pass, giving the same 169,325 and the same
-    level-3 band, so the axis is now confirmed rather than part-read.'
+  note: 'HF model card reports ~693,331 downloads in the last month (100K-1M band); additionally served
+    via OpenRouter and free in coding tools (Kilo Code). Headline figure is the HF monthly download count.
+    Artifact declared: 169,325 Hugging Face downloads in the trailing 30 days. Bands at 100K-1M, level 3.
+    This record previously claimed usage_volume - a download count - while declaring no artifact any signal
+    model reads, so no computed figure existed for the recorded band to disagree with. Declared artifact
+    is MiniMaxAI/MiniMax-M3, the release the product record says currently governs. Level unchanged; the
+    note''s previous ~693k figure was not re-derivable by anything.'
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/models/MiniMaxAI/MiniMax-M3
@@ -77,12 +73,11 @@ capability:
   value: SWE-bench Verified 80.2%, SWE-bench Pro 55.4%, GPQA-D 85.2%, AIME25 86.3%, BrowseComp 76.3%; VIBE-Pro on
     par with Opus 4.5
   confidence: medium
-  note: Frontier-tier among open-weights agentic chat models (SWE-bench Verified 80.2% with strong reasoning/browse
-    scores), at very low serving cost. Figures are MiniMax-reported on the HF card; not independently audited but
-    consistent with peer open models (Kimi K2.6, DeepSeek-V4). Re-read 2026-08-13 - all five figures
-    are still on the M2.5 card, so the band is re-derived and unchanged at 5. The caveat the openness
-    note raises still stands and is the real limit here - this describes M2.5 while M3 governs the
-    tier, and MiniMax has published no comparable table for M3.
+  note: 'Frontier-tier among open-weights agentic chat models (SWE-bench Verified 80.2% with strong reasoning/browse
+    scores), at very low serving cost. Figures are MiniMax-reported on the HF card; not independently audited
+    but consistent with peer open models (Kimi K2.6, DeepSeek-V4). The caveat the openness note raises is
+    the real limit here: the five figures come from the M2.5 card while M3 governs the tier, and MiniMax
+    has published no comparable table for M3.'
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/MiniMaxAI/MiniMax-M2.5

--- a/sources/scores/mistral-7b-instruct.yaml
+++ b/sources/scores/mistral-7b-instruct.yaml
@@ -15,10 +15,7 @@ openness:
     - name: Apache-2.0
       detail: OSI permissive
   confidence: high
-  note: Apache-2.0 open weights; instruction-tuning data and recipe undisclosed -> open_weights. Re-read
-    2026-08-13 - the card still carries `license:apache-2.0`, still reads `"gated":false`, and still describes
-    the instruction fine-tune in one paragraph with no SFT mixture, no RLHF data and no training code.
-    No change.
+  note: Apache-2.0 open weights; instruction-tuning data and recipe undisclosed -> open_weights.
   raw: weights:open(Apache-2.0, on HF);data:closed;code:closed(no training/post-training pipeline);license:Apache-2.0(OSI
     permissive)
   last_verified: '2026-08-13'
@@ -36,11 +33,10 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: ~2.5M downloads last month on HF plus a very large derivative ecosystem (~1,089 finetunes, 1,256 adapters,
-    349 merges); still a heavily used permissive 7B instruct base years after release. Re-read 2026-08-13
-    - the single declared SKU now reads 1,206,680 downloads in the trailing 30 days, still level 4, and
-    the model tree still shows roughly 1,100 finetunes, 1,200 adapters and 351 merges. The download figure
-    has roughly halved since the last read but stays inside 1M-10M. No change.
+  note: ~2.5M downloads last month on HF plus a very large derivative ecosystem (~1,089 finetunes, 1,256
+    adapters, 349 merges); still a heavily used permissive 7B instruct base years after release. The single
+    declared SKU reads 1,206,680 downloads in the trailing 30 days, still level 4, with a model tree of
+    roughly 1,100 finetunes, 1,200 adapters and 351 merges.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2
@@ -56,19 +52,11 @@ capability:
   value: Mistral 7B Instruct v0.2 MT-Bench 7.6 (Mistral-reported); underlying Mistral 7B base MMLU 60.1%;
     v0.1-Instruct MT-Bench 6.84. 2023-era 7B chat quality
   confidence: medium
-  note: Excellent for a 7B in 2023-24; clearly below 2026 frontier and below modern small instruct models (Phi-4-mini,
-    Qwen 3.x small). Capability low on a frontier-anchored scale. Re-read 2026-08-13 - the card carries no
-    benchmark table at all. It links arXiv:2310.06825, which is the base "Mistral 7B" paper rather than an
-    evaluation of this instruct tune, so neither the ~MT-Bench 7.6 nor the ~MMLU 60 in the recorded value is
-    re-derivable from the cited source. The 2 is not in doubt on the evidence, but the figures have no source
-    behind them. Both figures were found on 2026-08-14 and both needed re-attributing. The MT-Bench 7.6
-    is Mistral's own and is specifically about this tune - the La Plateforme launch post says
-    "Mistral-tiny. Our most cost-effective endpoint currently serves Mistral 7B Instruct v0.2 ... It
-    obtains 7.6 on MT-Bench." That it is version-specific matters, because Table 3 of the paper gives
-    v0.1-Instruct at 6.84, so the citation has to point at the post rather than the paper. The MMLU
-    ~60 is real at 60.1% but belongs to the Mistral 7B BASE model in Table 2 of the paper; Mistral
-    publishes no MMLU for the v0.2 instruct tune anywhere found, so the value now attributes it to the
-    base. Score unchanged at 2.
+  note: Excellent for a 7B in 2023-24; clearly below 2026 frontier and below modern small instruct models
+    (Phi-4-mini, Qwen 3.x small). Capability low on a frontier-anchored scale. The MT-Bench 7.6 comes from
+    Mistral's La Plateforme post and is specific to v0.2 - the paper's Table 3 gives v0.1-Instruct 6.84
+    - and the MMLU 60.1% belongs to the Mistral 7B BASE model in Table 2 rather than to this instruct tune.
+    The model card itself carries no benchmark table.
   last_verified: '2026-08-14'
   sources:
   - url: https://mistral.ai/news/la-plateforme

--- a/sources/scores/mistral-fine-tuning-api.yaml
+++ b/sources/scores/mistral-fine-tuning-api.yaml
@@ -19,11 +19,11 @@ openness:
   note: 'The hosted FT API on Mistral''s Studio platform (formerly branded La Plateforme) is a proprietary
     managed service (LoRA adapters under the hood); no source for the service. Mistral separately ships
     an OSS mistral-finetune SDK for self-hosting, but that is a distinct product from this managed API.
-    Verified 2026-08-09: Mistral''s own docs now file the service under ''Deprecated features > Fine-tuning
-    API (legacy)'' with a banner reading ''This feature is deprecated and is no longer actively supported'';
-    the current API pricing catalog lists ongoing training/storage billing only for the Classifier API tier,
-    with no separate catalog entry for general text/vision SFT. Openness is unaffected either way: still
-    a closed, proprietary managed offering with no self-hostable implementation.'
+    Mistral''s own docs file the service under ''Deprecated features > Fine-tuning API (legacy)'' with a
+    banner reading ''This feature is deprecated and is no longer actively supported'', and the current API
+    pricing catalog lists ongoing training/storage billing only for the Classifier API tier, with no separate
+    catalog entry for general text/vision SFT. Openness is unaffected either way: still a closed, proprietary
+    managed offering with no self-hostable implementation.'
   last_verified: '2026-08-09'
   raw: source:closed;training-pipeline:closed;runs-on:La-Plateforme-only;license:Proprietary(managed service,
     per-token + storage pricing); base-weights:Mistral-models(open-weight variants exist)
@@ -73,14 +73,11 @@ adoption:
   reach: null
   signal_type: unknown
   confidence: low
-  note: 'No disclosed standalone usage figure for the Mistral fine-tuning API located this run (jobs run /
-    customers tuning). La Plateforme is a widely used developer platform, but no honest per-SKU FT signal was
-    found; declining to assign a level.  ABSTENTION RE-CONFIRMED 2026-08-13, and the date records that rather
-    than a measurement. Re-read the cited page and no usage figure has appeared - no jobs run, customers
-    tuning, models fine-tuned or developer count. A null level is a value here, not a gap: it says somebody
-    looked and the vendor publishes nothing, which is the honest answer for a feature sold inside a larger
-    platform. The corpus already dates abstentions this way (9 null axes carry a last_verified), and leaving
-    them undated would make an axis unverifiable forever purely because its answer is ''none''.'
+  note: 'No disclosed standalone usage figure exists for the Mistral fine-tuning API - no jobs run, customers
+    tuning, models fine-tuned or developer count. La Plateforme is a widely used developer platform, but
+    no honest per-SKU FT signal is published, so no level is assigned. A null level is a value here rather
+    than a gap: it says somebody looked and the vendor publishes nothing, which is the honest answer for
+    a feature sold inside a larger platform.'
   last_verified: '2026-08-13'
   sources:
   - url: https://mistral.ai/news/customization
@@ -98,9 +95,9 @@ capability:
   note: 'Narrower managed method set than the SFT+DPO+RFT services - LoRA SFT + classifier factory only,
     over Mistral''s own models, black-box. Scored 3: a real, capable managed LoRA-FT service but below the
     preference/RL-capable OpenAI/Azure/Together/Fireworks offerings (C4) and far below the OSS scale definers.
-    Verified 2026-08-09: Mistral''s docs still describe both methods (deprecated fine-tuning guide), but
-    the live API pricing catalog now lists ongoing billing only for the Classifier API tier, with no separate
-    entry for general text/vision SFT - a possible narrowing worth a closer read.'
+    Mistral''s docs still describe both methods in the deprecated fine-tuning guide, but the live API pricing
+    catalog lists ongoing billing only for the Classifier API tier, with no separate entry for general text/vision
+    SFT - a possible narrowing worth a closer read.'
   last_verified: '2026-08-09'
   sources:
   - url: https://docs.mistral.ai/resources/deprecated/finetuning

--- a/sources/scores/mistral-large.yaml
+++ b/sources/scores/mistral-large.yaml
@@ -15,13 +15,10 @@ openness:
       detail: OSI
   governing_release: mistral-large-3
   confidence: high
-  note: 'Apache-2.0 weights with closed data and no training code, so 3. Mistral relicensed between releases: Large
-    2 shipped under the Mistral Research License, which permits research and non-commercial use only and scored
-    2, and Large 3 is Apache-2.0. Large 3 governs, so the tier records the relicensing rather than the family''s
-    worst historical terms. Re-read 2026-08-13 - the launch post still says "We release both the base
-    and instruction fine-tuned versions of Mistral Large 3 under the Apache 2.0 license", the base
-    checkpoint on the Hub is still apache-2.0 and ungated, and neither the post nor the docs release
-    a corpus or a training pipeline. Nothing moved.'
+  note: 'Apache-2.0 weights with closed data and no training code, so 3. Mistral relicensed between releases:
+    Large 2 shipped under the Mistral Research License, which permits research and non-commercial use only
+    and scored 2, and Large 3 is Apache-2.0. Large 3 governs, so the tier records the relicensing rather
+    than the family''s worst historical terms.'
   last_verified: '2026-08-13'
   raw: weights:open(Apache-2.0);data:closed;code:closed;license:Apache-2.0(OSI)
   sources:
@@ -59,10 +56,10 @@ adoption:
   signal_type: usage_volume
   confidence: medium
   note: 5,971 downloads in the trailing 30 days (mistralai/Mistral-Large-Instruct-2407 4,714; mistralai/Mistral-Large-3-675B-Base-2512
-    80; mistralai/Mistral-Large-3-675B-Instruct-2512 1,177), read 2026-08-12. Bands at level 1 (<10K). Corrected
-    from level 3. Summed across the 2407 release and both Mistral Large 3 repos. The flagship is consumed
-    via API rather than downloaded, so this understates real use - but the map bands on the declared artifacts,
-    and the honest label is the one they support.
+    80; mistralai/Mistral-Large-3-675B-Instruct-2512 1,177). Bands at level 1 (<10K). Corrected from level
+    3. Summed across the 2407 release and both Mistral Large 3 repos. The flagship is consumed via API rather
+    than downloaded, so this understates real use - but the map bands on the declared artifacts, and the
+    honest label is the one they support.
   last_verified: '2026-08-12'
   sources:
   - url: https://huggingface.co/api/models/mistralai/Mistral-Large-Instruct-2407
@@ -87,10 +84,8 @@ capability:
   value: null
   confidence: high
   note: 'Debuts #2 in LMArena OSS non-reasoning category (#6 among all OSS models). Per-benchmark MMLU-Pro/GPQA/SWE-bench
-    not given in the launch post. Re-read 2026-08-13 - the ranking sentence is still on the post
-    verbatim and the band is unchanged at 4. It is a launch-day placement rather than a current
-    leaderboard read, which is the limit of what this source can support and the reason the band is
-    not a 5.'
+    not given in the launch post. The ranking is a launch-day placement rather than a current leaderboard
+    read, which is the limit of what this source can support and the reason the band is not a 5.'
   last_verified: '2026-08-13'
   sources:
   - url: https://mistral.ai/news/mistral-3/

--- a/sources/scores/mlflow.yaml
+++ b/sources/scores/mlflow.yaml
@@ -13,10 +13,7 @@ openness:
     - core-fully-OSS(Databricks-Managed-MLflow is third-party hosting, not gated core)
   confidence: high
   note: Apache-2.0 across a fully published core; Databricks Managed MLflow is third-party hosting rather
-    than a gated core. Re-read 2026-08-13 and unchanged - LICENSE.txt is the Apache License 2.0 verbatim,
-    the repository publishes the whole platform, and mlflow.org still describes itself as "the leading
-    open source AI engineering platform" with observability, evaluations, prompt registry and gateway all
-    listed as features of it rather than of a paid tier.
+    than a gated core.
   raw: license:Apache-2.0;source:public;core-fully-OSS(Databricks-Managed-MLflow is third-party hosting,
     not gated core);core-gated:ungated
   last_verified: '2026-08-13'
@@ -52,13 +49,11 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: 'Re-scored 4->5. 37.10M PyPI downloads in the last 30 days (verified on
-    pypistats; the prior note already reported 25-30M+ but mislabeled the reach as
-    1M-10M). The map''s prevailing usage_volume level-5 floor is >10M/mo (cf.
-    pydantic-ai ~31M, langgraph ~58M at level 5). MLflow is the de facto open
-    experiment-tracking / ML-lifecycle platform and clears the floor comfortably. Re-read 2026-08-13 - the
-    pypistats endpoint now returns last_month 42,050,608, up from the 37,102,636 recorded and still well
-    clear of the >10M floor, so level 5 is unchanged.'
+  note: Re-scored 4->5. 37.10M PyPI downloads in the last 30 days (verified on pypistats; the prior note
+    already reported 25-30M+ but mislabeled the reach as 1M-10M). The map's prevailing usage_volume level-5
+    floor is >10M/mo (cf. pydantic-ai ~31M, langgraph ~58M at level 5). MLflow is the de facto open experiment-tracking
+    / ML-lifecycle platform and clears the floor comfortably. pypistats now returns last_month 42,050,608,
+    above the 37,102,636 this note was set on and still well clear of the >10M floor.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/mlflow/recent
@@ -81,8 +76,7 @@ capability:
   note: Single open platform combining distributed tracing, prompt versioning, automated evaluation, and
     trace replay for agents/LLMs plus classic ML tracking. No standard benchmark for observability; rated
     on feature matrix. The comparison is now recorded rather than left in prose - at the langfuse anchor,
-    the two being the pair the rest of this category is placed against. Re-read 2026-08-13 - the GenAI page
-    still lists observability, evaluation, prompt registry and AI gateway as one platform.
+    the two being the pair the rest of this category is placed against.
   last_verified: '2026-08-13'
   sources:
   - url: https://mlflow.org/genai/

--- a/sources/scores/mmlu-pro.yaml
+++ b/sources/scores/mmlu-pro.yaml
@@ -16,9 +16,7 @@ openness:
       value: public
       detail: test+validation, no hidden held-out
   confidence: high
-  note: 'Fully open: MIT, ungated, redistributable, comprehensive card. Re-read 2026-08-13: `license:mit`
-    is still in the repo tags, the embedded repo state reads `"gated":false`, and the card still
-    documents the test and validation splits with no hidden held-out set. No change.'
+  note: 'Fully open: MIT, ungated, redistributable, comprehensive card.'
   raw: license:MIT(OSI/open,redistributable);access:public(not gated);datasheet:present(comprehensive card+leaderboard);splits:public(test+validation,
     no hidden held-out)
   last_verified: '2026-08-13'
@@ -41,10 +39,10 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: 170,681 Hugging Face downloads in the trailing 30 days (TIGER-Lab/MMLU-Pro), read 2026-08-12. Bands
-    at level 4 (100K-1M) on the dataset adoption scale, whose top band is >1M - one order of magnitude below
-    the software and model scales, because no dataset artifact in the corpus has ever exceeded 10M. A standard
-    knowledge/reasoning benchmark cited across frontier model reports.
+  note: 170,681 Hugging Face downloads in the trailing 30 days (TIGER-Lab/MMLU-Pro). Bands at level 4 (100K-1M)
+    on the dataset adoption scale, whose top band is >1M - one order of magnitude below the software and
+    model scales, because no dataset artifact in the corpus has ever exceeded 10M. A standard knowledge/reasoning
+    benchmark cited across frontier model reports.
   last_verified: '2026-08-12'
   sources:
   - url: https://huggingface.co/api/datasets/TIGER-Lab/MMLU-Pro
@@ -57,9 +55,7 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: Dataset, not 'capable'; openness and adoption carry this category per recipe. Re-read 2026-08-13
-    and the abstention stands - the page publishes a static question set and no performance or feature
-    claim the capability axis could band.
+  note: Dataset, not 'capable'; openness and adoption carry this category per recipe.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/TIGER-Lab/MMLU-Pro

--- a/sources/scores/mmlu.yaml
+++ b/sources/scores/mmlu.yaml
@@ -18,10 +18,7 @@ openness:
       value: public
       detail: ICLR 2021
   confidence: high
-  note: 'Clean open data: MIT, downloadable, documented datasheet, public paper: full open class.
-    Re-read 2026-08-13: `license:mit` is still in the repo tags, the embedded repo state reads
-    `"gated":false` so the parquet is still freely downloadable, and the dataset card still renders.
-    No change.'
+  note: 'Clean open data: MIT, downloadable, documented datasheet, public paper: full open class.'
   raw: data:downloadable(HF parquet, cais/mmlu);license:MIT(OSI/open);datasheet:present(card documents 57
     subjects, splits dev/val/test, schema);redistributable:yes;paper:public(ICLR 2021)
   last_verified: '2026-08-13'
@@ -39,11 +36,11 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: 477,890 Hugging Face downloads in the trailing 30 days (cais/mmlu), read 2026-08-12. Bands at level
-    4 (100K-1M) on the dataset adoption scale, whose top band is >1M - one order of magnitude below the
-    software and model scales, because no dataset artifact in the corpus has ever exceeded 10M. The canonical
-    general-knowledge LLM benchmark, reported in essentially every frontier model release since 2021; a
-    universal reference even post-saturation.
+  note: 477,890 Hugging Face downloads in the trailing 30 days (cais/mmlu). Bands at level 4 (100K-1M) on
+    the dataset adoption scale, whose top band is >1M - one order of magnitude below the software and model
+    scales, because no dataset artifact in the corpus has ever exceeded 10M. The canonical general-knowledge
+    LLM benchmark, reported in essentially every frontier model release since 2021; a universal reference
+    even post-saturation.
   last_verified: '2026-08-12'
   sources:
   - url: https://huggingface.co/api/datasets/cais/mmlu
@@ -58,8 +55,6 @@ capability:
   confidence: high
   note: Dataset, not capability-scored. Saturation/contamination (top models 88-94%, superseded by MMLU-Pro
     for differentiation) is a quality caveat noted in version_note, not an openness or capability deduction.
-    Re-read 2026-08-13 and the abstention stands - the page publishes a static question set and no
-    performance or feature claim the capability axis could band.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/cais/mmlu

--- a/sources/scores/mmmu.yaml
+++ b/sources/scores/mmmu.yaml
@@ -18,10 +18,8 @@ openness:
       raw: dev+validation+test all public (test answers released 2026-02-12; previously EvalAI-gated)
   confidence: high
   note: 'Fully open: Apache-2.0, ungated, redistributable, comprehensive card. Test-set answers were released
-    2026-02-12 (previously held out via EvalAI), so there is no longer a held-out element; scored 5 as
-    a fully-public benchmark. Re-read 2026-08-13: the card news list still carries the 2026-02-12 entry
-    releasing the test answers, the EvalAI submission instruction is still struck through, `license:apache-2.0`
-    is still in the repo tags and the embedded repo state reads `"gated":false`. No change.'
+    2026-02-12 (previously held out via EvalAI), so there is no longer a held-out element; scored 5 as a
+    fully-public benchmark.'
   raw: license:Apache-2.0(OSI/open,redistributable);access:public(not gated);datasheet:present(comprehensive
     card);splits:dev+validation+test all public (test answers released 2026-02-12; previously EvalAI-gated)
   last_verified: '2026-08-13'
@@ -46,10 +44,10 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 51,058 Hugging Face downloads in the trailing 30 days (MMMU/MMMU), read 2026-08-12. Bands at level
-    3 (10K-100K) on the dataset adoption scale, whose top band is >1M - one order of magnitude below the
-    software and model scales, because no dataset artifact in the corpus has ever exceeded 10M. MMMU / MMMU-Pro
-    is a standard multimodal-understanding benchmark cited in frontier multimodal model reports.
+  note: 51,058 Hugging Face downloads in the trailing 30 days (MMMU/MMMU). Bands at level 3 (10K-100K) on
+    the dataset adoption scale, whose top band is >1M - one order of magnitude below the software and model
+    scales, because no dataset artifact in the corpus has ever exceeded 10M. MMMU / MMMU-Pro is a standard
+    multimodal-understanding benchmark cited in frontier multimodal model reports.
   last_verified: '2026-08-12'
   sources:
   - url: https://huggingface.co/api/datasets/MMMU/MMMU
@@ -62,9 +60,7 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: Dataset, not 'capable'; openness and adoption carry this category per recipe. Re-read 2026-08-13
-    and the abstention stands - the page publishes a static multimodal question set and no performance
-    or feature claim the capability axis could band.
+  note: Dataset, not 'capable'; openness and adoption carry this category per recipe.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/MMMU/MMMU

--- a/sources/scores/modal-sandboxes.yaml
+++ b/sources/scores/modal-sandboxes.yaml
@@ -20,14 +20,9 @@ openness:
       detail: free starter credits
       raw: pay-as-you-go usage, free starter credits
   confidence: high
-  note: 'Closed managed service. The client SDK is open, but the execution substrate is a proprietary
-    managed cloud with no self-host; an open client over a closed runtime is not open_core. Corrects a
-    prior mis-calibration that grouped Modal with the genuinely self-hostable E2B (E2B ships self-hostable
-    infra; Modal does not). Re-read 2026-08-13 - the pricing page still sells only metered access to
-    Modal''s own cloud across Starter, Team and Enterprise plans, with Sandbox compute billed per core-
-    and GiB-second and no self-hosted, on-premises or source-available option offered at any tier; the
-    Sandboxes guide still drives everything through Modal SDKs against that cloud. Source and license
-    both read as recorded.'
+  note: Closed managed service. The client SDK is open, but the execution substrate is a proprietary managed
+    cloud with no self-host; an open client over a closed runtime is not open_core. Corrects a prior mis-calibration
+    that grouped Modal with the genuinely self-hostable E2B (E2B ships self-hostable infra; Modal does not).
   raw: license:Proprietary;source:closed;service:proprietary Modal managed cloud (no self-host of the gVisor
     execution plane);open-part:client SDK only (modal Python/JS client libraries);pricing:pay-as-you-go
     usage, free starter credits
@@ -64,15 +59,13 @@ adoption:
   signal_type: reported_traction
   confidence: low
   banded_quantity: Modal platform teams (10,000+), not Sandboxes sessions or jobs
-  note: No disclosed Modal Sandboxes user/usage count on primary pages; Modal is a well-known managed
-    AI-compute platform with broad developer use and a documented free tier. Placed at 3 on reported multi-customer
-    traction, not a measured usage_volume figure (kept conservative absent a hard number). Re-read
-    2026-08-13 - still no Sandboxes user, session or job count anywhere on the docs or pricing pages,
-    and no free-tier signup number. The nearest figure Modal publishes is platform-wide rather than
-    per-product - its sandbox comparison page claims Modal "powers infrastructure for over 10,000
-    teams" and names Lovable and Quora as production users running untrusted code - which is a
-    reported-traction claim of exactly the kind already banded, not a count of Sandboxes use. The
-    abstention on reach and the level 3 both stand.
+  note: No disclosed Modal Sandboxes user/usage count on primary pages; Modal is a well-known managed AI-compute
+    platform with broad developer use and a documented free tier. Placed at 3 on reported multi-customer
+    traction, not a measured usage_volume figure (kept conservative absent a hard number). The nearest figure
+    Modal publishes is platform-wide rather than per-product - its sandbox comparison page claims Modal
+    "powers infrastructure for over 10,000 teams" and names Lovable and Quora as production users running
+    untrusted code - which is a reported-traction claim of exactly the kind already banded, not a count
+    of Sandboxes use, so the abstention on reach stands.
   last_verified: '2026-08-13'
   sources:
   - url: https://modal.com/docs/guide/sandbox
@@ -102,18 +95,15 @@ capability:
     sandbox lookup, custom images; scale:reported 50,000+ concurrent sessions; timeouts default 5min up
     to 24h
   confidence: medium
-  note: 'Strong, purpose-built agent sandbox: gVisor isolation + arbitrary images + high concurrency.
-    Sits just below the Firecracker-microVM frontier (Lambda/Vercel) on isolation strength; scored 4,
-    level with the Ray/Ollama capability anchors. Independent ComputeSDK TTI benchmarks measure ~470ms
-    median cold-start (13th of 19 sandbox providers), consistent with the fast-container-stack claim.
-    Re-read 2026-08-13 - the Sandboxes guide still documents arbitrary custom images, named lookup and
-    a 5-minute default lifetime extendable to 24 hours, and Modal''s own comparison page still states
-    gVisor isolation and 50,000+ concurrent sessions. The ComputeSDK leaderboard has moved on from the
-    run cited above - its 2026-08-07 run covers 24 providers and puts Modal at a 0.76s median TTI
-    (0.82s P95, composite 92.1), 14th by median rather than the ~470ms/13th-of-19 recorded here. Slower
-    in absolute terms and unchanged in placement - still mid-field, still short of the sub-0.3s leaders
-    and well clear of the multi-second tail. The comparison to the ray anchor (capability 4, confirmed
-    2026-08-13) is unchanged, so the band holds at 4.'
+  note: 'Strong, purpose-built agent sandbox: gVisor isolation, arbitrary images and high concurrency. The
+    Sandboxes guide documents arbitrary custom images, named lookup and a 5-minute default lifetime extendable
+    to 24 hours, and Modal''s own comparison page states gVisor isolation and 50,000+ concurrent sessions.
+    Sits just below the Firecracker-microVM frontier (Lambda/Vercel) on isolation strength; scored 4, level
+    with the Ray/Ollama capability anchors and recorded as relative_to ray with relation `at`. Independent
+    ComputeSDK TTI benchmarks put Modal at a 0.76s median cold-start, 0.82s P95, composite 92.1, 14th by
+    median of 24 providers, against ~470ms and 13th of 19 on the earlier run - slower in absolute terms
+    and unchanged in placement, still mid-field, still short of the sub-0.3s leaders and well clear of the
+    multi-second tail.'
   last_verified: '2026-08-13'
   sources:
   - url: https://modal.com/docs/guide/sandbox

--- a/sources/scores/model-context-protocol.yaml
+++ b/sources/scores/model-context-protocol.yaml
@@ -78,17 +78,11 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: 'De facto standard agent tool protocol, adopted natively by OpenAI (ChatGPT, Agents SDK, Responses
-    API), Google DeepMind (Gemini), Microsoft and AWS, with more than 16,000 MCP servers in the wild. Re-read
-    2026-08-13, and one recorded figure did not survive it: the note claimed "~97M monthly SDK downloads
-    in Mar 2026 (up from ~2M at Nov 2024 launch)" and "4,750% growth since launch" on the strength of the
-    Zuplo retrospective. That page carries neither figure and never could have - it is dated 2025-11-24,
-    four months before the month it was cited for. What it does say is "Over 16,000 MCP servers exist in
-    the wild" and the vendor-adoption list, both of which the note keeps. The download claim has been replaced
-    with a measured one from the two reference SDK registries, read the same day: 335,363,270 PyPI downloads
-    in the trailing 30 days for `mcp` and 198,046,096 npm downloads for @modelcontextprotocol/sdk. Either
-    alone clears the >10M level-5 floor by more than an order of magnitude, so level 5 and reach >10M are
-    unchanged and now rest on a countable figure rather than on an aggregator sentence that was not there.'
+  note: De facto standard agent tool protocol, adopted natively by OpenAI (ChatGPT, Agents SDK, Responses
+    API), Google DeepMind (Gemini), Microsoft and AWS, with more than 16,000 MCP servers in the wild. The
+    band rests on the two reference SDK registries - 335,363,270 PyPI downloads in the trailing 30 days
+    for `mcp` and 198,046,096 npm downloads for @modelcontextprotocol/sdk - either of which clears the >10M
+    level-5 floor by more than an order of magnitude.
   last_verified: '2026-08-13'
   sources:
   - url: https://en.wikipedia.org/wiki/Model_Context_Protocol
@@ -124,76 +118,72 @@ capability:
   note: 'A wire protocol is not benchmarked; capability is not a meaningful axis per recipe. Openness +
     adoption carry the signal.
 
-    A NULL WORTH SETTLING, flagged 2026-08-13. A null capability does not abstain the way a
-    null adoption does - build/serialize.py falls through to adoption alone rather than dropping the
-    product - so this record computes maturity 5.0 from its adoption 5 and counts as a mature open
-    product on one axis while a reader assumes two.
+    A NULL WORTH SETTLING, flagged 2026-08-13. A null capability does not abstain the way a null adoption
+    does - build/serialize.py falls through to adoption alone rather than dropping the product - so this
+    record computes maturity 5.0 from its adoption 5 and counts as a mature open product on one axis while
+    a reader assumes two.
 
-    CORRECTION, recorded because the first version of this note overstated it: it said the category''s
-    stage rested on this null, on the reasoning that one mature open product is the entire stage>=4
-    threshold. Re-derived against build/serialize.py during the category pass, agent_tools_protocols
-    has SEVEN mature open products, six of which reach 4.5 with no null in the arithmetic. That clears
-    _STAGE5_MIN_MATURE, so the category is stage 5 and deleting this record entirely would leave six
-    and change nothing. The defect is policy hygiene, not a threshold rescue.
+    CORRECTION, recorded because the first version of this note overstated it: it said the category''s stage
+    rested on this null, on the reasoning that one mature open product is the entire stage>=4 threshold.
+    Re-derived against build/serialize.py during the category pass, agent_tools_protocols has SEVEN mature
+    open products, six of which reach 4.5 with no null in the arithmetic. That clears _STAGE5_MIN_MATURE,
+    so the category is stage 5 and deleting this record entirely would leave six and change nothing. The
+    defect is policy hygiene, not a threshold rescue.
 
-    The recommendation from that pass is to DECLARE adoption-only grading for protocols rather than
-    score capability here, because implementation breadth is adoption wearing a capability label -
-    the map already bands this product''s adoption on SDK downloads, so putting breadth in capability
-    makes the blend (adoption + adoption) / 2. agent2agent-protocol has the identical shape. See
-    docs/reference/gap-analysis.md, "The two nulls are not symmetric".
+    The recommendation from that pass is to DECLARE adoption-only grading for protocols rather than score
+    capability here, because implementation breadth is adoption wearing a capability label - the map already
+    bands this product''s adoption on SDK downloads, so putting breadth in capability makes the blend (adoption
+    + adoption) / 2. agent2agent-protocol has the identical shape. See docs/reference/gap-analysis.md, "The
+    two nulls are not symmetric".
 
 
-    RE-DERIVED 2026-08-13 in the agent_tools_protocols pass, and the premise above is WRONG on the
-    facts, which changes what is at stake rather than whether it matters. The null is not load-bearing
-    for the category. Counting the rule in build/serialize.py against the current corpus, seven fully-open
-    products in this category clear the 4.5 maturity floor - model-context-protocol, fastmcp, qdrant,
-    mcp-python-sdk, mcp-typescript-sdk, docling and markitdown - and six of the seven get there from a
-    real adoption AND a real capability score with no null anywhere in the arithmetic. Seven is at or
-    above _STAGE5_MIN_MATURE, so the category is at stage 5 rather than stage 4, and striking this record
-    out entirely leaves six, still above the threshold. So the claim "this category''s stage-4 claim rests
-    on an axis nobody has scored" was an error; the stage does not move either way.
+    RE-DERIVED 2026-08-13 in the agent_tools_protocols pass, and the premise above is WRONG on the facts,
+    which changes what is at stake rather than whether it matters. The null is not load-bearing for the
+    category. Counting the rule in build/serialize.py against the current corpus, seven fully-open products
+    in this category clear the 4.5 maturity floor - model-context-protocol, fastmcp, qdrant, mcp-python-sdk,
+    mcp-typescript-sdk, docling and markitdown - and six of the seven get there from a real adoption AND
+    a real capability score with no null anywhere in the arithmetic. Seven is at or above _STAGE5_MIN_MATURE,
+    so the category is at stage 5 rather than stage 4, and striking this record out entirely leaves six,
+    still above the threshold. So the claim "this category''s stage-4 claim rests on an axis nobody has
+    scored" was an error; the stage does not move either way.
 
-    What remains true is the methodological defect, and it should still be settled - a record that
-    computes a maturity of 5.0 from one axis, while a reader assumes two, is wrong in a way that will
-    matter in a category with fewer mature products. The recommendation from this pass is the SECOND
-    option, declaring adoption-only grading, and against the first. Every candidate basis for a score
-    fails a different test. Implementation breadth is adoption wearing a capability label: the map already
-    bands MCP''s adoption on SDK downloads and A2A''s on the count of supporting organizations, so putting
-    breadth here would let one instrument vote twice and make the blend (adoption + adoption) / 2. Spec
-    maturity is genuinely independent of uptake, but there is no ladder for it anywhere in the four
-    rubrics, it would be a fifth instrument sharing the `capability` field name with benchmark,
-    feature_matrix and internal-eval - the collision docs/reference/evidence-and-freshness.md already names as the
-    reason not to structure this field - and with only two protocols on the map there is nothing to
-    anchor a `relative_to` against. A two-product feature matrix against agent2agent-protocol is the only
-    option the existing machinery could enforce, and it requires un-nulling A2A first, so it is not a
-    smaller change than the declaration. Declaring the exclusion fixes both protocols and every future
-    one in a single move, and it converts a fallback nobody chose into a policy someone can argue with.
+    What remains true is the methodological defect, and it should still be settled - a record that computes
+    a maturity of 5.0 from one axis, while a reader assumes two, is wrong in a way that will matter in a
+    category with fewer mature products. The recommendation from this pass is the SECOND option, declaring
+    adoption-only grading, and against the first. Every candidate basis for a score fails a different test.
+    Implementation breadth is adoption wearing a capability label: the map already bands MCP''s adoption
+    on SDK downloads and A2A''s on the count of supporting organizations, so putting breadth here would
+    let one instrument vote twice and make the blend (adoption + adoption) / 2. Spec maturity is genuinely
+    independent of uptake, but there is no ladder for it anywhere in the four rubrics, it would be a fifth
+    instrument sharing the `capability` field name with benchmark, feature_matrix and internal-eval - the
+    collision docs/reference/evidence-and-freshness.md already names as the reason not to structure this
+    field - and with only two protocols on the map there is nothing to anchor a `relative_to` against. A
+    two-product feature matrix against agent2agent-protocol is the only option the existing machinery could
+    enforce, and it requires un-nulling A2A first, so it is not a smaller change than the declaration. Declaring
+    the exclusion fixes both protocols and every future one in a single move, and it converts a fallback
+    nobody chose into a policy someone can argue with.
 
     DECLARED 2026-08-14, on the owner''s ruling. GRADING POLICY - A WIRE PROTOCOL IS GRADED ON OPENNESS
     AND ADOPTION ONLY, AND ITS CAPABILITY IS NULL BY POLICY RATHER THAN BY FALLBACK. The reasoning is the
-    one above and in docs/reference/gap-analysis.md, "The two nulls are not symmetric": implementation
-    breadth is adoption wearing a capability label, and this product''s adoption is ALREADY banded on SDK
-    downloads - 335M monthly PyPI downloads of `mcp` and 198M monthly npm downloads of
-    @modelcontextprotocol/sdk - so scoring breadth here would let one instrument vote twice and make the
-    blend (adoption + adoption) / 2. No score is invented to close the gap, which is the point of writing
-    the policy down instead.
-    What the reader should take from the null is therefore precise: not "nobody has got to this yet" but
-    "there is no independent capability question to ask of a specification". The known cost stands and is
-    stated rather than fixed here - build/serialize.py falls through to adoption alone rather than
-    dropping the product, so this record computes a maturity of 5.0 from one axis. That is a serializer
-    question, and it is not load-bearing for the category either way, since agent_tools_protocols has
-    seven mature open products and six reach 4.5 with no null in the arithmetic.
-    agent2agent-protocol has the identical shape and carries the same declaration.
-    Re-read 2026-08-14 and the premise still holds: the spec repo publishes a specification, a protocol
-    schema and documentation, and neither it nor anywhere the project points carries a benchmark,
-    leaderboard or measured performance figure for the protocol.'
+    one above and in docs/reference/gap-analysis.md, "The two nulls are not symmetric": implementation breadth
+    is adoption wearing a capability label, and this product''s adoption is ALREADY banded on SDK downloads
+    - 335M monthly PyPI downloads of `mcp` and 198M monthly npm downloads of @modelcontextprotocol/sdk -
+    so scoring breadth here would let one instrument vote twice and make the blend (adoption + adoption)
+    / 2. No score is invented to close the gap, which is the point of writing the policy down instead. What
+    the reader should take from the null is therefore precise: not "nobody has got to this yet" but "there
+    is no independent capability question to ask of a specification". The known cost stands and is stated
+    rather than fixed here - build/serialize.py falls through to adoption alone rather than dropping the
+    product, so this record computes a maturity of 5.0 from one axis. That is a serializer question, and
+    it is not load-bearing for the category either way, since agent_tools_protocols has seven mature open
+    products and six reach 4.5 with no null in the arithmetic. agent2agent-protocol has the identical shape
+    and carries the same declaration.'
   last_verified: '2026-08-14'
   sources:
   - url: https://api.github.com/repos/modelcontextprotocol/modelcontextprotocol
-    shows: 'Repo metadata read 2026-08-14 - description "Specification and documentation for the Model
-      Context Protocol", topics docs / mcp / specification / standard, 8,950 stars, homepage
-      modelcontextprotocol.io. What the project ships is a specification and its schema, and no benchmark
-      result, leaderboard entry or performance figure is published for it.'
+    shows: Repo metadata - description "Specification and documentation for the Model Context Protocol",
+      topics docs / mcp / specification / standard, 8,950 stars, homepage modelcontextprotocol.io. What
+      the project ships is a specification and its schema, and no benchmark result, leaderboard entry or
+      performance figure is published for it.
     accessed: '2026-08-14'
     http_status: 200
     content_sha256: 0756fabd71a36d29890ee7d2e08c29b43df3718acf2d99e45dba784e23572afe

--- a/sources/scores/morphic.yaml
+++ b/sources/scores/morphic.yaml
@@ -19,10 +19,6 @@ openness:
   confidence: high
   note: Fully OSI-licensed (Apache-2.0), full source public, Docker-deployable for self-hosting - a true
     open generative-search UI.
-    Re-read 2026-08-13. The repository still carries Apache-2.0 and the README still puts Docker first,
-    with a single compose file bringing up PostgreSQL, Redis, SearXNG and Morphic and no additional
-    search API key needed. Nothing is held back for a paid tier and no hosted edition is offered. Repo
-    now at 9,037 stars, latest release v1.5.0. Value unchanged at 5 / open_source.
   raw: license:Apache-2.0(OSI);source:public(github.com/miurla/morphic);self-host:primary(Docker);no-feature-gated-core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -36,10 +32,10 @@ adoption:
   level: 2
   signal_type: stars_fallback
   confidence: medium
-  note: 9,036 GitHub stars on miurla/morphic, read 2026-08-12. Bands at level 2 (1K-10K stars) on the stars
-    fallback scale, which caps at 3 because a star is not a use. Resynced because the note says stars_fallback
-    is 'capped at level 3' and recorded the cap. No download, install or customer figure is published for
-    this product, so stars remain the only honest signal and the level is directional.
+  note: 9,036 GitHub stars on miurla/morphic. Bands at level 2 (1K-10K stars) on the stars fallback scale,
+    which caps at 3 because a star is not a use. Resynced because the note says stars_fallback is 'capped
+    at level 3' and recorded the cap. No download, install or customer figure is published for this product,
+    so stars remain the only honest signal and the level is directional.
   reach: 1K-10K stars
   last_verified: '2026-08-12'
   sources:
@@ -55,16 +51,9 @@ capability:
     UI: rich inline components from streamed JSON; chat history + shareable URLs; file upload; guest mode;
     multi-user: limited'
   confidence: medium
-  note: Distinctive generative-UI answer surface with multi-provider/multi-search support, but scoped
-    to search-and-answer rather than the full chat-UI feature set (lighter on multimodal, plugins, enterprise
+  note: Distinctive generative-UI answer surface with multi-provider/multi-search support, but scoped to
+    search-and-answer rather than the full chat-UI feature set (lighter on multimodal, plugins, enterprise
     auth). Mid-tier for the category.
-    Re-read 2026-08-13. The README still lists the generative UI rendering source-credited inline
-    components from a streamed JSON spec, a model selector across OpenAI, Anthropic, Google, Ollama and
-    OpenAI-compatible providers, four search providers in Tavily, SearXNG, Brave and Exa, chat history
-    in PostgreSQL, shareable result URLs, file upload, Supabase auth and guest mode. The two search
-    modes are now named Quick and Adaptive rather than the earlier pair, and a Vercel AI Gateway
-    provider has been added. Still scoped to search-and-answer with no plugin surface or enterprise
-    auth. Band unchanged at 3.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/miurla/morphic

--- a/sources/scores/mt-bench.yaml
+++ b/sources/scores/mt-bench.yaml
@@ -55,11 +55,11 @@ adoption:
   level: 2
   signal_type: usage_volume
   confidence: medium
-  note: '2,361 downloads in the trailing 30 days (lmsys/mt_bench_human_judgments 2,361), read 2026-08-12.
-    Bands at level 2 (1K-10K) on the dataset adoption scale, whose top band is >1M. Moved off the stars
-    fallback: a real download signal exists, and docs/reference/adoption.md says to re-band when one does.
-    The package is the dataset itself rather than FastChat, whose 39.5k stars are shared across the whole
-    platform. This LOWERS the recorded level from 3 - the star count had been flattering it.'
+  note: '2,361 downloads in the trailing 30 days (lmsys/mt_bench_human_judgments 2,361). Bands at level
+    2 (1K-10K) on the dataset adoption scale, whose top band is >1M. Moved off the stars fallback: a real
+    download signal exists, and docs/reference/adoption.md says to re-band when one does. The package is
+    the dataset itself rather than FastChat, whose 39.5k stars are shared across the whole platform. This
+    LOWERS the recorded level from 3 - the star count had been flattering it.'
   reach: 1K-10K
   last_verified: '2026-08-12'
   sources:
@@ -73,11 +73,9 @@ capability:
   basis: feature_matrix
   value: 80 multi-turn questions across 8 categories; LLM-as-judge scoring
   confidence: medium
-  note: Seminal multi-turn chat benchmark that pioneered LLM-as-judge; now small and partly saturated vs harder
-    peers. Re-read 2026-08-13 - the paper abstract still introduces "MT-bench, a multi-turn question set"
-    as one of the two benchmarks behind the LLM-as-a-judge study, which is the feature reading the band
-    rests on, and the band is unchanged at 4. No peer is named in this note beyond a generic "harder
-    peers", so relative_to/relation stay unset per the capability-anchors rule.
+  note: Seminal multi-turn chat benchmark that pioneered LLM-as-judge; now small and partly saturated vs
+    harder peers. No peer is named in this note beyond a generic "harder peers", so relative_to and relation
+    stay unset per the capability-anchors rule.
   last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2306.05685

--- a/sources/scores/multipl-e.yaml
+++ b/sources/scores/multipl-e.yaml
@@ -25,8 +25,6 @@ openness:
     key no dimension reads, which left the ladder seeing clean MIT and computing 5/open. The dataset ladder
     declares no tier for a license that permits redistribution while bounding what you may use the corpus
     FOR, so the tier lookup abstains and the score stays where the curator put it rather than being invented.
-    Re-read 2026-08-13 - the repository LICENSE still carries clause 4 verbatim, the HF repo still tags
-    `license:mit` with `"gated":false`, and the card still documents the 47 subsets. No change.
   raw: data:downloadable(HF parquet, 47 subsets);license:BSD-3-Clause-with-ML-Restriction(the nuprl/MultiPL-E
     repository LICENSE, whose clause 4 forbids using the contents as training data for any machine learning
     model; the HF data artifact carries MIT);datasheet:present(card documents prompts/doctests/tests/stop-tokens);redistributable:yes(HF)
@@ -41,9 +39,9 @@ openness:
     content_sha256: 139bc9f97a3374a56283c91458ea94337b79577231751690bcdc70ea8594bf08
     establishes: [license, data, datasheet]
   - url: https://github.com/nuprl/MultiPL-E/blob/main/LICENSE
-    shows: LICENSE headed "BSD 3-Clause License with Machine Learning Restriction"; clause 4 still reads
-      "The contents of this repository may not be used as training data for any machine learning model,
-      including but not limited to neural networks." Re-fetched 2026-08-13 with an unchanged digest
+    shows: LICENSE headed "BSD 3-Clause License with Machine Learning Restriction"; clause 4 reads "The
+      contents of this repository may not be used as training data for any machine learning model, including
+      but not limited to neural networks."
     accessed: '2026-08-13'
     establishes:
     - license
@@ -67,9 +65,7 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: Dataset/translation framework, not capability-scored. Re-read 2026-08-13 and the abstention
-    stands - the corpus is a static translation of HumanEval and MBPP into other languages, with no
-    performance or feature claim the capability axis could band.
+  note: Dataset/translation framework, not capability-scored.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/nuprl/MultiPL-E

--- a/sources/scores/muse-spark.yaml
+++ b/sources/scores/muse-spark.yaml
@@ -13,22 +13,17 @@ openness:
     - name: Proprietary
       detail: meta.ai/Meta AI app + private API preview; no downloadable weights
   confidence: high
-  note: >-
-    No weights released, a closed assistant-surface model; only a private API preview. Fully closed.
-
-    Re-read 2026-08-13 - the Meta newsroom post still says Muse Spark "currently powers the Meta AI app and
-    website" and that "We will also be offering the model in private preview via API to select partners",
-    with no weights, corpus or training code anywhere on it. Two corrections to what this file recorded.
-    The clause about hoping to open source future versions is not on the page and has been dropped from the
-    source's `shows`. And the ai.meta.com blog answers HTTP 400 to a plain fetch on both attempts, so it
-    was not re-dated. No change to the score.
+  note: No weights released, a closed assistant-surface model; only a private API preview. Fully closed.
+    Meta's newsroom post says Muse Spark powers the Meta AI app and website and will be offered in private
+    preview via API to select partners, with no weights, corpus or training code anywhere on it; the ai.meta.com
+    engineering blog answers HTTP 400 to a plain fetch. The clause about hoping to open source future versions
+    is on neither page and has been dropped.
   raw: weights:closed;data:closed;code:closed;license:Proprietary(meta.ai/Meta AI app + private API preview;
     no downloadable weights)
   last_verified: '2026-08-13'
   sources:
   - url: https://ai.meta.com/blog/introducing-muse-spark-msl/
-    shows: Meta's engineering blog for Muse Spark. Returned HTTP 400 to a plain fetch on 2026-08-13, so
-      not re-dated.
+    shows: Meta's engineering blog for Muse Spark. It answers HTTP 400 to a plain fetch.
     accessed: '2026-06-04'
   - url: https://about.fb.com/news/2026/04/introducing-muse-spark-meta-superintelligence-labs/
     shows: 'Meta primary newsroom post - "Muse Spark is our most powerful model yet. It currently powers
@@ -45,16 +40,13 @@ adoption:
   signal_type: active_users
   confidence: low
   note: Powers the Meta AI assistant on meta.ai and the Meta AI app (rolling out to WhatsApp/Instagram/Facebook/Messenger/AI
-    glasses), an enormous consumer surface, but Meta discloses no Muse Spark-specific user count, and
-    at scoring time it is not yet the model behind the full family of surfaces. Placed at 4 on the consumer-app
-    surface it powers; not 5 because no standalone figure and rollout incomplete. Attributed honestly
-    to the surface, not the model. Re-read 2026-08-13 - the newsroom post now carries a 2026-05-12 update
-    saying the rollout the note called incomplete has happened ("When we launched Muse Spark last month,
-    we said we'd bring it everywhere. Today, we are"), covering WhatsApp, Instagram, Facebook, Messenger
-    and the Ray-Ban and Oakley glasses. The "rollout incomplete" half of the reason for holding this at 4
-    rather than 5 no longer holds; the "no standalone figure" half still does, and Meta still publishes no
-    Muse Spark user count. That is a scoring question rather than a freshness one and is FLAGGED. The band
-    is dated on the surface evidence, which was re-read in full.
+    glasses), an enormous consumer surface, but Meta discloses no Muse Spark-specific user count, and at
+    scoring time it is not yet the model behind the full family of surfaces. Placed at 4 on the consumer-app
+    surface it powers; not 5 because no standalone figure and rollout incomplete. Attributed honestly to
+    the surface, not the model. The newsroom post's 2026-05-12 update says the rollout has since happened
+    across WhatsApp, Instagram, Facebook, Messenger and the Ray-Ban and Oakley glasses, so the rollout-incomplete
+    half of the reason for holding this at 4 rather than 5 no longer applies; the no-standalone-figure half
+    still does, and Meta still publishes no Muse Spark user count. FLAGGED as a scoring question.
   last_verified: '2026-08-13'
   sources:
   - url: https://about.fb.com/news/2026/04/introducing-muse-spark-meta-superintelligence-labs/
@@ -65,8 +57,7 @@ adoption:
     http_status: 200
     content_sha256: b4da0bd8ec45f87c8e9286e187e29d136a5b4238efbe5b45f13b600c70aa2620
   - url: https://ai.meta.com/blog/introducing-muse-spark-msl/
-    shows: Meta's engineering blog for Muse Spark. Returned HTTP 400 to a plain fetch on 2026-08-13, so
-      not re-dated.
+    shows: Meta's engineering blog for Muse Spark. It answers HTTP 400 to a plain fetch.
     accessed: '2026-06-04'
 capability:
   score: 5
@@ -75,29 +66,15 @@ capability:
   value: 'arena.ai text leaderboard - muse-spark-1.2 (xHigh) ranked 4 of 391 models at 1498 +/-10;
     Artificial Analysis Intelligence Index 57, rank #14 of 188'
   confidence: medium
-  note: >-
-    Bumped 4 -> 5 on the strength of an LMArena placement that no longer exists.
-
-    Re-read 2026-08-13, and NEITHER source supports the record any more. The LMArena leaderboard does not
-    list Muse Spark at all - the string does not appear on the page - and it has changed instrument, now
-    ranking by win share with a confidence interval rather than by Elo, so the "~1487 Elo, #6 overall"
-    figure is gone in both senses. The top of the Agent board reads Claude Opus 5 (High) 12.01%, Claude
-    Opus 5 (Max) 12.00%, Claude Fable 5 (High) 11.98%. The Meta engineering blog that carried the HLE 58%
-    and FrontierScience 38% figures answers HTTP 400 to a plain fetch, so those are unsourced too. This is
-    exactly the failure the bump was meant to close, in reverse.
-
-    Replacement found 2026-08-14, and the band survives on it. lmarena.ai now 301s to arena.ai, whose
-    TEXT board still ranks by an Elo-style score - the win-share board hit on 2026-08-13 was the Agent
-    board, a different instrument on the same site. On the text board Muse Spark IS present, as
-    muse-spark-1.2 (xHigh), ranked 4 of 391 models at 1498 +/-10, behind only three Anthropic entries.
-    Artificial Analysis corroborates independently at 57 on their Intelligence Index, #14 of 188.
-
-    Two narrowings the new evidence forces. The placement belongs to the 1.2 xHigh release rather than
-    to "mid-2026" generally, and the value has been rewritten to say so. And the HLE 58% /
-    FrontierScience 38% figures still have no fetchable home - ai.meta.com answers HTTP 400 to the
-    repo's own fetcher on a third attempt, so those numbers are dropped from the value rather than
-    carried unsourced. The 5 now rests on a top-5 arena placement and a #14/188 index rank, both
-    re-derivable.
+  note: 'The 5 rests on a top-5 arena placement and a #14/188 index rank, both re-derivable. arena.ai''s
+    TEXT board - lmarena.ai 301s to it - ranks muse-spark-1.2 (xHigh) 4 of 391 models at 1498 +/-10, behind
+    only three Anthropic entries, and Artificial Analysis corroborates independently at 57 on its Intelligence
+    Index, rank #14 of 188. Two narrowings the evidence forces. The placement belongs to the 1.2 xHigh release
+    rather than to the tier generally, and the value says so. And the HLE 58% / FrontierScience 38% figures
+    the record once carried have no fetchable home - ai.meta.com answers HTTP 400 to the repo''s fetcher
+    - so they are dropped rather than carried unsourced. The LMArena Elo placement the original 4 -> 5 bump
+    rested on is gone in both senses: the site''s Agent board now ranks by win share rather than Elo, and
+    the old ~1487 Elo / #6 overall figure appears on neither board.'
   last_verified: '2026-08-14'
   sources:
   - url: https://arena.ai/leaderboard/text
@@ -114,7 +91,6 @@ capability:
     http_status: 200
     content_sha256: efd6d68244a9fbe139a9ab0b4851ad821fa126f8de802ce720b7dd1319915d3c
   - url: https://ai.meta.com/blog/introducing-muse-spark-msl/
-    shows: the former source of the HLE 58% and FrontierScience 38% figures. Answered HTTP 400 to the
-      repo's fetcher again on 2026-08-14, so those figures remain unsourced and have been dropped from
-      the value.
+    shows: The former source of the HLE 58% and FrontierScience 38% figures. It answers HTTP 400 to the
+      repo's fetcher, so those figures remain unsourced and have been dropped from the value.
     accessed: '2026-06-04'

--- a/sources/scores/n8n.yaml
+++ b/sources/scores/n8n.yaml
@@ -12,11 +12,7 @@ openness:
     commercial:
       value: n8n-Cloud/Enterprise
   confidence: high
-  note: 'Source-available fair-code, not OSI open source: the license restricts commercial/hosted use.
-    Re-read 2026-08-13 - the docs page still states that n8n uses the Sustainable Use License and the
-    n8n Enterprise License, both based on the fair-code model, with proprietary licenses available for
-    enterprise customers, and the repo README repeats it verbatim alongside "Source Available - always
-    visible source code". Stars are now 200.5k. Nothing moved.'
+  note: 'Source-available fair-code, not OSI open source: the license restricts commercial/hosted use.'
   raw: 'license:Sustainable-Use-License(fair-code,non-OSI: internal-use-only,no-resale/SaaS)+n8n-Enterprise-License;source:public;commercial:n8n-Cloud/Enterprise'
   last_verified: '2026-08-13'
   sources:
@@ -42,10 +38,9 @@ adoption:
   level: 4
   signal_type: usage_volume
   confidence: high
-  note: 'About 3,265,167 downloads a month across the product''s real distribution channels, read 2026-08-12.
-    Docker Hub reports 246,014,721 cumulative pulls of n8nio/n8n since 2019-06-22, which over 86 months
-    averages roughly 2,871,429 a month; 393,738 come from npm  in the trailing 30 days. Bands at level 4
-    (1M-10M).
+  note: 'About 3,265,167 downloads a month across the product''s real distribution channels. Docker Hub
+    reports 246,014,721 cumulative pulls of n8nio/n8n since 2019-06-22, which over 86 months averages roughly
+    2,871,429 a month; 393,738 come from npm in the trailing 30 days. Bands at level 4 (1M-10M).
 
 
     n8n is deployed overwhelmingly as a self-hosted Docker container; the npm package is a minority install
@@ -72,11 +67,8 @@ capability:
   value: visual node-based workflow builder; 400+ integrations; native AI/LLM + agent nodes (LangChain); custom
     JS/Python code; webhooks/triggers/scheduling; self-host or cloud; RBAC (gated)
   confidence: medium
-  note: 'Broad automation/iPaaS scope with AI as one native layer; wider but shallower on pure agent depth
-    than the dedicated frameworks. Re-read 2026-08-13 - the repo now leads as "the platform for AI agents
-    and workflow automation", combining a visual canvas with custom code, self-hosted or cloud, over the
-    same integration library and AI/agent nodes. The feature matrix that placed this band is unchanged.
-    At dify and langflow, the other visual builders on this map.'
+  note: Broad automation/iPaaS scope with AI as one native layer; wider but shallower on pure agent depth
+    than the dedicated frameworks. At dify and langflow, the other visual builders on this map.
   relative_to: dify
   relation: at
   last_verified: '2026-08-13'

--- a/sources/scores/nano-graphrag.yaml
+++ b/sources/scores/nano-graphrag.yaml
@@ -13,9 +13,8 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: 'Fully MIT. Re-read 2026-08-13 - the repo page still reports MIT over the whole tree and publishes
-    the entire reimplementation, with no hosted tier, enterprise directory or license key. Stars are now
-    4.0k. Nothing moved.'
+  note: 'Fully MIT: the entire reimplementation is published, with no hosted tier, enterprise directory
+    or license key, so the core is ungated as well as OSI-licensed.'
   raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -33,11 +32,10 @@ adoption:
   level: 1
   signal_type: usage_volume
   confidence: medium
-  note: '1,334 downloads in the trailing 30 days (nano-graphrag 1,334), read 2026-08-12. Bands at level
-    1 (<10K) on the software and model adoption scale. Moved off the stars fallback: a real download signal
-    exists, and docs/reference/adoption.md says to re-band when one does. The package is first-party; no release
-    since October 2024 and the figure is declining. This LOWERS the recorded level from 2 - the star count
-    had been flattering it.'
+  note: '1,334 downloads in the trailing 30 days (nano-graphrag 1,334). Bands at level 1 (<10K) on the software
+    and model adoption scale. Moved off the stars fallback: a real download signal exists, and docs/reference/adoption.md
+    says to re-band when one does. The package is first-party; no release since October 2024 and the figure
+    is declining. This LOWERS the recorded level from 2 - the star count had been flattering it.'
   reach: <10K
   last_verified: '2026-08-12'
   sources:
@@ -52,11 +50,9 @@ capability:
   value: global+local queries; KG community detection; pluggable stores; multi-provider LLMs; incremental insert;
     async+typed
   confidence: medium
-  note: 'Trades breadth/polish for a small readable core. Re-read 2026-08-13 - the repo still describes
-    itself as "a simple, easy-to-hack GraphRAG implementation" and publishes the same global and local
-    query modes, community detection, pluggable stores and multi-provider LLM support. Development has
-    stalled at 155 commits with no release since 2024, so the surface is unchanged in both senses. One
-    below graphrag, the fuller implementation it reimplements.'
+  note: Trades breadth/polish for a small readable core. Development has stalled at 155 commits with no
+    release since 2024, so the surface is unchanged in both senses. One below graphrag, the fuller implementation
+    it reimplements.
   relative_to: graphrag
   relation: one_below
   last_verified: '2026-08-13'

--- a/sources/scores/nemo-curator.yaml
+++ b/sources/scores/nemo-curator.yaml
@@ -16,9 +16,7 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (Apache-2.0), full source public. Vendor-backed but not gated. Re-read 2026-08-13
-    - the LICENSE body still carries the same license and the README still builds the whole product from
-    the published repo, with no paid tier, enterprise edition or license key anywhere in it.
+  note: Fully OSI-licensed (Apache-2.0), full source public. Vendor-backed but not gated.
   raw: license:Apache-2.0(OSI);source:public(NVIDIA/NeMo-Curator);governance:NVIDIA;no feature-gated core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -44,9 +42,9 @@ adoption:
   reach: <10K
   signal_type: usage_volume
   confidence: high
-  note: 4,075 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (nemo-curator 4,075). Bands at level 1 (<10K) on the software and model adoption scale. Corrected from
-    level 2, which the declared artifacts do not support.
+  note: 4,075 downloads in the trailing 30 days summed across the 1 declared artifact(s) (nemo-curator 4,075).
+    Bands at level 1 (<10K) on the software and model adoption scale. Corrected from level 2, which the
+    declared artifacts do not support.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/nemo-curator/recent
@@ -64,9 +62,7 @@ capability:
     ~4x more unique tokens than DCLM/FineWeb-Edu.
   confidence: high
   note: 'Benchmark-anchored on the output corpus (proxy): Nemotron-CC matches or beats the DCLM/FineWeb-Edu
-    frontier, especially at long-horizon token budgets. Re-read 2026-08-13 - the arXiv abstract still reports
-    +5.6 MMLU over DCLM at 8B/1T, four times more unique real tokens than DCLM, and the 15T-token run beating
-    Llama 3.1 8B. The recorded comparison to dclm holds, both sitting at 5.'
+    frontier, especially at long-horizon token budgets.'
   last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2412.02595

--- a/sources/scores/nemo-data-designer.yaml
+++ b/sources/scores/nemo-data-designer.yaml
@@ -21,13 +21,13 @@ openness:
     TechCrunch article, and NVIDIA''s own documentation contradicts it: the NeMo microservices Data Designer
     page states "The service is built on the open-source NVIDIA NeMo Data Designer library" and links to
     github.com/NVIDIA-NeMo/DataDesigner, which is Apache-2.0 and installs with pip install data-designer.
-    A read on 2026-08-12 settled the core-gated question the deferral was held on: the repository ships
-    data-designer-config, data-designer-engine and data-designer, so the generation engine itself is published,
-    and what the NeMo Platform adds over it is infrastructure - inference routed through the NMP gateway,
-    distributed job execution with monitoring, NMP fileset seeds, NMP artifact storage and the NMP Secrets
-    service. None of that is functionality withheld from the published source, which is the test this ladder
-    applies; it is a managed service sold alongside a complete open core, the langchain and otari shape
-    rather than the langgraph one. So core-gated is ungated and the product scores 5/open_source.'
+    A direct read settles the core-gated question the deferral was held on: the repository ships data-designer-config,
+    data-designer-engine and data-designer, so the generation engine itself is published, and what the NeMo
+    Platform adds over it is infrastructure - inference routed through the NMP gateway, distributed job
+    execution with monitoring, NMP fileset seeds, NMP artifact storage and the NMP Secrets service. None
+    of that is functionality withheld from the published source, which is the test this ladder applies;
+    it is a managed service sold alongside a complete open core, the langchain and otari shape rather than
+    the langgraph one. So core-gated is ungated and the product scores 5/open_source.'
   raw: license:Apache-2.0(OSI, NVIDIA-NeMo/DataDesigner LICENSE);source:public(pip install data-designer,
     the published framework runs locally against any configured inference provider);core-gated:ungated(the
     NeMo Platform adds infrastructure around the published library rather than withholding generation from
@@ -83,13 +83,13 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: '416,634 downloads in the trailing 30 days on the declared PyPI artifact `data-designer`,
-    read live 2026-08-13. Bands at 100K-1M, level 3. LEVEL UNCHANGED - what changed is that it is now
-    RECOMPUTABLE. The record previously read `reported_traction` at the same level against a page that
-    publishes no figure at all, so nothing could confirm or refute it; a model can now derive this one
-    independently and disagree with it. The package is unambiguously the product''s own rather than a
-    same-named stranger: NVIDIA-NeMo/DataDesigner''s README quick start is `pip install data-designer`,
-    and for a Python library PyPI is the primary channel, not a minority one.'
+  note: '416,634 downloads in the trailing 30 days on the declared PyPI artifact `data-designer`. Bands
+    at 100K-1M, level 3. LEVEL UNCHANGED - what changed is that it is now RECOMPUTABLE. The record previously
+    read `reported_traction` at the same level against a page that publishes no figure at all, so nothing
+    could confirm or refute it; a model can now derive this one independently and disagree with it. The
+    package is unambiguously the product''s own rather than a same-named stranger: NVIDIA-NeMo/DataDesigner''s
+    README quick start is `pip install data-designer`, and for a Python library PyPI is the primary channel,
+    not a minority one.'
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/data-designer/recent
@@ -108,11 +108,9 @@ capability:
   value: Synthetic-data generation for structured and unstructured data, building domain-specific datasets
     from scratch for training and evaluating specialized agents.
   confidence: medium
-  note: Capable synthetic-data engine; scored on the current NVIDIA-productized form. Re-read 2026-08-13
-    - the NVIDIA NeMo page still lists Data Designer under synthetic data generation. Its earlier claims
-    about transformation and augmentation workflows and a differential-privacy heritage from Gretel are
-    no longer on that page, so they were dropped from the value rather than carried forward. The band is
-    unchanged.
+  note: Capable synthetic-data engine; scored on the current NVIDIA-productized form. The transformation
+    and augmentation workflows and the differential-privacy heritage from Gretel that the record once claimed
+    are no longer on the NVIDIA page, so they are not part of the value.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.nvidia.com/en-us/ai-data-science/products/nemo/

--- a/sources/scores/nemo-guardrails.yaml
+++ b/sources/scores/nemo-guardrails.yaml
@@ -17,12 +17,11 @@ openness:
     core-gated:
       value: ungated
   confidence: high
-  note: 'Fully open source: Apache-2.0, complete source, self-hostable with no proprietary tier. Re-read
-    2026-08-13 and unchanged. Two things about the read are worth recording. The cited URL now redirects to
-    NVIDIA-NeMo/Guardrails, which is the repo the product declares. And GitHub''s own metadata reports the
-    license as NOASSERTION rather than Apache-2.0, which is a detection artifact of the LICENSE file rather
-    than a relicense - the README states in as many words that ''the NeMo Guardrails library is licensed
-    under the Apache License, Version 2.0''.'
+  note: 'Fully open source: Apache-2.0, complete source, self-hostable with no proprietary tier. Two details
+    are worth recording: the cited URL redirects to NVIDIA-NeMo/Guardrails, which is the repo the product
+    declares, and GitHub''s own metadata reports the license as NOASSERTION rather than Apache-2.0, which
+    is a detection artifact of the LICENSE file rather than a relicense - the README states in as many words
+    that ''the NeMo Guardrails library is licensed under the Apache License, Version 2.0''.'
   raw: license:Apache-2.0(OSI);source:public(full Python implementation);self-host:yes(library/CLI/Docker/server);service:none;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -45,14 +44,13 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: '401,369 downloads in the trailing 30 days on the newly declared PyPI artifact `nemoguardrails`,
-    read live 2026-08-13. Bands at 100K-1M, level 3. LEVEL CORRECTED FROM 2, and the cause is that
-    the band was set on the wrong instrument: it read stars_fallback, which adoption.md defines as
-    meaning no download signal existed when it was set, and which caps at 3 for the good reason that
-    a star is not a use. A download signal does exist, and the guide is explicit that a stars band
-    re-bands once one appears. The package is the product''s own rather than a same-named stranger -
-    its PyPI project_urls point at https://github.com/NVIDIA-NeMo/Guardrails - and for a Python library PyPI is the primary channel,
-    not a minority one.'
+  note: '401,369 downloads in the trailing 30 days on the newly declared PyPI artifact `nemoguardrails`.
+    Bands at 100K-1M, level 3. LEVEL CORRECTED FROM 2, and the cause is that the band was set on the wrong
+    instrument: it read stars_fallback, which adoption.md defines as meaning no download signal existed
+    when it was set, and which caps at 3 for the good reason that a star is not a use. A download signal
+    does exist, and the guide is explicit that a stars band re-bands once one appears. The package is the
+    product''s own rather than a same-named stranger - its PyPI project_urls point at https://github.com/NVIDIA-NeMo/Guardrails
+    - and for a Python library PyPI is the primary channel, not a minority one.'
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/nemoguardrails/recent
@@ -69,7 +67,6 @@ capability:
   confidence: medium
   note: One of the most feature-complete open guardrail orchestration layers; the Colang policy language
     adds flexibility beyond simple scanners, and two bands in this category are recorded relative to it.
-    Re-read 2026-08-13 and unchanged.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/NVIDIA/NeMo-Guardrails

--- a/sources/scores/nemo-rl.yaml
+++ b/sources/scores/nemo-rl.yaml
@@ -66,14 +66,11 @@ adoption:
   reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: medium
-  note: 'GitHub stars remain the only usable signal: 1,890 stars (displayed 1.9k, up from ~1.7k), still inside
-    the <10K band; ''Used by'' and contributor counts are unavailable in the static page. The nemo-rl package
-    on PyPI is a non-functional placeholder (v0.0.0) that explicitly directs users back to GitHub, so no
-    download figure exists to band on. Level 2 stands on stars_fallback; honest signal is limited. Stars read
-    2026-08-13: 1,903 across the 1 declared repo, which bands at 1K-10K stars, level 2 on the stars scale in
-    signal_routing.yaml. The previous reach ''<10K'' was not a label this instrument offers - stars have their
-    own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile, so a
-    digest of it would read as drift on every refetch, and the rest of the axis was not re-read.'
+  note: 'GitHub stars remain the only usable signal: 1,890 stars (displayed 1.9k, up from ~1.7k), which
+    bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml; ''Used by'' and contributor
+    counts are unavailable in the static page. The nemo-rl package on PyPI is a non-functional placeholder
+    (v0.0.0) that explicitly directs users back to GitHub, so no download figure exists to band on. Level
+    2 stands on stars_fallback; honest signal is limited.'
   last_verified: '2026-08-09'
   sources:
   - url: https://github.com/NVIDIA-NeMo/RL
@@ -102,9 +99,9 @@ capability:
   note: 'Frontier-tier scale/parallelism within finetuning_code: DTensor (FSDP2/TP/SP/PP/CP, via NeMo AutoModel)
     and Megatron Core with 6D parallelism (via NeMo Megatron Bridge), plus SGLang inference, speculative
     decoding and reward modeling. Capability is high even though adoption is still small. The band was previously
-    calibrated in prose against Megatron-LM and verl; that comparison could not be recorded as relative_to
-    today because Megatron-LM''s own capability confirmation is dated one day earlier (2026-08-08), which
-    would make this band fresher than the peer it derives from - see findings.'
+    calibrated in prose against Megatron-LM and verl; that comparison is not recorded as relative_to/relation,
+    because check_capability.py will not accept a derived band whose confirmation is more recent than the
+    anchor it derives from - see findings.'
   last_verified: '2026-08-09'
   sources:
   - url: https://github.com/NVIDIA-NeMo/RL

--- a/sources/scores/nemotron-cc.yaml
+++ b/sources/scores/nemotron-cc.yaml
@@ -11,10 +11,8 @@ openness:
     dataset_card:
       value: present
   confidence: high
-  note: 'Manually gated behind the NVIDIA Data Agreement for Model Training; synthetic portions may inherit
-    generator-model license terms. Re-read 2026-08-13: the Hub still shows “You need to agree to share your
-    contact information to access this dataset” and the API reports gated manual under the NVIDIA open-data
-    terms.'
+  note: Manually gated behind the NVIDIA Data Agreement for Model Training; synthetic portions may inherit
+    generator-model license terms.
   raw: license:NVIDIA-Open-Data;gated:manual(model-training-use);dataset_card:present
   last_verified: '2026-08-13'
   sources:
@@ -32,9 +30,8 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 45,663 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (nvidia/Nemotron-CC-v2 45,663). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top
-    band is >1M.
+  note: 45,663 downloads in the trailing 30 days summed across the 1 declared artifact(s) (nvidia/Nemotron-CC-v2
+    45,663). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/nvidia/Nemotron-CC-v2
@@ -48,11 +45,9 @@ capability:
   basis_detail: ablation
   value: null
   confidence: high
-  note: 'Wins vs DCLM at a long token horizon (Nemotron-CC-HQ +5.6 MMLU over DCLM; a 15T-token 8B beats
-    Llama 3.1 8B); current default for NVIDIA Nemotron models and Marin 8B late phases. Re-read 2026-08-13:
-    the Nemotron-CC listing still reports +5.6 MMLU over DCLM on the high-quality subset and an 8B trained
-    for 15T tokens beating Llama 3.1 8B by +5 MMLU, and the Marin retro report still records the switch
-    to Nemotron-CC in later phases.'
+  note: Wins vs DCLM at a long token horizon (Nemotron-CC-HQ +5.6 MMLU over DCLM; a 15T-token 8B beats Llama
+    3.1 8B); current default for NVIDIA Nemotron models and Marin 8B late phases. The 15T-token 8B beats
+    Llama 3.1 8B by +5 MMLU, and the Marin retro report records the switch to Nemotron-CC in later phases.
   last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2412.02595

--- a/sources/scores/nemotron.yaml
+++ b/sources/scores/nemotron.yaml
@@ -16,16 +16,13 @@ openness:
     license:
     - name: NVIDIA-Nemotron-Open-Model-License
       detail: permissive,commercial,non-OSI
-  note: 'Unusually open for post-trained models: NVIDIA releases weights, the post-training data and the recipes,
-    but under the non-OSI NVIDIA Open Model License, so open_weights not open_source. This category scores the post-training
-    data, which is genuinely released. The pretraining side is thinner than NVIDIA''s "fully open" framing suggests
-    -- Nemotron-Pretraining-Specialized-v1.2 ships 53.6GB of synthetic data, but Nemotron-Pretraining-Code-v3 ships
-    metadata parquet describing the code corpus rather than the corpus, so the earlier "~10T-token pretraining released"
-    wording overstated it and has been narrowed. Score is unaffected: the post-training answer is what this category
-    asks for. Re-read 2026-08-13 - the Nemotron 3 page still lists Nemotron-SFT-Data and Nemotron-RL-Data
-    under Data with a Model Recipes section beside them, and the developer blog still says Nemotron 3 Super
-    is "fully open with open weights, datasets, and recipes". The pretraining-side caveat also still holds
-    - Nemotron-Pretraining-Code-v3 still ships only Nemotron-Code-Metadata parquet. No change.'
+  note: 'Unusually open for post-trained models: NVIDIA releases weights, the post-training data and the
+    recipes, but under the non-OSI NVIDIA Open Model License, so open_weights not open_source. This category
+    scores the post-training data, which is genuinely released. The pretraining side is thinner than NVIDIA''s
+    "fully open" framing suggests -- Nemotron-Pretraining-Specialized-v1.2 ships 53.6GB of synthetic data,
+    but Nemotron-Pretraining-Code-v3 ships metadata parquet describing the code corpus rather than the corpus,
+    so the earlier "~10T-token pretraining released" wording overstated it and has been narrowed. Score
+    is unaffected: the post-training answer is what this category asks for.'
   raw: weights:open;data:open(~40M post-training/SFT+RL samples released as Nemotron-SFT-Data/Nemotron-RL-Data;
     pretraining sets only partly released);code:open(training recipes + RL env configs);license:NVIDIA-Nemotron-Open-Model-License(permissive,commercial,non-OSI)
   last_verified: '2026-08-13'
@@ -62,15 +59,15 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: 'Corrected from 3/reported_traction to 4/usage_volume on 2026-07-29, and this is the first score on the
-    map re-banded off a machine signal rather than a hand-read figure. The record previously said no hard download
-    count was available because the instruct repo was gated; all three shipped repos resolve ungated at HTTP 200.
-    Summing the family''s distributed SKUs, which is what the category''s adoption recipe specifies: Nano BF16 994,374
-    + Super BF16 855,265 + Ultra BF16 339,360 = 2,188,999 monthly downloads, squarely in the 1M-10M band. The NVFP4/FP8/GGUF
-    quantizations are excluded to avoid double counting the same weights. Also distributed free via OpenRouter (nemotron-3-super-120b-a12b:free)
-    and NVIDIA build/NIM, which the band does not capture, so 4 is a floor. Re-read 2026-08-13 - the three
-    BF16 repos now sum to 2,226,055 downloads in the trailing 30 days (Nano 914,120 + Super 870,782 +
-    Ultra 441,153), still squarely 1M-10M. No change.'
+  note: 'Corrected from 3/reported_traction to 4/usage_volume on 2026-07-29, and this is the first score
+    on the map re-banded off a machine signal rather than a hand-read figure. The record previously said
+    no hard download count was available because the instruct repo was gated; all three shipped repos resolve
+    ungated at HTTP 200. Summing the family''s distributed SKUs, which is what the category''s adoption
+    recipe specifies: Nano BF16 994,374 + Super BF16 855,265 + Ultra BF16 339,360 = 2,188,999 monthly downloads,
+    squarely in the 1M-10M band. The NVFP4/FP8/GGUF quantizations are excluded to avoid double counting
+    the same weights. Also distributed free via OpenRouter (nemotron-3-super-120b-a12b:free) and NVIDIA
+    build/NIM, which the band does not capture, so 4 is a floor. The three BF16 repos sum to 2,226,055 downloads
+    in the trailing 30 days (Nano 914,120 + Super 870,782 + Ultra 441,153), still squarely 1M-10M.'
   last_verified: '2026-08-13'
   sources:
   - url: https://research.nvidia.com/labs/nemotron/Nemotron-3/
@@ -100,17 +97,11 @@ capability:
   value: 'Nemotron 3 Super (per NVIDIA tech report): SWE-Bench Verified 60.47, AIME 2025 90.21, GPQA (no tools)
     79.23, MMLU-Pro 83.73; ~2.2x inference throughput vs GPT-OSS-120B'
   confidence: high
-  note: >-
-    Frontier-tier among open instruct models on the Super SKU. Nano is much smaller and would score
-    lower, but the family's headline SKU defines the score.
-
-    Re-read 2026-08-13 - every recorded figure is still in the technical report's Agentic Reasoning
-    Benchmark table, unchanged (MMLU-Pro 83.73, AIME25 no tools 90.21, GPQA no tools 79.23, SWE-Bench
-    OpenHands 60.47). One claim in the note did NOT survive - it said 60.47 was "the highest
-    open-weight score", and the same table's Qwen3.5-122B-A10B column reads 66.40 on that row and
-    86.70 on MMLU-Pro. Removed rather than re-dated, because it was our gloss rather than a figure
-    the report published. Whether a 5 still follows from second place on the report's own comparison
-    is a scoring question, not a freshness one, and is FLAGGED for the orchestrator.
+  note: Frontier-tier among open instruct models on the Super SKU. Nano is much smaller and would score
+    lower, but the family's headline SKU defines the score. The report's own comparison table puts Qwen3.5-122B-A10B
+    above Super on the same rows (SWE-Bench 66.40, MMLU-Pro 86.70), so Super is not the highest open-weight
+    score, and the earlier claim that it was has been removed as our gloss rather than a figure the report
+    published. Whether a 5 still follows from second place on that comparison is FLAGGED as a scoring question.
   last_verified: '2026-08-13'
   sources:
   - url: https://research.nvidia.com/labs/nemotron/Nemotron-3/

--- a/sources/scores/new-relic-ai-monitoring.yaml
+++ b/sources/scores/new-relic-ai-monitoring.yaml
@@ -16,9 +16,7 @@ openness:
       value: closed
   confidence: high
   note: Fully proprietary SaaS observability platform; AI Monitoring is a commercial module. OTel ingestion
-    support does not make the product open. Scored closed (1). Re-read 2026-08-13 and unchanged - the
-    product page still sells AI Monitoring as one capability of the hosted New Relic platform, lists
-    OpenTelemetry only as a way of getting data in, and publishes no source or self-hosted build.
+    support does not make the product open. Scored closed (1).
   raw: platform:proprietary-SaaS(closed);license:commercial(Standard/Pro/Enterprise tiers);ingestion:OpenTelemetry-compatible(open
     standard, not open product);source:closed
   last_verified: '2026-08-13'
@@ -42,30 +40,25 @@ adoption:
   note: 'New Relic platform reported at ~6.6M platform users / 75,000+ businesses in 2026 (1-10M band).
     Figure is platform-wide, not AIM-specific, and the hard numbers came from aggregators (landbase/zoominfo);
     vendor product page confirms the AIM module and broad enterprise tiers but I did not fetch a primary
-    user count; treat level as platform-attributed and directional.
-    RE-ROUTED 2026-08-14 to reported_traction, with the numeric reach dropped and the level kept. The
-    instrument is the correction: this record carried `usage_volume` and a `1M-10M` label over a figure
-    its own note says came from landbase and zoominfo and was never fetched. A numeric band is a claim
-    that somebody counted something, and nobody did, so the label is removed rather than restated - which
-    is what reported_traction is for, and why its vocabulary is three words and not a scale. No `reach`
-    word is recorded either; omitting it is the honest default on this instrument.
-    The level does not move, because what it rests on has not changed: AI observability is a module of a
-    large hosted platform with an enterprise customer base, and the band is platform-attributed and
-    directional exactly as recorded. Re-read 2026-08-14 and no first-party count has appeared - the page
-    publishes no customer, user or business figure of any kind. Note for a later pass, outside this
-    ruling: newrelic.com/platform/ai-monitoring now redirects to /platform/ai-observability and the page
-    has rebranded from AI Monitoring to AI Observability, which the openness axis still cites under the
-    old URL.'
+    user count; treat level as platform-attributed and directional. RE-ROUTED 2026-08-14 to reported_traction,
+    with the numeric reach dropped and the level kept. The instrument is the correction: this record carried
+    `usage_volume` and a `1M-10M` label over a figure its own note says came from landbase and zoominfo
+    and was never fetched. A numeric band is a claim that somebody counted something, and nobody did, so
+    the label is removed rather than restated - which is what reported_traction is for, and why its vocabulary
+    is three words and not a scale. No `reach` word is recorded either; omitting it is the honest default
+    on this instrument. The level does not move, because what it rests on has not changed: AI observability
+    is a module of a large hosted platform with an enterprise customer base, and the band is platform-attributed
+    and directional exactly as recorded. No first-party count exists: the product page publishes no customer,
+    user or business figure of any kind.'
   last_verified: '2026-08-14'
   sources:
   - url: https://newrelic.com/platform/ai-monitoring
     shows: AI Monitoring module of the broad New Relic observability platform; enterprise tiers
     accessed: '2026-06-04'
   - url: https://newrelic.com/platform/ai-monitoring
-    shows: 'Re-read 2026-08-14. The URL now redirects to newrelic.com/platform/ai-observability and the
-      page is branded AI Observability. It sells the module inside the hosted New Relic platform and
-      publishes NO customer, user or business count anywhere on it - which is what keeps this axis on
-      reported_traction with no numeric reach.'
+    shows: The URL redirects to newrelic.com/platform/ai-observability and the page is branded AI Observability.
+      It sells the module inside the hosted New Relic platform and publishes NO customer, user or business
+      count anywhere on it - which is what keeps this axis on reported_traction with no numeric reach.
     accessed: '2026-08-14'
     http_status: 200
     content_sha256: 213269aa961552263e613295c3475455b5903a26b02be912033852d54b451544
@@ -79,11 +72,9 @@ capability:
   confidence: medium
   relative_to: langfuse
   relation: at
-  note: Broad full-stack AI observability (traces, cost, quality, agentic spans) at the anchor C4 tier
-    on feature breadth; not an eval/prompt-mgmt frontier-definer, so 4 not 5. The comparison is now recorded
-    rather than left in prose - at the langfuse anchor. Re-read 2026-08-13 - the page still names AI metrics
-    from response time and quality through tokens and APM golden signals, token cost tracking with custom
-    alerts, and detection of bias, hallucination and toxicity.
+  note: Broad full-stack AI observability (traces, cost, quality, agentic spans) at the anchor C4 tier on
+    feature breadth; not an eval/prompt-mgmt frontier-definer, so 4 not 5. The comparison is now recorded
+    rather than left in prose - at the langfuse anchor.
   last_verified: '2026-08-13'
   sources:
   - url: https://newrelic.com/platform/ai-monitoring

--- a/sources/scores/nextchat.yaml
+++ b/sources/scores/nextchat.yaml
@@ -21,14 +21,6 @@ openness:
   confidence: high
   note: OSI MIT core with a separate proprietary Enterprise Edition for multi-user permissions and internal-KB
     RAG -> open_core (calibrated to the LiteLLM open_core anchor).
-    Re-read 2026-08-13. The repository still carries MIT and the root tree is still the whole
-    application - app, src-tauri, public, docs, scripts and test, with no ee/ or enterprise/ directory
-    anywhere in it. The README still carries the Enterprise Edition section quoted below verbatim,
-    unchanged, with the same business@nextchat.club contact, so the admin panel, the member and
-    knowledge-base permission model and the security auditing are still withheld from the published
-    source. The repository-root reading recorded on 2026-08-11 could not be refetched today because
-    api.github.com declined the request, so the source dimension was re-derived from the repository
-    page, whose embedded root listing shows the same tree. Value unchanged at 4 / open_core.
   raw: license:MIT(core, public source);enterprise-tier:NextChat Enterprise (permission controls, team resource
     mgmt, internal knowledge base/RAG);source:public(the app IS the repo; README ships one-click Vercel/Zeabur/Gitpod
     deploy, a Dockerfile and docker-compose, and desktop builds via src-tauri);core-gated:gated(Enterprise
@@ -72,20 +64,15 @@ adoption:
   reach: '>10K stars'
   signal_type: stars_fallback
   confidence: low
-  note: '88.2k GitHub stars and one-click Vercel deploy indicate broad lightweight use, but no verified
-    download/MAU figure from a primary source this run, and last release ~6-12mo ago. Capped at 3 on stars
-    fallback; momentum appears to have slowed. Stars read 2026-08-13 on ChatGPTNextWeb/NextChat: 88,617, which
-    bands at >10K stars, level 3 on the stars scale. The previous reach ''100K-1M'' was a download label,
-    which this instrument does not offer - a star is not a download. THE REAL DEFECT is upstream: this product
-    declares no artifacts at all, so a stars_fallback band had no stars source behind it and the count lived
-    only in this note. Declaring ChatGPTNextWeb/NextChat would fix it, and is deliberately not done here
-    because a declared code repo also re-routes the openness license dimension. No last_verified claimed: a
-    star count is volatile.
-    Re-read 2026-08-13 - ChatGPTNextWeb/NextChat shows 88,616 stars, still banding at >10K stars, level
-    3 on the stars scale, and v2.16.1 of 29 July 2025 is still the latest tagged release, so the
-    stalled-release observation above holds a year on. No download or MAU figure has appeared. This
-    supersedes the refusal to claim a date - the axis was re-read rather than aggregated. Level
-    unchanged.'
+  note: '88,617 GitHub stars on ChatGPTNextWeb/NextChat and a one-click Vercel deploy indicate broad lightweight
+    use, but no verified download or MAU figure is available from a primary source, and v2.16.1 of July
+    2025 is still the latest tagged release, so momentum appears to have slowed. The count bands at >10K
+    stars, level 3 on the stars scale, and the stars fallback caps there in any case. The previous reach
+    ''100K-1M'' was a download label, which this instrument does not offer - a star is not a download. THE
+    REAL DEFECT is upstream: this product declares no artifacts at all, so a stars_fallback band had no
+    stars source behind it and the count lived only in this note. Declaring ChatGPTNextWeb/NextChat would
+    fix it, and is deliberately not done here because a declared code repo also re-routes the openness license
+    dimension.'
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/ChatGPTNextWeb/NextChat
@@ -101,10 +88,6 @@ capability:
   confidence: medium
   note: Solid lightweight cross-platform client with plugins/MCP/vision, but RAG and multi-user are gated
     to Enterprise; thinner OSS feature surface than Open WebUI/LibreChat/AnythingLLM.
-    Re-read 2026-08-13. The README still shows the open surface the band rests on - many providers,
-    plugins from v2.15.0, artifacts from v2.14.0, realtime chat from v2.15.8, vision through the
-    VISION_MODELS setting, and MCP behind an ENABLE_MCP build flag - while stating that all data is
-    stored locally in the browser, so RAG and multi-user remain Enterprise-only. Band unchanged at 3.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/ChatGPTNextWeb/NextChat

--- a/sources/scores/nono.yaml
+++ b/sources/scores/nono.yaml
@@ -22,16 +22,8 @@ openness:
   confidence: high
   note: 'Fully open source: an Apache-2.0 Rust implementation that is self-hostable as a standalone CLI
     or library with no proprietary service tier. A clean contrast with the managed sandbox clouds (Vercel,
-    Cloudflare, Modal), which publish only a client SDK over a closed runtime. Re-read 2026-08-13 and
-    unchanged. The LICENSE body at repository head is a verbatim Apache License 2.0, the repository
-    metadata reports spdx_id Apache-2.0 on a public, unarchived Rust repository, and the README closes
-    on a bare "License - Apache-2.0". The README still installs the whole tool free by curl or Homebrew
-    with Debian, Fedora, Arch, RHEL, openSUSE, WSL2 and Nix listed alongside, still documents the policy
-    engine, credential proxy, L7 filtering and brokered tool sandboxes as ordinary features, and still
-    points the FFI bindings at nono-py, nono-ts and nono-go. Nothing is held back for a paid tier and no
-    license key or hosted dependency appears, so core-gated stays ungated. One change since the last
-    read - the registry namespace moved from always-further to nolabs-ai, which is a rename rather than
-    a gate.'
+    Cloudflare, Modal), which publish only a client SDK over a closed runtime. The registry namespace has
+    moved from always-further to nolabs-ai, which is a rename rather than a gate.'
   raw: license:Apache-2.0(OSI);source:public(full Rust implementation, self-hostable);distribution:curl
     / Homebrew / Debian-Ubuntu-Fedora-Arch-RHEL-openSUSE-Nix + FFI bindings (nono-py, nono-ts, nono-go);service:none(standalone
     CLI/library, no proprietary backend);core-gated:ungated
@@ -70,21 +62,15 @@ adoption:
   reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
-  note: '~2,900 GitHub stars (June 2026) for a 2026 release, with multi-platform packages and FFI bindings
-    published. Stars are the only public proxy here, so this is capped per the methodology and read as early
-    but real traction rather than scaled adoption. Stars read 2026-08-13: 3,640 across the 1 declared repo,
-    which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach
-    ''1K-10K'' was not a label this instrument offers - stars have their own vocabulary because a star is not
-    a download. No last_verified claimed: a star count is volatile, so a digest of it would read as drift on
-    every refetch, and the rest of the axis was not re-read. That last sentence is superseded - the rest
-    of the axis has now been re-read. Stars read again 2026-08-13 from the repository metadata endpoint
-    at 3,644, four above the earlier same-day reading and still inside the 1K-10K stars band at level 2,
-    and the reasoning under the band was re-derived rather than copied. The README confirms stars remain
-    the only public proxy - no download, install or user figure is published, and the closest thing to a
-    usage claim is unattributed marketing prose about engineers at large companies running nono in
-    production, which is not bandable. The digest-drift objection stands and is accepted rather than
-    avoided; the digested source below is the metadata endpoint, and a later refetch showing a different
-    hash means the count moved, which is what a star signal does.'
+  note: '3,644 GitHub stars and 241 forks across the 1 declared repo, which bands at 1K-10K stars, level
+    2 on the stars scale in signal_routing.yaml. Stars are the only public proxy: the README publishes no
+    download, install or user figure, and the closest thing to a usage claim is unattributed marketing prose
+    about engineers at large companies running nono in production, which is not bandable. So the band is
+    capped per the methodology and read as early but real traction for a 2026 release rather than scaled
+    adoption, notwithstanding the multi-platform packages and FFI bindings. The reach label uses the stars
+    vocabulary rather than a download band, because a star is not a download. The digested source is the
+    repository metadata endpoint, whose hash moves whenever the count does - that is what a star signal
+    does, and it does not weaken a band resting on order of magnitude.'
   last_verified: '2026-08-13'
   sources:
   - url: https://api.github.com/repos/nolabs-ai/nono
@@ -107,17 +93,15 @@ capability:
     for Rust / Python / TypeScript / Go, and an agent registry. Lighter-weight than the microVM-based sandboxes
     (E2B, Firecracker) but with the widest local-platform coverage and lowest setup friction.
   confidence: medium
-  note: 'Solid, cross-platform sandbox with very low setup friction; scored mid-range for the category
-    -- below the heavier microVM / OS-isolation options on hard isolation depth, but broad and easy to
-    adopt locally. Re-read 2026-08-13 and the band holds. nono.sh still leads on kernel-level isolation
-    for Linux, macOS and Windows with zero setup and zero latency, lists per-language sandboxes for
-    Python, Node.js and Go, and keeps the registry at registry.nono.sh. Both pages are explicit that the
-    mechanism is OS-level allow-lists rather than a virtual machine - the README says no daemon, no
-    container, no VM and no disk space usage - which is what holds this one below the microVM peers.
-    The feature surface has widened since the band was set, with brokered per-tool child sandboxes,
-    credential proxying with L7 endpoint policy, hash-chained audit records under a SHA-256 Merkle root,
-    rollback and Sigstore provenance. That is real depth in a different direction from hard isolation,
-    so it is recorded here rather than treated as a reason to move the score.'
+  note: 'Solid, cross-platform sandbox with very low setup friction; scored mid-range for the category --
+    below the heavier microVM / OS-isolation options on hard isolation depth, but broad and easy to adopt
+    locally. The mechanism is OS-level allow-lists rather than a virtual machine - the README says no daemon,
+    no container, no VM and no disk space usage - which is what holds this below the microVM peers. nono.sh
+    leads on kernel-level isolation for Linux, macOS and Windows with zero setup and zero latency, and lists
+    per-language sandboxes for Python, Node.js and Go. The feature surface has widened since the band was
+    set, with brokered per-tool child sandboxes, credential proxying with L7 endpoint policy, hash-chained
+    audit records under a SHA-256 Merkle root, rollback and Sigstore provenance: real depth in a different
+    direction from hard isolation, recorded here rather than treated as a reason to move the score.'
   last_verified: '2026-08-13'
   sources:
   - url: https://nono.sh

--- a/sources/scores/northflank-sandboxes.yaml
+++ b/sources/scores/northflank-sandboxes.yaml
@@ -15,10 +15,10 @@ openness:
     free_text:
     - no self-hostable open runtime
   confidence: high
-  note: Proprietary managed deployment/sandbox platform; no open source runtime published. Re-read 2026-08-13
-    - northflank.com and the Sandboxes product page still sell a commercial SaaS running on Northflank Cloud
-    or a customer VPC, with no source release and no self-hostable runtime; the microVM layer is built on
-    third-party projects (Kata Containers, gVisor) rather than anything Northflank publishes.
+  note: Proprietary managed deployment/sandbox platform; no open source runtime published. Sandboxes run
+    on Northflank Cloud or inside a customer VPC with no source release and no self-hostable runtime, and
+    the microVM layer is built on third-party projects (Kata Containers, gVisor) rather than anything Northflank
+    publishes.
   raw: license:Proprietary;service:proprietary(Northflank managed SaaS);source:closed;isolation:microVM;no
     self-hostable open runtime
   last_verified: '2026-08-13'
@@ -42,14 +42,12 @@ adoption:
   signal_type: reported_traction
   confidence: medium
   banded_quantity: Northflank platform developers (100k+) and organizations (2,000+), not Sandboxes use
-  note: 'Northflank (platform-wide, primary): 2,000+ organizations, 80,000+ developers in production,
-    130B+ requests, millions of containers, 330+ availability zones. These are platform-level figures
-    (not Sandboxes-specific); the Sandboxes product is newer. Placed at 3 on the developer/org base; the
-    Sandboxes feature alone is likely lower. Re-read 2026-08-13 - the homepage counters have moved up, now
-    reading 2,000+ start-ups and enterprises, 100k+ developers in production, 130B+ requests and 330+
-    availability zones, and the Sandboxes product page adds the first Sandboxes-specific claim, millions
-    of microVMs run monthly since 2021. Still a vendor claim with no countable artifact behind it, so the
-    record stays reported_traction with no reach word.'
+  note: 'Northflank platform-wide figures (primary): 2,000+ start-ups and enterprises, 100k+ developers
+    in production, 130B+ requests, millions of containers, 330+ availability zones. These are platform-level
+    rather than Sandboxes-specific and the Sandboxes product is newer, so this is placed at 3 on the developer/org
+    base; the Sandboxes feature alone is likely lower. The one Sandboxes-specific claim is on the product
+    page - millions of microVMs run monthly since 2021 - and it is still a vendor claim with no countable
+    artifact behind it, so the record stays reported_traction with no reach word.'
   last_verified: '2026-08-13'
   sources:
   - url: https://northflank.com/
@@ -72,15 +70,11 @@ capability:
     workloads / long-running agents supported; scale: multi-cloud, 330+ AZs, millions of containers'
   confidence: medium
   note: 'Strong: microVM isolation, ~200ms cold-start, broad runtime support, multi-cloud scale, and explicit
-    support for untrusted code-gen at scale. Just below frontier on proven sandbox-specific scale vs the
-    dedicated leaders; isolation+latency are top-tier. Independent ComputeSDK TTI benchmarks confirm the
-    top-tier latency, measuring ~100ms median cold-start (3rd-fastest of 19 sandbox providers), beating
-    the ~200ms spec. Re-read 2026-08-13 - the homepage still shows the microVM 200ms spin-up figure, and
-    the Sandboxes product page names Kata Containers and gVisor, boots a microVM in under a second, imposes
-    no forced session time limit, and offers deployment inside a customer VPC. The ComputeSDK leaderboard
-    has been rerun since (2026-08-07, 24 providers) and now measures Northflank at 0.25s median
-    time-to-interactive, still 3rd by composite score, so the top-tier latency reading holds at a slower
-    absolute number.'
+    support for untrusted code-gen at scale. The Sandboxes product page names Kata Containers and gVisor,
+    boots a microVM in under a second, imposes no forced session time limit, and offers deployment inside
+    a customer VPC. Just below frontier on proven sandbox-specific scale against the dedicated leaders;
+    isolation and latency are top-tier, and independent ComputeSDK TTI benchmarks confirm the latency, measuring
+    a 0.25s median cold-start and 3rd place by composite of 24 sandbox providers.'
   last_verified: '2026-08-13'
   sources:
   - url: https://northflank.com/

--- a/sources/scores/notion-mcp.yaml
+++ b/sources/scores/notion-mcp.yaml
@@ -13,11 +13,9 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: 'Fully MIT, first-party Notion server, no feature-gated core. Re-read 2026-08-13: the repository LICENSE
-    is the MIT permission grant, "Copyright (c) 2025 Notion Labs, Inc.", and the repo page carries the matching
-    badge. The whole server is in the tree and installs from npm with no key. Notion also runs a hosted MCP
-    endpoint documented at developers.notion.com, and that is a managed deployment of this same server rather
-    than a tier withholding tools from it, which the ladder settles as ungated.'
+  note: Fully MIT, first-party Notion server, no feature-gated core. Notion also runs a hosted MCP endpoint
+    documented at developers.notion.com, but that is a managed deployment of this same server rather than
+    a tier withholding tools from it, which the ladder settles as ungated.
   raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -42,11 +40,10 @@ adoption:
   level: 3
   signal_type: usage_volume
   confidence: medium
-  note: 739,577 npm downloads in the trailing 30 days for @notionhq/notion-mcp-server, read 2026-08-12.
-    The note previously argued the level up from stars because 'npm distribution ... implies higher real
-    usage'; that package publishes a figure, so the implication is now a measurement and the signal is usage_volume
-    rather than a star proxy. The package is also declared as an artifact so the fetcher routes to it from
-    here on.
+  note: 739,577 npm downloads in the trailing 30 days for @notionhq/notion-mcp-server. The note previously
+    argued the level up from stars because 'npm distribution ... implies higher real usage'; that package
+    publishes a figure, so the implication is now a measurement and the signal is usage_volume rather than
+    a star proxy. The package is also declared as an artifact so the fetcher routes to it from here on.
   reach: 100K-1M
   last_verified: '2026-08-12'
   sources:
@@ -61,13 +58,7 @@ capability:
   value: tools across search, data sources, pages, blocks and comments, with data sources the primary database
     abstraction since v2.0.0; OAuth installation; token-optimized responses and Markdown page editing
   confidence: medium
-  note: 'Comprehensive single-product Notion API coverage. Re-read 2026-08-13: v2.0.0 migrated the server
-    to the Notion API 2025-09-03, "which introduces data sources as the primary abstraction for databases",
-    adding seven tools around query-data-source, retrieve-a-data-source, update-a-data-source and create-a-data-source.
-    The README also now leads on "Easy installation via standard OAuth. No need to fiddle with JSON or API
-    tokens anymore" and on tools "designed with optimized token consumption in mind". The recorded "~22 tools"
-    count is not stated on the page any more, so the value drops the number and keeps the surface; the band
-    is unchanged at 4.'
+  note: Comprehensive single-product Notion API coverage.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/makenotion/notion-mcp-server

--- a/sources/scores/nvidia-jetson-agx-orin.yaml
+++ b/sources/scores/nvidia-jetson-agx-orin.yaml
@@ -23,11 +23,10 @@ openness:
       raw: distributor (via distributors)
   confidence: high
   note: Public datasheets and commercially purchasable, but SDK relies on proprietary NVIDIA blobs under
-    license, placing it in the documented tier. Re-read 2026-08-13 - the family page still publishes
-    module data sheets and points designers at the Product Design Guide rather than releasing the module's
-    own board files, still routes buyers through the Jetson partner ecosystem, and Jetson Linux 39.2.1
-    still ships kernel, UEFI bootloader and NVIDIA drivers under the NVIDIA Software License Agreement.
-    No dimension moved.
+    license, placing it in the documented tier. The family page publishes module data sheets and points
+    designers at the Product Design Guide rather than releasing the module's own board files, routes buyers
+    through the Jetson partner ecosystem, and Jetson Linux 39.2.1 ships kernel, UEFI bootloader and NVIDIA
+    drivers under the NVIDIA Software License Agreement.
   raw: schematics:partial (module datasheet + carrier design guide public);toolchain:closed (JetPack/Jetson
     Linux proprietary (NVIDIA SLA));datasheets:public;blobs:required (proprietary drivers/bootloader);retail:distributor
     (via distributors)
@@ -58,10 +57,8 @@ adoption:
   reach: niche
   signal_type: reported_traction
   confidence: medium
-  note: Available as a dev kit and production module through NVIDIA's distributor network with a large
-    Jetson community, but the high price targets professional robotics. Re-read 2026-08-13 - the family
-    page still lists the AGX Orin 64GB, 32GB and Industrial modules alongside the AGX Orin Developer Kit
-    and still routes purchase through the Jetson partner ecosystem. Reach unchanged.
+  note: Available as a dev kit and production module through NVIDIA's distributor network with a large Jetson
+    community, but the high price targets professional robotics.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin
@@ -76,10 +73,10 @@ capability:
   value: Up to 275 TOPS; 32GB or 64GB LPDDR5; runs large LLMs/VLMs and multi-model robotics pipelines
     at the edge
   confidence: high
-  note: Top-tier edge-AI compute; the 64GB/275 TOPS variant runs large models that exceed smaller Orin
-    modules. Re-derived 2026-08-13 from the same comparison table, which still reads 275 SPARSE INT8 TOPS
-    and 64GB 256-bit LPDDR5 for AGX Orin against 157 TOPS / 16GB for Orin NX and 67 TOPS / 8GB for Orin
-    Nano. It remains the top of the Orin line and the highest capability in this category.
+  note: Top-tier edge-AI compute; the 64GB/275 TOPS variant runs large models that exceed smaller Orin modules.
+    The Orin comparison table reads 275 SPARSE INT8 TOPS and 64GB 256-bit LPDDR5 for AGX Orin against 157
+    TOPS / 16GB for Orin NX and 67 TOPS / 8GB for Orin Nano. It is the top of the Orin line and the highest
+    capability in this category.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin

--- a/sources/scores/nvidia-jetson-orin-nano-super-developer-kit.yaml
+++ b/sources/scores/nvidia-jetson-orin-nano-super-developer-kit.yaml
@@ -23,11 +23,10 @@ openness:
       raw: open_market (mass-market)
   confidence: high
   note: Public datasheets and globally purchasable, but the SDK requires proprietary NVIDIA drivers/blobs
-    under license, so it sits in the documented tier despite the community OE4T BSP. Re-read 2026-08-13 -
-    the developer-kit page still publishes a datasheet link and directs buyers to worldwide partners,
-    the Jetson Orin family page still points designers at the Product Design Guide rather than releasing
-    the kit's own board files, and Jetson Linux 39.2.1 still ships its kernel, UEFI bootloader and NVIDIA
-    drivers under the NVIDIA Software License Agreement. No dimension moved.
+    under license, so it sits in the documented tier despite the community OE4T BSP. The developer-kit page
+    publishes a datasheet link and directs buyers to worldwide partners, the Jetson Orin family page points
+    designers at the Product Design Guide rather than releasing the kit's own board files, and Jetson Linux
+    39.2.1 ships its kernel, UEFI bootloader and NVIDIA drivers under the NVIDIA Software License Agreement.
   raw: schematics:partial (carrier design guide public);toolchain:closed (JetPack/Jetson Linux free but
     NVIDIA-SLA proprietary);datasheets:public;blobs:required (proprietary GPU drivers/bootloader required);retail:open_market
     (mass-market)
@@ -66,11 +65,11 @@ adoption:
   signal_type: reported_traction
   confidence: high
   note: Widely available developer kit at a low $249 price with a large NVIDIA Jetson developer community
-    and global distribution. Re-read 2026-08-13 - the product page no longer prints any price at all,
-    so the $249 figure the note rests on is no longer published there; what the page still shows is
-    "the most powerful and affordable embedded computer for generative AI. It can be purchased through
-    NVIDIA authorized distributors worldwide", which is the distribution the mass-market reach was
-    banded on. Level and reach unchanged; the price figure is flagged for a curator ruling.
+    and global distribution. The product page no longer prints any price at all, so the $249 figure the
+    note rests on is no longer published there and is flagged for a curator ruling. What the page does show
+    is "the most powerful and affordable embedded computer for generative AI. It can be purchased through
+    NVIDIA authorized distributors worldwide", which is the distribution the mass-market reach was banded
+    on.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin/nano-super-developer-kit/
@@ -84,10 +83,9 @@ capability:
   basis: feature_matrix
   value: 67 INT8 (sparse) TOPS; 8GB LPDDR5; runs small LLMs (~7B quantized) and VLMs locally
   confidence: high
-  note: Solid entry-tier generative-AI compute, but 8GB RAM caps model size versus higher Orin tiers.
-    Re-derived 2026-08-13 against the spec table, which still reads 67 INT8 TOPS and 8GB 128-bit LPDDR5,
-    against the 157 TOPS / 16GB Orin NX and the 275 TOPS / 64GB AGX Orin on the same family page. The
-    entry position in the Orin line is unchanged.
+  note: Solid entry-tier generative-AI compute, but 8GB RAM caps model size versus higher Orin tiers. The
+    spec table reads 67 INT8 TOPS and 8GB 128-bit LPDDR5, against the 157 TOPS / 16GB Orin NX and the 275
+    TOPS / 64GB AGX Orin on the same family page, which is the entry position in the Orin line.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin/nano-super-developer-kit/

--- a/sources/scores/nvidia-jetson-orin-nx.yaml
+++ b/sources/scores/nvidia-jetson-orin-nx.yaml
@@ -23,10 +23,10 @@ openness:
       raw: distributor (via distributors)
   confidence: high
   note: Public datasheets and purchasable through distributors, but the SDK depends on proprietary NVIDIA
-    blobs under license. Re-read 2026-08-13 - the family page still publishes module data sheets and
-    points designers at the Product Design Guide rather than releasing the module's own board files,
-    still routes buyers through the Jetson partner ecosystem, and Jetson Linux 39.2.1 still ships kernel,
-    UEFI bootloader and NVIDIA drivers under the NVIDIA Software License Agreement. No dimension moved.
+    blobs under license. The family page publishes module data sheets and points designers at the Product
+    Design Guide rather than releasing the module's own board files, routes buyers through the Jetson partner
+    ecosystem, and Jetson Linux 39.2.1 ships kernel, UEFI bootloader and NVIDIA drivers under the NVIDIA
+    Software License Agreement.
   raw: schematics:partial (module datasheet + carrier design guide public);toolchain:closed (JetPack/Jetson
     Linux proprietary (NVIDIA SLA));datasheets:public;blobs:required (proprietary drivers/bootloader);retail:distributor
     (via distributors)
@@ -58,9 +58,9 @@ adoption:
   signal_type: reported_traction
   confidence: medium
   note: Production SO-DIMM module sold through NVIDIA's distributor network with strong Jetson community;
-    popular in commercial drones/robotics but not mass-market. Re-read 2026-08-13 - the family page still
-    lists "Jetson Orin NX is available in 16GB and 8GB" as production modules routed through the Jetson
-    partner ecosystem, with no retail channel of its own. Reach unchanged.
+    popular in commercial drones/robotics but not mass-market. The family page lists "Jetson Orin NX is
+    available in 16GB and 8GB" as production modules routed through the Jetson partner ecosystem, with no
+    retail channel of its own.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin
@@ -75,9 +75,8 @@ capability:
   value: Up to 157 TOPS; 8GB or 16GB LPDDR5; runs mid-to-large LLMs/VLMs and multi-stream vision
   confidence: high
   note: Strong mid-range edge compute; the 16GB/157 TOPS variant handles sizeable models, below AGX Orin
-    but above Orin Nano. Re-derived 2026-08-13 from the same comparison table - 157 SPARSE INT8 TOPS and
-    16GB 128-bit LPDDR5 against AGX Orin's 275 TOPS / 64GB above it and Orin Nano's 67 TOPS / 8GB below.
-    The ordering within the Orin line is unchanged.
+    but above Orin Nano. The comparison table reads 157 SPARSE INT8 TOPS and 16GB 128-bit LPDDR5 against
+    AGX Orin's 275 TOPS / 64GB above it and Orin Nano's 67 TOPS / 8GB below.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin

--- a/sources/scores/nxp-imx-8m-plus.yaml
+++ b/sources/scores/nxp-imx-8m-plus.yaml
@@ -24,21 +24,20 @@ openness:
       detail: commercial via NXP and SoM partners
       raw: distributor (commercial via NXP and SoM partners)
   confidence: high
-  note: Public datasheets and a Linux BSP with broad commercial availability, but proprietary silicon
-    with no open board files. Re-read 2026-08-14 against substitutes, www.nxp.com being unfetchable -
-    it answers 404 to every path tried including its own root, and browser headers change nothing, so
-    this is the host and not the URL. Every component re-derived. `datasheets` is the strongest of
-    them - the document the component names by part number, "Document Number IMX8MPCEC, Rev. 2.1,
-    07/2023, i.MX 8M Plus Applications Processor Datasheet for Consumer Products", is mirrored in full
-    and openly downloadable from DigiKey, 111 pages of electrical characteristics, boot modes and pin
-    assignments. `toolchain` and `blobs` both come from NXP's own Yocto layer repo - the BSP is public
-    and buildable, and the same README states "The NXP i.MX End User License Agreement (EULA) is
-    displayed during the setup process ... The license must be accepted to allow access to the NXP
-    EULA-licensed recipes", which is the gated-blob half stated by the vendor. `schematics` stays none
-    - what the BSP publishes is machine configurations for NXP's own EVK and FRDM reference boards,
-    and what the datasheet publishes is package and pin data, neither of which is a board file.
-    `retail` from Toradex shipping a Verdin SoM around the part and DigiKey stocking the silicon. No
-    change.
+  note: 'Public datasheets and a Linux BSP with broad commercial availability, but proprietary silicon with
+    no open board files. Component detail: `datasheets` is the strongest of them - the document the component
+    names by part number, "Document Number IMX8MPCEC, Rev. 2.1, 07/2023, i.MX 8M Plus Applications Processor
+    Datasheet for Consumer Products", is mirrored in full and openly downloadable from DigiKey, 111 pages
+    of electrical characteristics, boot modes and pin assignments. `toolchain` and `blobs` both come from
+    NXP''s own Yocto layer repo - the BSP is public and buildable, and the same README states "The NXP i.MX
+    End User License Agreement (EULA) is displayed during the setup process ... The license must be accepted
+    to allow access to the NXP EULA-licensed recipes", which is the gated-blob half stated by the vendor.
+    `schematics` stays none - what the BSP publishes is machine configurations for NXP''s own EVK and FRDM
+    reference boards, and what the datasheet publishes is package and pin data, neither of which is a board
+    file. `retail` rests on Toradex shipping a Verdin SoM around the part and DigiKey stocking the silicon.
+    www.nxp.com itself is unfetchable - it answers 404 to every path tried including its own root, and browser
+    headers change nothing, so this is the host and not the URL - and these components therefore rest on
+    substitutes.'
   raw: schematics:none (EVK reference designs only);toolchain:open (Linux/Yocto BSP);datasheets:public (IMX8MPCEC);blobs:required
     (proprietary silicon + NPU firmware);retail:distributor (commercial via NXP and SoM partners)
   last_verified: '2026-08-14'
@@ -78,12 +77,11 @@ adoption:
   reach: broad
   signal_type: reported_traction
   confidence: high
-  note: Widely deployed industrial processor with SoMs from multiple vendors (ADLINK, Toradex Verdin,
-    SolidRun) and broad distributor availability. Re-read 2026-08-13 - the Verdin iMX8M Plus is still a
-    live, configurable Toradex module with free Embedded Linux and FreeRTOS support and a product
-    availability commitment to 2036+. NXP's own product pages could not be re-read (www.nxp.com answers
-    404 to an automated fetch, including its own root), so the multi-vendor half of the note rests on the
-    earlier read. Level and reach unchanged.
+  note: Widely deployed industrial processor with SoMs from multiple vendors (ADLINK, Toradex Verdin, SolidRun)
+    and broad distributor availability. The Verdin iMX8M Plus is a live, configurable Toradex module with
+    free Embedded Linux and FreeRTOS support and a product availability commitment to 2036+. NXP's own product
+    pages are unfetchable (www.nxp.com answers 404 to an automated fetch, including its own root), so the
+    multi-vendor half of the note rests on an earlier read.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.toradex.com/computer-on-modules/verdin-arm-family/nxp-imx-8m-plus
@@ -99,12 +97,11 @@ capability:
   value: 2.3 TOPS NPU; quad Cortex-A53 + Cortex-M7; LPDDR4 support
   confidence: high
   note: 2.3 TOPS integrated NPU with dual-ISP vision is solid for industrial ML but lower throughput than
-    the 4-12 TOPS dedicated kits here. Re-derived 2026-08-13 - the NXP fact sheet the value cited now
-    404s (www.nxp.com answers 404 to an automated fetch across every path tried, including its own root),
-    so the figure was re-confirmed against Toradex's Verdin iMX8M Plus page, which reads "Neural
-    Processing Unit (NPU) - up to 2.3 TOPS" with 4x Cortex-A53 at 1.8 GHz and a Cortex-M7F. That is
-    still below beagley-ai and ti-am67a at 4 TOPS and well below the Jetson Orin line, so the band is
-    unchanged. The dead NXP source is escalated rather than deleted.
+    the 4-12 TOPS dedicated kits here. The NXP fact sheet the value cited now 404s (www.nxp.com answers
+    404 to an automated fetch across every path tried, including its own root), so the figure rests on Toradex's
+    Verdin iMX8M Plus page, which reads "Neural Processing Unit (NPU) - up to 2.3 TOPS" with 4x Cortex-A53
+    at 1.8 GHz and a Cortex-M7F. That is still below beagley-ai and ti-am67a at 4 TOPS and well below the
+    Jetson Orin line, so the band holds. The dead NXP source is escalated rather than deleted.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.toradex.com/computer-on-modules/verdin-arm-family/nxp-imx-8m-plus

--- a/sources/scores/o-series.yaml
+++ b/sources/scores/o-series.yaml
@@ -13,9 +13,7 @@ openness:
     - name: Proprietary
       detail: API+ChatGPT only
   confidence: high
-  note: Proprietary OpenAI reasoning models; no weights, data, or code released. Re-read 2026-08-13 - both
-    sources still describe models served only through ChatGPT and the API, and OpenAI has still published
-    no weights, corpus or training code for the line. No change.
+  note: Proprietary OpenAI reasoning models; no weights, data, or code released.
   raw: weights:closed;data:closed;code:closed;license:Proprietary(API+ChatGPT only)
   last_verified: '2026-08-13'
   sources:
@@ -37,12 +35,10 @@ adoption:
   reach: '>10M users'
   signal_type: active_users
   confidence: medium
-  note: o3/o4-mini were rolled out as selectable models inside ChatGPT (Plus/Pro and some free) plus the API; ChatGPT
-    reached ~900M WAU (Feb 2026) rising toward ~1B (May 2026). Reach attributed to the ChatGPT surface these models
-    power, not a standalone o3 count. Now superseded as default by GPT-5.x but still used at scale. Re-read
-    2026-08-13 - the page still records o3-mini going to all ChatGPT users including the free tier, and
-    o3/o3-pro to paid tiers and the API, so the surface the band is attributed to is unchanged. The banded
-    quantity is the ChatGPT active-user count, not an o3 count, and the note says so. No change.
+  note: o3/o4-mini were rolled out as selectable models inside ChatGPT (Plus/Pro and some free) plus the
+    API; ChatGPT reached ~900M WAU (Feb 2026) rising toward ~1B (May 2026). Reach attributed to the ChatGPT
+    surface these models power, not a standalone o3 count. Now superseded as default by GPT-5.x but still
+    used at scale.
   last_verified: '2026-08-13'
   sources:
   - url: https://en.wikipedia.org/wiki/OpenAI_o3
@@ -58,12 +54,10 @@ capability:
   value: 'o3: SWE-bench Verified 71.7%, GPQA Diamond 87.7%, Codeforces Elo 2727; o4-mini: AIME 2025 99.5% pass@1
     with Python tool, GPQA ~81%'
   confidence: high
-  note: Frontier-class reasoning at Apr 2025 launch (SOTA on Codeforces/SWE-bench/MMMU at the time). By June 2026
-    surpassed by GPT-5.x / Opus 4.8 (88.6 SWE-bench) / Gemini 3.5, so frontier-relative score is 4, not 5.
-    Re-read 2026-08-13 - all three o3 figures are still on the page verbatim (SWE-bench Verified 71.7 against
-    o1's 48.9, GPQA Diamond 87.7, Codeforces Elo 2727 against o1's 1891). The o4-mini half of the recorded
-    value is NOT on that page - "99.5" does not appear on it at all - so that half rests on the system card
-    alone. Flagged in the report; it does not move the score, which is set by the o3 figures.
+  note: Frontier-class reasoning at Apr 2025 launch (SOTA on Codeforces/SWE-bench/MMMU at the time). By
+    June 2026 surpassed by GPT-5.x / Opus 4.8 (88.6 SWE-bench) / Gemini 3.5, so frontier-relative score
+    is 4, not 5. The o4-mini half of the recorded value is not on the Wikipedia source - 99.5 does not appear
+    on it - so it rests on the system card alone. That does not move the score, which is set by the o3 figures.
   last_verified: '2026-08-13'
   sources:
   - url: https://en.wikipedia.org/wiki/OpenAI_o3

--- a/sources/scores/oasst1.yaml
+++ b/sources/scores/oasst1.yaml
@@ -10,8 +10,7 @@ openness:
     dataset_card:
       value: present
   confidence: high
-  note: 'Apache-2.0, ungated, full dataset card. Re-read 2026-08-13: apache-2.0 on the Hub, gated false,
-    card intact.'
+  note: Apache-2.0, ungated, full dataset card.
   raw: license:Apache-2.0;gated:false;dataset_card:present
   last_verified: '2026-08-13'
   sources:
@@ -29,9 +28,8 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 20,967 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (OpenAssistant/oasst1 20,967). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top
-    band is >1M.
+  note: 20,967 downloads in the trailing 30 days summed across the 1 declared artifact(s) (OpenAssistant/oasst1
+    20,967). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/OpenAssistant/oasst1
@@ -46,13 +44,10 @@ capability:
   value: null
   confidence: high
   note: 'Proven with ongoing downstream use (Guanaco, Tulu 3, OLMo 3 Dolci) but dated, reduced to a fractional
-    ingredient, with no comparative results isolating its value. Re-read 2026-08-14 - the QLoRA citation
-    was pointed at the arXiv abstract page, which never mentions OASST1, so the Guanaco lineage this axis
-    rests on had no live source. It is repointed to the paper PDF, where the string OASST1 occurs 19
-    times. The load-bearing sentence reads "the top QLoRA tuned model, Guanaco 65B, which we finetune on
-    a variant of OASST1, is the best-performing open-source chatbot model", and the dataset appendix
-    pins that variant at 9,209 examples, being the top reply at each level of the conversation tree. The
-    band is unchanged; only the pointer moved from the abstract to the full text.'
+    ingredient, with no comparative results isolating its value. The Guanaco lineage rests on the QLoRA
+    paper''s full text rather than its abstract page, which does not mention OASST1: Guanaco 65B is finetuned
+    on a variant of OASST1, pinned in the dataset appendix at 9,209 examples taken as the top reply at each
+    level of the conversation tree, and is described there as the best-performing open-source chatbot model.'
   last_verified: '2026-08-14'
   sources:
   - url: https://arxiv.org/pdf/2305.14314

--- a/sources/scores/ogx.yaml
+++ b/sources/scores/ogx.yaml
@@ -17,12 +17,6 @@ openness:
   confidence: high
   note: Fully open (MIT, full source). Openness scored straightforwardly; the issue is category fit, not
     openness.
-    Re-read 2026-08-13. The repository still carries MIT and still publishes the whole server,
-    installable in one line or by pip, with nothing held back for a paid tier and no hosted edition
-    offered. The tagged release has moved on from the v1.0.2 recorded in the source line to v1.3.0 of 7
-    August 2026, and the star count is 8,420. The rename announcement still describes the move from
-    Llama Stack to a model-agnostic, multi-SDK server that routes to inference backends rather than
-    serving weights. Value unchanged at 5 / open_source.
   raw: license:MIT(OSI);source:public;no-feature-gated-core;implements OpenAI + Anthropic API surfaces;
     23 pluggable inference providers;core-gated:ungated
   last_verified: '2026-08-13'
@@ -46,19 +40,13 @@ adoption:
   reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
-  note: 'Only ~8.4k GitHub stars and no published download/usage volume found this run; capped low on stars
-    fallback (cannot exceed level 3). Recently renamed from Llama Stack, so historical signal is muddled.
-    Stars read 2026-08-13 on ogx-ai/ogx: 8,420, which bands at 1K-10K stars, level 2 on the stars scale. The
-    previous reach ''10K-100K'' was a download label, which this instrument does not offer - a star is not a
-    download. THE REAL DEFECT is upstream: this product declares no artifacts at all, so a stars_fallback band
-    had no stars source behind it and the count lived only in this note. Declaring ogx-ai/ogx would fix it,
-    and is deliberately not done here because a declared code repo also re-routes the openness license
-    dimension. No last_verified claimed: a star count is volatile.
-    Re-read 2026-08-13 - ogx-ai/ogx shows 8,420 stars, which still bands at 1K-10K stars, level 2 on the
-    stars scale, and the README still publishes no download or usage figure. The artifact defect
-    described above is unchanged and still the right thing to fix upstream. This supersedes the refusal
-    to claim a date - the axis was re-read rather than aggregated, and drift in the digest is expected
-    for the reason the earlier note gives.'
+  note: 'Only 8,420 GitHub stars on ogx-ai/ogx and no published download or usage volume; capped low on
+    stars fallback, which cannot exceed level 3. Recently renamed from Llama Stack, so historical signal
+    is muddled. The count bands at 1K-10K stars, level 2 on the stars scale. The previous reach ''10K-100K''
+    was a download label, which this instrument does not offer - a star is not a download. THE REAL DEFECT
+    is upstream: this product declares no artifacts at all, so a stars_fallback band had no stars source
+    behind it and the count lived only in this note. Declaring ogx-ai/ogx would fix it, and is deliberately
+    not done here because a declared code repo also re-routes the openness license dimension.'
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/ogx-ai/ogx
@@ -73,16 +61,11 @@ capability:
     safety backends, tool runtimes, file/batch storage into one agentic API server
   confidence: medium
   note: Capability is gateway/agentic-server breadth (multi-API-surface, provider composition), not inference
-    throughput. As an inference engine it scores low because it does no forward pass itself; scored on
-    its actual feature set in its true category. See recategorize.
-    Re-read 2026-08-13. The README still shows the gateway breadth the band rests on - chat completions,
-    completions and embeddings, a Responses API doing server-side agentic orchestration with tool
-    calling and MCP integration, vector stores and files, batches, and a pluggable provider architecture
-    spanning local Ollama through to production vLLM and managed services. Two things have moved since
-    the band was set - the multi-SDK surface now includes the Google GenAI SDK alongside the Anthropic
-    one, and a versioned Skills endpoint has appeared - while the README no longer states the provider
-    count of 23 in the source line, deferring to the provider documentation instead. Neither changes the
-    tier. Band unchanged at 3.
+    throughput. As an inference engine it scores low because it does no forward pass itself; scored on its
+    actual feature set in its true category. See recategorize. Two things have moved since the band was
+    set - the multi-SDK surface now includes the Google GenAI SDK alongside the Anthropic one, and a versioned
+    Skills endpoint has appeared - while the README no longer states the provider count of 23 that the value
+    records, deferring to the provider documentation instead. Neither changes the tier.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/ogx-ai/ogx

--- a/sources/scores/ollama.yaml
+++ b/sources/scores/ollama.yaml
@@ -12,13 +12,11 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: 'license:MIT;source:public;no-feature-gated-core. Re-read 2026-08-13 and unchanged. The LICENSE
-    body at repository head is a verbatim MIT text, "Copyright (c) Ollama", and the GitHub repository
-    metadata reports spdx_id MIT on a public, unarchived Go repository. The README ships the whole engine
-    for free - platform installers for macOS, Windows and Linux, an official Docker Hub image, the local
-    REST API on port 11434, and the model library - with no paid edition, license key or enterprise-only
-    build. Ollama now sells hosted cloud inference and lists a pricing page, but that is a separate
-    service alongside the engine rather than a capability withheld from it, so core-gated stays ungated.'
+  note: license:MIT;source:public;no-feature-gated-core. The whole engine ships free - platform installers
+    for macOS, Windows and Linux, an official Docker Hub image, the local REST API on port 11434, and the
+    model library - with no paid edition, license key or enterprise-only build. Ollama sells hosted cloud
+    inference alongside the engine, but that is a separate service rather than a capability withheld from
+    it, so core-gated stays ungated.
   raw: license:MIT;source:public;no-feature-gated-core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -64,30 +62,23 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: 'Reported 52M+ monthly model pulls in early 2026; 170K+ GitHub stars. Pull/usage volume places it in
-    the 1-10M+ active-user range; rated 4 conservatively on monthly pull volume (not stars). ARTIFACT
-    DELIBERATELY NOT DECLARED, checked 2026-08-13. A PyPI package named `ollama` exists and is genuinely this
-    project''s, so declaring it would satisfy check_instrument and would be wrong. Ollama is distributed as a
-    platform binary and a Docker image; the PyPI package is a client SDK for talking to a local server, not
-    how Ollama is obtained. 20.3M/mo is a large number attached to the wrong question. That is the under-
-    coverage rule in docs/reference/adoption.md - if the declared artifact is not the product''s primary
-    distribution channel, banding on it is a substitution rather than a measurement - applied before the
-    mistake rather than after. The band stands on the evidence already cited here; what this record needs is a
-    route to its real channel, not a convenient one. Re-read 2026-08-13. The band is unchanged and the
-    evidence under it has moved - the repository now reports 178,451 stars and 17,389 forks, and the
-    model library lists 233 models carrying about 1.0 billion cumulative pulls between them, led by
-    llama3.1 at 118.4M and deepseek-r1 at 91.3M. FIGURE CORRECTION - the "52M+ monthly model pulls" this
-    note opens with is not published on either cited page and could not be re-derived. ollama.com/library
-    publishes an all-time cumulative pull counter per model, never a monthly rate, and the word monthly
-    does not appear on it; the homepage publishes no volume figure at all. The level-4 band rests instead
-    on what those pages do show, which is a cumulative pull base around a billion across the library and
-    a very large installed developer base, still comfortably inside the 1M-10M active-user reading. The
-    monthly framing should come out of this note; flagged rather than edited because the wording is the
-    basis someone recorded. INSTRUMENT CAVEAT, recorded rather than worked around - this record uses
-    usage_volume while declaring no artifact a signal model can recompute from, and the artifact
-    paragraph above explains why declaring the PyPI package would be wrong. Neither the instrument nor
-    the artifact was changed; the axis now carries digested sources so the claim can be re-checked and
-    will age.'
+  note: 'The band rests on model-pull volume rather than stars: ollama.com/library lists 233 models carrying
+    about 1.0 billion cumulative pulls between them, led by llama3.1 at 118.4M and deepseek-r1 at 91.3M,
+    alongside 178,451 GitHub stars - comfortably inside a 1M-10M active-user reading, and rated 4 conservatively.
+    FIGURE CORRECTION: the "52M+ monthly model pulls" this record was originally banded on is not published
+    on either cited page and could not be re-derived - the library publishes an all-time cumulative pull
+    counter per model, never a monthly rate, and the homepage publishes no volume figure at all. The monthly
+    framing should come out of this note; flagged rather than edited because the wording is the basis someone
+    recorded. ARTIFACT DELIBERATELY NOT DECLARED: a PyPI package named `ollama` exists and is genuinely
+    this project''s, so declaring it would satisfy check_instrument and would be wrong. Ollama is distributed
+    as a platform binary and a Docker image; the PyPI package is a client SDK for talking to a local server,
+    not how Ollama is obtained, and its 20.3M/mo is a large number attached to the wrong question. That
+    is the under-coverage rule in docs/reference/adoption.md - if the declared artifact is not the product''s
+    primary distribution channel, banding on it is a substitution rather than a measurement - applied before
+    the mistake rather than after. INSTRUMENT CAVEAT, recorded rather than worked around: this record uses
+    usage_volume while declaring no artifact a signal model can recompute from, and the artifact paragraph
+    above explains why declaring the PyPI package would be wrong. Neither the instrument nor the artifact
+    was changed; the axis carries digested sources so the claim can be checked again and will age.'
   last_verified: '2026-08-13'
   sources:
   - url: https://api.github.com/repos/ollama/ollama
@@ -119,13 +110,11 @@ capability:
   confidence: high
   note: 'Local model serving with one-command run, OpenAI-compatible REST API, broad model library (Llama,
     Qwen, Gemma, gpt-oss, DeepSeek). Serving-layer tool; no MLPerf result cited, rated on feature/coverage
-    matrix. Re-read 2026-08-13 and the feature matrix holds, with the surface wider than when the band
-    was set. The README documents the local REST API on port 11434 with an OpenAI-compatible chat
-    endpoint, Python and JavaScript clients, and a new agent-launcher layer - ollama launch claude,
-    codex, copilot-cli, droid, opencode - plus the OpenClaw assistant integration. The library carries
-    233 model families including Llama, Qwen, Gemma, DeepSeek and gpt-oss, and the vendor site now also
-    serves several of them as cloud models. Still no benchmark result is published for the runtime
-    itself, so the basis stays feature_matrix.'
+    matrix. The surface is wider than when the band was set: the README documents the local REST API on
+    port 11434 with an OpenAI-compatible chat endpoint, Python and JavaScript clients, and an agent-launcher
+    layer - `ollama launch claude`, codex, copilot-cli, droid, opencode - plus the OpenClaw assistant integration,
+    and the library carries 233 model families, several of which the vendor site also serves as cloud models.
+    No benchmark result is published for the runtime itself, so the basis stays feature_matrix.'
   last_verified: '2026-08-13'
   sources:
   - url: https://raw.githubusercontent.com/ollama/ollama/main/README.md

--- a/sources/scores/olmo-instruct.yaml
+++ b/sources/scores/olmo-instruct.yaml
@@ -19,11 +19,8 @@ openness:
       detail: OSI
   confidence: high
   note: 'Fully-open instruct line: Apache-2.0 weights + open pretraining and post-training data + open training
-    code + checkpoints. Re-read 2026-08-13 - the 7B Instruct card still carries `license:apache-2.0` and
-    reads `"gated":false`, and the Olmo 3 blog still publishes the whole model flow (every stage, checkpoint,
-    dataset and dependency) with the code at allenai/open-instruct. The blog has since added an Olmo 3.1
-    update shipping 32B Think and Instruct checkpoints on the same open recipe, which does not change the
-    class. No change.'
+    code + checkpoints. The blog has since added an Olmo 3.1 update shipping 32B Think and Instruct checkpoints
+    on the same open recipe, which does not change the class.'
   raw: weights:open(Apache-2.0);data:open(Dolma 3 pretraining + open post-training mixtures);code:open(OLMo
     + open-instruct);checkpoints:open;license:Apache-2.0(OSI)
   last_verified: '2026-08-13'
@@ -48,15 +45,12 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: medium
-  note: 'Solid research/practitioner reach for a fully-open instruct line; below the Qwen/Llama instruct
-    workhorses. Downloads still ramping as it supersedes OLMo 2 Instruct. Read live 2026-08-13: 450,053
-    Hugging Face downloads in the trailing 30 days across the declared artifact(s), which bands at 100K-1M,
-    level 3. The previous reach ''10K-100K'' was a band off a different scale. No last_verified claimed: only
-    the figure was re-read, not the whole axis. Re-read in full 2026-08-13 and the band holds: allenai/Olmo-3-7B-Instruct
-    reads 450,053 downloads in the trailing 30 days, inside 100K-1M. The other declared artifact,
-    allenai/Olmo-3-1025-32B-Instruct, answers HTTP 401 and contributes nothing to the sum; that is flagged
-    separately as a declared artifact that no longer resolves, and it can only raise the figure, never
-    lower it.'
+  note: Solid research/practitioner reach for a fully-open instruct line; below the Qwen/Llama instruct
+    workhorses. Downloads still ramping as it supersedes OLMo 2 Instruct. The declared artifact allenai/Olmo-3-7B-Instruct
+    reads 450,053 Hugging Face downloads in the trailing 30 days, which bands at 100K-1M, level 3; the previous
+    reach '10K-100K' was a band off a different scale. The other declared artifact, allenai/Olmo-3-1025-32B-Instruct,
+    answers HTTP 401 and contributes nothing to the sum; that is flagged separately as a declared artifact
+    that no longer resolves, and it can only raise the figure, never lower it.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/allenai/Olmo-3-7B-Instruct
@@ -70,10 +64,8 @@ capability:
   basis_detail: IFEval/AlpacaEval/MMLU
   value: OLMo 3-Instruct 7B ties or surpasses Qwen 2.5, Gemma 3 and Llama 3.1 at its scale
   confidence: high
-  note: Strongest fully-open chat line; competitive with same-scale open-weight instruct models but below the 2026
-    frontier (=5). Re-read 2026-08-13 - the blog still reads "Olmo 3-Instruct ties or surpasses Qwen 2.5,
-    Gemma 3, and Llama 3.1 in our evaluations, and competes with the Qwen 3 family at similar scale", which
-    is the comparison the 4 rests on and still places it below the frontier. No change.
+  note: Strongest fully-open chat line; competitive with same-scale open-weight instruct models but below
+    the 2026 frontier (=5).
   last_verified: '2026-08-13'
   sources:
   - url: https://allenai.org/blog/olmo3

--- a/sources/scores/olmo.yaml
+++ b/sources/scores/olmo.yaml
@@ -20,10 +20,8 @@ openness:
       detail: OSI
   confidence: high
   note: 'Fully open: Apache-2.0 weights + the complete Dolma 3 corpus + training code + intermediate checkpoints.
-    The reference fully-open model line. Re-read 2026-08-13: Dolma is still ungated and `odc-by`
-    (2,724 downloads, 1,070 likes), the Olmo 3 blog still carries the Dolma 3 and open-checkpoint
-    claims, and the 7B card still reads apache-2.0 with safetensors and `isGated: false`. Nothing
-    moved.'
+    The reference fully-open model line. Dolma is ungated and `odc-by`, and the 7B card reads apache-2.0
+    with safetensors and `isGated: false`.'
   last_verified: '2026-08-13'
   raw: weights:open(Apache-2.0);data:open(Dolma 3, 9.3T tokens, all stages);code:open(training code+recipes+logs);checkpoints:open(intermediate);license:Apache-2.0(OSI)
   sources:
@@ -62,9 +60,9 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: medium
-  note: 146,145 downloads in the trailing 30 days summed across the 2 declared artifact(s), read 2026-08-13
-    (allenai/Olmo-3-1125-32B 43,671; allenai/Olmo-3-1025-7B 102,474). Bands at level 3 (100K-1M) on the
-    software and model adoption scale. Corrected from level 4, which the declared artifacts do not support.
+  note: 146,145 downloads in the trailing 30 days summed across the 2 declared artifact(s) (allenai/Olmo-3-1125-32B
+    43,671; allenai/Olmo-3-1025-7B 102,474). Bands at level 3 (100K-1M) on the software and model adoption
+    scale. Corrected from level 4, which the declared artifacts do not support.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/models/allenai/Olmo-3-1125-32B
@@ -83,11 +81,8 @@ capability:
   basis_detail: MMLU/GPQA/reasoning
   value: OLMo 3-Think 32B narrows the gap to Qwen3-32B on reasoning at ~6x fewer tokens
   confidence: high
-  note: Strongest fully-open base/reasoning model to date; competitive with Qwen2.5/Gemma3 and approaching Qwen3-32B,
-    but still a step below the trillion-param open-weight frontier (=5). Re-read 2026-08-13 - the
-    blog still carries both claims the band rests on, and the comparison it draws is to open-weight
-    models of similar scale rather than to the trillion-parameter frontier, which is the gap the 4
-    encodes.
+  note: Strongest fully-open base/reasoning model to date; competitive with Qwen2.5/Gemma3 and approaching
+    Qwen3-32B, but still a step below the trillion-param open-weight frontier (=5).
   last_verified: '2026-08-13'
   sources:
   - url: https://allenai.org/blog/olmo3

--- a/sources/scores/olmocr.yaml
+++ b/sources/scores/olmocr.yaml
@@ -16,9 +16,7 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (Apache-2.0), full source public. Re-read 2026-08-13 - the LICENSE body still
-    carries the same license and the README still builds the whole product from the published repo, with
-    no paid tier, enterprise edition or license key anywhere in it.
+  note: Fully OSI-licensed (Apache-2.0), full source public.
   raw: license:Apache-2.0(OSI);source:public(allenai/olmocr);governance:Allen Institute for AI;no feature-gated
     core;core-gated:ungated
   last_verified: '2026-08-13'
@@ -45,9 +43,8 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 22,925 PyPI downloads in the trailing 30 days for olmocr, read 2026-08-13. Bands at level 2 (10K-100K)
-    on the software and model adoption scale. Corrected from level 3, which the declared artifact does not
-    support.
+  note: 22,925 PyPI downloads in the trailing 30 days for olmocr. Bands at level 2 (10K-100K) on the software
+    and model adoption scale. Corrected from level 3, which the declared artifact does not support.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/olmocr/recent
@@ -63,10 +60,7 @@ capability:
     OmniDocBench it is mid-pack (85.74), behind MinerU-2.5 (93.04), Gemini 3 Pro (92.91) and GPT-5.2 (86.59).
   confidence: high
   note: 'Benchmark-anchored: leads open document-extraction tools on olmOCR-Bench but sits mid-pack on the
-    neutral OmniDocBench, so near-SOTA rather than SOTA. Snapshot; extraction leaderboards move. Re-read
-    2026-08-13 - the olmOCR-Bench table has dropped GPT-4o and now places Chandra OCR and Infinity-Parser
-    above olmOCR, and OmniDocBench lists olmOCR at 85.74. The band stays at 4, which the note already read
-    as near-SOTA rather than SOTA.'
+    neutral OmniDocBench, so near-SOTA rather than SOTA. Snapshot; extraction leaderboards move.'
   last_verified: '2026-08-13'
   sources:
   - url: https://raw.githubusercontent.com/allenai/olmocr/main/README.md

--- a/sources/scores/olmoe-instruct.yaml
+++ b/sources/scores/olmoe-instruct.yaml
@@ -19,11 +19,8 @@ openness:
     - name: Apache-2.0
       detail: OSI
   confidence: high
-  note: 'Fully-open MoE: Apache-2.0 weights + open pretraining data (OLMoE-mix-0924, on
-    Dolma/DataComp) + open post-training data + open code + 244 intermediate checkpoints.
-    Open_source tier 5. Re-read 2026-08-13 - the card still reads "OLMoE is 100% open-source" and still
-    links checkpoints, code, data and logs separately for pretraining, SFT and DPO/KTO, with
-    `license:apache-2.0` in the repo tags. No change.'
+  note: 'Fully-open MoE: Apache-2.0 weights + open pretraining data (OLMoE-mix-0924, on Dolma/DataComp)
+    + open post-training data + open code + 244 intermediate checkpoints. Open_source tier 5.'
   raw: weights:open(Apache-2.0);data:open(OLMoE-mix-0924 pretraining + Tulu/UltraFeedback post-training);code:open(OLMoE
     training code, SFT/DPO/KTO recipes);checkpoints:open(244 intermediate);license:Apache-2.0(OSI)
   last_verified: '2026-08-13'
@@ -47,10 +44,9 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 28,149 downloads in the trailing 30 days summed across the 2 declared artifact(s), read 2026-08-13
-    (allenai/OLMoE-1B-7B-0924-Instruct 26,721; allenai/OLMoE-mix-0924 1,428). Bands at level 2 (10K-100K)
-    on the software and model adoption scale. Corrected from level 3, which the declared artifacts do not
-    support.
+  note: 28,149 downloads in the trailing 30 days summed across the 2 declared artifact(s) (allenai/OLMoE-1B-7B-0924-Instruct
+    26,721; allenai/OLMoE-mix-0924 1,428). Bands at level 2 (10K-100K) on the software and model adoption
+    scale. Corrected from level 3, which the declared artifacts do not support.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/models/allenai/OLMoE-1B-7B-0924-Instruct
@@ -70,14 +66,10 @@ capability:
   value: OLMoE-1B-7B-Instruct MMLU 51.9, GSM8k 45.5, HumanEval 54.8, AlpacaEval1 84.0,
     IFEval 48.1
   confidence: medium
-  note: State-of-the-art among ~1B-active-parameter models at release (beats Gemma2,
-    Llama2-13B-Chat, OLMo-7B, DeepSeekMoE-16B per the blog), but absolute capability is
-    low-tier vs full-size 2026 chat models given the 1.3B active budget. Scored 2 on
-    absolute capability. Exact per-competitor numbers live in arXiv 2409.02060 (blog
-    charts are images), so the comparative claims are directional -- hence medium confidence.
-    Re-read 2026-08-13 - the card's Evaluation Snapshot still gives the +DPO row MMLU 51.9,
-    GSM8k 45.5, HumanEval 54.8, Alpaca-Eval 1.0 84.0 and IFEval 48.1, every figure unchanged,
-    and still claims parity with Llama2-13B-Chat at 1B active. No change.
+  note: State-of-the-art among ~1B-active-parameter models at release (beats Gemma2, Llama2-13B-Chat, OLMo-7B,
+    DeepSeekMoE-16B per the blog), but absolute capability is low-tier vs full-size 2026 chat models given
+    the 1.3B active budget. Scored 2 on absolute capability. Exact per-competitor numbers live in arXiv
+    2409.02060 (blog charts are images), so the comparative claims are directional -- hence medium confidence.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/allenai/OLMoE-1B-7B-0924-Instruct

--- a/sources/scores/onnx.yaml
+++ b/sources/scores/onnx.yaml
@@ -13,10 +13,9 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: 'Apache-2.0 license body confirmed; full source public on GitHub. Re-read 2026-08-13: the cited
-    LICENSE body still carries the Apache-2.0 terms, the GitHub API reports the repository public, unarchived
-    and licensed Apache-2.0, and the README describes the whole library with no paid, enterprise or hosted
-    tier beside it, so source stays public and core-gated stays ungated.'
+  note: Apache-2.0 license body confirmed; full source public on GitHub. The repository is public and unarchived,
+    and the README describes the whole library with no paid, enterprise or hosted tier beside it, so source
+    is public and the core ungated.
   raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -50,13 +49,11 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: 'Re-scored 4->5. 20.65M PyPI downloads in the last 30 days. The map''s prevailing usage_volume level-5
+  note: Re-scored 4->5. 20.65M PyPI downloads in the last 30 days. The map's prevailing usage_volume level-5
     floor is >10M/mo (cf. pydantic-ai ~31M, llama-index ~10.18M at level 5; the companion onnxruntime is
     already level 5 at ~74.7M); the prior level 4 applied the stricter ml_frameworks-batch band. ONNX is
-    the de facto cross-framework model-exchange standard and clears the floor. Re-read 2026-08-13 from the
-    cited pepy.tech reading of the declared PyPI artifact `onnx`: 19,619,971 downloads in the trailing 30
-    days, which bands at >10M, level 5 on the software scale. Unchanged. `onnxruntime` is a separate product
-    with its own package and is not summed in here.'
+    the de facto cross-framework model-exchange standard and clears the floor. `onnxruntime` is a separate
+    product with its own package and is not summed in here.
   last_verified: '2026-08-13'
   sources:
   - url: https://pepy.tech/projects/onnx
@@ -69,8 +66,7 @@ capability:
   basis: feature_matrix
   value: Foundational open model-exchange format and operator spec underpinning cross-framework interoperability.
   confidence: high
-  note: 'Defines the graph model, operators, and data types used as the de-facto interchange standard. Re-read
-    2026-08-13: the cited repository page still describes the product as recorded, so the band is unchanged.'
+  note: Defines the graph model, operators, and data types used as the de-facto interchange standard.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/onnx/onnx

--- a/sources/scores/open-llm-leaderboard.yaml
+++ b/sources/scores/open-llm-leaderboard.yaml
@@ -16,10 +16,9 @@ openness:
       detail: Space source public and docker-compose deployable, no paid tier
   confidence: high
   last_verified: '2026-08-13'
-  note: Open Apache-2.0 leaderboard built on open eval backends (now archived). Re-read 2026-08-13 - the
-    Space is still public and RUNNING, its card data still declares apache-2.0 and sdk docker, and the
-    README still brings the React frontend and FastAPI backend up with `docker-compose up`. Nothing has
-    been withdrawn or gated since archival.
+  note: Open Apache-2.0 leaderboard built on open eval backends (now archived). The Space is public and
+    RUNNING, its card data declares apache-2.0 and sdk docker, and the README brings the React frontend
+    and FastAPI backend up with `docker-compose up`; nothing has been withdrawn or gated since archival.
   raw: license:Apache-2.0(HF-Space);backend:lm-eval-harness/lighteval(open);source:public;core-gated:ungated(Space
     source public and docker-compose deployable, no paid tier)
   sources:
@@ -42,9 +41,9 @@ openness:
     - license
     - source
   - url: https://huggingface.co/spaces/open-llm-leaderboard/open_llm_leaderboard/raw/main/README.md
-    shows: 'Re-read 2026-08-13: frontmatter still declares ''license: apache-2.0'' and ''sdk: docker'',
-      and the body still documents bringing the React frontend and FastAPI backend up with `docker-compose
-      up`. No feature is described as paid, licensed or restricted.'
+    shows: 'Frontmatter declares ''license: apache-2.0'' and ''sdk: docker'', and the body documents bringing
+      the React frontend and FastAPI backend up with `docker-compose up`. No feature is described as paid,
+      licensed or restricted.'
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 506aed8ab5aeccd01310992962de01898974545083e3c38170203d52b7e57214
@@ -68,21 +67,19 @@ adoption:
   last_verified: '2026-08-13'
   banded_quantity: 'peak lifetime figures of an archived leaderboard: 13,000+ models evaluated and 2M+ unique
     visitors'
-  note: 'ARCHIVED 2025-03-13. At peak: 13,000+ models evaluated, 2M+ unique visitors - historically the most influential
-    open-model leaderboard. Re-read 2026-08-13 and both figures check out, from two different pages. The
-    retirement post says ''For the last 2 years, we''ve evaluated over 13K models with the Open LLM Leaderboard'';
-    the archive page carries the visitor figure - ''visited by more than 2 million unique people over
-    the last 10 months'', with around 300,000 community members using it monthly. The Space itself still
-    shows 14,072 likes. Level 4 unchanged, and the figures are historical by nature since the product
-    is retired.'
+  note: 'ARCHIVED 2025-03-13. At peak: 13,000+ models evaluated, 2M+ unique visitors - historically the
+    most influential open-model leaderboard. The two figures come from different pages - the retirement
+    post for the 13K models evaluated, the archive page for ''more than 2 million unique people over the
+    last 10 months'' and around 300,000 community members a month - and the Space still shows 14,072 likes.
+    They are historical by nature, the product being retired.'
   sources:
   - url: https://huggingface.co/spaces/open-llm-leaderboard/open_llm_leaderboard/discussions/1135
     shows: retirement announcement, 2025-03-13
     accessed: '2026-06-17'
   - url: https://huggingface.co/spaces/open-llm-leaderboard/open_llm_leaderboard/discussions/1135
-    shows: 'Re-read 2026-08-13: retirement announcement dated 2025-03-13, stating ''For the last 2 years,
-      we''ve evaluated over 13K models with the Open LLM Leaderboard'' and noting that over 200 community-led
-      leaderboards now exist on Hugging Face. It carries no visitor figure.'
+    shows: Retirement announcement dated 2025-03-13, stating 'For the last 2 years, we've evaluated over
+      13K models with the Open LLM Leaderboard' and noting that over 200 community-led leaderboards now
+      exist on Hugging Face. It carries no visitor figure.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: c1d074b0c1119d66df281824db0824ba1409a7e4cac8272d95d36215950b6c57
@@ -104,22 +101,22 @@ capability:
     runs; 13,000+ models'
   confidence: high
   last_verified: '2026-08-13'
-  note: 'Historically the most visible open-model leaderboard; static rather than human-preference; now archived.
-    Feature matrix re-read 2026-08-13, with one attribution correction. The archive URL cited here documents
-    the v1 leaderboard, not v2: six benchmarks (ARC 25-shot, HellaSwag 10-shot, MMLU 5-shot, TruthfulQA,
-    Winogrande 5-shot, GSM8k 5-shot) run on a single node of 8 H100s through lm-evaluation-harness, with
-    a reproduction command. So it establishes the shared-cluster reproducible-runs half of this value
-    and the 2M visitors, but not the v2 suite; the v2 benchmark list is corroborated by the Space''s own
-    tags. The 13,000+ model figure comes from the retirement post. Band unchanged.'
+  note: 'Historically the most visible open-model leaderboard; static rather than human-preference; now
+    archived. One attribution caveat on the evidence: the archive URL cited here documents the v1 leaderboard,
+    not v2 - six benchmarks (ARC 25-shot, HellaSwag 10-shot, MMLU 5-shot, TruthfulQA, Winogrande 5-shot,
+    GSM8k 5-shot) run on a single node of 8 H100s through lm-evaluation-harness, with a reproduction command
+    - so it establishes the shared-cluster reproducible-runs half of this value and the 2M visitors, but
+    not the v2 suite, which is corroborated instead by the Space''s own tags. The 13,000+ model figure comes
+    from the retirement post.'
   sources:
   - url: https://huggingface.co/docs/leaderboards/en/open_llm_leaderboard/archive
     shows: v2 benchmark suite, 2M visitors, archive
     accessed: '2026-06-17'
   - url: https://huggingface.co/docs/leaderboards/en/open_llm_leaderboard/archive
-    shows: 'Re-read 2026-08-13: this page covers Open LLM Leaderboard v1 - six benchmarks (ARC, HellaSwag,
-      MMLU, TruthfulQA, Winogrande, GSM8k) evaluated with the EleutherAI harness on a single node of 8
-      H100s, with the exact reproduction command published. Archived June 2024 and replaced by v2. It
-      does NOT list the v2 suite this value names.'
+    shows: This page covers Open LLM Leaderboard v1 - six benchmarks (ARC, HellaSwag, MMLU, TruthfulQA,
+      Winogrande, GSM8k) evaluated with the EleutherAI harness on a single node of 8 H100s, with the exact
+      reproduction command published. Archived June 2024 and replaced by v2. It does NOT list the v2 suite
+      this value names.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 9d39be4322e6018399babc9b4eca161a1906cd2828abb9fef0bfb40b32f2fb02

--- a/sources/scores/open-webui.yaml
+++ b/sources/scores/open-webui.yaml
@@ -17,12 +17,7 @@ openness:
     class of use and fails the OSS Definition, though it is widely marketed as open source. Score corrected
     from 3 to 2 on 2026-07-30. The software ladder has rungs at 1, 2, 4 and 5 and none at 3, so 3/source_available
     was not a pair any rule could produce; the ladder scores "you can read it and not run it freely" at
-    2.
-    Re-read 2026-08-13. The LICENSE still carries clause 4, which prohibits altering or removing Open
-    WebUI branding except where end users number fifty or fewer in any rolling thirty-day period, or
-    under prior written permission, or under an executed enterprise license. The repository still ships
-    the whole self-hostable product and the README still advertises an Enterprise Plan offering custom
-    theming and branding. Value unchanged at 2 / source_available.'
+    2.'
   raw: 'license:Open-WebUI-License(BSD-3-Clause-based + non-OSI branding clause: branding may not be removed
     above 50 end-users/30d without enterprise license or written permission);source:public;enterprise-tier:commercial
     license to remove branding'
@@ -45,9 +40,9 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: 879,127 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (open-webui 879,127). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected
-    from level 4, which the declared artifacts do not support.
+  note: 879,127 downloads in the trailing 30 days summed across the 1 declared artifact(s) (open-webui 879,127).
+    Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected from level 4, which the
+    declared artifacts do not support.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/open-webui/recent
@@ -63,13 +58,9 @@ capability:
     multi-user (RBAC, groups, LDAP/SCIM/SSO); plugins (Pipelines framework)
   confidence: high
   note: 'Broadest feature surface among open self-hosted chat UIs: hits all five recipe dimensions (model
-    breadth, RAG, multimodal, plugins, multi-user) with enterprise auth. Top-tier for the category.
-    Re-read 2026-08-13. The README still covers all five recipe dimensions - any OpenAI-compatible API
-    alongside local Ollama, RAG over nine vector databases with hybrid search and reranking, image
-    generation via DALL-E, Gemini, ComfyUI and AUTOMATIC1111 plus voice and video calling over several
-    STT and TTS providers, granular RBAC with groups, LDAP/Active Directory, SSO and SCIM 2.0
-    provisioning, and a plugin surface of Filters, Actions, Pipes, Tools and Skills reachable over MCP
-    and OpenAPI tool servers. The web-search provider list has grown past twenty. Band unchanged at 4.'
+    breadth, RAG, multimodal, plugins, multi-user) with enterprise auth. Top-tier for the category. The
+    web-search provider list has grown past twenty against the 15+ recorded in the value, and the plugin
+    surface spans Filters, Actions, Pipes, Tools and Skills reachable over MCP and OpenAPI tool servers.'
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/open-webui/open-webui

--- a/sources/scores/openai-code-interpreter.yaml
+++ b/sources/scores/openai-code-interpreter.yaml
@@ -17,9 +17,7 @@ openness:
       detail: no self-host, no open runtime
   confidence: high
   note: Fully proprietary managed code-execution sandbox; OpenAI does not document the isolation mechanism
-    or release any runtime. Re-read 2026-08-13 - the developer docs still describe only a sandboxed execution
-    environment reached through the Assistants and Responses APIs, priced per session, with no isolation
-    mechanism named, no runtime distributed and no self-hosted option offered.
+    or release any runtime.
   raw: license:Proprietary;service:proprietary(OpenAI-managed sandbox);source:closed;isolation:undisclosed;access:API/tool
     only(no self-host, no open runtime)
   last_verified: '2026-08-13'
@@ -38,11 +36,8 @@ adoption:
   confidence: low
   note: Code Interpreter ships inside ChatGPT (advanced data analysis) and the Assistants/Responses API;
     the ChatGPT surface it rides has ~1B weekly users (flagship anchor record, GPT-5). No standalone Code-Interpreter
-    usage figure is disclosed, so adoption is attributed to the surface, placed conservatively at 4 (a
-    fraction of ChatGPT users invoke code execution) with low confidence given no primary per-tool number.
-    Re-read 2026-08-13 - the developer docs still publish no adoption, session-count or frequency figure of
-    any kind for the tool, only the per-session price and the file and session limits, so the attribution
-    to the ChatGPT surface stands and no standalone number has appeared.
+    usage figure is disclosed, so adoption is attributed to the surface, placed conservatively at 4 (a fraction
+    of ChatGPT users invoke code execution) with low confidence given no primary per-tool number.
   last_verified: '2026-08-13'
   sources:
   - url: https://developers.openai.com/api/docs/assistants/tools/code-interpreter
@@ -60,10 +55,8 @@ capability:
   confidence: low
   note: Reliable Python-only data-analysis sandbox with iterative retry, but single-language, undisclosed
     isolation, and session-scoped, narrower than general-purpose deployment sandboxes. Mid-tier; capability
-    detail limited because OpenAI does not document the isolation/scale internals. Re-read 2026-08-13 -
-    every element of the recorded band is still on the docs page unchanged, Python as the only language,
-    a 512 MB per-file ceiling, a one-hour default session, $0.03 per session, and no isolation mechanism
-    named.
+    detail limited because OpenAI does not document the isolation/scale internals. The docs price the tool
+    at $0.03 per session, cap files at 512 MB, default the session to one hour, and name no isolation mechanism.
   last_verified: '2026-08-13'
   sources:
   - url: https://developers.openai.com/api/docs/assistants/tools/code-interpreter

--- a/sources/scores/openai-evals-api-dashboard.yaml
+++ b/sources/scores/openai-evals-api-dashboard.yaml
@@ -13,9 +13,8 @@ openness:
     - being deprecated Nov 2026
   confidence: high
   last_verified: '2026-08-13'
-  note: Closed hosted SaaS bound to the OpenAI platform; not the MIT-licensed openai/evals repo (that
-    is scored separately). Re-read 2026-08-13 - the guide still describes a hosted platform product with
-    no source, no self-host and no license offered, and still carries the same sunset dates.
+  note: Closed hosted SaaS bound to the OpenAI platform; not the MIT-licensed openai/evals repo (that is
+    scored separately).
   raw: license:Proprietary(SaaS, OpenAI-platform-only);source:closed;managed-only(no self-host); being deprecated
     Nov 2026
   sources:
@@ -24,11 +23,11 @@ openness:
       2026, shutdown Nov 30 2026)
     accessed: '2026-06-04'
   - url: https://developers.openai.com/api/docs/guides/evals
-    shows: 'Re-read 2026-08-13. The guide states ''OpenAI is deprecating the Evals platform'' and ''Evals
-      will become read-only for existing users on October 31, 2026, and the platform is scheduled to shut
-      down on November 30, 2026'', and now points new users at Datasets instead. It is documented purely
-      as a hosted surface of the OpenAI API - no repository, no self-hostable implementation and no license
-      to any evaluation code is offered anywhere on the page.'
+    shows: The guide states 'OpenAI is deprecating the Evals platform' and 'Evals will become read-only
+      for existing users on October 31, 2026, and the platform is scheduled to shut down on November 30,
+      2026', and points new users at Datasets instead. It is documented purely as a hosted surface of the
+      OpenAI API - no repository, no self-hostable implementation and no license to any evaluation code
+      is offered anywhere on the page.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 97f7c685f89228fcbcfc2374f139ed6daade56bb81d42d2a6d525ce2eb666c10
@@ -41,17 +40,15 @@ adoption:
   signal_type: unknown
   confidence: low
   last_verified: '2026-08-13'
-  note: OpenAI publishes no usage figures for the Evals API/dashboard specifically, and the product is
-    being sunset, so there is no honest adoption signal to report. Re-read 2026-08-13 - looked for a run
-    count, a customer count, a developer count or any usage statistic on the guide and found none, so
-    the abstention is re-confirmed rather than lifted.
+  note: OpenAI publishes no usage figures for the Evals API/dashboard specifically, and the product is being
+    sunset, so there is no honest adoption signal to report.
   sources:
   - url: https://developers.openai.com/api/docs/guides/evals
     shows: no usage/customer figures; product on sunset path
     accessed: '2026-06-04'
   - url: https://developers.openai.com/api/docs/guides/evals
-    shows: 'Re-read 2026-08-13: the guide publishes no eval-run count, no customer count and no developer
-      count for the Evals platform, and the deprecation notice adds none. Nothing bandable has appeared.'
+    shows: The guide publishes no eval-run count, no customer count and no developer count for the Evals
+      platform, and the deprecation notice adds none. Nothing bandable appears on it.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 97f7c685f89228fcbcfc2374f139ed6daade56bb81d42d2a6d525ce2eb666c10
@@ -65,17 +62,15 @@ capability:
   confidence: medium
   last_verified: '2026-08-13'
   note: Convenient managed eval surface for OpenAI-model users, but narrow (single-provider, no benchmark
-    library) and on a deprecation path, not a frontier harness. Feature matrix re-read 2026-08-13 and
-    unchanged; the deprecation is now dated rather than pending, which reinforces the band rather than
-    moving it.
+    library) and on a deprecation path, not a frontier harness. The deprecation is dated rather than pending,
+    which reinforces the band rather than moving it.
   sources:
   - url: https://developers.openai.com/api/docs/guides/evals
     shows: grading methods, dataset upload, run execution vs OpenAI APIs, dashboard + cost analysis
     accessed: '2026-06-04'
   - url: https://developers.openai.com/api/docs/guides/evals
-    shows: 'Re-read 2026-08-13: criteria-based grading against OpenAI models only, dataset upload, runs
-      and a dashboard; no multi-provider backend and no standardized benchmark suite. Read-only from 2026-10-31,
-      shut down 2026-11-30.'
+    shows: Criteria-based grading against OpenAI models only, dataset upload, runs and a dashboard; no multi-provider
+      backend and no standardized benchmark suite. Read-only from 2026-10-31, shut down 2026-11-30.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 97f7c685f89228fcbcfc2374f139ed6daade56bb81d42d2a6d525ce2eb666c10

--- a/sources/scores/openai-evals.yaml
+++ b/sources/scores/openai-evals.yaml
@@ -19,10 +19,8 @@ openness:
   confidence: high
   last_verified: '2026-08-13'
   note: Framework code is fully OSI (MIT); the included eval datasets carry their own open licenses, which
-    is standard for a harness. Re-read 2026-08-13 - LICENSE.md is still the unmodified MIT text, copyright
-    2023 OpenAI, followed by the per-dataset carve-out that the components already record. GitHub's own
-    detector reports NOASSERTION because of that appended section, which is a detector artifact rather
-    than a second license over the framework code.
+    is standard for a harness. GitHub's own detector reports NOASSERTION because of the appended per-dataset
+    section, which is a detector artifact rather than a second license over the framework code.
   raw: license:MIT(OSI);source:public(full framework + registry);per-dataset-licenses:mixed(CC/CC0/Apache
     for bundled data); no feature-gated core;core-gated:ungated
   sources:
@@ -57,17 +55,15 @@ adoption:
   reach: '>10K stars'
   signal_type: stars_fallback
   confidence: low
-  note: 'No PyPI/download count available for this repo (it is run from source, not pip-installed); 18.6k
-    GitHub stars + 3k forks is the only honest signal, so capped at level 3 per the stars-fallback rule.
-    Historically influential as one of the first open eval frameworks but largely superseded by the hosted
-    Evals API and by newer harnesses. Stars read 2026-08-13 on openai/evals: 19,159, which bands at >10K
-    stars, level 3 on the stars scale. The previous reach ''100K-1M'' was a download label, which this
-    instrument does not offer - a star is not a download. THE REAL DEFECT is upstream: this product declares
-    no artifacts at all, so a stars_fallback band had no stars source behind it and the count lived only in
-    this note. Declaring openai/evals would fix it, and is deliberately not done here because a declared code
-    repo also re-routes the openness license dimension. Re-read against the GitHub API on 2026-08-13 -
-    19,161 stars and 3,052 forks, last push 2026-04-14, so the band is unchanged and the repo has gone
-    four months without a commit.'
+  note: 'No PyPI/download count available for this repo (it is run from source, not pip-installed); 19,161
+    GitHub stars and 3,052 forks are the only honest signal, so capped at level 3 per the stars-fallback
+    rule, and that bands at >10K stars on the stars scale. The previous reach ''100K-1M'' was a download
+    label, which this instrument does not offer - a star is not a download. Historically influential as
+    one of the first open eval frameworks but largely superseded by the hosted Evals API and by newer harnesses,
+    and the repo has gone months without a commit. THE REAL DEFECT is upstream: this product declares no
+    artifacts at all, so a stars_fallback band had no stars source behind it and the count lived only in
+    this note. Declaring openai/evals would fix it, and is deliberately not done here because a declared
+    code repo also re-routes the openness license dimension.'
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/openai/evals
@@ -88,11 +84,10 @@ capability:
   relative_to: lm-evaluation-harness
   relation: two_below
   last_verified: '2026-08-13'
-  note: Solid general-purpose authoring framework but not frontier on task coverage, backend breadth,
-    or agentic-eval support relative to category leaders. Feature matrix re-read 2026-08-13 and unchanged
-    - the README still describes a registry of evals plus custom-eval authoring, and the repo has not
-    been pushed since 2026-04-14, which is the slowed maintenance the value already records. The comparison
-    to lm-eval-harness is now recorded structurally.
+  note: Solid general-purpose authoring framework but not frontier on task coverage, backend breadth, or
+    agentic-eval support relative to category leaders. The README describes a registry of evals plus custom-eval
+    authoring, and the slowed maintenance the value records still holds. The comparison to lm-eval-harness
+    is recorded structurally.
   sources:
   - url: https://github.com/openai/evals
     shows: framework + registry of benchmarks, custom eval authoring, model-graded grading

--- a/sources/scores/openai-fine-tuning-api.yaml
+++ b/sources/scores/openai-fine-tuning-api.yaml
@@ -102,10 +102,9 @@ capability:
     for reasoning models. Tunes frontier closed models (gpt-4.1 family, gpt-4o, o4-mini). Managed end-to-end
     (data validation, training, hosting, eval).'
   confidence: medium
-  note: 'Strong managed method coverage (SFT+DPO+RFT) over frontier base models, but black-box: no
-    parallelism/precision/scale knobs exposed, no MLPerf-Training basis. Scored 4 on method breadth + frontier
-    base quality; not 5 since the user cannot control training scale/internals. Re-read 2026-08-13 as an
-    anchor for this category''s closing pass; unchanged at 4.'
+  note: 'Strong managed method coverage (SFT+DPO+RFT) over frontier base models, but black-box: no parallelism/precision/scale
+    knobs exposed, no MLPerf-Training basis. Scored 4 on method breadth + frontier base quality; not 5 since
+    the user cannot control training scale/internals.'
   last_verified: '2026-08-13'
   sources:
   - url: https://developers.openai.com/api/docs/guides/model-optimization

--- a/sources/scores/openai-internal-evals.yaml
+++ b/sources/scores/openai-internal-evals.yaml
@@ -15,11 +15,7 @@ openness:
       detail: only summarized/redacted results released alongside major deployments
   confidence: high
   note: Fully internal/private eval datasets; only redacted result summaries are published, the underlying
-    example sets are not redistributable. Re-read 2026-08-13 - the Preparedness Framework v2 PDF (22
-    pages, "Last updated - 15th April, 2025") still describes capability evaluations run internally per
-    Tracked Category and still says disclosures "may be redacted or summarized where necessary, such as
-    to protect intellectual property or safety". No eval set, license or datasheet is published anywhere
-    in it, so all four recorded values stand.
+    example sets are not redistributable.
   raw: data:closed(internal eval sets for frontier-risk Tracked Categories, never published);datasheet:no;license:none;access:internal-only(only
     summarized/redacted results released alongside major deployments)
   last_verified: '2026-08-13'
@@ -41,9 +37,6 @@ adoption:
   confidence: high
   note: Internal-only eval sets used solely by OpenAI for its own deployment decisions; no external users,
     no downloads, no third-party citation as a runnable standard. No honest external adoption signal exists.
-    Re-read 2026-08-13 - the framework still frames the evaluations as part of OpenAI's own deployment
-    process, publishes no artifact anyone outside the lab could run, and gives no usage figure. The null
-    is a deliberate abstention and it stands.
   last_verified: '2026-08-13'
   sources:
   - url: https://cdn.openai.com/pdf/18a02b5d-6b67-4cec-ab64-68cdfbddebcd/preparedness-framework-v2.pdf
@@ -57,9 +50,8 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: Capability not a meaningful axis for an eval dataset. Re-read 2026-08-13 and the abstention
-    stands - the scored artifact is an unpublished eval set, and the framework describes the process
-    around it rather than any capability of the set itself.
+  note: Capability not a meaningful axis for an eval dataset. The framework describes the process around
+    the eval sets rather than any capability of the sets themselves.
   last_verified: '2026-08-13'
   sources:
   - url: https://cdn.openai.com/pdf/18a02b5d-6b67-4cec-ab64-68cdfbddebcd/preparedness-framework-v2.pdf

--- a/sources/scores/openai-moderation.yaml
+++ b/sources/scores/openai-moderation.yaml
@@ -13,9 +13,9 @@ openness:
     license:
     - name: proprietary
   confidence: high
-  note: Closed, API-only hosted classifier; no weights or source. Re-read 2026-08-13 and unchanged. The
-    cited URL now redirects to developers.openai.com and the page renders client-side, so the markdown
-    edition of the same document is cited beside it - that is the body the reading was taken from.
+  note: Closed, API-only hosted classifier; no weights or source. The cited URL redirects to developers.openai.com
+    and the page renders client-side, so the markdown edition of the same document is cited beside it -
+    that is the body the reading is taken from.
   raw: service:proprietary hosted API(no weights, no self-host);access:free moderation endpoint;source:closed;license:proprietary
   last_verified: '2026-08-13'
   sources:
@@ -45,12 +45,16 @@ adoption:
   confidence: medium
   banded_quantity: none published; the level reads the distribution of the free default moderation endpoint
     rather than any figure
-  note: 'INSTRUMENT CORRECTED on 2026-08-13, level unchanged. usage_volume claims a download or install count and OpenAI publishes
-    none for this endpoint - the guide carries no request volume, no developer count and no customer count,
-    and neither does anything else cited here. The 1M-10M label therefore asserts a measurement nobody
-    made, which adoption.md rules out on this instrument. The underlying reading is sound - it is the free
-    default filter in front of a very large developer base - but that is a reported_traction claim, not a
-    counted one. The instrument now reads reported_traction, which is what a credible claim with no count behind it is for, and the illegal numeric reach is gone. The LEVEL is deliberately unchanged: correcting how a band was read is not a reason to move where it sits, and nothing re-read today argues the standing is different. What changes is that the record no longer claims a measurement nobody made.'
+  note: 'INSTRUMENT CORRECTED on 2026-08-13, level unchanged. usage_volume claims a download or install
+    count and OpenAI publishes none for this endpoint - the guide carries no request volume, no developer
+    count and no customer count, and neither does anything else cited here. The 1M-10M label therefore asserts
+    a measurement nobody made, which adoption.md rules out on this instrument. The underlying reading is
+    sound - it is the free default filter in front of a very large developer base - but that is a reported_traction
+    claim, not a counted one. The instrument now reads reported_traction, which is what a credible claim
+    with no count behind it is for, and the illegal numeric reach is gone. The LEVEL is deliberately unchanged:
+    correcting how a band was read is not a reason to move where it sits, and nothing in the cited sources
+    argues the standing is different. What changes is that the record no longer claims a measurement nobody
+    made.'
   last_verified: '2026-08-13'
   sources:
   - url: https://developers.openai.com/api/docs/guides/moderation.md
@@ -67,7 +71,6 @@ capability:
     fixed taxonomy.
   confidence: low
   note: Convenient broad-category moderation; fixed policy, no customization vs policy-conditioned models.
-    Re-read 2026-08-13 and unchanged.
   last_verified: '2026-08-13'
   sources:
   - url: https://developers.openai.com/api/docs/guides/moderation.md

--- a/sources/scores/openclaw.yaml
+++ b/sources/scores/openclaw.yaml
@@ -17,9 +17,6 @@ openness:
     - no-feature-gated-core
   confidence: high
   note: Genuinely MIT open source; the NOASSERTION flag is a classifier artifact, not a restriction.
-    Re-read 2026-08-13. The LICENSE body is still a plain MIT License, now reading Copyright (c) 2026
-    OpenClaw Foundation, and the GitHub API still reports NOASSERTION for it - the classifier artifact
-    the note describes, not a restriction. Value unchanged at 5 / open_source.
   raw: license:MIT(OSI; body is MIT, GitHub NOASSERTION from custom copyright line);source:public;self-host:primary(local-first);no-feature-gated-core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -33,8 +30,8 @@ adoption:
   level: 5
   signal_type: usage_volume
   confidence: high
-  note: 11,365,016 npm downloads in the trailing 30 days for openclaw, read 2026-08-12. Bands at level 5
-    (>10M) on the software and model adoption scale. Exceptional growth for a project under a year old.
+  note: 11,365,016 npm downloads in the trailing 30 days for openclaw. Bands at level 5 (>10M) on the software
+    and model adoption scale. Exceptional growth for a project under a year old.
   reach: '>10M'
   last_verified: '2026-08-12'
   sources:
@@ -50,13 +47,10 @@ capability:
     voice (speak/listen); WebChat + live Canvas UI; companion apps (macOS/iOS/Android); skills/extensions SDK; model-agnostic
     routing
   confidence: high
-  note: Among the most ambitious open personal-assistant projects - unifies chat, voice, and many messaging surfaces;
-    broader channel reach than Open WebUI/Jan/Khoj.
-    Re-read 2026-08-13. The repository API still answers, and it confirms a live TypeScript project
-    created 2025-11-24 and pushed the same day this was read, now at 386,183 stars against the 379k
-    recorded. The channel and companion-app breadth the band rests on is a README claim rather than an
-    API one, so this confirms the project is real and moving rather than re-deriving the feature list
-    itself. Band unchanged at 5.
+  note: Among the most ambitious open personal-assistant projects - unifies chat, voice, and many messaging
+    surfaces; broader channel reach than Open WebUI/Jan/Khoj. The channel and companion-app breadth the
+    band rests on is a README claim rather than one the repository API re-derives; the API confirms only
+    that the project is live and moving, now at 386,183 stars.
   last_verified: '2026-08-13'
   sources:
   - url: https://api.github.com/repos/openclaw/openclaw

--- a/sources/scores/opencode.yaml
+++ b/sources/scores/opencode.yaml
@@ -13,10 +13,9 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: 'Fully MIT. Re-read 2026-08-13 - the repo page still reports MIT over the whole tree, calls itself
-    "the open source AI coding agent", and offers no paid tier, enterprise directory or license key; the
-    npm registry metadata for opencode-ai independently declares the same MIT license on the shipped package.
-    Stars are now 197.0k. Nothing moved.'
+  note: 'Fully MIT: the repo publishes the whole TUI agent and calls itself "the open source AI coding agent",
+    the npm registry metadata for opencode-ai declares the same MIT license on the shipped package, and
+    there is no paid tier, enterprise directory or license key.'
   raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -42,14 +41,12 @@ adoption:
   signal_type: reported_traction
   confidence: medium
   banded_quantity: npm downloads of opencode-ai (8,643,056 in the trailing month) and 197.0k stars
-  note: '197.0k GitHub stars and active npm distribution through opencode-ai. Re-read 2026-08-13, and
-    the recorded claim that a clean download count is "not retrievable" is now WRONG - the npm registry
-    download API returns 8,643,056 downloads for opencode-ai over the trailing month, which bands at level
-    4 (1M-10M) on the software adoption scale, the level already recorded. npm is the product''s declared
-    and primary distribution channel, so this is a countable figure rather than a reported claim, and
-    the instrument should move from reported_traction to usage_volume with a 1M-10M reach. That is a change
-    to a recorded field, so it is flagged rather than applied here. The level is unchanged either way,
-    and the claim is now re-checkable and digested.'
+  note: 197.0k GitHub stars and active npm distribution through opencode-ai. The npm registry download API
+    returns 8,643,056 downloads for opencode-ai over the trailing month, which bands at level 4 (1M-10M)
+    on the software adoption scale, the level already recorded. npm is the product's declared and primary
+    distribution channel, so this is a countable figure rather than a reported claim, and the instrument
+    should move from reported_traction to usage_volume with a 1M-10M reach. That is a change to a recorded
+    field, so it is flagged rather than applied here.
   last_verified: '2026-08-13'
   sources:
   - url: https://api.npmjs.org/downloads/point/last-month/opencode-ai
@@ -73,11 +70,8 @@ capability:
   value: native TUI agent; 75+ providers incl. local; multi-session concurrent agents; shareable sessions; built-in
     LSP; client/server
   confidence: high
-  note: 'Matches/exceeds the coding-agent peers on breadth, with standout provider-neutrality and TUI/LSP
-    polish. Re-read 2026-08-13 - the site still lists LSP auto-loading, multi-session parallel agents
-    on one project, shareable session links, sign-in with a GitHub Copilot or ChatGPT Plus/Pro account,
-    and 75+ LLM providers through Models.dev including local models, with terminal, desktop and editor
-    surfaces. The feature matrix that placed this band is unchanged.'
+  note: Matches/exceeds the coding-agent peers on breadth, with standout provider-neutrality and TUI/LSP
+    polish.
   last_verified: '2026-08-13'
   sources:
   - url: https://opencode.ai/

--- a/sources/scores/opencompass.yaml
+++ b/sources/scores/opencompass.yaml
@@ -15,9 +15,7 @@ openness:
     - no feature-gated core
   confidence: high
   last_verified: '2026-08-13'
-  note: Apache-2.0, fully public; OSI -> open_source. Re-read 2026-08-13 - the license endpoint still
-    reports Apache-2.0 and the README still installs and runs the whole platform locally with no paid
-    tier.
+  note: Apache-2.0, fully public; OSI -> open_source.
   raw: license:Apache-2.0(OSI);source:public(GitHub);no feature-gated core;core-gated:ungated
   sources:
   - url: https://github.com/open-compass/opencompass
@@ -48,13 +46,13 @@ adoption:
   confidence: medium
   last_verified: '2026-08-13'
   banded_quantity: GitHub stars (7,299) and framework distribution breadth
-  note: Widely used eval framework, especially in the China/HF ecosystem; 7.1k GitHub stars and broad
-    dataset+backend coverage. No clean PyPI/download headline located this run; level 3 on reported_traction
-    (framework distribution + star footprint), not on stars alone past the cap. Re-read 2026-08-13 - 7,299
-    stars and 837 forks, still actively pushed. A PyPI package `opencompass` does exist and is genuinely
-    this project's, and it is deliberately NOT declared as an artifact - it sees 5,728 downloads a month
-    against a project whose documented path is a git clone and a config tree, so banding on it would drop
-    this record to level 1 on a minority channel. Flagged for a ruling rather than declared here.
+  note: Widely used eval framework, especially in the China/HF ecosystem; 7.1k GitHub stars and broad dataset+backend
+    coverage. No clean PyPI/download headline located this run; level 3 on reported_traction (framework
+    distribution + star footprint), not on stars alone past the cap. A PyPI package `opencompass` does exist
+    and is genuinely this project's, and it is deliberately NOT declared as an artifact - it sees 5,728
+    downloads a month against a project whose documented path is a git clone and a config tree, so banding
+    on it would drop this record to level 1 on a minority channel. Flagged for a ruling rather than declared
+    here.
   sources:
   - url: https://github.com/open-compass/opencompass
     shows: 7.1k stars; 100+ datasets, multi-backend eval framework
@@ -80,9 +78,8 @@ capability:
   relation: one_below
   last_verified: '2026-08-13'
   note: Very broad multi-benchmark coverage and backend breadth -- just below lm-eval as the standardization
-    reference; strong but not the single de-facto global standard. Feature matrix re-read 2026-08-13 and
-    unchanged - the README still claims 100+ datasets and lists HF, LMDeploy, vLLM and API backends as
-    install extras. The comparison the note already made to lm-eval is now recorded structurally.
+    reference; strong but not the single de-facto global standard. The README claims 100+ datasets and lists
+    HF, LMDeploy, vLLM and API backends as install extras. The comparison to lm-eval is recorded structurally.
   sources:
   - url: https://github.com/open-compass/opencompass
     shows: 100+ datasets, 20+ HF + API model backends

--- a/sources/scores/openfn.yaml
+++ b/sources/scores/openfn.yaml
@@ -13,11 +13,7 @@ openness:
     free_text:
     - no feature-gated core per maintainers
   confidence: high
-  note: 'Fully open source DPG with copyleft licensing and no feature-gated core. Re-read 2026-08-13 -
-    the repo page still reports "LGPL-3.0, GPL-3.0 licenses found" over the whole tree and publishes the
-    complete Elixir/Phoenix platform, and the docs still point at the open adaptor library, the CLI and
-    the runtimes as separate open repos. No paid tier withholds anything from the published source. Stars
-    are now 292. Nothing moved.'
+  note: Fully open source DPG with copyleft licensing and no feature-gated core.
   raw: license:LGPL-3.0/GPL-3.0(OSI copyleft);source:public;no feature-gated core per maintainers;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -46,10 +42,10 @@ adoption:
   confidence: medium
   banded_quantity: workflow runs (~5M a year, about 417k a month) across 55+ countries, an institutional
     deployment count
-  note: 'OpenFn''s own about page, read 2026-08-12, states 55+ countries benefiting, about 5 million workflow
-    runs each year and roughly 50 million records handled each year. That is roughly 417k workflow runs
-    a month, which supports the recorded level on its own. Recorded as reported_traction rather than stars_fallback,
-    which was the defect - 286 GitHub stars was never what the level rested on, and an institutional deployment
+  note: 'OpenFn''s own about page, states 55+ countries benefiting, about 5 million workflow runs each year
+    and roughly 50 million records handled each year. That is roughly 417k workflow runs a month, which
+    supports the recorded level on its own. Recorded as reported_traction rather than stars_fallback, which
+    was the defect - 286 GitHub stars was never what the level rested on, and an institutional deployment
     count is not a star reading. The previously recorded claim of ''70+ NGOs/governments across 40+ countries''
     is superseded: the page now states 55+ countries and no longer gives an NGO count.'
   last_verified: '2026-08-12'
@@ -69,11 +65,7 @@ capability:
   value: 'End-to-end workflow automation: visual builder, 70+ integration adaptors, AI/LLM orchestration,
     run monitoring, alerting, per-project access management.'
   confidence: high
-  note: 'Broad integration platform spanning authoring, many connectors, and operational monitoring. Re-read
-    2026-08-13 - the docs still describe connecting any app through OpenFn''s open-source adaptor library
-    and orchestrating workflows from last-mile services to national-level reporting, over the same visual
-    builder, run monitoring and per-project access management. At dify on feature breadth for a workflow
-    platform.'
+  note: Broad integration platform spanning authoring, many connectors, and operational monitoring.
   relative_to: dify
   relation: at
   last_verified: '2026-08-13'

--- a/sources/scores/openguardrails.yaml
+++ b/sources/scores/openguardrails.yaml
@@ -18,11 +18,10 @@ openness:
       value: ungated
   confidence: high
   note: 'Fully open source: both the guardrails platform and the safety model are Apache-2.0 and self-hostable,
-    including on-prem deployment. Re-read 2026-08-13 and both halves still check out, but the repo has been
-    reshaped since the last read - it is now the monorepo for the OpenGuardrails (OGR) specification and
-    its reference implementations, with the Python and JavaScript SDKs and the integrations beside it. The
-    licence, the public source and the ungated core are unchanged, so the score is unaffected; what the
-    product IS has moved, and that is raised on the prose rather than settled here.'
+    including on-prem deployment. The repo is now the monorepo for the OpenGuardrails (OGR) specification
+    and its reference implementations, with the Python and JavaScript SDKs and the integrations beside it;
+    the licence, the public source and the ungated core are unaffected, so the score stands, but what the
+    product IS has moved and that is raised rather than settled here.'
   raw: license:Apache-2.0(OSI) for both platform and model;source:public;self-host:yes(on-prem/private);model:OpenGuardrails-Text-2510
     open weights Apache-2.0;core-gated:ungated
   last_verified: '2026-08-13'
@@ -54,11 +53,11 @@ adoption:
   reach: <1K stars
   signal_type: stars_fallback
   confidence: low
-  note: 'Early-stage project; stars-only proxy, capped at 3 because a star is not a use. Re-read 2026-08-13
-    - the repo shows 24 stargazers, which bands at <1K stars, level 1 on the stars scale in
-    signal_routing.yaml. The project publishes SDKs to PyPI and npm, so a download route may exist; PyPI
-    stats were rate-limited at the time of the read and no figure was obtained, which says nothing about
-    whether one exists. The stars band is what was re-derived.'
+  note: Early-stage project; stars-only proxy, capped at 3 because a star is not a use. The repo shows 24
+    stargazers, which bands at <1K stars, level 1 on the stars scale in signal_routing.yaml. The project
+    publishes SDKs to PyPI and npm, so a download route may exist, but PyPI stats were rate-limited and
+    no figure was obtained, which says nothing about whether one exists; the stars band is what the level
+    rests on.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/openguardrails/openguardrails
@@ -75,12 +74,11 @@ capability:
     components) covering content safety, prompt injection/jailbreak, code-interpreter abuse, and data
     leakage across 119 languages.
   confidence: low
-  note: 'Unusually complete for its age: ships both an open safety model and an on-prem platform, with
-    broad multilingual coverage. Re-read 2026-08-13 against the paper, which still supports every clause of
-    the value. Worth flagging that the repo has since repositioned as a vendor-neutral protocol and
-    benchmark rather than a detector - "we do not build detection capability" - so the platform the paper
-    describes and the thing the repo now ships are drifting apart. The published model and the paper are
-    what the band rests on.'
+  note: 'Unusually complete for its age: ships both an open safety model and an on-prem platform, with broad
+    multilingual coverage. The paper supports every clause of the value, but the repo has repositioned as
+    a vendor-neutral protocol and benchmark rather than a detector - "we do not build detection capability"
+    - so the platform the paper describes and the thing the repo now ships are drifting apart. The published
+    model and the paper are what the band rests on.'
   last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2510.19169

--- a/sources/scores/openhands.yaml
+++ b/sources/scores/openhands.yaml
@@ -16,13 +16,13 @@ openness:
     free_text:
     - OpenHands-Cloud-managed-tier
   confidence: high
-  note: 'MIT core with a separately licensed enterprise server, which is what open_core means here. A repo
-    read on 2026-08-12 confirmed it: the monorepo LICENSE opens "Portions of this software are licensed
-    as follows" and carves out everything under enterprise/ to enterprise/LICENSE, which is PolyForm Free
-    Trial License 1.0.0, and that directory README says outright "This is NOT an open source license. Usage
-    is limited to 30 days per calendar year without a commercial license." The enterprise server now lives
-    in its own active repo, OpenHands/OpenHands-Cloud, under the same PolyForm license, while OpenHands/OpenHands
-    stays MIT. Functionality is withheld from the published source for a paid tier, so core-gated is gated.'
+  note: 'MIT core with a separately licensed enterprise server, which is what open_core means here. A read
+    of the repo confirms it: the monorepo LICENSE opens "Portions of this software are licensed as follows"
+    and carves out everything under enterprise/ to enterprise/LICENSE, which is PolyForm Free Trial License
+    1.0.0, and that directory README says outright "This is NOT an open source license. Usage is limited
+    to 30 days per calendar year without a commercial license." The enterprise server now lives in its own
+    active repo, OpenHands/OpenHands-Cloud, under the same PolyForm license, while OpenHands/OpenHands stays
+    MIT. Functionality is withheld from the published source for a paid tier, so core-gated is gated.'
   raw: license:MIT(core);source:public;core-gated:gated(the enterprise server is PolyForm Free Trial 1.0.0,
     not an OSI license);enterprise-dir:separate-license;OpenHands-Cloud-managed-tier
   last_verified: '2026-08-12'
@@ -63,12 +63,8 @@ adoption:
   signal_type: reported_traction
   confidence: high
   banded_quantity: GitHub stars (83.9k) and Series A funding ($18.8M), not a user count
-  note: '~75.8k GitHub stars, $18.8M Series A, contributors from major firms, OpenHands Cloud with multi-user/Slack/Jira/Linear
-    integrations. No precise active-user/download count verified; rated 3 on reported traction. Re-read
-    2026-08-13 - the repo page now reports 83.9k stars and the AI Agent Index entry reports 83.6k stars,
-    MIT, self-hostable with no vendor lock-in, and neither publishes a user or download count. The standing
-    claim still holds and the level is unchanged; no countable artifact exists, which is why the instrument
-    stays reported_traction.'
+  note: ~75.8k GitHub stars, $18.8M Series A, contributors from major firms, OpenHands Cloud with multi-user/Slack/Jira/Linear
+    integrations. No precise active-user/download count verified; rated 3 on reported traction.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/All-Hands-AI/OpenHands
@@ -87,21 +83,17 @@ capability:
   basis_detail: SWE-bench Verified
   value: null
   confidence: high
-  note: 'Top of the open coding-agent field on SWE-bench Verified, at or above proprietary agents; model-agnostic
-    (100+ LLM providers, BYOK). Re-read 2026-08-13 - the 77.6% this note used to carry appears on none
-    of the cited sources any more. Marktechpost now reports 72% SWE-bench Verified and 67.9% GAIA for
-    OpenHands, and the AI Agent Index describes the All Hands leaderboard over 33 model configurations
-    without giving a headline number. 72% is the highest figure any cited source gives an open agent
-    and sits above Devin 2.0 and Cursor Background Agent, so the band is unchanged and only the figure
-    in this note moved. Replacement evidence found 2026-08-14 - All Hands AI publishes the OpenHands
-    Index itself, and its Issue Resolution board carries a "Swe-Bench Score" column per model run
-    inside the OpenHands SDK. The best run reads 95.8 (claude-fable-5, SDK v1.18.1) and the best
-    non-outlier 83.8 (claude-opus-4-8), with MiniMax-M3 at 76.4 the highest open-weights model of the
-    17 open and 16 closed models listed. That is a vendor-run harness rather than an independent
-    leaderboard, so what it establishes is narrower than the old claim - it places OpenHands at 83.8
-    on SWE-bench Verified on the scaffold''s own numbers, not "at or above proprietary agents" in
-    general. The 5 rests on that placement plus the same-model head-to-head on the Index''s
-    alternative-agents view; the marktechpost 72% stays as the independent floor.'
+  note: 'Top of the open coding-agent field on SWE-bench Verified; model-agnostic (100+ LLM providers, BYOK).
+    Marktechpost reports 72% SWE-bench Verified and 67.9% GAIA for OpenHands, the highest figure any independent
+    cited source gives an open agent, above Devin 2.0 and Cursor Background Agent. All Hands AI also publishes
+    the OpenHands Index itself, whose Issue Resolution board carries a "Swe-Bench Score" column for each
+    model run inside the OpenHands SDK: the best run reads 95.8 (claude-fable-5, SDK v1.18.1) and the best
+    non-outlier 83.8 (claude-opus-4-8), with MiniMax-M3 at 76.4 the highest open-weights model of the 17
+    open and 16 closed models listed. That is a vendor-run harness rather than an independent leaderboard,
+    so what it establishes is narrower than a general claim to sit at or above proprietary agents - it places
+    OpenHands at 83.8 on SWE-bench Verified on the scaffold''s own numbers. The 5 rests on that placement
+    plus the same-model head-to-head on the Index''s alternative-agents view; the marktechpost 72% stays
+    as the independent floor. The 77.6% this note used to carry appears on none of the cited sources.'
   last_verified: '2026-08-14'
   sources:
   - url: https://github.com/All-Hands-AI/OpenHands

--- a/sources/scores/openhermes-2-5.yaml
+++ b/sources/scores/openhermes-2-5.yaml
@@ -17,14 +17,12 @@ openness:
       value: ~1M
   confidence: medium
   note: 'Publicly downloadable and ungated with a full card, and no license anywhere the publisher controls.
-    A read on 2026-08-12 confirmed it: the card front matter carries language, pretty_name and tags and
-    no license key, the 126-line body runs from the source list through the format description to the citation
-    without a terms section, the repository holds only .gitattributes, README.md and openhermes2_5.json
+    A read of the card and repository confirms it: the card front matter carries language, pretty_name and
+    tags and no license key, the 126-line body runs from the source list through the format description
+    to the citation without a terms section, the repository holds only .gitattributes, README.md and openhermes2_5.json
     so there is no LICENSE file, and the Hub API returns no license. Files that download freely without
     a grant are not open, and not closed either, so the recorded 5/open drops to 3/gated. The commonly cited
-    as permissive detail this record used to carry was a third-party reading and has been dropped. Re-read
-    2026-08-13: the card, its raw README and the Hub API all still carry no licence field, no licence section
-    and no licence tag, and the API reports gated false.'
+    as permissive detail this record used to carry was a third-party reading and has been dropped.'
   raw: license:not-clearly-stated-on-card(no license field in the card YAML, no license section in the card
     body, no LICENSE file in the repository and no license tag on the Hub API);card:present;ungated:yes;format:JSON/Parquet;rows:~1M
   last_verified: '2026-08-13'
@@ -62,9 +60,8 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 17,420 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (teknium/OpenHermes-2.5 17,420). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top
-    band is >1M.
+  note: 17,420 downloads in the trailing 30 days summed across the 1 declared artifact(s) (teknium/OpenHermes-2.5
+    17,420). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/teknium/OpenHermes-2.5
@@ -78,9 +75,8 @@ capability:
   basis_detail: superseded
   value: null
   confidence: high
-  note: 'Attributed gains inside SmolTalk (MMLU/BBH/WinoGrande) but no standalone ablation; superseded by
-    Hermes 3 and survives as a 100k SmolTalk slice. Re-read 2026-08-13: the SmolLM2 paper still credits
-    a 100k OpenHermes-2.5 subset inside SmolTalk rather than any standalone ablation.'
+  note: Attributed gains inside SmolTalk (MMLU/BBH/WinoGrande) but no standalone ablation; superseded by
+    Hermes 3 and survives as a 100k SmolTalk slice.
   last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/html/2502.02737v1

--- a/sources/scores/openlit.yaml
+++ b/sources/scores/openlit.yaml
@@ -15,10 +15,7 @@ openness:
     - no enterprise-gated core observed
   confidence: high
   note: Fully Apache-2.0, OpenTelemetry-native, no feature-gated core; vendor-neutral by design (exports
-    to any OTel backend). Re-read 2026-08-13 and unchanged - GitHub's license endpoint still resolves the
-    repository to Apache-2.0, the root listing carries a docker-compose.yml and no ee/ or enterprise
-    directory, and the README presents guardrails, evaluations, prompt management and the vault as
-    features of the published stack rather than of a paid tier.
+    to any OTel backend).
   raw: license:Apache-2.0(OSI);source:public;OTel-native SDKs(Python/TS/Go);no enterprise-gated core observed;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -68,9 +65,7 @@ capability:
   note: Broad feature matrix covering all six recipe dimensions (tracing, prompt mgmt, evals, datasets/annotation-adjacent,
     cost, OTel+integrations) plus GPU observability; comparable to Langfuse C4. Held at 4 (not 5) as no
     observability product is a clear frontier-definer over MLflow/Langfuse anchors. The comparison is now
-    recorded rather than left in prose - at the langfuse anchor. Re-read 2026-08-13 - the README strapline
-    still names observability, GPU monitoring, guardrails, evaluations, prompt management, vault and
-    playground together, so the breadth the band rests on is intact.
+    recorded rather than left in prose - at the langfuse anchor.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/openlit/openlit

--- a/sources/scores/openllmetry.yaml
+++ b/sources/scores/openllmetry.yaml
@@ -14,11 +14,11 @@ openness:
     - no-feature-gated-core(SDK is fully OSS; Traceloop dashboard is an optional external export target,
       not gated core)
   confidence: high
-  note: Apache-2.0 instrumentation library; exports to any OTel backend (Datadog, Honeycomb, etc.), so
-    the OSS is genuinely standalone. Re-read 2026-08-13 on the repository, which still states the Apache-2.0
-    licensing and the export-anywhere design in the vendor's own words. The PyPI project page could not be
-    re-read this run - pypi.org served a JavaScript bot challenge rather than the project page on every
-    attempt - so that source keeps its earlier read date and the confirmation rests on the repository.
+  note: Apache-2.0 instrumentation library; exports to any OTel backend (Datadog, Honeycomb, etc.), so the
+    OSS is genuinely standalone. The PyPI project page cannot be fetched - pypi.org serves a JavaScript
+    bot challenge instead of the project page - so that source keeps its earlier read and the licensing
+    confirmation rests on the repository, which states the Apache-2.0 licensing and the export-anywhere
+    design in the vendor's own words.
   raw: license:Apache-2.0(OSI);source:public;no-feature-gated-core(SDK is fully OSS; Traceloop dashboard
     is an optional external export target, not gated core);core-gated:ungated
   last_verified: '2026-08-13'
@@ -46,10 +46,9 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: traceloop-sdk ~3.15M PyPI downloads/month; 15+ LLM providers, 7 vector DBs, 25+ tested export
-    destinations; ~7.2k stars corroborates only. Re-read 2026-08-13 - pypistats now reports 2,444,560
-    downloads last month for traceloop-sdk, down from the 3,149,787 recorded and still inside the 1M-10M
-    band, so level 4 is unchanged.
+  note: traceloop-sdk ~3.15M PyPI downloads/month; 15+ LLM providers, 7 vector DBs, 25+ tested export destinations;
+    ~7.2k stars corroborates only. pypistats now reports 2,444,560 downloads in the last month for traceloop-sdk,
+    below the 3,149,787 this note was set on and still inside the 1M-10M band.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/packages/traceloop-sdk
@@ -71,11 +70,10 @@ capability:
   confidence: high
   relative_to: langfuse
   relation: one_below
-  note: Strong on tracing + integrations but narrow vs full platforms; it is an instrumentation layer,
-    not an eval/prompt/dataset suite. Below the MLflow/Langfuse/Phoenix/Opik feature breadth (C4). The
-    comparison the band rests on is now recorded rather than left in prose - one rung below the langfuse
-    anchor at 4. Re-read 2026-08-13 - the README is still organized around instrumentations, an SDK and
-    export destinations, with no evals, prompt management or dataset surface in the repository.
+  note: Strong on tracing + integrations but narrow vs full platforms; it is an instrumentation layer, not
+    an eval/prompt/dataset suite. Below the MLflow/Langfuse/Phoenix/Opik feature breadth (C4). The comparison
+    the band rests on is now recorded rather than left in prose - one rung below the langfuse anchor at
+    4.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/traceloop/openllmetry

--- a/sources/scores/openmanus.yaml
+++ b/sources/scores/openmanus.yaml
@@ -15,9 +15,7 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: 'Fully MIT, run from source, no commercial layer. Re-read 2026-08-13 - the repo page still reports
-    MIT over the whole tree and publishes the agent to be run from a clone, with no managed tier, enterprise
-    directory or license key anywhere on it. Stars are now 58.0k. Nothing moved.'
+  note: Fully MIT, run from source, no commercial layer.
   raw: license:MIT(OSI);source:public;self-host:primary;no-feature-gated-core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -37,14 +35,12 @@ adoption:
   reach: '>10K stars'
   signal_type: stars_fallback
   confidence: medium
-  note: '~57k stars but negligible package usage (~186 PyPI downloads/month) - stars_fallback (capped at 3).
-    Stars read 2026-08-13: 57,954 across the 1 declared repo, which bands at >10K stars, level 3 on the stars
-    scale in signal_routing.yaml. The record carried no reach label at all before this. Re-read 2026-08-13
-    - the repo page reports 58.0k stars and 10.1k forks, and the pypistats API returns 144 downloads in
-    the trailing 30 days for openmanus. The download figure is deliberately NOT banded on - OpenManus
+  note: ~57k stars but negligible package usage (~186 PyPI downloads/month) - stars_fallback (capped at
+    3). 57,954 stars across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in
+    signal_routing.yaml. The record carried no reach label at all before this. The pypistats API returns
+    144 downloads in the trailing 30 days for openmanus, which is deliberately NOT banded on - OpenManus
     is run from a clone and the PyPI package is vestigial, so banding on it would be the under-coverage
-    error rather than a measurement. The stars fallback stays the instrument and >10K stars still bands
-    at 3.'
+    error rather than a measurement. The stars fallback stays the instrument.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/FoundationAgents/OpenManus
@@ -69,10 +65,7 @@ capability:
   value: single autonomous agent loop; tool use; browser automation; computer-use actions; planning; MCP; experimental
     RL branch
   confidence: medium
-  note: 'Capable demo agent but narrower and less battle-tested than the framework peers. Re-read 2026-08-13
-    - the repo still publishes the same single autonomous agent loop with tool use, browser automation,
-    computer-use actions, planning and MCP, and still shows no benchmark placement. Two below the openhands
-    anchor, unchanged.'
+  note: Capable demo agent but narrower and less battle-tested than the framework peers.
   relative_to: openhands
   relation: two_below
   last_verified: '2026-08-13'

--- a/sources/scores/openpcc.yaml
+++ b/sources/scores/openpcc.yaml
@@ -15,17 +15,14 @@ openness:
     - reference-impl(Go)+client-SDKs
     - commercial-managed-service(CONFSEC)separate
   confidence: high
-  note: Fully OSI-licensed (Apache-2.0) across the reference implementation and related repos, with the spec
-    and whitepaper public. Confident Security runs a commercial managed service (CONFSEC) on top, but that
-    is an open-core *business* around a fully open standard, not open-core licensing. Re-read 2026-08-13
-    and unchanged. The LICENSE body at repository head is a verbatim Apache License 2.0, and the
-    repository metadata reports spdx_id Apache-2.0 on a public, unarchived Go repository. The README
-    still frames the project as "deployable on your own infrastructure", links the whitepaper in-tree,
-    and points the compute-node half at a second public repository, confidentsecurity/confidentcompute,
-    which publishes the compute_boot, router_com and compute_worker binaries plus the Packer image
-    build - so the part that actually runs the inference is published rather than withheld. CONFSEC
-    remains a managed service Confident Security sells on top, mentioned but not required, which is why
-    core-gated stays ungated.
+  note: 'Fully OSI-licensed (Apache-2.0) across the reference implementation and related repos, with the
+    spec and whitepaper public. Confident Security runs a commercial managed service (CONFSEC) on top, but
+    that is an open-core *business* around a fully open standard, not open-core licensing. The compute-node
+    half is published rather than withheld: confidentsecurity/confidentcompute carries the compute_boot,
+    router_com and compute_worker binaries plus the Packer image build, so the part that actually runs the
+    inference is open, and the OpenPCC README frames the project as "deployable on your own infrastructure".
+    CONFSEC remains a managed service Confident Security sells on top, mentioned but not required, which
+    is why core-gated stays ungated.'
   raw: license:Apache-2.0(OSI);source:public(github.com/openpcc/openpcc + spec/whitepaper);reference-impl(Go)+client-SDKs;commercial-managed-service(CONFSEC)separate;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -79,16 +76,13 @@ adoption:
   signal_type: reported_traction
   confidence: low
   banded_quantity: GitHub stars (948) and seed funding ($5M), with no production adopter documented
-  note: 'Launched Nov 5 2025 with a $5M seed (Decibel, Ex/Ante, South Park Commons, Halcyon, SAIF); ~940 GitHub
-    stars by mid-2026 (notable for a young infra project) but no production adopters documented in primary
-    sources. Early-stage. Re-read 2026-08-13 and the picture is unchanged, so the level stands. The
-    repository reports 948 stars and 31 forks, and neither the README nor the launch write-up names a
-    production deployment; the only named consumer is Confident Security''s own CONFSEC managed service,
-    which is the vendor rather than an adopter. Two things worth a later look - the repository''s last
-    push is 2026-01-08, seven months before this read, and the launch post still closes on an open
-    waitlist rather than customers. Neither moves a level-2 reported_traction band on its own, but a
-    reference implementation that has not been pushed to since January is the kind of signal that
-    usually precedes one moving.'
+  note: 'Launched Nov 5 2025 with a $5M seed (Decibel, Ex/Ante, South Park Commons, Halcyon, SAIF); ~940
+    GitHub stars by mid-2026 (notable for a young infra project) but no production adopters documented in
+    primary sources. Early-stage. The only named consumer is Confident Security''s own CONFSEC managed service,
+    which is the vendor rather than an adopter: neither the README nor the launch write-up names a production
+    deployment, and the launch post closes on an open waitlist rather than customers. Worth a later look
+    - the reference implementation has gone months without a push, which does not move a level-2 reported_traction
+    band on its own but is the kind of signal that usually precedes one moving.'
   last_verified: '2026-08-13'
   sources:
   - url: https://api.github.com/repos/openpcc/openpcc
@@ -112,21 +106,19 @@ capability:
     requests via Oblivious HTTP; client SDKs (Go native + C lib for Python/JS); model/provider-agnostic (prototyped
     on Intel TDX + H100 serving Llama-3 8B on vLLM)'
   confidence: medium
-  note: 'Broad, well-architected confidential-serving stack with attestation plus anonymization that goes beyond
-    plain confidential compute. Not top because it is young with limited proven scale and no documented production
-    adopters. Re-read 2026-08-13 and the feature set holds, though the two cited pages divide the work
-    differently than this axis recorded. The launch write-up turns out to be a motivation and standards
-    piece - it establishes the anonymization scheme against timing, payment and metadata side channels,
-    and the Apache-2.0 Go implementation, and nothing more granular. The itemized scope comes from the
-    repositories instead. The OpenPCC README carries encrypted streaming, hardware attestation and
-    unlinkable requests over Oblivious HTTP, a transparency verifier with an identity policy, a Go client
-    plus a C library underlying the Python and JavaScript clients, and OpenAI-format completions against
-    an arbitrary tagged model, which is the provider-agnostic claim. The compute-node repository adds
-    the attestation target explicitly, with compute_boot attesting to the TPM, GPU and other hardware
-    before the router starts. One recorded detail did NOT re-derive - the "prototyped on Intel TDX + H100
-    serving Llama-3 8B on vLLM" clause in the value string appears on none of the pages read today, and
-    the README''s worked example runs qwen3:1.7b. Flagged rather than edited; the band does not rest on
-    it.'
+  note: Broad, well-architected confidential-serving stack with attestation plus anonymization that goes
+    beyond plain confidential compute. Not top because it is young with limited proven scale and no documented
+    production adopters. The itemized scope comes from the repositories rather than the launch write-up,
+    which is a motivation and standards piece establishing the anonymization scheme against timing, payment
+    and metadata side channels and the Apache-2.0 Go implementation, and nothing more granular. The OpenPCC
+    README carries encrypted streaming, hardware attestation and unlinkable requests over Oblivious HTTP,
+    a transparency verifier with an identity policy, a Go client plus a C library underlying the Python
+    and JavaScript clients, and OpenAI-format completions against an arbitrary tagged model, which is the
+    provider-agnostic claim; the compute-node repository adds the attestation target explicitly, with compute_boot
+    attesting to the TPM, GPU and other hardware before the router starts. One recorded detail does NOT
+    re-derive - the "prototyped on Intel TDX + H100 serving Llama-3 8B on vLLM" clause in the value string
+    appears on none of the cited pages, whose worked example runs qwen3:1.7b. Flagged rather than edited;
+    the band does not rest on it.
   last_verified: '2026-08-13'
   sources:
   - url: https://raw.githubusercontent.com/openpcc/openpcc/main/README.md

--- a/sources/scores/openpipe.yaml
+++ b/sources/scores/openpipe.yaml
@@ -20,16 +20,13 @@ openness:
         ART backend optional, for users who do not want to manage GPU infrastructure; no ART feature is
         withheld from the self-hostable LocalBackend
   confidence: high
-  note: List B re-read, 2026-08-11. The value on file was the single token `gated` while this record's own
-    note already argued the opposite, so the recorded value was the thing under suspicion rather than a
-    gap. The ART FAQ commits to "maintaining ART as a full-featured open source project" and calls the hosted
-    backend "an optional hosted ART backend for users who don't want to manage GPU infrastructure on their
-    own"; the backend docs describe a fully self-hostable LocalBackend alongside it. Nothing is withheld
-    from the published Apache-2.0 source -- no ee/ directory, no closed package, no license key -- and OpenPipe's
-    hosted training and serving SaaS is a separate product sold beside the open core, which software.yaml
-    explicitly does not count as gating. core-gated corrected to ungated with that evidence in the value,
-    moving the score 4/open_core -> 5/open_source, the same correction already applied to langchain, llama-index,
-    pydantic-ai, zed and otari.
+  note: 'Apache-2.0 with the full source public, and nothing withheld from it: no ee/ or enterprise directory,
+    no closed package the open one depends on, no license key. The ART FAQ commits to "maintaining ART as
+    a full-featured open source project" and calls the hosted backend "an optional hosted ART backend for
+    users who don''t want to manage GPU infrastructure on their own", and the backend docs describe a fully
+    self-hostable LocalBackend alongside it. OpenPipe''s hosted training and serving SaaS is a separate
+    product sold beside the open core, which software.yaml explicitly does not count as gating, so core-gated
+    is ungated and the class is open_source.'
   last_verified: '2026-08-11'
   raw: license:Apache-2.0(OSI, OpenPipe Inc.; some vendored code LGPL-3.0);source:public;methods:RL(GRPO)+SFT
     trajectory training;managed-tier:OpenPipe hosted training/serving SaaS on top of the OSS lib;core-gated:ungated(ART
@@ -104,10 +101,8 @@ capability:
     Qwen, Llama, GPT-OSS. Specialist agent-RL focus, not broad-method or large-scale-parallelism training
     infra.'
   confidence: medium
-  note: 'Capable, focused agent-RL trainer; mid-tier vs full training stacks (no TP/PP/EP at Megatron scale).
-    Feature-matrix basis per recipe; no MLPerf-Training submission. Re-read 2026-08-13 and unchanged at 3. The
-    note''s own comparison - "mid-tier vs full training stacks (no TP/PP/EP at Megatron scale)" - is now
-    recorded as two_below megatron-lm rather than left in prose.'
+  note: Capable, focused agent-RL trainer; mid-tier vs full training stacks (no TP/PP/EP at Megatron scale).
+    Feature-matrix basis per recipe; no MLPerf-Training submission.
   relative_to: megatron-lm
   relation: two_below
   last_verified: '2026-08-13'

--- a/sources/scores/openrag.yaml
+++ b/sources/scores/openrag.yaml
@@ -17,10 +17,8 @@ openness:
       value: none
   confidence: high
   note: Fully open AGPL-3.0 RAG application stack — the published source is the whole product, self-hosted
-    via Docker Compose, with no feature-gated enterprise tier and no vendor lock-in. AGPL is OSI-approved and
-    sits beside Apache on the software ladder, so osi + public + ungated lands at 5. Re-read 2026-08-13
-    - the repo page still reports AGPL-3.0 over the whole tree, publishes the backend and frontend together
-    with the Docker Compose deployment, and still offers no paid or enterprise tier. Nothing moved.
+    via Docker Compose, with no feature-gated enterprise tier and no vendor lock-in. AGPL is OSI-approved
+    and sits beside Apache on the software ladder, so osi + public + ungated lands at 5.
   raw: license:AGPL-3.0(OSI);source:public;self-host:primary(Docker Compose);core-gated:ungated;commercial:none
   last_verified: '2026-08-13'
   sources:
@@ -40,13 +38,10 @@ adoption:
   reach: <1K stars
   signal_type: stars_fallback
   confidence: medium
-  note: '~237 GitHub stars, 55 forks (Aug 2026) — early-stage. No download metric available (Docker-
-    distributed, no first-party PyPI/npm), so adoption falls back to stars, which the ladder caps at 3; 237
-    stars places it in the lowest band. Stars read 2026-08-13: 238 across the 1 declared repo, which bands at
-    <1K stars, level 1 on the stars scale in signal_routing.yaml. The record carried no reach label at all
-    before this. Re-read 2026-08-13 from the repo page itself, which reports 238 stars and 55 forks. OpenRAG
-    is Docker-distributed with no first-party PyPI or npm package and publishes no pull or user count,
-    so the stars fallback is still the only instrument and <1K stars still bands at 1.'
+  note: ~237 GitHub stars, 55 forks (Aug 2026) — early-stage. No download metric available (Docker- distributed,
+    no first-party PyPI/npm), so adoption falls back to stars, which the ladder caps at 3; 237 stars places
+    it in the lowest band. 238 stars across the 1 declared repo, which bands at <1K stars, level 1 on the
+    stars scale in signal_routing.yaml. The record carried no reach label at all before this.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/linagora/openrag
@@ -62,12 +57,9 @@ capability:
     hybrid semantic + keyword search with multilingual reranking; bundled chat UI + admin UI; OpenAI-compatible
     REST API; Ray-based distributed processing; GPU acceleration; Docker Compose deployment
   confidence: medium
-  note: Feature-complete, batteries-included general RAG stack with a broad ingestion + retrieval surface and
-    a bundled UI/API. A notch below RAGFlow (capability 4), whose distinctive layout-aware deep document
-    understanding and larger, more mature community set the ceiling for this category. Re-read 2026-08-13
-    - the repo still presents the same batteries-included stack, now describing itself as "the Open RAG
-    Experimentation Playground", lightweight, modular and extensible, with the same ingestion, hybrid
-    search, bundled UIs and OpenAI-compatible API. One below ragflow, unchanged.
+  note: Feature-complete, batteries-included general RAG stack with a broad ingestion + retrieval surface
+    and a bundled UI/API. A notch below RAGFlow (capability 4), whose distinctive layout-aware deep document
+    understanding and larger, more mature community set the ceiling for this category.
   relative_to: ragflow
   relation: one_below
   last_verified: '2026-08-13'

--- a/sources/scores/openrouter.yaml
+++ b/sources/scores/openrouter.yaml
@@ -12,11 +12,8 @@ openness:
     self-host:
       value: none
   confidence: high
-  note: Proprietary hosted routing gateway, the closed counterpart to open gateways (LiteLLM); listed
-    as closed in the recipe.
-    Re-read 2026-08-13. The homepage still sells a hosted gateway with sign-up and credits and still
-    publishes nothing of the routing service itself, with no self-host path anywhere on it. Value
-    unchanged at 1 / closed.
+  note: Proprietary hosted routing gateway, the closed counterpart to open gateways (LiteLLM); listed as
+    closed in the recipe.
   raw: license:proprietary(hosted gateway);source:closed(SDK present, core service closed);self-host:none
   last_verified: '2026-08-13'
   sources:
@@ -31,30 +28,26 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: 'Vendor homepage (primary) reports 100T monthly tokens processed and 8M+ global users; ~250k+ apps.
-    Token volume corroborated by external coverage (~25T tokens/week, ~1.5 quadrillion/yr run-rate; Menlo,
-    TechCrunch on $1.3B valuation / $113M raise May 2026). Reach placed at 1M-10M on the 8M user figure;
-    usage-volume signal is genuinely massive.
-    RE-BANDED 4 -> 5 on 2026-08-14, on the owner''s ruling, because the figure the old band was placed on
-    has been overtaken. SAY WHAT WAS BANDED - the quantity is the vendor''s own GLOBAL USERS stat tile,
-    which read 8M+ when this record was written and reads 10M+ today, clearing the >10M threshold the top
-    band needs. The tiles were re-read 2026-08-14 and now say 200T+ Monthly Tokens, 10M+ Global Users, 80+
-    Providers and 500+ Models, against the 100T / 8M / 60+ / 400+ this record carried; the monthly token
-    figure has doubled since and the provider and model counts have grown too.
+  note: Vendor homepage (primary) stat tiles read 200T+ Monthly Tokens, 10M+ Global Users, 80+ Providers
+    and 500+ Models, against the 100T / 8M+ / 60+ / 400+ this record originally carried - the monthly token
+    figure has doubled and the provider and model counts have grown. Token volume is corroborated by external
+    coverage (~25T tokens/week, ~1.5 quadrillion/yr run-rate; Menlo, and TechCrunch on the $1.3B valuation
+    and $113M raise). RE-BANDED 4 -> 5 on the owner's ruling, because the figure the old band was placed
+    on has been overtaken. SAY WHAT WAS BANDED - the quantity is the vendor's own GLOBAL USERS tile, which
+    read 8M+ when this record was written and reads 10M+ now, clearing the >10M threshold the top band needs.
     Two honesty notes on the instrument. The unit is a vendor-reported user count rather than the package
-    downloads the software scale is denominated in, and the label is the scale''s top band either way;
-    and OpenRouter does not say whether "global users" is an active or a cumulative count, which is why
-    this stays `usage_volume` rather than moving to `active_users`, where a cumulative total is not
-    admissible. The 200T+ monthly tokens is the corroborating measure and is unambiguously a volume.'
+    downloads the software scale is denominated in, and the label is the scale's top band either way; and
+    OpenRouter does not say whether "global users" is an active or a cumulative count, which is why this
+    stays usage_volume rather than moving to active_users, where a cumulative total is not admissible. The
+    200T+ monthly tokens is the corroborating measure and is unambiguously a volume.
   last_verified: '2026-08-14'
   sources:
   - url: https://openrouter.ai/
     shows: 'vendor headline: 100T monthly tokens, 8M+ global users, 400+ models / 60+ providers'
     accessed: '2026-06-04'
   - url: https://openrouter.ai/
-    shows: 'Homepage stat tiles, read 2026-08-14 - "200T+ Monthly Tokens", "10M+ Global Users", "80+
-      Providers", "500+ Models". The 10M+ users tile is the figure this band is taken on; the 200T+
-      monthly tokens corroborates it.'
+    shows: Homepage stat tiles - "200T+ Monthly Tokens", "10M+ Global Users", "80+ Providers", "500+ Models".
+      The 10M+ users tile is the figure this band is taken on; the 200T+ monthly tokens corroborates it.
     accessed: '2026-08-14'
     http_status: 200
     content_sha256: 42ed60b04fcb74780074943db6f21f0b57cd528c9c7389df72d8ed6b56055d07
@@ -69,14 +62,11 @@ capability:
     + data policies; OpenAI-compatible drop-in API; provider/model ranking analytics. Hits every gateway
     feature-matrix dimension at the top of the category.'
   confidence: high
-  note: Frontier-defining for the gateway slot, broadest provider coverage + routing/fallback at the
-    largest measured token scale; the closed counterpart that sets the bar LiteLLM (C4) approaches on
-    the open side.
-    Re-read 2026-08-13. The homepage stat tiles now read 200T+ monthly tokens, 400+ models and 70+
-    providers, up from the 100T and 60+ providers recorded, and the routing, fallback, cost tracking and
-    OpenAI-compatible drop-in surface are unchanged. The model count is the same and the provider count
-    has grown, so the breadth that made this the gateway frontier is if anything wider. Band unchanged
-    at 5.
+  note: Frontier-defining for the gateway slot, broadest provider coverage + routing/fallback at the largest
+    measured token scale; the closed counterpart that sets the bar LiteLLM (C4) approaches on the open side.
+    The homepage stat tiles now read 200T+ monthly tokens, 400+ models and 70+ providers, up from the 100T
+    and 60+ providers the value records, so the breadth that made this the gateway frontier is if anything
+    wider.
   last_verified: '2026-08-13'
   sources:
   - url: https://openrouter.ai/

--- a/sources/scores/opensandbox.yaml
+++ b/sources/scores/opensandbox.yaml
@@ -17,15 +17,14 @@ openness:
     - no-managed-tier-observed
     - no-feature-gated-core
   confidence: high
-  note: 'Apache-2.0, fully self-hostable, no managed/enterprise gating observed => open_source (not open_core).
-    Alibaba says it open sourced the sandbox infra used internally. Re-read 2026-08-13 and all three recorded
-    dimensions hold. The repository has moved from the alibaba org to opensandbox-group - the old URL 301s
-    to the new one and both return the same body - and the root LICENSE is the verbatim Apache License
-    2.0 with nothing appended. The untruncated tree is 2,642 entries with the whole product public - server/,
-    components/, kubernetes/, cli/, sdks/, specs/ - carrying ten LICENSE paths, all Apache-2.0 copies sitting
-    beside per-SDK and per-component roots, and no ee/, enterprise/, commercial/ or proprietary/ path.
-    open-sandbox.ai is a documentation site with no pricing page, no hosted offering and no sign-up, closing
-    with "Released under the Apache 2.0 License", so there is still no managed tier to gate against.'
+  note: Apache-2.0, fully self-hostable, no managed/enterprise gating observed => open_source (not open_core).
+    Alibaba says it open sourced the sandbox infra used internally. The repository has moved from the alibaba
+    org to opensandbox-group, with the old URL redirecting to the new one. The untruncated tree is 2,642
+    entries with the whole product public - server/, components/, kubernetes/, cli/, sdks/, specs/ - carrying
+    ten LICENSE paths, all Apache-2.0 copies beside per-SDK and per-component roots, and no ee/, enterprise/,
+    commercial/ or proprietary/ path. open-sandbox.ai is a documentation site with no pricing page, no hosted
+    offering and no sign-up, closing with "Released under the Apache 2.0 License", so there is no managed
+    tier to gate against.
   raw: license:Apache-2.0(OSI);source:public(Go execd + multi-language SDKs);runtimes:Docker/Kubernetes;no-managed-tier-observed;no-feature-gated-core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -76,17 +75,15 @@ adoption:
   reach: '>10K stars'
   signal_type: stars_fallback
   confidence: low
-  note: 'Only ~2-3 months old; no PyPI/download or named-deployment figures surfaced. ~11.3k GitHub stars
-    (3,845 within 72h of launch) is the only signal, stars_fallback, which caps level at 3. Placed at 2: rapid
-    early stars but no usage volume yet. Revisit as usage data emerges. Stars read 2026-08-13: 12,516 across
-    the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. Level
-    corrected from 2. The previous reach ''10K-100K'' was not a label this instrument offers - stars have
-    their own vocabulary because a star is not a download. Re-read in full 2026-08-13 against the GitHub
-    API - 12,522 stars, 1,056 forks - which is the same >10K stars band and the same level 3. The digest
-    below will drift on every refetch because a star count moves daily; that is expected of this instrument
-    and does not weaken the band, which depends only on the order of magnitude. One thing did change and
-    is escalated rather than applied - a Python SDK is now published on PyPI as `opensandbox`, so this
-    record may no longer need the stars fallback at all. It is not declared here.'
+  note: '12,522 stars and 1,056 forks across the 1 declared repo, which bands at >10K stars, level 3 on
+    the stars scale in signal_routing.yaml - the cap for stars_fallback, and a correction up from level
+    2. The project is only months old and no PyPI/download or named-deployment figure has surfaced, so stars
+    are the only signal: rapid early accumulation (3,845 within 72h of launch) with no usage volume behind
+    it yet. The reach label uses the stars vocabulary rather than a download band, because a star is not
+    a download, and the digest below drifts on every refetch because a star count moves daily - expected
+    of this instrument, and no weaker a band for it, since the band depends only on order of magnitude.
+    One thing is escalated rather than applied: a Python SDK is now published on PyPI as `opensandbox`,
+    so this record may no longer need the stars fallback at all. It is not declared here.'
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/alibaba/OpenSandbox

--- a/sources/scores/openthoughts-114k.yaml
+++ b/sources/scores/openthoughts-114k.yaml
@@ -12,8 +12,7 @@ openness:
     free_text:
     - GitHub repo + paper
   confidence: high
-  note: 'Apache-2.0 licensed, ungated, with dataset card, code repo, and paper. Re-read 2026-08-13: apache-2.0
-    on the Hub, gated false, card plus the open-thoughts repo and paper links intact.'
+  note: Apache-2.0 licensed, ungated, with dataset card, code repo, and paper.
   raw: license:apache-2.0;access:ungated;dataset_card:present;GitHub repo + paper
   last_verified: '2026-08-13'
   sources:
@@ -49,9 +48,9 @@ capability:
   basis_detail: superseded
   value: null
   confidence: high
-  note: 'Strong early-2025 reasoning results (OpenThinker-32B led open-data MATH500/GPQA-D) but superseded
-    by OpenThoughts3-1.2M. Re-read 2026-08-13: the OpenThinker-32B card still reports MATH500 90.6 and GPQA-Diamond
-    61.6 against LIMO-32B, s1-32B and s1.1-32B, and the OpenThoughts blog still recommends OpenThoughts3-1.2M.'
+  note: Strong early-2025 reasoning results (OpenThinker-32B led open-data MATH500/GPQA-D) but superseded
+    by OpenThoughts3-1.2M. The OpenThinker-32B card reports MATH500 90.6 and GPQA-Diamond 61.6 against LIMO-32B,
+    s1-32B and s1.1-32B, and the OpenThoughts blog now recommends OpenThoughts3-1.2M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/open-thoughts/OpenThinker-32B

--- a/sources/scores/openvino.yaml
+++ b/sources/scores/openvino.yaml
@@ -13,11 +13,10 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: 'Apache-2.0 license body confirmed; full source public. Re-read 2026-08-13: the cited LICENSE body
-    still carries the Apache-2.0 terms, the GitHub API reports the repository public, unarchived and licensed
-    Apache-2.0, and the README describes the whole library with no paid, enterprise or hosted tier beside
-    it, so source stays public and core-gated stays ungated. The README''s only ''enterprise'' string is
-    inside a third-party LLMWare integration blurb rather than an OpenVINO tier.'
+  note: Apache-2.0 license body confirmed; full source public. The repository is public and unarchived,
+    and the README describes the whole library with no paid, enterprise or hosted tier beside it, so source
+    is public and the core ungated. The README's only 'enterprise' string is inside a third-party LLMWare
+    integration blurb rather than an OpenVINO tier.
   raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -52,15 +51,12 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: 'PyPI last_month downloads ~1.38M. Read live 2026-08-13: 1,869,817 PyPI downloads in the trailing
-    30 days across the declared artifact(s), which bands at 1M-10M, level 4. Level corrected from 3. The
-    previous reach ''~1.4M/mo'' was free text carrying a figure rather than a band the scale declares, so
-    nothing could check it against the level beside it. No last_verified claimed: only the figure was re-read,
-    not the whole axis. Re-read 2026-08-13 from the cited pypistats reading of the declared PyPI artifact
-    `openvino`: 1,869,817 downloads in the trailing 30 days, which bands at 1M-10M, level 4 on the software
-    scale. Unchanged. OpenVINO also ships through conda-forge, Homebrew, npm, Docker and Intel''s own archives,
-    none of them counted here, so 1.87M/mo is a floor for the 1M-10M band rather than a full count of the
-    product''s distribution.'
+  note: 1,869,817 PyPI downloads in the trailing 30 days for the declared artifact `openvino`, which bands
+    at 1M-10M, level 4 on the software scale. Level corrected from 3; the previous reach '~1.4M/mo' was
+    free text carrying a figure rather than a band the scale declares, so nothing could check it against
+    the level beside it. OpenVINO also ships through conda-forge, Homebrew, npm, Docker and Intel's own
+    archives, none of them counted here, so 1.87M/mo is a floor for the 1M-10M band rather than a full count
+    of the product's distribution.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/openvino/recent
@@ -74,9 +70,7 @@ capability:
   value: Inference optimization/deployment toolkit across Intel CPU/GPU/NPU with multi-framework model
     conversion.
   confidence: high
-  note: 'Broad inference runtime with model conversion and GenAI API, primarily Intel-hardware oriented.
-    Re-read 2026-08-13: the cited repository page still describes the product as recorded, so the band is
-    unchanged.'
+  note: Broad inference runtime with model conversion and GenAI API, primarily Intel-hardware oriented.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/openvinotoolkit/openvino

--- a/sources/scores/openwebmath.yaml
+++ b/sources/scores/openwebmath.yaml
@@ -10,9 +10,7 @@ openness:
     dataset_card:
       value: present
   confidence: high
-  note: 'ODC-BY 1.0, ungated, full dataset card. Re-read 2026-08-13: the card''s License section still reads
-    ODC-By 1.0 alongside the Common Crawl ToU, the Hub metadata still tags odc-by, and the API reports gated
-    false.'
+  note: ODC-BY 1.0, ungated, full dataset card.
   raw: license:ODC-BY;gated:false;dataset_card:present
   last_verified: '2026-08-13'
   sources:
@@ -30,9 +28,8 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 33,285 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (open-web-math/open-web-math 33,285). Bands at level 3 (10K-100K) on the dataset adoption scale, whose
-    top band is >1M.
+  note: 33,285 downloads in the trailing 30 days summed across the 1 declared artifact(s) (open-web-math/open-web-math
+    33,285). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/open-web-math/open-web-math
@@ -46,10 +43,8 @@ capability:
   basis_detail: superseded
   value: null
   confidence: high
-  note: 'Proven math corpus (Llemma/Proof-Pile-2, OLMoE, StarCoder2 math supplement) but Oct-2023 vintage
-    and now the baseline that FineMath, MegaMath, and Nemotron-CC-Math beat in ablations. Re-read 2026-08-13:
-    the Nemotron-CC-Math paper still reports surpassing prior open math corpora including OpenWebMath, and
-    the FineMath card still reports beating it on GSM8k and MATH.'
+  note: Proven math corpus (Llemma/Proof-Pile-2, OLMoE, StarCoder2 math supplement) but Oct-2023 vintage
+    and now the baseline that FineMath, MegaMath, and Nemotron-CC-Math beat in ablations.
   relative_to: finemath
   relation: two_below
   last_verified: '2026-08-13'

--- a/sources/scores/opik.yaml
+++ b/sources/scores/opik.yaml
@@ -16,10 +16,8 @@ openness:
     free_text:
     - self-hostable-full-stack
   confidence: high
-  note: Apache-2.0, full platform self-hostable; cloud is managed hosting rather than a feature-gated
-    proprietary core. Re-read 2026-08-13 and unchanged - both the PyPI project page and the repository
-    README now say in the vendor's own words that the server, web application and evaluation components
-    are all Apache-2.0 and free to self-host, which is the core_gated question answered directly.
+  note: Apache-2.0, full platform self-hostable; cloud is managed hosting rather than a feature-gated proprietary
+    core.
   raw: license:Apache-2.0(OSI);source:public;self-hostable-full-stack;commercial:Comet-cloud-hosting(not
     a gated core);core-gated:ungated
   last_verified: '2026-08-13'
@@ -51,9 +49,9 @@ adoption:
   signal_type: usage_volume
   confidence: high
   note: opik ~6.19M PyPI downloads/month; 60-70+ framework integrations; ~19.4k stars corroborates only.
-    Re-read 2026-08-13 - pypistats now reports 3,512,727 downloads last month for opik, down from the
-    6,192,885 recorded and still inside the 1M-10M band, so level 4 is unchanged. The 40M+ traces/day
-    figure is no longer on the repository README and is dropped from this note rather than carried forward.
+    pypistats now reports 3,512,727 downloads in the last month for opik, below the 6,192,885 this note
+    was set on and still inside the 1M-10M band. The 40M+ traces/day figure is no longer on the repository
+    README, so the band rests on the download count.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/packages/opik
@@ -74,10 +72,8 @@ capability:
   value: tracing(OTel-native + 70+ integrations), evals(datasets/experiments, pytest CI/CD), LLM-as-judge
     metrics(hallucination/moderation/relevance/context-precision), prompt playground, datasets, cost tracking
   confidence: high
-  note: Covers all six feature-matrix dimensions; on par with MLflow/Langfuse anchors (C4). Not scored
-    5; closed Arize AX leads category capability. Re-read 2026-08-13 - the README still covers trace
-    logging, LLM-as-a-judge scoring, feedback annotation on traces and spans, datasets and third-party
-    integrations, so the recorded comparison at the langfuse anchor still holds.
+  note: Covers all six feature-matrix dimensions; on par with MLflow/Langfuse anchors (C4). Not scored 5;
+    closed Arize AX leads category capability.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/comet-ml/opik

--- a/sources/scores/optimum.yaml
+++ b/sources/scores/optimum.yaml
@@ -13,10 +13,9 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: 'LICENSE body is verbatim Apache License 2.0; full source public. Re-read 2026-08-13: the cited
-    LICENSE body still carries the Apache-2.0 terms, the GitHub API reports the repository public, unarchived
-    and licensed Apache-2.0, and the README describes the whole library with no paid, enterprise or hosted
-    tier beside it, so source stays public and core-gated stays ungated.'
+  note: LICENSE body is verbatim Apache License 2.0; full source public. The repository is public and unarchived,
+    and the README describes the whole library with no paid, enterprise or hosted tier beside it, so source
+    is public and the core ungated.
   raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -50,13 +49,10 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: 'PyPI last-month downloads of 1,759,764 fall in the 500k-5M range. Read live 2026-08-13: 1,919,623
-    PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at 1M-10M, level
-    4. Level corrected from 3. The previous reach ''1.7M+/month'' was free text carrying a figure rather
-    than a band the scale declares, so nothing could check it against the level beside it. No last_verified
-    claimed: only the figure was re-read, not the whole axis. Re-read 2026-08-13 from the cited pypistats
-    reading of the declared PyPI artifact `optimum`: 1,919,623 downloads in the trailing 30 days, which
-    bands at 1M-10M, level 4 on the software scale. Unchanged.'
+  note: 1,919,623 PyPI downloads in the trailing 30 days for the declared artifact `optimum`, which bands
+    at 1M-10M, level 4 on the software scale. Level corrected from 3; the previous reach '1.7M+/month' was
+    free text carrying a figure rather than a band the scale declares, so nothing could check it against
+    the level beside it.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/optimum/recent
@@ -69,10 +65,7 @@ capability:
   basis: feature_matrix
   value: Hardware-targeted optimization, export, and quantization across multiple accelerators/runtimes.
   confidence: high
-  note: 'Broad multi-backend optimization layer, though dependent on the core Transformers stack. Re-read
-    2026-08-13: the cited repository page still describes the product as recorded, so the band is unchanged.
-    The ''dependent on the core Transformers stack'' placement this note already made is now recorded as
-    relative_to/relation - one below Transformers'' 5.'
+  note: Broad multi-backend optimization layer, though dependent on the core Transformers stack.
   relative_to: transformers
   relation: one_below
   last_verified: '2026-08-13'

--- a/sources/scores/orange-pi-5.yaml
+++ b/sources/scores/orange-pi-5.yaml
@@ -25,11 +25,7 @@ openness:
       raw: open_market (global)
   confidence: high
   note: Proprietary Rockchip silicon with an open GPL-2.0 BSP, public datasheet and schematics, and global
-    retail availability, but bootable images depend on Rockchip firmware blobs. Re-read 2026-08-13 - the
-    official support page still offers a Schematic download alongside the user manual and Android/Linux
-    source, orangepi-build is still GPL-2.0 and still lists Orange Pi 5 under RK3588S, the product page
-    still carries AliExpress and Amazon store links, and Rockchip's rkbin repository still holds the
-    prebuilt DDR/SPL/BL31 boot binaries a bootable image needs. No dimension moved.
+    retail availability, but bootable images depend on Rockchip firmware blobs.
   raw: schematics:published (published PDF);toolchain:open (open GPL-2.0 BSP/build system);datasheets:public
     (public RK3588S);blobs:required (Rockchip firmware required);retail:open_market (global)
   last_verified: '2026-08-13'
@@ -74,10 +70,10 @@ adoption:
   signal_type: reported_traction
   confidence: high
   note: Sold directly on AliExpress and Amazon at ~$69-$115 across multiple SKUs, with a large third-party
-    software/community ecosystem. Re-read 2026-08-13 - the Amazon listing could not be re-read (the host
-    returns a "Click the button below to continue shopping" interstitial to an automated fetch, not the
-    listing), so the availability check was re-derived from Orange Pi's own product page, which carries
-    live Aliexpress, Amazon and Xunlong store links and the 4/8/16GB SKUs. Level and reach unchanged.
+    software/community ecosystem. The Amazon listing is not machine-readable (the host returns a "Click
+    the button below to continue shopping" interstitial to an automated fetch, not the listing), so availability
+    rests on Orange Pi's own product page, which carries live Aliexpress, Amazon and Xunlong store links
+    and the 4/8/16GB SKUs.
   last_verified: '2026-08-13'
   sources:
   - url: http://www.orangepi.org/html/hardWare/computerAndMicrocontrollers/details/Orange-Pi-5.html
@@ -95,9 +91,9 @@ capability:
   value: 6 TOPS NPU; up to 16GB LPDDR4/4X; runs quantized LLMs up to ~8B (W4A16) and CV models via RKNN/RKLLM
   confidence: high
   note: The RK3588S NPU does 6 TOPS with mixed-precision support and runs small on-device LLMs, but well
-    below discrete GPUs and dedicated NPUs. Re-derived 2026-08-13 - the spec table still reads 6 TOPS
-    with INT4/INT8/INT16 mixed operation and 4/8/16GB LPDDR4/4X, which is the same tier as khadas-edge2
-    (also 6 TOPS RK3588S2) and well under the 67-275 TOPS Jetson Orin parts.
+    below discrete GPUs and dedicated NPUs. The spec table reads 6 TOPS with INT4/INT8/INT16 mixed operation
+    and 4/8/16GB LPDDR4/4X, which is the same tier as khadas-edge2 (also 6 TOPS RK3588S2) and well under
+    the 67-275 TOPS Jetson Orin parts.
   last_verified: '2026-08-13'
   sources:
   - url: http://www.orangepi.org/html/hardWare/computerAndMicrocontrollers/details/Orange-Pi-5.html

--- a/sources/scores/ornith.yaml
+++ b/sources/scores/ornith.yaml
@@ -17,9 +17,8 @@ openness:
       detail: OSI
   confidence: high
   note: MIT-licensed open weights on a Qwen 3.5 base, but no open training data or recipe -> open_weights.
-    Re-read 2026-08-13 - the card still carries `license:mit` with `"gated":false` and the qwen3_5
-    architecture, and still publishes no training data and no recipe. Note the repo is now served under
-    the org `ornith-ai` rather than `deepreinforce-ai`; the declared URL still resolves. No change.
+    The repo is now served under the org `ornith-ai` rather than `deepreinforce-ai`; the declared URL still
+    resolves.
   raw: weights:open(MIT);base:Qwen3.5;data:closed;recipe:closed;license:MIT(OSI)
   last_verified: '2026-08-13'
   sources:
@@ -62,10 +61,9 @@ capability:
     Code); agentic coding with reasoning and tool-calling
   confidence: medium
   note: Strong agentic-coding scores for a 9B and competitive within the category, but below the frontier
-    coders; benchmarks are vendor-reported on the model card. Re-read 2026-08-13 - the card's model-index
-    still records SWE-bench Verified 69.4 and SWE-bench Pro 42.9, and now also carries SWE-bench
+    coders; benchmarks are vendor-reported on the model card. The card's model-index also carries SWE-bench
     Multilingual 52.0 and Claw-Eval 63.1. The Terminal-Bench figures in the recorded value are not in the
-    model-index and were not re-derivable from it. No change to the score.
+    model-index and are not re-derivable from it.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/deepreinforce-ai/Ornith-1.0-9B

--- a/sources/scores/oscar-2301.yaml
+++ b/sources/scores/oscar-2301.yaml
@@ -12,10 +12,7 @@ openness:
     free_text:
     - card notes access temporarily suspended
   confidence: high
-  note: 'Manually gated and the card states access is temporarily suspended pending clarification. Re-read
-    2026-08-13: the card still carries the extra_gated_prompt announcing that access to OSCAR is temporarily
-    suspended and that no access will be granted, the API reports gated manual, and the licence tag is still
-    cc0-1.0 on the metadata.'
+  note: Manually gated and the card states access is temporarily suspended pending clarification.
   raw: license:cc0-1.0(metadata);gated:manual(login + terms acceptance);card notes access temporarily suspended
   last_verified: '2026-08-13'
   sources:
@@ -33,9 +30,8 @@ adoption:
   reach: 1K-10K
   signal_type: usage_volume
   confidence: high
-  note: 2,036 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (oscar-corpus/OSCAR-2301 2,036). Bands at level 2 (1K-10K) on the dataset adoption scale, whose top
-    band is >1M.
+  note: 2,036 downloads in the trailing 30 days summed across the 1 declared artifact(s) (oscar-corpus/OSCAR-2301
+    2,036). Bands at level 2 (1K-10K) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/oscar-corpus/OSCAR-2301
@@ -49,10 +45,9 @@ capability:
   basis_detail: superseded
   value: null
   confidence: high
-  note: 'A dated 2022-snapshot web corpus with access suspended; the derived Colossal OSCAR trains ALIA/Salamandra
-    (2024) but the 2301 version itself is superseded by FineWeb-2/CulturaX. Re-read 2026-08-13: the Salamandra
-    card still puts Colossal OSCAR at 53.05% of the pretraining tokens, and the FineWeb-2 card still reports
-    the newer multilingual extraction ahead of it.'
+  note: A dated 2022-snapshot web corpus with access suspended; the derived Colossal OSCAR trains ALIA/Salamandra
+    (2024) but the 2301 version itself is superseded by FineWeb-2/CulturaX. The Salamandra card puts Colossal
+    OSCAR at 53.05% of its pretraining tokens.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/BSC-LT/salamandra-7b

--- a/sources/scores/osprey.yaml
+++ b/sources/scores/osprey.yaml
@@ -16,7 +16,7 @@ openness:
       value: ungated
   confidence: high
   note: 'Fully open source: Apache-2.0 real-time safety rules engine, self-hostable, no proprietary tier.
-    Donated by Discord to ROOST. Re-read 2026-08-13 and unchanged.'
+    Donated by Discord to ROOST.'
   raw: license:Apache-2.0(OSI);source:public;self-host:yes;service:none;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -40,13 +40,13 @@ adoption:
   banded_quantity: production deployment at named platforms and the v1.0 post's 50M+ figure; the previous
     '400M daily actions' is no longer carried by any cited source
   note: 'Community breadth is modest but Osprey runs in production at marquee platforms, which is what the
-    band rests on. Re-read 2026-08-13 and two recorded facts did not survive the read. The repo''s
-    ''Adopters'' list is now empty - the named production users have been removed from the README - and no
-    source cited here carries the ''400M daily actions, 2.3M rules/sec'' figure any more; the v1.0
-    announcement says Osprey ''processes over 50M events daily in production environments like Bluesky''.
-    The named deployments themselves are still confirmed on that announcement, with quotes from Discord,
-    Bluesky and Matrix, so the level and the niche reach stand and only the numbers were corrected. No
-    reach numeral is recorded, because this instrument carries a word or nothing.'
+    band rests on. Two recorded facts no longer hold: the repo''s ''Adopters'' list is empty, the named
+    production users having been removed from the README, and no source cited here carries the ''400M daily
+    actions, 2.3M rules/sec'' figure any more - the v1.0 announcement says Osprey ''processes over 50M events
+    daily in production environments like Bluesky''. The named deployments themselves are confirmed on that
+    announcement, with quotes from Discord, Bluesky and Matrix, so the level and the niche reach stand and
+    only the numbers were corrected. No reach numeral is recorded, because this instrument carries a word
+    or nothing.'
   last_verified: '2026-08-13'
   sources:
   - url: https://roost.tools/blog/introducing-osprey-v1-0-open-source-infrastructure-for-real-time-abuse-mitigation/
@@ -60,8 +60,7 @@ adoption:
     content_sha256: d6a88d5ed04eb1fe19fff71b8c8bbdd60ffe36fb3d226608bd8b549f144d2dc2
   - url: https://github.com/roostorg/osprey
     shows: stargazerCount 462 for roostorg/osprey. The README's 'Adopters' section reads 'Osprey is used
-      by:' with nothing under it, so the named production list recorded here on 2026-07-01 is no longer on
-      the page.
+      by:' with nothing under it.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 592ab20d0b28d1642d82318e38ce104ed1c1f625d061b8669c875182556375b7
@@ -73,25 +72,23 @@ capability:
     investigation console; human-written rules evaluate every event as it arrives; ROOST reports it
     processing over 50M events daily in production environments like Bluesky, and it was built at Discord.
   confidence: medium
-  note: 'Battle-tested at Discord scale; single-purpose Trust & Safety rules engine, not an AI-native guardrail.
+  note: Battle-tested at Discord scale; single-purpose Trust & Safety rules engine, not an AI-native guardrail.
     NOT confirmed on 2026-08-13, and the reason is in the value rather than the band. The throughput figures
-    the value leads with - ~2.3M rules/sec and 400M daily actions at Discord - appear on no source cited on
-    this product any more. The repo README has been rewritten and no longer describes the Rust coordinator
+    the value leads with - ~2.3M rules/sec and 400M daily actions at Discord - appear on no source cited
+    on this product any more. The repo README has been rewritten and no longer describes the Rust coordinator
     and stateless Python workers either; what it does still carry is the SML rules language, real-time event
     processing at scale, and the Discord provenance. The v1.0 announcement gives a different and smaller
-    published figure, ''over 50M events daily''. The engine description behind the 4 is intact and the band
+    published figure, 'over 50M events daily'. The engine description behind the 4 is intact and the band
     is not in doubt, but replacing a headline number in a recorded value is an owner call, so it is raised
-    rather than taken and no date is claimed.
-    REPLACED 2026-08-14, on the owner''s ruling, and the band does not move. The two vanished figures are
-    gone from the value and the only published throughput number takes their place - ROOST''s v1.0
-    announcement, re-read today and byte-identical to the 2026-08-13 read, says Osprey "processes over 50M
-    events daily in production environments like Bluesky". A fresh read of the README confirms the figures
-    are not there to recover - it carries no occurrence of 2.3M or 400M at all - while the engine
-    description the 4 rests on is intact - "a safety rules engine and investigation console for real-time
-    event processing at scale", rules "written in SML, Osprey''s structured rule language, and extended
-    with user-defined functions (UDFs)", built at Discord. A single-purpose Trust and Safety rules engine
-    running at that scale is still a 4 and still not an AI-native guardrail; the correction is to the
-    number quoted, not to the judgment.'
+    rather than taken and no date is claimed. REPLACED 2026-08-14, on the owner's ruling, and the band does
+    not move. The two vanished figures are gone from the value and the only published throughput number
+    takes their place - ROOST's v1.0 announcement says Osprey "processes over 50M events daily in production
+    environments like Bluesky". A fresh read of the README confirms the figures are not there to recover
+    - it carries no occurrence of 2.3M or 400M at all - while the engine description the 4 rests on is intact
+    - "a safety rules engine and investigation console for real-time event processing at scale", rules "written
+    in SML, Osprey's structured rule language, and extended with user-defined functions (UDFs)", built at
+    Discord. A single-purpose Trust and Safety rules engine running at that scale is still a 4 and still
+    not an AI-native guardrail; the correction is to the number quoted, not to the judgment.
   last_verified: '2026-08-14'
   sources:
   - url: https://github.com/roostorg/osprey
@@ -103,14 +100,13 @@ capability:
     http_status: 200
     content_sha256: 592ab20d0b28d1642d82318e38ce104ed1c1f625d061b8669c875182556375b7
   - url: https://roost.tools/blog/introducing-osprey-v1-0-open-source-infrastructure-for-real-time-abuse-mitigation/
-    shows: 'The published throughput figure that replaces the vanished ones - Osprey "processes over 50M
-      events daily in production environments like Bluesky and is designed for real-time incident
-      response". Re-fetched 2026-08-14, digest byte-identical to the 2026-08-13 read.'
+    shows: The published throughput figure that replaces the vanished ones - Osprey "processes over 50M
+      events daily in production environments like Bluesky and is designed for real-time incident response".
     accessed: '2026-08-14'
     http_status: 200
     content_sha256: d6a88d5ed04eb1fe19fff71b8c8bbdd60ffe36fb3d226608bd8b549f144d2dc2
   - url: https://github.com/roostorg/osprey
-    shows: 'Re-read 2026-08-14. The README carries no occurrence of "2.3M" or "400M" anywhere, so the
+    shows: 'The README carries no occurrence of "2.3M" or "400M" anywhere, so the
       figures the recorded value led with are not recoverable from it. What it does still carry is the
       engine the band rests on - "a safety rules engine and investigation console for real-time event
       processing at scale", rules written in SML and extended with user-defined functions.'

--- a/sources/scores/osworld.yaml
+++ b/sources/scores/osworld.yaml
@@ -18,9 +18,7 @@ openness:
   confidence: high
   last_verified: '2026-08-13'
   note: Apache-2.0, full harness + environment public. Scored as the evaluation harness; the bundled 369-task
-    set is also openly redistributable. Re-read 2026-08-13 - the license endpoint still reports Apache-2.0
-    and the README still sets the benchmark up to run locally under VMware, VirtualBox or Docker with
-    no paid tier.
+    set is also openly redistributable.
   raw: license:Apache-2.0(OSI);source:public(github.com/xlang-ai/OSWorld);execution-based eval harness +
     369-task environment public; multi-platform (VMware/VirtualBox/Docker/AWS);core-gated:ungated(full harness
     runs locally on VMware, VirtualBox or Docker, no paid tier)
@@ -52,9 +50,8 @@ openness:
     establishes:
     - license
   - url: https://raw.githubusercontent.com/xlang-ai/OSWorld/main/README.md
-    shows: 'Re-read 2026-08-13: unchanged from the 2026-08-11 read - Apache-2.0 badge, full local setup
-      under VMware, VirtualBox or Docker with KVM, AWS and Azure optional for parallel runs, and no paid
-      tier, commercial edition or license key.'
+    shows: Apache-2.0 badge, full local setup under VMware, VirtualBox or Docker with KVM, AWS and Azure
+      optional for parallel runs, and no paid tier, commercial edition or license key.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 83b8684c2f4ac4f31996b8b4752195fcb6cc5429f89d92398177b9b721d787fc
@@ -68,19 +65,18 @@ adoption:
   banded_quantity: frontier-lab release-report citations; 2.9k GitHub stars corroborate only
   note: 'Top adoption signal for a harness = cited as the standard in frontier release reports: OSWorld
     scores reported in OpenAI (CUA 38.1%, GPT-5.4 75.0%), Anthropic (Claude Sonnet 4.5 61.4%, Sonnet 4.6
-    72.5%, Opus 4.6 72.7%) computer-use launches through 2026. Reach band is directional. The harness
-    is run by a concentrated set of frontier labs/agent teams rather than a mass install base. 2.9k stars
-    corroborate only. Re-read 2026-08-13, with two notes. The Anthropic Sonnet 4.6 post still reports
-    OSWorld - ''Across sixteen months, our Sonnet models have made steady gains on OSWorld'' - but carries
-    the figure in a chart rather than in text, so the 72.5% in this note is not quotable from that page.
-    And os-world.github.io now 301-redirects to osworld-v1.xlang.ai, which is where the leaderboard lives;
-    the cited URL still resolves through the redirect. Level 3 unchanged; 3.1k stars.'
+    72.5%, Opus 4.6 72.7%) computer-use launches through 2026. Reach band is directional. The harness is
+    run by a concentrated set of frontier labs/agent teams rather than a mass install base. 2.9k stars corroborate
+    only. Two caveats on the evidence: the Anthropic Sonnet 4.6 post carries its OSWorld figure in a chart
+    rather than in prose, so the 72.5% cited above is not quotable from that page; and os-world.github.io
+    now 301-redirects to osworld-v1.xlang.ai, where the leaderboard lives, though the cited URL still resolves
+    through the redirect. 3.1k stars.'
   last_verified: '2026-08-13'
   sources:
   - url: https://www.anthropic.com/news/claude-sonnet-4-6
-    shows: 'Re-read 2026-08-13: the Sonnet 4.6 release post reports OSWorld results and charts Sonnet''s
-      progress on it across sixteen months. The benchmark is cited, which is the standard-citation signal;
-      the numeric score is in the chart rather than the prose.'
+    shows: The Sonnet 4.6 release post reports OSWorld results and charts Sonnet's progress on it across
+      sixteen months. The benchmark is cited, which is the standard-citation signal; the numeric score is
+      in the chart rather than the prose.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 589bbbfe76178ca13e5400a385164d4bae550ca83abbd587bb13f2533d9a867a
@@ -104,11 +100,10 @@ capability:
     Qwen, CogAgent baselines); reproducibility: multi-platform virtualization (VMware/VirtualBox/Docker/AWS)'
   confidence: high
   last_verified: '2026-08-13'
-  note: Frontier-defining within evaluation_code for the computer-use/agentic axis. Execution-based,
-    real-environment agent evaluation is the hardest eval modality and OSWorld is its reference harness.
-    A 5 here is for the category's frontier-definers; OSWorld qualifies for agentic eval. Feature matrix
-    re-read 2026-08-13 and unchanged - 369 tasks (361 excluding the eight Google Drive ones), 134 execution-based
-    evaluation functions, and the same multi-platform virtualization story.
+  note: 'Frontier-defining within evaluation_code for the computer-use/agentic axis. Execution-based, real-environment
+    agent evaluation is the hardest eval modality and OSWorld is its reference harness: 369 tasks (361 excluding
+    the eight Google Drive ones), 134 execution-based evaluation functions, and multi-platform virtualization.
+    A 5 here is for the category''s frontier-definers; OSWorld qualifies for agentic eval.'
   sources:
   - url: https://os-world.github.io/
     shows: 369 execution-based real-computer tasks, multi-OS, agent-trajectory evaluation

--- a/sources/scores/otari.yaml
+++ b/sources/scores/otari.yaml
@@ -17,18 +17,12 @@ openness:
   note: Apache-2.0 self-hostable gateway (github.com/mozilla-ai/otari) with a hosted Otari.ai platform on
     the same core. Scored 4/open_core until 2026-08-11 on an analogy to LiteLLM that the recorded evidence
     does not carry. LiteLLM's open_core rests on `enterprise-dir` naming a separately licensed directory
-    in its repo, and Otari records nothing of the kind. What it does record is a published Apache-2.0
-    core, self-hosting via Docker Compose, and a hosted platform on that same core, which the software
-    ladder calls ungated because hosting convenience is not gating. The old note's own conditional, that
-    this would be open_source if the hosted platform is not a commercial tier, was a hedge rather than
-    evidence of a tier.
-    Re-read 2026-08-13. The repository still carries Apache-2.0 and still describes a gateway you own
-    and run yourself, with the hosted otari.ai explicitly deploying this same proxy - the README
-    ecosystem table says so in as many words, that Otari is the proxy server otari.ai deploys and can be
-    run standalone or connected to the platform. So the hosted platform is convenience on the same core
-    rather than a tier withholding anything, which is the ungated reading. The Mozilla AI launch post
-    still describes otari.ai as the hosted platform built on the same foundation. Latest release v0.4.0.
-    Value unchanged at 5 / open_source.
+    in its repo, and Otari records nothing of the kind. What it does record is a published Apache-2.0 core,
+    self-hosting via Docker Compose, and a hosted platform on that same core, which the software ladder
+    calls ungated because hosting convenience is not gating. The old note's own conditional, that this would
+    be open_source if the hosted platform is not a commercial tier, was a hedge rather than evidence of
+    a tier. The README ecosystem table says so in as many words - Otari is the proxy server otari.ai deploys,
+    and it can be run standalone or connected to the platform.
   raw: license:Apache-2.0(OSI, core);source:public;self-host:yes(Docker Compose);service:hosted Otari.ai
     platform on the same core
   last_verified: '2026-08-13'
@@ -50,17 +44,12 @@ adoption:
   reach: <1K stars
   signal_type: stars_fallback
   confidence: low
-  note: '63 GitHub stars / 6 forks (July 2026), created April 2026. Very new; limited adoption signal so far.
-    (Mozilla AI''s underlying any-llm library is far more adopted at ~2.1K stars, but is a separate product.)
-    Stars read 2026-08-13: 379 across the 1 declared repo, which bands at <1K stars, level 1 on the stars
-    scale in signal_routing.yaml. The previous reach ''<10K'' was not a label this instrument offers - stars
-    have their own vocabulary because a star is not a download. No last_verified claimed: a star count is
-    volatile, so a digest of it would read as drift on every refetch, and the rest of the axis was not re-
-    read.
-    Re-read 2026-08-13 - mozilla-ai/otari shows 381 stars, still under a thousand and still level 1 on
-    the stars scale, though six times the 63 recorded in July. No download, deployment or customer
-    figure has appeared. This supersedes the refusal to claim a date - the axis was re-read rather than
-    aggregated. Level unchanged.'
+  note: 63 GitHub stars and 6 forks in July 2026 on a repository created April 2026; mozilla-ai/otari now
+    shows 381 stars, six times that, still under a thousand and still level 1 on the stars scale in signal_routing.yaml.
+    Very new, so the adoption signal is thin, and no download, deployment or customer figure has appeared.
+    (Mozilla AI's underlying any-llm library is far more adopted at ~2.1K stars, but is a separate product.)
+    The previous reach '<10K' was not a label this instrument offers - stars have their own vocabulary,
+    because a star is not a download.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/mozilla-ai/otari
@@ -73,14 +62,9 @@ capability:
   basis: feature_matrix
   value: null
   confidence: medium
-  note: OpenAI-compatible gateway to 40+ providers with virtual keys, budgets, usage tracking, and
-    sandboxed server-side code-execution tools. Solid feature set, but narrower provider coverage and less
-    proven than LiteLLM (140+ providers). No standard benchmark applies to a gateway.
-    Re-read 2026-08-13. The README still shows the same gateway surface - one endpoint speaking the
-    OpenAI and Anthropic APIs in front of 40+ providers via any-llm, virtual keys that can be scoped and
-    revoked, per-user and per-key budgets enforced before a request runs rather than reconciled
-    afterwards, and usage logged and queryable through /v1/usage. The provider count is unchanged at
-    40+, still narrower than the LiteLLM anchor. Band unchanged at 3.
+  note: OpenAI-compatible gateway to 40+ providers with virtual keys, budgets, usage tracking, and sandboxed
+    server-side code-execution tools. Solid feature set, but narrower provider coverage and less proven
+    than LiteLLM (140+ providers). No standard benchmark applies to a gateway.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/mozilla-ai/otari

--- a/sources/scores/pathway.yaml
+++ b/sources/scores/pathway.yaml
@@ -11,11 +11,8 @@ openness:
     source:
       value: public
   confidence: high
-  note: 'Source-available under BSL 1.1, not open source; production use is license-restricted with paid
-    enterprise tiers. Re-read 2026-08-13 - the README still states that "Pathway Live Data Framework is
-    distributed on a BSL 1.1 License which allows for unlimited non-commercial use", and GitHub still
-    shows a bare License entry rather than an SPDX badge, which is what BSL looks like to the classifier.
-    The full source is published. Stars are now 62.5k. Nothing moved.'
+  note: Source-available under BSL 1.1, not open source; production use is license-restricted with paid
+    enterprise tiers.
   raw: license:BSL-1.1(non-OSI:single-machine + no-compete, Change-Date 2027-07-20 -> Apache-2.0);commercial:Scale/Enterprise;source:public
   last_verified: '2026-08-13'
   sources:
@@ -33,9 +30,9 @@ adoption:
   level: 2
   signal_type: usage_volume
   confidence: medium
-  note: 14,405 PyPI downloads in the trailing 30 days for pathway, read 2026-08-12. Bands at level 2 (10K-100K)
-    on the software and model adoption scale. Down by roughly half since the score was authored. Corrected
-    from level 3, which the recorded evidence did not support.
+  note: 14,405 PyPI downloads in the trailing 30 days for pathway. Bands at level 2 (10K-100K) on the software
+    and model adoption scale. Down by roughly half since the score was authored. Corrected from level 3,
+    which the recorded evidence did not support.
   reach: 10K-100K
   last_verified: '2026-08-12'
   sources:
@@ -50,10 +47,7 @@ capability:
   value: unified batch+streaming incremental dataflow (Rust); real-time RAG with continuously-synced indexing; 300+
     connectors; hybrid search; single-node -> distributed/K8s
   confidence: medium
-  note: 'Stronger on streaming/incremental infra than LLM-orchestration breadth. Re-read 2026-08-13 -
-    the repo still publishes the same Rust incremental dataflow engine unifying batch and streaming, with
-    real-time RAG over continuously synced indexes, the connector library and single-node to Kubernetes
-    deployment. The feature matrix that placed this band is unchanged. One below the openhands anchor.'
+  note: Stronger on streaming/incremental infra than LLM-orchestration breadth.
   relative_to: openhands
   relation: one_below
   last_verified: '2026-08-13'

--- a/sources/scores/patronus-evaluation-platform.yaml
+++ b/sources/scores/patronus-evaluation-platform.yaml
@@ -21,11 +21,7 @@ openness:
     on the SDK repo page. Class corrected from open_core on 2026-07-30. In this ladder open_core means an
     OSI core with functionality withheld for a paid tier, and there is no open core here, only an open periphery.
     A repo that exists while the runtime does not ship is source:partial, which the ladder scores 2/source_available.
-    The score itself was already 2. Re-read 2026-08-13 and unchanged. The SDK README still carries the
-    comment 'This evaluator runs remotely on Patronus infrastructure', the repo still declares no license
-    at all (GitHub's license field is null), it is at 8 stars and has not been pushed since 2026-01-09,
-    and the docs still describe Lynx and Glider as evaluators the hosted platform runs. No self-hostable
-    engine has appeared.
+    The score itself was already 2.
   raw: platform:closed(hosted SaaS; remote Judge/Lynx/Glider evaluators run on Patronus infrastructure);source:partial(patronus-py
     is a client wiring to the hosted API, not the engine);client-SDKs:open(patronus-py public on GitHub,
     v0.1.25, but only 7 stars and wires to the hosted API);eval engine + proprietary evaluators not self-hostable
@@ -55,10 +51,10 @@ openness:
     establishes:
     - source
   - url: https://docs.patronus.ai/docs
-    shows: 'Re-read 2026-08-13: still an end-to-end hosted system for evaluating, monitoring and improving
-      performance, with Lynx and Glider as in-house evaluators, experiments, real-time production monitoring
-      and Python/TypeScript SDKs into the cloud service. No self-hostable or open-source evaluation engine
-      is offered anywhere in it.'
+    shows: An end-to-end hosted system for evaluating, monitoring and improving performance, with Lynx and
+      Glider as in-house evaluators, experiments, real-time production monitoring and Python/TypeScript
+      SDKs into the cloud service. No self-hostable or open-source evaluation engine is offered anywhere
+      in it.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 757070b285359722c692ea3a97d1b9447e0603af24f72cbe73d131587e65e13e
@@ -71,18 +67,16 @@ adoption:
   confidence: low
   last_verified: '2026-08-13'
   note: No disclosed user/customer counts or usage volume found on the docs/homepage this run; open source
-    SDK has only 7 GitHub stars (stars_fallback would cap at hobbyist and is not an honest signal for
-    a hosted platform). Declining to assign a level rather than infer from marketing. Re-read 2026-08-13
-    - looked on the docs for a customer count, an evaluation-run count or a seat count and found none.
-    The docs name three case studies (Nova AI, Etsy, Weaviate) and attach no figures to them. The SDK
-    is now at 8 stars. The abstention is re-confirmed rather than lifted.
+    SDK has only 7 GitHub stars (stars_fallback would cap at hobbyist and is not an honest signal for a
+    hosted platform). Declining to assign a level rather than infer from marketing. The docs name three
+    case studies (Nova AI, Etsy, Weaviate) and attach no figures to them.
   sources:
   - url: https://github.com/patronus-ai/patronus-py
     shows: 7 stars on the public SDK (no honest usage figure for the hosted platform)
     accessed: '2026-06-04'
   - url: https://docs.patronus.ai/docs
-    shows: 'Re-read 2026-08-13: no customer count, no usage volume and no seat count published. Three
-      named case studies (Nova AI, Etsy, Weaviate) carry no quantitative adoption data.'
+    shows: No customer count, no usage volume and no seat count published. Three named case studies (Nova
+      AI, Etsy, Weaviate) carry no quantitative adoption data.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 757070b285359722c692ea3a97d1b9447e0603af24f72cbe73d131587e65e13e
@@ -101,20 +95,18 @@ capability:
     independently reproducible (closed engine)'
   confidence: medium
   last_verified: '2026-08-13'
-  note: Solid, broad commercial eval feature set (evaluators + experiments + monitoring + agent eval)
-    but not frontier-defining within the category and the closed backend limits reproducibility. Mid-tier
-    on the feature matrix. Feature matrix re-read 2026-08-13 and unchanged. No `relative_to` is recorded
-    because the note names no peer - 'mid-tier' is a position in the category rather than a comparison
-    to a product.
+  note: Solid, broad commercial eval feature set (evaluators + experiments + monitoring + agent eval) but
+    not frontier-defining within the category, and the closed backend limits reproducibility. Mid-tier on
+    the feature matrix. No `relative_to` is recorded because the note names no peer - 'mid-tier' is a position
+    in the category rather than a comparison to a product.
   sources:
   - url: https://docs.patronus.ai/docs
     shows: Lynx/Glider evaluators, RAG/agent/NLP/OWASP metrics, experiments, red-teaming, monitoring
     accessed: '2026-06-04'
   - url: https://docs.patronus.ai/docs
-    shows: 'Re-read 2026-08-13: Lynx and Glider in-house evaluators plus custom ones, experiments for
-      A/B testing, real-time production monitoring through tracing and alerts, and Python/TypeScript SDKs.
-      Agent evaluation and Percival still present. Nothing independently reproducible, the engine being
-      closed.'
+    shows: Lynx and Glider in-house evaluators plus custom ones, experiments for A/B testing, real-time
+      production monitoring through tracing and alerts, and Python/TypeScript SDKs. Agent evaluation and
+      Percival present. Nothing independently reproducible, the engine being closed.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 757070b285359722c692ea3a97d1b9447e0603af24f72cbe73d131587e65e13e

--- a/sources/scores/perplexica.yaml
+++ b/sources/scores/perplexica.yaml
@@ -19,12 +19,8 @@ openness:
   confidence: high
   note: Fully OSI-licensed (MIT), complete source public, self-hosting is the primary distribution via a
     bundled Docker image - a true open answer engine. No premium tier or gated functionality identified.
-    Re-read 2026-08-13. The repository still carries MIT and the README still presents a self-hosted
-    product that runs entirely on hardware the reader owns, with the bundled SearXNG image as the
-    primary distribution and no paid tier or gated function anywhere in it. Repo now at 36,118 stars.
     Worth flagging for the maintainers rather than the score - the last commit and the last release are
-    both from April 2026, so the project has been quiet for four months. Value unchanged at 5 /
-    open_source.
+    both from April 2026, so the project has been quiet.
   raw: license:MIT(OSI);source:public(github.com/ItzCrazyKns/Vane);self-host:primary(single bundled Docker
     image);no-feature-gated-core;core-gated:ungated
   last_verified: '2026-08-13'
@@ -70,12 +66,6 @@ capability:
   confidence: medium
   note: Strong provider breadth, bundled metasearch, search modes, and file-upload RAG; loses a point for
     no built-in multi-user/auth and limited multimodal generation. Scoped to search-and-answer.
-    Re-read 2026-08-13. The README still shows the provider breadth across Ollama, OpenAI, Anthropic,
-    Google Gemini and Groq, the three search modes now named Speed, Balanced and Quality, source
-    selection across web, discussions and academic papers, bundled SearXNG metasearch, image and video
-    search, and file uploads covering PDFs, text and images. It has gained widgets for weather,
-    calculations and stock lookups, and it still ships no multi-user or auth layer. Tavily and Exa are
-    still listed as coming soon rather than shipped. Band unchanged at 4.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/ItzCrazyKns/Vane

--- a/sources/scores/perplexity-sonar-api.yaml
+++ b/sources/scores/perplexity-sonar-api.yaml
@@ -14,10 +14,7 @@ openness:
       detail: token + per-request pricing
       raw: cloud SaaS, token + per-request pricing
   confidence: high
-  note: 'Fully closed search-grounded API; no weights, source, or self-host path. Re-read 2026-08-13: the
-    docs still describe Sonar, the Search API, the Embeddings API and the Agent API as hosted developer surfaces
-    priced per token and per request, and document no weights download, no source release and no self-host
-    or on-premise deployment. source stays closed and the score stays 1.'
+  note: Fully closed search-grounded API; no weights, source, or self-host path.
   raw: license:Proprietary(API-only);source:closed(Sonar models, search index, ranking all proprietary);managed:cloud
     SaaS, token + per-request pricing
   last_verified: '2026-08-13'
@@ -37,16 +34,11 @@ adoption:
   signal_type: reported_traction
   confidence: medium
   banded_quantity: Perplexity consumer-app MAU (45M+, aggregator-reported), not API requests or developers
-  note: 'No standalone Sonar-API request/developer count is published by a primary source; Perplexity docs
+  note: No standalone Sonar-API request/developer count is published by a primary source; Perplexity docs
     confirm the API exists and is a core developer surface. Platform-level scale is large (45M+ MAU, ~1B+
-    queries/month per 2026 reporting) but that is the consumer app, not the API specifically. Rated 4
-    on reported developer-API traction within a clearly mass-scale parent platform; flagged that the headline
-    platform numbers are aggregator-reported and not API-specific. Re-read 2026-08-13. The docs still document
-    Sonar, Search, Embeddings and Agent as a full developer surface and still publish no request count, developer
-    count or customer count for the API - which is what was looked for and not found, and why the instrument
-    stays reported_traction rather than moving to a measured one. The vendor api-platform page could not
-    be re-read - perplexity.ai answered HTTP 403 to the fetcher - so that source keeps its June date and the
-    confirmation rests on the docs alone. Level 4 unchanged.'
+    queries/month per 2026 reporting) but that is the consumer app, not the API specifically. Rated 4 on
+    reported developer-API traction within a clearly mass-scale parent platform; flagged that the headline
+    platform numbers are aggregator-reported and not API-specific.
   last_verified: '2026-08-13'
   sources:
   - url: https://docs.perplexity.ai/
@@ -56,8 +48,8 @@ adoption:
     http_status: 200
     content_sha256: 19fc95d18eb21a0e33f6b8fed921be1d610daa1f1b0a70fbb08bcc977774d8da
   - url: https://www.perplexity.ai/api-platform
-    shows: Vendor API-platform page positioning Sonar for developers. Not re-read on 2026-08-13 - the host
-      answered HTTP 403 - so this source keeps its earlier access date.
+    shows: Vendor API-platform page positioning Sonar for developers. The host answers HTTP 403 to the fetcher,
+      so this source keeps its earlier access date.
     accessed: '2026-06-04'
 capability:
   score: 4
@@ -66,12 +58,9 @@ capability:
     ranked Search API with filtering; Embeddings API for RAG; Agent API routes to external models (e.g.
     GPT-5.x)
   confidence: medium
-  note: 'Strong {coverage, freshness, structured output}, grounded answers + raw search + embeddings in one
+  note: Strong {coverage, freshness, structured output}, grounded answers + raw search + embeddings in one
     API; near-frontier among agent search/retrieval APIs but a wrapper-plus-search rather than a category-defining
-    5. Re-read 2026-08-13: all four surfaces the recorded value names are still documented - the Sonar tiers,
-    the ranked Search API, the Embeddings API for RAG and the Agent API that routes to external models -
-    and nothing in the docs turns the product into something other than retrieval wrapped around a model.
-    Band unchanged at 4.'
+    5.
   last_verified: '2026-08-13'
   sources:
   - url: https://docs.perplexity.ai/

--- a/sources/scores/perplexity.yaml
+++ b/sources/scores/perplexity.yaml
@@ -14,17 +14,13 @@ openness:
       value: multi-provider
       detail: closed orchestration
   confidence: high
-  note: 'Proprietary SaaS chat/answer engine; closed counterpart on the shelf.
-    Re-checked 2026-08-14. www.perplexity.ai and its terms-of-service page both answer 403, six attempts
-    each under the raised retry budget, so the consumer surface cited below keeps its 2026-06-04 read.
-    The confirmation moves to Perplexity''s own developer docs, which are reachable. They sell hosted
-    access and nothing else - ''Unified access to open-weight models hosted by Perplexity through one
-    OpenAI-compatible endpoint'', plus ''third-party models from OpenAI, Anthropic, Google, and xAI'' -
-    and the FAQ puts the compute on Perplexity''s own infrastructure, ''Our compute is hosted via Amazon
-    Web Services in North America.'' No repository, no self-hostable build and no license grant appear
-    anywhere in the docs, only paid access to a service Perplexity runs. That is the closed rung, and
-    the multi-provider orchestration the record already records. The docs cover the API rather than the
-    consumer app, so this is a narrower surface than the original citation. Score unchanged at 1.'
+  note: Proprietary SaaS chat/answer engine; closed counterpart on the shelf. Perplexity's own developer
+    docs sell hosted access and nothing else - "Unified access to open-weight models hosted by Perplexity
+    through one OpenAI-compatible endpoint", plus "third-party models from OpenAI, Anthropic, Google, and
+    xAI" - and the FAQ puts the compute on Perplexity's own AWS infrastructure. No repository, no self-hostable
+    build and no license grant appears anywhere in them, only paid access to a service Perplexity runs.
+    The docs cover the API rather than the consumer app, so this is a narrower surface than the original
+    citation.
   raw: license:proprietary(SaaS);source:closed;self-host:none;models:multi-provider(closed orchestration)
   last_verified: '2026-08-14'
   sources:
@@ -57,22 +53,17 @@ adoption:
   reach: '>10M users'
   signal_type: active_users
   confidence: medium
-  note: CEO Aravind Srinivas (cited Apr 2026) reports 100M+ MAU across all products; standalone chatbot
-    ~33M MAU; ~780M queries/mo (May 2025) growing >20% MoM to an estimated 1.2-1.5B/mo by mid-2026. Even
-    the standalone-chat figure (33M) clears >10M. Headline user count is CEO-attributed via aggregators
-    (Sacra), not a directly-fetched primary disclosure, medium confidence.
-    Re-read 2026-08-13, and the aggregator has restated its numbers. Business of Apps now leads with 45
-    million active users on the website and app, plus over 80 million downloads since launch and $200M
-    2025 revenue - the 100M-plus all-products figure and the ~33M standalone-chatbot figure recorded
-    above are no longer on the page. 45 million is still an active count and still far above the >10M
-    users threshold, so the level is unchanged at 5 and only the supporting number has moved. It remains
-    an aggregator compilation rather than a vendor disclosure, so confidence stays medium.
+  note: Business of Apps reports 45 million active users on the website and app, plus over 80 million downloads
+    since launch and $200M 2025 revenue - far above the >10M threshold. An earlier read carried a CEO-attributed
+    100M+ MAU across all products and ~33M for the standalone chatbot, and neither figure is on the page
+    any more; the supporting number moved, not the band. The headline is an aggregator compilation rather
+    than a directly-fetched primary disclosure, so confidence stays medium.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.businessofapps.com/data/perplexity-ai-statistics/
-    shows: 45 million active users on the website and app, 80M+ downloads since launch and $200M 2025 revenue,
-      read 2026-08-13; the 100M+ all-products and ~33M standalone-chatbot figures this record was scored
-      on are no longer on the page (compiled)
+    shows: 45 million active users on the website and app, 80M+ downloads since launch and $200M 2025 revenue;
+      the 100M+ all-products and ~33M standalone-chatbot figures this record was scored on are no longer
+      on the page (compiled)
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 91c372e3bb20567064d4bc7a91e257a3de7994e6edfc02f7f1013aeebdaddd80
@@ -89,15 +80,9 @@ capability:
     the category.'
   confidence: medium
   note: 'Differentiated, capable consumer chat UI (citation-grounded answers, model choice); high feature
-    breadth but not the single category frontier-definer.
-    Re-checked 2026-08-14. www.perplexity.ai answers 403 after six attempts, so the feature list was
-    re-derived from Perplexity''s own docs plus the Wikipedia article. The docs carry the model choice
-    and the grounding - ''third-party models from OpenAI, Anthropic, Google, and xAI'' and ''web-grounded
-    answers with built-in citations in one call'' - and list four Sonar variants from lightweight
-    grounded search up to Sonar Deep Research. Wikipedia carries the paid tier searching uploaded
-    documents alongside web content. Two clauses of the old value could not be re-confirmed on any
-    reachable page and were dropped rather than restated - multimodal input, and Spaces/collections. The
-    narrowed value still sits at 4 on the same reasoning, strong breadth, not the frontier-definer.'
+    breadth but not the single category frontier-definer. Two clauses of the earlier value could not be
+    confirmed on any reachable page and were dropped rather than restated - multimodal input, and Spaces/collections.
+    The narrowed value still sits at 4 on the same reasoning: strong breadth, not the frontier-definer.'
   last_verified: '2026-08-14'
   sources:
   - url: https://docs.perplexity.ai/docs/getting-started/models

--- a/sources/scores/personahub.yaml
+++ b/sources/scores/personahub.yaml
@@ -20,8 +20,7 @@ openness:
     is redistributability rather than commercial reuse. The scale settles it on the commercial-use test,
     and the Open Definition agrees - data is not open unless it may be reused commercially. `restricted`
     is new to the dataset class vocabulary for this: it was the only product type with no word between `open`
-    and `gated`. Re-read 2026-08-13: cc-by-nc-sa-4.0 still on the Hub, gated false, card intact, so the
-    non-commercial cap stands.'
+    and `gated`.'
   raw: license:cc-by-nc-sa-4.0(non-commercial);card:present;ungated:yes;scope:~370M personas+seed samples
   last_verified: '2026-08-13'
   sources:
@@ -39,9 +38,8 @@ adoption:
   reach: 1K-10K
   signal_type: usage_volume
   confidence: high
-  note: 9,346 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (proj-persona/PersonaHub 9,346). Bands at level 2 (1K-10K) on the dataset adoption scale, whose top
-    band is >1M.
+  note: 9,346 downloads in the trailing 30 days summed across the 1 declared artifact(s) (proj-persona/PersonaHub
+    9,346). Bands at level 2 (1K-10K) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/proj-persona/PersonaHub
@@ -68,11 +66,10 @@ capability:
     assessed. The tell was `value: null` with `confidence: high` - a null is the category norm here, all
     38 members carry one, but a high confidence attached to a reasoning that never mentions training value
     is not. A licence says what you may do with a corpus; it says nothing about what training on it produces.
-    Re-derived from the sources already cited, which is why no `last_verified` is claimed - they were read
-    on 2026-07-04 and have not been re-fetched. Re-read 2026-08-13: the Persona Hub listing still describes
+    Re-derived from the sources already cited, which is why no `last_verified` is claimed. Persona Hub is
     1 billion curated personas used to synthesise mathematical and logical reasoning problems at scale,
-    and the Tulu 3 personas-math card still credits the persona methodology for its 149,960 examples. The
-    MATH figure is in the paper body rather than on the listing page.'
+    and the Tulu 3 personas-math card credits the persona methodology for its 149,960 examples. The MATH
+    figure is in the paper body rather than on the listing page.'
   last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2406.20094

--- a/sources/scores/perspective-api.yaml
+++ b/sources/scores/perspective-api.yaml
@@ -15,10 +15,10 @@ openness:
     license:
     - name: proprietary
   confidence: high
-  note: Closed, API-only hosted classifier; no weights or source. Long-standing and influential, but proprietary.
-    Re-read 2026-08-13 and the openness reading is unchanged, but the product is ending - the site now leads
-    with a sunset notice, and the API goes out of service after 2026. That is an availability fact rather
-    than an openness one, so the 1/closed stands; the consequences are on adoption, capability and the prose.
+  note: 'Closed, API-only hosted classifier; no weights or source. Long-standing and influential, but proprietary.
+    The product is ending: the site leads with a sunset notice and the API goes out of service after 2026.
+    That is an availability fact rather than an openness one, so the 1/closed stands; the consequences are
+    on adoption, capability and the prose.'
   raw: service:proprietary hosted API by Jigsaw/Google(no weights, no self-host);access:free with quota;scores:toxicity
     + related attributes;source:closed;license:proprietary
   last_verified: '2026-08-13'
@@ -40,14 +40,17 @@ adoption:
   signal_type: reported_traction
   confidence: medium
   banded_quantity: none published; Jigsaw has never published a usage figure
-  note: 'NOT confirmed on 2026-08-13, and the record has two problems rather than one. First the
-    instrument: usage_volume claims a download or install count, and Jigsaw has never published one for
-    Perspective - the 1M-10M label asserts a measurement nobody made, which is what adoption.md forbids on
-    a claim of this kind. Second the level: the site now announces the API is sunsetting, out of service
-    after December 31, 2026, and gives as the reason that ''AI capabilities have evolved, and there is now
-    less demand for a standalone tool specific to this area''. A level 4 on a discontinued free API is a
-    claim about the past. Recommend reported_traction with no reach and a level the owner sets; not taken
-    here. The instrument now reads reported_traction, which is what a credible claim with no count behind it is for, and the illegal numeric reach is gone. The LEVEL is deliberately unchanged: correcting how a band was read is not a reason to move where it sits, and nothing re-read today argues the standing is different. What changes is that the record no longer claims a measurement nobody made.'
+  note: 'NOT confirmed on 2026-08-13, and the record has two problems rather than one. First the instrument:
+    usage_volume claims a download or install count, and Jigsaw has never published one for Perspective
+    - the 1M-10M label asserts a measurement nobody made, which is what adoption.md forbids on a claim of
+    this kind. Second the level: the site now announces the API is sunsetting, out of service after December
+    31, 2026, and gives as the reason that ''AI capabilities have evolved, and there is now less demand
+    for a standalone tool specific to this area''. A level 4 on a discontinued free API is a claim about
+    the past. Recommend reported_traction with no reach and a level the owner sets; not taken here. The
+    instrument now reads reported_traction, which is what a credible claim with no count behind it is for,
+    and the illegal numeric reach is gone. The LEVEL is deliberately unchanged: correcting how a band was
+    read is not a reason to move where it sits, and nothing in the cited sources argues the standing is
+    different. What changes is that the record no longer claims a measurement nobody made.'
   last_verified: '2026-08-13'
   sources:
   - url: https://perspectiveapi.com/

--- a/sources/scores/pes2o.yaml
+++ b/sources/scores/pes2o.yaml
@@ -10,7 +10,7 @@ openness:
     dataset_card:
       value: present
   confidence: high
-  note: 'ODC-BY, ungated, full dataset card. Re-read 2026-08-13: odc-by on the Hub, gated false, card intact.'
+  note: ODC-BY, ungated, full dataset card.
   raw: license:ODC-BY;gated:false;dataset_card:present
   last_verified: '2026-08-13'
   sources:
@@ -28,9 +28,8 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 11,867 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (allenai/peS2o 11,867). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is
-    >1M.
+  note: 11,867 downloads in the trailing 30 days summed across the 1 declared artifact(s) (allenai/peS2o
+    11,867). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/allenai/peS2o
@@ -44,10 +43,10 @@ capability:
   basis_detail: downstream
   value: null
   confidence: high
-  note: 'The standard open science corpus with documented multi-model reuse (OLMoE 57B tokens, Marin, Nemotron
-    3), but no ablation leadership, and OLMo 3 replaced it with a new academic-PDF dataset. Re-read 2026-08-13:
-    the OLMoE mix card still lists peS2o at 57.2B tokens and the Nemotron 3 Nano card still names it among
-    its pretraining sources, and neither claims an ablation win for it.'
+  note: The standard open science corpus with documented multi-model reuse (OLMoE 57B tokens, Marin, Nemotron
+    3), but no ablation leadership, and OLMo 3 replaced it with a new academic-PDF dataset. The OLMoE mix
+    card lists peS2o at 57.2B tokens and the Nemotron 3 Nano card names it among its pretraining sources;
+    neither claims an ablation win for it.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/allenai/OLMoE-mix-0924

--- a/sources/scores/phi-instruct.yaml
+++ b/sources/scores/phi-instruct.yaml
@@ -16,10 +16,7 @@ openness:
     - name: MIT
       detail: OSI permissive
   confidence: high
-  note: MIT-licensed open weights; training/post-training data and code not released -> open_weights. Re-read
-    2026-08-13 - the card still carries `license:mit` and `"gated":false`, and still describes the training
-    mixture in prose (synthetic "textbook-like" data, filtered public web) without releasing it or any
-    training code. No change.
+  note: MIT-licensed open weights; training/post-training data and code not released -> open_weights.
   raw: weights:open(MIT, on HF);data:closed(synthetic-heavy training data undisclosed);code:closed(no training
     pipeline);license:MIT(OSI permissive)
   last_verified: '2026-08-13'
@@ -37,9 +34,9 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: 429,490 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (microsoft/Phi-4-mini-instruct 429,490). Bands at level 3 (100K-1M) on the software and model adoption
-    scale. Corrected from level 4, which the declared artifacts do not support.
+  note: 429,490 downloads in the trailing 30 days summed across the 1 declared artifact(s) (microsoft/Phi-4-mini-instruct
+    429,490). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected from level
+    4, which the declared artifacts do not support.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/models/microsoft/Phi-4-mini-instruct
@@ -53,10 +50,8 @@ capability:
   basis_detail: MMLU-Pro/GPQA
   value: MMLU 67.3, MMLU-Pro 52.8, GPQA 25.2, GSM8K 88.6, MATH 64.0 (overall 63.5)
   confidence: high
-  note: Strong-for-size 3.8B with good math (GSM8K 88.6) but low GPQA (25.2) and overall well below 2026 frontier
-    chat models; small-model tier on a frontier-anchored scale. Re-read 2026-08-13 - the card's quality
-    table still gives the Phi-4 mini-Ins column MMLU 67.3, MMLU-Pro 52.8, GPQA 25.2, GSM8K 88.6, MATH
-    64.0 and Overall 63.5, against GPT-4o-mini at 75.5 overall. Every figure unchanged. No change.
+  note: Strong-for-size 3.8B with good math (GSM8K 88.6) but low GPQA (25.2) and overall well below 2026
+    frontier chat models; small-model tier on a frontier-anchored scale.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/microsoft/Phi-4-mini-instruct

--- a/sources/scores/phi.yaml
+++ b/sources/scores/phi.yaml
@@ -14,14 +14,10 @@ openness:
     - name: MIT
       detail: OSI
   confidence: high
-  note: 'MIT weights, which is genuinely permissive with no use restrictions, but neither the training corpus nor
-    the training pipeline is published - Microsoft describes the synthetic data mix without releasing it. So 3/open_weights:
-    the artifact is free to use and the recipe is not reproducible. Reaching 4 or 5 would need the data or the pipeline,
-    not a more permissive license. Re-read 2026-08-13 - the Hub still reports `license:mit` and
-    ungated for microsoft/phi-4, and the model card still describes the corpus as "a blend of
-    synthetic datasets, data from filtered public domain websites, and acquired academic books and
-    Q&A datasets" totalling 9.8T tokens, none of which is released, and links no training pipeline.
-    Nothing moved.'
+  note: 'MIT weights, which is genuinely permissive with no use restrictions, but neither the training corpus
+    nor the training pipeline is published - Microsoft describes the synthetic data mix without releasing
+    it. So 3/open_weights: the artifact is free to use and the recipe is not reproducible. Reaching 4 or
+    5 would need the data or the pipeline, not a more permissive license.'
   last_verified: '2026-08-13'
   raw: weights:open(MIT);data:closed;code:closed;license:MIT(OSI)
   sources:
@@ -47,17 +43,17 @@ openness:
     http_status: 200
     content_sha256: aba3991f57db2e170cdc298f1940de6869ba68574c5552236dcbee8c7e226627
   - url: https://venturebeat.com/ai/microsoft-makes-powerful-phi-4-model-fully-open-source-on-hugging-face
-    shows: 'NOT RE-READ: the host answered HTTP 429 to the 2026-08-13 attempt after retries, so this source
-      was not re-confirmed and is not part of this axis''s date.'
+    shows: VentureBeat coverage of the Phi-4 MIT release; the host answers HTTP 429, so it is not a live
+      source for this axis.
     accessed: '2026-06-04'
 adoption:
   level: 3
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: 626,702 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (microsoft/phi-4 626,702). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected
-    from level 4, which the declared artifacts do not support.
+  note: 626,702 downloads in the trailing 30 days summed across the 1 declared artifact(s) (microsoft/phi-4
+    626,702). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected from level
+    4, which the declared artifacts do not support.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/models/microsoft/phi-4
@@ -71,13 +67,10 @@ capability:
   basis_detail: GPQA
   value: null
   confidence: high
-  note: '14B model with outsized math/reasoning: ~56.1% on graduate-level (GPQA-style) science questions, 80.4%
-    on competition math, strong AMC results; reportedly beats GPT-4 (its teacher) on some STEM. Strong-for-size
-    but a small/older model vs 2026 frontier. Re-read 2026-08-13 - both recorded figures are still on
-    the-decoder piece, and Artificial Analysis now places Phi-4 at #47 of 74 on its Intelligence
-    Index. That ranking is new information rather than a contradiction: a mid-table position on the
-    2026 comparison set is what a 3 encodes, so the band is unchanged and now has a live external
-    reference behind it as well as the launch coverage.'
+  note: '14B model with outsized math/reasoning: ~56.1% on graduate-level (GPQA-style) science questions,
+    80.4% on competition math, strong AMC results; reportedly beats GPT-4 (its teacher) on some STEM. Strong-for-size
+    but a small/older model vs 2026 frontier. Artificial Analysis places Phi-4 at #47 of 74 on its Intelligence
+    Index - a mid-table position on the 2026 comparison set, which is what a 3 encodes.'
   last_verified: '2026-08-13'
   sources:
   - url: https://the-decoder.com/microsoft-releases-full-phi-4-model-with-weights-under-mit-license/

--- a/sources/scores/phoenix.yaml
+++ b/sources/scores/phoenix.yaml
@@ -17,9 +17,7 @@ openness:
     open source platform" (open_washed). Source-available and self-hostable, with Arize AX as a separate
     closed SaaS product. Score corrected from 3 to 2 on 2026-07-30. The software ladder has rungs at 1,
     2, 4 and 5 and none at 3, so 3/source_available was not a pair any rule could produce; the ladder scores
-    "you can read it and not run it freely" at 2. Re-read 2026-08-13 and unchanged - the LICENSE file is
-    still ELv2 verbatim, and the vendor page still calls Phoenix "the open-source platform" while stating
-    "ELv2 licensed" in the same breath.
+    "you can read it and not run it freely" at 2.
   raw: 'license:Elastic-License-2.0(ELv2, non-OSI: prohibits offering as a managed/hosted service to third
     parties);source:public;self-hostable;commercial:Arize-AX-SaaS-is-separate-closed-product'
   last_verified: '2026-08-13'
@@ -52,9 +50,8 @@ adoption:
   signal_type: usage_volume
   confidence: high
   note: arize-phoenix ~2.46M PyPI downloads/month; broad OTel-based framework integrations; ~10k GitHub
-    stars corroborates only. Re-read 2026-08-13 - pypistats now reports 2,313,184 downloads last month
-    for arize-phoenix, down slightly from the 2,458,129 recorded and still inside the 1M-10M band, so
-    level 4 is unchanged.
+    stars corroborates only. pypistats now reports 2,313,184 downloads in the last month for arize-phoenix,
+    slightly below the 2,458,129 this note was set on and still inside the 1M-10M band.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/packages/arize-phoenix
@@ -76,9 +73,7 @@ capability:
     cost/latency, broad framework integrations (OpenAI/Claude/LangGraph/LlamaIndex/CrewAI)
   confidence: high
   note: Full-coverage observability/eval platform across all six feature-matrix dimensions; on par with
-    MLflow/Langfuse anchors (C4). Re-read 2026-08-13 - the README still lists Tracing (OpenTelemetry-based
-    instrumentation), Evaluation (response and retrieval evals), Playground and Prompt Management as
-    first-class features, so the comparison with the langfuse anchor at 4 still holds.
+    MLflow/Langfuse anchors (C4).
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/Arize-ai/phoenix

--- a/sources/scores/pinecone.yaml
+++ b/sources/scores/pinecone.yaml
@@ -14,13 +14,8 @@ openness:
     managed:
       value: Pinecone-Cloud
   confidence: high
-  note: 'Fully proprietary managed vector DB; no open source core (contrast Milvus/Qdrant which are OSI-licensed).
-    BYOC is still closed-source software run in customer cloud. Re-read 2026-08-13, and the BYOC judgment
-    in particular was checked rather than carried forward. The pricing page describes BYOC as "Pinecone in
-    your cloud account and VPC" with "Zero-access operations - no SSH, VPN, or inbound access required" -
-    which is Pinecone''s own software running on your infrastructure, not source you receive, so it does not
-    make the core self-hostable and `self-host: none` holds. The tier list is unchanged at Starter, Builder,
-    Standard and Enterprise, and the words "open source" appear nowhere on the page. Score stays 1.'
+  note: Fully proprietary managed vector DB; no open source core (contrast Milvus/Qdrant which are OSI-licensed).
+    BYOC is still closed-source software run in customer cloud.
   raw: license:proprietary(SaaS);source:closed;self-host:none(BYOC runs Pinecone-managed in customer VPC,
     not OSS);managed:Pinecone-Cloud
   last_verified: '2026-08-13'
@@ -53,13 +48,7 @@ adoption:
   note: Leading managed vector DB; production deployments cited at 1.4B vectors / 5,700 QPS for a single
     e-commerce customer and 135M vectors / 2,200 QPS load-tested for another. Broad enterprise/developer
     base via serverless + AWS Marketplace PAYG. No single hard user count published; placed at 4 on aggregate
-    production usage_volume. (Some churn noted, e.g. Notion left over cost.) Re-read 2026-08-13 and both cited
-    deployments are still on the page verbatim - "5,700 queries per second with a P50 latency of just 26
-    milliseconds across a database of 1.4 billion vectors" for the e-commerce customer, and 600 QPS at 45ms
-    across 135 million vectors with a load test reaching "2,200 queries per second with a P50 latency of
-    just 60 milliseconds" for the design platform. Still no single published user or customer count, which
-    is what was looked for; the band remains an aggregate judgment over production deployments and stays
-    at 4.
+    production usage_volume. (Some churn noted, e.g. Notion left over cost.)
   last_verified: '2026-08-13'
   sources:
   - url: https://siliconangle.com/2025/12/01/pinecone-scales-vector-database-support-demanding-workloads/
@@ -85,15 +74,10 @@ capability:
   value: P50 latency ~26-60ms at 1.4B-vector scale, 5,700 QPS; serverless auto-indexing, dedicated read
     nodes
   confidence: medium
-  note: 'Top-tier managed ANN search at billion-vector scale with strong latency/QPS. No independent ANN-Benchmarks/VectorDBBench
-    submission found (closed system, vendor-reported figures); rated 4 (peer to Milvus C4), reserving 5 for
-    benchmark-proven frontier. Re-read 2026-08-13. The latency and QPS figures in the recorded value are
-    still on the page as written - 26ms P50 at 5,700 QPS over 1.4 billion vectors, 60ms P50 at 2,200 QPS
-    on a load test - and Dedicated Read Nodes are still the mechanism described. Re-checked the absence too:
-    ann-benchmarks.com was fetched the same day and lists 38 algorithms, none of them Pinecone, so the "no
-    independent submission" half of this note is a confirmed finding rather than an assumption. The Milvus
-    anchor was re-read and re-dated the same day and also holds at 4, so `relation: at` remains arithmetically
-    true.'
+  note: Top-tier managed ANN search at billion-vector scale with strong latency/QPS. No independent ANN-Benchmarks/VectorDBBench
+    submission found (closed system, vendor-reported figures); rated 4 (peer to Milvus C4), reserving 5
+    for benchmark-proven frontier. ann-benchmarks.com lists 38 algorithms, none of them Pinecone, so the
+    absence of an independent submission is a confirmed finding rather than an assumption.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.infoq.com/news/2025/12/pinecone-drn-vector-workloads/

--- a/sources/scores/playwright-mcp.yaml
+++ b/sources/scores/playwright-mcp.yaml
@@ -15,10 +15,9 @@ openness:
     - no-feature-gated-core
     - no-managed-tier
   confidence: high
-  note: 'Fully OSI-licensed Microsoft repo, no open-core split. Re-read 2026-08-13: the repository LICENSE
-    resolves to the full Apache License 2.0 text and the repo page carries the matching Apache-2.0 badge.
-    The whole server is in the tree and it is installed as a single npm package with no key, no enterprise
-    directory and no hosted tier sold beside it, so nothing is withheld from the published source.'
+  note: Fully OSI-licensed Microsoft repo, no open-core split. The LICENSE resolves to the full Apache-2.0
+    text, and the whole server is in the tree and installed as a single npm package with no key, no enterprise
+    directory and no hosted tier sold beside it.
   raw: license:Apache-2.0(OSI);source:public(Microsoft repo);no-feature-gated-core;no-managed-tier;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -71,13 +70,8 @@ capability:
   value: structured accessibility-snapshot navigation, click/type/fill-form, screenshots, network requests,
     console, tabs, file upload, code-eval; cross-browser via Playwright
   confidence: medium
-  note: 'Deep, broad browser-control surface (the leading agentic browser tool); scored 4 on the scrape/browse
-    feature matrix, strong coverage but no standardized benchmark and not the single category-definer. Re-read
-    2026-08-13: the README''s tool list still works from structured accessibility snapshots rather than screenshots
-    and still spans navigation, browser_click / browser_type / browser_fill_form, screenshots, network requests,
-    console messages, tabs, file upload and code evaluation, across the Playwright browser set. The recorded
-    value is unchanged and no standardized benchmark for browser-control servers has appeared, so the basis
-    stays feature_matrix.'
+  note: Deep, broad browser-control surface (the leading agentic browser tool); scored 4 on the scrape/browse
+    feature matrix, strong coverage but no standardized benchmark and not the single category-definer.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/microsoft/playwright-mcp

--- a/sources/scores/poe.yaml
+++ b/sources/scores/poe.yaml
@@ -15,10 +15,6 @@ openness:
       detail: closed
   confidence: high
   note: Proprietary multi-model chat aggregator; closed counterpart on the shelf.
-    Re-read 2026-08-13. poe.com/about is still a sign-up page for a hosted Quora product fronting other
-    people models - the bot wall now runs from GPT-5.4 and Claude-Opus-4.6 through Gemini-3.1-Pro,
-    Grok-4.20, Veo-3.1 and dozens more - with nothing published and no self-host path. Value unchanged
-    at 1 / closed.
   raw: license:proprietary(SaaS);source:closed;self-host:none;models:multi-provider aggregation(closed)
   last_verified: '2026-08-13'
   sources:
@@ -33,44 +29,23 @@ adoption:
   reach: 1M-10M users
   signal_type: active_users
   confidence: low
-  note: 'CEO/Quora figures (compiled by multiple aggregators) report ~18M Poe MAU in 2026 (~40% using
-    paid features; ~$65M subscription ARR). 18M is comfortably in the >10M ''mass market'' band -> level
-    5. Quora publishes no primary Poe MAU page, so the exact figure remains aggregator-sourced (confidence
-    low), but the order of magnitude is consistent across sources and clearly clears the >10M threshold.
-    The reach label now reads ''>10M users'' on the active_users scale declared 2026-08-13, which is the
-    band this record has effectively been claiming since it was corrected off an invented ''10M-100M''
-    - the difference is that the band is now declared, so the claim can be checked rather than merely
-    asserted.
-
-    Re-read 2026-08-14, and the figure the band rests on appears to be a relabelled downloads number.
-    The cited aggregator no longer carries it, and no first-party figure exists to replace it - poe.com/blog
-    was read post by post and none carries a user, subscriber or revenue number; quorablog.quora.com is
-    403; and every "18M MAU" hit on the open web is an SEO statistics aggregator citing no source, one
-    of which carries an explicit "where exact figures are unavailable, we use estimates" disclaimer. The
-    only sourceable 18 million for Poe is TechCrunch on Quora''s Series B - "By October 2023, the Poe app
-    had been downloaded more than 18 million times and had reached over 1 million monthly active users."
-    Downloads, not MAU, and the contemporaneous MAU beside it is 1M. That is a level 4 signal at best on
-    an active_users scale, and it is nearly three years stale.
-
-    ESCALATED rather than changed. Two defensible readings and this pass will not choose between them -
-    re-band to 4 on the only sourceable active-user figure, accepting that it is from October 2023 and
-    Poe has plainly grown; or keep 5 and re-route the axis to a downloads instrument, where 18M+
-    cumulative installs is real and dated. No last_verified claimed on either reading.
-
-    RESOLVED 2026-08-14 on the first reading, and SAY WHAT WAS BANDED, per docs/reference/adoption.md.
-    THE QUANTITY BANDED IS MONTHLY ACTIVE USERS - "over 1 million monthly active users" as of October
-    2023, from TechCrunch on Quora''s Series B, re-fetched today and byte-identical to yesterday''s read.
-    That is level 4 and reach 1M-10M users on the active_users scale declared in signal_routing.yaml.
-    THE 18 MILLION IS INSTALLS, not users. The same sentence reads "the Poe app had been downloaded more
-    than 18 million times AND had reached over 1 million monthly active users", and the aggregators that
-    the old level 5 rested on collapsed the two into "18M MAU". That relabelling is exactly the
-    substitution the active_users route refuses to accept silently - a cumulative install total is not an
-    active count - so it is recorded here rather than carried.
-    The downloads reading was available and was not taken. Banding 18M cumulative installs against a
-    scale calibrated on trailing-30-day figures would overstate in the same direction the aggregator
-    already did, and the map has been corrected off that error roughly forty-five times. This band
-    understates a live consumer product instead, which is the honest failure of the two: the figure is
-    nearly three years old, Poe has plainly grown since, and confidence stays low to say so.'
+  note: 'RESOLVED, and SAY WHAT WAS BANDED, per docs/reference/adoption.md. THE QUANTITY BANDED IS
+    MONTHLY ACTIVE USERS - "over 1 million monthly active users" as of October 2023, from TechCrunch on
+    Quora''s Series B. That is level 4 and reach 1M-10M users on the active_users scale declared in
+    signal_routing.yaml. THE 18 MILLION IS INSTALLS, not users. The same sentence reads "the Poe app had
+    been downloaded more than 18 million times AND had reached over 1 million monthly active users", and
+    the aggregators the old level 5 rested on collapsed the two into "18M MAU". That relabelling is
+    exactly the substitution the active_users route refuses to accept silently - a cumulative install
+    total is not an active count - so it is recorded here rather than carried. No first-party figure
+    exists to replace it: poe.com/blog was read post by post and none carries a user, subscriber or
+    revenue number; quorablog.quora.com answers 403; and every "18M MAU" hit on the open web is an SEO
+    statistics aggregator citing no source, one of which carries an explicit "where exact figures are
+    unavailable, we use estimates" disclaimer. The downloads reading was available and was not taken -
+    banding 18M cumulative installs against a scale calibrated on trailing-30-day figures would overstate
+    in the same direction the aggregator already did, and the map has been corrected off that error
+    roughly forty-five times. This band understates a live consumer product instead, which is the honest
+    failure of the two: the figure is nearly three years old, Poe has plainly grown since, and confidence
+    stays low to say so.'
   last_verified: '2026-08-14'
   sources:
   - url: https://techcrunch.com/2024/01/10/quora-ai-poe-analysis/
@@ -94,14 +69,8 @@ capability:
     in one UI), user-created bots / custom bot builder, multimodal, points-based unified billing, multi-platform
     clients. Lighter on enterprise/RAG vs Copilot/Perplexity.'
   confidence: medium
-  note: Strongest pure model-breadth in the consumer aggregator slot (text/image/video/audio + custom
-    bots); high feature breadth, not the frontier-definer (LiteLLM anchors the gateway side at C4).
-    Re-read 2026-08-13. The about page still shows the model breadth the band rests on and it has
-    widened - text, image, video and audio models side by side, including GPT-5.4, Claude-Opus-4.6 and
-    Claude-Sonnet-4.6, Gemini-3.1-Pro, Grok-4.20-Multi-Agent, Kimi-K2.5, GLM-5, DeepSeek-R1, Veo-3.1,
-    Sora-2-Pro, Runway-Gen-4.5, FLUX-2-Pro, ElevenLabs-v3 and Lyria-3 - alongside user-created bots and
-    bot-builder tooling. Still lighter on enterprise and RAG than Copilot or Perplexity. Band unchanged
-    at 4.
+  note: Strongest pure model-breadth in the consumer aggregator slot (text/image/video/audio + custom bots);
+    high feature breadth, not the frontier-definer (LiteLLM anchors the gateway side at C4).
   last_verified: '2026-08-13'
   sources:
   - url: https://poe.com/about

--- a/sources/scores/postgres-mcp.yaml
+++ b/sources/scores/postgres-mcp.yaml
@@ -13,11 +13,10 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: 'Fully MIT, no feature-gated core. Re-read 2026-08-13: the repository LICENSE is the plain MIT License,
-    "Copyright (c) 2025, Crystal Corp.", and the repo page carries the matching badge. Despite the "Pro"
-    in the product name there is no paid edition - the whole server, index tuning and health checks included,
-    ships in the tree and runs from PyPI or the crystaldba/postgres-mcp Docker image with only a DATABASE_URI.
-    No license key, second license or enterprise directory.'
+  note: Fully MIT, no feature-gated core. Despite the "Pro" in the product name there is no paid edition
+    - the whole server, index tuning and health checks included, ships in the tree and runs from PyPI or
+    the crystaldba/postgres-mcp Docker image with only a DATABASE_URI, and there is no license key, second
+    license or enterprise directory.
   raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -41,9 +40,9 @@ adoption:
   level: 3
   signal_type: usage_volume
   confidence: medium
-  note: '491,612 downloads in the trailing 30 days (postgres-mcp 491,612), read 2026-08-12. Bands at level
-    3 (100K-1M) on the software and model adoption scale. Moved off the stars fallback: a real download
-    signal exists, and docs/reference/adoption.md says to re-band when one does. The package is first-party.'
+  note: '491,612 downloads in the trailing 30 days (postgres-mcp 491,612). Bands at level 3 (100K-1M) on
+    the software and model adoption scale. Moved off the stars fallback: a real download signal exists,
+    and docs/reference/adoption.md says to re-band when one does. The package is first-party.'
   reach: 100K-1M
   last_verified: '2026-08-12'
   sources:
@@ -58,13 +57,7 @@ capability:
   value: '9 tools: schema/object inspection, execute_sql w/ access modes, EXPLAIN + hypothetical indexes, slow-query
     analysis, index advising, health checks'
   confidence: medium
-  note: 'Richest open Postgres MCP surface, well beyond the archived read-only reference server. Re-read 2026-08-13
-    and every clause of the recorded value holds. The README''s own subtitle is "A Postgres MCP server with
-    index tuning, explain plans, health checks, and safe sql execution", and the feature list runs Database
-    Health, Index Tuning ("explore thousands of possible indexes ... using industrial-strength algorithms"),
-    Query Plans with hypothetical-index simulation, Schema Intelligence and Safe SQL Execution via the --access-mode
-    flag. The tool table still carries explain_query, get_top_queries and analyze_db_health. Band unchanged
-    at 4.'
+  note: Richest open Postgres MCP surface, well beyond the archived read-only reference server.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/crystaldba/postgres-mcp

--- a/sources/scores/privatemode.yaml
+++ b/sources/scores/privatemode.yaml
@@ -19,15 +19,15 @@ openness:
   confidence: high
   note: 'Not open source: the security-critical Trusted Computing Base is publicly readable (and the client
     proxy + web app are MIT), but the main license permits only viewing/compiling for audit, and the operational
-    service is a proprietary hosted offering. More open than a black-box API, less than open-core. A read
-    on 2026-08-12 recorded source as partial rather than public or closed, which is what the ladder was
-    missing. The repo README scopes itself to "all components of Privatemode that are part of the TCB",
-    so the operating service around them - accounts, billing, orchestration - is not published, and the
-    LICENSE grants permission "to view, analyze, and compile this source code solely for the purpose of
-    auditing and for verifying its reproducibility and cryptographic hashes", with redistribution,
-    modification and use for any other purpose prohibited. There is no self-hostable implementation, so
-    source is not public; a real component set does ship, so it is not closed either. That is the same
-    shape as lumo, apify and confer, which the ladder already places at 2.'
+    service is a proprietary hosted offering. More open than a black-box API, less than open-core. The record
+    puts source at partial rather than public or closed, which is what the ladder was missing. The repo
+    README scopes itself to "all components of Privatemode that are part of the TCB", so the operating service
+    around them - accounts, billing, orchestration - is not published, and the LICENSE grants permission
+    "to view, analyze, and compile this source code solely for the purpose of auditing and for verifying
+    its reproducibility and cryptographic hashes", with redistribution, modification and use for any other
+    purpose prohibited. There is no self-hostable implementation, so source is not public; a real component
+    set does ship, so it is not closed either. That is the same shape as lumo, apify and confer, which the
+    ladder already places at 2.'
   raw: license:custom-source-available(audit-only)+MIT-subdirs(proxy/web/internal-oss);source:partial(the
     TCB components are published and reproducibly buildable at github.com/edgelesssys/privatemode-public;
     the service around them is not, and the license permits building only to audit);service:proprietary-hosted;models:third-party-open-weight
@@ -63,10 +63,6 @@ adoption:
   confidence: low
   note: Announced Feb 18 2025; offers a free tier, pay-as-you-go, and enterprise plans, and is co-marketed
     with Capgemini for regulated industries, but no customer or usage numbers are published. New and unquantified.
-    Re-read 2026-08-13. The Edgeless Systems post is still up and still dated 18 February 2025, and
-    neither it nor the product site publishes any customer, seat or usage number - the customers section
-    is a logo wall rather than a count. So there is still nothing countable to band. Level unchanged at
-    2.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.edgeless.systems/blog/what-is-privatemode
@@ -85,12 +81,6 @@ capability:
   note: Broad model menu plus a drop-in OpenAI-compatible API, chat UI, and strong integration story. Not
     top-tier because it is a confidential inference relay for others' models rather than a frontier model
     or full platform.
-    Re-read 2026-08-13. The product site still shows the surface the band rests on - an
-    OpenAI-compatible API at api.privatemode.ai serving current open-weight models, a chat UI, a coding
-    agent install path, integrations including Claude Code and OpenCode, and the confidential-computing
-    guarantee that data is encrypted before it leaves the device and stays encrypted during processing.
-    The advertised model has moved on to kimi-k2.6. Still a confidential inference relay for other
-    people models rather than a platform of its own. Band unchanged at 4.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.privatemode.ai

--- a/sources/scores/promptfoo.yaml
+++ b/sources/scores/promptfoo.yaml
@@ -15,10 +15,8 @@ openness:
     - no feature-gated core observed (acquired by OpenAI, stated to remain MIT/open source)
   confidence: high
   last_verified: '2026-08-13'
-  note: MIT-licensed, fully public; OSI -> open_source. OpenAI ownership noted but does not change the
-    OSS license at scoring time. Re-read 2026-08-13 - the license endpoint still reports MIT and the README
-    still says 'Promptfoo remains open source and MIT licensed' under OpenAI, with no paid tier or license
-    key in it.
+  note: MIT-licensed, fully public; OSI -> open_source. OpenAI ownership noted but does not change the OSS
+    license at scoring time.
   raw: license:MIT(OSI);source:public(GitHub);no feature-gated core observed (acquired by OpenAI, stated
     to remain MIT/open source);core-gated:ungated
   sources:
@@ -49,18 +47,17 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: '~1.18M npm downloads/mo (May 4-Jun 2 2026); 21.9k stars; project states it powers LLM apps serving
-    10M+ users in production. Headline = npm registry primary source; 1-10M band. ARTIFACT DELIBERATELY NOT
-    DECLARED, checked 2026-08-13. A PyPI package named `promptfoo` exists and is genuinely this project''s, so
-    declaring it would satisfy check_instrument and would be wrong. promptfoo is an npm-first CLI; its PyPI
-    package sees 13,629 downloads a month against an npm channel nothing here reads. Banding on PyPI would
-    drop this record from 4 to 2 on a minority channel. That is the under-coverage rule in
-    docs/reference/adoption.md - if the declared artifact is not the product''s primary distribution channel,
-    banding on it is a substitution rather than a measurement - applied before the mistake rather than after.
-    The band stands on the evidence already cited here; what this record needs is a route to its real channel,
-    not a convenient one. Re-read 2026-08-13 - the npm registry reports 2,277,977 downloads for the window
-    2026-07-11 to 2026-08-09, still inside the 1M-10M band, and the PyPI package is now at 13,629 a month,
-    unchanged as a minority channel.'
+  note: ~1.18M npm downloads/mo (May 4-Jun 2 2026); 21.9k stars; project states it powers LLM apps serving
+    10M+ users in production. Headline = npm registry primary source; 1-10M band. ARTIFACT DELIBERATELY
+    NOT DECLARED. A PyPI package named `promptfoo` exists and is genuinely this project's, so declaring
+    it would satisfy check_instrument and would be wrong. promptfoo is an npm-first CLI; its PyPI package
+    sees 13,629 downloads a month against an npm channel nothing here reads. Banding on PyPI would drop
+    this record from 4 to 2 on a minority channel. That is the under-coverage rule in docs/reference/adoption.md
+    - if the declared artifact is not the product's primary distribution channel, banding on it is a substitution
+    rather than a measurement - applied before the mistake rather than after. The band stands on the evidence
+    already cited here; what this record needs is a route to its real channel, not a convenient one. The
+    npm registry reports 2,277,977 downloads in the trailing month, still inside the 1M-10M band, and the
+    PyPI package sits at 13,629 a month, unchanged as a minority channel.
   last_verified: '2026-08-13'
   sources:
   - url: https://api.npmjs.org/downloads/point/last-month/promptfoo
@@ -72,8 +69,8 @@ adoption:
     shows: 21.9k stars; '10M+ users in production' claim
     accessed: '2026-06-04'
   - url: https://raw.githubusercontent.com/promptfoo/promptfoo/main/README.md
-    shows: README re-read 2026-08-13; the repo carries 24.2k stars and the README still positions the
-      tool as used by OpenAI and Anthropic. No standalone user count is published beyond that.
+    shows: The repo carries 24.2k stars and the README positions the tool as used by OpenAI and Anthropic.
+      No standalone user count is published beyond that.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 426270e1b7c45d0bf456b1284cdc1af055218db73869864b9590b1e0bdaab5cb
@@ -88,9 +85,8 @@ capability:
   relation: one_below
   last_verified: '2026-08-13'
   note: Very broad eval coverage plus a distinctive red-teaming/security axis; top-tier for application
-    eval, below the academic-benchmark standardization references on raw benchmark coverage. Feature matrix
-    re-read 2026-08-13 and unchanged; the comparison to the standardization references is now recorded
-    structurally against lm-evaluation-harness.
+    eval, below the academic-benchmark standardization references on raw benchmark coverage. That comparison
+    is recorded structurally against lm-evaluation-harness.
   sources:
   - url: https://github.com/promptfoo/promptfoo
     shows: eval + red-teaming + model comparison + CI/CD features

--- a/sources/scores/promptlayer.yaml
+++ b/sources/scores/promptlayer.yaml
@@ -17,9 +17,6 @@ openness:
   confidence: high
   note: Open client SDK over a closed hosted backend (prompt CMS, logging, evals are SaaS), no OSS core,
     so 'closed' alongside the Braintrust/LangSmith pattern; the open library is instrumentation only.
-    Re-read 2026-08-13 and unchanged - the repository is still only the client library, described by its
-    own tagline as a log of prompts and API requests, and it publishes no server, no deployment manifest
-    and no self-host path.
   raw: source:closed;license:Apache-2.0(OSI, client library MagnivOrg/prompt-layer-library only);platform:proprietary-SaaS(API-key
     gated, hosted prompt registry/logging/evals);self-host:no(managed only)
   last_verified: '2026-08-13'
@@ -43,8 +40,8 @@ adoption:
   confidence: medium
   note: '~289K PyPI downloads in the last month for the `promptlayer` package (primary: pypistats) → 100K-1M
     band. Recognized but lighter-weight (no-code prompt CMS for non-technical teams) vs the deeper platforms;
-    no harder user count disclosed. Re-read 2026-08-13 - pypistats now reports 254,412 downloads last month,
-    down from the 289,237 recorded and still inside the 100K-1M band, so level 3 stands.'
+    no harder user count disclosed. pypistats now reports 254,412 downloads in the last month, below the
+    289,237 this note was set on and still inside the 100K-1M band.'
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/packages/promptlayer
@@ -62,9 +59,7 @@ capability:
     Missing: deep LLM-as-judge eval + broad OTel/framework observability vs anchors.'
   confidence: medium
   note: Strong prompt-lifecycle/versioning focus but shallower eval + production observability than MLflow/Langfuse
-    (C4) per 2026 comparisons, rated 3, mid-tier. Re-read 2026-08-13 - the repository still presents itself
-    as a log of prompts and API requests with track, debug and replay, which is narrower than the anchor
-    tier and consistent with the one-below comparison already recorded.
+    (C4) per 2026 comparisons, rated 3, mid-tier.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/MagnivOrg/prompt-layer-library

--- a/sources/scores/pydantic-ai.yaml
+++ b/sources/scores/pydantic-ai.yaml
@@ -64,8 +64,8 @@ adoption:
   level: 5
   signal_type: usage_volume
   confidence: medium
-  note: 15,835,159 PyPI downloads in the trailing 30 days for pydantic-ai, read 2026-08-12. Bands at level
-    5 (>10M) on the software and model adoption scale. Heavily transitive and CI-driven, so directional.
+  note: 15,835,159 PyPI downloads in the trailing 30 days for pydantic-ai. Bands at level 5 (>10M) on the
+    software and model adoption scale. Heavily transitive and CI-driven, so directional.
   reach: '>10M'
   last_verified: '2026-08-12'
   sources:
@@ -80,19 +80,17 @@ capability:
   value: typed/structured outputs; typed DI; model-agnostic; tool calling; streaming; multi-agent; MCP; OTel/Logfire
   confidence: medium
   note: 'Lean, type-safe DX; narrower built-in RAG than LlamaIndex and fewer prebuilt role abstractions
-    than CrewAI. Re-read 2026-08-13 - the PyPI project page no longer serves a readable description to
-    a fetcher, so the feature matrix was re-read from the repo instead. It documents structured streamed
-    outputs with immediate validation, tools and dynamic instructions, composable capabilities including
-    web search and thinking, MCP and UI event-stream integration, human-in-the-loop workflows and graph
-    support, plus agents definable entirely in YAML/JSON. One below llama-index, whose RAG and data-ingestion
-    depth sets the ceiling this note already compared against.'
+    than CrewAI. The feature matrix rests on the repo, the PyPI project page no longer serving a readable
+    description: structured streamed outputs with immediate validation, tools and dynamic instructions,
+    composable capabilities including web search and thinking, MCP and UI event-stream integration, human-in-the-loop
+    workflows and graph support, plus agents definable entirely in YAML/JSON.'
   relative_to: llama-index
   relation: one_below
   last_verified: '2026-08-13'
   sources:
   - url: https://pypi.org/project/pydantic-ai/
-    shows: 'previously cited for the MIT typed agent framework. Re-read 2026-08-13 - the page now returns
-      a 3KB stub with no project description.'
+    shows: Previously cited for the MIT typed agent framework; the page now returns a 3KB stub with no project
+      description.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 32ed63159c77e21ee19ca1b9aa3213ccf0218eb59539560b132a8e68ef0e18ea

--- a/sources/scores/pyrit.yaml
+++ b/sources/scores/pyrit.yaml
@@ -16,8 +16,7 @@ openness:
     core-gated:
       value: ungated
   confidence: high
-  note: 'Fully open source: MIT-licensed automation framework, self-hostable, no proprietary tier. Re-read
-    2026-08-13 and unchanged.'
+  note: 'Fully open source: MIT-licensed automation framework, self-hostable, no proprietary tier.'
   raw: license:MIT(OSI);source:public(full Python framework);self-host:yes;service:none;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -38,11 +37,11 @@ adoption:
   reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
-  note: 4,285 GitHub stars on microsoft/PyRIT, read 2026-08-12. Bands at level 2 (1K-10K stars) on the stars
-    fallback scale, which caps at 3 because a star is not a use. Resynced because the note says 'stars-only
-    proxy, capped per methodology' and recorded the cap; Microsoft backing is provenance, not adoption volume.
-    No download, install or customer figure is published for this product, so stars remain the only honest
-    signal and the level is directional.
+  note: 4,285 GitHub stars on microsoft/PyRIT. Bands at level 2 (1K-10K stars) on the stars fallback scale,
+    which caps at 3 because a star is not a use. Resynced because the note says 'stars-only proxy, capped
+    per methodology' and recorded the cap; Microsoft backing is provenance, not adoption volume. No download,
+    install or customer figure is published for this product, so stars remain the only honest signal and
+    the level is directional.
   last_verified: '2026-08-12'
   sources:
   - url: https://api.github.com/repos/microsoft/PyRIT
@@ -57,9 +56,9 @@ capability:
   value: Automated adversarial prompting, attack-strategy orchestration, and scoring to identify harms
     across providers.
   confidence: medium
-  note: A leading open red-teaming harness; strong automation and scoring, multi-provider. Re-read
-    2026-08-13. The README has been trimmed to a pointer at the docs site and no longer names the pieces,
-    so the package listing is cited alongside it - the modules are what the band was read off.
+  note: A leading open red-teaming harness; strong automation and scoring, multi-provider. The README has
+    been trimmed to a pointer at the docs site and no longer names the pieces, so the package listing is
+    cited alongside it - the shipped modules are what the band is read off.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/microsoft/PyRIT

--- a/sources/scores/pysyft.yaml
+++ b/sources/scores/pysyft.yaml
@@ -14,15 +14,15 @@ openness:
         under one Apache-2.0 license - and PySyft runs on cloud storage the user already has rather than
         on an OpenMined-operated plane. No enterprise path and no license key in the tree
   confidence: high
-  note: 'Apache-2.0 licensed with full public source code. `core-gated: ungated` transcribed 2026-08-12
-    from a read of the repo. PySyft''s architecture is the opposite of a gate: the README''s pitch is that
-    data scientists submit computations run by data owners "through cloud storage their organizations already
-    use (Google Drive, Microsoft 365, etc.). No new infrastructure required", so there is no OpenMined-operated
-    plane that could be withheld. Every runtime piece is published - packages/ holds eleven syft-* packages
-    (syft-bg, syft-datasets, syft-enclave, syft-job, syft-migration, syft-notebook-ui, syft-permissions,
-    syft-perms, syft-rds, syft-restrict and an enclave example) beside syft_client - under one Apache-2.0
-    LICENSE. A repo-wide code search for `enterprise` returns nothing and there is no license-key path.
-    OpenMined is a non-profit and sells no tier.'
+  note: 'Apache-2.0 licensed with full public source code. `core-gated: ungated` from a direct read of the
+    repo. PySyft''s architecture is the opposite of a gate: the README''s pitch is that data scientists
+    submit computations run by data owners "through cloud storage their organizations already use (Google
+    Drive, Microsoft 365, etc.). No new infrastructure required", so there is no OpenMined-operated plane
+    that could be withheld. Every runtime piece is published - packages/ holds eleven syft-* packages (syft-bg,
+    syft-datasets, syft-enclave, syft-job, syft-migration, syft-notebook-ui, syft-permissions, syft-perms,
+    syft-rds, syft-restrict and an enclave example) beside syft_client - under one Apache-2.0 LICENSE. A
+    repo-wide code search for `enterprise` returns nothing and there is no license-key path. OpenMined is
+    a non-profit and sells no tier.'
   raw: license:Apache-2.0(OSI permissive);source:public;core-gated:ungated(every runtime piece is published
     - eleven syft-* packages under packages/ plus syft_client under one Apache-2.0 license - and PySyft
     runs on cloud storage the user already has rather than on an OpenMined-operated plane. No enterprise
@@ -62,17 +62,14 @@ adoption:
   reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: medium
-  note: '9.9k GitHub stars (capped at 3 per stars-fallback rule); ~10.8k monthly PyPI downloads and 1M+
-    all-time. Stars read 2026-08-13: 9,938 across the 1 declared repo, which bands at 1K-10K stars, level
-    2 on the stars scale in signal_routing.yaml. Level corrected from 3. The previous reach ''broad'' was
-    not a label this instrument offers - stars have their own vocabulary because a star is not a download.
-    No last_verified claimed: a star count is volatile, so a digest of it would read as drift on every refetch,
-    and the rest of the axis was not re-read. Re-read 2026-08-13: the GitHub API reports 9,937 stargazers
-    on OpenMined/PySyft, which bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml.
-    pepy.tech reports 15,527 PyPI downloads of `syft` in the trailing 30 days, which lands at 10K-100K,
-    also level 2 on the software download scale - so the band holds on either instrument. Whether the record
-    should switch from stars_fallback to usage_volume now that a download signal exists is raised as a separate
-    question; it would change reach without changing level.'
+  note: The GitHub API reports 9,937 stargazers on OpenMined/PySyft, which bands at 1K-10K stars, level
+    2 on the stars scale in signal_routing.yaml; the stars fallback caps at 3 because a star is not a use.
+    Level corrected from 3. The previous reach 'broad' was not a label this instrument offers - stars have
+    their own vocabulary because a star is not a download. pepy.tech reports 15,527 PyPI downloads of `syft`
+    in the trailing 30 days against 1,066,264 all-time, which lands at 10K-100K, also level 2 on the software
+    download scale - so the band holds on either instrument. Whether the record should switch from stars_fallback
+    to usage_volume now that a download signal exists is a separate open question; it would change reach
+    without changing level.
   last_verified: '2026-08-13'
   sources:
   - url: https://api.github.com/repos/OpenMined/PySyft
@@ -91,9 +88,7 @@ capability:
   value: 'Remote/privacy-preserving data science: submit computations to private datasets via Datasite
     servers, NumPy-like remote analysis, sandboxed job execution, cross-platform.'
   confidence: high
-  note: 'Mature, feature-rich platform for remote data science on private data. Re-read 2026-08-13: the
-    PyPI project page still describes remote data science over Datasite servers with a NumPy-like remote
-    analysis interface, so the band is unchanged.'
+  note: Mature, feature-rich platform for remote data science on private data.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypi.org/project/syft/

--- a/sources/scores/pythia.yaml
+++ b/sources/scores/pythia.yaml
@@ -19,15 +19,11 @@ openness:
     - name: Apache-2.0
       detail: OSI
   confidence: high
-  note: 'The reference case for 5/open_source in this category. Apache-2.0 weights, the Pile released as the training
-    corpus together with dataloader tools that reconstruct the exact token order, training and analysis code on
-    GitHub, and 154 intermediate checkpoints per model size. Every dimension the rubric asks about is answered by
-    something downloadable, which is what separates 5 from the open-weights tier: the run is reproducible, not merely
-    the model usable. Re-read 2026-08-13: the Pile is still ungated on the Hub (2,601 downloads, 502
-    likes), the paper abstract still promises "154 checkpoints for each one of the 16 models,
-    alongside tools to download and reconstruct their exact training dataloaders", the pythia
-    repository is still public Apache-2.0, and the 12B card front matter still reads apache-2.0 with
-    datasets EleutherAI/pile. Nothing moved.'
+  note: 'The reference case for 5/open_source in this category. Apache-2.0 weights, the Pile released as
+    the training corpus together with dataloader tools that reconstruct the exact token order, training
+    and analysis code on GitHub, and 154 intermediate checkpoints per model size. Every dimension the rubric
+    asks about is answered by something downloadable, which is what separates 5 from the open-weights tier:
+    the run is reproducible, not merely the model usable.'
   last_verified: '2026-08-13'
   raw: weights:open(Apache-2.0);data:open(the Pile, with dataloader reconstruction tools);code:open(training+analysis
     code, GitHub);checkpoints:open(154 per model);license:Apache-2.0(OSI)
@@ -67,9 +63,9 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 30,007 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (EleutherAI/pythia-12b 30,007). Bands at level 2 (10K-100K) on the software and model adoption scale.
-    Corrected from level 3, which the declared artifacts do not support.
+  note: 30,007 downloads in the trailing 30 days summed across the 1 declared artifact(s) (EleutherAI/pythia-12b
+    30,007). Bands at level 2 (10K-100K) on the software and model adoption scale. Corrected from level
+    3, which the declared artifacts do not support.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/models/EleutherAI/pythia-12b
@@ -82,12 +78,9 @@ capability:
   basis: benchmark
   value: null
   confidence: high
-  note: Not built for capability. Pythia models (max 12B, 2023-era Pile training) are intentionally research instruments
-    for studying scaling/learning dynamics, not competitive on modern capability benchmarks. Scored 1 on a capability
-    axis where the comparison set is 2026 frontier models. Re-read 2026-08-13 - the abstract still
-    frames Pythia as a suite built to study how models "develop and evolve over the course of
-    training" and presents case studies in memorization, term frequency and bias rather than
-    capability results. The 1 records what the suite is for, and that has not changed.
+  note: Not built for capability. Pythia models (max 12B, 2023-era Pile training) are intentionally research
+    instruments for studying scaling/learning dynamics, not competitive on modern capability benchmarks.
+    Scored 1 on a capability axis where the comparison set is 2026 frontier models.
   last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2304.01373

--- a/sources/scores/pytorch.yaml
+++ b/sources/scores/pytorch.yaml
@@ -13,12 +13,11 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: 'BSD 3-Clause license with multiple contributor copyright lines; full source public. Re-read 2026-08-13:
-    the cited LICENSE body still carries the BSD-3-Clause terms, the GitHub API reports the repository public,
-    unarchived and licensed NOASSERTION, and the README describes the whole library with no paid, enterprise
-    or hosted tier beside it, so source stays public and core-gated stays ungated. The GitHub API reports
-    spdx_id NOASSERTION because the LICENSE prepends per-contributor copyright lines to the BSD text, so
-    the license was read from the body rather than the API field.'
+  note: BSD 3-Clause license with multiple contributor copyright lines; full source public. The repository
+    is public and unarchived, and the README describes the whole library with no paid, enterprise or hosted
+    tier beside it, so source is public and the core ungated. The GitHub API reports spdx_id NOASSERTION
+    because the LICENSE prepends per-contributor copyright lines to the BSD text, so the license is read
+    from the body rather than the API field.
   raw: license:BSD-3-Clause(OSI);source:public;no feature-gated core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -54,14 +53,11 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: '88.6M PyPI downloads in the last 30 days. Read live 2026-08-13: 95,449,310 PyPI downloads in the
-    trailing 30 days across the declared artifact(s), which bands at >10M, level 5. The previous reach ''88M+/mo''
-    was free text carrying a figure rather than a band the scale declares, so nothing could check it against
-    the level beside it. No last_verified claimed: only the figure was re-read, not the whole axis. Re-read
-    2026-08-13 from the cited pepy.tech reading of the declared PyPI artifact `torch`: 98,643,378 downloads
-    in the trailing 30 days, which bands at >10M, level 5 on the software scale. Unchanged. PyPI is one
-    of several channels here - conda and PyTorch''s own wheel index are not counted - so the figure is a
-    floor. It is already the top band, so the undercount cannot move the level.'
+  note: 98,643,378 PyPI downloads in the trailing 30 days for the declared artifact `torch`, which bands
+    at >10M, level 5 on the software scale. The previous reach '88M+/mo' was free text carrying a figure
+    rather than a band the scale declares, so nothing could check it against the level beside it. PyPI is
+    one of several channels here - conda and PyTorch's own wheel index are not counted - so the figure is
+    a floor. It is already the top band, so the undercount cannot move the level.
   last_verified: '2026-08-13'
   sources:
   - url: https://pepy.tech/projects/torch
@@ -75,10 +71,7 @@ capability:
   value: 'Foundational deep learning framework: GPU-accelerated tensors, dynamic autograd, neural network
     primitives, distributed training.'
   confidence: high
-  note: 'Defines the model-training layer alongside TensorFlow. Re-read 2026-08-13: the cited repository
-    page still describes the product as recorded, so the band is unchanged. The ''alongside TensorFlow''
-    placement this note already made is now recorded as relative_to/relation - both define the model-training
-    layer and both sit at 5.'
+  note: Defines the model-training layer alongside TensorFlow.
   relative_to: tensorflow
   relation: at
   last_verified: '2026-08-13'

--- a/sources/scores/qdrant.yaml
+++ b/sources/scores/qdrant.yaml
@@ -116,16 +116,11 @@ capability:
     highest RPS and lowest latency in almost all scenarios vs Milvus/Weaviate/Elasticsearch/Redis at matched
     precision; advanced filtered-search query planning.'
   confidence: medium
-  note: 'Top-tier ANN engine on RPS/latency; tied with the Milvus anchor at C4 (frontier vector-DB capability).
+  note: Top-tier ANN engine on RPS/latency; tied with the Milvus anchor at C4 (frontier vector-DB capability).
     Headline comparison is vendor-run (qdrant.tech/benchmarks); ANN-Benchmarks corroborates inclusion but
-    its interactive plots did not yield a clean ranking number this run, hence medium confidence. Re-read
-    2026-08-13, and both halves still hold. ANN-Benchmarks lists 38 algorithms rather than the 37 recorded,
-    with qdrant and Milvus(Knowhere) both among them, and it still publishes only interactive recall-versus-QPS
-    plots, no ranking table - so it corroborates inclusion and nothing more, exactly as the note says. The
-    vendor page still states "Qdrant achieves highest RPS and lowest latencies in almost all the scenarios,
-    no matter the precision threshold and the metric we choose", against Milvus, Weaviate, Elasticsearch
-    and Redis. The Milvus anchor was re-read and re-dated the same day and also holds at 4, so the recorded
-    relation `at` remains arithmetically true.'
+    its interactive plots did not yield a clean ranking number this run, hence medium confidence. ANN-Benchmarks
+    lists 38 algorithms, qdrant and Milvus(Knowhere) among them, and publishes only interactive recall-versus-QPS
+    plots with no ranking table, so it corroborates inclusion and nothing more.
   last_verified: '2026-08-13'
   sources:
   - url: https://ann-benchmarks.com/

--- a/sources/scores/qualcomm-ai-engine-direct.yaml
+++ b/sources/scores/qualcomm-ai-engine-direct.yaml
@@ -15,16 +15,13 @@ openness:
       detail: qualcomm/qai-appbuilder, formerly quic/ai-engine-direct-helper -- a convenience API layer
         that requires the proprietary SDK libraries
   confidence: high
-  note: 'Re-read against the ladder''s controlled vocabulary: source is closed (the core engine has no published
-    repo and ships only as an EULA-gated download from the Qualcomm Software Center), so the formula settles
+  note: 'Source is closed against the ladder''s controlled vocabulary: the core engine has no published
+    repo and ships only as an EULA-gated download from the Qualcomm Software Center, so the formula settles
     on source alone and the BSD-3 wrapper does not change the class. The wrapper repo has moved from quic/ai-engine-direct-helper
-    to qualcomm/qai-appbuilder; both names now redirect to the same place.
-
-    Re-derived 2026-08-13 against the repo under its CURRENT name rather than the redirect, which is what
-    earns the date: qualcomm/qai-appbuilder is BSD-3-Clause and states that "Some libraries from the
-    Qualcomm AI Runtime SDK are required to use QAI AppBuilder". So the open thing is a wrapper whose
-    dependency is still an EULA-gated binary download, the source dimension is still closed, and the
-    formula still settles on source alone. Score unchanged at 1/closed.'
+    to qualcomm/qai-appbuilder; both names now redirect to the same place. Under its current name the wrapper
+    is BSD-3-Clause and states that "Some libraries from the Qualcomm AI Runtime SDK are required to use
+    QAI AppBuilder", so the open thing is a wrapper whose dependency is still an EULA-gated binary download.
+    1/closed.'
   raw: source:closed(no published source for the QNN/Qualcomm AI Runtime SDK core engine; distributed as
     a proprietary binary via the Qualcomm Software Center under an EULA);license:proprietary(no license
     to the source since it is not published);open-wrapper:BSD-3-Clause(qualcomm/qai-appbuilder, formerly
@@ -32,9 +29,9 @@ openness:
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/qualcomm/qai-appbuilder
-    shows: 'the wrapper under its current name, re-read 2026-08-13: BSD 3-Clause, and "Some libraries from
-      the Qualcomm® AI Runtime SDK are required to use QAI AppBuilder" - an open wrapper over a
-      proprietary SDK that must be downloaded separately from Qualcomm''s Software Center'
+    shows: 'The wrapper under its current name: BSD 3-Clause, and "Some libraries from the Qualcomm® AI
+      Runtime SDK are required to use QAI AppBuilder" - an open wrapper over a proprietary SDK that must
+      be downloaded separately from Qualcomm''s Software Center.'
     accessed: '2026-08-13'
     establishes:
     - source

--- a/sources/scores/qualcomm-dragonwing-rb3-gen-2.yaml
+++ b/sources/scores/qualcomm-dragonwing-rb3-gen-2.yaml
@@ -24,21 +24,18 @@ openness:
       detail: via Thundercomm/distributors
       raw: distributor (via Thundercomm/distributors)
   confidence: high
-  note: Proprietary Qualcomm silicon with public docs and a Linux SDK, sold through distributors, but
-    the board itself is not fully open hardware. Re-read 2026-08-14. www.qualcomm.com serves a
-    client-rendered 9KB shell to a fetcher and no header set changes that, but the fact it was cited
-    for is published elsewhere by Qualcomm itself - docs.qualcomm.com serves the kit''s actual product
-    brief as a PDF, and that document carries four of the five components on its own. `datasheets` is
-    it - a public brief, document 87-74789-1 Rev. A. `schematics` reads partial off "The hardware
-    development kit is also compliant with the 96Boards open hardware specification to support a range
-    of mezzanine-board expansions", an open interface standard published with a block diagram but no
-    board files. `toolchain` off "Support for Linux, Android" plus the Intelligent Multimedia, Robotics,
-    Neural Processing and Hexagon SDKs, and off Qualcomm AI Hub Models being a BSD-3-Clause repo at
-    1,183 stars. `blobs` off the whole stack sitting on the proprietary QCS6490 with vendor SDKs.
-    `retail` from Edge Impulse, which names Advantech, Tria, Thundercomm and Quectel as manufacturers
-    of QCS6490 kits. One thing worth flagging for the corpus rather than for this score - the first
-    product-brief URL tried resolved 200 to a Snapdragon 8 Gen 3 brief instead, and was discarded
-    rather than cited. No change.
+  note: 'Proprietary Qualcomm silicon with public docs and a Linux SDK, sold through distributors, but the
+    board itself is not fully open hardware. Component detail: `datasheets` is a public product brief, document
+    87-74789-1 Rev. A, served by docs.qualcomm.com. `schematics` reads partial off "The hardware development
+    kit is also compliant with the 96Boards open hardware specification to support a range of mezzanine-board
+    expansions", an open interface standard published with a block diagram but no board files. `toolchain`
+    off "Support for Linux, Android" plus the Intelligent Multimedia, Robotics, Neural Processing and Hexagon
+    SDKs, and off Qualcomm AI Hub Models being a BSD-3-Clause repo at 1,183 stars. `blobs` off the whole
+    stack sitting on the proprietary QCS6490 with vendor SDKs. `retail` from Edge Impulse, which names Advantech,
+    Tria, Thundercomm and Quectel as manufacturers of QCS6490 kits. www.qualcomm.com serves a client-rendered
+    9KB shell to a fetcher and no header set changes that, which is why the brief is taken from docs.qualcomm.com
+    instead. One thing worth flagging for the corpus rather than for this score - the first product-brief
+    URL tried resolved 200 to a Snapdragon 8 Gen 3 brief instead, and was discarded rather than cited.'
   raw: schematics:partial (96Boards mezzanine standard);toolchain:open (open Qualcomm Linux + AI Hub);datasheets:brief
     (public brief);blobs:required (proprietary silicon + firmware);retail:distributor (via Thundercomm/distributors)
   last_verified: '2026-08-14'
@@ -78,11 +75,10 @@ adoption:
   signal_type: reported_traction
   confidence: medium
   note: Sold via Thundercomm and other distributors; first-class support in Edge Impulse, indicating an
-    established but specialist developer base. Re-read 2026-08-13 - Edge Impulse still lists the kit as
-    a supported board alongside the Dragonwing IQ-8275 and IQ-9075 EVKs, still says it is "fully
-    supported by Edge Impulse", and still documents a Qualcomm IM SDK GStreamer pipeline for it. The
-    Qualcomm developer page could not be re-read (it serves an empty client-rendered shell to a fetcher),
-    so the distributor half of the note rests on the earlier read. Level and reach unchanged.
+    established but specialist developer base. Edge Impulse lists the kit as a supported board alongside
+    the Dragonwing IQ-8275 and IQ-9075 EVKs, says it is "fully supported by Edge Impulse", and documents
+    a Qualcomm IM SDK GStreamer pipeline for it. The Qualcomm developer page is unfetchable (it serves an
+    empty client-rendered shell to a fetcher), so the distributor half of the note rests on an earlier read.
   last_verified: '2026-08-13'
   sources:
   - url: https://docs.edgeimpulse.com/hardware/boards/qualcomm-rb3-gen-2-dev-kit
@@ -97,12 +93,11 @@ capability:
   value: 12 TOPS (Hexagon NPU); QCS6490 octa-core; multi-camera vision
   confidence: high
   note: 12 dense TOPS with octa-core CPU and dual-ISP vision puts it among the more capable edge-AI dev
-    kits here. Re-derived 2026-08-13 from Edge Impulse's board page, which reads "a powerful Linux-based
-    development board based around the QCS6490 SoC. It has two built-in cameras, a Kryo 670 CPU, Adreno
-    643L GPU and 12 TOPS Hexagon 770 NPU". Qualcomm's own developer page could not be re-read (it serves
-    an empty client-rendered shell to a fetcher), so the figure was confirmed against the ecosystem
-    partner's documentation instead. 12 TOPS still sits above the 6 TOPS RK3588 boards and below the
-    Jetson Orin NX, so the band is unchanged.
+    kits here. Edge Impulse's board page reads "a powerful Linux-based development board based around the
+    QCS6490 SoC. It has two built-in cameras, a Kryo 670 CPU, Adreno 643L GPU and 12 TOPS Hexagon 770 NPU".
+    Qualcomm's own developer page is unfetchable (it serves an empty client-rendered shell to a fetcher),
+    so the figure rests on the ecosystem partner's documentation instead. 12 TOPS sits above the 6 TOPS
+    RK3588 boards and below the Jetson Orin NX.
   last_verified: '2026-08-13'
   sources:
   - url: https://docs.edgeimpulse.com/hardware/boards/qualcomm-rb3-gen-2-dev-kit

--- a/sources/scores/qwen-coder.yaml
+++ b/sources/scores/qwen-coder.yaml
@@ -18,12 +18,9 @@ openness:
   governing_release: qwen3-coder
   confidence: high
   note: Apache-2.0 weights with a closed corpus and inference code only, so 3, consistent across both generations
-    - Qwen2.5-Coder and Qwen3-Coder are both plain Apache with no use restrictions. Qwen3-Coder governs and contributes
-    capability 4; adoption 4 is carried from Qwen2.5-Coder, which has had longer to accumulate downloads. Kept apart
-    from the base Qwen tier because Alibaba ships and markets the Coder line separately. Re-read 2026-08-13
-    - the governing Qwen3-Coder card still carries the `license:apache-2.0` tag and reads `"gated":false`
-    with safetensors weights listed, and it still documents only inference, quickstart and agentic-coding
-    usage with no post-training pipeline or SFT/RL mixture published. No change.
+    - Qwen2.5-Coder and Qwen3-Coder are both plain Apache with no use restrictions. Qwen3-Coder governs
+    and contributes capability 4; adoption 4 is carried from Qwen2.5-Coder, which has had longer to accumulate
+    downloads. Kept apart from the base Qwen tier because Alibaba ships and markets the Coder line separately.
   raw: weights:open(Apache-2.0, on HF);data:closed(no training corpus released);code:partial(inference/usage
     + chat template; no training pipeline or post-training/SFT data);license:Apache-2.0(OSI permissive,
     no use restrictions)
@@ -42,12 +39,12 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: ~1.36M downloads last month for the 32B-Instruct SKU alone on HF; the broader Qwen2.5-Coder family (0.5B-32B
-    base+instruct) multiplies this. Squarely in the 1-10M reach band on measured monthly download volume.
-    Re-read 2026-08-13 - the 32B-Instruct SKU now reads 1,242,001 downloads in the trailing 30 days, which
-    bands at 4 on its own; summed across the four declared SKUs the family reads 4,715,952 (32B-Instruct
-    1,242,001; 7B-Instruct 1,926,647; Qwen3-Coder-30B-A3B-Instruct 1,198,501; Qwen3-Coder-480B-A35B-Instruct-FP8
-    348,803), also level 4. No change.
+  note: ~1.36M downloads last month for the 32B-Instruct SKU alone on HF; the broader Qwen2.5-Coder family
+    (0.5B-32B base+instruct) multiplies this. Squarely in the 1-10M reach band on measured monthly download
+    volume. The 32B-Instruct SKU reads 1,242,001 downloads in the trailing 30 days, which bands at 4 on
+    its own; summed across the four declared SKUs the family reads 4,715,952 (32B-Instruct 1,242,001; 7B-Instruct
+    1,926,647; Qwen3-Coder-30B-A3B-Instruct 1,198,501; Qwen3-Coder-480B-A35B-Instruct-FP8 348,803), also
+    level 4.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/Qwen/Qwen2.5-Coder-32B-Instruct
@@ -62,11 +59,9 @@ capability:
   value: Vendor positions agentic coding comparable to Claude Sonnet class; 480B-A35B MoE, repository-scale long
     context; non-thinking mode
   confidence: medium
-  note: Strong open-weight coding model (Claude Sonnet-class agentic coding per vendor card), a notch below 2026
-    frontier coders (DeepSeek-V4-Pro/Kimi K2.6/GLM-5.1). HF card is vendor-reported; no independent SWE-bench number
-    captured this run, so capped at 4 with medium confidence. Re-read 2026-08-13 - the card still claims
-    "results comparable to Claude Sonnet" on agentic coding and browser-use among open models, and still
-    inlines no independent SWE-bench figure. No change.
+  note: Strong open-weight coding model (Claude Sonnet-class agentic coding per vendor card), a notch below
+    2026 frontier coders (DeepSeek-V4-Pro/Kimi K2.6/GLM-5.1). HF card is vendor-reported; no independent
+    SWE-bench number captured this run, so capped at 4 with medium confidence.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct

--- a/sources/scores/qwen-instruct.yaml
+++ b/sources/scores/qwen-instruct.yaml
@@ -15,9 +15,7 @@ openness:
     - name: Apache-2.0
       detail: OSI permissive
   confidence: high
-  note: OSI Apache-2.0 open weights; post-training data and training code closed -> open_weights. Re-read
-    2026-08-13 - the card still carries `license:apache-2.0`, still reads `"gated":false`, and still ships
-    only a quickstart and chat template with no post-training pipeline or SFT/RLHF mixture. No change.
+  note: OSI Apache-2.0 open weights; post-training data and training code closed -> open_weights.
   raw: weights:open(Apache-2.0, on HF);data:closed;code:partial(inference/chat template; no training pipeline
     or SFT/RLHF data);license:Apache-2.0(OSI permissive)
   last_verified: '2026-08-13'
@@ -35,9 +33,9 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: ~2.22M downloads last month for the 14B-Instruct SKU on HF; one of the most-pulled mid-size instruct models
-    in the dominant Qwen2.5 family. Solidly in the 1-10M band on measured monthly downloads. Re-read 2026-08-13
-    - the single declared SKU now reads 3,137,049 downloads in the trailing 30 days, still level 4. No change.
+  note: ~2.22M downloads last month for the 14B-Instruct SKU on HF; one of the most-pulled mid-size instruct
+    models in the dominant Qwen2.5 family. Solidly in the 1-10M band on measured monthly downloads. The
+    single declared SKU reads 3,137,049 downloads in the trailing 30 days, still level 4.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/Qwen/Qwen2.5-14B-Instruct
@@ -52,11 +50,9 @@ capability:
   value: General-purpose 14B instruct; vendor reports gains in coding, math, instruction-following and long-text
     vs predecessor; detailed scores in Qwen2.5 blog
   confidence: medium
-  note: Capable mid-size (14B) 2024 general chat model; strong-for-size but well below 2026 frontier and below larger
-    Qwen2.5/3 SKUs. HF card does not inline MMLU/MMLU-Pro numbers; scored 3 on size/class with medium confidence.
-    Re-read 2026-08-13 - the card still lists the same vendor claims (coding, mathematics, instruction following,
-    long-text generation, 128K context, 29+ languages) and still defers the numbers to the Qwen2.5 blog. No
-    change.
+  note: Capable mid-size (14B) 2024 general chat model; strong-for-size but well below 2026 frontier and
+    below larger Qwen2.5/3 SKUs. HF card does not inline MMLU/MMLU-Pro numbers; scored 3 on size/class with
+    medium confidence.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/Qwen/Qwen2.5-14B-Instruct

--- a/sources/scores/qwen.yaml
+++ b/sources/scores/qwen.yaml
@@ -17,17 +17,14 @@ openness:
         so they fall outside this axis
   governing_release: qwen-3-6
   confidence: high
-  note: 'Apache-2.0 across the distributed base variants, data closed and only inference code published, so 3. The
-    load-bearing exclusion: Qwen3.7-Max is proprietary and served only through Alibaba Model Studio, so it is not
-    part of the distributed set and does not cap the family. Including it would publish Qwen as 1/closed, which
-    is what the rubric''s multi_sku_rule exists to prevent - API-only tiers are a different product surface from
-    the weights you can download. Qwen 2.5 scored 2 because its distributed 3B and 72B SKUs carried the Qwen License
-    Agreement; from Qwen3 onward the distributed set is Apache. Replaces an earlier note that was a copy of the
-    components string and recorded the license as `mixed`, a value the rubric forbids because it states that SKUs
-    differ without recording the outcome. Re-read 2026-08-13 - Qwen3.6-27B is still apache-2.0 and
-    ungated on the Hub, its card names no training corpus and declares no `datasets` in its front
-    matter, and QwenLM/Qwen3.6 is still an Apache-2.0 usage and deployment repository rather than a
-    training pipeline. Nothing moved.'
+  note: 'Apache-2.0 across the distributed base variants, data closed and only inference code published,
+    so 3. The load-bearing exclusion: Qwen3.7-Max is proprietary and served only through Alibaba Model Studio,
+    so it is not part of the distributed set and does not cap the family. Including it would publish Qwen
+    as 1/closed, which is what the rubric''s multi_sku_rule exists to prevent - API-only tiers are a different
+    product surface from the weights you can download. Qwen 2.5 scored 2 because its distributed 3B and
+    72B SKUs carried the Qwen License Agreement; from Qwen3 onward the distributed set is Apache. Replaces
+    an earlier note that was a copy of the components string and recorded the license as `mixed`, a value
+    the rubric forbids because it states that SKUs differ without recording the outcome.'
   last_verified: '2026-08-13'
   raw: weights:open(Apache-2.0 for open variants e.g. 27B/35B-A3B);data:closed;code:partial(inference/usage
     code on GitHub; no training pipeline/data);license:Apache-2.0(most restrictive distributed SKU; the
@@ -80,12 +77,12 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: medium
-  note: 14,030,698 downloads in the trailing 30 days summed across the 6 declared artifact(s), read
-    2026-08-13 (Qwen/Qwen2.5-72B 28,852; Qwen/Qwen2.5-7B 716,344; Qwen/Qwen3.6-27B 6,830,615;
-    Qwen/Qwen3.6-35B-A3B 5,609,980; Qwen/Qwen3-235B-A22B 529,067; Qwen/Qwen3.5-397B-A17B 315,840).
-    Bands at level 5 (>10M) on the software and model adoption scale, unchanged - and now on a counted
-    figure rather than a cumulative third-party estimate. The two Qwen3.6 checkpoints supply 89% of
-    it, so the family reach is current rather than inherited from the 2.5 generation.
+  note: 14,030,698 downloads in the trailing 30 days summed across the 6 declared artifact(s) (Qwen/Qwen2.5-72B
+    28,852; Qwen/Qwen2.5-7B 716,344; Qwen/Qwen3.6-27B 6,830,615; Qwen/Qwen3.6-35B-A3B 5,609,980; Qwen/Qwen3-235B-A22B
+    529,067; Qwen/Qwen3.5-397B-A17B 315,840). Bands at level 5 (>10M) on the software and model adoption
+    scale, unchanged - and now on a counted figure rather than a cumulative third-party estimate. The two
+    Qwen3.6 checkpoints supply 89% of it, so the family reach is current rather than inherited from the
+    2.5 generation.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/models/Qwen/Qwen2.5-72B
@@ -124,11 +121,9 @@ capability:
   basis_detail: SWE-bench/Terminal-Bench
   value: null
   confidence: high
-  note: 'Dense Qwen3.6-27B: SWE-bench Verified 77.2, Terminal-Bench 2.0 59.3 (reported matching Claude 4.5 Opus
-    class), outperforming a 397B MoE on agentic coding. Flagship Qwen3.6-Plus reported matching Claude Opus 4.5
-    on SWE-bench/Terminal-Bench. Frontier-tier open family. Re-read 2026-08-13 - both figures for the
-    dense 27B and the Opus-4.5 comparison for the hosted Plus tier are still on the cited pages, so
-    the band is re-derived and unchanged at 5.'
+  note: 'Dense Qwen3.6-27B: SWE-bench Verified 77.2, Terminal-Bench 2.0 59.3 (reported matching Claude 4.5
+    Opus class), outperforming a 397B MoE on agentic coding. Flagship Qwen3.6-Plus reported matching Claude
+    Opus 4.5 on SWE-bench/Terminal-Bench. Frontier-tier open family.'
   last_verified: '2026-08-13'
   sources:
   - url: https://www.marktechpost.com/2026/04/22/alibaba-qwen-team-releases-qwen3-6-27b-a-dense-open-weight-model-outperforming-397b-moe-on-agentic-coding-benchmarks/

--- a/sources/scores/qwen3guard.yaml
+++ b/sources/scores/qwen3guard.yaml
@@ -45,9 +45,9 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 39,581 downloads in the trailing 30 days (Qwen/Qwen3Guard-Gen-8B 39,581), read 2026-08-12. Bands
-    at level 2 (10K-100K). Corrected from level 4. A guardrail model; recorded 4 against a figure that has
-    never reached level 3.
+  note: 39,581 downloads in the trailing 30 days (Qwen/Qwen3Guard-Gen-8B 39,581). Bands at level 2 (10K-100K).
+    Corrected from level 4. A guardrail model; recorded 4 against a figure that has never reached level
+    3.
   last_verified: '2026-08-12'
   sources:
   - url: https://huggingface.co/api/models/Qwen/Qwen3Guard-Gen-8B
@@ -62,8 +62,7 @@ capability:
   value: Prompt and response classification across 119 languages with a three-level verdict and a token-level
     streaming variant; size ladder from 0.6B to 8B.
   confidence: medium
-  note: Among the broadest open guardrails on language coverage, with a streaming mode that few others
-    offer. Re-read 2026-08-13 and unchanged.
+  note: Among the broadest open guardrails on language coverage, with a streaming mode that few others offer.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/Qwen/Qwen3Guard-Gen-8B

--- a/sources/scores/radxa-rock-5b.yaml
+++ b/sources/scores/radxa-rock-5b.yaml
@@ -20,12 +20,8 @@ openness:
       detail: global
       raw: open_market (global)
   confidence: high
-  note: Schematics and mechanical files are publicly downloadable and the BSP is open, but the RK3588
-    needs proprietary Rockchip blobs and editable PCB source is not released. Re-read 2026-08-13 - the
-    Hardware Design section still offers v1.3/v1.42 schematic PDFs, SMD maps, 2D DXF and 3D STP plus CE
-    EMC test reports, and still publishes no editable PCB source; the Radxa BSP build tool is still
-    GPL-3.0; and Rockchip's rkbin still ships the DDR/BL31 boot binaries as prebuilt files. No dimension
-    moved.
+  note: Schematics and mechanical files are publicly downloadable and the BSP is open, but the RK3588 needs
+    proprietary Rockchip blobs and editable PCB source is not released.
   raw: schematics:published (PDF + SMD maps + DXF + 3D STP + CE/FCC public);toolchain:open (open BSP/kernel/U-Boot);blobs:required
     (Rockchip rkbin/DDR/TF-A required);retail:open_market (global)
   last_verified: '2026-08-13'
@@ -68,10 +64,10 @@ adoption:
   signal_type: reported_traction
   confidence: high
   note: One of the most popular RK3588 SBCs, sold globally through authorized distributors with 15+ third-party
-    OS ports and an active community. Re-read 2026-08-13 - the ameriDroid listing is still live at $289.95
-    though every RAM variant currently reads "Sold out" at that distributor, and Radxa's own docs still
-    list the third-party OS ports (Armbian, Arch, DietPi, openFyde, Batocera, RebornOS and others). The
-    stock-out is one distributor's inventory rather than a discontinuation; level and reach unchanged.
+    OS ports and an active community. The ameriDroid listing is live at $289.95 though every RAM variant
+    currently reads "Sold out" at that distributor, which is one distributor's inventory rather than a discontinuation;
+    Radxa's own docs list the third-party OS ports (Armbian, Arch, DietPi, openFyde, Batocera, RebornOS
+    and others).
   last_verified: '2026-08-13'
   sources:
   - url: https://ameridroid.com/products/rock5-model-b
@@ -92,10 +88,10 @@ capability:
   value: 6 TOPS NPU; up to 16GB LPDDR4X (5B) / 32GB LPDDR5 (5B+); RK3588 8-core CPU
   confidence: high
   note: 6 TOPS INT8 plus up to 16-32GB RAM runs quantized small/mid LLMs and real-time vision via RKNN,
-    strong for an edge SBC. Re-derived 2026-08-13 - the introduction still reads "up to 6TOPs" with
-    INT4/INT8/INT16/FP16/BF16/TF32 support and 4/8/16 LPDDR4X on the 5B and 4/8/16/32 LPDDR5 on the 5B+.
-    The 32GB ceiling is what places it a step above the other 6 TOPS RK3588 boards here (orange-pi-5,
-    khadas-edge2, both at 3), and still below the Jetson Orin NX.
+    strong for an edge SBC. The introduction reads "up to 6TOPs" with INT4/INT8/INT16/FP16/BF16/TF32 support
+    and 4/8/16 LPDDR4X on the 5B and 4/8/16/32 LPDDR5 on the 5B+. The 32GB ceiling is what places it a step
+    above the other 6 TOPS RK3588 boards here (orange-pi-5, khadas-edge2, both at 3), and still below the
+    Jetson Orin NX.
   last_verified: '2026-08-13'
   sources:
   - url: https://docs.radxa.com/en/rock5/rock5b/getting-started/introduction

--- a/sources/scores/ragas.yaml
+++ b/sources/scores/ragas.yaml
@@ -17,10 +17,9 @@ openness:
   last_verified: '2026-08-13'
   note: Core library is fully OSI (Apache-2.0) with no feature-gated functionality; could be argued open_core
     given the hosted cloud product, but the eval library itself is complete and open, so scored open_source.
-    Re-read 2026-08-13 against the repo the product declares, vibrantlabsai/ragas (the cited explodinggradients
-    path now redirects there after the org rename). The license endpoint still reports Apache-2.0 and
-    the README installs and runs the whole metric suite from PyPI or a git checkout with no account, no
-    hosted tier and no license key mentioned anywhere in it.
+    The repo the product declares is vibrantlabsai/ragas, the cited explodinggradients path redirecting
+    there after the org rename; the README installs and runs the whole metric suite from PyPI or a git checkout
+    with no account, no hosted tier and no license key mentioned anywhere in it.
   raw: license:Apache-2.0(OSI);source:public(full metrics + test-gen library); core un-gated. (Vendor also
     offers a hosted app.ragas.io tier; not required for the library.);core-gated:ungated
   sources:
@@ -54,9 +53,8 @@ adoption:
   last_verified: '2026-08-13'
   note: ~1.51M PyPI downloads in the last 30 days (pypistats), de facto standard for RAG/LLM-app evaluation,
     widely integrated (LangChain, LlamaIndex, observability platforms). Stars (14.2k) corroborate. Solidly
-    in the 1M-10M monthly band. Re-read 2026-08-13 - the pypistats API reports 1,587,521 ragas downloads
-    in the trailing 30 days, still inside the same band, and the repo is at 15.3k stars under its new
-    vibrantlabsai org.
+    in the 1M-10M monthly band. The pypistats API reports 1,587,521 ragas downloads in the trailing 30 days,
+    inside the same band, and the repo is at 15.3k stars under its new vibrantlabsai org.
   sources:
   - url: https://pypistats.org/packages/ragas
     shows: 1,513,553 downloads in the last month
@@ -81,9 +79,8 @@ capability:
   relation: one_below
   last_verified: '2026-08-13'
   note: Frontier within the application/RAG-eval niche (metric breadth + test generation), but not a general
-    academic-benchmark model harness; scored 4 not 5 because coverage is domain-scoped. Feature matrix
-    re-read 2026-08-13 and unchanged; the comparison the note draws to the academic-benchmark harnesses
-    is now recorded structurally against HELM.
+    academic-benchmark model harness; scored 4 not 5 because coverage is domain-scoped. The comparison to
+    the academic-benchmark harnesses is recorded structurally against HELM.
   sources:
   - url: https://github.com/explodinggradients/ragas
     shows: objective metrics (LLM-based + traditional), Aspect Critique, automatic test-data generation,

--- a/sources/scores/ragflow.yaml
+++ b/sources/scores/ragflow.yaml
@@ -17,10 +17,7 @@ openness:
     core-gated:
       value: ungated
   confidence: high
-  note: 'Apache-2.0 self-hostable engine; cloud is the commercial tier. Re-read 2026-08-13 - the repo
-    page still reports Apache-2.0 over the whole tree and publishes the whole engine for Docker Compose
-    self-hosting, with the managed cloud sold beside it rather than gating anything in the published source.
-    Stars are now 87.9k. Nothing moved.'
+  note: Apache-2.0 self-hostable engine; cloud is the commercial tier.
   raw: license:Apache-2.0(OSI);source:public;self-host:primary(Docker);commercial:cloud/enterprise(separate);core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -39,15 +36,15 @@ adoption:
   level: 3
   signal_type: usage_volume
   confidence: medium
-  note: 'About 129,133 downloads a month across the product’s real distribution channels, read 2026-08-13
-    (Docker Hub 3,590,166 cumulative since 2023-12-12, about 112,087 a month; ragflow-sdk 17,046 in the
-    trailing 30 days). Bands at level 3 (100K-1M). RAGFlow ships as a Docker Compose stack; ragflow-sdk
-    on PyPI is an API client rather than the server, so it measures a different thing and is added only
-    as a minor component. Moved off the stars fallback under the under-coverage rule in docs/reference/adoption.md:
-    banding on a channel the product does not ship through is a substitution rather than a measurement.
-    The level is UNCHANGED at 3 - the stars cap happened to give the right answer here - but it now rests
-    on a measured figure instead of a capped proxy. The Docker component is a lifetime average, not a trailing-30-day
-    count, so this is a floor.'
+  note: 'About 129,133 downloads a month across the product’s real distribution channels (Docker Hub 3,590,166
+    cumulative since 2023-12-12, about 112,087 a month; ragflow-sdk 17,046 in the trailing 30 days). Bands
+    at level 3 (100K-1M). RAGFlow ships as a Docker Compose stack; ragflow-sdk on PyPI is an API client
+    rather than the server, so it measures a different thing and is added only as a minor component. Moved
+    off the stars fallback under the under-coverage rule in docs/reference/adoption.md: banding on a channel
+    the product does not ship through is a substitution rather than a measurement. The level is UNCHANGED
+    at 3 - the stars cap happened to give the right answer here - but it now rests on a measured figure
+    instead of a capped proxy. The Docker component is a lifetime average, not a trailing-30-day count,
+    so this is a floor.'
   reach: 100K-1M
   last_verified: '2026-08-13'
   sources:
@@ -67,10 +64,8 @@ capability:
   value: deep document understanding / layout-aware parsing; template-based chunking; grounded citations with source
     traceback; hybrid (vector + full-text) retrieval; knowledge-base UI; LLM-agnostic; agent workflows
   confidence: medium
-  note: 'Opinionated, document-centric RAG application; deeper parsing than general frameworks, narrower
-    scope. Re-read 2026-08-13 - the README still leads with "quality in, quality out" and deep document
-    understanding as its knowledge-extraction basis, alongside template chunking, grounded citations and
-    hybrid retrieval. The feature matrix that placed this band is unchanged.'
+  note: Opinionated, document-centric RAG application; deeper parsing than general frameworks, narrower
+    scope.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/infiniflow/ragflow

--- a/sources/scores/raspberry-pi-5.yaml
+++ b/sources/scores/raspberry-pi-5.yaml
@@ -20,26 +20,22 @@ openness:
       detail: mass-market
       raw: open_market (mass-market)
   confidence: high
-  note: 'Open Linux kernel tree and public datasheets, globally purchasable, but Raspberry Pi
-    publishes no schematic for the Pi 5 at all. Corrected from 4/open_toolchain on 2026-08-14: the
-    record said "reduced published", which is true of the Pi 4 and not of the Pi 5.
-    datasheets.raspberrypi.com/rpi4/raspberry-pi-4-reduced-schematics.pdf answers 200 and the
-    matching rpi5 path 404s, and the documentation index lists for the Pi 5 only a mechanical
-    drawing (RP-008347-DS) and two STEP files, one with silkscreen. That set is a mechanical spec -
-    what a HAT or a case is designed against - so the ladder reads it as `partial`, and a partial
-    design scores 3/documented however open the kernel tree is. The three components that pass did
-    not carry the date are read on 2026-08-14 and the axis is dated on all five. `datasheets` rests
-    on the RP1 Peripherals datasheet, RP-008370-DS, 93 pages of register-level documentation for the
-    Pi 5''s own I/O controller, served without registration under CC BY-ND with no NDA or
-    confidentiality notice anywhere in it. `blobs` rests on the raspberrypi/firmware README, which
-    splits the tree by licence - "start*.elf, fixup*.dat and bootcode.bin are the GPU firmwares and
-    bootloader", licensed under boot/LICENCE.broadcom, against kernel images, device trees and
-    modules under the GPL. `retail` rests on The Pi Hut listing all five SKUs in stock with an add to
-    cart and no account gate. One thing to flag rather than change - `minimal` is this product''s
-    reading of a proprietary Broadcom boot chain, and all nineteen other boards in the category
-    record `required` for the same shape of fact, `beagley-ai` included. Nothing scored turns on it,
-    since no rung in hardware.yaml reads `blobs`, so the word is left as recorded and the
-    inconsistency is raised rather than resolved here.'
+  note: 'Open Linux kernel tree and public datasheets, globally purchasable, but Raspberry Pi publishes
+    no schematic for the Pi 5 at all. Corrected from 4/open_toolchain: the record said "reduced published",
+    which is true of the Pi 4 and not of the Pi 5. datasheets.raspberrypi.com/rpi4/raspberry-pi-4-reduced-schematics.pdf
+    answers 200 and the matching rpi5 path 404s, and the documentation index lists for the Pi 5 only a mechanical
+    drawing (RP-008347-DS) and two STEP files, one with silkscreen. That set is a mechanical spec - what
+    a HAT or a case is designed against - so the ladder reads it as `partial`, and a partial design scores
+    3/documented however open the kernel tree is. `datasheets` rests on the RP1 Peripherals datasheet, RP-008370-DS,
+    93 pages of register-level documentation for the Pi 5''s own I/O controller, served without registration
+    under CC BY-ND with no NDA or confidentiality notice anywhere in it. `blobs` rests on the raspberrypi/firmware
+    README, which splits the tree by licence - "start*.elf, fixup*.dat and bootcode.bin are the GPU firmwares
+    and bootloader", licensed under boot/LICENCE.broadcom, against kernel images, device trees and modules
+    under the GPL. `retail` rests on The Pi Hut listing all five SKUs in stock with an add to cart and no
+    account gate. One thing to flag rather than change - `minimal` is this product''s reading of a proprietary
+    Broadcom boot chain, and all nineteen other boards in the category record `required` for the same shape
+    of fact, `beagley-ai` included. Nothing scored turns on it, since no rung in hardware.yaml reads `blobs`,
+    so the word is left as recorded and the inconsistency is raised rather than resolved here.'
   raw: schematics:partial (mechanical drawing + STEP files only, no schematic);toolchain:open (open
     kernel tree + Raspberry Pi OS);datasheets:public;blobs:minimal;retail:open_market (mass-market)
   last_verified: '2026-08-14'
@@ -111,11 +107,10 @@ adoption:
   reach: mass-market
   signal_type: reported_traction
   confidence: high
-  note: Flagship Raspberry Pi SBC sold globally through countless distributors with a huge community;
-    in production until at least January 2036. Re-read 2026-08-13 - raspberrypi.com answered 403 to every
-    request across the session, so the check was re-derived from Raspberry Pi's own product brief on
-    datasheets.raspberrypi.com, published April 2026, which still commits to production until at least
-    January 2036 and still lists the full 1GB-16GB price ladder. Level and reach unchanged.
+  note: Flagship Raspberry Pi SBC sold globally through countless distributors with a huge community; in
+    production until at least January 2036. raspberrypi.com answers 403 to every automated request, so availability
+    rests on Raspberry Pi's own product brief on datasheets.raspberrypi.com, which commits to production
+    until at least January 2036 and lists the full 1GB-16GB price ladder.
   last_verified: '2026-08-13'
   sources:
   - url: https://datasheets.raspberrypi.com/rpi5/raspberry-pi-5-product-brief.pdf
@@ -134,10 +129,10 @@ capability:
     on CPU
   confidence: high
   note: General-purpose SBC with no dedicated AI accelerator; on-device AI is modest unless paired with
-    an accelerator HAT. Re-derived 2026-08-13 from the April 2026 product brief, whose full feature list
-    runs GPU, video, RAM, wireless, storage, USB, Ethernet, MIPI, PCIe, power and header, and names no
-    NPU and no TOPS figure anywhere. That absence is the whole of the band - every other board in this
-    category records an accelerator, and this one records only 16GB of LPDDR4X behind a Cortex-A76.
+    an accelerator HAT. The product brief's full feature list runs GPU, video, RAM, wireless, storage, USB,
+    Ethernet, MIPI, PCIe, power and header, and names no NPU and no TOPS figure anywhere. That absence is
+    the whole of the band - every other board in this category records an accelerator, and this one records
+    only 16GB of LPDDR4X behind a Cortex-A76.
   last_verified: '2026-08-13'
   sources:
   - url: https://datasheets.raspberrypi.com/rpi5/raspberry-pi-5-product-brief.pdf

--- a/sources/scores/raspberry-pi-ai-hat-plus.yaml
+++ b/sources/scores/raspberry-pi-ai-hat-plus.yaml
@@ -27,29 +27,26 @@ openness:
       detail: mass-market
       raw: open_market (mass-market)
   confidence: medium
-  note: Officially supported open Pi software stack and public product page, globally purchasable, but
-    the underlying Hailo model-compiler toolchain is registration-gated. Scored as an accessory on the
-    owner's ruling of 2026-08-12 - an add-on tracks the platform it completes, and what a builder gets
-    from this HAT is the openness of the Raspberry Pi 5 it plugs into. Its own design and toolchain
-    answers are both partial and neither describes the system anyone actually uses, so accessory-host
-    is what the ladder reads. See the dimension of that name in sources/rubrics/hardware.yaml for why
-    the principle is an axis rather than an extra rung. Moved 4 to 3 on 2026-08-14 with no new evidence
-    about the HAT - the host moved. `raspberry-pi-5` was corrected to 3/documented when it turned out
-    to publish no schematic, only a mechanical drawing, and an accessory cannot offer more openness
-    than the system it completes. All six components were re-read on 2026-08-14 and the axis is dated.
-    raspberrypi.com answers 403 to every automated request, so the product page it used to rest on was
-    replaced by Raspberry Pi''s own AI HAT+ product brief, RP-008133-DS, on datasheets.raspberrypi.com,
-    which carries four of the six on its own. `datasheets` is `brief` because that document is what it
-    says it is - six pages of overview, a specification table, a dimensioned drawing and safety text,
-    against the 93-page register-level datasheet the Pi 5 gets. `schematics` stays `partial` on the
-    HAT+ Specification, which describes itself as "A guide to designing Hardware-Attached-on-Top of a
-    Raspberry Pi" and licenses its contents for use "solely in conjunction with the Raspberry Pi
-    products" - an interface standard for building your own board, not this board''s design.
-    `accessory-host` off the brief pairing the HAT to one host and no other - it "communicates using
-    Raspberry Pi 5''s PCIe Gen 3 interface" and ships a stacking kit "to enable fitting on Raspberry
-    Pi 5". `toolchain` and `blobs` off Hailo''s own repositories rather than the vendor page, HailoRT
-    carrying the open half and the Model Zoo naming the customer-gated compiler. `retail` off The Pi
-    Hut stocking both variants. No value moved.
+  note: Officially supported open Pi software stack and public product page, globally purchasable, but the
+    underlying Hailo model-compiler toolchain is registration-gated. Scored as an accessory on the owner's
+    ruling - an add-on tracks the platform it completes, and what a builder gets from this HAT is the openness
+    of the Raspberry Pi 5 it plugs into. Its own design and toolchain answers are both partial and neither
+    describes the system anyone actually uses, so accessory-host is what the ladder reads. See the dimension
+    of that name in sources/rubrics/hardware.yaml for why the principle is an axis rather than an extra
+    rung. Moved 4 to 3 with no new evidence about the HAT - the host moved. `raspberry-pi-5` was corrected
+    to 3/documented when it turned out to publish no schematic, only a mechanical drawing, and an accessory
+    cannot offer more openness than the system it completes. raspberrypi.com answers 403 to every automated
+    request, so the product page it used to rest on was replaced by Raspberry Pi''s own AI HAT+ product
+    brief, RP-008133-DS, on datasheets.raspberrypi.com, which carries four of the six on its own. `datasheets`
+    is `brief` because that document is what it says it is - six pages of overview, a specification table,
+    a dimensioned drawing and safety text, against the 93-page register-level datasheet the Pi 5 gets. `schematics`
+    stays `partial` on the HAT+ Specification, which describes itself as "A guide to designing Hardware-Attached-on-Top
+    of a Raspberry Pi" and licenses its contents for use "solely in conjunction with the Raspberry Pi products"
+    - an interface standard for building your own board, not this board''s design. `accessory-host` off
+    the brief pairing the HAT to one host and no other - it "communicates using Raspberry Pi 5''s PCIe Gen
+    3 interface" and ships a stacking kit "to enable fitting on Raspberry Pi 5". `toolchain` and `blobs`
+    off Hailo''s own repositories rather than the vendor page, HailoRT carrying the open half and the Model
+    Zoo naming the customer-gated compiler. `retail` off The Pi Hut stocking both variants.
   raw: schematics:partial (HAT+ mechanical spec public);accessory-host:documented(Raspberry Pi 5, which
     scores 3/documented);toolchain:partial (open Pi driver integration, Hailo compiler gated);datasheets:brief
     (public brief);blobs:required (Hailo firmware required);retail:open_market (mass-market)
@@ -131,10 +128,9 @@ adoption:
   reach: mass-market
   signal_type: reported_traction
   confidence: high
-  note: First-party Raspberry Pi accessory sold through the global Pi distributor network with strong
-    community/tutorial coverage. Re-read 2026-08-13 - the product page still reads "Available now from
-    $70", still carries Buy links against the 13 TOPS and 26 TOPS variants and an Approved Resellers
-    list, and now also commits to production until at least January 2030. Level and reach unchanged.
+  note: First-party Raspberry Pi accessory sold through the global Pi distributor network with strong community/tutorial
+    coverage. The product page reads "Available now from $70", carries Buy links against the 13 TOPS and
+    26 TOPS variants and an Approved Resellers list, and commits to production until at least January 2030.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.raspberrypi.com/products/ai-hat/
@@ -148,12 +144,11 @@ capability:
   basis: feature_matrix
   value: 13 TOPS (Hailo-8L) or 26 TOPS (Hailo-8); vision inference; no onboard RAM (uses host Pi)
   confidence: high
-  note: Mid-tier vision-focused NPU; strong for CNN inference but not large LLMs, and dependent on the
-    host Pi for memory. Re-derived 2026-08-13 - the page still offers "Hailo-8 or Hailo-8L accelerator
-    offering 26 TOPS or 13 TOPS inferencing performance respectively" and still describes the workload
-    as camera post-processing (object detection, image segmentation, pose estimation) rather than
-    generative models. That places it above raspberry-pi-5 and the 6 TOPS RK3588 boards on throughput
-    and below the Jetson Orin parts on what it can actually run.
+  note: Mid-tier vision-focused NPU; strong for CNN inference but not large LLMs, and dependent on the host
+    Pi for memory. The page offers "Hailo-8 or Hailo-8L accelerator offering 26 TOPS or 13 TOPS inferencing
+    performance respectively" and describes the workload as camera post-processing (object detection, image
+    segmentation, pose estimation) rather than generative models. That places it above raspberry-pi-5 and
+    the 6 TOPS RK3588 boards on throughput and below the Jetson Orin parts on what it can actually run.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.raspberrypi.com/products/ai-hat/

--- a/sources/scores/ray.yaml
+++ b/sources/scores/ray.yaml
@@ -83,15 +83,15 @@ adoption:
   confidence: high
   note: 'Re-scored 4->5. The prior record had no verified download count (reported_traction). Direct registry
     data now shows ray at 61.31M PyPI downloads in the last 30 days, comfortably above the map''s prevailing
-    usage_volume level-5 floor of >10M/mo (and above even the stricter 50M floor the HF-stack files use, cf.
-    pytorch ~88.6M, triton ~64.7M at level 5). Ray is the standard open distributed-compute / model-serving
-    substrate (Ray Serve, Tune, Train, Data) under the PyTorch Foundation. Artifact declared and read live
-    2026-08-13: 63,273,910 PyPI downloads in the trailing 30 days. Bands at >10M, level 5. This record
-    previously claimed usage_volume - a download count - while declaring no artifact any signal model reads,
-    so no computed figure existed for the recorded band to disagree with. Level unchanged. Re-derived
-    2026-08-13 against the PyPI download API rather than the rendered pepy page: 63,273,910 downloads in
-    the trailing 30 days, 15,105,708 in the trailing week. The trailing-week figure alone clears the >10M
-    floor, so the band does not turn on which window is read. Level unchanged at 5.'
+    usage_volume level-5 floor of >10M/mo (and above even the stricter 50M floor the HF-stack files use,
+    cf. pytorch ~88.6M, triton ~64.7M at level 5). Ray is the standard open distributed-compute / model-serving
+    substrate (Ray Serve, Tune, Train, Data) under the PyTorch Foundation. Artifact declared: 63,273,910
+    PyPI downloads in the trailing 30 days. Bands at >10M, level 5. This record previously claimed usage_volume
+    - a download count - while declaring no artifact any signal model reads, so no computed figure existed
+    for the recorded band to disagree with. Level unchanged. Re-derived against the PyPI download API rather
+    than the rendered pepy page: 63,273,910 downloads in the trailing 30 days, 15,105,708 in the trailing
+    week. The trailing-week figure alone clears the >10M floor, so the band does not turn on which window
+    is read. Level unchanged at 5.'
   last_verified: '2026-08-13'
   sources:
   - url: https://pepy.tech/projects/ray
@@ -112,15 +112,13 @@ capability:
   basis: feature_matrix
   value: null
   confidence: high
-  note: General distributed-compute + model-serving framework (Ray Core, Serve, Tune, Train, Data). No
-    standardized inference/training benchmark (MLPerf) applies to Ray as a whole; scored on breadth of
-    distributed-serving feature coverage. Not directly comparable to single-engine inference benchmarks.
-    Re-read 2026-08-13 on the Anyscale docs page, which still describes the same matrix - Ray Core plus
-    the AI libraries (Data, Train, Tune, Serve, RLlib), clusters on VMs or Kubernetes, mixed CPU/GPU
-    scheduling, and the listed workloads of batch inference, model serving, distributed training,
-    hyperparameter tuning, feature engineering and reinforcement learning. It is a scheduling and serving
-    substrate rather than an isolation boundary, which is why it sits at 4 and not at the microVM
-    frontier this category's 5s occupy. Score unchanged.
+  note: 'General distributed-compute + model-serving framework (Ray Core, Serve, Tune, Train, Data). No
+    standardized inference/training benchmark (MLPerf) applies to Ray as a whole; scored on breadth of distributed-serving
+    feature coverage. Not directly comparable to single-engine inference benchmarks. It is a scheduling
+    and serving substrate rather than an isolation boundary, which is why it sits at 4 and not at the microVM
+    frontier this category''s 5s occupy: Ray Core plus the AI libraries (Data, Train, Tune, Serve, RLlib),
+    clusters on VMs or Kubernetes, mixed CPU/GPU scheduling, and workloads spanning batch inference, model
+    serving, distributed training, hyperparameter tuning, feature engineering and reinforcement learning.'
   last_verified: '2026-08-13'
   sources:
   - url: https://www.anyscale.com/product/open-source/ray

--- a/sources/scores/redpajama-data-v2.yaml
+++ b/sources/scores/redpajama-data-v2.yaml
@@ -12,9 +12,8 @@ openness:
     dataset_card:
       value: 'yes'
   confidence: high
-  note: 'Ungated with a full dataset card; redistributable per Common Crawl ToU with Apache-2.0 processing
-    code. Re-read 2026-08-13: the card''s License section still reads Common Crawl Foundation Terms of Use
-    for the data and Apache 2.0 for the processing code, and the API reports gated false.'
+  note: Ungated with a full dataset card; redistributable per Common Crawl ToU with Apache-2.0 processing
+    code.
   raw: license:CommonCrawl-ToU+Apache-2.0(code);ungated:yes;dataset_card:yes
   last_verified: '2026-08-13'
   sources:
@@ -32,9 +31,8 @@ adoption:
   reach: 1K-10K
   signal_type: usage_volume
   confidence: high
-  note: 5,035 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (togethercomputer/RedPajama-Data-V2 5,035). Bands at level 2 (1K-10K) on the dataset adoption scale,
-    whose top band is >1M.
+  note: 5,035 downloads in the trailing 30 days summed across the 1 declared artifact(s) (togethercomputer/RedPajama-Data-V2
+    5,035). Bands at level 2 (1K-10K) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/togethercomputer/RedPajama-Data-V2
@@ -48,10 +46,9 @@ capability:
   basis_detail: superseded
   value: null
   confidence: high
-  note: 'Competitive in its own filtered ablation but loses to FineWeb in FineWeb''s 1.82B run; primarily
-    a 2023 base (RedPajama-INCITE), superseded by DCLM/FineWeb. Re-read 2026-08-13: the RedPajama listing
-    still describes V2 as raw unfiltered web text plus quality signals rather than a filtered corpus, and
-    FineWeb still claims the stronger result.'
+  note: Competitive in its own filtered ablation but loses to FineWeb in FineWeb's 1.82B run; primarily
+    a 2023 base (RedPajama-INCITE), superseded by DCLM/FineWeb. V2 ships as raw unfiltered web text plus
+    quality signals rather than as a filtered corpus.
   relative_to: fineweb
   relation: one_below
   last_verified: '2026-08-13'

--- a/sources/scores/redpajama-data.yaml
+++ b/sources/scores/redpajama-data.yaml
@@ -13,9 +13,7 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (Apache-2.0), full source public. Re-read 2026-08-13 - the LICENSE body still
-    carries the same license and the README still builds the whole product from the published repo, with
-    no paid tier, enterprise edition or license key anywhere in it.
+  note: Fully OSI-licensed (Apache-2.0), full source public.
   raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -41,12 +39,12 @@ adoption:
   reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: medium
-  note: 4,977 GitHub stars on togethercomputer/RedPajama-Data, read 2026-08-13 from the repository API.
-    Bands at level 2 (1K-10K stars) on the stars fallback scale in signal_routing.yaml, which caps at 3
-    because a star is not a use. No PyPI package, and the last real commit was December 2024; widely referenced
-    as the RedPajama-v2 quality-signal pipeline. The API response is digested here the way bigcode-dataset
-    and ungoliant already are in this category; a star count drifts, so a later digest mismatch reads as
-    drift rather than as fabrication.
+  note: 4,977 GitHub stars on togethercomputer/RedPajama-Data, from the repository API. Bands at level 2
+    (1K-10K stars) on the stars fallback scale in signal_routing.yaml, which caps at 3 because a star is
+    not a use. No PyPI package, and the last real commit was December 2024; widely referenced as the RedPajama-v2
+    quality-signal pipeline. The API response is digested here the way bigcode-dataset and ungoliant already
+    are in this category; a star count drifts, so a later digest mismatch reads as drift rather than as
+    fabrication.
   last_verified: '2026-08-13'
   sources:
   - url: https://api.github.com/repos/togethercomputer/RedPajama-Data
@@ -60,8 +58,7 @@ capability:
   value: 'Three-stage pipeline: quality classifiers, quality-signal + dedup annotation (perplexity, toxicity,
     importance weights), and exact + fuzzy dedup (bloom/LSH); produced the 30T-token RedPajama-v2.'
   confidence: medium
-  note: Comprehensive quality-signal pipeline; produced a frontier-scale open corpus, but dormant. Re-read
-    2026-08-13 - the README still describes the feature set above.
+  note: Comprehensive quality-signal pipeline; produced a frontier-scale open corpus, but dormant.
   last_verified: '2026-08-13'
   sources:
   - url: https://raw.githubusercontent.com/togethercomputer/RedPajama-Data/main/README.md

--- a/sources/scores/refinedweb.yaml
+++ b/sources/scores/refinedweb.yaml
@@ -12,9 +12,8 @@ openness:
     note:
       value: public_extract
   confidence: high
-  note: 'Permissive ODC-BY 1.0 license, ungated download, with a dataset card (a public extract of the full
-    corpus). Re-read 2026-08-13: odc-by, gated false, and the card still describes the public 600B-token
-    extract.'
+  note: Permissive ODC-BY 1.0 license, ungated download, with a dataset card (a public extract of the full
+    corpus). The public extract is 600B tokens.
   raw: license:ODC-BY-1.0;gated:false;dataset_card:present;note:public_extract
   last_verified: '2026-08-13'
   sources:
@@ -32,9 +31,8 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 93,929 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (tiiuae/falcon-refinedweb 93,929). Bands at level 3 (10K-100K) on the dataset adoption scale, whose
-    top band is >1M.
+  note: 93,929 downloads in the trailing 30 days summed across the 1 declared artifact(s) (tiiuae/falcon-refinedweb
+    93,929). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/tiiuae/falcon-refinedweb
@@ -48,11 +46,8 @@ capability:
   basis_detail: superseded
   value: null
   confidence: high
-  note: 'Filtered web alone beat The Pile and was the best legacy corpus in DCLM''s tests; powered Falcon
-    (2023-24) but is now a component inside newer pipelines rather than a standalone default. Re-read 2026-08-13:
-    the RefinedWeb listing still states that filtered and deduplicated web data alone significantly outperforms
-    state-of-the-art models trained on The Pile, and DCLM-Baseline still reports the stronger result, which
-    is why this sits two bands below it.'
+  note: Filtered web alone beat The Pile and was the best legacy corpus in DCLM's tests; powered Falcon
+    (2023-24) but is now a component inside newer pipelines rather than a standalone default.
   relative_to: dclm-baseline
   relation: two_below
   last_verified: '2026-08-13'

--- a/sources/scores/reka-core.yaml
+++ b/sources/scores/reka-core.yaml
@@ -15,8 +15,6 @@ openness:
       detail: API/on-prem, no weights
   confidence: high
   note: Proprietary multimodal model; API/on-prem/on-device deployment but no downloadable weights.
-    Re-read 2026-08-13 - the launch page still describes API, on-prem and on-device deployment, still
-    names no corpus and still offers no weight download or training code. Nothing moved.
   last_verified: '2026-08-13'
   raw: weights:closed;data:closed(mix of public+licensed proprietary);code:closed;license:Proprietary(API/on-prem,
     no weights)
@@ -33,9 +31,7 @@ adoption:
   confidence: low
   note: Distributed via Reka API + Snowflake Cortex + Oracle Cloud Marketplace; a 2024 frontier-challenger
     now well behind. No disclosed usage; level 2 directional. (Snowflake/Oracle partnerships are not enumerated
-    on the cited launch page itself.) Re-read 2026-08-13 - the page still publishes no usage figure of
-    any kind, so the level stays directional rather than banded on a signal, and the caveat about the
-    Snowflake and Oracle partnerships not appearing on this page still holds.
+    on the cited launch page itself.)
   last_verified: '2026-08-13'
   sources:
   - url: https://reka.ai/news/reka-core-our-frontier-class-multimodal-language-model
@@ -51,9 +47,7 @@ capability:
     Ultra on video (Apr 2024 claims)
   confidence: low
   note: Frontier-class for early 2024 (~GPT-4V tier) but ~2yr stale vs 2026 anchors. Headline claims CONFIRMED
-    present on the primary launch page. Scored 2. Re-read 2026-08-13 - the sentence is still there
-    verbatim, and it is still dated April 2024, which is the whole basis for scoring a
-    once-frontier-class model at 2 against 2026 anchors.
+    present on the primary launch page. Scored 2.
   last_verified: '2026-08-13'
   sources:
   - url: https://reka.ai/news/reka-core-our-frontier-class-multimodal-language-model

--- a/sources/scores/replit-agent-code-execution-api.yaml
+++ b/sources/scores/replit-agent-code-execution-api.yaml
@@ -17,15 +17,14 @@ openness:
     free_text:
     - no self-hostable execution service
   confidence: medium
-  note: 'Closed managed service. The sandbox primitive (omegajail) is open source but it is a third-party
-    dependency, not Replit''s own open core, and the thin client is archived; there is no self-hostable
-    open product, so an open dependency under a closed service is not open_core. Reclassified from open_core
-    (borderline). Re-read 2026-08-13 - github.com/replit/replit-code-exec is still archived and read-only
-    under ISC, and its README still describes the execution service as a Repl the user forks and deploys
-    onto Replit Autoscale Deployments, sandboxed by the third-party omegaup/omegajail project. Nothing
-    Replit publishes is a self-hostable execution service, so source stays closed and the service license
-    stays proprietary. The two replit.com blog URLs cited beside it returned 403 to every fetch attempt
-    and were not re-read.'
+  note: Closed managed service. The sandbox primitive (omegajail) is open source but it is a third-party
+    dependency, not Replit's own open core, and the thin client is archived; there is no self-hostable open
+    product, so an open dependency under a closed service is not open_core. Reclassified from open_core
+    (borderline). github.com/replit/replit-code-exec is archived and read-only under ISC, and its README
+    describes the execution service as a Repl the user forks and deploys onto Replit Autoscale Deployments,
+    sandboxed by the third-party omegaup/omegajail project - nothing Replit publishes is a self-hostable
+    execution service. The two replit.com blog URLs cited beside it answer 403 to every fetch attempt and
+    could not be read.
   raw: license:Proprietary;source:closed;service:proprietary(Replit managed Autoscale Deployments, no self-host);open-part:third-party
     isolation primitive omegajail(github.com/omegaup/omegajail) + an ARCHIVED thin client (replit-code-exec,
     ISC, read-only since 2025-02-11);no self-hostable execution service
@@ -60,15 +59,13 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: medium
-  note: Replit platform serves >50M users (Replit docs/coverage) and runs >1M live projects on Cloud Run
-    (Google Next '26, primary). The code-execution API specifically discloses no standalone usage figures,
-    so adoption is attributed to the Replit Agent/platform surface it powers, not the raw API. Placed
-    at 4 (platform-surface reach); the API alone would be lower. Re-read 2026-08-13 - the Google Next '26
-    post still carries the Replit VP quote about over 1 million live projects hosted on Replit with Cloud
-    Run as the primary target, so the platform-surface attribution holds. Instrument caveat - the record
-    is labeled usage_volume but neither Replit nor the code-execution API exposes a countable artifact a
-    signal model can read, so the band rests on a vendor-quoted figure rather than a recomputable count.
-    replit.com/products/agent returned 403 to every fetch attempt and was not re-read.
+  note: 'Replit platform serves >50M users (Replit docs/coverage) and runs >1M live projects on Cloud Run
+    (Google Next ''26, primary). The code-execution API specifically discloses no standalone usage figures,
+    so adoption is attributed to the Replit Agent/platform surface it powers, not the raw API. Placed at
+    4 (platform-surface reach); the API alone would be lower. Instrument caveat: the record is labeled usage_volume
+    but neither Replit nor the code-execution API exposes a countable artifact a signal model can read,
+    so the band rests on a vendor-quoted figure rather than a recomputable count. replit.com/products/agent
+    answers 403 to every fetch attempt.'
   last_verified: '2026-08-13'
   sources:
   - url: https://cloud.google.com/blog/products/serverless/whats-new-for-cloud-run-at-next26
@@ -88,56 +85,39 @@ capability:
     scale: Replit Autoscale Deployments'
   confidence: medium
   note: 'Fast container-level execution tuned for agent code-eval, but container (not microVM) isolation,
-    narrow language focus, and no persistence put it mid-tier vs microVM-backed peers. Note: the public
-    self-serve client (replit-code-exec) is archived (2025-02-11); the capability now lives inside the
-    Replit Agent surface. Not dated 2026-08-13 - the only source this band cites, the Replit blog post,
-    returned 403 to every fetch attempt, so the ~100ms figure was not re-confirmed. The archived client
-    README was re-read instead and still supports the rest of the band, an ephemeral unprivileged container
-    sandboxed by omegajail, stateless, Python-focused, running on Replit Autoscale Deployments.
-    STILL NOT DATED on 2026-08-14 after a substitute hunt, and the reason is now specific rather than
-    general. Three of the value''s four elements re-derive from two independent fetchable channels -
-    the archived README and the package''s own PyPI metadata both describe an ephemeral unprivileged
-    container using omegajail, stateless, Python, on Replit Deployments. The ~100ms cold start is the
-    one element that does not: replit.com and blog.replit.com answer 403 to every request under every
-    header set tried, and the Wayback availability API reports no capture of the post at all
-    ("archived_snapshots": {}), so there is no surviving copy of the document that carries the figure.
-    Worth noting for whoever rules on it that the band does not rest on that number - 100ms is a point
-    in the product''s favour, and the 3 is placed on container-rather-than-microVM isolation, narrow
-    language focus and no persistence, all three of which re-derive.
-    RESOLVED AND DATED 2026-08-14 by dropping the unsourceable figure rather than by finding a source
-    for it. The ~100ms cold start and the "prior stateful-Repl experiment discontinued" parenthetical
-    both came only from the dead blog post, and the value string no longer asserts either. What remains
-    is what two independent fetchable channels state today - the archived README and the package''s own
-    PyPI metadata, re-fetched this morning byte-identical to their recorded digests, both describing
-    execution inside an ephemeral unprivileged container created on the fly on Replit Deployments with
-    omegaup/omegajail as the code sandbox, a stateless API optimized for AI agents, Python, with the
-    container image swappable via evalctl. Every clause of the value now re-derives from a live source,
-    so the axis is dated. The score is unchanged at 3 and rests on the same three re-derivable grounds
-    it always did, container-rather-than-microVM isolation, narrow language focus and no persistence.
-    Losing the 100ms claim removes a point in the product''s favour, so if anything it argues against
-    raising the band, never for it. The blog source is kept below, undated and marked dead, so a later
-    reader can see what was lost rather than rediscovering the 403.'
+    narrow language focus and no persistence put it mid-tier against microVM-backed peers. The public self-serve
+    client (replit-code-exec) is archived and read-only, and the capability now lives inside the Replit
+    Agent surface. Every clause of the value re-derives from two independent live channels - the archived
+    README and the package''s own PyPI metadata - both describing execution inside an ephemeral unprivileged
+    container created on the fly on Replit Deployments with omegaup/omegajail as the code sandbox, a stateless
+    API optimized for AI agents, Python, with the container image swappable via `evalctl`. The ~100ms cold
+    start and the "prior stateful-Repl experiment discontinued" parenthetical were dropped rather than sourced:
+    both came only from the Replit blog post, which answers 403 to every request under every header set
+    tried and has no Wayback capture at all, so no surviving copy of the document carries the figure. Losing
+    the 100ms claim removes a point in the product''s favour, so if anything it argues against raising the
+    band, never for it. The blog source is kept below, undated and marked dead, so a later reader can see
+    what was lost rather than rediscovering the 403. The 3 rests on the same three grounds it always did
+    - container-rather-than-microVM isolation, narrow language focus and no persistence - all of which re-derive.'
   last_verified: '2026-08-14'
   sources:
   - url: https://replit.com/blog/ai-agents-code-execution
-    shows: DEAD SOURCE, retained as a record. Formerly the sole basis for the ~100ms start figure and
-      the discontinued-stateful-Repl note, neither of which the value asserts any more. HTTP 403 to
-      every attempt on 2026-08-13 and 2026-08-14 under every header set tried, and the Wayback
-      availability API reports no capture of the post at all.
+    shows: DEAD SOURCE, retained as a record. Formerly the sole basis for the ~100ms start figure and the
+      discontinued-stateful-Repl note, neither of which the value asserts any more. It answers HTTP 403
+      to every fetch attempt under every header set tried, and the Wayback availability API reports no capture
+      of the post at all.
     accessed: '2026-06-04'
   - url: https://pypi.org/pypi/replit-code-exec/json
-    shows: 'the package''s own metadata, an independent channel for the same description - execution
-      "inside an ephemeral unprivileged container created on the fly running in Replit Deployments
-      using omegajail as code sandbox"; summary "A library for interacting with Replit''s code-exec
-      API"; carries no latency figure. Re-fetched 2026-08-14, byte-identical, same digest.'
+    shows: the package's own metadata, an independent channel for the same description - execution "inside
+      an ephemeral unprivileged container created on the fly running in Replit Deployments using omegajail
+      as code sandbox"; summary "A library for interacting with Replit's code-exec API"; carries no latency
+      figure.
     accessed: '2026-08-14'
     http_status: 200
     content_sha256: 271ca1e7ce0ef7396f312a387165972623accc5e1d91f3fde8b55eb834e1c7b9
   - url: https://raw.githubusercontent.com/replit/replit-code-exec/main/README.md
     shows: stateless API optimized for AI agents, executing untrusted Python inside an ephemeral unprivileged
-      container created on the fly on Replit Deployments using omegaup/omegajail as the code sandbox;
-      the container image is swappable via `evalctl image`; Autoscale Deployments only; no latency
-      figure stated. Re-fetched 2026-08-14, byte-identical, same digest.
+      container created on the fly on Replit Deployments using omegaup/omegajail as the code sandbox; the
+      container image is swappable via `evalctl image`; Autoscale Deployments only; no latency figure stated.
     accessed: '2026-08-14'
     http_status: 200
     content_sha256: 6a18761274efe9b9002120f29b64bea36c34476550c08be8a930c56be3b3b0a9

--- a/sources/scores/replit-agent.yaml
+++ b/sources/scores/replit-agent.yaml
@@ -11,11 +11,11 @@ openness:
     self-host:
       value: 'no'
   confidence: high
-  note: 'Proprietary cloud agent embedded in Replit''s hosted IDE; no source or self-hosting. Re-read 2026-08-13
-    - replit.com now answers 403 to a non-browser fetch, so the claim was re-derived from Replit''s own
-    documentation instead. The Replit Agent docs describe the agent entirely inside the hosted platform
-    - deployments, machines, hosted database, Replit Auth and SSO, workspace security, monetization -
-    with no source distribution and no self-host path anywhere in the tree. Nothing moved.'
+  note: Proprietary cloud agent embedded in Replit's hosted IDE; no source or self-hosting. The product
+    page is no longer fetchable - replit.com answers 403 to a non-browser request - so the claim rests on
+    Replit's own documentation, which describes the agent entirely inside the hosted platform (deployments,
+    machines, hosted database, Replit Auth and SSO, workspace security, monetization) with no source distribution
+    and no self-host path.
   raw: source:closed;license:proprietary(Replit cloud SaaS);self-host:no
   last_verified: '2026-08-13'
   sources:
@@ -39,13 +39,10 @@ adoption:
   signal_type: reported_traction
   confidence: medium
   banded_quantity: Replit platform registered users (50M+, March 2026), not an agent active count
-  note: 'Replit reported 50M+ platform users with agent-driven consumption as primary growth driver. User
+  note: Replit reported 50M+ platform users with agent-driven consumption as primary growth driver. User
     count is platform-wide, not agent-specific, so placed conservatively at 4 on reported traction rather
-    than treating the 50M as an agent active-user figure. Re-read 2026-08-13 - the Sacra profile still
-    records the same progression, 22.5M users in April 2023 to 40M+ by September 2025 and 50M+ by March
-    2026, with users from 85% of the Fortune 500, and still attributes the growth to usage-based agent
-    pricing. WHAT WAS BANDED - a platform-wide registered-user total, not an agent active count, which
-    is why the level sits below where 50M would otherwise land. Unchanged.'
+    than treating the 50M as an agent active-user figure. WHAT WAS BANDED - a platform-wide registered-user
+    total, not an agent active count, which is why the level sits below where 50M would otherwise land.
   last_verified: '2026-08-13'
   sources:
   - url: https://sacra.com/c/replit/
@@ -60,12 +57,8 @@ capability:
   value: Autonomous parallel multi-task app building, design+build concurrency, task-based team workflows,
     end-to-end deploy on Replit infra; no published SWE-bench/GAIA number
   confidence: low
-  note: 'Capable autonomous app-builder but oriented to full-app generation/deploy rather than benchmark-graded
-    SWE tasks; no first-party benchmark, scored 3 on feature matrix. Re-read 2026-08-13 from Replit''s
-    documentation, replit.com itself no longer being fetchable. The docs cover plan mode, agent modes,
-    a model selector, app testing, publishing and deployment, agent skills, automations, web search, a
-    task board with follow-up tasks, and artifact types from web apps to native mobile - a broad app-building
-    surface with no benchmark placement of any kind. Two below the openhands anchor, unchanged.'
+  note: Capable autonomous app-builder but oriented to full-app generation/deploy rather than benchmark-graded
+    SWE tasks; no first-party benchmark, scored 3 on feature matrix.
   relative_to: openhands
   relation: two_below
   last_verified: '2026-08-13'

--- a/sources/scores/rockchip-rk3588.yaml
+++ b/sources/scores/rockchip-rk3588.yaml
@@ -17,12 +17,11 @@ openness:
       detail: proprietary GPU/NPU firmware
       raw: required (proprietary GPU/NPU firmware)
   confidence: high
-  note: Documentation is unusually open (full TRM and datasheet public) and the RKNN toolkit is openly
-    distributed, but the SDK ships as prebuilt binaries under a proprietary license with closed firmware.
-    Re-read 2026-08-13 - the RK3588 brief datasheet is still downloadable straight from rock-chips.com
-    with no registration or NDA, the RKNN SDK licence in airockchip/rknn-toolkit2 is still the proprietary
-    "RKNN SDK License" (no reverse engineering, use restricted to Rockchip products), and rkbin still
-    distributes the DDR/BL31/OPTEE firmware as prebuilt binaries. No dimension moved.
+  note: Documentation is unusually open (full TRM and datasheet public) and the RKNN toolkit is openly distributed,
+    but the SDK ships as prebuilt binaries under a proprietary license with closed firmware. The brief datasheet
+    downloads straight from rock-chips.com with no registration or NDA, the RKNN SDK licence in airockchip/rknn-toolkit2
+    is the proprietary "RKNN SDK License" (no reverse engineering, use restricted to Rockchip products),
+    and rkbin distributes the DDR/BL31/OPTEE firmware as prebuilt binaries.
   raw: toolchain:partial (NPU SDK on GitHub but proprietary RKNN license + prebuilt blobs, rknpu kernel
     driver open);datasheets:public (full TRM + datasheet public, no NDA);blobs:required (proprietary GPU/NPU
     firmware)
@@ -66,10 +65,9 @@ adoption:
   confidence: high
   banded_quantity: the multi-vendor SBC set the SoC powers, not units shipped of the chip
   note: Powers a very large multi-vendor set of SBCs and modules (Orange Pi, Radxa, Khadas, FriendlyELEC,
-    Firefly), widely available at retail and broadly supported in community Linux. Re-read 2026-08-13 -
-    the Armbian community comparison still tabulates five RK3588/RK3588S boards from five different
-    vendors, and three of them (orange-pi-5, radxa-rock-5b, khadas-edge2) are separately on this map and
-    were separately confirmed on sale today. Level and reach unchanged.
+    Firefly), widely available at retail and broadly supported in community Linux. The Armbian community
+    comparison tabulates five RK3588/RK3588S boards from five different vendors, three of which (orange-pi-5,
+    radxa-rock-5b, khadas-edge2) are separately on this map and separately confirmed on sale.
   last_verified: '2026-08-13'
   sources:
   - url: https://forum.armbian.com/topic/26398-video-comparing-rk3588-sbcs-nanopi-r6s-khadas-edge2-radxa-rock5b-mekotronics-r58-mini-r58x-4g-orange-pi-5/
@@ -85,10 +83,10 @@ capability:
     on-device LLMs via RKNN-LLM
   confidence: high
   note: The 6 TOPS NPU is genuine edge-AI capability and the RKLLM SDK runs quantized LLMs on-chip, but
-    modest versus dedicated accelerators. Re-derived 2026-08-13 - the RKLLM repository still ships an
-    RK3588-series runtime and toolkit with working w8a8 demos for Qwen2.5-VL-3B, Qwen3-VL-2B, InternVL3-1B
-    and DeepSeek-OCR, and Rockchip's own product page still reads 6 TOPS triple-core NPU. Generative
-    workloads actually running on-chip is what keeps this a step above the 6 TOPS boards built on it.
+    modest versus dedicated accelerators. The RKLLM repository ships an RK3588-series runtime and toolkit
+    with working w8a8 demos for Qwen2.5-VL-3B, Qwen3-VL-2B, InternVL3-1B and DeepSeek-OCR, and Rockchip's
+    own product page reads 6 TOPS triple-core NPU. Generative workloads actually running on-chip is what
+    keeps this a step above the 6 TOPS boards built on it.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/airockchip/rknn-llm

--- a/sources/scores/rwkv.yaml
+++ b/sources/scores/rwkv.yaml
@@ -18,29 +18,26 @@ openness:
       detail: OSI
   confidence: high
   last_verified: '2026-08-13'
-  note: 'Corrected from 5/open_source on 2026-07-28, then re-examined the same day after challenge.
-    The correction stands but it is a close call, and RWKV published more than a first look suggests.
-    What IS released: an itemized, machine-readable index (index/train.jsonl, train.csv) naming every
-    component dataset with a resolvable URL, category and citation, essentially all of them public, plus
-    100k and 1M preview subsamples. That is real openness work and well beyond a prose description.
-    What is NOT released, and why this is not data:open: no corpus and no reconstruction scripts. The
-    exact subsampling amounts are referenced as "supplementary material (see wiki.txt, oscar.txt)" which
-    is not published in the dataset repo, not an arXiv ancillary file, and not in RWKV-LM, which carries
-    model and training code but no data-prep directory. No mixing proportions or per-component token
-    counts are given, one component (OSCAR23.01) is itself gated, and the maintainers'' own notes record
-    "peS2o - Which version out of the 3?", so the mixture is not reproducible in detail even in
-    principle. The rubric defines data:open as a released dataset OR scripts that reconstruct the corpus
-    end to end; neither holds. Weights, training code and license are unaffected and remain fully open
-    under Apache-2.0, so this narrows one claim rather than downgrading the project. NOTE: this lands in
-    a genuine rubric gap. "Every component named and publicly resolvable, but the mixture not
-    reproducible" is meaningfully more open than prose documentation and less than a released corpus,
-    and the data enum has no value for it. Nemotron 3''s partial release hits the same gap, so two of
-    the nine products checked fall between the available values. Re-read 2026-08-13. The component
-    index digests identically to the 2026-07-30 read, so the listing has not changed at all; the
-    Goose-World repo still holds only the index, the two preview subsamples, two READMEs and a figure,
-    with no corpus shards; RWKV-LM is still public Apache-2.0 at 14,661 stars with no data-prep
-    directory; and rwkv-7-world is still ungated apache-2.0. Nothing moved, and the rubric gap the
-    note describes is still open.'
+  note: 'Corrected from 5/open_source on 2026-07-28, then re-examined the same day after challenge. The
+    correction stands but it is a close call, and RWKV published more than a first look suggests. What IS
+    released: an itemized, machine-readable index (index/train.jsonl, train.csv) naming every component
+    dataset with a resolvable URL, category and citation, essentially all of them public, plus 100k and
+    1M preview subsamples. That is real openness work and well beyond a prose description. What is NOT released,
+    and why this is not data:open: no corpus and no reconstruction scripts. The exact subsampling amounts
+    are referenced as "supplementary material (see wiki.txt, oscar.txt)" which is not published in the dataset
+    repo, not an arXiv ancillary file, and not in RWKV-LM, which carries model and training code but no
+    data-prep directory. No mixing proportions or per-component token counts are given, one component (OSCAR23.01)
+    is itself gated, and the maintainers'' own notes record "peS2o - Which version out of the 3?", so the
+    mixture is not reproducible in detail even in principle. The rubric defines data:open as a released
+    dataset OR scripts that reconstruct the corpus end to end; neither holds. Weights, training code and
+    license are unaffected and remain fully open under Apache-2.0, so this narrows one claim rather than
+    downgrading the project. NOTE: this lands in a genuine rubric gap. "Every component named and publicly
+    resolvable, but the mixture not reproducible" is meaningfully more open than prose documentation and
+    less than a released corpus, and the data enum has no value for it. Nemotron 3''s partial release hits
+    the same gap, so two of the nine products checked fall between the available values. The Goose-World
+    repo holds only the component index, the two preview subsamples, two READMEs and a figure, with no corpus
+    shards; RWKV-LM is public Apache-2.0 at 14,661 stars with no data-prep directory; and rwkv-7-world is
+    ungated apache-2.0.'
   raw: weights:open(Apache-2.0);data:documented-not-released(itemized machine-readable component index with
     resolvable links to public datasets, but no released corpus and no reconstruction pipeline);code:open(github.com/BlinkDL/RWKV-LM);license:Apache-2.0(OSI)
   sources:
@@ -69,14 +66,15 @@ openness:
     content_sha256: cd92f52601e7771174a5709bbd8767b6de507813ce89fde15a62f66016d7f9f1
     establishes: [code]
   - url: https://huggingface.co/api/models/BlinkDL/rwkv-7-world
-    shows: '`gated: false`, `private: false`, card license `apache-2.0`, 4,537 downloads. Weight files
-      downloadable as `RWKV-x070-World-{0.1B,0.4B,1.5B}-*.pth`. Added on the 2026-07-30 re-read: the
-      axis recorded `weights:open(Apache-2.0)` while citing only the code repo and the dataset, so
-      nothing on file actually established the weights.'
+    shows: '`gated: false`, `private: false`, card license `apache-2.0`, 4,537 downloads. Weight files downloadable
+      as `RWKV-x070-World-{0.1B,0.4B,1.5B}-*.pth` - the only source on file that establishes the open weights
+      this axis records.'
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 3bcb5837ccdeac036c4d7ba6df9f10c98462c0d01eda7321c3005492ef352da5
-    establishes: [weights, license]
+    establishes:
+    - weights
+    - license
   - url: https://arxiv.org/abs/2503.14456
     shows: 'RWKV-7 Goose paper abstract: "we also present an extended open source 3.1 trillion token
       multilingual corpus". No arXiv ancillary files are attached, so the supplementary material the
@@ -89,9 +87,9 @@ adoption:
   signal_type: usage_volume
   confidence: medium
   note: '4,652 downloads in the trailing 30 days (BlinkDL/rwkv-7-world 4,395; RWKV/RWKV7-Goose-World3-1.5B-HF
-    257), read 2026-08-12. Bands at level 1 (<10K) on the software and model adoption scale. Moved off the
-    stars fallback: a real download signal exists, and docs/reference/adoption.md says to re-band when one
-    does. The package is summed across the two repos the product DECLARES, per the tier rule in docs/reference/identity.md.
+    257). Bands at level 1 (<10K) on the software and model adoption scale. Moved off the stars fallback:
+    a real download signal exists, and docs/reference/adoption.md says to re-band when one does. The package
+    is summed across the two repos the product DECLARES, per the tier rule in docs/reference/identity.md.
     Widening to every repo under the BlinkDL and RWKV orgs would give about 71k and level 2; the declared
     reading is the one the map''s own identity rule supports. This LOWERS the recorded level from 3 - the
     star count had been flattering it.'
@@ -116,9 +114,8 @@ capability:
     tokens; MMLU rose to ~43% across generations'
   confidence: medium
   note: Strong intelligence-per-token for its size via a linear-time RNN architecture; not at frontier absolute
-    capability. Re-read 2026-08-13 - the paper still makes the 3B-scale multilingual claim and the
-    efficiency argument, and still makes no frontier-scale claim, which is exactly the shape of a 4
-    rather than a 5 here.
+    capability. The paper makes a 3B-scale multilingual claim and an efficiency argument and makes no frontier-scale
+    claim at all, which is the shape of a 4 rather than a 5 here.
   last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2503.14456

--- a/sources/scores/safetensors.yaml
+++ b/sources/scores/safetensors.yaml
@@ -13,10 +13,9 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: 'LICENSE body is verbatim Apache License 2.0; full Rust/Python source public. Re-read 2026-08-13:
-    the cited LICENSE body still carries the Apache-2.0 terms, the GitHub API reports the repository public,
-    unarchived and licensed Apache-2.0, and the README describes the whole library with no paid, enterprise
-    or hosted tier beside it, so source stays public and core-gated stays ungated.'
+  note: LICENSE body is verbatim Apache License 2.0; full Rust/Python source public. The repository is public
+    and unarchived, and the README describes the whole library with no paid, enterprise or hosted tier beside
+    it, so source is public and the core ungated.
   raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -50,13 +49,9 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: 'PyPI last-month downloads of 78,250,137 exceed the 50M+ threshold. Read live 2026-08-13: 111,835,984
-    PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at >10M, level 5.
-    The previous reach ''78M+/month'' was free text carrying a figure rather than a band the scale declares,
-    so nothing could check it against the level beside it. No last_verified claimed: only the figure was
-    re-read, not the whole axis. Re-read 2026-08-13 from the cited pypistats reading of the declared PyPI
-    artifact `safetensors`: 111,835,984 downloads in the trailing 30 days, which bands at >10M, level 5
-    on the software scale. Unchanged.'
+  note: 111,835,984 PyPI downloads in the trailing 30 days for the declared artifact `safetensors`, which
+    bands at >10M, level 5 on the software scale. The previous reach '78M+/month' was free text carrying
+    a figure rather than a band the scale declares, so nothing could check it against the level beside it.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/safetensors/recent
@@ -69,8 +64,7 @@ capability:
   basis: feature_matrix
   value: Secure, zero-copy tensor serialization format and library used cross-framework.
   confidence: high
-  note: 'Narrow scope (storage format) but central as the default Hub weight format. Re-read 2026-08-13:
-    the cited repository page still describes the product as recorded, so the band is unchanged.'
+  note: Narrow scope (storage format) but central as the default Hub weight format.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/huggingface/safetensors

--- a/sources/scores/sandbox-runtime.yaml
+++ b/sources/scores/sandbox-runtime.yaml
@@ -17,11 +17,9 @@ openness:
     - no managed/proprietary tier(it is a local library, not a service)
   confidence: high
   note: Apache-2.0 OS-level sandboxing library, fully open and self-contained; no feature-gated core or
-    paid tier. Re-read 2026-08-13 - the GitHub API reports the repository public, unarchived and
-    licensed Apache-2.0, the LICENSE body is the verbatim Apache License 2.0, and the README installs
-    the whole tool with a single ``npm install -g @anthropic-ai/sandbox-runtime`` and documents no
-    hosted plan, license key or withheld capability. It is labeled a beta research preview, which is a
-    maturity statement rather than a gate.
+    paid tier. The README installs the whole tool with a single `npm install -g @anthropic-ai/sandbox-runtime`
+    and documents no hosted plan, license key or withheld capability. It is labeled a beta research preview,
+    which is a maturity statement rather than a gate.
   raw: license:Apache-2.0(OSI);source:public(GitHub);distribution:npm package;no managed/proprietary tier(it
     is a local library, not a service);core-gated:ungated
   last_verified: '2026-08-13'
@@ -105,12 +103,9 @@ capability:
     fs, deny/allow rules); scale:per-host, no managed fleet
   confidence: medium
   note: Best-in-class for low-overhead, no-container process isolation with fine-grained fs+network allow/deny
-    and pre-built seccomp filters; but a process-level sandbox is a weaker security boundary than the
-    microVM/gVisor frontier and offers no managed scale, so 3. Re-read 2026-08-13 - the README still
-    describes bubblewrap on Linux and sandbox-exec on macOS with proxy-based network filtering, still
-    documents seccomp filters as x64/arm64 only and warns that unix sockets go unrestricted where
-    seccomp is unavailable, and still ships no managed or multi-host mode. The feature matrix reads as
-    recorded and the band holds at 3.
+    and pre-built seccomp filters; but a process-level sandbox is a weaker security boundary than the microVM/gVisor
+    frontier and offers no managed scale, so 3. Seccomp filters are x64/arm64 only, with unix sockets going
+    unrestricted where seccomp is unavailable, and the tool ships no managed or multi-host mode.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/anthropic-experimental/sandbox-runtime

--- a/sources/scores/scale-evaluation.yaml
+++ b/sources/scores/scale-evaluation.yaml
@@ -21,11 +21,9 @@ openness:
   confidence: high
   last_verified: '2026-08-13'
   note: Proprietary by design; the deliberately-private benchmark datasets and hosted expert-eval workforce
-    are the moat; no open source eval code. Closed. Re-read 2026-08-13 and unchanged. The platform page
-    still offers only VPC deployment of the proprietary product, with no repository and no license to
-    the evaluation code, and the SEAL post still says the datasets 'will remain private and unpublished'.
-    The page now describes a 'largely open-source technology toolkit' in passing but names no repository
-    and offers nothing downloadable, so it does not move `source` off closed.
+    are the moat; no open source eval code. Closed. The platform page describes a 'largely open-source technology
+    toolkit' in passing but names no repository and offers nothing downloadable, so it does not move `source`
+    off closed.
   raw: platform:closed(proprietary hosted SaaS); datasets:closed(private, unpublished SEAL benchmarks kept
     private to prevent gaming/training contamination); methodology:partially-disclosed(leaderboard transparency)
     but no open eval code or self-hostable engine; human-eval workforce is a proprietary service;source:closed(proprietary
@@ -41,27 +39,27 @@ openness:
     shows: SEAL Leaderboards use curated PRIVATE/unpublished datasets that 'cannot be gamed'
     accessed: '2026-06-04'
   - url: https://scale.com/genai-platform
-    shows: 'Re-read: the platform page offers ''Deploy securely within your own VPC. Full support for AWS,
-      Azure, and GCP'' - a customer-cloud deployment of the proprietary product, not published source. No
-      repository, no self-hostable open implementation, and no license to the evaluation code is offered
-      anywhere on the page.'
+    shows: The platform page offers 'Deploy securely within your own VPC. Full support for AWS, Azure, and
+      GCP' - a customer-cloud deployment of the proprietary product, not published source. No repository,
+      no self-hostable open implementation, and no license to the evaluation code is offered anywhere on
+      the page.
     accessed: '2026-08-11'
     establishes:
     - source
   - url: https://scale.com/genai-platform
-    shows: 'Re-read 2026-08-13: the platform page still offers ''Deploy securely within your own VPC.
-      Full support for AWS, Azure, and GCP'' and still names SEAL as an in-house frontier benchmarking
-      lab. It refers to a ''largely open-source technology toolkit'' but identifies no repository and
-      offers no downloadable source or license to the evaluation engine.'
+    shows: The platform page offers 'Deploy securely within your own VPC. Full support for AWS, Azure, and
+      GCP' and names SEAL as an in-house frontier benchmarking lab. It refers to a 'largely open-source
+      technology toolkit' but identifies no repository and offers no downloadable source or license to the
+      evaluation engine.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: e8cc5a29bc75e06fbddb1457767e22782cd17820b8254a3b58620d076b1cabad
     establishes:
     - source
   - url: https://scale.com/blog/leaderboard
-    shows: 'Re-read 2026-08-13: ''Scale''s proprietary datasets will remain private and unpublished, ensuring
-      they cannot be exploited'', and the leaderboards use ''curated private datasets that can''t be gamed''.
-      No eval code is published alongside them.'
+    shows: '''Scale''s proprietary datasets will remain private and unpublished, ensuring they cannot be
+      exploited'', and the leaderboards use ''curated private datasets that can''t be gamed''. No eval code
+      is published alongside them.'
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 9ee56219a844162417efca29d4caaf8082562185d97f7cd31a8210e25307e038
@@ -73,11 +71,9 @@ adoption:
   confidence: low
   last_verified: '2026-08-13'
   note: SEAL Leaderboards are widely cited and 'trusted by leading AI labs' as a third-party evaluator;
-    SEAL Showdown reports 'millions of real-world conversations' across 100+ countries / 70 languages
-    / 200 professional domains. No disclosed paying-customer count for the Scale Evaluation platform specifically.
-    Level 3 reflects reported traction of the eval surface, not a verified user count; directional. Re-read
-    2026-08-13 - both cited figures are still on their pages verbatim, and no paying-customer count has
-    appeared.
+    SEAL Showdown reports 'millions of real-world conversations' across 100+ countries / 70 languages /
+    200 professional domains. No disclosed paying-customer count for the Scale Evaluation platform specifically.
+    Level 3 reflects reported traction of the eval surface, not a verified user count; directional.
   sources:
   - url: https://scale.com/blog/showdown
     shows: SEAL Showdown built on millions of real-world conversations, 100+ countries, 70 languages,
@@ -87,15 +83,14 @@ adoption:
     shows: third-party evaluator trusted by leading AI labs
     accessed: '2026-06-04'
   - url: https://scale.com/blog/showdown
-    shows: 'Re-read 2026-08-13: ''SEAL Showdown is based on millions of real-world conversations from
-      Scale''s diverse global contributor network'' spanning ''over 100 countries, 70 languages, and 200
-      professional domains'' - the same figures as recorded.'
+    shows: '''SEAL Showdown is based on millions of real-world conversations from Scale''s diverse global
+      contributor network'' spanning ''over 100 countries, 70 languages, and 200 professional domains''.'
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: bea77274d044a922262f1a4a747a1b1ba8e2650f2926a69e553833100c837554
   - url: https://scale.com/blog/leaderboard
-    shows: 'Re-read 2026-08-13: Scale is still described as ''a third-party model evaluator trusted by
-      leading AI labs''. No user, customer or run count is published.'
+    shows: Scale is described as 'a third-party model evaluator trusted by leading AI labs'. No user, customer
+      or run count is published.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 9ee56219a844162417efca29d4caaf8082562185d97f7cd31a8210e25307e038
@@ -109,14 +104,12 @@ capability:
   confidence: medium
   last_verified: '2026-08-13'
   note: 'Very broad professional eval coverage (multi-domain private benchmarks + expert workforce + adversarial
-    red-teaming + real-preference), strong commercial capability. Not a 5: closed/non-reproducible and
-    not a community-standard harness in the open-eval-code sense. Re-read 2026-08-13, with one correction
-    to the evidence rather than the band. The SEAL leaderboard post cited here announces four domains
-    - coding, instruction following, math (GSM1k) and multilinguality - and says more will follow; it
-    does not itself establish the reasoning, agentic, multimodal and safety coverage this value lists.
-    The breadth claim now rests on the platform page (auto-generated eval datasets, adversarial vulnerability
-    scans, expert human eval) plus SEAL Showdown''s real-preference stream, which is enough for a 4 and
-    is stated here rather than left implied.'
+    red-teaming + real-preference), strong commercial capability. Not a 5: closed/non-reproducible and not
+    a community-standard harness in the open-eval-code sense. One caveat on the evidence: the SEAL leaderboard
+    post cited here announces four domains - coding, instruction following, math (GSM1k) and multilinguality
+    - and does not itself establish the reasoning, agentic, multimodal and safety coverage this value lists.
+    That breadth rests instead on the platform page (auto-generated eval datasets, adversarial vulnerability
+    scans, expert human eval) plus SEAL Showdown''s real-preference stream, which is enough for a 4.'
   sources:
   - url: https://scale.com/blog/leaderboard
     shows: SEAL multi-domain expert-driven leaderboards (coding/IF/math/multilingual/reasoning/agentic/safety)
@@ -126,16 +119,16 @@ capability:
       human eval
     accessed: '2026-06-04'
   - url: https://scale.com/blog/leaderboard
-    shows: 'Re-read 2026-08-13: the post names four launch domains - coding, instruction following, math
-      (GSM1k) and multilinguality - with a stated intention to add more. It does NOT list reasoning, agentic
-      or safety leaderboards, which this axis previously recorded it as showing.'
+    shows: The post names four launch domains - coding, instruction following, math (GSM1k) and multilinguality
+      - with a stated intention to add more. It does NOT list reasoning, agentic or safety leaderboards,
+      which this axis previously recorded it as showing.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 9ee56219a844162417efca29d4caaf8082562185d97f7cd31a8210e25307e038
   - url: https://scale.com/genai-platform
-    shows: 'Re-read 2026-08-13: automated and human feedback in the evaluation loop, SEAL as the in-house
-      frontier benchmarking lab, and a continuous-learning flywheel over customer usage. Nothing externally
-      reproducible, the benchmarks being private by design.'
+    shows: Automated and human feedback in the evaluation loop, SEAL as the in-house frontier benchmarking
+      lab, and a continuous-learning flywheel over customer usage. Nothing externally reproducible, the
+      benchmarks being private by design.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: e8cc5a29bc75e06fbddb1457767e22782cd17820b8254a3b58620d076b1cabad

--- a/sources/scores/scale-seal-leaderboard.yaml
+++ b/sources/scores/scale-seal-leaderboard.yaml
@@ -18,12 +18,10 @@ openness:
       detail: results visible on leaderboard, dataset not downloadable
   confidence: high
   note: Intentionally private/held-out eval sets per the data-openness rubric (closed = proprietary held-out
-    test suite); only the leaderboard results are public, the data itself is not. Re-read 2026-08-13 -
-    the post still states under Leaderboard Integrity that "Scale's proprietary datasets will remain
-    private and unpublished, ensuring they cannot be exploited or incorporated into model training data",
-    which is the whole of the recorded reading. Two details the old shows carried are NOT on the page -
-    the "~1,000 examples" per domain and the mixing in of "some open source sets" - so the components
-    detail carrying the 1,000 figure is now unsourced and is flagged rather than silently kept or dropped.
+    test suite); only the leaderboard results are public, the data itself is not. Two details the components
+    carry are not on the page - the "~1,000 examples" per domain and the mixing in of "some open source
+    sets" - so the components detail carrying the 1,000 figure is unsourced, and is flagged rather than
+    silently kept or dropped.
   raw: data:closed(proprietary held-out prompt sets, ~1,000 examples/domain, deliberately unpublished to
     prevent contamination/training-set leakage);datasheet:no(methodology described but examples not redistributable);license:none(not
     distributed);access:held-out(results visible on leaderboard, dataset not downloadable)
@@ -41,13 +39,10 @@ adoption:
   level: 3
   signal_type: reported_traction
   confidence: medium
-  note: SEAL is a widely-referenced expert-driven private leaderboard cited across the LLM evaluation
-    community as a contamination-resistant ranking; broad press and industry attention but no published
-    download/usage count (the data is held-out by design). Reported-traction tier as an industry-standard
-    reference rather than a measured usage_volume figure. Re-read 2026-08-13 - the launch post still
-    positions SEAL as the answer to contamination and inconsistent reporting in frontier-model comparison,
-    and still publishes no usage figure of any kind, so both the reported_traction instrument and the
-    level-3 band stand unchanged.
+  note: SEAL is a widely-referenced expert-driven private leaderboard cited across the LLM evaluation community
+    as a contamination-resistant ranking; broad press and industry attention but no published download/usage
+    count (the data is held-out by design). Reported-traction tier as an industry-standard reference rather
+    than a measured usage_volume figure.
   last_verified: '2026-08-13'
   sources:
   - url: https://scale.com/blog/leaderboard
@@ -63,9 +58,7 @@ capability:
   value: null
   confidence: high
   note: Capability is not a meaningful axis for an eval dataset; openness + adoption carry this category
-    per the recipe. Re-read 2026-08-13 and the abstention stands - the scored artifact is a private
-    prompt set, and the page publishes no performance or feature claim about it the capability axis
-    could band.
+    per the recipe.
   last_verified: '2026-08-13'
   sources:
   - url: https://scale.com/blog/leaderboard

--- a/sources/scores/searxng.yaml
+++ b/sources/scores/searxng.yaml
@@ -18,13 +18,9 @@ openness:
     - reproducible-Docker-build
     - no-proprietary-backend
   confidence: high
-  note: 'Fully open source under copyleft AGPL-3.0, complete source public, reproducible official Docker
+  note: Fully open source under copyleft AGPL-3.0, complete source public, reproducible official Docker
     image, no proprietary backend or gated hosted tier - self-hosting (or community public instances) is
-    the only distribution. Re-read 2026-08-13: the repo page states "This project is licensed under the GNU
-    Affero General Public License (AGPL-3.0)" and GitHub''s own metadata reports spdxId AGPL-3.0. The whole
-    engine is in the tree - searx/, searxng_extra/, client/simple, container/, utils/ - with a container
-    build beside it and no ee/, enterprise/ or second-licensed path. There is nothing to gate with, because
-    the project sells nothing at all.'
+    the only distribution.
   raw: license:AGPL-3.0(OSI);source:public(github.com/searxng/searxng);self-host:only(no official SaaS);reproducible-Docker-build;no-proprietary-backend;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -75,16 +71,9 @@ capability:
     simple HTTP call, though many public instances disable the non-HTML formats; consumed as a web-search/RAG
     backend by Open WebUI, Perplexica, Morphic, LibreChat; self-hostable official Docker image'
   confidence: medium
-  note: 'The reference open implementation of the search-backend slot - broad source aggregation, clean structured
+  note: The reference open implementation of the search-backend slot - broad source aggregation, clean structured
     JSON, fully self-hosted. Below top among AI search APIs because it is raw metasearch without the AI-native
-    extraction/reranking that proprietary peers (Tavily/Exa) layer on. Re-read 2026-08-13, and one recorded
-    figure did not survive: the value claimed "up to 269 search services" on the strength of the search-API
-    page, and no number appears on that page at all - the engine roster lives in a separate Configured Engines
-    document and is a long unnumbered list. The count has been replaced by a description of what the list
-    covers rather than carried on an unsupported figure. What the page does establish is confirmed: GET and
-    POST /search, `?format=json` with CSV and RSS alternatives, and a caveat this record did not carry -
-    "many public instances have these formats disabled", which matters for anyone treating a public instance
-    as an API. Band unchanged at 4.'
+    extraction/reranking that proprietary peers (Tavily/Exa) layer on.
   last_verified: '2026-08-13'
   sources:
   - url: https://docs.searxng.org/dev/search_api.html

--- a/sources/scores/semantic-kernel.yaml
+++ b/sources/scores/semantic-kernel.yaml
@@ -15,12 +15,9 @@ openness:
     - model-agnostic
     - no-feature-gated-core
   confidence: high
-  note: 'MIT multi-language SDK; first-class Azure connectors but model-agnostic and self-hostable. Re-read
-    2026-08-13 - the repo page still reports MIT and the README still closes "Copyright (c) Microsoft
-    Corporation. All rights reserved. Licensed under the MIT license." The full C#, Python and Java source
-    is published with no enterprise directory or paid tier; the page now carries a banner that Semantic
-    Kernel is Microsoft Agent Framework, which is a succession notice rather than a change of terms. Stars
-    are now 28.4k. Nothing moved.'
+  note: MIT multi-language SDK; first-class Azure connectors but model-agnostic and self-hostable. The repo
+    page carries a banner that Semantic Kernel is now Microsoft Agent Framework, which is a succession notice
+    rather than a change of terms.
   raw: license:MIT(OSI);source:public(C#/Python/Java);model-agnostic;no-feature-gated-core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -39,11 +36,10 @@ adoption:
   level: 4
   signal_type: usage_volume
   confidence: medium
-  note: '2,638,796 downloads in the trailing 30 days (semantic-kernel 2,638,796), read 2026-08-12. Bands
-    at level 4 (1M-10M) on the software and model adoption scale. Moved off the stars fallback: a real download
-    signal exists, and docs/reference/adoption.md says to re-band when one does. The package is the Python
-    package only, so this is a floor: the .NET/NuGet channel is larger and is not counted. Recorded level
-    was 3.'
+  note: '2,638,796 downloads in the trailing 30 days (semantic-kernel 2,638,796). Bands at level 4 (1M-10M)
+    on the software and model adoption scale. Moved off the stars fallback: a real download signal exists,
+    and docs/reference/adoption.md says to re-band when one does. The package is the Python package only,
+    so this is a floor: the .NET/NuGet channel is larger and is not counted. Recorded level was 3.'
   reach: 1M-10M
   last_verified: '2026-08-12'
   sources:
@@ -58,11 +54,8 @@ capability:
   value: multi-LLM connectors; plugin/OpenAPI system; auto function-calling orchestration; agent abstractions; memory/vector
     connectors; telemetry; RAI filters; first-class .NET + Java
   confidence: medium
-  note: 'Enterprise multi-language orchestration with uniquely strong .NET/Java coverage; now superseded
-    by Microsoft Agent Framework. Re-read 2026-08-13 - the Microsoft Agent Framework overview still presents
-    MAF as the successor to Semantic Kernel and AutoGen, and the Semantic Kernel repo now carries the
-    same notice at the top of its README, so the succession the band already accounted for is confirmed
-    rather than new. At autogen, the other half of the merge.'
+  note: Enterprise multi-language orchestration with uniquely strong .NET/Java coverage; now superseded
+    by Microsoft Agent Framework.
   relative_to: autogen
   relation: at
   last_verified: '2026-08-13'

--- a/sources/scores/sentencepiece.yaml
+++ b/sources/scores/sentencepiece.yaml
@@ -13,10 +13,9 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: 'LICENSE body is verbatim Apache License 2.0; full C++/Python source public. Re-read 2026-08-13:
-    the cited LICENSE body still carries the Apache-2.0 terms, the GitHub API reports the repository public,
-    unarchived and licensed Apache-2.0, and the README describes the whole library with no paid, enterprise
-    or hosted tier beside it, so source stays public and core-gated stays ungated.'
+  note: LICENSE body is verbatim Apache License 2.0; full C++/Python source public. The repository is public
+    and unarchived, and the README describes the whole library with no paid, enterprise or hosted tier beside
+    it, so source is public and the core ungated.
   raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -50,14 +49,12 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: 'Re-scored 4->5. 37.65M PyPI downloads in the last 30 days. The map''s prevailing usage_volume level-5
+  note: Re-scored 4->5. 37.65M PyPI downloads in the last 30 days. The map's prevailing usage_volume level-5
     floor is >10M/mo (cf. pydantic-ai ~31M, langgraph ~58M at level 5); the prior note bucketed it into
     a 5M-50M=L4 band used only in one ml_frameworks batch, leaving a 37M/mo tokenizer below map peers of
     equal or lower volume. SentencePiece is the de facto subword tokenizer underpinning most LLM/NMT pipelines
-    and clears the prevailing floor. Re-read 2026-08-13 from the cited pepy.tech reading of the declared
-    PyPI artifact `sentencepiece`: 36,642,180 downloads in the trailing 30 days, which bands at >10M, level
-    5 on the software scale. Unchanged. The C++ library is also vendored directly into other projects and
-    is not counted here, so the figure is a floor for the top band.'
+    and clears the prevailing floor. The C++ library is also vendored directly into other projects and is
+    not counted here, so the figure is a floor for the top band.
   last_verified: '2026-08-13'
   sources:
   - url: https://pepy.tech/projects/sentencepiece
@@ -70,8 +67,7 @@ capability:
   basis: feature_matrix
   value: Language-independent subword tokenization (BPE/unigram) trained directly from raw text.
   confidence: high
-  note: 'Widely used tokenizer underpinning many LLM and NMT models, though narrow in scope. Re-read 2026-08-13:
-    the cited repository page still describes the product as recorded, so the band is unchanged.'
+  note: Widely used tokenizer underpinning many LLM and NMT models, though narrow in scope.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/google/sentencepiece

--- a/sources/scores/serper.yaml
+++ b/sources/scores/serper.yaml
@@ -12,11 +12,8 @@ openness:
       value: Serper-Cloud
       detail: key-gated
   confidence: high
-  note: 'Proprietary commercial SERP API; no source or self-host. Closed counterpart to OSS-adjacent search
-    tools, like Tavily/Exa per the recipe. Re-read 2026-08-13: serper.dev is still a key-gated hosted API
-    priced per query - "2,500 free queries" then "starting at $0.30 per 1,000 queries" - with no repository,
-    no license, and no self-host or on-premise option offered anywhere on the page. source stays closed and
-    the score stays 1.'
+  note: Proprietary commercial SERP API; no source or self-host. Closed counterpart to OSS-adjacent search
+    tools, like Tavily/Exa per the recipe.
   raw: license:proprietary(API-only);source:closed;managed:Serper-Cloud(key-gated)
   last_verified: '2026-08-13'
   sources:
@@ -35,15 +32,12 @@ adoption:
   reach: null
   signal_type: unknown
   confidence: low
-  note: 'Popular low-cost SERP API widely wired into agent stacks (LangChain/CrewAI tool integrations), but
-    vendor publishes no hard user/query-volume figure and no primary download/API-call count is verifiable.
-    Declining to score adoption rather than rely on marketing ''fastest & cheapest'' claims. Abstention re-confirmed
-    2026-08-13. What was looked for on serper.dev and not found - a user count, a customer count, a developer
-    count, a total or monthly query volume, or a named-customer list. What is there is price and speed copy
-    only - "The World''s Fastest and Cheapest Google Search API", "search results in 1-2 seconds, at an unbeatable
-    price starting at $0.30 per 1,000 queries" - and $0.30 per 1,000 queries is a rate card, not a volume.
-    There is no package, repository or registry artifact to band either. So the abstention stands and is
-    now dated rather than merely unfilled.'
+  note: Popular low-cost SERP API widely wired into agent stacks (LangChain/CrewAI tool integrations), but
+    the vendor publishes no hard user or query-volume figure and no primary download or API-call count is
+    verifiable. serper.dev carries price and speed copy only - "The World's Fastest and Cheapest Google
+    Search API", "search results in 1-2 seconds, at an unbeatable price starting at $0.30 per 1,000 queries"
+    - and a rate card is not a volume. There is no package, repository or registry artifact to band either.
+    Declining to score adoption rather than rely on marketing claims.
   last_verified: '2026-08-13'
   sources:
   - url: https://serper.dev
@@ -59,13 +53,9 @@ capability:
   value: 'coverage: web/images/news/maps/shopping/video/scholar/patents/autocomplete; structured JSON
     output; ~1-2s latency; freshness=live Google index'
   confidence: medium
-  note: 'Broad search-type coverage with structured output and live freshness; solid feature matrix for a
+  note: Broad search-type coverage with structured output and live freshness; solid feature matrix for a
     search API, but thinner than full agent-search tools (no built-in extraction/answer synthesis like Tavily/Exa).
-    Rated 3 on coverage/freshness/structured-output dimensions. Re-read 2026-08-13 and every element of the
-    recorded value is still on the page, including the latency figure: the vertical tabs still run through
-    Scholar and Patents, output is still structured JSON, and the meta description still promises "search
-    results in 1-2 seconds". Still no extraction or answer-synthesis endpoint, which is what keeps it a rung
-    under Tavily and Exa. Band unchanged at 3.'
+    Rated 3 on coverage/freshness/structured-output dimensions.
   last_verified: '2026-08-13'
   sources:
   - url: https://serper.dev

--- a/sources/scores/shieldgemma.yaml
+++ b/sources/scores/shieldgemma.yaml
@@ -13,7 +13,7 @@ openness:
       detail: NOT OSI, use-restricted
   confidence: medium
   note: Open weights under the Gemma license, which is use-restricted and not OSI-approved (per the openness
-    rubric, Gemma = open_weights, not open_source), so it sits at 3. Re-read 2026-08-13 and unchanged.
+    rubric, Gemma = open_weights, not open_source), so it sits at 3.
   raw: weights:open(shieldgemma 2B/9B/27B on HF);data:not-released;license:Gemma(NOT OSI, use-restricted)
   last_verified: '2026-08-13'
   sources:
@@ -43,9 +43,9 @@ adoption:
   reach: <10K
   signal_type: usage_volume
   confidence: medium
-  note: 4,761 downloads in the trailing 30 days (google/shieldgemma-2b 4,761), read 2026-08-12. Bands at
-    level 1 (<10K). Corrected from level 3. A guardrail model with modest standalone pull-through; most
-    use is via the Gemma tooling rather than direct download.
+  note: 4,761 downloads in the trailing 30 days (google/shieldgemma-2b 4,761). Bands at level 1 (<10K).
+    Corrected from level 3. A guardrail model with modest standalone pull-through; most use is via the Gemma
+    tooling rather than direct download.
   last_verified: '2026-08-12'
   sources:
   - url: https://huggingface.co/api/models/google/shieldgemma-2b
@@ -64,7 +64,7 @@ capability:
   confidence: medium
   note: Competent four-category classifier with a size ladder; narrower hazard taxonomy than Llama Guard
     / Granite Guardian. That comparison is the instrument, so it is recorded rather than left in prose -
-    four categories against Llama Guard's fourteen, one rung below. Re-read 2026-08-13 and unchanged.
+    four categories against Llama Guard's fourteen, one rung below.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/google/shieldgemma-2b

--- a/sources/scores/sillytavern.yaml
+++ b/sources/scores/sillytavern.yaml
@@ -21,10 +21,6 @@ openness:
     - no-managed-tier
   note: AGPL-3.0 (OSI-approved copyleft), full source public, self-host only, fully open. No proprietary/SaaS
     tier.
-    Re-read 2026-08-13. The repository still carries AGPL-3.0 and the README still states that the
-    project provides no online or hosted service, tracks no user data, and will always be free and open
-    sourced - so there is still nothing to gate and no managed tier. v1.18.0 of 3 May 2026 is still the
-    latest release. Value unchanged at 5 / open_source.
   raw: license:AGPL-3.0(OSI, copyleft);source:public(github.com/SillyTavern/SillyTavern);self-host:only(local
     install);no-managed-tier;extensions:third-party;core-gated:ungated
   last_verified: '2026-08-13'
@@ -40,17 +36,12 @@ adoption:
   reach: '>10K stars'
   signal_type: stars_fallback
   confidence: low
-  note: 'No published download/install or active-user counts found (self-hosted desktop app, no telemetry).
-    Falling back to 28.9k GitHub stars + 300+ contributors as the only honest signal, capped at level 3 per
-    the stars-fallback rule. Likely a large enthusiast/roleplay community but unverified. Stars read
-    2026-08-13: 32,041 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in
-    signal_routing.yaml. The previous reach ''100K-1M'' was not a label this instrument offers - stars have
-    their own vocabulary because a star is not a download. No last_verified claimed: a star count is volatile,
-    so a digest of it would read as drift on every refetch, and the rest of the axis was not re-read.
-    Re-read 2026-08-13 - the repository shows 32,056 stars and the README still says over 300
-    contributors, still with no install or usage count published anywhere, since the project runs
-    locally and collects no telemetry. That still bands at >10K stars, level 3 on the stars scale. This
-    supersedes the refusal to claim a date - the axis was re-read rather than aggregated.'
+  note: No published download, install or active-user count exists for a self-hosted desktop app that collects
+    no telemetry, so this falls back to GitHub stars as the only honest signal, capped at level 3 per the
+    stars-fallback rule. SillyTavern/SillyTavern shows 32,056 stars and the README states over 300 contributors,
+    which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml. Likely a large enthusiast/roleplay
+    community, but unverified. The previous reach '100K-1M' was not a label this instrument offers - stars
+    have their own vocabulary, because a star is not a download.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/SillyTavern/SillyTavern
@@ -68,11 +59,6 @@ capability:
   note: Feature-rich for its niche, broad backend coverage, image-gen/TTS, extensions, character/roleplay
     tooling (Visual Novel mode). Specialized toward roleplay rather than general-purpose assistant work;
     mid-tier on the general chat-UI matrix.
-    Re-read 2026-08-13. The README still opens on the same feature list - one interface over
-    KoboldAI/CPP, Horde, NovelAI, Ooba, Tabby, OpenAI, OpenRouter, Claude and Mistral, Visual Novel
-    Mode, image generation through the Automatic1111 and ComfyUI APIs, TTS, WorldInfo lorebooks and
-    third-party extensions - and it is still a locally installed single-user interface. Band unchanged
-    at 3.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/SillyTavern/SillyTavern

--- a/sources/scores/simple-evals.yaml
+++ b/sources/scores/simple-evals.yaml
@@ -15,10 +15,8 @@ openness:
     - no managed tier
   confidence: high
   last_verified: '2026-08-13'
-  note: Fully OSI (MIT); purely a reference-implementation library, no gated core. Re-read 2026-08-13
-    - the license endpoint still reports MIT and the README is unchanged apart from carrying the same
-    July 2025 deprecation notice. A frozen repo is still a published one, so `source` and `core-gated`
-    are unaffected.
+  note: Fully OSI (MIT); purely a reference-implementation library, no gated core. A frozen repo is still
+    a published one - the README carries only a deprecation notice - so `source` and `core-gated` are unaffected.
   raw: license:MIT(OSI);source:public(reference eval implementations); no managed tier;core-gated:ungated
   sources:
   - url: https://github.com/openai/simple-evals
@@ -48,14 +46,12 @@ adoption:
   reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
-  note: 'Run from source (no pip distribution), so no download signal; ~4.5k stars + 490 forks is the only
-    measure, capped at <=3 by the stars rule and lowered to 2 because the project is deprecated (frozen July
-    2025) and used mainly as a reference for a few specific benchmarks (HealthBench/BrowseComp/SimpleQA)
-    rather than as a live harness. Stars read 2026-08-13: 4,598 across the 1 declared repo, which bands at
-    1K-10K stars, level 2 on the stars scale in signal_routing.yaml. The previous reach ''10K-100K'' was not a
-    label this instrument offers - stars have their own vocabulary because a star is not a download. No
-    Re-read against the GitHub API on 2026-08-13 - 4,598 stars and 503 forks, and the README still leads
-    with the July 2025 deprecation notice, so both halves of the level hold.'
+  note: Run from source (no pip distribution), so no download signal; 4,598 stars and 503 forks across the
+    one declared repo are the only measure, capped at <=3 by the stars rule and lowered to 2 because the
+    project is deprecated and frozen and is used mainly as a reference for a few specific benchmarks (HealthBench/BrowseComp/SimpleQA)
+    rather than as a live harness. 4,598 bands at 1K-10K stars, level 2 on the stars scale in signal_routing.yaml.
+    The previous reach '10K-100K' was not a label this instrument offers - stars have their own vocabulary
+    because a star is not a download.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/openai/simple-evals
@@ -80,10 +76,9 @@ capability:
   confidence: medium
   last_verified: '2026-08-13'
   note: Deliberately minimal reference harness, now frozen; narrow coverage and feature set vs category
-    leaders (HELM, Inspect AI, lm-eval-harness). Feature matrix re-read 2026-08-13 and unchanged - the
-    README still lists the same nine bundled benchmarks and still says the repo is not actively maintained
-    and takes no new evals. No `relative_to` is recorded because the note's comparison is to three leaders
-    at once, three rungs above, which the relation vocabulary cannot express.
+    leaders (HELM, Inspect AI, lm-eval-harness). The README lists nine bundled benchmarks and says the repo
+    is not actively maintained and takes no new evals. No `relative_to` is recorded because the note's comparison
+    is to three leaders at once, three rungs above, which the relation vocabulary cannot express.
   sources:
   - url: https://github.com/openai/simple-evals
     shows: bundled benchmark list (MMLU/MATH/GPQA/HumanEval/HealthBench/etc.); zero-shot CoT approach

--- a/sources/scores/simpleaudit.yaml
+++ b/sources/scores/simpleaudit.yaml
@@ -15,10 +15,9 @@ openness:
     - Python
   confidence: high
   last_verified: '2026-08-13'
-  note: Permissive OSI (MIT) license with full public source. Re-read 2026-08-13 - the LICENSE body is
-    still the MIT text with Simula Research Laboratory's copyright, and the README still states 'MIT License'
-    and still describes a local-first framework that ships its scenario packs and needs no account. No
-    paid tier, hosted edition or license key appears in the 39KB of it.
+  note: Permissive OSI (MIT) license with full public source. The README describes a local-first framework
+    that ships its scenario packs and needs no account, and no paid tier, hosted edition or license key
+    appears anywhere in it.
   raw: license:MIT(OSI; verified LICENSE body, copyright Simula);source:public;Python;core-gated:ungated(local
     execution is the default mode, all scenario packs ship in the package)
   sources:
@@ -41,18 +40,18 @@ openness:
     establishes:
     - core-gated
   - url: https://raw.githubusercontent.com/kelkalot/simpleaudit/main/LICENSE
-    shows: 'Re-read 2026-08-13: LICENSE body is still ''MIT License'', copyright Simula Research Laboratory.'
+    shows: LICENSE body is 'MIT License', copyright Simula Research Laboratory.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 6a48f8bb76cd134073d1231f140425f5695b0659cc1fba3ea5596a0a0879fe19
     establishes:
     - license
   - url: https://raw.githubusercontent.com/kelkalot/simpleaudit/main/README.md
-    shows: 'Re-read 2026-08-13: ''SimpleAudit is a simple, extensible, local-first framework for multilingual
-      auditing and red-teaming of AI systems via adversarial probing. It supports open models running
-      locally (no APIs required)'', and it closes ''MIT License - see LICENSE for details''. The scenario
-      packs, rubric, auditor and judge configuration ship in the package; the only external dependency
-      is the reader''s own model API key if they choose to use one.'
+    shows: '''SimpleAudit is a simple, extensible, local-first framework for multilingual auditing and red-teaming
+      of AI systems via adversarial probing. It supports open models running locally (no APIs required)'',
+      and it closes ''MIT License - see LICENSE for details''. The scenario packs, rubric, auditor and judge
+      configuration ship in the package; the only external dependency is the reader''s own model API key
+      if they choose to use one.'
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 6c851942b0521b6cbf776a4b1b4905d8255fb261eff3cfcb3aa7abf07df09c46
@@ -64,10 +63,10 @@ adoption:
   reach: <1K stars
   signal_type: stars_fallback
   confidence: medium
-  note: 20 GitHub stars on kelkalot/simpleaudit, read 2026-08-12. Bands at level 1 (<1K stars) on the stars
-    fallback scale, which caps at 3 because a star is not a use. Resynced because 19 stars and 9 forks,
-    explicitly early-stage. No download, install or customer figure is published for this product, so stars
-    remain the only honest signal and the level is directional.
+  note: 20 GitHub stars on kelkalot/simpleaudit. Bands at level 1 (<1K stars) on the stars fallback scale,
+    which caps at 3 because a star is not a use. Resynced because 19 stars and 9 forks, explicitly early-stage.
+    No download, install or customer figure is published for this product, so stars remain the only honest
+    signal and the level is directional.
   last_verified: '2026-08-12'
   sources:
   - url: https://api.github.com/repos/kelkalot/simpleaudit
@@ -82,11 +81,10 @@ capability:
     healthcare) plus a broken-premise evaluator.
   confidence: high
   last_verified: '2026-08-13'
-  note: Focused but functional red-teaming toolkit with a distinctive broken-premise mode. Feature matrix
-    re-read 2026-08-13 and unchanged in kind, though the README has grown a validation section reporting
-    AUROC 0.89-1.00 for safe-versus-unsafe separation and a direct comparison against Petri. Still a single-purpose
-    adversarial-probing tool rather than a general harness, so the band holds. No `relative_to` is recorded
-    because Petri is not a product in this category.
+  note: Focused but functional red-teaming toolkit with a distinctive broken-premise mode. The README carries
+    a validation section reporting AUROC 0.89-1.00 for safe-versus-unsafe separation and a direct comparison
+    against Petri, but this is still a single-purpose adversarial-probing tool rather than a general harness,
+    so the band holds. No `relative_to` is recorded because Petri is not a product in this category.
   sources:
   - url: https://github.com/kelkalot/simpleaudit
     shows: 'README: adversarial probing, local-first, scenario packs, broken-premise runner'

--- a/sources/scores/sipeed-maixcam.yaml
+++ b/sources/scores/sipeed-maixcam.yaml
@@ -24,11 +24,8 @@ openness:
       detail: global via AliExpress/Taobao
       raw: open_market (global via AliExpress/Taobao)
   confidence: high
-  note: Open Apache-2.0 SDKs, public schematics/datasheets, and global retail availability, though the
-    SG2002 silicon itself is proprietary. Re-read 2026-08-13 - the wiki still links Schematic and
-    Datasheet downloads in its hardware resources, still points at the SOPHGO SG2002 as closed silicon,
-    still lists Sipeed Taobao and AliExpress purchase links, and MaixPy is still Apache-2.0. No dimension
-    moved.
+  note: Open Apache-2.0 SDKs, public schematics/datasheets, and global retail availability, though the SG2002
+    silicon itself is proprietary.
   raw: schematics:published (available via wiki/GitHub);toolchain:open (fully open (MaixPy/MaixCDK, Apache-2.0));datasheets:public
     (public on wiki);blobs:required (SG2002 silicon proprietary);retail:open_market (global via AliExpress/Taobao)
   last_verified: '2026-08-13'
@@ -59,10 +56,9 @@ adoption:
   signal_type: reported_traction
   confidence: medium
   note: Sold globally via AliExpress/Taobao with an active MaixPy/MaixHub community, but reach is concentrated
-    among hobbyist and RISC-V edge-AI developers. Re-read 2026-08-13 - MaixPy is still active and now
-    banners a successor part ("MaixCam 2 is LIVE"), while still listing MaixCAM and MaixCAM-Pro as
-    supported platforms, and the wiki still carries live Taobao and AliExpress purchase links. Level and
-    reach unchanged; a successor generation shipping is worth watching for a later pass.
+    among hobbyist and RISC-V edge-AI developers. MaixPy is active and now banners a successor part ("MaixCam
+    2 is LIVE") while still listing MaixCAM and MaixCAM-Pro as supported platforms, and the wiki carries
+    live Taobao and AliExpress purchase links; the successor generation is worth watching for a later pass.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/sipeed/MaixPy
@@ -81,10 +77,9 @@ capability:
   basis: feature_matrix
   value: 1 TOPS INT8 NPU; RISC-V C906; 256MB DDR3
   confidence: high
-  note: 1 TOPS and only 256MB RAM suit lightweight vision/audio models, the lowest compute tier among
-    these devices. Re-derived 2026-08-13 - the spec table still reads "1TOPS@INT8, BF16 model support"
-    with a 1GHz RISC-V C906 and 256MB DDR3, which is still the smallest part in this category, below
-    google-coral-dev-board's 4 TOPS.
+  note: 1 TOPS and only 256MB RAM suit lightweight vision/audio models, the lowest compute tier among these
+    devices. The spec table reads "1TOPS@INT8, BF16 model support" with a 1GHz RISC-V C906 and 256MB DDR3,
+    which is the smallest part in this category, below google-coral-dev-board's 4 TOPS.
   last_verified: '2026-08-13'
   sources:
   - url: https://wiki.sipeed.com/hardware/en/maixcam/maixcam.html

--- a/sources/scores/slack-mcp.yaml
+++ b/sources/scores/slack-mcp.yaml
@@ -13,10 +13,9 @@ openness:
     free_text:
     - no-feature-gated-core
   confidence: high
-  note: 'Fully MIT, no feature-gated core. Re-read 2026-08-13: the repository LICENSE is the plain MIT License,
-    "Copyright (c) 2025 Dmitrii Korotovskii", and the repo page carries the matching badge. The whole Go
-    server ships in the tree, installs from npm or Docker with no key, and the maintainer sells nothing beside
-    it - there is no hosted tier, enterprise directory or second license.'
+  note: Fully MIT, no feature-gated core. The LICENSE is the plain MIT License, the whole Go server ships
+    in the tree and installs from npm or Docker with no key, and the maintainer sells nothing beside it
+    - no hosted tier, enterprise directory or second license.
   raw: license:MIT(OSI);source:public;no-feature-gated-core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -40,11 +39,11 @@ adoption:
   level: 3
   signal_type: usage_volume
   confidence: medium
-  note: '111,307 downloads in the trailing 30 days (slack-mcp-server 111,307), read 2026-08-12. Bands at
-    level 3 (100K-1M) on the software and model adoption scale. Moved off the stars fallback: a real download
-    signal exists, and docs/reference/adoption.md says to re-band when one does. The package is the npm package,
-    whose registry metadata points at korotovsky/slack-mcp-server; the PyPI package of the same name is
-    an unedited template and is NOT this product. Recorded level was 2.'
+  note: '111,307 downloads in the trailing 30 days (slack-mcp-server 111,307). Bands at level 3 (100K-1M)
+    on the software and model adoption scale. Moved off the stars fallback: a real download signal exists,
+    and docs/reference/adoption.md says to re-band when one does. The package is the npm package, whose
+    registry metadata points at korotovsky/slack-mcp-server; the PyPI package of the same name is an unedited
+    template and is NOT this product. Recorded level was 2.'
   reach: 100K-1M
   last_verified: '2026-08-12'
   sources:
@@ -59,12 +58,7 @@ capability:
   value: '18 tools: history/replies/search, posting, reactions, channel/user/usergroup management, saved items;
     stealth + OAuth modes'
   confidence: medium
-  note: 'Broad Slack read/write surface with an unusual no-permission stealth mode. Re-read 2026-08-13: the
-    README still leads on the two access modes - "Run the server without requiring additional permissions
-    or bot installations (stealth mode), or use secure OAuth tokens" - and still lists stdio, SSE and HTTP
-    transports, proxy settings, DMs and group DMs, and Smart History fetch by date or count, alongside the
-    Tools table. Enterprise workspace support is named too, which the recorded value does not mention. Band
-    unchanged at 4.'
+  note: Broad Slack read/write surface with an unusual no-permission stealth mode.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/korotovsky/slack-mcp-server

--- a/sources/scores/smallpond.yaml
+++ b/sources/scores/smallpond.yaml
@@ -16,9 +16,7 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (MIT), full source public. Re-read 2026-08-13 - the LICENSE body still carries
-    the same license and the README still builds the whole product from the published repo, with no paid
-    tier, enterprise edition or license key anywhere in it.
+  note: Fully OSI-licensed (MIT), full source public.
   raw: license:MIT(OSI);source:public(deepseek-ai/smallpond);governance:DeepSeek;no feature-gated core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -44,9 +42,9 @@ adoption:
   reach: <10K
   signal_type: usage_volume
   confidence: high
-  note: 244 downloads in the trailing 30 days for smallpond, read 2026-08-13 from the pypistats API. Bands
-    at level 1 (<10K) on the software and model adoption scale. A large star count from the DeepSeek open-infra
-    launch with little sustained use, and no repo commit since March 2025.
+  note: 244 downloads in the trailing 30 days for smallpond, from the pypistats API. Bands at level 1 (<10K)
+    on the software and model adoption scale. A large star count from the DeepSeek open-infra launch with
+    little sustained use, and no repo commit since March 2025.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/smallpond/recent
@@ -59,8 +57,7 @@ capability:
   basis: feature_matrix
   value: Distributed preprocessing on DuckDB + 3FS for PB-scale data; capable but early-stage and unmaintained.
   confidence: medium
-  note: Promising design, but not proven on downstream corpora and dormant. Re-read 2026-08-13 - the README
-    still describes the feature set above.
+  note: Promising design, but not proven on downstream corpora and dormant.
   last_verified: '2026-08-13'
   sources:
   - url: https://raw.githubusercontent.com/deepseek-ai/smallpond/main/README.md

--- a/sources/scores/smolagents.yaml
+++ b/sources/scores/smolagents.yaml
@@ -15,10 +15,7 @@ openness:
     - no-feature-gated-core
     - model-agnostic
   confidence: high
-  note: 'Fully OSI-licensed (Apache-2.0), entire library public, no proprietary/managed core, top openness.
-    Re-read 2026-08-13 - the repo page still reports Apache-2.0 over the whole tree and publishes the
-    entire library, with no enterprise directory, no paid tier and no license key. Stars are now 28.8k.
-    Nothing moved.'
+  note: Fully OSI-licensed (Apache-2.0), entire library public, no proprietary/managed core, top openness.
   raw: license:Apache-2.0(OSI);source:public(github.com/huggingface/smolagents);no-feature-gated-core;model-agnostic;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -37,11 +34,11 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: '653,459 PyPI downloads in the trailing 30 days for smolagents, read 2026-08-13 from the pypistats
-    API. Bands at level 3 (100K-1M) on the software adoption scale, meaningful but below the heavyweight
-    framework anchors. The figure has drifted down slightly from the 694,642 recorded here and stays comfortably
-    inside the same band. smolagents is the declared and primary channel, so this is a measurement rather
-    than a substitute. Level and reach unchanged.'
+  note: 653,459 PyPI downloads in the trailing 30 days for smolagents, from the pypistats API. Bands at
+    level 3 (100K-1M) on the software adoption scale, meaningful but below the heavyweight framework anchors.
+    The figure has drifted down slightly from the 694,642 recorded here and stays comfortably inside the
+    same band. smolagents is the declared and primary channel, so this is a measurement rather than a substitute.
+    Level and reach unchanged.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/smolagents/recent
@@ -67,10 +64,7 @@ capability:
     headline for the framework
   confidence: medium
   note: 'Deliberately lightweight: strong on model-agnosticism, tool-use, and sandboxing but thinner orchestration/eval
-    surface than heavier frameworks; no benchmark, scored 3 on feature matrix. Re-read 2026-08-13 - the
-    repo still presents the same "agents that think in code" framework with sandboxed execution, MCP and
-    LangChain tool import and multi-provider models, and still publishes no benchmark placement. Two below
-    the openhands anchor, unchanged.'
+    surface than heavier frameworks; no benchmark, scored 3 on feature matrix.'
   relative_to: openhands
   relation: two_below
   last_verified: '2026-08-13'

--- a/sources/scores/smollm.yaml
+++ b/sources/scores/smollm.yaml
@@ -17,11 +17,9 @@ openness:
       detail: OSI
   confidence: high
   note: 'Fully-open small-model line: Apache-2.0 weights with the complete engineering blueprint (architecture,
-    data mixtures, training and post-training recipe) published. Re-read 2026-08-13 - the release post
-    still says "The complete recipe: We are releasing SmolLM3 with our engineering blueprint. It
-    includes architecture details, exact data mixtures ... and the methodology", still describes the
-    11T-token run as built "using public datasets and training frameworks", and the card is still
-    apache-2.0 and ungated. Nothing moved.'
+    data mixtures, training and post-training recipe) published. The release post publishes "the complete
+    recipe ... architecture details, exact data mixtures ... and the methodology" and describes the 11T-token
+    run as built using public datasets and training frameworks; the card is apache-2.0 and ungated.'
   last_verified: '2026-08-13'
   raw: weights:open(Apache-2.0);data:open(public data mixtures, ~11T tokens);code:open(training+post-training
     recipe published);license:Apache-2.0(OSI)
@@ -59,11 +57,10 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: medium
-  note: 849,030 downloads in the trailing 30 days summed across the 1 declared artifact(s), read
-    2026-08-13 (HuggingFaceTB/SmolLM3-3B 849,030). Bands at level 3 (100K-1M) on the software and
-    model adoption scale, unchanged - though it is now near the top of that band rather than the
-    ~184k the previous note carried from the SmolLM2 generation. Strong in on-device and edge use,
-    niche against the large open-weight families.
+  note: 849,030 downloads in the trailing 30 days summed across the 1 declared artifact(s) (HuggingFaceTB/SmolLM3-3B
+    849,030). Bands at level 3 (100K-1M) on the software and model adoption scale, unchanged - though it
+    is now near the top of that band rather than the ~184k the previous note carried from the SmolLM2 generation.
+    Strong in on-device and edge use, niche against the large open-weight families.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/models/HuggingFaceTB/SmolLM3-3B
@@ -77,10 +74,9 @@ capability:
   basis_detail: reasoning/multilingual
   value: Outperforms Llama-3.2-3B and Qwen2.5-3B; competitive with 4B Qwen3/Gemma3
   confidence: high
-  note: Strong intelligence-per-parameter for a 3B model, but small absolute capability vs larger open and open-weight
-    models. Re-read 2026-08-13 - the comparison the band rests on is still on the post verbatim, and
-    it is a comparison against other 3B and 4B models rather than against the frontier, which is what
-    the 3 encodes. Unchanged.
+  note: Strong intelligence-per-parameter for a 3B model, but small absolute capability vs larger open and
+    open-weight models. The comparison the band rests on is on the release post verbatim, and it is a comparison
+    against other 3B and 4B models rather than against the frontier, which is what the 3 encodes.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/blog/smollm3

--- a/sources/scores/smoltalk.yaml
+++ b/sources/scores/smoltalk.yaml
@@ -12,9 +12,7 @@ openness:
     dataset_card:
       value: present
   confidence: high
-  note: 'Ungated; newly created subsets are Apache-2.0, incorporated public datasets keep their own licenses.
-    Re-read 2026-08-13: the card''s License section still puts the four new subsets under Apache 2.0 and
-    defers the rest to their original datasets, and the API reports gated false.'
+  note: Ungated; newly created subsets are Apache-2.0, incorporated public datasets keep their own licenses.
   raw: access:ungated;license:apache-2.0(new-subsets)+per-component;dataset_card:present
   last_verified: '2026-08-13'
   sources:
@@ -32,9 +30,8 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 30,281 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (HuggingFaceTB/smoltalk 30,281). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top
-    band is >1M.
+  note: 30,281 downloads in the trailing 30 days summed across the 1 declared artifact(s) (HuggingFaceTB/smoltalk
+    30,281). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/HuggingFaceTB/smoltalk
@@ -48,10 +45,8 @@ capability:
   basis_detail: ablation
   value: null
   confidence: high
-  note: 'Leads head-to-head SFT-mixture ablations (beats OpenHermes-2.5, UltraChat, MagPie-Pro) and is the
-    current default across SmolLM2/3 and Marin 8B Instruct. Re-read 2026-08-13: the SmolLM2 paper still
-    reports SmolTalk ahead of OpenHermes-2.5, UltraChat and MagPie-Pro, and the Marin 8B Instruct card still
-    lists it.'
+  note: Leads head-to-head SFT-mixture ablations (beats OpenHermes-2.5, UltraChat, MagPie-Pro) and is the
+    current default across SmolLM2/3 and Marin 8B Instruct.
   last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/html/2502.02737v1

--- a/sources/scores/snorkel-flow.yaml
+++ b/sources/scores/snorkel-flow.yaml
@@ -12,13 +12,11 @@ openness:
       value: 'yes'
       detail: customer-deployed, but from a proprietary distribution rather than published source
   confidence: high
-  note: 'Re-read 2026-08-14 against docs.snorkel.ai, which is the source the record should have cited all
-    along. The documentation carries an administrator guide - "Find out how to install the Snorkel AI Data
-    Development Platform and manage users, roles, and permissions" - so the product IS customer-deployed,
-    which the previous record did not capture. That does not make it open: nothing on the documentation
-    site offers source, a repository or a license grant, and the footer carries Terms of Use, SOC and HIPAA
-    compliance badges rather than any OSI license. Self-hostable and closed-source are not in tension; the
-    software ladder settles on `source` regardless of deployment model. Score unchanged at 1/closed.'
+  note: 'The documentation carries an administrator installation guide, so the product is customer-deployed.
+    That does not make it open: nothing on the documentation site offers source, a repository or a license
+    grant, and the footer carries Terms of Use, SOC and HIPAA compliance badges rather than any OSI license.
+    Self-hostable and closed-source are not in tension; the software ladder settles on `source` regardless
+    of deployment model, which puts this at 1/closed.'
   last_verified: '2026-08-14'
   raw: source:closed(no published source; the platform is installed from a licensed enterprise distribution);license:Proprietary;self-host:yes(customer-deployed,
     but from a proprietary distribution rather than published source)
@@ -46,13 +44,13 @@ adoption:
   signal_type: reported_traction
   confidence: low
   banded_quantity: none published; the withdrawn $1.3B valuation was never an adoption figure
-  note: 'Re-read 2026-08-14. Snorkel publishes no usage figure of any kind - no customer count, no
-    deployment count, no download count - so reported_traction with a qualitative reach is the correct
-    instrument and there is nothing to band on. Held at 3 on established enterprise/government traction.
-    THE PREVIOUS BASIS IS WITHDRAWN: the band cited a ~$1.3B Series D valuation that is not on any page
-    the record cites, and funding is not adoption in any case. What the live documentation does establish
-    is that the product is actively maintained and shipping - v26.1, with dated release notes - which is
-    what a level-3 reported_traction band rests on here.'
+  note: 'Snorkel publishes no usage figure of any kind - no customer count, no deployment count, no download
+    count - so reported_traction with a qualitative reach is the correct instrument and there is nothing
+    to band on. Held at 3 on established enterprise/government traction. The earlier basis is withdrawn:
+    it cited a ~$1.3B Series D valuation that is not on any page the record cites, and funding is not adoption
+    in any case. What the live documentation does establish is that the product is actively maintained and
+    shipping - v26.1, with dated release notes - which is what a level-3 reported_traction band rests on
+    here.'
   last_verified: '2026-08-14'
   sources:
   - url: https://docs.snorkel.ai/
@@ -69,11 +67,10 @@ capability:
     over a customer-installed deployment. Documented at v26.1 with a separate legacy Predictive ML line
     ending at v25.4.
   confidence: medium
-  note: 'Re-derived 2026-08-14 from the live documentation rather than the marketing site. The feature
-    surface the score rests on - programmatic labeling, curation, an SDK, multi-user administration - is
-    all documented and current at v26.1. Score unchanged at 4: a mature, well-documented commercial data
-    development platform, below the open frontier tooling this category scores 5 on breadth of published
-    method rather than on product polish.'
+  note: 'Derived from the live documentation rather than the marketing site. The feature surface the score
+    rests on - programmatic labeling, curation, an SDK, multi-user administration - is all documented and
+    current at v26.1. Scored 4: a mature, well-documented commercial data development platform, below the
+    open frontier tooling this category scores 5 on breadth of published method rather than on product polish.'
   last_verified: '2026-08-14'
   basis_detail: Documentation sections for User Guide, Admin Guide and SDK at v26.1, plus a legacy
     Predictive ML line ending at v25.4.

--- a/sources/scores/spaces.yaml
+++ b/sources/scores/spaces.yaml
@@ -17,17 +17,16 @@ openness:
     hardware-tiers:
       value: CPU free + paid GPU upgrades
   confidence: medium
-  note: 'Closed managed hosting service. Apps are built with OSS SDKs (Gradio etc.) that run anywhere,
-    but Spaces itself - the managed host/orchestration - is proprietary and not self-hostable; those SDKs
-    are separate products, not a Spaces open core. Reclassified from open_core (borderline).
-    Re-read 2026-08-13 and unchanged. The Hub docs still describe Spaces only as apps hosted on Hugging
-    Face infrastructure - Gradio, arbitrary Dockerfile, static HTML/JS, with GPU hardware upgrades, dev
-    mode and persistent storage - and document no way to run the Spaces host anywhere else. The pricing
-    page sells that host as metered HF compute (CPU Basic free, CPU Upgrade $0.03/hr, ZeroGPU free with
-    a PRO quota, T4/L4/A100 hourly), and the terms of service reserve ownership of the service outright
-    - "we retain ownership of all of our intellectual property rights related to the Website and the
-    Services" - which is what the Proprietary license part records. No source repository or self-host
-    distribution for Spaces itself appeared.'
+  note: Closed managed hosting service. Apps are built with OSS SDKs (Gradio etc.) that run anywhere, but
+    Spaces itself - the managed host/orchestration - is proprietary and not self-hostable; those SDKs are
+    separate products, not a Spaces open core. Reclassified from open_core (borderline). The Hub docs describe
+    Spaces only as apps hosted on Hugging Face infrastructure - Gradio, arbitrary Dockerfile, static HTML/JS,
+    with GPU hardware upgrades, dev mode and persistent storage - and document no way to run the Spaces
+    host anywhere else. The pricing page sells that host as metered HF compute (CPU Basic free, CPU Upgrade
+    $0.03/hr, ZeroGPU free with a PRO quota, then hourly T4/L4/A100 tiers), and the terms of service reserve
+    ownership of the service outright - "we retain ownership of all of our intellectual property rights
+    related to the Website and the Services" - which is what the Proprietary license part records. No source
+    repository or self-host distribution for Spaces itself exists.
   raw: license:Proprietary;source:closed;platform:proprietary(HF-managed hosting/orchestration, no self-hostable
     Spaces);open-part:app SDKs only (Gradio Apache-2.0, Streamlit) which are separate, portable OSS products;hardware-tiers:CPU
     free + paid GPU upgrades
@@ -72,15 +71,12 @@ adoption:
   note: 'Hugging Face homepage (primary): Spaces hosts 1M+ AI applications, on a platform used by 50,000+
     organizations. 1M+ hosted apps plus the broad end-user traffic to those demos puts served reach into
     the >10M band. Headline (1M+ Spaces) cites HF''s own homepage; per-Space user totals not individually
-    disclosed so confidence medium. Re-read 2026-08-13 and both cited figures are still on the homepage
-    - the Spaces panel ends in "Browse 1M+ applications" and the organizations band still reads "More
-    than 50,000 organizations are using Hugging Face" - so the level stands unchanged. INSTRUMENT CAVEAT,
-    recorded rather than worked around - this record uses usage_volume, which claims a count, while the
-    product declares no artifact any signal model can recompute from. The instrument is not being
-    relabeled to dodge that and no artifact is being declared, because a Space is not a package and the
-    1M+ figure is the vendor''s own count of hosted apps rather than a countable channel. The axis now
-    carries a digested source so the claim can at least be re-checked and will age; a real route to a
-    countable Spaces signal is an open backlog item.'
+    disclosed so confidence medium. INSTRUMENT CAVEAT, recorded rather than worked around: this record uses
+    usage_volume, which claims a count, while the product declares no artifact any signal model can recompute
+    from. The instrument is not being relabeled to dodge that and no artifact is being declared, because
+    a Space is not a package and the 1M+ figure is the vendor''s own count of hosted apps rather than a
+    countable channel. The axis carries a digested source so the claim can at least be checked again and
+    will age; a real route to a countable Spaces signal is an open backlog item.'
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co
@@ -98,15 +94,12 @@ capability:
     (broad for app hosting); persistence: persistent storage tiers + dev mode; scale: CPU free tier +
     paid GPU upgrades on HF infra'
   confidence: medium
-  note: Excellent for hosting/demoing ML apps with broad SDK and GPU support, but it is an app-hosting
-    platform rather than a hardened arbitrary-untrusted-code sandbox (container, not microVM isolation),
-    and free Spaces sleep. Mid-tier within the deployment sandbox lens. Re-read 2026-08-13 - the Hub
-    docs still list Gradio, Streamlit, Docker and static HTML Spaces, GPU upgrades, ZeroGPU, dev mode,
-    and disk usage and storage, and the pricing page still starts the hardware ladder at a free 2 vCPU
-    CPU Basic tier. Nothing in either page claims microVM or hardened multi-tenant isolation, so the
-    band is unchanged. New since the last read - Spaces as MCP servers, agent tools and API endpoints
-    now have their own doc pages, which widens the surface without moving the isolation ceiling the
-    band rests on.
+  note: Excellent for hosting/demoing ML apps with broad SDK and GPU support, but it is an app-hosting platform
+    rather than a hardened arbitrary-untrusted-code sandbox (container, not microVM isolation), and free
+    Spaces sleep. Mid-tier within the deployment sandbox lens. Nothing in the Hub docs or the pricing page
+    claims microVM or hardened multi-tenant isolation, and the hardware ladder still starts at a free 2
+    vCPU CPU Basic tier. Spaces as MCP servers, agent tools and API endpoints now have their own doc pages,
+    which widens the surface without moving the isolation ceiling the band rests on.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/docs/hub/spaces

--- a/sources/scores/spec-kit.yaml
+++ b/sources/scores/spec-kit.yaml
@@ -14,9 +14,8 @@ openness:
     - no-feature-gated-core
     - no-commercial-tier
   confidence: high
-  note: 'Fully MIT, free. Re-read 2026-08-13 - the repo page still reports MIT over the whole tree and
-    publishes the whole toolkit, with no paid tier, enterprise directory or license key anywhere on it.
-    Stars are now 127.2k. Nothing moved.'
+  note: 'Fully MIT and free: the whole Spec-Driven Development toolkit is published, with no paid tier,
+    enterprise directory or license key.'
   raw: license:MIT(OSI);source:public;no-feature-gated-core;no-commercial-tier;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -34,11 +33,11 @@ adoption:
   level: 2
   signal_type: usage_volume
   confidence: medium
-  note: '76,423 downloads in the trailing 30 days (specify-cli 76,423), read 2026-08-12. Bands at level
-    2 (10K-100K) on the software and model adoption scale. Moved off the stars fallback: a real download
-    signal exists, and docs/reference/adoption.md says to re-band when one does. The package is PyPI carries
-    the same version as the repository''s latest tag, so the recorded claim of no telemetry was wrong. This
-    LOWERS the recorded level from 3 - the star count had been flattering it.'
+  note: '76,423 downloads in the trailing 30 days (specify-cli 76,423). Bands at level 2 (10K-100K) on the
+    software and model adoption scale. Moved off the stars fallback: a real download signal exists, and
+    docs/reference/adoption.md says to re-band when one does. The package is PyPI carries the same version
+    as the repository''s latest tag, so the recorded claim of no telemetry was wrong. This LOWERS the recorded
+    level from 3 - the star count had been flattering it.'
   reach: 10K-100K
   last_verified: '2026-08-12'
   sources:
@@ -53,11 +52,7 @@ capability:
   value: four-phase Spec-Driven workflow producing chained Markdown artifacts; specify CLI scaffolding; agent-agnostic
     (30+ agents); constitution/principles guardrail
   confidence: medium
-  note: 'Methodology/orchestration layer over coding agents rather than a code-writing engine itself.
-    Re-read 2026-08-13 - the GitHub blog post still defines Spec-Driven Development and its four-phase
-    process, and the repo still frames the tool as "define what to build before building it, with any
-    AI coding agent", which is exactly the layering this band rests on. One below the openhands anchor,
-    unchanged.'
+  note: Methodology/orchestration layer over coding agents rather than a code-writing engine itself.
   relative_to: openhands
   relation: one_below
   last_verified: '2026-08-13'

--- a/sources/scores/stack-edu.yaml
+++ b/sources/scores/stack-edu.yaml
@@ -10,9 +10,7 @@ openness:
     dataset_card:
       value: present
   confidence: medium
-  note: 'Ungated download with a card; the card defers the data license to The Stack v2''s terms. Re-read
-    2026-08-13: the card still says to refer to the-stack-v2 for the data licence and the API reports gated
-    false, so the deferred licence over an ungated, documented release stands.'
+  note: Ungated download with a card; the card defers the data license to The Stack v2's terms.
   raw: access:ungated;license:inherits-the-stack-v2;dataset_card:present
   last_verified: '2026-08-13'
   sources:
@@ -30,9 +28,8 @@ adoption:
   reach: 1K-10K
   signal_type: usage_volume
   confidence: high
-  note: 5,273 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (HuggingFaceTB/stack-edu 5,273). Bands at level 2 (1K-10K) on the dataset adoption scale, whose top
-    band is >1M.
+  note: 5,273 downloads in the trailing 30 days summed across the 1 declared artifact(s) (HuggingFaceTB/stack-edu
+    5,273). Bands at level 2 (1K-10K) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/HuggingFaceTB/stack-edu
@@ -46,10 +43,8 @@ capability:
   basis_detail: ablation
   value: null
   confidence: high
-  note: 'Leads controlled classifier ablations, beating StarCoder2Data on MultiPL-E across all languages
-    (SmolLM2 paper); current default in SmolLM3 and OLMo 3''s Dolma 3. Re-read 2026-08-13: the SmolLM2 paper
-    still reports Stack-Edu ahead of StarCoder2Data on MultiPL-E across languages, and the SmolLM3 post
-    still includes it in the pretraining mixture.'
+  note: Leads controlled classifier ablations, beating StarCoder2Data on MultiPL-E across all languages
+    (SmolLM2 paper); current default in SmolLM3 and OLMo 3's Dolma 3.
   last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/html/2502.02737v1

--- a/sources/scores/starcoder2.yaml
+++ b/sources/scores/starcoder2.yaml
@@ -18,17 +18,14 @@ openness:
     - name: BigCode-OpenRAIL-M
       detail: open but RAIL behavioral-use restrictions, not OSI
   confidence: high
-  note: 'The most open artifact in this category by evidence: weights, the full training corpus (The Stack v2) and
-    the self-align pipeline are all published. Held to 4 rather than 5 because BigCode-OpenRAIL-M is not OSI-approved
-    - its behavioral-use clauses discriminate against fields of endeavor, which the OSD forbids - and rule 5 of
-    the ladder reserves the top score for an OSI license. Class corrected from open_source to open_weights on 2026-07-29:
-    the score was right but 4/open_source is a pair this ladder cannot emit, and the mismatch is what flagged it.
-    Resolved under issue #117 by tiering RAIL as a conduct restriction, which is what keeps a fully-open pipeline
-    off the 2/restricted floor it would otherwise have hit on the license alone. Re-read 2026-08-13 - the
-    instruct card still describes "the very first entirely self-aligned code LLM trained with a fully
-    permissive and transparent pipeline", still links the code (bigcode-project/starcoder2-self-align)
-    and the dataset (bigcode/self-oss-instruct-sc2-exec-filter-50k) by name, still has a Full Data Pipeline
-    section, and both repos still carry `license:bigcode-openrail-m` with `"gated":false`. No change.'
+  note: 'The most open artifact in this category by evidence: weights, the full training corpus (The Stack
+    v2) and the self-align pipeline are all published. Held to 4 rather than 5 because BigCode-OpenRAIL-M
+    is not OSI-approved - its behavioral-use clauses discriminate against fields of endeavor, which the
+    OSD forbids - and rule 5 of the ladder reserves the top score for an OSI license. Class corrected from
+    open_source to open_weights on 2026-07-29: the score was right but 4/open_source is a pair this ladder
+    cannot emit, and the mismatch is what flagged it. Resolved under issue #117 by tiering RAIL as a conduct
+    restriction, which is what keeps a fully-open pipeline off the 2/restricted floor it would otherwise
+    have hit on the license alone.'
   raw: weights:open;data:open(self-oss-instruct-sc2-exec-filter-50k + 7 documented intermediate datasets);code:open(starcoder2-self-align
     pipeline on GitHub);base-data:open(The Stack v2);license:BigCode-OpenRAIL-M(open but RAIL behavioral-use
     restrictions, not OSI)
@@ -54,10 +51,10 @@ adoption:
   reach: <10K
   signal_type: usage_volume
   confidence: medium
-  note: Instruct SKU ~1.1k downloads/last-month; base StarCoder2-15B ~9.4k/last-month. Research-significant (fully-open
-    self-alignment recipe) but low production reach; placed at 1 on the instruct SKU's measured volume.
-    Re-read 2026-08-13 - both SKUs have fallen further, the instruct SKU to 856 downloads in the trailing
-    30 days and the base to 4,425. Level 1 (<10K) on either, and on their sum. No change.
+  note: Instruct SKU ~1.1k downloads/last-month; base StarCoder2-15B ~9.4k/last-month. Research-significant
+    (fully-open self-alignment recipe) but low production reach; placed at 1 on the instruct SKU's measured
+    volume. Both SKUs have since fallen further, the instruct SKU to 856 downloads in the trailing 30 days
+    and the base to 4,425 - level 1 (<10K) on either and on their sum.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/bigcode/starcoder2-15b-instruct-v0.1
@@ -76,11 +73,9 @@ capability:
   basis_detail: HumanEval
   value: StarCoder2-15B-Instruct-v0.1 HumanEval pass@1 72.6% (HumanEval+ 63.4%)
   confidence: high
-  note: Strong HumanEval for a fully-open 16B in 2024 (best fully-self-aligned code model at release), but HumanEval
-    is saturated and the model is below 2026 frontier coders on harder agentic benchmarks (SWE-bench). Mid-tier.
-    Re-read 2026-08-13 - the card's model-index still records HumanEval pass@1 72.6 and HumanEval+ 63.4,
-    both unchanged, and the evaluation section still covers EvalPlus, LiveCodeBench and DS-1000 rather
-    than any agentic benchmark. No change.
+  note: Strong HumanEval for a fully-open 16B in 2024 (best fully-self-aligned code model at release), but
+    HumanEval is saturated and the model is below 2026 frontier coders on harder agentic benchmarks (SWE-bench).
+    Mid-tier.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/bigcode/starcoder2-15b-instruct-v0.1

--- a/sources/scores/starcoderdata.yaml
+++ b/sources/scores/starcoderdata.yaml
@@ -11,9 +11,7 @@ openness:
     dataset_card:
       value: present
   confidence: high
-  note: 'Terms-gated like its parent The Stack v1; permissively licensed source files. Re-read 2026-08-13:
-    the Hub still shows “You need to agree to share your contact information to access this dataset” and
-    the API reports gated auto, with the card present.'
+  note: Terms-gated like its parent The Stack v1; permissively licensed source files.
   raw: license:permissive(SPDX per file);gated:terms-acceptance;dataset_card:present
   last_verified: '2026-08-13'
   sources:
@@ -31,9 +29,8 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 28,873 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (bigcode/starcoderdata 28,873). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top
-    band is >1M.
+  note: 28,873 downloads in the trailing 30 days summed across the 1 declared artifact(s) (bigcode/starcoderdata
+    28,873). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/bigcode/starcoderdata
@@ -47,10 +44,10 @@ capability:
   basis_detail: superseded
   value: null
   confidence: high
-  note: 'Proven pretraining component (TinyLlama, Granite Code, ALIA, OLMoE) but drawn from The Stack v1
-    and functionally superseded by The Stack v2 / Stack-Edu. Re-read 2026-08-13: the OLMoE mix card still
-    lists Starcoder at 101B tokens, and the StarCoder2 listing still describes The Stack v2 as 4x the first
-    StarCoder dataset, which is the supersession the band rests on.'
+  note: Proven pretraining component (TinyLlama, Granite Code, ALIA, OLMoE) but drawn from The Stack v1
+    and functionally superseded by The Stack v2 / Stack-Edu. The OLMoE mix card lists Starcoder at 101B
+    tokens, and The Stack v2 is 4x the size of the first StarCoder dataset, which is the supersession the
+    band rests on.
   relative_to: the-stack-v2
   relation: one_below
   last_verified: '2026-08-13'

--- a/sources/scores/suna.yaml
+++ b/sources/scores/suna.yaml
@@ -15,10 +15,7 @@ openness:
     providing the software as a hosted or managed service. Marketed as "open source" while carrying managed-service
     restrictions; flagged open_washed. Score corrected from 3 to 2 on 2026-07-30. The software ladder has
     rungs at 1, 2, 4 and 5 and none at 3, so 3/source_available was not a pair any rule could produce; the
-    ladder scores "you can read it and not run it freely" at 2. Re-read 2026-08-13 - the LICENSE file
-    still opens with "Elastic License 2.0" and links elastic.co/licensing/elastic-license, and the repo,
-    now presenting itself as Kortix, still publishes the whole stack while GitHub declines to place the
-    license under any SPDX badge. Stars are now 20.1k. Nothing moved.'
+    ladder scores "you can read it and not run it freely" at 2.'
   raw: license:Elastic License 2.0(non-OSI, source-available, restricts hosting as a managed service);source:public;managed
     cloud + self-host tiers
   last_verified: '2026-08-13'
@@ -44,15 +41,11 @@ adoption:
   reach: '>10K stars'
   signal_type: stars_fallback
   confidence: low
-  note: '19.8k stars and a managed cloud offering, but no published download/user-count figure; capped on
-    stars fallback. Placed at 2 given the relatively young, smaller community vs the leading agents;
-    directional. Stars read 2026-08-13: 20,094 across the 1 declared repo, which bands at >10K stars, level 3
-    on the stars scale in signal_routing.yaml. Level corrected from 2. The previous reach ''10K-100K'' was not
-    a label this instrument offers - stars have their own vocabulary because a star is not a download.
-    Re-read 2026-08-13 from the repo page, which reports 20.1k stars and 3.4k forks. Suna/Kortix ships
-    as a self-hosted stack or a managed cloud with no first-party registry package and publishes no user
-    or download figure, so the stars fallback is still the only instrument and >10K stars still bands
-    at 3.'
+  note: 19.8k stars and a managed cloud offering, but no published download/user-count figure; capped on
+    stars fallback. Placed at 2 given the relatively young, smaller community vs the leading agents; directional.
+    20,094 stars across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml.
+    Level corrected from 2. The previous reach '10K-100K' was not a label this instrument offers - stars
+    have their own vocabulary because a star is not a download.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/kortix-ai/suna
@@ -67,11 +60,8 @@ capability:
     3,000+ connectors; multi-agent: yes (parallel branches); model-agnostic: yes; reliability: review-before-merge
     gating. No public agent-benchmark placement.'
   confidence: medium
-  note: 'Feature-rich generalist agent platform with broad integrations and a novel review/merge workflow,
-    but no published benchmark; scored on feature matrix. Re-read 2026-08-13 - the repo now positions
-    itself as an "AI Management System" and the leading open-source alternative to the closed assistants,
-    with the same sandboxed specialist agents and connector breadth and still no published benchmark placement.
-    Two below the openhands anchor.'
+  note: Feature-rich generalist agent platform with broad integrations and a novel review/merge workflow,
+    but no published benchmark; scored on feature matrix.
   relative_to: openhands
   relation: two_below
   last_verified: '2026-08-13'

--- a/sources/scores/surfsense.yaml
+++ b/sources/scores/surfsense.yaml
@@ -19,21 +19,19 @@ openness:
     free_text:
     - no-feature-gated-core-found
   confidence: high
-  note: 'Re-read 2026-08-14 and the license is a two-part compound, not the single Apache-2.0 this record
-    carried. The root LICENSE opens ''Portions of this software are licensed as follows'' and puts all
-    content under surfsense_backend/app/proprietary/ under the Business Source License 1.1 defined in that
-    directory''s own LICENSE, with content outside it under Apache-2.0. The directory is live and is not a
-    stub - it holds LICENSE, __init__.py, platforms/ and web_crawler/, which is the live-data connector
-    surface the product now leads on. GitHub reads the split file as spdxId NOASSERTION, the same way it
-    declines to classify agenta''s.
-    The universal license cap settles the tier from there - BSL-1.1 is competition_restricted in the
-    software ladder, most-restrictive-wins across the recorded parts, and a public source under a
-    competition_restricted license is 2/source_available. You can read the whole tree and you may not run
-    the proprietary half in production on the license''s terms. `core-gated` stays `ungated` on the
-    ladder''s own definition - nothing is withheld FROM the published source, the restricted directory
-    ships in it - and the repo still says self-hosting stays free and open source, with self-hosted
-    installs running with billing off. Moved from 5/open_source, which had read the Apache half as the
-    whole license.'
+  note: The license is a two-part compound, not the single Apache-2.0 this record originally carried. The
+    root LICENSE opens 'Portions of this software are licensed as follows' and puts all content under surfsense_backend/app/proprietary/
+    under the Business Source License 1.1 defined in that directory's own LICENSE, with content outside
+    it under Apache-2.0. The directory is live and is not a stub - it holds LICENSE, __init__.py, platforms/
+    and web_crawler/, which is the live-data connector surface the product now leads on. GitHub reads the
+    split file as spdxId NOASSERTION, the same way it declines to classify agenta's. The universal license
+    cap settles the tier from there - BSL-1.1 is competition_restricted in the software ladder, most-restrictive-wins
+    across the recorded parts, and a public source under a competition_restricted license is 2/source_available.
+    You can read the whole tree and you may not run the proprietary half in production on the license's
+    terms. `core-gated` stays `ungated` on the ladder's own definition - nothing is withheld FROM the published
+    source, the restricted directory ships in it - and the repo still says self-hosting stays free and open
+    source, with self-hosted installs running with billing off. Moved from 5/open_source, which had read
+    the Apache half as the whole license.
   raw: license:Apache-2.0(OSI, everything outside the proprietary directory)+BSL-1.1(Business Source License
     1.1 - surfsense_backend/app/proprietary);source:public(github.com/MODSetter/SurfSense);self-host:primary(Docker/Compose);no-feature-gated-core-found;core-gated:ungated
   last_verified: '2026-08-14'
@@ -77,16 +75,10 @@ adoption:
   reach: '>10K stars'
   signal_type: stars_fallback
   confidence: medium
-  note: '~15k GitHub stars by mid-2026; no download/usage telemetry available for a self-hosted web app, so
-    stars_fallback (capped at level 3). Rapid star growth but unproven real-world deployment. Stars read
-    2026-08-13: 15,898 across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in
-    signal_routing.yaml. The record carried no reach label at all before this. No last_verified claimed: a
-    star count is volatile, so a digest of it would read as drift on every refetch, and the rest of the axis
-    was not re-read.
-    Re-read 2026-08-13 - MODSetter/SurfSense shows 15,902 stars, still banding at >10K stars, level 3 on
-    the stars scale, and the project still publishes no download or deployment telemetry for a
-    self-hosted web app. This supersedes the refusal to claim a date - the axis was re-read rather than
-    aggregated. Level unchanged.'
+  note: MODSetter/SurfSense shows 15,902 GitHub stars; no download or deployment telemetry is available
+    for a self-hosted web app, so stars_fallback applies and is capped at level 3. That bands at >10K stars,
+    level 3 on the stars scale in signal_routing.yaml. Rapid star growth but unproven real-world deployment.
+    The record carried no reach label at all before this.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/MODSetter/SurfSense
@@ -102,17 +94,14 @@ capability:
     Linear/Jira, Gmail, YouTube, GitHub); RAG: hybrid semantic + full-text with rank fusion; multimodal:
     podcast/video/image generation; multi-user: real-time collab + RBAC'
   confidence: low
-  note: Unusually broad connector, model, and collaboration surface on paper, but per-feature depth and quality
-    are unverified (README-sourced) and the project is far less proven than open-webui-class tools - so 4,
-    not top, with low confidence.
-    Re-read 2026-08-13. The README still claims the broad connector and model surface the band rests on,
-    but the project has repositioned since the band was set - it now leads as an open web research
-    platform for AI agents, with live data connectors to Reddit, YouTube, Instagram, TikTok, Amazon,
-    Walmart, Google Maps, Google Search and Indeed reachable over one REST API or an MCP server, plus
-    scheduled and event-triggered agents. The maintainers state that the knowledge base, cited chat,
-    reports, podcasts, presentations, automations and collaborative chats all keep working and
-    self-hosting stays free, so nothing the band rested on has been withdrawn. Per-feature depth is
-    still README-sourced and unverified, which is why confidence stays low. Band unchanged at 4.
+  note: Unusually broad connector, model, and collaboration surface on paper, but per-feature depth and
+    quality are unverified (README-sourced) and the project is far less proven than open-webui-class tools
+    - so 4, not top, with low confidence. The project has repositioned since the band was set - it now leads
+    as an open web research platform for AI agents, with live data connectors to Reddit, YouTube, Instagram,
+    TikTok, Amazon, Walmart, Google Maps, Google Search and Indeed reachable over one REST API or an MCP
+    server, plus scheduled and event-triggered agents. The maintainers state that the knowledge base, cited
+    chat, reports, podcasts, presentations, automations and collaborative chats all keep working and that
+    self-hosting stays free, so nothing the band rested on has been withdrawn.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/MODSetter/SurfSense

--- a/sources/scores/swe-agent.yaml
+++ b/sources/scores/swe-agent.yaml
@@ -14,10 +14,7 @@ openness:
     free_text:
     - no managed tier
     - model-agnostic
-  note: 'Verified MIT OSI, full source public; academic project with no proprietary tier. Re-read 2026-08-13
-    - the LICENSE file still carries the MIT text, copyright 2024 John Yang, Carlos E. Jimenez and others,
-    and the repo page still reports the MIT license over the whole tree with no managed or enterprise
-    offering anywhere on it. Stars are now 20.1k. Nothing moved.'
+  note: Verified MIT OSI, full source public; academic project with no proprietary tier.
   raw: license:MIT(OSI);source:public;no managed tier; model-agnostic;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -42,14 +39,11 @@ adoption:
   reach: '>10K stars'
   signal_type: stars_fallback
   confidence: low
-  note: 'Primarily a research/benchmark agent; 19.4k stars in the research community. No published
-    download/user volume; capped per stars-fallback rule. Adoption is research-circle, not production end-user
-    scale. Stars read 2026-08-13: 20,055 across the 1 declared repo, which bands at >10K stars, level 3 on the
-    stars scale in signal_routing.yaml. Level corrected from 2. The previous reach ''10K-100K'' was not a
-    label this instrument offers - stars have their own vocabulary because a star is not a download.
-    Re-read 2026-08-13 from the repo page itself, which reports 20.1k stars and 2.2k forks and still
-    publishes no download or user figure, so the stars fallback is still the only instrument available
-    and >10K stars still bands at 3.'
+  note: Primarily a research/benchmark agent; 19.4k stars in the research community. No published download/user
+    volume; capped per stars-fallback rule. Adoption is research-circle, not production end-user scale.
+    20,055 stars across the 1 declared repo, which bands at >10K stars, level 3 on the stars scale in signal_routing.yaml.
+    Level corrected from 2. The previous reach '10K-100K' was not a label this instrument offers - stars
+    have their own vocabulary because a star is not a download.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/SWE-agent/SWE-agent
@@ -64,9 +58,7 @@ capability:
   value: SWE-bench Verified 43.2% (SWE-agent v1, Claude Sonnet 4.5)
   confidence: medium
   note: 'Originator of the SWE-bench agent scaffold; mid-tier on the 2026 leaderboard (43.2%), above Aider
-    but below Cline/OpenHands. NOTE: figure from aggregator (awesomeagents.ai), not primary. Re-read 2026-08-13
-    - the leaderboard still carries SWE-agent v1 on Claude Sonnet 4.5 at 43.2% Verified and 31.1% Full,
-    row 9, plus a second row for the same scaffold on GPT-5.2 at 29.7%. Unchanged.'
+    but below Cline/OpenHands. NOTE: figure from aggregator (awesomeagents.ai), not primary.'
   last_verified: '2026-08-13'
   sources:
   - url: https://awesomeagents.ai/leaderboards/swe-bench-coding-agent-leaderboard/

--- a/sources/scores/swe-bench-verified.yaml
+++ b/sources/scores/swe-bench-verified.yaml
@@ -25,10 +25,7 @@ openness:
     beneath headed "For SWE-bench (Verified)". The HF card for Verified still declares no license field,
     and where a repository license and a distribution-point license differ the repository license governs,
     so the recorded 4 moves to the 5/open the ladder computes. (Distinct from SWE-bench broader/hidden variants,
-    which can carry held-out splits.) Re-read 2026-08-13 - the repository README still carries the
-    "Citation & license" section reading "MIT license" with the "For SWE-bench (Verified)" citation
-    directly beneath, the LICENSE file re-fetched with an unchanged digest, and the HF repo is still
-    ungated with a rendering card and no license field.
+    which can carry held-out splits.)
   raw: license:MIT(SWE-bench repository states MIT over its code and data; the HF card for Verified still
     declares no license field);redistributability:full(downloadable parquet, ungated);datasheet:yes(dataset
     card + arXiv:2310.06770);held-out:no hidden split in Verified itself(the public 500-instance set is
@@ -51,45 +48,43 @@ openness:
     accessed: '2026-06-04'
   - url: https://huggingface.co/datasets/princeton-nlp/SWE-bench_Verified/raw/main/README.md
     shows: card front matter carries dataset_info, splits and configs and no `license:` key; body describes
-      the 500 human-validated instances and the swebench.com leaderboard. Re-read on 2026-08-12 and
-      still unlicensed at source. The repository holds only .gitattributes, README.md and one parquet
-      file, so there is no LICENSE file alongside the data either. Re-fetched 2026-08-13 with an
-      unchanged digest
+      the 500 human-validated instances and the swebench.com leaderboard, so the data is unlicensed at source.
+      The repository holds only .gitattributes, README.md and one parquet file, so there is no LICENSE file
+      alongside the data either
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 6edb58b1b2c44ce858426c4ebc90077827713b75cebc243661e4433c81fd57f5
-    establishes: [license]
+    establishes:
+    - license
   - url: https://raw.githubusercontent.com/SWE-bench/SWE-bench/main/README.md
-    shows: '"Code and data for the following works:" listing SWE-bench and SWE-bench Multimodal; the
-      "Citation & license" section reads "MIT license. Check `LICENSE.md`." and the citation immediately
-      under it is headed "For SWE-bench (Verified)"; the news entry for Aug. 13, 2024 introduces Verified
-      as a 500-problem subset produced with OpenAI Preparedness. Re-read 2026-08-13 and all three
-      statements are still present; the digest moved (the README picked up unrelated edits), which
-      is why the whole section was re-read rather than assumed'
+    shows: '"Code and data for the following works:" listing SWE-bench and SWE-bench Multimodal; the "Citation
+      & license" section reads "MIT license. Check `LICENSE.md`." and the citation immediately under it
+      is headed "For SWE-bench (Verified)"; the news entry for Aug. 13, 2024 introduces Verified as a 500-problem
+      subset produced with OpenAI Preparedness'
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 910cf1bd353b898e9c6299d8e805c1a115d00c1b877e1239753be8d9caa4275f
-    establishes: [license]
+    establishes:
+    - license
   - url: https://raw.githubusercontent.com/SWE-bench/SWE-bench/main/LICENSE
-    shows: 'MIT License, copyright 2023 the SWE-bench authors. Note the README points at `LICENSE.md`,
-      which 404s; the file is `LICENSE`. Re-fetched 2026-08-13 with an unchanged digest'
+    shows: MIT License, copyright 2023 the SWE-bench authors. Note the README points at `LICENSE.md`, which
+      404s; the file is `LICENSE`
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 2bd2e08df7147f67a69b42c10efae09bd4bf119df397371036187d5dd1b02f57
-    establishes: [license]
+    establishes:
+    - license
 adoption:
   level: 4
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: 'The de-facto standard agentic-coding benchmark of 2025-2026: cited as the headline coding metric in
-    nearly every frontier model release (GPT-5, Claude Opus, DeepSeek, Qwen, Kimi all report SWE-bench
-    Verified). ~914k HF downloads/month plus a live, heavily-submitted leaderboard at swebench.com. Strongest
-    ''citation-as-standard'' signal in the batch. Read live 2026-08-13: 413,323 Hugging Face downloads in the
-    trailing 30 days across the declared artifact(s), which bands at 100K-1M, level 4. The previous reach
-    ''1M-10M'' was a band off a different scale. Re-read against the Hub API on 2026-08-13: still 413,323
-    downloads in the trailing 30 days, so level 4 / 100K-1M stands and the axis is now dated. The ~914k
-    figure the June source cited no longer appears anywhere on the dataset page.'
+  note: 'The de-facto standard agentic-coding benchmark of 2025-2026: cited as the headline coding metric
+    in nearly every frontier model release (GPT-5, Claude Opus, DeepSeek, Qwen, Kimi all report SWE-bench
+    Verified), alongside a live, heavily-submitted leaderboard at swebench.com. 413,323 Hugging Face downloads
+    in the trailing 30 days across the declared artifact(s), which bands at 100K-1M, level 4. Strongest
+    ''citation-as-standard'' signal in the batch. The previous reach ''1M-10M'' was a band off a different
+    scale, and the ~914k figure an earlier source cited no longer appears anywhere on the dataset page.'
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/princeton-nlp/SWE-bench_Verified
@@ -103,9 +98,8 @@ capability:
   value: null
   confidence: high
   note: Dataset, not 'capable'. Notably high contamination-resistance and discriminating power for coding
-    agents (real repo state, executable tests), but per recipe capability is n/a; the quality proxy is
-    noted, not numerically scored. Re-read 2026-08-13 and the abstention stands - the page publishes
-    a static instance set and no performance or feature claim the capability axis could band.
+    agents (real repo state, executable tests), but per recipe capability is n/a; the quality proxy is noted,
+    not numerically scored.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/princeton-nlp/SWE-bench_Verified

--- a/sources/scores/swe-bench.yaml
+++ b/sources/scores/swe-bench.yaml
@@ -16,9 +16,8 @@ openness:
     - no feature-gated core
   confidence: high
   last_verified: '2026-08-13'
-  note: MIT-licensed harness, full source public; OSI -> open_source. Re-read 2026-08-13 against the repo
-    the product declares, SWE-bench/SWE-bench (the cited princeton-nlp path now redirects there). The
-    license endpoint still reports MIT and the README still ships the whole harness with no paid tier.
+  note: MIT-licensed harness, full source public; OSI -> open_source. The repo the product declares is SWE-bench/SWE-bench,
+    the cited princeton-nlp path redirecting there; the README ships the whole harness with no paid tier.
   raw: license:MIT(OSI);source:public(GitHub);harness+inference+eval code public;no feature-gated core;core-gated:ungated
   sources:
   - url: https://pypi.org/project/swebench/
@@ -56,13 +55,13 @@ adoption:
     corroboration rather than the basis
   note: SWE-bench Verified is the de-facto-standard agentic-coding eval cited in essentially every 2025-26
     frontier release report (GPT-5 74.9%, DeepSeek-V4-Pro 80.6%, Qwen3.6, Kimi K2.6) -- the top adoption
-    signal for a harness per recipe. pypistats reports ~31.5M swebench downloads/mo but that figure is
-    almost certainly CI/benchmark-runner-inflated and not human installs, so used as corroboration only,
-    not the headline; level set on standard-status, capped at 4. Re-read 2026-08-13 - the pypistats API
-    now reports 45,994,790 swebench downloads in the trailing 30 days, up from the 31.5M cited here. On
-    the software download bands that figure would sit at level 5, and the level is deliberately not moved
-    on it, for the reason already recorded - this package is pulled by benchmark runners rather than
-    installed by people, so the count is not a use count. Flagged for review rather than edited.
+    signal for a harness per recipe. pypistats reports ~31.5M swebench downloads/mo but that figure is almost
+    certainly CI/benchmark-runner-inflated and not human installs, so used as corroboration only, not the
+    headline; level set on standard-status, capped at 4. pypistats now reports 45,994,790 swebench downloads
+    in the trailing 30 days, up from the 31.5M cited here; on the software download bands that figure would
+    sit at level 5, and the level is deliberately not moved on it, for the reason already recorded - the
+    package is pulled by benchmark runners rather than installed by people, so the count is not a use count.
+    Flagged for review rather than edited.
   sources:
   - url: https://pypistats.org/packages/swebench
     shows: ~31.5M monthly PyPI downloads (likely CI-inflated; corroboration only)
@@ -91,10 +90,9 @@ capability:
     most-cited coding benchmark'
   confidence: high
   last_verified: '2026-08-13'
-  note: Frontier-definer within evaluation_code for agentic/coding eval -- the reference harness for the
-    benchmark every lab reports against. Feature matrix re-read 2026-08-13 and unchanged - patch generation
-    against real GitHub issues, containerized test-based grading, and the Verified/Lite/Multimodal splits
-    all still documented in the repo README.
+  note: 'Frontier-definer within evaluation_code for agentic/coding eval -- the reference harness for the
+    benchmark every lab reports against: patch generation against real GitHub issues, containerized test-based
+    grading, and the Verified/Lite/Multimodal splits, all documented in the repo README.'
   sources:
   - url: https://github.com/princeton-nlp/SWE-bench
     shows: harness runs models on real GitHub issues with test-based verification; multimodal split

--- a/sources/scores/swift.yaml
+++ b/sources/scores/swift.yaml
@@ -80,9 +80,9 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: 122,381 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (ms-swift 122,381). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected from
-    level 4, which the declared artifacts do not support.
+  note: 122,381 downloads in the trailing 30 days summed across the 1 declared artifact(s) (ms-swift 122,381).
+    Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected from level 4, which the
+    declared artifacts do not support.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/ms-swift/recent

--- a/sources/scores/syfthub.yaml
+++ b/sources/scores/syfthub.yaml
@@ -14,9 +14,8 @@ openness:
     service:
       value: none
   confidence: high
-  note: 'Fully open source: Apache-2.0 SDK, self-hostable, no proprietary tier. Built on OpenMined''s
-    open Syft privacy stack. Re-read 2026-08-13 - the repo still reports Apache-2.0 over the whole tree
-    and publishes the SDK in full, with no hosted service and no paid tier. Nothing moved.'
+  note: 'Fully open source: Apache-2.0 SDK, self-hostable, no proprietary tier. Built on OpenMined''s open
+    Syft privacy stack.'
   raw: license:Apache-2.0(OSI);source:public(github.com/OpenMined/syft-hub-sdk);self-host:yes;service:none
   last_verified: '2026-08-13'
   sources:
@@ -35,13 +34,11 @@ adoption:
   reach: <1K stars
   signal_type: stars_fallback
   confidence: low
-  note: '~2 GitHub stars (July 2026), created Aug 2025 — pre-adoption. Part of OpenMined''s federated-RAG
-    effort (also local-rag, local-rag-router). Included as an emerging entry, not on adoption merit. Stars
-    read 2026-08-13: 2 across the 1 declared repo, which bands at <1K stars, level 1 on the stars scale in
-    signal_routing.yaml. The previous reach ''<10K'' was not a label this instrument offers - stars have their
-    own vocabulary because a star is not a download. Re-read 2026-08-13 from the repo page, which still
-    reports 2 stars and 0 forks and still publishes no download or user figure. <1K stars still bands
-    at 1.'
+  note: ~2 GitHub stars (July 2026), created Aug 2025 — pre-adoption. Part of OpenMined's federated-RAG
+    effort (also local-rag, local-rag-router). Included as an emerging entry, not on adoption merit. 2 stars
+    across the 1 declared repo, which bands at <1K stars, level 1 on the stars scale in signal_routing.yaml.
+    The previous reach '<10K' was not a label this instrument offers - stars have their own vocabulary because
+    a star is not a download.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/OpenMined/syft-hub-sdk
@@ -56,9 +53,7 @@ capability:
   confidence: low
   note: Implements a full federated RAG pipeline — distributed private indexing, federated query broadcast,
     local top-k retrieval, global aggregation/ranking, and LLM synthesis. A distinctive privacy-preserving
-    approach (nothing else on the map does federated RAG), but early-stage and narrow. Re-read 2026-08-13
-    - the OpenMined page still describes the same federated RAG architecture and the SDK repo still ships
-    only the client, with no benchmark placement. One below openrag, the nearest RAG stack on this map.
+    approach (nothing else on the map does federated RAG), but early-stage and narrow.
   relative_to: openrag
   relation: one_below
   last_verified: '2026-08-13'

--- a/sources/scores/synth.yaml
+++ b/sources/scores/synth.yaml
@@ -11,8 +11,7 @@ openness:
     dataset_card:
       value: present
   confidence: high
-  note: 'Permissively licensed, ungated dataset with a documented card. Re-read 2026-08-13: cc-by-4.0 on
-    the Hub, gated false, card intact.'
+  note: Permissively licensed, ungated dataset with a documented card.
   raw: license:CC-BY-4.0(permissive);access:ungated;dataset_card:present
   last_verified: '2026-08-13'
   sources:
@@ -50,9 +49,9 @@ capability:
   basis_detail: results
   value: null
   confidence: medium
-  note: 'A novel fully-open synthetic reasoning corpus with real first-party end-to-end results (Baguettotron
-    best-in-class sub-350M), but single-lab evidence. Re-read 2026-08-13: the PleIAs post still reports
-    Baguettotron at 321M and Monad at 56M trained end to end on SYNTH, and the evidence is still single-lab.'
+  note: A novel fully-open synthetic reasoning corpus with real first-party end-to-end results (Baguettotron
+    best-in-class sub-350M), but single-lab evidence. The PleIAs post reports Baguettotron at 321M and Monad
+    at 56M, both trained end to end on SYNTH.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/blog/Pclanglais/synth-data-frontier

--- a/sources/scores/tavily-search-api.yaml
+++ b/sources/scores/tavily-search-api.yaml
@@ -14,12 +14,8 @@ openness:
       detail: credits, rate limits
       raw: cloud SaaS with API keys, credits, rate limits
   confidence: high
-  note: 'Closed search/scrape API (the recipe''s closed counterpart to Milvus/Qdrant); only client SDKs are
-    open, the search service itself is proprietary. Re-read 2026-08-13: the docs are organized around API
-    credits and rate limits with hosted Search, Extract, Crawl, Map and Research endpoints, and the only
-    Open Source section in the navigation is a gallery of example projects BUILT WITH the API, not the API
-    itself. No self-host, on-premise or source-available option is documented anywhere in it. So source stays
-    closed and the score stays 1.'
+  note: Closed search/scrape API (the recipe's closed counterpart to Milvus/Qdrant); only client SDKs are
+    open, the search service itself is proprietary.
   raw: license:Proprietary(API-only);source:closed(no self-hostable core; only thin client SDKs are public);managed:cloud
     SaaS with API keys, credits, rate limits
   last_verified: '2026-08-13'
@@ -45,11 +41,9 @@ adoption:
   note: Tavily's own homepage states 2M+ developers and 300M+ monthly requests, billions of pages crawled
     (both figures re-confirmed on the live homepage 2026-06-04); it is the default search provider wired
     into LangChain/CrewAI/LlamaIndex agent stacks. Developer reach solidly in 1-10M band; request volume
-    is far higher. Acquisition by Nebius corroborates enterprise traction. Re-read 2026-08-13 and both figures
-    are still on the homepage unchanged - "Trusted by 2M+ developers around the world" and a stats grid reading
-    300M+ "monthly requests handled" and Billions of pages extracted. The band is taken on the developer
-    count, which is what puts it at 1M-10M; the request figure would band higher but requests are not the
-    quantity this scale measures, and it stays in the note as context rather than as the basis. Level 4 unchanged.'
+    is far higher. Acquisition by Nebius corroborates enterprise traction. The band is taken on the developer
+    count, which is what puts it at 1M-10M; the request figure would band higher, but requests are not the
+    quantity this scale measures, so it stands as context rather than as the basis.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.tavily.com/
@@ -70,13 +64,9 @@ capability:
   value: search + extract + crawl + map + research endpoints; real-time freshness; structured/LLM-ready
     output; SLA + rate limits; default integration across major agent frameworks
   confidence: medium
-  note: 'Full {coverage, freshness, structured output, rate limits} feature set purpose-built for agents and
-    the de-facto default in agent frameworks; near-frontier among agent search APIs but not the single category-definer.
-    Re-read 2026-08-13: the documented endpoint set is unchanged - Search, Extract, Crawl, Map and Research
-    - and the Research API now shows structured JSON-schema output with a citation_format option, which is
-    the structured-output dimension the band rests on. Rate limits and credits are still first-class documented
-    concerns. No independent benchmark for agent search APIs has appeared, so the basis stays feature_matrix
-    and the band stays 4.'
+  note: Full {coverage, freshness, structured output, rate limits} feature set purpose-built for agents
+    and the de-facto default in agent frameworks; near-frontier among agent search APIs but not the single
+    category-definer.
   last_verified: '2026-08-13'
   sources:
   - url: https://docs.tavily.com/

--- a/sources/scores/tensorflow.yaml
+++ b/sources/scores/tensorflow.yaml
@@ -13,10 +13,9 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: 'Apache-2.0 licensed with full public source. Re-read 2026-08-13: the cited repo page still carries
-    the Apache-2.0 terms, the GitHub API reports the repository public, unarchived and licensed Apache-2.0,
-    and the README describes the whole library with no paid, enterprise or hosted tier beside it, so source
-    stays public and core-gated stays ungated.'
+  note: Apache-2.0 licensed with full public source. The repository is public and unarchived, and the README
+    describes the whole library with no paid, enterprise or hosted tier beside it, so source is public and
+    the core ungated.
   raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -51,15 +50,13 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: 'Re-scored 4->5. 21.06M PyPI downloads in the last 30 days. The map''s prevailing usage_volume level-5
+  note: Re-scored 4->5. 21.06M PyPI downloads in the last 30 days. The map's prevailing usage_volume level-5
     floor is >10M/mo (cf. pydantic-ai ~31M, llama-index ~10.18M, langgraph ~58M, fastmcp ~72.7M, all level
     5); the prior level 4 here applied a stricter 5M-50M band used only in one ml_frameworks scoring batch,
     which placed these frameworks inconsistently below map peers of equal or lower volume. TensorFlow at
-    21M/mo is one of the two foundational training frameworks and clears the prevailing floor. Re-read 2026-08-13
-    from the cited pepy.tech reading of the declared PyPI artifact `tensorflow`: 19,669,609 downloads in
-    the trailing 30 days, which bands at >10M, level 5 on the software scale. Unchanged. The `tensorflow-cpu`
+    21M/mo is one of the two foundational training frameworks and clears the prevailing floor. The `tensorflow-cpu`
     wheel, conda and the official Docker images are separate uncounted channels, so the figure is a floor
-    for the top band rather than a full count.'
+    for the top band rather than a full count.
   last_verified: '2026-08-13'
   sources:
   - url: https://pepy.tech/projects/tensorflow
@@ -73,8 +70,7 @@ capability:
   value: 'Foundational ML platform: numerical computation graph engine, neural network training, multi-device
     (CPU/GPU/TPU) and edge deployment.'
   confidence: high
-  note: 'Defines the model-training layer alongside PyTorch. Re-read 2026-08-13: the cited repository page
-    still describes the product as recorded, so the band is unchanged.'
+  note: Defines the model-training layer alongside PyTorch.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/tensorflow/tensorflow

--- a/sources/scores/tensorlake-sandbox.yaml
+++ b/sources/scores/tensorlake-sandbox.yaml
@@ -85,10 +85,10 @@ adoption:
   reach: <1K stars
   signal_type: stars_fallback
   confidence: low
-  note: 986 GitHub stars on tensorlakeai/tensorlake, read 2026-08-12. Bands at level 1 (<1K stars) on the
-    stars fallback scale, which caps at 3 because a star is not a use. Resynced because the note placed
-    it at 2 on 'a low-thousands star base'; the count is under one thousand. No download, install or customer
-    figure is published for this product, so stars remain the only honest signal and the level is directional.
+  note: 986 GitHub stars on tensorlakeai/tensorlake. Bands at level 1 (<1K stars) on the stars fallback
+    scale, which caps at 3 because a star is not a use. Resynced because the note placed it at 2 on 'a low-thousands
+    star base'; the count is under one thousand. No download, install or customer figure is published for
+    this product, so stars remain the only honest signal and the level is directional.
   last_verified: '2026-08-12'
   sources:
   - url: https://api.github.com/repos/tensorlakeai/tensorlake
@@ -105,34 +105,22 @@ capability:
     thousands of concurrent sandboxes
   confidence: medium
   note: 'Firecracker microVM isolation plus durable-execution orchestration and snapshot/resume make for
-    a rich agent-runtime feature set, level with the microVM peers. Independent ComputeSDK TTI benchmarks
-    measure ~460ms median cold-start (12th of 19 sandbox providers), mid-pack and consistent with the
-    sub-second claim. NOT VERIFIED ON 2026-08-13 - deliberately left undated and escalated, because the
-    benchmark half of this band no longer reads as recorded. The ComputeSDK leaderboard has re-run since
-    (last run 7 August 2026) and now covers 24 providers. Tensorlake reads 1.35s median time-to-interactive,
-    1.44s P95, 1.44s P99, composite 86.1, 15th of 24 - not ~460ms and not 12th of 19. That is roughly
-    three times the recorded figure and it contradicts the "cold-start - sub-second" clause in the value
-    string above, which was the measured half of a band otherwise resting on feature breadth. Note also
-    that 460ms is the number the vendor site itself animates in its demo, so the earlier record may have
-    read the vendor claim and the leaderboard as agreeing when only one of them was measured. The feature
-    half does still hold - tensorlake.ai still leads on Firecracker isolation with each tool call and
-    harness in its own microVM, snapshots with pause/fork/resume, versioned mountable volumes, durable
-    serverless functions with queues, timers and retries, and cloud dev boxes. Whether a 1.35s
-    time-to-interactive should pull this off 4 is a score decision and is not being taken here.
-    DATED 2026-08-14 after re-deriving against the current leaderboard rerun. Both cited sources were
-    re-fetched and both read as the day before - tensorlake.ai returns a byte-identical body, and the
-    leaderboard still shows the 7 August 2026 run over 24 providers with Tensorlake at 86.1 composite,
-    1.35s median, 1.44s P95, 1.44s P99, 100% success. So the ~3x discrepancy against the recorded
-    ~460ms is a stable reading of a settled run, not a transient page state. The one change made here
-    is to the value string, which claimed "cold-start - sub-second" as if measured; it now records the
-    vendor claim and the measured figure separately, which is what the two sources actually support.
-    The 4 is left exactly where it was and the question of whether 1.35s should pull it down is
-    escalated rather than taken.'
+    a rich agent-runtime feature set, level with the microVM peers: tensorlake.ai leads on Firecracker isolation
+    with each tool call and harness in its own microVM, snapshots with pause/fork/resume, versioned mountable
+    volumes, durable serverless functions with queues, timers and retries, and cloud dev boxes. THE MEASURED
+    HALF OF THE BAND HAS MOVED AND IS ESCALATED RATHER THAN ACTED ON. Independent ComputeSDK TTI benchmarks
+    now put Tensorlake at 1.35s median time-to-interactive, 1.44s P95, composite 86.1, 15th of 24 providers
+    - roughly three times the ~460ms and 12th-of-19 reading this band was written against, and against the
+    vendor''s own sub-second creation claim. Note that 460ms is the number the vendor site itself animates
+    in its demo, so the earlier record may have read the vendor claim and the leaderboard as agreeing when
+    only one of them was measured. The value string no longer asserts sub-second as if measured; it records
+    the vendor claim and the measured figure separately, which is what the two sources actually support.
+    The 4 is left exactly where it was, and whether a 1.35s time-to-interactive should pull it down is escalated
+    rather than taken here.'
   last_verified: '2026-08-14'
   sources:
   - url: https://www.tensorlake.ai/
     shows: Firecracker microVM sandboxes, snapshot/suspend/resume, durable execution, scale to thousands.
-      Re-fetched 2026-08-14, byte-identical body, same digest.
     accessed: '2026-08-14'
     http_status: 200
     content_sha256: 7522474f25c2864dae63f26e180926d421d634994f2ba2b3f4405d4882578456

--- a/sources/scores/tensorrt-llm.yaml
+++ b/sources/scores/tensorrt-llm.yaml
@@ -15,12 +15,12 @@ openness:
       detail: vendor-hardware lock, not a license restriction
       raw: runs only on NVIDIA GPUs (vendor-hardware lock, not a license restriction)
   confidence: high
-  note: Apache-2.0 across the repo, re-confirmed today. The LICENSE body still opens "This project is licensed
-    under the Apache 2.0 license" and appends the terms of bundled third-party code (MIT, BSD-3-Clause,
-    and an LTX-2 Community License scoped to tensorrt_llm/_torch/visual_gen/models/ltx2/), which is why
-    GitHub's classifier reports NOASSERTION. The published tree carries the C++ runtime and kernels in cpp/
-    rather than a stub, so nothing is gated out of the source; NVIDIA sells NIM and enterprise support as
-    separate products. No change from the 2026-07-30 correction (4->5, open_core->open_source).
+  note: Apache-2.0 across the repo. The LICENSE body opens "This project is licensed under the Apache 2.0
+    license" and appends the terms of bundled third-party code (MIT, BSD-3-Clause, and an LTX-2 Community
+    License scoped to tensorrt_llm/_torch/visual_gen/models/ltx2/), which is why GitHub's classifier reports
+    NOASSERTION. The published tree carries the C++ runtime and kernels in cpp/ rather than a stub, so nothing
+    is gated out of the source; NVIDIA sells NIM and enterprise support as separate products. Corrected
+    from 4/open_core to 5/open_source.
   last_verified: '2026-08-09'
   raw: license:Apache-2.0(OSI, stated in LICENSE; GitHub reports NOASSERTION because of the bundled-dependency
     appendix);source:public;core-gated:ungated;caveat:runs only on NVIDIA GPUs (vendor-hardware lock, not
@@ -55,11 +55,10 @@ adoption:
   signal_type: reported_traction
   confidence: high
   banded_quantity: GitHub stars (14,342), not a download or user count
-  note: 'Re-confirmed today: 14,342 GitHub stars (up from ~13.8k), and both comparison pieces still frame
-    TensorRT-LLM as the specialist choice - highest raw throughput on standardized NVIDIA fleets, but narrower
-    reach than vLLM/SGLang because of compilation overhead and single-vendor lock-in. No clean standalone
-    user/download count exists to band directly; level 3 reflects significant but specialized production
-    usage.'
+  note: 14,342 GitHub stars (up from ~13.8k), and both comparison pieces frame TensorRT-LLM as the specialist
+    choice - highest raw throughput on standardized NVIDIA fleets, but narrower reach than vLLM/SGLang because
+    of compilation overhead and single-vendor lock-in. No clean standalone user/download count exists to
+    band directly; level 3 reflects significant but specialized production usage.
   last_verified: '2026-08-09'
   sources:
   - url: https://github.com/NVIDIA/TensorRT-LLM
@@ -87,14 +86,13 @@ capability:
   basis_detail: MLPerf
   value: null
   confidence: high
-  note: 'MLPerf Inference v4.0 (re-read today): NVIDIA''s own recap states the HGX H100 platform ''delivered
-    nearly 3x more performance on the GPT-J test compared to the prior round thanks to our TensorRT-LLM
-    software.'' A March 2026 independent H100 bake-off (Llama 3.3 70B, FP8) still puts TensorRT-LLM ahead
-    on raw throughput (2,100 tok/s vs. vLLM''s 1,850 and SGLang''s 1,920), at the cost of a much longer
-    cold start (~28 min vs. ~1 min). No relative_to peer recorded: the same source also cites a newer engine
-    (TokenSpeed) claiming a 9-11% edge over TensorRT-LLM on B200 for agentic workloads, and none of vLLM/SGLang/TokenSpeed''s
-    own capability bands in this map are confirmed as of today, so no comparison can be dated here without
-    borrowing a stale peer date.'
+  note: 'MLPerf Inference v4.0: NVIDIA''s own recap states the HGX H100 platform ''delivered nearly 3x more
+    performance on the GPT-J test compared to the prior round thanks to our TensorRT-LLM software.'' A March
+    2026 independent H100 bake-off (Llama 3.3 70B, FP8) puts TensorRT-LLM ahead on raw throughput (2,100
+    tok/s vs. vLLM''s 1,850 and SGLang''s 1,920), at the cost of a much longer cold start (~28 min vs. ~1
+    min). No relative_to peer is recorded: the same source cites a newer engine (TokenSpeed) claiming a
+    9-11% edge over TensorRT-LLM on B200 for agentic workloads, and none of vLLM/SGLang/TokenSpeed''s own
+    capability bands in this map carry a confirmation recent enough to derive from.'
   last_verified: '2026-08-09'
   sources:
   - url: https://www.hpcwire.com/2024/03/28/mlperf-inference-4-0-results-showcase-genai-nvidia-still-dominates/

--- a/sources/scores/text-generation-inference.yaml
+++ b/sources/scores/text-generation-inference.yaml
@@ -20,11 +20,12 @@ openness:
     free_text:
     - current LICENSE confirmed Apache-2.0
   confidence: high
-  note: 'Current LICENSE body re-read verbatim, still standard Apache-2.0 (not HFOIL). The repository page
-    confirms "Public archive" visibility, so source remains public despite the archive. core-gated recorded
-    ungated on 2026-08-11: no ee/ or enterprise directory, no closed package and no license key, and Hugging
-    Face''s hosted Inference Endpoints run this code rather than withhold from it. Archived and in maintenance
-    mode, which is a maintenance fact rather than an openness one and does not touch the ladder.'
+  note: 'The current LICENSE body is standard Apache-2.0, not the restrictive HFOIL license the project
+    briefly carried in 2023. The repository page shows a "Public archive" label, so source remains public
+    despite the archive. core-gated is ungated: no ee/ or enterprise directory, no closed package and no
+    license key, and Hugging Face''s hosted Inference Endpoints run this code rather than withhold from
+    it. Archived and in maintenance mode, which is a maintenance fact rather than an openness one and does
+    not touch the ladder.'
   last_verified: '2026-08-11'
   raw: license:Apache-2.0(OSI);source:public;core-gated:ungated(Apache-2.0 across the repo, no ee/ or enterprise
     directory and no license key; Hugging Face Inference Endpoints and HuggingChat are separate hosted products
@@ -56,8 +57,8 @@ adoption:
   level: 3
   signal_type: reported_traction
   confidence: medium
-  note: README still states production use at Hugging Face and now explicitly recommends vLLM/SGLang/llama.cpp/MLX
-    going forward, confirming a real but sunsetting footprint; unchanged from prior read.
+  note: README states production use at Hugging Face and explicitly recommends vLLM/SGLang/llama.cpp/MLX
+    going forward, confirming a real but sunsetting footprint.
   last_verified: '2026-08-09'
   sources:
   - url: https://github.com/huggingface/text-generation-inference
@@ -75,9 +76,11 @@ capability:
     distributed tracing (OpenTelemetry) + Prometheus metrics, OpenAI-compatible API. Feature set is frozen
     at the final release, v3.3.7 (2025-12-19), confirmed 'Latest' on the releases page.
   confidence: medium
-  note: No peer comparison is recorded for this product and none was found in today's read, so relative_to/relation
-    stay unset rather than borrowing a peer not confirmed as of this date. Development is stopped (archived);
-    feature set frozen while vLLM/SGLang continue advancing, holding it mid-pack rather than at the frontier.
+  note: No peer comparison is recorded for this product, so relative_to/relation stay unset rather than
+    borrowing an unconfirmed peer. Development is stopped (archived) and the feature set is frozen - continuous
+    batching, tensor parallelism, Flash Attention, token streaming, GPTQ/AWQ/EETQ quantization, OpenTelemetry
+    tracing, Prometheus metrics - while vLLM/SGLang continue advancing, holding it mid-pack rather than
+    at the frontier.
   basis_detail: README-documented feature set, re-read against the live page
   last_verified: '2026-08-09'
   sources:

--- a/sources/scores/the-pile-pipeline.yaml
+++ b/sources/scores/the-pile-pipeline.yaml
@@ -16,9 +16,7 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (MIT), full source public. Re-read 2026-08-13 - the LICENSE body still carries
-    the same license and the README still builds the whole product from the published repo, with no paid
-    tier, enterprise edition or license key anywhere in it.
+  note: Fully OSI-licensed (MIT), full source public.
   raw: license:MIT(OSI);source:public(EleutherAI/the-pile);governance:EleutherAI;no feature-gated core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -44,12 +42,12 @@ adoption:
   reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: medium
-  note: 1,674 GitHub stars on EleutherAI/the-pile, read 2026-08-13 from the repository API. Bands at level
-    2 (1K-10K stars) on the stars fallback scale in signal_routing.yaml, which caps at 3 because a star
-    is not a use. Frozen since April 2023 but the canonical documented-corpus construction pipeline behind
-    GPT-Neo, GPT-J and Pythia, so the level is directional. The API response is digested here the way bigcode-dataset
-    and ungoliant already are in this category; a star count drifts, so a later digest mismatch reads as
-    drift rather than as fabrication.
+  note: 1,674 GitHub stars on EleutherAI/the-pile, from the repository API. Bands at level 2 (1K-10K stars)
+    on the stars fallback scale in signal_routing.yaml, which caps at 3 because a star is not a use. Frozen
+    since April 2023 but the canonical documented-corpus construction pipeline behind GPT-Neo, GPT-J and
+    Pythia, so the level is directional. The API response is digested here the way bigcode-dataset and ungoliant
+    already are in this category; a star count drifts, so a later digest mismatch reads as drift rather
+    than as fabrication.
   last_verified: '2026-08-13'
   sources:
   - url: https://api.github.com/repos/EleutherAI/the-pile
@@ -63,8 +61,7 @@ capability:
   value: Assemble, weight/upsample, and format the 22-component Pile corpus; historically important, now
     dated.
   confidence: medium
-  note: Origin-node construction pipeline; not actively developed. Re-read 2026-08-13 - the README still
-    describes the feature set above.
+  note: Origin-node construction pipeline; not actively developed.
   last_verified: '2026-08-13'
   sources:
   - url: https://raw.githubusercontent.com/EleutherAI/the-pile/master/README.md

--- a/sources/scores/the-pile.yaml
+++ b/sources/scores/the-pile.yaml
@@ -10,11 +10,9 @@ openness:
     dataset_card:
       value: legacy-repo-only
   confidence: medium
-  note: 'Ungated download via the deduplicated HF repo; the original EleutherAI/pile repo is a loading script
+  note: Ungated download via the deduplicated HF repo; the original EleutherAI/pile repo is a loading script
     whose mirrors are dead. The card defers licensing to per-subset terms and Books3 has been withdrawn
-    from circulation. Re-read 2026-08-13: the deduplicated repo still downloads without a gate, and the
-    legacy EleutherAI/pile card still says to refer to the specific licence of whichever subset you use,
-    so the deferred licence and the legacy-repo-only card both stand.'
+    from circulation.
   raw: access:ungated;license:mixed-per-subset;dataset_card:legacy-repo-only
   last_verified: '2026-08-13'
   sources:
@@ -58,10 +56,8 @@ capability:
   basis_detail: superseded
   value: null
   confidence: high
-  note: 'The foundational 2020-era template, proven for a wide 2022-23 family (Pythia, GPT-NeoX-20B, GPT-J,
-    Cerebras-GPT), but dated and beaten by modern web corpora in FineWeb ablations. Re-read 2026-08-13:
-    the Cerebras-GPT paper still records training on the Pile alongside GPT-J, GPT-NeoX and Pythia, and
-    the FineWeb HTML still reports the newer corpus ahead of it.'
+  note: The foundational 2020-era template, proven for a wide 2022-23 family (Pythia, GPT-NeoX-20B, GPT-J,
+    Cerebras-GPT), but dated and beaten by modern web corpora in FineWeb ablations.
   relative_to: fineweb
   relation: one_below
   last_verified: '2026-08-13'

--- a/sources/scores/the-stack-v2.yaml
+++ b/sources/scores/the-stack-v2.yaml
@@ -11,9 +11,7 @@ openness:
     dataset_card:
       value: 'yes'
   confidence: high
-  note: 'Requires acceptance of terms and sharing contact info before download, so access is gated. Re-read
-    2026-08-13: the Hub still shows “You need to agree to share your contact information to access this
-    dataset” and the API reports gated auto, so the terms-acceptance-plus-contact-info gate stands.'
+  note: Requires acceptance of terms and sharing contact info before download, so access is gated.
   raw: license:permissive(SPDX);gated:terms-acceptance+contact-info;dataset_card:yes
   last_verified: '2026-08-13'
   sources:
@@ -32,9 +30,8 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 13,060 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (bigcode/the-stack-v2 13,060). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top
-    band is >1M.
+  note: 13,060 downloads in the trailing 30 days summed across the 1 declared artifact(s) (bigcode/the-stack-v2
+    13,060). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/bigcode/the-stack-v2
@@ -48,11 +45,10 @@ capability:
   basis_detail: downstream
   value: null
   confidence: high
-  note: 'Trained StarCoder2 (2024) and is the code base of SmolLM3 (2025) plus the source for Stack-Edu;
-    as the raw corpus it is beaten by its own edu-filtered slice in ablations. Re-read 2026-08-13: the StarCoder2
-    listing still records The Stack v2 at 619 programming languages and 4x the first StarCoder dataset,
-    and the SmolLM3 post still names it as the code source. Its edu-filtered slice remains the better corpus
-    in ablation, which is why this sits a band below Stack-Edu.'
+  note: Trained StarCoder2 (2024) and is the code base of SmolLM3 (2025) plus the source for Stack-Edu;
+    as the raw corpus it is beaten by its own edu-filtered slice in ablations. The Stack v2 spans 619 programming
+    languages and is 4x the first StarCoder dataset; its edu-filtered slice remains the better corpus in
+    ablation, which is why this sits a band below Stack-Edu.
   relative_to: stack-edu
   relation: one_below
   last_verified: '2026-08-13'

--- a/sources/scores/thunderbolt.yaml
+++ b/sources/scores/thunderbolt.yaml
@@ -18,12 +18,6 @@ openness:
   confidence: high
   note: OSI-licensed (MPL-2.0), full source public from launch, designed primarily for self-hosting - a
     true open AI client.
-    Re-read 2026-08-13. The repository still carries MPL-2.0 and still opens on AI You Control - choose
-    your models, own your data, eliminate vendor lock-in - with on-prem deployment as the primary path
-    and a Docker backend the reader is invited to run. The Phoronix launch report is still up and still
-    quotes the press release describing a sovereign AI client that organizations run with their own
-    choice of models. Latest release is v0.1.107 and the repo now shows 4,762 stars. Value unchanged at
-    5 / open_source.
   raw: license:MPL-2.0(OSI);source:public(github.com/thunderbird/thunderbolt);self-host:primary(enterprise
     self-hosting);governance:MZLA-Technologies(Mozilla-Foundation-subsidiary)
   last_verified: '2026-08-13'
@@ -47,12 +41,6 @@ adoption:
   note: Launched April 2026 and still in active development / mid-security-audit; no usage figures disclosed
     yet. Early-stage but backed by the Mozilla/Thunderbird brand. Conservative reported_traction pending
     real adoption signal.
-    Re-read 2026-08-13. The Register launch piece is still up and still positions Thunderbolt against
-    Copilot, ChatGPT Enterprise and Claude Enterprise, and it still discloses no usage figure. The
-    repository README still warns that the project is early and under active development and still
-    undergoing a security audit, four months on from launch, and there is still a waitlist rather than a
-    published customer or deployment count. The abstention from a measured signal therefore stands.
-    Level unchanged at 2.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.theregister.com/2026/04/16/mozilla_thunderbolt_enterprise_ai_client/
@@ -68,14 +56,9 @@ capability:
     enterprise-oriented'
   confidence: medium
   note: Broad feature surface (multi-provider, multi-platform, agentic task automation, self-host) comparable
-    to the leading open chat UIs, but newly launched and unproven; medium confidence pending maturity.
-    Re-read 2026-08-13. The gHacks launch write-up still describes the same surface - a unified
-    interface for chat, search and research over internal models, data sources and automation pipelines,
-    with administrators choosing commercial, open-source or locally hosted models, and integrations
-    spanning Haystack, MCP servers and Agent Client Protocol agents. The repository confirms web, iOS,
-    Android, Mac, Linux and Windows clients and still says there is no public inference endpoint, so the
-    user brings Ollama, llama.cpp or an OpenAI-compatible provider. Band unchanged at 4, and the
-    maturity caveat is unchanged.
+    to the leading open chat UIs, but newly launched and unproven; medium confidence pending maturity. The
+    repository confirms web, iOS, Android, Mac, Linux and Windows clients and states that there is no public
+    inference endpoint, so the user brings Ollama, llama.cpp or an OpenAI-compatible provider.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.ghacks.net/2026/04/20/mozillas-mzla-technologies-launches-thunderbolt-an-open-source-self-hosted-enterprise-ai-client/

--- a/sources/scores/ti-am67a.yaml
+++ b/sources/scores/ti-am67a.yaml
@@ -25,11 +25,10 @@ openness:
       raw: distributor (active via TI and partners)
   confidence: high
   note: Public datasheet and open SDK/TIDL tools on GitHub, commercially active, but proprietary silicon
-    and firmware keep it short of fully open hardware. Re-read 2026-08-13 - the part page still reads
-    ACTIVE, still publishes "AM67x Processors datasheet (Rev. B)" openly, still offers evaluation boards
-    in stock with an Order now path, still links Jacinto 7 LPDDR4 board design and layout guidelines
-    rather than the design of any product board, and still ships a FIRMWARE-BUILDER-AM67A alongside the
-    Linux SDKs; edgeai-tidl-tools is still a public repository. No dimension moved.
+    and firmware keep it short of fully open hardware. TI publishes the "AM67x Processors datasheet (Rev.
+    B)" openly and links Jacinto 7 LPDDR4 board design and layout guidelines rather than the design of any
+    product board, and ships a FIRMWARE-BUILDER-AM67A alongside the Linux SDKs; edgeai-tidl-tools is a public
+    repository.
   raw: schematics:partial (reference designs (BeagleY-AI board files open));toolchain:open (open SDK + TIDL
     tools + Edge AI Studio);datasheets:public (Rev B);blobs:required (proprietary silicon + TIDL firmware);retail:distributor
     (active via TI and partners)
@@ -61,9 +60,7 @@ adoption:
   signal_type: reported_traction
   confidence: high
   note: ACTIVE production part available from TI and distributors, and the basis of the widely sold BeagleY-AI
-    board, giving solid commercial and community reach. Re-read 2026-08-13 - BeagleY-AI still names the
-    "Texas Instruments AM67A Arm-based vision processor" as its processor and is still in stock at Seeed,
-    and TI's own part page still reads ACTIVE with evaluation boards in stock. Level and reach unchanged.
+    board, giving solid commercial and community reach.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.beagleboard.org/boards/beagley-ai
@@ -83,10 +80,9 @@ capability:
   value: 4 TOPS (dual C7x+MMA); quad A53 1.4 GHz; up to 8GB LPDDR4
   confidence: high
   note: 4 TOPS plus a strong vision/ISP pipeline and 8GB memory make it a capable dedicated edge-AI vision
-    SoC. Re-derived 2026-08-13 - the part page still reads "up to 4 TOPS total" from 2x C7x DSP with MMA,
-    quad Cortex-A53 at up to 1.4GHz, max LPDDR4 size of 8GB and a 600MP/s ISP feeding four cameras. It
-    sits a step above beagley-ai, the 4 TOPS board built on it, because the SoC supports 8GB where that
-    board fixes 4GB.
+    SoC. The part page reads "up to 4 TOPS total" from 2x C7x DSP with MMA, quad Cortex-A53 at up to 1.4GHz,
+    max LPDDR4 size of 8GB and a 600MP/s ISP feeding four cameras. It sits a step above beagley-ai, the
+    4 TOPS board built on it, because the SoC supports 8GB where that board fixes 4GB.
   last_verified: '2026-08-13'
   sources:
   - url: https://www.ti.com/product/AM67A

--- a/sources/scores/tinyllama-chat.yaml
+++ b/sources/scores/tinyllama-chat.yaml
@@ -19,16 +19,14 @@ openness:
     license:
     - name: Apache-2.0
       detail: OSI
-  note: 'Unusually transparent for a chat model: open base, and named public alignment datasets (UltraChat SFT +
-    UltraFeedback DPO). Corrected from 4 to 5 on 2026-07-29, and the post-training evidence moved out of a free-text
-    `post-training` key into `post-training-data` so it carries a value the rubric can read. The old 4 rested on
-    the base pretraining corpus being documented rather than packaged, but this category scores the post-training
-    data -- what the tuner released -- and zephyr scores 5/open_source on these same two datasets while sitting
-    on Mistral-7B, whose corpus is closed outright. Judging TinyLlama by its base while judging zephyr by its post-training
-    set penalized the more open of the two bases. Strongest openness in this batch alongside Nemotron.
-    Re-read 2026-08-13 - the card still carries `license:apache-2.0` and `"gated":false`, and still names
-    both alignment sets (HuggingFaceH4/ultrachat_200k for SFT, HuggingFaceH4/ultrafeedback_binarized for
-    DPO) with the TinyLlama pretraining project linked. No change.'
+  note: 'Unusually transparent for a chat model: open base, and named public alignment datasets (UltraChat
+    SFT + UltraFeedback DPO). Corrected from 4 to 5 on 2026-07-29, and the post-training evidence moved
+    out of a free-text `post-training` key into `post-training-data` so it carries a value the rubric can
+    read. The old 4 rested on the base pretraining corpus being documented rather than packaged, but this
+    category scores the post-training data -- what the tuner released -- and zephyr scores 5/open_source
+    on these same two datasets while sitting on Mistral-7B, whose corpus is closed outright. Judging TinyLlama
+    by its base while judging zephyr by its post-training set penalized the more open of the two bases.
+    Strongest openness in this batch alongside Nemotron.'
   raw: weights:open(Apache-2.0);base:TinyLlama-1.1B(open, 3T-token pretrain documented);post-training-data:open(SFT
     on UltraChat + DPO on UltraFeedback, both public datasets);code:open(pretraining project public);license:Apache-2.0(OSI)
   last_verified: '2026-08-13'
@@ -46,9 +44,9 @@ adoption:
   reach: 1M-10M
   signal_type: usage_volume
   confidence: high
-  note: ~2.31M HF downloads last month, a workhorse tiny-chat model for edge/testing/CI and educational use. Solidly
-    in the 1-10M monthly-download band. Re-read 2026-08-13 - the single declared SKU now reads 2,415,028
-    downloads in the trailing 30 days, still level 4. No change.
+  note: ~2.31M HF downloads last month, a workhorse tiny-chat model for edge/testing/CI and educational
+    use. Solidly in the 1-10M monthly-download band. The single declared SKU reads 2,415,028 downloads in
+    the trailing 30 days, still level 4.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0
@@ -63,10 +61,7 @@ capability:
   value: 1.1B Llama-2-era model; intended for lightweight/edge use, not competitive on 2026 capability benchmarks
   confidence: high
   note: Intentionally tiny (1.1B, 2023 Llama-2 architecture). Its value is footprint and openness, not capability;
-    scored 1 against a 2026 frontier comparison set. Not built to compete on reasoning/coding suites. Re-read
-    2026-08-13 - the card still publishes no benchmark table of any kind, only the 1.1B Llama 2 architecture,
-    the 3-trillion-token pretraining claim and the alignment pipeline. Nothing on it supports a higher band.
-    No change.
+    scored 1 against a 2026 frontier comparison set. Not built to compete on reasoning/coding suites.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0

--- a/sources/scores/together-fine-tuning.yaml
+++ b/sources/scores/together-fine-tuning.yaml
@@ -50,16 +50,12 @@ adoption:
   reach: null
   signal_type: unknown
   confidence: low
-  note: 'No disclosed standalone usage figure for the Together fine-tuning feature located this run (jobs run
-    / customers tuning). Together AI raised a $305M Series B and serves substantial inference traffic, and a
-    vendor case study cites a customer moving to daily iteration / 77%->87% accuracy, but no hard per-SKU FT
-    usage number was found; declining to assign a level rather than rely on a single anecdote.  ABSTENTION RE-
-    CONFIRMED 2026-08-13, and the date records that rather than a measurement. Re-read the cited page and no
-    usage figure has appeared - no jobs run, customers tuning, models fine-tuned or developer count. A null
-    level is a value here, not a gap: it says somebody looked and the vendor publishes nothing, which is the
-    honest answer for a feature sold inside a larger platform. The corpus already dates abstentions this way
-    (9 null axes carry a last_verified), and leaving them undated would make an axis unverifiable forever
-    purely because its answer is ''none''.'
+  note: 'No disclosed standalone usage figure exists for the Together fine-tuning feature - no jobs run,
+    customers tuning, models fine-tuned or developer count. Together AI raised a $305M Series B and serves
+    substantial inference traffic, and a vendor case study cites a customer moving to daily iteration /
+    77%->87% accuracy, but no hard per-SKU FT usage number is published; declining to assign a level rather
+    than rely on a single anecdote. A null level is a value here rather than a gap: the vendor publishes
+    nothing for a feature sold inside a larger platform.'
   last_verified: '2026-08-13'
   sources:
   - url: https://docs.together.ai/docs/fine-tuning-overview

--- a/sources/scores/tokenizers.yaml
+++ b/sources/scores/tokenizers.yaml
@@ -13,10 +13,9 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: 'LICENSE body is verbatim Apache License 2.0; full Rust/Python source public. Re-read 2026-08-13:
-    the cited LICENSE body still carries the Apache-2.0 terms, the GitHub API reports the repository public,
-    unarchived and licensed Apache-2.0, and the README describes the whole library with no paid, enterprise
-    or hosted tier beside it, so source stays public and core-gated stays ungated.'
+  note: LICENSE body is verbatim Apache License 2.0; full Rust/Python source public. The repository is public
+    and unarchived, and the README describes the whole library with no paid, enterprise or hosted tier beside
+    it, so source is public and the core ungated.
   raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -50,13 +49,9 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: 'PyPI last-month downloads of 189,770,639 exceed the 50M+ threshold. Read live 2026-08-13: 252,452,945
-    PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at >10M, level 5.
-    The previous reach ''189M+/month'' was free text carrying a figure rather than a band the scale declares,
-    so nothing could check it against the level beside it. No last_verified claimed: only the figure was
-    re-read, not the whole axis. Re-read 2026-08-13 from the cited pypistats reading of the declared PyPI
-    artifact `tokenizers`: 252,452,945 downloads in the trailing 30 days, which bands at >10M, level 5 on
-    the software scale. Unchanged.'
+  note: 252,452,945 PyPI downloads in the trailing 30 days for the declared artifact `tokenizers`, which
+    bands at >10M, level 5 on the software scale. The previous reach '189M+/month' was free text carrying
+    a figure rather than a band the scale declares, so nothing could check it against the level beside it.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/tokenizers/recent
@@ -69,8 +64,7 @@ capability:
   basis: feature_matrix
   value: Foundational, fast multi-algorithm tokenization with training, normalization, and pre/post-processing.
   confidence: high
-  note: 'Broad feature set and central dependency of the Transformers ecosystem. Re-read 2026-08-13: the
-    cited repository page still describes the product as recorded, so the band is unchanged.'
+  note: Broad feature set and central dependency of the Transformers ecosystem.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/huggingface/tokenizers

--- a/sources/scores/torchtune.yaml
+++ b/sources/scores/torchtune.yaml
@@ -16,9 +16,9 @@ openness:
     free_text:
     - no managed tier
   confidence: high
-  note: Fully OSI-licensed (BSD-3-Clause), re-read from the raw LICENSE body rather than the GitHub classifier
-    since this license is off the category's Apache-2.0 norm; text is clean, unmodified three-clause BSD
-    with no field-of-use or commercial carve-out. Full source public at the repo's current home (meta-pytorch/torchtune;
+  note: Fully OSI-licensed (BSD-3-Clause), read from the raw LICENSE body rather than the GitHub classifier
+    since this license is off the category's Apache-2.0 norm; the text is clean, unmodified three-clause
+    BSD with no field-of-use or commercial carve-out. Full source public at the repo's current home (meta-pytorch/torchtune;
     pytorch/torchtune 301-redirects there). No enterprise/pricing directory found; openness unaffected by
     the project being wound down.
   last_verified: '2026-08-09'
@@ -93,12 +93,11 @@ capability:
     wind-down; no FP8/FP4 or newer-method additions; behind actively-developed peers and the Megatron-LM
     anchor.'
   confidence: medium
-  note: 'Feature matrix (SFT, knowledge distillation, DPO/PPO/GRPO, QAT; FSDP2; single-device to multi-node
-    scaling; HF Hub and Weights & Biases integration) re-read and unchanged since the 2025 wind-down - no
-    new method or precision mode (FP8/FP4) added. The note''s comparison to the Megatron-LM anchor could
-    not be re-dated this pass: megatron-lm''s own capability confirmation (2026-08-08) is one day older
-    than this run (2026-08-09), so recording relative_to/relation now would make this band fresher than
-    the peer it derives from and fail check_capability.py. C3 held on feature-matrix competence alone.'
+  note: Feature matrix (SFT, knowledge distillation, DPO/PPO/GRPO, QAT; FSDP2; single-device to multi-node
+    scaling; HF Hub and Weights & Biases integration) unchanged since the 2025 wind-down - no new method
+    or precision mode (FP8/FP4) added. The note's comparison to the Megatron-LM anchor is not recorded as
+    relative_to/relation, because check_capability.py will not accept a derived band whose confirmation
+    is more recent than the anchor it derives from. C3 held on feature-matrix competence alone.
   last_verified: '2026-08-09'
   sources:
   - url: https://github.com/pytorch/torchtune

--- a/sources/scores/transformers.yaml
+++ b/sources/scores/transformers.yaml
@@ -13,12 +13,10 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: 'LICENSE file is the standard, unmodified Apache 2.0 text. Re-read 2026-08-13: the cited LICENSE
-    body still carries the Apache-2.0 terms, the GitHub API reports the repository public, unarchived and
-    licensed Apache-2.0, and the README describes the whole library with no paid, enterprise or hosted tier
-    beside it, so source stays public and core-gated stays ungated. The README''s only ''Enterprise'' string
-    links to the separate Hugging Face Enterprise Hub subscription rather than a feature withheld from this
-    library.'
+  note: LICENSE file is the standard, unmodified Apache 2.0 text. The repository is public and unarchived,
+    and the README describes the whole library with no paid, enterprise or hosted tier beside it, so source
+    is public and the core ungated. The README's only 'Enterprise' string links to the separate Hugging
+    Face Enterprise Hub subscription rather than a feature withheld from this library.
   raw: license:Apache-2.0(OSI);source:public;no feature-gated core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -53,13 +51,9 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: 'PyPI last_month downloads of 150,245,308 exceed the 50M+ Level 5 threshold. Read live 2026-08-13:
-    192,709,895 PyPI downloads in the trailing 30 days across the declared artifact(s), which bands at >10M,
-    level 5. The previous reach ''150M+/month'' was free text carrying a figure rather than a band the scale
-    declares, so nothing could check it against the level beside it. No last_verified claimed: only the
-    figure was re-read, not the whole axis. Re-read 2026-08-13 from the cited pypistats reading of the declared
-    PyPI artifact `transformers`: 192,709,895 downloads in the trailing 30 days, which bands at >10M, level
-    5 on the software scale. Unchanged.'
+  note: 192,709,895 PyPI downloads in the trailing 30 days for the declared artifact `transformers`, which
+    bands at >10M, level 5 on the software scale. The previous reach '150M+/month' was free text carrying
+    a figure rather than a band the scale declares, so nothing could check it against the level beside it.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/transformers/recent
@@ -73,9 +67,8 @@ capability:
   value: Unified framework for defining, loading, fine-tuning, and running 1M+ pretrained models across
     text, vision, audio, and multimodal tasks.
   confidence: high
-  note: 'Centralizes model definitions across training frameworks and inference engines; foundational to
-    the ecosystem. Re-read 2026-08-13: the cited repository page still describes the product as recorded,
-    so the band is unchanged.'
+  note: Centralizes model definitions across training frameworks and inference engines; foundational to
+    the ecosystem.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/huggingface/transformers

--- a/sources/scores/triton.yaml
+++ b/sources/scores/triton.yaml
@@ -13,10 +13,9 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: 'MIT license body confirmed (Tillet/OpenAI copyright); full source public. Re-read 2026-08-13: the
-    cited LICENSE body still carries the MIT terms, the GitHub API reports the repository public, unarchived
-    and licensed MIT, and the README describes the whole library with no paid, enterprise or hosted tier
-    beside it, so source stays public and core-gated stays ungated.'
+  note: MIT license body confirmed (Tillet/OpenAI copyright); full source public. The repository is public
+    and unarchived, and the README describes the whole library with no paid, enterprise or hosted tier beside
+    it, so source is public and the core ungated.
   raw: license:MIT(OSI);source:public;no feature-gated core;core-gated:ungated
   last_verified: '2026-08-13'
   sources:
@@ -51,14 +50,11 @@ adoption:
   reach: '>10M'
   signal_type: usage_volume
   confidence: high
-  note: 'PyPI last_month downloads ~64.7M. Read live 2026-08-13: 69,538,627 PyPI downloads in the trailing
-    30 days across the declared artifact(s), which bands at >10M, level 5. The previous reach ''50M+/mo''
-    was free text carrying a figure rather than a band the scale declares, so nothing could check it against
-    the level beside it. No last_verified claimed: only the figure was re-read, not the whole axis. Re-read
-    2026-08-13 from the cited pypistats reading of the declared PyPI artifact `triton`: 69,538,627 downloads
-    in the trailing 30 days, which bands at >10M, level 5 on the software scale. Unchanged. Most of these
-    installs arrive as a PyTorch dependency rather than a direct request; the wheel is still the product''s
-    own distribution channel, and no adjustment is made for it.'
+  note: 69,538,627 PyPI downloads in the trailing 30 days for the declared artifact `triton`, which bands
+    at >10M, level 5 on the software scale. The previous reach '50M+/mo' was free text carrying a figure
+    rather than a band the scale declares, so nothing could check it against the level beside it. Most of
+    these installs arrive as a PyTorch dependency rather than a direct request; the wheel is still the product's
+    own distribution channel, and no adjustment is made for it.
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/api/packages/triton/recent
@@ -71,8 +67,7 @@ capability:
   basis: feature_matrix
   value: GPU kernel language and MLIR-based compiler for custom high-performance deep-learning operators.
   confidence: high
-  note: 'Foundational kernel-authoring layer (e.g. PyTorch inductor backend) across NVIDIA/AMD GPUs. Re-read
-    2026-08-13: the cited repository page still describes the product as recorded, so the band is unchanged.'
+  note: Foundational kernel-authoring layer (e.g. PyTorch inductor backend) across NVIDIA/AMD GPUs.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/triton-lang/triton

--- a/sources/scores/trulens.yaml
+++ b/sources/scores/trulens.yaml
@@ -17,10 +17,8 @@ openness:
     core-gated:
       value: ungated
   confidence: high
-  note: MIT library that is fully functional standalone; the Snowflake Cortex hosted product is separate, not a
-    gate on the library. Re-read 2026-08-13 and unchanged - GitHub still resolves the single root LICENSE
-    to MIT, and the repository still carries the whole library with no ee/ or enterprise directory and no
-    second license beneath it.
+  note: MIT library that is fully functional standalone; the Snowflake Cortex hosted product is separate,
+    not a gate on the library.
   raw: license:MIT(OSI);source:public(github.com/truera/trulens);commercial:Snowflake-Cortex-AI-Observability(separate
     hosted product);library:not-feature-gated;core-gated:ungated
   last_verified: '2026-08-13'
@@ -40,9 +38,9 @@ adoption:
   level: 3
   signal_type: usage_volume
   confidence: medium
-  note: 111,932 PyPI downloads in the trailing 30 days for trulens, read 2026-08-12. Bands at level 3 (100K-1M)
-    on the software and model adoption scale. Nearly tripled since the score was authored and still bands
-    at 3. Corrected from level 4, which the recorded evidence did not support.
+  note: 111,932 PyPI downloads in the trailing 30 days for trulens. Bands at level 3 (100K-1M) on the software
+    and model adoption scale. Nearly tripled since the score was authored and still bands at 3. Corrected
+    from level 4, which the recorded evidence did not support.
   reach: 100K-1M
   last_verified: '2026-08-12'
   sources:
@@ -57,12 +55,10 @@ capability:
   value: feedback functions / LLM-as-judge (RAG triad, toxicity); instrumentation + tracing; experiment comparison
     across versions; Streamlit dashboard; OpenAI/HF/LiteLLM/Cortex providers
   confidence: medium
-  note: Eval-first observability; lighter than Langfuse/Helicone on production gateway and prompt management.
-    Re-read 2026-08-13 - the repository still leads on feedback functions and the RAG Triad, with no
-    gateway, prompt-registry or dataset-annotation surface, which is what the note already said. No
-    `relative_to` is recorded here on purpose - the note places TruLens BELOW langfuse and helicone while
+  note: 'Eval-first observability; lighter than Langfuse/Helicone on production gateway and prompt management.
+    No `relative_to` is recorded here on purpose: the note places TruLens BELOW langfuse and helicone while
     the score matches theirs at 4, so recording `at` would assert a comparison the prose contradicts and
-    recording `one_below` would change the score. The disagreement is left visible for a ruling.
+    recording `one_below` would change the score. The disagreement is left visible for a ruling.'
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/truera/trulens
@@ -74,9 +70,9 @@ capability:
     http_status: 200
     content_sha256: a692e7e08971b32cf73f93470bfb4c1674907e30cac99bbaace1c11d9e46a580
   - url: https://www.snowflake.com/en/blog/trulens-open-source-ai/
-    shows: '"TruLens ❤️ Snowflake OSS", published 2024-06-24, describing Snowflake''s acquisition of
-      TruEra''s AI observability platform and its continued open-source support for LLM app developers.
-      A 2024 post, re-read for what it still says rather than as current news.'
+    shows: '"TruLens ❤️ Snowflake OSS", published 2024-06-24, describing Snowflake''s acquisition of TruEra''s
+      AI observability platform and its continued open-source support for LLM app developers. A 2024 post,
+      cited for what it says rather than as current news.'
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 5e10f54f944e9a10f48858fa525ae548905b9a47ec56afacec5f3b28b44e5c81

--- a/sources/scores/truthfulqa.yaml
+++ b/sources/scores/truthfulqa.yaml
@@ -16,9 +16,7 @@ openness:
       value: public
       detail: 817 Qs, two configs, no hidden held-out
   confidence: high
-  note: 'Fully open: Apache-2.0, ungated, redistributable, complete card with creation methodology.
-    Re-read 2026-08-13: `license:apache-2.0` is still in the repo tags, the embedded repo state reads
-    `"gated":false`, and the card still documents both configs with no hidden split. No change.'
+  note: 'Fully open: Apache-2.0, ungated, redistributable, complete card with creation methodology.'
   raw: license:Apache-2.0(OSI/open,redistributable);access:public(not gated);datasheet:present(card+creation
     methodology+citation);splits:public(817 Qs, two configs, no hidden held-out)
   last_verified: '2026-08-13'
@@ -41,10 +39,10 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: medium
-  note: 109,020 Hugging Face downloads in the trailing 30 days (truthfulqa/truthful_qa), read 2026-08-12.
-    Bands at level 4 (100K-1M) on the dataset adoption scale, whose top band is >1M - one order of magnitude
-    below the software and model scales, because no dataset artifact in the corpus has ever exceeded 10M.
-    A long-standing truthfulness benchmark, though older (2021) and increasingly saturated.
+  note: 109,020 Hugging Face downloads in the trailing 30 days (truthfulqa/truthful_qa). Bands at level
+    4 (100K-1M) on the dataset adoption scale, whose top band is >1M - one order of magnitude below the
+    software and model scales, because no dataset artifact in the corpus has ever exceeded 10M. A long-standing
+    truthfulness benchmark, though older (2021) and increasingly saturated.
   last_verified: '2026-08-12'
   sources:
   - url: https://huggingface.co/api/datasets/truthfulqa/truthful_qa
@@ -57,9 +55,7 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: Dataset, not 'capable'; openness and adoption carry this category per recipe. Re-read 2026-08-13
-    and the abstention stands - the page publishes a static question set and no performance or feature
-    claim the capability axis could band.
+  note: Dataset, not 'capable'; openness and adoption carry this category per recipe.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/truthfulqa/truthful_qa

--- a/sources/scores/tulu-3-sft-mixture.yaml
+++ b/sources/scores/tulu-3-sft-mixture.yaml
@@ -11,9 +11,7 @@ openness:
     dataset_card:
       value: present
   confidence: high
-  note: 'ODC-BY licensed and ungated with a full dataset card, though some subsets carry non-commercial
-    licenses. Re-read 2026-08-13: odc-by on the Hub, gated false, card intact and still flagging the non-commercial
-    subsets.'
+  note: ODC-BY licensed and ungated with a full dataset card, though some subsets carry non-commercial licenses.
   raw: license:odc-by(mixed subset licenses incl CC-BY-NC);access:ungated;dataset_card:present
   last_verified: '2026-08-13'
   sources:
@@ -31,9 +29,8 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 36,267 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (allenai/tulu-3-sft-mixture 36,267). Bands at level 3 (10K-100K) on the dataset adoption scale, whose
-    top band is >1M.
+  note: 36,267 downloads in the trailing 30 days summed across the 1 declared artifact(s) (allenai/tulu-3-sft-mixture
+    36,267). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/allenai/tulu-3-sft-mixture
@@ -47,11 +44,9 @@ capability:
   basis_detail: downstream
   value: null
   confidence: high
-  note: 'Current multi-org SFT default (Marin, SmolLM3, OLMo 2) with SOTA open-recipe claims, but a reused
-    component rather than the head-to-head leader; Dolci now leads the fully-open frontier. Re-read 2026-08-13:
-    the Tulu 3 listing still claims results surpassing the instruct versions of Llama 3.1, Qwen 2.5, Mistral
-    and GPT-4o-mini, and the Marin 8B Instruct card still lists this mixture among its SFT sources. Dolci
-    remains the fully-open leader above it.'
+  note: Current multi-org SFT default (Marin, SmolLM3, OLMo 2) with SOTA open-recipe claims, but a reused
+    component rather than the head-to-head leader; Dolci now leads the fully-open frontier. The Tulu 3 listing
+    claims results surpassing the instruct versions of Llama 3.1, Qwen 2.5, Mistral and GPT-4o-mini.
   relative_to: dolci
   relation: one_below
   last_verified: '2026-08-13'

--- a/sources/scores/tulu.yaml
+++ b/sources/scores/tulu.yaml
@@ -22,22 +22,16 @@ openness:
       value: open
       detail: OLMES
   confidence: high
-  note: >-
-    The released weights inherit Meta's Llama 3.1 Community License (non-OSI, 700M-MAU cap), so
-    the license governs what a user downloading THIS checkpoint is bound by, not Ai2's post-
-    training layer. That layer is genuinely open - data, code, RLVR recipe and eval framework, all
-    Apache-2.0 - and it is credited where it lives: tulu-3-sft-mixture carries 5/open in
-    training_synthetic_datasets, and the same recipe produces olmo-3-instruct at 5/open_source on
-    an open base. Scoring the method on the checkpoint would score two things at once. Was 3,
-    corrected to 2 on 2026-07-29, and now 3 again on 2026-08-01 - but not a reversal to the
-    original reasoning. The 2026-07-29 correction was right at the time: the 3 it removed was
-    3/restricted, a pair no rule in the category ladder could produce. The universal license scale
-    now caps a bounded commercial license at 3/open_weights, which IS producible, so the score
-    returns while the objection that removed it stays answered.
-
-    Re-read 2026-08-13 - the 8B checkpoint still carries `license:llama3.1` and reads `"gated":false`,
-    the Tulu 3 blog still publishes the data mixes, recipe and eval framework, and open-instruct is still
-    Apache-2.0. No change.
+  note: 'The released weights inherit Meta''s Llama 3.1 Community License (non-OSI, 700M-MAU cap), so the
+    license governs what a user downloading THIS checkpoint is bound by, not Ai2''s post- training layer.
+    That layer is genuinely open - data, code, RLVR recipe and eval framework, all Apache-2.0 - and it is
+    credited where it lives: tulu-3-sft-mixture carries 5/open in training_synthetic_datasets, and the same
+    recipe produces olmo-3-instruct at 5/open_source on an open base. Scoring the method on the checkpoint
+    would score two things at once. Was 3, corrected to 2 on 2026-07-29, and now 3 again on 2026-08-01 -
+    but not a reversal to the original reasoning. The 2026-07-29 correction was right at the time: the 3
+    it removed was 3/restricted, a pair no rule in the category ladder could produce. The universal license
+    scale now caps a bounded commercial license at 3/open_weights, which IS producible, so the score returns
+    while the objection that removed it stays answered.'
   raw: weights:open(downloadable);license:Llama-3.1-Community(non-OSI;700M-MAU cap + use policy);post-training-data:open(Apache-2.0/ODC-BY);code:open(open-instruct
     Apache-2.0);recipe:open(SFT->DPO->RLVR);evals:open(OLMES)
   last_verified: '2026-08-13'
@@ -68,16 +62,12 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: >-
-    Research-scale reach. The note that stood here until 2026-08-13 was a verbatim copy of the
-    openness note and described the license rather than the adoption; it is replaced.
-
-    Re-read 2026-08-13 - the three declared model SKUs sum to 10,342 downloads in the trailing 30
-    days (Llama-3.1-Tulu-3-8B 9,421; -70B 680; -405B 241), which bands at level 2 (10K-100K) on
-    the model scale. The tulu-3-sft-mixture dataset the product also declares reads 36,267, but
-    the route takes the sum WITHIN the winning kind and the Hugging Face model route wins, so the
-    corpus is not added here; it is scored as its own product in training_synthetic_datasets. No
-    change.
+  note: Research-scale reach. The note that stood here until 2026-08-13 was a verbatim copy of the openness
+    note and described the license rather than the adoption; it is replaced. The three declared model SKUs
+    sum to 10,342 downloads in the trailing 30 days (Llama-3.1-Tulu-3-8B 9,421; -70B 680; -405B 241), which
+    bands at level 2 (10K-100K) on the model scale. The tulu-3-sft-mixture dataset the product also declares
+    reads 36,267, but the route takes the sum WITHIN the winning kind and the Hugging Face model route wins,
+    so the corpus is scored as its own product in training_synthetic_datasets rather than added here.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/models/allenai/Llama-3.1-Tulu-3-8B
@@ -101,16 +91,12 @@ capability:
   basis_detail: MMLU/GSM8K/IFEval
   value: Tulu-3-405B MMLU 87.0, GSM8K 95.5, IFEval 86.0, HumanEval 95.9, MATH 67.3
   confidence: high
-  note: >-
-    A 2025 post-training recipe on a Llama 3.1 base, at the top of its own generation and below
-    the 2026 frontier. The note that stood here until 2026-08-13 was a verbatim copy of the
-    openness note and described the license rather than the capability; it is replaced.
-
-    Re-read 2026-08-13 - the 405B card's results table still gives the Tülu 3 405B column MMLU
-    (5 shot, CoT) 87.0, GSM8K 95.5, IFEval 86.0, HumanEval 95.9 and MATH 67.3, against GPT-4o
-    (11-24) at 87.9 / 91.7 / 84.8 / 97.0 / 68.8. Every figure unchanged, and the GPT-4o column it
-    is scored against is now two model generations old, which is what keeps this at 3 rather than
-    higher. No change.
+  note: A 2025 post-training recipe on a Llama 3.1 base, at the top of its own generation and below the
+    2026 frontier. The note that stood here until 2026-08-13 was a verbatim copy of the openness note and
+    described the license rather than the capability; it is replaced. The 405B card's results table gives
+    the Tulu 3 405B column MMLU (5 shot, CoT) 87.0, GSM8K 95.5, IFEval 86.0, HumanEval 95.9 and MATH 67.3,
+    against a GPT-4o (11-24) column at 87.9 / 91.7 / 84.8 / 97.0 / 68.8 - a comparison set now two model
+    generations old, which is what keeps this at 3 rather than higher.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/allenai/Llama-3.1-Tulu-3-405B

--- a/sources/scores/txt360-pipeline.yaml
+++ b/sources/scores/txt360-pipeline.yaml
@@ -12,16 +12,13 @@ openness:
       detail: LLM360/TxT360
   confidence: low
   note: 'The README badge asserts Apache-2.0 but the repo ships no LICENSE file, so there is no actual redistribution
-    grant. Re-checked 2026-07-30: still no LICENSE file, and the GitHub license endpoint returns 404 while
-    the repo API reports a null license. Scored on that rather than on the badge. Score corrected from 3
-    to 2 on 2026-07-30. The software ladder has rungs at 1, 2, 4 and 5 and none at 3, so 3/source_available
-    was not a pair any rule could produce; the ladder scores "you can read it and not run it freely" at
-    2. On 2026-08-12 the license was moved from prose to the unstated form the corpus already uses for gaia
-    and openhermes-2-5, so the tier lookup reads a license name rather than a sentence. The value of the
-    fix is that the abstention is now about the map rather than about the record: none-declared is in no
-    tier, and no software category declares a tier for a license nobody granted. Re-read 2026-08-13 - the
-    repository API still reports a null license and the README badge still links to a LICENSE in a different
-    repository, so the abstention stands.'
+    grant: the GitHub license endpoint returns 404, the repo API reports a null license, and the badge links
+    to a LICENSE in a different repository. Scored on that rather than on the badge, corrected from 3 to
+    2. The software ladder has rungs at 1, 2, 4 and 5 and none at 3, so 3/source_available was not a pair
+    any rule could produce; the ladder scores "you can read it and not run it freely" at 2. The license
+    is recorded in the unstated form the corpus already uses for gaia and openhermes-2-5, so the tier lookup
+    reads a license name rather than a sentence - none-declared is in no tier, and no software category
+    declares a tier for a license nobody granted.'
   raw: license:none-declared(the README badge asserts Apache-2.0 but the repo ships no LICENSE file and
     the GitHub license endpoint 404s);source:public(LLM360/TxT360)
   last_verified: '2026-08-13'
@@ -46,11 +43,11 @@ adoption:
   reach: <1K stars
   signal_type: stars_fallback
   confidence: medium
-  note: 25 GitHub stars on LLM360/TxT360, read 2026-08-13 from the repository API. Bands at level 1 (<1K
-    stars) on the stars fallback scale in signal_routing.yaml, which caps at 3 because a star is not a use.
-    The value here is the 5.7T-token corpus the scripts build rather than the tool's own adoption. The API
-    response is digested here the way bigcode-dataset and ungoliant already are in this category; a star
-    count drifts, so a later digest mismatch reads as drift rather than as fabrication.
+  note: 25 GitHub stars on LLM360/TxT360, from the repository API. Bands at level 1 (<1K stars) on the stars
+    fallback scale in signal_routing.yaml, which caps at 3 because a star is not a use. The value here is
+    the 5.7T-token corpus the scripts build rather than the tool's own adoption. The API response is digested
+    here the way bigcode-dataset and ungoliant already are in this category; a star count drifts, so a later
+    digest mismatch reads as drift rather than as fabrication.
   last_verified: '2026-08-13'
   sources:
   - url: https://api.github.com/repos/LLM360/TxT360
@@ -63,8 +60,7 @@ capability:
   basis: feature_matrix
   value: Scripts for global-dedup construction of TxT360 from 99 Common Crawl snapshots + 14 curated sources.
   confidence: medium
-  note: Replication-oriented construction scripts rather than an evolving tool. Re-read 2026-08-13 - the
-    README still describes the feature set above.
+  note: Replication-oriented construction scripts rather than an evolving tool.
   last_verified: '2026-08-13'
   sources:
   - url: https://raw.githubusercontent.com/LLM360/TxT360/main/README.md

--- a/sources/scores/txt360.yaml
+++ b/sources/scores/txt360.yaml
@@ -10,8 +10,8 @@ openness:
     dataset_card:
       value: present
   confidence: high
-  note: 'ODC-BY, ungated, documented pipeline on GitHub. Re-read 2026-08-13: odc-by, gated false, card intact.
-    The LLM360 path now redirects to the IFM org on the Hub, same repo.'
+  note: ODC-BY, ungated, documented pipeline on GitHub. The LLM360 path redirects to the IFM org on the
+    Hub, same repo.
   raw: license:ODC-BY;gated:false;dataset_card:present
   last_verified: '2026-08-13'
   sources:
@@ -29,8 +29,8 @@ adoption:
   reach: 1K-10K
   signal_type: usage_volume
   confidence: high
-  note: 9,230 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (IFM/TxT360 9,230). Bands at level 2 (1K-10K) on the dataset adoption scale, whose top band is >1M.
+  note: 9,230 downloads in the trailing 30 days summed across the 1 declared artifact(s) (IFM/TxT360 9,230).
+    Bands at level 2 (1K-10K) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/LLM360/TxT360
@@ -44,11 +44,9 @@ capability:
   basis_detail: ablation
   value: null
   confidence: medium
-  note: 'A self-reported controlled ablation beats FineWeb (8x8B MoE, 1.5T tokens) but without published
-    numeric scores; trains K2 / K2-V2 (LLM360, 2024-25). Re-read 2026-08-13: the card still describes ~5T
-    globally deduplicated tokens and a mixing recipe reaching 15T+, still reports the 1.5T-token ablation
-    against FineWeb on an 8x8B mixture-of-experts with no published scores, and the K2-V2 collection still
-    lists it.'
+  note: A self-reported controlled ablation beats FineWeb (8x8B MoE, 1.5T tokens) but without published
+    numeric scores; trains K2 / K2-V2 (LLM360, 2024-25). The card describes ~5T globally deduplicated tokens
+    and a mixing recipe reaching 15T+, and the K2-V2 collection lists it.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/LLM360/TxT360

--- a/sources/scores/ultrachat-200k.yaml
+++ b/sources/scores/ultrachat-200k.yaml
@@ -10,8 +10,7 @@ openness:
     dataset_card:
       value: present
   confidence: high
-  note: 'MIT-licensed, ungated, full dataset card. Re-read 2026-08-13: mit on the Hub, gated false, card
-    intact.'
+  note: MIT-licensed, ungated, full dataset card.
   raw: license:MIT;gated:false;dataset_card:present
   last_verified: '2026-08-13'
   sources:
@@ -29,9 +28,8 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 75,198 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (HuggingFaceH4/ultrachat_200k 75,198). Bands at level 3 (10K-100K) on the dataset adoption scale, whose
-    top band is >1M.
+  note: 75,198 downloads in the trailing 30 days summed across the 1 declared artifact(s) (HuggingFaceH4/ultrachat_200k
+    75,198). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/HuggingFaceH4/ultrachat_200k
@@ -45,9 +43,8 @@ capability:
   basis_detail: superseded
   value: null
   confidence: high
-  note: 'Clean SFT before/after in the Zephyr paper (MT-Bench ~6.64), but dropped from 2024-25 default SFT
-    mixes (absent from SmolTalk and Tulu 3). Re-read 2026-08-13: the Zephyr paper still reports the dSFT
-    result on UltraChat, and UltraChat-200k is still absent from the Tulu 3 SFT mixture card.'
+  note: Clean SFT before/after in the Zephyr paper (MT-Bench ~6.64), but dropped from 2024-25 default SFT
+    mixes (absent from SmolTalk and Tulu 3).
   last_verified: '2026-08-13'
   sources:
   - url: https://ar5iv.labs.arxiv.org/html/2310.16944

--- a/sources/scores/ultrafeedback.yaml
+++ b/sources/scores/ultrafeedback.yaml
@@ -16,8 +16,7 @@ openness:
     size:
       value: 940MB
   confidence: high
-  note: 'Publicly downloadable and ungated under the permissive MIT license. Re-read 2026-08-13: mit on
-    the Hub, gated false, card intact.'
+  note: Publicly downloadable and ungated under the permissive MIT license.
   raw: license:mit;card:present;ungated:yes;rows:63,967;size:940MB
   last_verified: '2026-08-13'
   sources:
@@ -35,9 +34,8 @@ adoption:
   reach: 1K-10K
   signal_type: usage_volume
   confidence: high
-  note: 5,456 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (openbmb/UltraFeedback 5,456). Bands at level 2 (1K-10K) on the dataset adoption scale, whose top band
-    is >1M.
+  note: 5,456 downloads in the trailing 30 days summed across the 1 declared artifact(s) (openbmb/UltraFeedback
+    5,456). Bands at level 2 (1K-10K) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/openbmb/UltraFeedback
@@ -51,10 +49,8 @@ capability:
   basis_detail: ablation
   value: null
   confidence: high
-  note: 'Clean documented DPO before/after (Zephyr MT-Bench 6.64->7.34); its pipeline is the template for
-    Tulu 3 / OLMo 2 preference data, with cleaned subsets still in use. Re-read 2026-08-13: the Zephyr paper
-    still shows the dSFT-to-DPO lift on UltraFeedback, and the Tulu 3 listing still presents an open preference-data
-    recipe at scale.'
+  note: Clean documented DPO before/after (Zephyr MT-Bench 6.64->7.34); its pipeline is the template for
+    Tulu 3 / OLMo 2 preference data, with cleaned subsets still in use.
   last_verified: '2026-08-13'
   sources:
   - url: https://ar5iv.labs.arxiv.org/html/2310.16944

--- a/sources/scores/ungoliant.yaml
+++ b/sources/scores/ungoliant.yaml
@@ -16,9 +16,7 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: Fully OSI-licensed (Apache-2.0), full source public. Re-read 2026-08-13 - the LICENSE body still
-    carries the same license and the README still builds the whole product from the published repo, with
-    no paid tier, enterprise edition or license key anywhere in it.
+  note: Fully OSI-licensed (Apache-2.0), full source public.
   raw: license:Apache-2.0(OSI);source:public(oscar-project/ungoliant);governance:OSCAR project;no feature-gated
     core;core-gated:ungated
   last_verified: '2026-08-13'
@@ -45,11 +43,10 @@ adoption:
   reach: <1K stars
   signal_type: stars_fallback
   confidence: medium
-  note: 178 GitHub stars on oscar-project/ungoliant, read 2026-08-12. Bands at level 1 (<1K stars) on the
-    stars fallback scale, which caps at 3 because a star is not a use. Resynced because the recorded 2 rests
-    on importance - the official pipeline behind the OSCAR corpora - not on adoption. No download, install
-    or customer figure is published for this product, so stars remain the only honest signal and the level
-    is directional.
+  note: 178 GitHub stars on oscar-project/ungoliant. Bands at level 1 (<1K stars) on the stars fallback
+    scale, which caps at 3 because a star is not a use. Resynced because the recorded 2 rests on importance
+    - the official pipeline behind the OSCAR corpora - not on adoption. No download, install or customer
+    figure is published for this product, so stars remain the only honest signal and the level is directional.
   last_verified: '2026-08-12'
   sources:
   - url: https://api.github.com/repos/oscar-project/ungoliant
@@ -63,8 +60,7 @@ capability:
   value: Common Crawl WET processing with language ID, filtering, and metadata for multilingual corpus
     construction.
   confidence: medium
-  note: Focused single-corpus pipeline; mature for its scope. Re-read 2026-08-13 - the README still describes
-    the feature set above.
+  note: Focused single-corpus pipeline; mature for its scope.
   last_verified: '2026-08-13'
   sources:
   - url: https://raw.githubusercontent.com/oscar-project/ungoliant/main/README.md

--- a/sources/scores/v0.yaml
+++ b/sources/scores/v0.yaml
@@ -11,9 +11,7 @@ openness:
     self-host:
       value: 'no'
   confidence: high
-  note: 'Proprietary Vercel product; closed source, subscription SaaS tied to Vercel deploy infra. Re-read
-    2026-08-13 - v0.app still sells a hosted product with sign-up, pricing and enterprise tiers, one-click
-    deployment to Vercel and an iOS app, and publishes no source and no self-host path. Nothing moved.'
+  note: Proprietary Vercel product; closed source, subscription SaaS tied to Vercel deploy infra.
   raw: source:closed;license:proprietary(Vercel SaaS);self-host:no
   last_verified: '2026-08-13'
   sources:
@@ -32,12 +30,10 @@ adoption:
   signal_type: reported_traction
   confidence: medium
   banded_quantity: cumulative users since GA (4M+), not an active count
-  note: 'Vercel reports multi-million (4M+) cumulative v0 users since GA. Falls in the 1-10M band; reported_traction
-    since the figure is vendor cumulative-user rather than a hard active-user metric. Re-read 2026-08-13
-    - the Vercel blog post still states that since v0 became generally available in 2024, more than 4
-    million people have used it. WHAT WAS BANDED - a cumulative "have used it" total rather than an active
-    count, so the true active figure is lower, not higher, and that is why the instrument stays reported_traction.
-    Level unchanged.'
+  note: Vercel reports multi-million (4M+) cumulative v0 users since GA. Falls in the 1-10M band; reported_traction
+    since the figure is vendor cumulative-user rather than a hard active-user metric. WHAT WAS BANDED -
+    a cumulative "have used it" total rather than an active count, so the true active figure is lower, not
+    higher, and that is why the instrument stays reported_traction.
   last_verified: '2026-08-13'
   sources:
   - url: https://v0.app/
@@ -57,11 +53,8 @@ capability:
   value: Autonomous plan/code/DB management, NL-to-app generation, visual design mode, GitHub integration,
     one-click Vercel deploy; underlying model not publicly named; no published SWE-bench/GAIA
   confidence: low
-  note: 'Strong UI/full-stack generation autonomy scoped to web-app building; no benchmark and the backbone
-    model is not publicly disclosed (record''s ''Opus 4.8'' unverified), scored 3 on feature matrix. Re-read
-    2026-08-13 - the page still says "agentic by default - v0 plans, creates tasks, and connects to databases
-    as it builds", with design mode, design systems, app integrations, one-click deploy and an iOS app,
-    and still names no backbone model and publishes no benchmark. Two below the openhands anchor, unchanged.'
+  note: Strong UI/full-stack generation autonomy scoped to web-app building; no benchmark and the backbone
+    model is not publicly disclosed (record's 'Opus 4.8' unverified), scored 3 on feature matrix.
   relative_to: openhands
   relation: two_below
   last_verified: '2026-08-13'

--- a/sources/scores/vals-ai.yaml
+++ b/sources/scores/vals-ai.yaml
@@ -20,16 +20,14 @@ openness:
       value: published
       detail: Valkyrie AGPL-3.0 + model-library MIT
   confidence: high
-  note: 'Third-party eval platform whose benchmarks are deliberately held private to prevent dataset
-    leakage, with part of the infrastructure now published. Re-read 2026-08-14 and the correction the
-    2026-08-13 read escalated is applied. The about page states ''We have built, and even open-sourced,
-    the infrastructure we rely on to run these evaluations reproducibly and at scale across labs. This
-    includes Valkyrie, a distributed system to run agentic benchmarks, and our model library, a free
-    standard API to call models with''. Both repos are live, public and actively pushed - vals-ai/Valkyrie
-    is AGPL-3.0, pushed 2026-08-14, and vals-ai/model-library is MIT, pushed 2026-07-30. So
-    ''source:closed'' and ''eval-harness:closed'' were both wrong as written.
-    What has NOT changed is the part the tier turns on. Scores are still ''based on our privately held
-    test sets'', the Vals Index runtime is still a hosted service with no self-hostable implementation,
+  note: 'Third-party eval platform whose benchmarks are deliberately held private to prevent dataset leakage,
+    with part of the infrastructure now published. The about page states ''We have built, and even open-sourced,
+    the infrastructure we rely on to run these evaluations reproducibly and at scale across labs. This includes
+    Valkyrie, a distributed system to run agentic benchmarks, and our model library, a free standard API
+    to call models with''. Both repos are live, public and actively pushed - vals-ai/Valkyrie is AGPL-3.0
+    and vals-ai/model-library is MIT - so ''source:closed'' and ''eval-harness:closed'' were both wrong
+    as written. What has NOT changed is the part the tier turns on. Scores are still ''based on our privately
+    held test sets'', the Vals Index runtime is still a hosted service with no self-hostable implementation,
     and the held-out datasets still do not ship. That is `source: partial` in the software ladder''s own
     words - a repo exists but the runtime does not - and the ladder scores it 2/source_available. Moved
     from 1/closed.'
@@ -46,20 +44,19 @@ openness:
     shows: runs evaluations in-house on private/held-out datasets as neutral third party
     accessed: '2026-06-04'
   - url: https://www.vals.ai/about
-    shows: 'Re-read 2026-08-13: Vals still describes itself as ''the independent evaluator of artificial
-      intelligence'' running evaluations in-house on ''privately held test sets''. It now ALSO states
-      it has open-sourced Valkyrie, a distributed system for running agentic benchmarks, and a model library
-      offering a free standard API for calling models, both linked to GitHub. This contradicts the recorded
-      source:closed.'
+    shows: Vals describes itself as 'the independent evaluator of artificial intelligence' running evaluations
+      in-house on 'privately held test sets'. It ALSO states it has open-sourced Valkyrie, a distributed
+      system for running agentic benchmarks, and a model library offering a free standard API for calling
+      models, both linked to GitHub.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: deb010de89092a2071bc5e3e8168d9b85e7bfa3887d7105476aba611c90234fc
   - url: https://www.vals.ai/about
-    shows: 'Re-read 2026-08-14. ''We have built, and even open-sourced, the infrastructure we rely on
-      to run these evaluations reproducibly and at scale across labs. This includes Valkyrie, a distributed
-      system to run agentic benchmarks, and our model library, a free standard API to call models with.''
-      Beside it, ''Scores are based on our privately held test sets to preserve the integrity and signal
-      of our results'' - the harness ships, the sets and the Index runtime do not.'
+    shows: '''We have built, and even open-sourced, the infrastructure we rely on to run these evaluations
+      reproducibly and at scale across labs. This includes Valkyrie, a distributed system to run agentic
+      benchmarks, and our model library, a free standard API to call models with.'' Beside it, ''Scores
+      are based on our privately held test sets to preserve the integrity and signal of our results'' -
+      the harness ships, the sets and the Index runtime do not.'
     accessed: '2026-08-14'
     http_status: 200
     content_sha256: b90f2049e69c80ab973b902ea1524b11f79ea594d00ebf24b6d1fae7c7a7342a
@@ -89,14 +86,14 @@ adoption:
   level: 3
   signal_type: reported_traction
   confidence: medium
-  note: 'Widely cited independent leaderboard authority: 24 models tracked on the Vals Index (updated
-    2026-06-04); benchmark figures (e.g. GLM-5.1) are referenced in the project''s own flagship scoring
-    sources and across third-party model coverage; partnered with Legaltech Hub for industry studies.
-    No standalone user/traffic count published, so reported_traction; level 3 reflects broad referenced
-    use as a benchmark authority rather than a measured usage figure. Re-read 2026-08-13 - the benchmarks
-    page now tracks 43 models across the Vals Index, an RSI Index, the Multimodal Index and legal/finance/healthcare/math/academic/education/coding
-    families, with results dated 2026-08-13, so the leaderboard is broader and current. Still no user,
-    traffic or customer figure of any kind, so the level stays reported_traction at 3.'
+  note: 'Widely cited independent leaderboard authority: 24 models tracked on the Vals Index (updated 2026-06-04);
+    benchmark figures (e.g. GLM-5.1) are referenced in the project''s own flagship scoring sources and across
+    third-party model coverage; partnered with Legaltech Hub for industry studies. No standalone user/traffic
+    count published, so reported_traction; level 3 reflects broad referenced use as a benchmark authority
+    rather than a measured usage figure. The benchmarks page now tracks 43 models across the Vals Index,
+    an RSI Index, the Multimodal Index and legal, finance, healthcare, math, academic, education and coding
+    families, so the leaderboard is broader than the 24 recorded above, and it still publishes no user,
+    traffic or customer figure of any kind.'
   last_verified: '2026-08-13'
   sources:
   - url: https://www.vals.ai/benchmarks
@@ -104,9 +101,9 @@ adoption:
       updated June 2026
     accessed: '2026-06-04'
   - url: https://www.vals.ai/benchmarks
-    shows: 'Re-read 2026-08-13: 43 models tested; Vals Index, RSI Index and Vals Multimodal Index plus
-      legal, finance, healthcare, math, academic, education, coding, cybersecurity and games benchmarks;
-      several results dated 2026-08-13. No usage, traffic or customer figure is published on the page.'
+    shows: 43 models tested; Vals Index, RSI Index and Vals Multimodal Index plus legal, finance, healthcare,
+      math, academic, education, coding, cybersecurity and games benchmarks. No usage, traffic or customer
+      figure is published on the page.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 68b57a0a93207cd98932ef7bb54e1e638db27450bbb70d5e8fb6cae4841d5a6f
@@ -119,24 +116,23 @@ capability:
     indices.'
   confidence: medium
   last_verified: '2026-08-13'
-  note: 'Strong feature_matrix: leading independent/blind benchmark suite with deep vertical coverage
-    and agentic-eval, but narrower than a general harness (no self-host, fixed proprietary task set).
-    Not a frontier-definer (5) on standardization since methodology is closed; placed at 4. Feature matrix
-    re-read 2026-08-13 and the vertical coverage holds, with cybersecurity and games benchmarks added
-    since. The ''no self-host'' clause in this note is the part now under review - see the openness axis,
-    where two Vals repos have appeared - but self-hosting the index is still not offered, so the band
-    is unchanged.'
+  note: 'Strong feature_matrix: leading independent/blind benchmark suite with deep vertical coverage and
+    agentic-eval, but narrower than a general harness (no self-host, fixed proprietary task set). Not a
+    frontier-definer (5) on standardization since methodology is closed; placed at 4. The vertical coverage
+    holds, with cybersecurity and games benchmarks added since. The ''no self-host'' clause is the part
+    under review - see the openness axis, where two Vals repos have appeared - but self-hosting the index
+    is still not offered, so the band is unchanged.'
   sources:
   - url: https://www.vals.ai
     shows: Vals Index + Multimodal Index + domain benchmarks (finance/law/healthcare/coding/math/education)
       incl TaxEval, CorpFin, MedCode, LegalBench
     accessed: '2026-06-04'
   - url: https://www.vals.ai
-    shows: 'Re-read 2026-08-13: Vals Index and Vals Multimodal Index over finance (CorpFin v2, Finance
-      Agent v2, TaxEval v2), legal (LegalBench, Case Law v2, Legal Research Bench), healthcare (MedCode,
-      MedScribe, MedQA), coding (SWE-bench Verified, Terminal-Bench, Vibe Code Bench, IOI, LiveCodeBench),
-      math (ProofBench, AIME, GPQA Diamond) and education (SAGE, MMLU Pro, MMMU). ''We run all of our
-      own evaluations and create many of our benchmarks in-house''.'
+    shows: Vals Index and Vals Multimodal Index over finance (CorpFin v2, Finance Agent v2, TaxEval v2),
+      legal (LegalBench, Case Law v2, Legal Research Bench), healthcare (MedCode, MedScribe, MedQA), coding
+      (SWE-bench Verified, Terminal-Bench, Vibe Code Bench, IOI, LiveCodeBench), math (ProofBench, AIME,
+      GPQA Diamond) and education (SAGE, MMLU Pro, MMMU). 'We run all of our own evaluations and create
+      many of our benchmarks in-house'.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 303bde67a1b32448cbe8de1ef60414a71472450740363231f8cdda41ef4423db

--- a/sources/scores/vellum.yaml
+++ b/sources/scores/vellum.yaml
@@ -28,11 +28,9 @@ openness:
     earlier 4 rested on the managed memory/security layer being a differentiator, but the README states
     the managed runtime and the self-hosted one are the "Same codebase, same data model", so hosting is
     convenience rather than a feature tier. The ladder''s core_gated note is explicit that a hosted offering
-    alongside an ungated core is not gating, and 4 pairs with open_core in any case. Re-read 2026-08-13
-    - the LICENSE still carries the MIT text with "Copyright (c) 2025 Vellum AI", the repo still shows
-    an MIT badge over the full agent source, and vellum.ai still offers cloud or self-hosted. The vendor''s
-    own comparison post now says outright that "Vellum is also open source", so the "Proprietary" label
-    that prompted the original caveat is gone. Stars are now 1.1k. Nothing moved.'
+    alongside an ungated core is not gating, and 4 pairs with open_core in any case. The vendor''s own comparison
+    post now says outright that "Vellum is also open source", so the "Proprietary" label that prompted the
+    original caveat is gone.'
   raw: 'license:MIT(OSI, Copyright 2025 Vellum AI);source:public(the full agent - gateway, clients, skill
     framework, memory - in github.com/vellum-ai/vellum-assistant);core-gated:ungated(README: managed runtime
     on Vellum Platform or self-hosted, "Same codebase, same data model");self-host:yes(by design);managed-cloud:hosting
@@ -77,15 +75,13 @@ adoption:
   confidence: low
   note: 'No download/user/usage metrics disclosed (it''s a self-hosted app, not a registry package). Only
     signal available is GitHub stars (~577 on vellum-ai/vellum-assistant), used here strictly as a last-resort
-    proxy per the adoption!=stars rule; small/new entrant. Previously null; set to a conservative level 1 now
-    that a real (if weak) signal exists. Stars read 2026-08-13 on vellum-ai/vellum-assistant: 1,054, which
-    bands at 1K-10K stars, level 2 on the stars scale. The previous reach ''<1K'' was a download label, which
-    this instrument does not offer - a star is not a download. Level corrected from 1. THE REAL DEFECT is
-    upstream: this product declares no artifacts at all, so a stars_fallback band had no stars source behind
-    it and the count lived only in this note. Declaring vellum-ai/vellum-assistant would fix it, and is
-    deliberately not done here because a declared code repo also re-routes the openness license dimension.
-    Re-read 2026-08-13 from the repo page itself, which reports 1.1k stars and 156 forks, and from vellum.ai,
-    which still publishes no user or usage figure. 1K-10K stars still bands at 2.'
+    proxy per the adoption!=stars rule; small/new entrant. Previously null; set to a conservative level
+    1 now that a real (if weak) signal exists. 1,054 stars on vellum-ai/vellum-assistant, which bands at
+    1K-10K stars, level 2 on the stars scale. The previous reach ''<1K'' was a download label, which this
+    instrument does not offer - a star is not a download. Level corrected from 1. THE REAL DEFECT is upstream:
+    this product declares no artifacts at all, so a stars_fallback band had no stars source behind it and
+    the count lived only in this note. Declaring vellum-ai/vellum-assistant would fix it, and is deliberately
+    not done here because a declared code repo also re-routes the openness license dimension.'
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/vellum-ai/vellum-assistant
@@ -105,11 +101,9 @@ capability:
     multi-channel (Mac/Web/iOS/Slack/Telegram/phone), out-of-process credential isolation, ambient/proactive
     engine; no benchmark'
   confidence: low
-  note: 'Solid personal-agent feature breadth (8-type memory + multi-channel autonomous action + credential
+  note: Solid personal-agent feature breadth (8-type memory + multi-channel autonomous action + credential
     isolation + proactive engine), now confirmed against the open MIT source. No benchmark and no frontier
-    differentiator; scored 3 on feature matrix. Re-read 2026-08-13 - vellum.ai still describes the same
-    always-on personal agent across Mac, web, iOS, Slack and Telegram with structured memory and managed
-    OAuth connections, and still publishes no benchmark. Two below the openhands anchor, unchanged.'
+    differentiator; scored 3 on feature matrix.
   relative_to: openhands
   relation: two_below
   last_verified: '2026-08-13'

--- a/sources/scores/vercel-sandbox.yaml
+++ b/sources/scores/vercel-sandbox.yaml
@@ -18,14 +18,10 @@ openness:
       detail: proprietary service
       raw: Proprietary, proprietary service
   confidence: high
-  note: 'Closed managed service. The SDK/CLI are open, but they are only a client for Vercel''s proprietary
+  note: Closed managed service. The SDK/CLI are open, but they are only a client for Vercel's proprietary
     microVM cloud, which cannot be self-hosted; an open client over a closed runtime is not open_core (the
     core is proprietary). Reclassified from open_core; sits with the other proprietary sandbox clouds (Google
-    Cloud Run, Fly Sprites, Northflank). Re-read 2026-08-13 - the docs still place every sandbox in a
-    Firecracker microVM on Vercel''s own infrastructure, reached only through Vercel OIDC tokens or
-    Vercel access tokens, and the pricing and quotas page meters the product across Hobby, Pro and
-    Enterprise plans with no self-hosted or source-available option at any of them. Source and license
-    both read as recorded.'
+    Cloud Run, Fly Sprites, Northflank).
   raw: source:closed;service:proprietary Vercel Fluid-compute managed cloud (no self-host of the Firecracker
     microVM plane);open-part:client SDK/CLI only (@vercel/sandbox JS + Python, vercel/sandbox on GitHub);license:Proprietary,
     proprietary service

--- a/sources/scores/verl.yaml
+++ b/sources/scores/verl.yaml
@@ -16,9 +16,9 @@ openness:
     free_text:
     - no feature-gated core
   confidence: high
-  note: 'Re-confirmed 2026-08-09: Apache-2.0 is the unmodified boilerplate license text; the full training/rollout
-    source ships in the public repo (recipe/ is a public verl-project/verl-recipe submodule); no paid or
-    enterprise tier withholds any method from the published source.'
+  note: Apache-2.0 as unmodified boilerplate license text; the full training/rollout source ships in the
+    public repo (recipe/ is a public verl-project/verl-recipe submodule); no paid or enterprise tier withholds
+    any method from the published source.
   last_verified: '2026-08-09'
   raw: license:Apache-2.0(OSI);source:public;governance:community(ByteDance-Seed origin);no feature-gated
     core;core-gated:ungated
@@ -83,9 +83,9 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 82,590 downloads in the trailing 30 days (verl 82,590), read 2026-08-12. Bands at level 2 (10K-100K).
-    Corrected from level 4. A reinforcement-learning training framework; the note recorded 4 while citing
-    ~81,606, which is level 2 on this scale.
+  note: 82,590 downloads in the trailing 30 days, which bands at level 2 (10K-100K). A reinforcement-learning
+    training framework; corrected from level 4, which the previous note claimed while citing ~81,606 - also
+    level 2 on this scale.
   last_verified: '2026-08-12'
   sources:
   - url: https://pypistats.org/api/packages/verl/recent
@@ -102,11 +102,7 @@ capability:
   confidence: high
   note: 'Frontier-tier within finetuning_code: broadest modern RL-algorithm coverage and demonstrated use
     training production frontier reasoning models. Calibrated alongside Megatron-LM (C5) as a scale/method
-    definer for this category. Re-read 2026-08-13 and unchanged at 5. The peer comparison the note already
-    made in prose - "calibrated alongside Megatron-LM (C5) as a scale/method definer" - is now recorded as
-    relative_to/relation, which is what evidence-and-freshness.md asks for: that comparison was the instrument and it
-    was living in an English sentence where nothing could check it. `at` rather than a tier gap, because both
-    are scale/method definers for this category.'
+    definer for this category.'
   relative_to: megatron-lm
   relation: at
   last_verified: '2026-08-13'

--- a/sources/scores/vertex-ai-gen-ai-evaluation-service.yaml
+++ b/sources/scores/vertex-ai-gen-ai-evaluation-service.yaml
@@ -16,10 +16,8 @@ openness:
   confidence: high
   last_verified: '2026-08-13'
   note: Proprietary Google Cloud managed service; no source, no self-host, runs as Vertex AI eval pipelines.
-    Re-read 2026-08-13 - the overview still documents the service only as a managed part of the Gemini
-    Enterprise Agent Platform, with no source, no self-host and no license offered for the evaluation
-    service itself. The open-model references on the page are about models it can deploy and evaluate,
-    not about the service.
+    The open-model references on the overview are about models the service can deploy and evaluate, not
+    about the service itself, which is offered with no source, no self-host and no license.
   raw: license:proprietary(GCP managed service);source:closed;deployment:cloud-only(Vertex AI pipelines/AutoSxS);billing:GCP
     managed-service pricing
   sources:
@@ -28,10 +26,10 @@ openness:
       Agent Platform
     accessed: '2026-06-04'
   - url: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/evaluation-overview
-    shows: 'Re-read 2026-08-13: the Gen AI evaluation service is documented as part of the Gemini Enterprise
-      Agent Platform, run through computation-based pipelines, model-based metric templates and the AutoSxS
-      pipeline. No self-hosting option and no source for the service is offered; the ''self-deployed open
-      models'' links refer to models under evaluation, not to the evaluator.'
+    shows: The Gen AI evaluation service is documented as part of the Gemini Enterprise Agent Platform,
+      run through computation-based pipelines, model-based metric templates and the AutoSxS pipeline. No
+      self-hosting option and no source for the service is offered; the 'self-deployed open models' links
+      refer to models under evaluation, not to the evaluator.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 4d1f8992f97637bb096575d3c3f5c45fd47702c427c76e682e34eaf7cfd60641
@@ -44,18 +42,16 @@ adoption:
   signal_type: unknown
   confidence: low
   last_verified: '2026-08-13'
-  note: Managed GCP feature with no published standalone usage/customer count and no download or stars
-    signal (closed cloud service). Unlike Bedrock Evaluations there was no clear GA-scale traction figure
-    verifiable this run, so declining to assign a level rather than infer from the parent Vertex surface.
-    Re-read 2026-08-13 - looked for an evaluation-run count, a customer count or any usage statistic on
-    the overview and found none, so the abstention is re-confirmed rather than lifted.
+  note: Managed GCP feature with no published standalone usage/customer count and no download or stars signal
+    (closed cloud service). Unlike Bedrock Evaluations there was no clear GA-scale traction figure verifiable
+    this run, so declining to assign a level rather than infer from the parent Vertex surface.
   sources:
   - url: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/evaluation-overview
     shows: managed Vertex AI feature, no usage/adoption figures disclosed
     accessed: '2026-06-04'
   - url: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/evaluation-overview
-    shows: 'Re-read 2026-08-13: no usage, customer, run-count or adoption figure of any kind is published
-      on the evaluation-service overview.'
+    shows: No usage, customer, run-count or adoption figure of any kind is published on the evaluation-service
+      overview.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 4d1f8992f97637bb096575d3c3f5c45fd47702c427c76e682e34eaf7cfd60641
@@ -70,19 +66,18 @@ capability:
   relation: at
   last_verified: '2026-08-13'
   note: 'Broad managed eval suite: model/agent/RAG targets, both computation- and autorater-based metrics,
-    and pointwise + pairwise (AutoSxS) comparison. Comparable scope to Bedrock Evaluations; a custom-dataset
-    eval product rather than a public standardized leaderboard, so 4 not 5. Feature matrix re-read 2026-08-13
-    and unchanged; the comparison to Bedrock Evaluations the note already draws is now recorded structurally,
-    both sitting at 4.'
+    and pointwise + pairwise (AutoSxS) comparison. Comparable scope to Bedrock Evaluations - a comparison
+    now recorded structurally, both sitting at 4 - and a custom-dataset eval product rather than a public
+    standardized leaderboard, so 4 not 5.'
   sources:
   - url: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/evaluation-overview
     shows: evaluates models/agents/RAG with computation-based + autorater metrics and pointwise/pairwise
       AutoSxS
     accessed: '2026-06-04'
   - url: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/evaluation-overview
-    shows: 'Re-read 2026-08-13: separate sections for evaluating models, evaluating agents and grounding
-      responses using RAG; computation-based evaluation pipeline, model-based metric templates and the
-      AutoSxS pairwise pipeline all still documented.'
+    shows: Separate sections for evaluating models, evaluating agents and grounding responses using RAG;
+      computation-based evaluation pipeline, model-based metric templates and the AutoSxS pairwise pipeline
+      all documented.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 4d1f8992f97637bb096575d3c3f5c45fd47702c427c76e682e34eaf7cfd60641

--- a/sources/scores/vertex-ai-model-observability.yaml
+++ b/sources/scores/vertex-ai-model-observability.yaml
@@ -12,10 +12,8 @@ openness:
       value: tracing is built on the open OTel standard but the observability product/service itself is
         proprietary and cloud-locked
   confidence: high
-  note: Proprietary GCP managed offering (Agent Engine + Cloud Trace/Monitoring/Logging). OTel is the
-    wire standard but the service is closed and tied to Google Cloud. Re-read 2026-08-13 and unchanged -
-    the documentation still describes Cloud Trace as the place traces land, with no source, license or
-    self-hostable build of the observability service offered anywhere in it.
+  note: Proprietary GCP managed offering (Agent Engine + Cloud Trace/Monitoring/Logging). OTel is the wire
+    standard but the service is closed and tied to Google Cloud.
   raw: license:proprietary(Google Cloud managed service);source:closed;note:tracing is built on the open
     OTel standard but the observability product/service itself is proprietary and cloud-locked
   last_verified: '2026-08-13'
@@ -37,10 +35,9 @@ adoption:
   confidence: low
   banded_quantity: Vertex AI platform reach, not the tracing surface
   note: A feature surface within Vertex AI Agent Engine on Google Cloud; no standalone usage figures published
-    for the observability capability specifically. Level 3 reflects availability inside a large cloud
-    platform's agent stack, not a measured user count; directional. Re-read 2026-08-13 and unchanged - the
-    quantity actually banded here is the reach of Vertex AI, not usage of its tracing surface, and the
-    documentation still discloses no figure for either.
+    for the observability capability specifically. Level 3 reflects availability inside a large cloud platform's
+    agent stack, not a measured user count; directional. The quantity actually banded is the reach of Vertex
+    AI rather than usage of its tracing surface, and the documentation discloses no figure for either.
   last_verified: '2026-08-13'
   sources:
   - url: https://docs.cloud.google.com/agent-builder/agent-engine/manage/tracing
@@ -60,11 +57,9 @@ capability:
   confidence: medium
   relative_to: langfuse
   relation: one_below
-  note: Solid tracing + monitoring + integrated eval, but the observability matrix is thinner than the
-    dedicated OSS platforms on prompt versioning/datasets/annotation; scored 3 below the C4 anchors. The
-    comparison is now recorded rather than left in prose - one rung below the langfuse anchor at 4.
-    Re-read 2026-08-13 - the documentation still covers traces and spans over LLM and tool calls with no
-    prompt-management or annotation surface of its own.
+  note: Solid tracing + monitoring + integrated eval, but the observability matrix is thinner than the dedicated
+    OSS platforms on prompt versioning/datasets/annotation; scored 3 below the C4 anchors. The comparison
+    is now recorded rather than left in prose - one rung below the langfuse anchor at 4.
   last_verified: '2026-08-13'
   sources:
   - url: https://docs.cloud.google.com/agent-builder/agent-engine/manage/tracing

--- a/sources/scores/vibethinker.yaml
+++ b/sources/scores/vibethinker.yaml
@@ -16,9 +16,7 @@ openness:
     - name: MIT
   confidence: medium
   note: MIT-licensed weights, but a fine-tune of the open-weight Qwen2.5 line without a fully open/reproducible
-    data+training pipeline -> open_weights tier, not open_source. Re-read 2026-08-13 - the card still carries
-    `license:mit` with `"gated":false` and `base_model - Qwen/Qwen2.5-Coder-3B`, and still publishes no
-    RL or SFT mixture and no training pipeline. No change.
+    data+training pipeline -> open_weights tier, not open_source.
   raw: weights:open(MIT);base:open_weights(Qwen2.5);data:partial(RL/SFT data not fully released);license:MIT
   last_verified: '2026-08-13'
   sources:
@@ -60,9 +58,7 @@ capability:
   value: AIME 2026 94.3, GPQA Diamond 70.2, IMO-AnswerBench 76.4, LeetCode 96.1% accept
   confidence: medium
   note: Frontier-range on narrow verifiable math/code reasoning despite 3B, but explicitly not for general/agentic
-    use -> mid-tier on a general-capability scale. Re-read 2026-08-13 - the card's model-index still records
-    MathArena/aime_2026 94.3 and GPQA Diamond 70.2, and the Key Performance Data section still claims 76.4
-    on IMO-AnswerBench at 3B parameters. No change.
+    use -> mid-tier on a general-capability scale.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/WeiboAI/VibeThinker-3B

--- a/sources/scores/weave.yaml
+++ b/sources/scores/weave.yaml
@@ -92,9 +92,8 @@ adoption:
   confidence: high
   note: '~1.03M PyPI downloads in the last month for the `weave` package (primary: pypistats); rides the
     established W&B install base (ML teams adding LLM observability without leaving W&B). 1-10M monthly-download
-    band. Re-read 2026-08-13 - pypistats now reports 1,052,916 downloads last month, effectively unchanged
-    and still just inside the 1M-10M band, so level 4 stands. It sits close to the boundary, and a further
-    fall would put it at 3.'
+    band. pypistats reports 1,052,916 downloads in the last month, just inside the 1M-10M band; it sits
+    close to the boundary, and a further fall would put it at 3.'
   last_verified: '2026-08-13'
   sources:
   - url: https://pypistats.org/packages/weave
@@ -111,12 +110,12 @@ capability:
     + code scorers, experiments vs datasets); datasets/annotation; cost tracking; integrations(OpenAI/Anthropic
     + framework hooks). Missing dedicated prompt-management/versioning depth vs MLflow/Langfuse.
   confidence: medium
-  note: Competent end-to-end tracing+eval suite; rated 4 = at the MLflow/Langfuse anchor tier on feature
+  note: 'Competent end-to-end tracing+eval suite; rated 4 = at the MLflow/Langfuse anchor tier on feature
     breadth, just short of frontier (lighter prompt-versioning + OTel story than Langfuse/MLflow per 2026
-    comparisons). Re-read 2026-08-13 - the README still frames the product as logging and debugging model
-    inputs, outputs and traces plus rigorous evaluations, and states that Weave boards are on pause "as we
-    focus on Tracing and Evaluations", which narrows rather than widens the surface. The band holds at the
-    langfuse anchor but with less headroom than the note implied.
+    comparisons). The README frames the product as logging and debugging model inputs, outputs and traces
+    plus rigorous evaluations, and states that Weave boards are on pause "as we focus on Tracing and Evaluations",
+    which narrows rather than widens the surface: the band holds at the langfuse anchor, but with less headroom
+    than the rest of this note implies.'
   last_verified: '2026-08-13'
   sources:
   - url: https://raw.githubusercontent.com/wandb/weave/master/README.md

--- a/sources/scores/webcontainers.yaml
+++ b/sources/scores/webcontainers.yaml
@@ -23,13 +23,12 @@ openness:
       detail: proprietary binary
       raw: '@webcontainer/api npm (proprietary binary)'
   confidence: high
-  note: The MIT 'open' repo holds no implementation; the runtime is closed and gated by a commercial
-    license for production use. Best classed source_available leaning closed; flag open_washed for the
-    MIT-issue-tracker-as-open source framing. Re-read 2026-08-13 - stackblitz/webcontainer-core is still
-    MIT and still holds no runtime implementation, its last push predating this check by well over a year,
-    and the WebContainer enterprise licensing page still states that prototypes and proofs of concept need
-    no commercial license while production use in a commercial, for-profit setting does. That page no longer
-    states the 10k-requests-per-month threshold the recorded detail cites.
+  note: The MIT 'open' repo holds no implementation; the runtime is closed and gated by a commercial license
+    for production use. Best classed source_available leaning closed; flag open_washed for the MIT-issue-tracker-as-open
+    source framing. The WebContainer enterprise licensing page states that prototypes and proofs of concept
+    need no commercial license while production use in a commercial, for-profit setting does; it no longer
+    states the 10k-requests-per-month threshold the recorded license-terms detail cites, and stackblitz/webcontainer-core
+    has gone well over a year without a push.
   raw: source:partial;public-repo:webcontainer-core is MIT but issue-tracker only (no runtime source);actual-runtime:proprietary(StackBlitz);license-terms:Proprietary,
     free for OSS/prototypes, commercial license required for for-profit production(charge beyond 10k API
     req/mo);distribution:@webcontainer/api npm (proprietary binary)
@@ -62,11 +61,11 @@ adoption:
   confidence: low
   note: Powers StackBlitz's own IDE and is embedded by named projects (SvelteKit, Astro, Scrimba, egghead.io,
     Xata) for in-browser code experiences. No disclosed download/MAU figure on the primary pages; placed
-    at 3 on named-integration reported traction. No hard usage_volume number found, so confidence low.
-    Re-read 2026-08-13 - webcontainers.io still names the same integrations and adds Suborbital, re-tune
-    and Touchy Studios, and still publishes no download, user or session figure. The npm client package
-    does carry a countable download series, which is a candidate signal the record does not currently use;
-    it is left as reported_traction pending a ruling on whether npm is the product primary channel.
+    at 3 on named-integration reported traction. No hard usage_volume number found, so confidence low. webcontainers.io
+    also names Suborbital, re-tune and Touchy Studios among the integrations, and publishes no download,
+    user or session figure anywhere. The npm client package does carry a countable download series, which
+    is a candidate signal this record does not currently use; it is left as reported_traction pending a
+    ruling on whether npm is the product's primary channel.
   last_verified: '2026-08-13'
   sources:
   - url: https://webcontainers.io/
@@ -83,12 +82,9 @@ capability:
     npm ecosystem, JS/TS focused, plus arbitrary WASM (narrow vs general Linux sandboxes); persistence:
     per-session in-browser; scale: runs on the end-user''s device (no server cost, no server scale)'
   confidence: medium
-  note: Unique in-browser execution with instant start and zero server cost, but Node/JS-only and not
-    a general-purpose server-side code sandbox for arbitrary languages, a different (narrower) capability
-    profile than microVM/container peers. Mid-tier within deployment. Re-read 2026-08-13 - webcontainers.io
-    still claims native npm, pnpm and yarn running in the browser up to 10x faster than local, support in
-    all major browsers, disposable environments for any modern framework, and Wasm out of the box, with
-    nothing added that would broaden it toward general server-side execution.
+  note: Unique in-browser execution with instant start and zero server cost, but Node/JS-only and not a
+    general-purpose server-side code sandbox for arbitrary languages, a different (narrower) capability
+    profile than microVM/container peers. Mid-tier within deployment.
   last_verified: '2026-08-13'
   sources:
   - url: https://webcontainers.io/

--- a/sources/scores/whylabs.yaml
+++ b/sources/scores/whylabs.yaml
@@ -24,9 +24,7 @@ openness:
     The earlier 4 was justified by the hosted backend no longer operating and the OSS pieces being libraries
     rather than a turnkey observability product, which are maturity judgments and are already recorded as
     adoption 2 and capability 2. On the openness question the published source is the whole product, because
-    there is no longer anything else, and 4 pairs with open_core rather than open_source. Re-read 2026-08-13
-    and unchanged - the LangKit page still carries the closure notice and the statement that the complete
-    platform was open sourced, and whylogs still resolves to Apache-2.0 on GitHub.'
+    there is no longer anything else, and 4 pairs with open_core rather than open_source.'
   raw: license:Apache-2.0(OSI, whylogs + LangKit + open sourced platform);source:public(github.com/whylabs);core-gated:ungated(nothing
     is withheld - the company ceased operations and open sourced the platform on closure);hosted-SaaS:discontinued;status:company-ceased-ops,
     platform open sourced on closure
@@ -62,17 +60,13 @@ adoption:
   note: 'Hosted SaaS shut down (no active platform users). Remaining signal is the OSS libraries: whylogs
     ~2.8k GitHub stars, last release Dec 2024; stars_fallback caps at 3; placed at 2 given the dead commercial
     product and stalled release cadence. Honest signal is modest residual OSS usage, not a live platform.
-    Stars read 2026-08-13 on whylabs/whylogs: 2,830, which bands at 1K-10K stars, level 2 on the stars scale.
-    The previous reach ''10K-100K'' was a download label, which this instrument does not offer - a star is not
-    a download. THE REAL DEFECT is upstream: this product declares no artifacts at all, so a stars_fallback
-    band had no stars source behind it and the count lived only in this note. Declaring whylabs/whylogs would
-    fix it, and is deliberately not done here because a declared code repo also re-routes the openness license
-    dimension. Re-read 2026-08-13 - stargazers_count on whylabs/whylogs is 2,830, unchanged from the count
-    already in this note, and the repository''s last push was 2025-01-10, so the stalled cadence the level
-    rests on is if anything more pronounced. The earlier pass declined a date on the ground that a star
-    count is volatile; `check_refetch` reports drift rather than failing on it, and `helicone` in this same
-    category already carries a dated stars_fallback band over the same endpoint, so the date is claimed
-    here with the count digested.'
+    2,830 stars on whylabs/whylogs, which bands at 1K-10K stars, level 2 on the stars scale. The previous
+    reach ''10K-100K'' was a download label, which this instrument does not offer - a star is not a download.
+    THE REAL DEFECT is upstream: this product declares no artifacts at all, so a stars_fallback band had
+    no stars source behind it and the count lived only in this note. Declaring whylabs/whylogs would fix
+    it, and is deliberately not done here because a declared code repo also re-routes the openness license
+    dimension. The repository''s last push was in January 2025, so the stalled cadence the level rests on
+    is if anything more pronounced than the release date above suggests.'
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/whylabs/whylogs
@@ -95,17 +89,16 @@ capability:
   confidence: medium
   note: As living, usable capability it is a pair of monitoring libraries (drift + LLM safety metrics),
     not a full tracing/eval/prompt platform; with the hosted backend gone and releases stalled since Dec
-    2024, rated 2, well below the MLflow/Langfuse C4 anchors. Re-read 2026-08-13 - the repository's last
-    push was 2025-01-10, more than a year and a half ago, and the README is still a profiling library
-    integrating with Spark, Airflow, S3 and MLflow rather than an observability platform. The two-below
-    comparison holds.
+    2024, rated 2, well below the MLflow/Langfuse C4 anchors. The repository's last push was in January 2025
+    and the README is still a profiling library integrating with Spark, Airflow, S3 and MLflow rather than
+    an observability platform.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/whylabs/whylogs
     shows: 'README describes a data-logging and profiling library with integrations for AWS S3, Apache
       Airflow, Apache Spark and MLflow, designed to run "typically in a distributed environment, such as
       Ray or Apache Spark". There is no tracing backend, prompt-management or eval-experiment surface in
-      it. The repository''s last push was 2025-01-10.'
+      it. The repository''s last push was in January 2025.'
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 6054065fb6574c29c0ab15224a78c5c40cf274a60e749cdf9437442184a0e61e

--- a/sources/scores/wildchat-1m.yaml
+++ b/sources/scores/wildchat-1m.yaml
@@ -12,8 +12,8 @@ openness:
     free_text:
     - parquet downloadable
   confidence: medium
-  note: 'ODC-BY licensed and reported ungated by the HF API, though Ai2 datasets sometimes show an access
-    notice. Re-read 2026-08-13: the Hub API still returns odc-by and gated false for allenai/WildChat-1M.'
+  note: ODC-BY licensed and reported ungated by the HF API, though Ai2 datasets sometimes show an access
+    notice.
   raw: license:odc-by;gated:false per HF API;dataset_card:present;parquet downloadable
   last_verified: '2026-08-13'
   sources:
@@ -31,9 +31,8 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: high
-  note: 19,540 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (allenai/WildChat-1M 19,540). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band
-    is >1M.
+  note: 19,540 downloads in the trailing 30 days summed across the 1 declared artifact(s) (allenai/WildChat-1M
+    19,540). Bands at level 3 (10K-100K) on the dataset adoption scale, whose top band is >1M.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/datasets/allenai/WildChat-1M
@@ -47,9 +46,8 @@ capability:
   basis_detail: downstream
   value: null
   confidence: medium
-  note: 'A sustained cross-recipe SFT ingredient (Tulu 3 2024, OLMo 3 Dolci 2025), but its own ablation
-    is weak/dated and it does not lead comparisons. Re-read 2026-08-13: the Tulu 3 SFT mixture card still
-    names WildChat as a source, and the WildChat paper still reports only its own modest 2023-baseline ablation.'
+  note: A sustained cross-recipe SFT ingredient (Tulu 3 2024, OLMo 3 Dolci 2025), but its own ablation is
+    weak/dated and it does not lead comparisons.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/datasets/allenai/tulu-3-sft-mixture

--- a/sources/scores/wildguard.yaml
+++ b/sources/scores/wildguard.yaml
@@ -21,10 +21,9 @@ openness:
   note: Open weights under Apache-2.0 with the WildGuardMix training corpus published, which is more than
     most guardrail models release. The fine-tuning pipeline is not published, though. The allenai/wildguard
     repo ships an inference package only (nine files, no trainer or training config), the companion Safety-Eval
-    repo is an evaluation suite, and the model card refers readers to the paper appendix for training
-    details rather than to code. The 4-rung requires released data and released code, so this scores 3.
-    Recorded 4 until the components were completed; open data alone does not lift the rung. Re-read
-    2026-08-13 and unchanged on all four dimensions; both GitHub sources returned byte-identical digests.
+    repo is an evaluation suite, and the model card refers readers to the paper appendix for training details
+    rather than to code. The 4-rung requires released data and released code, so this scores 3. Recorded
+    4 until the components were completed; open data alone does not lift the rung.
   raw: weights:open(allenai/wildguard on HF);data:open(WildGuardMix corpus public);code:partial(inference/serving
     package only; no training pipeline);base:Mistral-7B;license:Apache-2.0(OSI)
   last_verified: '2026-08-13'
@@ -46,7 +45,7 @@ openness:
       (.gitignore, LICENSE.md, README.md, docs, examples, pyproject.toml, requirements.txt, tests, wildguard).
       No training directory, no trainer entrypoint, no SFT or DPO config. The `wildguard` package is the
       classifier wrapper and `examples/wildguard_filter` is a serving demo, so the published code is inference
-      and serving only. Re-fetched 2026-08-13 - the digest is unchanged, so the listing is the same one.
+      and serving only.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: c4fb6dc1020ec916c47d6d6a90161fa20226b7bac3f147f26da9521c542a26e6
@@ -55,9 +54,8 @@ openness:
   - url: https://github.com/allenai/wildguard/blob/main/README.md
     shows: The project's own README installs with `pip install wildguard` and documents `load_wildguard()`
       plus `classify()`. Its only outbound links are the paper, the WildGuardMix dataset, the model, and
-      the Safety-Eval companion repo, which it describes as holding "the details of evaluations run in
-      the WildGuard paper". No training pipeline is offered or linked. Re-fetched 2026-08-13 - the digest
-      is unchanged.
+      the Safety-Eval companion repo, which it describes as holding "the details of evaluations run in the
+      WildGuard paper". No training pipeline is offered or linked.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: e9b46a0e3e74792e8cebe692f444607e21767d1888a2ade3785d3657fd33c699
@@ -68,9 +66,9 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: 121,205 downloads in the trailing 30 days summed across the 1 declared artifact(s), read 2026-08-13
-    (allenai/wildguard 121,205). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected
-    from level 4, which the declared artifacts do not support.
+  note: 121,205 downloads in the trailing 30 days summed across the 1 declared artifact(s) (allenai/wildguard
+    121,205). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected from level
+    4, which the declared artifacts do not support.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/models/allenai/wildguard
@@ -86,7 +84,6 @@ capability:
     GPT-4 and prior open baselines, with low over-blocking on benign traffic.
   confidence: medium
   note: Strong precision and low over-refusal; the joint refusal-detection head is a useful differentiator.
-    Re-read 2026-08-13 and unchanged.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/allenai/wildguard

--- a/sources/scores/windsurf.yaml
+++ b/sources/scores/windsurf.yaml
@@ -11,10 +11,7 @@ openness:
     self-host:
       value: 'no'
   confidence: high
-  note: 'Proprietary agentic IDE; now part of Cognition''s Devin Desktop. Closed source, subscription SaaS.
-    Re-read 2026-08-13 - the Devin Desktop page still sells the product as a paid download across Free,
-    Pro, Teams and Enterprise tiers with no source and no self-host path, and Cognition''s own acquisition
-    post still records that it bought Windsurf''s IP, product, trademark and brand. Nothing moved.'
+  note: Proprietary agentic IDE; now part of Cognition's Devin Desktop. Closed source, subscription SaaS.
   raw: source:closed;license:proprietary(SaaS, Cognition);self-host:no
   last_verified: '2026-08-13'
   sources:
@@ -41,13 +38,10 @@ adoption:
   signal_type: reported_traction
   confidence: medium
   banded_quantity: a vendor headline user total (1M+) with no period attached, so not an active count
-  note: 'Devin Desktop (Windsurf) page reports ''1M+ Users'' and ''4000+ Enterprise Customers''. Vendor-reported
+  note: Devin Desktop (Windsurf) page reports '1M+ Users' and '4000+ Enterprise Customers'. Vendor-reported
     headline count places it in the 1-10M band. Cognition-reported Windsurf ARR ~$82M corroborates commercial
-    scale. Re-read 2026-08-13 - the stats block on the page still reads "1M+ Users - trusted by over a
-    million developers worldwide" and "4000+ Enterprise Customers", and the acquisition post still records
-    $82M of ARR with enterprise ARR doubling quarter-over-quarter. WHAT WAS BANDED - a vendor headline
-    user total with no period attached, so it is not an active count and the instrument stays reported_traction
-    rather than active_users. Level unchanged.'
+    scale. WHAT WAS BANDED - a vendor headline user total with no period attached, so it is not an active
+    count and the instrument stays reported_traction rather than active_users.
   last_verified: '2026-08-13'
   sources:
   - url: https://devin.ai/desktop
@@ -68,12 +62,8 @@ capability:
     run Codex/Claude side-by-side), Devin Local (Rust), Spaces shared context, in-house SWE-1.6 model;
     no public SWE-bench number for the IDE
   confidence: medium
-  note: 'Mature agentic-IDE feature set (multi-agent orchestration, model-agnostic via ACP) but no first-party
-    SWE-bench score published; scored on feature matrix, a notch below the benchmark anchor. Re-read 2026-08-13
-    - the page still leads on an Agent Command Center dispatching a team of agents, work across models
-    and agents over the Agent Client Protocol, Fast Context codebase retrieval and Supercomplete, with
-    named customers including Ramp and Intact Financial. Still no first-party benchmark, so the feature-matrix
-    band stands one below the openhands anchor.'
+  note: Mature agentic-IDE feature set (multi-agent orchestration, model-agnostic via ACP) but no first-party
+    SWE-bench score published; scored on feature matrix, a notch below the benchmark anchor.
   relative_to: openhands
   relation: one_below
   last_verified: '2026-08-13'

--- a/sources/scores/yi.yaml
+++ b/sources/scores/yi.yaml
@@ -17,9 +17,7 @@ openness:
       detail: OSI, permissive, no use restrictions
   confidence: high
   note: Permissive Apache-2.0 weights but training data and full training code are not released, so open_weights
-    not open_source. Re-read 2026-08-13 - both base cards still read apache-2.0 with downloadable
-    weights and name no training corpus, and 01-ai/Yi-1.5 is still an Apache-2.0 usage repository whose
-    README now defers even the benchmarks to the model card. Nothing moved.
+    not open_source.
   last_verified: '2026-08-13'
   raw: weights:open(Apache-2.0, on HF);data:closed(pretraining corpus not released);code:partial(inference/usage
     examples; no training pipeline);license:Apache-2.0(OSI, permissive, no use restrictions)
@@ -49,12 +47,11 @@ adoption:
   reach: 10K-100K
   signal_type: usage_volume
   confidence: medium
-  note: 10,283 downloads in the trailing 30 days summed across the 1 declared artifact(s), read
-    2026-08-13 (01-ai/Yi-1.5-34B 10,283). Bands at level 2 (10K-100K) on the software and model
-    adoption scale, unchanged, though it now sits barely over the 10K floor - a 2024-era family
-    superseded by the Qwen, Llama and DeepSeek generations, and one more month of decline would move
-    it. Yi-1.5-9B is cited in the note this replaces but is not a declared artifact, so it is not
-    summed.
+  note: 10,283 downloads in the trailing 30 days summed across the 1 declared artifact(s) (01-ai/Yi-1.5-34B
+    10,283). Bands at level 2 (10K-100K) on the software and model adoption scale, unchanged, though it
+    now sits barely over the 10K floor - a 2024-era family superseded by the Qwen, Llama and DeepSeek generations,
+    and one more month of decline would move it. Yi-1.5-9B is cited in the note this replaces but is not
+    a declared artifact, so it is not summed.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/models/01-ai/Yi-1.5-34B
@@ -68,16 +65,14 @@ capability:
   basis_detail: MMLU/GSM8K
   value: 'Yi-34B base - MMLU 76.3, BBH 54.3, C-Eval 81.4. Competitive in the 2024 mid-size class.'
   confidence: medium
-  note: 'Strong for a 2024 sub-35B model but well below 2026 frontier open models (DeepSeek-V4, Qwen 3.6); calibrates
-    near Falcon 3 (C2) on the dated-generation ladder. Replacement found 2026-08-14, and it corrects the
-    attribution rather than the numbers. All three figures are real and in text - Table 2 of the Yi tech
-    report gives MMLU 76.3, BBH 54.3 and C-Eval 81.4 - but the row is Yi-34B, the original 2023 model,
-    not Yi-1.5-34B as the value claimed. The value is relabelled to Yi-34B. Two things dropped rather
-    than re-sourced. There is no text source anywhere for Yi-1.5-34B''s MMLU/BBH/C-Eval; the HF card
-    carries only prose and chart images and the 01-ai/Yi-1.5 README defers to the card. And the
-    34B-Chat GSM8K 90.2 figure appears on none of the pages searched, so it is removed. The score of 2
-    and the dated-generation framing hold on either release, since the tier takes the max across its
-    releases and Yi-1.5 is the stronger of the two.'
+  note: 'Strong for a 2024 sub-35B model but well below 2026 frontier open models (DeepSeek-V4, Qwen 3.6);
+    calibrates near Falcon 3 (C2) on the dated-generation ladder. The figures belong to Yi-34B, the original
+    2023 model, rather than to Yi-1.5-34B: Table 2 of the Yi tech report gives MMLU 76.3, BBH 54.3 and C-Eval
+    81.4 for that row, and the value is labelled accordingly. There is no text source anywhere for Yi-1.5-34B''s
+    MMLU/BBH/C-Eval - the HF card carries only prose and chart images, and the 01-ai/Yi-1.5 README defers
+    to the card - and a 34B-Chat GSM8K 90.2 figure appears on none of the pages searched, so it is dropped
+    rather than re-sourced. The score of 2 and the dated-generation framing hold on either release, since
+    the tier takes the max across its releases and Yi-1.5 is the stronger of the two.'
   last_verified: '2026-08-14'
   sources:
   - url: https://arxiv.org/html/2403.04652v1
@@ -88,17 +83,15 @@ capability:
     http_status: 200
     content_sha256: d3233c6470af203bed646b708278c9c60fc96edb9170dc5cade6be8f945a464a
   - url: https://arxiv.org/abs/2403.04652
-    shows: Yi foundation-models tech report. Re-read 2026-08-13 - the abstract states "Our base models
-      achieve strong performance on a wide range of benchmarks like MMLU" but carries none of the
-      recorded figures.
+    shows: Yi foundation-models tech report. The abstract states "Our base models achieve strong performance
+      on a wide range of benchmarks like MMLU" but carries none of the recorded figures.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 4363a0464da4eaa37bbec1a2fdb2e6ac134ccac26184e2e0089c47a601c927e3
   - url: https://github.com/01-ai/Yi-1.5
-    shows: Cited for "Yi-1.5 base benchmark results (MMLU 76.3, BBH 54.3, C-Eval 81.4)". Re-read
-      2026-08-13 - the README no longer carries a benchmark table; it now says "For model details and
-      benchmarks, see Model Card", and none of the three figures appears on either base card either.
-      The recorded value has no live source, which is why this axis carries no confirmation.
+    shows: Cited for Yi-1.5 base benchmark results (MMLU 76.3, BBH 54.3, C-Eval 81.4), but the README no
+      longer carries a benchmark table - it says "For model details and benchmarks, see Model Card", and
+      none of the three figures appears on either base card. The recorded value has no live source here.
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: 56e1ad80901e3a4bccc2edf102da9d65fdb64b07a905d012bec1520b532389c7

--- a/sources/scores/yomo.yaml
+++ b/sources/scores/yomo.yaml
@@ -19,16 +19,16 @@ openness:
   confidence: medium
   note: 'Cargo.toml declares license = "Apache-2.0" at v2.0.6 and the README''s License section still points
     at Apache License 2.0, but no LICENSE file is committed at the repo root, so the GitHub API reports
-    license null. That is the weakest part of this record and it is unchanged. `core-gated: ungated` transcribed
-    2026-08-12 from a read of the repo and of Vivgrid. What is published is the whole runtime rather than
-    a client to a hosted one: src/ carries router.rs, zipper.rs, serverless.rs, agent_loop.rs, tool_invoker.rs,
-    tool_mgr.rs, llm_provider/, model_api_provider/, auth.rs, http_auth.rs, tls.rs and connector.rs - routing,
-    the serverless host, tool invocation, the OpenAI-compatible surface, auth and transport - with no ee/
-    directory, no second license and no license-key path. Vivgrid sells "serverless LLM function calling
-    that lets enterprise AI agents run their tools in the cloud - with observability, evaluation, and globally
-    distributed inference built in", on a free tier plus credits; its landing page does not mention YoMo
-    and the current YoMo README does not mention Vivgrid. A hosted platform sold beside a complete open
-    core is the langchain shape, not a gate.'
+    license null. That is the weakest part of this record and it is unchanged. `core-gated: ungated` from
+    a direct read of the repo and of Vivgrid. What is published is the whole runtime rather than a client
+    to a hosted one: src/ carries router.rs, zipper.rs, serverless.rs, agent_loop.rs, tool_invoker.rs, tool_mgr.rs,
+    llm_provider/, model_api_provider/, auth.rs, http_auth.rs, tls.rs and connector.rs - routing, the serverless
+    host, tool invocation, the OpenAI-compatible surface, auth and transport - with no ee/ directory, no
+    second license and no license-key path. Vivgrid sells "serverless LLM function calling that lets enterprise
+    AI agents run their tools in the cloud - with observability, evaluation, and globally distributed inference
+    built in", on a free tier plus credits; its landing page does not mention YoMo and the current YoMo
+    README does not mention Vivgrid. A hosted platform sold beside a complete open core is the langchain
+    shape, not a gate.'
   raw: license:Apache-2.0(declared in Cargo.toml+README);source:public;core-gated:ungated(the whole runtime
     is in src/ - router zipper serverless host tool invoker LLM and model providers auth and TLS - with
     no second license and no license key. Vivgrid sells a separate hosted serverless platform that the repo
@@ -78,11 +78,11 @@ adoption:
   reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: medium
-  note: 1,920 GitHub stars on yomorun/yomo, read 2026-08-12. Bands at level 2 (1K-10K stars) on the stars
-    fallback scale, which caps at 3 because a star is not a use. Resynced because the note argues the level
-    down itself - 'no mass-market usage volume', crates.io ~250 downloads/month - while recording 3. No
-    download, install or customer figure is published for this product, so stars remain the only honest
-    signal and the level is directional.
+  note: 1,920 GitHub stars on yomorun/yomo. Bands at level 2 (1K-10K stars) on the stars fallback scale,
+    which caps at 3 because a star is not a use. Resynced because the note argues the level down itself
+    - 'no mass-market usage volume', crates.io ~250 downloads/month - while recording 3. No download, install
+    or customer figure is published for this product, so stars remain the only honest signal and the level
+    is directional.
   last_verified: '2026-08-12'
   sources:
   - url: https://api.github.com/repos/yomorun/yomo
@@ -97,15 +97,9 @@ capability:
     nodes, QUIC transport + TLS 1.3, OpenAI-compatible chat completions API, MCP and A2A integration,
     TypeScript and Go SDKs
   confidence: medium
-  note: 'Distinctive full agent runtime with an edge/geo-distributed angle and multi-language SDKs. Functional
-    and coherent feature set for the agent-tooling layer but narrower ecosystem and integration surface than
-    the category leaders (MCP itself, FastMCP). Rated 3 on feature breadth from repo/README review. Re-read
-    2026-08-13 and the shape of the recorded value holds, with the emphasis shifted. The repo now describes
-    itself as a "Serverless AI Agent Framework with Geo-distributed Edge AI Infra" under a "Focuses on Geo-distributed
-    AI Inference Infra" heading, and its declared topics carry quic, function-calling, managed-skills, skills,
-    mcp, a2a-protocol and openai - so every element of the recorded value is still claimed by the project,
-    though the README states them as topics and headings rather than as the SDK list this record quotes.
-    Nothing found suggests the surface has widened toward the category leaders, so the 3 stands.'
+  note: Distinctive full agent runtime with an edge/geo-distributed angle and multi-language SDKs. Functional
+    and coherent feature set for the agent-tooling layer but narrower ecosystem and integration surface
+    than the category leaders (MCP itself, FastMCP). Rated 3 on feature breadth from repo/README review.
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/yomorun/yomo

--- a/sources/scores/zed.yaml
+++ b/sources/scores/zed.yaml
@@ -28,21 +28,15 @@ openness:
     and a hosted admin dashboard at dashboard.zed.dev; Zed states of the Business controls that ''Since
     Zed is open source, these controls govern Zed''s hosted services specifically'', and the FAQ confirms
     you can bring your own keys or disable AI entirely. The old 4 rested on `commercial:Zed-Pro/Business`,
-    and a hosted inference quota is not an editor feature withheld from the published source. STILL OPEN
-    FOR A HUMAN: the recorded license string names AGPL-3.0 for the collab server, and the tree read finds
-    no AGPL file at all - crates/collab now carries LICENSE-GPL. That does not move the tier, both being
-    osi, so it is left uncorrected here rather than edited in a sweep, and it is why this axis carries no
-    last_verified.
-    CORRECTED and confirmed 2026-08-14, on the owner''s ruling, and the score does not move. The AGPL-3.0
-    part is restated as GPL-3.0 for the collab server, because that is what the repository actually
-    carries - a fresh untruncated recursive tree of zed-industries/zed@main is 5,137 entries with ZERO
+    and a hosted inference quota is not an editor feature withheld from the published source. The recorded
+    license string named AGPL-3.0 for the collab server; that part is restated as GPL-3.0, because that
+    is what the repository actually carries - an untruncated recursive tree of 5,137 entries holds ZERO
     paths containing AGPL, 215 LICENSE-GPL files and 47 LICENSE-APACHE, and a direct read of crates/collab
     lists LICENSE-GPL beside Cargo.toml, migrations, k8s, seed, src and tests. Both licenses are OSI, so
-    most-restrictive-across-parts still resolves to the `osi` tier and the ladder still emits
-    5/open_source. The rest of the axis re-read unchanged - no ee/, enterprise/, commercial/ or
-    proprietary/ path anywhere in the tree, the root LICENSE-GPL is byte-identical to the 2026-08-11 read,
-    and zed.dev/pricing still runs Personal $0 forever with unlimited use on your own API keys while Pro
-    and Business sell Zed-hosted inference and a hosted admin dashboard.'
+    most-restrictive-across-parts still resolves to the `osi` tier and the ladder still emits 5/open_source.
+    There is no ee/, enterprise/, commercial/ or proprietary/ path anywhere in the tree, and zed.dev/pricing
+    runs Personal $0 forever with unlimited use on your own API keys while Pro and Business sell Zed-hosted
+    inference and a hosted admin dashboard.'
   last_verified: '2026-08-14'
   raw: license:GPL-3.0-or-later(editor)+GPL-3.0(collab-server, crates/collab/LICENSE-GPL)+Apache-2.0(GPUI);source:public;commercial:Zed-Pro/Business(hosted
     AI);core-gated:ungated(the whole editor and the collab server are in the repo under GPL/Apache; Pro
@@ -110,10 +104,9 @@ openness:
     establishes:
     - license
   - url: https://zed.dev/pricing
-    shows: 'Re-read 2026-08-14 and byte-identical to the 2026-08-11 read. Personal $0 forever with
-      ''Unlimited use with your API keys or external agents''; Pro and Business sell Zed-hosted models and
-      an org admin surface; ''Since Zed is open source, these controls govern Zed''s hosted services
-      specifically''.'
+    shows: 'Personal $0 forever with ''Unlimited use with your API keys or external agents''; Pro and
+      Business sell Zed-hosted models and an org admin surface; ''Since Zed is open source, these
+      controls govern Zed''s hosted services specifically''.'
     accessed: '2026-08-14'
     http_status: 200
     content_sha256: 7085628172e55cfa8c6b771d3fa4aff936ae01d9f49553cbc6b455c4c131da31
@@ -123,10 +116,7 @@ adoption:
   level: 4
   signal_type: reported_traction
   confidence: medium
-  note: 'A widely-used released editor with paid Pro/Business tiers, but no public install count. Re-read
-    2026-08-13 - the pricing page still runs Personal $0 forever, Pro $10 a month and Business per seat,
-    and still publishes no install, download or user figure; Zed ships as a direct download rather than
-    through a registry, so nothing countable exists. The standing claim holds and the level is unchanged.'
+  note: A widely-used released editor with paid Pro/Business tiers, but no public install count.
   last_verified: '2026-08-13'
   sources:
   - url: https://zed.dev/pricing
@@ -141,11 +131,7 @@ capability:
   value: GUI editor; agentic editing with task delegation + review; parallel multi-agent; OSS edit prediction (Zeta2);
     inline assistant; multi-model BYO-key + hosted; MCP; external agents via ACP; multiplayer; native Rust perf
   confidence: high
-  note: 'Full AI-editor feature set on par with Cursor/Windsurf, model-agnostic. Re-read 2026-08-13 -
-    the pricing page still confirms the model-agnostic half directly, offering "unlimited use with your
-    API keys or external agents like Claude Agent, Codex CLI, and more" on the free tier, with Zed-hosted
-    models as the paid convenience, and the site still presents the agentic editing surface. The feature
-    matrix that placed this band is unchanged.'
+  note: Full AI-editor feature set on par with Cursor/Windsurf, model-agnostic.
   last_verified: '2026-08-13'
   sources:
   - url: https://zed.dev

--- a/sources/scores/zentropi-cope.yaml
+++ b/sources/scores/zentropi-cope.yaml
@@ -14,7 +14,7 @@ openness:
       detail: OpenRAIL-M, use-restricted, NOT OSI
   confidence: medium
   note: Open weights and self-hostable, but under an OpenRAIL-M license with use restrictions (e.g. surveillance),
-    which is not OSI-approved, so open_weights (3). Re-read 2026-08-13 and unchanged.
+    which is not OSI-approved, so open_weights (3).
   raw: weights:open(zentropi-ai/cope-a-9b on HF);base:Gemma-2-9B(LoRA);license:zentropi-openrail-m(OpenRAIL-M,
     use-restricted, NOT OSI)
   last_verified: '2026-08-13'
@@ -34,11 +34,11 @@ adoption:
   level: 2
   signal_type: reported_traction
   confidence: low
-  note: 'Niche but notable: a ROOST Model Community partner model (distributed via RMC). Re-read
-    2026-08-13 - the Hub reports 23 likes and 0 downloads in the trailing 30 days, because the repo
-    distributes a LoRA adapter that most users merge rather than pull, so no download signal exists to
-    band and the instrument stays reported_traction. No reach recorded - the vendor publishes no usage
-    figure, and a numeric label on this instrument would assert a count nobody made.'
+  note: 'Niche but notable: a ROOST Model Community partner model (distributed via RMC). The Hub reports
+    23 likes and 0 downloads in the trailing 30 days, because the repo distributes a LoRA adapter that most
+    users merge rather than pull, so no download signal exists to band and the instrument stays reported_traction.
+    No reach is recorded - the vendor publishes no usage figure, and a numeric label on this instrument
+    would assert a count nobody made.'
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/zentropi-ai/cope-a-9b
@@ -56,8 +56,8 @@ capability:
     than a fixed taxonomy, with strong F1 across hate, sexual, violence, harassment, self-harm, and toxicity.'
   confidence: low
   note: Like gpt-oss-safeguard, a bring-your-own-policy model that generalizes to custom policies; strong
-    reported F1 across harm areas. That comparison is the instrument, so it is recorded rather than left in
-    prose - the same shape of product, at the same rung. Re-read 2026-08-13 and unchanged.
+    reported F1 across harm areas. That comparison is the instrument, so it is recorded rather than left
+    in prose - the same shape of product, at the same rung.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/zentropi-ai/cope-a-9b

--- a/sources/scores/zephyr.yaml
+++ b/sources/scores/zephyr.yaml
@@ -16,13 +16,10 @@ openness:
     - name: MIT
       detail: OSI
   confidence: high
-  note: 'Genuinely fully-open: MIT weights, the two DPO training datasets are public and
-    MIT, and the end-to-end training code (alignment-handbook) is Apache-2.0 and replicates
-    zephyr-7b-beta. Open_source tier 5. Caveat (does not change the class): upstream
-    UltraChat/UltraFeedback were partly generated with OpenAI model outputs, but the
-    released HF artifacts are open and MIT. Re-read 2026-08-13 - the card still carries `license:mit`
-    and `"gated":false`, and the alignment-handbook repo is still Apache-2.0 with the Zephyr recipes
-    in it. No change.'
+  note: 'Genuinely fully-open: MIT weights, the two DPO training datasets are public and MIT, and the end-to-end
+    training code (alignment-handbook) is Apache-2.0 and replicates zephyr-7b-beta. Open_source tier 5.
+    Caveat (does not change the class): upstream UltraChat/UltraFeedback were partly generated with OpenAI
+    model outputs, but the released HF artifacts are open and MIT.'
   raw: weights:open(MIT;base Mistral-7B Apache-2.0);data:open(UltraChat_200k + UltraFeedback_binarized,
     both MIT, ungated);code:open(alignment-handbook DPO recipe, Apache-2.0);license:MIT(OSI)
   last_verified: '2026-08-13'
@@ -45,10 +42,10 @@ adoption:
   reach: 100K-1M
   signal_type: usage_volume
   confidence: high
-  note: 232,148 downloads in the trailing 30 days summed across the 4 declared artifact(s), read 2026-08-13
-    (HuggingFaceH4/zephyr-7b-beta 142,355; HuggingFaceH4/zephyr-orpo-141b-A35b-v0.1 91; HuggingFaceH4/ultrachat_200k
-    73,327; HuggingFaceH4/ultrafeedback_binarized 16,375). Bands at level 3 (100K-1M) on the software and
-    model adoption scale. Corrected from level 4, which the declared artifacts do not support.
+  note: 232,148 downloads in the trailing 30 days summed across the 4 declared artifact(s) (HuggingFaceH4/zephyr-7b-beta
+    142,355; HuggingFaceH4/zephyr-orpo-141b-A35b-v0.1 91; HuggingFaceH4/ultrachat_200k 73,327; HuggingFaceH4/ultrafeedback_binarized
+    16,375). Bands at level 3 (100K-1M) on the software and model adoption scale. Corrected from level 4,
+    which the declared artifacts do not support.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/api/models/HuggingFaceH4/zephyr-7b-beta
@@ -78,11 +75,9 @@ capability:
   value: zephyr-7b-beta MT-Bench 7.34, AlpacaEval 90.6% win rate, Open LLM Leaderboard
     avg 52.15
   confidence: high
-  note: Notable late-2023 capability (a 7B beating much larger chat models on MT-Bench
-    at release), but weak by 2026 standards (GSM8K 12.74, DROP 9.66 on the leaderboard).
-    Low-tier on a scale where 5 = current frontier chat. Scored 2. Re-read 2026-08-13 - the card's
-    model-index still records MT-Bench 7.34 and an AlpacaEval win rate of 0.906, and the Open LLM
-    Leaderboard average of 52.15 is still on the card. No change.
+  note: Notable late-2023 capability (a 7B beating much larger chat models on MT-Bench at release), but
+    weak by 2026 standards (GSM8K 12.74, DROP 9.66 on the leaderboard). Low-tier on a scale where 5 = current
+    frontier chat. Scored 2.
   last_verified: '2026-08-13'
   sources:
   - url: https://huggingface.co/HuggingFaceH4/zephyr-7b-beta

--- a/tests/test_score_notes.py
+++ b/tests/test_score_notes.py
@@ -27,6 +27,7 @@ and the backlog shrank because it was counted.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -103,4 +104,53 @@ def test_the_known_backlog_has_not_silently_grown_stale(sources):
     assert not resolved, (
         f"{sorted(resolved)} no longer share a note across axes — remove them from "
         f"KNOWN_SHARED_NOTES so the list keeps meaning what it says."
+    )
+
+
+# ── The note is not the verification log ────────────────────────────────────────────────────
+
+VERIFICATION_PROSE = re.compile(r"Re-read|Re-checked|Re-fetched|Re-verified", re.I)
+
+
+def _prose_fields(score: dict):
+    """Every hand-written string on a score record that the payload publishes."""
+    for axis in ("openness", "adoption", "capability"):
+        block = score.get(axis) or {}
+        if block.get("note"):
+            yield f"{axis}.note", block["note"]
+        for i, source in enumerate(block.get("sources") or []):
+            if source.get("shows"):
+                yield f"{axis}.sources[{i}].shows", source["shows"]
+
+
+def test_no_score_prose_carries_a_verification_log(sources):
+    """A note says why the score is what it is. It is not the log of who checked it and when.
+
+    The payload publishes `note` and `sources[].shows` verbatim, and the product page renders
+    them as the prose a visitor reads to understand a score. Between 2026-04 and 2026-08 the
+    re-read passes appended their own narrative there — "Re-read 2026-08-13 - the source still
+    says X. No change." — until it was 44% of all note prose, in 1,035 of 1,416 notes. Every
+    fact those clauses stated was already a field on the same record: `last_verified`,
+    `sources[].accessed`, `sources[].http_status`, `sources[].content_sha256`. The page already
+    prints `Verified <date>` from the first of them.
+
+    The history is not lost by keeping it out of the prose. The scoring history is the git
+    history of the score file, which is complete, dated by commit, and needs no upkeep —
+    `git log -p --follow sources/scores/<slug>.yaml`. See docs/reference/evidence-and-freshness.md.
+
+    This is strict rather than a ratchet: the corpus was cleared in one pass (#322), so there is
+    no backlog left to name, and an allowlist would only give the next instance somewhere to hide.
+    """
+    offenders = [
+        f"{slug} {field}"
+        for slug, score in sources["scores"].items()
+        for field, text in _prose_fields(score)
+        if VERIFICATION_PROSE.search(text)
+    ]
+    assert not offenders, (
+        f"{len(offenders)} score prose fields carry a verification log:\n  "
+        + "\n  ".join(sorted(offenders)[:20])
+        + "\n\nA re-read that changed nothing leaves no trace in the note — that is what "
+        "`last_verified` moving is for. A re-read that changed something edits the note to say "
+        "the new durable thing, not to narrate the discovery."
     )


### PR DESCRIPTION
Closes #322.

A score note says why the score is what it is. Between 2026-04 and 2026-08 the re-read passes appended their own narrative to it, until that text was **44% of all note prose — 1,035 of 1,416 notes across 446 of 472 files**. The payload publishes `note` and `sources[].shows` verbatim, so all of it shipped to the public product page. Claude Opus 4.x printed one clause per axis, three to a card.

Every fact those clauses stated was already a field on the same record: `last_verified`, `sources[].accessed`, `sources[].http_status`, `sources[].content_sha256`. The page already prints `Verified <date>` from the first of them.

## Before / after

```
BEFORE  Anthropic-reported: state-of-the-art on GDPval-AA and Finance Agent; CursorBench 70%
        (vs 58% for Opus 4.6); BigLaw Bench 90.9% at high effort. Vendor-reported. Re-read
        2026-08-13 - every Anthropic-side figure is still on the Opus 4.7 post verbatim. The
        sentence claiming independent Gemini 3.5 Flash comparisons did NOT survive: the cited
        Google post does not mention Claude or Opus anywhere, so that clause has been removed
        rather than re-dated. The score does not rest on it.

AFTER   Anthropic-reported: state-of-the-art on GDPval-AA and Finance Agent; CursorBench 70%
        (vs 58% for Opus 4.6); BigLaw Bench 90.9% at high effort. Vendor-reported. No
        independent comparison stands behind these figures: the cited Google Gemini 3.5 post
        names neither Claude nor Opus, and the score does not rest on it.
```

The finding survives. The narration of finding it does not.

## What changed

| | |
|---|---:|
| Score files edited | **449** |
| Re-read markers removed | **1,130 → 0** |
| Reading dates removed (`, read 2026-08-13`) | **~250 → 0** |
| Note prose removed | ~370,000 chars |

**Durable facts were rewritten, not deleted.** Download counts, prices, versions, benchmark figures, licence findings, and searched absences ("ann-benchmarks lists 38 algorithms, none of them Algolia") were carried into the present tense. Where a note no longer explained its score after the cut, it was rewritten from the sources already cited — no fetching, no re-derivation.

## Where the history went

Nowhere — it was already there. **The scoring history is the git history of the score file**, complete, dated by commit, and maintained by the act of committing rather than by anyone remembering to append a paragraph:

```bash
git log -p --follow sources/scores/<slug>.yaml
```

`docs/reference/evidence-and-freshness.md` now says so under *The note is not the log*, and both re-read workflows point at it before they point at anything else. The alternative — a `verification_log` field withheld from the payload — was considered and rejected: it duplicates what git already holds and obliges every future pass to maintain the copy.

## The contract, and the guard

The three `note` descriptions in `score.schema.json` now state the rule. `test_no_score_prose_carries_a_verification_log` enforces it, strict rather than a ratchet — the corpus was cleared in one pass, so there is no backlog to name and an allowlist would only give the next instance somewhere to hide.

`skills/clean-score-notes/SKILL.md` carries the procedure and the three hazards this sweep actually hit:

- **A marker mid-sentence makes a bad cut look clean.** "…no source was re-read." is not a tail; cutting there truncates the note, and the audit passes because the text after the cut starts with the marker. Two records were damaged this way and repaired.
- **A verb list is not a rule.** `Re-derived` was not in the marker set and rode through 23 times before an agent noticed.
- **`set_source` addresses by URL and takes the first match.** An axis citing one URL twice has an unreachable second entry, and the reparse assertion still passes because the expected document is built from that same index. Needed an index-addressed editor.

## Verification

Every edit went through `build/components.py`, which reparses and asserts the document is unchanged apart from the one field. On top of that, audited across all 449 edited files against `HEAD`:

- **0** changes to `score`, `level`, `class`, `value`, `basis`, `confidence`, `reach`, `signal_type`, `relative_to`, `relation`, `last_verified`, `components`
- **0** changes to any source `url`, `accessed`, `http_status`, `content_sha256`; no source added or removed
- **0** notes left dangling mid-sentence
- **0** of 47 duplicate-URL `shows` edits mis-targeted
- `uv run pytest` — **651 passed**

## The real yield: a fact-checking backlog

The prose was hiding score-integrity problems, and 16 category passes surfaced them. The full log is below; the pattern worth naming is **notes carrying corrections the fields never received**:

- `agenta / capability` scores **3** beneath a note whose opening sentence argues **4** ("comparable to Langfuse anchor (C4)") for a product that no longer exists.
- `perspective-api / adoption` scores **4** beneath a note arguing "a level 4 on a discontinued free API is a claim about the past".
- `guardrails-ai / openness` scores **4** beneath a note that declares itself INCONCLUSIVE and says the evidence supports **5 or 2**.
- `composio / openness` carries its own "FLAG FOR A HUMAN": its cited evidence meets the definition for `source: partial` (2/source_available), not the recorded `public` and 4.

Plus, repeatedly: head figures contradicting their own cited sources (nine ML frameworks, eight fine-tuned-chat records), `basis: benchmark` pointing at aggregators, dead citations behind live scores, products scored after their vendor retired them, and duplicate `sources[]` rows in 8 of 25 evaluation-code files.

<details>
<summary><b>Full findings log — 16 categories, ~200 entries</b></summary>

### agent_tools_protocols
- `agent2agent-protocol / capability`, `model-context-protocol / capability` — four paragraphs of dated policy narrative ("DECLARED 2026-08-14", "SEE ALSO…"); MCP's argues against its own earlier version. Both need a hand rewrite (embedded blank lines block the applier).
- `agent2agent-protocol / capability` — cites the same source URL twice; `set_source` resolves to the first, so the second is unreachable. Duplicate URL is itself a defect.
- `browser-use`, `milvus`, `playwright-mcp`, `qdrant`, `searxng` / adoption — dated "RE-BANDED / Re-derived" prose carrying no Re-read marker.
- `qdrant / adoption` — two conflicting download figures (23,061,488 vs 19,077,155). `searxng / adoption` — two Docker pull totals.
- `composio / openness` — the note contains its own "FLAG FOR A HUMAN": cited evidence meets `source: partial` (2/source_available) yet the record keeps `source: public` and score 4.
- `filesystem-mcp / openness` — README says MIT, LICENSE is the MCP Apache-2.0 transition text.
- `mcp-inspector / openness`, `yomo / openness` — no LICENSE file at all; 5/open_source rests on a README sentence / package metadata.
- `mcp-python-sdk / capability` — 5 now rests on inference; the README no longer enumerates the features the band cited.
- `perplexity-sonar-api / adoption` — banded on consumer-app MAU, not any API figure.
- `browserbase / adoption` — level 3 rests on a companion open SDK's downloads, not the closed platform being scored.
- `apify` — "59,817 Actors" is a live store counter that drifts on every refetch.
- `firecrawl`, `github-mcp`, `jina-reader / adoption` — sources have live star counters, so `content_sha256` can never re-match.
- `cohere-rerank-api / capability` — head says nDCG numbers not disclosed while `value` quotes +26.4% nDCG@10.
### base_pretrained
- `apertus / openness` — the 5 rests on the 1.0/2509 stack; Apertus 1.5's promised data-reconstruction scripts and checkpoints have not shipped.
- `apertus`, `kimi`, `minimax`, `yi` / capability — `value` figures describe an older release than the one recorded as governing.
- `deepseek / capability`, `falcon / adoption`, `phi / openness`, `minimax / capability` — cited sources permanently 429 or unreachable; effectively dead citations.
- `ernie / adoption` — level 4 rests on an app-level MAU for the assistant, not the model, and is ageing.
- `ernie / capability` — two vendor Arena claims that disagree in shape; no independent read backs the 5.
- `gemma / openness` vs `/ adoption` — the axes had contradicting claims about which release carries downloads (contradicting clause removed).
- `gemma / capability` — 5 now rests solely on the vendor card's own table (arena placement is rank 60/391).
- `glm / capability` — vals.ai source is a 404; band rests on two third-party comparison sites.
- `gpt-4o / adoption` — banded on the ChatGPT surface, not the model; `/ capability` — MMLU/MMMU figures have no primary source.
- `inflection / adoption` and `/ capability` — both rest on absence of evidence at `confidence: low`.
- `llama / openness` — head carries a 2026-08-01 re-banding narrative; reads as changelog.
- `lucie-7b / openness` — 5 while the corpus is CC-BY-NC-SA-4.0; the note concedes the OSI claim doesn't survive strict reading.
- `luciole`, `yi` / adoption — within a few hundred downloads of a band boundary.
- `mimo-pro / adoption` — two different download figures for one reading.
- `mistral-large / adoption` — level 1 for a flagship consumed almost entirely by API; the note admits it understates use.
- `reka-core / adoption` — distribution claims appear on no cited page.
- `rwkv / openness` — documents a genuine rubric gap: "every component named and publicly resolvable, but the mixture not reproducible" has no `data` enum value. Nemotron 3 hits it too.
### benchmark_eval_data
- `apps / adoption`, `codecontests / adoption` — note and openness `shows` carry different download figures a day apart, unreconciled.
- `cruxeval / adoption`, `multipl-e / adoption` — the note is a changelog ("LEVEL CORRECTED 3 -> 2 on 2026-08-13"), dated prose outside this pass's pattern.
- `cruxeval / openness` — class `open` on a repo archived read-only since Sep 2025; nothing in the record flags the maintenance state.
- `gaia / adoption` — "the figure has fallen sharply since June" is a trend claim no cited source supports.
- `compar-ia-datasets / adoption` — level 1 off 31 downloads on one declared artifact, for a product that is an arena with more corpora; the artifact list looks incomplete.
- `livebench / openness`, `mt-bench / openness`, `swe-bench-verified / openness` — sources accessed 2026-06-17 / 06-04 with no digest and no `http_status`, under much later `last_verified` dates.
- `livecodebench / openness` — corpus license is a bare `cc` with no variant; the 3/gated rests entirely on that missing permission.
- `math / openness` — 1/closed on a DMCA-disabled canonical repo while mirrors and harnesses still ship the problems.
- `math / adoption` — level 4 now rests on a single OLMo 3 model card, narrower than the claim the band wants.
- `mt-bench / adoption` — the measured artifact is the human-judgment dataset, not MT-Bench's question set; the band measures a neighbouring artifact.
- `mt-bench / capability` — scored 4 while the note says "now small and partly saturated vs harder peers"; the argument points below the band.
- `multipl-e / openness` — 4/open although the governing repo LICENSE forbids using the contents as ML training data; the ladder abstains, so the 4 is curator-set.
- `scale-seal-leaderboard / openness` — the "~1,000 examples/domain" detail is not on the cited page.
- `swe-bench-verified / openness` — MIT established from the harness README while the HF data artifact declares no license; the two sources disagree.
- `anthropic-internal-coding-evals` and `openai-internal-evals` score openness 0 where `scale-seal-leaderboard` scores 1 for what reads as the same closed situation — worth a consistency check.
- `humaneval`, `gsm8k`, `mbpp`, `mmlu` / capability — all four record saturation as a discriminator while adoption sits at 4; the caveat exists only in prose (see #319).
### dataset_processing_tools
- `olmocr / capability` — head says it "leads open document-extraction tools on olmOCR-Bench", but `value` records Chandra OCR (83.1) and Infinity-Parser 7B (82.5) above olmOCR (82.4). The head contradicts its own value.
- `bigcode-dataset / adoption`, `ccnet / capability`, `redpajama-data / capability`, `smallpond` — dormancy/staleness claims ("frozen since 2023", "no commit since March 2025") with no dated source establishing them.
- `datology-ai / adoption` — the whole band rests on one funding article; `banded_quantity` admits funding "is credibility rather than usage".
- `snorkel-flow / adoption` — `banded_quantity` describes a *withdrawn* basis; level 3 now rests on "actively maintained and shipping", which is not adoption either.
- `txt360-pipeline / openness` — `confidence: low`, `none-declared` license in no tier; score 2 is a convention rather than a rule output.
- `nemo-curator / openness` — LICENSE source points at `NVIDIA/NeMo-Curator`, README source at `NVIDIA-NeMo/Curator`; two repo paths for one product.
- `dolma-toolkit / capability` — "Down from a feature-only read of 4" is a changelog fragment.
### deployment
- `daytona-sandbox / openness` — note records a CONFLICT: core went private, repo is a README stub with no LICENSE, so `source: public` reads as `partial` (2/source_available, not 4/open_core).
- `daytona-sandbox / capability` — declared GitHub source is a stub carrying neither the isolation nor the sub-90ms claim; band rests entirely on vendor docs.
- `tensorlake-sandbox / openness` — "runtime+SDK, BYOC self-host" unsupported; runtime and scheduler are in no public repo.
- `tensorlake-sandbox / capability` — measured TTI is 1.35s / 15th of 24, roughly 3x the ~460ms the 4 was built on.
- `cloudflare-sandboxes / capability` — 4 held on the isolate path while the arbitrary-code path benchmarks 4.42s, 21st of 24.
- `ollama / adoption` — the "52M+ monthly model pulls" the band was set on is published nowhere and cannot be re-derived.
- `blaxel-sandbox / capability`, `openpcc / capability` — `value` asserts claims no longer on (or never on) the cited pages.
- `vercel-sandbox / capability` — still cites the 2026-07-09 benchmark run while the category has moved to the 2026-08-07 one.
- `aws-lambda`, `firecracker`, `gvisor`, `google-cloud-run`, `spaces`, `replit-agent-code-execution-api` / adoption — `usage_volume` with no countable artifact any signal model reads.
- `beta9`, `opensandbox` / adoption — a countable channel now exists but is not declared, so `stars_fallback` may be the wrong instrument.
- `coder-oss / adoption` — no download channel exists at all.
- `sandbox-runtime / adoption` — level 4 rests on 1,000,104 npm downloads, 104 above the floor.
- `opensandbox / capability` — embedded blank line; untouched by the applier.
### edge_hardware
- `axelera-metis-aipu / capability` — `value` quotes "~214 TOPS"; the vendor now publishes only "50+ TOPs per core". The 214 figure is not citable from any source in the record.
- `memryx-mx3 / capability` — the datasheet no longer carries the TOPS or parameter-capacity table the `value` asserts.
- `nvidia-jetson-orin-nano-super / adoption` — bands mass-market reach on "a low $249 price"; the product page no longer prints a price.
- `nxp-imx-8m-plus / all axes` — `www.nxp.com` answers 404 on every path; the cited fact sheet is dead and still in `sources[]`.
- `hailo-8 / adoption` — the "100K+ users" figure is derivable from nothing; hailo.ai 403s automated fetches.
- `khadas-edge2 / openness` — component detail names an RK3588S2 TRM; what is public is a different document.
- `raspberry-pi-5 / openness` — `blobs: minimal` where all nineteen other boards record `required` for the same fact.
- `raspberry-pi-ai-hat-plus / openness` — note contains literal doubled single-quotes (`kit''s`), a YAML escaping artifact that renders wrong on the card.
- `qualcomm-dragonwing-rb3-gen-2 / openness` — a prior pass recorded a product-brief URL resolving 200 to the *wrong product*; a live trap for re-fetchers.
- `radxa-rock-5b / adoption` — level 5 rests partly on a listing where every variant reads "Sold out".
- `sipeed-maixcam / adoption` — MaixPy now banners "MaixCam 2 is LIVE"; the record describes the superseded generation.
- `arduino-uno-q / openness` — Arduino's own FAQ contradicts the record (says schematics only, source "soon"), while both repos are in fact public.
- `beagley-ai / adoption` — price corrected in place ($71.99 → $70.00) because the tail carrying the correction was being deleted.
### evaluation_code
- `amazon-bedrock-evaluations / capability` — arrived on the branch already truncated mid-sentence (my own batch-1 strip); repaired.
- `artificial-analysis-intelligence-index / openness` — components say "one of ten evals" against a live methodology of nine evals with unequal weights.
- `bigcodebench` — repo archived and read-only; nothing structural records it, and a source still shows 503 stars against a current 1,573.
- `chatbot-arena / adoption` — headline 10M requests / 1.5M votes frozen in the README since 2024.
- `helm / adoption` — crfm-helm at 5,097/mo would band level 1; level 3 rests entirely on citation reach. HELM entered maintenance mode 2026-06-01.
- `inspect-ai / adoption` — the cited AISI post does not support the lab list the note carried; the PyPI package is undeclared.
- `open-llm-leaderboard / capability` — the cited archive documents leaderboard v1, not the v2 suite in `value`.
- `openai-evals-api-dashboard` — dated shutdown path (read-only 2026-10-31); retirement candidate.
- `openai-evals / adoption` — declares no artifacts, so `stars_fallback` has no source; repo unpushed since 2026-04-14.
- `opencompass / adoption` — a real PyPI package exists and is deliberately undeclared (5,728/mo would drop it to level 1).
- `osworld / adoption` — the 72.5% figure is in a chart, not quotable from the cited page; domain now redirects.
- `patronus-evaluation-platform / openness` — SDK repo declares no license at all, unpushed since 2026-01-09.
- `ragas` — repo renamed; two sources still cite the old org path.
- `scale-evaluation / capability` — `value` lists coverage the cited SEAL post does not establish.
- `swe-bench / adoption` — pypistats now 46.0M/mo (was 31.5M), which would band level 5; deliberately not moved.
- `vertex-ai-gen-ai-evaluation-service / adoption` — abstains while the near-identical `amazon-bedrock-evaluations` takes level 3.
- Category-wide — duplicate `sources[]` rows citing an identical URL within one axis in 8 of 25 files (three copies in `scale-evaluation`).
### finetuned_chat
**Stale figures in note heads (live value differs, sometimes by 2x):** `deepseek-instruct` (~3.50M vs 2,213,519), `deepseek-r1` (~5.58M vs 8,316,405), `granite-code-instruct` (~1,925 vs 5,601; product also carries a vendor DEPRECATION banner), `mistral-7b-instruct` (~2.5M vs 1,206,680), `qwen-coder`, `qwen-instruct`, `starcoder2`, `tinyllama-chat` — all adoption.
- `command-r / adoption` — head argues the superseded 2024 checkpoint ("hobbyist/legacy scale") directly beneath the corrected level 3; the note contradicts its own band.
- `claude-fable / adoption`, `muse-spark / adoption` — the stated reason for capping at 4 ("launched ~2 weeks before scoring", "rollout incomplete") no longer holds.
- `gemini-pro / capability` — confidence held at medium for a reason that no longer applies (3.1 Pro is GA).
- `grok / openness` — `governing_release: grok-4-20` is stale; `/ capability` cites the same artificialanalysis URL twice.
- `nemotron / capability` — the report's own table puts Qwen3.5-122B-A10B above Nemotron 3 Super; whether a 5 follows from second place is unresolved.
- `o-series / capability`, `ornith / capability` — figures in `value` appear in no cited source except a system card / nowhere at all.
- `olmo-instruct / adoption` — declared artifact answers HTTP 401 and no longer resolves.
- `gpt-4-1 / capability`, `gpt-5 / adoption`, `muse-spark` — primary sources answer 403/400 to the repo's fetcher; figures rest on secondaries.
- 10 records carry embedded blank lines in notes, which `components.field_span` ends the span at: codegemma, codellama, gemini-pro, hermes, jamba-large, llama-instruct, muse-spark, nemotron, tulu, grok.
### finetuning_code / inference_code
- `axolotl / adoption` — note claims ~22.3K downloads; the cited source says 12,389. The band rests on a figure no source supports. The PyPI project is also undeclared.
- `mistral-fine-tuning-api` — docs file the service under "Deprecated features"; the scored method set may no longer be sold.
- `anyscale-fine-tuning / capability` — the only cited source is a retired product's page.
- `openai-fine-tuning-api / all axes` — platform winding down (new jobs end Jan 2027; sole RFT base model shuts down Oct 2026).
- `torchtune` — project wound down in 2025, last release 2025-04-07, still held at level 3.
- `nemo-rl`, `torchtune / capability` — both decline `relative_to` on a blocker (megatron-lm's anchor age) that no longer holds.
- `tensorrt-llm / openness` — same source URL cited twice in one axis; `/ capability` — `basis: benchmark` rests on MLPerf v4.0 from March 2024.
- `max / adoption` — declares no artifacts, so a stars band has no source; `/ openness` flagged `open_washed` (non-OSI licence with per-device caps over an Apache-2.0 repo).
- `llama-cpp / adoption` — level 4 inferred from stars and ecosystem centrality with no install count.
- `localai / capability` — score 5 on backend breadth alone, level with frontier throughput engines.
- `aws-neuron / capability` — the note contained no rationale for the band at all, only what was not found.
- `text-generation-inference / all axes` — repo archived Mar 2026, README redirects to vLLM/SGLang; still scored at adoption 3.
- `qualcomm-ai-engine-direct / adoption` — level 4 on integration breadth alone, no figure of any kind.
- Managed FT/inference class (`fireworks`, `mistral`, `together`, `openai`, `anyscale`) — all abstain on adoption with near-identical boilerplate; needs one instrument decision, not five notes.
### ml_frameworks
**Head figures contradict their own cited source** (all adoption): `accelerate` (25.01M vs 27,451,175), `gradio` (12.69M vs 15,829,897), `jax` (18.92M vs 20,195,276), `keras` (21.53M vs 18,774,405 — head is *higher*), `onnx` (20.65M vs 19,619,971), `sentencepiece` (37.65M vs 36,642,180), `tensorflow` (21.06M vs 19,669,609), `deepspeed`, `flax`.
- `diffusers / adoption` — cites a "5M-50M Level 4 band" that does not exist in the current scale; `optimum / adoption` cites a "500k-5M range" likewise.
- `pysyft / adoption` — `signal_type: stars_fallback` although a download signal now exists and is cited.
- `feluda / openness`, `pysyft / openness` — sources with `accessed: 2026-06-22` and no `http_status` or `content_sha256`, unlike every sibling.
- `pytorch / openness` — `license: BSD-3-Clause` asserted against a GitHub API source reporting `spdx_id NOASSERTION`.
- `tensorflow / capability` — states a peer relation to pytorch that is recorded on one side only.
### orchestration_agents
- `claude-code / capability` — `value` asserts Opus 4.8 at 88.6% SWE-bench Verified; neither cited source serves that figure any more. Surviving evidence is 87.6% on Opus 4.7 from an aggregator.
- `devin / capability` — the 45.8% in `value` now rests only on the awesomeagents aggregator.
- `cline`, `cursor`, `swe-agent` / capability — `basis: benchmark` on an aggregator leaderboard, not a primary source.
- `openhands / capability` — score 5 leans on All Hands AI's own harness (83.8); the only independent figure is 72%.
- `opencode / adoption` — `signal_type: reported_traction` is wrong; npm returns 8,643,056 monthly downloads.
- `dify / adoption`, `vellum / adoption` — declare no artifacts at all, so a `stars_fallback` band has no stars source behind it.
- `github-copilot / adoption` — level 5 rests on a 20M all-time count from a July 2025 earnings call: cumulative figure on an active scale, over a year old.
- `hermes-agent` — 230k stars against ~181k quoted elsewhere in the same file; `reach: 1M-10M` is download vocabulary sitting on an inference-token figure.
- `langflow`, `n8n`, `ragflow` / adoption — all three band partly on a Docker Hub lifetime average presented as a monthly rate.
- `nano-graphrag` — no release since 2024; still carried at capability 3.
- `semantic-kernel` — superseded by Microsoft Agent Framework per Microsoft's own docs.
- `zed / openness` — duplicated `zed.dev/pricing` and duplicated `api.github.com` sources with different `accessed` dates.
- `syfthub` — 2 GitHub stars, 0 forks; included as an emerging entry rather than on any adoption signal.
### safeguards
- `perspective-api / adoption` — the note argues "a level 4 on a discontinued free API is a claim about the past", yet the level is still 4. Direct contradiction between note and score.
- `perspective-api / capability` — product sunsets 2026-12-31; primary source now shows only the sunset notice, and the attribute list is corroborated only by a competitor's blog post.
- `guardrails-ai / openness` — note declares itself "INCONCLUSIVE" and argues the evidence supports 5 or 2, not the recorded 4.
- `openai-moderation / adoption` — level 4 rests on "free default filter in front of a very large developer base" with no published figure at all.
- `openguardrails / openness + capability` — repo repositioned from a detector to a protocol/benchmark ("we do not build detection capability"); the band rests on a paper describing a product it no longer ships.
- `coop / adoption`, `osprey / adoption` — README adopter lists are now empty; named deployments rest solely on ROOST blog announcements.
- `llamafirewall / capability` — the PurpleLlama root README no longer mentions LlamaFirewall.
- `lakera-guard / openness` — `components.note` records "acquired by Check Point Nov 2025" while the site no longer mentions it.
- `deepteam / adoption`, `giskard / adoption` — a PyPI signal exists and agrees with the band, but `signal_type` stays `stars_fallback`.
- `osprey / capability` — cites the same GitHub URL twice, so the second entry is unreachable through `set_source`.
- Change-log notes carrying dates but no marker: `azure-content-safety`, `bedrock-guardrails`, `openai-moderation`, `perspective-api` (adoption), `osprey` (capability), plus seven model-guardrail adoption notes with inline "read 2026-08-1x" counts.
### telemetry_observability
- `agenta / capability` — note's opening sentence argues "comparable to Langfuse anchor (C4)" (a 4) while the record scores 3; the re-score reasoning sits underneath it. Also: the product is now a no-code agent workspace, so category placement is the real question.
- `perspective-api`-style contradiction repeated: `trulens / capability` places TruLens *below* langfuse and helicone while scoring level with them.
- **Stale head figures:** `braintrust` (~6.08M vs 7,366,065), `opik` (6.19M → 3.51M, and the 40M+ traces/day claim is gone), `openllmetry` (3.15M → 2.44M), `mlflow` (37.10M vs 42.05M).
- `laminar / adoption` — the band explicitly disbelieves the only figure it cites.
- `langsmith / adoption` — band rests entirely on unquantified ecosystem reach; no number on the vendor page.
- `new-relic / adoption + openness` — product rebranded AI Observability; both axes still cite the old URL and call it AI Monitoring.
- `weave / adoption` — 1,052,916 downloads, barely inside the band; `/ capability` — Weave boards are paused while the note claims parity with the anchor.
- `whylabs / adoption` — declares no artifacts, so `stars_fallback` has no stars source; repo last pushed January 2025.
- `langtrace / capability` — README feature list has narrowed below what the note claims.
- `azure`, `vertex`, `datadog / adoption` — each bands the parent platform's reach rather than the module's.
- `helicone / openness` — 5/open_source while SAML SSO is sold on Enterprise with no SSO implementation in the repo.
- `braintrust / openness` — components claim a five-language SDK set; the repo now describes itself as JS/TS only.
- `openllmetry / openness` — the PyPI project page cannot be fetched (JS bot challenge), so a cited source is unverifiable.
- Duplicate source URLs (a `set_source` hazard): `laminar / adoption`, `new-relic / adoption`, `agenta / capability`.
### training_synthetic_datasets
- `aya-collection / capability` — no primary source states the Aya Collection trained Aya Expanse; lineage rests on a Medium secondary. Score 4 carried by an unverified link.
- `aya-collection / capability` — the `huggingface.co/blog/aya-expanse` source has `accessed: 2026-07-04` with no `http_status` or `content_sha256`, unlike its siblings.
- `personahub / capability` — head cites "~250K PersonaHub personas"; the cited card says 149,960 examples. Never reconciled.
- `personahub / capability` — the load-bearing 64.9% MATH figure is in the paper body, not on any cited listing page.
- `pes2o / capability` — claims OLMo 3 replaced it with a new academic-PDF dataset; no source in the record supports that.
- `flan-collection / adoption` — level 1 rests on 108 downloads of a third-party conversion; under-measures a corpus still consumed inside Tulu 3, Dolci and Marin.
- `synth / adoption` — level 3 rests on 10,111 downloads, 1.1% above the band floor.
- `the-pile / adoption` — near-boundary the same way (13,360 vs a prior 9,980).
- `the-pile / openness` — canonical repo is a loading script with dead mirrors and Books3 withdrawn; scored against a deduplicated mirror, not the named product.
- `oscar-2301 / openness` — card says access is suspended and "no access will be granted", yet scored 3/gated, and adoption reports 2,036 downloads against a corpus nobody can obtain.
- `c4 / capability`, `dolma / capability` — both rest on an arXiv abstract page that carries only FineWeb's general claim; the ablation rows are in the paper body.
- `openhermes-2-5 / openness` — head embeds a date in prose ("A read on 2026-08-12 confirmed it"). Not a re-read tail, so out of this pass's pattern.
- `txt360 / capability` — ablation beating FineWeb is self-reported with no published numbers, yet `confidence: high`.
### ui_api
- `continue / adoption` — note says 3,907,333 installs while its own `shows`, same accessed date, reads 3,209,395.
- `openrouter` — adoption says 80+ providers / 500+ models, capability says 70+ / 400+, from the same homepage on the same day; `value` is stale against both.
- `litellm / capability` (140+ vs 100+ providers), `glean-assistant` + `glean-workplace-search-ai` (100+ vs 250+ connectors), `open-webui` (15+ vs 20+ search providers), `huggingchat-chat-ui` (115-123 vs 132 models) — `value` fields stale against the live pages.
- `le-chat` — product renamed to Vibe; slug, product record and every axis still say le-chat. Needs `update-product`.
- `le-chat / openness` — the Vibe Code CLI ships Apache-2.0, so `source: closed` for the family no longer tells the truth alone.
- `meta-ai / capability` — agentic expansion argues for a re-band above 3.
- `chatgpt / capability`, `perplexity / capability` — openai.com, chatgpt.com and perplexity 403 the fetcher, so the consumer surface is unreadable and both bands now rest on narrower matrices.
- `perplexica` — repo quiet since April 2026 and renamed Perplexica → Vane while the slug still says perplexica.
- `gpt4all` — nothing pushed since May 2025; capability 3 on "maintenance slowdown" is a year further gone.
- `nextchat / adoption`, `ogx / adoption` — product declares no artifacts, so `stars_fallback` has no stars source behind it.
- `librechat / adoption` — vendor claims 47.3M Docker pulls; Docker Hub accounts for ~732k org-wide and the real image is on GHCR, which publishes nothing.
- `poe / adoption` — banded on >1M MAU from October 2023, nearly three years stale.
- `claude-ai / adoption` — `demandsage.com` unfetchable (403 to eight requests), keeps a 2026-06-04 read.
- `azure-ai-model-inference`, `ogx` — flagged in-note as miscategorized.


</details>

## Not in scope

Score history in notes — "RE-BANDED 2026-08-14", "corrected from open_core on 2026-07-30", "DECLARED 2026-08-14" — is a rewrite rather than a deletion and a different editorial question. Measured at **297 notes across 254 files** and filed as **#323**, with the git-history rationale already settled here.

Dates inside genuine product facts ("shipped 2026-07-24", "archived since 2025-04-07") stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VsMw63bXSy2vgdUMswhoC
