### PR TITLE
Never publish a static model for a table with no rows

### DIFF
--- a/build/publish_registry.py
+++ b/build/publish_registry.py
@@ -25,6 +25,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import csv
 import json
 import os
 import sys
@@ -66,7 +67,8 @@ def graphql(query: str, variables: dict, token: str) -> dict:
 
 
 Q_DATASETS = """query($where: JSON){ datasets(where:$where){ edges{ node{ id name type } } } }"""
-Q_STATIC = """query($where: JSON){ staticModels(where:$where){ edges{ node{ id name } } } }"""
+Q_STATIC = """query($where: JSON){ staticModels(where:$where){
+  edges{ node{ id name materializations(first:1){ totalCount } } } } }"""
 M_DATASET = """mutation($input: CreateDatasetInput!){
   createDataset(input:$input){ success dataset{ id name } } }"""
 M_STATIC = """mutation($input: CreateStaticModelInput!){
@@ -74,6 +76,7 @@ M_STATIC = """mutation($input: CreateStaticModelInput!){
 M_URL = """mutation($staticModelId: ID!){ createStaticModelUploadUrl(staticModelId:$staticModelId) }"""
 M_RUN = """mutation($input: CreateStaticModelRunRequestInput!){
   createStaticModelRunRequest(input:$input){ success run{ id status } } }"""
+M_DELETE = """mutation($id: ID!){ deleteStaticModel(id:$id) }"""
 
 
 def resolve_dataset(name: str, org_id: str, token: str) -> str:
@@ -101,15 +104,42 @@ def resolve_dataset(name: str, org_id: str, token: str) -> str:
     return created["createDataset"]["dataset"]["id"]
 
 
-def resolve_static_models(dataset_id: str, org_id: str, token: str) -> dict[str, str]:
+def data_rows(path: Path) -> int:
+    """Rows in a serialized CSV, not counting the header.
+
+    A serializer emits a header for every table it declares, whether or not anything
+    filled it, so file existence says nothing about content. `tail_products.csv` is 94
+    bytes of header on a push where every tail row was promoted or rejected.
+    """
+    with path.open(newline="", encoding="utf-8") as handle:
+        return max(0, sum(1 for _ in csv.reader(handle)) - 1)
+
+
+def resolve_static_models(
+    dataset_id: str, org_id: str, token: str, wanted: tuple[str, ...]
+) -> dict[str, tuple[str, bool]]:
+    """Model id and whether it has ever materialized a table, per wanted table.
+
+    Only `wanted` tables get created. A model created for a table with no rows is a
+    model that cannot succeed: dlt infers a schema from records, so zero records
+    produces zero tables, and the runner fails the whole materialization on
+    "No tables found after processing static model". That is what turned run
+    7cd22391 red on 2026-08-19 after all 16 populated tables had already loaded.
+    """
     found = graphql(Q_STATIC, {"where": {"dataset_id": {"eq": dataset_id}}}, token)
-    existing = {n["node"]["name"]: n["node"]["id"] for n in found["staticModels"]["edges"]}
-    for table in TABLES:
+    existing = {
+        n["node"]["name"]: (
+            n["node"]["id"],
+            bool((n["node"].get("materializations") or {}).get("totalCount")),
+        )
+        for n in found["staticModels"]["edges"]
+    }
+    for table in wanted:
         if table not in existing:
             created = graphql(
                 M_STATIC, {"input": {"orgId": org_id, "datasetId": dataset_id, "name": table}}, token
             )
-            existing[table] = created["createStaticModel"]["staticModel"]["id"]
+            existing[table] = (created["createStaticModel"]["staticModel"]["id"], False)
     return existing
 
 
@@ -145,27 +175,72 @@ def main() -> int:
         )
         return 2
 
+    counts = {t: data_rows(args.dir / f"{t}.csv") for t in TABLES}
+    populated = tuple(t for t in TABLES if counts[t])
+    empty = tuple(t for t in TABLES if not counts[t])
+
     dataset_id = resolve_dataset(dataset_name, org_id, token)
-    models = resolve_static_models(dataset_id, org_id, token)
+    models = resolve_static_models(dataset_id, org_id, token, populated)
     print(f"dataset {dataset_name} = {dataset_id}")
 
+    # An empty table is a real state, not an error: a category whose tail registry has been
+    # fully triaged declares `products: []` and keeps the file so the next discovery batch has
+    # somewhere to land. What must not happen is publishing nothing and leaving whatever was
+    # there before, which would serve rows the repo no longer declares. So the model is
+    # removed, and the table's absence is the honest reading of "no rows". A later push with
+    # rows recreates it, because resolve_static_models creates whatever is missing.
+    #
+    # Dropping a table that HOLDS rows is not something to do unattended, though. That shape
+    # means a serializer regressed or a filter went wrong, and the loud stop is the point.
+    stale = []
+    for table in empty:
+        model = models.get(table)
+        if model is None:
+            print(f"  skipped {table}.csv (no rows, no model to publish to)")
+            continue
+        model_id, materialized = model
+        if materialized:
+            stale.append(table)
+            continue
+        if args.dry_run:
+            print(f"  would delete empty {table} ({model_id})")
+        else:
+            graphql(M_DELETE, {"id": model_id}, token)
+            print(f"  deleted empty {table} ({model_id}); it had never materialized")
+
+    if stale:
+        print(
+            f"refusing to publish: {stale} serialized zero rows but already hold a "
+            f"materialized table. Publishing nothing would leave the old rows in place, and "
+            f"dropping a populated table is a human's call. Check the serializer before "
+            f"re-running.",
+            file=sys.stderr,
+        )
+        return 2
+
     if args.dry_run:
-        for table in TABLES:
-            print(f"  would upload {table}.csv -> {models[table]}")
+        for table in populated:
+            print(f"  would upload {table}.csv ({counts[table]:,} rows) -> {models[table][0]}")
         return 0
 
-    for table in TABLES:
+    for table in populated:
         path = args.dir / f"{table}.csv"
-        url = graphql(M_URL, {"staticModelId": models[table]}, token)["createStaticModelUploadUrl"]
+        model_id = models[table][0]
+        url = graphql(M_URL, {"staticModelId": model_id}, token)["createStaticModelUploadUrl"]
         upload(path, url)
-        print(f"  uploaded {table}.csv ({path.stat().st_size:,} bytes)")
+        print(f"  uploaded {table}.csv ({path.stat().st_size:,} bytes, {counts[table]:,} rows)")
 
     run = graphql(
         M_RUN,
-        {"input": {"datasetId": dataset_id, "selectedModels": [models[t] for t in TABLES]}},
+        {
+            "input": {
+                "datasetId": dataset_id,
+                "selectedModels": [models[t][0] for t in populated],
+            }
+        },
         token,
     )["createStaticModelRunRequest"]["run"]
-    print(f"materialization run {run['id']} ({run['status']})")
+    print(f"materialization run {run['id']} ({run['status']}) over {len(populated)} models")
     return 0
 
 

--- a/tests/test_publish_registry.py
+++ b/tests/test_publish_registry.py
@@ -1,0 +1,111 @@
+"""The empty-table guard in the registry publisher.
+
+`tail_products` turned the 2026-08-19 materialization run red after all 16 populated
+tables had already loaded: dlt infers a schema from records, so a header-only CSV
+produces no table and the runner fails the whole run. These tests pin the three
+outcomes an empty table can have, and the names say which contract each one holds.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import pytest
+
+from build import publish_registry as pr
+
+
+def write_csv(directory: Path, table: str, rows: list[dict]) -> None:
+    header = ["slug", "display_name"]
+    with (directory / f"{table}.csv").open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=header)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def test_data_rows_does_not_count_the_header(tmp_path: Path) -> None:
+    write_csv(tmp_path, "empty", [])
+    write_csv(tmp_path, "full", [{"slug": "a", "display_name": "A"}])
+    assert pr.data_rows(tmp_path / "empty.csv") == 0
+    assert pr.data_rows(tmp_path / "full.csv") == 1
+
+
+def test_an_empty_table_is_never_created(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No model for a table with no rows: a model that cannot succeed must not exist."""
+    created: list[str] = []
+
+    def fake_graphql(query: str, variables: dict, token: str) -> dict:
+        if query is pr.Q_STATIC:
+            return {"staticModels": {"edges": []}}
+        if query is pr.M_STATIC:
+            name = variables["input"]["name"]
+            created.append(name)
+            return {"createStaticModel": {"staticModel": {"id": f"id-{name}", "name": name}}}
+        raise AssertionError(f"unexpected query: {query[:40]}")
+
+    monkeypatch.setattr(pr, "graphql", fake_graphql)
+    models = pr.resolve_static_models("ds", "org", "tok", ("products",))
+    assert created == ["products"]
+    assert "tail_products" not in models
+
+
+def test_materialization_count_marks_a_model_that_holds_a_table(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A totalCount of zero or null means never materialized, which is what makes a
+    delete safe. Reading it as materialized would block a legitimate publish."""
+
+    def fake_graphql(query: str, variables: dict, token: str) -> dict:
+        return {
+            "staticModels": {
+                "edges": [
+                    {"node": {"id": "1", "name": "products", "materializations": {"totalCount": 139}}},
+                    {"node": {"id": "2", "name": "tail_products", "materializations": {"totalCount": None}}},
+                    {"node": {"id": "3", "name": "fresh", "materializations": None}},
+                ]
+            }
+        }
+
+    monkeypatch.setattr(pr, "graphql", fake_graphql)
+    models = pr.resolve_static_models("ds", "org", "tok", ())
+    assert models["products"] == ("1", True)
+    assert models["tail_products"] == ("2", False)
+    assert models["fresh"] == ("3", False)
+
+
+def test_publish_refuses_when_an_empty_table_already_holds_rows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Serializing zero rows for a table that HAS a materialized table stops the push.
+
+    Publishing nothing would leave the previous rows served as though the repo still
+    declared them, which is the stale-data direction this repo cares most about. The
+    exit code is what CI reads, so it is what this asserts.
+    """
+    for table in pr.TABLES:
+        write_csv(tmp_path, table, [] if table == "products" else [{"slug": "a", "display_name": "A"}])
+
+    def fake_graphql(query: str, variables: dict, token: str) -> dict:
+        if query is pr.Q_DATASETS:
+            return {"datasets": {"edges": [{"node": {"id": "ds", "name": "registry", "type": "STATIC_MODEL"}}]}}
+        if query is pr.Q_STATIC:
+            return {
+                "staticModels": {
+                    "edges": [
+                        {"node": {"id": f"id-{t}", "name": t, "materializations": {"totalCount": 5}}}
+                        for t in pr.TABLES
+                    ]
+                }
+            }
+        if query is pr.M_DELETE:
+            raise AssertionError("a populated table must never be deleted unattended")
+        raise AssertionError(f"unexpected query: {query[:40]}")
+
+    monkeypatch.setattr(pr, "graphql", fake_graphql)
+    monkeypatch.setenv("OSO_API_KEY", "tok")
+    monkeypatch.setenv("OSO_ORG_ID", "org")
+    monkeypatch.setattr("sys.argv", ["publish_registry", "--dir", str(tmp_path)])
+
+    assert pr.main() == 2
+    assert "products" in capsys.readouterr().err


### PR DESCRIPTION
The 2026-08-19 registry materialization run (`7cd22391`) went red **after all 16 populated tables had already loaded**. The only error in the log:

```
No tables found after processing static model 91255695-287c-41f5-91e7-134809c2b916
```

That id is `tail_products`.

## Cause

Ours, and this promotion's. #328 triaged every seeded tail row into either a head product or a rejection, so `sources/registry/compilers.yaml` and `storage.yaml` now read `products: []` — deliberately, since the files stay so the next discovery batch has somewhere to land. `serialize_registry` still emits the table, so `tail_products.csv` is 94 bytes of header. dlt infers a schema from records, zero records produces zero tables, and the runner fails the whole 17-model run on the post-check.

The failure is loud but not damaging: `products` (522), `organizations` (289), `categories` (18) and the other 13 all loaded fresh in that same run before it aborted. `check_parity` is green against them.

## What changes

A table with no rows is not uploaded, gets no model created, and is excluded from the materialization run. If a model for it already exists and **has never materialized**, it is deleted — the table's absence is then the honest reading of "no rows", and a later push with rows recreates it, because `resolve_static_models` creates whatever is missing.

The exception is the case worth being careful about: a table that serializes zero rows **while already holding a materialized table**. That means a serializer regressed or a filter went wrong, and both available moves are bad unattended — publishing nothing serves rows the repo no longer declares, and dropping a populated table is a human's call. It exits 2 and names the table.

Nothing reads `currentai.registry.tail_products` today. I grepped the repo including the platform mirror; the model was created 48 seconds before the run that failed on it.

## Test plan

`tests/test_publish_registry.py`, four tests:

- `data_rows` does not count the header
- an empty table is never created — no model that cannot succeed
- a `totalCount` of zero **or null** reads as never-materialized, which is what makes the delete safe; reading it as materialized would block a legitimate publish
- the refusal path: zero rows against an already-materialized table exits 2, and the test asserts the delete mutation is never reached

I confirmed the tests fail against the unpatched module before wiring them (all four red, since the module had no `data_rows`).

Dry run against the live API, which deletes nothing:

```
dataset registry = 6b735d7b-e38e-41e8-a951-d4d7f3fbf331
  would delete empty tail_products (91255695-287c-41f5-91e7-134809c2b916)
  would upload products.csv (522 rows) -> 41a565d5-...
  ... 16 populated tables
```

`build/publish_registry.py` is in this workflow's own push-path filter, so merging re-runs the publish: the empty model goes, the 16 tables re-materialize, and the dataset clears without a manual delete.