### PR TITLE
A bot wall is not evidence, and not fabrication either

### DIFF
--- a/build/check_refetch.py
+++ b/build/check_refetch.py
@@ -86,6 +86,49 @@ AXES = axes()  # build/vocabulary.py owns this; the score schema declares it
 
 # A real browser-ish UA. Several vendor docs sites answer 403 to the default python-requests
 # string, which would otherwise read as a dead source on every run.
+# A bot wall answers 200 and hands back a page that is not the document. PyPI serves one
+# ("Client Challenge", ~3KB, "JavaScript is disabled in your browser") and on 2026-08-13 two
+# sources were digested from it — `pypi.org/project/llm` and `pypi.org/project/pydantic-ai/`
+# recorded the SAME digest, because the wall is byte-identical whatever you asked for. That
+# tripped the duplicate-digest resolver, which called it fabrication. It was not: nobody
+# forged a digest, the fetcher was challenged and hashed the challenge.
+#
+# It also poisoned a score note. pydantic-ai concluded "the PyPI project page no longer
+# serving a readable description" — a permanent claim about the source, from a transient wall.
+#
+# Same class as the canonical-license and host-alias false positives this module already
+# documents: the body is real, it just is not the page. So it is detected in ONE place that
+# both the recorder and the re-fetch import, and neither treats it as content.
+BOT_WALL_MARKERS = (
+    "<title>Client Challenge</title>",
+    "JavaScript is disabled in your browser",
+    "Enable JavaScript and cookies to continue",
+    "Checking your browser before accessing",
+)
+# Generous next to a real page (PyPI's own project pages are 100KB+) and far above the walls
+# seen, which are ~3KB. The bound is what keeps a page that merely QUOTES one of these
+# strings — a docs page about bot protection, say — from being discarded as a wall.
+BOT_WALL_MAX_BYTES = 25_000
+
+
+def bot_wall(response: "requests.Response") -> str | None:
+    """The marker this body matched, or None if it looks like a document.
+
+    Deliberately narrow: a marker AND a body too small to be the real page. Read the pair as
+    "this host declined to serve the document", which is a 429 wearing a 200.
+    """
+    if len(response.content) > BOT_WALL_MAX_BYTES:
+        return None
+    try:
+        text = response.content.decode("utf-8", "replace")
+    except Exception:  # pragma: no cover - decode with replace does not raise
+        return None
+    for marker in BOT_WALL_MARKERS:
+        if marker in text:
+            return marker
+    return None
+
+
 USER_AGENT = (
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) "
     "Chrome/126.0.0.0 Safari/537.36 os-ai-map-verification/1.0"
@@ -282,6 +325,7 @@ def resolve_duplicates(
     for digest, urls in groups:
         seen: dict[str, list[str]] = defaultdict(list)
         unreachable = []
+        walled: list[tuple[str, str, str]] = []
         for url in urls:
             try:
                 # Through `canonical`, exactly as build/fetch_source does. A GitHub blob URL
@@ -299,10 +343,29 @@ def resolve_duplicates(
             if response.status_code >= 400:
                 unreachable.append(url)
                 continue
-            seen[hashlib.sha256(response.content).hexdigest()].append(url)
+            live = hashlib.sha256(response.content).hexdigest()
+            marker = bot_wall(response)
+            if marker:
+                # The wall is the reason this group looked like fabrication. If its digest is
+                # the RECORDED one, that is positive evidence the original fetch was walled
+                # too: the recorded bytes are a challenge page, so nothing behind this source
+                # was ever read.
+                walled.append((url, live, marker))
+                continue
+            seen[live].append(url)
 
         listed = ", ".join(urls)
-        if len(seen) > 1:
+        walls_matching = [w for w in walled if w[1] == digest]
+        if walls_matching:
+            wall_urls = ", ".join(u for u, _, _ in walls_matching)
+            failures.append(
+                f"digest {digest[:12]}… IS a bot-challenge page, not a document: re-fetching "
+                f"{wall_urls} returns that same digest over a body matching "
+                f"{walls_matching[0][2]!r}. So all {len(urls)} sources recorded against it "
+                f"({listed}) were digested behind the wall and never read. Re-verify them "
+                f"against a source the host will serve."
+            )
+        elif len(seen) > 1:
             split = " | ".join(
                 f"{d[:12]}…: {', '.join(u)}" for d, u in sorted(seen.items())
             )
@@ -317,6 +380,11 @@ def resolve_duplicates(
             benign.append(
                 f"digest {digest[:12]}… is shared by {len(urls)} URLs ({listed}), and "
                 f"re-fetching confirms their bodies really are identical{note}."
+            )
+        if walled and not walls_matching:
+            benign.append(
+                f"digest {digest[:12]}…: {', '.join(u for u, _, _ in walled)} answered with a "
+                f"bot wall this run, so the group is unresolved rather than cleared."
             )
         if unreachable:
             benign.append(
@@ -348,6 +416,20 @@ def refetch(source: Source, timeout: float) -> tuple[str, str]:
         return "gone", f"recorded {source.status}, now HTTP {response.status_code}"
 
     live = hashlib.sha256(response.content).hexdigest()
+
+    # A wall is "not now" wearing a 200, so it belongs with 429 rather than with drift. Two
+    # readings would both be wrong: DRIFTED implies the document changed, and CONFIRMED on a
+    # matching digest would be worse still — it would certify a source whose recorded bytes
+    # are a challenge page, turning the gate's one piece of positive evidence into a lie.
+    marker = bot_wall(response)
+    if marker:
+        if live == source.digest:
+            return "gone", (
+                f"the recorded digest reproduces, but over a bot-challenge page "
+                f"({marker!r}), so this source was digested behind the wall and never read"
+            )
+        return "unreachable", f"bot wall ({marker!r}); the host declined to serve the document"
+
     if live == source.digest:
         return "confirmed", ""
     return "drifted", f"body changed since {source.accessed}"

--- a/build/fetch_source.py
+++ b/build/fetch_source.py
@@ -37,6 +37,7 @@ import requests
 
 from build.check_refetch import (
     BACKOFF,
+    bot_wall,
     RETRIES,
     TRANSIENT,
     USER_AGENT,  # noqa: F401 — re-exported by import on purpose; a private copy would drift
@@ -103,6 +104,24 @@ def fetch(
             f"HTTP {response.status_code} after {attempts} attempts. The host declined to "
             f"answer; this says nothing about whether the fact exists. Retry later or defer "
             f"the axis. Do NOT record this as evidence and do NOT read it as an absence."
+        )
+        return record
+
+    # A bot wall answers 200, so the TRANSIENT branch above never sees it. Recording a digest
+    # here is how two sources came to share one on 2026-08-13: the wall is byte-identical
+    # whatever you asked for, and a score note then cited it as proof PyPI had stopped serving
+    # a description. Same treatment as a 429 — no digest, and a note saying not to read it as
+    # evidence or as an absence.
+    wall = bot_wall(response)
+    if wall:
+        record["transient"] = True
+        record["bytes"] = len(response.content)
+        record["note"] = (
+            f"HTTP {response.status_code} but the body is a bot-challenge page "
+            f"(matched {wall!r}) rather than the document. The host declined to serve it; "
+            f"this says nothing about whether the fact exists. Retry later, or cite a source "
+            f"the host will serve — for PyPI that is https://pypi.org/pypi/<name>/json. Do "
+            f"NOT record this as evidence and do NOT read it as an absence."
         )
         return record
 

--- a/sources/scores/llm.yaml
+++ b/sources/scores/llm.yaml
@@ -38,11 +38,11 @@ adoption:
     release is 0.32.
   last_verified: '2026-08-13'
   sources:
-  - url: https://pypi.org/project/llm
-    shows: llm v0.31 published ~Apr 2026
-    accessed: '2026-08-13'
+  - url: https://pypi.org/pypi/llm/json
+    shows: llm 0.32 is the current release
+    accessed: '2026-08-19'
     http_status: 200
-    content_sha256: 32ed63159c77e21ee19ca1b9aa3213ccf0218eb59539560b132a8e68ef0e18ea
+    content_sha256: b37c3ece3a870b61ff6465131865b1c4010f88a9927dcbbdedcb78fac418fd74
   - url: https://github.com/simonw/llm
     shows: ~12.1k stars, plugin ecosystem
     accessed: '2026-08-13'

--- a/sources/scores/pydantic-ai.yaml
+++ b/sources/scores/pydantic-ai.yaml
@@ -79,20 +79,19 @@ capability:
   value: typed/structured outputs; typed DI; model-agnostic; tool calling; streaming; multi-agent; MCP; OTel/Logfire
   confidence: medium
   note: 'Lean, type-safe developer experience, with narrower built-in RAG than LlamaIndex and fewer prebuilt
-    role abstractions than CrewAI. The feature reading rests on the repo, the PyPI project page no longer
-    serving a readable description: structured streamed outputs with immediate validation, tools and dynamic
-    instructions, composable capabilities including web search and thinking, MCP and UI event-stream integration,
-    human-in-the-loop workflows and graph support, plus agents definable entirely in YAML or JSON.'
+    role abstractions than CrewAI. The feature reading rests on the repo: structured streamed outputs with
+    immediate validation, tools and dynamic instructions, composable capabilities including web search and
+    thinking, MCP and UI event-stream integration, human-in-the-loop workflows and graph support, plus agents
+    definable entirely in YAML or JSON.'
   relative_to: llama-index
   relation: one_below
   last_verified: '2026-08-13'
   sources:
-  - url: https://pypi.org/project/pydantic-ai/
-    shows: Previously cited for the MIT typed agent framework; the page now returns a 3KB stub with no project
-      description.
-    accessed: '2026-08-13'
+  - url: https://pypi.org/pypi/pydantic-ai/json
+    shows: pydantic-ai 2.32.0 is the current release; the metadata carries no license field
+    accessed: '2026-08-19'
     http_status: 200
-    content_sha256: 32ed63159c77e21ee19ca1b9aa3213ccf0218eb59539560b132a8e68ef0e18ea
+    content_sha256: d5bf14a0a79cac36211657fbfce95006ec3beb11a03c379ab43c901215353f61
   - url: https://github.com/pydantic/pydantic-ai
     shows: structured streamed outputs with immediate validation, tools and dynamic instructions, composable
       capabilities including web search and thinking, MCP and UI event streams, human-in-the-loop, graph

--- a/tests/test_check_refetch.py
+++ b/tests/test_check_refetch.py
@@ -21,6 +21,7 @@ import pytest
 import requests
 
 from build.check_refetch import Source, offline_failures, refetch
+from build.check_refetch import bot_wall as pr_bot_wall
 
 DIGEST_A = "a" * 64
 DIGEST_B = "b" * 64
@@ -167,3 +168,51 @@ def test_network_error_is_unreachable_not_dead():
         "build.check_refetch.requests.get", side_effect=requests.Timeout("timed out")
     ):
         assert refetch(source, 5.0)[0] == "unreachable"
+
+
+# --- Bot walls -------------------------------------------------------------------------
+# A wall answers 200 and hands back a page that is not the document, so neither the
+# TRANSIENT branch nor the >=400 branch sees it. On 2026-08-13 two PyPI sources were
+# digested from one, recorded the same digest because the wall is byte-identical whatever
+# you ask for, and the duplicate resolver called it fabrication. Nobody forged anything.
+
+WALL = (
+    b"<html><head><title>Client Challenge</title></head>"
+    b"<body>JavaScript is disabled in your browser</body></html>"
+)
+
+
+def test_a_wall_is_recognised_by_marker_and_size():
+    assert "Client Challenge" in (pr_bot_wall(_response(200, WALL)) or "")
+
+
+def test_a_real_page_quoting_the_marker_is_not_a_wall():
+    """The size bound is what stops a docs page ABOUT bot protection being discarded.
+
+    Without it this check would silently drop legitimate evidence, which is a worse
+    failure than the one it is here to prevent.
+    """
+    big = WALL + b"x" * 30_000
+    assert pr_bot_wall(_response(200, big)) is None
+
+
+def test_a_walled_refetch_is_unreachable_not_drift():
+    """DRIFTED would assert the document changed. The host just declined to serve it."""
+    source = src("https://a.example/x", DIGEST_A)
+    with patch("build.check_refetch.requests.get", return_value=_response(200, WALL)):
+        outcome, detail = refetch(source, 5.0)
+    assert outcome == "unreachable"
+    assert "bot wall" in detail
+
+
+def test_a_wall_whose_digest_matches_is_never_confirmed():
+    """The one case that must not read as CONFIRMED.
+
+    A matching digest is this gate's only piece of positive evidence, and certifying a
+    source whose recorded bytes are a challenge page would turn that evidence into a lie.
+    """
+    source = src("https://a.example/x", hashlib.sha256(WALL).hexdigest())
+    with patch("build.check_refetch.requests.get", return_value=_response(200, WALL)):
+        outcome, detail = refetch(source, 5.0)
+    assert outcome != "confirmed"
+    assert "never read" in detail


### PR DESCRIPTION
The `refetch` workflow has been red on `main` since 2026-08-13. It reports:

```
FABRICATION — no innocent reading
  digest 32ed63159c77… is recorded for 2 URLs (pypi.org/project/llm,
  pypi.org/project/pydantic-ai/), and re-fetching them returns DIFFERENT bodies.
```

There was an innocent reading. I fetched both URLs the way the gate does:

| URL | bytes | digest |
|---|---|---|
| `pypi.org/project/llm` | 3,038 | `32ed63159c77…` — **the recorded one** |
| `pypi.org/project/pydantic-ai/` | 330,133 | `4f86eaa67481…` |

The 3,038-byte body is `<title>Client Challenge</title>` — PyPI's bot wall, served with **HTTP 200**, and byte-identical whatever you ask for. Both rows were digested from it on 2026-08-13. Nobody forged a digest; the fetcher was challenged and hashed the challenge.

This is the same class as the canonical-license and host-alias false positives the resolver already documents: the body is real, it just is not the page. Because it answers 200, neither the TRANSIENT branch nor the `>=400` branch sees it, so it flows straight into `content_sha256`.

## The wall also poisoned a score note

`pydantic-ai`'s capability note read "The feature reading rests on the repo, the PyPI project page no longer serving a readable description". That page serves 330KB including a description. A transient wall was written down as a permanent property of the source. Removed.

## What changes

Detected in one place that both the recorder and the re-fetch import:

- **`fetch_source`** records no digest for a wall, and its note names the endpoint the host will serve: `pypi.org/pypi/<name>/json`. Verified live — it now returns `transient: true` with no `content_sha256` for that URL.
- **`refetch`** reads a wall as `unreachable`, and refuses `CONFIRMED` when the recorded digest matches. That case matters most: a matching digest is this gate's only positive evidence, and certifying a source whose recorded bytes are a challenge page would turn that evidence into a lie.
- **the duplicate resolver** names a wall as a wall and says to re-verify, instead of alleging fabrication.

Scope note: 20 sources across 18 files cite `pypi.org/project/...`, and only these 2 carried the wall digest, so the wall is intermittent rather than universal.

## Test plan

Four new tests. Two are behavioral and I confirmed both go red with the guard disabled (`2 failed, 2 passed`), then restored it:

- a wall is recognised by marker and size
- **a real page quoting the marker is not a wall** — the size bound is what stops a docs page about bot protection being discarded, which would be a worse failure than the one this prevents
- a walled re-fetch is `unreachable`, not drift
- a wall whose digest matches is never `confirmed`

Full `tests/test_check_refetch.py`: 16 pass.

Gates run locally, all exit 0: `validate`, `check_verification`, `check_instrument`, `check_rubric`, `check_components`.

Both products re-fetch clean, `0 dead`:

```
llm:          5 sources, 3 confirmed, 2 drifted, 0 dead
pydantic-ai:  6 sources, 1 confirmed, 5 drifted, 0 dead
```

Re-verified facts come from the JSON API: llm 0.32, pydantic-ai 2.32.0. Neither carries a license field there, so neither `shows` claims one.