### PR TITLE
Make the schedule section describe what is configured

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,8 +266,11 @@ After any `components` edit, regenerate `raw` or CI fails.
 - **The scoring-chain SQL is not in this repo.** It lives on the OSO platform, and its deploy
   script and `.sql` sit one directory up in `currentai-org/{tools,udms}/`, not under version
   control. See `docs/operations/deploy-models.md`.
-- **The chain does not run on a schedule.** Its crons were set at the model-revision layer; the
-  platform schedules from the dataset, and zero scheduled runs have ever fired. Treat every
+- **The chain runs weekly, and that is verified rather than declared.** Dataset-level crons:
+  `evidence` Monday 03:00 UTC, `scores` 04:00, with `parity` grading at 06:00. A scheduled run
+  was observed firing on 2026-08-19, so this is an observation and not a cron field. It was NOT
+  running before that date — the crons had been set at the model-revision layer, which is a
+  throttle rather than a sweep. Treat every
   scoring-chain recompute as manual, and check run history before believing a freshness claim.
 - **A real-corpus test asserts an invariant, or derives its count. Never a census.** Six tests here
   have now failed because the work succeeded rather than because anything broke;

--- a/docs/operations/deploy-models.md
+++ b/docs/operations/deploy-models.md
@@ -66,18 +66,46 @@ Two traps in the run step, both of which have cost hours:
 
 ## The schedule
 
-The **intended** operating schedule is weekly, upstream first: `evidence.product_evidence` Monday
-03:00 UTC, `scores.openness_facts` 04:00, `scores.openness_computed` 05:00, with the parity gate
-grading at 06:00, and the signal fetchers refreshing ahead of it. On that schedule the warehouse
-is at most a week behind the repo.
+This is what is **configured**, verified on the platform 2026-08-19. The workflow files are
+authoritative for the gates; this table is a copy and a copy can drift, so `tests/test_schedule_doc.py`
+holds it against the `cron:` lines it quotes.
 
-**This repository does not verify whether those scheduled runs actually fired** — that is a
-platform concern, not something the repo tracks. When you are diagnosing a freshness problem,
-inspect the datasets' run history on the platform rather than assuming this schedule held.
+| What | When (UTC) | Where the cron lives |
+|---|---|---|
+| `registry` static models | every push to `main` touching `sources/**` | `.github/workflows/registry.yml`, no cron |
+| `evidence` dataset | Monday 03:00 | dataset cron, timezone UTC |
+| `scores` dataset | Monday 04:00 | dataset cron, timezone UTC |
+| `parity` gate | Monday 06:00 | `.github/workflows/parity.yml` |
+| `artifacts` | Monday 07:00 | `.github/workflows/artifacts.yml` |
+| `freshness` report | Monday 08:00 | `.github/workflows/freshness.yml` |
 
-**Schedule a model on its dataset, not its model revision** (`updateDataModelSchedule`) — the
-platform's scheduler reads the dataset-level cron. Keep the 03/04/05 spacing so parity, at 06:00,
-grades a warehouse that has just recomputed.
+The chain lands two hours before parity grades it, and the warehouse is at most a week behind
+the repo.
+
+**The chain is two datasets, not three model times.** An earlier version of this section gave
+`openness_facts` 04:00 and `openness_computed` 05:00, which cannot be configured: both models
+live in the `scores` dataset and the platform sweeps per dataset. Within a sweep they run in
+dependency order anyway, so one dataset time covers both. Splitting them would mean splitting
+the dataset.
+
+**Set the cron on the dataset, and keep the models' own cron empty.** The dataset cron is when
+the sweep happens (`updateDataset`); a model's cron is a THROTTLE on top of it, where `""` means
+eligible on every sweep and `@manual` means never scheduled. `updateDataModelSchedule` sets that
+throttle, not the sweep — reaching for it to change *when* the chain runs mints a revision and
+changes nothing about the timing.
+
+**Pin the timezone to UTC.** These ran on `America/New_York` until 2026-08-19, which moves the
+real hour by one across DST while every gate that grades them is UTC-pinned. The margin is
+hours, so nothing inverted, but the two clocks had no reason to differ.
+
+**A configured cron is not an observed run, and the repo cannot tell you which you have.** Check
+`triggerType` in the dataset's run history: `MANUAL` everywhere means nothing has fired on its
+own, however healthy the cron field looks. Two ways that reads as a bug when it is not — a cron
+set after this week's slot has passed shows `lastRunAt: null` until the next one comes round, and
+`nextRunAt` is computed from the cron whether or not the scheduler ever acts on it. To settle it
+in minutes rather than waiting a week, point the cron a few minutes out, watch for a run whose
+`triggerType` is `SCHEDULED`, then set the real one back. Confirmed working that way on
+2026-08-19: `SCHEDULED/RUNNING started=2026-08-19T18:45:18Z` against a cron set for 18:45.
 
 ## A publish is only half a refresh
 

--- a/tests/test_schedule_doc.py
+++ b/tests/test_schedule_doc.py
@@ -1,0 +1,74 @@
+"""The schedule table in deploy-models.md must match the workflows it describes.
+
+Written because the table did not. On 2026-08-19 a change to that section recorded the
+parity gate at 07:00 UTC when `parity.yml` says `0 6 * * 1` — 07:00 is `artifacts.yml`,
+misread off a loop that printed workflow names and crons out of step. The PR carrying it
+also claimed the repo had been searched for surviving copies of the old times, and two
+survived.
+
+Prose about a cron is a copy of the cron, and a copy drifts. This makes the workflow file
+the authority and the doc answerable to it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+DOC = ROOT / "docs/operations/deploy-models.md"
+# The gates whose times the doc's table quotes. Dataset crons live on the platform and
+# cannot be read from the repo, so they are out of scope here by construction.
+GATES = ("parity", "artifacts", "freshness")
+
+_DAYS = {"1": "Monday", "2": "Tuesday", "3": "Wednesday", "4": "Thursday",
+         "5": "Friday", "6": "Saturday", "0": "Sunday"}
+
+
+def workflow_cron(name: str) -> tuple[str, str]:
+    """(day, HH:MM) from the workflow's first `cron:` line."""
+    text = (ROOT / ".github/workflows" / f"{name}.yml").read_text()
+    match = re.search(r'cron:\s*"([^"]+)"', text)
+    assert match, f"{name}.yml declares no cron"
+    minute, hour, _dom, _mon, dow = match.group(1).split()
+    return _DAYS[dow], f"{int(hour):02d}:{int(minute):02d}"
+
+
+def doc_row(name: str) -> str:
+    """The doc table row mentioning this workflow file."""
+    rows = [line for line in DOC.read_text().splitlines()
+            if line.startswith("|") and f"workflows/{name}.yml" in line]
+    assert len(rows) == 1, f"expected exactly one table row for {name}.yml, found {len(rows)}"
+    return rows[0]
+
+
+@pytest.mark.parametrize("name", GATES)
+def test_the_doc_quotes_the_cron_the_workflow_actually_declares(name: str):
+    day, hhmm = workflow_cron(name)
+    row = doc_row(name)
+    assert hhmm in row, f"{name}.yml runs at {hhmm} {day}; the doc row says: {row.strip()}"
+
+
+def test_the_chain_lands_before_parity_grades_it():
+    """Parity compares the repo against a warehouse the chain has just recomputed.
+
+    The dataset crons are 03:00 and 04:00 UTC and live on the platform, so this asserts the
+    documented order rather than reading them: if parity ever moves ahead of 04:00 it would
+    grade a warehouse that has not recomputed and fail for a reason that is not a drift.
+    """
+    _, parity = workflow_cron("parity")
+    assert parity > "04:00", (
+        f"parity runs at {parity}, at or before the scores dataset's documented 04:00 sweep"
+    )
+
+
+def test_no_stale_claim_that_the_chain_never_runs_on_a_schedule():
+    """A scheduled run was observed on 2026-08-19, so this claim is false wherever it survives."""
+    for path in (ROOT / "AGENTS.md", DOC, ROOT / "README.md"):
+        if not path.exists():
+            continue
+        text = path.read_text()
+        assert "zero scheduled runs have ever fired" not in text, path
+        assert "chain does not run on a schedule" not in text, path


### PR DESCRIPTION
Follow-up to #334. **The first version of this PR was wrong in the same way as the doc it corrected**, so this one comes with a test.

## What I got wrong

I recorded the parity gate at 07:00 UTC. `parity.yml` says `cron: "0 6 * * 1"` — **06:00**. 07:00 is `artifacts.yml`, misread off a loop that printed workflow names and crons out of step. The original doc had parity right all along.

That PR also claimed the repo had been searched for surviving copies of the old times. Two survived: this file's own "The parity gate" section, and `AGENTS.md`. The claim was overstated — I grepped specific strings, not the concept.

## So the times now come with a test

`tests/test_schedule_doc.py` parses the `cron:` line out of `parity.yml`, `artifacts.yml` and `freshness.yml` and asserts the doc table quotes it. The workflow file is authoritative; the prose is answerable to it. Injecting the exact 07:00 error I made fails the test:

```
FAILED tests/test_schedule_doc.py::test_the_doc_quotes_the_cron_the_workflow_actually_declares[parity]
```

It also asserts parity stays after the chain's documented 04:00 sweep — grading before the recompute would fail for a reason that is not a drift — and that nothing anywhere still claims the chain never runs on a schedule.

## The configured schedule

| What | When (UTC) | Where the cron lives |
|---|---|---|
| `registry` static models | every push to `main` touching `sources/**` | `registry.yml`, no cron |
| `evidence` dataset | Monday 03:00 | dataset cron, UTC |
| `scores` dataset | Monday 04:00 | dataset cron, UTC |
| `parity` gate | Monday 06:00 | `parity.yml` |
| `artifacts` | Monday 07:00 | `artifacts.yml` |
| `freshness` | Monday 08:00 | `freshness.yml` |

## Three claims in the old section that were wrong against the platform

- **`openness_facts` 04:00 and `openness_computed` 05:00 were never configurable.** Both live in the `scores` dataset and the platform sweeps per dataset. Within a sweep they run in dependency order anyway.
- **`updateDataModelSchedule` sets a model's throttle, not the sweep.** The sweep is the dataset's cron via `updateDataset`; a model cron of `""` means eligible on every sweep.
- **The crons ran on `America/New_York`**, which moves the real hour across DST while every gate grading them is UTC-pinned. Both datasets are UTC now.

## AGENTS.md

It said the chain does not run on a schedule and that zero scheduled runs had ever fired. True when written, false now — a `SCHEDULED` run was observed on 2026-08-19. Updated to record the observation, and to keep the reason it had been true (the crons were at the model-revision layer, which is a throttle rather than a sweep).

## Test plan

`tests/test_schedule_doc.py` + `tests/test_docs_integrity.py` — 18 pass. Red-test proof run against the committed state, then restored and re-confirmed green.