### PR TITLE
Document where each axis actually lives

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ When in doubt about which door, start there.
 | [`reference/adoption.md`](reference/adoption.md) | The adoption bands and instruments |
 | [`reference/capability.md`](reference/capability.md) | The capability axis and the peer-comparison instrument |
 | [`reference/evidence-and-freshness.md`](reference/evidence-and-freshness.md) | What `last_verified` means, how an axis earns it, the gates |
+| [`reference/where-scores-live.md`](reference/where-scores-live.md) | Which axis is in the repo, which is in the warehouse, and which tables only look like scores |
 | [`reference/product-copy.md`](reference/product-copy.md) | The `description`/`comments` prose spec |
 | [`reference/gap-analysis.md`](reference/gap-analysis.md) | How the map derives gaps from scores |
 | [`reference/queries.md`](reference/queries.md) | Query conventions for the warehouse |

--- a/docs/reference/where-scores-live.md
+++ b/docs/reference/where-scores-live.md
@@ -1,0 +1,118 @@
+# Where each axis lives, in the repo and in the warehouse
+
+Written 2026-08-19 from a sweep of every dataset in the `currentai` org: **22 datasets, 95
+tables**, every column name matched against `adopt|capab|combined_score|maturity|overall|score`.
+
+The short answer, and the distinction that gets missed: **`sources/` is the source of truth for
+all three axes, and `currentai.registry.product_scores` is a complete current mirror of it** —
+every product, every axis, one row. What only openness has is a *recomputation*: the warehouse
+walks the ladder itself and `check_parity` fails if the two disagree. Adoption and capability are
+mirrored, not recomputed, so nothing in the warehouse can contradict them. Everything else that
+looks like a score is frozen, external, or keyed to something other than a gap-map product.
+
+Recorded, mirrored, recomputed and measured are four different things here, and a query is only
+as good as knowing which one it hit.
+
+## The one table — `currentai.registry.product_scores`
+
+522 rows, one per product per category, all three axes with their own confidence and
+`last_verified`, plus the derived `overall_score`, `maturity`, `is_mature` and `score_tier`.
+Published by `build/serialize_scores.py` on every push to `main` touching `sources/**`.
+
+Two properties to know before querying it:
+
+- **It transcribes the payload; it derives nothing.** The blend comes out of
+  `serialize._maturity_score` against the category's weights, and there is exactly one
+  implementation of it. So these numbers are the numbers the front end shows.
+- **Published-map products only.** `build_payload` excludes preliminary categories by design, so
+  a preliminary category's products are absent from this table even though
+  `currentai.registry.categories` would carry the category itself. All 18 categories are
+  published today, which is why the count is 522 and not a subset.
+
+Coverage: openness on all 522 rows, adoption on 502, capability on 496. An unmeasured axis is
+NULL rather than absent, so "not measured" and "no such column" cannot be confused.
+
+`adoption_signal_type` travels with `adoption_level` deliberately: a stars band and a downloads
+band are different scales, so a query that ranks across `signal_type` is wrong.
+
+## Openness — computed and gated
+
+| Where | What | Currency |
+|---|---|---|
+| `sources/scores/*.yaml` | The recorded score, class, components and sources | current |
+| `currentai.registry.product_openness_evidence` | Dimension values, per product and category | republished on every push to `main` |
+| `currentai.scores.openness_facts` | One resolved fact per declared dimension | Monday 03:00 UTC (`evidence`) then 04:00 (`scores`) |
+| `currentai.scores.openness_computed` | The score and class the ladder produces | same |
+
+`build/check_parity.py` compares the repo against `openness_computed` per product and fails on
+any divergence. This is the only axis with a warehouse recomputation to disagree with, which is
+why it is the only axis parity can grade.
+
+## Adoption — curated in the repo, measured in three signal tables
+
+The **score** is curated in `sources/scores/*.yaml` as `adoption.level`, and mirrored into
+`registry.product_scores`. Nothing recomputes it.
+
+What the warehouse does hold is a **measured band per product**, from whichever channel the
+product declares:
+
+| Table | Instrument | Products | Agrees with the repo |
+|---|---|---|---|
+| `currentai.signal_huggingface.product_adoption` | 30-day Hub downloads | 115 | **96%** (111/115) |
+| `currentai.signal_pypi.package_downloads` | monthly PyPI downloads | 106 | **91%** (97/106) |
+| `currentai.signal_github.product_adoption` | stars, a declared **fallback** | 120 | **50%** (60/120) |
+
+Read those three rates together and they say something specific rather than alarming. Where a
+product publishes a download channel, the repo and the warehouse agree. Where adoption rests on
+stars, they part company — and in 56 of the 60 disagreements the repo bands **higher**, by one
+level 28 times, two levels 21 times, and three or more 7 times.
+
+That is the fallback behaving like a fallback: stars are a weaker proxy than downloads and land
+lower on their own scale, and `docs/reference/adoption.md` is explicit that a band is only comparable
+within its `signal_type`. So it is not 60 errors. It is 56 products whose adoption rests on the
+weakest instrument the map has, banded above what that instrument alone would support, with no
+gate over any of it. Worth a pass, not a correction sweep.
+
+**The 50 products promoted on 2026-08-19 have no signal rows yet.** The signal crons are Sunday,
+so the earliest is 2026-08-23.
+
+## Capability — mirrored, never recomputed
+
+`sources/scores/*.yaml`, `capability.score`, mirrored into `registry.product_scores`.
+**No warehouse table recomputes capability for a gap-map product**, so there is nothing for a
+parity gate to compare and no independent check on the value. Corroborating instruments exist and are deliberately left unjoined —
+`signal_lmarena` (Elo), `signal_artificialanalysis` (benchmarks), `signal_semanticscholar`
+(citations) — see `docs/reference/capability.md` on why a peer comparison is recorded rather than
+derived.
+
+## Frozen and lookalike tables — do not read these as current
+
+Four things carry columns named like ours and answer a different question.
+
+| Table | What it really is | State |
+|---|---|---|
+| `currentai.stack_map.product_scores` | The **v1 hand-scored upload**: `adoption_level`, `capability_score`, `capability_value`, `combined_score` per product | **Frozen.** 282 products, 11 categories, newest `last_verified` 2026-05-29, keyed on `product_name` rather than slug. **No deployed model reads it.** |
+| `currentai.catalog.stack_map` | The repo→warehouse taxonomy bridge, carrying `adoption`, `capability`, `maturity` per product | **Live and stale.** 205 rows / 199 products / 14 categories, and 0 rows for `compilers` or `storage`. Read by `scores.stack_contributors`, so the open-stack developer counts are computed over a 199-product roster. Rebuilt by `warehouse/ingest/build_stack_map.py`, declared `refresh: on-curation-change` — which means a human, and #328 did not trigger one. |
+| `currentai.catalog.osai_gap_map` | The **external** OSAI gap map: `ease_of_adoption`, `maturity`, `overall_score` | A different organisation's taxonomy and scale. Not our products, not our axes. |
+| `currentai.ai_demand_curve.*` | `capability_score`, `adoption_level` against **OpenRouter/LMArena models** | Keyed to model names from a leaderboard, not to gap-map product slugs. |
+
+`currentai.stack_map.category_scores` and `.gap` are the same v1 freeze at category grain.
+
+## How to answer "is this axis in the warehouse" without guessing
+
+```sql
+-- openness, current and gated
+SELECT product_slug, openness_score, openness_class, last_checked
+FROM currentai.scores.openness_computed WHERE category_slug = 'compilers';
+
+-- adoption, measured where a channel exists
+SELECT product_slug, adoption_level FROM currentai.signal_huggingface.product_adoption;
+
+-- all three axes at once, mirrored from the repo
+SELECT product_slug, openness_score, adoption_level, capability_score, overall_score
+FROM currentai.registry.product_scores WHERE category_slug = 'compilers';
+```
+
+If a table has `adoption` or `capability` in a column name, check the table against the four
+lookalikes above before quoting it. Two of them are frozen at May and one belongs to another
+organisation.


### PR DESCRIPTION
There was no document answering "are the adoption and capability scores on OSO?". This adds `docs/reference/where-scores-live.md` from a full sweep: **22 datasets, 95 tables**, every column name matched against `adopt|capab|combined_score|maturity|overall|score`.

## The distinction is four-way, not two-way

Reconciled with #338, whose table **is already live in the warehouse** — so this document describes it now rather than after that PR merges. There is no window where the doc is false.

- **Recorded** — `sources/scores/*.yaml`, all three axes, the source of truth.
- **Mirrored** — `currentai.registry.product_scores`, 522 rows, a complete current copy of all three axes.
- **Recomputed** — openness only. The warehouse walks the ladder itself and `check_parity` fails on divergence. Adoption and capability have no recomputation, so nothing in the warehouse can contradict them and no gate can check them.
- **Measured** — the signal tables, adoption for about a third of the corpus.

A query is only as good as knowing which of those four it hit, which is the point of the doc.

## The measured-vs-recorded numbers

| Table | Instrument | Products | Agrees with repo |
|---|---|---|---|
| `signal_huggingface.product_adoption` | 30-day downloads | 115 | **96%** |
| `signal_pypi.package_downloads` | monthly downloads | 106 | **91%** |
| `signal_github.product_adoption` | stars, a declared fallback | 120 | **50%** |

Where a product publishes a download channel, repo and warehouse agree. Where adoption rests on stars they part company, and **56 of the 60 disagreements have the repo banding higher** — one level 28 times, two 21 times, three or more 7 times. A band is only comparable within its `signal_type`, so that is a fallback behaving like a fallback, not 60 errors. It does mean 56 products rest on the weakest instrument the map has, banded above what that instrument alone supports, with no gate. Flagged as worth a pass, not asserted as wrong.

## Four lookalikes

- `stack_map.product_scores` — the **v1 hand-scored upload**. Frozen: 282 products, 11 categories, newest `last_verified` 2026-05-29, keyed on `product_name` rather than slug. I read the SQL of every deployed model: **nothing reads it.**
- `catalog.stack_map` — carries `adoption`, `capability`, `maturity`, and **is** read, by `scores.stack_contributors`. **205 rows / 199 products / 14 categories, 0 rows for `compilers` or `storage`**, so open-stack developer counts run over a 199-product roster. Its fetcher is `refresh: on-curation-change`, and #328 did not trigger one.
- `catalog.osai_gap_map` — another organisation's taxonomy and scale.
- `ai_demand_curve.*` — keyed to OpenRouter/LMArena model names, not gap-map slugs.

## Fixed since the first version

Bare `reference/adoption.md` style references were misleading from the repo root; they now read `docs/reference/...`, matching how the sibling reference docs cross-link.

## Two follow-ups, neither in this PR

1. Regenerate `catalog.stack_map` so `stack_contributors` stops counting over a stale roster.
2. Retire or mark-frozen `stack_map.product_scores`, so nobody reads May numbers as current.

## Test plan

`tests/test_docs_integrity.py` — 13 pass, including the link check for the new `docs/README.md` row. Every number re-verified against the live warehouse immediately before pushing: `product_scores` 522 rows / 18 categories / openness 522 / adoption 502 / capability 496; `stack_map.product_scores` 282; `catalog.stack_map` 205 rows / 199 products / 14 categories.