### PR TITLE
docs: fold the compilers/storage promotion's findings back into the guides

### DIFF
--- a/.claude/skills/promote-category
+++ b/.claude/skills/promote-category
@@ -1,0 +1,1 @@
+../../skills/promote-category

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,6 +261,13 @@ After any `components` edit, regenerate `raw` or CI fails.
 - **The chain does not run on a schedule.** Its crons were set at the model-revision layer; the
   platform schedules from the dataset, and zero scheduled runs have ever fired. Treat every
   scoring-chain recompute as manual, and check run history before believing a freshness claim.
+- **A real-corpus test asserts an invariant, or derives its count. Never a census.** Six tests here
+  have now failed because the work succeeded rather than because anything broke;
+  `tests/test_sweep_status.py` tells that story in its own docstring, and its `== 16` categories and
+  `== 472` products became the sixth on 2026-08-18. Both are now derived from the published
+  categories. Where a census IS pinned deliberately - `test_check_parity`'s computed/deferred split,
+  `test_serialize_rubric`'s per-category row counts - the comment beside it says what moves the
+  number, so whoever updates it next knows whether they are recording a change or hiding one.
 
 ## Editor posture (read-only on the warehouse)
 
@@ -281,13 +288,14 @@ once in `docs/reference/`, not in the skill. Skills are registered under `.claud
 Claude Code session discovers them by name; if yours does not list them, read
 `skills/<name>/SKILL.md` directly.
 
-**Five primary editor skills** (the contributor front door):
+**Six primary editor skills** (the contributor front door):
 
 | Skill | When to use | Workflow |
 |-------|------------|----------|
 | `add-product` | Add a new product | `docs/workflows/add-product.md` |
 | `update-product` | Change an existing product (identity, prose, a score, rosters, retirement) | `docs/workflows/update-product.md` |
 | `edit-category` | Create a category, or change its definition/weights/roster | `docs/workflows/edit-category.md` |
+| `promote-category` | Turn a preliminary category's seed roster into published head products | `docs/workflows/promote-category.md` |
 | `refresh-category` | Re-verify a whole category, scores and prose, to the PR | `docs/workflows/refresh-category.md` |
 | `migrate-axis` | Change an axis's schema or meaning corpus-wide (script-only) | `docs/workflows/migrate-axis.md` |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,13 +5,14 @@ name for it. Find your task below, open the one workflow it points to, and follo
 workflow names the reference material and the exact gates it needs; you should not have to
 know the internal vocabulary before you begin.
 
-## Five doors
+## Six doors
 
 | I want to… | Workflow | Skill |
 |---|---|---|
 | Add a new product to the map | [`workflows/add-product.md`](workflows/add-product.md) | `add-product` |
 | Change something about an existing product | [`workflows/update-product.md`](workflows/update-product.md) | `update-product` |
 | Create a category, or change its definition, weights, or roster | [`workflows/edit-category.md`](workflows/edit-category.md) | `edit-category` |
+| Turn a preliminary category's seed roster into published products | [`workflows/promote-category.md`](workflows/promote-category.md) | `promote-category` |
 | Re-verify a whole category against its sources | [`workflows/refresh-category.md`](workflows/refresh-category.md) | `refresh-category` |
 | Change the schema or meaning of an axis, corpus-wide | [`workflows/migrate-axis.md`](workflows/migrate-axis.md) | `migrate-axis` |
 
@@ -44,7 +45,7 @@ When in doubt about which door, start there.
 
 ## Skills off the primary path
 
-Every skill is classified in `skills/registry.yaml` (validated in CI). Beyond the five primary
+Every skill is classified in `skills/registry.yaml` (validated in CI). Beyond the six primary
 doors above:
 
 - **Advanced** — deep editorial skills for maintainers: `build-rubric` (derive a category's

--- a/docs/reference/adoption.md
+++ b/docs/reference/adoption.md
@@ -472,6 +472,51 @@ floor and its note says so.
 The tell to look for when reviewing: **a note that describes the signal as understating the
 product, followed by a band recorded on that signal anyway.**
 
+## The third trap: the package that is not the product
+
+Both traps above are about ATTRIBUTION - a real count of the product credited to the wrong
+product, or a real count of the wrong channel credited to the right one. This one happens a step
+earlier, at IDENTIFICATION, and it is the one a gate cannot catch.
+
+> **A registry package sharing the product's name is not evidence that it is the product.** Before
+> banding on it, establish that the package CONTAINS the product rather than talking to it.
+
+Measured on 2026-08-18 while promoting the `storage` category: ten of twenty-seven products have a
+PyPI package matching their name, and in none of the ten is that package the product. Two shapes,
+and the second is worse:
+
+- **The client of a self-hostable server.** `elasticsearch` on PyPI is elasticsearch-py at 52.8M
+  downloads a month; the product is the Java engine at `elastic/elasticsearch`. `pgvector` is
+  pgvector-python at 36.6M; the product is a Postgres extension written in C. Same shape for
+  `meilisearch`, `typesense`, `lakefs`, `infinity-sdk`, `aistore` and `vearch`. Every one of those
+  figures is a real count of client installs, and none of them measures the server.
+- **A different project entirely.** `dolt` on PyPI is an unrelated REST wrapper by another author.
+  `flash-attention` is a Huawei Ascend port, not `Dao-AILab/flash-attention`. `juicefs` is a
+  third-party SDK published from another organization's repository, drawing under 200 downloads a
+  month against a product with 14,000 stars.
+
+**`check_artifacts --live` does not catch the first shape, and cannot.** Its `pypi_repo_mismatch`
+check compares the package's declared project URL against the product's repo, and a well-behaved
+client library points at exactly that repo - elasticsearch-py names `elastic/elasticsearch`. The
+gate is doing its job; the question it asks is not this one. That is why this rule lives here.
+
+Three questions settle it, and all three are answerable from the package's own JSON:
+
+1. **Does installing it give you the product, or a way to reach one?** A wheel for a Java engine, a
+   C extension, or a Go binary is a client by construction.
+2. **Who publishes it?** A package published from a different organization than the product's repo
+   is somebody else's software until proven otherwise, whatever it is called.
+3. **Does the magnitude make sense?** A server product whose package outdraws its stars by three
+   orders of magnitude is being measured through its client. `juicefs` at 169 downloads against
+   14,334 stars is the same tell inverted.
+
+Where the package turns out to be a client, the server usually has no countable channel at all, so
+the honest outcome is `stars_fallback` and its cap of 3 - understating a widely deployed system,
+and saying so in the note. Thirteen of `storage`'s twenty-seven bands are there for this reason,
+which is the highest share on the map after `dataset_processing_tools`, and it is a property of the
+category rather than a defect in it. Docker pull counts would fix most of them; there is no
+`docker` artifact kind to declare, which is the platform-side ask.
+
 ## Checklist
 
 - [ ] `level` is 1-5 and follows the band table for the product's **type**.
@@ -479,6 +524,8 @@ product, followed by a band recorded on that signal anyway.**
 - [ ] `signal_type` names the instrument actually used, not the one that sounds strongest.
 - [ ] `stars_fallback` never exceeds level 3.
 - [ ] A `usage_volume` band has a countable, **declared** artifact behind it.
+- [ ] A same-named registry package was checked for being the product rather than its client or
+      an unrelated project, per "The third trap" above. `check_artifacts` cannot ask this.
 - [ ] A `reported_traction` record cites a source with a date and a digest, and records a word
       from the vocabulary or no `reach` at all — never a number.
 - [ ] Anything read off something other than the product — a parent platform, a revenue or

--- a/docs/reference/capability.md
+++ b/docs/reference/capability.md
@@ -99,6 +99,38 @@ answerable and a sentence never did:
 The gate ratchets like the others — it covers the products that record a comparison and does
 not block the ones that do not.
 
+## Writing the rungs
+
+The bands are per category, so somebody writes their definitions, and that writing is where the
+axis is won or lost. Two rules, both learned on 2026-08-18 while banding `compilers` and `storage`.
+
+**Count the products per rung before you accept the wording.** A rung holding a third of the
+category is not discriminating between anything; it is a label. `storage`'s top rung was first
+written as "a distributed retrieval platform that also ranks or runs inference in the serving
+path", which admitted seven of twenty-seven products - Vespa and Elasticsearch, but also every
+vector database that fuses scores, since Qdrant has RRF and DBSF, Infinity has tensor reranking and
+Milvus has rerank functions. Reworded to "hosts and evaluates ranking or embedding models inside
+the serving path" it admits two. Nothing about the products changed; the definition stopped being
+satisfiable by almost all of them. The distribution is the diagnostic, and it costs one query.
+
+**Prefer a definition stated as a capability the product either has or has not, over one stated as
+an outcome.** "Ranks results" is an outcome, and outcomes generalize until they are vacuous -
+everything ranks results, that is what retrieval is. "Hosts a model" is a capability: it is
+checkable against a repository tree, it either ships an inference plugin or it does not, and two
+reviewers reading the same evidence reach the same answer. The same move works in the other
+direction: `compilers` bands on how much of the model-to-hardware transformation a product
+performs, which is why a kernel library tops out at 3 there - it supplies the primitives a compiler
+targets and transforms nothing itself. That is a fact about the product, not a judgment about its
+quality.
+
+A corollary for the evidence: **`basis_detail` is per product, never per cluster.** Three products
+moved into `storage` carrying `basis_detail: ANN-Benchmarks` from their old category, and it was
+wrong on all three - Pinecone is not in ANN-Benchmarks at all and its own note said so, while
+Milvus and Qdrant are listed but the harness publishes recall-versus-QPS plots with no ranking
+table, so it corroborates inclusion while their headline numbers come from their vendors' own
+harnesses. One name for a group of products reads as a shared measurement that does not exist.
+**Moving a product between categories re-opens the instrument, not just the band.**
+
 ## What it does not do
 
 - **It is not routable from signals.** `signal_routing.yaml` records the axis as effectively
@@ -114,6 +146,10 @@ not block the ones that do not.
 
 - [ ] `score` is 1-5 and comparable only within the category, or null with `basis: n/a`.
 - [ ] `basis` names the instrument; `basis_detail` and `value` carry what it was and what it said.
+- [ ] `basis_detail` names the instrument for THIS product - not one inherited from a cluster of
+      peers, and not a harness the product is absent from.
+- [ ] A new or reworded rung was checked against its own distribution: no rung quietly holds a
+      third of the category (see "Writing the rungs").
 - [ ] A comparison-placed band records `relative_to` (same category) and `relation`, and the
       arithmetic holds against the peer's score.
 - [ ] A non-null score cites at least one source.

--- a/docs/reference/sibling-invariants.md
+++ b/docs/reference/sibling-invariants.md
@@ -17,8 +17,9 @@ the same three constants get rediscovered as findings every time somebody greps 
 | product artifact kinds | `sources/signal_routing.yaml` `artifact_key` | `build/vocabulary.artifact_kinds` | `test_proposer_support_is_defined_by_handlers_not_by_routing` |
 | method words a provenance line may not name | `build/product_prose.py` `METHOD_WORDS` | imported | `test_the_method_vocabulary_has_exactly_one_definition` |
 | date handling | `build/vocabulary.py` — `is_iso_date`, `parse_date` | imported | `test_date_validation_rejects_impossible_dates`, `test_date_handling_has_exactly_one_owner` |
+| which products are publicly visible | `build/validate.published_products` | imported by `serialize` | `test_preliminary_products_reach_no_public_index`, `test_long_tail_scored_counts_published_categories_only` |
 
-Two of these carry a decision worth keeping in view.
+Several of these carry a decision worth keeping in view.
 
 **`render.py` is not exempt from the axes rule**, though it was briefly, on the grounds that it
 was the only build module invoked as a script and so could not import from the package. That
@@ -30,6 +31,20 @@ supported kinds *from* the routing table, which fails in the other direction: a 
 `artifact_key` would become an accepted `--kind` with no URL pattern, no live check and no
 renderer behind it. Support is defined by the three handlers a kind needs, and asserted to be
 an intentional subset with `arxiv` the named gap.
+
+**Visibility is one fact, and it was three copies before anyone looked.** A category's lifecycle
+status decides whether its products appear in the map, and the payload emits five indexes that each
+have to honour it: the categories themselves, `n_total`, the organization rosters, the alias
+redirects, and the long-tail sample. When preliminary status was introduced, three of the five did
+and two did not, so marking a category preliminary hid its products from `/map` while leaving them
+listed under `/map/org/<slug>` and shipping organizations that existed on the map nowhere else. The
+long-tail count had the same shape one level up, comparing a snapshot against every product file
+while the payload showed only the published ones - and it passed silently, because a count that is
+too high looks like a count.
+
+The rule that follows generalizes past this axis: **when a filter has to be applied in more than one
+place, it is not a filter, it is a set.** Compute it once, name it, and derive every consumer from
+it. Anything the payload grows next derives from `published_products` or it leaks.
 
 **There are two date helpers, and the split is deliberate.** `is_iso_date` GATES a field's
 spelling and requires both the hyphenated shape and a successful parse: shape alone accepts
@@ -56,7 +71,7 @@ happens to find has stopped being a test.
 | openness class → bucket | `serialize._GAP_OPEN` / `_GAP_OPENISH`, `render._OPEN` | `tests/test_openness_buckets.py` already asserts all three agree with `docs/openness-class-map.json`. Same protection, arrived at first; moving the constants would churn a working invariant for symmetry. |
 | adoption instrument subset | `check_adoption._DOWNLOAD_INSTRUMENTS` | not a mirror of the `signal_type` enum. It names the subset measured on a download scale, and the module states why `unknown` is excluded. A narrower vocabulary with a written reason is a decision. |
 
-## Two related shapes, both swept clean
+## Three related shapes, all swept clean
 
 **A status or exit derived from fewer conditions than the printed report.** `check_instrument
 --strict` once printed a violation, followed it with `[OK]`, and exited 0. Every checker was
@@ -67,6 +82,17 @@ it prints, and a line that is deliberately non-gating is marked `~` with a writt
 
 **Malformed or unknown input becoming a pass.** The `except` paths in `build/` each record the
 failure — `False`, an `unreachable` list, or an error — rather than falling through to success.
+
+**A normalizer for two syntaxes must not become an exemption for one of them.** `taxonomy.yaml`
+accepts a category as a bare slug or as a mapping with a lifecycle status, and `build/taxonomy.py`
+normalizes both - a scalar entry means published. The category contract in `validate` then keyed off
+which SPELLING had been used rather than off the normalized status, on the reasonable-sounding
+ground that scalar entries predate the feature and should not be disturbed. What that bought was a
+published category owing nothing: a scalar entry pointing at a file with only `name`,
+`display_name` and an empty roster produced zero errors and would have shipped visibly empty. The
+checks now run on the normalized value, and every one of the sixteen scalar entries already
+satisfied them, which is the measurement that should have preceded the exemption.
+
 
 ## What was deliberately not done
 

--- a/docs/workflows/add-product.md
+++ b/docs/workflows/add-product.md
@@ -29,7 +29,13 @@ Five, and all in the same PR:
 3. **Verify against PRIMARY sources.** Never assert a 2025+ release from memory; confirm it
    against the vendor HF org / blog / registry. If it cannot be confirmed, mark it SKIP rather
    than guess. Read the LICENSE **body** for the OSI call (a custom copyright line makes a
-   genuine MIT/Apache repo report `NOASSERTION`).
+   genuine MIT/Apache repo report `NOASSERTION`). Two shapes worth knowing before you hunt: a
+   repository following the **REUSE convention** carries no root LICENSE at all - the texts sit in
+   `LICENSES/*.txt` with a `REUSE.toml` declaring which covers what, and the API reports no license
+   rather than `NOASSERTION` (`arm-compute-library`). And a **split license** states its own split
+   in the body: `elasticsearch` names a default triple license and carves out `x-pack`,
+   `meilisearch` reads `MIT AND BUSL-1.1` and names an Enterprise Edition. Those are `core-gated`
+   evidence, not just a license question.
 4. **Write the score.** Record the openness evidence in `openness.components` and let the
    category's `scoring_recipe` decide the `(score, class)` — do not hand-assign unless the
    category defers the product. Every non-null openness/capability value needs a `sources`

--- a/docs/workflows/edit-category.md
+++ b/docs/workflows/edit-category.md
@@ -3,8 +3,9 @@
 ## Use this when
 You are creating a category, or changing an existing one's definition, strapline, axis
 weights, or product roster. For giving a category its openness ladder (`scoring_recipe`),
-escalate to the `build-rubric` skill — that is its own craft. For re-verifying every product
-in a category, use [`refresh-category.md`](refresh-category.md).
+escalate to the `build-rubric` skill — that is its own craft. For turning a preliminary category's
+seed roster into published head products, use [`promote-category.md`](promote-category.md). For
+re-verifying every product in a category, use [`refresh-category.md`](refresh-category.md).
 
 ## Inputs you need
 - The category **slug** (`underscore_form`), and for a new one, its `display_name` and where it
@@ -40,7 +41,11 @@ here and not next door — is prose: put it in the category's `comments`, and in
    full `products:` roster. Registry rows carry stable identity and artifact IDs but no editorial
    scores. A slug or artifact may not duplicate a head product or another tail row.
 6. **Publication:** change the taxonomy entry to `status: published` only after the category has
-   a strapline and at least ten promoted, fully scored head products. Validation enforces both.
+   a strapline and at least ten promoted, fully scored head products. Validation enforces both, and
+   holds every category to the same contract whichever taxonomy spelling it uses — a scalar entry
+   means published and owes a description, weights, a ladder, a strapline and ten products.
+   Researching a seed roster into those products is its own job: see
+   [`promote-category.md`](promote-category.md).
 7. **Regrouping / reordering across arcs** happens in `sources/taxonomy.yaml` only — a category
    file no longer carries `arc` or cross-category `order`.
 

--- a/docs/workflows/promote-category.md
+++ b/docs/workflows/promote-category.md
@@ -1,0 +1,148 @@
+# Promote a preliminary category to published
+
+## Use this when
+A category exists as a **preliminary** taxonomy entry with a signal-only seed roster in
+`sources/registry/<slug>.yaml`, and the job is to turn those candidates into fully researched head
+products and publish the category into the map.
+
+Neighboring doors: [`edit-category.md`](edit-category.md) creates the category and owns its record;
+[`add-product.md`](add-product.md) is one product added to a category that already exists;
+[`refresh-category.md`](refresh-category.md) re-verifies a category that is already published.
+This workflow is the middle passage between the first and the last, and it is a long one - roughly
+a day per twenty-five candidates.
+
+## Inputs you need
+- The category slug, its **boundary** (what it includes and, more usefully, what it excludes), and
+  the neighboring categories whose products it must not duplicate.
+- A seed roster in `sources/registry/<slug>.yaml`, or a discovery source to build one from.
+- A working `GITHUB_TOKEN`. See the note under Validation: the unauthenticated API ceiling is 60
+  requests an hour and this workflow needs three to four per candidate.
+
+## Files this changes
+Per promoted product, six concerns:
+1. `sources/products/<slug>.yaml` and 2. `sources/scores/<slug>.yaml` - the records.
+3. `sources/categories/<cat>.yaml` - the head roster, in display order.
+4. `sources/organizations/<org>.yaml` - the org roster, created if the org is new.
+5. `sources/registry/<cat>.yaml` - the row comes **out**.
+6. `sources/snapshots/long_tail.json` - `counts.scored` follows the published roster (gated).
+
+Plus, once per category: the category's `strapline`, its `scoring_recipe.derived_from` counts, and
+`sources/taxonomy.yaml` when the status flips. A product moved in from another category also
+touches that category's roster and its own capability band.
+
+## Procedure
+
+1. **Triage every seeded row before believing any of it.** A registry row is a candidate, not a
+   decision, and its fields are a discovery source's guess. Measured on the `compilers` and
+   `storage` seeds: one repository had moved (`quic/aimet` redirects to `qualcomm/aimet`) and five
+   of fifty `org` fields named the wrong organization, including one that named a different company
+   outright. Fetch each repo's API record and confirm the canonical `full_name`, that it is neither
+   archived nor a fork, and that the row names a distinct product rather than a release, a
+   submodule, or a rename of something already on the map.
+
+2. **Apply the boundary, and record every rejection.** A row that fails the boundary does not
+   belong to the category at any tier, so it is removed rather than parked in the registry - and
+   the reason goes in the category's `comments`, because "why is X not here" is the question a
+   reader asks next. Reject shapes worth knowing: a product whose own README leads with a different
+   product kind (`litert` leads "Google's on-device runtime" and the boundary excluded complete
+   runtimes); a dormant thin wrapper superseded by something already on the roster (`torch2trt`, no
+   commit in two years, against `nvidia-model-optimizer`); a paper's reference implementation whose
+   production successor is on the roster (`llm-awq` against `llm-compressor`); a general-purpose
+   system that added one feature in the category's direction (`redis`, `tidb`).
+
+3. **Replace what you reject** with a candidate that meets the boundary, verified the same way. Do
+   not pad to a number: the point of the count is that the category is representative, and a forced
+   add is worse than a shorter roster.
+
+4. **Decide cross-category moves explicitly, before scoring.** If the category's direct peers sit
+   in another published category, the map has two ladders banding the same kind of product and the
+   bands cannot be compared. Either move them here and reband them against this category's matrix,
+   or state a boundary that genuinely excludes them. Documenting the tension is not a resolution.
+   Qdrant, Milvus and Pinecone moved into `storage` on exactly this reasoning; a move is cheap when
+   the products form a self-contained comparison cluster (nothing outside them pointed in) and
+   expensive when they do not.
+
+5. **Write the records.** [`add-product.md`](add-product.md) governs each one; read it, because the
+   traps are per product and this workflow does not restate them. Two that bite hardest at batch
+   scale:
+   - **Read the LICENSE body, never the label.** Five of the fifty candidates reported
+     `NOASSERTION` on a verbatim BSD or MIT text behind a vendor copyright line, and one reported
+     no license at all because it follows the REUSE convention with no root LICENSE file.
+   - **A same-named registry package is not the product.** See the identification trap in
+     [`../reference/adoption.md`](../reference/adoption.md): ten of `storage`'s products have a
+     PyPI package matching their name and in none of them is it the product. `check_artifacts`
+     cannot catch the client case.
+
+6. **Author the capability matrix once, for the whole category, and check its distribution.** This
+   is the judgment-heavy part and the axis has no shared formula. Write the rung definitions into
+   the category's `scoring_recipe.note`, name a top anchor, and record every other band against a
+   peer with `relative_to` and `relation` so `check_capability` can check the arithmetic rather
+   than trusting a sentence. Then count the products per rung - see "Writing the rungs" in
+   [`../reference/capability.md`](../reference/capability.md), which is the rule this step exists
+   to point at.
+
+7. **Expect the ladder to abstain on something, and let it.** A license the shared tier does not
+   name maps to no tier and the formula abstains; record the product in `scoring_recipe.deferred`
+   with a substantive reason and move on. Two of fifty landed there, both because the `osi` tier
+   lists names literally and had never been asked to name `BSD-2-Clause` or `PostgreSQL`. Extending
+   a shared tier reaches every category that inherits it, so it is a maintainer's ruling and not
+   part of a promotion - and `check_recipe` will report the deferral stale the moment the ruling
+   lands, which is how it closes.
+
+8. **Publish only when the conditions hold.** Flip `sources/taxonomy.yaml` to `status: published`
+   when the category has an evidence-based strapline, at least ten fully scored head products,
+   coherent capability anchors, and no unresolved identity or boundary dispute on the roster. Then
+   re-sync `counts.scored` in `sources/snapshots/long_tail.json`. If a condition fails, leave the
+   category preliminary and say in the PR exactly what blocks it.
+
+**Head products in a preliminary category are normal, not an error.** That is the state this whole
+workflow passes through, and `validate` allows it deliberately. While a category is preliminary its
+products are absent from every public index - categories, `n_total`, the organization roster, the
+alias redirects and the long-tail sample - and `build/validate.published_products` is the single
+owner of that visibility. Anything new the payload emits derives from it.
+
+## Validation
+```bash
+uv run python -m build.validate            # must print 0 error(s)
+uv run python -m build.check_recipe        # the ladder accepts every recorded score
+uv run python -m build.check_rubric        # per-category reproduction, deferrals itemized
+uv run python -m build.check_verification  # producible pairs, digests, the dated-claim invariant
+uv run python -m build.check_capability    # the anchor arithmetic and same-category rule
+uv run python -m build.check_adoption      # every band against its declared instrument
+uv run python -m build.check_instrument    # the instrument a band claims exists for it
+uv run python -m build.check_artifacts     # artifacts still resolve; --live also checks PyPI
+uv run python -m build.serialize_registry --check
+uv run python -m build.serialize_rubric --check
+uv run pytest -q
+```
+
+**Budget the GitHub API.** Unauthenticated it is 60 requests an hour, and verifying one candidate
+costs three to four (repo record, license, README, sometimes a tree listing), so a
+twenty-five-product category exceeds the ceiling twice over. A stale token is worse than none: it
+fails as a silent 401, which reads as *every repository is dead*, and that is what a first pass over
+fifty live repos reported before the token was checked.
+
+Preview only, never commit: `build/notebook_data.json`, `notebooks/ai-stack-map.py` (bot-owned).
+
+## Expected PR contents
+The six files per product, the category record, `sources/taxonomy.yaml`, and the long-tail
+snapshot. In the description: the final count, every rejection and replacement with its reason,
+the capability rung definitions and anchors, and anything still deferred or resting on weak
+evidence. A census pinned in a test - a per-category row count, a corpus total - moves in the same
+PR with the reason written beside it.
+
+## Stop and escalate when
+- The category has **no `scoring_recipe`**, or its evidence is prose the ladder cannot read →
+  `build-rubric`.
+- A promotion would need a **shared rubric change** - a license tier, a new dimension → defer the
+  product, report it, and leave the ruling to a maintainer.
+- A candidate's **identity cannot be settled** against primary sources → leave it in the registry
+  rather than promoting a guess.
+
+## Relevant reference material
+[`../reference/identity.md`](../reference/identity.md) ·
+[`../reference/openness.md`](../reference/openness.md) ·
+[`../reference/adoption.md`](../reference/adoption.md) ·
+[`../reference/capability.md`](../reference/capability.md) ·
+[`../reference/product-copy.md`](../reference/product-copy.md) ·
+[`../reference/evidence-and-freshness.md`](../reference/evidence-and-freshness.md)

--- a/docs/workflows/refresh-category.md
+++ b/docs/workflows/refresh-category.md
@@ -107,6 +107,13 @@ uv run python -m pytest tests/ -q
 Expect gates to fail first and tell you something — read the failure before working around it.
 Never commit while a gate is failing. Never commit `build/notebook_data.json` or `notebooks/`.
 
+**Budget the GitHub API before the sweep, not during it.** Unauthenticated it allows 60 requests an
+hour, and re-verifying one product costs three to four — the repo record, the license body, the
+README, sometimes a tree listing — so any category past about fifteen products exceeds the ceiling.
+Confirm `GITHUB_TOKEN` actually works first: a stale one fails as a silent 401 on every call, which
+reads as *every repository in the category is dead*, and that is exactly how a first pass over fifty
+live repositories reported itself on 2026-08-18 before anyone checked the token.
+
 ## Expected PR contents
 One PR for the category: every moved score with its evidence, every held product with its
 reason, and the re-fetch confirmation count. Then stop — a human merges.

--- a/skills/promote-category/SKILL.md
+++ b/skills/promote-category/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: promote-category
+description: Use when a preliminary category's signal-only seed roster in sources/registry/ must become fully researched head products and the category published into the map. For creating the category or editing its record use edit-category; for one product use add-product; for re-verifying a published category use refresh-category.
+---
+
+# Promote a preliminary category to published
+
+Thin wrapper. The procedure lives in the workflow doc; this file does not restate it.
+
+## Trigger
+A category sits in `sources/taxonomy.yaml` as `{name: <slug>, status: preliminary}` with candidates
+in `sources/registry/<slug>.yaml`, and the task is to research them into head products and publish.
+Not for creating the category (`edit-category`), not for a single product (`add-product`), not for
+re-verifying one already published (`refresh-category`).
+
+## Required reading
+**Read `docs/workflows/promote-category.md` and follow it.** It carries the triage rules, the
+boundary-rejection convention, the six files each promotion touches, the capability-matrix step and
+the publication conditions. Read `docs/workflows/add-product.md` too - it governs each individual
+record and this workflow does not repeat its traps.
+
+## Agent orchestration
+Long job, so it parallelizes badly on judgment and well on fetching. Harvest the evidence for every
+candidate first - repo record, license body, README, package metadata - and cache it, then make the
+identity, boundary and scoring calls against what was fetched rather than against memory. Never
+assert a 2025+ release, a license or a download figure from recall.
+
+Budget the GitHub API: 60 requests an hour unauthenticated, three to four per candidate. Check
+`GITHUB_TOKEN` works before the first sweep, because a stale one 401s silently and reads as every
+repository being dead.
+
+Write new files with `yaml.safe_dump(..., sort_keys=False, allow_unicode=True)`. Edit existing
+corpus files only through `build/components.py` - never load-modify-dump a file in `sources/`.
+
+## Scripts to run
+```bash
+uv run python -m build.validate            # 0 error(s)
+uv run python -m build.check_recipe
+uv run python -m build.check_rubric
+uv run python -m build.check_verification
+uv run python -m build.check_capability
+uv run python -m build.check_adoption
+uv run python -m build.check_instrument
+uv run python -m build.check_artifacts --live
+uv run python -m build.serialize_registry --check
+uv run python -m build.serialize_rubric --check
+uv run pytest -q
+```
+
+## Stop and escalate
+- Category has no `scoring_recipe`, or its evidence is prose the ladder cannot read → `build-rubric`.
+- A product needs a change to a **shared** rubric (a license tier, a dimension) → defer the product
+  with a substantive reason and leave the ruling to a maintainer.
+- A candidate's identity cannot be settled against primary sources → leave it in the registry.
+- Never commit `build/notebook_data.json` or `notebooks/`.

--- a/skills/registry.yaml
+++ b/skills/registry.yaml
@@ -2,7 +2,7 @@
 # what is actually in skills/: every skill directory must appear here exactly once, and each
 # primary skill must map to an existing workflow doc that no other primary skill claims.
 #
-# - primary:  the five contributor front doors, one per task, each backed by a workflow.
+# - primary:  the contributor front doors, one per task, each backed by a workflow.
 # - advanced: deep editorial skills, off the primary path (a ladder, the whole-corpus sweep).
 # - internal: infrastructure / read-only analysis, not editorial map-editing.
 
@@ -13,6 +13,8 @@ primary:
     workflow: docs/workflows/update-product.md
   - skill: edit-category
     workflow: docs/workflows/edit-category.md
+  - skill: promote-category
+    workflow: docs/workflows/promote-category.md
   - skill: refresh-category
     workflow: docs/workflows/refresh-category.md
   - skill: migrate-axis

--- a/tests/test_docs_integrity.py
+++ b/tests/test_docs_integrity.py
@@ -23,7 +23,8 @@ DOC_FILES = sorted(
     + [REPO / n for n in ("README.md", "CONTRIBUTING.md", "AGENTS.md", "CLAUDE.md")]
 )
 
-PRIMARY_SKILLS = ["add-product", "update-product", "edit-category", "refresh-category", "migrate-axis"]
+PRIMARY_SKILLS = ["add-product", "update-product", "edit-category", "promote-category",
+                  "refresh-category", "migrate-axis"]
 
 # Paths that were deleted or renamed in the reorg. A live reference to one is a regression.
 DEAD_FRAGMENTS = [


### PR DESCRIPTION
## What

The findings from the compilers/storage promotion (#328), folded back into the guides so the next
promotion does not rediscover them. Seven changes, each with a defect or a near-miss behind it.

**Stacked on #328** — its base is `carl/compilers-storage-promotion`, because two of the seven
reference things that only exist there (`build/validate.published_products`, the tail registry).
GitHub will retarget this to `main` when #328 merges.

## The new door

`docs/workflows/promote-category.md` + `skills/promote-category/` — a **sixth primary door**.
Nothing covered the job #328 actually was: taking twenty-five signal-only registry rows to a
published category. `edit-category` creates the category, `add-product` handles one product, and
the middle passage was undocumented, so the triage rules, the boundary-rejection convention, the
six files per promotion and the publication conditions lived nowhere.

It carries what cost the most time, including the thing I had to establish by experiment: **head
products in a preliminary category are normal, not an error** — that is the state the whole job
passes through, and prohibiting them would make the workflow impossible.

Registering a sixth workflow touches `skills/registry.yaml`, the router in `docs/README.md`
("Five doors" → "Six doors"), `AGENTS.md`'s skills table, `PRIMARY_SKILLS` in
`tests/test_docs_integrity.py`, and a `.claude/skills/` symlink. That surface is by design — the
integrity test's own docstring anticipates "an unregistered sixth workflow".

## The six additions

| Doc | What it gains | The defect behind it |
|---|---|---|
| `reference/adoption.md` | The **identification** trap, upstream of the two attribution traps it already documents | Ten of storage's 27 products have a same-named PyPI package and in none is it the product. `check_artifacts --live` **cannot** catch the client case, because a well-behaved client points its project URL at exactly the right repo |
| `reference/capability.md` | **"Writing the rungs"** — count products per rung; prefer a capability over an outcome; `basis_detail` is per product | Storage's top rung first admitted 7 of 27 and discriminated nothing; three products carried a harness name one of them is absent from |
| `reference/sibling-invariants.md` | Visibility as a fact with one owner, and the normalizer-as-exemption shape | Three public indexes leaked preliminary products; the scalar taxonomy spelling bypassed the whole category contract |
| `AGENTS.md` | The **census-vs-invariant** rule for real-corpus tests, out of one docstring and into the traps list | Six tests here have now failed because the work succeeded rather than because anything broke |
| `workflows/add-product.md` | The two license shapes that cost a hunt: REUSE, and a split license | `arm-compute-library` reports *no* license rather than NOASSERTION; `elasticsearch` and `meilisearch` state their own splits in the body |
| `workflows/refresh-category.md` | The **API budget** | 60 requests/hour unauthenticated against 3–4 per product, and a stale token 401s silently in a way that reads as every repository being dead |

## One thing this PR found in #328

Writing these I hit `product-copy.md`'s own rule — "American English everywhere, `license` not
`licence`" — which `refresh-category.md` lists as a defect class. I had written `licence` 26 times
across 11 files in #328, most of it in score notes and category prose that serialize into the
published notebook. Fixed there in `999d3ef` rather than here, since it is that branch's content:
same-length substitution so nothing reflowed, every touched YAML asserted to reparse to an
identical structure, and the two deliberate British spellings preserved (`test_validate` feeds
`licence` to `establishes` precisely to assert rejection — a blanket pass had flattened that test
into one that asserted nothing).

**Left alone: 33 pre-existing instances across 20 files** elsewhere in `sources/`, including three
rubrics and two published category records. A corpus-wide sweep belongs in its own PR.

## What I deliberately did not add

Score notes and dates, "never load-modify-dump", the NOASSERTION rule in general, and the deferral
mechanism all worked exactly as documented — the gates caught me where they should have, and the
deferral did its job twice before closing on a ruling. No doc changes there.

## Test plan

```
uv run python -m build.validate           0 error(s)
uv run pytest -q                          666 passed
uv run pytest -q tests/test_docs_integrity.py   13 passed
git diff --check                          clean
```

`test_docs_integrity` is the one that matters here: it holds the router, the registry
classification, the one-to-one skill/workflow mapping, the `.claude/skills` delivery, and that
every workflow has a `## Validation` section naming real modules. All of it passes with the sixth
door in place.
