### PR TITLE
Fix the empty-table guard: selection set, error bodies, and a non-fatal delete

### DIFF
--- a/build/publish_registry.py
+++ b/build/publish_registry.py
@@ -59,8 +59,16 @@ def graphql(query: str, variables: dict, token: str) -> dict:
             "User-Agent": USER_AGENT,
         },
     )
-    with urllib.request.urlopen(request, timeout=60) as response:
-        body = json.load(response)
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            body = json.load(response)
+    except urllib.error.HTTPError as error:
+        # A malformed query is a GraphQL VALIDATION error served with a 4xx, and the reason is
+        # in the body urlopen never reads. Without this, `deleteStaticModel` returning
+        # SimplePayload! rather than a scalar surfaced as a bare "HTTP Error 400: Bad Request"
+        # with no hint that the mutation was missing its selection set (2026-08-19).
+        detail = error.read().decode("utf-8", "replace")[:500]
+        raise RuntimeError(f"HTTP {error.code} from the API: {detail}") from error
     if body.get("errors"):
         raise RuntimeError(f"GraphQL error: {json.dumps(body['errors'])[:500]}")
     return body["data"]
@@ -76,7 +84,7 @@ M_STATIC = """mutation($input: CreateStaticModelInput!){
 M_URL = """mutation($staticModelId: ID!){ createStaticModelUploadUrl(staticModelId:$staticModelId) }"""
 M_RUN = """mutation($input: CreateStaticModelRunRequestInput!){
   createStaticModelRunRequest(input:$input){ success run{ id status } } }"""
-M_DELETE = """mutation($id: ID!){ deleteStaticModel(id:$id) }"""
+M_DELETE = """mutation($id: ID!){ deleteStaticModel(id:$id){ success message } }"""
 
 
 def resolve_dataset(name: str, org_id: str, token: str) -> str:
@@ -204,9 +212,21 @@ def main() -> int:
             continue
         if args.dry_run:
             print(f"  would delete empty {table} ({model_id})")
-        else:
+            continue
+        # Best effort, and deliberately not fatal. The delete is tidying: the model is already
+        # excluded from the run below, so the publish is correct whether or not it goes. Making
+        # it fatal would mean a token without delete permission cannot publish the registry at
+        # all, which is a far worse failure than an empty model sitting in the dataset.
+        try:
             graphql(M_DELETE, {"id": model_id}, token)
             print(f"  deleted empty {table} ({model_id}); it had never materialized")
+        except (RuntimeError, urllib.error.URLError) as error:
+            print(
+                f"  WARNING could not delete empty {table} ({model_id}): {error}. "
+                f"It is excluded from this run, so the publish is unaffected, but the dataset "
+                f"will keep showing it as broken until it is removed.",
+                file=sys.stderr,
+            )
 
     if stale:
         print(

--- a/tests/test_publish_registry.py
+++ b/tests/test_publish_registry.py
@@ -109,3 +109,97 @@ def test_publish_refuses_when_an_empty_table_already_holds_rows(
 
     assert pr.main() == 2
     assert "products" in capsys.readouterr().err
+
+
+def test_delete_mutation_asks_for_fields_because_it_returns_an_object() -> None:
+    """`deleteStaticModel` returns SimplePayload!, so a bare call is a validation error.
+
+    Sent without a selection set it is rejected with an HTTP 400 before it reaches the
+    resolver, which is how the 2026-08-19 registry publish died. Pinning the selection
+    set here because the symptom carried no hint of the cause.
+    """
+    assert "deleteStaticModel" in pr.M_DELETE
+    body = pr.M_DELETE.split("deleteStaticModel", 1)[1]
+    assert "{" in body and "success" in body
+
+
+def test_http_error_bodies_are_surfaced(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 4xx carries the GraphQL validation message in a body urlopen never reads.
+
+    Without this the only thing printed was "HTTP Error 400: Bad Request", which says
+    nothing about which query was malformed or why.
+    """
+    import io
+    import urllib.error
+
+    def boom(request, timeout=None):  # noqa: ANN001, ARG001
+        raise urllib.error.HTTPError(
+            "https://api.oso.xyz/v1/graphql",
+            400,
+            "Bad Request",
+            {},
+            io.BytesIO(b'{"errors":[{"message":"Field must have a selection of subfields"}]}'),
+        )
+
+    monkeypatch.setattr("urllib.request.urlopen", boom)
+    with pytest.raises(RuntimeError, match="selection of subfields"):
+        pr.graphql("mutation{ x }", {}, "tok")
+
+
+def test_a_failed_delete_does_not_fail_the_publish(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Tidying must not gate publishing.
+
+    The empty model is already excluded from the materialization run, so a token without
+    delete permission should still publish the populated tables. Fatal here would mean a
+    permission gap blocks the registry entirely.
+    """
+    for table in pr.TABLES:
+        write_csv(
+            tmp_path,
+            table,
+            [] if table == "tail_products" else [{"slug": "a", "display_name": "A"}],
+        )
+
+    uploaded: list[str] = []
+    ran: list[list[str]] = []
+
+    def fake_graphql(query: str, variables: dict, token: str) -> dict:
+        if query is pr.Q_DATASETS:
+            return {"datasets": {"edges": [{"node": {"id": "ds", "name": "registry", "type": "STATIC_MODEL"}}]}}
+        if query is pr.Q_STATIC:
+            return {
+                "staticModels": {
+                    "edges": [
+                        {
+                            "node": {
+                                "id": f"id-{t}",
+                                "name": t,
+                                "materializations": {"totalCount": None if t == "tail_products" else 5},
+                            }
+                        }
+                        for t in pr.TABLES
+                    ]
+                }
+            }
+        if query is pr.M_DELETE:
+            raise RuntimeError("HTTP 403 from the API: User not authorized")
+        if query is pr.M_URL:
+            return {"createStaticModelUploadUrl": "https://upload.example/put"}
+        if query is pr.M_RUN:
+            ran.append(variables["input"]["selectedModels"])
+            return {"createStaticModelRunRequest": {"run": {"id": "run-1", "status": "QUEUED"}}}
+        raise AssertionError(f"unexpected query: {query[:40]}")
+
+    monkeypatch.setattr(pr, "graphql", fake_graphql)
+    monkeypatch.setattr(pr, "upload", lambda path, url: uploaded.append(path.name))
+    monkeypatch.setenv("OSO_API_KEY", "tok")
+    monkeypatch.setenv("OSO_ORG_ID", "org")
+    monkeypatch.setattr("sys.argv", ["publish_registry", "--dir", str(tmp_path)])
+
+    assert pr.main() == 0
+    assert "tail_products.csv" not in uploaded
+    assert len(uploaded) == len(pr.TABLES) - 1
+    assert "id-tail_products" not in ran[0]
+    assert "WARNING could not delete empty tail_products" in capsys.readouterr().err


### PR DESCRIPTION
Follow-up to #331. Its guard was right about what to do and wrong about how to call the API, and the first real run of it failed — the dry run never sends the mutation, which is exactly the gap.

The failing run is [`32244972776`](https://github.com/currentai-org/os-ai-map/actions/runs/32244972776). It died before uploading anything, so the registry tables are untouched and still hold the 522-product load from this morning; `check_parity` is green against them.

## Three defects

1. **`deleteStaticModel` returns `SimplePayload!`, not a scalar.** A bare `deleteStaticModel(id:$id)` is a validation error, rejected with a 400 before it reaches the resolver. Confirmed by introspection and by sending both forms: the bare one gets a 400, the one with `{ success message }` gets a 200.
2. **`graphql` threw away the reason.** `urlopen` raises `HTTPError` without reading the body, and a 4xx from this API carries the GraphQL message in that body. All the log showed was `HTTP Error 400: Bad Request`, with nothing pointing at the selection set. It now reads the body into the raised error.
3. **The delete was fatal, and should not be.** It is tidying: the empty model is already excluded from the materialization run, so the publish is correct whether or not the delete lands. Fatal meant a token without delete permission could not publish the registry **at all** — strictly worse than leaving an empty model in the dataset. I found this while probing: a delete against an id the key does not own answers `FORBIDDEN / User not authorized`, so this is a live possibility for the CI token, not a hypothetical.

## Test plan

Three new tests (seven in the file):

- the delete mutation asks for subfields, because it returns an object
- an HTTP error body is surfaced — asserts the raised `RuntimeError` carries `selection of subfields` from a mocked 400
- a failed delete does not fail the publish — 16 tables still upload, the empty model is absent from `selectedModels`, exit 0, and the warning names the table

I restored the bare mutation and confirmed the first test goes red on it specifically (1 failed, 6 passed), then restored the fix.

Dry run against the live API is unchanged: `would delete empty tail_products (91255695-...)`, then the 16 populated tables.

If the CI token cannot delete, this publish now goes green with a warning and the dataset keeps showing `tail_products` as broken until someone with permission removes it. That is the intended trade.