### PR TITLE
Archive the v1 stack_map, and record what is not superseded

### DIFF
--- a/docs/reference/where-scores-live.md
+++ b/docs/reference/where-scores-live.md
@@ -91,12 +91,29 @@ Four things carry columns named like ours and answer a different question.
 
 | Table | What it really is | State |
 |---|---|---|
-| `currentai.stack_map.product_scores` | The **v1 hand-scored upload**: `adoption_level`, `capability_score`, `capability_value`, `combined_score` per product | **Frozen.** 282 products, 11 categories, newest `last_verified` 2026-05-29, keyed on `product_name` rather than slug. **No deployed model reads it.** |
+| `currentai.stack_map.*` | The **v1 hand-scored upload**: `adoption_level`, `capability_score`, `capability_value`, `combined_score` per product, plus its own products, sources, categories, gap and featured tables | **ARCHIVED 2026-08-20.** Superseded by `registry.product_scores`: 282 products against 522, frozen at 2026-05-29, keyed on `product_name` rather than slug. Read by no deployed model. The dataset is renamed `Stack Map [ARCHIVED 2026-08-20]` and all nine tables were snapshotted to CSV first — the 282 product scores and 821 source citations are hand-curated work that exists nowhere else. |
 | `currentai.catalog.stack_map` | The repo→warehouse taxonomy bridge, carrying `adoption`, `capability`, `maturity` per product | **Live and stale.** 205 rows / 199 products / 14 categories, and 0 rows for `compilers` or `storage`. Read by `scores.stack_contributors`, so the open-stack developer counts are computed over a 199-product roster. Rebuilt by `warehouse/ingest/build_stack_map.py`, declared `refresh: on-curation-change` — which means a human, and #328 did not trigger one. |
 | `currentai.catalog.osai_gap_map` | The **external** OSAI gap map: `ease_of_adoption`, `maturity`, `overall_score` | A different organisation's taxonomy and scale. Not our products, not our axes. |
 | `currentai.ai_demand_curve.*` | `capability_score`, `adoption_level` against **OpenRouter/LMArena models** | Keyed to model names from a leaderboard, not to gap-map product slugs. |
 
-`currentai.stack_map.category_scores` and `.gap` are the same v1 freeze at category grain.
+
+
+## Superseded models, and the ones that only look superseded
+
+A model is safe to archive when something newer covers the same ground **and** nothing reads it.
+Both halves matter, and row counts alone answer neither. Verified 2026-08-20:
+
+| Old | Replacement | Verdict |
+|---|---|---|
+| `stack_map.*` (282 products, May) | `registry.product_scores` (522, current) | **Archived.** Superset, no deployed reader, snapshotted first |
+| `catalog.goodailist_repos` (15,396 rows) | `signal_goodailist.repo_catalog` (17,641, live) | **Superseded.** 15,053 of its repos are in the live table; the 343 that are not are entries goodailist.com has delisted from its own catalogue, which is the staleness the live model exists to avoid. No deployed reader — the only apparent one is a docstring in the model that replaced it |
+| `catalog.pypi_downloads` (1.6M rows, day × package × country, 2025-05-01 → 2026-05-01) | `signal_pypi.package_downloads` (106 rows, per-product monthly) | **NOT superseded.** Different grain and a year of history the live table does not have. Keep |
+| `catalog.stack_map` (205 rows) | `registry.product_artifacts` ⋈ `product_scores` (307 rows, covering 190 of its 205 repos) | **Not yet.** Live: `scores.stack_contributors` reads it. The registry can supersede it, but 15 of its repos are absent from the registry's github artifacts and need explaining first. Also stale, at 199 products with nothing for compilers or storage — regenerating it is a fix, not a retirement |
+| `catalog.osai_gap_map`, `taxonomy_crosswalk`, `osai_subcategory_mapping`, `country_populations` | none | **Keep.** External or reference data with no newer equivalent |
+
+The pattern worth carrying forward: `catalog.pypi_downloads` and `signal_pypi.package_downloads`
+share a name-shape and answer different questions, and a row-count comparison makes the older one
+look obsolete when it holds history nothing else has.
 
 ## How to answer "is this axis in the warehouse" without guessing
 

--- a/tests/test_archived_datasets.py
+++ b/tests/test_archived_datasets.py
@@ -1,0 +1,58 @@
+"""An archived dataset must not be described anywhere as if it were current.
+
+The point of archiving is that a reader who finds the table knows not to trust it. That only
+holds if the docs agree, and docs are where this repo has drifted before: on 2026-08-19 the
+schedule section named a parity time the workflow had never used, and the PR carrying it claimed
+the repo had been searched.
+
+So the archive list lives here, in code, and every mention of an archived table in the docs has
+to carry a word that says so. Adding a dataset to ARCHIVED without updating the prose fails.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# table prefix -> the date it was archived, for the message only
+ARCHIVED = {
+    "currentai.stack_map.": "2026-08-20",
+}
+# Words that mark a mention as historical rather than a recommendation.
+MARKERS = ("archived", "superseded", "frozen", "deprecated", "retired", "do not")
+
+DOC_GLOBS = ("docs/**/*.md", "warehouse/**/*.md", "AGENTS.md", "README.md", "skills/**/*.md")
+
+
+def doc_files() -> list[Path]:
+    out: list[Path] = []
+    for pattern in DOC_GLOBS:
+        out.extend(p for p in ROOT.glob(pattern) if p.is_file())
+    return sorted(set(out))
+
+
+@pytest.mark.parametrize("prefix", sorted(ARCHIVED))
+def test_no_doc_presents_an_archived_table_as_current(prefix: str):
+    offenders: list[str] = []
+    for path in doc_files():
+        for i, line in enumerate(path.read_text(errors="replace").splitlines(), 1):
+            if prefix not in line:
+                continue
+            if not any(m in line.lower() for m in MARKERS):
+                offenders.append(f"{path.relative_to(ROOT)}:{i}: {line.strip()[:100]}")
+    assert not offenders, (
+        f"{prefix} was archived {ARCHIVED[prefix]}, but these lines describe it without saying "
+        f"so — a reader would take them as current:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_the_archive_list_is_not_empty_and_the_check_can_fail():
+    """Guard on the guard: an empty ARCHIVED map would make the test above vacuous."""
+    assert ARCHIVED, "nothing archived; delete this test rather than leaving it green by default"
+    # And prove the marker logic actually rejects an unmarked mention.
+    line = "query currentai.stack_map.product_scores for adoption"
+    assert not any(m in line.lower() for m in MARKERS)

--- a/warehouse/models/README.md
+++ b/warehouse/models/README.md
@@ -93,7 +93,7 @@ The OSAI/Raffi v2 taxonomy layer (scores.taxonomy, scores.investment_ranking) wa
 | `currentai.scores.project_summary` | [scores_project_summary.sql](scores_project_summary.sql) | declared 7am | ~14K | Rolled-up snapshot per project |
 | `currentai.scores.repos_summary` | [scores_repos_summary.sql](scores_repos_summary.sql) | declared 7am | ~15K | Per-repo snapshot: catalog metadata + 90-day activity + contributors |
 | `currentai.scores.ossd_coverage` | [scores_ossd_coverage.sql](scores_ossd_coverage.sql) | declared 6am | ~10K | Per-org oss-directory match rates |
-| `currentai.scores.stack_contributors` | [scores_stack_contributors.sql](scores_stack_contributors.sql) | @manual | ~68K | Distinct GitHub code committers (12mo, bots excluded) per scored product, bridged to stack-map category/layer/openness via `catalog.stack_map` |
+| `currentai.scores.stack_contributors` | [scores_stack_contributors.sql](scores_stack_contributors.sql) | @manual | ~68K | Distinct GitHub code committers (12mo, bots excluded) per scored product, bridged to stack-map category/layer/openness via `catalog.stack_map` — which is **stale** at 199 products with nothing for `compilers` or `storage`, so these counts run over a 199-product roster until `build_stack_map.py` is re-run |
 
 ## Subscribed External Datasets
 


### PR DESCRIPTION
Applies the criterion **redundant AND replaced** — not merely unread — and checks both halves before touching anything.

## Archived

**`currentai.stack_map.*`** — the v1 hand-scored upload. 282 products against `registry.product_scores`'s 522, frozen at 2026-05-29, keyed on display name rather than slug, and read by **no deployed model** (I scanned all 41 models' SQL).

All nine tables were **snapshotted to CSV first** — 17,468 rows, including 282 product scores and **821 source citations** that are hand-curated work existing nowhere else. Frozen and unread is not the same as worthless. The dataset now reads `Stack Map [ARCHIVED 2026-08-20]` on the platform, with a description naming the replacement.

## Superseded, no reader

**`catalog.goodailist_repos`** → `signal_goodailist.repo_catalog`. 15,053 of its 15,396 repos are in the live table. The 343 that are not are alive and popular (top one has 168k stars, none archived) — they are entries **goodailist.com delisted from its own catalogue**, which is precisely the staleness the live model was built to fix.

Its only apparent deployed reader turned out to be a **docstring** in the model that replaced it. Left in place for now rather than renamed, since renaming a static model renames the table and nothing yet requires that.

## Not superseded — and this is the one worth writing down

**`catalog.pypi_downloads`** has **1,632,300 rows at day × package × country, covering 2025-05-01 → 2026-05-01**. Its apparent replacement `signal_pypi.package_downloads` has **106 rows at per-product monthly grain**.

A row-count comparison makes the older table look obsolete when it actually holds **a year of history nothing else has**, at a grain the newer table does not have. Two Live notebooks (`pypi-geo-trends`, `pypi-china-openclaw`) are the likely readers. **Keep.**

## Not yet

**`catalog.stack_map`** is live — `scores.stack_contributors` reads it — and stale at 199 products with nothing for `compilers` or `storage`. The registry join (`product_artifacts` ⋈ `product_scores`) yields 307 rows and covers **190 of its 205 repos**, so it can supersede it, but 15 repos are absent from the registry's github artifacts and need explaining first.

Regenerating it is a **fix, not a retirement**, and `warehouse/models/README.md` now says so at the point where its row count is quoted, so nobody reads those contributor counts as covering the full corpus.

## Kept

`catalog.osai_gap_map`, `taxonomy_crosswalk`, `osai_subcategory_mapping`, `country_populations` — external or reference data with no newer equivalent.

## Test plan

`tests/test_archived_datasets.py` holds the docs to the archive: every mention of an archived table must carry a word marking it historical (`archived`, `superseded`, `frozen`, `deprecated`, `retired`, `do not`). Adding a dataset to the list without updating the prose fails.

Proved it goes red before committing — appended an unmarked `Query currentai.stack_map.product_scores for per-product adoption.` to `queries.md`:

```
FAILED test_no_doc_presents_an_archived_table_as_current[currentai.stack_map.]
```

It also carries a guard on itself so an empty archive list cannot make it vacuous. 15 tests pass across it and `test_docs_integrity.py`.

## One thing I got wrong and corrected

I reported a contradiction between `queries.md` and `skills/pyoso-analyst/SKILL.md` over whether `catalog.goodailist_repos` was retired. There is none — both call it retired, and the "when querying it" in `queries.md` refers to `repo_catalog`, not the old table. I misread the antecedent.