### PR TITLE
Base64 the Details payload so marimo stops dropping it

### DIFF
--- a/build/render.py
+++ b/build/render.py
@@ -758,6 +758,7 @@ __SECTION_CELLS__
 
 @app.cell(hide_code=True)
 def details_payload(DATA, ORDER, mo):
+    import base64 as _b64
     import json as _json
     # Build a per-product payload keyed by product name, then install a delegated
     # click handler + modal via a hidden-iframe onload bootstrap (marimo strips
@@ -766,7 +767,17 @@ def details_payload(DATA, ORDER, mo):
     for _cid in ORDER:
         for _p in DATA["categories"][_cid]["products"]:
             _payload[_p["product"]] = {**_p, "category_label": DATA["categories"][_cid]["label"]}
-    _pj = _json.dumps(_payload, ensure_ascii=False)
+    # Base64, not raw JSON. This payload is interpolated into an HTML *attribute*, so it
+    # gets escaped (" -> &quot;), and a single astral character anywhere in it (a Hugging
+    # Face emoji, in practice) widens the whole Python string to 4 bytes per character.
+    # On 2026-08-18 those two multipliers put this cell's output at 24.5 MB against
+    # marimo's 8 MB output_max_bytes; marimo dropped the output silently and every
+    # Details button rendered wired to a handler that was never installed. Base64 is pure
+    # ASCII -- 1 byte per character, nothing for the attribute escaping to expand, and
+    # immune to whatever character lands in a score note next.
+    _pj = "'" + _b64.b64encode(
+        _json.dumps(_payload, ensure_ascii=False).encode("utf-8")
+    ).decode("ascii") + "'"
     _css = (
         ".v3-details{padding:3px 9px;font-size:11px;font-family:'DM Mono',ui-monospace,monospace;"
         "border:1px solid #a5bbbe;background:#fff;color:#0b252f;border-radius:0;cursor:pointer;font-weight:500;"
@@ -788,8 +799,9 @@ def details_payload(DATA, ORDER, mo):
     )
     _js = r\'\'\'
     (function(){
-      if (window.__V3_INSTALLED__) { window.__V3_PAYLOAD__ = __PAYLOAD__; return; }
-      window.__V3_INSTALLED__ = true; window.__V3_PAYLOAD__ = __PAYLOAD__;
+      var dec=function(b){return JSON.parse(new TextDecoder().decode(Uint8Array.from(atob(b),function(c){return c.charCodeAt(0);})));};
+      if (window.__V3_INSTALLED__) { window.__V3_PAYLOAD__ = dec(__PAYLOAD__); return; }
+      window.__V3_INSTALLED__ = true; window.__V3_PAYLOAD__ = dec(__PAYLOAD__);
       var esc=function(s){return String(s==null?'':s).replace(/[&<>"']/g,function(c){return ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'})[c];});};
       function ocol(sc){return sc==null?'#dcdcda':(sc>=4?'#e86f57':(sc==3?'#f4886f':(sc==2?'#f8ad99':'#f6cabd')));}
       function otext(sc){return '#0b252f';}

--- a/tests/test_details_payload_size.py
+++ b/tests/test_details_payload_size.py
@@ -1,0 +1,89 @@
+"""The Details modal's payload has to stay inside marimo's per-cell output cap.
+
+On 2026-08-18 it did not, and nothing noticed. marimo does not raise when a cell's
+output exceeds `output_max_bytes` -- it silently replaces the output with a "Your
+output is too large" callout and carries on. The Details *buttons* are rendered by a
+different cell, so the published notebook looked correct: 472 buttons, right product
+count, right prose. Every one of them was wired to a click handler that had never been
+installed, and the only way to find out was to click one.
+
+Two multipliers stacked to get there, and both are worth stating because either alone
+would have fit:
+
+  1. The payload doubled (1.28 MB -> 2.44 MB of JSON) when the score notes were
+     rewritten and source provenance was added.
+  2. A single astral character -- one U+1F917 in PEFT's openness note -- widened the
+     whole Python string from 2 bytes per character to 4. `sys.getsizeof`, which is
+     what marimo measures, doubled on the strength of one emoji.
+
+Base64 removes both: it is pure ASCII (1 byte per character, and no astral character
+can ever appear in it) and contains none of `&"<`, so the HTML-attribute escaping that
+inflated the raw JSON has nothing to expand. This test fails if anyone reverts to
+interpolating raw JSON, or if the payload simply grows past the cap again.
+"""
+
+import base64
+import json
+import sys
+from pathlib import Path
+
+# marimo's default, from marimo/_config/config.py. Overridable via
+# MARIMO_OUTPUT_MAX_BYTES or [tool.marimo.runtime], but CI and the OSO publish
+# runner both use the default, so that is what has to hold.
+OUTPUT_MAX_BYTES = 8_000_000
+
+# marimo measures the serialized cell output, which carries the attribute value through
+# one further round of HTML escaping. Observed 2026-08-18: a 12,239,840-byte attribute
+# was reported by marimo as 24,505,824 bytes.
+MARIMO_SERIALIZATION_FACTOR = 2
+
+PAYLOAD = Path(__file__).resolve().parents[1] / "build" / "notebook_data.json"
+
+
+def _details_attribute() -> str:
+    """Rebuild exactly what build/render.py puts in the iframe's onload attribute."""
+    data = json.loads(PAYLOAD.read_text(encoding="utf-8"))
+    order = data["order"] if isinstance(data.get("order"), list) else list(data["categories"])
+    payload = {}
+    for cid in order:
+        for product in data["categories"][cid]["products"]:
+            payload[product["product"]] = {
+                **product,
+                "category_label": data["categories"][cid]["label"],
+            }
+    encoded = base64.b64encode(
+        json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    ).decode("ascii")
+    # The attribute escaping render.py applies. A no-op on base64, deliberately.
+    return encoded.replace("&", "&amp;").replace('"', "&quot;").replace("<", "&lt;")
+
+
+def test_the_details_payload_fits_in_a_marimo_cell_output():
+    attribute = _details_attribute()
+    measured = sys.getsizeof(attribute) * MARIMO_SERIALIZATION_FACTOR
+    assert measured < OUTPUT_MAX_BYTES, (
+        f"the Details payload measures ~{measured:,} bytes against marimo's "
+        f"{OUTPUT_MAX_BYTES:,}-byte output_max_bytes. marimo will drop this cell's output "
+        f"silently and every Details button in the published notebook will do nothing when "
+        f"clicked. Trim the payload to the fields the modal actually renders (it ignores "
+        f"freshness, slug, org_slug, tier, overall_score and the sources' content_sha256 / "
+        f"accessed / http_status), or split it across cells."
+    )
+
+
+def test_the_payload_is_ascii_so_one_emoji_cannot_widen_it():
+    """The property that makes the size predictable, asserted directly.
+
+    A non-ASCII character here would mean someone stopped base64-encoding, which
+    reintroduces both multipliers at once -- and it would do so silently, since the
+    size test above might still pass on a smaller payload.
+    """
+    attribute = _details_attribute()
+    assert attribute.isascii(), (
+        "the Details payload is no longer pure ASCII, so it is no longer base64. "
+        "Raw JSON in an HTML attribute is what broke the modal on 2026-08-18."
+    )
+    assert sys.getsizeof(attribute) // max(1, len(attribute)) == 1, (
+        "the payload is stored at more than 1 byte per character, which means a "
+        "wide character crept in and doubled what marimo measures."
+    )


### PR DESCRIPTION
The published notebook rendered **472 Details buttons, every one of them dead**. Clicking did nothing — no modal, no error, nothing in the console.

## What happened

marimo does not raise when a cell's output exceeds `output_max_bytes` (8 MB). It swaps in a "Your output is too large" callout and carries on. The Details *buttons* are rendered by a different cell than the payload, so the notebook looked completely healthy: right product count, right prose, right vocabulary. Nothing in `marimo check`, `regenerate.yml`, or the publish runbook could see it — the runbook's step 3 asks you to "confirm it renders and shows the expected product count", which this build passed. The only way to find out was to click a button.

## Why it went over

Two multipliers stacked, and **either one alone would have fit**:

1. **The payload doubled** — 1.28 MB → 2.44 MB of JSON — when the score notes were rewritten (#324/#325) and source provenance was added. Growth was almost entirely in the three axis blocks: `openness` +566 KB, `capability` +301 KB, `adoption` +247 KB.
2. **One astral character.** A single U+1F917 🤗 in PEFT's `openness` note — the only non-BMP character in the entire payload — widened the whole Python string from 2 bytes per character to 4. `sys.getsizeof` is what marimo measures, so one emoji doubled the measured size of three million characters.

Together: **24,505,824 bytes against an 8,000,000 cap.**

Verified against the last good build: the 2026-07-20 notebook exports with no "too large" callout and its modal opens correctly (476 payload keys). So this is a regression, not a long-standing limitation.

## The fix

Base64 the payload instead of interpolating raw JSON into the iframe's `onload` attribute. That removes both multipliers at once:

- it is **pure ASCII**, so Python stores it at 1 byte per character and no future emoji can widen it;
- it contains none of `&"<`, so the HTML-attribute escaping that inflated the raw JSON has nothing left to expand.

| approach | measured | fits in 8 MB |
|---|---|---|
| current — HTML-escaped JSON | 24.5 MB | ✗ |
| trimmed to the fields the modal renders | 18.2 MB | ✗ |
| trimmed + emoji stripped | 9.1 MB | ✗ |
| **base64 (this PR)** | **6.5 MB** | ✓ |

Trimming the payload to what the modal actually renders was **not** sufficient on its own, which is why this fixes the encoding rather than the contents. The JS decodes with `TextDecoder` over `atob`, so UTF-8 survives — the 🤗 round-trips, verified in the browser.

## The guard

`tests/test_details_payload_size.py` asserts both the size and the ASCII-ness that makes the size predictable. Verified non-vacuous: against the pre-fix construction the size check computes 24,479,680 bytes (matching marimo's reported 24,505,824 to 0.1%) and the ASCII check fails too. It runs under `pytest -q` in `validate.yml`, which fires on pushes to `main` — so it covers the bot's regeneration commits, which is where the payload actually grows.

## Test plan

- `marimo check` clean; `build.validate` 0 errors; `build.check_payload` ok; **655 tests pass**.
- Exported the notebook and drove it in a real browser: modal opens for OLMo 3, DSPy and Google Coral Dev Board, 3 score sections and 3–8 source links each, 472 payload keys.
- Confirmed the emoji survives the base64 UTF-8 round-trip.

## Already published

The live notebook at `/currentai/ai-stack-map` **has already been republished with this fix** (`sourceHash e7ae4cc2…`, 8.4 MB vs the broken build's 1.9 MB) because it was broken for every visitor. That means the published artifact is currently ahead of `main` until this merges — after which the bot regenerates `notebooks/ai-stack-map.py` normally and the two reconverge. The notebook artifact is deliberately **not** included here; it is the bot's to regenerate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VsMw63bXSy2vgdUMswhoC
