### PR TITLE
Publish every product and axis as one table

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -1,8 +1,10 @@
 name: registry
 
 # The "config in" bridge: the repo declares what exists, and CI pushes that
-# declaration to OSO. Nothing flows back in here — scores are computed downstream
-# and serialized outward separately.
+# declaration to OSO. Nothing flows back in here. Openness is COMPUTED downstream, in the
+# warehouse, and check_parity grades it against the repo; the recorded scores for all three
+# axes go out from here as registry.product_scores, which is a mirror rather than a
+# computation.
 
 # One publish at a time. Tables upload individually and are then materialized, so two
 # overlapping runs can commit a snapshot that is half registry and half rubric. Not
@@ -15,16 +17,46 @@ on:
   pull_request:
     paths:
       - "sources/**"
+      # Every module the three serializers reach, transitively — not just the serializers
+      # themselves. A change to build/serialize.py alters the derived scores in
+      # product_scores, and a change to build/freshness_payload.py alters its freshness
+      # columns, so either can change what gets published. Neither used to trigger this
+      # workflow. tests/test_registry_triggers.py recomputes the import closure and fails
+      # if this list falls behind it, so a new import is caught rather than remembered.
+      - "build/check_freshness.py"
+      - "build/check_rubric.py"
+      - "build/freshness_payload.py"
+      - "build/rubrics.py"
+      - "build/serialize.py"
       - "build/serialize_registry.py"
       - "build/serialize_rubric.py"
+      - "build/serialize_scores.py"
+      - "build/taxonomy.py"
+      - "build/validate.py"
+      - "build/vocabulary.py"
       - "build/publish_registry.py"
       - ".github/workflows/registry.yml"
   push:
     branches: [main]
     paths:
       - "sources/**"
+      # Every module the three serializers reach, transitively — not just the serializers
+      # themselves. A change to build/serialize.py alters the derived scores in
+      # product_scores, and a change to build/freshness_payload.py alters its freshness
+      # columns, so either can change what gets published. Neither used to trigger this
+      # workflow. tests/test_registry_triggers.py recomputes the import closure and fails
+      # if this list falls behind it, so a new import is caught rather than remembered.
+      - "build/check_freshness.py"
+      - "build/check_rubric.py"
+      - "build/freshness_payload.py"
+      - "build/rubrics.py"
+      - "build/serialize.py"
       - "build/serialize_registry.py"
       - "build/serialize_rubric.py"
+      - "build/serialize_scores.py"
+      - "build/taxonomy.py"
+      - "build/validate.py"
+      - "build/vocabulary.py"
       - "build/publish_registry.py"
   workflow_dispatch:
 
@@ -36,6 +68,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history: serialize_scores builds the payload, and build.freshness_payload
+          # dates each score file from its last commit. A shallow clone collapses all 522
+          # onto the tip commit, and resolve_freshness refuses rather than publishing a
+          # freshness field that is uniformly wrong. Same reason regenerate.yml and
+          # freshness.yml pin it.
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
@@ -48,6 +87,11 @@ jobs:
       # products into `otherwise`, so it has to fail here.
       - name: Check rubric consistency
         run: uv run python -m build.serialize_rubric --check
+      # The fat table transcribes the payload, so this also fails if the payload itself
+      # cannot be built — which is the same failure `regenerate` would hit later, caught
+      # here on the PR instead.
+      - name: Check the scores table builds
+        run: uv run python -m build.serialize_scores --check
 
   # On main, serialize and push. Static models are created on first run and
   # reused after, so this is safe to run on every change to sources/.
@@ -56,6 +100,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history: serialize_scores builds the payload, and build.freshness_payload
+          # dates each score file from its last commit. A shallow clone collapses all 522
+          # onto the tip commit, and resolve_freshness refuses rather than publishing a
+          # freshness field that is uniformly wrong. Same reason regenerate.yml and
+          # freshness.yml pin it.
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
@@ -65,6 +116,8 @@ jobs:
         run: uv run python -m build.serialize_registry
       - name: Serialize rubric and evidence
         run: uv run python -m build.serialize_rubric
+      - name: Serialize the recorded scores
+        run: uv run python -m build.serialize_scores
       - name: Publish to OSO
         env:
           OSO_API_KEY: ${{ secrets.OSO_API_KEY }}

--- a/build/publish_registry.py
+++ b/build/publish_registry.py
@@ -5,9 +5,12 @@ to score it, CI pushes that declaration outward. Nothing is pulled back in here,
 and no generated CSV is committed — the repo stays YAML, and OSO gets a flat mirror
 of it.
 
-Two serializers feed this. `serialize_registry` emits identity; `serialize_rubric`
-emits each category's scoring rules plus the evidence currently on record. Layer-2
-cannot compute a score without both, so they publish together.
+Three serializers feed this. `serialize_registry` emits identity; `serialize_rubric`
+emits each category's scoring rules plus the evidence currently on record; and
+`serialize_scores` emits the recorded scores themselves, every product and axis in one
+row. Layer-2 cannot compute a score without the first two, so they publish together, and
+the third is what lets a reader query adoption and capability at all — those axes are
+recomputed nowhere, so before this the warehouse held their sources and not their values.
 
 Idempotent. Static models are created on first run and reused after, so this can
 run on every push to sources/.
@@ -36,12 +39,14 @@ from pathlib import Path
 from build.serialize_registry import OUT_DIR
 from build.serialize_registry import TABLES as REGISTRY_TABLES
 from build.serialize_rubric import TABLES as RUBRIC_TABLES
+from build.serialize_scores import TABLES as SCORES_TABLES
 
-# One dataset, two serializers. `serialize_registry` declares what exists;
-# `serialize_rubric` declares how to score it and what evidence is on record.
-# Both are configuration flowing outward, so they share the `registry` dataset
-# and this publisher. Order is stable so the materialization run is reproducible.
-TABLES: tuple[str, ...] = tuple(REGISTRY_TABLES) + tuple(RUBRIC_TABLES)
+# One dataset, three serializers. `serialize_registry` declares what exists;
+# `serialize_rubric` declares how to score it and what evidence is on record; and
+# `serialize_scores` carries the recorded scores themselves. All three are the repo's own
+# declarations flowing outward, so they share the `registry` dataset and this publisher.
+# Order is stable so the materialization run is reproducible.
+TABLES: tuple[str, ...] = tuple(REGISTRY_TABLES) + tuple(RUBRIC_TABLES) + tuple(SCORES_TABLES)
 
 API = "https://api.oso.xyz/v1/graphql"
 USER_AGENT = "os-ai-map-registry-publisher/1.0"
@@ -103,7 +108,10 @@ def resolve_dataset(name: str, org_id: str, token: str) -> str:
                 "description": (
                     "The os-ai-map registry: which products, organizations and categories "
                     "exist and how they relate. Pushed by CI on every change to sources/. "
-                    "Declarative only — scores are computed downstream, not mirrored here."
+                    "Declarative only. Openness is COMPUTED downstream in "
+                    "currentai.scores and graded against this by check_parity; the recorded "
+                    "scores for all three axes are mirrored here as product_scores, which is "
+                    "a copy of what the repo says rather than a computation over it."
                 ),
             }
         },
@@ -177,8 +185,8 @@ def main() -> int:
     missing = [t for t in TABLES if not (args.dir / f"{t}.csv").exists()]
     if missing:
         print(
-            f"missing CSVs: {missing}. Run build.serialize_registry and "
-            f"build.serialize_rubric first.",
+            f"missing CSVs: {missing}. Run build.serialize_registry, build.serialize_rubric "
+            f"and build.serialize_scores first.",
             file=sys.stderr,
         )
         return 2

--- a/build/serialize_scores.py
+++ b/build/serialize_scores.py
@@ -1,0 +1,194 @@
+"""Flatten the payload into one row per product per category, for the warehouse.
+
+The fat table: every published product, every axis, one row.
+`currentai.registry.product_scores`.
+
+## Why this reads the payload rather than `sources/`
+
+Because the derived numbers are the point, and there must be exactly one implementation
+of them. `overall_score`, `tier`, `maturity` and `mature` are not recorded anywhere — they
+come out of `serialize._maturity_score` against the category's weights, and `mature` folds
+in the openness bucket on top. A second implementation over here, or in SQL, is the
+repo/warehouse split that `check_parity` exists to catch, one axis over: openness had
+exactly that shape and it cost seven wrong scores.
+
+So this calls `build_payload` and transcribes. Every number in the CSV is the number the
+front end reads, because it is the same object.
+
+## Grain
+
+One row per (category_slug, product_slug). A product in two categories gets two rows and
+they may legitimately differ: openness ladders are per category, and `overall_score` is
+weighted by the category's own adoption/capability split.
+
+## Scope: published-map products only
+
+This table carries exactly what the payload carries, which means **preliminary categories are
+absent** — `build_payload` drops them, deliberately, so /map never shows a category still being
+assembled (see `serialize._filter_long_tail`).
+
+That is narrower than the rest of the registry. `currentai.registry.categories` carries a
+`status` column and will happily list a preliminary category whose products have no row here.
+The contract is deliberate rather than incidental: this table mirrors what is published, so a
+reader can trust that every row in it is a row a visitor to the map could see. A table covering
+preliminary categories too would need a second serialization mode through `build_payload`, and
+the one thing not worth having is a second implementation of the score derivation.
+
+Today all 18 categories are published, so the table is the whole corpus at 522 rows. The day a
+preliminary category lands, its products will be missing from here and present in
+`registry.categories` — `test_preliminary_categories_are_out_of_scope_by_construction` pins
+that as intended rather than leaving it to be rediscovered.
+
+Usage:
+    uv run python -m build.serialize_scores
+    uv run python -m build.serialize_scores --out build/registry
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from build.freshness_payload import resolve_freshness
+from build.serialize import ROOT, build_payload
+from build.serialize_registry import write_tables
+from build.validate import load_sources
+
+TABLES: dict[str, tuple[str, ...]] = {
+    "product_scores": (
+        "product_slug",
+        "category_slug",
+        "product_type",
+        "org_slug",
+        # Openness, as recorded. The computed counterpart is
+        # currentai.scores.openness_computed; check_parity is what holds them together.
+        "openness_score",
+        "openness_class",
+        "openness_bucket",
+        "openness_components",
+        "openness_confidence",
+        "openness_last_verified",
+        # Adoption. `level` is the band, `reach` its human range, and `signal_type` decides
+        # what this level may be compared to — a stars band and a downloads band are not
+        # the same scale, so a query that ranks across signal_types is wrong.
+        "adoption_level",
+        "adoption_reach",
+        "adoption_signal_type",
+        "adoption_confidence",
+        "adoption_last_verified",
+        # Capability. `basis` names the instrument, and it is the peer comparison rather
+        # than an absolute: see docs/reference/capability.md.
+        "capability_score",
+        "capability_basis",
+        "capability_value",
+        "capability_confidence",
+        "capability_last_verified",
+        # Derived, and transcribed rather than recomputed. `overall_score` blends adoption
+        # and capability on the category's weights, or is adoption alone where capability
+        # is unmeasured; `maturity` is its old name and ships identically. `is_mature`
+        # gates the same 4.5 bar on the fully-open bucket, because only fully-open
+        # products advance a category's stage.
+        "overall_score",
+        "maturity",
+        "is_mature",
+        "score_tier",
+        # When the whole row was last confirmed, and on what basis. Not the max of the
+        # axes' dates: see docs/reference/evidence-and-freshness.md.
+        "freshness_date",
+        "freshness_basis",
+    )
+}
+
+
+def _cell(value) -> str:
+    """None becomes the empty string, explicitly.
+
+    `tier` is None for an unranked product and `overall_score` is None where adoption is
+    unmeasured. csv.DictWriter would coerce either to an empty field anyway; spelling it
+    out means the CSV does not depend on that, and a reader sees one representation of
+    "no value" instead of two.
+    """
+    return "" if value is None else str(value)
+
+
+def _axis(product: dict, axis: str) -> dict:
+    value = product.get(axis)
+    return value if isinstance(value, dict) else {}
+
+
+def _flat(payload: dict) -> list[dict]:
+    """One row per (category, product), in the payload's own order."""
+    rows: list[dict] = []
+    for category_slug, category in (payload.get("categories") or {}).items():
+        for product in category.get("products") or []:
+            openness = _axis(product, "openness")
+            adoption = _axis(product, "adoption")
+            capability = _axis(product, "capability")
+            freshness = _axis(product, "freshness")
+            rows.append(
+                {
+                    "product_slug": _cell(product.get("slug", "")),
+                    "category_slug": category_slug,
+                    "product_type": _cell(product.get("type", "")),
+                    "org_slug": _cell(product.get("org_slug", "")),
+                    "openness_score": _cell(openness.get("score", "")),
+                    "openness_class": _cell(openness.get("class", "")),
+                    "openness_bucket": _cell(openness.get("bucket", "")),
+                    "openness_components": _cell(openness.get("components", "")),
+                    "openness_confidence": _cell(openness.get("confidence", "")),
+                    "openness_last_verified": _cell(openness.get("last_verified", "")),
+                    "adoption_level": _cell(adoption.get("level", "")),
+                    "adoption_reach": _cell(adoption.get("reach", "")),
+                    "adoption_signal_type": _cell(adoption.get("signal_type", "")),
+                    "adoption_confidence": _cell(adoption.get("confidence", "")),
+                    "adoption_last_verified": _cell(adoption.get("last_verified", "")),
+                    "capability_score": _cell(capability.get("score", "")),
+                    "capability_basis": _cell(capability.get("basis", "")),
+                    "capability_value": _cell(capability.get("value", "")),
+                    "capability_confidence": _cell(capability.get("confidence", "")),
+                    "capability_last_verified": _cell(capability.get("last_verified", "")),
+                    "overall_score": _cell(product.get("overall_score", "")),
+                    "maturity": _cell(product.get("maturity", "")),
+                    "is_mature": _cell(product.get("mature", "")),
+                    "score_tier": _cell(product.get("tier", "")),
+                    "freshness_date": _cell(freshness.get("date", "")),
+                    "freshness_basis": _cell(freshness.get("basis", "")),
+                }
+            )
+    return rows
+
+
+def build_scores(payload: dict) -> dict[str, list[dict]]:
+    return {"product_scores": _flat(payload)}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="build only, write nothing")
+    parser.add_argument("--out", type=Path, default=ROOT / "build" / "registry")
+    parser.add_argument("--date", default=None, help="the payload's 'generated' value")
+    args = parser.parse_args()
+
+    sources = load_sources(ROOT)
+    frozen = json.load(open(ROOT / "sources" / "snapshots" / "long_tail.json"))
+    payload = build_payload(sources, frozen, generated=args.date,
+                            freshness=resolve_freshness(ROOT))
+    tables = build_scores(payload)
+    rows = tables["product_scores"]
+    if not rows:
+        print("no product rows in the payload; refusing to publish an empty table",
+              file=sys.stderr)
+        return 2
+    if not args.check:
+        write_tables(tables, args.out, TABLES)
+    products = len({r["product_slug"] for r in rows})
+    print(f"{'checked' if args.check else 'wrote'} product_scores.csv "
+          f"({len(rows)} rows, {products} products, "
+          f"{len({r['category_slug'] for r in rows})} categories)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_registry_triggers.py
+++ b/tests/test_registry_triggers.py
@@ -1,0 +1,77 @@
+"""registry.yml must trigger on every module that can change what it publishes.
+
+The workflow used to list the three serializers and nothing they import. So a change to
+`build/serialize.py` — which derives `overall_score`, `maturity` and `score_tier` — or to
+`build/freshness_payload.py`, which supplies the freshness columns, could alter
+`currentai.registry.product_scores` with the publishing workflow never running. The table
+would then disagree with the repo until something unrelated touched `sources/`.
+
+This recomputes the import closure from the serializers and fails if the trigger lists have
+fallen behind it, so the next import declares itself instead of being remembered.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW = ROOT / ".github/workflows/registry.yml"
+# What the publish job actually runs. Anything these reach, transitively, is an input.
+SEEDS = ("build.serialize_registry", "build.serialize_rubric", "build.serialize_scores")
+
+
+def _first_party_imports(module: str) -> set[str]:
+    path = ROOT / (module.replace(".", "/") + ".py")
+    if not path.exists():
+        return set()
+    found: set[str] = set()
+    for node in ast.walk(ast.parse(path.read_text())):
+        if isinstance(node, ast.ImportFrom) and node.module and node.module.startswith("build"):
+            found.add(node.module)
+        elif isinstance(node, ast.Import):
+            found.update(a.name for a in node.names if a.name.startswith("build"))
+    return found
+
+
+def import_closure() -> set[str]:
+    seen, queue = set(SEEDS), list(SEEDS)
+    while queue:
+        for dep in _first_party_imports(queue.pop()):
+            if dep not in seen:
+                seen.add(dep)
+                queue.append(dep)
+    return seen
+
+
+def trigger_paths(event: str) -> set[str]:
+    # PyYAML reads the `on:` key as the boolean True, this being YAML.
+    doc = yaml.safe_load(WORKFLOW.read_text())
+    triggers = doc.get("on") or doc.get(True)
+    return set(triggers[event]["paths"])
+
+
+@pytest.mark.parametrize("event", ["push", "pull_request"])
+def test_every_module_the_serializers_reach_triggers_the_workflow(event: str):
+    paths = trigger_paths(event)
+    missing = sorted(
+        module.replace(".", "/") + ".py"
+        for module in import_closure()
+        if module.replace(".", "/") + ".py" not in paths
+    )
+    assert not missing, (
+        f"registry.yml's {event} trigger does not include {missing}. A change to any of them "
+        f"can alter what the publish emits without this workflow running."
+    )
+
+
+def test_the_closure_is_actually_walking_transitively():
+    """Guard on the guard: if the walk stopped at the seeds, the test above would pass
+    vacuously the moment someone trimmed the trigger list back to three entries."""
+    closure = import_closure()
+    assert "build.serialize" in closure, "serialize is reached via serialize_scores"
+    assert "build.freshness_payload" in closure, "freshness_payload is reached via serialize_scores"
+    assert len(closure) > len(SEEDS) + 2, f"closure looks too small: {sorted(closure)}"

--- a/tests/test_serialize_scores.py
+++ b/tests/test_serialize_scores.py
@@ -1,0 +1,125 @@
+"""The fat table transcribes the payload; it does not recompute it.
+
+`overall_score`, `maturity`, `mature` and `tier` are derived by `serialize._maturity_score`
+against each category's weights. A second implementation of that blend — here, or in SQL —
+is the repo/warehouse split `check_parity` exists to catch, one axis over. Openness had
+exactly that shape and it published seven wrong scores.
+
+So the contract these tests hold is equality with the payload, not plausibility.
+"""
+
+from __future__ import annotations
+
+from build.serialize_scores import TABLES, build_scores
+
+COLUMNS = TABLES["product_scores"]
+
+
+def _payload(**products) -> dict:
+    return {
+        "categories": {
+            "cat_a": {
+                "products": [
+                    {
+                        "slug": "prod-one",
+                        "type": "software",
+                        "org_slug": "org-one",
+                        "openness": {"score": "5", "class": "open_source", "bucket": "open",
+                                     "components": "license:MIT(OSI)", "confidence": "high",
+                                     "last_verified": "2026-08-01"},
+                        "adoption": {"level": "4", "reach": "1M-10M",
+                                     "signal_type": "usage_volume", "confidence": "high",
+                                     "last_verified": "2026-08-02"},
+                        "capability": {"score": "3", "basis": "feature_matrix",
+                                       "value": "does the thing", "confidence": "medium",
+                                       "last_verified": "2026-08-03"},
+                        "overall_score": "3.5", "maturity": "3.5", "mature": "False",
+                        "tier": "None",
+                        "freshness": {"date": "2026-08-03", "basis": "verified"},
+                        **products,
+                    }
+                ]
+            }
+        }
+    }
+
+
+def test_every_declared_column_is_emitted():
+    rows = build_scores(_payload())["product_scores"]
+    assert len(rows) == 1
+    assert set(rows[0]) == set(COLUMNS)
+
+
+def test_derived_numbers_are_transcribed_not_recomputed():
+    """The payload's number wins, whatever it is.
+
+    Deliberately feeds an overall_score that no blend of 4 and 3 would produce. If this
+    module ever starts deriving instead of copying, this is the test that goes red.
+    """
+    rows = build_scores(_payload(overall_score="1.25", maturity="1.25", tier="Leading",
+                                mature="True"))["product_scores"]
+    assert rows[0]["overall_score"] == "1.25"
+    assert rows[0]["maturity"] == "1.25"
+    assert rows[0]["score_tier"] == "Leading"
+    assert rows[0]["is_mature"] == "True"
+
+
+def test_all_three_axes_travel_with_their_own_provenance():
+    row = build_scores(_payload())["product_scores"][0]
+    assert (row["openness_score"], row["openness_last_verified"]) == ("5", "2026-08-01")
+    assert (row["adoption_level"], row["adoption_last_verified"]) == ("4", "2026-08-02")
+    assert (row["capability_score"], row["capability_last_verified"]) == ("3", "2026-08-03")
+    # signal_type decides what an adoption level may be compared to, so it must not be
+    # dropped: a stars band and a downloads band are different scales.
+    assert row["adoption_signal_type"] == "usage_volume"
+
+
+def test_a_missing_axis_is_empty_rather_than_absent():
+    """An unmeasured axis must still leave a column, or a reader cannot tell 'not measured'
+    from 'column does not exist'."""
+    payload = _payload()
+    del payload["categories"]["cat_a"]["products"][0]["capability"]
+    row = build_scores(payload)["product_scores"][0]
+    assert row["capability_score"] == ""
+    assert set(row) == set(COLUMNS)
+
+
+def test_the_grain_is_product_times_category():
+    payload = _payload()
+    second = dict(payload["categories"]["cat_a"]["products"][0])
+    payload["categories"]["cat_b"] = {"products": [second]}
+    rows = build_scores(payload)["product_scores"]
+    assert len(rows) == 2
+    assert {r["category_slug"] for r in rows} == {"cat_a", "cat_b"}
+
+
+def test_preliminary_categories_are_out_of_scope_by_construction():
+    """The table mirrors the payload, and the payload excludes preliminary categories.
+
+    Pinned as intended rather than left to be rediscovered: every row here is a row a
+    visitor to /map could see. `currentai.registry.categories` is wider — it carries a
+    `status` column and will list a preliminary category whose products have no row in this
+    table. Covering them too would need a second path through `build_payload`, and a second
+    implementation of the score derivation is the one thing worth avoiding.
+    """
+    payload = _payload()
+    # What a preliminary category looks like from here: absent. serialize.build_payload has
+    # already dropped it before this module ever sees the object.
+    assert "cat_preliminary" not in payload["categories"]
+    rows = build_scores(payload)["product_scores"]
+    assert {r["category_slug"] for r in rows} == {"cat_a"}
+
+
+def test_no_category_key_is_invented_for_a_category_the_payload_omits():
+    """A guard on the guard above: if this module ever read the taxonomy directly instead of
+    the payload, it could resurrect a preliminary category and the test above would not see
+    it. build_scores takes the payload as its only input, so this asserts the signature."""
+    import inspect
+
+    from build import serialize_scores
+
+    params = list(inspect.signature(serialize_scores.build_scores).parameters)
+    assert params == ["payload"], (
+        f"build_scores takes {params}; taking anything but the payload would let a preliminary "
+        f"category back in through a second source of truth"
+    )


### PR DESCRIPTION
Adds **`currentai.registry.product_scores`** — one row per published product per category, all three axes. 522 rows, 18 categories.

```sql
SELECT product_slug, openness_score, adoption_level, capability_score,
       overall_score, score_tier, is_mature
FROM currentai.registry.product_scores WHERE category_slug = 'storage' ORDER BY overall_score DESC
```
```
qdrant   5 open_source   5   4 benchmark        4.6  leading  true
chroma   5 open_source   5   4 feature_matrix   4.6  leading  true
faiss    5 open_source   5   3 feature_matrix   4.2  strong   false
pinecone 1 closed        4   4 benchmark        4.0  strong   false
```

## Why

Openness was recomputed and parity-gated in the warehouse; adoption and capability had their **sources** published and their **values** nowhere. The two things a reader would have found instead were both wrong: `stack_map.product_scores`, frozen at 282 products on 2026-05-29 and keyed on display name, or the `signal_*` tables, one channel each over a third of the corpus.

## It transcribes; it does not derive

`overall_score`, `maturity`, `mature` and `tier` come out of `serialize._maturity_score` against the category weights. A second implementation here or in SQL is the repo/warehouse split `check_parity` exists to catch, one axis over — openness had exactly that shape and it published seven wrong scores. So `build_scores` calls `build_payload` and copies.

`test_derived_numbers_are_transcribed_not_recomputed` feeds a payload whose `overall_score` is `1.25` for a product scoring 4 and 3 — a figure no blend produces — and asserts the table says `1.25`. End-to-end over the real corpus: **522 rows, 0 derived-field mismatches.**

## Three blockers from review, all addressed

**1. Trigger closure — it was worse than the two files named.** The workflow listed three serializers and nothing they import. The transitive first-party closure is **eleven modules**: `check_freshness`, `check_rubric`, `freshness_payload`, `rubrics`, `serialize`, `serialize_registry`, `serialize_rubric`, `serialize_scores`, `taxonomy`, `validate`, `vocabulary`. All eleven are now in both the `push` and `pull_request` path lists, plus `publish_registry.py`.

`tests/test_registry_triggers.py` recomputes the closure by walking the AST and fails if the lists fall behind — that is the part that keeps working after this PR. Removing `build/serialize.py` from both lists fails it for both events:

```
FAILED test_every_module_the_serializers_reach_triggers_the_workflow[push]
FAILED test_every_module_the_serializers_reach_triggers_the_workflow[pull_request]
```

It also carries a guard on itself, so a future trim back to three seeds cannot make it pass vacuously.

**2. Documentation.** The reconciliation is in **#337**, which merges first in the agreed sequence — so there is no window where the doc is false, given the table is already live. That doc now names four states rather than two: recorded in `sources/`, **mirrored** in `registry.product_scores`, **recomputed** for openness only, **measured** in the signal tables. Capability's "nothing to query" is gone.

**3. Published-map products only, explicitly.** `build_payload` drops preliminary categories, so their products are absent here while `registry.categories` still lists the category. Chose the explicit contract over a second serialization mode: every row here is a row a visitor to /map could see, and a second path through `build_payload` risks a second implementation of the derivation. Stated in the module docstring and pinned by two tests — one that a payload without a preliminary category yields no rows for it, and one asserting `build_scores` takes **only** the payload, so the module cannot reach a second source of truth and resurrect one.

## Stale publisher text, all four

- `One dataset, two serializers` → three.
- Dataset description's "scores are computed downstream, not mirrored here" → now distinguishes the computed openness from the mirrored three axes.
- Workflow header's "scores are computed downstream and serialized outward separately" → corrected.
- Missing-CSV error named only two serializers → names all three.

## Test plan

35 pass across `test_serialize_scores`, `test_registry_triggers`, `test_publish_registry`, `test_serialize_registry`. Both new red-test proofs run against a committed state and restored.

Table published and verified live: 522 rows, openness 522, adoption 502, capability 496.