### PR TITLE
feat(operations): normalize pipeline schedules to UTC (Phase 1)

### DIFF
--- a/docs/architecture/migration-status.md
+++ b/docs/architecture/migration-status.md
@@ -10,8 +10,8 @@ file records only where the work has got to. Delete a row when it stops being te
 | Phase | State | Note |
 |---|---|---|
 | 0 — architecture record and inventory | done | Merged (#345). The repository now mirrors the warehouse. |
-| 0b — deployed model audit | in review | This PR. Read-only: all 41 deployed model definitions read; `platform_models` now `checked` on every asset. |
-| 1 — schedule normalization | not started | <!-- observed:2026-08-20 -->10 datasets on `America/New_York`; <!-- count:unobserved_crons -->18 assets have a cron and no observed run. No platform metadata change is pending — see below. |
+| 0b — deployed model audit | done | Merged (#347). All 41 deployed model definitions read; `platform_models` `checked` on every asset; receipt at `warehouse/audits/platform_models.json`. |
+| 1 — schedule normalization | runbook prepared, writes pending maintainer | <!-- observed:2026-08-20 -->13 datasets on `America/New_York`; Phase 1 relabels the 10 in-scope pipeline datasets to UTC (runbook `docs/operations/normalize-schedules.md`), leaving the 3 out-of-scope analytical datasets. <!-- count:unobserved_crons -->18 assets have a cron and no observed run. See below. |
 | 2 — normalized adoption observations | not started | Must compile `registry.adoption_routes` before any signal roll-up retires. |
 | 2B — incremental adoption history | blocked | Blocked on OSO incremental-model support. Not approximated with full-refresh models. |
 | 3 — reconciliation report | not started | Report-only first. |
@@ -54,6 +54,14 @@ line. The remediation is therefore ordered and platform-side:
 2. release a new revision of each affected model;
 3. refetch those revisions into the mirror under `warehouse/models/<dataset>/`;
 4. update each mirror's `revision`, `hash`, `local_sha256` and `synced_at` together.
+
+**Schedule normalization to UTC (Phase 1).** Ten in-scope pipeline datasets carry a
+daylight-saving `cronTimezone: America/New_York`. The relabel-only change (set `cronTimezone: UTC`,
+keep the cron digits) is scoped, its rollback captured, and the exact reversible `updateDataset`
+mutations prepared in `docs/operations/normalize-schedules.md`. The writes are a maintainer step
+and are not yet applied; `SCHEDULED`-run verification waits for the first weekly (Sunday) fire
+under UTC on/after 2026-08-23. The repository's `timezone` declarations stay `America/New_York`
+until the platform actually reflects UTC.
 
 **No description or schema change is pending.** An earlier draft of this file recorded a
 correction for the `catalog.stack_map` dataset description, on the grounds that its "read by no

--- a/docs/architecture/migration-status.md
+++ b/docs/architecture/migration-status.md
@@ -11,7 +11,7 @@ file records only where the work has got to. Delete a row when it stops being te
 |---|---|---|
 | 0 — architecture record and inventory | done | Merged (#345). The repository now mirrors the warehouse. |
 | 0b — deployed model audit | done | Merged (#347). All 41 deployed model definitions read; `platform_models` `checked` on every asset; receipt at `warehouse/audits/platform_models.json`. |
-| 1 — schedule normalization | runbook prepared, writes pending maintainer | <!-- observed:2026-08-20 -->13 datasets on `America/New_York`; Phase 1 relabels the 10 in-scope pipeline datasets to UTC (runbook `docs/operations/normalize-schedules.md`), leaving the 3 out-of-scope analytical datasets. <!-- count:unobserved_crons -->18 assets have a cron and no observed run. See below. |
+| 1 — schedule normalization | **applied 2026-08-22, verification pending** | Ten in-scope datasets relabelled to UTC; 3 out-of-scope analytical datasets left on `America/New_York` deliberately. <!-- count:unobserved_crons -->18 assets still have no observed run: §13 requires run history, not configuration, so this is not complete until a `SCHEDULED` fire is seen on/after 2026-08-23 01:00Z. See `docs/operations/normalize-schedules.md`. |
 | 2 — normalized adoption observations | not started | Must compile `registry.adoption_routes` before any signal roll-up retires. |
 | 2B — incremental adoption history | blocked | Blocked on OSO incremental-model support. Not approximated with full-refresh models. |
 | 3 — reconciliation report | not started | Report-only first. |

--- a/docs/architecture/migration-status.md
+++ b/docs/architecture/migration-status.md
@@ -55,13 +55,11 @@ line. The remediation is therefore ordered and platform-side:
 3. refetch those revisions into the mirror under `warehouse/models/<dataset>/`;
 4. update each mirror's `revision`, `hash`, `local_sha256` and `synced_at` together.
 
-**Schedule normalization to UTC (Phase 1).** Ten in-scope pipeline datasets carry a
-daylight-saving `cronTimezone: America/New_York`. The relabel-only change (set `cronTimezone: UTC`,
-keep the cron digits) is scoped, its rollback captured, and the exact reversible `updateDataset`
-mutations prepared in `docs/operations/normalize-schedules.md`. The writes are a maintainer step
-and are not yet applied; `SCHEDULED`-run verification waits for the first weekly (Sunday) fire
-under UTC on/after 2026-08-23. The repository's `timezone` declarations stay `America/New_York`
-until the platform actually reflects UTC.
+The Phase 1 schedule normalization is **no longer pending** — it was applied 2026-08-22 and is
+recorded in the phase table above and in `docs/operations/normalize-schedules.md`; `assets.yaml`
+declares `timezone: UTC` for the fifteen affected assets. The only thing still outstanding there
+is the observed `SCHEDULED` run, which is a verification (tracked by `unobserved_crons`), not an
+unapplied change.
 
 **No description or schema change is pending.** An earlier draft of this file recorded a
 correction for the `catalog.stack_map` dataset description, on the grounds that its "read by no

--- a/docs/operations/normalize-schedules.md
+++ b/docs/operations/normalize-schedules.md
@@ -5,13 +5,25 @@
 daylight-saving `cronTimezone: America/New_York`. Phase 1 normalizes the **10 in-scope
 pipeline datasets** to `UTC`.
 
-**Warehouse writes are a maintainer step** (see `AGENTS.md`, and §17). The change was
-scoped, its rollback captured, and the exact mutations prepared here, but the writes
-themselves must be run by a maintainer with OSO write credentials — the implementation agent
-cannot mutate the platform.
+**Warehouse writes are a maintainer step** (see `AGENTS.md`, and §17). This runbook was
+prepared read-only, then **applied on 2026-08-22 with maintainer authorization**. All ten
+mutations succeeded and were verified independently of the mutation responses: a fresh
+`ListDatasets` filtered on `cron_timezone` returns 3 datasets on `America/New_York`, down from
+13, and those 3 are the out-of-scope analytical datasets this runbook deliberately excludes.
+
+The rollback below remains valid and is kept for that reason, not because the change is
+pending.
 
 ## Decision on record
 
+- **The cron digits are a dependency staircase, and that is why relabelling is safe.** The
+  ten jobs are staged one hour apart, and the offsets encode the actual dependency order:
+  signals at 01:00–03:00, then `entities` at 04:00 (which reads `signal_goodailist`), `events`
+  at 05:00 (which reads `entities`), `metrics` at 06:00 (which reads `events`). Relabelling
+  moves all ten by the same four hours, so the ordering is preserved exactly. Recomputing the
+  digits per dataset to hold the wall-clock instant — the rejected alternative — would have
+  had to reproduce that staircase by hand, and a single wrong digit would run a model before
+  its input.
 - **Relabel only.** Set `cronTimezone: UTC` and keep the cron digits unchanged. Each job's
   fire time therefore moves from `HH:00` America/New_York to `HH:00` UTC (4–5 hours earlier
   in wall-clock terms), and stops drifting with daylight saving. This was chosen deliberately
@@ -73,6 +85,39 @@ for dataset_id, cron in TARGETS.items():
     r = graphql(M, {"input": {"id": dataset_id, "cron": cron, "cronTimezone": "UTC"}}, tok)
     print(dataset_id, r["updateDataset"]["success"])
 ```
+
+## Applied 2026-08-22
+
+All ten returned `success: true`. Verified by re-query, not by the mutation responses:
+
+| Dataset | cron | cronTimezone | nextRunAt |
+|---|---|---|---|
+| `signal_pypi` | `0 1 * * 0` | UTC | 2026-08-23T01:00:00Z |
+| `signal_lmarena` | `0 1 * * 0` | UTC | 2026-08-23T01:00:00Z |
+| `signal_goodailist` | `0 1 * * 0` | UTC | 2026-08-23T01:00:00Z |
+| `signal_semanticscholar` | `0 1 * * 0` | UTC | 2026-08-23T01:00:00Z |
+| `signal_artificialanalysis` | `0 1 * * 0` | UTC | 2026-08-23T01:00:00Z |
+| `signal_huggingface` | `0 2 * * 0` | UTC | 2026-08-23T02:00:00Z |
+| `signal_github` | `0 3 * * 0` | UTC | 2026-08-23T03:00:00Z |
+| `entities` | `0 4 * * 0` | UTC | 2026-08-23T04:00:00Z |
+| `events` | `0 5 * * 0` | UTC | 2026-08-23T05:00:00Z |
+| `metrics` | `0 6 * * 0` | UTC | 2026-08-23T06:00:00Z |
+
+The staircase is intact, and the Monday openness chain (`evidence` 03:00, `scores` 04:00 UTC)
+still runs a day after `metrics` finishes. The three excluded datasets remain on
+`America/New_York` at 12:00 UTC Sunday, still downstream of `metrics`.
+
+`warehouse/assets.yaml` declares `timezone: UTC` for the 15 assets those ten datasets hold —
+now a statement of platform truth rather than a claim ahead of it.
+
+## Still pending: an observed SCHEDULED run
+
+`last_observed_trigger` remains `null` on all 18 assets that have never been seen to fire, and
+`unobserved_crons` still reads 18. §13 requires run history, not configuration, as proof — so
+this phase is not complete until a `SCHEDULED` run is observed.
+
+The first fire under UTC is **2026-08-23 01:00Z**. Until then the change is applied but
+unproven, and that distinction is the whole point of the gate.
 
 ## Verify (after the next weekly fire)
 

--- a/docs/operations/normalize-schedules.md
+++ b/docs/operations/normalize-schedules.md
@@ -1,0 +1,104 @@
+# Runbook: Normalize pipeline schedules to UTC (Phase 1, maintainer)
+
+`data-architecture.md` §13 requires pinning actual schedules to UTC and verifying a
+`SCHEDULED` run from run history afterward. The Phase 0b audit confirmed 13 datasets carry a
+daylight-saving `cronTimezone: America/New_York`. Phase 1 normalizes the **10 in-scope
+pipeline datasets** to `UTC`.
+
+**Warehouse writes are a maintainer step** (see `AGENTS.md`, and §17). The change was
+scoped, its rollback captured, and the exact mutations prepared here, but the writes
+themselves must be run by a maintainer with OSO write credentials — the implementation agent
+cannot mutate the platform.
+
+## Decision on record
+
+- **Relabel only.** Set `cronTimezone: UTC` and keep the cron digits unchanged. Each job's
+  fire time therefore moves from `HH:00` America/New_York to `HH:00` UTC (4–5 hours earlier
+  in wall-clock terms), and stops drifting with daylight saving. This was chosen deliberately
+  over recomputing the digits to preserve the current wall-clock instant.
+- **In-scope pipeline only.** The out-of-scope analytical datasets `ai_demand_curve`,
+  `state_of_os_ai` and `aiid` are on `America/New_York` too but are **not** touched here —
+  they are outside the inventory this migration governs.
+
+## Baseline and target (captured 2026-08-22, read-only)
+
+`cron` is unchanged; only `cronTimezone` moves. The `America/New_York` value in each row is
+the rollback value.
+
+| Dataset | dataset_id | cron (unchanged) | cronTimezone | last observed run |
+|---|---|---|---|---|
+| `entities` | `663132ed-ea4a-4fce-97a8-742e4479269c` | `0 4 * * 0` | `America/New_York` → `UTC` | — |
+| `events` | `b2109421-64a8-4681-9d28-65a37a286f97` | `0 5 * * 0` | `America/New_York` → `UTC` | — |
+| `metrics` | `5a73a919-79da-4029-ae5c-f5653bcc1e62` | `0 6 * * 0` | `America/New_York` → `UTC` | — |
+| `signal_github` | `cc74e8db-7718-4615-a004-7f27cabaf967` | `0 3 * * 0` | `America/New_York` → `UTC` | 2026-08-15T07:00:13Z |
+| `signal_huggingface` | `6108e4d6-868f-4cba-8df5-ee64f8fb301e` | `0 2 * * 0` | `America/New_York` → `UTC` | 2026-08-15T07:00:13Z |
+| `signal_pypi` | `c7c3a04c-7e2d-4cea-a7e6-5861c725ea65` | `0 1 * * 0` | `America/New_York` → `UTC` | — |
+| `signal_lmarena` | `f248f653-2ea6-4fdf-badb-c99adf9bcbe4` | `0 1 * * 0` | `America/New_York` → `UTC` | 2026-08-15T07:00:13Z |
+| `signal_goodailist` | `f7f36dd4-ba41-4ee6-9547-65e409046893` | `0 1 * * 0` | `America/New_York` → `UTC` | 2026-08-16T07:00:14Z |
+| `signal_semanticscholar` | `a48ec2ff-1e15-4b22-a38e-8ae03e0096f7` | `0 1 * * 0` | `America/New_York` → `UTC` | — |
+| `signal_artificialanalysis` | `7ce58fca-9dda-4a95-8a17-9cef500c0656` | `0 1 * * 0` | `America/New_York` → `UTC` | 2026-08-15T07:00:13Z |
+
+## Apply (maintainer, with OSO write credentials)
+
+Each dataset is one `updateDataset` mutation against `https://api.oso.xyz/v1/graphql`, cron
+unchanged, `cronTimezone: "UTC"`:
+
+```graphql
+mutation($input: UpdateDatasetInput!){
+  updateDataset(input: $input){ success message dataset{ id name cron cronTimezone } }
+}
+```
+
+Run it for each `dataset_id` above, e.g. with the repo's existing client:
+
+```python
+import os
+from build.publish_registry import graphql
+M = ("mutation($input: UpdateDatasetInput!){ updateDataset(input:$input){ "
+     "success message dataset{ id name cron cronTimezone } } }")
+tok = os.environ["OSO_API_KEY"]           # a key with write scope
+TARGETS = {
+    "663132ed-ea4a-4fce-97a8-742e4479269c": "0 4 * * 0",   # entities
+    "b2109421-64a8-4681-9d28-65a37a286f97": "0 5 * * 0",   # events
+    "5a73a919-79da-4029-ae5c-f5653bcc1e62": "0 6 * * 0",   # metrics
+    "cc74e8db-7718-4615-a004-7f27cabaf967": "0 3 * * 0",   # signal_github
+    "6108e4d6-868f-4cba-8df5-ee64f8fb301e": "0 2 * * 0",   # signal_huggingface
+    "c7c3a04c-7e2d-4cea-a7e6-5861c725ea65": "0 1 * * 0",   # signal_pypi
+    "f248f653-2ea6-4fdf-badb-c99adf9bcbe4": "0 1 * * 0",   # signal_lmarena
+    "f7f36dd4-ba41-4ee6-9547-65e409046893": "0 1 * * 0",   # signal_goodailist
+    "a48ec2ff-1e15-4b22-a38e-8ae03e0096f7": "0 1 * * 0",   # signal_semanticscholar
+    "7ce58fca-9dda-4a95-8a17-9cef500c0656": "0 1 * * 0",   # signal_artificialanalysis
+}
+for dataset_id, cron in TARGETS.items():
+    r = graphql(M, {"input": {"id": dataset_id, "cron": cron, "cronTimezone": "UTC"}}, tok)
+    print(dataset_id, r["updateDataset"]["success"])
+```
+
+## Verify (after the next weekly fire)
+
+The crons fire weekly on **Sunday**; the first fire under UTC is **2026-08-23**. `SCHEDULED`
+verification cannot be done at apply time — wait for that fire, then confirm each dataset's
+run history shows a `SCHEDULED` (not `MANUAL`) trigger:
+
+```python
+q = "query($w: JSON){ datasets(where:$w){ edges{ node{ name cron cronTimezone lastRunAt } } } }"
+# and GetRunsForDataset / the runs API for the trigger type on the newest run
+```
+
+Confirm `cronTimezone == "UTC"` on all ten, and a `SCHEDULED` run dated on/after 2026-08-23.
+
+## Then, in the repository (a follow-up PR)
+
+Only once the platform reflects UTC — never before, or the inventory would declare a state
+that is not true:
+
+1. Set `timezone: UTC` on the ten datasets' assets in `warehouse/assets.yaml` (cron digits in
+   `refresh:` are unchanged).
+2. Set `last_observed_trigger: SCHEDULED` and `last_run_at` for each verified dataset.
+3. Regenerate any affected count markers (`unobserved_crons`) and run `uv run pytest -q`.
+
+## Rollback
+
+Reversible: re-run the apply mutation for the affected `dataset_id`(s) with
+`cronTimezone: "America/New_York"` and the same `cron`. No data is rewritten — only schedule
+metadata — so a rollback restores the prior state exactly.

--- a/warehouse/assets.yaml
+++ b/warehouse/assets.yaml
@@ -372,7 +372,7 @@ assets:
   producer: warehouse/models/entities/models.sql
   classification_note: discovered from the goodailist roster, not curated
   refresh: dataset cron '0 4 * * 0'
-  timezone: America/New_York
+  timezone: UTC
   last_observed_trigger: null
   last_run_at: null
   dataset_id: 663132ed-ea4a-4fce-97a8-742e4479269c
@@ -413,7 +413,7 @@ assets:
   producer: warehouse/models/entities/packages.sql
   classification_note: discovered from the goodailist roster, not curated
   refresh: dataset cron '0 4 * * 0'
-  timezone: America/New_York
+  timezone: UTC
   last_observed_trigger: null
   last_run_at: null
   dataset_id: 663132ed-ea4a-4fce-97a8-742e4479269c
@@ -455,7 +455,7 @@ assets:
   producer: warehouse/models/entities/projects.sql
   classification_note: discovered from the goodailist roster, not curated
   refresh: dataset cron '0 4 * * 0'
-  timezone: America/New_York
+  timezone: UTC
   last_observed_trigger: null
   last_run_at: null
   dataset_id: 663132ed-ea4a-4fce-97a8-742e4479269c
@@ -512,7 +512,7 @@ assets:
   producer: warehouse/models/entities/repos.sql
   classification_note: discovered from the goodailist roster, not curated
   refresh: dataset cron '0 4 * * 0'
-  timezone: America/New_York
+  timezone: UTC
   last_observed_trigger: null
   last_run_at: null
   dataset_id: 663132ed-ea4a-4fce-97a8-742e4479269c
@@ -552,7 +552,7 @@ assets:
   producer: warehouse/models/events/github_events.sql
   classification_note: artifact-level measurement over time
   refresh: dataset cron '0 5 * * 0'
-  timezone: America/New_York
+  timezone: UTC
   last_observed_trigger: null
   last_run_at: null
   dataset_id: b2109421-64a8-4681-9d28-65a37a286f97
@@ -660,7 +660,7 @@ assets:
   producer: warehouse/models/metrics/daily.sql
   classification_note: artifact-level measurement over time
   refresh: dataset cron '0 6 * * 0'
-  timezone: America/New_York
+  timezone: UTC
   last_observed_trigger: null
   last_run_at: null
   dataset_id: 5a73a919-79da-4029-ae5c-f5653bcc1e62
@@ -1596,7 +1596,7 @@ assets:
   grain: one row per Artificial Analysis model id
   producer: warehouse/models/signal_artificialanalysis/model_evaluations.py
   refresh: dataset cron '0 1 * * 0'
-  timezone: America/New_York
+  timezone: UTC
   last_observed_trigger: MANUAL
   last_run_at: '2026-08-15'
   dataset_id: 7ce58fca-9dda-4a95-8a17-9cef500c0656
@@ -1648,7 +1648,7 @@ assets:
   producer: warehouse/models/signal_github/product_adoption.sql
   classification_note: a banded candidate assessment, not a raw measurement
   refresh: dataset cron '0 3 * * 0'
-  timezone: America/New_York
+  timezone: UTC
   last_observed_trigger: MANUAL
   last_run_at: '2026-08-15'
   dataset_id: cc74e8db-7718-4615-a004-7f27cabaf967
@@ -1699,7 +1699,7 @@ assets:
   grain: one row per (product_slug, repo) at one fetched_at
   producer: warehouse/models/signal_github/repo_state.py
   refresh: dataset cron '0 3 * * 0'
-  timezone: America/New_York
+  timezone: UTC
   last_observed_trigger: MANUAL
   last_run_at: '2026-08-15'
   dataset_id: cc74e8db-7718-4615-a004-7f27cabaf967
@@ -1748,7 +1748,7 @@ assets:
     UDM on its own cron, so there is nothing to mirror into warehouse/data/. A mirror could only be
     staler than the live table, and it was: the frozen CSV still listed 300 repos goodailist.com had delisted.'
   refresh: dataset cron '0 1 * * 0'
-  timezone: America/New_York
+  timezone: UTC
   last_observed_trigger: MANUAL
   last_run_at: '2026-08-16'
   dataset_id: f7f36dd4-ba41-4ee6-9547-65e409046893
@@ -1791,7 +1791,7 @@ assets:
   grain: one row per (product_slug, artifact_kind, artifact_id) at one fetched_at
   producer: warehouse/models/signal_huggingface/hub_state.py
   refresh: dataset cron '0 2 * * 0'
-  timezone: America/New_York
+  timezone: UTC
   last_observed_trigger: MANUAL
   last_run_at: '2026-08-15'
   dataset_id: 6108e4d6-868f-4cba-8df5-ee64f8fb301e
@@ -1838,7 +1838,7 @@ assets:
   producer: warehouse/models/signal_huggingface/product_adoption.sql
   classification_note: a banded candidate assessment, not a raw measurement
   refresh: dataset cron '0 2 * * 0'
-  timezone: America/New_York
+  timezone: UTC
   last_observed_trigger: MANUAL
   last_run_at: '2026-08-15'
   dataset_id: 6108e4d6-868f-4cba-8df5-ee64f8fb301e
@@ -1876,7 +1876,7 @@ assets:
   grain: one row per (model_name, category, arena_config)
   producer: warehouse/models/signal_lmarena/text_leaderboard.py
   refresh: dataset cron '0 1 * * 0'
-  timezone: America/New_York
+  timezone: UTC
   last_observed_trigger: MANUAL
   last_run_at: '2026-08-15'
   dataset_id: f248f653-2ea6-4fdf-badb-c99adf9bcbe4
@@ -2024,7 +2024,7 @@ assets:
   grain: one row per (product_slug, package) over a 30-day window
   producer: warehouse/models/signal_pypi/package_downloads.sql
   refresh: dataset cron '0 1 * * 0'
-  timezone: America/New_York
+  timezone: UTC
   last_observed_trigger: null
   last_run_at: null
   dataset_id: c7c3a04c-7e2d-4cea-a7e6-5861c725ea65
@@ -2063,7 +2063,7 @@ assets:
   grain: one row per (product_slug, arxiv_id)
   producer: warehouse/models/signal_semanticscholar/paper_citations.py
   refresh: dataset cron '0 1 * * 0'
-  timezone: America/New_York
+  timezone: UTC
   last_observed_trigger: null
   last_run_at: null
   dataset_id: a48ec2ff-1e15-4b22-a38e-8ae03e0096f7


### PR DESCRIPTION
## What

Phase 1 pins the pipeline schedules to UTC (`data-architecture.md` §13). The change is a
**platform write** — a maintainer step (`AGENTS.md`; §17). The runbook was prepared read-only
(the implementation environment denies platform writes), then the writes were **applied on
2026-08-22 with maintainer authorization**.

## Decisions (maintainer)

- **Relabel-only**: `cronTimezone → UTC`, cron digits unchanged. Each job moves from `HH:00`
  ET to `HH:00` UTC and stops drifting with DST. Chosen over recomputing digits to preserve
  the wall-clock instant.
- **In-scope pipeline only** (10 datasets). The out-of-scope analytical datasets
  `ai_demand_curve`, `state_of_os_ai`, `aiid` are on `America/New_York` too but are left
  untouched.

## Applied, and verified by re-query

Ten `updateDataset` calls, all `success: true`. Verified independently of the mutation
responses: a fresh read returns **10/10** in-scope datasets on `cronTimezone: UTC` (cron digits
unchanged) and the **3** out-of-scope analytical datasets still on `America/New_York` — down
from 13.

`warehouse/assets.yaml` now declares `timezone: UTC` for the **15** assets those ten datasets
hold (15 rather than 10 because the inventory is per-table and `entities` alone holds four).
That declaration was withheld until the writes landed — declaring ahead of the platform is a
false claim the gates would then "pass".

## Why relabelling was safe — the dependency staircase

The cron digits encode the real dependency order; the ten jobs are staged an hour apart:

```
01:00  pypi, lmarena, goodailist, semanticscholar, artificialanalysis
02:00  huggingface
03:00  github
04:00  entities   <- reads signal_goodailist
05:00  events     <- reads entities
06:00  metrics    <- reads events
```

Relabelling moves all ten by the same four hours, so the ordering survives exactly. Recomputing
the digits to hold the wall-clock instant would have had to reproduce that staircase by hand,
and one wrong digit runs a model before its input. The Monday openness chain (`evidence` 03:00,
`scores` 04:00 UTC) still runs a day after `metrics`; the three excluded datasets (12:00 UTC
Sunday) stay downstream of it.

## What is deliberately NOT claimed

`last_observed_trigger` stays `null` on all 18 assets never seen to fire, and `unobserved_crons`
still reads **18**. §13 requires run history rather than configuration as proof, so Phase 1 is
**applied and unproven** until a `SCHEDULED` run is observed on or after **2026-08-23 01:00Z**.
That distinction is the point of the gate.

## Contents

- `docs/operations/normalize-schedules.md` — baseline (rollback values), the 10 `updateDataset`
  mutations, the applied-and-re-queried result, the `SCHEDULED`-run verification procedure, and
  the rollback.
- `warehouse/assets.yaml` — `timezone: UTC` on the 15 affected assets (platform truth, post-apply).
- `migration-status.md` — Phase 1 → **applied 2026-08-22, verification pending**; the stale
  "not yet applied" paragraph removed (it now points at the applied record); the "13 datasets"
  figure carried; 0b row marked done (#347).

## Follow-up (separate PR, after a Sunday fire is observed)

Set `last_observed_trigger: SCHEDULED` / `last_run_at` on the verified datasets, regenerate
`unobserved_crons`, and run the suite. The cloud verification is gated to the 2026-08-23 fire.

## Checklist

- [x] Writes applied with maintainer authorization; rollback captured (per-dataset prior `cronTimezone` + `cron`)
- [x] Verified by re-query, not by mutation responses (10/10 UTC; 3 out-of-scope untouched)
- [x] `timezone: UTC` declared only after the platform reflected it; `last_observed_trigger`/`unobserved_crons` unchanged (verification, not config, still pending)
- [x] `uv run pytest -q` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)