### PR TITLE
Say "nothing is gated" rather than printing the field name

### DIFF
--- a/sources/scores/agent2agent-protocol.yaml
+++ b/sources/scores/agent2agent-protocol.yaml
@@ -20,7 +20,7 @@ openness:
         registries
   confidence: high
   note: 'Reference spec and SDKs are Apache-2.0 under neutral LF governance; for a protocol this is the
-    openness ceiling. `core-gated: ungated` comes from a direct read of the repo, and it rests on there
+    openness ceiling. Nothing is gated, established by a direct read of the repo: the finding rests on there
     being nothing to gate with rather than on a pricing page saying so. The root tree is LICENSE, GOVERNANCE.md,
     MAINTAINERS.md, specification/, docs/ and adrs/ with no ee/, enterprise/ or commercial/ path, and the
     README''s closing section reads "The A2A Protocol is an open source project under the Linux Foundation,


### PR DESCRIPTION
One note the editorial pass in #325 left half-done. `agent2agent-protocol/openness` still opened its second sentence with a backticked field name:

> `core-gated: ungated` comes from a direct read of the repo, and it rests on there being nothing to gate with rather than on a pricing page saying so.

Now:

> Nothing is gated, established by a direct read of the repo: the finding rests on there being nothing to gate with rather than on a pricing page saying so.

Found by sweeping the regenerated payload for rubric syntax after #325 merged. The only other hit was `ornith/capability` — "the Terminal-Bench figures quoted here … cannot be re-derived from it" — which is ordinary English and was left alone.

`build.validate` 0 errors, `tests/test_score_notes.py` 5 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VsMw63bXSy2vgdUMswhoC
