### PR TITLE
docs(migration): verify Phase 1 scheduled runs

### DIFF
--- a/docs/architecture/migration-status.md
+++ b/docs/architecture/migration-status.md
@@ -3,7 +3,7 @@
 Temporary phase state and the retirement ledger. Rules live in `data-architecture.md`; this
 file records only where the work has got to. Delete a row when it stops being temporary.
 
-**As of 2026-08-20; deployed-model audit (Phase 0b) 2026-08-22.**
+**As of 2026-08-20; deployed-model audit (Phase 0b) 2026-08-22; Phase 1 verified 2026-08-23.**
 
 ## Phase state
 
@@ -11,7 +11,7 @@ file records only where the work has got to. Delete a row when it stops being te
 |---|---|---|
 | 0 — architecture record and inventory | done | Merged (#345). The repository now mirrors the warehouse. |
 | 0b — deployed model audit | done | Merged (#347). All 41 deployed model definitions read; `platform_models` `checked` on every asset; receipt at `warehouse/audits/platform_models.json`. |
-| 1 — schedule normalization | **applied 2026-08-22, verification pending** | Ten in-scope datasets relabelled to UTC; 3 out-of-scope analytical datasets left on `America/New_York` deliberately. <!-- count:unobserved_crons -->18 assets still have no observed run: §13 requires run history, not configuration, so this is not complete until a `SCHEDULED` fire is seen on/after 2026-08-23 01:00Z. See `docs/operations/normalize-schedules.md`. |
+| 1 — schedule normalization | done | Applied (#349) and **verified 2026-08-23**: all ten in-scope datasets fired a `SCHEDULED` run on their UTC cron (01:00–06:00Z Sunday), the run-history proof §13 requires; 3 out-of-scope analytical datasets left on `America/New_York` deliberately. <!-- count:unobserved_crons -->10 assets still have no observed run, all outside Phase 1's scope. Two model runs failed on the scheduled fire — a transient `ConnectTimeout` on `metrics` (cleared on re-run) and a reproducible upstream `429` on `signal_semanticscholar.paper_citations` — but neither is a schedule defect; see the note below. `docs/operations/normalize-schedules.md` carries the per-dataset evidence. |
 | 2 — normalized adoption observations | not started | Must compile `registry.adoption_routes` before any signal roll-up retires. |
 | 2B — incremental adoption history | blocked | Blocked on OSO incremental-model support. Not approximated with full-refresh models. |
 | 3 — reconciliation report | not started | Report-only first. |
@@ -55,11 +55,26 @@ line. The remediation is therefore ordered and platform-side:
 3. refetch those revisions into the mirror under `warehouse/models/<dataset>/`;
 4. update each mirror's `revision`, `hash`, `local_sha256` and `synced_at` together.
 
-The Phase 1 schedule normalization is **no longer pending** — it was applied 2026-08-22 and is
-recorded in the phase table above and in `docs/operations/normalize-schedules.md`; `assets.yaml`
-declares `timezone: UTC` for the fifteen affected assets. The only thing still outstanding there
-is the observed `SCHEDULED` run, which is a verification (tracked by `unobserved_crons`), not an
-unapplied change.
+The Phase 1 schedule normalization is **complete** — applied 2026-08-22 and verified 2026-08-23,
+recorded in the phase table above and in `docs/operations/normalize-schedules.md`. All ten in-scope
+datasets fired a `SCHEDULED` run on their UTC cron, so `assets.yaml` records `last_observed_trigger:
+SCHEDULED` and `last_run_at: '2026-08-23'` for the fifteen affected assets alongside `timezone: UTC`.
+Nothing there is outstanding.
+
+**Two deployed-model failures surfaced on the first scheduled fire — tracked here, not Phase 1
+blockers.** The schedule is what Phase 1 changed and what it verified; whether a model's own body
+then succeeds is separate. Both failing models fired exactly on their UTC cron.
+
+1. `metrics.daily` failed its 06:00Z run on a transient `ConnectTimeout` while materializing. A
+   manual re-run the same morning succeeded, so this was infrastructure flakiness, not a defect;
+   the model is healthy.
+2. `signal_semanticscholar.paper_citations` failed its 01:00Z run on an upstream Semantic Scholar
+   HTTP `429` (`semantic scholar batch returned 429 for 24 ids`), and a manual re-run failed
+   identically — reproducible, not a blip. Root cause: the deployed UDM has no 429 backoff/retry,
+   unlike the repo's own `warehouse/models/catalog/model_repos.py`. The fix (backoff, or an
+   authenticated Semantic Scholar key) is a **platform-owned model change** under §17, out of Phase
+   1's scope. The asset has no reviewed consumer (pre-positioned per the inventory below), so no
+   pipeline is affected. Recorded for a maintainer; not acted on here.
 
 **No description or schema change is pending.** An earlier draft of this file recorded a
 correction for the `catalog.stack_map` dataset description, on the grounds that its "read by no

--- a/docs/operations/normalize-schedules.md
+++ b/docs/operations/normalize-schedules.md
@@ -110,37 +110,47 @@ still runs a day after `metrics` finishes. The three excluded datasets remain on
 `warehouse/assets.yaml` declares `timezone: UTC` for the 15 assets those ten datasets hold —
 now a statement of platform truth rather than a claim ahead of it.
 
-## Still pending: an observed SCHEDULED run
+## Verified 2026-08-23 — every dataset fired SCHEDULED on its UTC cron
 
-`last_observed_trigger` remains `null` on all 18 assets that have never been seen to fire, and
-`unobserved_crons` still reads 18. §13 requires run history, not configuration, as proof — so
-this phase is not complete until a `SCHEDULED` run is observed.
+The first weekly fire under UTC was **Sunday 2026-08-23**. Run history — not configuration — is
+the proof §13 demands, and it is now in hand. Each dataset's newest run at or after its UTC fire
+time carries `triggerType: SCHEDULED` (verified by the runs API, not `datasets.lastRunAt`, which
+lags), and `cronTimezone == "UTC"` still holds on all ten. The schedule normalization is proven.
 
-The first fire under UTC is **2026-08-23 01:00Z**. Until then the change is applied but
-unproven, and that distinction is the whole point of the gate.
+| Dataset | UTC fire | Trigger | Model status | Run started |
+|---|---|---|---|---|
+| `signal_pypi` | 01:00 | SCHEDULED | SUCCESS | 2026-08-23T01:00:15Z |
+| `signal_lmarena` | 01:00 | SCHEDULED | SUCCESS | 2026-08-23T01:00:17Z |
+| `signal_goodailist` | 01:00 | SCHEDULED | SUCCESS | 2026-08-23T01:00:16Z |
+| `signal_semanticscholar` | 01:00 | SCHEDULED | **FAILED** (upstream 429) | 2026-08-23T01:00:14Z |
+| `signal_artificialanalysis` | 01:00 | SCHEDULED | SUCCESS | 2026-08-23T01:00:15Z |
+| `signal_huggingface` | 02:00 | SCHEDULED | SUCCESS | 2026-08-23T02:01:42Z |
+| `signal_github` | 03:00 | SCHEDULED | SUCCESS | 2026-08-23T03:01:43Z |
+| `entities` | 04:00 | SCHEDULED | SUCCESS | 2026-08-23T04:00:29Z |
+| `events` | 05:00 | SCHEDULED | SUCCESS | 2026-08-23T05:00:16Z |
+| `metrics` | 06:00 | SCHEDULED | **FAILED** (transient ConnectTimeout) | 2026-08-23T06:00:16Z |
 
-## Verify (after the next weekly fire)
+**The two failures are model-body failures, not schedule defects — both fired exactly on their UTC
+cron.** They are recorded here and in `docs/architecture/migration-status.md`; neither gates Phase 1.
 
-The crons fire weekly on **Sunday**; the first fire under UTC is **2026-08-23**. `SCHEDULED`
-verification cannot be done at apply time — wait for that fire, then confirm each dataset's
-run history shows a `SCHEDULED` (not `MANUAL`) trigger:
+- `metrics.daily` timed out (`ConnectTimeout`) during materialization at 06:00Z. A manual re-run
+  the same morning (08:54→09:02Z) succeeded, so this was transient infrastructure, not a defect.
+- `signal_semanticscholar.paper_citations` hit an upstream Semantic Scholar HTTP `429`
+  (`semantic scholar batch returned 429 for 24 ids`); a manual re-run failed identically, so it is
+  reproducible. The deployed UDM has no 429 backoff (the repo's `warehouse/models/catalog/model_repos.py`
+  does). The fix is a platform-owned model change under §17; the asset has no reviewed consumer, so
+  nothing downstream is affected. Recorded for a maintainer, not acted on here.
 
-```python
-q = "query($w: JSON){ datasets(where:$w){ edges{ node{ name cron cronTimezone lastRunAt } } } }"
-# and GetRunsForDataset / the runs API for the trigger type on the newest run
-```
+## Recorded in the repository (this PR)
 
-Confirm `cronTimezone == "UTC"` on all ten, and a `SCHEDULED` run dated on/after 2026-08-23.
+The inventory now reflects the proven platform state — never ahead of it:
 
-## Then, in the repository (a follow-up PR)
-
-Only once the platform reflects UTC — never before, or the inventory would declare a state
-that is not true:
-
-1. Set `timezone: UTC` on the ten datasets' assets in `warehouse/assets.yaml` (cron digits in
-   `refresh:` are unchanged).
-2. Set `last_observed_trigger: SCHEDULED` and `last_run_at` for each verified dataset.
-3. Regenerate any affected count markers (`unobserved_crons`) and run `uv run pytest -q`.
+1. `timezone: UTC` was already set on the fifteen affected assets at apply time (unchanged here).
+2. `last_observed_trigger: SCHEDULED` and `last_run_at: '2026-08-23'` set on all fifteen — every
+   one of the ten datasets fired SCHEDULED, so every asset they hold records the observation
+   (including `signal_semanticscholar`, whose schedule fired even though its model failed).
+3. `unobserved_crons` recomputed 18 → 10 (the remaining ten are all out of Phase 1's scope); the
+   marker in `docs/architecture/migration-status.md` is updated and `uv run pytest -q` passes.
 
 ## Rollback
 

--- a/warehouse/assets.yaml
+++ b/warehouse/assets.yaml
@@ -373,8 +373,8 @@ assets:
   classification_note: discovered from the goodailist roster, not curated
   refresh: dataset cron '0 4 * * 0'
   timezone: UTC
-  last_observed_trigger: null
-  last_run_at: null
+  last_observed_trigger: SCHEDULED
+  last_run_at: '2026-08-23'
   dataset_id: 663132ed-ea4a-4fce-97a8-742e4479269c
   owner: carl
   status: active
@@ -414,8 +414,8 @@ assets:
   classification_note: discovered from the goodailist roster, not curated
   refresh: dataset cron '0 4 * * 0'
   timezone: UTC
-  last_observed_trigger: null
-  last_run_at: null
+  last_observed_trigger: SCHEDULED
+  last_run_at: '2026-08-23'
   dataset_id: 663132ed-ea4a-4fce-97a8-742e4479269c
   owner: carl
   status: active
@@ -456,8 +456,8 @@ assets:
   classification_note: discovered from the goodailist roster, not curated
   refresh: dataset cron '0 4 * * 0'
   timezone: UTC
-  last_observed_trigger: null
-  last_run_at: null
+  last_observed_trigger: SCHEDULED
+  last_run_at: '2026-08-23'
   dataset_id: 663132ed-ea4a-4fce-97a8-742e4479269c
   owner: carl
   status: active
@@ -513,8 +513,8 @@ assets:
   classification_note: discovered from the goodailist roster, not curated
   refresh: dataset cron '0 4 * * 0'
   timezone: UTC
-  last_observed_trigger: null
-  last_run_at: null
+  last_observed_trigger: SCHEDULED
+  last_run_at: '2026-08-23'
   dataset_id: 663132ed-ea4a-4fce-97a8-742e4479269c
   owner: carl
   status: active
@@ -553,8 +553,8 @@ assets:
   classification_note: artifact-level measurement over time
   refresh: dataset cron '0 5 * * 0'
   timezone: UTC
-  last_observed_trigger: null
-  last_run_at: null
+  last_observed_trigger: SCHEDULED
+  last_run_at: '2026-08-23'
   dataset_id: b2109421-64a8-4681-9d28-65a37a286f97
   owner: carl
   status: active
@@ -661,8 +661,8 @@ assets:
   classification_note: artifact-level measurement over time
   refresh: dataset cron '0 6 * * 0'
   timezone: UTC
-  last_observed_trigger: null
-  last_run_at: null
+  last_observed_trigger: SCHEDULED
+  last_run_at: '2026-08-23'
   dataset_id: 5a73a919-79da-4029-ae5c-f5653bcc1e62
   owner: carl
   status: active
@@ -1597,8 +1597,8 @@ assets:
   producer: warehouse/models/signal_artificialanalysis/model_evaluations.py
   refresh: dataset cron '0 1 * * 0'
   timezone: UTC
-  last_observed_trigger: MANUAL
-  last_run_at: '2026-08-15'
+  last_observed_trigger: SCHEDULED
+  last_run_at: '2026-08-23'
   dataset_id: 7ce58fca-9dda-4a95-8a17-9cef500c0656
   owner: carl
   status: active
@@ -1649,8 +1649,8 @@ assets:
   classification_note: a banded candidate assessment, not a raw measurement
   refresh: dataset cron '0 3 * * 0'
   timezone: UTC
-  last_observed_trigger: MANUAL
-  last_run_at: '2026-08-15'
+  last_observed_trigger: SCHEDULED
+  last_run_at: '2026-08-23'
   dataset_id: cc74e8db-7718-4615-a004-7f27cabaf967
   owner: carl
   status: active
@@ -1700,8 +1700,8 @@ assets:
   producer: warehouse/models/signal_github/repo_state.py
   refresh: dataset cron '0 3 * * 0'
   timezone: UTC
-  last_observed_trigger: MANUAL
-  last_run_at: '2026-08-15'
+  last_observed_trigger: SCHEDULED
+  last_run_at: '2026-08-23'
   dataset_id: cc74e8db-7718-4615-a004-7f27cabaf967
   owner: carl
   status: active
@@ -1749,8 +1749,8 @@ assets:
     staler than the live table, and it was: the frozen CSV still listed 300 repos goodailist.com had delisted.'
   refresh: dataset cron '0 1 * * 0'
   timezone: UTC
-  last_observed_trigger: MANUAL
-  last_run_at: '2026-08-16'
+  last_observed_trigger: SCHEDULED
+  last_run_at: '2026-08-23'
   dataset_id: f7f36dd4-ba41-4ee6-9547-65e409046893
   owner: carl
   status: active
@@ -1792,8 +1792,8 @@ assets:
   producer: warehouse/models/signal_huggingface/hub_state.py
   refresh: dataset cron '0 2 * * 0'
   timezone: UTC
-  last_observed_trigger: MANUAL
-  last_run_at: '2026-08-15'
+  last_observed_trigger: SCHEDULED
+  last_run_at: '2026-08-23'
   dataset_id: 6108e4d6-868f-4cba-8df5-ee64f8fb301e
   owner: carl
   status: active
@@ -1839,8 +1839,8 @@ assets:
   classification_note: a banded candidate assessment, not a raw measurement
   refresh: dataset cron '0 2 * * 0'
   timezone: UTC
-  last_observed_trigger: MANUAL
-  last_run_at: '2026-08-15'
+  last_observed_trigger: SCHEDULED
+  last_run_at: '2026-08-23'
   dataset_id: 6108e4d6-868f-4cba-8df5-ee64f8fb301e
   owner: carl
   status: active
@@ -1877,8 +1877,8 @@ assets:
   producer: warehouse/models/signal_lmarena/text_leaderboard.py
   refresh: dataset cron '0 1 * * 0'
   timezone: UTC
-  last_observed_trigger: MANUAL
-  last_run_at: '2026-08-15'
+  last_observed_trigger: SCHEDULED
+  last_run_at: '2026-08-23'
   dataset_id: f248f653-2ea6-4fdf-badb-c99adf9bcbe4
   owner: carl
   status: active
@@ -2025,8 +2025,8 @@ assets:
   producer: warehouse/models/signal_pypi/package_downloads.sql
   refresh: dataset cron '0 1 * * 0'
   timezone: UTC
-  last_observed_trigger: null
-  last_run_at: null
+  last_observed_trigger: SCHEDULED
+  last_run_at: '2026-08-23'
   dataset_id: c7c3a04c-7e2d-4cea-a7e6-5861c725ea65
   owner: carl
   status: active
@@ -2064,8 +2064,8 @@ assets:
   producer: warehouse/models/signal_semanticscholar/paper_citations.py
   refresh: dataset cron '0 1 * * 0'
   timezone: UTC
-  last_observed_trigger: null
-  last_run_at: null
+  last_observed_trigger: SCHEDULED
+  last_run_at: '2026-08-23'
   dataset_id: a48ec2ff-1e15-4b22-a38e-8ae03e0096f7
   owner: carl
   status: active


### PR DESCRIPTION
Closes the Phase 1 (schedule normalization) verification. The relabel to UTC was applied in #349; §13 requires an observed `SCHEDULED` run from run history as proof, not merely the configuration. The first weekly fire under UTC — Sunday 2026-08-23 — is now in hand.

## Result: all ten in-scope datasets fired SCHEDULED on their UTC cron

Verified via the runs API (not the lagging `datasets.lastRunAt`); `cronTimezone == "UTC"` still holds on all ten.

| Dataset | UTC fire | Trigger | Model status | Run started |
|---|---|---|---|---|
| `signal_pypi` | 01:00 | SCHEDULED | SUCCESS | 2026-08-23T01:00:15Z |
| `signal_lmarena` | 01:00 | SCHEDULED | SUCCESS | 2026-08-23T01:00:17Z |
| `signal_goodailist` | 01:00 | SCHEDULED | SUCCESS | 2026-08-23T01:00:16Z |
| `signal_semanticscholar` | 01:00 | SCHEDULED | **FAILED** (upstream 429) | 2026-08-23T01:00:14Z |
| `signal_artificialanalysis` | 01:00 | SCHEDULED | SUCCESS | 2026-08-23T01:00:15Z |
| `signal_huggingface` | 02:00 | SCHEDULED | SUCCESS | 2026-08-23T02:01:42Z |
| `signal_github` | 03:00 | SCHEDULED | SUCCESS | 2026-08-23T03:01:43Z |
| `entities` | 04:00 | SCHEDULED | SUCCESS | 2026-08-23T04:00:29Z |
| `events` | 05:00 | SCHEDULED | SUCCESS | 2026-08-23T05:00:16Z |
| `metrics` | 06:00 | SCHEDULED | **FAILED** (transient ConnectTimeout) | 2026-08-23T06:00:16Z |

The schedule — the only thing Phase 1 changed — is proven for every dataset.

## Two model-body failures, tracked separately (not schedule defects)

Both failing models fired exactly on their UTC cron; the failure was inside the model, not in the schedule. Recorded as deployed-model items; neither gates Phase 1.

- **`metrics.daily`** — transient `ConnectTimeout` during materialization at 06:00Z. A manual re-run the same morning (08:54→09:02Z) succeeded, so this was infrastructure flakiness; the model is healthy.
- **`signal_semanticscholar.paper_citations`** — upstream Semantic Scholar HTTP `429` (`semantic scholar batch returned 429 for 24 ids`); a manual re-run failed identically, so it is reproducible. The deployed UDM has no 429 backoff (the repo's `warehouse/models/catalog/model_repos.py` does). The fix — backoff or an authenticated Semantic Scholar key — is a platform-owned model change under §17; the asset has no reviewed consumer, so nothing downstream is affected.

## Changes

- `warehouse/assets.yaml` — `last_observed_trigger: SCHEDULED` and `last_run_at: '2026-08-23'` on the fifteen assets held by the ten datasets (including `signal_semanticscholar`, whose schedule fired even though its model failed). `timezone: UTC` was already set at apply time.
- `docs/architecture/migration-status.md` — Phase 1 row → **done**; `unobserved_crons` marker 18 → 10 (the remaining ten are all out of Phase 1 scope); the pending-note paragraph rewritten and the two model failures recorded.
- `docs/operations/normalize-schedules.md` — verification section filled with the per-dataset evidence above.

`uv run pytest -q` passes (768 passed, no skips), including the inventory count-claim and DAG-drift gates.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5bY5TtNtdqoxaeJBdNmXv)_