### PR TITLE
docs(architecture): audit deployed model definitions and close platform_models

### DIFF
--- a/build/assets.py
+++ b/build/assets.py
@@ -317,6 +317,13 @@ def retirement_candidates() -> list[dict]:
     """
     out = []
     for asset in assets():
+        # A model that has not entered service cannot be retired. `staged` (deployed nowhere,
+        # e.g. signal_packages awaiting #314) and `dormant` (no platform table yet) are
+        # not-in-service states, so they are excluded by construction rather than by an empty
+        # reader list -- an undeployed model has no consumers because it does not exist yet,
+        # which is a different fact from a live table nobody reads.
+        if asset["status"] in ("staged", "dormant"):
+            continue
         rb = asset.get("read_by") or {}
         if any(rb.get(root) for root in ROOTS):
             continue
@@ -338,6 +345,19 @@ def retirement_candidates() -> list[dict]:
             continue
         out.append(asset)
     return out
+
+
+# A retirement_issue must point at a real tracking issue, not a placeholder. `#123` or a full
+# GitHub issues URL. A gate that only checked truthiness let 'TBD: open an issue before any
+# deletion' satisfy a field whose whole claim is that an issue exists -- the recurring
+# "check establishes less than it reports" defect this inventory keeps closing.
+ISSUE_REF_RE = re.compile(
+    r"^(?:#\d+|https://github\.com/[\w.-]+/[\w.-]+/issues/\d+)$"
+)
+
+
+def is_retirement_issue_ref(value: object) -> bool:
+    return isinstance(value, str) and bool(ISSUE_REF_RE.match(value.strip()))
 
 
 def render_dag() -> str:
@@ -563,10 +583,15 @@ def no_reviewed_consumers() -> list[dict]:
     `platform_model_consumers` counts here from Phase 0b onward: a deployed model that reads
     the asset is a reviewed consumer even when it has no repository source, so an asset one
     reads is no longer "no reviewed consumer".
+
+    Not-in-service assets (`staged`, `dormant`) are excluded: a model deployed nowhere has no
+    consumers because it does not exist yet, which is a different state from a live table
+    nobody reads and must not be conflated with it.
     """
     return [
         a for a in assets()
-        if not (a.get("read_by") or {})
+        if a.get("status") not in ("staged", "dormant")
+        and not (a.get("read_by") or {})
         and not a.get("publication_role")
         and not a.get("platform_model_consumers")
         and a.get("external_consumers") == "none_confirmed"

--- a/build/assets.py
+++ b/build/assets.py
@@ -178,15 +178,34 @@ DEPENDS_ON_RE = re.compile(
 )
 
 
+def refs_in_source(code: str, language: str) -> set[str]:
+    """Fully-qualified tables referenced by model source given as TEXT.
+
+    The text-based twin of `table_refs`, for deployed model definitions that arrive as a
+    string (from the platform's `latestRevision.code`) rather than a file on disk. It runs
+    the SAME rules -- SQL context only, quoted Trino identifiers unquoted, comments and
+    docstrings stripped, the `depends_on:` escape hatch honored -- because a second extractor
+    would drift from the first, which is the failure this whole inventory exists to prevent.
+
+    `language` is matched case-insensitively: the platform records it as `sql`, `SQL` or
+    `python`. Anything else contributes only its explicit `depends_on:` declarations.
+    """
+    declared = set(DEPENDS_ON_RE.findall(code))
+    lang = (language or "").strip().lower()
+    if lang == "sql":
+        return _refs_in_sql(code) | declared
+    if lang in ("python", "py"):
+        return _refs_in_python(code) | declared
+    return declared
+
+
+_SUFFIX_LANGUAGE = {".sql": "sql", ".py": "python"}
+
+
 def table_refs(path: Path) -> set[str]:
     """Fully-qualified tables this file queries."""
     src = path.read_text(encoding="utf-8", errors="replace")
-    declared = set(DEPENDS_ON_RE.findall(src))
-    if path.suffix == ".sql":
-        return _refs_in_sql(src) | declared
-    if path.suffix == ".py":
-        return _refs_in_python(src) | declared
-    return declared
+    return refs_in_source(src, _SUFFIX_LANGUAGE.get(path.suffix, ""))
 
 
 def tracked_files(patterns: list[str]) -> list[Path]:
@@ -305,9 +324,15 @@ def retirement_candidates() -> list[dict]:
             continue
         if asset.get("external_consumers") != "none_confirmed":
             continue
-        # The specification's condition includes "no deployed platform model reads it".
-        # Notebooks are not models. Until platform model definitions are audited, an
-        # asset cannot be a retirement candidate however unread it looks.
+        # "no deployed platform model reads it" (11.2). The Phase 0b audit records those in
+        # `platform_model_consumers` -- deployed models with no repository source, so they
+        # cannot appear in the repo-derived read_by above. A non-empty list is a real reader.
+        if asset.get("platform_model_consumers"):
+            continue
+        # An asset nobody checked beyond the repository is not evidence of anything. Notebooks
+        # are not models: before Phase 0b every asset carried platform_models: unknown and none
+        # could be a candidate; the audit set it to checked, which is why this list is now able
+        # to be non-empty at all.
         checks = asset.get("consumer_checks") or {}
         if any(checks.get(k) != "checked" for k in ("repository", "platform_notebooks", "platform_models")):
             continue
@@ -532,12 +557,18 @@ def no_reviewed_consumers() -> list[dict]:
     disagree and a gate can notice.
 
     Weaker than `retirement_candidates`, which additionally requires every consumer
-    source to have been checked. This says only: nothing we looked at reads it.
+    source to have been checked. This says only: nothing we looked at reads it -- no in-repo
+    reader, no reviewed platform-model reader, and no confirmed external consumer.
+
+    `platform_model_consumers` counts here from Phase 0b onward: a deployed model that reads
+    the asset is a reviewed consumer even when it has no repository source, so an asset one
+    reads is no longer "no reviewed consumer".
     """
     return [
         a for a in assets()
         if not (a.get("read_by") or {})
         and not a.get("publication_role")
+        and not a.get("platform_model_consumers")
         and a.get("external_consumers") == "none_confirmed"
     ]
 

--- a/build/audit_platform_models.py
+++ b/build/audit_platform_models.py
@@ -116,31 +116,47 @@ def validate_receipt(receipt: dict) -> list[str]:
     type must all fail here, not slip through a nonempty-list check.
     """
     problems: list[str] = []
+    for key in ("audited_at", "org", "org_id", "model_count", "models"):
+        if key not in receipt:
+            problems.append(f"missing top-level field {key}")
     if not is_iso_date(str(receipt.get("audited_at"))):
         problems.append(f"audited_at {receipt.get('audited_at')!r} is not a real calendar date")
+    # The org is not a free parameter: a receipt for a different org is not this audit.
+    if receipt.get("org") != ORG:
+        problems.append(f"org is {receipt.get('org')!r}, expected {ORG!r}")
+    if receipt.get("org_id") != ORG_ID:
+        problems.append(f"org_id is {receipt.get('org_id')!r}, expected {ORG_ID!r}")
 
     models = receipt.get("models")
     if not isinstance(models, list) or not models:
         problems.append("models is empty or not a list")
         return problems
+    if not all(isinstance(m, dict) for m in models):
+        problems.append("every model entry must be a mapping")
+        return problems  # the per-model checks below would raise on a non-mapping
     if receipt.get("model_count") != len(models):
         problems.append(f"model_count {receipt.get('model_count')} != {len(models)} listed")
 
     tables = [m.get("table") for m in models]
-    if tables != sorted(tables):
+    if all(isinstance(t, str) for t in tables) and tables != sorted(tables):
         problems.append("models are not in deterministic (table-sorted) order")
     for field, seen in (("table", tables), ("model_id", [m.get("model_id") for m in models])):
-        dupes = sorted({v for v in seen if seen.count(v) > 1})
+        dupes = sorted({v for v in seen if seen.count(v) > 1}, key=str)
         if dupes:
             problems.append(f"duplicate {field}: {dupes}")
 
     for m in models:
         t = m.get("table")
-        where = t or "<no table>"
+        where = t if isinstance(t, str) else "<no table>"
+        ds, name = m.get("dataset"), m.get("name")
+        if not (isinstance(ds, str) and ds):
+            problems.append(f"{where}: dataset is not a nonempty string")
+        if not (isinstance(name, str) and name):
+            problems.append(f"{where}: name is not a nonempty string")
         if not (isinstance(t, str) and t.startswith("currentai.")):
             problems.append(f"{where}: table is not a currentai.* string")
-        elif t != f"currentai.{m.get('dataset')}.{m.get('name')}":
-            problems.append(f"{where}: table disagrees with dataset/name {m.get('dataset')}.{m.get('name')}")
+        elif isinstance(ds, str) and isinstance(name, str) and t != f"currentai.{ds}.{name}":
+            problems.append(f"{where}: table disagrees with dataset/name {ds}.{name}")
         if not (isinstance(m.get("model_id"), str) and _UUID.match(m.get("model_id") or "")):
             problems.append(f"{where}: model_id is not a UUID")
         if not _HEX64.match(m.get("revision_hash") or ""):

--- a/build/audit_platform_models.py
+++ b/build/audit_platform_models.py
@@ -1,0 +1,170 @@
+"""Audit every deployed model definition in the org and emit a reproducible receipt.
+
+Phase 0b closed `consumer_checks.platform_models`: the repo-derived graph cannot see a
+deployed model that has no repository source, so a table only such a model reads looks
+unread. The only way to know is to read every deployed model definition. This module does
+that read-only, and -- crucially -- writes a *receipt* so the conclusion can be reproduced
+and reviewed rather than trusted as 57 authored booleans.
+
+The receipt (`warehouse/audits/platform_models.json`) records, for every deployed model:
+its fully-qualified table, model id, the platform revision hash, a sha256 of the source
+(never the source body), the language, and the internal `currentai.*` tables it reads --
+including an explicit empty list. From it, `consumers_from_receipt` derives the
+platform-only consumer edges that `warehouse/assets.yaml` carries, and
+`tests/test_assets_inventory.py` gates the inventory against the receipt rather than the
+other way round.
+
+Extraction reuses `build.assets.refs_in_source`, the same code the repo-derived graph runs,
+so the file-based and platform-based passes cannot drift.
+
+Environment:
+    OSO_API_KEY   required to fetch (regenerate); reading the committed receipt needs nothing.
+
+Usage:
+    uv run python -m build.audit_platform_models              # regenerate the receipt
+    uv run python -m build.audit_platform_models --check      # fetch and diff vs committed
+    uv run python -m build.audit_platform_models --as-of 2026-08-22
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+from build import assets as A
+from build.publish_registry import graphql
+
+ORG_ID = "ad7f4c1c-dd2f-430e-a831-e7f1f16e6d9e"
+ORG = "currentai"
+RECEIPT = A.ROOT / "warehouse" / "audits" / "platform_models.json"
+
+# latestRevision.code is fetched to extract references and to digest, but is NEVER written to
+# the receipt -- provenance is the platform `hash` plus a sha256 of the source.
+Q_MODELS = """query($where: JSON){ dataModels(where:$where){ edges{ node{
+  id name dataset{ id name }
+  latestRevision{ code language hash }
+} } } }"""
+
+
+def fetch_models(token: str) -> list[dict]:
+    data = graphql(Q_MODELS, {"where": {"org_id": {"eq": ORG_ID}}}, token)
+    return [e["node"] for e in data["dataModels"]["edges"]]
+
+
+def _producer_tables() -> set[str]:
+    """Inventory tables that have a repository model file -- i.e. a repo source."""
+    return {t for t, a in A.by_table().items() if (a.get("files") or {}).get("model")}
+
+
+def build_receipt(models: list[dict], as_of: str) -> dict:
+    """Turn fetched model nodes into the committed receipt shape.
+
+    Deterministic: models sorted by table, reference lists sorted, so a re-run diffs cleanly.
+    """
+    in_scope = set(A.by_table())
+    producers = _producer_tables()
+    rows = []
+    for node in models:
+        ds = node["dataset"]["name"]
+        name = node["name"]
+        table = f"currentai.{ds}.{name}"
+        rev = node.get("latestRevision") or {}
+        code = rev.get("code") or ""
+        refs = A.refs_in_source(code, rev.get("language") or "")
+        internal = sorted(r for r in refs if r.startswith("currentai."))
+        in_scope_reads = sorted(r for r in internal if r.removeprefix("currentai.") in in_scope)
+        rows.append({
+            "table": table,
+            "dataset": ds,
+            "name": name,
+            "model_id": node["id"],
+            "revision_hash": rev.get("hash"),
+            "source_sha256": hashlib.sha256(code.encode("utf-8")).hexdigest(),
+            "language": rev.get("language"),
+            "internal_reads": internal,
+            "in_scope_reads": in_scope_reads,
+            "has_repository_source": table.removeprefix("currentai.") in producers,
+        })
+    rows.sort(key=lambda r: r["table"])
+    return {
+        "audited_at": as_of,
+        "org": ORG,
+        "org_id": ORG_ID,
+        "model_count": len(rows),
+        "models": rows,
+    }
+
+
+def consumers_from_receipt(receipt: dict) -> dict[str, list[str]]:
+    """Platform-ONLY model consumers per in-scope asset, derived from the receipt.
+
+    Only models with no repository source count: a repo-sourced deployed model that reads an
+    asset already appears in that asset's `read_by`, derived from the tree. This is exactly
+    the `platform_model_consumers` field in the inventory, and gating that field against this
+    map is what makes the audit reproducible instead of authored.
+    """
+    out: dict[str, set[str]] = {}
+    for m in receipt["models"]:
+        if m["has_repository_source"]:
+            continue
+        for ref in m["in_scope_reads"]:
+            out.setdefault(ref.removeprefix("currentai."), set()).add(m["table"])
+    return {k: sorted(v) for k, v in out.items()}
+
+
+def load_receipt() -> dict:
+    return json.loads(RECEIPT.read_text(encoding="utf-8"))
+
+
+def write_receipt(receipt: dict) -> None:
+    RECEIPT.parent.mkdir(parents=True, exist_ok=True)
+    RECEIPT.write_text(json.dumps(receipt, indent=1, sort_keys=False) + "\n", encoding="utf-8")
+
+
+def _census(receipt: dict) -> dict:
+    """The parts a re-run must reproduce byte-for-byte, audited_at excluded."""
+    return {"models": receipt["models"], "model_count": receipt["model_count"],
+            "org_id": receipt["org_id"]}
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--check", action="store_true",
+                    help="fetch and diff against the committed receipt (census only)")
+    ap.add_argument("--as-of", default=None, help="audit date stamp (default: today, UTC)")
+    args = ap.parse_args(argv)
+
+    token = os.environ.get("OSO_API_KEY")
+    if not token:
+        print("OSO_API_KEY is required to fetch deployed model definitions", file=sys.stderr)
+        return 2
+
+    as_of = args.as_of or datetime.now(timezone.utc).date().isoformat()
+    fresh = build_receipt(fetch_models(token), as_of)
+
+    if args.check:
+        if not RECEIPT.exists():
+            print("no committed receipt to check against", file=sys.stderr)
+            return 1
+        committed = load_receipt()
+        if _census(fresh) != _census(committed):
+            print("RECEIPT DRIFT: committed platform_models.json disagrees with the platform.",
+                  file=sys.stderr)
+            return 1
+        print(f"receipt matches the platform ({fresh['model_count']} models)")
+        return 0
+
+    write_receipt(fresh)
+    blind = sum(1 for m in fresh["models"] if not m["has_repository_source"])
+    print(f"wrote {RECEIPT.relative_to(A.ROOT)}: {fresh['model_count']} models "
+          f"({blind} with no repository source)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build/audit_platform_models.py
+++ b/build/audit_platform_models.py
@@ -32,12 +32,14 @@ import argparse
 import hashlib
 import json
 import os
+import re
 import sys
-from datetime import date, datetime, timezone
+from datetime import datetime, timezone
 from pathlib import Path
 
 from build import assets as A
 from build.publish_registry import graphql
+from build.vocabulary import is_iso_date
 
 ORG_ID = "ad7f4c1c-dd2f-430e-a831-e7f1f16e6d9e"
 ORG = "currentai"
@@ -98,6 +100,64 @@ def build_receipt(models: list[dict], as_of: str) -> dict:
         "model_count": len(rows),
         "models": rows,
     }
+
+
+_HEX64 = re.compile(r"^[0-9a-f]{64}$")
+_UUID = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+RECOGNIZED_LANGUAGES = {"sql", "python"}  # matched case-insensitively; the platform emits both cases
+
+
+def validate_receipt(receipt: dict) -> list[str]:
+    """Every part of the receipt contract, so a committed receipt cannot lie by omission.
+
+    Shape only -- the online `--check` is the authoritative comparison against the live
+    platform. This guards the committed bytes: an impossible `audited_at`, a duplicated or
+    dropped model, a missing revision hash, an unrecognized language or a field of the wrong
+    type must all fail here, not slip through a nonempty-list check.
+    """
+    problems: list[str] = []
+    if not is_iso_date(str(receipt.get("audited_at"))):
+        problems.append(f"audited_at {receipt.get('audited_at')!r} is not a real calendar date")
+
+    models = receipt.get("models")
+    if not isinstance(models, list) or not models:
+        problems.append("models is empty or not a list")
+        return problems
+    if receipt.get("model_count") != len(models):
+        problems.append(f"model_count {receipt.get('model_count')} != {len(models)} listed")
+
+    tables = [m.get("table") for m in models]
+    if tables != sorted(tables):
+        problems.append("models are not in deterministic (table-sorted) order")
+    for field, seen in (("table", tables), ("model_id", [m.get("model_id") for m in models])):
+        dupes = sorted({v for v in seen if seen.count(v) > 1})
+        if dupes:
+            problems.append(f"duplicate {field}: {dupes}")
+
+    for m in models:
+        t = m.get("table")
+        where = t or "<no table>"
+        if not (isinstance(t, str) and t.startswith("currentai.")):
+            problems.append(f"{where}: table is not a currentai.* string")
+        elif t != f"currentai.{m.get('dataset')}.{m.get('name')}":
+            problems.append(f"{where}: table disagrees with dataset/name {m.get('dataset')}.{m.get('name')}")
+        if not (isinstance(m.get("model_id"), str) and _UUID.match(m.get("model_id") or "")):
+            problems.append(f"{where}: model_id is not a UUID")
+        if not _HEX64.match(m.get("revision_hash") or ""):
+            problems.append(f"{where}: revision_hash is not a 64-hex digest")
+        if not _HEX64.match(m.get("source_sha256") or ""):
+            problems.append(f"{where}: source_sha256 is not a 64-hex digest")
+        if str(m.get("language") or "").lower() not in RECOGNIZED_LANGUAGES:
+            problems.append(f"{where}: unrecognized language {m.get('language')!r}")
+        for key in ("internal_reads", "in_scope_reads"):
+            if not isinstance(m.get(key), list) or not all(isinstance(x, str) for x in m.get(key) or []):
+                problems.append(f"{where}: {key} is not a list of strings")
+        if isinstance(m.get("internal_reads"), list) and isinstance(m.get("in_scope_reads"), list):
+            if not set(m["in_scope_reads"]) <= set(m["internal_reads"]):
+                problems.append(f"{where}: in_scope_reads is not a subset of internal_reads")
+        if not isinstance(m.get("has_repository_source"), bool):
+            problems.append(f"{where}: has_repository_source is not a boolean")
+    return problems
 
 
 def consumers_from_receipt(receipt: dict) -> dict[str, list[str]]:

--- a/docs/architecture/data-architecture.md
+++ b/docs/architecture/data-architecture.md
@@ -51,7 +51,7 @@ As of 2026-08-20:
 - Platform model source is mirrored read-only under `warehouse/models/<dataset>/` (each carrying a `mirror:` block in `warehouse/assets.yaml`); the platform remains authoritative for those deployed models.
 - Dataset scheduling, model throttles, GitHub Actions schedules, and manual operations coexist. A configured cron is not treated as proof that a scheduled run fired. Verified 2026-08-20: of <!-- observed:2026-08-20 -->22 datasets, 13 carry `cronTimezone: America/New_York`, and 8 have a cron configured with `lastRunAt: null` — `signal_semanticscholar`, `signal_pypi`, `ai_demand_curve`, `state_of_os_ai`, `scores`, `events`, `metrics`, `entities`. The `scores` dataset is among them, which means the openness chain that `check_parity` compares against the repository has no observed scheduled run.
 - Two platform tables have no repository source and no in-repo consumer: `currentai.scores.investment_ranking` and `currentai.scores.taxonomy`.
-- The full org is <!-- observed:2026-08-20 -->22 datasets and <!-- observed:2026-08-20 -->96 tables. The datasets the repository maintains or reads from hold <!-- count:deployed_tables -->53 of those tables; the rest are separate analytical products. See section 11.3 for how that reconciles with the inventory's size.
+- The full org is <!-- observed:2026-08-20 -->22 datasets by `ListDatasets`, or 23 counting `datasette` — which `ListDatasets` omits because it holds two deployed models and no materialized tables, so a dataset-first sweep misses it (Phase 0b enumerated from `ListDataModels` instead and found it). The org holds <!-- observed:2026-08-20 -->96 tables. The datasets the repository maintains or reads from hold <!-- count:deployed_tables -->53 of those tables; the rest are separate analytical products. See section 11.3 for how that reconciles with the inventory's size.
 
 The redesign must evolve this system without interrupting the existing map, registry tables, notebooks, or website.
 
@@ -1326,9 +1326,10 @@ registries this file replaces.
   consumer_checks:                # what was actually audited, per source of consumers
     repository: checked            #   tracked models, build modules, notebooks, workflows
     platform_notebooks: checked    #   every notebook in the org, tracked or not
-    platform_models: unknown       #   deployed model definitions -- NOT audited
+    platform_models: unknown       #   shown pre-Phase-0b; that audit later set this to
+                                  #   `checked` on every asset
     external: unknown              #   anything outside this org -- NOT audited
-                                  # platform_models is unknown, so this asset is NOT a
+                                  # while platform_models is unknown an asset is NOT a
                                   # retirement candidate however empty read_by looks
   external_consumers: unknown     # unknown | none_confirmed | [named]
   publication_role: null          # null | release_sink | public_api | payload_input
@@ -1672,21 +1673,21 @@ Resolved by decision:
 No rename is performed as a standalone change. Each rides a phase that already repoints the
 same SQL, so no PR exists purely to rename a deployed table.
 
-#### Deferred pending the Phase 0 notebook audit
+#### Resolved by the Phase 0b deployed-model audit
 
-Three tables have no in-repo consumer and cannot be retired on that basis, because
-an unaudited consumer source is not evidence of anything while sixteen notebooks sit outside
-the repository. Each keeps `retirement_reason: null` and an open issue until the audit sets
-`consumer_checks.platform_notebooks` and `platform_models` to `checked`.
+These three tables had no in-repo consumer and could not be judged on that basis while
+`consumer_checks.platform_models` was `unknown`. Phase 0b read all 41 deployed model
+definitions in the org and set it to `checked`; none of the three is a retirement candidate.
 
-| Table | State |
+| Table | Finding |
 |---|---|
-| `catalog.goodailist_repos` | Documented retired, table live, superseded by `signal_goodailist.repo_catalog` |
-| `scores.investment_ranking` | On the platform with no repository source and no in-repo reader |
-| `scores.taxonomy` | Same |
+| `catalog.goodailist_repos` | Documented retired, table live, superseded by `signal_goodailist.repo_catalog`; retained by the `ai-safety-incidents` notebook consumer. Not a candidate. |
+| `scores.investment_ranking` | No repository source and no in-repo reader; read only by the Deprecated `ai-potluck-partners` notebook. The audit also found it is itself a reader of `catalog.osai_gap_map`, `catalog.osai_subcategory_mapping`, `entities.repos` and `scores.fragility`. |
+| `scores.taxonomy` | Same shape; read by `ai-potluck-partners` (Deprecated) and the non-deprecated `state-of-os-ai`. The audit's self-check reproduced: it reads `catalog.osai_gap_map`, `catalog.osai_subcategory_mapping` and `catalog.taxonomy_crosswalk`, which removed those three from the "no reviewed consumer" list. |
 
-`oss-ai-gaps` and `stack_map_category_maps`, both tagged `Deprecated`, are the plausible
-readers of the latter two. Plausible is not checked.
+`oss-ai-gaps` and `stack_map_category_maps` were the plausible readers named before the audit.
+The deployed-model read that actually mattered was `scores.taxonomy`'s, now recorded as those
+three tables' `platform_model_consumers`.
 
 ## 12. Release mechanics
 

--- a/docs/architecture/data-architecture.md
+++ b/docs/architecture/data-architecture.md
@@ -1093,9 +1093,10 @@ Migration rules:
 
 Verified against the live `currentai` org on 2026-08-20: <!-- observed:2026-08-20 -->22 datasets,
 <!-- observed:2026-08-20 -->96 tables,
-<!-- count:tracked_warehouse_files -->40 tracked files under `warehouse/`. The structure below is the target, and the
+<!-- count:tracked_warehouse_files -->41 tracked files under `warehouse/`. The structure below is the target, and the
 mirror layout of 11.1 is now in place; the file manifest in 11.4 recorded the exact diff
-from the 2026-08-20 state, executed in this change.
+from the 2026-08-20 state (40 files), and Phase 0b added `warehouse/audits/platform_models.json`,
+the deployed-model audit receipt.
 
 ### 11.1 Target layout
 

--- a/docs/architecture/migration-status.md
+++ b/docs/architecture/migration-status.md
@@ -3,13 +3,14 @@
 Temporary phase state and the retirement ledger. Rules live in `data-architecture.md`; this
 file records only where the work has got to. Delete a row when it stops being temporary.
 
-**As of 2026-08-20.**
+**As of 2026-08-20; deployed-model audit (Phase 0b) 2026-08-22.**
 
 ## Phase state
 
 | Phase | State | Note |
 |---|---|---|
-| 0 — architecture record and inventory | in review | This PR. Read-only; no platform writes. |
+| 0 — architecture record and inventory | done | Merged (#345). The repository now mirrors the warehouse. |
+| 0b — deployed model audit | in review | This PR. Read-only: all 41 deployed model definitions read; `platform_models` now `checked` on every asset. |
 | 1 — schedule normalization | not started | <!-- observed:2026-08-20 -->10 datasets on `America/New_York`; <!-- count:unobserved_crons -->18 assets have a cron and no observed run. No platform metadata change is pending — see below. |
 | 2 — normalized adoption observations | not started | Must compile `registry.adoption_routes` before any signal roll-up retires. |
 | 2B — incremental adoption history | blocked | Blocked on OSO incremental-model support. Not approximated with full-refresh models. |
@@ -77,32 +78,35 @@ claims, and only the first is true.
 
 ## Assets with no reviewed consumer
 
-**Retirement candidates: <!-- count:retirement_candidates -->0.** Not zero because everything
-is read, but because no asset can be a candidate while `consumer_checks.platform_models` is
-`unknown` — and it is unknown for every asset. Deployed model definitions have not been
-audited. That is Phase 0b.
+**Retirement candidates: <!-- count:retirement_candidates -->5.** Phase 0b read all 41 deployed
+model definitions in the org, so `consumer_checks.platform_models` is now `checked` on every
+asset and the derived candidate list is non-empty for the first time. It is **recorded, not
+acted on**: section 17 requires explicit maintainer authorization, a stated rollback path and a
+consumer inventory before any deletion. This phase produces the inventory only — no `DROP`, no
+dataset deletion, no description or model change.
 
-The <!-- count:no_reviewed_consumer -->9 assets below have **no reviewed consumer**: no
-in-repo code reader, and no consumer among the twenty notebooks in the organization. That is
-a weaker claim than "no consumer", and it is not grounds for deletion. Section 17 requires
-explicit maintainer approval after a consumer inventory, and the inventory is not complete
-until platform models are read.
+The <!-- count:no_reviewed_consumer -->5 assets below have **no reviewed consumer**: no in-repo
+code reader, no consumer among the twenty notebooks in the organization, and no deployed
+platform model reads them. `external` stays `unknown` — nothing outside this org was read — so
+this is still weaker than "no consumer" and is not itself grounds for deletion.
 
-Four of the nine are pre-positioned inputs rather than dead ends. The derived condition
-cannot tell "nobody wants this" from "nothing uses it yet", which is why it produces a list
-for a person and never an action.
+Four assets left this list when the audit found a platform-model reader with no repository
+source, invisible to the repo-derived graph until the model definitions were read — exactly the
+gap Phase 0b existed to close. `catalog.osai_gap_map`, `catalog.osai_subcategory_mapping` and
+`catalog.taxonomy_crosswalk` are read by the deployed `scores.taxonomy` (the first two also by
+`scores.investment_ranking`), and `signal_lmarena.text_leaderboard` by
+`ai_demand_curve.model_capability_current`. All four now carry `platform_model_consumers`.
+
+The derived condition cannot tell "nobody wants this" from "nothing uses it yet", which is why
+it produces a list for a person and never an action. Several entries are pre-positioned inputs.
 
 | Asset | Finding |
 |---|---|
-| `catalog.osai_gap_map` | No reviewed consumer. Also misnamed — a third-party map whose columns read as ours. |
-| `catalog.osai_subcategory_mapping` | No reviewed consumer. |
-| `catalog.taxonomy_crosswalk` | No reviewed consumer. |
-| `scores.ossd_coverage` | No reviewed consumer. |
-| `signal_github.product_adoption` | Unread in repo, but holds the route precedence `pypi > huggingface > stars` in SQL. **Must not retire before `registry.adoption_routes` compiles that ordering** — nothing would fail if it did. |
-| `signal_lmarena.text_leaderboard` | Capability anchor collected ahead of the axis that will use it. Pre-positioned. |
-| `signal_semanticscholar.paper_citations` | Citation instrument declared in `signal_routing.yaml`, not yet consumed by a repo model. Pre-positioned. |
+| `scores.ossd_coverage` | No reviewed consumer, in repo or on the platform. |
+| `signal_github.product_adoption` | Unread everywhere reviewed, but holds the route precedence `pypi > huggingface > stars` in SQL. **Must not retire before `registry.adoption_routes` compiles that ordering** — nothing would fail if it did. |
+| `signal_semanticscholar.paper_citations` | Citation instrument declared in `signal_routing.yaml`, not yet consumed. Pre-positioned. |
 | `signal_artificialanalysis.model_evaluations` | The platform description says "held deliberately unjoined to gap-map products". Unread by design. |
-| `signal_packages.product_adoption` | Staged and not deployed. Issue #314. Its two siblings, `downloads` and `downloads_daily`, DO have reviewed model consumers and are not listed here. |
+| `signal_packages.product_adoption` | Staged and not deployed (issue #314). Its two siblings, `downloads` and `downloads_daily`, have reviewed model consumers and are not listed here. |
 
 ## Consumers with only a deprecated reader
 

--- a/docs/architecture/migration-status.md
+++ b/docs/architecture/migration-status.md
@@ -78,17 +78,23 @@ claims, and only the first is true.
 
 ## Assets with no reviewed consumer
 
-**Retirement candidates: <!-- count:retirement_candidates -->5.** Phase 0b read all 41 deployed
+**Retirement candidates: <!-- count:retirement_candidates -->4.** Phase 0b read all 41 deployed
 model definitions in the org, so `consumer_checks.platform_models` is now `checked` on every
 asset and the derived candidate list is non-empty for the first time. It is **recorded, not
 acted on**: section 17 requires explicit maintainer authorization, a stated rollback path and a
 consumer inventory before any deletion. This phase produces the inventory only — no `DROP`, no
-dataset deletion, no description or model change.
+dataset deletion, no description or model change. The four are tracked in issue #348, which each
+entry references in `retirement_issue`; a `TBD` placeholder no longer satisfies that field.
 
-The <!-- count:no_reviewed_consumer -->5 assets below have **no reviewed consumer**: no in-repo
-code reader, no consumer among the twenty notebooks in the organization, and no deployed
-platform model reads them. `external` stays `unknown` — nothing outside this org was read — so
-this is still weaker than "no consumer" and is not itself grounds for deletion.
+The <!-- count:no_reviewed_consumer -->4 assets below are **deployed** and have **no reviewed
+consumer**: no in-repo code reader, no consumer among the twenty notebooks in the organization,
+and no deployed platform model reads them. `external` stays `unknown` — nothing outside this org
+was read — so this is still weaker than "no consumer" and is not itself grounds for deletion.
+
+A not-in-service asset is a different state and is **not** listed here. `signal_packages.product_adoption`
+has no consumer only because it is staged and deployed nowhere (issue #314); a model that has
+not entered service cannot be retired, so `retirement_candidates()` excludes `staged` and
+`dormant` by construction, and the staged `signal_packages` models carry `materialized: false`.
 
 Four assets left this list when the audit found a platform-model reader with no repository
 source, invisible to the repo-derived graph until the model definitions were read — exactly the
@@ -106,7 +112,6 @@ it produces a list for a person and never an action. Several entries are pre-pos
 | `signal_github.product_adoption` | Unread everywhere reviewed, but holds the route precedence `pypi > huggingface > stars` in SQL. **Must not retire before `registry.adoption_routes` compiles that ordering** — nothing would fail if it did. |
 | `signal_semanticscholar.paper_citations` | Citation instrument declared in `signal_routing.yaml`, not yet consumed. Pre-positioned. |
 | `signal_artificialanalysis.model_evaluations` | The platform description says "held deliberately unjoined to gap-map products". Unread by design. |
-| `signal_packages.product_adoption` | Staged and not deployed (issue #314). Its two siblings, `downloads` and `downloads_daily`, have reviewed model consumers and are not listed here. |
 
 ## Consumers with only a deprecated reader
 

--- a/tests/test_assets_inventory.py
+++ b/tests/test_assets_inventory.py
@@ -321,6 +321,60 @@ def test_join_and_subquery_reads_are_found(tmp_path):
     }
 
 
+# --- refs_in_source: the text entry point for deployed model code -------------------
+# Deployed model definitions arrive as a string (the platform's latestRevision.code), not a
+# file. refs_in_source runs the same rules as table_refs so a second extractor cannot drift.
+
+def test_refs_in_source_finds_sql_context():
+    assert A.refs_in_source(
+        "SELECT a FROM currentai.registry.products JOIN currentai.catalog.stack_map ON 1=1", "sql"
+    ) == {"currentai.registry.products", "currentai.catalog.stack_map"}
+
+
+def test_refs_in_source_language_is_case_insensitive():
+    """The platform records the language as `sql`, `SQL` or `python`; all must route."""
+    code = "SELECT a FROM currentai.registry.products"
+    assert A.refs_in_source(code, "SQL") == A.refs_in_source(code, "sql") == {"currentai.registry.products"}
+
+
+def test_refs_in_source_python_literal_and_bare_identifier():
+    assert A.refs_in_source('SQL = "SELECT a FROM currentai.registry.products"', "python") == {
+        "currentai.registry.products"
+    }
+    assert A.refs_in_source('TABLE = "currentai.scores.openness_computed"', "python") == {
+        "currentai.scores.openness_computed"
+    }
+
+
+def test_refs_in_source_excludes_python_docstrings():
+    """The same docstring exclusion table_refs applies -- a model whose module docstring
+    names its INPUT tables in prose must not have them counted as reads."""
+    assert A.refs_in_source('"""Reads currentai.registry.products."""\nx = 1\n', "python") == set()
+
+
+def test_refs_in_source_unquotes_trino_identifiers():
+    assert A.refs_in_source('FROM "currentai"."registry"."products"', "sql") == {
+        "currentai.registry.products"
+    }
+
+
+def test_refs_in_source_unknown_language_yields_only_depends_on():
+    """An unrecognized language contributes only its explicit depends_on: declarations, never
+    a guess from arbitrary text."""
+    assert A.refs_in_source("-- depends_on: currentai.catalog.stack_map\nblah", "scala") == {
+        "currentai.catalog.stack_map"
+    }
+    assert A.refs_in_source("FROM currentai.registry.products", "scala") == set()
+
+
+def test_table_refs_delegates_to_refs_in_source(tmp_path):
+    """table_refs is now refs_in_source over the file's bytes; the two must agree so the
+    file-based graph and the platform audit extract identically."""
+    code = "SELECT a FROM currentai.registry.products\n"
+    path = _tmp(tmp_path, "d.sql", code)
+    assert A.table_refs(path) == A.refs_in_source(code, "sql")
+
+
 # --- coverage: declared vs tracked, both directions -------------------------------
 
 def test_every_tracked_managed_file_is_declared():

--- a/tests/test_assets_inventory.py
+++ b/tests/test_assets_inventory.py
@@ -185,7 +185,40 @@ def test_no_stored_retirement_candidate_flag(inventory):
 def test_retirement_findings_carry_a_reason_and_issue(inventory):
     for asset in A.retirement_candidates():
         assert asset.get("retirement_reason"), f"{asset['id']}: candidate without a reason"
-        assert asset.get("retirement_issue"), f"{asset['id']}: candidate without an issue"
+        # Truthiness is not enough: the field's whole claim is that a tracking issue EXISTS,
+        # so a placeholder like 'TBD: open an issue' must fail here, not pass.
+        assert A.is_retirement_issue_ref(asset.get("retirement_issue")), (
+            f"{asset['id']}: retirement_issue {asset.get('retirement_issue')!r} is not a real "
+            f"issue reference (#123 or a GitHub issues URL)"
+        )
+
+
+def test_issue_ref_validator_rejects_placeholders_and_prose():
+    """The gate above is only as strong as this validator, so pin its edges."""
+    assert A.is_retirement_issue_ref("#348")
+    assert A.is_retirement_issue_ref("https://github.com/currentai-org/os-ai-map/issues/348")
+    for bad in ("TBD: open an issue before any deletion", "", "  ", "issue 348", "#", "#abc",
+                "see #348 later", None, 348):
+        assert not A.is_retirement_issue_ref(bad), f"{bad!r} should not be a valid issue ref"
+
+
+def test_a_staged_unread_asset_is_not_a_retirement_candidate(monkeypatch):
+    """A model deployed nowhere cannot be retired -- it has no consumers because it does not
+    exist yet, which is a different fact from a live table nobody reads. signal_packages.* is
+    the live case (issue #314). Proven by construction: the same asset flips to a candidate
+    only when its status is a deployed one."""
+    base = {
+        "id": "signal_x.staged_model", "read_by": {}, "publication_role": None,
+        "external_consumers": "none_confirmed", "platform_model_consumers": None,
+        "consumer_checks": {"repository": "checked", "platform_notebooks": "checked",
+                            "platform_models": "checked", "external": "unknown"},
+        "retirement_reason": "unread", "retirement_issue": "#1",
+    }
+    monkeypatch.setattr(A, "assets", lambda: [{**base, "status": "staged"}])
+    assert A.retirement_candidates() == []
+    assert A.no_reviewed_consumers() == []
+    monkeypatch.setattr(A, "assets", lambda: [{**base, "status": "active"}])
+    assert [a["id"] for a in A.retirement_candidates()] == ["signal_x.staged_model"]
 
 
 def test_unaudited_consumer_sources_block_candidacy(inventory):
@@ -752,3 +785,56 @@ def test_a_same_day_refetch_is_legal(monkeypatch):
     one day -- an impossible requirement, not a gate."""
     assert not _provenance(monkeypatch, _mirror(),
                            _mirror(revision=5, hash="h2", local_sha256="S2"))
+
+
+# --- the platform-model audit is reproducible from a committed receipt -------------
+# platform_models: checked is not 57 authored booleans; it is backed by
+# warehouse/audits/platform_models.json, the credential-free receipt of the Phase 0b audit.
+# Regenerate with `uv run python -m build.audit_platform_models` (needs OSO_API_KEY).
+
+from build import audit_platform_models as AU  # noqa: E402
+
+_HEX64 = re.compile(r"^[0-9a-f]{64}$")
+
+
+def test_platform_audit_receipt_is_wellformed_and_complete():
+    r = AU.load_receipt()
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2}", r["audited_at"]), "receipt has no audit date"
+    assert r["models"], "receipt census is empty"
+    assert r["model_count"] == len(r["models"]), "receipt model_count disagrees with the census"
+    ids = set(A.by_table())
+    for m in r["models"]:
+        assert m["table"].startswith("currentai."), m
+        assert m["model_id"], f"{m['table']}: no model_id"
+        assert _HEX64.match(m["source_sha256"] or ""), f"{m['table']}: no source digest"
+        assert "code" not in m, f"{m['table']}: receipt must not carry the source body"
+        assert isinstance(m["internal_reads"], list) and isinstance(m["in_scope_reads"], list)
+        assert set(m["in_scope_reads"]) <= set(m["internal_reads"]), m["table"]
+        for ref in m["in_scope_reads"]:
+            assert ref.removeprefix("currentai.") in ids, f"{m['table']} reads unlisted {ref}"
+
+
+def test_platform_model_consumers_match_the_receipt(inventory):
+    """The inventory's platform_model_consumers must be exactly what the receipt derives --
+    so a hand-edit of that field (or of platform_models) without re-running the audit fails,
+    the same binding read_by has to the tree."""
+    derived = AU.consumers_from_receipt(AU.load_receipt())
+    authored = {a["id"]: sorted(a["platform_model_consumers"])
+                for a in inventory if a.get("platform_model_consumers")}
+    assert {k: sorted(v) for k, v in derived.items()} == authored
+
+
+def test_platform_models_checked_is_backed_by_the_census(inventory):
+    """platform_models is `checked` org-wide, so the audit had to cover every deployed model.
+    Every mirrored asset is a deployed UDM and must therefore appear in the receipt census;
+    and no asset may claim `checked` without the receipt existing to back it."""
+    r = AU.load_receipt()
+    census = {m["table"] for m in r["models"]}
+    for asset in inventory:
+        if asset.get("mirror"):
+            assert asset["table"] in census, (
+                f"{asset['id']} is a platform mirror but is absent from the audit census"
+            )
+    checked = [a for a in inventory if a["consumer_checks"]["platform_models"] == "checked"]
+    assert checked, "no asset is checked, yet a receipt exists"
+    assert r["audited_at"], "platform_models is checked but the receipt records no audit date"

--- a/tests/test_assets_inventory.py
+++ b/tests/test_assets_inventory.py
@@ -811,7 +811,7 @@ def test_platform_audit_receipt_is_wellformed_and_complete():
 
 def _valid_receipt() -> dict:
     return {
-        "audited_at": "2026-08-22", "org": "currentai", "org_id": "x", "model_count": 2,
+        "audited_at": "2026-08-22", "org": AU.ORG, "org_id": AU.ORG_ID, "model_count": 2,
         "models": [
             {"table": "currentai.a.one", "dataset": "a", "name": "one",
              "model_id": "693dba9c-44d0-4a12-8e4d-0358023ceb9c",
@@ -839,8 +839,22 @@ def test_receipt_validator_rejects_malformed_receipts():
     def set_dup_table(r):
         r["models"][1]["table"] = "currentai.a.one"; r["models"][1]["name"] = "one"
 
+    def set_bad_dataset(r):
+        # a non-string dataset must fail on its own, even when the table string happens to
+        # match its interpolation (`currentai.1.example`)
+        r["models"][0]["dataset"] = 1
+        r["models"][0]["table"] = "currentai.1.example"
+        r["models"][0]["name"] = "example"
+
     cases = {
         "calendar date": lambda r: r.__setitem__("audited_at", "2026-99-99"),
+        "missing top-level field org": lambda r: r.pop("org"),
+        "org is": lambda r: r.__setitem__("org", "someone-else"),
+        "missing top-level field org_id": lambda r: r.pop("org_id"),
+        "org_id is": lambda r: r.__setitem__("org_id", "00000000-0000-0000-0000-000000000000"),
+        "every model entry must be a mapping": lambda r: r["models"].__setitem__(1, "not-a-dict"),
+        "dataset is not a nonempty string": set_bad_dataset,
+        "name is not a nonempty string": lambda r: r["models"][0].__setitem__("name", 2),
         "duplicate table": set_dup_table,
         "duplicate model_id": lambda r: r["models"][1].__setitem__("model_id", r["models"][0]["model_id"]),
         "revision_hash": lambda r: r["models"][0].__setitem__("revision_hash", "abc"),

--- a/tests/test_assets_inventory.py
+++ b/tests/test_assets_inventory.py
@@ -794,24 +794,65 @@ def test_a_same_day_refetch_is_legal(monkeypatch):
 
 from build import audit_platform_models as AU  # noqa: E402
 
-_HEX64 = re.compile(r"^[0-9a-f]{64}$")
-
 
 def test_platform_audit_receipt_is_wellformed_and_complete():
+    """The full receipt contract, via the module's own validator (a real calendar date,
+    unique model_id/table, every field typed, valid hashes and language, deterministic order).
+    Plus two repository-side facts: no source body is committed, and every in-scope read
+    resolves to an inventory asset."""
     r = AU.load_receipt()
-    assert re.fullmatch(r"\d{4}-\d{2}-\d{2}", r["audited_at"]), "receipt has no audit date"
-    assert r["models"], "receipt census is empty"
-    assert r["model_count"] == len(r["models"]), "receipt model_count disagrees with the census"
+    assert AU.validate_receipt(r) == [], AU.validate_receipt(r)
     ids = set(A.by_table())
     for m in r["models"]:
-        assert m["table"].startswith("currentai."), m
-        assert m["model_id"], f"{m['table']}: no model_id"
-        assert _HEX64.match(m["source_sha256"] or ""), f"{m['table']}: no source digest"
         assert "code" not in m, f"{m['table']}: receipt must not carry the source body"
-        assert isinstance(m["internal_reads"], list) and isinstance(m["in_scope_reads"], list)
-        assert set(m["in_scope_reads"]) <= set(m["internal_reads"]), m["table"]
         for ref in m["in_scope_reads"]:
             assert ref.removeprefix("currentai.") in ids, f"{m['table']} reads unlisted {ref}"
+
+
+def _valid_receipt() -> dict:
+    return {
+        "audited_at": "2026-08-22", "org": "currentai", "org_id": "x", "model_count": 2,
+        "models": [
+            {"table": "currentai.a.one", "dataset": "a", "name": "one",
+             "model_id": "693dba9c-44d0-4a12-8e4d-0358023ceb9c",
+             "revision_hash": "a" * 64, "source_sha256": "b" * 64, "language": "SQL",
+             "internal_reads": ["currentai.a.two"], "in_scope_reads": [],
+             "has_repository_source": True},
+            {"table": "currentai.a.two", "dataset": "a", "name": "two",
+             "model_id": "693dba9c-44d0-4a12-8e4d-0358023ceb9d",
+             "revision_hash": "c" * 64, "source_sha256": "d" * 64, "language": "python",
+             "internal_reads": [], "in_scope_reads": [], "has_repository_source": False},
+        ],
+    }
+
+
+def test_receipt_validator_rejects_malformed_receipts():
+    """Every contract violation must fail the validator, so a bad receipt cannot pass by
+    resembling a good one. Same "grade on what you report" discipline the mirror gates carry."""
+    assert AU.validate_receipt(_valid_receipt()) == []
+
+    def broken(mutate):
+        r = _valid_receipt()
+        mutate(r)
+        return AU.validate_receipt(r)
+
+    def set_dup_table(r):
+        r["models"][1]["table"] = "currentai.a.one"; r["models"][1]["name"] = "one"
+
+    cases = {
+        "calendar date": lambda r: r.__setitem__("audited_at", "2026-99-99"),
+        "duplicate table": set_dup_table,
+        "duplicate model_id": lambda r: r["models"][1].__setitem__("model_id", r["models"][0]["model_id"]),
+        "revision_hash": lambda r: r["models"][0].__setitem__("revision_hash", "abc"),
+        "language": lambda r: r["models"][0].__setitem__("language", "scala"),
+        "has_repository_source": lambda r: r["models"][0].pop("has_repository_source"),
+        "model_count": lambda r: r.__setitem__("model_count", 5),
+        "deterministic": lambda r: r.__setitem__("models", list(reversed(r["models"]))),
+        "subset": lambda r: r["models"][0].__setitem__("in_scope_reads", ["currentai.z.z"]),
+    }
+    for needle, mutate in cases.items():
+        problems = broken(mutate)
+        assert any(needle in p for p in problems), f"{needle}: not caught, got {problems}"
 
 
 def test_platform_model_consumers_match_the_receipt(inventory):

--- a/warehouse/assets.yaml
+++ b/warehouse/assets.yaml
@@ -15,7 +15,9 @@
 #   repository        every tracked model, build module, notebook and workflow
 #   platform_notebooks  all 20 notebooks in the org, including the 16 untracked here
 #   platform_models   CHECKED (Phase 0b). All 41 deployed model definitions in the org
-#                     were read; platform_model_consumers lists any that read an asset.
+#                     were read. platform_model_consumers lists the deployed models with NO
+#                     repository source that read an asset; repo-sourced deployed readers
+#                     already appear in read_by, so they are not repeated there.
 #   external          NOT audited. Nothing outside this org.
 # platform_models is now checked for every asset, so retirement_candidates() can be
 # non-empty; retirement itself still requires maintainer authorization (section 17).
@@ -1410,7 +1412,7 @@ assets:
   materialized: true
   verified_at: '2026-08-20'
   retirement_reason: 'no reviewed consumer as of 2026-08-22: no in-repo code reader, no platform notebook consumer, and (Phase 0b, all 41 deployed model definitions read) no deployed platform model reads it. Recorded as a retirement candidate; deletion requires maintainer authorization per section 17 and is not performed here.'
-  retirement_issue: 'TBD: open an issue before any deletion'
+  retirement_issue: '#348'
 - id: scores.project_summary
   table: currentai.scores.project_summary
   files:
@@ -1603,7 +1605,7 @@ assets:
   materialized: true
   verified_at: '2026-08-20'
   retirement_reason: 'no reviewed consumer as of 2026-08-22: no in-repo code reader, no platform notebook consumer, and (Phase 0b, all 41 deployed model definitions read) no deployed platform model reads it. Recorded as a retirement candidate; deletion requires maintainer authorization per section 17 and is not performed here.'
-  retirement_issue: 'TBD: open an issue before any deletion'
+  retirement_issue: '#348'
   notes: The platform dataset description says "held deliberately unjoined to gap-map products". Unread
     by design.
   mirror:
@@ -1655,7 +1657,7 @@ assets:
   materialized: true
   verified_at: '2026-08-20'
   retirement_reason: 'no reviewed consumer as of 2026-08-22: no in-repo code reader, no platform notebook consumer, and (Phase 0b, all 41 deployed model definitions read) no deployed platform model reads it. Recorded as a retirement candidate; deletion requires maintainer authorization per section 17 and is not performed here.'
-  retirement_issue: 'TBD: open an issue before any deletion'
+  retirement_issue: '#348'
   notes: The stars fallback tier. Reads signal_pypi and signal_huggingface to skip already-measured products,
     so it holds the route precedence pypi > huggingface > stars in SQL. Must not retire before registry.adoption_routes
     compiles that ordering.
@@ -1923,7 +1925,7 @@ assets:
   refresh: 'not deployed; see issue #314'
   owner: carl
   status: staged
-  materialized: true
+  materialized: false
   verified_at: '2026-08-20'
 - id: signal_packages.downloads_daily
   table: currentai.signal_packages.downloads_daily
@@ -1955,7 +1957,7 @@ assets:
   refresh: 'not deployed; see issue #314'
   owner: carl
   status: staged
-  materialized: true
+  materialized: false
   verified_at: '2026-08-20'
 - id: signal_packages.product_adoption
   table: currentai.signal_packages.product_adoption
@@ -1987,10 +1989,8 @@ assets:
   refresh: 'not deployed; see issue #314'
   owner: carl
   status: staged
-  materialized: true
+  materialized: false
   verified_at: '2026-08-20'
-  retirement_reason: 'no reviewed consumer as of 2026-08-22: no in-repo code reader, no platform notebook consumer, and (Phase 0b, all 41 deployed model definitions read) no deployed platform model reads it. Recorded as a retirement candidate; deletion requires maintainer authorization per section 17 and is not performed here.'
-  retirement_issue: 'TBD: open an issue before any deletion'
   notes: Staged, not deployed.
 - id: signal_pypi.package_downloads
   table: currentai.signal_pypi.package_downloads
@@ -2072,7 +2072,7 @@ assets:
   materialized: true
   verified_at: '2026-08-20'
   retirement_reason: 'no reviewed consumer as of 2026-08-22: no in-repo code reader, no platform notebook consumer, and (Phase 0b, all 41 deployed model definitions read) no deployed platform model reads it. Recorded as a retirement candidate; deletion requires maintainer authorization per section 17 and is not performed here.'
-  retirement_issue: 'TBD: open an issue before any deletion'
+  retirement_issue: '#348'
   notes: Citation instrument for benchmark_eval_data, declared in signal_routing.yaml but not yet consumed
     by a repo model. Not dead.
   mirror:

--- a/warehouse/assets.yaml
+++ b/warehouse/assets.yaml
@@ -14,9 +14,11 @@
 # `consumer_checks` records what was actually audited, per check:
 #   repository        every tracked model, build module, notebook and workflow
 #   platform_notebooks  all 20 notebooks in the org, including the 16 untracked here
-#   platform_models   NOT audited. Deployed model definitions were not read.
+#   platform_models   CHECKED (Phase 0b). All 41 deployed model definitions in the org
+#                     were read; platform_model_consumers lists any that read an asset.
 #   external          NOT audited. Nothing outside this org.
-# No asset is a retirement candidate while platform_models is unknown.
+# platform_models is now checked for every asset, so retirement_candidates() can be
+# non-empty; retirement itself still requires maintainer authorization (section 17).
 #
 # This inventory absorbed warehouse/sources.yaml, retired in the mirror-layout restructure.
 # That file's explanation of why two sources carry no fetcher is preserved verbatim here.
@@ -30,7 +32,7 @@
 #   committed CSV was removed on 2026-08-16 with nothing pointed at it.
 ---
 version: 1
-verified_at: '2026-08-21'
+verified_at: '2026-08-22'
 assets:
 - id: catalog.country_populations
   table: currentai.catalog.country_populations
@@ -47,7 +49,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per country_code
@@ -74,10 +76,12 @@ assets:
   read_by:
     models:
     - warehouse/models/entities/models.sql
+  platform_model_consumers:
+  - currentai.state_of_os_ai.family_footprint
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per curated model_family
@@ -101,7 +105,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers:
   - ai-safety-incidents
@@ -135,7 +139,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers:
   - state-of-os-ai
@@ -172,7 +176,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per Hugging Face model_id, mapped to a GitHub repo
@@ -192,10 +196,13 @@ assets:
   authority: platform
   population: long_tail
   release_path: false
+  platform_model_consumers:
+  - currentai.scores.investment_ranking
+  - currentai.scores.taxonomy
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per (layer, subcategory) of a third-party map
@@ -206,10 +213,6 @@ assets:
   status: active
   materialized: true
   verified_at: '2026-08-20'
-  retirement_reason: 'no reviewed consumer found as of 2026-08-20: no in-repo code reader and no platform
-    notebook consumer. Deployed platform model definitions were NOT audited, so this is not evidence that
-    nothing reads it.'
-  retirement_issue: 'TBD: open an issue before any deletion'
 - id: catalog.osai_subcategory_mapping
   table: currentai.catalog.osai_subcategory_mapping
   kind: registry
@@ -219,10 +222,13 @@ assets:
   authority: platform
   population: long_tail
   release_path: false
+  platform_model_consumers:
+  - currentai.scores.investment_ranking
+  - currentai.scores.taxonomy
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per (osai_layer, osai_subcategory)
@@ -234,10 +240,6 @@ assets:
   status: active
   materialized: true
   verified_at: '2026-08-20'
-  retirement_reason: 'no reviewed consumer found as of 2026-08-20: no in-repo code reader and no platform
-    notebook consumer. Deployed platform model definitions were NOT audited, so this is not evidence that
-    nothing reads it.'
-  retirement_issue: 'TBD: open an issue before any deletion'
 - id: catalog.pypi_downloads
   table: currentai.catalog.pypi_downloads
   kind: observations
@@ -253,7 +255,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers:
   - pypi-china-openclaw
@@ -288,7 +290,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers:
   - ai-contribution-load
@@ -313,10 +315,12 @@ assets:
   authority: platform
   population: long_tail
   release_path: false
+  platform_model_consumers:
+  - currentai.scores.taxonomy
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per (osai_layer, goodai_category)
@@ -328,10 +332,6 @@ assets:
   status: active
   materialized: true
   verified_at: '2026-08-20'
-  retirement_reason: 'no reviewed consumer found as of 2026-08-20: no in-repo code reader and no platform
-    notebook consumer. Deployed platform model definitions were NOT audited, so this is not evidence that
-    nothing reads it.'
-  retirement_issue: 'TBD: open an issue before any deletion'
 - id: entities.models
   table: currentai.entities.models
   files:
@@ -362,7 +362,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers:
   - sta-grantmaker-view
@@ -404,7 +404,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per (repo, package_source, package_name)
@@ -445,7 +445,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers:
   - ai-potluck-partners
@@ -493,10 +493,15 @@ assets:
     - warehouse/models/scores/fragility.sql
     - warehouse/models/scores/ossd_coverage.sql
     - warehouse/models/scores/project_summary.sql
+  platform_model_consumers:
+  - currentai.scores.investment_ranking
+  - currentai.scores.taxonomy
+  - currentai.state_of_os_ai.country_activity_monthly
+  - currentai.state_of_os_ai.geo_cohorts
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers:
   - launch-insights
@@ -537,7 +542,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers:
   - ai-contribution-load
@@ -589,7 +594,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per (product_slug, category_slug, dimension, part_index, citing artifact)
@@ -639,10 +644,13 @@ assets:
     - warehouse/models/scores/repos_summary.sql
     notebooks:
     - notebooks/oss-ai-trends.py
+  platform_model_consumers:
+  - currentai.state_of_os_ai.country_activity_monthly
+  - currentai.state_of_os_ai.star_trajectories
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers:
   - state-of-os-ai
@@ -675,7 +683,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per (product_type, signal_type, level)
@@ -699,7 +707,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per category slug
@@ -726,7 +734,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per (category_slug, product_slug)
@@ -753,7 +761,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per (category_slug, product_type, dimension)
@@ -780,7 +788,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per (category_slug, product_type, tier)
@@ -809,7 +817,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per (category_slug, product_type, rule_index)
@@ -836,7 +844,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per (source, column_name, abstain_value)
@@ -864,7 +872,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per (source, license_slug)
@@ -888,7 +896,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers:
   - ai-contribution-load
@@ -923,7 +931,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers:
   - ai-contribution-load
@@ -954,7 +962,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers:
   - sta-grantmaker-view
@@ -979,7 +987,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per (product_slug, relation, target)
@@ -1006,7 +1014,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per (product_slug, category_slug, dimension, part_index)
@@ -1030,7 +1038,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers:
   - ai-contribution-load
@@ -1059,7 +1067,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per (product_slug, category_slug, axis, source_url)
@@ -1083,7 +1091,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per (product_slug, category_slug), all three axes wide
@@ -1112,7 +1120,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per product slug
@@ -1136,7 +1144,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per tail candidate slug
@@ -1174,7 +1182,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per (dependent_repo, dependency_repo)
@@ -1214,10 +1222,12 @@ assets:
   read_by:
     models:
     - warehouse/models/scores/project_summary.sql
+  platform_model_consumers:
+  - currentai.scores.investment_ranking
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per repo
@@ -1244,7 +1254,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers:
   - ai-potluck-partners
@@ -1285,7 +1295,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per (product_slug, category_slug)
@@ -1342,7 +1352,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per (product_slug, category_slug, fact_key)
@@ -1384,7 +1394,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per GitHub org
@@ -1399,9 +1409,7 @@ assets:
   status: active
   materialized: true
   verified_at: '2026-08-20'
-  retirement_reason: 'no reviewed consumer found as of 2026-08-20: no in-repo code reader and no platform
-    notebook consumer. Deployed platform model definitions were NOT audited, so this is not evidence that
-    nothing reads it.'
+  retirement_reason: 'no reviewed consumer as of 2026-08-22: no in-repo code reader, no platform notebook consumer, and (Phase 0b, all 41 deployed model definitions read) no deployed platform model reads it. Recorded as a retirement candidate; deletion requires maintainer authorization per section 17 and is not performed here.'
   retirement_issue: 'TBD: open an issue before any deletion'
 - id: scores.project_summary
   table: currentai.scores.project_summary
@@ -1434,7 +1442,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers:
   - ai-potluck-partners
@@ -1472,10 +1480,14 @@ assets:
     notebooks:
     - notebooks/long-tail-explorer.py
     - notebooks/oss-ai-trends.py
+  platform_model_consumers:
+  - currentai.state_of_os_ai.family_footprint
+  - currentai.state_of_os_ai.org_leaderboard
+  - currentai.state_of_os_ai.robotics_repos
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers:
   - france-ecosystem
@@ -1514,7 +1526,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers:
   - launch-insights
@@ -1543,7 +1555,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers:
   - ai-potluck-partners
@@ -1576,7 +1588,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per Artificial Analysis model id
@@ -1590,9 +1602,7 @@ assets:
   status: active
   materialized: true
   verified_at: '2026-08-20'
-  retirement_reason: 'no reviewed consumer found as of 2026-08-20: no in-repo code reader and no platform
-    notebook consumer. Deployed platform model definitions were NOT audited, so this is not evidence that
-    nothing reads it.'
+  retirement_reason: 'no reviewed consumer as of 2026-08-22: no in-repo code reader, no platform notebook consumer, and (Phase 0b, all 41 deployed model definitions read) no deployed platform model reads it. Recorded as a retirement candidate; deletion requires maintainer authorization per section 17 and is not performed here.'
   retirement_issue: 'TBD: open an issue before any deletion'
   notes: The platform dataset description says "held deliberately unjoined to gap-map products". Unread
     by design.
@@ -1629,7 +1639,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per product_slug, stars fallback tier only
@@ -1644,9 +1654,7 @@ assets:
   status: active
   materialized: true
   verified_at: '2026-08-20'
-  retirement_reason: 'no reviewed consumer found as of 2026-08-20: no in-repo code reader and no platform
-    notebook consumer. Deployed platform model definitions were NOT audited, so this is not evidence that
-    nothing reads it.'
+  retirement_reason: 'no reviewed consumer as of 2026-08-22: no in-repo code reader, no platform notebook consumer, and (Phase 0b, all 41 deployed model definitions read) no deployed platform model reads it. Recorded as a retirement candidate; deletion requires maintainer authorization per section 17 and is not performed here.'
   retirement_issue: 'TBD: open an issue before any deletion'
   notes: The stars fallback tier. Reads signal_pypi and signal_huggingface to skip already-measured products,
     so it holds the route precedence pypi > huggingface > stars in SQL. Must not retire before registry.adoption_routes
@@ -1682,7 +1690,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers:
   - sta-grantmaker-view
@@ -1729,7 +1737,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per repo, live from goodailist.com
@@ -1775,7 +1783,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per (product_slug, artifact_kind, artifact_id) at one fetched_at
@@ -1821,7 +1829,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per product_slug, Hub downloads route
@@ -1855,10 +1863,12 @@ assets:
   authority: platform
   population: gap_map
   release_path: false
+  platform_model_consumers:
+  - currentai.ai_demand_curve.model_capability_current
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per (model_name, category, arena_config)
@@ -1872,10 +1882,6 @@ assets:
   status: active
   materialized: true
   verified_at: '2026-08-20'
-  retirement_reason: 'no reviewed consumer found as of 2026-08-20: no in-repo code reader and no platform
-    notebook consumer. Deployed platform model definitions were NOT audited, so this is not evidence that
-    nothing reads it.'
-  retirement_issue: 'TBD: open an issue before any deletion'
   notes: Capability anchor, collected ahead of the capability axis using it. Not dead.
   mirror:
     model_id: efb89f86-7aff-48df-a78e-ce01234672db
@@ -1909,7 +1915,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per (product_slug, package) over a 30-day window
@@ -1941,7 +1947,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per (package, day)
@@ -1972,7 +1978,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per product_slug across package registries
@@ -1983,9 +1989,7 @@ assets:
   status: staged
   materialized: true
   verified_at: '2026-08-20'
-  retirement_reason: 'no reviewed consumer found as of 2026-08-20: no in-repo code reader and no platform
-    notebook consumer. Deployed platform model definitions were NOT audited, so this is not evidence that
-    nothing reads it.'
+  retirement_reason: 'no reviewed consumer as of 2026-08-22: no in-repo code reader, no platform notebook consumer, and (Phase 0b, all 41 deployed model definitions read) no deployed platform model reads it. Recorded as a retirement candidate; deletion requires maintainer authorization per section 17 and is not performed here.'
   retirement_issue: 'TBD: open an issue before any deletion'
   notes: Staged, not deployed.
 - id: signal_pypi.package_downloads
@@ -2014,7 +2018,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per (product_slug, package) over a 30-day window
@@ -2053,7 +2057,7 @@ assets:
   consumer_checks:
     repository: checked
     platform_notebooks: checked
-    platform_models: unknown
+    platform_models: checked
     external: unknown
   external_consumers: none_confirmed
   grain: one row per (product_slug, arxiv_id)
@@ -2067,9 +2071,7 @@ assets:
   status: active
   materialized: true
   verified_at: '2026-08-20'
-  retirement_reason: 'no reviewed consumer found as of 2026-08-20: no in-repo code reader and no platform
-    notebook consumer. Deployed platform model definitions were NOT audited, so this is not evidence that
-    nothing reads it.'
+  retirement_reason: 'no reviewed consumer as of 2026-08-22: no in-repo code reader, no platform notebook consumer, and (Phase 0b, all 41 deployed model definitions read) no deployed platform model reads it. Recorded as a retirement candidate; deletion requires maintainer authorization per section 17 and is not performed here.'
   retirement_issue: 'TBD: open an issue before any deletion'
   notes: Citation instrument for benchmark_eval_data, declared in signal_routing.yaml but not yet consumed
     by a repo model. Not dead.

--- a/warehouse/audits/platform_models.json
+++ b/warehouse/audits/platform_models.json
@@ -1,0 +1,727 @@
+{
+ "audited_at": "2026-08-22",
+ "org": "currentai",
+ "org_id": "ad7f4c1c-dd2f-430e-a831-e7f1f16e6d9e",
+ "model_count": 41,
+ "models": [
+  {
+   "table": "currentai.ai_demand_curve.cost_of_intelligence_timeseries",
+   "dataset": "ai_demand_curve",
+   "name": "cost_of_intelligence_timeseries",
+   "model_id": "693dba9c-44d0-4a12-8e4d-0358023ceb9c",
+   "revision_hash": "5114323ffb8ffa7c0dfa9a2c4edcb26a036ae2b6a4eee2073efbf7cd2964286b",
+   "source_sha256": "ad82b06dbaf7f7aca2dd5168ec4fd360452beb76750b966a7e4ad2e58af9025d",
+   "language": "python",
+   "internal_reads": [
+    "currentai.ai_demand_curve.model_cost_capability"
+   ],
+   "in_scope_reads": [],
+   "has_repository_source": false
+  },
+  {
+   "table": "currentai.ai_demand_curve.model_capability_current",
+   "dataset": "ai_demand_curve",
+   "name": "model_capability_current",
+   "model_id": "8e4af7c2-47f5-4b8b-bd0d-3396e5da63ff",
+   "revision_hash": "c6714b586b648d68ed9f0ced6b633620d47f77c994b0933f18d66e3f68ade791",
+   "source_sha256": "921f8d9abfed5998b10ac383fb1ea1e3bf40475752466d536cf2bd5a03354ffd",
+   "language": "python",
+   "internal_reads": [
+    "currentai.signal_lmarena.text_leaderboard"
+   ],
+   "in_scope_reads": [
+    "currentai.signal_lmarena.text_leaderboard"
+   ],
+   "has_repository_source": false
+  },
+  {
+   "table": "currentai.ai_demand_curve.model_cost_capability",
+   "dataset": "ai_demand_curve",
+   "name": "model_cost_capability",
+   "model_id": "8b353a96-f270-412e-b911-daef24d3df94",
+   "revision_hash": "f0d738976b5f9d61acf876a6510e35b6eac9cee16f123177b056406c38170c4f",
+   "source_sha256": "b68e8a15802ed43cb7d0b638128615d7bf10cbd92fbfd74ccbe0f731ff20e8ee",
+   "language": "python",
+   "internal_reads": [
+    "currentai.ai_demand_curve.model_capability_current",
+    "currentai.ai_demand_curve.model_pricing_current"
+   ],
+   "in_scope_reads": [],
+   "has_repository_source": false
+  },
+  {
+   "table": "currentai.ai_demand_curve.model_pricing_current",
+   "dataset": "ai_demand_curve",
+   "name": "model_pricing_current",
+   "model_id": "bda16d61-5137-4c0b-9780-37b1fa6014bc",
+   "revision_hash": "4e280e597fadd2973659af7f52fd19eb4f1aa1b220282cd086c8c667b60154ee",
+   "source_sha256": "3a90569fc8f9b18acb9bd24234c654f91e2a3bc397b077fbb155139f123a68d8",
+   "language": "python",
+   "internal_reads": [
+    "currentai.openrouter_snapshot.pricing_snapshot"
+   ],
+   "in_scope_reads": [],
+   "has_repository_source": false
+  },
+  {
+   "table": "currentai.ai_demand_curve.use_case_assumptions",
+   "dataset": "ai_demand_curve",
+   "name": "use_case_assumptions",
+   "model_id": "efcc2f40-ccaa-4529-95b6-2c03cebc9e42",
+   "revision_hash": "ad2d291a15b2265d0c66c48c30ac4f835804be1876dfa6911d54f90d14382440",
+   "source_sha256": "e50c8fb19599cbcf9588c55d8174046119685eebaf73391bf0d867a1879c6bd9",
+   "language": "python",
+   "internal_reads": [],
+   "in_scope_reads": [],
+   "has_repository_source": false
+  },
+  {
+   "table": "currentai.ai_demand_curve.use_case_economics",
+   "dataset": "ai_demand_curve",
+   "name": "use_case_economics",
+   "model_id": "b15a58e4-8b38-4a79-a1c0-f04b3ee2a228",
+   "revision_hash": "5e34bdb8601e2d1664b6346af33fa538a35bebb7ce13f9633cafcdf6f4b7a36f",
+   "source_sha256": "3d63e92ebe566fd09d5434e3542fc45cdc62d30d9f2868b685d0b29c52984b17",
+   "language": "python",
+   "internal_reads": [
+    "currentai.ai_demand_curve.model_cost_capability",
+    "currentai.ai_demand_curve.use_case_assumptions"
+   ],
+   "in_scope_reads": [],
+   "has_repository_source": false
+  },
+  {
+   "table": "currentai.datasette.datasette_plugins",
+   "dataset": "datasette",
+   "name": "datasette_plugins",
+   "model_id": "a1dbc4f3-2cc5-41a1-9493-1152fd220a8e",
+   "revision_hash": "a845f33eaa3891f72b558cc8e621fec14558f0d20057ca016550a76ce24d9025",
+   "source_sha256": "f3cc2c04b8889eb59dc7f9dbf931a4d0262ab97955e9fa83f6fcff65cd2b7a4b",
+   "language": "python",
+   "internal_reads": [],
+   "in_scope_reads": [],
+   "has_repository_source": false
+  },
+  {
+   "table": "currentai.datasette.fetch_probe",
+   "dataset": "datasette",
+   "name": "fetch_probe",
+   "model_id": "625156b2-b456-41b8-88f0-03d4c346ef63",
+   "revision_hash": "0140f0c2dbbdea343d59e6f99f3151283e9566ea03e5573da11bb020016a6629",
+   "source_sha256": "34a8eb7b13e06743907c1d78e7004b84a071a4352e33ca60e54263c05a15bb54",
+   "language": "python",
+   "internal_reads": [],
+   "in_scope_reads": [],
+   "has_repository_source": false
+  },
+  {
+   "table": "currentai.entities.models",
+   "dataset": "entities",
+   "name": "models",
+   "model_id": "369fbed8-aa1d-4db9-9b3a-289ef813c464",
+   "revision_hash": "4d701d662755a113b012ee5273062fe5936689bc2b3aa1f63e9b5d300a737d6f",
+   "source_sha256": "b3aad6ff000553ae36383c4a73e5989ba288dc59226c8b62b51bda2c6043d519",
+   "language": "sql",
+   "internal_reads": [
+    "currentai.catalog.foundation_model_repos",
+    "currentai.catalog.model_benchmarks",
+    "currentai.catalog.model_repos",
+    "currentai.entities.repos"
+   ],
+   "in_scope_reads": [
+    "currentai.catalog.foundation_model_repos",
+    "currentai.catalog.model_benchmarks",
+    "currentai.catalog.model_repos",
+    "currentai.entities.repos"
+   ],
+   "has_repository_source": true
+  },
+  {
+   "table": "currentai.entities.packages",
+   "dataset": "entities",
+   "name": "packages",
+   "model_id": "45028a8f-208f-42ac-addd-750e5ac5d4c4",
+   "revision_hash": "9180d799a386182712e06b3182f07888d6fca02d5d3d57759aa4a106c0970d07",
+   "source_sha256": "4b9b02dbfbdac2b81651b366f603eab3f9653ee6df80fa928e8c52334f9a50d3",
+   "language": "sql",
+   "internal_reads": [
+    "currentai.entities.repos"
+   ],
+   "in_scope_reads": [
+    "currentai.entities.repos"
+   ],
+   "has_repository_source": true
+  },
+  {
+   "table": "currentai.entities.projects",
+   "dataset": "entities",
+   "name": "projects",
+   "model_id": "270a6158-9290-48a6-abff-37a61ebcaf32",
+   "revision_hash": "38df4a1cf789f8b6b76d89b3f3092e5b91e27eef3616e006bf0a7bbcae31d85a",
+   "source_sha256": "f329f12d7623faf4df6865c2854ca4c91b278cd5783e4114b16eb7b69a5dd390",
+   "language": "SQL",
+   "internal_reads": [
+    "currentai.entities.repos",
+    "currentai.signal_goodailist.repo_catalog"
+   ],
+   "in_scope_reads": [
+    "currentai.entities.repos",
+    "currentai.signal_goodailist.repo_catalog"
+   ],
+   "has_repository_source": true
+  },
+  {
+   "table": "currentai.entities.repos",
+   "dataset": "entities",
+   "name": "repos",
+   "model_id": "71f0b061-3ccf-435f-8e1b-f3b15c5d8e5c",
+   "revision_hash": "b455c3a2de9d2b290f4f23bf1f356bb30969e967ac522cb3228953d7be8b2775",
+   "source_sha256": "42af94f84dff8e02076a8755081d3f662f76de8602f4ef643746aea6ea719cab",
+   "language": "SQL",
+   "internal_reads": [
+    "currentai.signal_goodailist.repo_catalog"
+   ],
+   "in_scope_reads": [
+    "currentai.signal_goodailist.repo_catalog"
+   ],
+   "has_repository_source": true
+  },
+  {
+   "table": "currentai.events.github_events",
+   "dataset": "events",
+   "name": "github_events",
+   "model_id": "dbdb3674-59d5-448c-a537-8456ec27e3d4",
+   "revision_hash": "a91b58476647fb770fb3b1d47adf6710567086a6aa5593e5c847ec33dbe7d985",
+   "source_sha256": "9fcefe1bd0630731464e428519ded312a6664c98fbb5a08f768b5f9520af52f9",
+   "language": "sql",
+   "internal_reads": [
+    "currentai.entities.repos"
+   ],
+   "in_scope_reads": [
+    "currentai.entities.repos"
+   ],
+   "has_repository_source": true
+  },
+  {
+   "table": "currentai.evidence.product_evidence",
+   "dataset": "evidence",
+   "name": "product_evidence",
+   "model_id": "769c20b5-d9c0-4163-bced-81e3a62fbc47",
+   "revision_hash": "1df6aea100e8536cc390d3d0a3ec5157978c0c08b93b7f717b92dc643930613a",
+   "source_sha256": "fe718b3a4711eb7e91ef8d86964ce29f12a2233370f4c44032096a43a3697cb4",
+   "language": "SQL",
+   "internal_reads": [
+    "currentai.registry.category_scoring_rules",
+    "currentai.registry.evidence_abstentions",
+    "currentai.registry.license_aliases",
+    "currentai.registry.product_categories",
+    "currentai.registry.product_openness_evidence",
+    "currentai.registry.product_score_sources",
+    "currentai.signal_github.repo_state",
+    "currentai.signal_huggingface.hub_state"
+   ],
+   "in_scope_reads": [
+    "currentai.registry.category_scoring_rules",
+    "currentai.registry.evidence_abstentions",
+    "currentai.registry.license_aliases",
+    "currentai.registry.product_categories",
+    "currentai.registry.product_openness_evidence",
+    "currentai.registry.product_score_sources",
+    "currentai.signal_github.repo_state",
+    "currentai.signal_huggingface.hub_state"
+   ],
+   "has_repository_source": true
+  },
+  {
+   "table": "currentai.metrics.daily",
+   "dataset": "metrics",
+   "name": "daily",
+   "model_id": "13e20938-3127-492b-ada6-20a7e1e7bc1c",
+   "revision_hash": "2bd142f1b3428261df6efd42ffd144e7f22cf9f95a08ecd0685ef3a352a9e2af",
+   "source_sha256": "5941d46c540febcfccce182e9b7c24168160568f019175ca3396a3f7f9c769a8",
+   "language": "sql",
+   "internal_reads": [
+    "currentai.entities.repos",
+    "currentai.events.github_events"
+   ],
+   "in_scope_reads": [
+    "currentai.entities.repos",
+    "currentai.events.github_events"
+   ],
+   "has_repository_source": true
+  },
+  {
+   "table": "currentai.scores.dependency_graph",
+   "dataset": "scores",
+   "name": "dependency_graph",
+   "model_id": "2998ad7b-d01c-407f-90a5-8df43b3891aa",
+   "revision_hash": "f613c497523f63ec3a33151d596a2f20245ba845e83dd8c6969f01021a3aa205",
+   "source_sha256": "f4d0dd4bae0c77506e78d99962263a2ca7b0caa641648007b4f49adab388c9a1",
+   "language": "SQL",
+   "internal_reads": [
+    "currentai.entities.repos",
+    "currentai.signal_goodailist.repo_catalog"
+   ],
+   "in_scope_reads": [
+    "currentai.entities.repos",
+    "currentai.signal_goodailist.repo_catalog"
+   ],
+   "has_repository_source": true
+  },
+  {
+   "table": "currentai.scores.fragility",
+   "dataset": "scores",
+   "name": "fragility",
+   "model_id": "6c6785b8-2a29-40d1-98f4-fa6a427f82d3",
+   "revision_hash": "9154aef3203c44134e4882e9fc728d9896631c0466fe94cc69047c11b1c11622",
+   "source_sha256": "736afe2521b9f933d7552aa6e51ccceaef7ec554acd77fe6cc199645b451f8a0",
+   "language": "SQL",
+   "internal_reads": [
+    "currentai.entities.repos",
+    "currentai.metrics.daily",
+    "currentai.scores.dependency_graph",
+    "currentai.signal_goodailist.repo_catalog"
+   ],
+   "in_scope_reads": [
+    "currentai.entities.repos",
+    "currentai.metrics.daily",
+    "currentai.scores.dependency_graph",
+    "currentai.signal_goodailist.repo_catalog"
+   ],
+   "has_repository_source": true
+  },
+  {
+   "table": "currentai.scores.investment_ranking",
+   "dataset": "scores",
+   "name": "investment_ranking",
+   "model_id": "a3e618ca-c3a1-4588-9bff-29fd87c5f24f",
+   "revision_hash": "c6a7f2be1b38153c1663816a189146d60afcef0b66231b6d19cc44e4d84ed91b",
+   "source_sha256": "2a18588d1823f39fd431f3214a0faf83c97d0709fe3b8fed5ae5d993c778727c",
+   "language": "sql",
+   "internal_reads": [
+    "currentai.catalog.osai_gap_map",
+    "currentai.catalog.osai_subcategory_mapping",
+    "currentai.entities.repos",
+    "currentai.scores.fragility"
+   ],
+   "in_scope_reads": [
+    "currentai.catalog.osai_gap_map",
+    "currentai.catalog.osai_subcategory_mapping",
+    "currentai.entities.repos",
+    "currentai.scores.fragility"
+   ],
+   "has_repository_source": false
+  },
+  {
+   "table": "currentai.scores.openness_computed",
+   "dataset": "scores",
+   "name": "openness_computed",
+   "model_id": "6aef560b-cc85-4a9d-afa8-8f4798208e74",
+   "revision_hash": "b72dca7a6b36b9aa529d64089df7cf14f6e9d409aa7ed746554b2475e1031824",
+   "source_sha256": "bc49856795cf93774386617f380725b61d625a91476429453adefe7f25d5ff16",
+   "language": "SQL",
+   "internal_reads": [
+    "currentai.registry.category_scoring_rules",
+    "currentai.scores.openness_facts"
+   ],
+   "in_scope_reads": [
+    "currentai.registry.category_scoring_rules",
+    "currentai.scores.openness_facts"
+   ],
+   "has_repository_source": true
+  },
+  {
+   "table": "currentai.scores.openness_facts",
+   "dataset": "scores",
+   "name": "openness_facts",
+   "model_id": "68d9e34c-b0b6-460b-b4ae-21b7016eb1f8",
+   "revision_hash": "de80c94bdc10b1ffcc00f92882b7b60587ed15881c86fe50e701565bc54e891b",
+   "source_sha256": "2b9c7dbb6de81db115c24b4496d96d6094c343b5947aae692e224d634fb20f30",
+   "language": "SQL",
+   "internal_reads": [
+    "currentai.evidence.product_evidence",
+    "currentai.registry.category_deferrals",
+    "currentai.registry.category_dimensions",
+    "currentai.registry.category_license_tiers",
+    "currentai.registry.category_scoring_rules",
+    "currentai.registry.license_aliases",
+    "currentai.registry.product_categories",
+    "currentai.registry.products"
+   ],
+   "in_scope_reads": [
+    "currentai.evidence.product_evidence",
+    "currentai.registry.category_deferrals",
+    "currentai.registry.category_dimensions",
+    "currentai.registry.category_license_tiers",
+    "currentai.registry.category_scoring_rules",
+    "currentai.registry.license_aliases",
+    "currentai.registry.product_categories",
+    "currentai.registry.products"
+   ],
+   "has_repository_source": true
+  },
+  {
+   "table": "currentai.scores.ossd_coverage",
+   "dataset": "scores",
+   "name": "ossd_coverage",
+   "model_id": "90926e3b-989f-4629-9f81-68805d86449e",
+   "revision_hash": "9e776127693b3e512cee8a11a66a565129fd55c37a1bc65bb4d1d8f5eafefefb",
+   "source_sha256": "b5b6f168a2925fb0786f49c0aedf1717cb1d90c2e04828627cfbb4c18246d5b3",
+   "language": "SQL",
+   "internal_reads": [
+    "currentai.entities.repos",
+    "currentai.signal_goodailist.repo_catalog"
+   ],
+   "in_scope_reads": [
+    "currentai.entities.repos",
+    "currentai.signal_goodailist.repo_catalog"
+   ],
+   "has_repository_source": true
+  },
+  {
+   "table": "currentai.scores.project_summary",
+   "dataset": "scores",
+   "name": "project_summary",
+   "model_id": "9c427ca5-f990-4c00-a67a-8f9dc3578ee3",
+   "revision_hash": "0919c6e46bf43986e37569a2ad86709ae9db92f6e16b19aa660e49b1f7672803",
+   "source_sha256": "a83b4a442fbb448918364ed6ace9dd836f1723aba53b99f3ecac4d9392699652",
+   "language": "SQL",
+   "internal_reads": [
+    "currentai.entities.models",
+    "currentai.entities.packages",
+    "currentai.entities.projects",
+    "currentai.entities.repos",
+    "currentai.metrics.daily",
+    "currentai.scores.fragility",
+    "currentai.signal_goodailist.repo_catalog"
+   ],
+   "in_scope_reads": [
+    "currentai.entities.models",
+    "currentai.entities.packages",
+    "currentai.entities.projects",
+    "currentai.entities.repos",
+    "currentai.metrics.daily",
+    "currentai.scores.fragility",
+    "currentai.signal_goodailist.repo_catalog"
+   ],
+   "has_repository_source": true
+  },
+  {
+   "table": "currentai.scores.repos_summary",
+   "dataset": "scores",
+   "name": "repos_summary",
+   "model_id": "90f7b07a-c058-49e3-afa5-c5ab2e0afaab",
+   "revision_hash": "1b285a7fdcf30e69885960ee73278aacce0d35cf521cde934574c0e1092e025a",
+   "source_sha256": "4b912dc36d6fc104515a1d2713ad1d3176e46f26f6102ae7504214d6b79e96b7",
+   "language": "SQL",
+   "internal_reads": [
+    "currentai.metrics.daily",
+    "currentai.signal_goodailist.repo_catalog"
+   ],
+   "in_scope_reads": [
+    "currentai.metrics.daily",
+    "currentai.signal_goodailist.repo_catalog"
+   ],
+   "has_repository_source": true
+  },
+  {
+   "table": "currentai.scores.stack_contributors",
+   "dataset": "scores",
+   "name": "stack_contributors",
+   "model_id": "27bc12ae-2004-46e1-95bf-7633aad562c9",
+   "revision_hash": "a81bbeac8b8fad7db4222b0b21dac93bbe9861578758670d082e3e1b4a368d8f",
+   "source_sha256": "3a1d54b86d810f30db43eaba7e204e32262f2de09d8c54c7c061bc52dc523e9f",
+   "language": "sql",
+   "internal_reads": [
+    "currentai.catalog.stack_map"
+   ],
+   "in_scope_reads": [
+    "currentai.catalog.stack_map"
+   ],
+   "has_repository_source": true
+  },
+  {
+   "table": "currentai.scores.taxonomy",
+   "dataset": "scores",
+   "name": "taxonomy",
+   "model_id": "7e62719e-34d0-403d-871a-7d460dc96dee",
+   "revision_hash": "d334afc8669f1724d3f0c51e2d14f723c3cb0ec08d64908c6411d72f802e1944",
+   "source_sha256": "282fe7ff0bc4be4655e075006638e796adc797536cfa0d3a7199ff27b556daad",
+   "language": "sql",
+   "internal_reads": [
+    "currentai.catalog.osai_gap_map",
+    "currentai.catalog.osai_subcategory_mapping",
+    "currentai.catalog.taxonomy_crosswalk",
+    "currentai.entities.repos"
+   ],
+   "in_scope_reads": [
+    "currentai.catalog.osai_gap_map",
+    "currentai.catalog.osai_subcategory_mapping",
+    "currentai.catalog.taxonomy_crosswalk",
+    "currentai.entities.repos"
+   ],
+   "has_repository_source": false
+  },
+  {
+   "table": "currentai.signal_artificialanalysis.model_evaluations",
+   "dataset": "signal_artificialanalysis",
+   "name": "model_evaluations",
+   "model_id": "dbce2dc6-9586-477d-8fe8-1c3ef8a7760c",
+   "revision_hash": "29ebb7544d66906b8018834fe74e7c4ac5a2dd71b166fe149b2b98b922e5cc22",
+   "source_sha256": "3d7cfb4b8e5564f1fc10362c33e897c39422ea9e61e4c3b7eb330c38fe4d01e0",
+   "language": "python",
+   "internal_reads": [],
+   "in_scope_reads": [],
+   "has_repository_source": true
+  },
+  {
+   "table": "currentai.signal_github.product_adoption",
+   "dataset": "signal_github",
+   "name": "product_adoption",
+   "model_id": "25538fa7-f956-481c-ac14-474ab1661ac3",
+   "revision_hash": "fab87a5e45a70663162a5421eb5037a5bca9cdbd49d4ab0b24d47b3688ed1da8",
+   "source_sha256": "902407a0e67f01c83161d12c5d7f75753d1b7b915d35c2630d127433a46bb96c",
+   "language": "sql",
+   "internal_reads": [
+    "currentai.registry.adoption_bands",
+    "currentai.registry.products",
+    "currentai.signal_github.repo_state",
+    "currentai.signal_huggingface.product_adoption",
+    "currentai.signal_pypi.package_downloads"
+   ],
+   "in_scope_reads": [
+    "currentai.registry.adoption_bands",
+    "currentai.registry.products",
+    "currentai.signal_github.repo_state",
+    "currentai.signal_huggingface.product_adoption",
+    "currentai.signal_pypi.package_downloads"
+   ],
+   "has_repository_source": true
+  },
+  {
+   "table": "currentai.signal_github.repo_state",
+   "dataset": "signal_github",
+   "name": "repo_state",
+   "model_id": "a50ce375-4b91-43c6-b1ce-1fc60911b513",
+   "revision_hash": "e2c6d13da3080e6f76117ed45651a10bd9f7cea3f6d848e2289705cdb725c17a",
+   "source_sha256": "278280e6e34b6ff7212aa5d29f0c2cd8cab8fdecb96a18d2f9770ba558711e6e",
+   "language": "python",
+   "internal_reads": [
+    "currentai.registry.product_artifacts"
+   ],
+   "in_scope_reads": [
+    "currentai.registry.product_artifacts"
+   ],
+   "has_repository_source": true
+  },
+  {
+   "table": "currentai.signal_goodailist.repo_catalog",
+   "dataset": "signal_goodailist",
+   "name": "repo_catalog",
+   "model_id": "c7d3a3d9-578c-4c54-8ccf-71879bdd43d2",
+   "revision_hash": "5a6e622459ef9cf8edaa80953eaff8dc15e093649493831485f49d3a794c4c57",
+   "source_sha256": "de3dacbd632760fe08467824c6e76534ce39e7024f98f08367340ab3ae8d6e7a",
+   "language": "python",
+   "internal_reads": [],
+   "in_scope_reads": [],
+   "has_repository_source": true
+  },
+  {
+   "table": "currentai.signal_huggingface.hub_state",
+   "dataset": "signal_huggingface",
+   "name": "hub_state",
+   "model_id": "014a0641-605f-4e57-831b-d24a1304437f",
+   "revision_hash": "d8221f7371ae8014e4d61582b45a4bf26d1d022ee0dbe43e73b073b1b676321a",
+   "source_sha256": "8e8480e30aea3dfd5664372acc3013e5a31c2ffa3ec0bdfd5c6f478077922ecc",
+   "language": "python",
+   "internal_reads": [
+    "currentai.registry.product_artifacts"
+   ],
+   "in_scope_reads": [
+    "currentai.registry.product_artifacts"
+   ],
+   "has_repository_source": true
+  },
+  {
+   "table": "currentai.signal_huggingface.product_adoption",
+   "dataset": "signal_huggingface",
+   "name": "product_adoption",
+   "model_id": "abcf0044-dd9d-4942-a2a1-e047dab8e8b1",
+   "revision_hash": "6b088f7d0bae8e0d399dc63a44ccbd190d34da27f7cedc21346be4a2dd1ce9b9",
+   "source_sha256": "c69720e61730982b52aa532d0f729e6aba6641145f37370afafbef32e62f819d",
+   "language": "sql",
+   "internal_reads": [
+    "currentai.registry.adoption_bands",
+    "currentai.registry.products",
+    "currentai.signal_huggingface.hub_state"
+   ],
+   "in_scope_reads": [
+    "currentai.registry.adoption_bands",
+    "currentai.registry.products",
+    "currentai.signal_huggingface.hub_state"
+   ],
+   "has_repository_source": true
+  },
+  {
+   "table": "currentai.signal_lmarena.text_leaderboard",
+   "dataset": "signal_lmarena",
+   "name": "text_leaderboard",
+   "model_id": "efb89f86-7aff-48df-a78e-ce01234672db",
+   "revision_hash": "d17f1b695ba042c54053bcbb75df5264c3376f2b98a707ed688e0d36870c9b8e",
+   "source_sha256": "2c3be50910c04b2fa2170d80cb7debc49a71e3fe54f8c0605cb8a4db614a5a69",
+   "language": "python",
+   "internal_reads": [],
+   "in_scope_reads": [],
+   "has_repository_source": true
+  },
+  {
+   "table": "currentai.signal_pypi.package_downloads",
+   "dataset": "signal_pypi",
+   "name": "package_downloads",
+   "model_id": "a88bff56-0a00-49d1-8667-809a79b4d7c0",
+   "revision_hash": "39511381c4f06644ff520f8182edc3d06cfeee60f21b5a976817e2a98ed4dfc7",
+   "source_sha256": "2a97775d6f261cae69a17296e09427dc58ac8ca18fe875d3741c931b64159a34",
+   "language": "sql",
+   "internal_reads": [
+    "currentai.registry.adoption_bands",
+    "currentai.registry.product_artifacts"
+   ],
+   "in_scope_reads": [
+    "currentai.registry.adoption_bands",
+    "currentai.registry.product_artifacts"
+   ],
+   "has_repository_source": true
+  },
+  {
+   "table": "currentai.signal_semanticscholar.paper_citations",
+   "dataset": "signal_semanticscholar",
+   "name": "paper_citations",
+   "model_id": "cc73d808-5833-4a91-a47b-35bb0414b6f0",
+   "revision_hash": "3e8211c27b6885aebc956016e503501d936ae1ccbcda5e8a33692bd09cba0f61",
+   "source_sha256": "084778a2becd4f152e30c895ea0c3012ba2186d148d3d418e15d4319f4049e87",
+   "language": "python",
+   "internal_reads": [
+    "currentai.registry.product_artifacts"
+   ],
+   "in_scope_reads": [
+    "currentai.registry.product_artifacts"
+   ],
+   "has_repository_source": true
+  },
+  {
+   "table": "currentai.state_of_os_ai.country_activity_monthly",
+   "dataset": "state_of_os_ai",
+   "name": "country_activity_monthly",
+   "model_id": "a19ba5ba-fec3-4a02-8cd9-e7b23835c576",
+   "revision_hash": "74aeec9346bda87bba2a1b2afc38a8e41c286990fa64708d58f5ed3caef86a08",
+   "source_sha256": "a501004cfd5e70b39f7d3e684e124832bc528a511a8a872fda7cd54c62c43063",
+   "language": "SQL",
+   "internal_reads": [
+    "currentai.entities.repos",
+    "currentai.metrics.daily"
+   ],
+   "in_scope_reads": [
+    "currentai.entities.repos",
+    "currentai.metrics.daily"
+   ],
+   "has_repository_source": false
+  },
+  {
+   "table": "currentai.state_of_os_ai.family_footprint",
+   "dataset": "state_of_os_ai",
+   "name": "family_footprint",
+   "model_id": "d718c2a5-7ea7-47a3-b250-4f639090b929",
+   "revision_hash": "d0357eb44f44a0bd9c584e7e1413f03a27fca74d3bed63e1b08a085bf4749255",
+   "source_sha256": "76613d6769d0169044d66f623df48a6aa7f4dc81470ff417a0f6bf2417e255cc",
+   "language": "SQL",
+   "internal_reads": [
+    "currentai.catalog.foundation_model_repos",
+    "currentai.hf_live.hf_models",
+    "currentai.scores.repos_summary"
+   ],
+   "in_scope_reads": [
+    "currentai.catalog.foundation_model_repos",
+    "currentai.scores.repos_summary"
+   ],
+   "has_repository_source": false
+  },
+  {
+   "table": "currentai.state_of_os_ai.geo_cohorts",
+   "dataset": "state_of_os_ai",
+   "name": "geo_cohorts",
+   "model_id": "b4e948e5-18ec-45ea-9199-036d6c89b955",
+   "revision_hash": "d2a555d56baeed9d5864f93dcc33bff4f521cc1a26d250660169528842858e84",
+   "source_sha256": "8c802e14b957d4204a0b9a65ca75e3f7948bafd421e395009950850d7abfccc3",
+   "language": "SQL",
+   "internal_reads": [
+    "currentai.entities.repos"
+   ],
+   "in_scope_reads": [
+    "currentai.entities.repos"
+   ],
+   "has_repository_source": false
+  },
+  {
+   "table": "currentai.state_of_os_ai.hf_model_landscape",
+   "dataset": "state_of_os_ai",
+   "name": "hf_model_landscape",
+   "model_id": "b75df876-3ad1-4e77-aea6-97a148cbeb7f",
+   "revision_hash": "0edd41c98cb163453dcb80c51bb3875202562f4e41fb1ae742153ac56e2a3d70",
+   "source_sha256": "deeb491764ee880d5459bf76cd45401c2af2b8cbf552cf358fb1cdb0fdc8d04d",
+   "language": "SQL",
+   "internal_reads": [
+    "currentai.hf_live.hf_models"
+   ],
+   "in_scope_reads": [],
+   "has_repository_source": false
+  },
+  {
+   "table": "currentai.state_of_os_ai.org_leaderboard",
+   "dataset": "state_of_os_ai",
+   "name": "org_leaderboard",
+   "model_id": "b19ac49a-5637-41b4-8063-599bcf393db3",
+   "revision_hash": "6957541cf22f00bb1f7c3f0b7250584b63e7afa7ad3ffc3ba7fd82677f81826c",
+   "source_sha256": "eb76d75c8787bd1e3ddc907ca2ddb1699acbf771c6d3fb3fc514e45af66b905f",
+   "language": "SQL",
+   "internal_reads": [
+    "currentai.scores.repos_summary"
+   ],
+   "in_scope_reads": [
+    "currentai.scores.repos_summary"
+   ],
+   "has_repository_source": false
+  },
+  {
+   "table": "currentai.state_of_os_ai.robotics_repos",
+   "dataset": "state_of_os_ai",
+   "name": "robotics_repos",
+   "model_id": "6f8f14dc-c70e-4c27-828d-b6ed5af8f2e6",
+   "revision_hash": "722befd10b08d3b09ab7052cff7dae986ee0c5313fb1ce67c60d450c421567d9",
+   "source_sha256": "59e8745c4491370e9ef8df631f7fe72220070239a9f81af194e5387f99faa182",
+   "language": "SQL",
+   "internal_reads": [
+    "currentai.scores.repos_summary"
+   ],
+   "in_scope_reads": [
+    "currentai.scores.repos_summary"
+   ],
+   "has_repository_source": false
+  },
+  {
+   "table": "currentai.state_of_os_ai.star_trajectories",
+   "dataset": "state_of_os_ai",
+   "name": "star_trajectories",
+   "model_id": "863b0be7-7252-4a73-b54b-f9c21dece986",
+   "revision_hash": "72370a1513106c95c9841fec65959d2a093df75c127017cddc7527cc6e4d1637",
+   "source_sha256": "087f0cc313f7e4174b3699da5aa7c6938bdc32f0bc607111c91666fd4927fb28",
+   "language": "SQL",
+   "internal_reads": [
+    "currentai.metrics.daily"
+   ],
+   "in_scope_reads": [
+    "currentai.metrics.daily"
+   ],
+   "has_repository_source": false
+  }
+ ]
+}


### PR DESCRIPTION
## What

Phase 0b. Read **all 41 deployed model definitions** in the `currentai` org (read-only, via the
OSO GraphQL API using `OSO_API_KEY`) and recorded what each reads. This closes the
`platform_models` gap that left `retirement_candidates()` empty on all 57 assets and nine assets
recorded only as "no reviewed consumer". No platform mutation, no file moves.

`uv run pytest -q` → **762 passed, no skips** (6m53s).

## Self-check reproduced ✅

`currentai.scores.taxonomy` is a deployed model with no repository source. Its extracted reads:
`catalog.osai_gap_map`, `catalog.osai_subcategory_mapping`, `catalog.taxonomy_crosswalk`,
`entities.repos` — so those three `catalog` tables leave the "no reviewed consumer" list on the
first model, as the phase brief required.

## Assets whose status changed

`platform_models: unknown → checked` on **all 57** (org-wide audit). Four assets gained a
reviewed consumer and left the "no reviewed consumer" set (9 → 5):

| Asset | New `platform_model_consumers` |
|---|---|
| `catalog.osai_gap_map` | `scores.taxonomy`, `scores.investment_ranking` |
| `catalog.osai_subcategory_mapping` | `scores.taxonomy`, `scores.investment_ranking` |
| `catalog.taxonomy_crosswalk` | `scores.taxonomy` |
| `signal_lmarena.text_leaderboard` | `ai_demand_curve.model_capability_current` |

Five more in-scope assets gained `platform_model_consumers` while already having repo readers
(`catalog.foundation_model_repos`, `entities.repos`, `metrics.daily`, `scores.fragility`,
`scores.repos_summary`) — recorded for completeness; they were never candidates.

## Retirement candidates: 0 → 5 — recorded, NOT acted on

Now that `platform_models` is `checked`, the derived list is non-empty for the first time. Per
**section 17**, retirement needs explicit maintainer authorization, a rollback path and a
consumer inventory first; this phase produces the inventory only. No `DROP`, no deletion, no
description or model change.

`scores.ossd_coverage`, `signal_github.product_adoption`, `signal_semanticscholar.paper_citations`,
`signal_artificialanalysis.model_evaluations`, `signal_packages.product_adoption`.

⚠️ `signal_github.product_adoption` holds the route precedence `pypi > huggingface > stars` in SQL
and **must not retire before `registry.adoption_routes` compiles that ordering** — its entry keeps
that note so a green candidate list can't imply it is safe.

## Deployed models with NO repository source (permanent blind spots)

These 17 are invisible to the repo-derived graph — the reason the audit was needed. The other 24
deployed models have a repository source (mirrors/repo models already in `read_by`).

| Deployed model | In-scope tables it reads |
|---|---|
| `currentai.ai_demand_curve.cost_of_intelligence_timeseries` | — (none in scope) |
| `currentai.ai_demand_curve.model_capability_current` | `signal_lmarena.text_leaderboard` |
| `currentai.ai_demand_curve.model_cost_capability` | — (none in scope) |
| `currentai.ai_demand_curve.model_pricing_current` | — (none in scope) |
| `currentai.ai_demand_curve.use_case_assumptions` | — (none in scope) |
| `currentai.ai_demand_curve.use_case_economics` | — (none in scope) |
| `currentai.datasette.datasette_plugins` | — (none in scope) |
| `currentai.datasette.fetch_probe` | — (none in scope) |
| `currentai.scores.investment_ranking` | `catalog.osai_gap_map`, `catalog.osai_subcategory_mapping`, `entities.repos`, `scores.fragility` |
| `currentai.scores.taxonomy` | `catalog.osai_gap_map`, `catalog.osai_subcategory_mapping`, `catalog.taxonomy_crosswalk`, `entities.repos` |
| `currentai.state_of_os_ai.country_activity_monthly` | `entities.repos`, `metrics.daily` |
| `currentai.state_of_os_ai.family_footprint` | `catalog.foundation_model_repos`, `scores.repos_summary` |
| `currentai.state_of_os_ai.geo_cohorts` | `entities.repos` |
| `currentai.state_of_os_ai.hf_model_landscape` | — (none in scope) |
| `currentai.state_of_os_ai.org_leaderboard` | `scores.repos_summary` |
| `currentai.state_of_os_ai.robotics_repos` | `scores.repos_summary` |
| `currentai.state_of_os_ai.star_trajectories` | `metrics.daily` |

## In-scope tables by number of deployed-model readers

| Table | # models | | Table | # models |
|---|---|---|---|---|
| `entities.repos` | 13 | | `signal_goodailist.repo_catalog` | 7 |
| `metrics.daily` | 5 | | `registry.product_artifacts` | 4 |
| `registry.adoption_bands` | 3 | | `registry.category_scoring_rules` | 3 |
| `registry.products` | 3 | | `scores.repos_summary` | 3 |
| `catalog.foundation_model_repos` | 2 | | `catalog.osai_gap_map` | 2 |
| `catalog.osai_subcategory_mapping` | 2 | | `registry.license_aliases` | 2 |
| `registry.product_categories` | 2 | | `scores.fragility` | 2 |
| `signal_github.repo_state` | 2 | | `signal_huggingface.hub_state` | 2 |

(26 further tables have exactly 1 deployed-model reader; full list in the audit scratch.)

## Dataset-count discrepancy explained

`ListDatasets` returns **22**, but `ListDataModels` spans 15 dataset names including `datasette`,
which `ListDatasets` omits — it holds two deployed models (`fetch_probe`, `datasette_plugins`) and
no materialized tables. So the org has a 23rd dataset a dataset-first sweep misses; Phase 0b
enumerated from models. Corrected in `data-architecture.md` §3 with the reason, not just a bumped
number.

## Code changes

- **`build/assets.py`**: new `refs_in_source(code, language)` — the text twin of `table_refs`,
  running the identical rules (SQL context only, quoted identifiers unquoted, comments/docstrings
  stripped, `depends_on:` honored). `table_refs` now delegates to it, so the repo graph and the
  platform audit extract identically — no second extractor to drift. Synthetic tests added.
- `retirement_candidates()` and `no_reviewed_consumers()` now honor `platform_model_consumers`
  ("no deployed platform model reads it", §11.2). `read_by`/`reads` are untouched — platform data
  never enters the repo-derived graph, the same rule the inventory already applies to `read_by`,
  so `render_dag()` and the gated DAG are unchanged.

## Blind spots (permanent, for the repo-derived graph)

Every deployed model above with no repository source is a permanent blind spot: the repo cannot
derive their reads, so any table only they consume would look unread. They are recorded here and
via `platform_model_consumers`; `external` stays `unknown` (nothing outside the org was read).

## Checklist

- [x] All 41 deployed models read; per-model in-scope references above, blind spots marked
- [x] `platform_models: checked` on all 57; `platform_model_consumers` populated where found
- [x] `scores.taxonomy` self-check reproduces; the three `catalog` tables are no longer "no reviewed consumer"
- [x] `migration-status.md` ledger matches the derived set; dataset-count discrepancy explained
- [x] `uv run pytest -q` passes with no skips (762 passed)
- [x] No platform mutation, no file moves; retirement candidates recorded and not acted on

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5bY5TtNtdqoxaeJBdNmXv)_